### PR TITLE
FIX Move lcmv normal orientation picking

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -160,11 +160,6 @@ def _apply_lcmv(data, info, tmin, forward, noise_cov, data_cov, reg,
     if pick_ori == 'max-power':
         W = W[0::3]
 
-    # Pick source orientation normal to cortical surface
-    if pick_ori == 'normal':
-        W = W[2::3]
-        is_free_ori = False
-
     # noise normalization
     noise_norm = np.sum(W ** 2, axis=1)
     if is_free_ori:
@@ -173,6 +168,11 @@ def _apply_lcmv(data, info, tmin, forward, noise_cov, data_cov, reg,
 
     if not is_free_ori:
         W /= noise_norm[:, None]
+
+    # Pick source orientation normal to cortical surface
+    if pick_ori == 'normal':
+        W = W[2::3]
+        is_free_ori = False
 
     if isinstance(data, np.ndarray) and data.ndim == 2:
         data = [data]

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -83,7 +83,7 @@ def test_lcmv():
     stc_normal = lcmv(evoked, forward_surf_ori, noise_cov, data_cov, reg=0.01,
                       pick_ori="normal")
 
-    assert_true((np.abs(stc_normal.data) <= stc.data + 0.4).all())
+    assert_true((np.abs(stc_normal.data) <= stc.data).all())
 
     # Test picking source orientation maximizing output source power
     stc_max_power = lcmv(evoked, forward, noise_cov, data_cov, reg=0.01,


### PR DESCRIPTION
Normal orientation picking is now done on `W` instead of on `G`. This ensures consistency with the minimum_norm implementation of picking the normal orientation. Addresses discussion in issue #635. 

For future reference - I think it might be worthwhile (although I'm less and less sure it would be) to consider adding the option of choosing source orientation on the gain matrix and therefore ensuring this is a scalar beamformer implementation.

Also note that now (in the test modified in this commit) the results from the normal orientation never differ from results of the free orientation solution by more than 0.4 (compared to 0.8 before moving the orientation picking). I also checked that when the picking is moved after noise normalization (i.e. around [line 176](https://github.com/rgoj/mne-python/blob/c09f97018a06a5e659e52009cdc57e1aafe17d99/mne/beamformer/_lcmv.py#L176)), then the normal solution is always smaller than the free orientation one. Interesting how big a difference numerical issues caused here.
