### PR TITLE
Bug/brainvision/nostim

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -340,7 +340,7 @@ def _read_vmrk_events(fname):
         except IndexError:
             pass
 
-    events = np.array(events)
+    events = np.array(events).reshape(-1,3)
     return events
 
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -340,7 +340,7 @@ def _read_vmrk_events(fname):
         except IndexError:
             pass
 
-    events = np.array(events).reshape(-1,3)
+    events = np.array(events).reshape(-1, 3)
     return events
 
 


### PR DESCRIPTION
Small bugfix in case there is no events caught in the data.
Other part of software expects specific dimensions/shape for the events array.

I have a related question: which subset of events are extracted with regexp "^Mk\d+=(.*)" ?
Is the purpose is to only select stimulation or could there be other events of interest (eg. ttl from other device...) or they would fit better in another field of the raw data?
Or maybe their could be an event descritor added in this array?

Thanks