### PR TITLE
MRG: GAT small fixes

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -161,7 +161,8 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(train_times={'start': 0.090,
                                                 'stop': 0.250})
     # predict without fit
-    assert_raises(RuntimeError, gat.predict, epochs)
+    gat.predict(epochs)
+    gat.score(epochs)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
     gat.score(epochs)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -84,13 +84,13 @@ def test_generalization_across_time():
     assert_equal(gat.ch_names, epochs.ch_names)
     gat.predict(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predicted 15 epochs, no score>",
+                 "predicted 14 epochs, no score>",
                  "%s" % gat)
     gat.score(epochs)
     gat.score(epochs, y=epochs.events[:, 2])
     gat.score(epochs, y=epochs.events[:, 2].tolist())
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predicted 15 epochs,\n scored "
+                 "predicted 14 epochs,\n scored "
                  "(accuracy_score)>", "%s" % gat)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs, y=epochs.events[:, 2])

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -72,6 +72,8 @@ def test_generalization_across_time():
     assert_equal("<GAT | no fit, no prediction, no score>", "%s" % gat)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
+        gat.fit(epochs, y=epochs.events[:, 2])
+        gat.fit(epochs, y=epochs.events[:, 2].tolist())
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)
@@ -80,6 +82,8 @@ def test_generalization_across_time():
                  "predicted 15 epochs, no score>",
                  "%s" % gat)
     gat.score(epochs)
+    gat.score(epochs, y=epochs.events[:, 2])
+    gat.score(epochs, y=epochs.events[:, 2].tolist())
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
                  "predicted 15 epochs,\n scored "
                  "(accuracy_score)>", "%s" % gat)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -70,10 +70,15 @@ def test_generalization_across_time():
     # Test default running
     gat = GeneralizationAcrossTime()
     assert_equal("<GAT | no fit, no prediction, no score>", "%s" % gat)
+    assert_raises(ValueError, gat.fit, epochs, picks='foo')
     with warnings.catch_warnings(record=True):
-        gat.fit(epochs)
+        # check classic fit + check manual picks
+        gat.fit(epochs, picks=[0])
+        # check optional y as array
         gat.fit(epochs, y=epochs.events[:, 2])
+        # check optional y as list
         gat.fit(epochs, y=epochs.events[:, 2].tolist())
+    assert_equal(len(gat.picks_), len(gat.ch_names), 1)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -74,6 +74,7 @@ def test_generalization_across_time():
         gat.fit(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
+    assert_equal(gat.ch_names, epochs.ch_names)
     gat.predict(epochs)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
                  "predicted 15 epochs, no score>",

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -4,6 +4,7 @@
 # License: BSD (3-clause)
 
 import warnings
+import copy
 import os.path as op
 
 from nose.tools import assert_equal, assert_true, assert_raises
@@ -115,7 +116,8 @@ def test_generalization_across_time():
     # the y-check
     gat.predict_mode = 'mean-prediction'
     epochs2.events[:, 2] += 10
-    assert_raises(ValueError, gat.score, epochs2)
+    gat_ = copy.deepcopy(gat)
+    assert_raises(ValueError, gat_.score, epochs2)
     gat.predict_mode = 'cross-validation'
 
     # Test basics

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -161,8 +161,7 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(train_times={'start': 0.090,
                                                 'stop': 0.250})
     # predict without fit
-    gat.predict(epochs)
-    gat.score(epochs)
+    assert_raises(RuntimeError, gat.predict, epochs)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
     gat.score(epochs)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 from ..io.pick import pick_types
-from ..viz.decoding import plot_gat_matrix, _plot_gat_times
+from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
 from ..utils import logger, verbose, deprecated
 
@@ -539,11 +539,11 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        return _plot_gat_times(self, train_time='diagonal', title=title,
-                               xmin=xmin, xmax=xmax,
-                               ymin=ymin, ymax=ymax, ax=ax, show=show,
-                               color=color, xlabel=xlabel, ylabel=ylabel,
-                               legend=legend, chance=chance, label=label)
+        return plot_gat_times(self, train_time='diagonal', title=title,
+                              xmin=xmin, xmax=xmax,
+                              ymin=ymin, ymax=ymax, ax=ax, show=show,
+                              color=color, xlabel=xlabel, ylabel=ylabel,
+                              legend=legend, chance=chance, label=label)
 
     def plot_times(self, train_time, title=None, xmin=None, xmax=None,
                    ymin=None, ymax=None, ax=None, show=True, color='steelblue',
@@ -551,11 +551,11 @@ class GeneralizationAcrossTime(object):
                    label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
-        Plot the scores of the classifier trained at specific \'train_time\'.
+        Plot the scores of the classifier trained at specific training time(s).
 
         Parameters
         ----------
-        train_time : float
+        train_time : float | list or array of float
             Plots scores of the classifier trained at train_time.
         title : str | None
             Figure title. Defaults to None.
@@ -572,8 +572,8 @@ class GeneralizationAcrossTime(object):
             Defaults to None.
         show : bool
             If True, the figure will be shown. Defaults to True.
-        color : str
-            Score line color. Defaults to 'steelblue'.
+        color : str or list of str
+            Score line color(s). Defaults to 'steelblue'.
         xlabel : bool
             If True, the xlabel is displayed. Defaults to True.
         ylabel : bool
@@ -591,11 +591,11 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        return _plot_gat_times(self, train_time=train_time, title=title,
-                               xmin=xmin, xmax=xmax,
-                               ymin=ymin, ymax=ymax, ax=ax, show=show,
-                               color=color, xlabel=xlabel, ylabel=ylabel,
-                               legend=legend, chance=chance, label=label)
+        return plot_gat_times(self, train_time=train_time, title=title,
+                              xmin=xmin, xmax=xmax,
+                              ymin=ymin, ymax=ymax, ax=ax, show=False,
+                              color=color[0], xlabel=xlabel, ylabel=ylabel,
+                              legend=legend, chance=chance, label=label)
 
 
 def _predict_time_loop(X, estimators, cv, slices, predict_mode):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -769,7 +769,7 @@ def _predict(X, estimators):
         _y_pred = clf.predict(X)
         # initialize predict_results array
         if fold == 0:
-            predict_size = _y_pred.shape[1] if _y_pred.n_dim > 1 else 1
+            predict_size = _y_pred.shape[1] if _y_pred.ndim > 1 else 1
             y_pred = np.ones((n_epochs, predict_size, n_clf))
         if predict_size == 1:
             y_pred[:, 0, fold] = _y_pred

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -172,7 +172,7 @@ class GeneralizationAcrossTime(object):
         else:
             s += 'no fit'
         if hasattr(self, 'y_pred_'):
-            s += (", predicted %d epochs" % len(self.y_pred_))
+            s += (", predicted %d epochs" % len(self.y_pred_[0][0]))
         else:
             s += ", no prediction"
         if hasattr(self, "estimators_") and hasattr(self, 'scores_'):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -147,7 +147,7 @@ class GeneralizationAcrossTime(object):
                  predict_mode='cross-validation', n_jobs=1):
 
         from sklearn.preprocessing import StandardScaler
-        from sklearn.linear_model import SGDClassifier
+        from sklearn.linear_model import LogisticRegression
         from sklearn.pipeline import Pipeline
 
         # Store parameters in object
@@ -159,8 +159,8 @@ class GeneralizationAcrossTime(object):
         # Default classification pipeline
         if clf is None:
             scaler = StandardScaler()
-            svc = SGDClassifier()
-            clf = Pipeline([('scaler', scaler), ('svc', svc)])
+            estimator = LogisticRegression()
+            clf = Pipeline([('scaler', scaler), ('estimator', estimator)])
         self.clf = clf
         self.predict_mode = predict_mode
         self.n_jobs = n_jobs

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -978,8 +978,8 @@ def time_generalization(epochs_list, clf=None, cv=5, scoring="roc_auc",
     cv = check_cv(cv, X, y, classifier=True)
 
     ch_types = set(channel_type(info, idx) for idx in data_picks)
-    logger.info('Running time generalization on %s epochs using %s.' % (
-        len(X), ' and '.join(ch_types)))
+    logger.info('Running time generalization on %s epochs using %s.'
+                % (len(X), ' and '.join(ch_types)))
 
     if shuffle:
         rng = check_random_state(random_state)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -113,6 +113,8 @@ class GeneralizationAcrossTime(object):
 
     Attributes
     ----------
+    scorer_ : object
+        scikit-learn Scorer instance. Default: accuracy_score
     y_train_ : list | np.ndarray, shape (n_samples,)
         The categories used for training.
     estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
@@ -120,9 +122,10 @@ class GeneralizationAcrossTime(object):
     y_pred_ : np.ndarray, shape (n_train_times, n_test_times, n_epochs, n_prediction_dims)
         Class labels for samples in X.
     scores_ : list of lists of float
-        The scores (mean accuracy of self.predict(X) wrt. y.).
-        It's not an array as the testing times per training time
-        need not be regular.
+        The scores estimated by self.scorer_ at each training time and each
+        testing time (e.g. mean accuracy of self.predict(X)). Note that the
+        number of testing times per training time need not be regular;
+        else, np.shape(scores) = [n_train_time, n_test_time].
     test_times_ : dict
         The same structure as ``train_times``.
     cv_ : CrossValidation object
@@ -395,9 +398,10 @@ class GeneralizationAcrossTime(object):
         Returns
         -------
         scores : list of lists of float
-            The scores (mean accuracy of self.predict(X) wrt. y.).
-            It's not an array as the testing times per training time
-            need not be regular.
+            The scores estimated by self.scorer_ at each training time and each
+            testing time (e.g. mean accuracy of self.predict(X)). Note that the
+            number of testing times per training time need not be regular;
+            else, np.shape(scores) = [n_train_time, n_test_time].
         """
 
         from sklearn.metrics import accuracy_score

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -464,7 +464,7 @@ class GeneralizationAcrossTime(object):
                 raise ValueError('Classes (y) passed differ from classes used '
                                  'for training. Please explicitly pass your y '
                                  'for scoring.')
-        elif type(y) is list:
+        elif isinstance(y, list):
             y = np.array(y)
         self.y_true_ = y  # true regressor to be compared with y_pred
 
@@ -619,12 +619,11 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        if (type(train_time) not in [float, np.float32, np.float64] and
-            (type(train_time) not in [list, np.ndarray] or
-             np.any([type(time) not in [float, np.float32, np.float64]
-                    for time in train_time]))):
+        if (not isinstance(train_time, float) and
+            not (isinstance(train_time, (list, np.ndarray)) and
+                 np.all([isinstance(time, float) for time in train_time]))):
             raise ValueError('train_time must be float | list or array of '
-                             'floats.')
+                             'floats. Got %s.' % type(train_time))
 
         return plot_gat_times(self, train_time=train_time, title=title,
                               xmin=xmin, xmax=xmax,
@@ -734,7 +733,7 @@ def _check_epochs_input(epochs, y, picks=None):
     """
     if y is None:
         y = epochs.events[:, 2]
-    elif type(y) is list:
+    elif isinstance(y, list):
         y = np.array(y)
 
     # Convert MNE data into trials x features x time matrix
@@ -745,9 +744,8 @@ def _check_epochs_input(epochs, y, picks=None):
         picks = pick_types(epochs.info, meg=True, eeg=True, seeg=True,
                            eog=False, ecg=False, misc=False, stim=False,
                            ref_meg=False, exclude='bads')
-    if (type(picks) in [list, np.ndarray]) and \
-       (np.all([type(idx) in [int, np.int64, np.int32] for idx in picks])):
-            picks = np.array(picks)
+    if isinstance(picks, (list, np.ndarray)):
+        picks = np.array(picks, dtype=np.int)
     else:
         raise ValueError('picks must be a list or a numpy.ndarray of int')
     X = X[:, picks, :]

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -269,11 +269,12 @@ class GeneralizationAcrossTime(object):
         epochs : instance of Epochs
             The epochs. Can be similar to fitted epochs or not. See
             predict_mode parameter.
-        test_times : str | dict | None
-            A dict to configure the testing times.
-            If test_times = 'diagonal', test_times = train_times: decode at
-            each time point but does not generalize.
-
+        test_times : 'diagonal' | dict | None
+            Configures the testing times.
+            If set to 'diagonal', predictions are made at the time at which.
+                each classifier is trained.
+            If set to None, predictions are made at all time points.
+            If set to dict, the dict should contain:
             'slices' : np.ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
@@ -289,8 +290,7 @@ class GeneralizationAcrossTime(object):
             'length' : float
                 Duration of each classifier (in seconds).
                 Defaults to one time sample.
-
-            If None, empty dict. Defaults to None.
+            Defaults to None.
 
         Returns
         -------
@@ -369,11 +369,12 @@ class GeneralizationAcrossTime(object):
             Defaults to None.
         scorer : object
             scikit-learn Scorer instance. Default: accuracy_score
-        test_times : str | dict | None
-            if test_times = 'diagonal', test_times = train_times: decode at
-            each time point but does not generalize. If dict, the following
-            structure is expected:
-
+        test_times : 'diagonal' | dict | None
+            Configures the testing times.
+            If set to 'diagonal', predictions are made at the time at which.
+                each classifier is trained.
+            If set to None, predictions are made at all time points.
+            If set to dict, the dict should contain:
             'slices' : np.ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
@@ -389,8 +390,7 @@ class GeneralizationAcrossTime(object):
             'length' : float
                 Duration of each classifier (in seconds).
                 Defaults to one time sample.
-
-            If None, empty dict. Defaults to None.
+            Defaults to None.
 
         Returns
         -------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -267,8 +267,8 @@ class GeneralizationAcrossTime(object):
         Parameters
         ----------
         epochs : instance of Epochs
-            The epochs. Can be similar to fitted epochs or not. See independent
-            parameter.
+            The epochs. Can be similar to fitted epochs or not. See
+            predict_mode parameter.
         test_times : str | dict | None
             A dict to configure the testing times.
             If test_times = 'diagonal', test_times = train_times: decode at
@@ -361,8 +361,8 @@ class GeneralizationAcrossTime(object):
         Parameters
         ----------
         epochs : instance of Epochs | None
-            The epochs. Can be similar to fitted epochs or not. See independent
-            parameter.
+            The epochs. Can be similar to fitted epochs or not. See
+            predict_mode parameter.
             If None, it relies on the ``y_pred_`` generated from predit()
         y : list | np.ndarray, shape (n_epochs,) | None
             To-be-fitted model, If None, y = epochs.events[:,2].

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -221,8 +221,8 @@ class GeneralizationAcrossTime(object):
         # Extract data from MNE structure
         X, y, picks = _check_epochs_input(epochs, y, picks)
         self.picks_ = picks
-        self.ch_names = [ch for idx, ch in enumerate(epochs.ch_names)
-                         if idx in picks]
+        self.ch_names = [epochs.ch_names[p] for p in picks]
+
         cv = self.cv
         if isinstance(cv, (int, np.int)):
             cv = StratifiedKFold(y, cv)
@@ -490,9 +490,9 @@ class GeneralizationAcrossTime(object):
                                tlim=tlim, ax=ax, cmap=cmap, show=show,
                                colorbar=colorbar, xlabel=xlabel, ylabel=ylabel)
 
-    def plot_diagonal(self, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
-                      ax=None, show=True, color='steelblue', xlabel=True,
-                      ylabel=True, legend=True, chance=True,
+    def plot_diagonal(self, title=None, xmin=None, xmax=None, ymin=None,
+                      ymax=None, ax=None, show=True, color='steelblue',
+                      xlabel=True, ylabel=True, legend=True, chance=True,
                       label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
@@ -507,10 +507,10 @@ class GeneralizationAcrossTime(object):
             Min time value. Defaults to None.
         xmax : float | None, optional
             Max time value. Defaults to None.
-        ymin : float
-            Min score value. Defaults to 0.
-        ymax : float
-            Max score value. Defaults to 1.
+        ymin : float | None, optional
+            Min score value. If None, sets to min(scores). Defaults to None.
+        ymax : float | None, optional
+            Max score value. If None, sets to max(scores). Defaults to None.
         ax : object | None
             Instance of mataplotlib.axes.Axis. If None, generate new figure.
             Defaults to None.
@@ -539,11 +539,11 @@ class GeneralizationAcrossTime(object):
                               xmin=xmin, xmax=xmax,
                               ymin=ymin, ymax=ymax, ax=ax, show=show,
                               color=color, xlabel=xlabel, ylabel=ylabel,
-                              legend=legend, chance=chance)
+                              legend=legend, chance=chance, label=label)
 
-    def plot_slice(self, train_time, title=None, xmin=None, xmax=None, ymin=0.,
-                   ymax=1., ax=None, show=True, color='steelblue', xlabel=True,
-                   ylabel=True, legend=True, chance=True,
+    def plot_slice(self, train_time, title=None, xmin=None, xmax=None,
+                   ymin=None, ymax=None, ax=None, show=True, color='steelblue',
+                   xlabel=True, ylabel=True, legend=True, chance=True,
                    label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
@@ -559,10 +559,10 @@ class GeneralizationAcrossTime(object):
             Min time value. Defaults to None.
         xmax : float | None, optional
             Max time value. Defaults to None.
-        ymin : float
-            Min score value. Defaults to 0.
-        ymax : float
-            Max score value. Defaults to 1.
+        ymin : float | None, optional
+            Min score value. If None, sets to min(scores). Defaults to None.
+        ymax : float | None, optional
+            Max score value. If None, sets to max(scores). Defaults to None.
         ax : object | None
             Instance of mataplotlib.axes.Axis. If None, generate new figure.
             Defaults to None.
@@ -591,7 +591,7 @@ class GeneralizationAcrossTime(object):
                               xmin=xmin, xmax=xmax,
                               ymin=ymin, ymax=ymax, ax=ax, show=show,
                               color=color, xlabel=xlabel, ylabel=ylabel,
-                              legend=legend, chance=chance)
+                              legend=legend, chance=chance, label=label)
 
 
 def _predict_time_loop(X, estimators, cv, slices, predict_mode):
@@ -710,7 +710,7 @@ def _check_epochs_input(epochs, y, picks=None):
             picks = np.array(picks)
     else:
         raise ValueError('picks must be a list or a numpy.ndarray of int')
-    X = X[:, picks.tolist(), :]
+    X = X[:, picks, :]
 
     # Check data sets
     assert X.shape[0] == y.shape[0]

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -603,6 +603,13 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
+        if (type(train_time) not in [float, np.float32, np.float64] and
+            (type(train_time) not in [list, np.ndarray] or
+             np.any([type(time) not in [float, np.float32, np.float64]
+                    for time in train_time]))):
+            raise ValueError('train_time must be float | list or array of '
+                             'floats.')
+
         return plot_gat_times(self, train_time=train_time, title=title,
                               xmin=xmin, xmax=xmax,
                               ymin=ymin, ymax=ymax, ax=ax, show=show,

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -127,6 +127,8 @@ class GeneralizationAcrossTime(object):
         The same structure as ``train_times``.
     cv_ : CrossValidation object
         The actual CrossValidation input depending on y.
+    ch_names : np.array, shape (n_channels)
+        Names of the channels used for training.
 
     Notes
     -----
@@ -212,6 +214,7 @@ class GeneralizationAcrossTime(object):
         from sklearn.cross_validation import check_cv, StratifiedKFold
         n_jobs = self.n_jobs
         # Extract data from MNE structure
+        self.ch_names = epochs.ch_names
         X, y = _check_epochs_input(epochs, y)
         cv = self.cv
         if isinstance(cv, (int, np.int)):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -428,7 +428,7 @@ class GeneralizationAcrossTime(object):
 
         # Check scorer
         if scorer is None:
-            # XXX Need API to identify propper scorer from the clf
+            # XXX Need API to identify proper scorer from the clf
             scorer = accuracy_score
         self.scorer_ = scorer
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -729,7 +729,8 @@ def _check_epochs_input(epochs, y, picks=None):
         To-be-fitted data.
     y : np.ndarray, shape (n_epochs,)
         To-be-fitted model.
-    picks : np.ndarray, shape (n_selected_chans)
+    picks : np.ndarray, shape (n_selected_chans,)
+        The channels to be used.
     """
     if y is None:
         y = epochs.events[:, 2]

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -449,7 +449,7 @@ class GeneralizationAcrossTime(object):
         self.scores_ = scores
         return scores
 
-    def plot(self, title=None, vmin=0., vmax=1., tlim=None, ax=None,
+    def plot(self, title=None, vmin=None, vmax=None, tlim=None, ax=None,
              cmap='RdBu_r', show=True, colorbar=True,
              xlabel=True, ylabel=True):
         """Plotting function of GeneralizationAcrossTime object
@@ -460,10 +460,12 @@ class GeneralizationAcrossTime(object):
         ----------
         title : str | None
             Figure title. Defaults to None.
-        vmin : float
-            Min color value for score. Defaults to 0..
-        vmax : float
-            Max color value for score. Defaults to 1.
+        vmin : float | None
+            Min color value for scores. If None, sets to min(gat.scores_).
+            Defaults to None.
+        vmax : float | None
+            Max color value for scores. If None, sets to max(gat.scores_).
+            Defaults to None.
         tlim : np.ndarray, (train_min, test_max) | None
             The temporal boundaries. Defaults to None.
         ax : object | None

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 from ..io.pick import pick_types
-from ..viz.decoding import plot_gat_matrix, plot_gat_slice
+from ..viz.decoding import plot_gat_matrix, _plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
 from ..utils import logger, verbose, deprecated
 
@@ -539,19 +539,19 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        return plot_gat_slice(self, train_time='diagonal', title=title,
-                              xmin=xmin, xmax=xmax,
-                              ymin=ymin, ymax=ymax, ax=ax, show=show,
-                              color=color, xlabel=xlabel, ylabel=ylabel,
-                              legend=legend, chance=chance, label=label)
+        return _plot_gat_times(self, train_time='diagonal', title=title,
+                               xmin=xmin, xmax=xmax,
+                               ymin=ymin, ymax=ymax, ax=ax, show=show,
+                               color=color, xlabel=xlabel, ylabel=ylabel,
+                               legend=legend, chance=chance, label=label)
 
-    def plot_slice(self, train_time, title=None, xmin=None, xmax=None,
+    def plot_times(self, train_time, title=None, xmin=None, xmax=None,
                    ymin=None, ymax=None, ax=None, show=True, color='steelblue',
                    xlabel=True, ylabel=True, legend=True, chance=True,
                    label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
-        Plot the scores of the classifier trained at \'train_time\'.
+        Plot the scores of the classifier trained at specific \'train_time\'.
 
         Parameters
         ----------
@@ -591,11 +591,11 @@ class GeneralizationAcrossTime(object):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        return plot_gat_slice(self, train_time=train_time, title=title,
-                              xmin=xmin, xmax=xmax,
-                              ymin=ymin, ymax=ymax, ax=ax, show=show,
-                              color=color, xlabel=xlabel, ylabel=ylabel,
-                              legend=legend, chance=chance, label=label)
+        return _plot_gat_times(self, train_time=train_time, title=title,
+                               xmin=xmin, xmax=xmax,
+                               ymin=ymin, ymax=ymax, ax=ax, show=show,
+                               color=color, xlabel=xlabel, ylabel=ylabel,
+                               legend=legend, chance=chance, label=label)
 
 
 def _predict_time_loop(X, estimators, cv, slices, predict_mode):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -130,9 +130,9 @@ class GeneralizationAcrossTime(object):
         The same structure as ``train_times``.
     cv_ : CrossValidation object
         The actual CrossValidation input depending on y.
-    picks_ : np.array, shape (n_channels)
+    picks_ : np.array, shape (n_channels,)
         Indices of the channels used for training.
-    ch_names : list, shape (n_channels)
+    ch_names : list, shape (n_channels,)
         Names of the channels used for training.
 
     Notes
@@ -280,8 +280,8 @@ class GeneralizationAcrossTime(object):
             predict_mode parameter.
         test_times : 'diagonal' | dict | None
             Configures the testing times.
-            If set to 'diagonal', predictions are made at the time at which.
-                each classifier is trained.
+            If set to 'diagonal', predictions are made at the time at which
+            each classifier is trained.
             If set to None, predictions are made at all time points.
             If set to dict, the dict should contain:
             'slices' : np.ndarray, shape (n_clfs,)
@@ -378,7 +378,7 @@ class GeneralizationAcrossTime(object):
         epochs : instance of Epochs | None
             The epochs. Can be similar to fitted epochs or not. See
             predict_mode parameter.
-            If None, it relies on the ``y_pred_`` generated from predit()
+            If None, it relies on the ``y_pred_`` generated from predict()
         y : list | np.ndarray, shape (n_epochs,) | None
             To-be-fitted model, If None, y = epochs.events[:,2].
             Defaults to None.
@@ -386,8 +386,8 @@ class GeneralizationAcrossTime(object):
             scikit-learn Scorer instance. Default: accuracy_score
         test_times : 'diagonal' | dict | None
             Configures the testing times.
-            If set to 'diagonal', predictions are made at the time at which.
-                each classifier is trained.
+            If set to 'diagonal', predictions are made at the time at which
+            each classifier is trained.
             If set to None, predictions are made at all time points.
             If set to dict, the dict should contain:
             'slices' : np.ndarray, shape (n_clfs,)
@@ -423,7 +423,7 @@ class GeneralizationAcrossTime(object):
             self.predict(epochs, test_times=test_times)
         else:
             if not hasattr(self, 'y_pred_'):
-                raise RuntimeError('Please predit() epochs first or pass '
+                raise RuntimeError('Please predict() epochs first or pass '
                                    'epochs to score()')
 
         # Check scorer

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -593,8 +593,8 @@ class GeneralizationAcrossTime(object):
         """
         return plot_gat_times(self, train_time=train_time, title=title,
                               xmin=xmin, xmax=xmax,
-                              ymin=ymin, ymax=ymax, ax=ax, show=False,
-                              color=color[0], xlabel=xlabel, ylabel=ylabel,
+                              ymin=ymin, ymax=ymax, ax=ax, show=show,
+                              color=color, xlabel=xlabel, ylabel=ylabel,
                               legend=legend, chance=chance, label=label)
 
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -220,6 +220,12 @@ class GeneralizationAcrossTime(object):
         """
         from sklearn.base import clone
         from sklearn.cross_validation import check_cv, StratifiedKFold
+
+        # clean in case gat.fit() is called at unexpected moments
+        for att in ['y_pred_', 'scores_', 'scorer_', 'test_times_', 'y_true_']:
+            if hasattr(self, att):
+                delattr(self, att)
+
         n_jobs = self.n_jobs
         # Extract data from MNE structure
         X, y, picks = _check_epochs_input(epochs, y, picks)
@@ -301,6 +307,12 @@ class GeneralizationAcrossTime(object):
                                n_prediction_dim)
             Class labels for samples in X.
         """
+
+        # clean in case gat.predict() is called at unexpected moments
+        for att in ['scores_', 'scorer_', 'y_true_']:
+            if hasattr(self, att):
+                delattr(self, att)
+
         n_jobs = self.n_jobs
 
         # Check that at least one classifier has been trained
@@ -406,12 +418,6 @@ class GeneralizationAcrossTime(object):
 
         from sklearn.metrics import accuracy_score
 
-        # Check scorer
-        if scorer is None:
-            # XXX Need API to identify propper scorer from the clf
-            scorer = accuracy_score
-        self.scorer_ = scorer
-
         # Run predictions if not already done
         if epochs is not None:
             self.predict(epochs, test_times=test_times)
@@ -419,6 +425,12 @@ class GeneralizationAcrossTime(object):
             if not hasattr(self, 'y_pred_'):
                 raise RuntimeError('Please predit() epochs first or pass '
                                    'epochs to score()')
+
+        # Check scorer
+        if scorer is None:
+            # XXX Need API to identify propper scorer from the clf
+            scorer = accuracy_score
+        self.scorer_ = scorer
 
         # If no regressor is passed, use default epochs events
         if y is None:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -5,6 +5,7 @@
 #
 # License: BSD (3-clause)
 
+import copy
 import numpy as np
 from ..viz.decoding import plot_gat_matrix, plot_gat_slice
 from ..parallel import parallel_func, check_n_jobs
@@ -18,17 +19,16 @@ class _DecodingTime(dict):
         Array of time slices (in indices) used for each classifier.
         If not given, computed from 'start', 'stop', 'length', 'step'.
     'start' : float
-        Time at which to start decoding (in seconds). By default,
-        min(epochs.times).
+        Time at which to start decoding (in seconds).
+        Defaults to min(epochs.times).
     'stop' : float
-        Maximal time at which to stop decoding (in seconds). By default,
-        max(times).
+        Maximal time at which to stop decoding (in seconds).
+        Defaults to max(times).
     'step' : float
         Duration separating the start of subsequent classifiers (in
-        seconds). By default, equals one time sample.
+        seconds). Defaults to one time sample.
     'length' : float
-        Duration of each classifier (in seconds). By default, equals one
-        time sample.
+        Duration of each classifier (in seconds). Defaults to one time sample.
     If None, empty dict. Defaults to None."""
 
     def __repr__(self):
@@ -83,17 +83,17 @@ class GeneralizationAcrossTime(object):
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
             ``start`` : float
-                Time at which to start decoding (in seconds). By default,
-                min(epochs.times).
+                Time at which to start decoding (in seconds).
+                Defaults to min(epochs.times).
             ``stop`` : float
-                Maximal time at which to stop decoding (in seconds). By
-                default, max(times).
+                Maximal time at which to stop decoding (in seconds).
+                Defaults to max(times).
             ``step`` : float
                 Duration separating the start of subsequent classifiers (in
-                seconds). By default, equals one time sample.
+                seconds). Defaults to one time sample.
             ``length`` : float
-                Duration of each classifier (in seconds). By default, equals
-                one time sample.
+                Duration of each classifier (in seconds).
+                Defaults to one time sample.
 
         If None, empty dict. Defaults to None.
     predict_mode : {'cross-validation', 'mean-prediction'}
@@ -214,7 +214,7 @@ class GeneralizationAcrossTime(object):
         from sklearn.cross_validation import check_cv, StratifiedKFold
         n_jobs = self.n_jobs
         # Extract data from MNE structure
-        self.ch_names = epochs.ch_names
+        self.ch_names = copy.deepcopy(epochs.ch_names)
         X, y = _check_epochs_input(epochs, y)
         cv = self.cv
         if isinstance(cv, (int, np.int)):
@@ -271,17 +271,17 @@ class GeneralizationAcrossTime(object):
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
             'start' : float
-                Time at which to start decoding (in seconds). By default,
-                min(epochs.times).
+                Time at which to start decoding (in seconds).
+                Defaults to min(epochs.times).
             'stop' : float
-                Maximal time at which to stop decoding (in seconds). By
-                default, max(times).
+                Maximal time at which to stop decoding (in seconds).
+                Defaults to max(times).
             'step' : float
                 Duration separating the start of to subsequent classifiers (in
-                seconds). By default, equals one time sample.
+                seconds). Defaults to one time sample.
             'length' : float
-                Duration of each classifier (in seconds). By default, equals
-                one time sample.
+                Duration of each classifier (in seconds).
+                Defaults to one time sample.
 
             If None, empty dict. Defaults to None.
 
@@ -371,17 +371,17 @@ class GeneralizationAcrossTime(object):
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
             'start' : float
-                Time at which to start decoding (in seconds). By default,
-                min(epochs.times).
+                Time at which to start decoding (in seconds).
+                Defaults to min(epochs.times).
             'stop' : float
-                Maximal time at which to stop decoding (in seconds). By
-                default, max(times).
+                Maximal time at which to stop decoding (in seconds).
+                Defaults to max(times).
             'step' : float
                 Duration separating the start of to subsequent classifiers (in
-                seconds). By default, equals one time sample.
+                seconds). Defaults to one time sample.
             'length' : float
-                Duration of each classifier (in seconds). By default, equals
-                one time sample.
+                Duration of each classifier (in seconds).
+                Defaults to one time sample.
 
             If None, empty dict. Defaults to None.
 
@@ -456,7 +456,7 @@ class GeneralizationAcrossTime(object):
         vmax : float
             Max color value for score. Defaults to 1.
         tlim : np.ndarray, (train_min, test_max) | None
-            The temporal boundaries. defaults to None.
+            The temporal boundaries. Defaults to None.
         ax : object | None
             Plot pointer. If None, generate new figure. Defaults to None.
         cmap : str | cmap object
@@ -491,10 +491,10 @@ class GeneralizationAcrossTime(object):
         ----------
         title : str | None
             Figure title. Defaults to None.
-        xmin : float | None, optional, defaults to None.
-            Min time value.
-        xmax : float | None, optional, defaults to None.
-            Max time value.
+        xmin : float | None, optional
+            Min time value. Defaults to None.
+        xmax : float | None, optional
+            Max time value. Defaults to None.
         ymin : float
             Min score value. Defaults to 0.
         ymax : float
@@ -525,7 +525,7 @@ class GeneralizationAcrossTime(object):
                               xmin=xmin, xmax=xmax,
                               ymin=ymin, ymax=ymax, ax=ax, show=show,
                               color=color, xlabel=xlabel, ylabel=ylabel,
-                              legend=legend)
+                              legend=legend, chance=chance)
 
     def plot_slice(self, train_time, title=None, xmin=None, xmax=None, ymin=0.,
                    ymax=1., ax=None, show=True, color='steelblue', xlabel=True,
@@ -537,13 +537,13 @@ class GeneralizationAcrossTime(object):
         Parameters
         ----------
         train_time : float
-            Plots plots scores of the classifier trained at train_time.
+            Plots scores of the classifier trained at train_time.
         title : str | None
             Figure title. Defaults to None.
-        xmin : float | None, optional, defaults to None.
-            Min time value.
-        xmax : float | None, optional, defaults to None.
-            Max time value.
+        xmin : float | None, optional
+            Min time value. Defaults to None.
+        xmax : float | None, optional
+            Max time value. Defaults to None.
         ymin : float
             Min score value. Defaults to 0.
         ymax : float
@@ -561,9 +561,9 @@ class GeneralizationAcrossTime(object):
             If True, the ylabel is displayed. Defaults to True.
         legend : bool
             If True, a legend is displayed. Defaults to True.
-        chance : bool | float. Defaults to None
+        chance : bool | float.
             Plot chance level. If True, chance level is estimated from the type
-            of scorer.
+            of scorer. Defaults to None.
 
         Returns
         -------
@@ -883,18 +883,19 @@ def time_generalization(epochs_list, clf=None, cv=5, scoring="roc_auc",
         If an integer is passed, it is the number of folds (default 5).
         Specific cross-validation objects can be passed, see
         sklearn.cross_validation module for the list of possible objects.
-    scoring : {string, callable, None}, default: "roc_auc"
+    scoring : {string, callable, None}
         A string (see model evaluation documentation in scikit-learn) or
         a scorer callable object / function with signature
-        ``scorer(y_true, y_pred)``.
+        ``scorer(y_true, y_pred)``. Defaults to "roc_auc".
     shuffle : bool
         If True, shuffle the epochs before splitting them in folds.
+        Defaults to True.
     random_state : None | int
         The random state used to shuffle the epochs. Ignored if
-        shuffle is False.
+        shuffle is False. Defaults to None.
     n_jobs : int
         Number of jobs to run in parallel. Each fold is fit
-        in parallel.
+        in parallel. Defaults to 1.
 
     Returns
     -------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -6,7 +6,7 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from ..viz.decoding import plot_gat_matrix, plot_gat_diagonal
+from ..viz.decoding import plot_gat_matrix, plot_gat_slice
 from ..parallel import parallel_func, check_n_jobs
 from ..utils import logger, verbose, deprecated
 
@@ -445,9 +445,7 @@ class GeneralizationAcrossTime(object):
              xlabel=True, ylabel=True):
         """Plotting function of GeneralizationAcrossTime object
 
-        Predict each classifier. If multiple classifiers are passed, average
-        prediction across all classifiers to result in a single prediction per
-        classifier.
+        Plot the score of each classifier at each tested time window.
 
         Parameters
         ----------
@@ -483,12 +481,11 @@ class GeneralizationAcrossTime(object):
 
     def plot_diagonal(self, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
                       ax=None, show=True, color='steelblue', xlabel=True,
-                      ylabel=True, legend=True):
+                      ylabel=True, legend=True, chance=True):
         """Plotting function of GeneralizationAcrossTime object
 
-        Predict each classifier. If multiple classifiers are passed, average
-        prediction across all classifiers to result in a single prediction per
-        classifier.
+        Plot each classifier score trained and tested at identical time
+        windows.
 
         Parameters
         ----------
@@ -515,16 +512,69 @@ class GeneralizationAcrossTime(object):
             If True, the ylabel is displayed. Defaults to True.
         legend : bool
             If True, a legend is displayed. Defaults to True.
+        chance : bool | float. Defaults to None
+            Plot chance level. If True, chance level is estimated from the type
+            of scorer.
 
         Returns
         -------
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        return plot_gat_diagonal(self, title=title, xmin=xmin, xmax=xmax,
-                                 ymin=ymin, ymax=ymax, ax=ax, show=show,
-                                 color=color, xlabel=xlabel, ylabel=ylabel,
-                                 legend=legend)
+        return plot_gat_slice(self, train_time='diagonal', title=title,
+                              xmin=xmin, xmax=xmax,
+                              ymin=ymin, ymax=ymax, ax=ax, show=show,
+                              color=color, xlabel=xlabel, ylabel=ylabel,
+                              legend=legend)
+
+    def plot_slice(self, train_time, title=None, xmin=None, xmax=None, ymin=0.,
+                   ymax=1., ax=None, show=True, color='steelblue', xlabel=True,
+                   ylabel=True, legend=True, chance=True):
+        """Plotting function of GeneralizationAcrossTime object
+
+        Plot the scores of the classifier trained at \'train_time\'.
+
+        Parameters
+        ----------
+        train_time : float
+            Plots plots scores of the classifier trained at train_time.
+        title : str | None
+            Figure title. Defaults to None.
+        xmin : float | None, optional, defaults to None.
+            Min time value.
+        xmax : float | None, optional, defaults to None.
+            Max time value.
+        ymin : float
+            Min score value. Defaults to 0.
+        ymax : float
+            Max score value. Defaults to 1.
+        ax : object | None
+            Instance of mataplotlib.axes.Axis. If None, generate new figure.
+            Defaults to None.
+        show : bool
+            If True, the figure will be shown. Defaults to True.
+        color : str
+            Score line color. Defaults to 'steelblue'.
+        xlabel : bool
+            If True, the xlabel is displayed. Defaults to True.
+        ylabel : bool
+            If True, the ylabel is displayed. Defaults to True.
+        legend : bool
+            If True, a legend is displayed. Defaults to True.
+        chance : bool | float. Defaults to None
+            Plot chance level. If True, chance level is estimated from the type
+            of scorer.
+
+        Returns
+        -------
+        fig : instance of matplotlib.figure.Figure
+            The figure.
+        """
+        return plot_gat_slice(self, train_time=train_time, title=title,
+                              xmin=xmin, xmax=xmax,
+                              ymin=ymin, ymax=ymax, ax=ax, show=show,
+                              color=color, xlabel=xlabel, ylabel=ylabel,
+                              legend=legend, chance=chance)
 
 
 def _predict_time_loop(X, estimators, cv, slices, predict_mode):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -113,7 +113,7 @@ class GeneralizationAcrossTime(object):
 
     Attributes
     ----------
-    y_train_ : np.ndarray, shape (n_samples,)
+    y_train_ : list | np.ndarray, shape (n_samples,)
         The categories used for training.
     estimators_ : list of list of sklearn.base.BaseEstimator subclasses.
         The estimators for each time point and each fold.
@@ -193,7 +193,7 @@ class GeneralizationAcrossTime(object):
         ----------
         epochs : instance of Epochs
             The epochs.
-        y : np.ndarray of int, shape (n_samples,) | None
+        y : list or np.ndarray of int, shape (n_samples,) or None
             To-be-fitted model values. If None, y = epochs.events[:, 2].
             Defaults to None.
 
@@ -425,6 +425,8 @@ class GeneralizationAcrossTime(object):
                 raise ValueError('Classes (y) passed differ from classes used '
                                  'for training. Please explicitly pass your y '
                                  'for scoring.')
+        elif type(y) is list:
+            y = np.array(y)
         self.y_true_ = y  # true regressor to be compared with y_pred
 
         # Preprocessing for parallelization:
@@ -661,7 +663,8 @@ def _check_epochs_input(epochs, y):
     epochs : instance of Epochs
             The epochs.
     y : np.ndarray shape (n_epochs) | list shape (n_epochs) | None
-        To-be-fitted model. If y is None, y == epochs.events
+        To-be-fitted model. If y is None, y == epochs.events.
+        Defaults to None.
 
     Returns
     -------
@@ -672,6 +675,8 @@ def _check_epochs_input(epochs, y):
     """
     if y is None:
         y = epochs.events[:, 2]
+    elif type(y) is list:
+        y = np.array(y)
 
     # Convert MNE data into trials x features x time matrix
     X = epochs.get_data()

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -766,15 +766,15 @@ def _predict(X, estimators):
     # Compute prediction for each sub-estimator (i.e. per fold)
     # if independent, estimators = all folds
     for fold, clf in enumerate(estimators):
-        predict = clf.predict(X)
+        _y_pred = clf.predict(X)
         # initialize predict_results array
         if fold == 0:
-            predict_size = predict.shape[1] if len(predict.shape) > 1 else 1
+            predict_size = _y_pred.shape[1] if _y_pred.n_dim > 1 else 1
             y_pred = np.ones((n_epochs, predict_size, n_clf))
         if predict_size == 1:
-            y_pred[:, 0, fold] = predict
+            y_pred[:, 0, fold] = _y_pred
         else:
-            y_pred[:, :, fold] = predict
+            y_pred[:, :, fold] = _y_pred
 
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -143,7 +143,7 @@ class GeneralizationAcrossTime(object):
                  predict_mode='cross-validation', n_jobs=1):
 
         from sklearn.preprocessing import StandardScaler
-        from sklearn.svm import SVC
+        from sklearn.linear_model import SGDClassifier
         from sklearn.pipeline import Pipeline
 
         # Store parameters in object
@@ -155,7 +155,7 @@ class GeneralizationAcrossTime(object):
         # Default classification pipeline
         if clf is None:
             scaler = StandardScaler()
-            svc = SVC(C=1, kernel='linear')
+            svc = SGDClassifier()
             clf = Pipeline([('scaler', scaler), ('svc', svc)])
         self.clf = clf
         self.predict_mode = predict_mode

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -492,7 +492,8 @@ class GeneralizationAcrossTime(object):
 
     def plot_diagonal(self, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
                       ax=None, show=True, color='steelblue', xlabel=True,
-                      ylabel=True, legend=True, chance=True):
+                      ylabel=True, legend=True, chance=True,
+                      label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
         Plot each classifier score trained and tested at identical time
@@ -526,6 +527,8 @@ class GeneralizationAcrossTime(object):
         chance : bool | float. Defaults to None
             Plot chance level. If True, chance level is estimated from the type
             of scorer.
+        label : str
+            Score label used in the legend. Defaults to 'Classif. score'.
 
         Returns
         -------
@@ -540,7 +543,8 @@ class GeneralizationAcrossTime(object):
 
     def plot_slice(self, train_time, title=None, xmin=None, xmax=None, ymin=0.,
                    ymax=1., ax=None, show=True, color='steelblue', xlabel=True,
-                   ylabel=True, legend=True, chance=True):
+                   ylabel=True, legend=True, chance=True,
+                   label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
 
         Plot the scores of the classifier trained at \'train_time\'.
@@ -575,6 +579,8 @@ class GeneralizationAcrossTime(object):
         chance : bool | float.
             Plot chance level. If True, chance level is estimated from the type
             of scorer. Defaults to None.
+        label : str
+            Score label used in the legend. Defaults to 'Classif. score'.
 
         Returns
         -------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -507,7 +507,7 @@ class GeneralizationAcrossTime(object):
                                colorbar=colorbar, xlabel=xlabel, ylabel=ylabel)
 
     def plot_diagonal(self, title=None, xmin=None, xmax=None, ymin=None,
-                      ymax=None, ax=None, show=True, color='steelblue',
+                      ymax=None, ax=None, show=True, color=None,
                       xlabel=True, ylabel=True, legend=True, chance=True,
                       label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
@@ -533,7 +533,7 @@ class GeneralizationAcrossTime(object):
         show : bool
             If True, the figure will be shown. Defaults to True.
         color : str
-            Score line color. Defaults to 'steelblue'.
+            Score line color.
         xlabel : bool
             If True, the xlabel is displayed. Defaults to True.
         ylabel : bool
@@ -558,7 +558,7 @@ class GeneralizationAcrossTime(object):
                               legend=legend, chance=chance, label=label)
 
     def plot_times(self, train_time, title=None, xmin=None, xmax=None,
-                   ymin=None, ymax=None, ax=None, show=True, color='steelblue',
+                   ymin=None, ymax=None, ax=None, show=True, color=None,
                    xlabel=True, ylabel=True, legend=True, chance=True,
                    label='Classif. score'):
         """Plotting function of GeneralizationAcrossTime object
@@ -585,7 +585,7 @@ class GeneralizationAcrossTime(object):
         show : bool
             If True, the figure will be shown. Defaults to True.
         color : str or list of str
-            Score line color(s). Defaults to 'steelblue'.
+            Score line color(s).
         xlabel : bool
             If True, the xlabel is displayed. Defaults to True.
         ylabel : bool

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -20,4 +20,4 @@ from .epochs import (plot_image_epochs, plot_drop_log, plot_epochs,
 from .raw import plot_raw, plot_raw_psd, plot_raw_psds
 from .ica import plot_ica_scores, plot_ica_sources, plot_ica_overlay
 from .montage import plot_montage
-from .decoding import plot_gat_matrix, _plot_gat_times
+from .decoding import plot_gat_matrix, plot_gat_times

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -20,4 +20,4 @@ from .epochs import (plot_image_epochs, plot_drop_log, plot_epochs,
 from .raw import plot_raw, plot_raw_psd, plot_raw_psds
 from .ica import plot_ica_scores, plot_ica_sources, plot_ica_overlay
 from .montage import plot_montage
-from .decoding import plot_gat_matrix, plot_gat_slice
+from .decoding import plot_gat_matrix, _plot_gat_times

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -20,4 +20,4 @@ from .epochs import (plot_image_epochs, plot_drop_log, plot_epochs,
 from .raw import plot_raw, plot_raw_psd, plot_raw_psds
 from .ica import plot_ica_scores, plot_ica_sources, plot_ica_overlay
 from .montage import plot_montage
-from .decoding import plot_gat_matrix, plot_gat_diagonal
+from .decoding import plot_gat_matrix, plot_gat_slice

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -32,7 +32,7 @@ def plot_gat_matrix(gat, title=None, vmin=0., vmax=1., tlim=None,
     tlim : array-like, (4,) | None
         The temporal boundaries. If None, expands to
         [tmin_train, tmax_train, tmin_test, tmax_test]
-        Defaults to None.
+        Default : None.
     ax : object | None
         Plot pointer. If None, generate new figure. Defaults to None.
     cmap : str | cmap object
@@ -75,6 +75,8 @@ def plot_gat_matrix(gat, title=None, vmin=0., vmax=1., tlim=None,
         ax.set_title(title)
     ax.axvline(0, color='k')
     ax.axhline(0, color='k')
+    ax.set_xlim(tlim[:2])
+    ax.set_ylim(tlim[2:])
     if colorbar is True:
         plt.colorbar(im, ax=ax)
     if show is True:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 # License: Simplified BSD
 
 import numpy as np
+import warnings
 
 
 def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
@@ -95,7 +96,7 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
 
 def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
                       ymax=None, ax=None, show=True, color='b', xlabel=True,
-                      ylabel=True, legend=True):
+                      ylabel=True, legend=True, chance=True):
     """Plotting function of GeneralizationAcrossTime object
 
     Predict each classifier. If multiple classifiers are passed, average
@@ -128,6 +129,9 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
         If True, the ylabel is displayed. Defaults to True.
     legend : bool
         If True, a legend is displayed. Defaults to True.
+    chance : bool | float. Defaults to None
+        Plot chance level. If True, chance level is estimated from the type
+        of scorer.
 
     Returns
     -------
@@ -156,7 +160,18 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
                     scores[i] = gat.scores_[i][j]
     ax.plot(gat.train_times['times_'], scores, color=color,
             label="Classif. score")
-    ax.axhline(0.5, color='k', linestyle='--', label="Chance level")
+    # Find chance level
+    if chance is True:
+        # XXX JRK This should probably be solved within sklearn?
+        if gat.scorer_.__name__ is 'accuracy_score':
+            chance = 1. / len(np.unique(gat.y_train_))
+        elif gat.scorer_.__name__ is 'roc_auc_score':
+            chance = 0.5
+        else:
+            chance = np.nan
+            warnings.warn('Cannot find chance level from %s, specify chance'
+                          ' level' % gat.scorer.__name__)
+        ax.axhline(chance, color='k', linestyle='--', label="Chance level")
     if title is not None:
         ax.set_title(title)
     if ymin is None:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -28,10 +28,10 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
     title : str | None
         Figure title. Defaults to None.
     vmin : float | None
-        Min color value for score. If None, sets to min(gat.scores_).
+        Min color value for scores. If None, sets to min(gat.scores_).
         Defaults to None.
     vmax : float | None
-        Max color value for score. If None, sets to max(gat.scores_).
+        Max color value for scores. If None, sets to max(gat.scores_).
         Defaults to None.
     tlim : array-like, (4,) | None
         The temporal boundaries. If None, expands to

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -163,8 +163,9 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
                 if train_time - test_times[j] <= gat.train_times['step']:
                     scores[i] = gat.scores_[i][j]
     elif type(train_time) in [float, np.float64, np.float32]:
-        idx = np.abs(gat.train_times['times_'] - train_time).argmin()
-        if not idx:
+        train_times = gat.train_times['times_']
+        idx = np.abs(train_times - train_time).argmin()
+        if train_times[idx] - train_time > gat.train_times['step']:
             raise ValueError("No classifier trained at %s " % train_time)
         scores = gat.scores_[idx]
     else:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -143,7 +143,16 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
     if np.all(np.unique([len(t) for t in gat.test_times_['times_']]) == 1):
         scores = gat.scores_
     else:
-        scores = np.diag(gat.scores_)
+        # Get scores from identical training and testing times even if GAT
+        # is not square.
+        scores = np.zeros(len(gat.scores_))
+        for i, T in enumerate(gat.train_times['times_']):
+            for t in gat.test_times_['times_']:
+                # find closest testing time from train_time
+                j = np.abs(t - T).argmin()
+                # check that not more than 1 classifier away
+                if T - t[j] <= gat.train_times['step']:
+                    scores[i] = gat.scores_[i][j]
     ax.plot(gat.train_times['times_'], scores, color=color,
             label="Classif. score")
     ax.axhline(0.5, color='k', linestyle='--', label="Chance level")

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import numpy as np
 
 
-def plot_gat_matrix(gat, title=None, vmin=0., vmax=1., tlim=None,
+def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
                     ax=None, cmap='RdBu_r', show=True, colorbar=True,
                     xlabel=True, ylabel=True):
     """Plotting function of GeneralizationAcrossTime object
@@ -25,14 +25,16 @@ def plot_gat_matrix(gat, title=None, vmin=0., vmax=1., tlim=None,
         The gat object.
     title : str | None
         Figure title. Defaults to None.
-    vmin : float
-        Min color value for score. Defaults to 0.
-    vmax : float
-        Max color value for score. Defaults to 1.
+    vmin : float | None
+        Min color value for score. If None, sets to min(gat.scores_).
+        Defaults to None.
+    vmax : float | None
+        Max color value for score. If None, sets to max(gat.scores_).
+        Defaults to None.
     tlim : array-like, (4,) | None
         The temporal boundaries. If None, expands to
         [tmin_train, tmax_train, tmin_test, tmax_test]
-        Default : None.
+        Defaults to None.
     ax : object | None
         Plot pointer. If None, generate new figure. Defaults to None.
     cmap : str | cmap object
@@ -57,6 +59,12 @@ def plot_gat_matrix(gat, title=None, vmin=0., vmax=1., tlim=None,
     import matplotlib.pyplot as plt
     if ax is None:
         fig, ax = plt.subplots(1, 1)
+
+    # Define color limits
+    if vmin is None:
+        vmin = np.min(gat.scores_)
+    if vmax is None:
+        vmax = np.max(gat.scores_)
 
     # Define time limits
     if tlim is None:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -157,8 +157,9 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
 
     if type(train_time) in [str, float, np.float32, np.float64]:
         train_time = [train_time]
+        label = [label]
     elif type(train_time) in [list, np.ndarray]:
-        pass
+        label = train_time
     else:
         raise ValueError("train_time must be \'diagonal\' | float | list or "
                          "array of float.")
@@ -166,8 +167,8 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
     if type(color) is str:
         color = np.tile(color, len(train_time))
 
-    for _train_time, _color in zip(train_time, color):
-        _plot_gat_time(gat, _train_time, ax, _color)
+    for _train_time, _color, _label in zip(train_time, color, label):
+        _plot_gat_time(gat, _train_time, ax, _color, _label)
 
     if title is not None:
         ax.set_title(title)
@@ -187,7 +188,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
     return fig if ax is None else ax.get_figure()
 
 
-def _plot_gat_time(gat, train_time, ax, color):
+def _plot_gat_time(gat, train_time, ax, color, label):
     """Aux function og plot_gat_time
 
     Plots a unique score 1d array"""
@@ -218,7 +219,7 @@ def _plot_gat_time(gat, train_time, ax, color):
     else:
         raise ValueError("train_time must be \'diagonal\' or a float.")
     ax.plot(gat.train_times['times_'], scores, color=color,
-            label=train_time)
+            label=label)
 
 
 def _get_chance_level(scorer, y_train):

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -87,10 +87,10 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
     return fig if ax is None else ax.get_figure()
 
 
-def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
-                   xmax=None, ymin=None, ymax=None, ax=None, show=True,
-                   color='b', xlabel=True, ylabel=True, legend=True,
-                   chance=True, label='Classif. score'):
+def _plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
+                    xmax=None, ymin=None, ymax=None, ax=None, show=True,
+                    color='b', xlabel=True, ylabel=True, legend=True,
+                    chance=True, label='Classif. score'):
     """Plotting function of GeneralizationAcrossTime object
 
     Plot the scores of the classifier trained at \'train_time\'.

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -143,6 +143,15 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
     if ax is None:
         fig, ax = plt.subplots(1, 1)
 
+    # Find and plot chance level
+    if chance is not False:
+        if chance is True:
+            chance = _get_chance_level(gat.scorer_, gat.y_train_)
+        elif type(chance) not in [int, float, np.float64, np.float32]:
+            raise ValueError('\'chance\' must be int or float')
+        ax.axhline(chance, color='k', linestyle='--', label="Chance level")
+    ax.axvline(0, color='k', label='')
+
     # Detect whether gat is a full matrix or just its diagonal
     if np.all(np.unique([len(t) for t in gat.test_times_['times_']]) == 1):
         scores = gat.scores_
@@ -171,15 +180,6 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
         raise ValueError("train_time must be \'diagonal\' or a float.")
     ax.plot(gat.train_times['times_'], scores, color=color,
             label=label)
-
-    # Find chance level
-    if chance is not False:
-        if chance is True:
-            chance = _get_chance_level(gat.scorer_, gat.y_train_)
-        elif type(chance) not in [int, float, np.float64, np.float32]:
-            raise ValueError('\'chance\' must be int or float')
-        ax.axhline(chance, color='k', linestyle='--', label="Chance level")
-        ax.axvline(0, color='k', label='Onset')
 
     if title is not None:
         ax.set_title(title)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -150,21 +150,20 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
     if chance is not False:
         if chance is True:
             chance = _get_chance_level(gat.scorer_, gat.y_train_)
-        elif type(chance) not in [int, float, np.float64, np.float32]:
-            raise ValueError('\'chance\' must be int or float')
-        ax.axhline(chance, color='k', linestyle='--', label="Chance level")
+        ax.axhline(float(chance), color='k', linestyle='--',
+                   label="Chance level")
     ax.axvline(0, color='k', label='')
 
-    if type(train_time) in [str, float, np.float32, np.float64]:
+    if isinstance(train_time, (str, float)):
         train_time = [train_time]
         label = [label]
-    elif type(train_time) in [list, np.ndarray]:
+    elif isinstance(train_time, (list, np.ndarray)):
         label = train_time
     else:
-        raise ValueError("train_time must be \'diagonal\' | float | list or "
+        raise ValueError("train_time must be 'diagonal' | float | list or "
                          "array of float.")
 
-    if color is None or type(color) is str:
+    if color is None or isinstance(color, str):
         color = np.tile(color, len(train_time))
 
     for _train_time, _color, _label in zip(train_time, color, label):
@@ -189,7 +188,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
 
 
 def _plot_gat_time(gat, train_time, ax, color, label):
-    """Aux function og plot_gat_time
+    """Aux function of plot_gat_time
 
     Plots a unique score 1d array"""
     # Detect whether gat is a full matrix or just its diagonal
@@ -210,7 +209,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
                 else:
                     score = gat.scores_[train_idx][test_idx]
                 scores[train_idx] = score
-    elif type(train_time) in [float, np.float64, np.float32]:
+    elif isinstance(train_time, float):
         train_times = gat.train_times['times_']
         idx = np.abs(train_times - train_time).argmin()
         if train_times[idx] - train_time > gat.train_times['step']:
@@ -227,7 +226,8 @@ def _plot_gat_time(gat, train_time, ax, color, label):
 def _get_chance_level(scorer, y_train):
     # XXX JRK This should probably be solved within sklearn?
     if scorer.__name__ == 'accuracy_score':
-        chance = 1. / len(np.unique(y_train))
+        chance = np.sum([np.mean(y_train == c) ** 2
+                         for c in np.unique(y_train)])
     elif scorer.__name__ == 'roc_auc_score':
         chance = 0.5
     else:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -92,9 +92,9 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
     return fig if ax is None else ax.get_figure()
 
 
-def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
-                      ax=None, show=True, color='b', xlabel=True, ylabel=True,
-                      legend=True):
+def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
+                      ymax=None, ax=None, show=True, color='b', xlabel=True,
+                      ylabel=True, legend=True):
     """Plotting function of GeneralizationAcrossTime object
 
     Predict each classifier. If multiple classifiers are passed, average
@@ -111,10 +111,10 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
         Min time value.
     xmax : float | None, optional, defaults to None.
         Max time value.
-    ymin : float, optional, defaults to 0.
-        Min score value.
-    ymax : float, optional, defaults to 1.
-        Max score value.
+    ymin : float | None, optional, defaults to None.
+        Min score value. If None, sets to min(scores).
+    ymax : float | None, optional, defaults to None.
+        Max score value. If None, sets to max(scores).
     ax : object | None
         Plot pointer. If None, generate new figure. Defaults to None.
     show : bool, optional, defaults to True.
@@ -149,6 +149,10 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=0., ymax=1.,
     ax.axhline(0.5, color='k', linestyle='--', label="Chance level")
     if title is not None:
         ax.set_title(title)
+    if ymin is None:
+        ymin = np.min(scores)
+    if ymax is None:
+        ymax = np.max(scores)
     ax.set_ylim(ymin, ymax)
     if xmin is not None and xmax is not None:
         ax.set_xlim(xmin, xmax)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -90,7 +90,7 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
 def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
                    xmax=None, ymin=None, ymax=None, ax=None, show=True,
                    color='b', xlabel=True, ylabel=True, legend=True,
-                   chance=True):
+                   chance=True, label='Classif. score'):
     """Plotting function of GeneralizationAcrossTime object
 
     Plot the scores of the classifier trained at \'train_time\'.
@@ -128,6 +128,8 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
     chance : bool | float.
         Plot chance level. If True, chance level is estimated from the type
         of scorer. Defaults to None.
+    label : str
+        Score label used in the legend. Defaults to 'Classif. score'.
 
     Returns
     -------
@@ -168,7 +170,7 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
     else:
         raise ValueError("train_time must be \'diagonal\' or a float.")
     ax.plot(gat.train_times['times_'], scores, color=color,
-            label="Classif. score")
+            label=label)
 
     # Find chance level
     if chance is True:
@@ -176,6 +178,7 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
     elif type(chance) not in [int, float, np.float64, np.float32]:
         raise ValueError('\'chance\' must be int or float')
     ax.axhline(chance, color='k', linestyle='--', label="Chance level")
+    ax.axvline(0, color='k', label='Onset')
 
     if title is not None:
         ax.set_title(title)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -226,8 +226,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
 def _get_chance_level(scorer, y_train):
     # XXX JRK This should probably be solved within sklearn?
     if scorer.__name__ == 'accuracy_score':
-        chance = np.sum([np.mean(y_train == c) ** 2
-                         for c in np.unique(y_train)])
+        chance = np.max([np.mean(y_train == c) for c in np.unique(y_train)])
     elif scorer.__name__ == 'roc_auc_score':
         chance = 0.5
     else:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -93,7 +93,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
                    chance=True, label='Classif. score'):
     """Plotting function of GeneralizationAcrossTime object
 
-    Plot the scores of the classifier trained at \'train_time\'.
+    Plot the scores of the classifier trained at 'train_time'.
 
     Parameters
     ----------
@@ -216,7 +216,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
             raise ValueError("No classifier trained at %s " % train_time)
         scores = gat.scores_[idx]
     else:
-        raise ValueError("train_time must be \'diagonal\' or a float.")
+        raise ValueError("train_time must be 'diagonal' or a float.")
     kwargs = dict()
     if color is not None:
         kwargs['color'] = color

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -197,9 +197,9 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
 
 def _get_chance_level(scorer, y_train):
     # XXX JRK This should probably be solved within sklearn?
-    if scorer.func_name == 'accuracy_score':
+    if scorer.__name__ == 'accuracy_score':
         chance = 1. / len(np.unique(y_train))
-    elif scorer.func_name == 'roc_auc_score':
+    elif scorer.__name__ == 'roc_auc_score':
         chance = 0.5
     else:
         chance = np.nan

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -173,12 +173,13 @@ def plot_gat_slice(gat, train_time='diagonal', title=None, xmin=None,
             label=label)
 
     # Find chance level
-    if chance is True:
-        chance = _get_chance_level(gat.scorer_, gat.y_train_)
-    elif type(chance) not in [int, float, np.float64, np.float32]:
-        raise ValueError('\'chance\' must be int or float')
-    ax.axhline(chance, color='k', linestyle='--', label="Chance level")
-    ax.axvline(0, color='k', label='Onset')
+    if chance is not False:
+        if chance is True:
+            chance = _get_chance_level(gat.scorer_, gat.y_train_)
+        elif type(chance) not in [int, float, np.float64, np.float32]:
+            raise ValueError('\'chance\' must be int or float')
+        ax.axhline(chance, color='k', linestyle='--', label="Chance level")
+        ax.axvline(0, color='k', label='Onset')
 
     if title is not None:
         ax.set_title(title)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -164,7 +164,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
                          "array of float.")
 
     if type(color) is str:
-        color = np.tile(str, len(train_time))
+        color = np.tile(color, len(train_time))
 
     for _train_time, _color in zip(train_time, color):
         _plot_gat_time(gat, _train_time, ax, _color)

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -89,7 +89,7 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
 
 def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
                    xmax=None, ymin=None, ymax=None, ax=None, show=True,
-                   color='b', xlabel=True, ylabel=True, legend=True,
+                   color=None, xlabel=True, ylabel=True, legend=True,
                    chance=True, label='Classif. score'):
     """Plotting function of GeneralizationAcrossTime object
 
@@ -164,7 +164,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
         raise ValueError("train_time must be \'diagonal\' | float | list or "
                          "array of float.")
 
-    if type(color) is str:
+    if color is None or type(color) is str:
         color = np.tile(color, len(train_time))
 
     for _train_time, _color, _label in zip(train_time, color, label):
@@ -218,8 +218,10 @@ def _plot_gat_time(gat, train_time, ax, color, label):
         scores = gat.scores_[idx]
     else:
         raise ValueError("train_time must be \'diagonal\' or a float.")
-    ax.plot(gat.train_times['times_'], scores, color=color,
-            label=label)
+    kwargs = dict()
+    if color is not None:
+        kwargs['color'] = color
+    ax.plot(gat.train_times['times_'], scores, label=label, **kwargs)
 
 
 def _get_chance_level(scorer, y_train):

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 # Authors: Denis Engemann <denis.engemann@gmail.com>
 #          Clement Moutard <clement.moutard@gmail.com>
+#          Jean-Remi King <jeanremi.king@gmail.com>
 #
 # License: Simplified BSD
 
@@ -71,10 +72,10 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
         tt_times = gat.train_times['times_']
         tn_times = gat.test_times_['times_']
         tlim = [tn_times[0][0], tn_times[-1][-1], tt_times[0], tt_times[-1]]
+
     # Plot scores
     im = ax.imshow(gat.scores_, interpolation='nearest', origin='lower',
-                   extent=tlim, vmin=vmin, vmax=vmax,
-                   cmap=cmap)
+                   extent=tlim, vmin=vmin, vmax=vmax, cmap=cmap)
     if xlabel is True:
         ax.set_xlabel('Testing Time (s)')
     if ylabel is True:
@@ -146,12 +147,12 @@ def plot_gat_diagonal(gat, title=None, xmin=None, xmax=None, ymin=None,
         # Get scores from identical training and testing times even if GAT
         # is not square.
         scores = np.zeros(len(gat.scores_))
-        for i, T in enumerate(gat.train_times['times_']):
-            for t in gat.test_times_['times_']:
+        for i, train_time in enumerate(gat.train_times['times_']):
+            for test_times in gat.test_times_['times_']:
                 # find closest testing time from train_time
-                j = np.abs(t - T).argmin()
+                j = np.abs(test_times - train_time).argmin()
                 # check that not more than 1 classifier away
-                if T - t[j] <= gat.train_times['step']:
+                if train_time - test_times[j] <= gat.train_times['step']:
                     scores[i] = gat.scores_[i][j]
     ax.plot(gat.train_times['times_'], scores, color=color,
             label="Classif. score")

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -64,14 +64,14 @@ def test_gat_plot_diagonal():
 
 
 @requires_sklearn
-def test_gat_plot_slice():
-    """Test GAT slice plot"""
+def test_gat_plot_times():
+    """Test GAT times plot"""
     gat = _get_data()
-    gat.plot_slice(gat.train_times['times_'][0])
+    gat.plot_times(gat.train_times['times_'][0])
     # test invalid time point
-    assert_raises(ValueError, gat.plot_slice, -1.)
+    assert_raises(ValueError, gat.plot_times, -1.)
     # test float type
-    assert_raises(ValueError, gat.plot_slice, 1)
+    assert_raises(ValueError, gat.plot_times, 1)
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 
@@ -82,7 +82,7 @@ def chance(ax):
 
 @requires_sklearn
 def test_gat_chance_level():
-    """Test GAT plot_slice chance level"""
+    """Test GAT plot_times chance level"""
     gat = _get_data()
     ax = gat.plot_diagonal(chance=False)
     ax = gat.plot_diagonal()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -68,6 +68,8 @@ def test_gat_plot_times():
     """Test GAT times plot"""
     gat = _get_data()
     gat.plot_times(gat.train_times['times_'][0])
+    gat.plot_times(gat.train_times['times_'])
+    gat.plot_times('diagonal')
     # test invalid time point
     assert_raises(ValueError, gat.plot_times, -1.)
     # test float type

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -10,6 +10,7 @@ from nose.tools import assert_raises, assert_equals
 
 import numpy as np
 
+from mne.epochs import equalize_epoch_counts, concatenate_epochs
 from mne.decoding import GeneralizationAcrossTime
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_sklearn, run_tests_if_main
@@ -39,6 +40,9 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     with warnings.catch_warnings(record=True):
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True, decim=decim)
+    epochs_list = [epochs[k] for k in event_id]
+    equalize_epoch_counts(epochs_list)
+    epochs = concatenate_epochs(epochs_list)
 
     # Test default running
     gat = GeneralizationAcrossTime()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -71,11 +71,9 @@ def test_gat_plot_times():
     gat = _get_data()
     # test one line
     gat.plot_times(gat.train_times['times_'][0])
-    gat.plot_times('diagonal')
     # test multiple lines
     gat.plot_times(gat.train_times['times_'])
-    # test color
-    gat.plot_times('diagonal', color='b')
+    # test multiple colors
     n_times = len(gat.train_times['times_'])
     colors = np.tile(['r', 'g', 'b'], np.ceil(n_times / 3))[:n_times]
     gat.plot_times(gat.train_times['times_'], color=colors)
@@ -83,6 +81,7 @@ def test_gat_plot_times():
     assert_raises(ValueError, gat.plot_times, -1.)
     # test float type
     assert_raises(ValueError, gat.plot_times, 1)
+    assert_raises(ValueError, gat.plot_times, 'diagonal')
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -103,7 +103,7 @@ def test_gat_plot_nonsquared():
     gat = _get_data(test_times=dict(start=0.))
     gat.plot()
     ax = gat.plot_diagonal()
-    scores = ax.get_children()[1].get_lines()[0].get_ydata()
+    scores = ax.get_children()[1].get_lines()[2].get_ydata()
     assert_equals(len(scores), len(gat.estimators_))
 
 run_tests_if_main()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -85,7 +85,7 @@ def test_gat_chance_level():
     assert_equals(chance(ax), .25)
     ax = gat.plot_diagonal(chance=1.234)
     assert_equals(chance(ax), 1.234)
-    assert_raises(ValueError, gat.plot_diagonal, **dict(chance='foo'))
+    assert_raises(ValueError, gat.plot_diagonal, chance='foo')
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -78,6 +78,7 @@ def test_gat_chance_level():
     """Test GAT plot_slice chance level"""
     chance = lambda ax: ax.get_children()[1].get_lines()[1].get_ydata()[0]
     gat = _get_data()
+    ax = gat.plot_diagonal(chance=False)
     ax = gat.plot_diagonal()
     assert_equals(chance(ax), .5)
     gat = _get_data(event_id=dict(aud_l=1, vis_l=3, aud_r=2, vis_r=4))

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -65,4 +65,17 @@ def test_gat_plot_diagonal():
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 
+
+def test_gat_plot_slice():
+    """Test GAT slice plot"""
+    gat = _get_data()
+    gat.plot_slice(gat.train_time['times_'][0])
+    # test invalid time point
+    assert_raises(ValueError, gat.plot_slice, -1.)
+    # test float type
+    assert_raises(ValueError, gat.plot_slice, 1)
+    del gat.scores_
+    assert_raises(RuntimeError, gat.plot)
+
+
 run_tests_if_main()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -24,7 +24,7 @@ warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 @requires_sklearn
 def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
-              event_id_gen=dict(aud_l=2, vis_l=4)):
+              event_id_gen=dict(aud_l=2, vis_l=4), test_times=None):
     """Aux function for testing GAT viz"""
     gat = GeneralizationAcrossTime()
     raw = io.Raw(raw_fname, preload=False)
@@ -41,7 +41,7 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     # Test default running
     gat = GeneralizationAcrossTime()
     gat.fit(epochs)
-    gat.score(epochs)
+    gat.score(epochs, test_times=test_times)
     return gat
 
 
@@ -85,5 +85,13 @@ def test_gat_chance_level():
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 
+
+def test_gat_plot_nonsquared():
+    """Test GAT diagonal plot"""
+    gat = _get_data(test_times=dict(start=0.))
+    gat.plot()
+    ax = gat.plot_diagonal()
+    scores = ax.get_children()[1].get_lines()[0].get_ydata()
+    assert_equals(len(scores), len(gat.estimators_))
 
 run_tests_if_main()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -76,7 +76,7 @@ def test_gat_plot_slice():
 
 def test_gat_chance_level():
     """Test GAT plot_slice chance level"""
-    chance = lambda ax: ax.get_children()[1].get_lines()[1].get_ydata()[0]
+    chance = lambda ax: ax.get_children()[1].get_lines()[0].get_ydata()[0]
     gat = _get_data()
     ax = gat.plot_diagonal(chance=False)
     ax = gat.plot_diagonal()

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -64,7 +64,7 @@ def test_gat_plot_diagonal():
 def test_gat_plot_slice():
     """Test GAT slice plot"""
     gat = _get_data()
-    gat.plot_slice(gat.train_time['times_'][0])
+    gat.plot_slice(gat.train_times['times_'][0])
     # test invalid time point
     assert_raises(ValueError, gat.plot_slice, -1.)
     # test float type

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -1,4 +1,5 @@
 # Authors: Denis Engemann <denis.engemann@gmail.com>
+#          Jean-Remi King <jeanremi.king@gmail.com>
 #
 # License: Simplified BSD
 
@@ -82,6 +83,9 @@ def test_gat_chance_level():
     gat = _get_data(event_id=dict(aud_l=1, vis_l=3, aud_r=2, vis_r=4))
     ax = gat.plot_diagonal()
     assert_equals(chance(ax), .25)
+    ax = gat.plot_diagonal(chance=1.234)
+    assert_equals(chance(ax), 1.234)
+    assert_raises(ValueError, gat.plot_diagonal, **dict(chance='foo'))
     del gat.scores_
     assert_raises(RuntimeError, gat.plot)
 

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -8,6 +8,8 @@ import warnings
 
 from nose.tools import assert_raises, assert_equals
 
+import numpy as np
+
 from mne.decoding import GeneralizationAcrossTime
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_sklearn, run_tests_if_main
@@ -67,9 +69,16 @@ def test_gat_plot_diagonal():
 def test_gat_plot_times():
     """Test GAT times plot"""
     gat = _get_data()
+    # test one line
     gat.plot_times(gat.train_times['times_'][0])
-    gat.plot_times(gat.train_times['times_'])
     gat.plot_times('diagonal')
+    # test multiple lines
+    gat.plot_times(gat.train_times['times_'])
+    # test color
+    gat.plot_times('diagonal', color='b')
+    n_times = len(gat.train_times['times_'])
+    colors = np.tile(['r', 'g', 'b'], np.ceil(n_times / 3))[:n_times]
+    gat.plot_times(gat.train_times['times_'], color=colors)
     # test invalid time point
     assert_raises(ValueError, gat.plot_times, -1.)
     # test float type

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -23,7 +23,6 @@ event_name = op.join(data_dir, 'test-eve.fif')
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
-@requires_sklearn
 def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
               event_id_gen=dict(aud_l=2, vis_l=4), test_times=None):
     """Aux function for testing GAT viz"""
@@ -46,6 +45,7 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     return gat
 
 
+@requires_sklearn
 def test_gat_plot_matrix():
     """Test GAT matrix plot"""
     gat = _get_data()
@@ -54,6 +54,7 @@ def test_gat_plot_matrix():
     assert_raises(RuntimeError, gat.plot)
 
 
+@requires_sklearn
 def test_gat_plot_diagonal():
     """Test GAT diagonal plot"""
     gat = _get_data()
@@ -62,6 +63,7 @@ def test_gat_plot_diagonal():
     assert_raises(RuntimeError, gat.plot)
 
 
+@requires_sklearn
 def test_gat_plot_slice():
     """Test GAT slice plot"""
     gat = _get_data()
@@ -74,9 +76,13 @@ def test_gat_plot_slice():
     assert_raises(RuntimeError, gat.plot)
 
 
+def chance(ax):
+    return ax.get_children()[1].get_lines()[0].get_ydata()[0]
+
+
+@requires_sklearn
 def test_gat_chance_level():
     """Test GAT plot_slice chance level"""
-    chance = lambda ax: ax.get_children()[1].get_lines()[0].get_ydata()[0]
     gat = _get_data()
     ax = gat.plot_diagonal(chance=False)
     ax = gat.plot_diagonal()
@@ -91,6 +97,7 @@ def test_gat_chance_level():
     assert_raises(RuntimeError, gat.plot)
 
 
+@requires_sklearn
 def test_gat_plot_nonsquared():
     """Test GAT diagonal plot"""
     gat = _get_data(test_times=dict(start=0.))


### PR DESCRIPTION
This PR aims at cleaning up, testing and enhancing small features of the GAT.
* By default, the classifier is changed from an SVC to a LogisticRegression to improve memory load and computation time. (SVC keeps all support vectors, and make the gat object quite heavy)
* The ```picks``` parameters is now saved together with `ch_names`
* The size of the prediction is now estimated from the first prediction. (In most use cases, this sizes is equal to 1, but for some prediction (derived from predict_proba or decision_function for instance), we can get higher ```y_pred``` dimensionality
* The basic plots are improved:  1. chance level is estimated from the classifier,  2. the default ```ylim``` is empirically derived ([0 1] doesn't fit many classifiers) 3. a new plot gat.plot_slice(train_time) is added to allow users to make a non-diagonal slice of the gat matrix (as in King et al PLoS One). => Perhaps we should add this to the example?
* Some more test to the plotting function.

I'll keep to separate PR:
* TimeResolvedDecoding
* logarithmic level for >2 class plots