### PR TITLE
ENH: Raw meas_info io

### DIFF
--- a/mne/fiff/meas_info.py
+++ b/mne/fiff/meas_info.py
@@ -262,19 +262,14 @@ def write_meas_info(fid, info, data_type=None):
     blocks = [FIFF.FIFFB_SUBJECT, FIFF.FIFFB_HPI_MEAS,
               FIFF.FIFFB_PROCESSING_HISTORY]
 
-    have_isotrak = False
-
-    if len(blocks) > 0 and 'filename' in info and \
-            info['filename'] is not None:
+    if 'filename' in info and info['filename'] is not None:
         fid2, tree, _ = fiff_open(info['filename'])
         for block in blocks:
             nodes = dir_tree_find(tree, block)
             copy_tree(fid2, tree['id'], nodes, fid)
         fid2.close()
 
-    #
-    #    megacq parameters
-    #
+    #   megacq parameters
     if info['acq_pars'] is not None or info['acq_stim'] is not None:
         start_block(fid, FIFF.FIFFB_DACQ_PARS)
         if info['acq_pars'] is not None:
@@ -293,7 +288,7 @@ def write_meas_info(fid, info, data_type=None):
         write_coord_trans(fid, info['ctf_head_t'])
 
     #   Polhemus data
-    if info['dig'] is not None and not have_isotrak:
+    if info['dig'] is not None:
         start_block(fid, FIFF.FIFFB_ISOTRAK)
         for d in info['dig']:
             write_dig_point(fid, d)

--- a/mne/fiff/tests/test_raw.py
+++ b/mne/fiff/tests/test_raw.py
@@ -242,7 +242,7 @@ def test_io_raw():
         # check transformations
         for trans in ['dev_head_t', 'dev_ctf_t', 'ctf_head_t']:
             if raw.info[trans] is None:
-                assert raw2.info[trans] is None
+                assert_true(raw2.info[trans] is None)
             else:
                 assert_array_equal(raw.info[trans]['trans'],
                                    raw2.info[trans]['trans'])
@@ -257,8 +257,8 @@ def test_io_raw():
                 else:
                     to_id = FIFF.FIFFV_MNE_COORD_CTF_HEAD
                 for raw_ in [raw, raw2]:
-                    assert raw_.info[trans]['from'] == from_id
-                    assert raw_.info[trans]['to'] == to_id
+                    assert_true(raw_.info[trans]['from'] == from_id)
+                    assert_true(raw_.info[trans]['to'] == to_id)
 
         if fname_in == fif_fname or fname_in == fif_fname + '.gz':
             assert_array_almost_equal(raw.info['dig'][0]['r'],


### PR DESCRIPTION
- Raw.save(): Write dev_to_head transformation from raw.info (instead of copying it form the source file)
- FIX read_meas_info(): Don't base info['dev_ctf_t'] on shallow copy of info['dev_head_t'] 
