### PR TITLE
FIX: Fix projection in raw plotting

### DIFF
--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -478,8 +478,8 @@ def make_projector(projs, ch_names, bads=[], include_active=True):
 
             # If there is something to pick, pickit
             if len(sel) > 0:
-                for v in range(p['data']['nrow']):
-                    vecs[sel, nvec + v] = p['data']['data'][v, vecsel].T
+                nrow = p['data']['nrow']
+                vecs[sel, nvec:nvec + nrow] = p['data']['data'][:, vecsel].T
 
             # Rescale for better detection of small singular values
             for v in range(p['data']['nrow']):

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -22,10 +22,11 @@ from ..defaults import _handle_default
 
 def _plot_update_raw_proj(params, bools):
     """Helper only needs to be called when proj is changed"""
-    inds = np.where(bools)[0]
-    params['info']['projs'] = [copy.deepcopy(params['projs'][ii])
-                               for ii in inds]
-    params['proj_bools'] = bools
+    if bools is not None:
+        inds = np.where(bools)[0]
+        params['info']['projs'] = [copy.deepcopy(params['projs'][ii])
+                                   for ii in inds]
+        params['proj_bools'] = bools
     params['projector'], _ = setup_proj(params['info'], add_eeg_ref=False,
                                         verbose=False)
     _update_raw_data(params)
@@ -142,9 +143,9 @@ def _pick_bad_channels(event, params):
         params['ax_vertline'].set_data(x, np.array(params['ax'].get_ylim()))
         params['ax_hscroll_vertline'].set_data(x, np.array([0., 1.]))
         params['vertline_t'].set_text('%0.3f' % x[0])
-    event.canvas.draw()
     # update deep-copied info to persistently draw bads
     params['info']['bads'] = bads
+    _plot_update_raw_proj(params, None)
 
 
 def _mouse_click(event, params):
@@ -364,7 +365,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
         'original' plots in the order of ch_names, array gives the
         indices to use in plotting.
     show_options : bool
-        If True, a dialog for options related to projecion is shown.
+        If True, a dialog for options related to projection is shown.
     title : str | None
         The title of the window. If None, and either the filename of the
         raw object or '<unknown>' will be displayed as title.
@@ -571,7 +572,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
     # plot event_line first so it's in the back
     event_lines = [ax.plot([np.nan], color=event_color[ev_num])[0]
                    for ev_num in sorted(event_color.keys())]
-    lines = [ax.plot([np.nan])[0] for _ in range(n_ch)]
+    lines = [ax.plot([np.nan], antialiased=False, linewidth=0.5)[0]
+             for _ in range(n_ch)]
     ax.set_yticklabels(['X' * max([len(ch) for ch in info['ch_names']])])
     vertline_color = (0., 0.75, 0.)
     params['ax_vertline'] = ax.plot([0, 0], ylim, color=vertline_color,
@@ -591,9 +593,10 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
                                  event_color=event_color, offsets=offsets)
 
     # set up callbacks
-    opt_button = mpl.widgets.Button(ax_button, 'Opt')
-    callback_option = partial(_toggle_options, params=params)
-    opt_button.on_clicked(callback_option)
+    if len(raw.info['projs']) > 0:
+        opt_button = mpl.widgets.Button(ax_button, 'Proj')
+        callback_option = partial(_toggle_options, params=params)
+        opt_button.on_clicked(callback_option)
     callback_key = partial(_plot_raw_onkey, params=params)
     fig.canvas.mpl_connect('key_press_event', callback_key)
     callback_scroll = partial(_plot_raw_onscroll, params=params)
@@ -611,8 +614,6 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
     # store these for use by callbacks in the options figure
     params['callback_proj'] = callback_proj
     params['callback_key'] = callback_key
-    # have to store this, or it could get garbage-collected
-    params['opt_button'] = opt_button
 
     # do initial plots
     callback_proj('none')

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -593,6 +593,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
                                  event_color=event_color, offsets=offsets)
 
     # set up callbacks
+    opt_button = None
     if len(raw.info['projs']) > 0:
         opt_button = mpl.widgets.Button(ax_button, 'Proj')
         callback_option = partial(_toggle_options, params=params)
@@ -614,6 +615,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
     # store these for use by callbacks in the options figure
     params['callback_proj'] = callback_proj
     params['callback_key'] = callback_key
+    # have to store this, or it could get garbage-collected
+    params['opt_button'] = opt_button
 
     # do initial plots
     callback_proj('none')


### PR DESCRIPTION
Closes #2020.

Also fixes a long-standing bug where projectors are not updated when marking bad channels in raw. Try the following code on `master`, then on this PR, scrolling down to `EEG001` and marking it bad:
```Python
import mne
raw = mne.io.Raw(mne.datasets.testing.data_path() +
                 '/MEG/sample/sample_audvis_trunc_raw.fif', preload=True)
raw._data[315, 300] = 1e-2
raw.plot()
```
I also modified the line width, it looks clearer to me -- see if you agree. In either case we should disable antialiasing because it doesn't do much for data sampled this highly, and it is much faster not to have it on.