### PR TITLE
Import joblib directly if sklearn not installed

### DIFF
--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -39,8 +39,7 @@ def parallel_func(func, n_jobs, verbose=5):
             n_jobs = 1
             my_func = func
             parallel = list
-
-        return parallel, my_func, n_jobs
+            return parallel, my_func, n_jobs
 
     parallel = Parallel(n_jobs, verbose=verbose)
     my_func = delayed(func)


### PR DESCRIPTION
Modified the parallel.py file based on your comment (re trying both sklearn and joblib).  It will now try both locations before giving up (sorry I couldn't figure out how to amend the original pull request so I created a new one).
