### PR TITLE
FIX: added missing coreg package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
           platforms='any',
           packages=['mne', 'mne.tests',
                     'mne.beamformer', 'mne.beamformer.tests',
+                    'mne.coreg',
                     'mne.connectivity', 'mne.connectivity.tests',
                     'mne.data',
                     'mne.datasets',


### PR DESCRIPTION
Added missing package in setup.py. Without this patch "import mne" fails if installed.
