### PR TITLE
Storing MNE sample data in local directory and including error handling ...

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -81,10 +81,16 @@ def _data_path(path=None, force_update=False, update_path=True,
             except OSError:
                 try:
                     logger.info("Trying to create "
-                                "'MNE/' in home directory")
+                                "'MNE/mne_data' in home directory")
                     def_path = op.join(op.expanduser("~"), "MNE")
                     if not op.exists(def_path):
                         os.mkdir(def_path)
+                        def_path = op.join(def_path, "mne_data")
+                        os.mkdir(def_path)
+                    else:
+                        def_path = op.join(def_path, "mne_data")
+                        if not op.exists(def_path):
+                            os.mkdir(def_path)
                 except OSError:
                     raise OSError("User doesn't have write permission "
                                   "at '%s', try giving a path as an argument "


### PR DESCRIPTION
1)Instead of storing the data in a place where there are permission issue's, sample data can be stored in local folder as mentioned by @dengemann. This is implemented using `op.expanduser("~")` which work in windows and posix system. Data will be stored in ``"~/MNE/examples"`. 
2)Error handling is also included to take into consideration the cases where user doesn't have write permission(not sure when that case will arise!).@dgwakeman
