### PR TITLE
change find_events to accomodate neuromag bug

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -438,7 +438,7 @@ def _find_events(data, first_samp, verbose=None, output='onset',
 @verbose
 def find_events(raw, stim_channel=None, verbose=None, output='onset',
                 consecutive='increasing', min_duration=0, 
-                short_event_warn=1):
+                shortest_event=2):
     """Find events from raw file
 
     Parameters
@@ -464,13 +464,10 @@ def find_events(raw, stim_channel=None, verbose=None, output='onset',
         the first.
     min_duration : float
         The minimum duration of a change in the events channel required
-        to consider it as an event (in seconds). By default this value is set
-        to the equivalent of 2 samples.
-    short_event_warn : int
-        find_events will check to make sure there are no events shorter than
-        the number of samples this integer is set to (default is 1). If there 
-        are short events, it will issue a ValueError suggesting that you should
-        consider changing min_duration.
+        to consider it as an event (in seconds).
+    shortest_event : int
+        Minimum number of samples an event must last (default is 2). If the
+        duration is less than this an exception will be raised.
 
     Returns
     -------
@@ -554,13 +551,13 @@ def find_events(raw, stim_channel=None, verbose=None, output='onset',
                           
     # add safety check for spurious events (for ex. from neuromag syst.) by
     # checking the number of low sample events
-    n_single = np.sum(np.diff(events[:, 0]) == short_event_warn)
-    if ( n_single > 0 ):
-        raise ValueError(("You have %i events shorter than the "
+    n_short_events = np.sum(np.diff(events[:, 0]) < shortest_event)
+    if n_short_events > 0:
+        raise ValueError("You have %i events shorter than the "
                           "short_event_warn. These are very unusual and you "
                           "may want to set min_duration to a larger value e.g."
-                          " x / raw.info['sfreq']. Where x > shortest event "
-                          " length.") % (n_single))
+                          " x / raw.info['sfreq']. Where x = 1 sample shorter "
+                          "than the shortest event length." % (n_short_events))
 
     return events
 

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -3,7 +3,8 @@ import os
 
 from nose.tools import assert_true
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_raises)
 
 from mne import (read_events, write_events, make_fixed_length_events,
                  find_events, find_stim_steps, fiff)
@@ -157,7 +158,9 @@ def test_find_events():
                         [31, 0, 5],
                         [40, 0, 6],
                         [14399, 0, 9]])
-    assert_array_equal(find_events(raw, output='step', consecutive=True),
+    assert_raises(ValueError,find_events,raw, output='step', consecutive=True)
+    assert_array_equal(find_events(raw, output='step', consecutive=True,
+                                   shortest_event=1),
                        [[10, 0, 5],
                         [20, 5, 6],
                         [30, 6, 5],


### PR DESCRIPTION
I have changed the defaults for find_events. This sets the default min_duration to 2 samples. This is useful, because a common Neuromag system "bug" exists which can result in the first sample of an event having a value less than the true trigger value (due to the combined binary trigger numbers). e.g. a trigger of 17 can have one sample of 16 prior to the real trigger value of 17.
