### PR TITLE
ENH: Allow AverageTFR to be computed from Evoked

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -661,6 +661,7 @@ Time-Frequency
    ar_raw
    compute_raw_psd
    compute_epochs_psd
+   cwt_morlet
    iir_filter_raw
    morlet
    tfr_morlet

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -59,6 +59,8 @@ Changelog
 
    - Improve EEG referencing support and add support for bipolar referencing by `Marijn van Vliet`_ and `Alex Gramfort`_
 
+   - Enable TFR calculation on Evoked objects by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -390,7 +390,7 @@ def _epoch_spectral_connectivity(data, sig_idx, tmin_idx, tmax_idx, sfreq,
                                  wavelets, use_fft=True, mode='same')
 
             if accumulate_psd:
-                this_psd.append(np.abs(this_x_cwt) ** 2)
+                this_psd.append((this_x_cwt * this_x_cwt.conj()).real)
 
             x_cwt.append(this_x_cwt)
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -284,6 +284,7 @@ def _filter(x, Fs, freq, gain, filter_length='10s', picks=None, n_jobs=1,
     freq = np.array(freq) / (Fs / 2.)
     gain = np.array(gain)
     filter_length = _get_filter_length(filter_length, Fs, len_x=x.shape[1])
+    n_jobs = check_n_jobs(n_jobs, allow_cuda=True)
 
     if filter_length is None or x.shape[1] <= filter_length:
         # Use direct FFT filtering for short signals
@@ -359,7 +360,7 @@ def _check_coefficients(b, a):
 def _filtfilt(x, b, a, padlen, picks, n_jobs, copy):
     """Helper to more easily call filtfilt"""
     # set up array for filtering, reshape to 2D, operate on last axis
-    n_jobs = check_n_jobs(n_jobs, allow_negative=False)
+    n_jobs = check_n_jobs(n_jobs)
     x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
     _check_coefficients(b, a)
     if n_jobs == 1:
@@ -1056,7 +1057,7 @@ def _mt_spectrum_proc(x, sfreq, line_freqs, notch_widths, mt_bandwidth,
                       p_value, picks, n_jobs, copy):
     """Helper to more easily call _mt_spectrum_remove"""
     # set up array for filtering, reshape to 2D, operate on last axis
-    n_jobs = check_n_jobs(n_jobs, allow_negative=False)
+    n_jobs = check_n_jobs(n_jobs)
     x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
     if n_jobs == 1:
         freq_list = list()

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1151,7 +1151,7 @@ def _mt_spectrum_remove(x, sfreq, line_freqs, notch_widths,
         x_hat = A * H0[:, np.newaxis]
 
         # numerator for F-statistic
-        num = (n_tapers - 1) * (np.abs(A) ** 2) * H0_sq
+        num = (n_tapers - 1) * (A * A.conj()).real * H0_sq
         # denominator for F-statistic
         den = (np.sum(np.abs(x_p[:, tapers_odd, :] - x_hat) ** 2, 1) +
                np.sum(np.abs(x_p[:, tapers_even, :]) ** 2, 1))

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -359,13 +359,13 @@ def _check_coefficients(b, a):
 def _filtfilt(x, b, a, padlen, picks, n_jobs, copy):
     """Helper to more easily call filtfilt"""
     # set up array for filtering, reshape to 2D, operate on last axis
+    n_jobs = check_n_jobs(n_jobs, allow_negative=False)
     x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
     _check_coefficients(b, a)
     if n_jobs == 1:
         for p in picks:
             x[p] = filtfilt(b, a, x[p], padlen=padlen)
     else:
-        check_n_jobs(n_jobs, allow_negative=False)
         parallel, p_fun, _ = parallel_func(filtfilt, n_jobs)
         data_new = parallel(p_fun(b, a, x[p], padlen=padlen)
                             for p in picks)
@@ -1056,6 +1056,7 @@ def _mt_spectrum_proc(x, sfreq, line_freqs, notch_widths, mt_bandwidth,
                       p_value, picks, n_jobs, copy):
     """Helper to more easily call _mt_spectrum_remove"""
     # set up array for filtering, reshape to 2D, operate on last axis
+    n_jobs = check_n_jobs(n_jobs, allow_negative=False)
     x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
     if n_jobs == 1:
         freq_list = list()
@@ -1066,7 +1067,6 @@ def _mt_spectrum_proc(x, sfreq, line_freqs, notch_widths, mt_bandwidth,
                                                p_value)
                 freq_list.append(f)
     else:
-        check_n_jobs(n_jobs, allow_negative=False)
         parallel, p_fun, _ = parallel_func(_mt_spectrum_remove, n_jobs)
         data_new = parallel(p_fun(x_, sfreq, line_freqs, notch_widths,
                                   mt_bandwidth, p_value)

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -110,11 +110,11 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
 
         if update_mode == 1:
             # MacKay fixed point update (10) in [1]
-            numer = gammas ** 2 * np.mean(np.abs(A) ** 2, axis=1)
+            numer = gammas ** 2 * np.mean((A * A.conj()).real, axis=1)
             denom = gammas * np.sum(G * CMinvG, axis=0)
         elif update_mode == 2:
             # modified MacKay fixed point update (11) in [1]
-            numer = gammas * np.sqrt(np.mean(np.abs(A) ** 2, axis=1))
+            numer = gammas * np.sqrt(np.mean((A * A.conj()).real, axis=1))
             denom = np.sum(G * CMinvG, axis=0)  # sqrt is applied below
         else:
             raise ValueError('Invalid value for update_mode')

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -71,8 +71,8 @@ def prox_l21(Y, alpha, n_orient, shape=None, is_stft=False):
     if is_stft:
         rows_norm = np.sqrt(stft_norm2(Y).reshape(n_positions, -1).sum(axis=1))
     else:
-        rows_norm = np.sqrt(np.sum((np.abs(Y) ** 2).reshape(n_positions, -1),
-                                   axis=1))
+        rows_norm = np.sqrt((Y * Y.conj()).real.reshape(n_positions,
+                                                        -1).sum(axis=1))
     # Ensure shrink is >= 0 while avoiding any division by zero
     shrink = np.maximum(1.0 - alpha / np.maximum(rows_norm, alpha), 0.0)
     active_set = shrink > 0.0
@@ -110,7 +110,7 @@ def prox_l1(Y, alpha, n_orient):
     [ True  True False False]
     """
     n_positions = Y.shape[0] // n_orient
-    norms = np.sqrt(np.sum((np.abs(Y) ** 2).T.reshape(-1, n_orient), axis=1))
+    norms = np.sqrt((Y * Y.conj()).real.T.reshape(-1, n_orient).sum(axis=1))
     # Ensure shrink is >= 0 while avoiding any division by zero
     shrink = np.maximum(1.0 - alpha / np.maximum(norms, alpha), 0.0)
     shrink = shrink.reshape(-1, n_positions).T

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -90,14 +90,11 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
     frequencies = np.concatenate([np.arange(band[0], band[1] + df / 2.0, df)
                                  for _, band in six.iteritems(bands)])
 
-    powers, _, vertno = _source_induced_power(epochs,
-                                              inverse_operator, frequencies,
-                                              label=label,
-                                              lambda2=lambda2, method=method,
-                                              nave=nave, n_cycles=n_cycles,
-                                              decim=decim, use_fft=use_fft,
-                                              pca=pca, n_jobs=n_jobs,
-                                              with_plv=False, prepared=prepared)
+    powers, _, vertno = _source_induced_power(
+        epochs, inverse_operator, frequencies, label=label, lambda2=lambda2,
+        method=method, nave=nave, n_cycles=n_cycles, decim=decim,
+        use_fft=use_fft, pca=pca, n_jobs=n_jobs, with_plv=False,
+        prepared=prepared)
 
     Fs = epochs.info['sfreq']  # sampling in Hz
     stcs = dict()
@@ -132,7 +129,7 @@ def _compute_pow_plv(data, K, sel, Ws, source_ori, use_fft, Vh, with_plv,
     n_freqs = len(Ws)
     n_sources = K.shape[0]
     is_free_ori = False
-    if (source_ori == FIFF.FIFFV_MNE_FREE_ORI and pick_ori == None):
+    if (source_ori == FIFF.FIFFV_MNE_FREE_ORI and pick_ori is None):
         is_free_ori = True
         n_sources //= 3
 
@@ -244,7 +241,7 @@ def _source_induced_power(epochs, inverse_operator, frequencies, label=None,
     out = parallel(my_compute_pow_plv(data, K, sel, Ws,
                                       inv['source_ori'], use_fft, Vh,
                                       with_plv, pick_ori, decim)
-                        for data in np.array_split(epochs_data, n_jobs))
+                   for data in np.array_split(epochs_data, n_jobs))
     power = sum(o[0] for o in out)
     power /= len(epochs_data)  # average power over epochs
 
@@ -463,10 +460,10 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
         data_fft = fftpack.fft(data)[:, freqs_mask]
         sol = np.dot(K, data_fft)
 
-        if is_free_ori and pick_ori == None:
+        if is_free_ori and pick_ori is None:
             sol = combine_xyz(sol, square=True)
         else:
-            sol = np.abs(sol) ** 2
+            sol = (sol * sol.conj()).real
 
         if method != "MNE":
             sol *= noise_norm ** 2
@@ -606,7 +603,7 @@ def _compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
             pos += K_part.shape[0]
 
         # combine orientations
-        if is_free_ori and pick_ori == None:
+        if is_free_ori and pick_ori is None:
             psd = combine_xyz(psd, square=False)
 
         if method != "MNE":

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -103,7 +103,7 @@ def parallel_func(func, n_jobs, verbose=None, max_nbytes='auto'):
     return parallel, my_func, n_jobs
 
 
-def check_n_jobs(n_jobs, allow_cuda=False, allow_negative=True):
+def check_n_jobs(n_jobs, allow_cuda=False):
     """Check n_jobs in particular for negative values
 
     Parameters
@@ -112,8 +112,6 @@ def check_n_jobs(n_jobs, allow_cuda=False, allow_negative=True):
         The number of jobs.
     allow_cuda : bool
         Allow n_jobs to be 'cuda'. Default: False.
-    allow_negative : bool
-        Allow negative integers (will be wrapped to positive counterparts).
 
     Returns
     -------
@@ -127,8 +125,6 @@ def check_n_jobs(n_jobs, allow_cuda=False, allow_negative=True):
         elif not isinstance(n_jobs, string_types) or n_jobs != 'cuda':
             raise ValueError('n_jobs must be an integer, or "cuda"')
         # else, we have n_jobs='cuda' and this is okay, so do nothing
-    elif n_jobs <= 0 and not allow_negative:
-        raise ValueError('n_jobs must be >= 1')
     elif _force_serial:
         n_jobs = 1
         logger.info('... MNE_FORCE_SERIAL set. Processing in forced '

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -18,6 +18,7 @@ if 'MNE_FORCE_SERIAL' in os.environ:
 else:
     _force_serial = None
 
+
 @verbose
 def parallel_func(func, n_jobs, verbose=None, max_nbytes='auto'):
     """Return parallel instance with delayed function
@@ -102,7 +103,7 @@ def parallel_func(func, n_jobs, verbose=None, max_nbytes='auto'):
     return parallel, my_func, n_jobs
 
 
-def check_n_jobs(n_jobs, allow_cuda=False):
+def check_n_jobs(n_jobs, allow_cuda=False, allow_negative=True):
     """Check n_jobs in particular for negative values
 
     Parameters
@@ -111,6 +112,8 @@ def check_n_jobs(n_jobs, allow_cuda=False):
         The number of jobs.
     allow_cuda : bool
         Allow n_jobs to be 'cuda'. Default: False.
+    allow_negative : bool
+        Allow negative integers (will be wrapped to positive counterparts).
 
     Returns
     -------
@@ -122,14 +125,15 @@ def check_n_jobs(n_jobs, allow_cuda=False):
         n_jobs = 1
         logger.info('... MNE_FORCE_SERIAL set. Processing in forced '
                     'serial mode.')
-
     elif not isinstance(n_jobs, int):
         if not allow_cuda:
             raise ValueError('n_jobs must be an integer')
         elif not isinstance(n_jobs, string_types) or n_jobs != 'cuda':
             raise ValueError('n_jobs must be an integer, or "cuda"')
-        #else, we have n_jobs='cuda' and this is okay, so do nothing
+        # else, we have n_jobs='cuda' and this is okay, so do nothing
     elif n_jobs <= 0:
+        if not allow_negative:
+            raise ValueError('n_jobs must be >= 1')
         try:
             import multiprocessing
             n_cores = multiprocessing.cpu_count()

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -121,19 +121,19 @@ def check_n_jobs(n_jobs, allow_cuda=False, allow_negative=True):
         The checked number of jobs. Always positive (or 'cuda' if
         applicable.)
     """
-    if _force_serial:
-        n_jobs = 1
-        logger.info('... MNE_FORCE_SERIAL set. Processing in forced '
-                    'serial mode.')
-    elif not isinstance(n_jobs, int):
+    if not isinstance(n_jobs, int):
         if not allow_cuda:
             raise ValueError('n_jobs must be an integer')
         elif not isinstance(n_jobs, string_types) or n_jobs != 'cuda':
             raise ValueError('n_jobs must be an integer, or "cuda"')
         # else, we have n_jobs='cuda' and this is okay, so do nothing
+    elif n_jobs <= 0 and not allow_negative:
+        raise ValueError('n_jobs must be >= 1')
+    elif _force_serial:
+        n_jobs = 1
+        logger.info('... MNE_FORCE_SERIAL set. Processing in forced '
+                    'serial mode.')
     elif n_jobs <= 0:
-        if not allow_negative:
-            raise ValueError('n_jobs must be >= 1')
         try:
             import multiprocessing
             n_cores = multiprocessing.cpu_count()

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -118,8 +118,9 @@ def test_filters():
                       filter_length=fl)
     for nj in ['blah', 0.5]:
         assert_raises(ValueError, band_pass_filter, a, sfreq, 4, 8, n_jobs=nj)
-    assert_raises(ValueError, band_pass_filter, a, sfreq, 4, sfreq / 2.)  # > Nyq/2
-    assert_raises(ValueError, low_pass_filter, a, sfreq, sfreq / 2.)  # > Nyq/2
+    # > Nyq/2
+    assert_raises(ValueError, band_pass_filter, a, sfreq, 4, sfreq / 2.)
+    assert_raises(ValueError, low_pass_filter, a, sfreq, sfreq / 2.)
     # check our short-filter warning:
     with warnings.catch_warnings(record=True) as w:
         # Warning for low attenuation
@@ -213,8 +214,8 @@ def test_cuda():
         lp = low_pass_filter(a, sfreq, 8, n_jobs=1, filter_length=fl)
         hp = high_pass_filter(lp, sfreq, 4, n_jobs=1, filter_length=fl)
 
-        bp_c = band_pass_filter(a, sfreq, 4, 8, n_jobs='cuda', filter_length=fl,
-                                verbose='INFO')
+        bp_c = band_pass_filter(a, sfreq, 4, 8, n_jobs='cuda',
+                                filter_length=fl, verbose='INFO')
         bs_c = band_stop_filter(a, sfreq, 4 - 0.5, 8 + 0.5, n_jobs='cuda',
                                 filter_length=fl, verbose='INFO')
         lp_c = low_pass_filter(a, sfreq, 8, n_jobs='cuda', filter_length=fl,

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -115,7 +115,7 @@ def test_filters():
     for fl in ['blah', [0, 1], 1000.5, '10ss', '10']:
         assert_raises(ValueError, band_pass_filter, a, Fs, 4, 8,
                       filter_length=fl)
-    for nj in ['blah', 0.5, 0]:
+    for nj in ['blah', 0.5]:
         assert_raises(ValueError, band_pass_filter, a, Fs, 4, 8, n_jobs=nj)
     assert_raises(ValueError, band_pass_filter, a, Fs, 4, Fs / 2.)  # > Nyq/2
     assert_raises(ValueError, low_pass_filter, a, Fs, Fs / 2.)  # > Nyq/2

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -1,8 +1,8 @@
 """Time frequency analysis tools
 """
 
-from .tfr import single_trial_power, morlet, tfr_morlet
-from .tfr import AverageTFR, tfr_multitaper, read_tfrs, write_tfrs
+from .tfr import (single_trial_power, morlet, tfr_morlet, cwt_morlet,
+                  AverageTFR, tfr_multitaper, read_tfrs, write_tfrs)
 from .psd import compute_raw_psd, compute_epochs_psd
 from .csd import CrossSpectralDensity, compute_epochs_csd
 from .ar import yule_walker, ar_raw, iir_filter_raw

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -171,22 +171,14 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
     psd = np.empty((n_channels, n_freq, n_out))
     itc = np.empty((n_channels, n_freq, n_out)) if return_itc else None
 
-    if n_jobs == 1:
-        for c in range(n_channels):
-            psd[c], this_itc = \
-                _st_power_itc(data[:, c, :], start_f, return_itc, zero_pad,
-                              decim, W)
-            if return_itc:
-                itc[c] = this_itc
-    else:
-        parallel, my_st, _ = parallel_func(_st_power_itc, n_jobs)
-        tfrs = parallel(my_st(data[:, c, :], start_f, return_itc, zero_pad,
-                              decim, W)
-                        for c in range(n_channels))
-        for c, (this_psd, this_itc) in enumerate(iter(tfrs)):
-            psd[c] = this_psd
-            if this_itc is not None:
-                itc[c] = this_itc
+    parallel, my_st, _ = parallel_func(_st_power_itc, n_jobs)
+    tfrs = parallel(my_st(data[:, c, :], start_f, return_itc, zero_pad,
+                          decim, W)
+                    for c in range(n_channels))
+    for c, (this_psd, this_itc) in enumerate(iter(tfrs)):
+        psd[c] = this_psd
+        if this_itc is not None:
+            itc[c] = this_itc
 
     return psd, itc, freqs
 

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -15,8 +15,7 @@ from ..parallel import parallel_func, check_n_jobs
 from .tfr import AverageTFR, _get_data
 
 
-@verbose
-def _check_input_st(x_in, n_fft, verbose=None):
+def _check_input_st(x_in, n_fft):
     """Aux function"""
     # flatten to 2 D and memorize original shape
     n_times = x_in.shape[-1]
@@ -32,16 +31,16 @@ def _check_input_st(x_in, n_fft, verbose=None):
     if n_times < n_fft:
         msg = ('The input signal is shorter ({0}) than "n_fft" ({1}). '
                'Applying zero padding.').format(x_in.shape[-1], n_fft)
-        logger.warn(msg)
+        logger.warning(msg)
         zero_pad = n_fft - n_times
-        pad_array = np.zeros(list(x_in.shape[:-1]) + [zero_pad], dtype=x_in.dtype)
+        pad_array = np.zeros(list(x_in.shape[:-1]) + [zero_pad], x_in.dtype)
         x_in = np.concatenate((x_in, pad_array), axis=-1)
         return x_in, n_fft, zero_pad
 
 
-def _precompute_st_windows(M, start_f, stop_f, sfreq, width):
-    """Precompute stockwell gausian windows """
-    tw = fftpack.fftfreq(M, 1. / sfreq) / M
+def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
+    """Precompute stockwell gausian windows (in the freq domain)"""
+    tw = fftpack.fftfreq(n_samp, 1. / sfreq) / n_samp
     tw = np.r_[tw[:1], tw[1:][::-1]]
 
     k = width  # 1 for classical stowckwell transform
@@ -55,51 +54,45 @@ def _precompute_st_windows(M, start_f, stop_f, sfreq, width):
                       np.exp(-0.5 * (1. / k ** 2.) * (f ** 2.) * tw ** 2.))
         window /= window.sum()  # normalisation
         windows[i_f] = fftpack.fft(window)
-    return M, f_range, windows
+    return windows
 
 
-def _st(x, M, f_range, windows):
-    """Implementation based on Matlab code by Ali Moukadem"""
-    if x.ndim == 1:
-        x = x[np.newaxis, :]
+def _st(x, start_f, windows):
+    """Implementation based on Ali Moukadem Matlab code (only used in tests)"""
+    n_samp = x.shape[-1]
+    ST = np.empty(x.shape[:-1] + (len(windows), n_samp), dtype=np.complex)
+    # do the work
     Fx = fftpack.fft(x)
-    XF = np.c_[Fx, Fx]
-    ST = np.empty((x.shape[0], len(f_range), M), dtype=np.complex)
-    for i_f, (window, f) in enumerate(zip(windows, f_range)):
-        for i in range(len(x)):
-            ST[i, i_f, :] = fftpack.ifft(XF[i, f:f + M] * window)
-    if ST.shape[0] == 1:
-        ST = ST[0]
+    XF = np.concatenate([Fx, Fx], axis=-1)
+    for i_f, window in enumerate(windows):
+        f = start_f + i_f
+        ST[..., i_f, :] = fftpack.ifft(XF[..., f:f + n_samp] * window)
     return ST
 
 
-def _st_power_itc(x, M, f_range, windows, compute_itc, zero_pad, decim,
-                  final_times):
+def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     """Aux function"""
-    psd = np.zeros((len(f_range), final_times))
-    if compute_itc is True:
-        itc = np.zeros((len(f_range), final_times), dtype=np.complex)
-    else:
-        itc = None
-    for tfr in _st(x, M, f_range, windows):
-        tfr = tfr[..., :-zero_pad]
-        tfr = tfr[..., ::decim]
-        tfr_abs = np.abs(tfr)
-        psd += tfr_abs ** 2
+    n_samp = x.shape[-1]
+    n_out = (n_samp - zero_pad) // decim
+    psd = np.empty((len(W), n_out))
+    itc = np.empty_like(psd) if compute_itc else None
+    X = fftpack.fft(x)
+    XX = np.concatenate([X, X], axis=-1)
+    for i_f, window in enumerate(W):
+        f = start_f + i_f
+        ST = fftpack.ifft(XX[:, f:f + n_samp] * window)
+        TFR = ST[:, :-zero_pad:decim]
+        TFR_abs = np.abs(TFR)
         if compute_itc:
-            itc += tfr / tfr_abs
-
-    n_signals = x.shape[0]
-    psd /= n_signals
-    if compute_itc:
-        itc = np.abs(itc) / n_signals
+            TFR /= TFR_abs
+            itc[i_f] = np.abs(np.mean(TFR, axis=0))
+        TFR_abs *= TFR_abs
+        psd[i_f] = np.mean(TFR_abs, axis=0)
     return psd, itc
 
 
-@verbose
 def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
-                             decim=1, return_itc=False, n_jobs=1,
-                             verbose=None):
+                             decim=1, return_itc=False, n_jobs=1):
     """Computes power and intertrial coherence using Stockwell (S) transform
 
     Parameters
@@ -127,8 +120,6 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
         Return intertrial coherence (ITC) as well as averaged power.
     n_jobs : int
         Number of parallel jobs to use.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
 
     Returns
     -------
@@ -160,8 +151,9 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
         individuals diagnosed with alcoholism.
         Clinical Neurophysiology 117 2128--2143
     """
-    n_epochs, n_channels, n_times = data[:, :, ::decim].shape
-    data, n_fft_, zero_pad = _check_input_st(data, n_fft, verbose)
+    n_epochs, n_channels = data.shape[:2]
+    n_out = max(data.shape[2] // decim, 1)
+    data, n_fft_, zero_pad = _check_input_st(data, n_fft)
 
     freqs = fftpack.fftfreq(n_fft_, 1. / sfreq)
     if fmin is None:
@@ -171,30 +163,37 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
 
     start_f = np.abs(freqs - fmin).argmin()
     stop_f = np.abs(freqs - fmax).argmin()
-
-    M, f_range, windows = _precompute_st_windows(data.shape[-1], start_f,
-                                                 stop_f, sfreq, width)
-    n_frequencies = len(f_range)
-    psd = np.empty((n_channels, n_frequencies, n_times))
-    itc = np.empty((n_channels, n_frequencies, n_times))
-
-    n_jobs = check_n_jobs(n_jobs)
-    parallel, my_st, _ = parallel_func(_st_power_itc, n_jobs)
-    tfrs = parallel(my_st(data[:, c, :], M, f_range, windows,
-                          return_itc, zero_pad, decim, n_times)
-                    for c in range(n_channels))
-    tfrs = iter(tfrs)
-    for i_chan, (this_psd, this_itc) in enumerate(tfrs):
-        psd[i_chan] = this_psd
-        if this_itc is not None:
-            itc[i_chan] = this_itc
-
     freqs = freqs[start_f:stop_f]
+
+    W = _precompute_st_windows(data.shape[-1], start_f, stop_f, sfreq, width)
+    n_freq = stop_f - start_f
+    psd = np.empty((n_channels, n_freq, n_out))
+    itc = np.empty((n_channels, n_freq, n_out)) if return_itc else None
+
+    if n_jobs == 1:
+        for c in range(n_channels):
+            psd[c], this_itc = \
+                _st_power_itc(data[:, c, :], start_f, return_itc, zero_pad,
+                              decim, W)
+            if return_itc:
+                itc[c] = this_itc
+    else:
+        parallel, my_st, _ = parallel_func(_st_power_itc, n_jobs)
+        tfrs = parallel(my_st(data[:, c, :], start_f, return_itc, zero_pad,
+                              decim, W)
+                        for c in range(n_channels))
+        for c, (this_psd, this_itc) in enumerate(iter(tfrs)):
+            psd[c] = this_psd
+            if this_itc is not None:
+                itc[c] = this_itc
+
     return psd, itc, freqs
 
 
+@verbose
 def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
-                  width=1.0, decim=1, return_itc=False, n_jobs=1):
+                  width=1.0, decim=1, return_itc=False, n_jobs=1,
+                  verbose=None):
     """Time-Frequency Representation (TFR) using Stockwell Transform
 
     Parameters
@@ -219,6 +218,8 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
         Return intertrial coherence (ITC) as well as averaged power.
     n_jobs : int
         The number of jobs to run in parallel (over channels).
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
 
     Returns
     -------
@@ -227,10 +228,12 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     itc : AverageTFR
         The intertrial coherence. Only returned if return_itc is True.
     """
+    # verbose dec is used b/c subfunctions are verbose
     data = _get_data(inst, return_itc)
     picks = pick_types(inst.info, meg=True, eeg=True)
     info = pick_info(inst.info, picks)
     data = data[:, picks, :]
+    n_jobs = check_n_jobs(n_jobs)
     power, itc, freqs = _induced_power_stockwell(data,
                                                  sfreq=info['sfreq'],
                                                  fmin=fmin, fmax=fmax,

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -73,7 +73,8 @@ def _st(x, start_f, windows):
 def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     """Aux function"""
     n_samp = x.shape[-1]
-    n_out = (n_samp - zero_pad) // decim
+    n_out = (n_samp - zero_pad)
+    n_out = n_out // decim + bool(n_out % decim)
     psd = np.empty((len(W), n_out))
     itc = np.empty_like(psd) if compute_itc else None
     X = fftpack.fft(x)
@@ -152,7 +153,7 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
         Clinical Neurophysiology 117 2128--2143
     """
     n_epochs, n_channels = data.shape[:2]
-    n_out = max(data.shape[2] // decim, 1)
+    n_out = data.shape[2] // decim + bool(data.shape[2] % decim)
     data, n_fft_, zero_pad = _check_input_st(data, n_fft)
 
     freqs = fftpack.fftfreq(n_fft_, 1. / sfreq)

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -33,7 +33,7 @@ def _check_input_st(x_in, n_fft):
                'Applying zero padding.').format(x_in.shape[-1], n_fft)
         logger.warning(msg)
         zero_pad = n_fft - n_times
-        pad_array = np.zeros(list(x_in.shape[:-1]) + [zero_pad], x_in.dtype)
+        pad_array = np.zeros(x_in.shape[:-1] + (zero_pad,), x_in.dtype)
         x_in = np.concatenate((x_in, pad_array), axis=-1)
         return x_in, n_fft, zero_pad
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -378,10 +378,9 @@ def _psd_from_mt(x_mt, weights):
     psd : array
         The computed PSD
     """
-
-    psd = np.sum(np.abs(weights * x_mt) ** 2, axis=-2)
-    psd *= 2 / np.sum(np.abs(weights) ** 2, axis=-2)
-
+    psd = weights * x_mt
+    psd = (psd * psd.conj()).real.sum(axis=-2)
+    psd *= 2 / (weights * weights.conj()).real.sum(axis=-2)
     return psd
 
 
@@ -404,14 +403,10 @@ def _csd_from_mt(x_mt, y_mt, weights_x, weights_y):
     psd: array
         The computed PSD
     """
-
     csd = np.sum(weights_x * x_mt * (weights_y * y_mt).conj(), axis=-2)
-
-    denom = (np.sqrt(np.sum(np.abs(weights_x) ** 2, axis=-2))
-             * np.sqrt(np.sum(np.abs(weights_y) ** 2, axis=-2)))
-
+    denom = (np.sqrt((weights_x * weights_x.conj()).real.sum(axis=-2)) *
+             np.sqrt((weights_y * weights_y.conj()).real.sum(axis=-2)))
     csd *= 2 / denom
-
     return csd
 
 

--- a/mne/time_frequency/stft.py
+++ b/mne/time_frequency/stft.py
@@ -230,7 +230,7 @@ def stft_norm2(X):
     norms2 : array
         The squared L2 norm of every row of X.
     """
-    X2 = np.abs(X) ** 2
+    X2 = (X * X.conj()).real
     # compute all L2 coefs and remove first and last frequency once.
     norms2 = (2. * X2.sum(axis=2).sum(axis=1) - np.sum(X2[:, 0, :], axis=1) -
               np.sum(X2[:, -1, :], axis=1))

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -14,6 +14,7 @@ from mne import io, read_events, Epochs, pick_types
 from mne.time_frequency._stockwell import (tfr_stockwell, _st,
                                            _precompute_st_windows)
 from mne.time_frequency.tfr import AverageTFR
+from mne.utils import slow_test
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -72,8 +73,9 @@ def test_stockwell_core():
     assert_array_almost_equal(pulse, y_inv)
 
 
+@slow_test
 def test_stockwell_api():
-    """test stockwell functions"""
+    """Test stockwell functions"""
     epochs = Epochs(raw, events,  # XXX pick 2 has epochs of zeros.
                     event_id, tmin, tmax, picks=[0, 1, 3], baseline=(None, 0))
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -85,6 +85,9 @@ def test_stockwell_api():
             assert_true(power.freqs.max() <= fmax)
         power_evoked = tfr_stockwell(epochs.average(), fmin=fmin, fmax=fmax,
                                      return_itc=False)
+        # for multitaper these don't necessarily match, but they seem to
+        # for stockwell... if this fails, this maybe could be changed
+        # just to check the shape
         assert_array_almost_equal(power_evoked.data, power.data)
     assert_true(isinstance(power, AverageTFR))
     assert_true(isinstance(itc, AverageTFR))

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -5,8 +5,8 @@
 
 import numpy as np
 import os.path as op
-from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true, assert_equals
+from numpy.testing import assert_array_almost_equal, assert_allclose
+from nose.tools import assert_true, assert_equal
 
 from scipy import fftpack
 
@@ -33,30 +33,30 @@ flat = dict(grad=1e-15, mag=1e-15)
 
 def test_stockwell_core():
     """Test stockwell transform"""
-    # taken from
-
+    # adapted from
     # http://vcs.ynic.york.ac.uk/docs/naf/intro/concepts/timefreq.html
     sfreq = 1000.0  # make things easy to understand
-    t = np.arange(sfreq)   # make an array for time
-    t /= sfreq        # scale it so it goes to 1, i.e. 1 sec of time
+    dur = 0.5
+    onset, offset = 0.175, 0.275
+    n_samp = int(sfreq * dur)
+    t = np.arange(n_samp) / sfreq   # make an array for time
     pulse_freq = 15.
     pulse = np.cos(2. * np.pi * pulse_freq * t)
-    pulse[0:175] = 0.        # Zero before our desired pulse
-    pulse[275:] = 0.         # and zero after our desired pulse
+    pulse[0:int(onset * sfreq)] = 0.        # Zero before our desired pulse
+    pulse[int(offset * sfreq):] = 0.         # and zero after our desired pulse
 
     width = 0.5
     freqs = fftpack.fftfreq(len(pulse), 1. / sfreq)
     fmin, fmax = 1.0, 100.0
     start_f, stop_f = [np.abs(freqs - f).argmin() for f in (fmin, fmax)]
-    st_precomputed = _precompute_st_windows(1000, start_f, stop_f,
-                                            sfreq, width)
+    W = _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width)
 
-    st_pulse = _st(pulse, *st_precomputed)
+    st_pulse = _st(pulse, start_f, W)
     st_pulse = np.abs(st_pulse) ** 2
-    assert_equals(st_pulse.shape[-1], len(pulse))
-    st_max_freq = st_pulse.max(axis=1).argmax(axis=0)  # max freq
-    assert_equals(st_max_freq, pulse_freq)
-    assert_true(175 < st_pulse.max(axis=0).argmax(axis=0) < 275)  # max time
+    assert_equal(st_pulse.shape[-1], len(pulse))
+    st_max_freq = freqs[st_pulse.max(axis=1).argmax(axis=0)]  # max freq
+    assert_allclose(st_max_freq, pulse_freq, atol=1.0)
+    assert_true(onset < t[st_pulse.max(axis=0).argmax(axis=0)] < offset)
 
     # test inversion to FFT, by averaging local spectra, see eq. 5 in
     # Moukadem, A., Bouguila, Z., Ould Abdeslam, D. and Alain Dieterlen.
@@ -65,12 +65,10 @@ def test_stockwell_core():
 
     width = 1.0
     start_f, stop_f = 0, len(pulse)
-    st_precomputed = _precompute_st_windows(1000, start_f, stop_f,
-                                            sfreq, width)
-    y = _st(pulse, *st_precomputed)
+    W = _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width)
+    y = _st(pulse, start_f, W)
     # invert stockwell
     y_inv = fftpack.ifft(np.sum(y, axis=1)).real
-
     assert_array_almost_equal(pulse, y_inv)
 
 
@@ -81,6 +79,10 @@ def test_stockwell_api():
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:
         power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
                                    return_itc=True)
+        power_par, itc_par = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
+                                           return_itc=True, n_jobs=2)
+        assert_array_almost_equal(power.data, power_par.data)
+        assert_array_almost_equal(itc.data, itc_par.data)
         if fmax is not None:
             assert_true(power.freqs.max() <= fmax)
         power_evoked = tfr_stockwell(epochs.average(), fmin=fmin, fmax=fmax,
@@ -91,7 +93,7 @@ def test_stockwell_api():
         assert_array_almost_equal(power_evoked.data, power.data)
     assert_true(isinstance(power, AverageTFR))
     assert_true(isinstance(itc, AverageTFR))
-    assert_equals(power.data.shape, itc.data.shape)
+    assert_equal(power.data.shape, itc.data.shape)
     assert_true(itc.data.min() >= 0.0)
     assert_true(itc.data.max() <= 1.0)
     assert_true(np.log(power.data.max()) * 20 <= 0.0)

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -48,7 +48,8 @@ def test_stockwell_core():
     freqs = fftpack.fftfreq(len(pulse), 1. / sfreq)
     fmin, fmax = 1.0, 100.0
     start_f, stop_f = [np.abs(freqs - f).argmin() for f in (fmin, fmax)]
-    st_precomputed = _precompute_st_windows(1000, start_f, stop_f, sfreq, width)
+    st_precomputed = _precompute_st_windows(1000, start_f, stop_f,
+                                            sfreq, width)
 
     st_pulse = _st(pulse, *st_precomputed)
     st_pulse = np.abs(st_pulse) ** 2
@@ -64,7 +65,8 @@ def test_stockwell_core():
 
     width = 1.0
     start_f, stop_f = 0, len(pulse)
-    st_precomputed = _precompute_st_windows(1000, start_f, stop_f, sfreq, width)
+    st_precomputed = _precompute_st_windows(1000, start_f, stop_f,
+                                            sfreq, width)
     y = _st(pulse, *st_precomputed)
     # invert stockwell
     y_inv = fftpack.ifft(np.sum(y, axis=1)).real
@@ -81,6 +83,9 @@ def test_stockwell_api():
                                    return_itc=True)
         if fmax is not None:
             assert_true(power.freqs.max() <= fmax)
+        power_evoked = tfr_stockwell(epochs.average(), fmin=fmin, fmax=fmax,
+                                     return_itc=False)
+        assert_array_almost_equal(power_evoked.data, power.data)
     assert_true(isinstance(power, AverageTFR))
     assert_true(isinstance(itc, AverageTFR))
     assert_equals(power.data.shape, itc.data.shape)

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -73,7 +73,6 @@ def test_stockwell_core():
     assert_array_almost_equal(pulse, y_inv)
 
 
-@slow_test
 def test_stockwell_api():
     """Test stockwell functions"""
     epochs = Epochs(raw, events,  # XXX pick 2 has epochs of zeros.
@@ -81,10 +80,6 @@ def test_stockwell_api():
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:
         power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
                                    return_itc=True)
-        power_par, itc_par = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
-                                           return_itc=True, n_jobs=2)
-        assert_array_almost_equal(power.data, power_par.data)
-        assert_array_almost_equal(itc.data, itc_par.data)
         if fmax is not None:
             assert_true(power.freqs.max() <= fmax)
         power_evoked = tfr_stockwell(epochs.average(), fmin=fmin, fmax=fmax,

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -166,6 +166,12 @@ def test_tfr_multitaper():
     assert_true(tmax > 0.3 and tmax < 0.7)
     assert_false(np.any(itc.data < 0.))
     assert_true(fmax > 40 and fmax < 60)
+    power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
+                                  n_cycles=freqs / 2., time_bandwidth=4.0,
+                                  return_itc=False)
+    # XXX The other two transforms (stockwell, CWT) have data equal but this
+    # one does not, need to think about if it should be
+    assert_array_equal(power.data.shape, power_evoked.data.shape)
 
 
 def test_io():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -59,8 +59,13 @@ def test_time_frequency():
     power, itc = tfr_morlet(epochs[0], freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
 
+    evoked = epochs.average()
+    power_evoked = tfr_morlet(evoked, freqs, n_cycles, use_fft=True,
+                              return_itc=False)
+    assert_raises(ValueError, tfr_morlet, evoked, freqs, 1., return_itc=True)
     power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
+    assert_array_almost_equal(power.data, power_evoked.data)
 
     print(itc)  # test repr
     print(itc.ch_names)  # test property

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -65,6 +65,7 @@ def test_time_frequency():
     assert_raises(ValueError, tfr_morlet, evoked, freqs, 1., return_itc=True)
     power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
+    # the actual data arrays here are equivalent, too...
     assert_array_almost_equal(power.data, power_evoked.data)
 
     print(itc)  # test repr
@@ -164,7 +165,12 @@ def test_tfr_multitaper():
     power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
                                   n_cycles=freqs / 2., time_bandwidth=4.0,
                                   return_itc=False)
-    assert_array_almost_equal(power.data, power_evoked.data)
+    # one is squared magnitude of the average (evoked) and
+    # the other is average of the squared magnitudes (epochs PSD)
+    # so values shouldn't match, but shapes should
+    assert_array_equal(power.data.shape, power_evoked.data.shape)
+    assert_raises(AssertionError, assert_array_almost_equal,
+                  power.data, power_evoked.data)
 
     tmax = t[np.argmax(itc.data[0, freqs == 50, :])]
     fmax = freqs[np.argmax(power.data[1, :, t == 0.5])]

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -5,7 +5,7 @@ from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 import mne
 from mne import io, Epochs, read_events, pick_types, create_info, EpochsArray
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import _TempDir, run_tests_if_main, slow_test
 from mne.time_frequency import single_trial_power
 from mne.time_frequency.tfr import cwt_morlet, morlet, tfr_morlet
 from mne.time_frequency.tfr import _dpss_wavelet, tfr_multitaper
@@ -121,7 +121,7 @@ def test_time_frequency():
 
 
 def test_dpsswavelet():
-    """Some tests for DPSS wavelet"""
+    """Test DPSS wavelet"""
     freqs = np.arange(5, 25, 3)
     Ws = _dpss_wavelet(1000, freqs=freqs, n_cycles=freqs/2.,
                        time_bandwidth=4.0, zero_mean=True)
@@ -134,8 +134,9 @@ def test_dpsswavelet():
     assert_true(len(Ws[0]) == len(freqs))  # As many wavelets as asked for
 
 
+@slow_test
 def test_tfr_multitaper():
-    """ Some tests for tfr_multitaper() """
+    """Test tfr_multitaper"""
     sfreq = 200.0
     ch_names = ['SIM0001', 'SIM0002', 'SIM0003']
     ch_types = ['grad', 'grad', 'grad']

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -5,7 +5,7 @@ from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 import mne
 from mne import io, Epochs, read_events, pick_types, create_info, EpochsArray
-from mne.utils import _TempDir
+from mne.utils import _TempDir, run_tests_if_main
 from mne.time_frequency import single_trial_power
 from mne.time_frequency.tfr import cwt_morlet, morlet, tfr_morlet
 from mne.time_frequency.tfr import _dpss_wavelet, tfr_multitaper
@@ -161,17 +161,16 @@ def test_tfr_multitaper():
     freqs = np.arange(5, 100, 3, dtype=np.float)
     power, itc = tfr_multitaper(epochs, freqs=freqs, n_cycles=freqs / 2.,
                                 time_bandwidth=4.0)
+    power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
+                                  n_cycles=freqs / 2., time_bandwidth=4.0,
+                                  return_itc=False)
+    assert_array_almost_equal(power.data, power_evoked.data)
+
     tmax = t[np.argmax(itc.data[0, freqs == 50, :])]
     fmax = freqs[np.argmax(power.data[1, :, t == 0.5])]
     assert_true(tmax > 0.3 and tmax < 0.7)
     assert_false(np.any(itc.data < 0.))
     assert_true(fmax > 40 and fmax < 60)
-    power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
-                                  n_cycles=freqs / 2., time_bandwidth=4.0,
-                                  return_itc=False)
-    # XXX The other two transforms (stockwell, CWT) have data equal but this
-    # one does not, need to think about if it should be
-    assert_array_equal(power.data.shape, power_evoked.data.shape)
 
 
 def test_io():
@@ -215,3 +214,5 @@ def test_io():
     assert_equal(tfr2.comment, tfr4.comment)
 
     assert_raises(ValueError, read_tfrs, fname, condition='nonono')
+
+run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -58,11 +58,6 @@ def test_time_frequency():
     # Test first with a single epoch
     power, itc = tfr_morlet(epochs[0], freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
-    power_par, itc_par = tfr_morlet(epochs[0], freqs=freqs, n_cycles=n_cycles,
-                                    use_fft=True, return_itc=True, n_jobs=2)
-    assert_array_almost_equal(power.data, power_par.data)
-    assert_array_almost_equal(itc.data, itc_par.data)
-
     evoked = epochs.average()
     power_evoked = tfr_morlet(evoked, freqs, n_cycles, use_fft=True,
                               return_itc=False)
@@ -167,12 +162,6 @@ def test_tfr_multitaper():
     freqs = np.arange(5, 100, 3, dtype=np.float)
     power, itc = tfr_multitaper(epochs, freqs=freqs, n_cycles=freqs / 2.,
                                 time_bandwidth=4.0)
-    power_par, itc_par = tfr_multitaper(epochs, freqs=freqs,
-                                        n_cycles=freqs / 2.,
-                                        time_bandwidth=4.0, n_jobs=2)
-    assert_array_almost_equal(power.data, power_par.data)
-    assert_array_almost_equal(itc.data, itc_par.data)
-
     power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
                                   n_cycles=freqs / 2., time_bandwidth=4.0,
                                   return_itc=False)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -58,6 +58,10 @@ def test_time_frequency():
     # Test first with a single epoch
     power, itc = tfr_morlet(epochs[0], freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
+    power_par, itc_par = tfr_morlet(epochs[0], freqs=freqs, n_cycles=n_cycles,
+                                    use_fft=True, return_itc=True, n_jobs=2)
+    assert_array_almost_equal(power.data, power_par.data)
+    assert_array_almost_equal(itc.data, itc_par.data)
 
     evoked = epochs.average()
     power_evoked = tfr_morlet(evoked, freqs, n_cycles, use_fft=True,
@@ -162,6 +166,12 @@ def test_tfr_multitaper():
     freqs = np.arange(5, 100, 3, dtype=np.float)
     power, itc = tfr_multitaper(epochs, freqs=freqs, n_cycles=freqs / 2.,
                                 time_bandwidth=4.0)
+    power_par, itc_par = tfr_multitaper(epochs, freqs=freqs,
+                                        n_cycles=freqs / 2.,
+                                        time_bandwidth=4.0, n_jobs=2)
+    assert_array_almost_equal(power.data, power_par.data)
+    assert_array_almost_equal(itc.data, itc_par.data)
+
     power_evoked = tfr_multitaper(epochs.average(), freqs=freqs,
                                   n_cycles=freqs / 2., time_bandwidth=4.0,
                                   return_itc=False)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -341,7 +341,7 @@ def _time_frequency(X, Ws, use_fft):
     """
     n_epochs, n_times = X.shape
     n_frequencies = len(Ws)
-    psd = np.zeros((n_frequencies, n_times), np.complex)  # PSD
+    psd = np.zeros((n_frequencies, n_times))  # PSD
     plf = np.zeros((n_frequencies, n_times), np.complex)  # phase lock
 
     mode = 'same'
@@ -351,10 +351,10 @@ def _time_frequency(X, Ws, use_fft):
         tfrs = _cwt_convolve(X, Ws, mode)
 
     for tfr in tfrs:
-        psd += tfr
-        plf += tfr / np.abs(tfr)
-    psd = np.abs(psd) / n_epochs
-    psd *= psd
+        tfr_abs = np.abs(tfr)
+        psd += tfr_abs ** 2
+        plf += tfr / tfr_abs
+    psd /= n_epochs
     plf = np.abs(plf) / n_epochs
     return psd, plf
 
@@ -1172,7 +1172,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0, use_fft=True,
     Returns
     -------
     power : AverageTFR
-        The averaged power.
+        The averaged power (PSD).
     itc : AverageTFR
         The intertrial coherence (ITC). Only returned if return_itc
         is True.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -340,7 +340,7 @@ def _time_frequency(X, Ws, use_fft, decim):
     """Aux of time_frequency for parallel computing over channels
     """
     n_epochs, n_times = X.shape
-    n_times = max(n_times // decim, 1)
+    n_times = n_times // decim + bool(n_times % decim)
     n_frequencies = len(Ws)
     psd = np.zeros((n_frequencies, n_times))  # PSD
     plf = np.zeros((n_frequencies, n_times), np.complex)  # phase lock

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -435,12 +435,13 @@ def single_trial_power(data, sfreq, frequencies, use_fft=True, n_cycles=7,
     cwt_kw = dict(Ws=Ws, use_fft=use_fft, mode=mode, decim=decim)
     if n_jobs == 1:
         for k, e in enumerate(data):
-            power[k] = np.abs(cwt(e, **cwt_kw)) ** 2
+            x = cwt(e, **cwt_kw)
+            power[k] = (x * x.conj()).real
     else:
         # Precompute tf decompositions in parallel
         tfrs = parallel(my_cwt(e, **cwt_kw) for e in data)
         for k, tfr in enumerate(tfrs):
-            power[k] = np.abs(tfr) ** 2
+            power[k] = (tfr * tfr.conj()).real
 
     # Run baseline correction.  Be sure to decimate the times array as well if
     # needed.

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -18,8 +18,8 @@ import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
 import matplotlib.pyplot as plt
 
-from mne import io, read_events, Epochs
-from mne import pick_types, read_cov
+from mne import io, read_events, Epochs, pick_types, read_cov
+from mne.utils import slow_test
 from mne.channels import read_layout
 
 
@@ -72,6 +72,7 @@ def _get_epochs_delayed_ssp():
     return epochs_delayed_ssp
 
 
+@slow_test
 def test_plot_evoked():
     """Test plotting of evoked
     """


### PR DESCRIPTION
I recently wanted to compute the CWT representation of an evoked dataset, and didn't see a way to do it. Unless I missed something I think this is how it should be done with our API?

I also exposed the `cwt_morlet` function, since I'll also need it for analysis.