### PR TITLE
FIX: including datasets in mne/__init__.py

### DIFF
--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -28,10 +28,8 @@ from .proj import read_proj, write_proj, compute_proj_epochs, \
 
 from .selection import read_selection
 from .dipole import read_dip
-
 from . import artifacts
 from . import beamformer
-from . import data
 from . import datasets
 from . import fiff
 from . import layouts
@@ -39,7 +37,7 @@ from . import minimum_norm
 from . import mixed_norm
 from . import preprocessing
 from . import simulation
+from . import stats
 from . import tests
 from . import time_frequency
 from . import viz
-


### PR DESCRIPTION
- on a new clone of mne all examples failed because this was missing. Could someone reproduce this? Anyways anyhting against including the datasets module here?
