### PR TITLE
MRG event_id

### DIFF
--- a/examples/make_event_id.py
+++ b/examples/make_event_id.py
@@ -1,0 +1,39 @@
+"""
+===========================
+Make an event id for Epochs
+===========================
+
+Combine triggers into a single event id while maintaining their value.
+"""
+# Author: Teon Brooks <teon.brooks@gmail.com>
+#
+# License: BSD (3-clause)
+
+import mne
+from mne.datasets import sample
+
+print(__doc__)
+
+data_path = sample.data_path()
+fname = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
+raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
+tmin, tmax = -1, .2
+
+# Reading events
+events = mne.read_events(fname)
+
+# Combine triggers across
+event_id = {'aud-l': 1,
+            'aud-r': 2,
+            'vis-l': 3,
+            'vis-r': 4,
+            'aud': [1, 2],
+            'vis': [3, 4]}
+
+# Make Raw instance
+raw = mne.io.read_raw_fif(raw_fname)
+
+# Make Epochs instance
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax)
+
+print epochs

--- a/examples/make_event_id.py
+++ b/examples/make_event_id.py
@@ -30,10 +30,10 @@ event_id = {'aud-l': 1,
             'aud': [1, 2],
             'vis': [3, 4]}
 
-# Make Raw instance
+# Read Raw data
 raw = mne.io.read_raw_fif(raw_fname)
 
 # Make Epochs instance
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax)
 
-print epochs
+print(epochs)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1230,8 +1230,15 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
         s += ', tmax : %s (s)' % self.tmax
         s += ', baseline : %s' % str(self.baseline)
         if len(self.event_id) > 1:
-            counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                      for k, v in sorted(self.event_id.items())]
+            counts = []
+            for key, val in sorted(self.event_id.items()):
+                if isinstance(val, list):
+                    total = 0
+                    for v in val:
+                        total += sum(self.events[:, 2] == v)
+                else:
+                    total = sum(self.events[:, 2] == val)
+                counts.append('%r: %i' % (key, total))
             s += ',\n %s' % ', '.join(counts)
 
         return '<Epochs  |  %s>' % s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -65,9 +65,10 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                 for val in event_id.values():
                     if isinstance(val, list):
                         if not all([isinstance(v, int) for v in val]):
-                            raise ValueError('Event IDs must be of type integer')
+                            raise ValueError('Event IDs must be of '
+                                             'type integer.')
                     elif not isinstance(v, int):
-                        raise ValueError('Event IDs must be of type integer')
+                        raise ValueError('Event IDs must be of type integer.')
             elif not all([isinstance(v, int) for v in event_id.values()]):
                 raise ValueError('Event IDs must be of type integer')
             if not all([isinstance(k, string_types) for k in event_id]):
@@ -855,8 +856,8 @@ class Epochs(_BaseEpochs, ToDataFrameMixin):
         values = []
         for key, val in self.event_id.items():
             if not isinstance(val, list):
-               val = [val]
-            for v in val:         
+                val = [val]
+            for v in val:
                 if v not in events[:, 2]:
                     msg = ('No matching events found for %s '
                            '(event id %i)' % (key, v))
@@ -1751,11 +1752,11 @@ class EpochsArray(Epochs):
 
         for key, val in self.event_id.items():
             if isinstance(val, list):
-                 for v in val:
-                     if v not in events[:, 2]:
-                         msg = ('No matching events found for %s '
-                                '(event id %i)' % (key, val))
-                         raise ValueError(msg)
+                for v in val:
+                    if v not in events[:, 2]:
+                        msg = ('No matching events found for %s '
+                               '(event id %i)' % (key, val))
+                        raise ValueError(msg)
             else:
                 if val not in events[:, 2]:
                     msg = ('No matching events found for %s '

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -145,6 +145,24 @@ def test_epoch_combine_ids():
         # should probably add test + functionality for non-replacement XXX
 
 
+def test_epoch_event_id():
+    """Test combining event ids in epochs compared to events
+    """
+    raw, events, picks = _get_data()
+    for preload in [False]:
+        event_id = {'odd': [1, 3, 5], 'even': [2, 4, 32],
+                    '1': 1, '3': 3, '5': 5}
+        epochs = Epochs(raw, events, event_id,
+                        tmin, tmax, picks=picks, preload=preload)
+        total = epochs['odd'].events.shape[0]
+        parts = (epochs['1'].events.shape[0] + epochs['3'].events.shape[0] +
+                 epochs['5'].events.shape[0])
+        assert_equal(total, parts)
+        # insert value not in range
+        event_id = {'odd': [1, 3, 5, 7]}
+        assert_raises(ValueError, Epochs, raw, events, event_id, tmin, tmax)
+
+
 def test_read_epochs_bad_events():
     """Test epochs when events are at the beginning or the end of the file
     """


### PR DESCRIPTION
Currently the only way to map several triggers to one event is by combining them. This posts a problem when the trigger has different meanings. For instance, if you are doing a priming study and each word is uniquely identified [1:8]. for the priming condition, unprimed is (3,4) and primed is (5,6) and you varying whether it is a word (1,3,5,7) or nonword (2,4,6,8). It is possible you want to look only at whether it was primed or not primed for a contrast or whether it is a word or nonword.