### PR TITLE
Check that inv['orient_prior'] is not None

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -636,7 +636,8 @@ def _assemble_kernel(inv, label, method, pick_ori, verbose=None):
             raise ValueError('Picking normal orientation can only be done '
                              'with a free orientation inverse operator.')
 
-        is_loose = 0 < inv['orient_prior']['data'][0] < 1
+        is_loose = (inv['orient_prior'] is not None and 
+                    0 < inv['orient_prior']['data'][0] < 1)
         if not is_loose:
             raise ValueError('Picking normal orientation can only be done '
                              'when working with loose orientations.')


### PR DESCRIPTION
This line failed on my inverse operator:

```python
/Users/tallinzen/Dropbox/mne-python/mne/minimum_norm/inverse.pyc in _assemble_kernel(inv, label, method, pick_ori, verbose)
    637                              'with a free orientation inverse operator.')
    638 
--> 639         is_loose = 0 < inv['orient_prior']['data'][0] < 1
    640         if not is_loose:
    641             raise ValueError('Picking normal orientation can only be done '

TypeError: 'NoneType' object has no attribute '__getitem__' 
```

by the way the two error messages around this line seem contradictory -- I think in the manual "free orientation" and "loose orientation" are mutually exclusive. but anyway it seems that only the second error message is necessary (though the first check still needs to be done)