### PR TITLE
FIX: Disallow discrete source space with interpolation

### DIFF
--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -973,7 +973,8 @@ def setup_volume_source_space(subject, fname=None, pos=5.0, mri=None,
         with the spacing given by `pos` in mm, generating a volume source
         space. If dict, pos['rr'] and pos['nn'] will be used as the source
         space locations (in meters) and normals, respectively, creating a
-        discrete source space.
+        discrete source space. NOTE: For a discrete source space (`pos` is
+        a dict), `mri` must be None.
     mri : str | None
         The filename of an MRI volume (mgh or mgz) to create the
         interpolation matrix over. Source estimates obtained in the
@@ -1063,6 +1064,10 @@ def setup_volume_source_space(subject, fname=None, pos=5.0, mri=None,
         if not all([key in pos for key in ['rr', 'nn']]):
             raise KeyError('pos, if dict, must contain "rr" and "nn"')
         pos_extra = 'dict()'
+        if mri is not None:
+            raise ValueError('Cannot create interpolation matrix for '
+                             'discrete source space, mri must be None if '
+                             'pos is a dict')
     else:  # pos should be float-like
         try:
             pos = float(pos)

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -143,7 +143,8 @@ def test_discrete_source_space():
         _compare_source_spaces(src_c, src_c2)
 
         # now do MRI
-        setup_volume_source_space('sample', pos=pos_dict, mri=fname_mri)
+        assert_raises(ValueError, setup_volume_source_space, 'sample',
+                      pos=pos_dict, mri=fname_mri)
     finally:
         if op.isfile(temp_name):
             os.remove(temp_name)


### PR DESCRIPTION
Changes to match those implemented by Matti in the C code, namely disallowing MRI interpolation for discrete source spaces. In principle I think it should be possible, but it hasn't been implemented yet.
