### PR TITLE
decim keyword for epochs fails if lowpass filter is None

### DIFF
--- a/mne/decoding/classifier.py
+++ b/mne/decoding/classifier.py
@@ -366,14 +366,14 @@ class FilterEstimator(TransformerMixin):
         if self.h_freq is not None and not isinstance(self.h_freq, float):
             self.h_freq = float(self.h_freq)
 
-        if self.h_freq is not None and \
+        if self.info['lowpass'] is None or (self.h_freq is not None and \
                 (self.l_freq is None or self.l_freq < self.h_freq) and \
-                self.h_freq < self.info['lowpass']:
+                self.h_freq < self.info['lowpass']):
             self.info['lowpass'] = self.h_freq
 
-        if self.l_freq is not None and \
+        if self.info['highpass'] is None or (self.l_freq is not None and \
                 (self.h_freq is None or self.l_freq < self.h_freq) and \
-                self.l_freq > self.info['highpass']:
+                self.l_freq > self.info['highpass']):
             self.info['highpass'] = self.l_freq
 
         return self

--- a/mne/decoding/classifier.py
+++ b/mne/decoding/classifier.py
@@ -366,14 +366,18 @@ class FilterEstimator(TransformerMixin):
         if self.h_freq is not None and not isinstance(self.h_freq, float):
             self.h_freq = float(self.h_freq)
 
-        if self.info['lowpass'] is None or (self.h_freq is not None and \
-                (self.l_freq is None or self.l_freq < self.h_freq) and \
-                self.h_freq < self.info['lowpass']):
+        if self.info['lowpass'] is None or (self.h_freq is not None and
+                                            (self.l_freq is None or
+                                             self.l_freq < self.h_freq)
+                                            and self.h_freq
+                                            < self.info['lowpass']):
             self.info['lowpass'] = self.h_freq
 
-        if self.info['highpass'] is None or (self.l_freq is not None and \
-                (self.h_freq is None or self.l_freq < self.h_freq) and \
-                self.l_freq > self.info['highpass']):
+        if self.info['highpass'] is None or (self.l_freq is not None and
+                                             (self.h_freq is None or
+                                              self.l_freq < self.h_freq)
+                                             and self.l_freq
+                                             > self.info['highpass']):
             self.info['highpass'] = self.l_freq
 
         return self

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -142,7 +142,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                        'low-pass filtered. The decim=%i parameter will '
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
-                       % (decim, new_sfreq))         
+                       % (decim, new_sfreq))
             elif new_sfreq < 2.5 * lowpass:
                 msg = ('The measurement information indicates a low-pass '
                        'frequency of %g Hz. The decim=%i parameter will '

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -148,8 +148,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                        'frequency of %g Hz. The decim=%i parameter will '
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
-                       % (lowpass, decim, new_sfreq))
-                       # nyquist says freq * 2 but 2.5 is safer
+                       % (lowpass, decim, new_sfreq))  # 50% over nyquist limit
                 warnings.warn(msg)
 
             i_start = start_idx % decim

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -137,11 +137,12 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         if decim > 1:
             new_sfreq = sfreq / decim
             lowpass = self.info['lowpass']
-            if new_sfreq < 2.5 * lowpass:  # nyquist says 2 but 2.5 is safer
+            if (lowpass is not None) and (new_sfreq < 2.5 * lowpass):
                 msg = ('The measurement information indicates a low-pass '
                        'frequency of %g Hz. The decim=%i parameter will '
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
+                       # nyquist says freq * 2 but 2.5 is safer
                        % (lowpass, decim, new_sfreq))
                 warnings.warn(msg)
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -137,13 +137,19 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         if decim > 1:
             new_sfreq = sfreq / decim
             lowpass = self.info['lowpass']
-            if (lowpass is not None) and (new_sfreq < 2.5 * lowpass):
+            if lowpass is None:
+                msg = ('The measurement information indicates data is not '
+                       'low-pass filtered. The decim=%i parameter will '
+                       'result in a sampling frequency of %g Hz, which can '
+                       'cause aliasing artifacts.'
+                       % (decim, new_sfreq))         
+            elif new_sfreq < 2.5 * lowpass:
                 msg = ('The measurement information indicates a low-pass '
                        'frequency of %g Hz. The decim=%i parameter will '
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
-                       # nyquist says freq * 2 but 2.5 is safer
                        % (lowpass, decim, new_sfreq))
+                       # nyquist says freq * 2 but 2.5 is safer
                 warnings.warn(msg)
 
             i_start = start_idx % decim


### PR DESCRIPTION
(I guess I'm partially responsible for this problem myself in the first place, as I helped get BV importing done when no filter is set ...)

If info["lowpass"] is None, which can happen e.g. if importing underspecified BV files, and epoching uses the decim keyword, an error is thrown b/c ```new_sfreq < 2.5 * lowpass``` in line 140 fails if lowpass is None.
This is a simple workaround.

Might be worth considering if low/highpass = None should actually be allowed, or if import filters (specifically for BV) should default to something like 0 (or 1/length) and srate instead.