### PR TITLE
WIP add a general read_raw function

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -105,6 +105,7 @@ Functions:
   :toctree: generated/
   :template: function.rst
 
+  read_raw
   read_raw_bti
   read_raw_edf
   read_raw_kit

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -91,6 +91,8 @@ Changelog
 
    - `rename_channels` and `set_channel_types` added as methods to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_ 
 
+   - Add ``read_raw``, an all-purpose raw data reader by `Teon Brooks`_
+
 
 BUG
 ~~~

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -9,7 +9,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-   - Add support for mayavi figures in `add_section` method in Report by `Mainak Jas`_
+   - Add support for mayavi figures in ``add_section`` method in Report by `Mainak Jas`_
 
    - Add extract volumes of interest from freesurfer segmentation and setup as volume source space by `Alan Leggitt`_
 
@@ -17,7 +17,7 @@ Changelog
 
    - Add support for source estimate for mixed source spaces by `Alan Leggitt`_
 
-   - Add `SourceSpaces.export_volume` method by `Alan Leggitt`_
+   - Add ``SourceSpaces.export_volume`` method by `Alan Leggitt`_
 
    - Automatically compute proper box sizes when generating layouts on the fly by `Marijn van Vliet`_
 
@@ -25,7 +25,7 @@ Changelog
 
    - Add option to Report class to save images as vector graphics (SVG) by `Denis Engemann`_
 
-   - Add events count to `mne.viz.plot_events` by `Denis Engemann`_
+   - Add events count to ``mne.viz.plot_events`` by `Denis Engemann`_
 
    - Add support for stereotactic EEG (sEEG) channel type by `Marmaduke Woodman`_
 
@@ -41,19 +41,19 @@ Changelog
 
    - Add reading and writing support for digitizer data, and function for adding dig points to info by `Teon Brooks`_
 
-   - Add methods `get_channel_positions`, `set_channel_positions` for setting channel positions,
-     and `plot_projs_topomap` to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_
+   - Add methods ``get_channel_positions``, ``set_channel_positions`` for setting channel positions,
+     and ``plot_projs_topomap`` to ``Raw``, ``Epochs`` and ``Evoked`` objects by `Teon Brooks`_
 
-   - Add EEG bad channel interpolation method (based on spherical splines) to `Raw`, `Epochs` and `Evoked` objects
+   - Add EEG bad channel interpolation method (based on spherical splines) to ``Raw``, ``Epochs`` and ``Evoked`` objects
      by `Denis Engemann`_
 
-   - Add parameter to `whiten_evoked`, `compute_whitener` and `prepare_noise_cov` to set the exact rank by `Martin Luessi`_ and `Denis Engemann`_
+   - Add parameter to ``whiten_evoked``, ``compute_whitener`` and ``prepare_noise_cov`` to set the exact rank by `Martin Luessi`_ and `Denis Engemann`_
 
    - Add fiff I/O for processing history and MaxFilter info by `Denis Engemann`_ and `Eric Larson`_
 
    - Add automated regularization with support for multiple sensor types to mne.cov.compute_covariance by `Denis Engemann`_ and `Alex Gramfort`_
 
-   - Add ``mne.viz.plot_evoked_white`` function and `Evoked.plot_white` method to diagnose the quality of the estimated noise covariance and its impact on spatial whitening by `Denis Engemann`_ and `Alex Gramfort`_
+   - Add ``mne.viz.plot_evoked_white`` function and ``Evoked.plot_white`` method to diagnose the quality of the estimated noise covariance and its impact on spatial whitening by `Denis Engemann`_ and `Alex Gramfort`_
 
    - Add ``mne.evoked.grand_average`` function to compute grand average of Evoked data while interpolating bad EEG channels if necessary by `Mads Jensen`_ and `Alex Gramfort`_
 
@@ -77,19 +77,19 @@ Changelog
 
    - Add support for Savitsky-Golay filtering of Evoked and Epochs by `Eric Larson`_
 
-   - Add `render_bem`, `add_htmls_to_section` methods to `mne.Report` by `Teon Brooks`_
+   - Add ``render_bem``, ``add_htmls_to_section`` methods to ``mne.Report`` by `Teon Brooks`_
 
-   - Add support for adding an empty reference channel to data by `Teon Brooks`_
+   - Add support for adding an empty reference channel to data by ``Teon Brooks``_
 
-   - Add reader function for Raw FIF files by `Teon Brooks`_
+   - Add reader function for Raw FIF files by ``Teon Brooks``_
 
    - Add example of creating MNE objects from arbitrary data and NEO files by `Jaakko Leppakangas`_
 
-   - Add plot_psd and plot_psd_topomap methods to epochs by `Yousra Bekhti`_, `Eric Larson`_ and `Denis Engemann`_
+   - Add ``plot_psd`` and ``plot_psd_topomap`` methods to epochs by `Yousra Bekhti`_, `Eric Larson`_ and `Denis Engemann`_
 
-   - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
+   - ``evoked.pick_types``, ``epochs.pick_types``, and ``tfr.pick_types`` added by `Eric Larson`_
 
-   - `rename_channels` and `set_channel_types` added as methods to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_ 
+   - ``rename_channels`` and ``set_channel_types`` added as methods to ``Raw``, ``Epochs`` and ``Evoked`` objects by `Teon Brooks`_ 
 
    - Add ``read_raw``, an all-purpose raw data reader by `Teon Brooks`_
 
@@ -99,12 +99,12 @@ BUG
 
    - Fix energy conservation for STFT with tight frames by `Daniel Strohmeier`_
 
-   - Fix incorrect data matrix when tfr was plotted with parameters `tmin`, `tmax`, `fmin` and `fmax` by `Mainak Jas`_
+   - Fix incorrect data matrix when tfr was plotted with parameters ``tmin``, ``tmax``, ``fmin`` and ``fmax`` by `Mainak Jas`_
 
    - Fix channel names in topomaps by `Alex Gramfort`_
 
-   - Fix mapping of `l_trans_bandwidth` (to low frequency) and
-    `h_trans_bandwidth` (to high frequency) in `_BaseRaw.filter` by `Denis Engemann`_
+   - Fix mapping of ``l_trans_bandwidth`` (to low frequency) and
+    ``h_trans_bandwidth`` (to high frequency) in ``_BaseRaw.filter`` by `Denis Engemann`_
 
    - Fix scaling source spaces when distances have to be recomputed by `Christian Brodbeck`_
 
@@ -122,7 +122,7 @@ BUG
 
    - The API change to the edf, brainvision, and egi break backwards compatibility for when importing eeg data by `Teon Brooks`_
 
-   - Fix bug in `mne.viz.plot_topo` if ylim was passed for single sensor layouts by `Denis Engemann`_
+   - Fix bug in ``mne.viz.plot_topo`` if ylim was passed for single sensor layouts by `Denis Engemann`_
 
    - Average reference projections will no longer by automatically added after applying a custom EEG reference by `Marijn van Vliet`_
 
@@ -130,7 +130,7 @@ BUG
 
    - Fix beamformer code LCMV/DICS for CTF data with reference channels by `Denis Engemann`_ and `Alex Gramfort`_
 
-   - Fix scalings for bad EEG channels in `mne.viz.plot_topo` by `Marijn van Vliet`_
+   - Fix scalings for bad EEG channels in ``mne.viz.plot_topo`` by `Marijn van Vliet`_
 
    - Fix EGI reading when no events are present by `Federico Raimondo`_
 
@@ -143,45 +143,45 @@ BUG
 API
 ~~~
 
-   - apply_inverse functions have a new boolean parameter `prepared` which saves computation time by calling `prepare_inverse_operator` only if it is False
+   - apply_inverse functions have a new boolean parameter ``prepared`` which saves computation time by calling ``prepare_inverse_operator`` only if it is False
 
-   - find_events and read_events functions have a new parameter `mask` to set some bits to a don't care state by `Teon Brooks`_
+   - find_events and read_events functions have a new parameter ``mask`` to set some bits to a don't care state by `Teon Brooks`_
 
    - New channels module including layouts, electrode montages, and neighbor definitions of sensors which deprecates
     `mne.layouts` by `Denis Engemann`_
 
-   - `read_raw_brainvision`, `read_raw_edf`, `read_raw_egi` all use a standard montage import by `Teon Brooks`_
+   - ``read_raw_brainvision``, ``read_raw_edf``, ``read_raw_egi`` all use a standard montage import by `Teon Brooks`_
 
    - Fix missing calibration factors for ``mne.io.egi.read_raw_egi`` by `Denis Engemann`_ and `Federico Raimondo`_
 
-   - Allow multiple filename patterns as a list (e.g., *raw.fif and *-eve.fif) to be parsed by mne report in `Report.parse_folder()` by `Mainak Jas`_
+   - Allow multiple filename patterns as a list (e.g., *raw.fif and *-eve.fif) to be parsed by mne report in ``Report.parse_folder()`` by `Mainak Jas`_
 
-   - `read_hsp`, `read_elp`, and `write_hsp`, `write_mrk` were removed and made private by `Teon Brooks`_
+   - ``read_hsp``, ``read_elp``, and ``write_hsp``, ``write_mrk`` were removed and made private by `Teon Brooks`_
 
    - When computing the noise covariance or MNE inverse solutions, the rank is estimated empirically using more sensitive thresholds, which stabilizes results by `Denis Engemann`_ and `Eric Larson`_ and `Alex Gramfort`_
 
    - Raw FIFF files can be preloaded after class instantiation using ``raw.preload_data()``
 
-   - Add `label` parameter to `apply_inverse` by `Teon Brooks`_
+   - Add ``label`` parameter to ``apply_inverse`` by `Teon Brooks`_
 
-   - Deprecated `label_time_courses` for `in_label` method in `SourceEstimate` by `Teon Brooks`_
+   - Deprecated ``label_time_courses`` for ``in_label`` method in `SourceEstimate` by `Teon Brooks`_
 
-   - Deprecated `as_data_frame` for `to_data_frame` by `Chris Holdgraf`_
+   - Deprecated ``as_data_frame`` for ``to_data_frame`` by `Chris Holdgraf`_
 
-   - Add `transform`, `unit` parameters to `read_montage` by `Teon Brooks`_
+   - Add ``transform``, ``unit`` parameters to ``read_montage`` by `Teon Brooks`_
 
-   - Deprecated `fmin, fmid, fmax` in stc.plot and added `clim` by `Mark Wronkiewicz`_
+   - Deprecated ``fmin, fmid, fmax`` in stc.plot and added ``clim`` by `Mark Wronkiewicz`_
 
-   - Use `scipy.signal.welch` instead of matplotlib.psd inside `compute_raw_psd` and `compute_epochs_psd` by `Yousra Bekhti_`
+   - Use ``scipy.signal.welch`` instead of matplotlib.psd inside ``compute_raw_psd`` and ``compute_epochs_psd`` by `Yousra Bekhti_`
      `Eric Larson_` and `Denis Engemann_`. As a consquence, `Raw.plot_raw_psds` has been deprecated.
 
-   - `Raw` instances returned by `mne.forward.apply_forward_raw` now always have times starting from
-     zero to be consistent with all other `Raw` instances. To get the former `start` and `stop` times,
-     use `raw.first_samp / raw.info['sfreq']` and `raw.last_samp / raw.info['sfreq']`.
+   - ``Raw`` instances returned by ``mne.forward.apply_forward_raw`` now always have times starting from
+     zero to be consistent with all other ``Raw`` instances. To get the former ``start`` and ``stop`` times,
+     use ``raw.first_samp / raw.info['sfreq']`` and ``raw.last_samp / raw.info['sfreq']``.
 
-   - `pick_types_evoked` has been deprecated in favor of `evoked.pick_types`.
+   - ``pick_types_evoked`` has been deprecated in favor of ``evoked.pick_types``.
 
-   - Deprecated changing the sensor type of channels in `rename_channels` by `Teon Brooks`_
+   - Deprecated changing the sensor type of channels in ``rename_channels`` by `Teon Brooks`_
 
    - CUDA is no longer initialized at module import, but only when first used.
 
@@ -195,25 +195,25 @@ Changelog
 
    - Add Python3 support by `Nick Ward`_, `Alex Gramfort`_, `Denis Engemann`_, and `Eric Larson`_
 
-   - Add `get_peak` method for evoked and stc objects by  `Denis Engemann`_
+   - Add ``get_peak`` method for evoked and stc objects by  `Denis Engemann`_
 
-   - Add `iter_topography` function for radically simplified custom sensor topography plotting by `Denis Engemann`_
+   - Add ``iter_topography`` function for radically simplified custom sensor topography plotting by `Denis Engemann`_
 
    - Add field line interpolation by `Eric Larson`_
 
-   - Add full provenance tacking for epochs and improve `drop_log` by `Tal Linzen`_, `Alex Gramfort`_ and `Denis Engemann`_
+   - Add full provenance tacking for epochs and improve ``drop_log`` by `Tal Linzen`_, `Alex Gramfort`_ and `Denis Engemann`_
 
-   - Add systematic contains method to Raw, Epochs and Evoked for channel type membership testing by `Denis Engemann`_
+   - Add systematic contains method to ``Raw``, ``Epochs`` and ``Evoked`` for channel type membership testing by `Denis Engemann`_
 
    - Add fiff unicode writing and reading support by `Denis Engemann`_
 
    - Add 3D MEG/EEG field plotting function and evoked method by `Denis Engemann`_ and  `Alex Gramfort`_
 
-   - Add consistent channel-dropping methods to Raw, Epochs and Evoked by `Denis Engemann`_ and  `Alex Gramfort`_
+   - Add consistent channel-dropping methods to ``Raw``, ``Epochs`` and ``Evoked`` by `Denis Engemann`_ and  `Alex Gramfort`_
 
-   - Add `equalize_channnels` function to set common channels for a list of Raw, Epochs, or Evoked objects by `Denis Engemann`_
+   - Add ``equalize_channnels`` function to set common channels for a list of ``Raw``, ``Epochs``, or ``Evoked`` objects by `Denis Engemann`_
 
-   - Add `plot_events` function to visually display paradigm by `Alex Gramfort`_
+   - Add ``plot_events`` function to visually display paradigm by `Alex Gramfort`_
 
    - Improved connectivity circle plot by `Martin Luessi`_
 
@@ -223,21 +223,21 @@ Changelog
 
    - Add ability to add patch information to source spaces by `Eric Larson`_
 
-   - Add `split_label` function to divide labels into multiple parts by `Christian Brodbeck`_
+   - Add ``split_label`` function to divide labels into multiple parts by `Christian Brodbeck`_
 
-   - Add `color` attribute to `Label` objects by `Christian Brodbeck`_
+   - Add ``color`` attribute to ``Label`` objects by `Christian Brodbeck`_
 
-   - Add `max` mode for extract_label_time_course by `Mads Jensen`_
+   - Add ``max`` mode for ``extract_label_time_course`` by `Mads Jensen`_
 
-   - Add `rename_channels` function to change channel names and types in info object by `Dan Wakeman`_ and `Denis Engemann`_
+   - Add ``rename_channels`` function to change channel names and types in info object by `Dan Wakeman`_ and `Denis Engemann`_
 
-   - Add  `compute_ems` function to extract the time course of experimental effects by `Denis Engemann`_, `Sébastien Marti`_ and `Alex Gramfort`_
+   - Add  ``compute_ems`` function to extract the time course of experimental effects by `Denis Engemann`_, `Sébastien Marti`_ and `Alex Gramfort`_
 
-   - Add option to expand Labels defined in a source space to the original surface (`Label.fill()`) by `Christian Brodbeck`_
+   - Add option to expand Labels defined in a source space to the original surface (``Label.fill()``) by `Christian Brodbeck`_
 
    - GUIs can be invoked form the command line using `$ mne coreg` and `$ mne kit2fiff` by `Christian Brodbeck`_
 
-   - Add `add_channels_epochs` function to combine different recordings at the Epochs level by `Christian Brodbeck`_ and `Denis Engemann`_
+   - Add ``add_channels_epochs`` function to combine different recordings at the Epochs level by `Christian Brodbeck`_ and `Denis Engemann`_
 
    - Add support for EGI Netstation simple binary files by `Denis Engemann`_
 
@@ -251,29 +251,29 @@ Changelog
 
    - Add color and event_id with legend options in plot_events in viz.py by `Cathy Nangini`_
 
-   - Add `events_list` parameter to `mne.concatenate_raws` to concatenate events corresponding to runs by `Denis Engemann`_
+   - Add ``events_list`` parameter to ``mne.concatenate_raws`` to concatenate events corresponding to runs by `Denis Engemann`_
 
-   - Add `read_ch_connectivity` function to read FieldTrip neighbor template .mat files and obtain sensor adjacency matrices by `Denis Engemann`_
+   - Add ``read_ch_connectivity`` function to read FieldTrip neighbor template .mat files and obtain sensor adjacency matrices by `Denis Engemann`_
 
    - Add display of head in helmet from -trans.fif file to check coregistration quality by `Mainak Jas`_
 
-   - Add `raw.add_events` to allow adding events to a raw file by `Eric Larson`_
+   - Add ``raw.add_events`` to allow adding events to a raw file by `Eric Larson`_
 
-   - Add `plot_image` method to Evoked object to display data as images by `JR King`_ and `Alex Gramfort`_ and `Denis Engemann`_
+   - Add ``plot_image`` method to Evoked object to display data as images by `JR King`_ and `Alex Gramfort`_ and `Denis Engemann`_
 
    - Add BCI demo with CSP on motor imagery by `Martin Billinger`_
 
-   - New ICA API with unified methods for processing Raw, Epochs and Evoked objects by `Denis Engemann`_
+   - New ICA API with unified methods for processing ``Raw``, ``Epochs`` and ``Evoked`` objects by `Denis Engemann`_
 
    - Apply ICA at the evoked stage by `Denis Engemann`_
 
    - New ICA methods for visualizing unmixing quality, artifact detection and rejection by `Denis Engemann`_
 
-   - Add `pick_channels` and `drop_channels` mixin class to pick and drop channels from Raw, Epochs, and Evoked objects by `Andrew Dykstra`_ and `Denis Engemann`_
+   - Add ``pick_channels`` and ``drop_channels`` mixin class to pick and drop channels from ``Raw``, ``Epochs``, and ``Evoked`` objects by `Andrew Dykstra`_ and `Denis Engemann`_
 
-   - Add `EvokedArray` class to create an Evoked object from an array by `Andrew Dykstra`_
+   - Add ``EvokedArray`` class to create an Evoked object from an array by `Andrew Dykstra`_
 
-   - Add `plot_bem` method to visualize BEM contours on MRI anatomical images by `Mainak Jas`_ and `Alex Gramfort`_
+   - Add ``plot_bem`` method to visualize BEM contours on MRI anatomical images by `Mainak Jas`_ and `Alex Gramfort`_
 
    - Add automated ECG detection using cross-trial phase statistics by `Denis Engemann`_ and `Juergen Dammers`_
 
@@ -285,13 +285,13 @@ Changelog
 
    - Add computation of point spread and cross-talk functions for MNE type solutions by `Alex Gramfort`_ and `Olaf Hauk`_
 
-   - Add mask parameter to `plot_evoked_topomap` and `evoked.plot_topomap` by `Denis Engemann`_ and `Alex Gramfort`_
+   - Add mask parameter to `plot_evoked_topomap` and ``evoked.plot_topomap`` by `Denis Engemann`_ and `Alex Gramfort`_
 
    - Add infomax and extended infomax ICA by `Denis Engemann`_, `Juergen Dammers`_ and `Lukas Breuer`_ and `Federico Raimondo`_
 
    - Aesthetically redesign interpolated topography plots by `Denis Engemann`_ and `Alex Gramfort`_
 
-   - Simplify sensor space time-frequency analysis API with `tfr_morlet` function by `Alex Gramfort`_ and `Denis Engemann`_
+   - Simplify sensor space time-frequency analysis API with ``tfr_morlet`` function by `Alex Gramfort`_ and `Denis Engemann`_
 
    - Add new somatosensory MEG dataset with nice time-frequency content by `Alex Gramfort`_
 
@@ -306,7 +306,7 @@ Changelog
 BUG
 ~~~
 
-   - Fix incorrect `times` attribute when stc was computed using `apply_inverse` after decimation at epochs stage for certain, arbitrary sample frequencies by `Denis Engemann`_
+   - Fix incorrect ``times`` attribute when stc was computed using ``apply_inverse`` after decimation at epochs stage for certain, arbitrary sample frequencies by `Denis Engemann`_
 
    - Fix corner case error for step-down-in-jumps permutation test (when step-down threshold was high enough to include all clusters) by `Eric Larson`_
 
@@ -327,21 +327,21 @@ API
 
    - Deprecate Epochs.drop_picks in favor of a new method called drop_channels
 
-   - Deprecate `labels_from_parc` and `parc_from_labels` in favor of `read_labels_from_annot` and `write_labels_to_annot`
+   - Deprecate ``labels_from_parc`` and ``parc_from_labels`` in favor of ``read_labels_from_annot`` and ``write_labels_to_annot``
 
-   - The default of the new add_dist option of `setup_source_space` to add patch information will change from False to True in MNE-Python 0.9
+   - The default of the new add_dist option of ``setup_source_space`` to add patch information will change from False to True in MNE-Python 0.9
 
-   - Deprecate `read_evoked` and `write_evoked` in favor of `read_evokeds` and `write_evokeds`. read_evokeds will return all Evoked instances in a file by default.
+   - Deprecate ``read_evoked`` and ``write_evoked`` in favor of ``read_evokeds`` and ``write_evokeds``. read_evokeds will return all `Evoked` instances in a file by default.
 
-   - Deprecate `setno` in favor of `condition` in the initialization of an Evoked instance. This affects `mne.fiff.Evoked` and `read_evokeds`, but not `read_evoked`.
+   - Deprecate ``setno`` in favor of ``condition`` in the initialization of an Evoked instance. This affects ``mne.fiff.Evoked`` and ``read_evokeds``, but not ``read_evoked``.
 
-   - Deprecate `mne.fiff` module, use `mne.io` instead e.g. `mne.io.Raw` instead of `mne.fiff.Raw`.
+   - Deprecate ``mne.fiff`` module, use ``mne.io`` instead e.g. ``mne.io.Raw`` instead of ``mne.fiff.Raw``.
 
-   - Pick functions (e.g., `pick_types`) are now in the mne namespace (e.g. use `mne.pick_types`).
+   - Pick functions (e.g., ``pick_types``) are now in the mne namespace (e.g. use ``mne.pick_types``).
 
    - Deprecated ICA methods specific to one container type. Use ICA.fit, ICA.get_sources ICA.apply and ICA.plot_XXX for processing Raw, Epochs and Evoked objects.
 
-   - The default smoothing method for `mne.stc_to_label` will change in v0.9, and the old method is deprecated.
+   - The default smoothing method for ``mne.stc_to_label`` will change in v0.9, and the old method is deprecated.
 
    - As default, for ICA the maximum number of PCA components equals the number of channels passed. The number of PCA components used to reconstruct the sensor space signals now defaults to the maximum number of PCA components estimated.
 
@@ -403,7 +403,7 @@ Changelog
 
    - Decoding with Common Spatial Patterns (CSP) by `Romain Trachel`_ and `Alex Gramfort`_
 
-   - Add ICA plot_topomap function and method for displaying the spatial sensitivity of ICA sources by `Denis Engemann`_
+   - Add ICA ``plot_topomap`` function and method for displaying the spatial sensitivity of ICA sources by `Denis Engemann`_
 
    - Plotting multiple brain views at once by `Eric Larson`_
 
@@ -429,7 +429,7 @@ Changelog
 
    - Add `ico` and `oct` source space creation in native Python by `Eric Larson`_
 
-   - Add interactive rejection of bad trials in `plot_epochs` by `Denis Engemann`_
+   - Add interactive rejection of bad trials in ``plot_epochs`` by `Denis Engemann`_
 
    - Add morph map calculation by `Eric Larson`_ and `Martin Luessi`_
 
@@ -478,7 +478,7 @@ Changelog
 API
 ~~~
 
-   - The pick_normal parameter for minimum norm solvers has been renamed as `pick_ori` and normal orientation picking is now achieved by passing the value "normal" for the `pick_ori` parameter.
+   - The pick_normal parameter for minimum norm solvers has been renamed as ``pick_ori`` and normal orientation picking is now achieved by passing the value "normal" for the `pick_ori` parameter.
 
    - ICA objects now expose the measurment info of the object fitted.
 
@@ -486,9 +486,9 @@ API
 
    - Removed deprecated read/write_stc/w, use SourceEstimate methods instead
 
-   - The `chs` argument in `mne.layouts.find_layout` is deprecated and will be removed in MNE-Python 0.9. Use `info` instead.
+   - The ``chs`` argument in ``mne.layouts.find_layout`` is deprecated and will be removed in MNE-Python 0.9. Use ``info`` instead.
 
-   - `plot_evoked` and `Epochs.plot` now open a new figure by default. To plot on an existing figure please specify the `axes` parameter.
+   - ``plot_evoked`` and ``Epochs.plot`` now open a new figure by default. To plot on an existing figure please specify the `axes` parameter.
 
 
 Authors
@@ -569,7 +569,7 @@ Changelog
 
    - Events now contain the pre-event stim channel value in the middle column, by `Christian Brodbeck`_
 
-   - New function `mne.find_stim_steps` for finding all steps in a stim channel by `Christian Brodbeck`_
+   - New function ``mne.find_stim_steps`` for finding all steps in a stim channel by `Christian Brodbeck`_
 
    - Get information about FIFF files using mne.fiff.show_fiff() by `Eric Larson`_
 
@@ -591,7 +591,7 @@ Changelog
 
    - Support selective parameter updating in functions taking dicts as arguments by `Denis Engemann`_
 
-   - New ICA method `sources_as_epochs` to create Epochs in ICA space by `Denis Engemann`_
+   - New ICA method ``sources_as_epochs`` to create Epochs in ICA space by `Denis Engemann`_
 
    - New method in Evoked and Epoch classes to shift time scale by `Mainak Jas`_
 
@@ -636,7 +636,7 @@ Changelog
 API
 ~~~
 
-   - Deprecated use of fiff.pick_types without specifying exclude -- use either [] (none), `bads` (bad channels), or a list of string (channel names).
+   - Deprecated use of fiff.pick_types without specifying exclude -- use either [] (none), ``bads`` (bad channels), or a list of string (channel names).
 
    - Depth bias correction in dSPM/MNE/sLORETA make_inverse_operator is now done like in the C code using only gradiometers if present, else magnetometers, and EEG if no MEG channels are present.
 
@@ -953,7 +953,7 @@ of commits):
 
 .. _Simon Kornblith: http://simonster.com
 
-.. _Teon Brooks: https://files.nyu.edu/tlb331/public/
+.. _Teon Brooks: http://sites.google.com/a/nyu.edu/teon/
 
 .. _Mainak Jas: http://ltl.tkk.fi/wiki/Mainak_Jas
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -91,7 +91,6 @@ Changelog
 
    - `rename_channels` and `set_channel_types` added as methods to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_ 
 
-
 BUG
 ~~~
 
@@ -182,6 +181,9 @@ API
    - Deprecated changing the sensor type of channels in `rename_channels` by `Teon Brooks`_
 
    - CUDA is no longer initialized at module import, but only when first used.
+
+   - Deprecated changing the sensor type of channels in `rename_channels` for `define_sensor` by `Teon Brooks`_
+
 
 .. _changes_0_8:
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -91,6 +91,7 @@ Changelog
 
    - `rename_channels` and `set_channel_types` added as methods to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_ 
 
+
 BUG
 ~~~
 
@@ -181,9 +182,6 @@ API
    - Deprecated changing the sensor type of channels in `rename_channels` by `Teon Brooks`_
 
    - CUDA is no longer initialized at module import, but only when first used.
-
-   - Deprecated changing the sensor type of channels in `rename_channels` for `define_sensor` by `Teon Brooks`_
-
 
 .. _changes_0_8:
 

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -27,6 +27,7 @@ from .edf import read_raw_edf
 from .egi import read_raw_egi
 from .kit import read_raw_kit
 from .fiff import read_raw_fif
+from .base import read_raw
 
 # for backward compatibility
 from .fiff import RawFIF

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2061,8 +2061,9 @@ def _check_update_montage(info, montage):
                 raise KeyError(err)
 
 
+@verbose
 def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
-             params=None, preload=False, verbose=None):
+             preload=False, **kwargs):
     """Reader function for Raw data
 
     Note: This assumes the default parameters of a given system. This is
@@ -2094,10 +2095,6 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
     reference : bool | str
         If True, add average EEG reference projector (if it's not already
         present).
-    params : None | dict
-        A dict defining the custom parameters for a given system (see
-        system-specific reader for more details). The supported system names
-        are : brainvision, bti, edf, bdf, egi, fif, kit.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires
@@ -2106,6 +2103,9 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         on the hard drive (slower, requires less memory).
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
+    **kwargs :
+        Keyword arguments to pass to read_raw_* (see system-specific reader
+        for more details).
 
     Returns
     -------
@@ -2135,114 +2135,43 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
 
     # (MEG) KIT systems
     if ext in ['.con', '.sqd']:
-        elp, hsp, mrk = None, None, montage
-        stim, slope, stimthresh = '>', '-', 1
-        if params is not None:
-            if 'kit' in params:
-                msg = 'You can either specify a DigMontage or elp/hsp/mrk '
-                      'combination, not both.'
-                kit = params['kit']
-                if 'stim' in kit:
-                    stim = kit['stim']
-                if 'slope' in kit:
-                    kit = kit['slope']
-                if 'stimthresh' in kit:
-                    stimthresh = kit['tal_channel']
-                if 'elp' in kit:
-                    if montage is None:
-                        elp = kit['elp']
-                    else:
-                        raise ValueError(msg)
-                if 'hsp' in kit:
-                    if montage is None:
-                        hsp = kit['hsp']
-                    else:
-                        raise ValueError(msg)
-                if 'mrk' in kit:
-                    if montage is None:
-                        mrk = kit['mrk']
-                    else:
-                        raise ValueError(msg)
-        raw = read_raw_kit(input_fname, mrk=mrk, elp=elp, hsp=hsp,
-                           stim=stim, slope=slope, stimthresh=stimthresh,
-                           preload=preload, verbose=verbose)
+        raw = read_raw_kit(input_fname, preload=preload, verbose=verbose,
+                           **kwargs)
         if eog is not None:
             raw.set_channels_type(eog_map)
         if misc is not None:
             raw.set_channels_type(misc_map)
     # (EEG) EDF and Biosemi systems
     elif ext in ['bdf', '.edf']:
-        annot, annotmap, tal_channel, stim_channel = None, None, None, -1
-        if params is not None:
-            if ext in params:
-                edf = params[ext]
-                if 'annot' in edf:
-                    annot = edf['annot']
-                if 'annotmap' in edf:
-                    annotmap = edf['annotmap']
-                if 'tal_channel' in edf:
-                    tal_channel = edf['tal_channel']
-                if 'stim_channel' in edf:
-                    stim_channel = edf['stim_channel']
         raw = read_raw_edf(input_fname, montage=montage, eog=eog, misc=eog,
-                           annot=annot, annotmap=annotmap,
-                           tal_channel=tal_channel, preload=preload,
-                           verbose=verbose)
+                  preload=preload, verbose=verbose, **kwargs)
     # (EEG) EGI systems
     elif ext == '.raw':
-        include, exclude = None, None
-        if 'egi' in params:
-            egi = params['egi']
-            if 'include' in egi:
-                include = kit['include']
-            if 'exclude' in egi:
-                exclude = kit['exclude']
         raw = read_raw_egi(input_fname, montage=montage, eog=eog, misc=misc,
-                  include=include, exclude=exclude, preload=preload,
-                  verbose=verbose)
+                  preload=preload, verbose=verbose, **kwargs)
     # (MEG) Neuromag or converted-to-fif systems
     elif ext == '.fif':
-        if 'fif' in params:
-            fif = params['fif']
-            if 'allow_maxshield' in fif:
-                allow_maxshield = fif['allow_maxshield']
-            if 'compensation' in fif:
-                compensation = fif['compensation']
         raw = read_raw_fif(input_fname, add_eeg_ref=reference,
-                  allow_maxshield=allow_maxshield, compensation=compensation,
-                  preload=preload, verbose=verbose)
+                  preload=preload, verbose=verbose, **kwargs)
         if eog is not None:
             raw.set_channels_type(eog_map)
         if misc is not None:
             raw.set_channels_type(misc_map)
     # (MEG) BTi systems
     elif ext == '':
-        config_fname, rotation_x, ecg_ch = 'config', (0.0, 0.02, 0.11), 'E31'
-        if 'bti' in params:
-            bti = params['bti']
-            if 'config_fname' in bti:
-                config_fname = bti['config_fname']
-            if 'rotation_x' in bti:
-                rotation_x = bti['rotation_x']
-            if 'ecg_ch' in bti:
-                ecg_ch = bti['ecg_ch']
-        raw = read_raw_bti(input_fname, head_shape_fname=montage,
-                  config_fname=config_fname,  rotation_x=rotation_x,
-                  translation=translation, ecg_ch=ecg_ch,
-                  preload=preload, verbose=verbose)
+        if os.path.exists(input_fname):
+            raw = read_raw_bti(input_fname, preload=preload, verbose=verbose,
+                               **kwargs)
+        else:
+            raise IOError('This file does not exist.')
         if eog is not None:
             raw.set_channels_type(eog_map)
         if misc is not None:
             raw.set_channels_type(misc_map)
     # (EEG) Brainvision systems
     elif ext == '.vhdr':
-        scale = 1
-        if 'brainvision' in params:
-            brainvision = params['brainvision']
-            if 'scale' in brainvision:
-                scale = brainvision['scale']
         raw = read_raw_brainvision(input_fname, montage=montage, eog=eog,
-                  misc=misc, reference=reference, scale=scale, preload=preload,
-                  verbose=verbose)
+                  misc=misc, reference=reference, preload=preload,
+                  verbose=verbose, **kwargs)
 
     return raw

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2137,7 +2137,7 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         if misc is not None:
             rename_sensor(raw.info, misc_map)
     # (EEG) EDF and Biosemi systems
-    elif ext == '.edf':
+    elif ext in ['bdf', '.edf']:
         raw = read_raw_edf(input_fname, montage=montage, eog=eog, misc=eog,
                            preload=preload, verbose=verbose)
     # (EEG) EGI systems

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2153,7 +2153,7 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         if misc is not None:
             rename_sensor(raw.info, misc_map)
     # (MEG) BTi systems
-    elif ext == '.pdf':
+    elif ext == '':
         raw = read_raw_bti(input_fname, eog=eog, misc=['E31'], preload=preload,
                            verbose=verbose)
         if eog is not None:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2116,7 +2116,7 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
     from mne.io import (read_raw_brainvision, read_raw_bti, read_raw_edf,
                         read_raw_egi, read_raw_fif, read_raw_kit)
 
-    if isinstance(input_fname, str):
+    if isinstance(input_fname, string_types):
         fname, ext = os.path.splitext(input_fname)
     elif isinstance(input_fname, list):
         for f in input_fname:
@@ -2124,14 +2124,14 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
             err = "File must be '.fif', not %s." % ext
             assert_equal(ext, '.fif', err)
 
-        if eog is not None:
-            eog_map = dict()
-            for s in eog:
-                eog_map[s] = 'eog'
-        if misc is not None:
-            misc_map = dict()
-            for s in misc:
-                misc_map[s] = 'misc'
+    if eog is not None:
+        eog_map = dict()
+        for s in eog:
+            eog_map[s] = 'eog'
+    if misc is not None:
+        misc_map = dict()
+        for s in misc:
+            misc_map[s] = 'misc'
 
     # (MEG) KIT systems
     if ext in ['.con', '.sqd']:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2150,7 +2150,7 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         raw = read_raw_egi(input_fname, montage=montage, eog=eog, misc=misc,
                   preload=preload, verbose=verbose, **kwargs)
     # (MEG) Neuromag or converted-to-fif systems
-    elif ext == '.fif':
+    elif ext in ['.fif', '.gz']:
         raw = read_raw_fif(input_fname, add_eeg_ref=reference,
                   preload=preload, verbose=verbose, **kwargs)
         if eog is not None:
@@ -2159,7 +2159,7 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
             raw.set_channels_type(misc_map)
     # (MEG) BTi systems
     elif ext == '':
-        if os.path.exists(input_fname):
+        if os.path.isfile(input_fname):
             raw = read_raw_bti(input_fname, preload=preload, verbose=verbose,
                                **kwargs)
         else:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -24,8 +24,7 @@ from .pick import pick_types, channel_type, pick_channels, pick_info
 from .meas_info import write_meas_info
 from .proj import setup_proj, activate_proj, proj_equal, ProjMixin
 from ..channels.channels import (ContainsMixin, PickDropChannelsMixin,
-                                 SetChannelsMixin, InterpolationMixin,
-                                 set_channels_type)
+                                 SetChannelsMixin, InterpolationMixin)
 from ..channels.layout import read_montage, apply_montage, Montage
 from .compensator import set_current_comp
 from .write import (start_file, end_file, start_block, end_block,
@@ -2135,9 +2134,9 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         raw = read_raw_kit(input_fname, mrk=montage, eog=eog, misc=misc,
                            preload=preload, verbose=verbose)
         if eog is not None:
-            set_channels_type(raw.info, eog_map)
+            raw.set_channels_type(eog_map)
         if misc is not None:
-            set_channels_type(raw.info, misc_map)
+            raw.set_channels_type(misc_map)
     # (EEG) EDF and Biosemi systems
     elif ext in ['bdf', '.edf']:
         raw = read_raw_edf(input_fname, montage=montage, eog=eog, misc=eog,
@@ -2151,17 +2150,17 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         raw = read_raw_fif(input_fname, add_eeg_ref=reference, eog=eog,
                            misc=misc, preload=preload, verbose=verbose)
         if eog is not None:
-            set_channels_type(raw.info, eog_map)
+            raw.set_channels_type(eog_map)
         if misc is not None:
-            set_channels_type(raw.info, misc_map)
+            raw.set_channels_type(misc_map)
     # (MEG) BTi systems
     elif ext == '':
         raw = read_raw_bti(input_fname, eog=eog, misc=['E31'], preload=preload,
                            verbose=verbose)
         if eog is not None:
-            set_channels_type(raw.info, eog_map)
+            raw.set_channels_type(eog_map)
         if misc is not None:
-            set_channels_type(raw.info, misc_map)
+            raw.set_channels_type(misc_map)
     # (EEG) Brainvision systems
     elif ext == '.vhdr':
         raw = read_raw_brainvision(input_fname, montage=montage, eog=eog,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -17,13 +17,15 @@ import os.path as op
 import numpy as np
 from scipy.signal import hilbert
 from scipy import linalg
+from nose.tools import assert_equal
 
 from .constants import FIFF
 from .pick import pick_types, channel_type, pick_channels, pick_info
 from .meas_info import write_meas_info
 from .proj import setup_proj, activate_proj, proj_equal, ProjMixin
 from ..channels.channels import (ContainsMixin, PickDropChannelsMixin,
-                                 SetChannelsMixin, InterpolationMixin)
+                                 SetChannelsMixin, InterpolationMixin,
+                                 set_channels_type)
 from ..channels.layout import read_montage, apply_montage, Montage
 from .compensator import set_current_comp
 from .write import (start_file, end_file, start_block, end_block,
@@ -2133,9 +2135,9 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         raw = read_raw_kit(input_fname, mrk=montage, eog=eog, misc=misc,
                            preload=preload, verbose=verbose)
         if eog is not None:
-            rename_sensor(raw.info, eog_map)
+            set_channels_type(raw.info, eog_map)
         if misc is not None:
-            rename_sensor(raw.info, misc_map)
+            set_channels_type(raw.info, misc_map)
     # (EEG) EDF and Biosemi systems
     elif ext in ['bdf', '.edf']:
         raw = read_raw_edf(input_fname, montage=montage, eog=eog, misc=eog,
@@ -2149,17 +2151,17 @@ def read_raw(input_fname, montage=None, eog=[], misc=[], reference=None,
         raw = read_raw_fif(input_fname, add_eeg_ref=reference, eog=eog,
                            misc=misc, preload=preload, verbose=verbose)
         if eog is not None:
-            rename_sensor(raw.info, eog_map)
+            set_channels_type(raw.info, eog_map)
         if misc is not None:
-            rename_sensor(raw.info, misc_map)
+            set_channels_type(raw.info, misc_map)
     # (MEG) BTi systems
     elif ext == '':
         raw = read_raw_bti(input_fname, eog=eog, misc=['E31'], preload=preload,
                            verbose=verbose)
         if eog is not None:
-            rename_sensor(raw.info, eog_map)
+            set_channels_type(raw.info, eog_map)
         if misc is not None:
-            rename_sensor(raw.info, misc_map)
+            set_channels_type(raw.info, misc_map)
     # (EEG) Brainvision systems
     elif ext == '.vhdr':
         raw = read_raw_brainvision(input_fname, montage=montage, eog=eog,

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -17,7 +17,7 @@ from mne.utils import _TempDir
 from mne import pick_types, concatenate_raws
 from mne.io.constants import FIFF
 from mne.io import Raw
-from mne.io import read_raw_brainvision
+from mne.io import read_raw_brainvision, read_raw
 
 FILE = inspect.getfile(inspect.currentframe())
 data_dir = op.join(op.dirname(op.abspath(FILE)), 'data')
@@ -31,7 +31,7 @@ eog = ['HL', 'HR', 'Vb']
 def test_brainvision_data_filters():
     """Test reading raw Brain Vision files
     """
-    raw = read_raw_brainvision(vhdr_highpass_path, montage, eog=eog,
+    raw = read_raw(vhdr_highpass_path, montage, eog=eog,
                                preload=True)
     assert_equal(raw.info['highpass'], 0.1)
     assert_equal(raw.info['lowpass'], 250.)

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -10,6 +10,7 @@
 import os.path as op
 from itertools import count
 import numpy as np
+import warnings
 
 from ...utils import logger, verbose, sum_squared
 from ..constants import FIFF
@@ -1157,7 +1158,7 @@ class RawBTi(_BaseRaw):
 def read_raw_bti(pdf_fname, config_fname='config',
                  head_shape_fname='hs_file', rotation_x=None,
                  translation=(0.0, 0.02, 0.11), ecg_ch='E31',
-                 eog_ch=('E63', 'E64'), verbose=None):
+                 eog_ch=('E63', 'E64'), verbose=None, **kwargs):
     """ Raw object from 4D Neuroimaging MagnesWH3600 data
 
     Note.
@@ -1204,6 +1205,8 @@ def read_raw_bti(pdf_fname, config_fname='config',
     --------
     mne.io.Raw : Documentation of attribute and methods.
     """
+    if 'preload' in kwargs:
+        warnings.warn('Preload is not enabled for this module.')
     return RawBTi(pdf_fname, config_fname=config_fname,
                   head_shape_fname=head_shape_fname,
                   rotation_x=rotation_x, translation=translation,

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -76,7 +76,7 @@ def test_raw():
             params = dict()
             params['bti'] = dict()
             params['bti']['config'] = config
-            with read_raw(pdf, montage=hs, params=params) as ra:
+            with read_raw(pdf, head_shape_fname=hs, config=config) as ra:
                 assert_equal(ex.ch_names[:NCH], ra.ch_names[:NCH])
                 assert_array_almost_equal(ex.info['dev_head_t']['trans'],
                                           ra.info['dev_head_t']['trans'], 7)

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -14,7 +14,7 @@ from nose.tools import assert_true, assert_raises, assert_equal
 from mne.io import Raw as Raw
 from mne.io.bti.bti import (_read_config, _setup_head_shape,
                             _read_data, _read_bti_header)
-from mne.io import read_raw_bti
+from mne.io import read_raw_bti, read_raw
 from mne import concatenate_raws
 
 
@@ -73,7 +73,10 @@ def test_raw():
         if op.exists(tmp_raw_fname):
             os.remove(tmp_raw_fname)
         with Raw(exported, preload=True) as ex:
-            with read_raw_bti(pdf, config, hs) as ra:
+            params = dict()
+            params['bti'] = dict()
+            params['bti']['config'] = config
+            with read_raw(pdf, montage=hs, params=params) as ra:
                 assert_equal(ex.ch_names[:NCH], ra.ch_names[:NCH])
                 assert_array_almost_equal(ex.info['dev_head_t']['trans'],
                                           ra.info['dev_head_t']['trans'], 7)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -19,7 +19,7 @@ import numpy as np
 from mne import pick_types, concatenate_raws
 from mne.externals.six import iterbytes
 from mne.utils import _TempDir
-from mne.io import Raw, read_raw_edf
+from mne.io import Raw, read_raw_edf, read_raw
 import mne.io.edf.edf as edfmodule
 from mne.event import find_events
 
@@ -42,8 +42,8 @@ misc = ['EXG1', 'EXG5', 'EXG8', 'M1', 'M2']
 def test_bdf_data():
     """Test reading raw bdf files
     """
-    raw_py = read_raw_edf(bdf_path, montage=montage_path, eog=eog,
-                          misc=misc, preload=True)
+    raw_py = read_raw(bdf_path, montage=montage_path, eog=eog,
+                      misc=misc, preload=True)
     picks = pick_types(raw_py.info, meg=False, eeg=True, exclude='bads')
     data_py, _ = raw_py[picks]
 
@@ -109,7 +109,10 @@ def test_read_segment():
     """Test writing raw edf files when preload is False
     """
     tempdir = _TempDir()
-    raw1 = read_raw_edf(edf_path, stim_channel=None, preload=False)
+    params = dict()
+    params['edf'] = dict()
+    params['edf']['stim_channel'] = None
+    raw1 = read_raw(edf_path, params=params, preload=False)
     raw1_file = op.join(tempdir, 'test1-raw.fif')
     raw1.save(raw1_file, overwrite=True, buffer_size_sec=1)
     raw11 = Raw(raw1_file, preload=True)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -109,10 +109,7 @@ def test_read_segment():
     """Test writing raw edf files when preload is False
     """
     tempdir = _TempDir()
-    params = dict()
-    params['edf'] = dict()
-    params['edf']['stim_channel'] = None
-    raw1 = read_raw(edf_path, params=params, preload=False)
+    raw1 = read_raw(edf_path, stim_channel=None, preload=False)
     raw1_file = op.join(tempdir, 'test1-raw.fif')
     raw1.save(raw1_file, overwrite=True, buffer_size_sec=1)
     raw11 = Raw(raw1_file, preload=True)

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_raises, assert_equal
 
 from mne import find_events, pick_types, concatenate_raws
-from mne.io import read_raw_egi, Raw
+from mne.io import read_raw_egi, Raw, read_raw
 from mne.io.egi import _combine_triggers
 from mne.utils import _TempDir
 
@@ -24,9 +24,12 @@ def test_io_egi():
     """Test importing EGI simple binary files"""
     # test default
     tempdir = _TempDir()
+    params = dict()
+    params['egi'] = dict()
+    params['egi']['include'] = None
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always', category=RuntimeWarning)
-        read_raw_egi(egi_fname, include=None)
+        read_raw(egi_fname, params=params)
         assert_equal(len(w), 1)
         assert_true(w[0].category == RuntimeWarning)
         msg = 'Did not find any event code with more than one event.'

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -26,7 +26,7 @@ def test_io_egi():
     tempdir = _TempDir()
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always', category=RuntimeWarning)
-        read_raw(egi_fname, include=include)
+        read_raw(egi_fname, include=None)
         assert_equal(len(w), 1)
         assert_true(w[0].category == RuntimeWarning)
         msg = 'Did not find any event code with more than one event.'

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -24,12 +24,9 @@ def test_io_egi():
     """Test importing EGI simple binary files"""
     # test default
     tempdir = _TempDir()
-    params = dict()
-    params['egi'] = dict()
-    params['egi']['include'] = None
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always', category=RuntimeWarning)
-        read_raw(egi_fname, params=params)
+        read_raw(egi_fname, include=include)
         assert_equal(len(w), 1)
         assert_true(w[0].category == RuntimeWarning)
         msg = 'Did not find any event code with more than one event.'

--- a/mne/io/fiff/tests/test_raw.py
+++ b/mne/io/fiff/tests/test_raw.py
@@ -20,7 +20,7 @@ from nose.tools import assert_true, assert_raises, assert_not_equal
 from mne.datasets import testing
 from mne.io.constants import FIFF
 from mne.io import (Raw, concatenate_raws, get_chpi_positions,
-                    read_raw_fif)
+                    read_raw_fif, read_raw)
 from mne import (concatenate_events, find_events, equalize_channels,
                  compute_proj_raw, pick_types, pick_channels)
 from mne.utils import (_TempDir, requires_nitime, requires_pandas,
@@ -53,7 +53,7 @@ def test_hash_raw():
     """
     raw = read_raw_fif(fif_fname)
     assert_raises(RuntimeError, raw.__hash__)
-    raw = Raw(fif_fname, preload=True).crop(0, 0.5)
+    raw = read_raw(fif_fname, preload=True).crop(0, 0.5)
     raw_2 = Raw(fif_fname, preload=True).crop(0, 0.5)
     assert_equal(hash(raw), hash(raw_2))
     # do NOT use assert_equal here, failing output is terrible

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -65,13 +65,8 @@ def test_read_segment():
     """Test writing raw kit files when preload is False
     """
     tempdir = _TempDir()
-    params = dict()
-    params['kit'] = dict()
-    params['mrk'] = mrk_path
-    params['elp'] = elp_path
-    params['hsp'] = hsp_path
-    params['stim'] = '<'
-    raw1 = read_raw(sqd_path, params=params, preload=False)
+    raw1 = read_raw(sqd_path, mrk=mrk_path, elp=elp_path, hsp=hsp_path,
+                    stim='<', preload=False)
     raw1_file = op.join(tempdir, 'test1-raw.fif')
     raw1.save(raw1_file, buffer_size_sec=.1, overwrite=True)
     raw2 = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path, stim='<',

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -14,7 +14,7 @@ import scipy.io
 
 from mne import pick_types, concatenate_raws
 from mne.utils import _TempDir
-from mne.io import Raw, read_raw_kit
+from mne.io import Raw, read_raw_kit, read_raw
 from mne.io.kit.coreg import read_sns
 
 FILE = inspect.getfile(inspect.currentframe())
@@ -65,8 +65,13 @@ def test_read_segment():
     """Test writing raw kit files when preload is False
     """
     tempdir = _TempDir()
-    raw1 = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path, stim='<',
-                        preload=False)
+    params = dict()
+    params['kit'] = dict()
+    params['mrk'] = mrk_path
+    params['elp'] = elp_path
+    params['hsp'] = hsp_path
+    params['stim'] = '<'
+    raw1 = read_raw(sqd_path, params=params, preload=False)
     raw1_file = op.join(tempdir, 'test1-raw.fif')
     raw1.save(raw1_file, buffer_size_sec=.1, overwrite=True)
     raw2 = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path, stim='<',


### PR DESCRIPTION
The proposal is to have one read_raw function that will read any
supported data format and internally point it to the proper reader module.
It uses the default settings of those readers except for the exposed
parameters.
This will rely on the `mne.define_sensor` #1909 (currently referred to as
`mne.rename_sensor` in PR).