### PR TITLE
ENH/WIP: implement reject buffer in ICA

### DIFF
--- a/examples/preprocessing/plot_ica_from_raw.py
+++ b/examples/preprocessing/plot_ica_from_raw.py
@@ -56,7 +56,7 @@ ica = ICA(n_components=0.90, n_pca_components=None, max_pca_components=100,
 # the entire data range
 
 # decompose sources for raw data using each third sample.
-ica.decompose_raw(raw, picks=picks, decim=3)
+ica.decompose_raw(raw, picks=picks, decim=3, reject=dict(mag=4e-12))
 print ica
 
 # plot reasonable time window for inspection

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -9,6 +9,7 @@ import inspect
 import warnings
 from inspect import getargspec, isfunction
 from collections import namedtuple
+from math import ceil
 
 import os
 import json
@@ -219,7 +220,8 @@ class ICA(object):
 
     @verbose
     def decompose_raw(self, raw, picks=None, start=None, stop=None,
-                      decim=None, reject=None, flat=None, verbose=None):
+                      decim=None, reject=None, flat=None, tstep=2.0,
+                      verbose=None):
         """Run the ICA decomposition on raw data
 
         Caveat! If supplying a noise covariance keep track of the projections
@@ -244,6 +246,21 @@ class ICA(object):
             Increment for selecting each nth time slice. If None, all samples
             within ``start`` and ``stop`` are used.
         reject : dict
+            Rejection parameters based on peak to peak amplitude.
+            Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
+            If reject is None then no rejection is done. Example::
+
+                reject = dict(grad=4000e-13, # T / m (gradiometers)
+                              mag=4e-12, # T (magnetometers)
+                              eeg=40e-6, # uV (EEG channels)
+                              eog=250e-6 # uV (EOG channels)
+                              )
+        flat : dict
+            Rejection parameters based on flatness of signal
+            Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'
+            If flat is None then no rejection is done.
+        tstep : float
+            Size of data chunks for artefact rejection.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -273,21 +290,31 @@ class ICA(object):
         self.ch_names = self.info['ch_names']
         start, stop = _check_start_stop(raw, start, stop)
         info = self.info
-        step = 1 if decim is None else decim
-        data = np.empty([len(picks), stop - start])[:, ::step]
+        data = np.empty((len(picks), len(np.arange(stop - start)[::decim])))
         idx_by_type = channel_indices_by_type(info)
+        step = int(ceil(tstep * raw.info['sfreq']))
+        this_start = 0
+        this_stop = 0
         for first in xrange(start, stop, step):
             last = first + step
-            if last >= stop:
+            if last > stop:
                 last = stop
             raw_segment, times = raw[picks, first:last]
-            if not raw_segment.any():
+            if raw_segment.shape[1] < (last - first):
                 break
             if _is_good(raw_segment, info['ch_names'], idx_by_type, reject,
                        flat, ignore_chs=info['bads']):
-                data[:, first:last] = raw_segment[:, ::decim]
+                raw_segment = raw_segment[:, ::decim]
+                this_stop = this_start + raw_segment.shape[1]
+                data[:, this_start:this_stop] = raw_segment
+                this_start += raw_segment.shape[1]
             else:
-                logger.info("Artefact detected in [%d, %d]" % (first, last))
+                logger.info("Artifact detected in [%d, %d]" % (first, last))
+        data = data[:, :this_stop]
+        if not data.any():
+            raise RuntimeError('No clean segment found. Please '
+                               'consider updating your rejection '
+                               'thresholds.')
 
         data, self._pre_whitener = self._pre_whiten(data,
                                                     raw.info, picks)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -364,6 +364,7 @@ def test_ica_reject_buffer():
     raw._data[2, 1000:1005] = 3e-12
     drop_log = op.join(op.dirname(tempdir), 'ica_drop.log')
     set_log_file(drop_log, overwrite=True)
-    ica.decompose_raw(raw, picks[:5], reject=dict(mag=2.5e-12), decim=3)
+    ica.decompose_raw(raw, picks[:5], reject=dict(mag=2.5e-12), decim=3,
+                     tstep=0.005)
     log = [l for l in open(drop_log) if 'detected' in l]
     assert_true(len(log) == 1)


### PR DESCRIPTION
I recently saw for the first time what I had always suspected. Nonstationary artifacts mess with the ICA solution. In one particular situation using the SPM data set, despite seemingly reasonable unmixing performance, the artifacts could not be satisfyingly removed as long as the ICA estimation included corrupted segments. This PR proposes a rejection buffer for decompose raw to tackle this issue.
