### PR TITLE
FIX: save epochs.event_id dict to fiff and read back

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -718,15 +718,11 @@ class Epochs(object):
     def copy(self):
         """ Return copy of Epochs instance
         """
-        if hasattr(self, 'raw'):
-            raw = self.raw
-            del self.raw
-
+        raw = self.raw
+        del self.raw
         new = deepcopy(self)
-
-        if hasattr(self, 'raw'):
-            self.raw = raw
-            new.raw = raw
+        self.raw = raw
+        new.raw = raw
 
         return new
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -70,8 +70,6 @@ def _read_events_fif(fid, tree):
         fid.close()
         raise ValueError('Could not find event data')
 
-    mappings = dir_tree_find(tree, FIFF.FIFF_DESCRIPTION)
-
     events = events[0]
 
     for d in events['directory']:
@@ -84,20 +82,22 @@ def _read_events_fif(fid, tree):
     else:
         raise ValueError('Could not find any events')
 
-    if mappings:
-        for d in mappings['directory']:
-            kind = d.kind
-            pos = d.pos
-            if kind == FIFF.FIFF_DESCRIPTION:
-                tag = read_tag(fid, pos)
-                event_list = tag.data
-                break
+    mappings = dir_tree_find(tree, FIFF.FIFFB_MNE_EVENTS)
+    mappings = mappings[0]
+
+    for d in mappings['directory']:
+        kind = d.kind
+        pos = d.pos
+        if kind == FIFF.FIFF_DESCRIPTION:
+            tag = read_tag(fid, pos)
+            mappings = tag.data
+            break
     else:
         mappings = None
 
     if mappings is not None:
         m_ = (m.split(':') for m in mappings.split(';'))
-        mappings = dict((k, str(v)) for k, v in m_)
+        mappings = dict((k, int(v)) for k, v in m_)
     event_list = event_list.reshape(len(event_list) / 3, 3)
     return event_list, mappings
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -98,7 +98,7 @@ def test_read_write_epochs():
     epochs.event_id.pop('1')
     epochs.event_id.update({'a': 1})
     epochs.save(op.join(base_dir, 'foo_events.fif'))
-    epochs_read2 = read_epochs('foo_events.fif')
+    epochs_read2 = read_epochs(op.join(base_dir, 'foo_events.fif'))
     assert_equal(epochs_read2.event_id, epochs.event_id)
 
 


### PR DESCRIPTION
- formally it works
- but the dict serialized is not resotred on reading back
- any thoughts?

Example test:

``` Python
run examples/plot_read_epochs.py

epochs.event_id.update({'a': 1})

print epochs.event_id

epochs.save('this_cool_feature.fif')

e2 = mne.read_epochs('this_cool_feature.fif')

print e2.event_id

```
