### PR TITLE
FIX: raw dtype, preload

### DIFF
--- a/mne/fiff/tests/test_raw.py
+++ b/mne/fiff/tests/test_raw.py
@@ -227,6 +227,12 @@ def test_io_complex():
         n_samp = raw2_data.shape[1]
         assert_array_almost_equal(raw2_data[:, :n_samp],
                                   raw_cp._data[picks, :n_samp])
+        # with preloading
+        raw2 = Raw('raw.fif', preload=True)
+        raw2_data, _ = raw2[picks, :]
+        n_samp = raw2_data.shape[1]
+        assert_array_almost_equal(raw2_data[:, :n_samp],
+                                  raw_cp._data[picks, :n_samp])
 
 
 def test_getitem():


### PR DESCRIPTION
This fixes a bug which resulted in the data type of Raw to be float32 whenever preloading is used. For complex Raw files, preloading was completely broken (test was missing) and for real files, the data was float32 when preload=True and float64 when preload=False.

Since the data type is propagated to Epochs, proj, etc., using float32 can result in problems due to numerical accuracy. The failed test in proj discussed here https://github.com/mne-tools/mne-python/pull/128 was caused by this.  
