### PR TITLE
FIX: single_trial_power examples

### DIFF
--- a/examples/stats/plot_cluster_1samp_test_time_frequency.py
+++ b/examples/stats/plot_cluster_1samp_test_time_frequency.py
@@ -74,8 +74,8 @@ evoked_data = np.mean(data, 0)
 # spectrotemporal resolution.
 decim = 5
 frequencies = np.arange(8, 40, 2)  # define frequencies of interest
-Fs = raw.info['sfreq']  # sampling in Hz
-epochs_power = single_trial_power(data, Fs=Fs, frequencies=frequencies,
+sfreq = raw.info['sfreq']  # sampling in Hz
+epochs_power = single_trial_power(data, sfreq=sfreq, frequencies=frequencies,
                                   n_cycles=4, use_fft=False, n_jobs=1,
                                   baseline=(-100, 0), times=times,
                                   baseline_mode='ratio', decim=decim)

--- a/examples/stats/plot_cluster_stats_time_frequency.py
+++ b/examples/stats/plot_cluster_stats_time_frequency.py
@@ -84,14 +84,14 @@ times = 1e3 * epochs_condition_1.times  # change unit to ms
 # spectrotemporal resolution.
 decim = 2
 frequencies = np.arange(7, 30, 3)  # define frequencies of interest
-Fs = raw.info['sfreq']  # sampling in Hz
+sfreq = raw.info['sfreq']  # sampling in Hz
 n_cycles = 1.5
-epochs_power_1 = single_trial_power(data_condition_1, Fs=Fs,
+epochs_power_1 = single_trial_power(data_condition_1, sfreq=sfreq,
                                     frequencies=frequencies,
                                     n_cycles=n_cycles, use_fft=False,
                                     decim=decim)
 
-epochs_power_2 = single_trial_power(data_condition_2, Fs=Fs,
+epochs_power_2 = single_trial_power(data_condition_2, sfreq=sfreq,
                                     frequencies=frequencies,
                                     n_cycles=n_cycles, use_fft=False,
                                     decim=decim)

--- a/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
+++ b/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
@@ -74,14 +74,14 @@ times = 1e3 * epochs.times  # change unit to ms
 # single_trial_power.
 decim = 2
 frequencies = np.arange(7, 30, 3)  # define frequencies of interest
-Fs = raw.info['sfreq']  # sampling in Hz
+sfreq = raw.info['sfreq']  # sampling in Hz
 n_cycles = frequencies / frequencies[0]
 baseline_mask = times[::decim] < 0
 
 # now create TFR representations for all conditions
 epochs_power = []
 for condition in [epochs[k].get_data()[:, 97:98, :] for k in event_id]:
-    this_power = single_trial_power(condition, Fs=Fs, frequencies=frequencies,
+    this_power = single_trial_power(condition, sfreq=sfreq, frequencies=frequencies,
                                     n_cycles=n_cycles, use_fft=False,
                                     decim=decim)
     this_power = this_power[:, 0, :, :]  # we only have one channel.


### PR DESCRIPTION
Fixes examples that were failing due to the change of kwarg `Fs` to `sfreq`
