### PR TITLE
FIX: Reference bug

### DIFF
--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -174,7 +174,7 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
                            'added. The data has been left untouched.')
             return inst, None
         else:
-            inst.add_proj(make_eeg_average_ref_proj(inst.info), activate=False)
+            inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
             return inst, None
     else:
         logger.info('Applying a custom EEG reference.')

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -109,8 +109,9 @@ def _apply_reference(inst, ref_from, ref_to=None, copy=True):
         ref_data = data[..., ref_from, :].mean(-2)
 
         if isinstance(inst, Epochs):
-            data[:, ref_to, :] -= np.tile(ref_data[:, np.newaxis, :],
-                                          (len(ref_to), 1))
+            data = data.transpose(1, 0, 2)
+            data[ref_to, :, :] -= ref_data
+            data = data.transpose(1, 0, 2)
         else:
             data[ref_to] -= ref_data
     else:

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -109,9 +109,7 @@ def _apply_reference(inst, ref_from, ref_to=None, copy=True):
         ref_data = data[..., ref_from, :].mean(-2)
 
         if isinstance(inst, Epochs):
-            data = data.transpose(1, 0, 2)
-            data[ref_to, :, :] -= ref_data
-            data = data.transpose(1, 0, 2)
+            data[:, ref_to, :] -= ref_data[:, np.newaxis, :]
         else:
             data[ref_to] -= ref_data
     else:

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -3,8 +3,9 @@
 #
 # License: BSD (3-clause)
 
-import os.path as op
 import warnings
+import numpy as np
+import os.path as op
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_array_equal, assert_allclose
@@ -57,9 +58,7 @@ def _test_reference(raw, reref, ref_data, ref_from):
 
     # Undo rereferencing of EEG channels
     if isinstance(raw, Epochs):
-        unref_eeg_data = reref_eeg_data.transpose(1, 0, 2)
-        unref_eeg_data += ref_data
-        unref_eeg_data = unref_eeg_data.transpose(1, 0, 2)
+        unref_eeg_data = reref_eeg_data + ref_data[:, np.newaxis, :]
     else:
         unref_eeg_data = reref_eeg_data + ref_data
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -4,8 +4,8 @@
 # License: BSD (3-clause)
 
 import warnings
-import numpy as np
 import os.path as op
+import numpy as np
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_array_equal, assert_allclose

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -71,7 +71,7 @@ def _test_reference(raw, reref, ref_data, ref_from):
 @testing.requires_testing_data
 def test_apply_reference():
     """Test base function for rereferencing"""
-    raw = Raw(fif_fname, preload=True, add_eeg_ref=True)
+    raw = Raw(fif_fname, preload=True)
 
     # Rereference raw data by creating a copy of original data
     reref, ref_data = _apply_reference(raw, ref_from=['EEG 001', 'EEG 002'],
@@ -114,6 +114,13 @@ def test_apply_reference():
 def test_set_eeg_reference():
     """Test rereference eeg data"""
     raw = Raw(fif_fname, preload=True)
+    raw.info['projs'] = []
+
+    # Test setting an average reference
+    assert_true(not _has_eeg_average_ref_proj(raw.info['projs']))
+    reref, ref_data = set_eeg_reference(raw)
+    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    assert_true(ref_data is None)
 
     # Rereference raw data by creating a copy of original data
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'], copy=True)
@@ -124,6 +131,10 @@ def test_set_eeg_reference():
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'],
                                         copy=False)
     assert_true(raw is reref)
+
+    # Setting an average reference on a dataset that already contains a custom
+    # reference should fail
+    assert_raises(RuntimeError, set_eeg_reference, reref)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
This bug slipped by the tests. I've fixed it and modified the test to cover this piece of the code. I also took the opportunity to replace a `tile` call with broadcasting. See #1750.