### PR TITLE
A possible solution to #1183

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -84,7 +84,7 @@ def _data_path(path=None, force_update=False, update_path=True,
 
     if name == 'sample':
         archive_name = "MNE-sample-data-processed.tar.gz"
-        url = "ftp://surfer.nmr.mgh.harvard.edu/pub/data/" + archive_name
+        url = "ftp://surfer.nmr.mgh.harvard.edu/pub/data/MNE/" + archive_name
         folder_name = "MNE-sample-data"
         folder_path = op.join(path, folder_name)
         rm_archive = False


### PR DESCRIPTION
In  utils.py:_data_path() had url which was pointing to MNE-sample-data-processed.tar.gz which was of 0 Byte. New location of MNE-sample-data-processed.tar.gz is ftp://surfer.nmr.mgh.harvard.edu/pub/data/MNE/. I made these changes in url.
