### PR TITLE
Sample dataset broken..

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1233,7 +1233,7 @@ def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
         methods = FIFF.FIFFV_MNE_EEG
 
     # We set this for consistency with mne C code written inverses
-    if fixed or (depth is None):
+    if depth is None:
         depth_prior = None
     inv_op = dict(eigen_fields=eigen_fields, eigen_leads=eigen_leads,
                   sing=sing, nave=nave, depth_prior=depth_prior,


### PR DESCRIPTION
I have updated the sample dataset, but for some reason it is broken. What I do to rebuild it, is take the "clean version" with only the necessary files and then run `run_anatomy_tutorial.sh`, `run_meg_tutorial.sh`, `run_meg_volume_tutorial.sh` from mne-scripts with the nightly version of MNE to produce the updated sample data. For some reason, there are 5 inverse operator tests that fail.

One problem I tracked down so far is that MNE C code does allow fixed orientation inverse operators while mne-python doesn't but with this fix included, other inverse tests fails. This is must be somehow related to recent depth-weighting changes. The strange thing is that the tests pass with the old sample dataset.

I have put the data here 

http://www.nmr.mgh.harvard.edu/~mluessi/MNE-sample-data-processed_0.5.tar.gz

if one of you wants to help track down the source of this problem..
