### PR TITLE
allow ch_type change without ch_name change

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -290,7 +290,7 @@ def rename_channels(info, mapping):
         a dictionary mapping the old channel to a new channel name {'EEG061' :
         'EEG161'}. If changing the sensor type, make the new name a tuple with
         the name (str) and the new channel type (str)
-        {'EEG061',('EOG061','eog')}.
+        {'EEG061':('EOG061','eog')}.
     """
     human2fiff = {'eog': FIFF.FIFFV_EOG_CH,
                   'emg': FIFF.FIFFV_EMG_CH,
@@ -320,10 +320,6 @@ def rename_channels(info, mapping):
                                  'channel type: %s.' % new_type)
             new_kinds.append((c_ind, human2fiff[new_type]))
 
-        if new_name in ch_names:
-            raise ValueError('The new name ({new}) already exists. Choose a '
-                             'unique name'.format(new=new_name))
-
         new_names.append((c_ind, new_name))
         if ch_name in bads:  # check bads
             new_bads.append((bads.index(ch_name), new_name))
@@ -332,6 +328,7 @@ def rename_channels(info, mapping):
     for key, collection in [('ch_name', new_names), ('kind', new_kinds)]:
         for c_ind, new_name in collection:
             chs[c_ind][key] = new_name
+
     for c_ind, new_name in new_bads:
         bads[c_ind] = new_name
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -44,9 +44,6 @@ def test_rename_channels():
     # Test improper mapping configuration
     mapping = {'MEG 2641': 1.0}
     assert_raises(ValueError, rename_channels, info, mapping)
-    # Test duplicate named channels
-    mapping = {'EEG 060': 'EOG 061'}
-    assert_raises(ValueError, rename_channels, info, mapping)
     # Test successful changes
     # Test ch_name and ch_names are changed
     info2 = deepcopy(info)  # for consistency at the start of each test
@@ -68,15 +65,20 @@ def test_rename_channels():
     assert_true(info2['chs'][374]['ch_name'] == 'EOG 060')
     assert_true(info2['ch_names'][374] == 'EOG 060')
     assert_true('EOG 060' in info2['bads'])
-    assert_true(info2['chs'][374]['kind'] is FIFF.FIFFV_EOG_CH)
+    assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][373]['ch_name'] == 'EOG 059')
     assert_true(info2['ch_names'][373] == 'EOG 059')
     assert_true('EOG 059' in info2['bads'])
-    assert_true(info2['chs'][373]['kind'] is FIFF.FIFFV_EOG_CH)
+    assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][375]['ch_name'] == "OT'7")
     assert_true(info2['ch_names'][375] == "OT'7")
     assert_true("OT'7" in info2['bads'])
-    assert_true(info2['chs'][375]['kind'] is FIFF.FIFFV_SEEG_CH)
+    assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
+    # Test change of type without change of name
+    mapping = {'EEG 060': ('EEG 060', 'seeg')}
+    info2 = deepcopy(info)
+    rename_channels(info2, mapping)
+    assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_SEEG_CH)
 
 
 def test_read_ch_connectivity():


### PR DESCRIPTION
with this fix now you can do this to change type of all channels:

```
mne.rename_channels(evoked.info, dict((c, (c, 'seeg')) for c in evoked.ch_names))
```

cc @aestrivex  