### PR TITLE
FIX missing fs attribute in filter

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -66,8 +66,6 @@ Changelog
 BUG
 ~~~
 
-   - Fix picks argument to filter in 3 dimensions, and bug in highpass filtering for FilterEstimator by `Mainak Jas`_
-
    - Fix energy conservation for STFT with tight frames by `Daniel Strohmeier`_
 
    - Fix incorrect data matrix when tfr was plotted with parameters `tmin`, `tmax`, `fmin` and `fmax` by `Mainak Jas`_
@@ -96,6 +94,8 @@ BUG
    - Fix bug in `mne.viz.plot_topo` if ylim was passed for single sensor layouts by `Denis Engemann`_
 
    - Average reference projections will no longer by automatically added after applying a custom EEG reference by `Marijn van Vliet`_
+
+   - Fix picks argument to filter in n dimensions (affects FilterEstimator), and highpass filter in FilterEstimator by `Mainak Jas`_
 
 API
 ~~~

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -66,6 +66,8 @@ Changelog
 BUG
 ~~~
 
+   - Fix picks argument to filter in 3 dimensions, and bug in highpass filtering for FilterEstimator by `Mainak Jas`_
+
    - Fix energy conservation for STFT with tight frames by `Daniel Strohmeier`_
 
    - Fix incorrect data matrix when tfr was plotted with parameters `tmin`, `tmax`, `fmin` and `fmax` by `Mainak Jas`_

--- a/mne/decoding/classifier.py
+++ b/mne/decoding/classifier.py
@@ -359,8 +359,12 @@ class FilterEstimator(TransformerMixin):
 
         if self.l_freq == 0:
             self.l_freq = None
-        if self.h_freq > (self.info['sfreq'] / 2.):
+        if self.h_freq is not None and self.h_freq > (self.info['sfreq'] / 2.):
             self.h_freq = None
+        if self.l_freq is not None and not isinstance(self.l_freq, float):
+            self.l_freq = float(self.l_freq)
+        if self.h_freq is not None and not isinstance(self.h_freq, float):
+            self.h_freq = float(self.h_freq)
 
         if self.h_freq is not None and \
                 (self.l_freq is None or self.l_freq < self.h_freq) and \

--- a/mne/decoding/classifier.py
+++ b/mne/decoding/classifier.py
@@ -395,7 +395,7 @@ class FilterEstimator(TransformerMixin):
 
         if self.l_freq is None and self.h_freq is not None:
             epochs_data = \
-                low_pass_filter(epochs_data, self.fs, self.h_freq,
+                low_pass_filter(epochs_data, self.info['sfreq'], self.h_freq,
                                 filter_length=self.filter_length,
                                 trans_bandwidth=self.l_trans_bandwidth,
                                 method=self.method, iir_params=self.iir_params,

--- a/mne/decoding/tests/test_classifier.py
+++ b/mne/decoding/tests/test_classifier.py
@@ -58,17 +58,33 @@ def test_filterestimator():
     raw = io.Raw(raw_fname, preload=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
-                            eog=False, exclude='bads')
+                       eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     epochs_data = epochs.get_data()
-    filt = FilterEstimator(epochs.info, 1, 40)
+
+    # Add tests for different combinations of l_freq and h_freq
+    filt = FilterEstimator(epochs.info, l_freq=1, h_freq=40)
     y = epochs.events[:, -1]
     with warnings.catch_warnings(record=True):  # stop freq attenuation warning
         X = filt.fit_transform(epochs_data, y)
         assert_true(X.shape == epochs_data.shape)
         assert_array_equal(filt.fit(epochs_data, y).transform(epochs_data), X)
+
+    filt = FilterEstimator(epochs.info, l_freq=0, h_freq=40)
+    y = epochs.events[:, -1]
+    with warnings.catch_warnings(record=True):  # stop freq attenuation warning
+        X = filt.fit_transform(epochs_data, y)
+
+    filt = FilterEstimator(epochs.info, l_freq=1, h_freq=1)
+    y = epochs.events[:, -1]
+    with warnings.catch_warnings(record=True):  # stop freq attenuation warning
+        assert_raises(ValueError, filt.fit_transform, epochs_data, y)
+
+    filt = FilterEstimator(epochs.info, l_freq=1, h_freq=None)
+    with warnings.catch_warnings(record=True):  # stop freq attenuation warning
+        X = filt.fit_transform(epochs_data, y)
 
     # Test init exception
     assert_raises(ValueError, filt.fit, epochs, y)

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -235,6 +235,9 @@ def _prep_for_filtering(x, copy, picks=None):
         offset = np.repeat(np.arange(0, n_channels * n_epochs, n_channels),
                            len(picks))
         picks = np.tile(picks, n_epochs) + offset
+    elif len(orig_shape) > 3:
+        raise ValueError('picks argument is not supported for data with more'
+                         ' than three dimensions')
 
     return x, orig_shape, picks
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -230,6 +230,12 @@ def _prep_for_filtering(x, copy, picks=None):
     x.shape = (np.prod(x.shape[:-1]), x.shape[-1])
     if picks is None:
         picks = np.arange(x.shape[0])
+    elif len(orig_shape) == 3:
+        n_epochs, n_channels, n_times = orig_shape
+        offset = np.repeat(np.arange(0, n_channels * n_epochs, n_channels),
+                           len(picks))
+        picks = np.tile(picks, n_epochs) + offset
+
     return x, orig_shape, picks
 
 

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -192,6 +192,11 @@ def test_filters():
     assert_true(iir_params['a'].size - 1 == 4)
     assert_true(iir_params['b'].size - 1 == 4)
 
+    # check for n-dimensional case
+    a = np.random.randn(2, 2, 2, 2)
+    assert_raises(ValueError, band_pass_filter, a, sfreq, Fp1=4, Fp2=8,
+                  picks=np.array([0, 1]))
+
 
 def test_cuda():
     """Test CUDA-based filtering

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -192,6 +192,16 @@ def test_filters():
     assert_true(iir_params['a'].size - 1 == 4)
     assert_true(iir_params['b'].size - 1 == 4)
 
+    # check that picks work for 3d array with one channel and picks=[0]
+    a = np.random.randn(5 * sfreq, 5 * sfreq)
+    b = a[:, None, :]
+
+    with warnings.catch_warnings(record=True) as w:
+        a_filt = band_pass_filter(a, sfreq, 4, 8)
+        b_filt = band_pass_filter(b, sfreq, 4, 8, picks=[0])
+
+    assert_array_equal(a_filt[:, None, :], b_filt)
+
     # check for n-dimensional case
     a = np.random.randn(2, 2, 2, 2)
     assert_raises(ValueError, band_pass_filter, a, sfreq, Fp1=4, Fp2=8,


### PR DESCRIPTION
There appears to be another problem. Only the first epoch appears to be getting filtered. I though `low_pass_filter` takes care of the fact that there are 3 dimensions, but it doesn't? What's the best way to fix this? Reshape to 2D and filter or filter each epoch separately?