### PR TITLE
FIX + ENH: ICA Bugfix + improved exception handling for noise covariance

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -743,12 +743,10 @@ class ICA(object):
             data *= pre_whitener
         else:  # pick cov
             ncov = deepcopy(self.noise_cov)
-            if ncov['names'] != self.ch_names:
+            if data.shape[0] != ncov['data'].shape[0]:
                 ncov['data'] = ncov['data'][picks][:, picks]
-            assert data.shape[0] == ncov['data'].shape[0]
-            if info['bads'] != ncov['bads']:
-                raise RuntimeError('The noise cov must have the same bad '
-                                   'channels as the MEEG data.')
+                assert data.shape[0] == ncov['data'].shape[0]
+
             pre_whitener, _ = compute_whitener(ncov, info, picks)
             data = np.dot(pre_whitener, data)
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -152,9 +152,9 @@ def test_ica_additional():
     stop2 = 500
 
     test_cov2 = deepcopy(test_cov)
-    test_cov2['bads'].append('MEG 0112')
     ica = ICA(noise_cov=test_cov2, n_components=3, max_n_components=4)
-    assert_raises(RuntimeError, ica.decompose_raw, raw)
+    ica.decompose_raw(raw, picks[:5])
+    assert_true(ica.n_components < 5)
 
     ica = ICA(n_components=3, max_n_components=4)
     ica.decompose_raw(raw, picks=None, start=start, stop=stop2)


### PR DESCRIPTION
- fixed cases that didn't show up due to lazy evaluation
- added regression test to cover this case
- added exception handler that makes sure that info['bads'] and noise_cov['bads'] are the same. In fact there may be cases where the channel names can be identical but the bads info differs. The compute_whitening then would fail.

If you think this is too rigorous an alternative would be to apply some magic and 'equalize' the bads field from info and noise_cov. 
