### PR TITLE
FIX: No drop_log property for read epochs

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1606,6 +1606,7 @@ def read_epochs(fname, proj=True, add_eeg_ref=True, verbose=None):
     epochs.event_id = (dict((str(e), e) for e in np.unique(events[:, 2]))
                        if mappings is None else mappings)
     epochs.verbose = verbose
+    epochs.drop_log = []
     fid.close()
 
     return epochs

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -148,6 +148,8 @@ def test_read_write_epochs():
     # test copying loaded one (raw property)
     epochs_read4 = epochs_read3.copy()
     assert_array_almost_equal(epochs_read4.get_data(), data)
+    # test equalizing loaded one (drop_log property)
+    epochs_read4.equalize_event_counts(epochs.event_id)
 
 
 def test_epochs_proj():


### PR DESCRIPTION
The drop_log was not created on epochs read.
