### PR TITLE
EHN: Contrast default comment

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -759,7 +759,11 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         this_evoked = deepcopy(evoked)
         this_evoked.data *= -1.
         out = combine_evoked([self, this_evoked])
-        out.comment = self.comment + " - " + this_evoked.comment
+        if self.comment is None or this_evoked.comment is None:
+            warnings.warn('evoked.comment expects a string but is None')
+            out.comment = 'unknown'
+        else:
+            out.comment = self.comment + " - " + this_evoked.comment
         return out
 
     def __hash__(self):

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -348,6 +348,7 @@ def test_evoked_arithmetic():
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
     ev = ev1 - ev2
     assert_equal(ev.nave, ev1.nave + ev2.nave)
+    assert_equal(ev.comment, ev1.comment + ' - ' + ev2.comment)
     assert_allclose(ev.data, np.ones_like(ev1.data))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
@@ -362,6 +363,7 @@ def test_evoked_arithmetic():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         ev = ev1 - ev2
+        assert_equal(ev.comment, 'unknown')
     ev1.comment = old_comment1
     ev2.comment = old_comment2
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -355,6 +355,16 @@ def test_evoked_arithmetic():
     assert_true(len(w) >= 1)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
 
+    # default comment behavior if evoked.comment is None
+    old_comment1 = ev1.comment
+    old_comment2 = ev2.comment
+    ev1.comment = None
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        ev = ev1 - ev2
+    ev1.comment = old_comment1
+    ev2.comment = old_comment2
+
     # equal weighting
     ev = combine_evoked([ev1, ev2], weights='equal')
     assert_allclose(ev.data, np.zeros_like(ev1.data))


### PR DESCRIPTION
This handles contrast cases (epochs1 - epochs2) where epochs1.comment and/or epochs2.comment is/are None.