### PR TITLE
MRG FIX: Fix scaling

### DIFF
--- a/mne/report.py
+++ b/mne/report.py
@@ -82,7 +82,11 @@ def _scale_mpl_figure(fig, scale):
         sfactor = -((1. / scale) ** 2)
     for text in fig.findobj(mpl.text.Text):
         fs = text.get_fontsize()
-        text.set_fontsize(fs + sfactor)
+        try:
+            text.set_fontsize(fs + sfactor)
+        except RuntimeError:
+            raise ValueError('could not rescale matplotlib fonts, consider '
+                             'using a different value for "scale"')
 
     fig.canvas.draw()
 
@@ -769,9 +773,6 @@ class Report(object):
             warnings.warn('Could not import mayavi. Trying to render '
                           '`mayavi.core.scene.Scene` figure instances'
                           ' will throw an error.')
-        if np.isscalar(scale) and scale < 1.:
-            raise ValueError('scale, if float, must be >= 1 not %s'
-                             % scale)
         figs, captions, comments = self._validate_input(figs, captions,
                                                         section, comments)
         for fig, caption, comment in zip(figs, captions, comments):
@@ -846,8 +847,9 @@ class Report(object):
         scale : float | None | callable
             Scale the images maintaining the aspect ratio.
             If None, no scaling is applied. If float, scale will determine
-            the relative width in percent (must be >= 1). If function,
-            should take a figure object as input parameter. Defaults to None.
+            the relative scaling (might not work for scale <= 1 depending on
+            font sizes). If function, should take a figure object as input
+            parameter. Defaults to None.
         image_format : {'png', 'svg'}
             The image format to be used for the report. Defaults to 'png'.
         comments : None | str | list of str

--- a/mne/report.py
+++ b/mne/report.py
@@ -82,11 +82,11 @@ def _scale_mpl_figure(fig, scale):
         sfactor = -((1. / scale) ** 2)
     for text in fig.findobj(mpl.text.Text):
         fs = text.get_fontsize()
-        try:
-            text.set_fontsize(fs + sfactor)
-        except RuntimeError:
+        new_size = fs + sfactor
+        if new_size <= 0:
             raise ValueError('could not rescale matplotlib fonts, consider '
-                             'using a different value for "scale"')
+                             'increasing "scale"')
+        text.set_fontsize(new_size)
 
     fig.canvas.draw()
 
@@ -672,6 +672,12 @@ toc_list = Template(u"""
 """)
 
 
+def _check_scale(scale):
+    """Helper to ensure valid scale value is passed"""
+    if np.isscalar(scale) and scale <= 0:
+        raise ValueError('scale must be positive, not %s' % scale)
+
+
 class Report(object):
     """Object for rendering HTML
 
@@ -775,6 +781,7 @@ class Report(object):
                           ' will throw an error.')
         figs, captions, comments = self._validate_input(figs, captions,
                                                         section, comments)
+        _check_scale(scale)
         for fig, caption, comment in zip(figs, captions, comments):
             caption = 'custom plot' if caption == '' else caption
             sectionvar = self._sectionvars[section]
@@ -887,6 +894,7 @@ class Report(object):
         from PIL import Image
         fnames, captions, comments = self._validate_input(fnames, captions,
                                                           section, comments)
+        _check_scale(scale)
 
         for fname, caption, comment in zip(fnames, captions, comments):
             caption = 'custom plot' if caption == '' else caption

--- a/mne/report.py
+++ b/mne/report.py
@@ -769,6 +769,9 @@ class Report(object):
             warnings.warn('Could not import mayavi. Trying to render '
                           '`mayavi.core.scene.Scene` figure instances'
                           ' will throw an error.')
+        if np.isscalar(scale) and scale < 1.:
+            raise ValueError('scale, if float, must be >= 1 not %s'
+                             % scale)
         figs, captions, comments = self._validate_input(figs, captions,
                                                         section, comments)
         for fig, caption, comment in zip(figs, captions, comments):
@@ -800,7 +803,7 @@ class Report(object):
                                              caption=caption,
                                              show=True,
                                              image_format=image_format,
-                                             width=scale, comment=comment)
+                                             comment=comment)
             self.fnames.append('%s-#-%s-#-custom' % (caption, sectionvar))
             self._sectionlabels.append(sectionvar)
             self.html.append(html)
@@ -842,10 +845,9 @@ class Report(object):
             will be appended to the end of the section
         scale : float | None | callable
             Scale the images maintaining the aspect ratio.
-            If None, no scaling is applied.
-            If float, scale will determine the relative width in percent.
-            If function, should take a figure object as input parameter.
-            Defaults to None.
+            If None, no scaling is applied. If float, scale will determine
+            the relative width in percent (must be >= 1). If function,
+            should take a figure object as input parameter. Defaults to None.
         image_format : {'png', 'svg'}
             The image format to be used for the report. Defaults to 'png'.
         comments : None | str | list of str

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -136,6 +136,10 @@ def test_render_add_sections():
                   captions='H')
     assert_raises(ValueError, report.add_figs_to_section, figs=fig,
                   captions=['foo'], scale=0, image_format='svg')
+    assert_raises(ValueError, report.add_figs_to_section, figs=fig,
+                  captions=['foo'], scale=1e-10, image_format='svg')
+    # need to recreate because calls above change size
+    fig = plt.plot([1, 2], [1, 2])[0].figure
 
     # Check add_images_to_section
     img_fname = op.join(tempdir, 'testimage.png')

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -135,7 +135,7 @@ def test_render_add_sections():
     assert_raises(ValueError, report.add_figs_to_section, figs=[fig, fig],
                   captions='H')
     assert_raises(ValueError, report.add_figs_to_section, figs=fig,
-                  captions=['foo'], scale=0.5, image_format='svg')
+                  captions=['foo'], scale=0, image_format='svg')
 
     # Check add_images_to_section
     img_fname = op.join(tempdir, 'testimage.png')

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -134,6 +134,8 @@ def test_render_add_sections():
                                image_format='svg')
     assert_raises(ValueError, report.add_figs_to_section, figs=[fig, fig],
                   captions='H')
+    assert_raises(ValueError, report.add_figs_to_section, figs=fig,
+                  captions=['foo'], scale=0.5, image_format='svg')
 
     # Check add_images_to_section
     img_fname = op.join(tempdir, 'testimage.png')


### PR DESCRIPTION
Closes #2014.

I'm pretty sure the docstring was wrong, too, so I changed it. At least it didn't do what it said it would do on my system (set the percentage). I'm not sure how you could have it both scale the figure by `scale` *and* have `scale` be the percentage of the page it should take up...