### PR TITLE
Clarify procedure that finds layout

### DIFF
--- a/mne/fiff/evoked.py
+++ b/mne/fiff/evoked.py
@@ -410,9 +410,11 @@ class Evoked(ProjMixin):
         ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg'
             The channel type to plot. For 'grad', the gradiometers are collec-
             ted in pairs and the RMS for each pair is plotted.
-        layout : None | str | Layout
-            Layout name or instance specifying sensor positions (does not need
-            to be specified for Neuromag data).
+        layout : None | Layout
+            Layout instance specifying sensor positions (does not need to
+            be specified for Neuromag data). If possible, the correct layout file
+            is inferred from the data; if no appropriate layout file was found, the
+            layout is automatically generated from the sensor locations.
         vmax : scalar
             The value specfying the range of the color scale (-vmax to +vmax).
             If None, the largest absolute value in the data is used.

--- a/mne/viz.py
+++ b/mne/viz.py
@@ -750,8 +750,9 @@ def plot_evoked_topomap(evoked, times=None, ch_type='mag', layout=None,
         pairs and the RMS for each pair is plotted.
     layout : None | Layout
         Layout instance specifying sensor positions (does not need to
-        be specified for Neuromag data). If possible, the correct layout is
-        inferred from the data.
+        be specified for Neuromag data). If possible, the correct layout file
+        is inferred from the data; if no appropriate layout file was found, the
+        layout is automatically generated from the sensor locations.
     vmax : scalar
         The value specfying the range of the color scale (-vmax to +vmax). If
         None, the largest absolute value in the data is used.


### PR DESCRIPTION
Explain how layout is generated, following https://github.com/mne-tools/mne-python/issues/994

I realized that part of the confusion stems from the fact that there are two different docstrings for the method in Evoked and for the top-level function in viz.py, and the two can get out of sync (the latter is probably updated more often). One way to fix this would be:

```
Evoked.plot_topomap.__func__.__doc__ = viz.plot_evoked_topomap.__doc__
```

tbh I'm not sure what viz.plot_evoked_topomap is useful for but that's a separate issue ;)
