### PR TITLE
Option to use different raw files for event detection and SSP comp.

### DIFF
--- a/bin/mne_compute_proj_ecg.py
+++ b/bin/mne_compute_proj_ecg.py
@@ -83,6 +83,8 @@ if __name__ == '__main__':
                     default=None)
     parser.add_option("--event-id", dest="event_id", type="int",
                     help="ID to use for events", default=999)
+    parser.add_option("--event-raw", dest="raw_event_fname",
+                    help="raw file to use for event detection", default=None)
 
     options, args = parser.parse_args()
 
@@ -113,6 +115,7 @@ if __name__ == '__main__':
     bad_fname = options.bad_fname
     event_id = options.event_id
     proj_fname = options.proj
+    raw_event_fname = options.raw_event_fname
 
     if bad_fname is not None:
         bads = [w.rstrip().split()[0] for w in open(bad_fname).readlines()]
@@ -134,12 +137,21 @@ if __name__ == '__main__':
 
     raw = mne.fiff.Raw(raw_in, preload=preload)
 
-    projs, events = mne.preprocessing.compute_proj_ecg(raw, tmin, tmax,
-                            n_grad, n_mag, n_eeg, l_freq, h_freq, average,
-                            filter_length, n_jobs, ch_name, reject,
+    if raw_event_fname is not None:
+        raw_event = mne.fiff.Raw(raw_event_fname)
+    else:
+        raw_event = raw
+
+    projs, events = mne.preprocessing.compute_proj_ecg(raw, raw_event,
+                            tmin, tmax, n_grad, n_mag, n_eeg,
+                            l_freq, h_freq, average, filter_length,
+                            n_jobs, ch_name, reject,
                             bads, avg_ref, no_proj, event_id)
 
     raw.close()
+
+    if raw_event_fname is not None:
+        raw_event.close()
 
     if proj_fname is not None:
         print 'Including SSP projections from : %s' % proj_fname

--- a/bin/mne_compute_proj_eog.py
+++ b/bin/mne_compute_proj_eog.py
@@ -86,6 +86,8 @@ if __name__ == '__main__':
                     default=None)
     parser.add_option("--event-id", dest="event_id", type="int",
                     help="ID to use for events", default=998)
+    parser.add_option("--event-raw", dest="raw_event_fname",
+                    help="raw file to use for event detection", default=None)
 
     options, args = parser.parse_args()
 
@@ -115,6 +117,7 @@ if __name__ == '__main__':
     bad_fname = options.bad_fname
     event_id = options.event_id
     proj_fname = options.proj
+    raw_event_fname = options.raw_event_fname
 
     if bad_fname is not None:
         bads = [w.rstrip().split()[0] for w in open(bad_fname).readlines()]
@@ -136,12 +139,21 @@ if __name__ == '__main__':
 
     raw = mne.fiff.Raw(raw_in, preload=preload)
 
-    projs, events = mne.preprocessing.compute_proj_eog(raw, tmin, tmax,
-                            n_grad, n_mag, n_eeg, l_freq, h_freq, average,
-                            filter_length, n_jobs, reject, bads,
+    if raw_event_fname is not None:
+        raw_event = mne.fiff.Raw(raw_event_fname)
+    else:
+        raw_event = raw
+
+    projs, events = mne.preprocessing.compute_proj_eog(raw, raw_event,
+                            tmin, tmax, n_grad, n_mag, n_eeg,
+                            l_freq, h_freq, average, filter_length,
+                            n_jobs, reject, bads,
                             avg_ref, no_proj, event_id)
 
     raw.close()
+
+    if raw_event_fname is not None:
+        raw_event.close()
 
     if proj_fname is not None:
         print 'Including SSP projections from : %s' % proj_fname


### PR DESCRIPTION
For ECG-SSP this is useful when the ECG events are detected from a MEG channel and the SSP proj. should be computed for data to which SSS has been applied. In this case, the QRS detection doesn't work properly with the data to which SSS has been applied, so it is useful to use the original raw file for event detection but then compute the SSP proj. from the data with SSS. 

For completeness I also added the option to the EOG SSP, maybe it is useful for someone.
