### PR TITLE
API: rename export method 'export_sources' to 'sources_as_raw'

### DIFF
--- a/examples/preprocessing/plot_ica_from_raw.py
+++ b/examples/preprocessing/plot_ica_from_raw.py
@@ -184,7 +184,7 @@ pl.show()
 
 from mne.layouts import make_grid_layout
 
-ica_raw = ica.export_sources(raw, start=start, stop=stop, picks=None)
+ica_raw = ica.sources_as_raw(raw, start=start, stop=stop, picks=None)
 
 print ica_raw.ch_names
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -399,7 +399,7 @@ class ICA(object):
             raise inst
         end_file(fid)
 
-    def export_sources(self, raw, picks=None, start=None, stop=None):
+    def sources_as_raw(self, raw, picks=None, start=None, stop=None):
         """Export sources as raw object
 
         Parameters


### PR DESCRIPTION
This allows to later (0.6.) add a counterpart named 'sources_as_epochs'
which will allow us to directly create epochs in ICA space. Also see #319 

-- the alternative names would be
 -- to_raw, to_epochs
 -- as_raw, as_epochs.

I would prefer the names I proposed.
If somehow possible I  would like to settle this issue before releasing, otherwise we will need to deprecate things unnecessarily. 
