### PR TITLE
fix lcmv example

### DIFF
--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -69,11 +69,8 @@ for pick_ori, name, desc, color in zip(pick_oris, names, descriptions, colors):
     stc = lcmv(evoked, forward, noise_cov, data_cov, reg=0.01,
                pick_ori=pick_ori)
 
-    # Save result in stc files
-    stc.save('lcmv-' + name)
-
     # View activation time-series
-    label = mne.read_label(fname_label, "lcmv-" + name + "-lh.stc")
+    label = mne.read_label(fname_label)
     stc_label = stc.in_label(label)
     plt.plot(1e3 * stc_label.times, np.mean(stc_label.data, axis=0), color,
              hold=True, label=desc)


### PR DESCRIPTION
Here is a quick fix for the example @teonlamont. It was because of the stc and the label were not having the same subject name.

And I don't know actually why the stc was saved.