### PR TITLE
ENH: Specify noise covariance rank

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1080,7 +1080,8 @@ def _xyz2lf(Lf_xyz, normals):
 # Assemble the inverse operator
 
 @verbose
-def _prepare_forward(forward, info, noise_cov, pca=False, verbose=None):
+def _prepare_forward(forward, info, noise_cov, pca=False, ncov_rank=None,
+                     verbose=None):
     """Util function to prepare forward solution for inverse solvers
     """
     fwd_ch_names = [c['ch_name'] for c in forward['info']['chs']]
@@ -1101,7 +1102,7 @@ def _prepare_forward(forward, info, noise_cov, pca=False, verbose=None):
     #
     #   Handle noise cov
     #
-    noise_cov = prepare_noise_cov(noise_cov, info, ch_names)
+    noise_cov = prepare_noise_cov(noise_cov, info, ch_names, ncov_rank)
 
     #   Omit the zeroes due to projection
     eig = noise_cov['eig']
@@ -1132,7 +1133,8 @@ def _prepare_forward(forward, info, noise_cov, pca=False, verbose=None):
 
 @verbose
 def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
-                          fixed=False, limit_depth_chs=True, verbose=None):
+                          fixed=False, limit_depth_chs=True, ncov_rank=None,
+                          verbose=None):
     """Assemble inverse operator
 
     Parameters
@@ -1157,6 +1159,11 @@ def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
         If True, use only grad channels in depth weighting (equivalent to MNE
         C code). If grad chanels aren't present, only mag channels will be
         used (if no mag, then eeg). If False, use all channels.
+    ncov_rank : None | int | dict
+        Specified rank of the noise covariance matrix. If None, the rank is
+        detected automatically. If int, the rank is specified for the MEG
+        channels. A dictionary with entries 'eeg' and/or 'meg' can be used
+        to specify the rank for each modality.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -1250,7 +1257,7 @@ def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
     #
 
     gain_info, gain, noise_cov, whitener, n_nzero = \
-        _prepare_forward(forward, info, noise_cov)
+        _prepare_forward(forward, info, noise_cov, ncov_rank=ncov_rank)
 
     #
     # 5. Compose the depth-weighting matrix


### PR DESCRIPTION
Allows specifying the ncov rank when computing inverse operators and also when whitening evoked responses.
