### PR TITLE
ENH: plot time-frequency representations on sensor layout

### DIFF
--- a/examples/time_frequency/plot_tfr_topography.py
+++ b/examples/time_frequency/plot_tfr_topography.py
@@ -63,7 +63,7 @@ baseline = (None, 0)  # set the baseline for induced power
 mode = 'ratio'  # set mode for baseline rescaling
 
 ###############################################################################
-# Show topography of power (be patient, this may take some time)
+# Show topography of power.
 
 plot_topo_power(epochs, power, frequencies, layout, baseline=baseline,
                 mode=mode, decim=decim)
@@ -73,7 +73,9 @@ pl.show()
 
 
 ###############################################################################
-# Show topography of phase_locking value (be patient, this may take some time)
+# Show topography of phase locking value (PLV)
+
+mode = None  # no baseline rescaling for PLV
 
 plot_topo_phase_lock(epochs, phase_lock, frequencies, layout,
                      baseline=baseline, mode=mode, decim=decim)


### PR DESCRIPTION
- 2 user functions for power / phase lock
- private function that does the actual job
- example

For the time being the user functions may seem redundant. However we later might want to add autmatic text plotting for more convenience where having two seperate functions make sense.
The the colorbar / borders / scaling issue now is resolved and to me the plot looks fine. However there might be a more elegant way of doing it (scaling the layout and the color scale).
Anyways, If you are fine with the functionality / API, I would include it as is. We can later optimize the implementation.
