### PR TITLE
ENH: Speeding up filtering

### DIFF
--- a/mne/fiff/raw.py
+++ b/mne/fiff/raw.py
@@ -452,7 +452,7 @@ class Raw(object):
     def filter(self, l_freq, h_freq, picks=None, filter_length=None,
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5, n_jobs=1,
                method='fft', iir_params=dict(order=4, ftype='butter'),
-               verbose=None):
+               skip_check=False, verbose=None):
         """Filter a subset of channels.
 
         Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
@@ -502,6 +502,9 @@ class Raw(object):
         iir_params : dict
             Dictionary of parameters to use for IIR filtering.
             See mne.filter.construct_iir_filter for details.
+        skip_check : bool
+            If True, skip filter attenuation check. Only used in FFT-based
+            filtering (and only recommended for advanced users).
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -534,7 +537,8 @@ class Raw(object):
             self.apply_function(low_pass_filter, picks, None, n_jobs, verbose,
                                 fs, h_freq, filter_length=filter_length,
                                 trans_bandwidth=l_trans_bandwidth,
-                                method=method, iir_params=iir_params)
+                                method=method, iir_params=iir_params,
+                                skip_check=skip_check)
         if l_freq is not None and h_freq is None:
             logger.info('High-pass filtering at %0.2g Hz' % l_freq)
             if method.lower() == 'iir':
@@ -544,7 +548,8 @@ class Raw(object):
             self.apply_function(high_pass_filter, picks, None, n_jobs, verbose,
                                 fs, l_freq, filter_length=filter_length,
                                 trans_bandwidth=h_trans_bandwidth,
-                                method=method, iir_params=iir_params)
+                                method=method, iir_params=iir_params,
+                                skip_check=skip_check)
         if l_freq is not None and h_freq is not None:
             if l_freq < h_freq:
                 logger.info('Band-pass filtering from %0.2g - %0.2g Hz'
@@ -558,7 +563,8 @@ class Raw(object):
                                     filter_length=filter_length,
                                     l_trans_bandwidth=l_trans_bandwidth,
                                     h_trans_bandwidth=h_trans_bandwidth,
-                                    method=method, iir_params=iir_params)
+                                    method=method, iir_params=iir_params,
+                                    skip_check=skip_check)
             else:
                 logger.info('Band-stop filtering from %0.2g - %0.2g Hz'
                             % (h_freq, l_freq))
@@ -571,13 +577,15 @@ class Raw(object):
                                     filter_length=filter_length,
                                     l_trans_bandwidth=h_trans_bandwidth,
                                     h_trans_bandwidth=l_trans_bandwidth,
-                                    method=method, iir_params=iir_params)
+                                    method=method, iir_params=iir_params,
+                                    skip_check=skip_check)
 
     @verbose
     def notch_filter(self, freqs, picks=None, filter_length=None,
                      notch_widths=None, trans_bandwidth=1.0, n_jobs=1,
                      method='fft', iir_params=dict(order=4, ftype='butter'),
-                     mt_bandwidth=None, p_value=0.05, verbose=None):
+                     mt_bandwidth=None, p_value=0.05, skip_check=False,
+                     verbose=None):
         """Notch filter a subset of channels.
 
         Applies a zero-phase notch filter to the channels selected by
@@ -626,6 +634,9 @@ class Raw(object):
             sinusoidal components to remove when method='spectrum_fit' and
             freqs=None. Note that this will be Bonferroni corrected for the
             number of frequencies, so large p-values may be justified.
+        skip_check : bool
+            If True, skip filter attenuation check. Only used in FFT-based
+            filtering (and only recommended for advanced users).
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -645,7 +656,8 @@ class Raw(object):
                             notch_widths=notch_widths,
                             trans_bandwidth=trans_bandwidth,
                             method=method, iir_params=iir_params,
-                            mt_bandwidth=mt_bandwidth, p_value=p_value)
+                            mt_bandwidth=mt_bandwidth, p_value=p_value,
+                            skip_check=skip_check)
 
     @verbose
     def resample(self, sfreq, npad=100, window='boxcar',

--- a/mne/fiff/tests/test_raw.py
+++ b/mne/fiff/tests/test_raw.py
@@ -399,16 +399,17 @@ def test_filter():
     picks = picks_meg[:4]
 
     raw_lp = raw.copy()
-    raw_lp.filter(0., 4.0 - 0.25, picks=picks, n_jobs=2)
+    raw_lp.filter(0., 4.0 - 0.25, picks=picks, n_jobs=2, skip_check=True)
 
     raw_hp = raw.copy()
-    raw_hp.filter(8.0 + 0.25, None, picks=picks, n_jobs=2)
+    raw_hp.filter(8.0 + 0.25, None, picks=picks, n_jobs=2, skip_check=True)
 
     raw_bp = raw.copy()
-    raw_bp.filter(4.0 + 0.25, 8.0 - 0.25, picks=picks)
+    raw_bp.filter(4.0 + 0.25, 8.0 - 0.25, picks=picks, skip_check=True)
 
     raw_bs = raw.copy()
-    raw_bs.filter(8.0 + 0.25, 4.0 - 0.25, picks=picks, n_jobs=2)
+    raw_bs.filter(8.0 + 0.25, 4.0 - 0.25, picks=picks, n_jobs=2,
+                  skip_check=True)
 
     data, _ = raw[picks, :]
 
@@ -443,16 +444,19 @@ def test_filter():
     # do a very simple check on line filtering
     raw_bs = raw.copy()
     with warnings.catch_warnings(True) as w:
-        raw_bs.filter(60.0 + 0.5, 60.0 - 0.5, picks=picks, n_jobs=2)
+        raw_bs.filter(60.0 + 0.5, 60.0 - 0.5, picks=picks, n_jobs=2,
+                      skip_check=True)
         data_bs, _ = raw_bs[picks, :]
         raw_notch = raw.copy()
-        raw_notch.notch_filter(60.0, picks=picks, n_jobs=2, method='fft')
+        raw_notch.notch_filter(60.0, picks=picks, n_jobs=2, method='fft',
+                               skip_check=True)
     data_notch, _ = raw_notch[picks, :]
     assert_array_almost_equal(data_bs, data_notch, sig_dec_notch)
 
     # now use the sinusoidal fitting
     raw_notch = raw.copy()
-    raw_notch.notch_filter(None, picks=picks, n_jobs=2, method='spectrum_fit')
+    raw_notch.notch_filter(None, picks=picks, n_jobs=2, method='spectrum_fit',
+                           skip_check=True)
     data_notch, _ = raw_notch[picks, :]
     data, _ = raw[picks, :]
     assert_array_almost_equal(data, data_notch, sig_dec_notch_fit)


### PR DESCRIPTION
Apparently the attenuation check can take up a substantial amount (~10-50%) of the time in FIR/FFT filtering:

```
>>> raw.crop(0, 60, copy=False)
<Raw  |  n_channels x n_times : 401 x [60001]>
>>> t = time.time(); raw.filter(None, 55, n_jobs=6); print time.time() - t
24.48
>>> t = time.time(); raw.filter(None, 55, n_jobs=6, skip_check=True); print time.time() - t
12.81
>>> t = time.time(); raw.filter(None, 55, n_jobs=6, filter_length=8192); print time.time() - t
6.68
>>> t = time.time(); raw.filter(None, 55, n_jobs=6, filter_length=8192, skip_check=True); print time.time() - t
5.81
```

This adds an option to skip the check for advanced users who have already considered the filter length tradeoffs.
