### PR TITLE
ENH: Speed up CUDA resampling, reduce GPU memory reqs

### DIFF
--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_array_almost_equal, assert_almost_equal
 from nose.tools import assert_true, assert_raises
 import os.path as op
 from scipy.signal import resample as sp_resample
+from scipy.fftpack import fft, fftshift
 
 from mne.filter import band_pass_filter, high_pass_filter, low_pass_filter, \
                        band_stop_filter, resample, construct_iir_filter, \
@@ -171,3 +172,12 @@ def test_cuda():
     out = open(log_file).readlines()
     assert_true(sum(['Using CUDA for FFT FIR filtering' in o
                      for o in out]) == 8)
+
+    # check resampling
+    a1 = resample(a, 1, 2, n_jobs=2)
+    a2 = resample(a, 1, 2, n_jobs='cuda')
+    a3 = resample(a1, 2, 1, n_jobs=2)
+    a4 = resample(a2, 2, 1, n_jobs='cuda')
+    # DC component can be a little off a little bit for such a long array
+    assert_array_almost_equal(a1, a2, 1)
+    assert_array_almost_equal(a3, a4, 1)


### PR DESCRIPTION
This speeds up CUDA resampling by 10-20%, and reduces memory requirements for performing the resampling. Also, added a test. 

I noticed that the resampling is only good to 1 decimal place (for a given long `randn()` vector) due to slight differences between CUDA and FFTPack's FFT routines. Looking at the signals, they are very nearly identical. Looking at the FFT of each resulting signal, there appear to be very slight differences in the DC and Nyquist freq values only. I think it should be okay...
