### PR TITLE
FIX: vertex ordering when combining labels

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -187,6 +187,9 @@ class Label(object):
         name0 = self.name if self.name else 'unnamed'
         name1 = other.name if other.name else 'unnamed'
 
+        indcs = np.argsort(vertices)
+        vertices, pos, values = vertices[indcs], pos[indcs, :], values[indcs]
+
         label = Label(vertices, pos=pos, values=values, hemi=self.hemi,
                       comment="%s + %s" % (self.comment, other.comment),
                       name="%s + %s" % (name0, name1))


### PR DESCRIPTION
I was receiving a vertex-ordering error when trying to combine labels.  The two lines I added seem to fix the issue, just reordering vertices, pos, and values.
