### PR TITLE
WIP: simplifying gat

### DIFF
--- a/examples/decoding/plot_decoding_time_generalization.py
+++ b/examples/decoding/plot_decoding_time_generalization.py
@@ -46,8 +46,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                     reject=dict(mag=1.5e-12), decim=decim, verbose=False)
 
 # Define decoder. The decision_function is employed to use AUC for scoring
-gat = GeneralizationAcrossTime(predict_mode='cross-validation',
-                               predict_type='decision_function', n_jobs=2)
+gat = GeneralizationAcrossTime(predict_mode='cross-validation', n_jobs=2)
 
 # fit and score
 gat.fit(epochs)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -54,6 +54,7 @@ def test_generalization_across_time():
     """
     from sklearn.svm import SVC
     from sklearn.preprocessing import LabelEncoder
+    from sklearn.metrics import mean_squared_error
 
     raw = io.Raw(raw_fname, preload=False)
     events = read_events(event_name)
@@ -215,12 +216,13 @@ def test_generalization_across_time():
 
     svcp = SVC_proba(C=1, kernel='linear', probability=True)
     clfs = [svc, svcp]
+    scorers = [None, mean_squared_error]
     # Test all combinations
-    for clf_n, clf in enumerate(clfs):
+    for clf, scorer in zip(clfs, scorers):
         for y in ys:
             for n_class in n_classes:
                 y_ = y % n_class
                 with warnings.catch_warnings(record=True):
                     gat = GeneralizationAcrossTime(cv=2, clf=clf)
                     gat.fit(epochs, y=y_)
-                    gat.score(epochs, y=y_)
+                    gat.score(epochs, y=y_, scorer=scorer)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -91,7 +91,7 @@ def test_generalization_across_time():
     gat.predict_mode = old_mode
 
     gat.score(epochs, y=epochs.events[:, 2])
-    assert_true("accuracy_score" in '%s' % gat.scorer)
+    assert_true("accuracy_score" in '%s' % gat.scorer_)
     epochs2 = epochs.copy()
 
     # check _DecodingTime class

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -198,14 +198,21 @@ def test_generalization_across_time():
 
     # Test combinations of complex scenarios
     # 2 or more distinct classes
-    n_classes = [2]  # 4 tested
+    n_classes = [2, 4]  # 4 tested
     # nicely ordered labels or not
     y = epochs.events[:, 2]
     y[len(y) // 2:] += 2
     ys = (y, y + 1000)
-    # Classifier and regressor
-    svc = SVC(C=1, kernel='linear', probability=True)
-    clfs = [svc]  # SVR tested
+    # Univariate and multivariate prediction
+    svc = SVC(C=1, kernel='linear')
+
+    class SVC_proba(SVC):
+        def predict(self, x):
+            probas = super(SVC_proba, self).predict_proba(x)
+            return probas[:, 0]
+
+    svcp = SVC_proba(C=1, kernel='linear', probability=True)
+    clfs = [svc, svcp]
     # Test all combinations
     for clf_n, clf in enumerate(clfs):
         for y in ys:

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -74,11 +74,11 @@ def test_generalization_across_time():
                  "prediction, no score>", '%s' % gat)
     gat.predict(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predict on 15 epochs, no score>",
+                 "predicted 15 epochs, no score>",
                  "%s" % gat)
     gat.score(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predict on 15 epochs,\n scored "
+                 "predicted 15 epochs,\n scored "
                  "(accuracy_score)>", "%s" % gat)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs, y=epochs.events[:, 2])
@@ -89,7 +89,7 @@ def test_generalization_across_time():
     gat.predict_mode = old_mode
 
     gat.score(epochs, y=epochs.events[:, 2])
-    assert_true("accuracy_score" in '%s' % gat.scorer_)
+    assert_true("accuracy_score" in '%s' % gat.scorer)
     epochs2 = epochs.copy()
 
     # check _DecodingTime class

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -53,6 +53,7 @@ def test_generalization_across_time():
     """Test time generalization decoding
     """
     from sklearn.svm import SVC
+    from sklearn.preprocessing import LabelEncoder
 
     raw = io.Raw(raw_fname, preload=False)
     events = read_events(event_name)
@@ -200,7 +201,8 @@ def test_generalization_across_time():
     # 2 or more distinct classes
     n_classes = [2, 4]  # 4 tested
     # nicely ordered labels or not
-    y = epochs.events[:, 2]
+    le = LabelEncoder()
+    y = le.fit_transform(epochs.events[:, 2])
     y[len(y) // 2:] += 2
     ys = (y, y + 1000)
     # Univariate and multivariate prediction

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -74,19 +74,14 @@ def test_generalization_across_time():
                  "prediction, no score>", '%s' % gat)
     gat.predict(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predict_type : 'predict' on 15 epochs, no score>",
+                 "predict on 15 epochs, no score>",
                  "%s" % gat)
     gat.score(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predict_type : 'predict' on 15 epochs,\n scored "
+                 "predict on 15 epochs,\n scored "
                  "(accuracy_score)>", "%s" % gat)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs, y=epochs.events[:, 2])
-
-    old_type = gat.predict_type
-    gat.predict_type = 'foo'
-    assert_raises(ValueError, gat.predict, epochs)
-    gat.predict_type = old_type
 
     old_mode = gat.predict_mode
     gat.predict_mode = 'super-foo-mode'
@@ -180,8 +175,7 @@ def test_generalization_across_time():
     gat.score(epochs[7:])
 
     svc = SVC(C=1, kernel='linear', probability=True)
-    gat = GeneralizationAcrossTime(clf=svc, predict_type='predict_proba',
-                                   predict_mode='mean-prediction')
+    gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
 
@@ -193,30 +187,6 @@ def test_generalization_across_time():
     scores = sum(scores, [])  # flatten
     assert_true(0.0 <= np.min(scores) <= 1.0)
     assert_true(0.0 <= np.max(scores) <= 1.0)
-
-    # test various predict_type
-    gat = GeneralizationAcrossTime(clf=svc, predict_type="predict_proba")
-    with warnings.catch_warnings(record=True):
-        gat.fit(epochs)
-    gat.predict(epochs)
-    # check that 2 class probabilistic estimates are [p, 1-p]
-    assert_true(gat.y_pred_.shape[3] == 2)
-    gat.score(epochs)
-    # check that continuous prediction leads to AUC rather than accuracy
-    assert_true("roc_auc_score" in '%s' % gat.scorer_)
-
-    gat = GeneralizationAcrossTime(predict_type="decision_function")
-    # XXX Sklearn doesn't like non-binary inputs. We could binarize the data,
-    # or change Sklearn default behavior
-    epochs.events[:, 2][epochs.events[:, 2] == 3] = 0
-    with warnings.catch_warnings(record=True):
-        gat.fit(epochs)
-    gat.predict(epochs)
-    # check that 2 class non-probabilistic continuous estimates are [distance]
-    assert_true(gat.y_pred_.shape[3] == 1)
-    gat.score(epochs)
-    # check that continuous prediction leads to AUC rather than accuracy
-    assert_true("roc_auc_score" in '%s' % gat.scorer_)
 
     # Test that gets error if train on one dataset, test on another, and don't
     # specify appropriate cv:
@@ -236,16 +206,12 @@ def test_generalization_across_time():
     # Classifier and regressor
     svc = SVC(C=1, kernel='linear', probability=True)
     clfs = [svc]  # SVR tested
-    # Continuous, and probabilistic estimate
-    predict_types = ['predict_proba', 'decision_function']
     # Test all combinations
     for clf_n, clf in enumerate(clfs):
         for y in ys:
             for n_class in n_classes:
-                for pt in predict_types:
-                    y_ = y % n_class
-                    with warnings.catch_warnings(record=True):
-                        gat = GeneralizationAcrossTime(
-                            cv=2, clf=clf, predict_type=pt)
-                        gat.fit(epochs, y=y_)
-                        gat.score(epochs, y=y_)
+                y_ = y % n_class
+                with warnings.catch_warnings(record=True):
+                    gat = GeneralizationAcrossTime(cv=2, clf=clf)
+                    gat.fit(epochs, y=y_)
+                    gat.score(epochs, y=y_)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -599,7 +599,7 @@ def _score_loop(y_true, y_pred, slices, scorer):
     scores = [0] * n_time
     for t, indices in enumerate(slices):
         # Scores across trials
-        scores[t] = scorer(y_true, y_pred[t], scorer)
+        scores[t] = scorer(y_true, y_pred[t])
     return scores
 
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -774,7 +774,10 @@ def _predict(X, estimators):
     # Compute prediction for each sub-estimator (i.e. per fold)
     # if independent, estimators = all folds
     for fold, clf in enumerate(estimators):
-        y_pred[:, :, fold] = clf.predict(X)
+        if n_class > 1:
+            y_pred[:, 0, fold] = clf.predict(X)
+        else:
+            y_pred[:, :, fold] = clf.predict(X)
 
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -173,8 +173,8 @@ class GeneralizationAcrossTime(object):
             s += ', '
         if hasattr(self, 'scores_'):
             s += "scored"
-            if callable(self.scorer):
-                s += " (%s)" % (self.scorer.__name__)
+            if callable(self.scorer_):
+                s += " (%s)" % (self.scorer_.__name__)
         else:
             s += "no score"
 
@@ -400,8 +400,9 @@ class GeneralizationAcrossTime(object):
 
         # Check scorer
         if scorer is None:
+            # XXX Need API to identify propper scorer from the clf
             scorer = accuracy_score
-        self.scorer = scorer
+        self.scorer_ = scorer
 
         # Run predictions if not already done
         if epochs is not None:
@@ -781,6 +782,7 @@ def _predict(X, estimators):
 
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:
+        # XXX need API to identify how multiple predictions can be combined?
         if is_classifier(clf):
             y_pred, _ = stats.mode(y_pred, axis=2)
         else:
@@ -838,7 +840,7 @@ def time_generalization(epochs_list, clf=None, cv=5, scoring="roc_auc",
     scoring : {string, callable, None}, default: "roc_auc"
         A string (see model evaluation documentation in scikit-learn) or
         a scorer callable object / function with signature
-        ``scorer(estimator, X, y)``.
+        ``scorer(y_true, y_pred)``.
     shuffle : bool
         If True, shuffle the epochs before splitting them in folds.
     random_state : None | int

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -173,8 +173,8 @@ class GeneralizationAcrossTime(object):
             s += ', '
         if hasattr(self, 'scores_'):
             s += "scored"
-            if callable(self.scorer_):
-                s += " (%s)" % (self.scorer_.__name__)
+            if callable(self.scorer):
+                s += " (%s)" % (self.scorer.__name__)
         else:
             s += "no score"
 
@@ -364,7 +364,7 @@ class GeneralizationAcrossTime(object):
             To-be-fitted model, If None, y = epochs.events[:,2].
             Defaults to None.
         scorer : object
-            scikit-learn Scorer instance.
+            scikit-learn Scorer instance. Default: accuracy_score
         test_times : str | dict | None
             if test_times = 'diagonal', test_times = train_times: decode at
             each time point but does not generalize. If dict, the following

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -763,10 +763,9 @@ def _predict(X, estimators):
     y_pred : np.ndarray, shape (n_epochs, m_prediction_dimensions)
         Classifier's prediction for each trial.
     """
+    from scipy import stats
+    from sklearn.base import is_classifier
     # Initialize results:
-    # XXX Here I did not manage to find an efficient and generic way to guess
-    # the number of output provided by predict, and could thus not initalize
-    # the y_pred values.
     n_epochs = X.shape[0]
     n_clf = len(estimators)
     n_class = estimators[0].predict(X[0, :]).shape[-1]  # initialize
@@ -779,8 +778,10 @@ def _predict(X, estimators):
 
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:
-        # XXX JRK: need mode in case discrete prediction. Need extra parameter
-        y_pred = np.mean(y_pred, axis=2)
+        if is_classifier(clf):
+            y_pred, _ = stats.mode(y_pred, axis=2)
+        else:
+            y_pred = np.mean(y_pred, axis=2)
 
     # Format shape
     y_pred = y_pred.reshape((n_epochs, n_class))

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -774,7 +774,7 @@ def _predict(X, estimators):
     # Compute prediction for each sub-estimator (i.e. per fold)
     # if independent, estimators = all folds
     for fold, clf in enumerate(estimators):
-        if n_class > 1:
+        if n_class == 1:
             y_pred[:, 0, fold] = clf.predict(X)
         else:
             y_pred[:, :, fold] = clf.predict(X)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -146,8 +146,7 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
         ax.set_xlabel('Time (s)')
     if ylabel is True:
         ax.set_ylabel('Classif. score ({0})'.format(
-                      'AUC' if 'roc' in repr(gat.scorer_) else r'%'
-                      ))
+                      'AUC' if 'roc' in repr(gat.scorer) else r'%'))
     if legend is True:
         ax.legend(loc='best')
     if show is True:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -146,7 +146,7 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
         ax.set_xlabel('Time (s)')
     if ylabel is True:
         ax.set_ylabel('Classif. score ({0})'.format(
-                      'AUC' if 'roc' in repr(gat.scorer) else r'%'))
+                      'AUC' if 'roc' in repr(gat.scorer_) else r'%'))
     if legend is True:
         ax.legend(loc='best')
     if show is True:


### PR DESCRIPTION
Following https://github.com/mne-tools/mne-python/issues/1964,  I propose to
*    Drop the 'predict_type' option. If users want to use a decision_function or a predict_proba (or anything else we currently don't support) they could easily make their own classifier with a inherited class: e.g.

```
from sklearn.svm import SVC
class my_SVC(SVC):
    def predict(self, x):
        probas = super(my_SVC, self).predict_proba(x)
        return probas[:,0]
```

*  Drop the automatic definition of the scorer (AUC if predict_type is probabilistic, Accuracy if discrete, Least Square if Regression etc...) and let the user takes care of this by defining the scorer him/herself.
