### PR TITLE
ENH: use stc.plot instead of bar graphs in connectivity example

### DIFF
--- a/examples/connectivity/plot_mne_inverse_coherence_epochs.py
+++ b/examples/connectivity/plot_mne_inverse_coherence_epochs.py
@@ -16,7 +16,6 @@ MNE-dSPM inverse soltions.
 print __doc__
 
 import numpy as np
-import pylab as pl
 import mne
 from mne.datasets import sample
 from mne.fiff import Raw, pick_types
@@ -31,8 +30,6 @@ fname_raw = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 fname_event = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 label_name_lh = 'Aud-lh'
 fname_label_lh = data_path + '/MEG/sample/labels/%s.label' % label_name_lh
-label_name_rh = 'Aud-rh'
-fname_label_rh = data_path + '/MEG/sample/labels/%s.label' % label_name_rh
 
 event_id, tmin, tmax = 1, -0.2, 0.5
 method = "dSPM"  # use dSPM method (could also be MNE or sLORETA)
@@ -40,7 +37,6 @@ method = "dSPM"  # use dSPM method (could also be MNE or sLORETA)
 # Load data
 inverse_operator = read_inverse_operator(fname_inv)
 label_lh = mne.read_label(fname_label_lh)
-label_rh = mne.read_label(fname_label_rh)
 raw = Raw(fname_raw)
 events = mne.read_events(fname_event)
 
@@ -107,7 +103,7 @@ print freqs[0]
 print 'Frequencies in Hz over which coherence was averaged for beta: '
 print freqs[1]
 
-# Generate a source estimate with the coherence. This is simple since we
+# Generate a SourceEstimate with the coherence. This is simple since we
 # used a single seed. For more than one seeds we would have to split coh.
 # Note: We use a hack to save the frequency axis as time
 tmin = np.mean(freqs[0])
@@ -115,19 +111,7 @@ tstep = np.mean(freqs[1]) - tmin
 coh_stc = mne.SourceEstimate(coh, vertices=stc.vertno, tmin=1e-3 * tmin,
                              tstep=1e-3 * tstep)
 
-# Save the coherence for visualization using e.g. mne_analyze
-#coh_stc.save('seed_coh_alpha_beta_vertno_%d' % (seed_vertno))
-
-# Plot the average coherence inside label_rh for each band
-aud_rh_coh = dict()  # store the coherence for each band
-aud_rh_coh['alpha'] = np.mean(coh_stc.in_label(label_rh).data[:, 0], axis=0)
-aud_rh_coh['beta'] = np.mean(coh_stc.in_label(label_rh).data[:, 1], axis=0)
-
-pl.figure()
-width = 0.5
-pos = np.arange(2) + 0.25
-pl.bar(pos, [aud_rh_coh['alpha'], aud_rh_coh['beta']], width)
-pl.ylabel('Coherence')
-pl.title('Coherence left-right auditory')
-pl.xticks(pos + width / 2, ('alpha', 'beta'))
-pl.show()
+# Now we can visualize the coherence using the plot method
+brain = coh_stc.plot('sample', 'inflated', 'rh', fmin=0.25, fmid=0.4,
+                     fmax=0.65, time_label='Coherence %0.1f Hz')
+brain.show_view('lateral')


### PR DESCRIPTION
![coherence](https://f.cloud.github.com/assets/647005/17825/c2babda0-4889-11e2-8c59-c78b08dda6f8.png)

Thanks to #276 we no longer have to use the silly bar graphs :-)
