### PR TITLE
ENH: Speed up ECG and EOG detection / SSP calculation

### DIFF
--- a/mne/fiff/raw.py
+++ b/mne/fiff/raw.py
@@ -479,7 +479,7 @@ class Raw(object):
             self.apply_function(hilbert, picks, np.complex64, n_jobs)
 
     @verbose
-    def filter(self, l_freq, h_freq, picks=None, filter_length='auto',
+    def filter(self, l_freq, h_freq, picks=None, filter_length='10s',
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5, n_jobs=1,
                method='fft', iir_params=dict(order=4, ftype='butter'),
                verbose=None):
@@ -514,13 +514,13 @@ class Raw(object):
         picks : list of int | None
             Indices of channels to filter. If None only the data (MEG/EEG)
             channels will be filtered.
-        filter_length : str (Default: 'auto') | int | None
+        filter_length : str (Default: '10s') | int | None
             Length of the filter to use. If None or "len(x) < filter_length",
             the filter length used is len(x). Otherwise, if int, overlap-add
             filtering with a filter of the specified length in samples) is
-            used (faster for long signals). If 'auto', a reasonable filter
-            length will be chosen. If str, a human-readable time in units of
-            "s" or "ms" should be used, e.g., "10s" or "5500ms".
+            used (faster for long signals). If str, a human-readable time in
+            units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+            to the shortest power-of-two length at least that duration.
         l_trans_bandwidth : float
             Width of the transition band at the low cut-off frequency in Hz.
         h_trans_bandwidth : float
@@ -594,7 +594,7 @@ class Raw(object):
                     copy=False)
 
     @verbose
-    def notch_filter(self, freqs, picks=None, filter_length='auto',
+    def notch_filter(self, freqs, picks=None, filter_length='10s',
                      notch_widths=None, trans_bandwidth=1.0, n_jobs=1,
                      method='fft', iir_params=dict(order=4, ftype='butter'),
                      mt_bandwidth=None, p_value=0.05, verbose=None):
@@ -618,13 +618,13 @@ class Raw(object):
         picks : list of int | None
             Indices of channels to filter. If None only the data (MEG/EEG)
             channels will be filtered.
-        filter_length : str (Default: 'auto') | int | None
+        filter_length : str (Default: '10s') | int | None
             Length of the filter to use. If None or "len(x) < filter_length",
             the filter length used is len(x). Otherwise, if int, overlap-add
             filtering with a filter of the specified length in samples) is
-            used (faster for long signals). If 'auto', a reasonable filter
-            length will be chosen. If str, a human-readable time in units of
-            "s" or "ms" should be used, e.g., "10s" or "5500ms".
+            used (faster for long signals). If str, a human-readable time in
+            units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+            to the shortest power-of-two length at least that duration.
         notch_widths : float | array of float | None
             Width of each stop band (centred at each freq in freqs) in Hz.
             If None, freqs / 200 is used.

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -234,7 +234,7 @@ def _prep_for_filtering(x, copy, picks=None):
     return x, orig_shape, picks
 
 
-def _filter(x, Fs, freq, gain, filter_length='auto', picks=None, n_jobs=1,
+def _filter(x, Fs, freq, gain, filter_length='10s', picks=None, n_jobs=1,
             copy=True):
     """Filter signal using gain control points in the frequency domain.
 
@@ -254,13 +254,13 @@ def _filter(x, Fs, freq, gain, filter_length='auto', picks=None, n_jobs=1,
         Frequency sampling points in Hz.
     gain : 1d array
         Filter gain at frequency sampling points.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     picks : list of int | None
         Indices to filter. If None all indices will be filtered.
     n_jobs : int | str
@@ -284,7 +284,7 @@ def _filter(x, Fs, freq, gain, filter_length='auto', picks=None, n_jobs=1,
     # normalize frequencies
     freq = np.array([f / (Fs / 2) for f in freq])
     gain = np.array(gain)
-    filter_length = _get_filter_length(filter_length, Fs)
+    filter_length = _get_filter_length(filter_length, Fs, len_x=x.shape[1])
 
     if filter_length is None or x.shape[1] <= filter_length:
         # Use direct FFT filtering for short signals
@@ -507,7 +507,7 @@ def construct_iir_filter(iir_params=dict(b=[1, 0], a=[1, 0], padlen=0),
 
 
 @verbose
-def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='auto',
+def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='10s',
                      l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
                      method='fft', iir_params=dict(order=4, ftype='butter'),
                      picks=None, n_jobs=1, copy=True, verbose=None):
@@ -526,13 +526,13 @@ def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='auto',
         Low cut-off frequency in Hz.
     Fp2 : float
         High cut-off frequency in Hz.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     l_trans_bandwidth : float
         Width of the transition band at the low cut-off frequency in Hz.
     h_trans_bandwidth : float
@@ -606,7 +606,7 @@ def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='auto',
 
 
 @verbose
-def band_stop_filter(x, Fs, Fp1, Fp2, filter_length='auto',
+def band_stop_filter(x, Fs, Fp1, Fp2, filter_length='10s',
                      l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
                      method='fft', iir_params=dict(order=4, ftype='butter'),
                      picks=None, n_jobs=1, copy=True, verbose=None):
@@ -625,13 +625,13 @@ def band_stop_filter(x, Fs, Fp1, Fp2, filter_length='auto',
         Low cut-off frequency in Hz.
     Fp2 : float | array of float
         High cut-off frequency in Hz.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     l_trans_bandwidth : float
         Width of the transition band at the low cut-off frequency in Hz.
     h_trans_bandwidth : float
@@ -718,7 +718,7 @@ def band_stop_filter(x, Fs, Fp1, Fp2, filter_length='auto',
 
 
 @verbose
-def low_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
+def low_pass_filter(x, Fs, Fp, filter_length='10s', trans_bandwidth=0.5,
                     method='fft', iir_params=dict(order=4, ftype='butter'),
                     picks=None, n_jobs=1, copy=True, verbose=None):
     """Lowpass filter for the signal x.
@@ -734,13 +734,13 @@ def low_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
         Sampling rate in Hz.
     Fp : float
         Cut-off frequency in Hz.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     trans_bandwidth : float
         Width of the transition band in Hz.
     method : str
@@ -800,7 +800,7 @@ def low_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
 
 
 @verbose
-def high_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
+def high_pass_filter(x, Fs, Fp, filter_length='10s', trans_bandwidth=0.5,
                      method='fft', iir_params=dict(order=4, ftype='butter'),
                      picks=None, n_jobs=1, copy=True, verbose=None):
     """Highpass filter for the signal x.
@@ -816,13 +816,13 @@ def high_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
         Sampling rate in Hz.
     Fp : float
         Cut-off frequency in Hz.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     trans_bandwidth : float
         Width of the transition band in Hz.
     method : str
@@ -889,7 +889,7 @@ def high_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth=0.5,
 
 
 @verbose
-def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
+def notch_filter(x, Fs, freqs, filter_length='10s', notch_widths=None,
                  trans_bandwidth=1, method='fft',
                  iir_params=dict(order=4, ftype='butter'), mt_bandwidth=None,
                  p_value=0.05, picks=None, n_jobs=1, copy=True, verbose=None):
@@ -908,13 +908,13 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
         Frequencies to notch filter in Hz, e.g. np.arange(60, 241, 60).
         None can only be used with the mode 'spectrum_fit', where an F
         test is used to find sinusoidal components.
-    filter_length : str (Default: 'auto') | int | None
+    filter_length : str (Default: '10s') | int | None
         Length of the filter to use. If None or "len(x) < filter_length",
         the filter length used is len(x). Otherwise, if int, overlap-add
         filtering with a filter of the specified length in samples) is
-        used (faster for long signals). If 'auto', a reasonable filter
-        length will be chosen. If str, a human-readable time in units of
-        "s" or "ms" should be used, e.g., "10s" or "5500ms".
+        used (faster for long signals). If str, a human-readable time in
+        units of "s" or "ms" (e.g., "10s" or "5500ms") will be converted
+        to the shortest power-of-two length at least that duration.
     notch_widths : float | array of float | None
         Width of the stop band (centred at each freq in freqs) in Hz.
         If None, freqs / 200 is used.
@@ -1288,45 +1288,44 @@ def detrend(x, order=1, axis=-1):
     return y
 
 
-def _get_filter_length(filter_length, sfreq, min_length=1024):
+def _get_filter_length(filter_length, sfreq, min_length=128, len_x=np.inf):
     """Helper to determine a reasonable filter length"""
     if not isinstance(min_length, int):
         raise ValueError('min_length must be an int')
     if isinstance(filter_length, basestring):
-        if filter_length.lower() == 'auto':
-            # automatically determine filter_length, use 10 seconds
-            filter_length = max(2 ** int(np.ceil(np.log2(10 * sfreq))),
-                                min_length)
+        # parse time values
+        if filter_length[-2:].lower() == 'ms':
+            mult_fact = 1e-3
+            filter_length = filter_length[:-2]
+        elif filter_length[-1].lower() == 's':
+            mult_fact = 1
+            filter_length = filter_length[:-1]
         else:
-            # parse time values
-            if filter_length[-2:].lower() == 'ms':
-                mult_fact = 1e-3
-                filter_length = filter_length[:-2]
-            elif filter_length[-1].lower() == 's':
-                mult_fact = 1
-                filter_length = filter_length[:-1]
-            else:
-                raise ValueError('filter_length, if a string, must be "auto" '
-                                 'or human-readable time (e.g., "10s"), not '
-                                 '"%s"' % filter_length)
-            # now get the number
-            try:
-                filter_length = float(filter_length)
-            except ValueError:
-                raise ValueError('filter_length, if a string, must be "auto" '
-                                 'or human-readable time (e.g., "10s"), not '
-                                 '"%s"' % filter_length)
-            filter_length = int(filter_length * mult_fact * sfreq)
-            if filter_length < min_length:
-                filter_length = min_length
-                warnings.warn('filter_length was too short, using filter of '
-                              'length %d samples (%0.1fs)'
-                              %(filter_length, filter_length / float(sfreq)))
+            raise ValueError('filter_length, if a string, must be a '
+                             'human-readable time (e.g., "10s"), not '
+                             '"%s"' % filter_length)
+        # now get the number
+        try:
+            filter_length = float(filter_length)
+        except ValueError:
+            raise ValueError('filter_length, if a string, must be a '
+                             'human-readable time (e.g., "10s"), not '
+                             '"%s"' % filter_length)
+        filter_length = 2 ** int(np.ceil(np.log2(filter_length
+                                                 * mult_fact * sfreq)))
+        # shouldn't make filter longer than length of x
+        if filter_length >= len_x:
+            filter_length = len_x
+        # only need to check min_length if the filter is shorter than len_x
+        elif filter_length < min_length:
+            filter_length = min_length
+            warnings.warn('filter_length was too short, using filter of '
+                          'length %d samples ("%0.1fs")'
+                          % (filter_length, filter_length / float(sfreq)))
 
     if filter_length is not None:
         if not isinstance(filter_length, int):
-            raise ValueError('filter_length must be "auto", an integer, '
-                             'or None')
+            raise ValueError('filter_length must be str, int, or None')
     return filter_length
 
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -8,7 +8,7 @@ from ..filter import band_pass_filter
 
 
 def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
-                 l_freq=5, h_freq=35, tstart=0, filter_length='auto'):
+                 l_freq=5, h_freq=35, tstart=0, filter_length='10s'):
     """Detect QRS component in ECG channels.
 
     QRS is the main wave on the heart beat.
@@ -31,7 +31,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
         High pass frequency
     tstart : float
         Start detection after tstart seconds.
-    filter_length : 'auto' | int | None
+    filter_length : str | int | None
         Number of taps to use for filtering.
 
     Returns
@@ -92,8 +92,8 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
 
 @verbose
 def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
-                    l_freq=5, h_freq=35, qrs_threshold=0.6, filter_length=None,
-                    verbose=None):
+                    l_freq=5, h_freq=35, qrs_threshold=0.6,
+                    filter_length='10s', verbose=None):
     """Find ECG peaks
 
     Parameters
@@ -115,7 +115,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
         High pass frequency.
     qrs_threshold : float
         Between 0 and 1. qrs detection threshold.
-    filter_length : int
+    filter_length : str | int | None
         Number of taps to use for filtering.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -10,7 +10,7 @@ from ..filter import band_pass_filter
 
 @verbose
 def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
-                    filter_length='auto', verbose=None):
+                    filter_length='10s', verbose=None):
     """Locate EOG artifacts
 
     Parameters
@@ -23,7 +23,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
         Low pass frequency.
     high_pass : float
         High pass frequency.
-    filter_length : 'auto' | int | None
+    filter_length : str | int | None
         Number of taps to use for filtering.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
@@ -61,7 +61,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
 
 
 def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
-                     filter_length='auto'):
+                     filter_length='10s'):
     """Helper function"""
 
     logger.info('Filtering the data to remove DC offset to help '

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -199,7 +199,7 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
 @verbose
 def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                      n_grad=2, n_mag=2, n_eeg=2, l_freq=1.0, h_freq=35.0,
-                     average=False, filter_length=4096, n_jobs=1, ch_name=None,
+                     average=False, filter_length='10s', n_jobs=1, ch_name=None,
                      reject=dict(grad=2000e-13, mag=3000e-15, eeg=50e-6,
                      eog=250e-6), flat=None, bads=[], avg_ref=False,
                      no_proj=False, event_id=999, ecg_l_freq=5, ecg_h_freq=35,
@@ -232,7 +232,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         Filter high cut-off frequency in Hz.
     average : bool
         Compute SSP after averaging.
-    filter_length : int
+    filter_length : str | int | None
         Number of taps to use for filtering.
     n_jobs : int
         Number of jobs to run in parallel.
@@ -287,7 +287,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
 @verbose
 def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      n_grad=2, n_mag=2, n_eeg=2, l_freq=1.0, h_freq=35.0,
-                     average=False, filter_length=4096, n_jobs=1,
+                     average=False, filter_length='10s', n_jobs=1,
                      reject=dict(grad=2000e-13, mag=3000e-15, eeg=500e-6,
                      eog=np.inf), flat=None, bads=[], avg_ref=False,
                      no_proj=False, event_id=998, eog_l_freq=1, eog_h_freq=10,
@@ -322,7 +322,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         Compute SSP after averaging.
     preload : string (or True)
         Temporary file used during computaion.
-    filter_length : int
+    filter_length : str | int | None
         Number of taps to use for filtering.
     n_jobs : int
         Number of jobs to run in parallel.

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -82,7 +82,7 @@ def test_filters():
     assert_true(len(w) >= 2)
 
     # try new default and old default
-    for fl in ['auto', '10s', '5000ms', None]:
+    for fl in ['10s', '5000ms', None]:
         bp = band_pass_filter(a, Fs, 4, 8, filter_length=fl)
         bs = band_stop_filter(a, Fs, 4 - 0.5, 8 + 0.5, filter_length=fl)
         lp = low_pass_filter(a, Fs, 8, filter_length=fl, n_jobs=2)
@@ -162,7 +162,7 @@ def test_cuda():
     a = np.random.randn(sig_len_secs * Fs)
 
     set_log_file(log_file, overwrite=True)
-    for fl in ['auto', None, 2048]:
+    for fl in ['10s', None, 2048]:
         bp = band_pass_filter(a, Fs, 4, 8, n_jobs=1, filter_length=fl)
         bs = band_stop_filter(a, Fs, 4 - 0.5, 8 + 0.5, n_jobs=1,
                               filter_length=fl)


### PR DESCRIPTION
I had some long raw files, and this sped up the calculation (and made filtering methods more consistent).

@mluessi, this sped it up mostly because ~90% of the time was spent in `_filter_attenuation()` in `mne.filter` because the signal was so long. Do you think we can do something like skip the filter attenuation tests for a sufficiently long filter...? This isn't the first time I've hit a hangup with that function being slow because the filter is long.
