### PR TITLE
FIX TEST test_forward: change subjects_dir

### DIFF
--- a/mne/tests/test_forward.py
+++ b/mne/tests/test_forward.py
@@ -1,3 +1,4 @@
+import os
 import os.path as op
 import warnings
 import commands
@@ -244,6 +245,8 @@ def test_average_forward_solution():
 def test_do_forward_solution():
     """Test making forward solution from python
     """
+    subjects_dir = os.path.join(data_path, 'subjects')
+
     raw = Raw(fname_raw)
     mri = read_trans(fname_mri)
     fname_fake = op.join(temp_dir, 'no_have.fif')
@@ -301,10 +304,10 @@ def test_do_forward_solution():
     # make a meas from raw (tests all steps in creating evoked),
     # don't do EEG or 5120-5120-5120 BEM because they're ~3x slower
     fwd_py = do_forward_solution('sample', raw, mindist=5, spacing='oct-6',
-                                 bem='sample-5120', mri=fname_mri, eeg=False)
+                                 bem='sample-5120', mri=fname_mri, eeg=False,
+                                 subjects_dir=subjects_dir)
     fwd = read_forward_solution(fname)
     assert_allclose(fwd['sol']['data'], fwd_py['sol']['data'],
                     rtol=1e-5, atol=1e-8)
     assert_equal(fwd_py['sol']['data'].shape, (306, 22494))
     assert_equal(len(fwd['sol']['row_names']), 306)
-

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -11,6 +11,7 @@ import os
 import os.path as op
 from functools import wraps
 import inspect
+import subprocess
 import sys
 from sys import stdout
 import tempfile
@@ -620,6 +621,23 @@ def sizeof_fmt(num):
         return '0 bytes'
     if num == 1:
         return '1 byte'
+
+
+def run_subprocess(*args, **kwargs):
+    """Calls subprocess.Popen
+
+    Returns
+    -------
+    returncode : int
+        The return code.
+    stdout : str
+        Stdout returned by the process.
+    stderr : str
+        Stderr returned by the process.
+    """
+    p = subprocess.Popen(*args, **kwargs)
+    stdout, stderr = p.communicate()
+    return p.returncode, stdout, stderr
 
 
 def _url_to_local_path(url, path):


### PR DESCRIPTION
As suggested in https://github.com/mne-tools/mne-python/pull/434#issuecomment-13411325

I still get two errors in the tests on master:

``` Python

ERROR: Test reading labels from parc. by comparing with mne_annot2labels
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/7.3/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Library/Frameworks/Python.framework/Versions/7.3/lib/python2.7/site-packages/numpy/testing/decorators.py", line 146, in skipper_func
    return f(*args, **kwargs)
  File "/Users/christian/Documents/Eclipse/projects/mne-python/mne/tests/test_label.py", line 183, in test_labels_from_parc_annot2labels
    labels_mne = _mne_annot2labels('sample', subjects_dir, 'aparc')
  File "/Users/christian/Documents/Eclipse/projects/mne-python/mne/tests/test_label.py", line 172, in _mne_annot2labels
    % st)
RuntimeError: mne_annot2labels non-zero exit status 256
```

and

``` Python
ERROR: Test sensitivity map computation
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/7.3/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/christian/Documents/Eclipse/projects/mne-python/mne/tests/test_proj.py", line 42, in test_sensitivity_maps
    w_lh = mne.read_w(sensmap_fname % (ch_type, 'lh'))
  File "/Users/christian/Documents/Eclipse/projects/mne-python/mne/source_estimate.py", line 155, in read_w
    fid = open(filename, 'rb')
IOError: [Errno 2] No such file or directory: u'/Users/christian/Documents/Eclipse/projects/mne-python/examples/MNE-sample-data/MEG/sample/sample_audvis-eeg-oct-6-fwd-sensmap-lh.w'
```
