### PR TITLE
correct bug parallel in gat for n_jobs>n_times

### DIFF
--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -257,6 +257,10 @@ class GeneralizationAcrossTime(object):
         else:
             n_chunk = multiprocessing.cpu_count()
 
+        # Avoid splitting the data in more time chunk than there is time points
+        if n_chunk > X.shape[2]:
+            n_chunk = X.shape[2]
+
         # Parallel across training time
         parallel, p_time_gen, n_jobs = parallel_func(_fit_slices, n_jobs)
         splits = np.array_split(self.train_times['slices'], n_chunk)


### PR DESCRIPTION
The GeneralizationAcrossTime.fit() crashes when gat.n_jobs > len(epochs.times).

This provides a quick fix by splitting the data before parallelization at a max number of n_times.