### PR TITLE
FIX: Dealing with tag=None in bad channels

### DIFF
--- a/mne/fiff/channels.py
+++ b/mne/fiff/channels.py
@@ -30,6 +30,6 @@ def read_bad_channels(fid, node):
     if len(nodes) > 0:
         for node in nodes:
             tag = find_tag(fid, node, FIFF.FIFF_MNE_CH_NAME_LIST)
-            if tag.data is not None:
+            if tag is not None and tag.data is not None:
                 bads = tag.data.split(':')
     return bads


### PR DESCRIPTION
Addresses #394.

I didn't add a test specifically for this case because it would require another 4MB FIF file in our test dataset, and it's pretty straightforward fix.
