### PR TITLE
ENH: replace pandas hack, add support for old matplotlib and current pandas master

### DIFF
--- a/examples/export/plot_epochs_as_data_frame.py
+++ b/examples/export/plot_epochs_as_data_frame.py
@@ -207,7 +207,7 @@ df.condition = df.condition.apply(lambda name: name + ' ')
 
 pl.figure()
 max_latency.plot(kind='barh', title='Latency of Maximum Reponse',
-                 color='steelblue')
+                 color=['steelblue'])
 mne.viz.tight_layout()
 
 # Finally, we will again remove the index to create a proper data table that

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1272,9 +1272,9 @@ class Epochs(_BaseEpochs):
         [df.insert(i, k, v) for i, (k, v) in enumerate(mindex)]
         if index is not None:
             with warnings.catch_warnings(True):
+                if 'time' in index:
+                    df['time'] = df['time'].astype(np.int64)
                 df.set_index(index, inplace=True)
-            if 'time' in df.index.names and hasattr(df.index, 'levels'):
-                df.index.levels[1] = df.index.levels[1].astype(int)
 
         return df
 

--- a/mne/fiff/evoked.py
+++ b/mne/fiff/evoked.py
@@ -534,9 +534,10 @@ class Evoked(ProjMixin):
         df.insert(0, 'time', times * scale_time)
 
         if use_time_index is True:
+            if 'time' in df:
+                df['time'] = df['time'].astype(np.int64)
             with warnings.catch_warnings(True):
                 df.set_index('time', inplace=True)
-            df.index = df.index.astype(int)
 
         return df
 

--- a/mne/fiff/raw.py
+++ b/mne/fiff/raw.py
@@ -1364,9 +1364,10 @@ class Raw(ProjMixin):
         df.insert(0, 'time', times * scale_time)
 
         if use_time_index is True:
+            if 'time' in df:
+                df['time'] = df['time'].astype(np.int64)
             with warnings.catch_warnings(True):
                 df.set_index('time', inplace=True)
-            df.index = df.index.astype(int)
 
         return df
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -862,10 +862,10 @@ class _BaseSourceEstimate(object):
         [df.insert(i, k, v) for i, (k, v) in enumerate(mindex)]
 
         if index is not None:
+            if 'time' in index:
+                df['time'] = df['time'].astype(np.int64)
             with warnings.catch_warnings(True):
                 df.set_index(index, inplace=True)
-            if 'time' in df.index.names and hasattr(df.index, 'levels'):
-                df.index.levels[1] = df.index.levels[1].astype(int)
 
         return df
 


### PR DESCRIPTION
The recent pandas master implements Indexers as subclasses of frozensets -- as a consequence the brutal type casting  would fail. I replaced it by a an obviously better variant but kept it since we don'y want to get into the FloatIndexers recently added in Pandas.
For older Pandas/Matplotlib combinations the example would fail. Added a fix.
