### PR TITLE
minor enh: remove axes border from connectivity circle display

### DIFF
--- a/mne/viz.py
+++ b/mne/viz.py
@@ -2480,6 +2480,9 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     # Set y axes limit, add additonal space if requested
     plt.ylim(0, 10 + padding)
 
+    # Remove the black axes border which may obscure the labels
+    axes.spines['polar'].set_visible(False)
+
     # Draw lines between connected nodes, only draw the strongest connections
     if n_lines is not None and len(con) > n_lines:
         con_thresh = np.sort(np.abs(con).ravel())[-n_lines]


### PR DESCRIPTION
When the background color for the circle plot is not black, the axes border is displayed in the figure and can obscure the labels. This PR simply removes the axes border.
![matplotlib_axes](https://cloud.githubusercontent.com/assets/605470/2616618/c526089e-bc08-11e3-8383-205cbc74e966.png)
