### PR TITLE
Update montage.py

### DIFF
--- a/mne/montages/montage.py
+++ b/mne/montages/montage.py
@@ -100,7 +100,7 @@ def read_montage(kind, ch_names=None, path=None, scale=True):
         dtype = np.dtype('S4, f8, f8, f8')
         data = np.loadtxt(fname, dtype=dtype)
         pos = np.c_[data['f1'], data['f2'], data['f3']]
-        ch_names_ = data['f0']
+        ch_names_ = (data['f0']).astype(np.str)
     elif ext == '.elc':
         # 10-5 system
         ch_names_ = []


### PR DESCRIPTION
Using Python3 and the dev version of MNE, I get an error trying to read a montage (.sfp), in line 147/148 of mne/montages/montage.py:
`ValueError: need more than 0 values to unpack`

This is possibly because ch_names_ is a list of items of type S4 and ch_names is a list of strings (see line 100-103).
I get no errors if I add a conversion of ch_names_ to np.string (see line 103).

Don't know if this breaks Python2 or anything further down in the processing pipeline though.
