### PR TITLE
WIP adding inherited members to doc

### DIFF
--- a/doc/source/_templates/class.rst
+++ b/doc/source/_templates/class.rst
@@ -9,6 +9,5 @@
    .. automethod:: __init__
    {% endblock %}
 
-   :inherited-members:
 
 

--- a/doc/source/_templates/class.rst
+++ b/doc/source/_templates/class.rst
@@ -9,4 +9,6 @@
    .. automethod:: __init__
    {% endblock %}
 
+   :inherited-members:
+
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,7 @@ except:
     # Older version of sphinx
     extensions.append('numpy_ext_old.numpydoc')
 
-autodoc_default_flags=['inherited-members']
+autodoc_default_flags = ['members', 'inherited-members']
 
 # extensions = ['sphinx.ext.autodoc',
 #               'sphinx.ext.doctest',

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -614,7 +614,7 @@ class Epochs(_BaseEpochs):
         Measurement info.
     event_id : dict
         Names of  of conditions corresponding to event_ids.
-    ch_names : list of string
+    <ch_names> : list of string
         List of channels' names.
     selection : array
         List of indices of selected events (not dropped or ignored etc.). For


### PR DESCRIPTION
This doesn't work for some reason. According to the sphinx documentation, inherited members are automatically documented when `inherited-members` is enabled, but for some reason they are not for us. Any ideas?