### PR TITLE
multi-index/hierarchical epoch selection

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -9,6 +9,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+   - Add selecting epochs by multiple and/or partially matching keys by `Jona Sassenhagen`_
+
    - Add support for mayavi figures in `add_section` method in Report by `Mainak Jas`_
 
    - Add extract volumes of interest from freesurfer segmentation and setup as volume source space by `Alan Leggitt`_

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -9,8 +9,6 @@ Current
 Changelog
 ~~~~~~~~~
 
-   - Add selecting epochs by multiple and/or partially matching keys by `Jona Sassenhagen`_
-
    - Add support for mayavi figures in `add_section` method in Report by `Mainak Jas`_
 
    - Add extract volumes of interest from freesurfer segmentation and setup as volume source space by `Alan Leggitt`_

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -779,16 +779,16 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
         Return Epochs object with a subset of epochs corresponding to an
         experimental condition as specified by 'name'.
 
-        If conditions are hierarchical (separated by '/', e.g. 'audio/left',
-        'audio/right') and 'name' is not in itself an event key, selects every
-        event whose condition contains 'name' (e.g., 'left' matches
-        'audio/left' and 'visual/left'; but not 'audio_left').
+        If conditions are separated by '/' (e.g. 'audio/left', 'audio/right'), 
+        and 'name' is not in itself an event key, selects every event whose 
+        condition contains 'name' (e.g., 'left' matches 'audio/left' 
+        and 'visual/left'; but not 'audio_left').
 
     epochs[['name_1', 'name_2', ... ]] : Epochs
         Return Epochs object with a subset of epochs corresponding to multiple
         experimental conditions as specified by 'name_1', 'name_2', ... .
 
-        If conditions are hierarchical, selects every item containing every
+        If conditions are separated by '/', selects every item containing every
         list item (e.g. ['audio', 'left'] selects 'audio/left' and
         'audio/center/left', but not 'audio/right').
 
@@ -1249,9 +1249,9 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
                            if all([set(k_i.split('/')).issubset(k.split("/"))
                                    for k_i in key])]
                     if len(key) == 0:
-                        raise KeyError('Attempting hierarchical selection '
-                                       'of events, but no event matches all '
-                                       'criteria.')
+                        raise KeyError('Attempting selection of events via '
+                                       'multiple/partial matching, but no '
+                                       'event matches all criteria.')
             select = np.any(np.atleast_2d([epochs._key_match(k)
                                            for k in key]), axis=0)
             epochs.name = ('+'.join(key) if epochs.name == 'Unknown'

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -779,9 +779,9 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
         Return Epochs object with a subset of epochs corresponding to an
         experimental condition as specified by 'name'.
 
-        If conditions are separated by '/' (e.g. 'audio/left', 'audio/right'), 
-        and 'name' is not in itself an event key, selects every event whose 
-        condition contains 'name' (e.g., 'left' matches 'audio/left' 
+        If conditions are separated by '/' (e.g. 'audio/left', 'audio/right'),
+        and 'name' is not in itself an event key, selects every event whose
+        condition contains 'name' (e.g., 'left' matches 'audio/left'
         and 'visual/left'; but not 'audio_left').
 
     epochs[['name_1', 'name_2', ... ]] : Epochs

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -779,9 +779,18 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
         Return Epochs object with a subset of epochs corresponding to an
         experimental condition as specified by 'name'.
 
+        If conditions are hierarchical (separated by '/', e.g. 'audio/left',
+        'audio/right') and 'name' is not in itself an event key, selects every
+        event whose condition contains 'name' (e.g., 'left' matches
+        'audio/left' and 'visual/left'; but not 'audio_left').
+
     epochs[['name_1', 'name_2', ... ]] : Epochs
         Return Epochs object with a subset of epochs corresponding to multiple
         experimental conditions as specified by 'name_1', 'name_2', ... .
+
+        If conditions are hierarchical, selects every item containing every
+        list item (e.g. ['audio', 'left'] selects 'audio/left' and
+        'audio/center/left', but not 'audio/right').
 
     See also
     --------
@@ -1233,6 +1242,16 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
             key = [key]
 
         if isinstance(key, (list, tuple)) and isinstance(key[0], string_types):
+            if any(["/" in k_i for k_i in epochs.event_id.keys()]):
+                if any([k_e not in list(epochs.event_id.keys())
+                       for k_e in key]):
+                    key = [k for k in list(epochs.event_id.keys())
+                           if all([set(k_i.split('/')).issubset(k.split("/"))
+                                   for k_i in key])]
+                    if len(key) == 0:
+                        raise KeyError('Attempting hierarchical selection '
+                                       'of events, but no event matches all '
+                                       'criteria.')
             select = np.any(np.atleast_2d([epochs._key_match(k)
                                            for k in key]), axis=0)
             epochs.name = ('+'.join(key) if epochs.name == 'Unknown'

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -135,27 +135,25 @@ def test_epoch_combine_ids():
     """Test combining event ids in epochs compared to events
     """
     raw, events, picks = _get_data()
-    for preload in [False]:
-        epochs = Epochs(raw, events, {'a': 1, 'b': 2, 'c': 3,
-                                      'd': 4, 'e': 5, 'f': 32},
-                        tmin, tmax, picks=picks, preload=preload)
-        events_new = merge_events(events, [1, 2], 12)
-        epochs_new = combine_event_ids(epochs, ['a', 'b'], {'ab': 12})
-        assert_array_equal(events_new, epochs_new.events)
-        # should probably add test + functionality for non-replacement XXX
+    epochs = Epochs(raw, events, {'a': 1, 'b': 2, 'c': 3,
+                                  'd': 4, 'e': 5, 'f': 32},
+                    tmin, tmax, picks=picks, preload=False)
+    events_new = merge_events(events, [1, 2], 12)
+    epochs_new = combine_event_ids(epochs, ['a', 'b'], {'ab': 12})
+    assert_array_equal(events_new, epochs_new.events)
+    # should probably add test + functionality for non-replacement XXX
 
 
-def test_epoch_hierarchical_ids():
-    """Test multi-index/hierarchical indexing
+def test_epoch_multi_ids():
+    """Test epoch selection via multiple/partial keys
     """
     raw, events, picks = _get_data()
-    for preload in [False]:
-        epochs = Epochs(raw, events, {'a/b/a': 1, 'a/b/b': 2, 'a/c': 3,
-                                      'b/d': 4, 'b/e': 5, 'b/f': 32},
-                        tmin, tmax, picks=picks, preload=preload)
-        epochs_regular = epochs[['a', 'b']]
-        epochs_multi = epochs[['a/b/a', 'a/b/b']]
-        assert_array_equal(epochs_regular.events, epochs_multi.events)
+    epochs = Epochs(raw, events, {'a/b/a': 1, 'a/b/b': 2, 'a/c': 3,
+                                  'b/d': 4, 'b/e': 5, 'b/f': 32},
+                    tmin, tmax, picks=picks, preload=False)
+    epochs_regular = epochs[['a', 'b']]
+    epochs_multi = epochs[['a/b/a', 'a/b/b']]
+    assert_array_equal(epochs_regular.events, epochs_multi.events)
 
 
 def test_read_epochs_bad_events():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -145,6 +145,19 @@ def test_epoch_combine_ids():
         # should probably add test + functionality for non-replacement XXX
 
 
+def test_epoch_hierarchical_ids():
+    """Test multi-index/hierarchical indexing
+    """
+    raw, events, picks = _get_data()
+    for preload in [False]:
+        epochs = Epochs(raw, events, {'a/b/a': 1, 'a/b/b': 2, 'a/c': 3,
+                                      'b/d': 4, 'b/e': 5, 'b/f': 32},
+                        tmin, tmax, picks=picks, preload=preload)
+        epochs_regular = epochs[['a', 'b']]
+        epochs_multi = epochs[['a/b/a', 'a/b/b']]
+        assert_array_equal(epochs_regular.events, epochs_multi.events)
+
+
 def test_read_epochs_bad_events():
     """Test epochs when events are at the beginning or the end of the file
     """


### PR DESCRIPTION
Closes #1562.

From the docs:

```
    epochs['name'] : Epochs
        Return Epochs object with a subset of epochs corresponding to an
        experimental condition as specified by 'name'.

        If conditions are hierarchical (separated by '/', e.g. 'audio/left',
        'audio/right') and 'name' is not in itself an event key, selects every
        event whose condition contains 'name' (e.g., 'left' matches
        'audio/left' and 'visual/left'; but not 'audio_left').

    epochs[['name_1', 'name_2', ... ]] : Epochs
        Return Epochs object with a subset of epochs corresponding to multiple
        experimental conditions as specified by 'name_1', 'name_2', ... .

        If conditions are hierarchical, selects every item containing every
        list item (e.g. ['audio', 'left'] selects 'audio/left' and
        'audio/center/left', but not 'audio/right').
```
EDITED by @Eric89GXL to say that it closes the relevant issue