### PR TITLE
Protect filter against info["{high|low}pass"] None

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -364,12 +364,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
 
             # update info if filter is applied to all data channels,
             # and it's not a band-stop filter
-            if h_freq is not None and (l_freq is None or l_freq < h_freq) and \
-                    h_freq < self.info['lowpass']:
-                self.info['lowpass'] = h_freq
-            if l_freq is not None and (h_freq is None or l_freq < h_freq) and \
-                    l_freq > self.info['highpass']:
-                self.info['highpass'] = l_freq
+            if h_freq is not None:
+                if (l_freq is None or l_freq < h_freq) and \
+                   (self.info["lowpass"] is None or h_freq < self.info['lowpass']):
+                    self.info['lowpass'] = h_freq
+            if l_freq is not None:
+                if (h_freq is None or l_freq < h_freq) and \
+                (self.info["highpass"] is None or l_freq > self.info['highpass']):
+                    self.info['highpass'] = l_freq
         if l_freq is None and h_freq is not None:
             logger.info('Low-pass filtering at %0.2g Hz' % h_freq)
             low_pass_filter(self._data, fs, h_freq,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -366,12 +366,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             # and it's not a band-stop filter
             if h_freq is not None:
                 if (l_freq is None or l_freq < h_freq) and \
-                   (self.info["lowpass"] is None or h_freq < self.info['lowpass']):
-                    self.info['lowpass'] = h_freq
+                   (self.info["lowpass"] is None or
+                   h_freq < self.info['lowpass']):
+                        self.info['lowpass'] = h_freq
             if l_freq is not None:
                 if (h_freq is None or l_freq < h_freq) and \
-                (self.info["highpass"] is None or l_freq > self.info['highpass']):
-                    self.info['highpass'] = l_freq
+                   (self.info["highpass"] is None or
+                   l_freq > self.info['highpass']):
+                        self.info['highpass'] = l_freq
         if l_freq is None and h_freq is not None:
             logger.info('Low-pass filtering at %0.2g Hz' % h_freq)
             low_pass_filter(self._data, fs, h_freq,

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -35,6 +35,8 @@ def test_brainvision_data_filters():
                                preload=False)
     assert_equal(raw.info['highpass'], 0.1)
     assert_equal(raw.info['lowpass'], 250.)
+    raw.info["lowpass"] = None
+    raw.filter(1, 30)
 
 
 def test_brainvision_data():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -32,7 +32,7 @@ def test_brainvision_data_filters():
     """Test reading raw Brain Vision files
     """
     raw = read_raw_brainvision(vhdr_highpass_path, montage, eog=eog,
-                               preload=False)
+                               preload=True)
     assert_equal(raw.info['highpass'], 0.1)
     assert_equal(raw.info['lowpass'], 250.)
     raw.info["lowpass"] = None


### PR DESCRIPTION
Proposal for dealing with filtering data where info["highpass"] or info["lowpass"] == None. Currently, the filter compares these fields to a float, which throws an error. Now, instead of checking ```(h_freq < info["lowpass"])```, we check ```(info["lowpass"] is None or h_freq < info["lowpass"])```.

Resolves #1833 