### PR TITLE
FIX: plot_topo scalings for bad EEG channels

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -117,6 +117,8 @@ BUG
 
    - Fix beamformer code LCMV/DICS for CTF data with reference channels by `Denis Engemann`_ and `Alex Gramfort`_
 
+   - Fix scalings for bad EEG channels in `mne.viz.plot_topo` by `Marijn van Vliet`_
+
 API
 ~~~
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -333,7 +333,7 @@ def plot_topo(evoked, layout=None, layout_scale=0.945, color=None,
                  for kk in types_used]
     else:
         types_used_kwargs = dict((t, True) for t in types_used)
-        picks = [pick_types(info, meg=False, **types_used_kwargs)]
+        picks = [pick_types(info, meg=False, exclude=[], **types_used_kwargs)]
     assert isinstance(picks, list) and len(types_used) == len(picks)
 
     scalings = _mutable_defaults(('scalings', scalings))[0]


### PR DESCRIPTION
I'm playing with FASTER, so I'm making plots **including** bad channels.
There's a bug in `plot_topo` where scalings are not applied to bad channels, but only when plotting EEG.

You can reproduce the bug like this:

    import mne
    import os.path as op
    
    data = op.join(mne.datasets.sample.data_path(),
                   'MEG', 'sample', 'sample_audvis-ave.fif')
    evokeds = mne.read_evokeds(data)
    
    # Plot EEG channels
    l = mne.channels.make_eeg_layout(evokeds[0].info, exclude=[])
    mne.viz.plot_topo(evokeds, l)
    
    # Set EEG 012 as bad
    for ev in evokeds:
        ev.info['bads'] += ['EEG 012']
    
    # Scalings for EEG 012 are not applied now
    mne.viz.plot_topo(evokeds, l)
