### PR TITLE
Make RawEDF correctly set `cals` property

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -108,7 +108,7 @@ class RawEDF(_BaseRaw):
         self._last_samps = np.array([self.last_samp])
         self._raw_lengths = np.array([self._edf_info['nsamples']])
         self.rawdirs = np.array([])
-        self.cals = np.array([])
+        self.cals = np.array([ch['cal'] for ch in self.info['chs']])
         self.orig_format = 'int'
 
         if preload:


### PR DESCRIPTION
Make the EDF loader properly set the `cals` property in the RawEDF object. It used to be set to an empty array, which caused some trouble in `pick_channels`, where it is assumed to have a length of `info['nchan']`.
