### PR TITLE
FIX: use half bandwidth

### DIFF
--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -479,9 +479,11 @@ def _compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
     n_times = len(epochs.times)
     sfreq = epochs.info['sfreq']
 
-    bw_norm = float(bandwidth) * n_times / sfreq
-    n_tapers_max = int(2 * bw_norm)
-    dpss, eigvals = dpss_windows(n_times, bw_norm, n_tapers_max,
+    # compute standardized half-bandwidth
+    half_nbw = float(bandwidth) * n_times / (2 * sfreq)
+    n_tapers_max = int(2 * half_nbw)
+
+    dpss, eigvals = dpss_windows(n_times, half_nbw, n_tapers_max,
                                  low_bias=low_bias)
     n_tapers = len(dpss)
 

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -9,17 +9,17 @@ def test_dpss_windows():
     """ Test computation of DPSS windows """
 
     N = 1000
-    NW = 4
-    Kmax = 2 * NW
+    half_nbw = 4
+    Kmax = int(2 * half_nbw)
 
-    dpss, eigs = dpss_windows(N, NW, Kmax, low_bias=False)
-    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, NW, Kmax)
+    dpss, eigs = dpss_windows(N, half_nbw, Kmax, low_bias=False)
+    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
 
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)
 
-    dpss, eigs = dpss_windows(N, NW, Kmax, interp_from=200, low_bias=False)
-    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, NW, Kmax, interp_from=200)
+    dpss, eigs = dpss_windows(N, half_nbw, Kmax, interp_from=200, low_bias=False)
+    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax, interp_from=200)
 
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)


### PR DESCRIPTION
Go back to using standardized half-bandwidth, such that it is the same as in nitime and matlab. See nipy/nitime#105

Improved the variable name and comments, such that it is clear that it is the half-bandwidth.
