### PR TITLE
MRG: importing EEGLAB exported BV files: units

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -469,7 +469,7 @@ def _get_eeg_info(vhdr_fname, eog, misc):
         else:
             name, _, resolution, unit = props[:4]
         ch_names[n - 1] = name
-        if len(resolution) > 0:
+        if resolution == '':
             cals[n - 1] = float(resolution)
         else:
             cals[n - 1] = 0.000001

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -469,7 +469,10 @@ def _get_eeg_info(vhdr_fname, eog, misc):
         else:
             name, _, resolution, unit = props[:4]
         ch_names[n - 1] = name
-        cals[n - 1] = float(resolution)
+        try:
+            cals[n - 1] = float(resolution)
+        except ValueError:
+            cals[n - 1] = 0.000001
         unit = unit.replace('\xc2', '')  # Remove unwanted control characters
         if u(unit) == u('\xb5V'):
             units[n - 1] = 1e-6

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -469,9 +469,9 @@ def _get_eeg_info(vhdr_fname, eog, misc):
         else:
             name, _, resolution, unit = props[:4]
         ch_names[n - 1] = name
-        try:
+        if len(resolution) > 0:
             cals[n - 1] = float(resolution)
-        except ValueError:
+        else:
             cals[n - 1] = 0.000001
         unit = unit.replace('\xc2', '')  # Remove unwanted control characters
         if u(unit) == u('\xb5V'):

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -469,10 +469,10 @@ def _get_eeg_info(vhdr_fname, eog, misc):
         else:
             name, _, resolution, unit = props[:4]
         ch_names[n - 1] = name
-        if resolution == '':
-            cals[n - 1] = float(resolution)
+        if resolution == "":        # For truncated vhdrs (e.g. EEGLAB export)
+            cals[n - 1] = 0.000001  # Fill in a default
         else:
-            cals[n - 1] = 0.000001
+            cals[n - 1] = float(resolution)
         unit = unit.replace('\xc2', '')  # Remove unwanted control characters
         if u(unit) == u('\xb5V'):
             units[n - 1] = 1e-6


### PR DESCRIPTION
EEGLAB can export to BV and it's possibly one of the easier ways to export from EEGLAB to MNE. However, EEGLAB writes very minimal BV headers. In the ones I'm working on right now, no unit information is given at all; importing the file fails with a value error, because unit and resolution info is missing.
These proposed changes allow reading these underspecified files by simply filling in a default.

Sorry for these coming in incrementally, I discover new strange things about our huge collection of BV files every day.

@teonlamont