### PR TITLE
FIX: tril_indices for old numpy

### DIFF
--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -13,6 +13,7 @@ logger = logging.getLogger('mne')
 
 
 from .utils import check_indices
+from ..fixes import tril_indices
 from ..parallel import parallel_func
 from .. import Epochs, SourceEstimate
 from ..time_frequency.multitaper import dpss_windows, _mt_spectra,\
@@ -690,7 +691,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
 
             if indices is None:
                 # only compute r for lower-triangular region
-                indices_use = np.tril_indices(n_signals, -1)
+                indices_use = tril_indices(n_signals, -1)
             else:
                 indices_use = check_indices(indices)
 

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_true, assert_raises
 
+from mne.fixes import tril_indices
 from mne.connectivity import spectral_connectivity
 from mne.connectivity.spectral import _CohEst
 
@@ -137,7 +138,7 @@ def test_spectral_connectivity():
 
                 # compute same connections using indices and 2 jobs,
                 # also add a second method
-                indices = np.tril_indices(n_signals, -1)
+                indices = tril_indices(n_signals, -1)
 
                 test_methods = (method, _CohEst)
                 stc_data = _stc_gen(data, sfreq, tmin)

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -168,6 +168,19 @@ else:
     in1d = np.in1d
 
 
+def _tril_indices(n, k=0):
+    """Replacement for tril_indices that is provided for numpy >= 1.4"""
+    mask = np.greater_equal(np.subtract.outer(np.arange(n), np.arange(n)), -k)
+    indices = np.where(mask)
+
+    return indices
+
+if not hasattr(np, 'tril_indices'):
+    tril_indices = _tril_indices
+else:
+    tril_indices = np.tril_indices
+
+
 def _unravel_index(indices, dims):
     """Add support for multiple indices in unravel_index that is provided
     for numpy >= 1.4"""

--- a/mne/tests/test_fixes.py
+++ b/mne/tests/test_fixes.py
@@ -8,7 +8,7 @@ import numpy as np
 from nose.tools import assert_equal
 from numpy.testing import assert_array_equal
 
-from ..fixes import _in1d, _copysign, _unravel_index
+from ..fixes import _in1d, _tril_indices, _copysign, _unravel_index
 
 
 def test_in1d():
@@ -16,6 +16,22 @@ def test_in1d():
     a = np.arange(10)
     b = a[a % 2 == 0]
     assert_equal(_in1d(a, b).sum(), 5)
+
+
+def test_tril_indices():
+    """Test numpy.tril_indices() replacement"""
+    il1 = _tril_indices(4)
+    il2 = _tril_indices(4, -1)
+
+    a = np.array([[1, 2, 3, 4],
+                  [5, 6, 7, 8],
+                  [9, 10, 11, 12],
+                  [13, 14, 15, 16]])
+
+    assert_array_equal(a[il1],
+                       np.array([1,  5,  6,  9, 10, 11, 13, 14, 15, 16]))
+
+    assert_array_equal(a[il2], np.array([5, 9, 10, 13, 14, 15]))
 
 
 def test_unravel_index():


### PR DESCRIPTION
Fixes #228. The connectivity tests now work on Ubuntu with numpy 1.3. Unfortunately I can't run all the tests as the virtual machine crashes for some reason when I try to do so..
