### PR TITLE
Travis test case without optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ install:
     - sudo apt-get update -qq
     - sudo apt-get install $PYTHON-dev $PYTHON-numpy $PYTHON-scipy
     - sudo apt-get install $PYTHON-setuptools $PYTHON-nose
-    - sudo apt-get update -qq
     - sudo $EASY_INSTALL pip
     - if [ "${DEPS}" == "full" ]; then
         sudo apt-key adv --recv-keys --keyserver pgp.mit.edu 2649A5A9;
         wget -O- http://neuro.debian.net/lists/precise.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list;
+        sudo apt-get update -qq;
         sudo $PIP install nibabel;
         sudo $PIP install scikit-learn;
         sudo $PIP install patsy;


### PR DESCRIPTION
- Patsy and statsmodels are now installed
- Pandas installed using pip rather than apt-get (need more recent
  version for statsmodels)

I think I'm done here.

(re https://github.com/mne-tools/mne-python/issues/1023)
