### PR TITLE
ENH: return individual figures in plot_cov

### DIFF
--- a/examples/plot_estimate_covariance_matrix_raw.py
+++ b/examples/plot_estimate_covariance_matrix_raw.py
@@ -34,5 +34,5 @@ print cov
 
 ###############################################################################
 # Show covariance
-mne.viz.plot_cov(cov, raw.info, colorbar=True, proj=True)
+fig_cov, fig_svd = mne.viz.plot_cov(cov, raw.info, colorbar=True, proj=True)
 # try setting proj to False to see the effect


### PR DESCRIPTION
I'd like to be able to access the cov figures individually without applying matplotlib tricks. ....

Second part ...
