### PR TITLE
FIX: fixing API / error handling in plot_evoked

### DIFF
--- a/mne/viz.py
+++ b/mne/viz.py
@@ -8,8 +8,10 @@
 # License: Simplified BSD
 import os
 import warnings
-from itertools import cycle, combinations
+from itertools import cycle
 from functools import partial
+from operator import add
+
 import copy
 import inspect
 
@@ -569,24 +571,8 @@ def plot_evoked(evoked, picks=None, unit=True, show=True, ylim=None,
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
     """
-
-    keys = [scalings.keys(), units.keys(), titles.keys()]
-    iter_keys = combinations(keys, 2)
-    if any([len(set(a) - set(b)) for a, b in iter_keys]):
-        names = ['scalings', 'units', 'titles']
-        keys_unique = np.unique(np.concatenate(keys))
-        misses = [[k for k in keys_unique if k not in k2] for k2 in keys]
-        inds = np.array([len(m) for m in misses]) > 0
-        names = np.array(names)[inds]
-        misses = np.array(misses)[inds]
-        strs = ''.join(['    ' + n + ' was missing: "' + '", "'.join(m) + '"\n'
-                        for n, m in zip(names, misses)])
-
-        raise ValueError('scalings, units, and titles must all have the same '
-                         'keys.\nPassed keys: "%s"\n%s'
-                         % ('", "'.join(keys_unique), strs))
-    else:
-        channel_types = sorted(scalings.keys())
+    dict_args = dict(scalings=scalings, units=units, titles=titles, ylim=ylim)
+    channel_types = set(reduce(add, [d.keys() for d in dict_args.values()]))
 
     import pylab as pl
     if picks is None:
@@ -598,6 +584,18 @@ def plot_evoked(evoked, picks=None, unit=True, show=True, ylim=None,
         if t in types:
             n_channel_types += 1
             ch_types_used.append(t)
+
+    check_k = dict(((k, t), not t in v) for t in ch_types_used
+                   for (k, v) in dict_args.items())
+    if any(check_k.values()):
+        missings = dict((k, t) for (k, t), misses in check_k.items() if misses)
+        msg = ('For some of the data types in evoked parameters'
+               ' are missing:')
+        for param, t in missings.items():
+            msg += ('\n   No \'%s\' parameter for channels of type'
+                    ' %s.' % (param, t))
+
+        raise ValueError(msg)
 
     if axes is None:
         pl.clf()


### PR DESCRIPTION
- now the catcher does exactly what I initially wanted it to do:
  check whether all parameters are present for the data types foound in
  evoked.

Addresses #375 #337 

In the TFxMNE example now the following wrong arguments would generate an informative error message:

``` Python
ylim = dict(eeg=[-10, 10], grad=[-200, 250], mag=[-600, 600])
plot_evoked(evoked, ylim=ylim, proj=True,
            titles=dict(mag='Evoked Response (grad)'))

ValueError: For some of the data types in evoked parameters are missing:
   No 'titles' parameter for channels of type grad.

ylim = dict(eeg=[-10, 10], misc=[-200, 250], mag=[-600, 600])
plot_evoked(evoked, ylim=ylim, proj=True,
            titles=dict(mag='Evoked Response (grad)'))

ValueError: For some of the data types in evoked parameters are missing:
   No 'titles' parameter for channels of type grad.
   No 'ylim' parameter for channels of type grad.
```
