### PR TITLE
FIX kit2fiff marker GUI:  resetting

### DIFF
--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -262,8 +262,7 @@ class Kit2FiffModel(HasPrivateTraits):
 
     def clear_all(self):
         """Clear all specified input parameters"""
-        self.markers.mrk1.clear = True
-        self.markers.mrk2.clear = True
+        self.markers.clear = True
         self.reset_traits(['sqd_file', 'hsp_file', 'fid_file'])
 
     def get_event_info(self):

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -186,7 +186,7 @@ class MarkerPointSource(MarkerPoints):
             self.points = pts
 
     def _clear_fired(self):
-        self.reset_traits(['file', 'points'])
+        self.reset_traits(['file', 'points', 'use'])
 
     def _edit_fired(self):
         self.edit_traits(view=mrk_view_edit)
@@ -312,8 +312,15 @@ class CombineMarkersModel(HasPrivateTraits):
     mrk2 = Instance(MarkerPointSource)
     mrk3 = Instance(MarkerPointDest)
 
+    clear = Button(desc="Clear the current marker data")
+
     # stats
     distance = Property(Str, depends_on=['mrk1.points', 'mrk2.points'])
+
+    def _clear_fired(self):
+        self.mrk1.clear = True
+        self.mrk2.clear = True
+        self.mrk3.reset_traits(['method'])
 
     def _mrk1_default(self):
         mrk = MarkerPointSource()

--- a/mne/gui/tests/test_marker_gui.py
+++ b/mne/gui/tests/test_marker_gui.py
@@ -26,22 +26,45 @@ def test_combine_markers_model():
     from mne.gui._marker_gui import CombineMarkersModel
 
     model = CombineMarkersModel()
+
+    # set one marker file
     assert_false(model.mrk3.can_save)
     model.mrk1.file = mrk_pre_path
     assert_true(model.mrk3.can_save)
-    assert_array_equal(model.mrk1.points, model.mrk3.points)
+    assert_array_equal(model.mrk3.points, model.mrk1.points)
 
+    # setting second marker file
     model.mrk2.file = mrk_pre_path
-    assert_array_equal(model.mrk1.points, model.mrk3.points)
+    assert_array_equal(model.mrk3.points, model.mrk1.points)
 
-    model.mrk2._clear_fired()
+    # set second marker
+    model.mrk2.clear = True
     model.mrk2.file = mrk_post_path
     assert_true(np.any(model.mrk3.points))
+    points_interpolate_mrk1_mrk2 = model.mrk3.points
 
+    # change interpolation method
     model.mrk3.method = 'Average'
     mrk_avg = read_mrk(mrk_avg_path)
     assert_array_equal(model.mrk3.points, mrk_avg)
 
+    # clear second marker
+    model.mrk2.clear = True
+    assert_array_equal(model.mrk1.points, model.mrk3.points)
+
+    # I/O
+    model.mrk2.file = mrk_post_path
     model.mrk3.save(tgt_fname)
     mrk_io = read_mrk(tgt_fname)
     assert_array_equal(mrk_io, model.mrk3.points)
+
+    # exlude an individual marker
+    model.mrk1.use = [1, 2, 3, 4]
+    assert_array_equal(model.mrk3.points[0], model.mrk2.points[0])
+    assert_array_equal(model.mrk3.points[1:], mrk_avg[1:])
+
+    # reset model
+    model.clear = True
+    model.mrk1.file = mrk_pre_path
+    model.mrk2.file = mrk_post_path
+    assert_array_equal(model.mrk3.points, points_interpolate_mrk1_mrk2)


### PR DESCRIPTION
Minor fix affecting only Kit2fiff conversion through the GUI: when resetting through the button also reset marker `use` parameter (& add a test covering that problem)
