### PR TITLE
FIX _write_raw():  don’t set meas_id to invalid value

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1445,8 +1445,6 @@ def _write_raw(fname, raw, info, picks, format, data_type, reset_range, start,
     logger.info('Writing %s' % use_fname)
 
     meas_id = info['meas_id']
-    if meas_id is None:
-        meas_id = 0
 
     fid, cals = _start_writing_raw(use_fname, info, picks, data_type,
                                    reset_range)
@@ -1460,7 +1458,8 @@ def _write_raw(fname, raw, info, picks, format, data_type, reset_range, start,
         start_block(fid, FIFF.FIFFB_REF)
         write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
         write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
-        write_id(fid, FIFF.FIFF_REF_FILE_ID, meas_id)
+        if meas_id is not None:
+            write_id(fid, FIFF.FIFF_REF_FILE_ID, meas_id)
         write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
         end_block(fid, FIFF.FIFFB_REF)
 
@@ -1509,7 +1508,8 @@ def _write_raw(fname, raw, info, picks, format, data_type, reset_range, start,
             start_block(fid, FIFF.FIFFB_REF)
             write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_NEXT_FILE)
             write_string(fid, FIFF.FIFF_REF_FILE_NAME, op.basename(next_fname))
-            write_id(fid, FIFF.FIFF_REF_FILE_ID, meas_id)
+            if meas_id is not None:
+                write_id(fid, FIFF.FIFF_REF_FILE_ID, meas_id)
             write_int(fid, FIFF.FIFF_REF_FILE_NUM, next_idx)
             end_block(fid, FIFF.FIFFB_REF)
             break


### PR DESCRIPTION
I've encountered a bug with kit2fiff, but I think it's a bug in the general write raw code:
- if `raw.info['meas_id']` is `None` (as it was for my kit-raw file), `_write_raw()` sets `meas_id = 0` before calling `write_id(fid, FIFF.FIFF_REF_FILE_ID, meas_id)` (https://github.com/mne-tools/mne-python/blob/master/mne/io/base.py#L1449)
- `write_id()` however expects `meas_id` to be a dictionary (https://github.com/mne-tools/mne-python/blob/master/mne/io/write.py#L181)

Since `write_id()` seems to be able to handle `meas_id == None` I think this PR should solve it, currently running the tests...
