### PR TITLE
FIX: fix pandas test in source estimates

### DIFF
--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -589,8 +589,8 @@ def test_as_data_frame():
                         if isinstance(ind, list) else [ind])
             assert_array_equal(df.values.T[ncat:], stc.data)
             # test that non-indexed data were present as categorial variables
-            with warnings.catch_warnings(record=True):  # pandas
-                df.reset_index().columns[:2] == ['subject', 'time']
+            assert_true(all([c in ['time', 'subject'] for c in
+                             df.reset_index().columns][:2]))
 
 
 def test_get_peak():


### PR DESCRIPTION
the new version apparently created issues and deprecated some stuff. I replaced the test by a supposedly more stable one. 

cc @agramfort 
