### PR TITLE
BUG: y_pred_ must be list of list similar to estimators_

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -124,7 +124,7 @@ def test_generalization_across_time():
     # --- number of trials
     assert_true(gat.y_train_.shape[0] ==
                 gat.y_true_.shape[0] ==
-                gat.y_pred_.shape[2] == 14)
+                len(gat.y_pred_[0][0]) == 14)
     # ---  number of folds
     assert_true(np.shape(gat.estimators_)[1] == gat.cv)
     # ---  length training size


### PR DESCRIPTION
I just found a potential bug in GAT. the attribute ```y_pred_``` must be of the same sort than ```estimators_``` and thus be a list of list not an array. I hope it's not too late for the release.