### PR TITLE
FIX to catch error when frequency range too narrow

### DIFF
--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -169,6 +169,11 @@ def compute_csd(epochs, mode='multitaper', fmin=0, fmax=np.inf, tmin=None,
         # Preparing frequencies of interest
         freq_mask = (frequencies > fmin) & (frequencies < fmax)
 
+        if not freq_mask.any():
+            raise ValueError('No discrete fourier transform results within '
+                             'the given frequency window. Please widen either '
+                             'the frequency window or the time window')
+
         if mt_adaptive:
             # Compute adaptive weights
             _, weights = _psd_from_mt_adaptive(x_mt, eigvals, freq_mask,

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -42,6 +42,7 @@ def test_compute_csd():
     # Check that wrong parameters are recognized
     assert_raises(ValueError, compute_csd, epochs, mode='notamode')
     assert_raises(ValueError, compute_csd, epochs, fmin=20, fmax=10)
+    assert_raises(ValueError, compute_csd, epochs, fmin=20, fmax=20.1)
     assert_raises(ValueError, compute_csd, epochs, tmin=0.15, tmax=0.1)
     assert_raises(ValueError, compute_csd, epochs, tmin=0, tmax=10)
     assert_raises(ValueError, compute_csd, epochs, tmin=10, tmax=11)


### PR DESCRIPTION
This is just a small PR to fix a problem where compute_csd would silently failed when presented with too narrow a frequency range, i.e. when there are no DFT frequencies between fmin and fmax. Now a ValueError is raised in such cases and there's a test as well.
