### PR TITLE
Allow wget to continue download of a partially downloaded file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ sample_data: $(CURDIR)/examples/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
 	@echo "Target needs sample data"
 
 $(CURDIR)/examples/MNE-sample-data/MEG/sample/sample_audvis_raw.fif:
-	wget ftp://surfer.nmr.mgh.harvard.edu/pub/data/MNE-sample-data-processed.tar.gz
+	wget -c ftp://surfer.nmr.mgh.harvard.edu/pub/data/MNE-sample-data-processed.tar.gz
 	tar xvzf MNE-sample-data-processed.tar.gz
 	mv MNE-sample-data examples/
 	ln -sf ${PWD}/examples/MNE-sample-data ${PWD}/MNE-sample-data


### PR DESCRIPTION
If `make` is interrupted, wget should be able to continue download from the partially downloaded file.
If the 1.4G file download is interrupted at 1G(which happened in my case), the make script tends to download everything all over again, slowing down the whole process.
