### PR TITLE
FIX: X is a list in cluster_permutation_test

### DIFF
--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -565,7 +565,7 @@ def permutation_cluster_test(X, stat_fun=f_oneway, threshold=1.67,
 
     # convert clusters to old format
     if connectivity is not None and out_type == 'mask':
-        clusters = _clusters_to_bool(clusters, X.shape[1])
+        clusters = _clusters_to_bool(clusters, X[0].shape[1])
 
     # The clusters and stat should have the same shape as the samples
     clusters = _reshape_clusters(clusters, sample_shape)


### PR DESCRIPTION
@Eric89GXL can you very verify that this is correct. This should have been caught by a test, we have to improve the coverage for the cluster stats.
