### PR TITLE
FIX: Fix raw plotting

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -848,7 +848,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin):
             so the effective filter order will be twice ``filtorder``.
             Filtering the lines for display may also produce some edge
             artifacts (at the left and right edges) of the signals
-            during display.
+            during display. Filtering requires scipy >= 0.10.
         clipping : str | None
             If None, channels are allowed to exceed their designated bounds in
             the plot. If "clamp", then values are clamped to the appropriate

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -337,7 +337,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
         so the effective filter order will be twice ``filtorder``.
         Filtering the lines for display may also produce some edge
         artifacts (at the left and right edges) of the signals
-        during display.
+        during display. Filtering requires scipy >= 0.10.
     clipping : str | None
         If None, channels are allowed to exceed their designated bounds in
         the plot. If "clamp", then values are clamped to the appropriate

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -8,7 +8,7 @@ import warnings
 from numpy.testing import assert_raises
 
 from mne import io, read_events, pick_types
-
+from mne.utils import requires_scipy_version, run_tests_if_main
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -85,7 +85,13 @@ def test_plot_raw():
         fig.canvas.key_press_event('o')
         fig.canvas.key_press_event('escape')
         plt.close('all')
-    # filtering of raw plots
+
+
+@requires_scipy_version('0.10')
+def test_plot_raw_filtered():
+    """Test filtering of raw plots
+    """
+    raw = _get_raw()
     assert_raises(ValueError, raw.plot, lowpass=raw.info['sfreq'] / 2.)
     assert_raises(ValueError, raw.plot, highpass=0)
     assert_raises(ValueError, raw.plot, lowpass=1, highpass=1)
@@ -111,3 +117,6 @@ def test_plot_raw_psds():
     assert_raises(ValueError, raw.plot_psds, ax=ax)
     raw.plot_psds(picks=picks, ax=ax)
     plt.close('all')
+
+
+run_tests_if_main()


### PR DESCRIPTION
This should make Jenkins happy. I couldn't find an easy fix for older scipy versions here, because the old version of `filtfilt` isn't in the documentation before version 0.9 (where both `axis` and `padlen` exist).
