### PR TITLE
MRG ADD set_channels_type function RM parts from rename_channels

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -341,9 +341,6 @@ Manipulate channels and set sensors locations for processing and plotting:
    read_ch_connectivity
    equalize_channels
    rename_channels
-   get_channel_positions
-   set_channel_positions
-   _set_channels_type
 
 :py:mod:`mne.preprocessing`:
 

--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -30,7 +30,7 @@ Classes
    :template: class.rst
 
    io.Raw
-   io.RawFIFF
+   io.RawFIF
    Epochs
    Evoked
    SourceSpaces
@@ -341,6 +341,9 @@ Manipulate channels and set sensors locations for processing and plotting:
    read_ch_connectivity
    equalize_channels
    rename_channels
+   get_channel_positions
+   set_channel_positions
+   _set_channels_type
 
 :py:mod:`mne.preprocessing`:
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -89,6 +89,8 @@ Changelog
 
    - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
 
+   - `rename_channels` and `set_channel_types` added as methods to `Raw`, `Epochs` and `Evoked` objects by `Teon Brooks`_ 
+
 
 BUG
 ~~~

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -89,8 +89,6 @@ Changelog
 
    - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
 
-   - Add `set_channels_type` for changing the channel type by `Teon Brooks`_
-
 
 BUG
 ~~~
@@ -175,16 +173,9 @@ API
      zero to be consistent with all other `Raw` instances. To get the former `start` and `stop` times,
      use `raw.first_samp / raw.info['sfreq']` and `raw.last_samp / raw.info['sfreq']`.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
    - `pick_types_evoked` has been deprecated in favor of `evoked.pick_types`.
-=======
-   - Deprecated changing the sensor type of channels in `rename_channels` for `define_sensor` by `Teon Brooks`_
->>>>>>> Update whats_new
-=======
-   - Deprecated changing the sensor type of channels in `rename_channels` for `set_channels_type` by `Teon Brooks`_
 
->>>>>>> ENH name and error messages
+   - Deprecated changing the sensor type of channels in `rename_channels` by `Teon Brooks`_
 
    - CUDA is no longer initialized at module import, but only when first used.
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -89,7 +89,7 @@ Changelog
 
    - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
 
-   - Add `set_channel_type` for changing the channel type by `Teon Brooks`_
+   - Add `set_channels_type` for changing the channel type by `Teon Brooks`_
 
 
 BUG
@@ -176,10 +176,15 @@ API
      use `raw.first_samp / raw.info['sfreq']` and `raw.last_samp / raw.info['sfreq']`.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
    - `pick_types_evoked` has been deprecated in favor of `evoked.pick_types`.
 =======
    - Deprecated changing the sensor type of channels in `rename_channels` for `define_sensor` by `Teon Brooks`_
 >>>>>>> Update whats_new
+=======
+   - Deprecated changing the sensor type of channels in `rename_channels` for `set_channels_type` by `Teon Brooks`_
+
+>>>>>>> ENH name and error messages
 
    - CUDA is no longer initialized at module import, but only when first used.
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -89,6 +89,9 @@ Changelog
 
    - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
 
+   - Add `define_sensor` for changing the sensor type of channels by `Teon Brooks`_
+
+
 BUG
 ~~~
 
@@ -141,13 +144,13 @@ API
    - find_events and read_events functions have a new parameter `mask` to set some bits to a don't care state by `Teon Brooks`_
 
    - New channels module including layouts, electrode montages, and neighbor definitions of sensors which deprecates
-    ``mne.layouts`` by `Denis Engemann`_
+    `mne.layouts` by `Denis Engemann`_
 
    - `read_raw_brainvision`, `read_raw_edf`, `read_raw_egi` all use a standard montage import by `Teon Brooks`_
 
    - Fix missing calibration factors for ``mne.io.egi.read_raw_egi`` by `Denis Engemann`_ and `Federico Raimondo`_
 
-   - Allow multiple filename patterns as a list (e.g., *raw.fif and *-eve.fif) to be parsed by mne report in ``Report.parse_folder()`` by `Mainak Jas`_
+   - Allow multiple filename patterns as a list (e.g., *raw.fif and *-eve.fif) to be parsed by mne report in `Report.parse_folder()` by `Mainak Jas`_
 
    - `read_hsp`, `read_elp`, and `write_hsp`, `write_mrk` were removed and made private by `Teon Brooks`_
 
@@ -172,7 +175,11 @@ API
      zero to be consistent with all other `Raw` instances. To get the former `start` and `stop` times,
      use `raw.first_samp / raw.info['sfreq']` and `raw.last_samp / raw.info['sfreq']`.
 
+<<<<<<< HEAD
    - `pick_types_evoked` has been deprecated in favor of `evoked.pick_types`.
+=======
+   - Deprecated changing the sensor type of channels in `rename_channels` for `define_sensor` by `Teon Brooks`_
+>>>>>>> Update whats_new
 
    - CUDA is no longer initialized at module import, but only when first used.
 

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -89,7 +89,7 @@ Changelog
 
    - `evoked.pick_types`, `epochs.pick_types`, and `tfr.pick_types` added by `Eric Larson`_
 
-   - Add `define_sensor` for changing the sensor type of channels by `Teon Brooks`_
+   - Add `set_channel_type` for changing the channel type by `Teon Brooks`_
 
 
 BUG

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -6,5 +6,5 @@ setting of sensors locations used for processing and plotting.
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage)
 
-from .channels import (equalize_channels, rename_channels, set_channel_type,
+from .channels import (equalize_channels, rename_channels, set_channels_type,
                        read_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -6,5 +6,5 @@ setting of sensors locations used for processing and plotting.
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage)
 
-from .channels import (equalize_channels, rename_channels, define_sensor,
+from .channels import (equalize_channels, rename_channels, set_channel_type,
                        read_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -6,5 +6,5 @@ setting of sensors locations used for processing and plotting.
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage)
 
-from .channels import (equalize_channels, rename_channels,
+from .channels import (equalize_channels, rename_channels, define_sensor,
                        read_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -6,5 +6,4 @@ setting of sensors locations used for processing and plotting.
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage)
 
-from .channels import (equalize_channels, rename_channels, _set_channels_type,
-                       read_ch_connectivity)
+from .channels import (equalize_channels, rename_channels, read_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -6,5 +6,5 @@ setting of sensors locations used for processing and plotting.
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, read_montage, apply_montage)
 
-from .channels import (equalize_channels, rename_channels, set_channels_type,
+from .channels import (equalize_channels, rename_channels, _set_channels_type,
                        read_ch_connectivity)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -437,6 +437,22 @@ def define_sensor(info, mapping):
                   'stim': FIFF.FIFFV_STIM_CH,
                   'syst': FIFF.FIFFV_SYST_CH}
 
+    human2unit = {'ecg': FIFF.FIFF_UNIT_V,
+                  'eeg': FIFF.FIFF_UNIT_V,
+                  'emg': FIFF.FIFF_UNIT_V,
+                  'eog': FIFF.FIFF_UNIT_V,
+                  'exci': FIFF.FIFF_UNIT_NONE,
+                  'ias': FIFF.FIFF_UNIT_NONE,
+                  'meg': FIFF.FIFF_UNIT_T,
+                  'mcg': FIFF.FIFF_UNIT_T,
+                  'misc': FIFF.FIFF_UNIT_NONE,
+                  'ref_meg': FIFF.FIFF_UNIT_T,
+                  'resp': FIFF.FIFF_UNIT_NONE,
+                  'seeg': FIFF.FIFF_UNIT_V,
+                  'stim': FIFF.FIFF_UNIT_NONE,
+                  'syst': FIFF.FIFF_UNIT_NONE}
+
+
     ch_names = info['ch_names']
 
     # first check and assemble clean mappings of index and name
@@ -451,7 +467,7 @@ def define_sensor(info, mapping):
                              'channel type: %s.' % ch_type)
     # Set sensor type
         info['chs'][c_ind]['kind'] = human2fiff[ch_type]
-
+        info['chs'][c_ind]['unit'] = human2unit[ch_type]
 
 def _recursive_flatten(cell, dtype):
     """Helper to unpack mat files in Python"""

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -345,8 +345,8 @@ def rename_channels(info, mapping):
     """Rename channels.
 
     Note : The ability to change sensor types has been deprecated in favor of
-    `define_sensor`. Please use this function if you would changing or defining
-    sensor type.
+    `set_channel_type`. Please use this function if you would changing or
+    defining sensor type.
 
 
     Parameters
@@ -407,7 +407,7 @@ def rename_channels(info, mapping):
     assert len(info['ch_names']) == np.unique(info['ch_names']).shape[0]
 
 
-def define_sensor(info, mapping):
+def set_channel_type(info, mapping):
     """Define the sensor type of channels.
 
     Note: The following sensor types are accepted:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -229,14 +229,15 @@ class SetChannelsMixin(object):
         # first check and assemble clean mappings of index and name
         for ch_name, ch_type in mapping.items():
             if ch_name not in ch_names:
-                raise ValueError("This channel name (%s) doesn't exist in info."
-                                 % ch_name)
+                raise ValueError("This channel name (%s) doesn't exist in "
+                                 "info." % ch_name)
 
             c_ind = ch_names.index(ch_name)
             if ch_type not in human2fiff:
                 raise ValueError('This function cannot change to this '
-                                 'channel type: %s. Accepted channel types are '
-                                 '%s.' % (ch_type, ", ".join(human2unit.keys())))
+                                 'channel type: %s. Accepted channel types '
+                                 'are %s.' % (ch_type,
+                                              ", ".join(human2unit.keys())))
             # Set sensor type
             self.info['chs'][c_ind]['kind'] = human2fiff[ch_type]
             unit_old = self.info['chs'][c_ind]['unit']
@@ -255,9 +256,9 @@ class SetChannelsMixin(object):
     def rename_channels(self, mapping):
         """Rename channels.
 
-        Note : The ability to change sensor types has been deprecated in favor of
-        `set_channels_type`. Please use this function if you would changing or
-        defining sensor type.
+        Note : The ability to change sensor types has been deprecated in favor
+        of `set_channel_types`. Please use this function if you would changing
+        or defining sensor type.
 
 
         Parameters
@@ -427,8 +428,8 @@ def rename_channels(info, mapping):
     """Rename channels.
 
     Note : The ability to change sensor types has been deprecated in favor of
-    `set_channels_type`. Please use this function if you would changing or
-    defining sensor type.
+    `set_channel_types` method for Raw, Epochs, Evoked . Please use this
+    method if you would changing or defining sensor type.
 
 
     Parameters

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -459,6 +459,8 @@ def set_channel_type(info, mapping):
                              'channel type: %s.' % ch_type)
         # Set sensor type
         info['chs'][c_ind]['kind'] = human2fiff[ch_type]
+        if info['chs'][c_ind]['unit'] != human2unit[ch_type]:
+            warnings.warn("The unit for Channel %s has changed." % ch_name)
         info['chs'][c_ind]['unit'] = human2unit[ch_type]
         if ch_type in ['eeg', 'seeg']:
             info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -345,7 +345,7 @@ def rename_channels(info, mapping):
     """Rename channels.
 
     Note : The ability to change sensor types has been deprecated in favor of
-    `set_channel_type`. Please use this function if you would changing or
+    `set_channels_type`. Please use this function if you would changing or
     defining sensor type.
 
 
@@ -380,7 +380,7 @@ def rename_channels(info, mapping):
 
         elif isinstance(new_name, tuple):  # name and type change
             warnings.warn("Changing sensor type is now deprecated. Please use "
-                          "'define_sensor' instead.", DeprecationWarning)
+                          "'set_channels_type' instead.", DeprecationWarning)
             new_name, new_type = new_name  # unpack
             if new_type not in human2fiff:
                 raise ValueError('This function cannot change to this '
@@ -407,7 +407,7 @@ def rename_channels(info, mapping):
     assert len(info['ch_names']) == np.unique(info['ch_names']).shape[0]
 
 
-def set_channel_type(info, mapping):
+def set_channels_type(info, mapping):
     """Define the sensor type of channels.
 
     Note: The following sensor types are accepted:
@@ -445,6 +445,8 @@ def set_channel_type(info, mapping):
                   'stim': FIFF.FIFF_UNIT_NONE,
                   'syst': FIFF.FIFF_UNIT_NONE}
 
+    unit2human = {FIFF.FIFF_UNIT_V: 'V',
+                  FIFF.FIFF_UNIT_NONE: 'NA'}
     ch_names = info['ch_names']
 
     # first check and assemble clean mappings of index and name
@@ -456,11 +458,18 @@ def set_channel_type(info, mapping):
         c_ind = ch_names.index(ch_name)
         if ch_type not in human2fiff:
             raise ValueError('This function cannot change to this '
-                             'channel type: %s.' % ch_type)
+                             'channel type: %s. Accepted channel types are '
+                             'ecg, eeg, emg, eog, exci, ias, misc, resp, '
+                             'seeg, stim, syst.' % ch_type)
         # Set sensor type
         info['chs'][c_ind]['kind'] = human2fiff[ch_type]
-        if info['chs'][c_ind]['unit'] != human2unit[ch_type]:
-            warnings.warn("The unit for Channel %s has changed." % ch_name)
+        unit_old = info['chs'][c_ind]['unit']
+        unit_new = human2unit[ch_type]
+        if unit_old != human2unit[ch_type]:
+            warnings.warn("The unit for Channel %s has changed "
+                          "from %s to %s." % (ch_name,
+                                              unit2human[unit_old],
+                                              unit2human[unit_new]))
         info['chs'][c_ind]['unit'] = human2unit[ch_type]
         if ch_type in ['eeg', 'seeg']:
             info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -411,7 +411,7 @@ def define_sensor(info, mapping):
     """Define the sensor type of channels.
 
     Note: The following sensor types are accepted:
-        ecg, eeg, emg, eog, exci, ias, meg, mcg,
+        ecg, eeg, emg, eog, exci, grad, ias, mag, mcg,
         misc, ref_meg, resp, seeg, stim, syst
 
     Parameters
@@ -427,6 +427,7 @@ def define_sensor(info, mapping):
                   'emg': FIFF.FIFFV_EMG_CH,
                   'eog': FIFF.FIFFV_EOG_CH,
                   'exci': FIFF.FIFFV_EXCI_CH,
+                  'grad': FIFF.FIFFV_MEG_CH,
                   'ias': FIFF.FIFFV_IAS_CH,
                   'meg': FIFF.FIFFV_MEG_CH,
                   'mcg': FIFF.FIFFV_MCG_CH,
@@ -442,8 +443,9 @@ def define_sensor(info, mapping):
                   'emg': FIFF.FIFF_UNIT_V,
                   'eog': FIFF.FIFF_UNIT_V,
                   'exci': FIFF.FIFF_UNIT_NONE,
+                  'grad': FIFF.FIFF_UNIT_T,
                   'ias': FIFF.FIFF_UNIT_NONE,
-                  'meg': FIFF.FIFF_UNIT_T,
+                  'mag': FIFF.FIFF_UNIT_T,
                   'mcg': FIFF.FIFF_UNIT_T,
                   'misc': FIFF.FIFF_UNIT_NONE,
                   'ref_meg': FIFF.FIFF_UNIT_T,
@@ -451,7 +453,6 @@ def define_sensor(info, mapping):
                   'seeg': FIFF.FIFF_UNIT_V,
                   'stim': FIFF.FIFF_UNIT_NONE,
                   'syst': FIFF.FIFF_UNIT_NONE}
-
 
     ch_names = info['ch_names']
 
@@ -465,9 +466,14 @@ def define_sensor(info, mapping):
         if ch_type not in human2fiff:
             raise ValueError('This function cannot change to this '
                              'channel type: %s.' % ch_type)
-    # Set sensor type
+        # Set sensor type
         info['chs'][c_ind]['kind'] = human2fiff[ch_type]
         info['chs'][c_ind]['unit'] = human2unit[ch_type]
+        if ch_type in ['eeg', 'seeg']:
+            info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG
+        else:
+            info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_NONE
+
 
 def _recursive_flatten(cell, dtype):
     """Helper to unpack mat files in Python"""

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -186,6 +186,88 @@ class SetChannelsMixin(object):
                        % name)
                 raise ValueError(msg)
 
+    def set_channel_types(self, mapping):
+        """Define the sensor type of channels.
+
+        Note: The following sensor types are accepted:
+            ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst
+
+        Parameters
+        ----------
+        mapping : dict
+            a dictionary mapping a channel to a sensor type (str)
+            {'EEG061': 'eog'}.
+        """
+        human2fiff = {'ecg': FIFF.FIFFV_ECG_CH,
+                      'eeg': FIFF.FIFFV_EEG_CH,
+                      'emg': FIFF.FIFFV_EMG_CH,
+                      'eog': FIFF.FIFFV_EOG_CH,
+                      'exci': FIFF.FIFFV_EXCI_CH,
+                      'ias': FIFF.FIFFV_IAS_CH,
+                      'misc': FIFF.FIFFV_MISC_CH,
+                      'resp': FIFF.FIFFV_RESP_CH,
+                      'seeg': FIFF.FIFFV_SEEG_CH,
+                      'stim': FIFF.FIFFV_STIM_CH,
+                      'syst': FIFF.FIFFV_SYST_CH}
+
+        human2unit = {'ecg': FIFF.FIFF_UNIT_V,
+                      'eeg': FIFF.FIFF_UNIT_V,
+                      'emg': FIFF.FIFF_UNIT_V,
+                      'eog': FIFF.FIFF_UNIT_V,
+                      'exci': FIFF.FIFF_UNIT_NONE,
+                      'ias': FIFF.FIFF_UNIT_NONE,
+                      'misc': FIFF.FIFF_UNIT_NONE,
+                      'resp': FIFF.FIFF_UNIT_NONE,
+                      'seeg': FIFF.FIFF_UNIT_V,
+                      'stim': FIFF.FIFF_UNIT_NONE,
+                      'syst': FIFF.FIFF_UNIT_NONE}
+
+        unit2human = {FIFF.FIFF_UNIT_V: 'V',
+                      FIFF.FIFF_UNIT_NONE: 'NA'}
+        ch_names = info['ch_names']
+
+        # first check and assemble clean mappings of index and name
+        for ch_name, ch_type in mapping.items():
+            if ch_name not in ch_names:
+                raise ValueError("This channel name (%s) doesn't exist in info."
+                                 % ch_name)
+
+            c_ind = ch_names.index(ch_name)
+            if ch_type not in human2fiff:
+                raise ValueError('This function cannot change to this '
+                                 'channel type: %s. Accepted channel types are '
+                                 '%s.' % (ch_type, ", ".join(human2unit.keys())))
+            # Set sensor type
+            info['chs'][c_ind]['kind'] = human2fiff[ch_type]
+            unit_old = info['chs'][c_ind]['unit']
+            unit_new = human2unit[ch_type]
+            if unit_old != human2unit[ch_type]:
+                warnings.warn("The unit for Channel %s has changed "
+                              "from %s to %s." % (ch_name,
+                                                  unit2human[unit_old],
+                                                  unit2human[unit_new]))
+            info['chs'][c_ind]['unit'] = human2unit[ch_type]
+            if ch_type in ['eeg', 'seeg']:
+                info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG
+            else:
+                info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_NONE
+
+    def rename_channels(self, mapping):
+        """Rename channels.
+
+        Note : The ability to change sensor types has been deprecated in favor of
+        `set_channels_type`. Please use this function if you would changing or
+        defining sensor type.
+
+
+        Parameters
+        ----------
+        mapping : dict
+            a dictionary mapping the old channel to a new channel name
+            e.g. {'EEG061' : 'EEG161'}.
+        """
+        rename_channels(self.info, mapping)
+
 
 class PickDropChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs, AverageTFR
@@ -405,75 +487,6 @@ def rename_channels(info, mapping):
 
     # assert channel names are unique
     assert len(info['ch_names']) == np.unique(info['ch_names']).shape[0]
-
-
-def _set_channels_type(info, mapping):
-    """Define the sensor type of channels.
-
-    Note: The following sensor types are accepted:
-        ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst
-
-    Parameters
-    ----------
-    info : dict
-        Measurement info.
-    mapping : dict
-        a dictionary mapping a channel to a sensor type (str)
-        {'EEG061': 'eog'}.
-    """
-    human2fiff = {'ecg': FIFF.FIFFV_ECG_CH,
-                  'eeg': FIFF.FIFFV_EEG_CH,
-                  'emg': FIFF.FIFFV_EMG_CH,
-                  'eog': FIFF.FIFFV_EOG_CH,
-                  'exci': FIFF.FIFFV_EXCI_CH,
-                  'ias': FIFF.FIFFV_IAS_CH,
-                  'misc': FIFF.FIFFV_MISC_CH,
-                  'resp': FIFF.FIFFV_RESP_CH,
-                  'seeg': FIFF.FIFFV_SEEG_CH,
-                  'stim': FIFF.FIFFV_STIM_CH,
-                  'syst': FIFF.FIFFV_SYST_CH}
-
-    human2unit = {'ecg': FIFF.FIFF_UNIT_V,
-                  'eeg': FIFF.FIFF_UNIT_V,
-                  'emg': FIFF.FIFF_UNIT_V,
-                  'eog': FIFF.FIFF_UNIT_V,
-                  'exci': FIFF.FIFF_UNIT_NONE,
-                  'ias': FIFF.FIFF_UNIT_NONE,
-                  'misc': FIFF.FIFF_UNIT_NONE,
-                  'resp': FIFF.FIFF_UNIT_NONE,
-                  'seeg': FIFF.FIFF_UNIT_V,
-                  'stim': FIFF.FIFF_UNIT_NONE,
-                  'syst': FIFF.FIFF_UNIT_NONE}
-
-    unit2human = {FIFF.FIFF_UNIT_V: 'V',
-                  FIFF.FIFF_UNIT_NONE: 'NA'}
-    ch_names = info['ch_names']
-
-    # first check and assemble clean mappings of index and name
-    for ch_name, ch_type in mapping.items():
-        if ch_name not in ch_names:
-            raise ValueError("This channel name (%s) doesn't exist in info."
-                             % ch_name)
-
-        c_ind = ch_names.index(ch_name)
-        if ch_type not in human2fiff:
-            raise ValueError('This function cannot change to this '
-                             'channel type: %s. Accepted channel types are '
-                             '%s.' % (ch_type, ", ".join(human2unit.keys())))
-        # Set sensor type
-        info['chs'][c_ind]['kind'] = human2fiff[ch_type]
-        unit_old = info['chs'][c_ind]['unit']
-        unit_new = human2unit[ch_type]
-        if unit_old != human2unit[ch_type]:
-            warnings.warn("The unit for Channel %s has changed "
-                          "from %s to %s." % (ch_name,
-                                              unit2human[unit_old],
-                                              unit2human[unit_new]))
-        info['chs'][c_ind]['unit'] = human2unit[ch_type]
-        if ch_type in ['eeg', 'seeg']:
-            info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG
-        else:
-            info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_NONE
 
 
 def _recursive_flatten(cell, dtype):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -8,6 +8,7 @@
 
 import os
 import os.path as op
+import warnings
 
 import numpy as np
 from scipy.io import loadmat

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -407,7 +407,7 @@ def rename_channels(info, mapping):
     assert len(info['ch_names']) == np.unique(info['ch_names']).shape[0]
 
 
-def set_channels_type(info, mapping):
+def _set_channels_type(info, mapping):
     """Define the sensor type of channels.
 
     Note: The following sensor types are accepted:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -459,8 +459,7 @@ def set_channels_type(info, mapping):
         if ch_type not in human2fiff:
             raise ValueError('This function cannot change to this '
                              'channel type: %s. Accepted channel types are '
-                             'ecg, eeg, emg, eog, exci, ias, misc, resp, '
-                             'seeg, stim, syst.' % ch_type)
+                             '%s.' % (ch_type, ", ".join(human2unit.keys())))
         # Set sensor type
         info['chs'][c_ind]['kind'] = human2fiff[ch_type]
         unit_old = info['chs'][c_ind]['unit']

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -411,8 +411,7 @@ def define_sensor(info, mapping):
     """Define the sensor type of channels.
 
     Note: The following sensor types are accepted:
-        ecg, eeg, emg, eog, exci, grad, ias, mag, mcg,
-        misc, ref_meg, resp, seeg, stim, syst
+        ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst
 
     Parameters
     ----------
@@ -427,12 +426,8 @@ def define_sensor(info, mapping):
                   'emg': FIFF.FIFFV_EMG_CH,
                   'eog': FIFF.FIFFV_EOG_CH,
                   'exci': FIFF.FIFFV_EXCI_CH,
-                  'grad': FIFF.FIFFV_MEG_CH,
                   'ias': FIFF.FIFFV_IAS_CH,
-                  'meg': FIFF.FIFFV_MEG_CH,
-                  'mcg': FIFF.FIFFV_MCG_CH,
                   'misc': FIFF.FIFFV_MISC_CH,
-                  'ref_meg': FIFF.FIFFV_REF_MEG_CH,
                   'resp': FIFF.FIFFV_RESP_CH,
                   'seeg': FIFF.FIFFV_SEEG_CH,
                   'stim': FIFF.FIFFV_STIM_CH,
@@ -443,12 +438,8 @@ def define_sensor(info, mapping):
                   'emg': FIFF.FIFF_UNIT_V,
                   'eog': FIFF.FIFF_UNIT_V,
                   'exci': FIFF.FIFF_UNIT_NONE,
-                  'grad': FIFF.FIFF_UNIT_T,
                   'ias': FIFF.FIFF_UNIT_NONE,
-                  'mag': FIFF.FIFF_UNIT_T,
-                  'mcg': FIFF.FIFF_UNIT_T,
                   'misc': FIFF.FIFF_UNIT_NONE,
-                  'ref_meg': FIFF.FIFF_UNIT_T,
                   'resp': FIFF.FIFF_UNIT_NONE,
                   'seeg': FIFF.FIFF_UNIT_V,
                   'stim': FIFF.FIFF_UNIT_NONE,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -437,7 +437,6 @@ def define_sensor(info, mapping):
                   'stim': FIFF.FIFFV_STIM_CH,
                   'syst': FIFF.FIFFV_SYST_CH}
 
-    bads, chs = info['bads'], info['chs']
     ch_names = info['ch_names']
 
     # first check and assemble clean mappings of index and name
@@ -451,7 +450,7 @@ def define_sensor(info, mapping):
             raise ValueError('This function cannot change to this '
                              'channel type: %s.' % ch_type)
     # Set sensor type
-        info['chs'][c_ind]['kind'] = ch_type
+        info['chs'][c_ind]['kind'] = human2fiff[ch_type]
 
 
 def _recursive_flatten(cell, dtype):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -356,7 +356,6 @@ def rename_channels(info, mapping):
         a dictionary mapping the old channel to a new channel name
         e.g. {'EEG061' : 'EEG161'}.
     """
-    # section to go after depr
     human2fiff = {'eog': FIFF.FIFFV_EOG_CH,
                   'emg': FIFF.FIFFV_EMG_CH,
                   'ecg': FIFF.FIFFV_ECG_CH,
@@ -366,7 +365,7 @@ def rename_channels(info, mapping):
     bads, chs = info['bads'], info['chs']
     ch_names = info['ch_names']
     new_names, new_kinds, new_bads = list(), list(), list()
-    # end section
+
     # first check and assemble clean mappings of index and name
     for ch_name, new_name in mapping.items():
         if ch_name not in ch_names:
@@ -374,8 +373,11 @@ def rename_channels(info, mapping):
                              % ch_name)
 
         c_ind = ch_names.index(ch_name)
-        # section to go after depr
-        if isinstance(new_name, tuple):  # name and type change
+        if not isinstance(new_name, (string_types, tuple)):
+            raise ValueError('Your mapping is not configured properly. '
+                             'Please see the help: mne.rename_channels?')
+
+        elif isinstance(new_name, tuple):  # name and type change
             warnings.warn("Changing sensor type is now deprecated. Please use "
                           "'define_sensor' instead.", DeprecationWarning)
             new_name, new_type = new_name  # unpack
@@ -383,19 +385,19 @@ def rename_channels(info, mapping):
                 raise ValueError('This function cannot change to this '
                                  'channel type: %s.' % new_type)
             new_kinds.append((c_ind, human2fiff[new_type]))
-        # end section
+
         new_names.append((c_ind, new_name))
         if ch_name in bads:  # check bads
             new_bads.append((bads.index(ch_name), new_name))
 
-    # Reset ch_names and Check that all the channel names are unique. depr
+    # Reset ch_names and Check that all the channel names are unique.
     for key, collection in [('ch_name', new_names), ('kind', new_kinds)]:
         for c_ind, new_name in collection:
             chs[c_ind][key] = new_name
 
     for c_ind, new_name in new_bads:
         bads[c_ind] = new_name
-    # end section
+
     # reference magic, please don't change (with the local binding
     # it doesn't work)
     info['ch_names'] = [c['ch_name'] for c in chs]

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -224,7 +224,7 @@ class SetChannelsMixin(object):
 
         unit2human = {FIFF.FIFF_UNIT_V: 'V',
                       FIFF.FIFF_UNIT_NONE: 'NA'}
-        ch_names = info['ch_names']
+        ch_names = self.info['ch_names']
 
         # first check and assemble clean mappings of index and name
         for ch_name, ch_type in mapping.items():
@@ -238,19 +238,19 @@ class SetChannelsMixin(object):
                                  'channel type: %s. Accepted channel types are '
                                  '%s.' % (ch_type, ", ".join(human2unit.keys())))
             # Set sensor type
-            info['chs'][c_ind]['kind'] = human2fiff[ch_type]
-            unit_old = info['chs'][c_ind]['unit']
+            self.info['chs'][c_ind]['kind'] = human2fiff[ch_type]
+            unit_old = self.info['chs'][c_ind]['unit']
             unit_new = human2unit[ch_type]
             if unit_old != human2unit[ch_type]:
                 warnings.warn("The unit for Channel %s has changed "
                               "from %s to %s." % (ch_name,
                                                   unit2human[unit_old],
                                                   unit2human[unit_new]))
-            info['chs'][c_ind]['unit'] = human2unit[ch_type]
+            self.info['chs'][c_ind]['unit'] = human2unit[ch_type]
             if ch_type in ['eeg', 'seeg']:
-                info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG
+                self.info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_EEG
             else:
-                info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_NONE
+                self.info['chs'][c_ind]['coil_type'] = FIFF.FIFFV_COIL_NONE
 
     def rename_channels(self, mapping):
         """Rename channels.

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -76,10 +76,13 @@ def test_define_sensor():
     define_sensor(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
+    assert_true(info2['chs'][374]['kind'] == FIFF.FIFF_UNIT_V)
     assert_true(info2['chs'][373]['ch_name'] == 'EEG 059')
     assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
+    assert_true(info2['chs'][373]['kind'] == FIFF.FIFF_UNIT_V)
     assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
     assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
+    assert_true(info2['chs'][375]['kind'] == FIFF.FIFF_UNIT_V)
 
 
 def test_read_ch_connectivity():

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import (rename_channels, set_channels_type,
+from mne.channels import (rename_channels, _set_channels_type,
                           read_ch_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
@@ -66,15 +66,15 @@ def test_set_channels_type():
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, set_channels_type, info, mapping)
+    assert_raises(ValueError, _set_channels_type, info, mapping)
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
-    assert_raises(ValueError, set_channels_type, info, mapping)
+    assert_raises(ValueError, _set_channels_type, info, mapping)
     # Test type change
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
-    set_channels_type(info2, mapping)
+    _set_channels_type(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,8 +12,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import (rename_channels, set_channels_type,
-                          read_ch_connectivity)
+from mne.channels import rename_channels, read_ch_connectivity
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
 from mne.io.constants import FIFF

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -76,13 +76,16 @@ def test_define_sensor():
     define_sensor(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
-    assert_true(info2['chs'][374]['kind'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][374]['coil'] == FIFF.FIFFV_COIL_EEG)
     assert_true(info2['chs'][373]['ch_name'] == 'EEG 059')
     assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
-    assert_true(info2['chs'][373]['kind'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][373]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][373]['coil'] == FIFF.FIFFV_COIL_NONE)
     assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
     assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
-    assert_true(info2['chs'][375]['kind'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][375]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info2['chs'][375]['coil'] == FIFF.FIFFV_COIL_EEG)
 
 
 def test_read_ch_connectivity():

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -61,6 +61,7 @@ def test_rename_channels():
 def test_define_sensor():
     """Test define sensor
     """
+    info = read_info(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -73,10 +73,10 @@ def test_define_sensor():
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
-    rename_channels(info2, mapping)
-    assert_true(info2['chs'][374]['ch_name'] == 'EOG 060')
+    define_sensor(info2, mapping)
+    assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
-    assert_true(info2['chs'][373]['ch_name'] == 'EOG 059')
+    assert_true(info2['chs'][373]['ch_name'] == 'EEG 059')
     assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
     assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
     assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import rename_channels, read_ch_connectivity
+from mne.channels import rename_channels, define_sensor, read_ch_connectivity
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
 from mne.io.constants import FIFF
@@ -56,29 +56,29 @@ def test_rename_channels():
     assert_true(info2['chs'][375]['ch_name'] == 'EOG061')
     assert_true(info2['ch_names'][375] == 'EOG061')
     assert_true('EOG061' in info2['bads'])
+
+
+def test_define_sensor():
+    """Test define sensor
+    """
+    # Error Tests
+    # Test channel name exists in ch_names
+    mapping = {'EEG 160': 'EEG060'}
+    assert_raises(ValueError, define_sensor, info, mapping)
+    # Test change to illegal channel type
+    mapping = {'EOG 061': 'xxx'}
+    assert_raises(ValueError, define_sensor, info, mapping)
     # Test type change
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
-    mapping = {'EEG 060': ('EOG 060', 'eog'), 'EEG 059': ('EOG 059', 'eog'),
-               'EOG 061': ("OT'7", 'seeg')}
+    mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
     rename_channels(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EOG 060')
-    assert_true(info2['ch_names'][374] == 'EOG 060')
-    assert_true('EOG 060' in info2['bads'])
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][373]['ch_name'] == 'EOG 059')
-    assert_true(info2['ch_names'][373] == 'EOG 059')
-    assert_true('EOG 059' in info2['bads'])
-    assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_EOG_CH)
-    assert_true(info2['chs'][375]['ch_name'] == "OT'7")
-    assert_true(info2['ch_names'][375] == "OT'7")
-    assert_true("OT'7" in info2['bads'])
+    assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
+    assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
     assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
-    # Test change of type without change of name
-    mapping = {'EEG 060': ('EEG 060', 'seeg')}
-    info2 = deepcopy(info)
-    rename_channels(info2, mapping)
-    assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_SEEG_CH)
 
 
 def test_read_ch_connectivity():

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import (rename_channels, _set_channels_type,
+from mne.channels import (rename_channels, set_channels_type,
                           read_ch_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
@@ -62,31 +62,32 @@ def test_rename_channels():
 def test_set_channels_type():
     """Test Set Channels Type
     """
-    info = read_info(raw_fname)
+    raw = Raw(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, _set_channels_type, info, mapping)
+    assert_raises(ValueError, raw.set_channel_types, mapping)
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
-    assert_raises(ValueError, _set_channels_type, info, mapping)
+    assert_raises(ValueError, raw.set_channel_types, mapping)
     # Test type change
-    info2 = deepcopy(info)
-    info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
+    raw2 = Raw(raw_fname)
+    raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
-    _set_channels_type(info2, mapping)
-    assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
-    assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
-    assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][374]['coil_type'] == FIFF.FIFFV_COIL_NONE)
-    assert_true(info2['chs'][373]['ch_name'] == 'EEG 059')
-    assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
-    assert_true(info2['chs'][373]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][373]['coil_type'] == FIFF.FIFFV_COIL_NONE)
-    assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
-    assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
-    assert_true(info2['chs'][375]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG)
+    raw2.set_channel_types(mapping)
+    info = raw2.info
+    assert_true(info['chs'][374]['ch_name'] == 'EEG 060')
+    assert_true(info['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
+    assert_true(info['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info['chs'][374]['coil_type'] == FIFF.FIFFV_COIL_NONE)
+    assert_true(info['chs'][373]['ch_name'] == 'EEG 059')
+    assert_true(info['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
+    assert_true(info['chs'][373]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info['chs'][373]['coil_type'] == FIFF.FIFFV_COIL_NONE)
+    assert_true(info['chs'][375]['ch_name'] == 'EOG 061')
+    assert_true(info['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
+    assert_true(info['chs'][375]['unit'] == FIFF.FIFF_UNIT_V)
+    assert_true(info['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG)
 
 
 def test_read_ch_connectivity():

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,7 +12,8 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import rename_channels, define_sensor, read_ch_connectivity
+from mne.channels import (rename_channels, set_channel_type,
+                          read_ch_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
 from mne.io.constants import FIFF
@@ -58,22 +59,22 @@ def test_rename_channels():
     assert_true('EOG061' in info2['bads'])
 
 
-def test_define_sensor():
-    """Test define sensor
+def test_set_channel_type():
+    """Test Set Channel Type
     """
     info = read_info(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, define_sensor, info, mapping)
+    assert_raises(ValueError, set_channel_type, info, mapping)
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
-    assert_raises(ValueError, define_sensor, info, mapping)
+    assert_raises(ValueError, set_channel_type, info, mapping)
     # Test type change
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
-    define_sensor(info2, mapping)
+    set_channel_type(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
 from scipy.io import savemat
 
-from mne.channels import (rename_channels, set_channel_type,
+from mne.channels import (rename_channels, set_channels_type,
                           read_ch_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, Raw
@@ -59,22 +59,22 @@ def test_rename_channels():
     assert_true('EOG061' in info2['bads'])
 
 
-def test_set_channel_type():
-    """Test Set Channel Type
+def test_set_channels_type():
+    """Test Set Channels Type
     """
     info = read_info(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, set_channel_type, info, mapping)
+    assert_raises(ValueError, set_channels_type, info, mapping)
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
-    assert_raises(ValueError, set_channel_type, info, mapping)
+    assert_raises(ValueError, set_channels_type, info, mapping)
     # Test type change
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
-    set_channel_type(info2, mapping)
+    set_channels_type(info2, mapping)
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -77,15 +77,15 @@ def test_define_sensor():
     assert_true(info2['chs'][374]['ch_name'] == 'EEG 060')
     assert_true(info2['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
     assert_true(info2['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][374]['coil'] == FIFF.FIFFV_COIL_EEG)
+    assert_true(info2['chs'][374]['coil_type'] == FIFF.FIFFV_COIL_NONE)
     assert_true(info2['chs'][373]['ch_name'] == 'EEG 059')
     assert_true(info2['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
     assert_true(info2['chs'][373]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][373]['coil'] == FIFF.FIFFV_COIL_NONE)
+    assert_true(info2['chs'][373]['coil_type'] == FIFF.FIFFV_COIL_NONE)
     assert_true(info2['chs'][375]['ch_name'] == 'EOG 061')
     assert_true(info2['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
     assert_true(info2['chs'][375]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info2['chs'][375]['coil'] == FIFF.FIFFV_COIL_EEG)
+    assert_true(info2['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG)
 
 
 def test_read_ch_connectivity():


### PR DESCRIPTION
Currently this removes the tuple ability to resign channel type from rename_channels.

This functionality has been moved to the `define_sensors` function.

addresses issue #1909