### PR TITLE
Update mne/parallel.py

### DIFF
--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -30,7 +30,7 @@ def parallel_func(func, n_jobs, verbose=5):
         Number of jobs >= 0
     """
     try:
-        from sklearn.externals.joblib import Parallel, delayed
+        from joblib import Parallel, delayed
         parallel = Parallel(n_jobs, verbose=verbose)
         my_func = delayed(func)
 


### PR DESCRIPTION
Joblib is now available as an external library (http://packages.python.org/joblib/).  It's probably better to require a dependency on joblib rather than scikits.learn for using parallel functions.
