### PR TITLE
ENH: Allow sparse csc matrices in H5

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1157,7 +1157,7 @@ def create_info(ch_names, sfreq, ch_types=None):
     if len(ch_types) != nchan:
         raise ValueError('ch_types and ch_names must be the same length')
     info = _empty_info()
-    info['meas_date'] = [0, 0]
+    info['meas_date'] = np.array([0, 0], np.int32)
     info['sfreq'] = sfreq
     info['ch_names'] = ch_names
     info['nchan'] = nchan

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -25,7 +25,7 @@ _proc_ids = [FIFF.FIFF_PARENT_FILE_ID,
 _proc_writers = [write_id, write_id, write_id,
                  write_int, write_string, write_string]
 _proc_casters = [dict, dict, dict,
-                 list, str, str]
+                 np.array, str, str]
 
 
 def _read_proc_history(fid, tree, info):
@@ -162,7 +162,7 @@ _sss_ctc_ids = (FIFF.FIFF_PARENT_FILE_ID,
 _sss_ctc_writers = (write_id, write_id, write_id,
                     write_int, write_string, write_float_sparse_rcs)
 _sss_ctc_casters = (dict, dict, dict,
-                    list, str, csc_matrix)
+                    np.array, str, csc_matrix)
 
 _sss_cal_keys = ('cal_chans', 'cal_corrs')
 _sss_cal_ids = (FIFF.FIFF_SSS_CAL_CHANS, FIFF.FIFF_SSS_CAL_CORRS)

--- a/mne/tests/test_hdf5.py
+++ b/mne/tests/test_hdf5.py
@@ -3,9 +3,10 @@ from os import path as op
 from nose.tools import assert_raises, assert_true, assert_equal
 
 import numpy as np
+from scipy import sparse
 
 from mne._hdf5 import write_hdf5, read_hdf5
-from mne.utils import requires_h5py, _TempDir, object_diff
+from mne.utils import requires_h5py, _TempDir, object_diff, run_tests_if_main
 
 
 @requires_h5py
@@ -14,8 +15,10 @@ def test_hdf5():
     """
     tempdir = _TempDir()
     test_file = op.join(tempdir, 'test.hdf5')
+    sp = sparse.eye(3, format='csc')
+    sp[2, 2] = 2
     x = dict(a=dict(b=np.zeros(3)), c=np.zeros(2, np.complex128),
-             d=[dict(e=(1, -2., 'hello', u'goodbyeu\u2764')), None])
+             d=[dict(e=(1, -2., 'hello', u'goodbyeu\u2764')), None], f=sp)
     write_hdf5(test_file, 1)
     assert_equal(read_hdf5(test_file), 1)
     assert_raises(IOError, write_hdf5, test_file, x)  # file exists
@@ -23,3 +26,6 @@ def test_hdf5():
     assert_raises(IOError, read_hdf5, test_file + 'FOO')  # not found
     xx = read_hdf5(test_file)
     assert_true(object_diff(x, xx) == '')  # no assert_equal, ugly output
+
+
+run_tests_if_main()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -3,6 +3,7 @@ from nose.tools import assert_true, assert_raises, assert_not_equal
 from copy import deepcopy
 import os.path as op
 import numpy as np
+from scipy import sparse
 import os
 import warnings
 
@@ -157,6 +158,18 @@ def test_hash():
     d2[1] = (x for x in d0)
     assert_raises(RuntimeError, object_diff, d1, d2)
     assert_raises(RuntimeError, object_hash, d1)
+
+    x = sparse.eye(2, format='csc')
+    y = sparse.eye(2, format='csr')
+    assert_true('type mismatch' in object_diff(x, y))
+    y = sparse.eye(2, format='csc')
+    assert_equal(len(object_diff(x, y)), 0)
+    y[1, 1] = 2
+    assert_true('elements' in object_diff(x, y))
+    y = sparse.eye(3, format='csc')
+    assert_true('shape' in object_diff(x, y))
+    y = 0
+    assert_true('type mismatch' in object_diff(x, y))
 
 
 def test_md5sum():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -30,7 +30,7 @@ import atexit
 
 import numpy as np
 import scipy
-from scipy import linalg
+from scipy import linalg, sparse
 
 
 from .externals.six.moves import urllib
@@ -170,6 +170,17 @@ def object_diff(a, b, pre=''):
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():
             out += pre + ' StringIO mismatch\n'
+    elif sparse.isspmatrix(a):
+        # sparsity and sparse type of b vs a already checked above by type()
+        if b.shape != a.shape:
+            out += pre + (' sparse matrix a and b shape mismatch'
+                          '(%s vs %s)' % (a.shape, b.shape))
+        else:
+            c = a - b
+            c.eliminate_zeros()
+            if c.nnz > 0:
+                out += pre + (' sparse matrix a and b differ on %s '
+                              'elements' % c.nnz)
     else:
         raise RuntimeError(pre + ': unsupported type %s (%s)' % (type(a), a))
     return out


### PR DESCRIPTION
Recent changes to `meas_info` made it so that `sparse.csc_matrix` types can be in info, which in turn means our `write_hdf5` / `read_hdf5` files need to be changed to accommodate that use case. This adds that functionality.