### PR TITLE
ENH: Parallelizing SSP a little bit

### DIFF
--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -2,8 +2,10 @@ import os.path as op
 import warnings
 
 from nose.tools import assert_true, assert_equal
+from numpy.testing import assert_array_equal
 
 from ...fiff import Raw
+from ...fiff.proj import make_projector, activate_proj
 from ..ssp import compute_proj_ecg, compute_proj_eog
 
 data_path = op.join(op.dirname(__file__), '..', '..', 'fiff', 'tests', 'data')
@@ -24,6 +26,13 @@ def test_compute_proj_ecg():
         assert_true(len(projs) == 7)
         #XXX: better tests
 
+        # without setting a bad channel, this should throw a warning
+        projs, events = compute_proj_ecg(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                        ch_name='MEG 1531', bads=[],
+                                        average=average, avg_ref=True,
+                                        no_proj=True)
+        assert_equal(projs, None)
+
 
 def test_compute_proj_eog():
     """Test computation of EOG SSP projectors"""
@@ -36,3 +45,32 @@ def test_compute_proj_eog():
         raw.close()
         assert_true(len(projs) == (7 + n_projs_init))
         #XXX: better tests
+
+        # without setting a bad channel, this should throw a warning
+        projs, events = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                     average=average, bads=[],
+                                     avg_ref=True, no_proj=False)
+        assert_equal(projs, None)
+
+
+
+def test_compute_proj_parallel():
+    """Test computation of projectors using parallelization"""
+    raw = Raw(raw_fname, preload=True)
+    projs, _ = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                bads=['MEG 2443'], average=False,
+                                avg_ref=True, no_proj=False, n_jobs=1)
+    raw.close()
+
+    raw = Raw(raw_fname, preload=True)
+    projs_2, _ = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                  bads=['MEG 2443'], average=False,
+                                  avg_ref=True, no_proj=False, n_jobs=2)
+    projs = activate_proj(projs)
+    projs_2 = activate_proj(projs_2)
+    projs, _, _ = make_projector(projs, raw.info['ch_names'],
+                                 bads=['MEG 2443'])
+    projs_2, _, _ = make_projector(projs_2, raw.info['ch_names'],
+                                   bads=['MEG 2443'])
+    raw.close()
+    assert_array_equal(projs, projs_2)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -2,7 +2,7 @@ import os.path as op
 from nose.tools import assert_true
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from mne.fiff import Raw, pick_types
 from mne import compute_proj_epochs, compute_proj_evoked, compute_proj_raw
@@ -15,12 +15,11 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 event_fname = op.join(base_dir, 'test-eve.fif')
 proj_fname = op.join(base_dir, 'test_proj.fif')
 
-
 def test_compute_proj():
     """Test SSP computation"""
     event_id, tmin, tmax = 1, -0.2, 0.3
 
-    raw = Raw(raw_fname)
+    raw = Raw(raw_fname, preload=True)
     events = read_events(event_fname)
     exclude = []
     bad_ch = 'MEG 2443'
@@ -30,7 +29,7 @@ def test_compute_proj():
                         baseline=None, proj=False)
 
     evoked = epochs.average()
-    projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0)
+    projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0, n_jobs=1)
 
     projs2 = read_proj(proj_fname)
 
@@ -69,11 +68,17 @@ def test_compute_proj():
     projs_evoked = compute_proj_evoked(evoked, n_grad=1, n_mag=1, n_eeg=0)
     # XXX : test something
 
+    # test parallelization
+    projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0, n_jobs=2)
+    projs = activate_proj(projs)
+    proj_par, _, _ = make_projector(projs, epochs.ch_names, bads=[])
+    assert_array_equal(proj, proj_par)
 
     # Test that the raw projectors work
     for ii in (1, 2, 4, 8, 12, 24):
         raw = Raw(raw_fname)
-        projs = compute_proj_raw(raw, duration=ii-0.1, n_grad=1, n_mag=1, n_eeg=0)
+        projs = compute_proj_raw(raw, duration=ii-0.1, n_grad=1, n_mag=1,
+                                 n_eeg=0)
 
         # test that you can compute the projection matrix
         projs = activate_proj(projs)
@@ -85,6 +90,17 @@ def test_compute_proj():
         # test that you can save them
         raw.info['projs'] += projs
         raw.save('foo_%d_raw.fif' % ii)
+
+    # test parallelization
+    raw = Raw(raw_fname)
+    projs = compute_proj_raw(raw, duration=1, n_grad=1, n_mag=1, n_eeg=0,
+                             n_jobs=2)
+    proj, _, _ = make_projector(projs, epochs.ch_names, bads=[])
+    raw = Raw(raw_fname)
+    projs = compute_proj_raw(raw, duration=1, n_grad=1, n_mag=1, n_eeg=0,
+                             n_jobs=1)
+    proj_par, _, _ = make_projector(projs, epochs.ch_names, bads=[])
+    assert_array_equal(proj, proj_par)
 
     # Test that purely continuous (no duration) raw projection works
     raw = Raw(raw_fname)


### PR DESCRIPTION
This leads to modest (1.1x) to decent (2x) speed gains in SSP calculations with minimal additional code complications. The slowest part is the filtering of the EOG/ECG channels for blink/heartbeat detection, but I don't know if there's much we can do about that.
