### PR TITLE
WIP: enhancements to topo plotting

### DIFF
--- a/mne/viz.py
+++ b/mne/viz.py
@@ -91,7 +91,8 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None):
 
 
 def _plot_topo(info, times, show_func, layout, decim, vmin, vmax, colorbar,
-               cmap, layout_scale, title=None, x_label=None, y_label=None):
+               cmap, layout_scale, comment=None, color=None, title=None, 
+               x_label=None, y_label=None):
     """Helper function to plot on sensor layout"""
     import pylab as pl
     orig_facecolor = pl.rcParams['axes.facecolor']
@@ -114,7 +115,7 @@ def _plot_topo(info, times, show_func, layout, decim, vmin, vmax, colorbar,
             cb = fig.colorbar(sm, ax=ax)
             cb_yticks = pl.getp(cb.ax.axes, 'yticklabels')
             pl.setp(cb_yticks, color='w')
-        pl.rcParams['axes.edgecolor'] = 'w'
+        pl.rcParams['axes.edgecolor'] = 'none'
         for idx, name in enumerate(_clean_names(layout.names)):
             if name in ch_names:
                 ax = pl.axes(pos[idx], axisbg='k')
@@ -122,9 +123,22 @@ def _plot_topo(info, times, show_func, layout, decim, vmin, vmax, colorbar,
                 # hack to inlcude channel idx and name, to use in callback
                 ax.__dict__['_mne_ch_name'] = name
                 ax.__dict__['_mne_ch_idx'] = ch_idx
-                show_func(ax, ch_idx, tmin, tmax, vmin, vmax)
+                if layout.kind == 'Vectorview-all':
+                    if info['chs'][ch_idx]['unit']==112:
+                        show_func(ax, ch_idx, tmin, tmax, vmin[0], vmax[0])
+                    elif info['chs'][ch_idx]['unit']==201:
+                        show_func(ax, ch_idx, tmin, tmax, vmin[1], vmax[1])
+                else:
+                    show_func(ax, ch_idx, tmin, tmax, vmin, vmax)
                 pl.xticks([], ())
                 pl.yticks([], ())
+            if layout.kind == 'Vectorview-all':
+                if info['chs'][ch_idx]['unit']==112:
+                    pl.ylim(vmin[0],vmax[0])
+                elif info['chs'][ch_idx]['unit']==201:
+                    pl.ylim(vmin[1],vmax[1])
+            else:
+                pl.ylim(vmin,vmax)
 
         # register callback
         callback = partial(_plot_topo_onpick, show_func=show_func, tmin=tmin,
@@ -136,6 +150,12 @@ def _plot_topo(info, times, show_func, layout, decim, vmin, vmax, colorbar,
         if title is not None:
             pl.figtext(0.03, 0.9, title, color='w', fontsize=19)
 
+        if comment is not None:
+            pos = 0
+            for comment_,color in zip(comment[::-1],color[::-1]):
+                pl.figtext(0.775, pos, comment_, color=color, fontsize=12)
+                pos += 0.035
+  
     finally:
         # Revert global pylab config
         pl.rcParams['axes.facecolor'] = orig_facecolor
@@ -186,9 +206,16 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, tfr=None, freq=None):
 
 def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, data, color, times):
     """ Aux function to show time series on topo """
-    # use large tol for picker so we can click anywhere in the axes
+    ax.plot(times, np.zeros(len(times)), '#FFFFFF')
+    ax.plot(np.array([0,0]), np.array([0.25*vmin,0.25*vmax]), '#FFFFFF')
+    picker_flag = False
     for data_, color in zip(data, color):
-        ax.plot(times, data_[ch_idx], color, picker=1e9)
+        if not picker_flag:
+            # use large tol for picker so we can click anywhere in the axes
+            ax.plot(times, data_[ch_idx], color, picker=1e9)
+            picker_flag = True
+        else:
+            ax.plot(times, data_[ch_idx], color)
 
 
 def plot_topo(evoked, layout, layout_scale=0.945, color=None, title=None):
@@ -247,11 +274,39 @@ def plot_topo(evoked, layout, layout_scale=0.945, color=None, title=None):
     plot_fun = partial(_plot_timeseries, data=[e.data for e in evoked],
                        color=color, times=times)
 
+    # scale each channel to max svalue of channel type across all channels
+    picks = pick_types(evoked[0].info, meg=True, eeg=True, stim=False, 
+                       eog=False)
+    
+    names = list(layout.names)
+    for bad in evoked[0].info['bads']:
+        if bad in names:
+            names.pop(names.index(bad))
+    for name in names:
+        if name not in ch_names:
+            names.pop(names.index(name))
+            
+    unit = np.array([evoked[0].info['chs'][ch_names.index(names[index])]['unit'] 
+                    for index in range(len(names))])
+                    
+    if unit[0] == 107:  # EEG layout
+        picks = pick_types(evoked[0].info, meg=False, eeg=True, stim=False, eog=False)
+        dummy_max = np.max([np.max(np.abs(cond.data[picks,:])) for cond in evoked])
+    else:               # MEG layout
+        picks = pick_types(evoked[0].info, meg=True, eeg=False, stim=False, eog=False)	        
+        if len(np.unique(unit))>1: # handle mags and grads
+            mags = np.intersect1d(picks,np.where(unit==112)[0])
+            grads = np.intersect1d(picks,np.where(unit==201)[0])
+            dummy_max = np.array([np.max([np.max(np.abs(cond.data[mags,:])) for cond in evoked]),
+                                  np.max([np.max(np.abs(cond.data[grads,:])) for cond in evoked])])
+        else:
+            dummy_max = np.max([np.max(np.abs(cond.data[picks,:])) for cond in evoked])
+
     info = evoked[0].info
+    comment = [e.comment for e in evoked]
     fig = _plot_topo(info, times, plot_fun, layout,
-                     decim=1, colorbar=False, vmin=0, vmax=0,
-                     cmap=None, layout_scale=layout_scale, title=title,
-                     x_label='Time (s)')
+                     decim=1, colorbar=False, vmin=-dummy_max, vmax=dummy_max,
+                     cmap=None, layout_scale=layout_scale, comment=comment, color=color, title=title, x_label='Time (s)')
     return fig
 
 


### PR DESCRIPTION
Hi everyone,

I've been working on the topo_plot section of viz.py (the viz module? - not up on Python jargon) with the goal of improving (I think) the display. The version I'm running now scales all the plots for a given channel type to the same max and min values, gets rid of the border around each subplot, adds white lines for time=0 and amplitude=0, and adds condition labels in the same colors as the waveforms. Also, I edited the picker function to only bring up a single new figure (for me, it was bringing up as many figures as were ojbects in the subplot). It's a bit hackish, and probably there is a better way to accomplish what I did, but it does handle all known MEG and EEG layouts, and it brings the figure close to what the C-code does. The Vectorview (same layout as Triux, yes?) is the only system with multiple channel types as far as I know. See an example of the figure the code produces below. 

It's not a fix, technically, except for the picker functionality. However, because the subplots in the example topo plots are all automatically scaled to their own respective min/max values, it's harder to see where the evoked response truly exceeds baseline. BTW, what I've hacked looks nothing like the scalings argument for the viz.plot_evoked (didn't notice those before), but I'm not sure that one needs that parameter. What I've done sets the vertical axes limits which, again, are easily defined by the data itself anyway, across all channels of a given type, to the max abs value, across all channels and time points of said type.  

The other, ahem, more elegant option would be to add a scaling parameter as in plot_evoked, but that introduces more work to the user (having to define the scale they want), and I think it's fair to assume that most users (all?) will want to see their evoked responses in their max dynamic range (across channels rather than within them).  

New plot:
![new_topo_plot](https://f.cloud.github.com/assets/2804716/56816/c6ebdb32-5b2d-11e2-8451-61436fa29d93.png)
