### PR TITLE
EHN: Gat score optional epochs

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -158,11 +158,13 @@ def test_generalization_across_time():
     assert_equal(gat.train_times['times_'][0], epochs.times[6])
     assert_equal(gat.train_times['times_'][-1], epochs.times[9])
 
-    # Test diagonal decoding
+    # Test score without passing epochs
     gat = GeneralizationAcrossTime()
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
-    scores = gat.score(epochs, test_times='diagonal')
+    assert_raises(RuntimeError, gat.score)
+    gat.predict(epochs, test_times='diagonal') # Test diagonal decoding
+    scores = gat.score()
     assert_true(scores is gat.scores_)
     assert_equal(np.shape(gat.scores_), (15, 1))
 
@@ -172,6 +174,7 @@ def test_generalization_across_time():
         gat.fit(epochs[0:6])
     gat.predict(epochs[7:])
     assert_raises(ValueError, gat.predict, epochs, test_times='hahahaha')
+    assert_raises(RuntimeError, gat.score)
     gat.score(epochs[7:])
 
     svc = SVC(C=1, kernel='linear', probability=True)
@@ -244,11 +247,3 @@ def test_generalization_across_time():
                             cv=2, clf=clf, predict_type=pt)
                         gat.fit(epochs, y=y_)
                         gat.score(epochs, y=y_)
-
-    # Test score without passing epochs
-    gat = GeneralizationAcrossTime()
-    with warnings.catch_warnings(record=True):
-        gat.fit(epochs)
-    assert_raises(RuntimeError, gat.score)
-    gat.predict(epochs)
-    gat.score()

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -163,7 +163,7 @@ def test_generalization_across_time():
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
     assert_raises(RuntimeError, gat.score)
-    gat.predict(epochs, test_times='diagonal') # Test diagonal decoding
+    gat.predict(epochs, test_times='diagonal')  # Test diagonal decoding
     scores = gat.score()
     assert_true(scores is gat.scores_)
     assert_equal(np.shape(gat.scores_), (15, 1))

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -244,3 +244,11 @@ def test_generalization_across_time():
                             cv=2, clf=clf, predict_type=pt)
                         gat.fit(epochs, y=y_)
                         gat.score(epochs, y=y_)
+
+    # Test score without passing epochs
+    gat = GeneralizationAcrossTime()
+    with warnings.catch_warnings(record=True):
+        gat.fit(epochs)
+    assert_raises(RuntimeError, gat.score)
+    gat.predict(epochs)
+    gat.score()

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -257,6 +257,10 @@ class GeneralizationAcrossTime(object):
         else:
             n_chunk = multiprocessing.cpu_count()
 
+        # Avoid splitting the data in more time chunk than there is time points
+        if n_chunk > X.shape[2]:
+            n_chunk = X.shape[2]
+
         # Parallel across training time
         parallel, p_time_gen, n_jobs = parallel_func(_fit_slices, n_jobs)
         splits = np.array_split(self.train_times['slices'], n_chunk)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -372,7 +372,7 @@ class GeneralizationAcrossTime(object):
         self.y_pred_ = np.transpose(tuple(zip(*packed)), (1, 0, 2, 3))
         return self.y_pred_
 
-    def score(self, epochs, y=None, scorer=None, test_times=None):
+    def score(self, epochs=None, y=None, scorer=None, test_times=None):
         """Score Epochs
 
         Estimate scores across trials by comparing the prediction estimated for
@@ -382,9 +382,10 @@ class GeneralizationAcrossTime(object):
 
         Parameters
         ----------
-        epochs : instance of Epochs
+        epochs : instance of Epochs | None
             The epochs. Can be similar to fitted epochs or not. See independent
             parameter.
+            If None, it relies on the y_pred_ generated from predit()
         y : list | np.ndarray, shape (n_epochs,) | None
             To-be-fitted model, If None, y = epochs.events[:,2].
             Defaults to None.
@@ -426,8 +427,13 @@ class GeneralizationAcrossTime(object):
         from sklearn.base import is_classifier
         from sklearn.preprocessing import LabelEncoder
 
-        # Run predictions
-        self.predict(epochs, test_times=test_times)
+        # Run predictions if not already done
+        if epochs is not None:
+            self.predict(epochs, test_times=test_times)
+        else:
+            if not hasattr(self, 'y_pred_'):
+                raise RuntimeError('Please predit() epochs first or pass epochs'
+                                    ' to score()')
 
         # If no regressor is passed, use default epochs events
         if y is None:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -440,7 +440,12 @@ class GeneralizationAcrossTime(object):
             if self.predict_mode == 'cross-validation':
                 y = self.y_train_
             else:
-                y = epochs.events[:, 2]
+                if epochs is not None:
+                    y = epochs.events[:, 2]
+                else:
+                    raise RuntimeError('y is undefined because'
+                        'predict_mode="mean-prediction" and epochs are missing.'
+                        'You need to explicitly specify y.')
             if not np.all(np.unique(y) == np.unique(self.y_train_)):
                 raise ValueError('Classes (y) passed differ from classes used '
                                  'for training. Please explicitly pass your y '

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -432,8 +432,8 @@ class GeneralizationAcrossTime(object):
             self.predict(epochs, test_times=test_times)
         else:
             if not hasattr(self, 'y_pred_'):
-                raise RuntimeError('Please predit() epochs first or pass epochs'
-                                    ' to score()')
+                raise RuntimeError('Please predit() epochs first or pass '
+                                   'epochs to score()')
 
         # If no regressor is passed, use default epochs events
         if y is None:
@@ -444,8 +444,9 @@ class GeneralizationAcrossTime(object):
                     y = epochs.events[:, 2]
                 else:
                     raise RuntimeError('y is undefined because'
-                        'predict_mode="mean-prediction" and epochs are missing.'
-                        'You need to explicitly specify y.')
+                                       'predict_mode="mean-prediction" and '
+                                       'epochs are missing. You need to '
+                                       'explicitly specify y.')
             if not np.all(np.unique(y) == np.unique(self.y_train_)):
                 raise ValueError('Classes (y) passed differ from classes used '
                                  'for training. Please explicitly pass your y '


### PR DESCRIPTION
@cmoutard @dengemann @agramfort 

This is a small EHN that allows using gat.score() without passing the epochs if and only if the user has already used gat.predict(). 

As the object already stores the epochs predictions (in gat.y_pred_) it already possess all the necessary information which can be useful when you want to happened to have already predicted your epochs and want to test several different scorers.