### PR TITLE
DOC:  add TOC to Python Reference

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -12,6 +12,12 @@ are collected in a separate section. Functions and classes that are not below
 a module heading are found in the :py:mod:`mne` namespace.
 
 
+.. toctree::
+   :maxdepth: 2
+   
+   python_reference
+
+
 Classes
 =======
 


### PR DESCRIPTION
This would add a TOC to the top of the reference section to make the different subsections more accessible (see https://dl.dropboxusercontent.com/u/659990/mne-python/html/python_reference.html). I couldn't find a way to turn off the top-most "Reference" heading, but maybe there is a way?
