### PR TITLE
FIX: Fix Mayavi import

### DIFF
--- a/mne/report.py
+++ b/mne/report.py
@@ -765,7 +765,7 @@ class Report(object):
             # on some version mayavi.core won't be exposed unless ...
             from mayavi import mlab  # noqa, mlab imported
             import mayavi
-        except ImportError:
+        except:  # on some systems importing Mayavi raises SystemExit (!)
             warnings.warn('Could not import mayavi. Trying to render '
                           '`mayavi.core.scene.Scene` figure instances'
                           ' will throw an error.')


### PR DESCRIPTION
I couldn't actually run @teonlamont's code example because an attempted `Mayavi` import ended up raising a `SystemExit` due to `wx`. Yikes. This fixes that problem.