### PR TITLE
FIX: python3 + additional ica fixes

### DIFF
--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -405,6 +405,7 @@ def test_ica_additional():
 
     # test float n pca components
     ica.pca_explained_variance_ = np.array([0.2] * 5)
+    ica.n_components_ = 0
     for ncomps, expected in [[0.3, 1], [0.9, 4], [1, 1]]:
         ncomps_ = _check_n_pca_components(ica, ncomps)
         assert_true(ncomps_ == expected)


### PR DESCRIPTION
examples were broken in Python 3
also the recent fix of explained variance broke the epochs example.
