### PR TITLE
FIX: PySurfer SUBJECTS_DIR

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -880,6 +880,14 @@ class SourceEstimate(object):
              transparent=True, time_viewer=False, subjects_dir=None):
         """Plot SourceEstimates with PySurfer
 
+        Note: PySurfer currently needs the SUBJECTS_DIR environment variable,
+        which will automatically be set by this function. Plotting multiple
+        SourceEstimates with different values for subjects_dir will cause
+        PySurfer to use the wrong FreeSurfer surfaces when using methods of
+        the returned Brain object. It is therefore recommended to set the
+        SUBJECTS_DIR environment variable or always use the same value for
+        subjects_dir (within the same Python session).
+
         Parameters
         ----------
         stc : SourceEstimates

--- a/mne/viz.py
+++ b/mne/viz.py
@@ -879,6 +879,14 @@ def plot_source_estimates(stc, subject, surface='inflated', hemi='lh',
                           subjects_dir=None):
     """Plot SourceEstimates with PySurfer
 
+    Note: PySurfer currently needs the SUBJECTS_DIR environment variable,
+    which will automatically be set by this function. Plotting multiple
+    SourceEstimates with different values for subjects_dir will cause
+    PySurfer to use the wrong FreeSurfer surfaces when using methods of
+    the returned Brain object. It is therefore recommended to set the
+    SUBJECTS_DIR environment variable or always use the same value for
+    subjects_dir (within the same Python session).
+
     Parameters
     ----------
     stc : SourceEstimates


### PR DESCRIPTION
Currently PySurfer needs the SUBJECTS_DIR environment variable. I will submit a PR to PySurfer such that subjects_dir can be set using a keyword argument to Brain, like we do in mne-python. This is designed to work with future versions of PySurfer where the subjects_dir argument can be used.

For old (=current) versions. I currently set `os.environ['SUBJECTS_DIR']` in `plot_source_estimates`. This is not ideal as it can break things, e.g., a user can plot one stc with a value for subjects_dir and then plot another stc with a different value for subjects_dir. After this, the Brain from the first plot will no longer work correctly (as some Brain methods query `os.environ['SUBJECTS_DIR']`). An alternative solution for old (current) PySurfer would be:

```
if 'SUBJECTS_DIR' in os.environ:
    if os.environ['SUBJECTS_DIR'] != subjects_dir:
        raise ValueError('for old PySurfer versions, the subjects directory has to be set using the              
                                        'SUBJECTS_DIR environment variable')
else:
    raise ValueError('for old PySurfer versions, the subjects directory has to be set using the              
                                   'SUBJECTS_DIR environment variable')
```
