### PR TITLE
WIP scale_source_space():  add support for vol source spaces

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1101,7 +1101,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
         spacing = src_name  # spacing in mm
         src_pattern = src_fname
     else:
-        match = re.match("(oct|ico)-?(\d+)$", src_name)
+        match = re.match("(oct|ico|vol)-?(\d+)$", src_name)
         if match:
             spacing = '-'.join(match.groups())
             src_pattern = src_fname

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy import dot
 from scipy.optimize import leastsq
 from scipy.spatial.distance import cdist
-from scipy.linalg import norm
+from scipy.linalg import norm, inv
 
 from .fiff.meas_info import read_fiducials, write_fiducials
 from .label import read_label, Label
@@ -1095,6 +1095,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
                                                                 subject_from,
                                                                 scale,
                                                                 subjects_dir)
+    # if n_params==1 scale is a scalar; if n_params==3 scale is a (3,) array
 
     # find the source space file names
     if src_name.isdigit():
@@ -1139,6 +1140,10 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
                 ss['dist'] *= scale
                 ss['nearest_dist'] *= scale
                 ss['dist_limit'] *= scale
+            # additional tags for volume source spaces
+            if 'vox_mri_t' in ss:
+                ss['vox_mri_t']['trans'][:3] *= scale
+                ss['src_mri_t']['trans'][:3] *= scale
         else:
             nn = ss['nn']
             nn *= norm_scale
@@ -1146,6 +1151,13 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
             nn /= norm[:, np.newaxis]
             if ss['dist'] is not None:
                 add_dist = True
+            # additional tags for volume source spaces
+            if 'vox_mri_t' in ss:
+                trans = scaling(*scale)
+                ss['vox_mri_t']['trans'] = np.dot(trans,
+                                                  ss['vox_mri_t']['trans'])
+                ss['src_mri_t']['trans'] = np.dot(trans,
+                                                  ss['src_mri_t']['trans'])
 
     if add_dist:
         logger.info("Recomputing distances, this might take a while")


### PR DESCRIPTION
Trying to adapt scale_source_space to handle volume source spaces. As far as I can tell the additional source space entries that need scaling are: 

* vox_mri_t
* src_mri_t
* interpolator

What exactly is the interpolator/how does it need to be scaled?

[Edit: sorry I confused the from/to tags. Is it intended that both transformation matrices have the same `from` tag even though they are different transformations?]

```py
>>> pprint(vsrc['src_mri_t'])
{'from': 2001,
 'to': 5,
 'trans': array([[ 0.01,  0.  ,  0.  , -0.08],
       [ 0.  ,  0.01,  0.  , -0.12],
       [ 0.  ,  0.  ,  0.01, -0.08],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])}
>>> pprint(vsrc['vox_mri_t'])
{'from': 2001,
 'to': 5,
 'trans': array([[-0.001     ,  0.        ,  0.        ,  0.12800001],
       [ 0.        ,  0.        ,  0.001     , -0.12800001],
       [ 0.        , -0.001     ,  0.        ,  0.12800001],
       [ 0.        ,  0.        ,  0.        ,  1.        ]])}
```

The `setup_volume_source_space()` documentation was not clear to me as to which MRI should be provided. I just used `orig.mgz`, is that right? (@mluessi?)