### PR TITLE
Simplify BEM rendering closes #1443

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -77,8 +77,6 @@ Changelog
 
    - Add support for Savitsky-Golay filtering of Evoked and Epochs by `Eric Larson`_
 
-   - Add ``render_bem``, ``add_htmls_to_section`` methods to ``mne.Report`` by `Teon Brooks`_
-
    - Add support for adding an empty reference channel to data by ``Teon Brooks``_
 
    - Add reader function for Raw FIF files by ``Teon Brooks``_
@@ -94,6 +92,8 @@ Changelog
    - Add RAP-MUSIC inverse method by `Yousra Bekhti`_ and `Alex Gramfort`_
 
    - Add ``evoked.as_type`` to  allow remapping data in MEG channels to virtual magnetometer or gradiometer channels by `Mainak Jas`_
+
+   - Add ``add_bem_to_section``, ``add_htmls_to_section`` methods to ``mne.Report`` by `Teon Brooks`_
 
 BUG
 ~~~
@@ -185,6 +185,8 @@ API
    - Deprecated changing the sensor type of channels in ``rename_channels`` by `Teon Brooks`_
 
    - CUDA is no longer initialized at module import, but only when first used.
+
+   - ``add_figs_to_section`` and ``add_images_to_section`` now have a ``textbox`` parameter to add comments to the image by `Teon Brooks`_
 
 .. _changes_0_8:
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -867,6 +867,28 @@ class Report(object):
             self._sectionlabels.append(sectionvar)
             self.html.append(html)
 
+    def add_htmls_to_section(self, htmls, captions, section='custom'):
+        """Append htmls to the report.
+
+        Parameters
+        ----------
+        htmls : str | list of str
+            An html str or a list of html str.
+        captions : str | list of str
+            A caption or a list of captions to the htmls.
+        section : str
+            Name of the section. If section already exists, the images
+            will be appended to the end of the section.
+        """
+        htmls, captions = self._validate_input(htmls, captions, section)
+        for html, caption in zip(htmls, captions):
+            caption = 'custom plot' if caption == '' else caption
+            sectionvar = self._sectionvars[section]
+
+            self.fnames.append('%s-#-%s-#-custom' % (caption, sectionvar))
+            self._sectionlabels.append(sectionvar)
+            self.html.append(html)
+
     def add_bem_to_section(self, subject, caption='BEM', section='bem',
                            decim=2, n_jobs=1, subjects_dir=None):
         """Renders a bem slider html str.

--- a/mne/report.py
+++ b/mne/report.py
@@ -528,6 +528,7 @@ image_template = Template(u"""
 {{default id = False}}
 {{default image_format = 'png'}}
 {{default scale = None}}
+{{default comments = None}}
 
 <li class="{{div_klass}}" {{if id}}id="{{id}}"{{endif}}
 {{if not show}}style="display: none"{{endif}}>
@@ -550,11 +551,11 @@ image_template = Template(u"""
             {{img}}
         </div>
     {{endif}}
-    {{if textbox is not None}}
+    {{if comments is not None}}
         <br><br>
-        <div class="textbox">
+        <div class="comments">
         <div style="text-align:center;">
-            {{textbox}}
+            {{comments}}
         </div>
     {{endif}}
     </div>
@@ -710,7 +711,7 @@ class Report(object):
         return items, captions
 
     def _add_figs_to_section(self, figs, captions, section='custom',
-                             image_format='png', scale=None, textbox=None):
+                             image_format='png', scale=None, comments=None):
         """Auxiliary method for `add_section` and `add_figs_to_section`.
         """
         from scipy.misc import imread
@@ -748,15 +749,15 @@ class Report(object):
 
             img = _fig_to_img(fig=fig, scale=scale,
                               image_format=image_format)
-            if isinstance(textbox, list):
-                textbox = '<br>'.join(textbox)
+            if isinstance(comments, list):
+                comments = '<br>'.join(comments)
             html = image_template.substitute(img=img, id=global_id,
                                              div_klass=div_klass,
                                              img_klass=img_klass,
                                              caption=caption,
                                              show=True,
                                              image_format=image_format,
-                                             width=scale, textbox=textbox)
+                                             width=scale, comments=comments)
             self.fnames.append('%s-#-%s-#-custom' % (caption, sectionvar))
             self._sectionlabels.append(sectionvar)
             self.html.append(html)
@@ -782,7 +783,7 @@ class Report(object):
                                          section=section)
 
     def add_figs_to_section(self, figs, captions, section='custom',
-                            scale=None, image_format='png', textbox=None):
+                            scale=None, image_format='png', comments=None):
         """Append custom user-defined figures.
 
         Parameters
@@ -804,17 +805,18 @@ class Report(object):
             Defaults to None.
         image_format : {'png', 'svg'}
             The image format to be used for the report. Defaults to 'png'.
-        textbox : None | str | list of str
+        comments : None | str | list of str
             A string of text or a list of strings of text to be appended after
-            the image.
+            the figure. If list of str, each element will appear on a
+            new line.
         """
         return self._add_figs_to_section(figs=figs, captions=captions,
                                          section=section, scale=scale,
                                          image_format=image_format,
-                                         textbox=textbox)
+                                         comments=comments)
 
     def add_images_to_section(self, fnames, captions, scale=None,
-                              section='custom', textbox=None):
+                              section='custom', comments=None):
         """Append custom user-defined images.
 
         Parameters
@@ -829,17 +831,18 @@ class Report(object):
         section : str
             Name of the section. If section already exists, the images
             will be appended to the end of the section.
-        textbox : None | str | list of str
+        comments : None | str | list of str
             A string of text or a list of strings of text to be appended after
-            the image.
+            the image. If list of str, each element will appear on a
+            new line.
         """
         # Note: using scipy.misc is equivalent because scipy internally
         # imports PIL anyway. It's not possible to redirect image output
         # to binary string using scipy.misc.
         from PIL import Image
         fnames, captions = self._validate_input(fnames, captions, section)
-        if isinstance(textbox, list):
-            textbox = '<br>'.join(textbox)
+        if isinstance(comments, list):
+            comments = '<br>'.join(comments)
 
         for fname, caption in zip(fnames, captions):
             caption = 'custom plot' if caption == '' else caption
@@ -858,7 +861,7 @@ class Report(object):
                                              img_klass=img_klass,
                                              caption=caption,
                                              width=scale,
-                                             textbox=textbox,   
+                                             comments=comments,   
                                              show=True)
             self.fnames.append('%s-#-%s-#-custom' % (caption, sectionvar))
             self._sectionlabels.append(sectionvar)

--- a/mne/report.py
+++ b/mne/report.py
@@ -861,7 +861,7 @@ class Report(object):
                                              img_klass=img_klass,
                                              caption=caption,
                                              width=scale,
-                                             comments=comments,   
+                                             comments=comments,
                                              show=True)
             self.fnames.append('%s-#-%s-#-custom' % (caption, sectionvar))
             self._sectionlabels.append(sectionvar)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -197,19 +197,4 @@ def test_render_mri_without_bem():
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
 
-@testing.requires_testing_data
-@requires_nibabel()
-def test_add_htmls_to_section():
-    """Test adding html str to mne report.
-    """
-    report = Report(info_fname=raw_fname,
-                    subject='sample', subjects_dir=subjects_dir)
-    html = '<b>MNE-Python is AWESOME</b>'
-    caption, section = 'html', 'html_section'
-    report.add_htmls_to_section(html, caption, section)
-    idx = report._sectionlabels.index('report_' + section)
-    html_compare = report.html[idx]
-    assert_equal(html, html_compare)
-
-
 run_tests_if_main()

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -197,4 +197,19 @@ def test_render_mri_without_bem():
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
 
+@testing.requires_testing_data
+@requires_nibabel()
+def test_add_htmls_to_section():
+    """Test adding html str to mne report.
+    """
+    report = Report(info_fname=raw_fname,
+                    subject='sample', subjects_dir=subjects_dir)
+    html = '<b>MNE-Python is AWESOME</b>'
+    caption, section = 'html', 'html_section'
+    report.add_htmls_to_section(html, caption, section)
+    idx = report._sectionlabels.index('report_' + section)
+    html_compare = report.html[idx]
+    assert_equal(html, html_compare)
+
+
 run_tests_if_main()


### PR DESCRIPTION
Removes `render_bem` and `add_htmls_to_section` for `add_bem_to_section`.
Add textbox attribute to images and figs for adding notes, and commentary to the images.