### PR TITLE
FIX: doc image width < 850

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -570,6 +570,27 @@ def make_thumbnail(in_fname, out_fname, width, height):
     thumb.save(out_fname)
 
 
+def scale_image(in_fname, max_width):
+    """Scale image such that width <= max_width
+    """
+    img = Image.open(in_fname)
+    width_in, height_in = img.size
+
+    if width_in <= max_width:
+        return
+
+    scale = max_width / float(width_in)
+
+    width_sc = int(round(scale * width_in))
+    height_sc = int(round(scale * height_in))
+
+    # resize the image
+    img.thumbnail((width_sc, height_sc), Image.ANTIALIAS)
+
+    # overwrite the image
+    img.save(in_fname)
+
+
 def get_short_module_name(module_name, obj_name):
     """ Get the shortest possible module name """
     parts = module_name.split('.')
@@ -764,6 +785,9 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
                         plt.savefig(image_path % fig_num, facecolor='black')
                     else:
                         plt.savefig(image_path % fig_num)
+
+                    # make sure the image is not too large
+                    scale_image(image_path % fig_num, 850)
                     figure_list.append(image_fname % fig_num)
                     last_fig_num = fig_num
 
@@ -771,6 +795,8 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
                 for scene in e.scenes:
                     last_fig_num += 1
                     mlab.savefig(image_path % last_fig_num)
+                    # make sure the image is not too large
+                    scale_image(image_path % last_fig_num, 850)
                     figure_list.append(image_fname % last_fig_num)
                     mlab.close(scene)
 


### PR DESCRIPTION
Limits the width of images in the doc. So we don't have ugly pages like e.g. this one:

http://martinos.org/mne/dev/auto_examples/plot_read_and_write_raw_data.html
