### PR TITLE
ENH: Improve epochs drop_log

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1465,14 +1465,9 @@ def bootstrap(epochs, random_state=None):
 
 
 def _check_add_drop_log(epochs, indices):
-    """Aux Function """
-    log = 'equalized count'
-    if hasattr(epochs, 'drop_log'):
-        # let's not overwrite exisiting logs
-        drop_log = [[log] if (i in indices and not l) else l
-                    for i, l in enumerate(epochs.drop_log)]
-    else:
-        drop_log = [[log] if l in indices else []
-                    for l in xrange(len(epochs.events))]
-    epochs.drop_log = drop_log
+    """Aux Function"""
+    # never called before dropping bads, so its safe to iterate over log
+    # ... we'll not gonna change existing logs
+    epochs.drop_log = [['EQUALIZED_COUNT'] if (i in indices and not l) else l
+                       for i, l in enumerate(epochs.drop_log)]
     return epochs

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -554,7 +554,8 @@ def test_epoch_eq():
     drop_log1 = epochs_1.drop_log = [[] for _ in range(len(epochs_1.events))]
     assert_true(epochs_1.events.shape[0] != epochs_2.events.shape[0])
     equalize_epoch_counts([epochs_1, epochs_2], method='mintime')
-    drop_log2 = [[] if l == ['equalized count'] else l for l in epochs_1.drop_log]
+    log = 'EQUALIZED_COUNT'
+    drop_log2 = [[] if l == [log] else l for l in epochs_1.drop_log]
     assert_true(drop_log1 == drop_log2)
 
     assert_true(epochs_1.events.shape[0] == epochs_2.events.shape[0])
@@ -571,8 +572,8 @@ def test_epoch_eq():
     drop_log1 = [l for l in epochs.drop_log]  # now copy the log
     old_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     epochs.equalize_event_counts(['a', 'b'], copy=False)
-    # undo the eq logginglen()
-    drop_log2 = [[] if l == ['equalized count'] else l for l in epochs.drop_log]
+    # undo the eq logging
+    drop_log2 = [[] if l == [log] else l for l in epochs.drop_log]
     assert_true(drop_log1 == drop_log2)
     new_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     assert_true(new_shapes[0] == new_shapes[1])


### PR DESCRIPTION
@agramfort / @Eric89GXL here I outlined the idea exposed in #592.
It will add a new logging message to the dorp log indicating that the particular epoch was dropped during count equalization. 

For reconstructing the full index of dropped epochs one can then say: 
`[i for i, e in epochs.drop_log if e]` 

Which can be very useful when e.g. integrating reaction time data into the analysis.

We might also consider adding a drop_index attribute but I'm somewhat reluctant of adding another attribute ...

wdyt?

D
