### PR TITLE
ENH: fixed size thumbnails, doc fix

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -18,6 +18,7 @@ import cPickle
 import re
 import urllib2
 
+import PIL
 import matplotlib
 matplotlib.use('Agg')
 
@@ -255,7 +256,7 @@ def generate_example_rst(app):
         }
 
     .figure .caption {
-        width: 170px;
+        width: 180px;
         text-align: center !important;
     }
     </style>
@@ -334,6 +335,34 @@ def generate_dir_rst(dir, fhindex, example_dir, root_dir, plot_gallery):
 
 # modules for which we embed links into example code
 DOCMODULES = ['mne', 'matplotlib', 'numpy', 'mayavi']
+
+
+def make_thumbnail(in_fname, out_fname, width, height):
+    """Make a thumbnail with the same aspect ratio centered in an
+       image with a given width and height
+    """
+    img = PIL.Image.open(in_fname)
+    width_in, height_in = img.size
+    scale_w = width / float(width_in)
+    scale_h = height / float(height_in)
+
+    if height_in * scale_w <= height:
+        scale = scale_w
+    else:
+        scale = scale_h
+
+    width_sc = int(round(scale * width_in))
+    height_sc = int(round(scale * height_in))
+
+    # resize the image
+    img.thumbnail((width_sc, height_sc), PIL.Image.ANTIALIAS)
+
+    # insert centered
+    thumb = PIL.Image.new('RGB', (width, height), (255, 255, 255))
+    pos_insert = ((width - width_sc) / 2, (height - height_sc) / 2)
+    thumb.paste(img, pos_insert)
+
+    thumb.save(out_fname)
 
 
 def get_short_module_name(module_name, obj_name):
@@ -554,13 +583,12 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
 
         # generate thumb file
         this_template = plot_rst_template
-        from matplotlib import image
         if os.path.exists(first_image_file):
-            image.thumbnail(first_image_file, thumb_file, 0.2)
+            make_thumbnail(first_image_file, thumb_file, 180, 120)
 
     if not os.path.exists(thumb_file):
-        # create something not to replace the thumbnail
-        shutil.copy('source/_images/mne_helmet.png', thumb_file)
+        # use the default thumbnail
+        make_thumbnail('source/_images/mne_helmet.png', thumb_file, 180, 120)
 
     docstring, short_desc, end_row = extract_docstring(example_file)
 

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -450,8 +450,8 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
     In this case con_flat.shape = (3, n_freqs). The connectivity scores are
     in the same order as defined indices.
 
-    Supported Connectivity Measures
-    -------------------------------
+    Supported Connectivity Measures:
+
     The connectivity method(s) is specified using the "method" parameter. The
     following methods are supported (note: E[] denotes average over epochs).
     Multiple measures can be computed at once by using a list/tuple, e.g.


### PR DESCRIPTION
Use fixed size (180px x 120px) thumbnails on the examples page. This solves some layout issues caused by large thumbnails generated for some examples. The page looks now much cleaner (in my opinion) and everything is aligned. The original image is centered in the generated thumbnail with the size maximized. 

Also a minor fix in the spectral_connectivity docstring which caused sphinx to not properly generate the rst doc.
