### PR TITLE
Make sure we can load epochs saved in 0.7.1

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1856,6 +1856,12 @@ def read_epochs(fname, proj=True, add_eeg_ref=True, verbose=None):
     epochs.event_id = (dict((str(e), e) for e in np.unique(events[:, 2]))
                        if mappings is None else mappings)
     epochs.verbose = verbose
+
+    # In case epochs didn't have a FIFF.FIFFB_MNE_EPOCHS_SELECTION tag
+    # (version < 0.8):
+    if selection is None:
+        selection = range(len(epochs))
+
     epochs.selection = selection
     epochs.drop_log = drop_log
     fid.close()


### PR DESCRIPTION
The default for the selection attribute was None when the FIFF file doesn't have it (i.e. files saved in older versions). It then breaks when you try to subset the epochs. Changed the default to `range(len(epochs))` and added a test file saved using 0.7.1
