### PR TITLE
[MRG] EHN: add TimeDecoding class for simplification

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -48,6 +48,7 @@ Classes
    decoding.FilterEstimator
    decoding.PSDEstimator
    decoding.GeneralizationAcrossTime
+   decoding.TimeDecoding
    realtime.RtEpochs
    realtime.RtClient
    realtime.MockRtClient

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -29,6 +29,7 @@ Changelog
 
     - Add ICA plotters for raw and epoch components by `Jaakko Leppakangas`_
 
+    - Add support for decoding sensors' evoked response across time by `Jean-Remi King`_
 
 BUG
 ~~~

--- a/examples/decoding/plot_decoding_sensors.py
+++ b/examples/decoding/plot_decoding_sensors.py
@@ -13,7 +13,6 @@ point.
 # License: BSD (3-clause)
 
 import matplotlib.pyplot as plt
-import numpy as np
 
 import mne
 from mne import io

--- a/examples/decoding/plot_decoding_sensors.py
+++ b/examples/decoding/plot_decoding_sensors.py
@@ -53,10 +53,10 @@ data_picks = mne.pick_types(epochs.info, meg=True, exclude='bads')
 
 ###############################################################################
 # Setup decoding: default is linear SVC
-tg = TimeDecoding(predict_mode='cross-validation', n_jobs=1)
+td = TimeDecoding(predict_mode='cross-validation', n_jobs=1)
 # Fit
-tg.fit(epochs)
+td.fit(epochs)
 # Compute accuracy
-tg.score(epochs)
+td.score(epochs)
 # Plot scores across time
-tg.plot(title='Sensor space decoding')
+td.plot(title='Sensor space decoding')

--- a/examples/decoding/plot_decoding_sensors.py
+++ b/examples/decoding/plot_decoding_sensors.py
@@ -54,7 +54,7 @@ data_picks = mne.pick_types(epochs.info, meg=True, exclude='bads')
 
 ###############################################################################
 # Setup decoding: default is linear SVC
-tg = TimeDecoding(predict_mode='cross-validation', n_jobs=-1)
+tg = TimeDecoding(predict_mode='cross-validation', n_jobs=1)
 # Fit
 tg.fit(epochs)
 # Compute accuracy

--- a/examples/decoding/plot_decoding_sensors.py
+++ b/examples/decoding/plot_decoding_sensors.py
@@ -8,6 +8,7 @@ data in sensor space. Here the classifier is applied to every time
 point.
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#          Jean-Remi King <jeanremi.king@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -17,6 +18,7 @@ import numpy as np
 import mne
 from mne import io
 from mne.datasets import sample
+from mne.decoding import TimeDecoding
 
 print(__doc__)
 
@@ -48,53 +50,14 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 
 epochs_list = [epochs[k] for k in event_id]
 mne.epochs.equalize_epoch_counts(epochs_list)
+data_picks = mne.pick_types(epochs.info, meg=True, exclude='bads')
 
 ###############################################################################
-# Decoding in sensor space using a linear SVM
-n_times = len(epochs.times)
-# Take only the data channels (here the gradiometers)
-data_picks = mne.pick_types(epochs.info, meg=True, exclude='bads')
-# Make arrays X and y such that :
-# X is 3d with X.shape[0] is the total number of epochs to classify
-# y is filled with integers coding for the class to predict
-# We must have X.shape[0] equal to y.shape[0]
-X = [e.get_data()[:, data_picks, :] for e in epochs_list]
-y = [k * np.ones(len(this_X)) for k, this_X in enumerate(X)]
-X = np.concatenate(X)
-y = np.concatenate(y)
-
-from sklearn.svm import SVC  # noqa
-from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
-
-clf = SVC(C=1, kernel='linear')
-# Define a monte-carlo cross-validation generator (reduce variance):
-cv = ShuffleSplit(len(X), 10, test_size=0.2)
-
-scores = np.empty(n_times)
-std_scores = np.empty(n_times)
-
-for t in range(n_times):
-    Xt = X[:, :, t]
-    # Standardize features
-    Xt -= Xt.mean(axis=0)
-    Xt /= Xt.std(axis=0)
-    # Run cross-validation
-    # Note : for sklearn the Xt matrix should be 2d (n_samples x n_features)
-    scores_t = cross_val_score(clf, Xt, y, cv=cv, n_jobs=1)
-    scores[t] = scores_t.mean()
-    std_scores[t] = scores_t.std()
-
-times = 1e3 * epochs.times
-scores *= 100  # make it percentage
-std_scores *= 100
-plt.plot(times, scores, label="Classif. score")
-plt.axhline(50, color='k', linestyle='--', label="Chance level")
-plt.axvline(0, color='r', label='stim onset')
-plt.legend()
-hyp_limits = (scores - std_scores, scores + std_scores)
-plt.fill_between(times, hyp_limits[0], y2=hyp_limits[1], color='b', alpha=0.5)
-plt.xlabel('Times (ms)')
-plt.ylabel('CV classification score (% correct)')
-plt.ylim([30, 100])
-plt.title('Sensor space decoding')
-plt.show()
+# Setup decoding: default is linear SVC
+tg = TimeDecoding(predict_mode='cross-validation', n_jobs=-1)
+# Fit
+tg.fit(epochs)
+# Compute accuracy
+tg.score(epochs)
+# Plot scores across time
+tg.plot(title='Sensor space decoding')

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -3,4 +3,4 @@ from .classifier import PSDEstimator, ConcatenateChannels
 from .mixin import TransformerMixin
 from .csp import CSP
 from .ems import compute_ems
-from .time_gen import GeneralizationAcrossTime
+from .time_gen import GeneralizationAcrossTime, TimeDecoding

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -232,7 +232,7 @@ def test_generalization_across_time():
 
 
 @requires_sklearn
-def test_DecodingTime():
+def test_decoding_time():
     epochs = make_epochs()
     tg = TimeDecoding()
     assert_equal("<TimeDecoding | no fit, no prediction, no score>", '%s' % tg)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -231,7 +231,6 @@ def test_generalization_across_time():
                     gat.score(epochs, y=y_)
 
 
-@slow_test
 @requires_sklearn
 def test_DecodingTime():
     epochs = make_epochs()

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -231,6 +231,8 @@ def test_generalization_across_time():
                     gat.score(epochs, y=y_)
 
 
+@slow_test
+@requires_sklearn
 def test_DecodingTime():
     epochs = make_epochs()
     tg = TimeDecoding()

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -235,15 +235,24 @@ def test_generalization_across_time():
 def test_DecodingTime():
     epochs = make_epochs()
     tg = TimeDecoding()
+    assert_equal("<TimeDecoding | no fit, no prediction, no score>", '%s' % tg)
     assert_true(hasattr(tg, 'times'))
     assert_true(not hasattr(tg, 'train_times'))
     assert_true(not hasattr(tg, 'test_times'))
     tg.fit(epochs)
+    assert_equal("<TimeDecoding | fitted, start : -0.200 (s), stop : 0.499 "
+                 "(s), no prediction, no score>", '%s' % tg)
     assert_true(not hasattr(tg, 'train_times_'))
     assert_true(not hasattr(tg, 'test_times_'))
     assert_raises(RuntimeError, tg.score, epochs=None)
     tg.predict(epochs)
+    assert_equal("<TimeDecoding | fitted, start : -0.200 (s), stop : 0.499 "
+                 "(s), predicted 14 epochs, no score>",
+                 '%s' % tg)
     assert_array_equal(np.shape(tg.y_pred_), [15, 14, 1])
     tg.score(epochs)
     tg.score()
     assert_array_equal(np.shape(tg.scores_), [15])
+    assert_equal("<TimeDecoding | fitted, start : -0.200 (s), stop : 0.499 "
+                 "(s), predicted 14 epochs,\n scored (accuracy_score)>",
+                 '%s' % tg)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -248,5 +248,3 @@ def test_DecodingTime():
     tg.score(epochs)
     tg.score()
     assert_array_equal(np.shape(tg.scores_), [15])
-    assert_raises(RuntimeError, tg.plot_times)
-    assert_raises(RuntimeError, tg.plot_diagonal)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1129,3 +1129,13 @@ class TimeDecoding(GeneralizationAcrossTime):
                                                 color=color, xlabel=xlabel,
                                                 ylabel=ylabel, legend=legend,
                                                 chance=chance, label=label)
+
+    def plot_times():
+        # XXX JRK: This is pretty ugly, we'd need to re organize the classes
+        # in heritances.
+        raise RuntimeError('plot_times() isn\'t adequate for TimeDecoding')
+
+    def plot_diagonal():
+        # XXX JRK: This is pretty ugly, we'd need to re organize the classes
+        # in heritances.
+        raise RuntimeError('plot_diagonal() isn\'t adequate for TimeDecoding')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1025,6 +1025,30 @@ class TimeDecoding(GeneralizationAcrossTime):
                                            predict_mode=predict_mode,
                                            scorer=scorer, n_jobs=n_jobs)
 
+    def __repr__(self):
+        s = ''
+        if hasattr(self, "estimators_"):
+            s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (
+                self.train_times_['start'], self.train_times_['stop'])
+        else:
+            s += 'no fit'
+        if hasattr(self, 'y_pred_'):
+            s += (", predicted %d epochs" % len(self.y_pred_[0]))
+        else:
+            s += ", no prediction"
+        if hasattr(self, "estimators_") and hasattr(self, 'scores_'):
+            s += ',\n '
+        else:
+            s += ', '
+        if hasattr(self, 'scores_'):
+            s += "scored"
+            if callable(self.scorer_):
+                s += " (%s)" % (self.scorer_.__name__)
+        else:
+            s += "no score"
+
+        return "<TimeDecoding | %s>" % s
+
     def predict(self, X, test_times='diagonal', **kwargs):
         """ Test each classifier at each time point.
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -155,10 +155,10 @@ class GeneralizationAcrossTime(object):
             ``times`` : np.ndarray, shape (n_clfs, n_testing_times)
                 The testing times (in seconds) for each training time.
 
-    estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
-        The estimators for each time point and each fold.
     cv_ : CrossValidation object
         The actual CrossValidation input depending on y.
+    estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
+        The estimators for each time point and each fold.
     y_pred_ : list of lists of arrays of floats,
               shape (n_train_times, n_test_times, n_epochs, n_prediction_dims)
         The single-trial predictions estimated by self.predict() at each
@@ -946,7 +946,7 @@ class TimeDecoding(GeneralizationAcrossTime):
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including
         StandardScaler and a linear SVM with default parameters.
-    train_times : dict | None
+    times : dict | None
         A dictionary to configure the training times:
 
             ``slices`` : np.ndarray, shape (n_clfs,)
@@ -977,39 +977,44 @@ class TimeDecoding(GeneralizationAcrossTime):
                 these predictions into a single estimate per sample.
 
         Default: 'cross-validation'
+    scorer : object | None
+        scikit-learn Scorer instance. If None, set to accuracy_score.
+        Defaults to None.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
 
     Attributes
     ----------
+    picks_ : array-like of int
+        Channels to be included.
+    ch_names : list, shape (n_channels,)
+        Names of the channels used for training.
     y_train_ : np.ndarray, shape (n_samples,)
         The categories used for training.
-    estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
-        The estimators for each time point and each fold.
-    y_pred_ : np.ndarray, shape (n_train_times, n_test_times, n_epochs,
-                                 n_prediction_dims)
-        Class labels for samples in X.
-    scores_ : list of lists of float
-        The scores (mean accuracy of self.predict(X) wrt. y.).
-        It's not an array as the testing times per training time
-        need not be regular.
-    test_times_ : dict
-        The same structure as ``train_times``.
+    times_ : dict
+        A dictionary that configures the training times:
+
+            ``slices`` : np.ndarray, shape (n_clfs,)
+                Array of time slices (in indices) used for each classifier.
+                If not given, computed from 'start', 'stop', 'length', 'step'.
+            ``times`` : np.ndarray, shape (n_clfs,)
+                The training times (in seconds).
     cv_ : CrossValidation object
         The actual CrossValidation input depending on y.
+    estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
+        The estimators for each time point and each fold.
+    y_pred_ : np.ndarray, shape (n_times, n_epochs, n_prediction_dims)
+        Class labels for samples in X.
+    y_true_ : list | np.ndarray, shape (n_samples,)
+        The categories used for scoring y_pred_.
+    scorer_ : object
+        scikit-learn Scorer instance.
+    scores_ : list of float, shape (n_times)
+        The scores (mean accuracy of self.predict(X) wrt. y.).
 
     Notes
     -----
-    The function implements the method used in:
-
-        Jean-Remi King, Alexandre Gramfort, Aaron Schurger, Lionel Naccache
-        and Stanislas Dehaene, "Two distinct dynamic modes subtend the
-        detection of unexpected sounds", PLOS ONE, 2013
-
-    .. versionadded:: 0.9.0
-
-    Returns
-    -------
+    The function is equivalent to the diagonal of GeneralizationAcrossTime()
     """
 
     def predict(self, X, test_times='diagonal', **kwargs):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -30,7 +30,7 @@ class _DecodingTime(dict):
         seconds). Defaults to one time sample.
     'length' : float
         Duration of each classifier (in seconds). Defaults to one time sample.
-    If None, empty dict. Defaults to None."""
+    If None, empty dict. """
 
     def __repr__(self):
         s = ""
@@ -68,9 +68,9 @@ class GeneralizationAcrossTime(object):
 
     Parameters
     ----------
-    picks : array-like of int | None, optional
-        Channels to be included. If None only good data channels are used.
-        Defaults to None.
+    picks : array-like of int | None
+        The channels indices to include. If None the data
+        channels in info, except bad channels, are used.
     cv : int | object
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
@@ -99,7 +99,7 @@ class GeneralizationAcrossTime(object):
                 Duration of each classifier (in seconds).
                 Defaults to one time sample.
 
-        If None, empty dict. Defaults to None.
+        If None, empty dict.
     test_times : 'diagonal' | dict | None, optional
         Configures the testing times.
         If set to 'diagonal', predictions are made at the time at which
@@ -111,7 +111,7 @@ class GeneralizationAcrossTime(object):
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
 
-        If None, empty dict. Defaults to None.
+        If None, empty dict.
     predict_mode : {'cross-validation', 'mean-prediction'}
         Indicates how predictions are achieved with regards to the cross-
         validation procedure:
@@ -126,14 +126,13 @@ class GeneralizationAcrossTime(object):
         Default: 'cross-validation'
     scorer : object | None
         scikit-learn Scorer instance. If None, set to accuracy_score.
-        Defaults to None.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
 
     Attributes
     ----------
-    picks_ : array-like of int
-        Channels to be included.
+    picks_ : array-like of int | None
+        The channels indices to include.
     ch_names : list, shape (n_channels,)
         Names of the channels used for training.
     y_train_ : list | np.ndarray, shape (n_samples,)
@@ -256,7 +255,6 @@ class GeneralizationAcrossTime(object):
             The epochs.
         y : list or np.ndarray of int, shape (n_samples,) or None, optional
             To-be-fitted model values. If None, y = epochs.events[:, 2].
-            Defaults to None.
 
         Returns
         -------
@@ -411,7 +409,6 @@ class GeneralizationAcrossTime(object):
             True values to be compared with the predictions ``y_pred_``
             generated with ``predict()`` via ``scorer_``.
             If None and ``predict_mode``=='cross-validation' y = ``y_train_``.
-            Defaults to None.
 
         Returns
         -------
@@ -484,17 +481,15 @@ class GeneralizationAcrossTime(object):
         Parameters
         ----------
         title : str | None
-            Figure title. Defaults to None.
+            Figure title.
         vmin : float | None
             Min color value for scores. If None, sets to min(gat.scores_).
-            Defaults to None.
         vmax : float | None
             Max color value for scores. If None, sets to max(gat.scores_).
-            Defaults to None.
         tlim : np.ndarray, (train_min, test_max) | None
-            The temporal boundaries. Defaults to None.
+            The temporal boundaries.
         ax : object | None
-            Plot pointer. If None, generate new figure. Defaults to None.
+            Plot pointer. If None, generate new figure.
         cmap : str | cmap object
             The color map to be used. Defaults to 'RdBu_r'.
         show : bool
@@ -527,18 +522,17 @@ class GeneralizationAcrossTime(object):
         Parameters
         ----------
         title : str | None
-            Figure title. Defaults to None.
+            Figure title.
         xmin : float | None, optional
-            Min time value. Defaults to None.
+            Min time value.
         xmax : float | None, optional
-            Max time value. Defaults to None.
+            Max time value.
         ymin : float | None, optional
-            Min score value. If None, sets to min(scores). Defaults to None.
+            Min score value. If None, sets to min(scores).
         ymax : float | None, optional
-            Max score value. If None, sets to max(scores). Defaults to None.
+            Max score value. If None, sets to max(scores).
         ax : object | None
             Instance of mataplotlib.axes.Axis. If None, generate new figure.
-            Defaults to None.
         show : bool
             If True, the figure will be shown. Defaults to True.
         color : str
@@ -579,18 +573,17 @@ class GeneralizationAcrossTime(object):
         train_time : float | list or array of float
             Plots scores of the classifier trained at train_time.
         title : str | None
-            Figure title. Defaults to None.
+            Figure title.
         xmin : float | None, optional
-            Min time value. Defaults to None.
+            Min time value.
         xmax : float | None, optional
-            Max time value. Defaults to None.
+            Max time value.
         ymin : float | None, optional
-            Min score value. If None, sets to min(scores). Defaults to None.
+            Min score value. If None, sets to min(scores).
         ymax : float | None, optional
-            Max score value. If None, sets to max(scores). Defaults to None.
+            Max score value. If None, sets to max(scores).
         ax : object | None
             Instance of mataplotlib.axes.Axis. If None, generate new figure.
-            Defaults to None.
         show : bool
             If True, the figure will be shown. Defaults to True.
         color : str or list of str
@@ -603,7 +596,7 @@ class GeneralizationAcrossTime(object):
             If True, a legend is displayed. Defaults to True.
         chance : bool | float.
             Plot chance level. If True, chance level is estimated from the type
-            of scorer. Defaults to None.
+            of scorer.
         label : str
             Score label used in the legend. Defaults to 'Classif. score'.
 
@@ -710,10 +703,9 @@ def _check_epochs_input(epochs, y, picks=None):
             The epochs.
     y : np.ndarray shape (n_epochs) | list shape (n_epochs) | None
         To-be-fitted model. If y is None, y == epochs.events.
-        Defaults to None.
     picks : array-like of int | None
-        Channels to be included. If None only good data channels are used.
-        Defaults to None.
+        The channels indices to include. If None the data
+        channels in info, except bad channels, are used.
 
     Returns
     -------
@@ -721,8 +713,9 @@ def _check_epochs_input(epochs, y, picks=None):
         To-be-fitted data.
     y : np.ndarray, shape (n_epochs,)
         To-be-fitted model.
-    picks : np.ndarray, shape (n_selected_chans,)
-        The channels to be used.
+    picks : array-like of int | None
+        The channels indices to include. If None the data
+        channels in info, except bad channels, are used.
     """
     if y is None:
         y = epochs.events[:, 2]
@@ -932,14 +925,14 @@ def _time_gen_one_fold(clf, X, y, train, test, scoring):
 
 
 class TimeDecoding(GeneralizationAcrossTime):
-    """Train and test a classifier at each time point to obtain a score across
-    time.
+    """Train and test a series of classifiers at each time point to obtain a
+    score across time.
 
     Parameters
     ----------
-    picks : array-like of int | None, optional
-        Channels to be included. If None only good data channels are used.
-        Defaults to None.
+    picks : array-like of int | None
+        The channels indices to include. If None the data
+        channels in info, except bad channels, are used.
     cv : int | object
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
@@ -967,8 +960,7 @@ class TimeDecoding(GeneralizationAcrossTime):
             ``length`` : float
                 Duration of each classifier (in seconds). By default, equals
                 one time sample.
-
-        If None, empty dict. Defaults to None.
+        If None, empty dict.
     predict_mode : {'cross-validation', 'mean-prediction'}
         Indicates how predictions are achieved with regards to the cross-
         validation procedure:
@@ -982,14 +974,13 @@ class TimeDecoding(GeneralizationAcrossTime):
         Default: 'cross-validation'
     scorer : object | None
         scikit-learn Scorer instance. If None, set to accuracy_score.
-        Defaults to None.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
 
     Attributes
     ----------
-    picks_ : array-like of int
-        Channels to be included.
+    picks_ : array-like of int | None
+        The channels indices to include.
     ch_names : list, shape (n_channels,)
         Names of the channels used for training.
     y_train_ : np.ndarray, shape (n_samples,)
@@ -1067,7 +1058,6 @@ class TimeDecoding(GeneralizationAcrossTime):
             The epochs.
         y : list or np.ndarray of int, shape (n_samples,) or None, optional
             To-be-fitted model values. If None, y = epochs.events[:, 2].
-            Defaults to None.
 
         Returns
         -------
@@ -1140,7 +1130,6 @@ class TimeDecoding(GeneralizationAcrossTime):
             True values to be compared with the predictions ``y_pred_``
             generated with ``predict()`` via ``scorer_``.
             If None and ``predict_mode``=='cross-validation' y = ``y_train_``.
-            Defaults to None.
 
         Returns
         -------
@@ -1175,10 +1164,10 @@ class TimeDecoding(GeneralizationAcrossTime):
         Parameters
         ----------
         title : str | None
-            Figure title. Defaults to None.
-        xmin : float | None, optional, defaults to None.
+            Figure title.
+        xmin : float | None, optional,
             Min time value.
-        xmax : float | None, optional, defaults to None.
+        xmax : float | None, optional,
             Max time value.
         ymin : float
             Min score value. Defaults to 0.
@@ -1186,7 +1175,6 @@ class TimeDecoding(GeneralizationAcrossTime):
             Max score value. Defaults to 1.
         ax : object | None
             Instance of mataplotlib.axes.Axis. If None, generate new figure.
-            Defaults to None.
         show : bool
             If True, the figure will be shown. Defaults to True.
         color : str

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1017,6 +1017,14 @@ class TimeDecoding(GeneralizationAcrossTime):
     The function is equivalent to the diagonal of GeneralizationAcrossTime()
     """
 
+    def __init__(self, picks=None, cv=5, clf=None, times=None,
+                 predict_mode='cross-validation', scorer=None, n_jobs=1):
+        super(TimeDecoding, self).__init__(picks=picks, cv=cv, clf=None,
+                                           train_times=times,
+                                           test_times='diagonal',
+                                           predict_mode=predict_mode,
+                                           scorer=scorer, n_jobs=n_jobs)
+
     def predict(self, X, test_times='diagonal', **kwargs):
         """ Test each classifier at each time point.
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -648,7 +648,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         The single-trial predictions estimated by self.predict() at each
         training time and each testing time. Note that the number of testing
         times per training time need not be regular, else
-        np.shape(y_pred_) = [n_train_time, n_test_time, n_epochs].
+        np.shape(y_pred_) = (n_train_time, n_test_time, n_epochs).
     y_true_ : list | ndarray, shape (n_samples,)
         The categories used for scoring y_pred_.
     scorer_ : object
@@ -657,7 +657,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         The scores estimated by self.scorer_ at each training time and each
         testing time (e.g. mean accuracy of self.predict(X)). Note that the
         number of testing times per training time need not be regular;
-        else, np.shape(scores) = [n_train_time, n_test_time].
+        else, np.shape(scores) = (n_train_time, n_test_time).
 
 
     Notes
@@ -750,7 +750,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             The single-trial predictions at each training time and each testing
             time. Note that the number of testing times per training time need
             not be regular;
-            else, np.shape(y_pred_) = [n_train_time, n_test_time, n_epochs].
+            else, np.shape(y_pred_) = (n_train_time, n_test_time, n_epochs).
         """
         return super(GeneralizationAcrossTime, self).predict(epochs)
 
@@ -782,7 +782,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             The scores estimated by ``scorer_`` at each training time and each
             testing time (e.g. mean accuracy of ``predict(X)``). Note that the
             number of testing times per training time need not be regular;
-            else, np.shape(scores) = [n_train_time, n_test_time].
+            else, np.shape(scores) = (n_train_time, n_test_time).
         """
         return super(GeneralizationAcrossTime, self).score(epochs=epochs, y=y)
 
@@ -802,7 +802,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         vmax : float | None
             Max color value for scores. If None, sets to max(gat.scores_).
         tlim : ndarray, (train_min, test_max) | None
-            The temporal boundaries.
+            The time limits used for plotting.
         ax : object | None
             Plot pointer. If None, generate new figure.
         cmap : str | cmap object

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -669,6 +669,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         detection of unexpected sounds", PLoS ONE, 2014
         DOI: 10.1371/journal.pone.0085791
 
+    .. versionadded:: 0.9.0
     """
     def __init__(self, picks=None, cv=5, clf=None, train_times=None,
                  test_times=None, predict_mode='cross-validation', scorer=None,
@@ -717,8 +718,8 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
 
         Returns
         -------
-        self : object
-            Returns self.
+        self : GeneralizationAcrossTime
+            Returns fitted GeneralizationAcrossTime object.
 
         Notes
         ------
@@ -1017,6 +1018,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
     Notes
     -----
     The function is equivalent to the diagonal of GeneralizationAcrossTime()
+
+    .. versionadded:: 0.10
     """
 
     def __init__(self, picks=None, cv=5, clf=None, times=None,
@@ -1067,8 +1070,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
         Returns
         -------
-        self : object
-            Returns self.
+        self : TimeDecoding
+            Returns fitted TimeDecoding object.
 
         Notes
         ------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -33,6 +33,7 @@ class _DecodingTime(dict):
     If None, empty dict. """
 
     def __repr__(self):
+        """Human readable representation"""
         s = ""
         if "start" in self:
             s += "start: %0.3f (s)" % (self["start"])
@@ -618,7 +619,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     ----------
     picks_ : array-like of int | None
         The channels indices to include.
-    ch_names : list, shape (n_channels,)
+    ch_names : list, array-like, shape (n_channels,)
         Names of the channels used for training.
     y_train_ : list | ndarray, shape (n_samples,)
         The categories used for training.
@@ -680,6 +681,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             n_jobs=n_jobs)
 
     def __repr__(self):
+        """Human readable representation"""
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (
@@ -950,7 +952,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including
-        StandardScaler and a linear SVM with default parameters.
+        StandardScaler and a Logistic Regression with default parameters.
     times : dict | None
         A dictionary to configure the training times:
 
@@ -990,7 +992,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
     ----------
     picks_ : array-like of int | None
         The channels indices to include.
-    ch_names : list, shape (n_channels,)
+    ch_names : list, array-like, shape (n_channels,)
         Names of the channels used for training.
     y_train_ : ndarray, shape (n_samples,)
         The categories used for training.
@@ -1032,6 +1034,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
         self._clean_times()
 
     def __repr__(self):
+        """Human readable representation"""
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1024,6 +1024,8 @@ class TimeDecoding(GeneralizationAcrossTime):
                                            test_times='diagonal',
                                            predict_mode=predict_mode,
                                            scorer=scorer, n_jobs=n_jobs)
+        delattr(self, 'test_times')
+        return self
 
     def __repr__(self):
         s = ''
@@ -1048,6 +1050,13 @@ class TimeDecoding(GeneralizationAcrossTime):
             s += "no score"
 
         return "<TimeDecoding | %s>" % s
+
+    def fit(self, epochs, y=None):
+        self.test_times = 'diagonal'
+        super(TimeDecoding, self).fit(epochs, y=y)
+        # squeeze testing times
+        self.estimators_ = [clf[0] for clf in self.estimators_]
+        return self
 
     def predict(self, X, test_times='diagonal', **kwargs):
         """ Test each classifier at each time point.

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1024,7 +1024,9 @@ class TimeDecoding(GeneralizationAcrossTime):
                                            test_times='diagonal',
                                            predict_mode=predict_mode,
                                            scorer=scorer, n_jobs=n_jobs)
+        self.times = self.train_times
         delattr(self, 'test_times')
+        delattr(self, 'train_times')
 
     def __repr__(self):
         s = ''
@@ -1051,9 +1053,11 @@ class TimeDecoding(GeneralizationAcrossTime):
         return "<TimeDecoding | %s>" % s
 
     def fit(self, epochs, y=None):
+        self.train_times = self.times
         super(TimeDecoding, self).fit(epochs, y=y)
         self.times_ = self.train_times_
         delattr(self, 'train_times_')
+        delattr(self, 'train_times')
         return self
 
     def predict(self, epochs):
@@ -1078,6 +1082,7 @@ class TimeDecoding(GeneralizationAcrossTime):
         self.test_times_ = dict(slices=[[s] for s in self.times_['slices']])
         self.y_pred_ = [[y_pred] for y_pred in self.y_pred_]
         super(TimeDecoding, self).score(epochs=None, y=y)
+        self.y_pred_ = [y_pred[0] for y_pred in self.y_pred_]
         self.scores_ = [score[0] for score in self.scores_]
         delattr(self, 'test_times_')
         return self.scores_
@@ -1138,12 +1143,12 @@ class TimeDecoding(GeneralizationAcrossTime):
         self.y_pred_ = [y_pred[0] for y_pred in self.y_pred_]
         return fig
 
-    def plot_times():
+    def plot_times(self):
         # XXX JRK: This is pretty ugly, we'd need to re organize the classes
         # in heritances.
         raise RuntimeError('plot_times() isn\'t adequate for TimeDecoding')
 
-    def plot_diagonal():
+    def plot_diagonal(self):
         # XXX JRK: This is pretty ugly, we'd need to re organize the classes
         # in heritances.
         raise RuntimeError('plot_diagonal() isn\'t adequate for TimeDecoding')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1061,7 +1061,7 @@ class TimeDecoding(GeneralizationAcrossTime):
         return self
 
     def predict(self, epochs):
-        # unsqueeze testing time
+        # unsqueeze across testing times for compatibility with GAT
         self.estimators_ = [[clf] for clf in self.estimators_]
         self.y_pred_ = super(TimeDecoding, self).predict(epochs)
         # squeeze testing times
@@ -1069,6 +1069,19 @@ class TimeDecoding(GeneralizationAcrossTime):
         self.estimators_ = [clf[0] for clf in self.estimators_]
         delattr(self, 'test_times_')
         return self.y_pred_
+
+    def score(self, epochs=None, y=None):
+        if epochs is not None:
+            self.predict(epochs)
+        else:
+            if not hasattr(self, 'y_pred_'):
+                raise RuntimeError('Please predict() epochs first or pass '
+                                   'epochs to score()')
+        # unsqueeze across testing times for compatibility with GAT
+        self.y_pred_ = [[y_pred] for y_pred in self.y_pred_]
+        self.scores_ = super(TimeDecoding, self).score(epochs=None, y=y)
+        self.scores_ = [score[0] for score in self.scores_]
+        return self.scores_
 
     def plot(self, **kwargs):
         """Plotting function of GeneralizationAcrossTime object

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -16,7 +16,7 @@ from ..parallel import parallel_func, check_n_jobs
 class _DecodingTime(dict):
     """A dictionary to configure the training times that has the following keys:
 
-    'slices' : np.ndarray, shape (n_clfs,)
+    'slices' : ndarray, shape (n_clfs,)
         Array of time slices (in indices) used for each classifier.
         If not given, computed from 'start', 'stop', 'length', 'step'.
     'start' : float
@@ -262,7 +262,7 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
 
     Parameters
     ----------
-    X : np.ndarray, shape (n_epochs, n_features, n_times)
+    X : ndarray, shape (n_epochs, n_features, n_times)
         To-be-fitted data.
     estimators : arraylike, shape (n_times, n_folds)
         Array of Sklearn classifiers fitted in cross-validation.
@@ -338,7 +338,7 @@ def _check_epochs_input(epochs, y, picks=None):
     ----------
     epochs : instance of Epochs
             The epochs.
-    y : np.ndarray shape (n_epochs) | list shape (n_epochs) | None
+    y : ndarray shape (n_epochs) | list shape (n_epochs) | None
         To-be-fitted model. If y is None, y == epochs.events.
     picks : array-like of int | None
         The channels indices to include. If None the data
@@ -346,9 +346,9 @@ def _check_epochs_input(epochs, y, picks=None):
 
     Returns
     -------
-    X : np.ndarray, shape (n_epochs, n_selected_chans, n_times)
+    X : ndarray, shape (n_epochs, n_selected_chans, n_times)
         To-be-fitted data.
-    y : np.ndarray, shape (n_epochs,)
+    y : ndarray, shape (n_epochs,)
         To-be-fitted model.
     picks : array-like of int | None
         The channels indices to include. If None the data
@@ -387,7 +387,7 @@ def _fit_slices(clf, x_chunk, y, slices, cv):
     ----------
     clf : scikit-learn classifier
         The classifier object.
-    x_chunk : np.ndarray, shape (n_epochs, n_features, n_times)
+    x_chunk : ndarray, shape (n_epochs, n_features, n_times)
         To-be-fitted data.
     y : list | array, shape (n_epochs,)
         To-be-fitted model.
@@ -438,7 +438,7 @@ def _sliding_window(times, window_params):
 
     Parameters
     ----------
-    times : np.ndarray, shape (n_times,)
+    times : ndarray, shape (n_times,)
         Array of times from MNE epochs.
     window_params : dict keys: ('start', 'stop', 'step', 'length')
         Either train or test times. See GAT documentation.
@@ -503,13 +503,13 @@ def _predict(X, estimators):
 
     Parameters
     ----------
-    estimators : np.ndarray, shape (n_folds,) | shape (1,)
+    estimators : ndarray, shape (n_folds,) | shape (1,)
         Array of scikit-learn classifiers to predict data.
-    X : np.ndarray, shape (n_epochs, n_features, n_times)
+    X : ndarray, shape (n_epochs, n_features, n_times)
         To-be-predicted data
     Returns
     -------
-    y_pred : np.ndarray, shape (n_epochs, m_prediction_dimensions)
+    y_pred : ndarray, shape (n_epochs, m_prediction_dimensions)
         Classifier's prediction for each trial.
     """
     from scipy import stats
@@ -568,7 +568,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     train_times : dict | None
         A dictionary to configure the training times:
 
-            ``slices`` : np.ndarray, shape (n_clfs,)
+            ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
             ``start`` : float
@@ -592,7 +592,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         If set to None, predictions are made at all time points.
         If set to dict, the dict should contain ``slices`` or be contructed in
         a similar way to train_times
-            ``slices`` : np.ndarray, shape (n_clfs,)
+            ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
 
@@ -620,23 +620,23 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         The channels indices to include.
     ch_names : list, shape (n_channels,)
         Names of the channels used for training.
-    y_train_ : list | np.ndarray, shape (n_samples,)
+    y_train_ : list | ndarray, shape (n_samples,)
         The categories used for training.
     train_times_ : dict
         A dictionary that configures the training times:
 
-            ``slices`` : np.ndarray, shape (n_clfs,)
+            ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
-            ``times`` : np.ndarray, shape (n_clfs,)
+            ``times`` : ndarray, shape (n_clfs,)
                 The training times (in seconds).
 
     test_times_ : dict
         A dictionary that configures the testing times for each training time:
 
-            ``slices`` : np.ndarray, shape (n_clfs, n_testing_times)
+            ``slices`` : ndarray, shape (n_clfs, n_testing_times)
                 Array of time slices (in indices) used for each classifier.
-            ``times`` : np.ndarray, shape (n_clfs, n_testing_times)
+            ``times`` : ndarray, shape (n_clfs, n_testing_times)
                 The testing times (in seconds) for each training time.
 
     cv_ : CrossValidation object
@@ -649,7 +649,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         training time and each testing time. Note that the number of testing
         times per training time need not be regular, else
         np.shape(y_pred_) = [n_train_time, n_test_time, n_epochs].
-    y_true_ : list | np.ndarray, shape (n_samples,)
+    y_true_ : list | ndarray, shape (n_samples,)
         The categories used for scoring y_pred_.
     scorer_ : object
         scikit-learn Scorer instance.
@@ -669,8 +669,6 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         detection of unexpected sounds", PLoS ONE, 2014
         DOI: 10.1371/journal.pone.0085791
 
-
-    .. versionadded:: 0.9.0
     """
     def __init__(self, picks=None, cv=5, clf=None, train_times=None,
                  test_times=None, predict_mode='cross-validation', scorer=None,
@@ -714,7 +712,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         ----------
         epochs : instance of Epochs
             The epochs.
-        y : list or np.ndarray of int, shape (n_samples,) or None, optional
+        y : list or ndarray of int, shape (n_samples,) or None, optional
             To-be-fitted model values. If None, y = epochs.events[:, 2].
 
         Returns
@@ -772,7 +770,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             The epochs. Can be similar to fitted epochs or not.
             If None, it needs to rely on the predictions ``y_pred_``
             generated with ``predict()``.
-        y : list | np.ndarray, shape (n_epochs,) | None, optional
+        y : list | ndarray, shape (n_epochs,) | None, optional
             True values to be compared with the predictions ``y_pred_``
             generated with ``predict()`` via ``scorer_``.
             If None and ``predict_mode``=='cross-validation' y = ``y_train_``.
@@ -802,7 +800,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             Min color value for scores. If None, sets to min(gat.scores_).
         vmax : float | None
             Max color value for scores. If None, sets to max(gat.scores_).
-        tlim : np.ndarray, (train_min, test_max) | None
+        tlim : ndarray, (train_min, test_max) | None
             The temporal boundaries.
         ax : object | None
             Plot pointer. If None, generate new figure.
@@ -955,7 +953,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
     times : dict | None
         A dictionary to configure the training times:
 
-            ``slices`` : np.ndarray, shape (n_clfs,)
+            ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
             ``start`` : float
@@ -993,23 +991,23 @@ class TimeDecoding(_GeneralizationAcrossTime):
         The channels indices to include.
     ch_names : list, shape (n_channels,)
         Names of the channels used for training.
-    y_train_ : np.ndarray, shape (n_samples,)
+    y_train_ : ndarray, shape (n_samples,)
         The categories used for training.
     times_ : dict
         A dictionary that configures the training times:
 
-            ``slices`` : np.ndarray, shape (n_clfs,)
+            ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
-            ``times`` : np.ndarray, shape (n_clfs,)
+            ``times`` : ndarray, shape (n_clfs,)
                 The training times (in seconds).
     cv_ : CrossValidation object
         The actual CrossValidation input depending on y.
     estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
         The estimators for each time point and each fold.
-    y_pred_ : np.ndarray, shape (n_times, n_epochs, n_prediction_dims)
+    y_pred_ : ndarray, shape (n_times, n_epochs, n_prediction_dims)
         Class labels for samples in X.
-    y_true_ : list | np.ndarray, shape (n_samples,)
+    y_true_ : list | ndarray, shape (n_samples,)
         The categories used for scoring y_pred_.
     scorer_ : object
         scikit-learn Scorer instance.
@@ -1064,7 +1062,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
         ----------
         epochs : instance of Epochs
             The epochs.
-        y : list or np.ndarray of int, shape (n_samples,) or None, optional
+        y : list or ndarray of int, shape (n_samples,) or None, optional
             To-be-fitted model values. If None, y = epochs.events[:, 2].
 
         Returns
@@ -1125,7 +1123,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
             The epochs. Can be similar to fitted epochs or not.
             If None, it needs to rely on the predictions ``y_pred_``
             generated with ``predict()``.
-        y : list | np.ndarray, shape (n_epochs,) | None, optional
+        y : list | ndarray, shape (n_epochs,) | None, optional
             True values to be compared with the predictions ``y_pred_``
             generated with ``predict()`` via ``scorer_``.
             If None and ``predict_mode``=='cross-validation' y = ``y_train_``.

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1057,10 +1057,18 @@ class TimeDecoding(GeneralizationAcrossTime):
         # squeeze testing times
         self.estimators_ = [clf[0] for clf in self.estimators_]
         self.times_ = self.train_times_
-        delattr(self, 'test_times_')
         delattr(self, 'train_times_')
         return self
 
+    def predict(self, epochs):
+        # unsqueeze testing time
+        self.estimators_ = [[clf] for clf in self.estimators_]
+        self.y_pred_ = super(TimeDecoding, self).predict(epochs)
+        # squeeze testing times
+        self.y_pred_ = [y[0] for y in self.y_pred_]
+        self.estimators_ = [clf[0] for clf in self.estimators_]
+        delattr(self, 'test_times_')
+        return self.y_pred_
 
     def plot(self, **kwargs):
         """Plotting function of GeneralizationAcrossTime object

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -33,7 +33,6 @@ class _DecodingTime(dict):
     If None, empty dict. """
 
     def __repr__(self):
-        """Human readable representation"""
         s = ""
         if "start" in self:
             s += "start: %0.3f (s)" % (self["start"])
@@ -748,7 +747,6 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             n_jobs=n_jobs)
 
     def __repr__(self):
-        """Human readable representation"""
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (
@@ -1018,7 +1016,6 @@ class TimeDecoding(_GeneralizationAcrossTime):
         self._clean_times()
 
     def __repr__(self):
-        """Human readable representation"""
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1198,6 +1198,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
                                           self.train_times_['slices']]
             self.test_times_['times'] = [[tim] for tim in
                                          self.train_times_['times']]
+        if hasattr(self, 'scores_'):
+            self.scores_ = [[score] for score in self.scores_]
         if hasattr(self, 'y_pred_'):
             self.y_pred_ = [[y_pred] for y_pred in self.y_pred_]
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -544,23 +544,6 @@ def _predict(X, estimators):
     return y_pred
 
 
-def _time_gen_one_fold(clf, X, y, train, test, scoring):
-    """Aux function of time_generalization"""
-    from sklearn.metrics import SCORERS
-    n_times = X.shape[2]
-    scores = np.zeros((n_times, n_times))
-    scorer = SCORERS[scoring]
-
-    for t_train in range(n_times):
-        X_train = X[train, :, t_train]
-        clf.fit(X_train, y[train])
-        for t_test in range(n_times):
-            X_test = X[test, :, t_test]
-            scores[t_test, t_train] += scorer(clf, X_test, y[test])
-
-    return scores
-
-
 class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     """Generalize across time and conditions
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1034,7 +1034,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (
-                self.train_times_['start'], self.train_times_['stop'])
+                self.times_['start'], self.times_['stop'])
         else:
             s += 'no fit'
         if hasattr(self, 'y_pred_'):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1056,51 +1056,11 @@ class TimeDecoding(GeneralizationAcrossTime):
         super(TimeDecoding, self).fit(epochs, y=y)
         # squeeze testing times
         self.estimators_ = [clf[0] for clf in self.estimators_]
+        self.times_ = self.train_times_
+        delattr(self, 'test_times_')
+        delattr(self, 'train_times_')
         return self
 
-    def predict(self, X, test_times='diagonal', **kwargs):
-        """ Test each classifier at each time point.
-
-        Note. This function sets and updates the ``y_pred_`` and the
-        ``test_times`` attribute.
-
-        Parameters
-        ----------
-        epochs : instance of Epochs
-            The epochs. Can be similar to fitted epochs or not. See independent
-            parameter.
-        test_times : str | dict | None
-            A dict to configure the testing times.
-            If test_times = 'diagonal', test_times = train_times: decode at
-            each time point but does not generalize.
-
-            'slices' : np.ndarray, shape (n_clfs,)
-                Array of time slices (in indices) used for each classifier.
-                If not given, computed from 'start', 'stop', 'length', 'step'.
-            'start' : float
-                Time at which to start decoding (in seconds). By default,
-                min(epochs.times).
-            'stop' : float
-                Maximal time at which to stop decoding (in seconds). By
-                default, max(times).
-            'step' : float
-                Duration separating the start of to subsequent classifiers (in
-                seconds). By default, equals one time sample.
-            'length' : float
-                Duration of each classifier (in seconds). By default, equals
-                one time sample.
-
-            If None, empty dict. Defaults to None.
-        picks : np.ndarray (n_selected_chans,) | None
-            Channels to be included.
-
-        Returns
-        -------
-        y_pred_ : np.ndarray, shape (n_train_time, n_test_time, n_epochs,
-                               n_prediction_dim)
-            Class labels for samples in X.
-        """
-        super(TimeDecoding, self).predict(X, test_times, **kwargs)
 
     def plot(self, **kwargs):
         """Plotting function of GeneralizationAcrossTime object

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1083,7 +1083,9 @@ class TimeDecoding(GeneralizationAcrossTime):
         self.scores_ = [score[0] for score in self.scores_]
         return self.scores_
 
-    def plot(self, **kwargs):
+    def plot(self, title=None, xmin=None, xmax=None, ymin=None, ymax=None,
+             ax=None, show=True, color=None, xlabel=True, ylabel=True,
+             legend=True, chance=True, label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
         Predict each classifier. If multiple classifiers are passed, average
@@ -1121,103 +1123,9 @@ class TimeDecoding(GeneralizationAcrossTime):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        super(TimeDecoding, self).plot_diagonal(**kwargs)
-
-
-@deprecated("'time_generalization' will be removed"
-            " in MNE v0.10. Use 'GeneralizationAcrossTime' instead.")
-@verbose
-def time_generalization(epochs_list, clf=None, cv=5, scoring="roc_auc",
-                        shuffle=True, random_state=None, n_jobs=1,
-                        verbose=None):
-    """Fit decoder at each time instant and test at all others
-
-    The function returns the cross-validation scores when the train set
-    is from one time instant and the test from all others.
-
-    The decoding will be done using all available data channels, but
-    will only work if 1 type of channel is availalble. For example
-    epochs should contain only gradiometers.
-
-    Parameters
-    ----------
-    epochs_list : list of Epochs
-        The epochs in all the conditions.
-    clf : object | None
-        A object following scikit-learn estimator API (fit & predict).
-        If None the classifier will be a linear SVM (C=1.) after
-        feature standardization.
-    cv : integer or cross-validation generator
-        If an integer is passed, it is the number of folds (default 5).
-        Specific cross-validation objects can be passed, see
-        sklearn.cross_validation module for the list of possible objects.
-    scoring : {string, callable, None}, default: "roc_auc"
-        A string (see model evaluation documentation in scikit-learn) or
-        a scorer callable object / function with signature
-        ``scorer(y_true, y_pred)``.
-    shuffle : bool
-        If True, shuffle the epochs before splitting them in folds.
-    random_state : None | int
-        The random state used to shuffle the epochs. Ignored if
-        shuffle is False.
-    n_jobs : int
-        Number of jobs to run in parallel. Each fold is fit
-        in parallel.
-
-    Returns
-    -------
-    scores : np.ndarray, shape (n_times, n_times)
-        The scores averaged across folds. scores[i, j] contains
-        the generalization score when learning at time j and testing
-        at time i. The diagonal is the cross-validation score
-        at each time-independent instant.
-
-    Notes
-    -----
-    The function implements the method used in:
-
-    Jean-Remi King, Alexandre Gramfort, Aaron Schurger, Lionel Naccache
-    and Stanislas Dehaene, "Two distinct dynamic modes subtend the detection of
-    unexpected sounds", PLOS ONE, 2013
-    """
-    from sklearn.base import clone
-    from sklearn.utils import check_random_state
-    from sklearn.svm import SVC
-    from sklearn.pipeline import Pipeline
-    from sklearn.preprocessing import StandardScaler
-    from sklearn.cross_validation import check_cv
-
-    if clf is None:
-        scaler = StandardScaler()
-        svc = SVC(C=1, kernel='linear')
-        clf = Pipeline([('scaler', scaler), ('svc', svc)])
-
-    info = epochs_list[0].info
-    data_picks = pick_types(info, meg=True, eeg=True, exclude='bads')
-
-    # Make arrays X and y such that :
-    # X is 3d with X.shape[0] is the total number of epochs to classify
-    # y is filled with integers coding for the class to predict
-    # We must have X.shape[0] equal to y.shape[0]
-    X = [e.get_data()[:, data_picks, :] for e in epochs_list]
-    y = [k * np.ones(len(this_X)) for k, this_X in enumerate(X)]
-    X = np.concatenate(X)
-    y = np.concatenate(y)
-
-    cv = check_cv(cv, X, y, classifier=True)
-
-    ch_types = set(channel_type(info, idx) for idx in data_picks)
-    logger.info('Running time generalization on %s epochs using %s.' %
-                (len(X), ' and '.join(ch_types)))
-
-    if shuffle:
-        rng = check_random_state(random_state)
-        order = np.argsort(rng.randn(len(X)))
-        X = X[order]
-        y = y[order]
-
-    parallel, p_time_gen, _ = parallel_func(_time_gen_one_fold, n_jobs)
-    scores = parallel(p_time_gen(clone(clf), X, y, train, test, scoring)
-                      for train, test in cv)
-    scores = np.mean(scores, axis=0)
-    return scores
+        super(TimeDecoding, self).plot_diagonal(title=title, xmin=xmin,
+                                                xmax=xmax, ymin=ymin,
+                                                ymax=ymax, ax=ax, show=show,
+                                                color=color, xlabel=xlabel,
+                                                ylabel=ylabel, legend=legend,
+                                                chance=chance, label=label)


### PR DESCRIPTION
This creates a TimeDecoding class that deals with the specific case of diagonal decoding in the GAT analyses.

Also see https://github.com/mne-tools/mne-python/pull/2058