### PR TITLE
Automate TAL detection

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -561,9 +561,8 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
     if tal_channel == -1:
         tal_channel = info['nchan'] - 1
     elif tal_ch_name in ch_names:
-        edf_info['tal_channel'] = tal_channel = ch_names.index(tal_ch_name)
-    else:
-        edf_info['tal_channel'] = tal_channel
+        tal_channel = ch_names.index(tal_ch_name)
+    edf_info['tal_channel'] = tal_channel
     if all([tal_channel, stim_channel]) and not preload:
         raise RuntimeError('%s' % ('EDF+ Annotations (TAL) channel needs to be'
                                    ' parsed completely on loading.'
@@ -718,7 +717,8 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
     """
     if tal_channel is not None:
         warnings.warn("`tal_channel` arg is deprecated and will be removed in "
-                      "0.10. This channel will be automatically detected.")
+                      "0.10. This channel will be automatically detected.",
+                      category=DeprecationWarning)
     return RawEDF(input_fname=input_fname, montage=montage, eog=eog, misc=misc,
                   stim_channel=stim_channel, annot=annot, annotmap=annotmap,
                   tal_channel=tal_channel, preload=preload, verbose=verbose)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -556,18 +556,18 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
     logger.info('Setting channel info structure...')
     info['chs'] = []
     info['ch_names'] = ch_names
-    # TODO: deprecate keyword argument for TAL?
+    tal_ch_name = 'EDF Annotations'
+    # TODO: keyword argument for TAL is deprecated
     if tal_channel == -1:
-        edf_info['tal_channel'] = info['nchan'] - 1
+        tal_channel = info['nchan'] - 1
+    elif tal_ch_name in ch_names:
+        edf_info['tal_channel'] = tal_channel = ch_names.index(tal_ch_name)
     else:
         edf_info['tal_channel'] = tal_channel
-
-    if tal_channel and not preload:
+    if all([tal_channel, stim_channel]) and not preload:
         raise RuntimeError('%s' % ('EDF+ Annotations (TAL) channel needs to be'
                                    ' parsed completely on loading.'
                                    'Must set preload=True'))
-    if 'EDF Annotations' in ch_names:
-        edf_info['tal_channel'] = tal_channel = ch_names.index('EDF Annotations')
     if stim_channel == -1:
         stim_channel = info['nchan'] - 1
     for idx, ch_info in enumerate(zip(ch_names, physical_ranges, cals)):
@@ -716,6 +716,9 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
     --------
     mne.io.Raw : Documentation of attribute and methods.
     """
+    if tal_channel is not None:
+        warnings.warn("`tal_channel` arg is deprecated and will be removed in "
+                      "0.10. This channel will be automatically detected.")
     return RawEDF(input_fname=input_fname, montage=montage, eog=eog, misc=misc,
                   stim_channel=stim_channel, annot=annot, annotmap=annotmap,
                   tal_channel=tal_channel, preload=preload, verbose=verbose)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -556,6 +556,18 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
     logger.info('Setting channel info structure...')
     info['chs'] = []
     info['ch_names'] = ch_names
+    # TODO: deprecate keyword argument for TAL?
+    if tal_channel == -1:
+        edf_info['tal_channel'] = info['nchan'] - 1
+    else:
+        edf_info['tal_channel'] = tal_channel
+
+    if tal_channel and not preload:
+        raise RuntimeError('%s' % ('EDF+ Annotations (TAL) channel needs to be'
+                                   ' parsed completely on loading.'
+                                   'Must set preload=True'))
+    if 'EDF Annotations' in ch_names:
+        edf_info['tal_channel'] = tal_channel = ch_names.index('EDF Annotations')
     if stim_channel == -1:
         stim_channel = info['nchan'] - 1
     for idx, ch_info in enumerate(zip(ch_names, physical_ranges, cals)):
@@ -593,28 +605,26 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
             info['ch_names'][idx] = chan_info['ch_name']
             if isinstance(stim_channel, str):
                 stim_channel = idx
+        if tal_channel == idx:
+            chan_info['range'] = 1
+            chan_info['cal'] = 1
+            chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
+            chan_info['unit'] = FIFF.FIFF_UNIT_NONE
+            chan_info['kind'] = FIFF.FIFFV_MISC_CH
         info['chs'].append(chan_info)
     edf_info['stim_channel'] = stim_channel
 
     # sfreq defined as the max sampling rate of eeg
     picks = pick_types(info, meg=False, eeg=True)
-    edf_info['max_samp'] = max_samp = n_samps[picks].max()
+    if len(picks) == 0:
+        edf_info['max_samp'] = max_samp = n_samps.max()
+    else:
+        edf_info['max_samp'] = max_samp = n_samps[picks].max()
     info['sfreq'] = max_samp / record_length
     edf_info['nsamples'] = int(n_records * max_samp)
 
     if info['lowpass'] is None:
         info['lowpass'] = info['sfreq'] / 2.
-
-    # TODO: automatic detection of the tal_channel?
-    if tal_channel == -1:
-        edf_info['tal_channel'] = info['nchan'] - 1
-    else:
-        edf_info['tal_channel'] = tal_channel
-
-    if tal_channel and not preload:
-        raise RuntimeError('%s' % ('EDF+ Annotations (TAL) channel needs to be'
-                                   ' parsed completely on loading.'
-                                   'Must set preload=True'))
 
     return info, edf_info
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -563,7 +563,7 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
     elif tal_ch_name in ch_names:
         tal_channel = ch_names.index(tal_ch_name)
     edf_info['tal_channel'] = tal_channel
-    if all([tal_channel, stim_channel]) and not preload:
+    if tal_channel is not None and stim_channel is not None and not preload:
         raise RuntimeError('%s' % ('EDF+ Annotations (TAL) channel needs to be'
                                    ' parsed completely on loading.'
                                    'Must set preload=True'))

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -90,7 +90,7 @@ def test_read_segment():
     """Test writing raw edf files when preload is False
     """
     tempdir = _TempDir()
-    raw1 = read_raw_edf(edf_path, stim_channel=139, preload=False)
+    raw1 = read_raw_edf(edf_path, stim_channel=None, preload=False)
     raw1_file = op.join(tempdir, 'test1-raw.fif')
     raw1.save(raw1_file, overwrite=True, buffer_size_sec=1)
     raw11 = Raw(raw1_file, preload=True)
@@ -100,7 +100,7 @@ def test_read_segment():
     assert_array_almost_equal(times1, times11)
     assert_equal(sorted(raw1.info.keys()), sorted(raw11.info.keys()))
 
-    raw2 = read_raw_edf(edf_path, stim_channel=139, preload=True)
+    raw2 = read_raw_edf(edf_path, stim_channel=None, preload=True)
     raw2_file = op.join(tempdir, 'test2-raw.fif')
     raw2.save(raw2_file, overwrite=True)
     data2, times2 = raw2[:139, :]
@@ -112,8 +112,8 @@ def test_read_segment():
     assert_array_equal(raw1._data, raw2._data)
 
     # test the _read_segment function by only loading some of the data
-    raw1 = read_raw_edf(edf_path, preload=False)
-    raw2 = read_raw_edf(edf_path, preload=True)
+    raw1 = read_raw_edf(edf_path, stim_channel=None, preload=False)
+    raw2 = read_raw_edf(edf_path, stim_channel=None, preload=True)
 
     # select some random range of data to compare
     data1, times1 = raw1[:, 345:417]


### PR DESCRIPTION
noticed when doing https://github.com/mne-tools/mne-python/pull/1805. This pr automates TAL detection. all annotations are stored in raw._edf_info['events']. 

@agramfort in reference to `SC4001EC-Hypnogram.edf`, this file only stores the annotations. these annotations belong to `SC4001E0-PSG.edf`. I think we wanted to properly read these edf particular edfs, the reader should take `*-Hypnogram.edf` as the `tal_channel` for `*.PSG.edf`. We could then add the annotations to raw file.