### PR TITLE
Fix docstring for Layout class

### DIFF
--- a/mne/layouts/layout.py
+++ b/mne/layouts/layout.py
@@ -20,16 +20,10 @@ from ..externals.six.moves import zip
 class Layout(object):
     """Sensor layouts
 
-    Parameters
-    ----------
-    kind : str
-        Type of layout (can also be custom for EEG). Valid layouts are
-        {'Vectorview-all', 'Vectorview-grad', 'Vectorview-mag',  'CTF-275',
-         'magnesWH3600'}
-    path : string
-        Path to folder where to find the layout file.
+    Layouts are typically loaded from a file using read_layout. Only use this
+    class directly if you're constructing a new layout.
 
-    Attributes
+    Parameters
     ----------
     box : tuple of length 4
         The box dimension (x_min, x_max, y_min, y_max)


### PR DESCRIPTION
Current docstring seems to refer to old version of this class, changed it make it more up to date.

(Commit rebased on master.)
