### PR TITLE
FIX: don't call _data_path on import

### DIFF
--- a/mne/datasets/sample/sample.py
+++ b/mne/datasets/sample/sample.py
@@ -6,7 +6,12 @@
 import numpy as np
 
 from ...utils import get_config, verbose
+from ...fixes import partial
 from ..utils import has_dataset, _data_path, _doc
+
+
+has_sample_data = partial(has_dataset, name='sample')
+
 
 @verbose
 def data_path(path=None, force_update=False, update_path=True,
@@ -21,8 +26,10 @@ data_path.__doc__ = _doc.format(name='sample',
 
 # Allow forcing of sample dataset skip (for tests) using:
 # `make test-no-sample`
-has_sample_data = has_dataset('sample')
-skip_sample = get_config('MNE_SKIP_SAMPLE_DATASET_TESTS', 'false') == 'true'
-requires_sample_data = np.testing.dec.skipif(not has_dataset('sample')
-                                             or skip_sample,
+def _skip_sample_data():
+    skip_sample = get_config('MNE_SKIP_SAMPLE_DATASET_TESTS', 'false') == 'true'
+    skip = skip_sample or not has_sample_data()
+    return skip
+
+requires_sample_data = np.testing.dec.skipif(_skip_sample_data,
                                              'Requires sample dataset')

--- a/mne/datasets/spm_face/spm_data.py
+++ b/mne/datasets/spm_face/spm_data.py
@@ -8,7 +8,9 @@ from ...utils import get_config, verbose
 from ...fixes import partial
 from ..utils import has_dataset, _data_path, _doc
 
+
 has_spm_data = partial(has_dataset, name='spm')
+
 
 @verbose
 def data_path(path=None, force_update=False, update_path=True,
@@ -23,8 +25,10 @@ data_path.__doc__ = _doc.format(name='spm',
 
 # Allow forcing of sample dataset skip (for tests) using:
 # `make test-no-sample`
-skip_spm = get_config('MNE_SKIP_SPM_DATASET_TESTS', 'false') == 'true'
-has_spm_data = has_dataset('spm')
-requires_spm_data = np.testing.dec.skipif(not has_spm_data
-                                          or skip_spm,
+def _skip_spm_sample_data():
+    skip_spm = get_config('MNE_SKIP_SPM_DATASET_TESTS', 'false') == 'true'
+    skip = skip_spm or not has_spm_data()
+    return skip
+
+requires_spm_data = np.testing.dec.skipif(_skip_spm_sample_data,
                                           'Requires spm dataset')

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -104,7 +104,7 @@ def _data_path(path=None, force_update=False, update_path=True,
         return ''
 
     if not op.exists(folder_path) or force_update:
-        logger.info('Downloading or reinstalling data archive %s at location %s' % 
+        logger.info('Downloading or reinstalling data archive %s at location %s' %
                     (archive_name, path))
 
         if op.exists(martinos_path):
@@ -181,5 +181,5 @@ def has_dataset(name):
     """Helper for sample dataset presence"""
     endswith = {'sample': 'MNE-sample-data',
                 'spm': 'MNE-spm-face'}[name]
-    dp = _data_path(download=False, name=name, check_version=False) 
+    dp = _data_path(download=False, name=name, check_version=False)
     return dp.endswith(endswith)


### PR DESCRIPTION
This fixes the problem that `mne.datasets.utils._data_path` is called for all datasets when importing mne, which had several unwanted side effects:
- Whenever importing mne, warnings about outdated datasets are generated.
- When using mne on a machine where the dataset is missing, the config file would always be overwritten with the default dataset location.

The second point doesn't seem like a big deal, but it creates a number of other problems. In my setup, I have all the datasets in `/tmp/data` on my workstation (for the nightly doc-build so the long paths don't show up on the website). Whenever using mne on a different machine (which doesn't have the sample data), the config file would be overwritten. This can be bad when e.g. running things on a cluster and several jobs try to read/write the config file at the same time (this just happened to me, resulting in a number of strange JSON Errors).
