### PR TITLE
FIX: drop testing support for pandas < 0.8

### DIFF
--- a/mne/utils.py
+++ b/mne/utils.py
@@ -376,7 +376,7 @@ def requires_pandas(function):
         try:
             import pandas
             version = LooseVersion(pandas.__version__)
-            if version < '0.7.3':
+            if version < '0.8.0':
                 skip = True
         except ImportError:
             skip = True


### PR DESCRIPTION
This addresses #585.
We could think about adding additional warning / hints for users not to use certain parameter combinations == not requesting the full hierarchical index.
