### PR TITLE
FIX+ENH: Making calibration consistent, adding orig_format to raw

### DIFF
--- a/mne/fiff/tests/test_raw.py
+++ b/mne/fiff/tests/test_raw.py
@@ -31,8 +31,8 @@ tempdir = _TempDir()
 def test_output_formats():
     """Test saving and loading raw data using multiple formats
     """
-    formats = ['short', 'single', 'double']
-    tols = [1e-4, 1e-7, 1e-15]
+    formats = ['short', 'int', 'single', 'double']
+    tols = [1e-4, 1e-7, 1e-7, 1e-15]
 
     # let's fake a raw file with different formats
     raw = Raw(fif_fname, preload=True)
@@ -47,6 +47,7 @@ def test_output_formats():
         raw2 = Raw(temp_file)
         raw2_data = raw2[:, :][0]
         assert_allclose(raw2_data, raw._data, rtol=tol, atol=1e-25)
+        assert_true(raw2.orig_format == format)
 
 
 def test_multiple_files():


### PR DESCRIPTION
This is to address @mshamalainen's comment here:
https://github.com/mne-tools/mne-python/pull/419/files#L1R331

Basically, this does two things:
1. Add support for writing "int" type (32-bit integers). If users load a raw file, tinker with something in "info" (e.g., digitization), it would be nice if they could write the data back out in their original format. This should cover the last option, which @mshamalainen mentioned in his post, which is 32-bit ints.
2. He also mentioned that we should always calibrate and de-calibrated using "scale". Although we typically don't bother saving "scale" with epochs and evoked, I put them in the calibration calls for consistency (I think it's cleaner to have it than not).

Note that I added a parameter to `Raw` as `raw.orig_format` so users can easily tell which format their data had been stored in, since it's something I've been curious about before but it was difficult to tell.
