### PR TITLE
allow long (e.g. 10L) filter length

### DIFF
--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1364,7 +1364,7 @@ def _get_filter_length(filter_length, sfreq, min_length=128, len_x=np.inf):
                           % (filter_length, filter_length / float(sfreq)))
 
     if filter_length is not None:
-        if not isinstance(filter_length, int):
+        if not isinstance(filter_length, (int, long)):
             raise ValueError('filter_length must be str, int, or None')
     return filter_length
 


### PR DESCRIPTION
For some reason, I hit a case where `filter_length` had type `long` (e.g. `22034L`) and this `isinstance` test fails, so I included `long` as a valid length type. I can't imagine filter length should exceed `int` capacity, but it doesn't seem necessary to coerce.
