### PR TITLE
Viz minor bug fix and some docs fixes.

### DIFF
--- a/examples/time_frequency/plot_single_trial_spectra.py
+++ b/examples/time_frequency/plot_single_trial_spectra.py
@@ -70,7 +70,7 @@ ax2.set_title('averaged over trials', fontsize=10)
 ax2.imshow(average_psds[:, freq_mask].T, aspect='auto', origin='lower')
 ax2.set_xticks(np.arange(0, len(picks), 30))
 ax2.set_xticklabels(picks[::30])
-ax2.set_xlabel('MEG channel index (Gradiomemters)')
+ax2.set_xlabel('MEG channel index (Gradiometers)')
 
 mne.viz.tight_layout()
 plt.show()

--- a/mne/commands/mne_bti2fiff.py
+++ b/mne/commands/mne_bti2fiff.py
@@ -2,7 +2,7 @@
 """
 Import BTi / 4D MagnesWH3600 data to fif file.
 
-example usage: mne bti2fiff -pdf C,rfDC -o my_raw.fif
+example usage: mne bti2fiff --pdf C,rfDC -o my_raw.fif
 
 Note.
 1) Currently direct inclusion of reference channel weights

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -558,7 +558,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude=None,
     """Regularize noise covariance matrix
 
     This method works by adding a constant to the diagonal for each
-    channel type separatly. Special care is taken to keep the
+    channel type separately. Special care is taken to keep the
     rank of the data constant.
 
     Parameters

--- a/mne/fiff/raw.py
+++ b/mne/fiff/raw.py
@@ -1067,7 +1067,7 @@ class Raw(ProjMixin):
             'original' plots in the order of ch_names, array gives the
             indices to use in plotting.
         show_options : bool
-            If True, a dialog for options related to projecion is shown.
+            If True, a dialog for options related to projection is shown.
         title : str | None
             The title of the window. If None, and either the filename of the
             raw object or '<unknown>' will be displayed as title.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1621,7 +1621,7 @@ def run_ica(raw, n_components, max_pca_components=100,
     - It is highly recommended to bandpass filter ECG and EOG
     data and pass them instead of the channel names as ecg_ch and eog_ch
     arguments.
-    - please check your results. Detection by kurtosis and variance
+    - Please check your results. Detection by kurtosis and variance
     can be powerful but misclassification of brain signals as
     noise cannot be precluded. If you are not sure set those to None.
     - Consider using shorter times for start_find and stop_find than
@@ -1630,7 +1630,7 @@ def run_ica(raw, n_components, max_pca_components=100,
     Example invocation (taking advantage of defaults):
 
     ica = run_ica(raw, n_components=.9, start_find=10000, stop_find=12000,
-                  ecg_channel='MEG 1531', eog_channel='EOG 061')
+                  ecg_ch='MEG 1531', eog_ch='EOG 061')
 
     Parameters
     ----------

--- a/mne/viz.py
+++ b/mne/viz.py
@@ -3209,6 +3209,8 @@ def _epochs_axes_onclick(event, params):
     """Aux function"""
     reject_color = (0.8, 0.8, 0.8)
     ax = event.inaxes
+    if event.inaxes is None:
+        return
     p = params
     here = vars(ax)[p['axes_handler'][0]]
     if here.get('reject', None) is False:


### PR DESCRIPTION
Minor bug that can be reproduced when running example plot_from_raw_to_epochs_to_evoked.py 

When clicking outside axis on the plot with all the epochs- 

```
  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_qt4.py", line 169, in mousePressEvent
    FigureCanvasBase.button_press_event( self, x, y, button )
  File "/usr/lib/pymodules/python2.7/matplotlib/backend_bases.py", line 1632, in button_press_event
    self.callbacks.process(s, mouseevent)
  File "/usr/lib/pymodules/python2.7/matplotlib/cbook.py", line 262, in process
    proxy(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/matplotlib/cbook.py", line 192, in __call__
    return mtd(*args, **kwargs)
  File "/home/prav/mne/mne-python/mne/viz.py", line 3250, in _epochs_axes_onclick
    here = vars(ax)[p['axes_handler'][0]]
TypeError: vars() argument must have __dict__ attribute
```

And some other small doc fixes. 
