### PR TITLE
FIX bug related to loading datablocks.

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -196,7 +196,7 @@ class RawEDF(_BaseRaw):
         blockstop = int(ceil(float(stop) / block_samp) * block_samp)
         if blockstop > self.last_samp:
             blockstop = self.last_samp + 1
-        
+
         if start >= stop:
             raise ValueError('No data in this range')
 
@@ -239,11 +239,13 @@ class RawEDF(_BaseRaw):
                     data = data.reshape(-1, 3).astype(np.int32)
                     # this converts to 24-bit little endian integer
                     # # no support in numpy
-                    data = (data[:, 0] + (data[:, 1] << 8) + (data[:, 2] << 16))
+                    data = (data[:, 0] + (data[:, 1] << 8) +
+                            (data[:, 2] << 16))
                     # 24th bit determines the sign
                     data[data >= (1 << 23)] -= (1 << 24)
 
-                    data = data.reshape((int(sfreq), n_chan, blocks), order='F')
+                    data = data.reshape((int(sfreq), n_chan, blocks),
+                                        order='F')
                     for i in range(blocks):
                         start_pt = int((sfreq * i) + (k * buffer_step))
                         stop_pt = int(start_pt + sfreq)
@@ -273,10 +275,12 @@ class RawEDF(_BaseRaw):
                             else:
                                 warnings.warn('Interpolating stim channel. '
                                               'Events may jitter.')
-                                oldrange = np.linspace(0, 1, samp*blocks, True)
+                                oldrange = np.linspace(0, 1, samp*blocks + 1,
+                                                       True)
                                 newrange = np.linspace(0, 1, max_samp*blocks,
                                                        False)
-                                chan_data = interp1d(oldrange, chan_data,
+                                chan_data = interp1d(oldrange,
+                                                     np.append(chan_data, 0),
                                                      kind='zero')(newrange)
                         elif samp != max_samp:
                             mult = max_samp / samp


### PR DESCRIPTION
datablocks can have a length different than the sampling frequency. The current code assumes that the sampling frequency and the number of samples per block are the same. This turns out to be a bad assumption.

addresses issue: https://github.com/mne-tools/mne-python/issues/1324

@herrlich10 or someone else, could you test this to see if this resolves the issue. I would do so but my Matlab is not compatible with the beta Yosemite I installed (a bit impulsively).
