### PR TITLE
ENH: Adding STC expansion

### DIFF
--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -27,6 +27,21 @@ fname_inv = op.join(data_path, 'MEG', 'sample',
 tempdir = _TempDir()
 
 
+def test_expand():
+    """Test stc expansion
+    """
+    stc = read_source_estimate(fname)
+    labels_lh, _ = labels_from_parc('sample', hemi='lh',
+                                    subjects_dir=subjects_dir)
+    stc_limited = stc.in_label(labels_lh[0] + labels_lh[1])
+    stc_new = stc_limited.copy()
+    stc_new.data.fill(0)
+    for label in labels_lh[:2]:
+        stc_new += stc.in_label(label).expand(stc_limited.vertno)
+    # make sure we can't add unless vertno agree
+    assert_raises(RuntimeError, stc.__add__, stc.in_label(labels_lh[0]))
+
+
 def test_io_stc():
     """Test IO for STC files
     """


### PR DESCRIPTION
This basically allows one to un-do `stc.in_label()` operations. Can be useful in simulation, I'm finding.

Note that I added a check on `__add__()` and `__iadd__()` that the `vertno` from each `SourceEstimate` must match. We could basically use this type of functionality to expand the STCs if they don't match, but I think it's much safer to make the user expand each STC first, if they want, then add them together.
