### PR TITLE
FIX : for empty tag

### DIFF
--- a/mne/fiff/open.py
+++ b/mne/fiff/open.py
@@ -85,8 +85,11 @@ def fiff_open(fname, preload=False, verbose=None):
         while tag.next >= 0:
             pos = fid.tell()
             tag = read_tag_info(fid)
-            tag.pos = pos
-            directory.append(tag)
+            if tag is None:
+                break  # HACK : to fix file ending with empty tag...
+            else:
+                tag.pos = pos
+                directory.append(tag)
 
     tree, _ = make_dir_tree(fid, directory)
 

--- a/mne/fiff/tag.py
+++ b/mne/fiff/tag.py
@@ -139,6 +139,8 @@ def read_tag_info(fid):
     """Read Tag info (or header)
     """
     s = fid.read(4 * 4)
+    if len(s) == 0:
+        return None
     tag = Tag(*struct.unpack(">iiii", s))
     if tag.next == 0:
         fid.seek(tag.size, 1)


### PR DESCRIPTION
for Andrew Dykstra

don't know why this happens but matlab does not complain so I guess Python shouldn't
