### PR TITLE
Cov proj option (addresses part of 113)

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -296,7 +296,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         projs = cp.deepcopy(epochs[0].info['projs'])
     else:
         projs = cp.deepcopy(proj)
-    ch_names = cp.deepcopy(epochs[0].ch_names)
+    ch_names = epochs[0].ch_names
 
     # make sure Epochs are compatible
     for epochs_t in epochs[1:]:


### PR DESCRIPTION
This adds the user option to input a "proj" variable in the compute_covariance function. It also changes uses of "copy" to "cp" to be more consistent with other files. This addresses the first part of issue #113, adding projector options, but does not address the ability to compute projectors across multiple runs (still in progress, will use a different pull request).
