### PR TITLE
FIX: correct warning message when decimating epoch data

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -144,13 +144,14 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
                        % (decim, new_sfreq))
+                warnings.warn(msg)
             elif new_sfreq < 2.5 * lowpass:
                 msg = ('The measurement information indicates a low-pass '
                        'frequency of %g Hz. The decim=%i parameter will '
                        'result in a sampling frequency of %g Hz, which can '
                        'cause aliasing artifacts.'
                        % (lowpass, decim, new_sfreq))  # 50% over nyquist limit
-            warnings.warn(msg)
+                warnings.warn(msg)
 
             i_start = start_idx % decim
             self._decim_idx = slice(i_start, ep_len, decim)


### PR DESCRIPTION
@jona-sassenhagen, @dengemann 

When decimating the epoch data, the ```msg``` variable can be unspecified which creates a crash.

I put the warning in each condition instead. I hope this follows what the original authors aimed at doing?