### PR TITLE
add local fdr correction

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -628,6 +628,7 @@ Statistics
 
    bonferroni_correction
    fdr_correction
+   local_fdr_correction
    permutation_cluster_test
    permutation_cluster_1samp_test
    permutation_t_test

--- a/examples/stats/plot_fdr_stats_evoked.py
+++ b/examples/stats/plot_fdr_stats_evoked.py
@@ -20,7 +20,8 @@ from scipy import stats
 import mne
 from mne import io
 from mne.datasets import sample
-from mne.stats import bonferroni_correction, fdr_correction
+from mne.stats import (bonferroni_correction, fdr_correction,
+                       local_fdr_correction)
 
 ###############################################################################
 # Set parameters
@@ -61,6 +62,11 @@ threshold_bonferroni = stats.t.ppf(1.0 - alpha / n_tests, n_samples - 1)
 reject_fdr, pval_fdr = fdr_correction(pval, alpha=alpha, method='indep')
 threshold_fdr = np.min(np.abs(T)[reject_fdr])
 
+X_ = X.reshape(-1)
+qvals = local_fdr_correction(X_)
+sort_xq = np.argsort(qvals)
+threshold_lfdr = np.interp(0.05, qvals[sort_xq], X_[sort_xq])
+
 ###############################################################################
 # Plot
 times = 1e3 * epochs.times
@@ -75,6 +81,8 @@ plt.hlines(threshold_bonferroni, xmin, xmax, linestyle='--', colors='r',
            label='p=0.05 (Bonferroni)', linewidth=2)
 plt.hlines(threshold_fdr, xmin, xmax, linestyle='--', colors='b',
            label='p=0.05 (FDR)', linewidth=2)
+plt.hlines(threshold_fdr, xmin, xmax, linestyle='--', colors='c',
+           label='q=0.05 (lFDR)', linewidth=2)
 plt.legend()
 plt.xlabel("Time (ms)")
 plt.ylabel("T-stat")

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -9,4 +9,5 @@ from .cluster_level import (permutation_cluster_test,
                             _st_mask_from_s_inds,
                             ttest_1samp_no_p,
                             summarize_clusters_stc)
-from .multi_comp import fdr_correction, bonferroni_correction
+from .multi_comp import (fdr_correction, bonferroni_correction,
+                         local_fdr_correction)

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -105,7 +105,8 @@ def bonferroni_correction(pval, alpha=0.05):
 
 
 def _local_fdr_h0_err(f, xb, par):
-    "Error function for H0 subdensity used in local FDR optimization"
+    """Error function for H0 subdensity used in local FDR optimization.
+    """
     mu, sigma, alo, ahi = par
     sl = slice(np.argmin(np.abs(xb - alo)), np.argmin(np.abs(xb - ahi)))
     if sl.start == sl.stop:
@@ -126,39 +127,26 @@ def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
     Parameters
     ----------
     n_bins : int
-        Number of points at which to evaluate the density
+        Number of points at which to evaluate the density.
     h0_maxtier : int
-        Max no of iteratios for H0 fit optimization
+        Max no of iteratios for H0 fit optimization.
     decimate : int
-        Factor by which to decimate data prior to density estimation
+        Factor by which to decimate data prior to density estimation.
 
     Returns
     -------
     xb : array
-        Points at which the densities are evaluated
+        Points at which the densities are evaluated.
     f : array
-        Density of `x`
+        Density of x.
     cf : array
-        Estimated "center density" of H0
+        Estimated "center density" of H0.
     fdr : array
-        Estimated false discovery rate
+        Estimated false discovery rate.
     mu : float
-        Mean of H0 distribution
+        Mean of H0 distribution.
     sig : float
-        Std of H0 distribution
-
-    Notes
-    -----
-
-    The use of a Gaussian in this implementation is not required, in fact, the
-    distribution to be fit does not even have to have an analytic PDF, rather
-    it is simply necessary to be able to compute a numerical density for the
-    H0.
-
-    Reference:
-    Efron B, Tibshirani R.
-    Empirical Bayes methods and false discovery rates for microarrays.
-    Genetic epidemiology 2002; 23(1): 70-86.
+        Std of H0 distribution.
     """
 
     x = data.reshape(-1)[::decimate]
@@ -197,32 +185,43 @@ def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
 
 
 def local_fdr_correction(data, n_bins=100, h0_maxiter=500, decimate=1):
-    """
-    Correction for multiple comparison based on local FDR.
+    """Correction for multiple comparison based on local FDR.
 
     Rather than working directly with the p-values, local FDR determines
     the FDR of each sample based on empirical and assumed H0 distributions,
     and thresholds on the sample's FDR value.
 
+    As with fdr_correction, this operates on the entire flattened array.
+
     Parameters
     ----------
-
     data : array_like
-        set of observations to test
+        Set of observations to test.
     n_bins : int
-        Number of points at which to evaluate the density
+        Number of points at which to evaluate the density.
     h0_maxtier : int
-        Max no of iteratios for H0 fit optimization
+        Max no of iteratios for H0 fit optimization.
     decimate : int
-        Factor by which to decimate data prior to density estimation
+        Factor by which to decimate data prior to density estimation.
 
 
     Returns
     -------
-
     qvals : array
-        Values of FDR for each element of data
+        Values of FDR for each element of data.
 
+    Notes
+    -----
+
+    The use of a Gaussian in this implementation is not required, in fact, the
+    distribution to be fit does not even have to have an analytic PDF, rather
+    it is simply necessary to be able to compute a numerical density for the
+    H0.
+
+    Reference:
+    Efron B, Tibshirani R.
+    Empirical Bayes methods and false discovery rates for microarrays.
+    Genetic epidemiology 2002; 23(1): 70-86.
     """
 
     xb, _, _, fdr, _, _ = _local_fdr(data, n_bins=n_bins,

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -208,7 +208,7 @@ def local_fdr_correction(data, n_bins=100, h0_maxiter=500, decimate=1):
 
     Returns
     -------
-    qvals : array, any shape
+    qvals : array, data.shape
         Values of FDR for each element of data.
 
     Notes

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -126,6 +126,8 @@ def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
 
     Parameters
     ----------
+    data : array, any shape
+        Set of observations on which to estimate FDR.
     n_bins : int
         Number of points at which to evaluate the density.
     h0_maxtier : int
@@ -135,13 +137,13 @@ def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
 
     Returns
     -------
-    xb : array
+    xb : array, (n_bins*2,)
         Points at which the densities are evaluated.
-    f : array
+    f : array, (n_bins*2,)
         Density of x.
-    cf : array
+    cf : array, (n_bins*2,)
         Estimated "center density" of H0.
-    fdr : array
+    fdr : array, (n_bins*2,)
         Estimated false discovery rate.
     mu : float
         Mean of H0 distribution.
@@ -195,8 +197,8 @@ def local_fdr_correction(data, n_bins=100, h0_maxiter=500, decimate=1):
 
     Parameters
     ----------
-    data : array_like
-        Set of observations to test.
+    data : array, any shape
+        Set of observations on which to estimate FDR.
     n_bins : int
         Number of points at which to evaluate the density.
     h0_maxtier : int
@@ -204,10 +206,9 @@ def local_fdr_correction(data, n_bins=100, h0_maxiter=500, decimate=1):
     decimate : int
         Factor by which to decimate data prior to density estimation.
 
-
     Returns
     -------
-    qvals : array
+    qvals : array, any shape
         Values of FDR for each element of data.
 
     Notes

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -6,8 +6,9 @@
 # License: BSD (3-clause)
 
 import numpy as np
-
 from scipy import stats, optimize
+from ..fixes import partial
+
 
 def _ecdf(x):
     '''no frills empirical cdf used in fdrcorrection
@@ -103,31 +104,29 @@ def bonferroni_correction(pval, alpha=0.05):
     return reject, pval_corrected
 
 
-def local_fdr(data, nbins=100, h0_maxiter=500, decimate=1):
-    """
-    Implements the local false discovery rate correction, due to Efron 2005, 
-    for univariate data.
+def _local_fdr_h0_err(f, xb, par):
+    "Error function for H0 subdensity used in local FDR optimization"
+    mu, sigma, alo, ahi = par
+    sl = slice(np.argmin(np.abs(xb - alo)), np.argmin(np.abs(xb - ahi)))
+    if sl.start == sl.stop:
+        raise ValueError('insufficient n_bins, restart with higher value')
+    f0 = stats.norm.pdf(xb[sl], loc=mu, scale=sigma)
+    f1 = f[sl]
+    f0 = f0 / f0.max() * f1.max()
+    return np.sum((f0 - f1) ** 2) / np.sum(f1 ** 2) - f1.sum()
 
-    Where FDR performs a correction based on the CDF, lFDR performs a
-    correction based on the PDF, which works by computing density statistics on
-    `x`, where a "null" hypothesis distribution H0, here a Gaussian
-    distribution, is fit to the center of the data, and this provides an
-    estimation of how likely each bin comes from the Gaussian distribution, a
-    measure called the local false discovery rate.
 
-    The use of a Gaussian in this implementation is not required, in fact, the
-    distribution to be fit does not even have to have an analytic PDF, rather
-    it is simply necessary to be able to compute a numerical density for the
-    H0.
+def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
+    """Local false discovery rate correction for univariate data.
 
-    This function performs the density and FDR estimation, while
-    `local_fdr_correction` provides an interface similar to `fdr_correction`.
-
+    Where FDR corrects multiple comparisons based on the CDF, lFDR corrects
+    based on the PDF, and provides a per-sample estimate of the false discovery
+    rate, assuming a Gaussian null hypothesis.
 
     Parameters
     ----------
-    nbins : int
-        Number of points at which to evaluate the density.
+    n_bins : int
+        Number of points at which to evaluate the density
     h0_maxtier : int
         Max no of iteratios for H0 fit optimization
     decimate : int
@@ -142,7 +141,7 @@ def local_fdr(data, nbins=100, h0_maxiter=500, decimate=1):
     cf : array
         Estimated "center density" of H0
     fdr : array
-        Estimated false discovery rate 
+        Estimated false discovery rate
     mu : float
         Mean of H0 distribution
     sig : float
@@ -151,55 +150,53 @@ def local_fdr(data, nbins=100, h0_maxiter=500, decimate=1):
     Notes
     -----
 
-    Reference:
-    Efron B, Local false discovery rates. 2005
+    The use of a Gaussian in this implementation is not required, in fact, the
+    distribution to be fit does not even have to have an analytic PDF, rather
+    it is simply necessary to be able to compute a numerical density for the
+    H0.
 
+    Reference:
+    Efron B, Tibshirani R.
+    Empirical Bayes methods and false discovery rates for microarrays.
+    Genetic epidemiology 2002; 23(1): 70-86.
     """
 
     x = data.reshape(-1)[::decimate]
 
     # initial estimate of density
     k = stats.gaussian_kde(x)
-    xb = np.r_[x.min() : x.max() : 1j*nbins]
-    f = k(xb)
-    f /= f.sum()
-    
-    # adapt estimation points' density to actual density
-    F = np.cumsum(f)
-    Fb = np.r_[0.0:1.0:1j*nbins]
-    dxb = np.interp(Fb, F, xb + (xb[1] - xb[0])/2.0)
-    xb = np.unique(np.r_[xb, dxb])
-    xb.sort()                
+    xb = np.r_[x.min():x.max():1j * n_bins]
     f = k(xb)
     f /= f.sum()
 
-    # estimate center sub-density
-    def err(par):
-        mu, sigma, alo, ahi = par
-        sl = slice(np.argmin(np.abs(xb - alo)), np.argmin(np.abs(xb - ahi)))
-        if sl.start == sl.stop:
-            raise ValueError('insufficient nbins, restart with higher value')
-        f0 = stats.norm.pdf(xb[sl], loc=mu, scale=sigma)
-        f1 = f[sl]
-        f0 = f0/f0.max()*f1.max()
-        return np.sum((f0 - f1)**2)/np.sum(f1**2) - f1.sum()
-    
-    # initialize opt with guess
+    # adapt estimation points' density to actual density
+    F = np.cumsum(f)
+    Fb = np.r_[0.0:1.0:1j * n_bins]
+    dxb = np.interp(Fb, F, xb + (xb[1] - xb[0]) / 2.0)
+    xb = np.unique(np.r_[xb, dxb])
+    xb.sort()
+    f = k(xb)
+    f /= f.sum()
+
+    # initial search params
     mu0, sig0 = x.mean(), x.std()
-    par0 = mu0, sig0, mu0-sig0, mu0+sig0
-    mu, sig, _, _ = optimize.fmin(err, par0, disp=0, maxiter=h0_maxiter)
+    par0 = mu0, sig0, mu0 - sig0, mu0 + sig0
+
+    # optimize error wrt density
+    err_func = partial(_local_fdr_h0_err, f, xb)
+    mu, sig, _, _ = optimize.fmin(err_func, par0, disp=0, maxiter=h0_maxiter)
 
     # compute center density
     cf = stats.norm.pdf(xb, loc=mu, scale=sig)
-    cf = cf/cf.max()*f.max()
+    cf = cf / cf.max() * f.max()
 
-    # lfdr 
-    fdr = np.clip(cf/f, 0.0, 1.0)
+    # lfdr
+    fdr = np.clip(cf / f, 0.0, 1.0)
 
     return xb, f, cf, fdr, mu, sig
 
 
-def local_fdr_correction(data, q=0.2, **lfdr_kwds):
+def local_fdr_correction(data, q=0.2, n_bins=100, h0_maxiter=500, decimate=1):
     """
     Correction for multiple comparison based on local FDR.
 
@@ -212,27 +209,16 @@ def local_fdr_correction(data, q=0.2, **lfdr_kwds):
 
     data : array_like
         set of observations to test
-    q : float
-        acceptable false discovery rate below which H0 rejected
 
-    **lfdr_kwds : 
-        keywords to pass to the local_fdr routine
-  
     Returns
     -------
 
-    reject : array, bool
-        True if H0 rejected else False
     qvals : array
         Values of FDR for each element of data
 
     """
 
-    xb, _, _, fdr, _, _ = local_fdr(data, **lfdr_kwds)
+    xb, _, _, fdr, _, _ = _local_fdr(data, n_bins=n_bins,
+                                     h0_maxiter=h0_maxiter, decimate=decimate)
     qvals = np.interp(data, xb, fdr, 0.0, 0.0)
     return qvals <= q, qvals
-    
-
-
-
-

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -196,7 +196,7 @@ def _local_fdr(data, n_bins=100, h0_maxiter=500, decimate=1):
     return xb, f, cf, fdr, mu, sig
 
 
-def local_fdr_correction(data, q=0.2, n_bins=100, h0_maxiter=500, decimate=1):
+def local_fdr_correction(data, n_bins=100, h0_maxiter=500, decimate=1):
     """
     Correction for multiple comparison based on local FDR.
 
@@ -209,6 +209,13 @@ def local_fdr_correction(data, q=0.2, n_bins=100, h0_maxiter=500, decimate=1):
 
     data : array_like
         set of observations to test
+    n_bins : int
+        Number of points at which to evaluate the density
+    h0_maxtier : int
+        Max no of iteratios for H0 fit optimization
+    decimate : int
+        Factor by which to decimate data prior to density estimation
+
 
     Returns
     -------
@@ -221,4 +228,4 @@ def local_fdr_correction(data, q=0.2, n_bins=100, h0_maxiter=500, decimate=1):
     xb, _, _, fdr, _, _ = _local_fdr(data, n_bins=n_bins,
                                      h0_maxiter=h0_maxiter, decimate=decimate)
     qvals = np.interp(data, xb, fdr, 0.0, 0.0)
-    return qvals <= q, qvals
+    return qvals

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 
+from scipy import stats, optimize
 
 def _ecdf(x):
     '''no frills empirical cdf used in fdrcorrection
@@ -100,3 +101,138 @@ def bonferroni_correction(pval, alpha=0.05):
     pval_corrected = pval * float(pval.size)
     reject = pval < alpha
     return reject, pval_corrected
+
+
+def local_fdr(data, nbins=100, h0_maxiter=500, decimate=1):
+    """
+    Implements the local false discovery rate correction, due to Efron 2005, 
+    for univariate data.
+
+    Where FDR performs a correction based on the CDF, lFDR performs a
+    correction based on the PDF, which works by computing density statistics on
+    `x`, where a "null" hypothesis distribution H0, here a Gaussian
+    distribution, is fit to the center of the data, and this provides an
+    estimation of how likely each bin comes from the Gaussian distribution, a
+    measure called the local false discovery rate.
+
+    The use of a Gaussian in this implementation is not required, in fact, the
+    distribution to be fit does not even have to have an analytic PDF, rather
+    it is simply necessary to be able to compute a numerical density for the
+    H0.
+
+    This function performs the density and FDR estimation, while
+    `local_fdr_correction` provides an interface similar to `fdr_correction`.
+
+
+    Parameters
+    ----------
+    nbins : int
+        Number of points at which to evaluate the density.
+    h0_maxtier : int
+        Max no of iteratios for H0 fit optimization
+    decimate : int
+        Factor by which to decimate data prior to density estimation
+
+    Returns
+    -------
+    xb : array
+        Points at which the densities are evaluated
+    f : array
+        Density of `x`
+    cf : array
+        Estimated "center density" of H0
+    fdr : array
+        Estimated false discovery rate 
+    mu : float
+        Mean of H0 distribution
+    sig : float
+        Std of H0 distribution
+
+    Notes
+    -----
+
+    Reference:
+    Efron B, Local false discovery rates. 2005
+
+    """
+
+    x = data.reshape(-1)[::decimate]
+
+    # initial estimate of density
+    k = stats.gaussian_kde(x)
+    xb = np.r_[x.min() : x.max() : 1j*nbins]
+    f = k(xb)
+    f /= f.sum()
+    
+    # adapt estimation points' density to actual density
+    F = np.cumsum(f)
+    Fb = np.r_[0.0:1.0:1j*nbins]
+    dxb = np.interp(Fb, F, xb + (xb[1] - xb[0])/2.0)
+    xb = np.unique(np.r_[xb, dxb])
+    xb.sort()                
+    f = k(xb)
+    f /= f.sum()
+
+    # estimate center sub-density
+    def err(par):
+        mu, sigma, alo, ahi = par
+        sl = slice(np.argmin(np.abs(xb - alo)), np.argmin(np.abs(xb - ahi)))
+        if sl.start == sl.stop:
+            raise ValueError('insufficient nbins, restart with higher value')
+        f0 = stats.norm.pdf(xb[sl], loc=mu, scale=sigma)
+        f1 = f[sl]
+        f0 = f0/f0.max()*f1.max()
+        return np.sum((f0 - f1)**2)/np.sum(f1**2) - f1.sum()
+    
+    # initialize opt with guess
+    mu0, sig0 = x.mean(), x.std()
+    par0 = mu0, sig0, mu0-sig0, mu0+sig0
+    mu, sig, _, _ = optimize.fmin(err, par0, disp=0, maxiter=h0_maxiter)
+
+    # compute center density
+    cf = stats.norm.pdf(xb, loc=mu, scale=sig)
+    cf = cf/cf.max()*f.max()
+
+    # lfdr 
+    fdr = np.clip(cf/f, 0.0, 1.0)
+
+    return xb, f, cf, fdr, mu, sig
+
+
+def local_fdr_correction(data, q=0.2, **lfdr_kwds):
+    """
+    Correction for multiple comparison based on local FDR.
+
+    Rather than working directly with the p-values, local FDR determines
+    the FDR of each sample based on empirical and assumed H0 distributions,
+    and thresholds on the sample's FDR value.
+
+    Parameters
+    ----------
+
+    data : array_like
+        set of observations to test
+    q : float
+        acceptable false discovery rate below which H0 rejected
+
+    **lfdr_kwds : 
+        keywords to pass to the local_fdr routine
+  
+    Returns
+    -------
+
+    reject : array, bool
+        True if H0 rejected else False
+    qvals : array
+        Values of FDR for each element of data
+
+    """
+
+    xb, _, _, fdr, _, _ = local_fdr(data, **lfdr_kwds)
+    qvals = np.interp(data, xb, fdr, 0.0, 0.0)
+    return qvals <= q, qvals
+    
+
+
+
+

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -51,12 +51,14 @@ def test_local_fdr_correction():
     rng = np.random.RandomState(0)
     X = rng.randn(15, 1000)
 
-    rej, qs = local_fdr_correction(X)
+    qs = local_fdr_correction(X)
+    rej = qs < 0.02
     assert_true(rej.shape==qs.shape==X.shape)
     assert_false(rej.any())
 
     X[3, 234] = 5.0
-    rej, qs = local_fdr_correction(X)
+    qs = local_fdr_correction(X)
+    rej = qs < 0.02
     assert_true(rej[3, 234])
     rej[3, 234] = False
     assert_false(rej.any())

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -1,9 +1,10 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose, assert_raises
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_false
 from scipy import stats
 
-from mne.stats import fdr_correction, bonferroni_correction
+from mne.stats import (fdr_correction, bonferroni_correction,
+                       local_fdr_correction)
 
 
 def test_multi_pval_correction():
@@ -42,3 +43,22 @@ def test_multi_pval_correction():
     thresh_fdr = np.min(np.abs(T)[reject_fdr])
     assert_true(0 <= (reject_fdr.sum() - 50) <= 50 * 1.05)
     assert_true(thresh_uncorrected <= thresh_fdr <= thresh_bonferroni)
+
+
+def test_local_fdr_correction():
+    "Test local fdr correction"
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(15, 1000)
+
+    rej, qs = local_fdr_correction(X)
+    assert_true(rej.shape==qs.shape==X.shape)
+    assert_false(rej.any())
+
+    X[3, 234] = 5.0
+    rej, qs = local_fdr_correction(X)
+    assert_true(rej[3, 234])
+    rej[3, 234] = False
+    assert_false(rej.any())
+
+

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -48,20 +48,18 @@ def test_multi_pval_correction():
 def test_local_fdr_correction():
     """Test local fdr correction
     """
-
     rng = np.random.RandomState(0)
-    X = rng.randn(15, 1000)
 
+    X = rng.randn(15, 100)
     qs = local_fdr_correction(X)
-    rej = qs < 0.02
-    assert_true(rej.shape==qs.shape==X.shape)
+    rej = qs < 0.05
+    assert_true(qs.shape == X.shape)
     assert_false(rej.any())
 
-    X[3, 234] = 5.0
+    outlier_index = (3, 24)
+    X[outlier_index] = 5.0
     qs = local_fdr_correction(X)
-    rej = qs < 0.02
-    assert_true(rej[3, 234])
-    rej[3, 234] = False
+    rej = qs < 0.05
+    assert_true(rej[outlier_index])
+    rej[outlier_index] = False
     assert_false(rej.any())
-
-

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -46,7 +46,8 @@ def test_multi_pval_correction():
 
 
 def test_local_fdr_correction():
-    "Test local fdr correction"
+    """Test local fdr correction
+    """
 
     rng = np.random.RandomState(0)
     X = rng.randn(15, 1000)


### PR DESCRIPTION
This PR adds Efron's local false discovery rate correction for multiple comparisons. This can be useful when the number of comparisons is huge eg. source space x time or detection problems (our applications).