### PR TITLE
ENH: use union of bad channels when merging Evoked and Cov

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -31,9 +31,6 @@ def _check_covs_algebra(cov1, cov2):
     if map(str, cov1['projs']) != map(str, cov2['projs']):
         raise ValueError('Both Covariance do not have the same list of '
                          'SSP projections.')
-    if cov1['bads'] != cov2['bads']:
-        raise ValueError('Both Covariance do not have the same list of '
-                         'bad channels.')
 
 
 class Covariance(dict):
@@ -133,6 +130,9 @@ class Covariance(dict):
                             (self['data'] * self['nfree'])) / \
                                 (self['nfree'] + this_cov['nfree'])
         this_cov['nfree'] += self['nfree']
+
+        this_cov['bads'] = list(set(this_cov['bads']).union(self['bads']))
+
         return this_cov
 
     def __iadd__(self, cov):
@@ -142,6 +142,9 @@ class Covariance(dict):
                             (cov['data'] * cov['nfree'])) / \
                                 (self['nfree'] + cov['nfree'])
         self['nfree'] += cov['nfree']
+
+        self['bads'] = list(set(self['bads']).union(cov['bads']))
+
         return self
 
 

--- a/mne/fiff/evoked.py
+++ b/mne/fiff/evoked.py
@@ -585,6 +585,11 @@ def merge_evoked(all_evoked):
                 ValueError("%s and %s do not "
                            "contain the same time instants" % (evoked, e))
 
+    # use union of bad channels
+    bads = list(set(evoked.info['bads']).union(*(ev.info['bads']
+                                                 for ev in all_evoked[1:])))
+    evoked.info['bads'] = bads
+
     all_nave = sum(e.nave for e in all_evoked)
     evoked.data = sum(e.nave * e.data for e in all_evoked) / all_nave
     evoked.nave = all_nave


### PR DESCRIPTION
Until now, when merging Evoked, the bad channels of the first Evoked instance was used while for Cov merging was only supported when all Cov instances have the same bad channels. I think it is better to instead use the union of bad channels, i.e., if a channel is bad in one instance it will also be bad in the merged instance. 
