### PR TITLE
FIX: wrong number of proj

### DIFF
--- a/mne/fiff/proj.py
+++ b/mne/fiff/proj.py
@@ -275,7 +275,7 @@ def make_projector(projs, ch_names, bads=[], include_active=True):
 
     #   Check whether all of the vectors are exactly zero
     if nonzero == 0:
-        return proj, nproj, U
+        return proj, 0, U
 
     # Reorthogonalize the vectors
     U, S, V = linalg.svd(vecs[:, :nvec], full_matrices=False)


### PR DESCRIPTION
Fixes a bug introduced in commit 7962858a133cabdd37caa169e94da24206740ac7, which caused make_projector() to return a wrong number of projectors when "nonzero == 0".
