### PR TITLE
FIX: Throw exception if >2GB

### DIFF
--- a/mne/fiff/raw.py
+++ b/mne/fiff/raw.py
@@ -1954,6 +1954,12 @@ def write_raw_buffer(fid, buf, cals, format, inv_comp):
 
     write_function(fid, FIFF.FIFF_DATA_BUFFER, buf)
 
+    # make sure we didn't go over the 2GB file size limit
+    pos = fid.tell()
+    if pos >= 2147483647:  # np.iinfo(np.int32).max
+        raise IOError('2GB file size limit reached. Support for larger '
+                      'raw files will be added in the future.')
+
 
 def finish_writing_raw(fid):
     """Finish writing raw FIF file


### PR DESCRIPTION
Addresses #923. I didn't add a test because I didn't want to write a 2GB file in the test suite.. a simple test is this:

```
import mne
from mne.datasets import sample

data_path = sample.data_path()

raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'

raws = [mne.fiff.Raw(raw_fname) for ii in range(20)]

comb_raw = raws[0]
comb_raw.append(raws[1:])

tmp_dir = '/local_mount/space/megmix/2/users/mluessi/temp'
comb_raw.save(tmp_dir + '/test_raw.fif', overwrite=True)
```

it would be great if someone else who is using a non-Linux platform (Mac, Win?) could also check if it throws an error  when the file size reaches 2GB.
