### PR TITLE
Evoked: Verify comment is not None when checking its length

### DIFF
--- a/mne/fiff/evoked.py
+++ b/mne/fiff/evoked.py
@@ -747,7 +747,7 @@ def write_evoked(fname, evoked):
         start_block(fid, FIFF.FIFFB_EVOKED)
 
         # Comment is optional
-        if len(e.comment) > 0:
+        if e.comment is not None and len(e.comment) > 0:
             write_string(fid, FIFF.FIFF_COMMENT, e.comment)
 
         # First and last sample


### PR DESCRIPTION
Fixing https://github.com/mne-tools/mne-python/issues/987#issuecomment-30600109
