### PR TITLE
WIP:  Read Polhemus Montage

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -324,6 +324,7 @@ Manipulate channels and set sensors locations for processing and plotting:
    :template: function.rst
 
    read_montage
+   read_montage_polhemus
    apply_montage
    read_layout
    find_layout

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -4,7 +4,8 @@ setting of sensors locations used for processing and plotting.
 """
 
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
-                     find_layout, read_montage, apply_montage)
+                     find_layout, read_montage, apply_montage,
+                     read_polhemus_montage)
 
 from .channels import (equalize_channels, rename_channels,
                        read_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -5,7 +5,7 @@ setting of sensors locations used for processing and plotting.
 
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage,
-                     read_polhemus_montage)
+                     read_montage_polhemus)
 
 from .channels import (equalize_channels, rename_channels,
                        read_ch_connectivity)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -16,6 +16,7 @@ import os
 import os.path as op
 import numpy as np
 from scipy.spatial.distance import pdist
+from ..io.meas_info import _read_dig_points
 from ..io.pick import pick_types
 from ..io.constants import FIFF
 from ..utils import _clean_names
@@ -23,7 +24,8 @@ from ..externals.six.moves import map
 from .channels import _contains_ch_type
 from ..viz import plot_montage
 from ..transforms import (_sphere_to_cartesian, _polar_to_cartesian,
-                          _cartesian_to_sphere)
+                          _cartesian_to_sphere, apply_trans, als_ras_trans_mm,
+                          get_ras_to_neuromag_trans)
 
 
 class Layout(object):
@@ -924,3 +926,59 @@ def apply_montage(info, montage):
         raise ValueError('None of the sensors defined in the montage were '
                          'found in the info structure. Check the channel '
                          'names.')
+
+
+def read_polhemus_montage(fname, point_names, kind='Polhemus digitized montage',
+                          transform=True):
+    """Read a Montage from points exported by Polhemus FastScan
+
+    Parameters
+    ----------
+    fname : str
+        Filename of the Polhemus Points file. The file should be exported as
+        text file.
+    point_names : list of str
+        The names of the points, in the same order as points in the file. Needs
+        to have the same lenght as the Points file. Points named with the empty
+        string ('') are ignored.
+    kind : str
+        Name for the Montage.
+    transform : bool
+        Transform the points to MNE's coordinate system. This requires the
+        'Nasion', 'LPA' and 'RPA' points to be specified. When False, the
+        points are still transformed to the RAS coordinate system but are not
+        aligned using Nasion, LPA and RPA.
+
+    Returns
+    -------
+    montage : Montage
+        Montage created from the points.
+    """
+    points = _read_dig_points(fname)
+    if len(points) != len(point_names):
+        raise ValueError("The file %s contains %i points, but %i names were "
+                         "specified." % (fname, len(points), len(point_names)))
+    points = apply_trans(als_ras_trans_mm, points)
+
+    if transform:
+        names_lower = [name.lower() for name in point_names]
+
+        # check that all needed points are present
+        missing = tuple(name for name in ('nasion', 'lpa', 'rpa')
+                        if name not in names_lower)
+        if missing:
+            raise ValueError("The points %s are missing, but are needed "
+                             "to transform the points to the MNE coordinate "
+                             "system. Either add the points, or read the "
+                             "montage with transform=False." % str(missing))
+
+        nasion = points[names_lower.index('nasion')]
+        lpa = points[names_lower.index('lpa')]
+        rpa = points[names_lower.index('rpa')]
+        neuromag_trans = get_ras_to_neuromag_trans(nasion, lpa, rpa)
+        points = apply_trans(neuromag_trans, points)
+
+    # drop points
+    index = np.array([bool(name) for name in point_names])
+    point_names = filter(bool, point_names)
+    return Montage(points[index], point_names, kind, np.arange(len(points)))

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -11,17 +11,18 @@
 import logging
 from collections import defaultdict
 from itertools import combinations
-import re
 import os
 import os.path as op
+
 import numpy as np
 from scipy.spatial.distance import pdist
+
+from .channels import _contains_ch_type
 from ..io.meas_info import _read_dig_points
 from ..io.pick import pick_types
 from ..io.constants import FIFF
 from ..utils import _clean_names
 from ..externals.six.moves import map
-from .channels import _contains_ch_type
 from ..viz import plot_montage
 from ..transforms import (_sphere_to_cartesian, _polar_to_cartesian,
                           _cartesian_to_sphere, apply_trans, als_ras_trans_mm,

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -976,13 +976,13 @@ def read_montage_polhemus(fname, point_names, kind='Polhemus digitized montage',
         names_lower = [name.lower() for name in point_names]
 
         # check that all needed points are present
-        missing = tuple(name for name in ('nasion', 'lpa', 'rpa')
-                        if name not in names_lower)
+        missing = [name for name in ('nasion', 'lpa', 'rpa')
+                   if name not in names_lower]
         if missing:
             raise ValueError("The points %s are missing, but are needed "
                              "to transform the points to the MNE coordinate "
                              "system. Either add the points, or read the "
-                             "montage with transform=False." % str(missing))
+                             "montage with transform=False." % missing)
 
         nasion = points[names_lower.index('nasion')]
         lpa = points[names_lower.index('lpa')]

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -930,7 +930,7 @@ def apply_montage(info, montage):
                          'names.')
 
 
-def read_polhemus_montage(fname, point_names, kind='Polhemus digitized montage',
+def read_montage_polhemus(fname, point_names, kind='Polhemus digitized montage',
                           transform=True):
     """Read a Montage from points exported by Polhemus FastScan
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -992,5 +992,5 @@ def read_montage_polhemus(fname, point_names, kind='Polhemus digitized montage',
 
     # drop points
     index = np.array([bool(name) for name in point_names])
-    point_names = filter(bool, point_names)
+    point_names = [name for name in point_names if name]
     return Montage(points[index], point_names, kind, np.arange(len(points)))

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1,20 +1,26 @@
+import inspect
 import os.path as op
 
-from nose.tools import assert_equal, assert_true, assert_false
+from nose.tools import (assert_equal, assert_true, assert_false,
+                        assert_almost_equal)
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_allclose)
 
-from mne.channels import read_montage, apply_montage
+from mne.channels import read_montage, apply_montage, read_montage_polhemus
 from mne.utils import _TempDir
 from mne import create_info
 
 
-tempdir = _TempDir()
+dir_path = op.dirname(inspect.getfile(inspect.currentframe()))
+points_fname = op.abspath(op.join(dir_path, '..', '..', 'io', 'kit', 'tests',
+                                  'data', 'test_elp.txt'))
 
 
 def test_montage():
     """Test making montages"""
+    tempdir = _TempDir()
     # no pep8
     input_str = ["""FidNz 0.00000 10.56381 -2.05108
     FidT9 -7.82694 0.45386 -3.76056
@@ -79,3 +85,21 @@ def test_montage():
     assert_array_equal(pos2, montage.pos)
     assert_array_equal(pos3, montage.pos)
     assert_equal(montage.ch_names, info['ch_names'])
+
+
+def test_read_montage_polhemus():
+    """Test read_montage_polhemus"""
+    names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']
+    kind = 'test montage'
+    m = read_montage_polhemus(points_fname, names, kind)
+    assert_equal(m.ch_names, names)
+    assert_equal(m.kind, kind)
+    # check coordinate transformation
+    assert_almost_equal(m.pos[0, 0], 0)
+    assert_almost_equal(m.pos[0, 2], 0)
+    assert_allclose(m.pos[1:3, 1:], 0, atol=1e-16)
+
+    # dropping points
+    names = ['nasion', 'lpa', 'rpa', '', '', '3', '4', '5']
+    m = read_montage_polhemus(points_fname, names)
+    assert_equal(m.ch_names, ['nasion', 'lpa', 'rpa', '3', '4', '5'])

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -6,11 +6,11 @@
 
 from warnings import warn
 from copy import deepcopy
+from datetime import datetime as dt
 import os.path as op
+
 import numpy as np
 from scipy import linalg
-from ..externals.six import BytesIO, string_types
-from datetime import datetime as dt
 
 from .pick import channel_type
 from .constants import FIFF
@@ -26,7 +26,7 @@ from .write import (start_file, end_file, start_block, end_block,
 from ..utils import logger, verbose
 from ..fixes import Counter
 from .. import __version__
-from ..externals.six import b
+from ..externals.six import b, BytesIO, string_types
 
 
 _kind_dict = dict(


### PR DESCRIPTION
Read Montage from Polhemus Point files (following up on https://github.com/mne-tools/mne-python/issues/1703#issuecomment-67361977)

To do:
- [x] allow point names to be specified in a file
- [x] TESTS
- [x] update DOCs

Questions:
 - ~~Do you prefer leaving this in `io.meas_info` or would you rather move it to a dedicated `io.polhemus` module?~~
 - ~~Can it be a problem to have superfluous points in the montage? (Should I drop Nasion, LPA and RPA after using them for the transform or add them to the Montage?)~~
 - `Montage.__init__` does not check its inputs, is it only for internal use so we can assume they're safe?
