### PR TITLE
FIX: Use range instead of unit_mul to deal with EEG units 

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -596,7 +596,7 @@ def _get_edf_info(fname, n_eeg, stim_channel, annot, annotmap, tal_channel,
         chan_info['logno'] = idx
         chan_info['scanno'] = idx
         chan_info['range'] = physical_range * (10 ** unit_mul)
-        chan_info['unit_mul'] = 0
+        chan_info['unit_mul'] = 0.
         chan_info['ch_name'] = ch_name
         chan_info['unit'] = FIFF.FIFF_UNIT_V
         chan_info['coord_frame'] = FIFF.FIFFV_COORD_HEAD


### PR DESCRIPTION
This maintains compatibility with .fif format and MNE-C and things show up properly in mne_browse_raw
