### PR TITLE
ENH: Speeding up ST clustering by 30%

### DIFF
--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal
+from numpy.testing import assert_equal, assert_array_equal,\
+                          assert_array_almost_equal
 from nose.tools import assert_true
 from scipy import sparse, linalg, stats
 
@@ -34,18 +35,18 @@ def test_cluster_permutation_test():
                                       (condition2_1d, condition2_2d)):
         T_obs, clusters, cluster_p_values, hist = permutation_cluster_test(
                                     [condition1, condition2],
-                                    n_permutations=500, tail=1, seed=1)
+                                    n_permutations=100, tail=1, seed=1)
         assert_equal(np.sum(cluster_p_values < 0.05), 1)
 
         T_obs, clusters, cluster_p_values, hist = permutation_cluster_test(
                                     [condition1, condition2],
-                                    n_permutations=500, tail=0, seed=1)
+                                    n_permutations=100, tail=0, seed=1)
         assert_equal(np.sum(cluster_p_values < 0.05), 1)
 
         # test with 2 jobs
         T_obs, clusters, cluster_p_values_buff, hist =\
             permutation_cluster_test([condition1, condition2],
-                                    n_permutations=500, tail=0, seed=1,
+                                    n_permutations=100, tail=0, seed=1,
                                     n_jobs=2)
 
         assert_array_equal(cluster_p_values, cluster_p_values_buff)
@@ -54,27 +55,26 @@ def test_cluster_permutation_test():
 def test_cluster_permutation_t_test():
     """Test cluster level permutations T-test."""
     for condition1 in (condition1_1d, condition1_2d):
+        # these are so significant we can get away with fewer perms
         T_obs, clusters, cluster_p_values, hist =\
-            permutation_cluster_1samp_test(condition1, n_permutations=500,
+            permutation_cluster_1samp_test(condition1, n_permutations=100,
                                            tail=0, seed=1)
         assert_equal(np.sum(cluster_p_values < 0.05), 1)
 
         T_obs_pos, c_1, cluster_p_values_pos, _ =\
-            permutation_cluster_1samp_test(condition1, n_permutations=500,
+            permutation_cluster_1samp_test(condition1, n_permutations=100,
                                     tail=1, threshold=1.67, seed=1)
 
         T_obs_neg, _, cluster_p_values_neg, _ =\
-            permutation_cluster_1samp_test(-condition1, n_permutations=500,
+            permutation_cluster_1samp_test(-condition1, n_permutations=100,
                                     tail=-1, threshold=-1.67, seed=1)
         assert_array_equal(T_obs_pos, -T_obs_neg)
         assert_array_equal(cluster_p_values_pos < 0.05,
                            cluster_p_values_neg < 0.05)
 
-        print c_1
-
         # test with 2 jobs
         T_obs_neg, _, cluster_p_values_neg_buff, _ = \
-            permutation_cluster_1samp_test(-condition1, n_permutations=500,
+            permutation_cluster_1samp_test(-condition1, n_permutations=100,
                                             tail=-1, threshold=-1.67, seed=1,
                                             n_jobs=2)
 
@@ -91,10 +91,11 @@ def test_cluster_permutation_t_test_with_connectivity():
     except ImportError:
         return
 
-    out = permutation_cluster_1samp_test(condition1_1d, n_permutations=500)
+    # we don't care about p-values in any of these, so do fewer permutations
+    out = permutation_cluster_1samp_test(condition1_1d, n_permutations=50)
     connectivity = grid_to_graph(1, condition1_1d.shape[1])
     out_connectivity = permutation_cluster_1samp_test(condition1_1d,
-                  n_permutations=500, connectivity=connectivity)
+                  n_permutations=50, connectivity=connectivity)
     assert_array_equal(out[0], out_connectivity[0])
     for a, b in zip(out_connectivity[1], out[1]):
         assert_true(np.sum(out[0][a]) == np.sum(out[0][b]))
@@ -108,7 +109,7 @@ def test_cluster_permutation_t_test_with_connectivity():
                                    condition1_1d), axis=1)
 
     out_connectivity_2 = permutation_cluster_1samp_test(condition1_2,
-                    n_permutations=500, connectivity=connectivity_2)
+                    n_permutations=50, connectivity=connectivity_2)
     # make sure we were operating on the same values
     split = len(out[0])
     assert_array_equal(out[0], out_connectivity_2[0][:split])
@@ -128,7 +129,7 @@ def test_cluster_permutation_t_test_with_connectivity():
     # now use the other algorithm
     condition1_3 = np.reshape(condition1_2, (40, 2, 350))
     out_connectivity_3 = mnestats.spatio_temporal_cluster_1samp_test(
-                             condition1_3, n_permutations=500,
+                             condition1_3, n_permutations=50,
                              connectivity=connectivity, max_step=0,
                              threshold=1.67, check_disjoint=True)
     # make sure we were operating on the same values
@@ -144,6 +145,22 @@ def test_cluster_permutation_t_test_with_connectivity():
     data_2 = set([np.sum(out_connectivity_3[0][a[0], a[1]]) for a in
         out_connectivity_3[1]])
     assert_true(len(data_1.intersection(data_2)) == len(data_1))
+
+    # test new versus old method old method
+    out_connectivity_4 = mnestats.spatio_temporal_cluster_1samp_test(
+                             condition1_3, n_permutations=50,
+                             connectivity=connectivity, max_step=2,
+                             threshold=1.67)
+    out_connectivity_5 = mnestats.spatio_temporal_cluster_1samp_test(
+                             condition1_3, n_permutations=50,
+                             connectivity=connectivity, max_step=1,
+                             threshold=1.67)
+    # clutsers could be in a different order
+    sums_4 = [np.sum(out_connectivity_4[0][a]) for a in out_connectivity_4[1]]
+    sums_5 = [np.sum(out_connectivity_4[0][a]) for a in out_connectivity_5[1]]
+    sums_4 = np.sort(sums_4)
+    sums_5 = np.sort(sums_5)
+    assert_array_almost_equal(sums_4, sums_5)
 
 
 def ttest_1samp(X):


### PR DESCRIPTION
This increases code complexity a little bit, but it makes spatio-temporal clustering 30% faster. We can decrease code complexity back to old levels if we remove the max_step option (because then we can remove the slower method _get_clusters_st), which I don't expect to be a terribly popular option anyway and mostly included for completeness before.
