### PR TITLE
Make behaviour of `_transform_*` consistent.

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -524,8 +524,7 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA')
 
-        picks = pick_types(epochs.info, include=self.ch_names, exclude=[],
-                           ref_meg=False)
+        picks = [epochs.ch_names.index(k) for k in self.ch_names]
 
         # special case where epochs come picked but fit was 'unpicked'.
         if len(picks) != len(self.ch_names):
@@ -551,8 +550,7 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please first fit ICA')
 
-        picks = pick_types(evoked.info, include=self.ch_names, exclude=[],
-                           ref_meg=False)
+        picks = [evoked.ch_names.index(k) for k in self.ch_names]
 
         if len(picks) != len(self.ch_names):
             raise RuntimeError('Epochs don\'t match fitted data: %i channels '


### PR DESCRIPTION
when computing ICA sources on Epochs or Evoked, the current ICA implementation is very picky about the presence of extra channels:

    ica = mne.prepreprocessing.ICA().fit(epochs, picks=[0, 1])
    ica.get_sources(epochs) # ERROR!

This PR makes the behaviour consistent with transforming Raw objects, which is less picky.