### PR TITLE
ENH: Use Python 3.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ install:
       fi;
     - pip install -q coverage coveralls nose-timer > /dev/null
     # Suppress the parallel outputs for logging cleanliness
-    - MNE_LOGGING_LEVEL=warning
-    - MNE_SKIP_SAMPLE_DATASET_TESTS=1
+    - export MNE_LOGGING_LEVEL=warning
+    - export MNE_SKIP_SAMPLE_DATASET_TESTS=1
     # Skip tests that require large downloads over the network to save bandwith
     # usage as travis workers are stateless and therefore traditional local
     # disk caching does not work.


### PR DESCRIPTION
We'll see if Travis is okay with this. Seems like we might as well test the most recent Python.
