### PR TITLE
ENH: drop preload requirement

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -833,7 +833,7 @@ class ICA(object):
             picks_ = np.array([ii for ii in xrange(raw.info['nchan'])
                                if ii not in picks])
             data = np.concatenate([raw[picks_, start:stop][0], recomposed])
-            raw._data = data[np.concatenate([picks, picks_]).argsort()]
+            raw._data = data[np.concatenate([picks_, picks]).argsort()]
             raw._preloaded = True
 
         return raw


### PR DESCRIPTION
This PR intends to make ICA source picking less picky about the state of the object. If Raw / Epochs aren't preloaded the returned / picked object will be of course. I employed to different strategies to allow for picking without loosing the unpicked channels int the resulting object. The epochs variant is less efficient, but it does not matter since epochs normally don't consume too much memory.
