### PR TITLE
Make pick_channels faster on big datasets

### DIFF
--- a/mne/channels.py
+++ b/mne/channels.py
@@ -197,13 +197,13 @@ class PickDropChannelsMixin(object):
             self._projector = self._projector[idx][:, idx]
 
         if isinstance(self, _BaseRaw) and inst_has('_data'):
-            self._data = self._data[idx, :]
+            self._data = self._data.take(idx, axis=0)
         elif isinstance(self, Epochs) and inst_has('_data'):
-            self._data = self._data[:, idx, :]
+            self._data = self._data.take(idx, axis=1)
         elif isinstance(self, AverageTFR) and inst_has('data'):
-            self.data = self.data[idx, :, :]
+            self.data = self.data.take(idx, axis=0)
         elif isinstance(self, Evoked):
-            self.data = self.data[idx, :]
+            self.data = self.data.take(idx, axis=0)
 
 
 def rename_channels(info, mapping):


### PR DESCRIPTION
When selecting indices along a single axis, `array.take` is faster
than fancy indexing. This becomes noticable when dealing with big
arrays, such as preloaded raw datasets:

```
>>> import numpy as np
>>> X = np.random.rand(400, 100000)
>>> picks = np.random.randint(400, size=300)
>>> %timeit -n10 X[picks,:]
10 loops, best of 3: 789 ms per loop

>>> %timeit -n10 X.take(picks, axis=0)
10 loops, best of 3: 297 ms per loop
```

before the patch:

```
>>> import mne
>>> raw = mne.io.Raw(mne.datasets.sample.data_path() + 
...                  '/MEG/sample/sample_audvis_filt-0-40_raw.fif',
...                  preload=True)
>>> # Make it a long recording
>>> raw_long = mne.concatenate_raws([raw.copy() for i in range(10)])
>>> picks = np.random.random_integers(raw.info['nchan']-1, size=300)
>>> picks = [raw.ch_names[i] for i in picks]    
>>> %timeit raw_long.pick_channels(picks)
1 loops, best of 3: 3.28 s per loop
```

after the patch:

```
>>> %timeit raw_long.pick_channels(picks)
1 loops, best of 3: 1.26 s per loop
```

A small change in the code for a small gain.
