### PR TITLE
ENH: addition of the argument show=True in viz functions when missing

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1088,7 +1088,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
     def plot_psd(self, tmin=0.0, tmax=60.0, fmin=0, fmax=np.inf,
                  proj=False, n_fft=2048, picks=None, ax=None,
                  color='black', area_mode='std', area_alpha=0.33,
-                 n_overlap=0, dB=True, n_jobs=1, verbose=None):
+                 n_overlap=0, dB=True, show=True, n_jobs=1, verbose=None):
         """Plot the power spectral density across channels
 
         Parameters
@@ -1125,6 +1125,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             is 0 (no overlap).
         dB : bool
             If True, transform data to decibels.
+        show : bool
+            Call pyplot.show() at the end.
         n_jobs : int
             Number of jobs to run in parallel.
         verbose : bool, str, int, or None
@@ -1138,8 +1140,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         return plot_raw_psd(self, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax,
                             proj=proj, n_fft=n_fft, picks=picks, ax=ax,
                             color=color, area_mode=area_mode,
-                            area_alpha=area_alpha,
-                            n_overlap=n_overlap, dB=dB, n_jobs=n_jobs)
+                            area_alpha=area_alpha, n_overlap=n_overlap,
+                            dB=dB, show=show, n_jobs=n_jobs)
 
     @deprecated("'plot_psds' will be removed in v0.10, please use 'plot_psd' "
                 "instead")

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -670,7 +670,7 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
 def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
                  n_fft=2048, picks=None, ax=None, color='black',
                  area_mode='std', area_alpha=0.33,
-                 n_overlap=0, dB=True, n_jobs=1, verbose=None):
+                 n_overlap=0, dB=True, show=True, n_jobs=1, verbose=None):
     """Plot the power spectral density across channels
 
     Parameters
@@ -709,6 +709,8 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         is 0 (no overlap).
     dB : bool
         If True, transform data to decibels.
+    show : bool
+        Call pyplot.show() at the end.
     n_jobs : int
         Number of jobs to run in parallel.
     verbose : bool, str, int, or None
@@ -758,7 +760,8 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
             ax.set_xlim(freqs[0], freqs[-1])
     if make_label:
         tight_layout(pad=0.1, h_pad=0.1, w_pad=0.1, fig=fig)
-    plt.show()
+    if show is True:
+        plt.show()
     return fig
 
 


### PR DESCRIPTION
Reimplementing [#1968](https://github.com/mne-tools/mne-python/pull/1968) and generalizing to all viz functions when needed.