### PR TITLE
MISC/COSMITS: addresses minor doc and viz style issues

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1022,9 +1022,6 @@ class Epochs(object):
         it would remove events at times [1, 2] in the first epochs and not
         [20, 21].
 
-        Note that this operates in-place, and will call drop_bad_epochs() if
-        bad epochs have not yet been dropped.
-
         Parameters
         ----------
         event_ids : list
@@ -1052,7 +1049,7 @@ class Epochs(object):
         For example (if epochs.event_id was {'Left': 1, 'Right': 2,
         'Nonspatial':3}:
 
-            epochs.equalize_event_counts(['Left', 'Right'], 'Nonspatial')
+            epochs.equalize_event_counts([['Left', 'Right'], 'Nonspatial'])
 
         would equalize the number of trials in the 'Nonspatial' condition with
         the total number of trials in the 'Left' and 'Right' conditions.

--- a/mne/viz.py
+++ b/mne/viz.py
@@ -26,7 +26,7 @@ from warnings import warn
 
 
 # XXX : don't import pylab here or you will break the doc
-from .fixes import tril_indices, in1d
+from .fixes import tril_indices
 from .baseline import rescale
 from .utils import deprecated, get_subjects_dir
 from .fiff.pick import channel_type, pick_types
@@ -671,7 +671,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
 
             if hline is not None:
                 for h in hline:
-                    pl.axhline(h, color='k', linestyle='--', linewidth=2)
+                    pl.axhline(h, color='r', linestyle='--', linewidth=2)
 
     pl.subplots_adjust(0.175, 0.08, 0.94, 0.94, 0.2, 0.63)
     tight_layout()


### PR DESCRIPTION
- fix doc string for equalize epochs count method
- red instead of black hline for evoked plots (now that the default to black
  black hlines are not easy to discern.). I prefer this to adding another compicated dict as param.
  Looks like this:

![whitened_lower-prestim-baseline_room](https://f.cloud.github.com/assets/1908618/186061/ea0be7a4-7d1c-11e2-8b41-56c597291386.png)
