### PR TITLE
apply_montage 

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -913,7 +913,7 @@ def apply_montage(info, montage, ch_type='eeg'):
     montage : instance of Montage
         The montage to apply.
     ch_type : string
-        The type of electrode contained in this montage. Can be 'eeg' or 'ieeg'.
+        The type of electrode contained in this montage. Can be 'eeg' or 'ieeg'
     """
     supported_types = ('eeg', 'ieeg')
     if ch_type not in supported_types:

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -919,7 +919,7 @@ def apply_montage(info, montage, electrode_type='eeg'):
     if electrode_type not in supported_types:
         raise ValueError('Montage type not supported')
 
-    if not _contains_ch_type(info, 'eeg') and type=='eeg':
+    if not _contains_ch_type(info, 'eeg') and type == 'eeg':
         raise ValueError('No EEG channels found.')
 
     sensors_found = False
@@ -933,7 +933,7 @@ def apply_montage(info, montage, electrode_type='eeg'):
         info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
         sensors_found = True
 
-    if electrode_type=='ieeg': 
+    if electrode_type == 'ieeg':
         info['chs'][ch_idx]['kind'] = FIFF.FIFF_SEEG_CH
         info['chs'][ch_idx]['coord_frame'] = FIFF.COORD_MRI
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -898,10 +898,10 @@ def read_montage(kind, ch_names=None, path=None, scale=True):
     return Montage(pos=pos, ch_names=ch_names_, kind=kind, selection=selection)
 
 
-def apply_montage(info, montage):
-    """Apply montage to EEG data.
+def apply_montage(info, montage, electrode_type='eeg'):
+    """Apply montage.
 
-    This function will replace the EEG channel names and locations with
+    This function will replace the channel names and locations with
     the values specified for the particular montage.
 
     Note: This function will change the info variable in place.
@@ -912,8 +912,14 @@ def apply_montage(info, montage):
         The measurement info to update.
     montage : instance of Montage
         The montage to apply.
+    electrode_type : string
+        The type of electrode contained in this montage. Can be eeg or ieeg.
     """
-    if not _contains_ch_type(info, 'eeg'):
+    supported_types = ('eeg', 'ieeg')
+    if electrode_type not in supported_types:
+        raise ValueError('Montage type not supported')
+
+    if not _contains_ch_type(info, 'eeg') and type=='eeg':
         raise ValueError('No EEG channels found.')
 
     sensors_found = False
@@ -926,6 +932,10 @@ def apply_montage(info, montage):
         info['chs'][ch_idx]['eeg_loc'] = np.c_[pos, [0.] * 3]
         info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
         sensors_found = True
+
+    if electrode_type=='ieeg': 
+        info['chs'][ch_idx]['kind'] = FIFF.FIFF_SEEG_CH
+        info['chs'][ch_idx]['coord_frame'] = FIFF.COORD_MRI
 
     if not sensors_found:
         raise ValueError('None of the sensors defined in the montage were '

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -916,7 +916,7 @@ def apply_montage(info, montage, ch_type='eeg'):
         The type of electrode contained in this montage. Can be 'eeg' or 'ieeg'.
     """
     supported_types = ('eeg', 'ieeg')
-    if electrode_type not in supported_types:
+    if ch_type not in supported_types:
         raise ValueError('Montage type not supported')
 
     if not _contains_ch_type(info, 'eeg') and ch_type == 'eeg':

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -934,8 +934,8 @@ def apply_montage(info, montage, ch_type='eeg'):
         sensors_found = True
 
     if ch_type == 'ieeg':
-        info['chs'][ch_idx]['kind'] = FIFF.FIFF_SEEG_CH
-        info['chs'][ch_idx]['coord_frame'] = FIFF.COORD_MRI
+        info['chs'][ch_idx]['kind'] = FIFF.FIFFV_SEEG_CH
+        info['chs'][ch_idx]['coord_frame'] = FIFF.FIFFV_COORD_MRI
 
     if not sensors_found:
         raise ValueError('None of the sensors defined in the montage were '

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -933,9 +933,9 @@ def apply_montage(info, montage, ch_type='eeg'):
         info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
         sensors_found = True
 
-    if ch_type == 'ieeg':
-        info['chs'][ch_idx]['kind'] = FIFF.FIFFV_SEEG_CH
-        info['chs'][ch_idx]['coord_frame'] = FIFF.FIFFV_COORD_MRI
+        if ch_type == 'ieeg':
+            info['chs'][ch_idx]['kind'] = FIFF.FIFFV_SEEG_CH
+            info['chs'][ch_idx]['coord_frame'] = FIFF.FIFFV_COORD_MRI
 
     if not sensors_found:
         raise ValueError('None of the sensors defined in the montage were '

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -898,7 +898,7 @@ def read_montage(kind, ch_names=None, path=None, scale=True):
     return Montage(pos=pos, ch_names=ch_names_, kind=kind, selection=selection)
 
 
-def apply_montage(info, montage, electrode_type='eeg'):
+def apply_montage(info, montage, ch_type='eeg'):
     """Apply montage.
 
     This function will replace the channel names and locations with
@@ -912,14 +912,14 @@ def apply_montage(info, montage, electrode_type='eeg'):
         The measurement info to update.
     montage : instance of Montage
         The montage to apply.
-    electrode_type : string
-        The type of electrode contained in this montage. Can be eeg or ieeg.
+    ch_type : string
+        The type of electrode contained in this montage. Can be 'eeg' or 'ieeg'.
     """
     supported_types = ('eeg', 'ieeg')
     if electrode_type not in supported_types:
         raise ValueError('Montage type not supported')
 
-    if not _contains_ch_type(info, 'eeg') and type == 'eeg':
+    if not _contains_ch_type(info, 'eeg') and ch_type == 'eeg':
         raise ValueError('No EEG channels found.')
 
     sensors_found = False
@@ -933,7 +933,7 @@ def apply_montage(info, montage, electrode_type='eeg'):
         info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
         sensors_found = True
 
-    if electrode_type == 'ieeg':
+    if ch_type == 'ieeg':
         info['chs'][ch_idx]['kind'] = FIFF.FIFF_SEEG_CH
         info['chs'][ch_idx]['coord_frame'] = FIFF.COORD_MRI
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from mne.channels import read_montage, apply_montage
 from mne.utils import _TempDir
 from mne import create_info
+from mne.io import constants
 
 
 def test_montage():
@@ -80,3 +81,35 @@ def test_montage():
     assert_array_equal(pos2, montage.pos)
     assert_array_equal(pos3, montage.pos)
     assert_equal(montage.ch_names, info['ch_names'])
+
+def test_ieeg_montage():
+    """Test an iEEG montage"""
+    tempdir = _TempDir()
+    # no pep8
+    input_str = """
+GR1	-35.6774	-58.8438	10.0284
+GR9	-35.3662	-56.7556	20.0054
+GR17	-35.0972	-54.6765	28.9835
+GR25	-33.8428	-51.5357	38.9114
+GR49	-20.3683	-40.6186	63.2681
+    """
+    kind = 'test.sfp'
+    fname = op.join(tempdir, kind)
+    with open(fname, 'w') as fid:
+        fid.write(input_str)
+    montage = read_montage(fname)
+    assert_equal(len(montage.ch_names), 5)
+    assert_equal(len(montage.ch_names), len(montage.pos))
+    assert_equal(montage.pos.shape, (5, 3))
+    assert_equal(montage.kind, op.splitext(kind)[0])
+
+    info = create_info(montage.ch_names, 1e3, ['misc'] * len(montage.ch_names))
+    apply_montage(info, montage, ch_type='ieeg')
+    pos2 = np.array([c['loc'][:3] for c in info['chs']])
+    pos3 = np.array([c['eeg_loc'][:, 0] for c in info['chs']])
+    assert_array_equal(pos2, montage.pos)
+    assert_array_equal(pos3, montage.pos)
+    kinds = np.array([c['kind'] for c in info['chs']])
+    coord_frames = np.array([c['coord_frame'] for c in info['chs']])
+    assert_array_equal(kinds, [constants.FIFF.FIFF_SEEG_CH]*5)
+    assert_array_equal(coord_frames, [constants.FIFF.COORD_MRI]*5)

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -82,16 +82,17 @@ def test_montage():
     assert_array_equal(pos3, montage.pos)
     assert_equal(montage.ch_names, info['ch_names'])
 
+
 def test_ieeg_montage():
     """Test an iEEG montage"""
     tempdir = _TempDir()
     # no pep8
     input_str = """
-GR1	-35.6774	-58.8438	10.0284
-GR9	-35.3662	-56.7556	20.0054
-GR17	-35.0972	-54.6765	28.9835
-GR25	-33.8428	-51.5357	38.9114
-GR49	-20.3683	-40.6186	63.2681
+    GR1	-35.6774	-58.8438	10.0284
+    GR9	-35.3662	-56.7556	20.0054
+    GR17	-35.0972	-54.6765	28.9835
+    GR25	-33.8428	-51.5357	38.9114
+    GR49	-20.3683	-40.6186	63.2681
     """
     kind = 'test.sfp'
     fname = op.join(tempdir, kind)

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from mne.channels import read_montage, apply_montage
 from mne.utils import _TempDir
 from mne import create_info
-from mne.io import constants
+from mne.io.constants import FIFF
 
 
 def test_montage():
@@ -111,5 +111,5 @@ GR49	-20.3683	-40.6186	63.2681
     assert_array_equal(pos3, montage.pos)
     kinds = np.array([c['kind'] for c in info['chs']])
     coord_frames = np.array([c['coord_frame'] for c in info['chs']])
-    assert_array_equal(kinds, [constants.FIFF.FIFF_SEEG_CH]*5)
-    assert_array_equal(coord_frames, [constants.FIFF.COORD_MRI]*5)
+    assert_array_equal(kinds, [FIFF.FIFFV_SEEG_CH]*5)
+    assert_array_equal(coord_frames, [FIFF.FIFFV_COORD_MRI]*5)


### PR DESCRIPTION
Adds a field to the apply_montage() function to allow imports of montages of different types, which might also need to implement small changes in metadata.

Also add functionality to add localized iEEG electrodes from montage files, in the surface space and using the SEEG coordinate frame. This seems to be the best way to import the types of data that I am working with into .fif format.