### PR TITLE
ENH: embed links in examples

### DIFF
--- a/examples/inverse/plot_dipole_fit_result.py
+++ b/examples/inverse/plot_dipole_fit_result.py
@@ -24,7 +24,7 @@ import numpy as np
 import mne
 from mne.datasets import sample
 
-data_path = sample.data_path('.')
+data_path = sample.data_path('..')
 fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 dip_fname = data_path + '/MEG/sample/sample_audvis_set1.dip'
 bem_fname = data_path + '/subjects/sample/bem/sample-5120-bem-sol.fif'

--- a/examples/inverse/plot_read_inverse.py
+++ b/examples/inverse/plot_read_inverse.py
@@ -12,7 +12,7 @@ print __doc__
 from mne.datasets import sample
 from mne.minimum_norm import read_inverse_operator
 
-data_path = sample.data_path('.')
+data_path = sample.data_path('..')
 fname = data_path
 fname += '/MEG/sample/sample_audvis-meg-oct-6-meg-inv.fif'
 

--- a/examples/plot_simulate_evoked_data.py
+++ b/examples/plot_simulate_evoked_data.py
@@ -24,7 +24,7 @@ from mne.simulation import generate_sparse_stc, generate_evoked
 data_path = sample.data_path('.')
 
 raw = mne.fiff.Raw(data_path + '/MEG/sample/sample_audvis_raw.fif')
-proj = mne.read_proj(data_path + '/MEG/sample/ecg_proj.fif')
+proj = mne.read_proj(data_path + '/MEG/sample/sample_audvis_ecg_proj.fif')
 raw.info['projs'] += proj
 raw.info['bads'] = ['MEG 2443', 'EEG 053']  # mark bad channels
 


### PR DESCRIPTION
Hack to use magic (=introspection) to "wikify" the example code in the documentation. If you want to see what it does build the doc and look at the examples :-)
