### PR TITLE
ENH: pick_events() adapted to step events

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -35,8 +35,10 @@ def pick_events(events, include=None, exclude=None, step=False):
         If None no event is excluded. If include is not None
         the exclude parameter is ignored.
     step : bool
-        If True (default is False), events have a step format.
-        In this case, the two last columns are considered in inclusion/exclusion criteria.
+        If True (default is False), events have a step format according
+        to the argument output='step' in the function find_events().
+        In this case, the two last columns are considered in inclusion/
+        exclusion criteria.
 
     Returns
     -------

--- a/mne/event.py
+++ b/mne/event.py
@@ -4,6 +4,7 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 #          Teon Brooks <teon.brooks@gmail.com>
+#          Clement Moutard <clement.moutard@polytechnique.org>
 #
 # License: BSD (3-clause)
 
@@ -19,7 +20,7 @@ from .io.write import write_int, start_block, start_file, end_block, end_file
 from .io.pick import pick_channels
 
 
-def pick_events(events, include=None, exclude=None):
+def pick_events(events, include=None, exclude=None, step=False):
     """Select some events
 
     Parameters
@@ -33,6 +34,9 @@ def pick_events(events, include=None, exclude=None):
         A event id to exclude or a list of them.
         If None no event is excluded. If include is not None
         the exclude parameter is ignored.
+    step : bool
+        If True (default is False), events have a step format.
+        In this case, the two last columns are considered in inclusion/exclusion criteria.
 
     Returns
     -------
@@ -45,6 +49,8 @@ def pick_events(events, include=None, exclude=None):
         mask = np.zeros(len(events), dtype=np.bool)
         for e in include:
             mask = np.logical_or(mask, events[:, 2] == e)
+            if step:
+                mask = np.logical_or(mask, events[:, 1] == e)
         events = events[mask]
     elif exclude is not None:
         if not isinstance(exclude, list):
@@ -52,6 +58,8 @@ def pick_events(events, include=None, exclude=None):
         mask = np.ones(len(events), dtype=np.bool)
         for e in exclude:
             mask = np.logical_and(mask, events[:, 2] != e)
+            if step:
+                mask = np.logical_and(mask, events[:, 1] != e)
         events = events[mask]
     else:
         events = np.copy(events)

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 import warnings
 
 from mne import (read_events, write_events, make_fixed_length_events,
-                 find_events, find_stim_steps, io, pick_channels)
+                 find_events, pick_events, find_stim_steps, io, pick_channels)
 from mne.utils import _TempDir
 from mne.event import define_target_events, merge_events
 
@@ -273,6 +273,27 @@ def test_find_events():
     for s, o in zip(extra_ends, orig_envs):
         if o is not None:
             os.environ['MNE_STIM_CHANNEL%s' % s] = o
+
+
+def test_pick_events():
+    """Test pick events in a events ndarray
+    """
+    events = np.array([[1, 0, 1],
+                       [2, 1, 0],
+                       [3, 0, 4],
+                       [4, 4, 2],
+                       [5, 2, 0]])
+    assert_array_equal(pick_events(events, include=[1, 4], exclude=4),
+                       [[1, 0, 1],
+                        [3, 0, 4]])
+    assert_array_equal(pick_events(events, exclude=[0, 2]),
+                       [[1, 0, 1],
+                        [3, 0, 4]])
+    assert_array_equal(pick_events(events, include=[1, 2], step=True),
+                       [[1, 0, 1],
+                        [2, 1, 0],
+                        [4, 4, 2],
+                        [5, 2, 0]])
 
 
 def test_make_fixed_length_events():


### PR DESCRIPTION
# Example

Let's say I have a data set called raw. I am extracting the events from it with the step option which gives the following:

```
>>> events_step = mne.find_events(raw, output = 'step')
Trigger channel contains negative values. Taking absolute value.
484 events found
Events id: [    0     5     6     9    10    17    18    33    34 32768]

>>> events_step[:10]
array([[222225,      0,     10],
       [222229,     10,      0],
       [223476,      0,     18],
       [223480,     18,      0],
       [224726,      0,     34],
       [224730,     34,      0],
       [228862,      0,  32768],
       [229030,  32768,      0],
       [237048,      0,      5],
       [237055,      5,      0]])
```

Now I want to exclude from the events list all the events 32768, but still keeping the step format...
With the present pick_events() function, I can either use the argument *include*:

```
>>> events_step = mne.pick_events(events_step, include = [0, 5, 6, 9, 10, 17, 18, 33, 34])
```
Or the argument *exclude*:

```
>>> events_step = mne.pick_events(events_step, exclude = [32768])
```

In both cases, the output is:

```
>>> events_step[:10]
array([[222225,      0,     10],
       [222229,     10,      0],
       [223476,      0,     18],
       [223480,     18,      0],