### PR TITLE
FIX:  sample datasets download target folder

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -71,7 +71,7 @@ def _data_path(path=None, force_update=False, update_path=True,
     if path is None:
         # use an intelligent guess if it's not defined
         def_path = op.abspath(op.join(op.dirname(__file__),
-                                      '..', 'examples'))
+                                      '..', '..', 'examples'))
 
         path = get_config(key, def_path)
         # use the same for all datasets


### PR DESCRIPTION
I think this might be a recently introduced bug? I got

``` python
In [3]: mne.datasets.spm_face.data_path()
Sample data archive MNE-spm-face.tar.bz2 not found at:
/Users/christian/Documents/Eclipse/projects/mne-python/mne/examples/MNE-spm-face
It will be downloaded and extracted at this location.
Downloading data from ftp://surfer.nmr.mgh.harvard.edu/pub/data/MNE/MNE-spm-face.tar.bz2 (814.2 MB)
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-3-0a86fb805d67> in <module>()
----> 1 mne.datasets.spm_face.data_path()

/Users/christian/Documents/Eclipse/projects/mne-python/mne/utils.py in dec(*args, **kwargs)
    358             return ret
    359         else:
--> 360             return function(*args, **kwargs)
    361 
    362     # set __wrapped__ attribute so ?? in IPython gets the right source

/Users/christian/Documents/Eclipse/projects/mne-python/mne/datasets/spm_face/spm_data.pyc in data_path(path, force_update, update_path, download, verbose)
     17                       update_path=update_path, name='spm',
     18                       download=download,
---> 19                       verbose=verbose)
     20 
     21 data_path.__doc__ = _doc.format(name='spm',

/Users/christian/Documents/Eclipse/projects/mne-python/mne/datasets/utils.py in _data_path(path, force_update, update_path, download, name, verbose)
    125                                   'location %r.' % archive_name)
    126 
--> 127             _fetch_file(url, archive_name, print_destination=False)
    128 
    129         if op.exists(folder_path):

/Users/christian/Documents/Eclipse/projects/mne-python/mne/utils.py in _fetch_file(url, file_name, print_destination, resume)
   1086                 _chunk_read_ftp_resume(url, temp_file_name, local_file)
   1087         else:
-> 1088             local_file = open(temp_file_name, "wb")
   1089             data = urllib2.urlopen(url)
   1090             _chunk_read(data, local_file, initial_size=initial_size)

IOError: [Errno 2] No such file or directory: '/Users/christian/Documents/Eclipse/projects/mne-python/mne/examples/MNE-spm-face.tar.bz2.part'

```
