### PR TITLE
ENH: Quieter Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,35 +13,35 @@ env:
     - PYTHON=2.7 DEPS=minimal
 # Setup anaconda
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
+  - wget -q http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
+  - ./miniconda.sh -b &> /dev/null;
   - export PATH=/home/travis/anaconda/bin:$PATH
-  - conda update --yes conda
+  - conda update --yes --quiet conda &> /dev/null;
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
 
 install:
-    - conda create -n testenv --yes pip python=$PYTHON
-    - source activate testenv
-    - conda install --yes ipython==1.1.0 numpy scipy nose matplotlib
+    - conda create -n testenv --yes pip python=$PYTHON &> /dev/null
+    - source activate testenv &> /dev/null
+    - conda install --yes --quiet ipython==1.1.0 numpy scipy nose matplotlib > /dev/null
     - if [ "${DEPS}" == "full" ]; then
-        conda install --yes pandas statsmodels scikit-learn patsy pytables;
-        pip install nibabel;
+        conda install --yes --quiet pandas statsmodels scikit-learn patsy pytables > /dev/null;
+        pip install -q nibabel;
         if [ ${PYTHON:0:1} == "2" ]; then
-          pip install nitime;
+          pip install -q nitime;
         fi;
       fi;
-    - pip install coverage; pip install coveralls; pip install nose-timer
+    - pip install -q coverage coveralls nose-timer > /dev/null
     - MNE_FORCE_SERIAL=1
     - MNE_SKIP_SAMPLE_DATASET_TESTS=1
     # Skip tests that require large downloads over the network to save bandwith
     # usage as travis workers are stateless and therefore traditional local
     # disk caching does not work.
     - export MNE_SKIP_NETWORK_TESTS=1
-    - python setup.py build
-    - python setup.py install
+    - python setup.py build > /dev/null
+    - python setup.py install > /dev/null
     - myscripts='browse_raw bti2fiff surf2bem'
     - for script in $myscripts; do mne $script --help >/dev/null; done;
     - SRC_DIR=$(pwd)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,9 +10,8 @@ recursive-include mne/data *.fif.gz
 recursive-include mne/layouts *.lout
 recursive-include mne/layouts *.lay
 recursive-exclude examples/MNE-sample-data *
-# recursive-include mne/fiff/tests/data *
-recursive-exclude mne/fiff/tests/data *
-recursive-exclude mne/fiff/bti/tests/data *
-recursive-exclude mne/fiff/kit/tests/data *
-recursive-exclude mne/fiff/edf/tests/data *
-recursive-exclude mne/fiff/brainvision/tests/data *
+# recursive-exclude mne/io/tests/data *
+# recursive-exclude mne/io/bti/tests/data *
+# recursive-exclude mne/io/kit/tests/data *
+# recursive-exclude mne/io/edf/tests/data *
+# recursive-exclude mne/io/brainvision/tests/data *


### PR DESCRIPTION
Not ready for merge or review. Should just make the Travis logs easier to parse by omitting things we don't care about (like the `pip` logs). This will make it slightly harder to debug Travis _testing platform_ issues, but easier to debug real Travis _mne-python testing_ errors.
