### PR TITLE
FIX: Add dev_head_t to info

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1090,18 +1090,15 @@ class RawBTi(_BaseRaw):
         dev_head_t = _convert_dev_head_t(dev_ctf_t, bti_to_nm,
                                          ctf_head_t)
 
-        info['dev_head_t'] = dict()
-        info['dev_head_t']['from'] = FIFF.FIFFV_COORD_DEVICE
-        info['dev_head_t']['to'] = FIFF.FIFFV_COORD_HEAD
-        info['dev_head_t']['trans'] = dev_head_t
-        info['dev_ctf_t'] = dict()
-        info['dev_ctf_t']['from'] = FIFF.FIFFV_MNE_COORD_CTF_DEVICE
-        info['dev_ctf_t']['to'] = FIFF.FIFFV_COORD_HEAD
-        info['dev_ctf_t']['trans'] = dev_ctf_t
-        info['ctf_head_t'] = dict()
-        info['ctf_head_t']['from'] = FIFF.FIFFV_MNE_COORD_CTF_HEAD
-        info['ctf_head_t']['to'] = FIFF.FIFFV_COORD_HEAD
-        info['ctf_head_t']['trans'] = ctf_head_t
+        info['dev_head_t'] = {'from': FIFF.FIFFV_COORD_DEVICE,
+                              'to': FIFF.FIFFV_COORD_HEAD,
+                              'trans': dev_head_t}
+        info['dev_ctf_t'] = {'from': FIFF.FIFFV_MNE_COORD_CTF_DEVICE,
+                             'to': FIFF.FIFFV_COORD_HEAD,
+                             'trans': dev_ctf_t}
+        info['ctf_head_t'] = {'from': FIFF.FIFFV_MNE_COORD_CTF_HEAD,
+                              'to': FIFF.FIFFV_COORD_HEAD,
+                              'trans': ctf_head_t}
         logger.info('Done.')
 
         if False:  # XXX : reminds us to support this as we go

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -376,17 +376,6 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, tal_channel,
         misc = []
     info = _empty_info()
     info['filename'] = fname
-    # Add info for fif object
-    info['ctf_head_t'] = None
-    info['dev_ctf_t'] = []
-    info['dig'] = None
-    info['dev_head_t'] = None
-    info['proj_id'] = None
-    info['proj_name'] = None
-    info['experimenter'] = None
-    info['line_freq'] = None
-    info['subject_info'] = None
-    info['custom_ref_applied'] = False
 
     edf_info = dict()
     edf_info['annot'] = annot

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1167,8 +1167,6 @@ def create_info(ch_names, sfreq, ch_types=None):
     info['sfreq'] = sfreq
     info['ch_names'] = ch_names
     info['nchan'] = nchan
-    info['dev_head_t'] = {'from': FIFF.FIFFV_COORD_DEVICE,
-                          'to': FIFF.FIFFV_COORD_HEAD, 'trans': np.eye(4)}
     loc = np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(np.float32)
     for ci, (name, kind) in enumerate(zip(ch_names, ch_types)):
         if not isinstance(name, string_types):
@@ -1201,7 +1199,7 @@ def _empty_info():
     """Create an empty info dictionary"""
     _none_keys = (
         'acq_pars', 'acq_stim', 'ctf_head_t', 'description',
-        'dev_ctf_t', 'dev_head_t', 'dig', 'experimenter',
+        'dev_ctf_t', 'dig', 'experimenter',
         'file_id', 'filename', 'highpass', 'hpi_subsystem', 'line_freq',
         'lowpass', 'meas_date', 'meas_id', 'proj_id', 'proj_name',
         'subject_info',
@@ -1217,5 +1215,7 @@ def _empty_info():
         info[k] = list()
     info['custom_ref_applied'] = False
     info['nchan'] = info['sfreq'] = 0
+    info['dev_head_t'] = {'from': FIFF.FIFFV_COORD_DEVICE,
+                          'to': FIFF.FIFFV_COORD_HEAD, 'trans': np.eye(4)}
     assert set(info.keys()) == set(RAW_INFO_FIELDS)
     return info

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1146,6 +1146,9 @@ def create_info(ch_names, sfreq, ch_types=None):
     within the rest of the package. Advanced functionality such as source
     localization can only be obtained through substantial, proper
     modifications of the info structure (not recommended).
+
+    Note that the MEG device-to-head transform ``info['dev_head_t']`` will
+    be initialized to the identity transform.
     """
     if not isinstance(ch_names, (list, tuple)):
         raise TypeError('ch_names must be a list or tuple')
@@ -1164,6 +1167,8 @@ def create_info(ch_names, sfreq, ch_types=None):
     info['sfreq'] = sfreq
     info['ch_names'] = ch_names
     info['nchan'] = nchan
+    info['dev_head_t'] = {'from': FIFF.FIFFV_COORD_DEVICE,
+                          'to': FIFF.FIFFV_COORD_HEAD, 'trans': np.eye(4)}
     loc = np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(np.float32)
     for ci, (name, kind) in enumerate(zip(ch_names, ch_types)):
         if not isinstance(name, string_types):


### PR DESCRIPTION
The C tools seem to require that files have a `dev_head_t`, so this should make it so that they all do.