### PR TITLE
WIP/ENH: Time-frequency beamformer Wilcoxon across epochs

### DIFF
--- a/examples/inverse/plot_tf_lcmv_ranksum.py
+++ b/examples/inverse/plot_tf_lcmv_ranksum.py
@@ -1,0 +1,148 @@
+"""
+=====================================
+Time-frequency beamforming using LCMV
+=====================================
+
+Compute LCMV source power in a grid of time-frequency windows and display
+results.
+
+The original reference is:
+Dalal et al. Five-dimensional neuroimaging: Localization of the time-frequency
+dynamics of cortical activity. NeuroImage (2008) vol. 40 (4) pp. 1686-1700
+"""
+
+# XXX: the ranksums option should be documented above
+# XXX: Maybe this example could replace the tf_lcmv example?
+
+# Author: Roman Goj <roman.goj@gmail.com>
+#
+# License: BSD (3-clause)
+
+print(__doc__)
+
+import mne
+from mne import compute_covariance
+from mne.io import Raw
+from mne.datasets import sample
+from mne.event import make_fixed_length_events
+from mne.beamformer import tf_lcmv
+from mne.viz import plot_source_spectrogram
+
+
+data_path = sample.data_path()
+raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
+noise_fname = data_path + '/MEG/sample/ernoise_raw.fif'
+event_fname = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
+fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
+subjects_dir = data_path + '/subjects'
+label_name = 'Aud-lh'
+fname_label = data_path + '/MEG/sample/labels/%s.label' % label_name
+
+###############################################################################
+# Read raw data, preload to allow filtering
+raw = Raw(raw_fname, preload=True)
+raw.info['bads'] = ['MEG 2443']  # 1 bad MEG channel
+
+# Pick a selection of magnetometer channels. A subset of all channels was used
+# to speed up the example. For a solution based on all MEG channels use
+# meg=True, selection=None and add grad=4000e-13 to the reject dictionary.
+left_temporal_channels = mne.read_selection('Left-temporal')
+picks = mne.pick_types(raw.info, meg='mag', eeg=False, eog=False,
+                       stim=False, exclude='bads',
+                       selection=left_temporal_channels)
+reject = dict(mag=4e-12)
+
+# Setting time limits for reading epochs. Note that tmin and tmax are set so
+# that time-frequency beamforming will be performed for a wider range of time
+# points than will later be displayed on the final spectrogram. This ensures
+# that all time bins displayed represent an average of an equal number of time
+# windows.
+tmin, tmax = -0.55, 0.75  # s
+tmin_plot, tmax_plot = -0.3, 0.5  # s
+
+# Read epochs. Note that preload is set to False to enable tf_lcmv to read the
+# underlying raw object from epochs.raw, which would be set to None during
+# preloading. Filtering is then performed on raw data in tf_lcmv and the epochs
+# parameters passed here are used to create epochs from filtered data. However,
+# reading epochs without preloading means that bad epoch rejection is delayed
+# until later. To perform bad epoch rejection based on the reject parameter
+# passed here, run epochs.drop_bad_epochs(). This is done automatically in
+# tf_lcmv to reject bad epochs based on unfiltered data.
+event_id = 1
+events = mne.read_events(event_fname)
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
+                    picks=picks, baseline=None, preload=False,
+                    reject=reject)
+
+# Read empty room noise, preload to allow filtering
+raw_noise = Raw(noise_fname, preload=True)
+raw_noise.info['bads'] = ['MEG 2443']  # 1 bad MEG channel
+
+# Create artificial events for empty room noise data
+events_noise = make_fixed_length_events(raw_noise, event_id, duration=1.)
+# Create an epochs object using preload=True to reject bad epochs based on
+# unfiltered data
+epochs_noise = mne.Epochs(raw_noise, events_noise, event_id, tmin, tmax,
+                          proj=True, picks=picks, baseline=None,
+                          preload=True, reject=reject)
+
+# Make sure the number of noise epochs is the same as data epochs
+epochs_noise = epochs_noise[:len(epochs.events)]
+
+# Read forward operator
+forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+
+# Read label
+label = mne.read_label(fname_label)
+
+###############################################################################
+# Time-frequency beamforming based on LCMV
+
+# Setting frequency bins as in Dalal et al. 2008 (high gamma was subdivided)
+freq_bins = [(4, 12), (12, 30), (30, 55), (65, 299)]  # Hz
+win_lengths = [0.3, 0.2, 0.15, 0.1]  # s
+
+# Setting the time step
+tstep = 0.05
+
+# Setting the noise covariance and whitened data covariance regularization
+# parameters
+noise_reg = 0.03
+data_reg = 0.001
+
+# Subtract evoked response prior to computation?
+subtract_evoked = False
+
+# Calculating covariance from empty room noise. To use baseline data as noise
+# substitute raw for raw_noise, epochs.events for epochs_noise.events, tmin for
+# desired baseline length, and 0 for tmax_plot.
+# Note, if using baseline data, the averaged evoked response in the baseline
+# period should be flat.
+noise_covs = []
+for (l_freq, h_freq) in freq_bins:
+    raw_band = raw_noise.copy()
+    raw_band.filter(l_freq, h_freq, picks=epochs.picks, method='iir', n_jobs=1)
+    epochs_band = mne.Epochs(raw_band, epochs_noise.events, event_id,
+                             tmin=tmin_plot, tmax=tmax_plot, baseline=None,
+                             picks=epochs.picks, proj=True)
+
+    noise_cov = compute_covariance(epochs_band)
+    noise_cov = mne.cov.regularize(noise_cov, epochs_band.info, mag=noise_reg,
+                                   grad=noise_reg, eeg=noise_reg, proj=True)
+    noise_covs.append(noise_cov)
+    del raw_band  # to save memory
+
+# Computing LCMV solutions for time-frequency windows in a label in source
+# space for faster computation, use label=None for full solution
+# XXX: the ranksums option should be commented on
+stcs = tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
+               freq_bins=freq_bins, subtract_evoked=subtract_evoked,
+               baseline_mode='ranksums', reg=data_reg, label=label)
+
+# Plotting source spectrogram for source with maximum activity.
+# Note that tmin and tmax are set to display a time range that is smaller than
+# the one for which beamforming estimates were calculated. This ensures that
+# all time bins shown are a result of smoothing across an identical number of
+# time windows.
+plot_source_spectrogram(stcs, freq_bins, tmin=tmin_plot, tmax=tmax_plot,
+                        source_index=None, colorbar=True)

--- a/examples/inverse/plot_tf_lcmv_wilcoxon.py
+++ b/examples/inverse/plot_tf_lcmv_wilcoxon.py
@@ -137,7 +137,7 @@ for (l_freq, h_freq) in freq_bins:
 # XXX: the wilcoxon option should be commented on
 stcs = tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                freq_bins=freq_bins, subtract_evoked=subtract_evoked,
-               baseline_mode='wilcoxon', reg=data_reg, label=label)
+               mode='wilcoxon', reg=data_reg, label=label)
 #               baseline_mode=None, reg=data_reg, label=label)
 
 # Plotting source spectrogram for source with maximum activity.

--- a/examples/inverse/plot_tf_lcmv_wilcoxon.py
+++ b/examples/inverse/plot_tf_lcmv_wilcoxon.py
@@ -11,7 +11,7 @@ Dalal et al. Five-dimensional neuroimaging: Localization of the time-frequency
 dynamics of cortical activity. NeuroImage (2008) vol. 40 (4) pp. 1686-1700
 """
 
-# XXX: the ranksums option should be documented above
+# XXX: the wilcoxon option should be documented above
 # XXX: Maybe this example could replace the tf_lcmv example?
 
 # Author: Roman Goj <roman.goj@gmail.com>
@@ -134,15 +134,18 @@ for (l_freq, h_freq) in freq_bins:
 
 # Computing LCMV solutions for time-frequency windows in a label in source
 # space for faster computation, use label=None for full solution
-# XXX: the ranksums option should be commented on
+# XXX: the wilcoxon option should be commented on
 stcs = tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                freq_bins=freq_bins, subtract_evoked=subtract_evoked,
-               baseline_mode='ranksums', reg=data_reg, label=label)
+               baseline_mode='wilcoxon', reg=data_reg, label=label)
+#               baseline_mode=None, reg=data_reg, label=label)
 
 # Plotting source spectrogram for source with maximum activity.
 # Note that tmin and tmax are set to display a time range that is smaller than
 # the one for which beamforming estimates were calculated. This ensures that
 # all time bins shown are a result of smoothing across an identical number of
 # time windows.
+# XXX: The colorbar should be symmetrical when displaying z-scores (although
+# note z scores now returned are always negative)
 plot_source_spectrogram(stcs, freq_bins, tmin=tmin_plot, tmax=tmax_plot,
                         source_index=None, colorbar=True)


### PR DESCRIPTION
This is a WIP implementation of Wilcoxon tests across trials comparing each time window with a baseline period (see, e.g. [1]), which was a feature suggested by @adykstra.

I'm posting this as a WIP, because I'd like to discuss the API and the way tf_lcmv now treats baselines and noise, and also to ease contributions (I might be slow in finishing this).

`tf_lcmv` currently (before this PR) returns these quantities:
* `tf_bin_power / noise_power` or,
* `tf_bin_power / baseline_power`,
depending on whether noise_cov is calculated from empty room noise or a baseline period. (The division is not actual division of estimated source power, instead covariance is whitened and the result is equivalent to van Veen's neural activity index).

We'd like to be able to return also:
* z score from Wilcoxon test across trials (neural activity index in active time window vs. neural activity index in baseline)
* logratio of `tf_bin_power / noise_power` or logratio of `tf_bin_power / baseline_power`

We could also compute what the original 2008 Dalal 5d t-f beamforming publication uses:
* `Fdb = 10 log10 ((tf_bin_power - noise_power) / (baseline_power - noise_power)`

...and many more pseudo t, z, F options...

What keeps confusing me is how to cleanly make the user choose between these options and make clear when the baseline period is used and when only noise covariance is used. At the moment there are two new parameters for `tf_lcmv`: `baseline` and `mode`. There's a slight ambiguity, because a user could still pass baseline-calculated covariance through the `noise_cov` parameters. And if the user wants to get `tf_bin_power / baseline_power` then `noise_cov` should also be explicitly allowed to be None. Any thoughts welcome, or I can just go on and implement something completely and then we can discuss that.

Also, I had to copy the code of the wilcoxon function from scipy, because it didn't return the z scores we'd like to have. There's even an issue about it in scipy, so I'll submit a PR there, but in the meantime we'd probably have to keep the modified code locally, no? What's the best place to put it? Separate file in mne/stats or keep here in _lcmv.py where it's used?

Here's a list of TODOs before I'd see this PR as complete:
* [ ] Implement choosing baseline period.
* [ ] The wilcoxon test should be run on time windows rather than (as is the case now) on tf bins calculated by smoothing across multiple time windows. For this, the baseline period's covariance needs a separate calculation outside of the main loop across all tf bins.
* [ ] Using subtract_evoked doesn't seem to change much. Why? Look into this.
* [ ] The wilcoxon code returns only negative z-scores irrespective of how it is invoked. I would expect both negative and positive z-scores. Compare the scipy implementation with NUTMEG code.
* [ ] Should the modified wilcoxon code be placed somewhere else? Any procedures for approaching switching back to using scipy code once the changes are (hopefully) implemented upstream?
* [ ] Submit PR to scipy implementing returning z-scores in scipy.stats.wilcoxon.

[1]: Dalal et al. Simultaneous MEG and intracranial EEG recordings during attentive reading. NeuroImage (2009) vol. 45 (4) pp. 1289-1304