### PR TITLE
ENH: Added temporal decimation to Morlet analysis

### DIFF
--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -143,7 +143,7 @@ def _compute_pow_plv(data, K, sel, Ws, source_ori, use_fft, Vh, with_plv,
             e = np.dot(Vh, e)  # reducing data rank
 
         for f, w in enumerate(Ws):
-            tfr = cwt(e, [w], use_fft=use_fft)[:, :, ::decim]
+            tfr = cwt(e, [w], use_fft=use_fft, decim=decim)
             tfr = np.asfortranarray(tfr.reshape(len(e), -1))
 
             # phase lock and power at freq f


### PR DESCRIPTION
To help minimize memory usage when processing large datasets, added decim
parameter to `single_trial_power` and `cwt`.

This allows me to analyze some datasets where the final result of
`single_trial_power` would not have fit in memory otherwise.  Having `cwt`
perform the decimation before returning the result also sidesteps the issue of
multiple jobs (using joblib) returning large arrays to the parent process that
crashed my Python interpreter.

Also includes a docstring fix for `single_trial_power` and a bugfix where
`single_trial_power` was not calling `cwt` with correct arguments when njobs
was 1.
