### PR TITLE
FIX: Addressing numpy non-integer warnings

### DIFF
--- a/mne/filter.py
+++ b/mne/filter.py
@@ -655,7 +655,7 @@ def resample(x, up, down, npad=100, axis=0, window='boxcar'):
         y = signal.resample(x_padded, new_len, axis=axis, window=window)
 
         # now let's trim it back to the correct size (if there was padding)
-        to_remove = np.round(ratio * npad)
+        to_remove = np.round(ratio * npad).astype(int)
         if to_remove > 0:
             keep = np.ones((new_len), dtype='bool')
             keep[:to_remove] = False

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -37,7 +37,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
     events : array
         Indices of ECG peaks
     """
-    win_size = round((60.0 * sfreq) / 120.0)
+    win_size = int(round((60.0 * sfreq) / 120.0))
 
     filtecg = band_pass_filter(ecg, sfreq, l_freq, h_freq)
 


### PR DESCRIPTION
Newest version of numpy (1.8.0-dev) throws warnings for non-integer slicing.
