### PR TITLE
Change IC names for ica.get_sources

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -706,7 +706,7 @@ class ICA(ContainsMixin):
         ch_names = info['ch_names'] = []
         ch_info = info['chs'] = []
         for ii in range(self.n_components_):
-            this_source = 'ICA %03d' % (ii + 1)
+            this_source = 'ICA %03d' % (ii)
             ch_names.append(this_source)
             ch_info.append(dict(ch_name=this_source, cal=1,
                                 logno=ii + 1, coil_type=FIFF.FIFFV_COIL_NONE,


### PR DESCRIPTION
closes #2000. The names for the IC in plot_topomap and the names in the `Raw` object after `ica.get_sources` differ. One solution is to name the channels as we are displayed in the topo for a clear and consistent nomenclature.