### PR TITLE
add buffer for BDF files

### DIFF
--- a/mne/io/edf/tests/__init__.py
+++ b/mne/io/edf/tests/__init__.py
@@ -1,8 +1,0 @@
-"""EDF,BDF tests"""
-
-# Author: Teon Brooks <teon@nyu.edu>
-#
-# License: BSD (3-clause)
-
-from .test_edf import (test_bdf_data, test_edf_data,
-                       test_read_segment, test_append)


### PR DESCRIPTION
This PR is to address a concern brought up on the mne listserv earlier this year. Since bdf files are stored as 24-bit, and numpy doesn't support this data format, this module currently copies the data twice for conversion. If you try to preload a bdf file, it may tax the computer memory given the size of the file. To alleviate this problem, I added a small subroutine that buffers the data in 10s increment to do the conversion. This should make loading these files easier.
