### PR TITLE
FIX: click & shift to open figure

### DIFF
--- a/mne/viz.py
+++ b/mne/viz.py
@@ -108,6 +108,9 @@ def _plot_topo_onpick(event, show_func=None, tmin=None, tmax=None,
                       vmin=None, vmax=None, colorbar=False, title=None,
                       x_label=None, y_label=None):
     """Onpick callback that shows a single channel in a new figure"""
+    # we only open a figure when shift is pressed
+    if event.mouseevent.key is None or event.mouseevent.key != 'shift':
+        return
     artist = event.artist
     try:
         import pylab as pl


### PR DESCRIPTION
This is one possible option to fix the swipe problem in OS-X mentioned in #229. @dengemann, @agramfort can you test if it indeed fixes it? I'm not a huge fan of having to hold shift and then click, but at the moment I can't think of another good solution.
