### PR TITLE
FIX: Fix np.fromfile bug better

### DIFF
--- a/mne/fiff/kit/coreg.py
+++ b/mne/fiff/kit/coreg.py
@@ -34,7 +34,7 @@ def read_mrk(fname):
     """
     ext = os.path.splitext(fname)[-1]
     if ext in ('.sqd', '.mrk'):
-        with open(fname, 'rb+') as fid:
+        with open(fname, 'rb', buffering=0) as fid:
             fid.seek(KIT.MRK_INFO)
             mrk_offset = unpack('i', fid.read(KIT.INT))[0]
             fid.seek(mrk_offset)

--- a/mne/fiff/kit/kit.py
+++ b/mne/fiff/kit/kit.py
@@ -323,7 +323,7 @@ class RawKIT(Raw):
                     (start, stop - 1, start / float(self.info['sfreq']),
                      (stop - 1) / float(self.info['sfreq'])))
 
-        with open(self._sqd_params['fname'], 'rb+') as fid:
+        with open(self._sqd_params['fname'], 'rb', buffering=0) as fid:
             # extract data
             fid.seek(KIT.DATA_OFFSET)
             # data offset info
@@ -528,7 +528,7 @@ def get_sqd_params(rawfile):
     """
     sqd = dict()
     sqd['rawfile'] = rawfile
-    with open(rawfile, 'rb+') as fid:
+    with open(rawfile, 'rb', buffering=0) as fid:  # buffering=0 for np bug
         fid.seek(KIT.BASIC_INFO)
         basic_offset = unpack('i', fid.read(KIT.INT))[0]
         fid.seek(basic_offset)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -133,28 +133,25 @@ def _read_w(filename):
            data           The data matrix (nvert long)
     """
 
-    fid = open(filename, 'rb+')
+    with open(filename, 'rb', buffering=0) as fid:  # buffering=0 for np bug
+        # skip first 2 bytes
+        fid.read(2)
 
-    # skip first 2 bytes
-    fid.read(2)
+        # read number of vertices/sources (3 byte integer)
+        vertices_n = int(_read_3(fid))
 
-    # read number of vertices/sources (3 byte integer)
-    vertices_n = int(_read_3(fid))
+        vertices = np.zeros((vertices_n), dtype=np.int32)
+        data = np.zeros((vertices_n), dtype=np.float32)
 
-    vertices = np.zeros((vertices_n), dtype=np.int32)
-    data = np.zeros((vertices_n), dtype=np.float32)
+        # read the vertices and data
+        for i in range(vertices_n):
+            vertices[i] = _read_3(fid)
+            data[i] = np.fromfile(fid, dtype='>f4', count=1)[0]
 
-    # read the vertices and data
-    for i in range(vertices_n):
-        vertices[i] = _read_3(fid)
-        data[i] = np.fromfile(fid, dtype='>f4', count=1)[0]
+        w = dict()
+        w['vertices'] = vertices
+        w['data'] = data
 
-    w = dict()
-    w['vertices'] = vertices
-    w['data'] = data
-
-    # close the file
-    fid.close()
     return w
 
 

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -562,7 +562,7 @@ def read_surface(fname, verbose=None):
         Triangulation (each line contains indexes for three points which
         together form a face).
     """
-    with open(fname, "rb+") as fobj:  # plus necessary for Py3k here
+    with open(fname, "rb", buffering=0) as fobj:  # buffering=0 for np bug
         magic = _fread3(fobj)
         if (magic == 16777215) or (magic == 16777213):  # Quad file or new quad
             nvert = _fread3(fobj)


### PR DESCRIPTION
Let's just make sure Travis is happy. There is a bug with `np` that shows up on some systems, on some versions of Python, where `np.fromfile` incorrectly advances the file pointer. I saw this happen on Windows (Python2.7) last year, and never fixed it because I couldn't track down the issue. I've now been seeing it on Python3.3 under Linux. Changing `rb` to `rb+` worked, but this is less clean than just setting `buffering=0` and leaving mode as `rb` (which is what this PR does).
