### PR TITLE
ENH: add GSOC info

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,3 +1,11 @@
+=====================
+Google summer of code
+=====================
+
+For the Google Summer of Code 2014 (GSOC) we are looking for two ambitious students with strong Python skills and a background and / or interest in brain imaging research. If you feel addressed or happen to know someone who might be interested please get in touch with us or forward this message to her / him. Here are our our [GSOC projects](http://goo.gl/4KkmRC)
+[Registration](http://goo.gl/KMPQRf) opens on March 10, 2014, 7 p.m. UTC. 
+
+
 ========
 MNE Home
 ========


### PR DESCRIPTION
make it more visible and avoid sharing uniformative links via FB.
