### PR TITLE
FIX: change donwload test URL

### DIFF
--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -267,7 +267,7 @@ def test_fetch_file():
         from nose.plugins.skip import SkipTest
         raise SkipTest('No internet connection, skipping download test.')
 
-    urls = ['http://martinos.org/mne/stable/_static/mne_logo.png',
+    urls = ['http://www.google.com',
             'ftp://surfer.nmr.mgh.harvard.edu/pub/data/bert.recon.md5sum.txt']
     for url in urls:
         archive_name = op.join(tempdir, "download_test")


### PR DESCRIPTION
Jenkins and also my nightly test frequently fails to download the test file from github. Changed file to one from the mne website. Hopefully this is more reliable.
