### PR TITLE
WIP : Added functions to restrict forward to stc or label

### DIFF
--- a/mne/forward.py
+++ b/mne/forward.py
@@ -861,26 +861,42 @@ def apply_forward_raw(fwd, stc, raw_template, start=None, stop=None,
     return raw
 
 
-def restrict_foward_to_stc(fwd, stc):
+def restrict_forward_to_stc(fwd, stc):
+    """Restricts forward operator to active sources in a source estimate
+
+    Parameters
+    ----------
+    fwd : dict
+        Forward operator.
+    stc : SourceEstimate
+        Source estimate.
+
+    Returns
+    -------
+    fwd_out : dict
+        Restricted forward operator.
+    """
+
     fwd_out = deepcopy(fwd)
     src_sel = _stc_src_sel(fwd['src'], stc)
 
     fwd_out['source_rr'] = fwd['source_rr'][src_sel]
     fwd_out['nsource'] = len(src_sel)
-    if fwd['source_ori'] == 1:
-        fwd_out['source_nn'] = fwd['source_nn'][src_sel]
-        fwd_out['sol']['data'] = fwd['sol']['data'][:, src_sel]
-        fwd_out['sol']['ncol'] = len(src_sel)
+
+    if is_fixed_orient(fwd):
+        idx = src_sel
     else:
-        idx_3D = (3 * src_sel[:, None] + np.arange(3)).ravel()
-        fwd_out['source_nn'] = fwd['source_nn'][idx_3D]
-        fwd_out['sol']['data'] = fwd['sol']['data'][:, idx_3D]
-        fwd_out['sol']['ncol'] = len(idx_3D)
+        idx = (3 * src_sel[:, None] + np.arange(3)).ravel()
+
+    fwd_out['source_nn'] = fwd['source_nn'][idx]
+    fwd_out['sol']['data'] = fwd['sol']['data'][:, idx]
+    fwd_out['sol']['ncol'] = len(idx)
 
     for i in range(2):
         fwd_out['src'][i]['vertno'] = stc.vertno[i]
         fwd_out['src'][i]['nuse'] = len(stc.vertno[i])
-        fwd_out['src'][i]['inuse'] = np.zeros_like(fwd['src'][i]['inuse'])
+        fwd_out['src'][i]['inuse'] = fwd['src'][i]['inuse'].copy()
+        fwd_out['src'][i]['inuse'].fill(0)
         fwd_out['src'][i]['inuse'][stc.vertno[i]] = 1
         fwd_out['src'][i]['use_tris'] = np.array([])
         fwd_out['src'][i]['nuse_tri'] = np.array([0])
@@ -888,12 +904,24 @@ def restrict_foward_to_stc(fwd, stc):
     return fwd_out
 
 
-def restrict_foward_to_label(fwd, label_names, label_path):
-    import os.path as op
-    from mne import read_label
+def restrict_forward_to_label(fwd, labels):
+    """Restricts forward operator to labels
 
-    if not isinstance(label_names, list):
-        label_names = [label_names]
+    Parameters
+    ----------
+    fwd : dict
+        Forward operator.
+    labels : label object | list
+        Label object or list of label objects.
+
+    Returns
+    -------
+    fwd_out : dict
+        Restricted forward operator.
+    """
+
+    if not isinstance(labels, list):
+        labels = [labels]
 
     fwd_out = deepcopy(fwd)
     fwd_out['source_rr'] = np.zeros((0, 3))
@@ -901,16 +929,16 @@ def restrict_foward_to_label(fwd, label_names, label_path):
     fwd_out['source_nn'] = np.zeros((0, 3))
     fwd_out['sol']['data'] = np.zeros((fwd['sol']['data'].shape[0], 0))
     fwd_out['sol']['ncol'] = 0
+
     for i in range(2):
         fwd_out['src'][i]['vertno'] = np.array([])
         fwd_out['src'][i]['nuse'] = 0
-        fwd_out['src'][i]['inuse'] = np.zeros_like(fwd['src'][i]['inuse'])
+        fwd_out['src'][i]['inuse'] = fwd['src'][i]['inuse'].copy()
+        fwd_out['src'][i]['inuse'].fill(0)
         fwd_out['src'][i]['use_tris'] = np.array([])
         fwd_out['src'][i]['nuse_tri'] = np.array([0])
 
-    for ln in label_names:
-        label = read_label(op.join(label_path, '%s.label' % ln))
-
+    for label in labels:
         if label.hemi == 'lh':
             i = 0
             src_sel = np.intersect1d(fwd['src'][0]['vertno'], label.vertices)
@@ -924,23 +952,21 @@ def restrict_foward_to_label(fwd, label_names, label_path):
         fwd_out['source_rr'] = np.vstack([fwd_out['source_rr'],
                                           fwd['source_rr'][src_sel]])
         fwd_out['nsource'] += len(src_sel)
-        if fwd['source_ori'] == 1:
-            fwd_out['source_nn'] = np.vstack([fwd_out['source_nn'],
-                                          fwd['source_nn'][src_sel]])
-            fwd_out['sol']['data'] = np.hstack([fwd_out['sol']['data'],
-                                            fwd['sol']['data'][:, src_sel]])
-            fwd_out['sol']['ncol'] += len(src_sel)
-        else:
-            idx_3D = (3 * src_sel[:, None] + np.arange(3)).ravel()
-            fwd_out['source_nn'] = np.vstack([fwd_out['source_nn'],
-                                              fwd['source_nn'][idx_3D]])
-            fwd_out['sol']['data'] = np.hstack([fwd_out['sol']['data'],
-                                                fwd['sol']['data'][:, idx_3D]])
-            fwd_out['sol']['ncol'] += len(idx_3D)
 
         fwd_out['src'][i]['vertno'] = np.r_[fwd_out['src'][i]['vertno'],
                                             src_sel]
         fwd_out['src'][i]['nuse'] += len(src_sel)
         fwd_out['src'][i]['inuse'][src_sel] = 1
+
+        if is_fixed_orient(fwd):
+            idx = src_sel
+        else:
+            idx = (3 * src_sel[:, None] + np.arange(3)).ravel()
+
+        fwd_out['source_nn'] = np.vstack([fwd_out['source_nn'],
+                                          fwd['source_nn'][idx]])
+        fwd_out['sol']['data'] = np.hstack([fwd_out['sol']['data'],
+                                            fwd['sol']['data'][:, idx]])
+        fwd_out['sol']['ncol'] += len(idx)
 
     return fwd_out

--- a/mne/tests/test_forward.py
+++ b/mne/tests/test_forward.py
@@ -9,9 +9,8 @@ from mne.datasets import sample
 from mne.fiff import Raw, Evoked, pick_types_forward
 from mne import read_forward_solution, apply_forward, apply_forward_raw
 from mne import SourceEstimate
-from mne import read_label
-from mne.forward import restrict_foward_to_stc, restrict_foward_to_label
-
+from mne.label import read_label
+from mne.forward import restrict_forward_to_stc, restrict_forward_to_label
 
 data_path = sample.data_path()
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis-meg-oct-6-fwd.fif')
@@ -85,7 +84,7 @@ def test_apply_forward():
         assert_array_almost_equal(times[-1], t_start + (n_times - 1) / sfreq)
 
 
-def test_restrict_foward_to_stc():
+def test_restrict_forward_to_stc():
     """Test restriction of source space to source SourceEstimate
     """
     start = 0
@@ -101,7 +100,7 @@ def test_restrict_foward_to_stc():
     stc_data = np.ones((len(vertno[0]) + len(vertno[1]), n_times))
     stc = SourceEstimate(stc_data, vertno, tmin=t_start, tstep=1.0 / sfreq)
 
-    fwd_out = restrict_foward_to_stc(fwd, stc)
+    fwd_out = restrict_forward_to_stc(fwd, stc)
 
     assert_equal(fwd_out['sol']['ncol'], 20)
     assert_equal(fwd_out['src'][0]['nuse'], 15)
@@ -109,8 +108,23 @@ def test_restrict_foward_to_stc():
     assert_equal(fwd_out['src'][0]['vertno'], fwd['src'][0]['vertno'][0:15])
     assert_equal(fwd_out['src'][1]['vertno'], fwd['src'][1]['vertno'][0:5])
 
+    fwd = read_forward_solution(fname, force_fixed=False)
+    fwd = pick_types_forward(fwd, meg=True)
 
-def test_restrict_foward_to_label():
+    vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
+    stc_data = np.ones((len(vertno[0]) + len(vertno[1]), n_times))
+    stc = SourceEstimate(stc_data, vertno, tmin=t_start, tstep=1.0 / sfreq)
+
+    fwd_out = restrict_forward_to_stc(fwd, stc)
+
+    assert_equal(fwd_out['sol']['ncol'], 60)
+    assert_equal(fwd_out['src'][0]['nuse'], 15)
+    assert_equal(fwd_out['src'][1]['nuse'], 5)
+    assert_equal(fwd_out['src'][0]['vertno'], fwd['src'][0]['vertno'][0:15])
+    assert_equal(fwd_out['src'][1]['vertno'], fwd['src'][1]['vertno'][0:5])
+
+
+def test_restrict_forward_to_label():
     """Test restriction of source space to source SourceEstimate
     """
     fwd = read_forward_solution(fname, force_fixed=True)
@@ -118,11 +132,10 @@ def test_restrict_foward_to_label():
 
     label_path = op.join(data_path, 'MEG', 'sample', 'labels')
     labels = ['Aud-lh', 'Vis-rh']
-
-    fwd_out = restrict_foward_to_label(fwd, labels, label_path)
-
     label_lh = read_label(op.join(label_path, labels[0] + '.label'))
     label_rh = read_label(op.join(label_path, labels[1] + '.label'))
+
+    fwd_out = restrict_forward_to_label(fwd, [label_lh, label_rh])
 
     src_sel_lh = np.intersect1d(fwd['src'][0]['vertno'], label_lh.vertices)
     src_sel_lh = np.searchsorted(fwd['src'][0]['vertno'], src_sel_lh)
@@ -132,6 +145,30 @@ def test_restrict_foward_to_label():
                  + len(fwd['src'][0]['vertno'])
 
     assert_equal(fwd_out['sol']['ncol'], len(src_sel_lh) + len(src_sel_rh))
+    assert_equal(fwd_out['src'][0]['nuse'], len(src_sel_lh))
+    assert_equal(fwd_out['src'][1]['nuse'], len(src_sel_rh))
+    assert_equal(fwd_out['src'][0]['vertno'], src_sel_lh)
+    assert_equal(fwd_out['src'][1]['vertno'], src_sel_rh)
+
+    fwd = read_forward_solution(fname, force_fixed=False)
+    fwd = pick_types_forward(fwd, meg=True)
+
+    label_path = op.join(data_path, 'MEG', 'sample', 'labels')
+    labels = ['Aud-lh', 'Vis-rh']
+    label_lh = read_label(op.join(label_path, labels[0] + '.label'))
+    label_rh = read_label(op.join(label_path, labels[1] + '.label'))
+
+    fwd_out = restrict_forward_to_label(fwd, [label_lh, label_rh])
+
+    src_sel_lh = np.intersect1d(fwd['src'][0]['vertno'], label_lh.vertices)
+    src_sel_lh = np.searchsorted(fwd['src'][0]['vertno'], src_sel_lh)
+
+    src_sel_rh = np.intersect1d(fwd['src'][1]['vertno'], label_rh.vertices)
+    src_sel_rh = np.searchsorted(fwd['src'][1]['vertno'], src_sel_rh)\
+                 + len(fwd['src'][0]['vertno'])
+
+    assert_equal(fwd_out['sol']['ncol'],
+                 3 * (len(src_sel_lh) + len(src_sel_rh)))
     assert_equal(fwd_out['src'][0]['nuse'], len(src_sel_lh))
     assert_equal(fwd_out['src'][1]['nuse'], len(src_sel_rh))
     assert_equal(fwd_out['src'][0]['vertno'], src_sel_lh)


### PR DESCRIPTION
These functions restrict a forward operator to specific vertices defined in an stc (e.g. after running MxNE) or from a list of labels.

The 'use_tris' and 'nuse_tris' values are not set, as triangulation with the restricted source spaces might be hard or even impossible if sources in stc or labels are sparse.

Comments, critics and hints are welcome.

Bye Daniel
