### PR TITLE
Fixed the time indexing bug with to_data_frame

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -186,7 +186,6 @@ class ToDataFrameMixin(object):
             data = data.copy()
 
         times = np.round(times * scale_time)
-        print times
 
         assert all(len(mdx) == len(mindex[0]) for mdx in mindex)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -115,7 +115,6 @@ class ToDataFrameMixin(object):
             data = self.data.T
             times = self.times
             shape = data.shape
-            mindex.append(('time', self.times * scale_time))
             mindex.append(('subject', np.repeat(self.subject, shape[0])))
 
             if isinstance(self.vertices, list):
@@ -138,7 +137,7 @@ class ToDataFrameMixin(object):
                 data = np.hstack(data).T  # (time*epochs) x signals
 
                 # Multi-index creation
-                mindex.append(('time', np.tile(times, n_epochs)))
+                times = np.tile(times, n_epochs)
                 id_swapped = dict((v, k) for k, v in self.event_id.items())
                 names = [id_swapped[k] for k in self.events[:, 2]]
                 mindex.append(('condition', np.repeat(names, n_times)))
@@ -151,12 +150,11 @@ class ToDataFrameMixin(object):
                 default_index = ['time']
                 if isinstance(self, (RawFIF, RawArray)):
                     data, times = self[picks, start:stop]
-                elif isinstance(self, (Evoked)):
+                elif isinstance(self, Evoked):
                     data = self.data[picks, :]
                     times = self.times
                     n_picks, n_times = data.shape
                 data = data.T
-                mindex.append(('time', times))
                 col_names = [self.ch_names[k] for k in picks]
 
             types = [channel_type(self.info, idx) for idx in picks]
@@ -175,6 +173,10 @@ class ToDataFrameMixin(object):
                 if len(idx) > 0:
                     data[:, idx] *= scaling
 
+        # Make sure that the time index is scaled correctly
+        times = np.round(times * scale_time)
+        mindex.append(('time', times))
+
         if index is not None:
             _check_pandas_index_arguments(index, default_index)
         else:
@@ -184,6 +186,7 @@ class ToDataFrameMixin(object):
             data = data.copy()
 
         times = np.round(times * scale_time)
+        print times
 
         assert all(len(mdx) == len(mindex[0]) for mdx in mindex)
 

--- a/mne/io/fiff/tests/test_raw.py
+++ b/mne/io/fiff/tests/test_raw.py
@@ -887,8 +887,10 @@ def test_raw_to_nitime():
 def test_to_data_frame():
     """Test raw Pandas exporter"""
     raw = Raw(test_fif_fname, preload=True)
+    _, times = raw[0, :10]
     df = raw.to_data_frame()
     assert_true((df.columns == raw.ch_names).all())
+    assert_array_equal(np.round(times * 1e3), df.index.values[:10])
     df = raw.to_data_frame(index=None)
     assert_true('time' in df.index.names)
     assert_array_equal(df.values[:, 0], raw._data[0] * 1e13)


### PR DESCRIPTION
I think that the bug reported on the listserv is fixed. In classy fashion, by implementing the "ToDataFrameMixin" base class, I also managed to undo the fix that led me to create the Mixin in the first place. I think that I've fixed it now, take a look and let me know if all looks well.