### PR TITLE
FIX self-morph, vertex order

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -71,6 +71,10 @@ class Label(object):
         if not isinstance(hemi, basestring):
             raise ValueError('hemi must be a string, not %s' % type(hemi))
         vertices = np.asarray(vertices)
+        if np.any(np.diff(vertices.astype(int)) <= 0):
+            raise ValueError('Vertices must be ordered in increasing '
+                             'order.')
+
         if values is None:
             values = np.ones(len(vertices))
         if pos is None:

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -975,7 +975,8 @@ def _make_morph_map(subject_from, subject_to, subjects_dir=None):
             fname = op.join(subjects_dir, subject_from, 'surf',
                             '%s.sphere.reg' % hemi)
             from_pts = read_surface(fname, verbose=False)[0]
-            morph_maps.append(sparse.eye(len(from_pts), format='csr'))
+            n_pts = len(from_pts)
+            morph_maps.append(sparse.eye(n_pts, n_pts, format='csr'))
         return morph_maps
 
     for hemi in ['lh', 'rh']:

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -342,7 +342,7 @@ def test_morph_data():
     stc_to3 = morph_data(subject_from, subject_to, stc_from,
                          grade=vertices_to, smooth=12, buffer_size=3,
                          subjects_dir=subjects_dir)
-    # indexing silliness here due to mne_make_movie's indexing oddities
+
     assert_array_almost_equal(stc_to.data, stc_to1.data, 5)
     assert_array_almost_equal(stc_to1.data, stc_to2.data)
     assert_array_almost_equal(stc_to1.data, stc_to3.data)
@@ -361,6 +361,15 @@ def test_morph_data():
     stc_to5 = morph_data(subject_from, subject_to, stc_from, grade=None,
                          smooth=12, buffer_size=3, subjects_dir=subjects_dir)
     assert_true(stc_to5.data.shape[0] == 163842 + 163842)
+
+    # test morphing to the same subject
+    stc_to6 = stc_from.morph(subject_from, grade=stc_from.vertno, smooth=1,
+                             subjects_dir=subjects_dir)
+    mask = np.ones(stc_from.data.shape[0], dtype=np.bool)
+    # XXX: there is a bug somewhere that causes a difference at 2 vertices..
+    mask[6799] = False
+    mask[6800] = False
+    assert_array_almost_equal(stc_from.data[mask], stc_to6.data[mask], 5)
 
 
 def _my_trans(data):


### PR DESCRIPTION
Fixes two bugs:
- Shortcut for creating self-morph matrices had a bug and wasn't covered by a test
- In some cases, morphing also caused the vertex indices in `SourceEstimate` to be un-ordered. This leads to problems because we often use e.g. `np.searchsorted` which assumes that the arrays are sorted. To fix it, I modified the morph code so the vertex indices are ordered. I also changed `read_source_estimate` so the vertex indices are re-ordered when reading `.stc` files that have a strange vertex order (e.g. those produced by `mne_make_movie`)

To prevent the second problem in the future, I added checks to `SourceEstimate` and `Label` to make sure the vertex indices are ordered.

Note: There is some strange bug in the morph code that causes the values to be different at exactly 2 vertices.. I spent a long time trying to figure out where it comes from but ran out of time (for now). Bug bounty: 1 beer from me.  
