### PR TITLE
MRG FIX: Cast to 64-bit

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -223,6 +223,11 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                  filenames=(), rawdirs=(),
                  comp=None, orig_comp_grade=None,
                  orig_format='double', verbose=None):
+        # some functions (e.g., filtering) only work w/64-bit data
+        if data is not None:
+            if data.dtype not in (np.float64, np.complex128):
+                raise RuntimeError('datatype must be float64 or complex128, '
+                                   'not %s' % data.dtype)
         self.info = info
         self._data = data
         cals = np.empty(info['nchan'])

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -896,6 +896,7 @@ def _read_data(info, start=None, stop=None):
     -------
     data : ndarray
         The measurement data, a channels x time slices array.
+        The data will be cast to np.float64 for compatibility.
     """
 
     total_slices = info['total_slices']
@@ -918,7 +919,7 @@ def _read_data(info, start=None, stop=None):
     for ch in info['chs']:
         data[:, ch['index']] *= ch['cal']
 
-    return data[:, info['order']].T
+    return data[:, info['order']].T.astype(np.float64)
 
 
 class RawBTi(_BaseRaw):


### PR DESCRIPTION
Closes #1613.

For consistency all readers should cast their inputs to 64-bit float.