### PR TITLE
MRG: Revert default

### DIFF
--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -624,7 +624,7 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
     @verbose
     def plot(self, picks=None, baseline=None, mode='mean', tmin=None,
              tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
-             cmap='RdBu_r', dB=True, colorbar=True, show=True,
+             cmap='RdBu_r', dB=False, colorbar=True, show=True,
              title=None, verbose=None):
         """Plot TFRs in a topography with images
 
@@ -706,7 +706,7 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
 
     def plot_topo(self, picks=None, baseline=None, mode='mean', tmin=None,
                   tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
-                  layout=None, cmap='RdBu_r', title=None, dB=True,
+                  layout=None, cmap='RdBu_r', title=None, dB=False,
                   colorbar=True, layout_scale=0.945, show=True,
                   border='none', fig_facecolor='k', font_color='w'):
         """Plot TFRs in a topography with images


### PR DESCRIPTION
Closes #1986.

@dengemann this seems to fix the examples. The default `dB=False` was changed to `dB=True`. In some places `dB=True` is default (plotting PSD for raw or epochs) and in others it is `dB=False` (plotting TFRs), but I guess that is okay.