### PR TITLE
FIX: CSP fit bug fixed!

### DIFF
--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -160,7 +160,7 @@ class CSP(TransformerMixin):
         lambda2_ = lambda_[ind]
 
         u = u[:, ind]
-        p = np.dot(np.sqrt(linalg.pinv(np.diag(lambda2_))),u.T)
+        p = np.dot(np.sqrt(linalg.pinv(np.diag(lambda2_))), u.T)
 
         # Compute the generalized eigen value problem
         w_a = np.dot(np.dot(p, cov_a), p.T)


### PR DESCRIPTION
Hi,

I found a small bug in csp._fit in which \* product was used instead of dot product.
I didn't run the test but it wont change much the results since decoding accuracy was already high using the mne data set.

Cheers,
Romain
