### PR TITLE
ICA get sources named w/ zero based indices

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -624,6 +624,8 @@ class ICA(ContainsMixin):
         stop : int | float | None
             Last sample to not include. If float, data will be interpreted as
             time in seconds. If None, the entire data will be used.
+        one_based : bool | True
+            If True, source channel names' index start with 1, otherwise 0.
 
         Returns
         -------


### PR DESCRIPTION
Pedantic, but allows `ica.get_sources(obj, one_based=False)` so the resulting channel names start with `ICA 000` for consistency with results of `ica.plot_components()`. The default behavior does not change.
