### PR TITLE
Fix doctest due to changes in Info (?)

### DIFF
--- a/doc/source/python_tutorial.rst
+++ b/doc/source/python_tutorial.rst
@@ -111,7 +111,7 @@ Read data from file:
     >>> print(raw)
     <Raw  |  n_channels x n_times : 376 x 41700>
     >>> print(raw.info) # doctest:+ELLIPSIS
-    <Info | 19 non-empty ...
+    <Info | 18 non-empty ...
 
 Look at the channels in raw:
 


### PR DESCRIPTION
I'm getting a doctest failure caused by `Info` no longer containing `filenames`, so there are 18 non-empty items instead of 19 we had previously, which causes a doctest failure in `python_tutorial.rst`. @Eric89GXL this change seems to be due to 

https://github.com/mne-tools/mne-python/commit/1a75d690b81d2f12398021a1ebc5fa33bfaa8a16#diff-877c1516babd7396e85b4525b5127203

was no longer merging `filenames` intentional?
