### PR TITLE
FIX:  sample dataset data_path in cases where the data has been removed

### DIFF
--- a/mne/datasets/sample/sample.py
+++ b/mne/datasets/sample/sample.py
@@ -58,6 +58,8 @@ def data_path(path=None, force_update=False, update_path=True, verbose=None):
         def_path = op.abspath(op.join(op.dirname(__file__), '..', '..',
                                       '..', 'examples'))
         path = get_config('MNE_DATASETS_SAMPLE_PATH', def_path)
+        if not os.path.exists(path):
+            path = def_path
 
     if not isinstance(path, basestring):
         raise ValueError('path must be a string or None')


### PR DESCRIPTION
After manually moving my sample dataset I got an error. This here is a quick fix by reverting to the default location.
