### PR TITLE
WIP: runtime error if layout not found (not mergeable) 

### DIFF
--- a/mne/layouts/layout.py
+++ b/mne/layouts/layout.py
@@ -385,7 +385,7 @@ def find_layout(info=None, ch_type=None, chs=None):
     elif has_CTF_grad:
         layout_name = 'CTF-275'
     else:
-        return None
+        raise RuntimeError('Could not find an appropriate layout.')
 
     layout = read_layout(layout_name)
     if not is_old_vv:


### PR DESCRIPTION
This breaks one of the existing tests in a way that I don't understand. I think part of the problem is that layout=None has two meanings ("Neuromag of any kind" and "unknown layout"), but I'm a little out of my depth here. Perhaps whoever wrote this code could pitch in?
