### PR TITLE
API/ENH: better handling of STI 014 synthesis for the EGI io

### DIFF
--- a/mne/fiff/egi/tests/test_egi.py
+++ b/mne/fiff/egi/tests/test_egi.py
@@ -23,7 +23,8 @@ egi_fname = op.join(base_dir, 'test_egi.raw')
 
 def test_io_egi():
     """Test importing EGI simple binary files"""
-    raw = read_raw_egi(egi_fname, include=['TRSP', 'XXX1'])
+    include = ['TRSP', 'XXX1']
+    raw = read_raw_egi(egi_fname, include=include)
 
     _ = repr(raw)
     _ = repr(raw.info)  # analysis:ignore, noqa
@@ -63,3 +64,6 @@ def test_io_egi():
                   include=['Foo'])
     assert_raises(ValueError, read_raw_egi, egi_fname,
                   exclude=['Bar'])
+    for ii, k in enumerate(include, 1):
+        assert_true(k in raw.event_id)
+        assert_true(raw.event_id[k] == ii)


### PR DESCRIPTION
This improves the success rate of STI 014 assembly on reading data. The problem is that on combining experiment related and machine related event codes like sync mutually non-exclusive events may emerge. This is now avoided by either directly selecting the relevant channels or by excluding the ones that e.g. only have one event or are clearly machine related such as `sync`.
To simplify the API I dropped the event_id parameter and added include / exclude parameters that allow to select the relevant channels.

cc @mluessi @fraimondo @sebastienmarti @agramfort 
