### PR TITLE
FIX : find clusters in 1d data with TFCE

### DIFF
--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -378,6 +378,8 @@ def _find_clusters(x, threshold, tail=0, connectivity=None, max_step=1,
                 # triage based on cluster storage type
                 if isinstance(c, slice):
                     len_c = c.stop - c.start
+                elif isinstance(c, tuple):
+                    len_c = len(c)
                 elif c.dtype == bool:
                     len_c = np.sum(c)
                 else:


### PR DESCRIPTION
Hi Guys,

I just found a small bug while doing TFCE stats in 1d data... which I'm usually doing on 2d data.
At line 383 c.dtype doesnt like tuple!
Cheers,

Romain
