### PR TITLE
ICA fails if n_components=None

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -455,12 +455,13 @@ class ICA(ContainsMixin):
                         n_components_)
             sel = slice(n_components_)
         else:
-            logger.info('Selection by number: %i components' %
-                        self.n_components)
             if self.n_components is not None:  # normal n case
                 sel = slice(self.n_components)
+                logger.info('Selection by number: %i components' %
+                        self.n_components)
             else:  # None case
-                logger.info('Using all PCA components: %i' % pca.components_)
+                logger.info('Using all PCA components: %i' 
+                                          % len(pca.components_))
                 sel = slice(len(pca.components_))
 
         # the things to store for PCA

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -249,7 +249,7 @@ def test_ica_additional():
         ica = ICA(n_components=None,
                    max_pca_components=None,
                    n_pca_components=None, random_state=0)
-        ica.fit(raw, picks=picks, decim=3)                    
+        ica.fit(epochs, picks=picks, decim=3)                    
     # for testing eog functionality
     picks2 = pick_types(raw.info, meg=True, stim=False, ecg=False,
                         eog=True, exclude='bads')

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -244,6 +244,16 @@ def test_ica_additional():
                        eog=False, exclude='bads')
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
+    # test if n_components=None works
+    raw = io.Raw(raw_fname, preload=True).crop(0, stop, False).crop(1.5)
+    picks = pick_types(raw.info, meg='grad', exclude='bads')
+    n_components = None
+    max_pca_components = None
+    with warnings.catch_warnings(record=True):
+        ica = ICA(n_components=n_components,
+                   max_pca_components=max_pca_components,
+                   n_pca_components=n_pca_components, random_state=0)
+        ica.fit(raw, picks=picks, decim=3)                    
     # for testing eog functionality
     picks2 = pick_types(raw.info, meg=True, stim=False, ecg=False,
                         eog=True, exclude='bads')

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -245,12 +245,10 @@ def test_ica_additional():
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     # test if n_components=None works
-    n_components = None
-    max_pca_components = None
     with warnings.catch_warnings(record=True):
-        ica = ICA(n_components=n_components,
-                   max_pca_components=max_pca_components,
-                   n_pca_components=n_pca_components, random_state=0)
+        ica = ICA(n_components=None,
+                   max_pca_components=None,
+                   n_pca_components=None, random_state=0)
         ica.fit(raw, picks=picks, decim=3)                    
     # for testing eog functionality
     picks2 = pick_types(raw.info, meg=True, stim=False, ecg=False,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -245,8 +245,6 @@ def test_ica_additional():
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     # test if n_components=None works
-    raw = io.Raw(raw_fname, preload=True).crop(0, stop, False).crop(1.5)
-    picks = pick_types(raw.info, meg='grad', exclude='bads')
     n_components = None
     max_pca_components = None
     with warnings.catch_warnings(record=True):


### PR DESCRIPTION
If I understand the documentation correctly, you should be able to do ICA with both max_pca_components and n_components set to ```None```.

Currently, I get an error when n_components is ```None``` - this is because the loop responsible for selecting components and logging them checks if n_components is a float, and ```else``` (assuming it to be an int I guess) it tries to log it as a string, which will fail if n_components is None. Also, the logger currently tries to log pca.components_, which can be an array. I think it should log ```len(pca.components_)```.

If this is not the intended behavior, this PR fixes it. Including these changes, I can run ICA with ```n_components=None```.