### PR TITLE
ENH: Improving Evoked error message

### DIFF
--- a/mne/fiff/evoked.py
+++ b/mne/fiff/evoked.py
@@ -123,7 +123,7 @@ class Evoked(object):
                                  'must be set. Candidate setno names:\n%s'
                                  % (len(evoked_node), t))
             else:
-                 setno = 0
+                setno = 0
 
         # find string-based entry
         elif isinstance(setno, basestring):


### PR DESCRIPTION
This makes it so if there are multiple datasets present but the user doesn't supply a setno, the user is told the names of the candidate datasets.
