### PR TITLE
MRG: FIX: kwarg should be res

### DIFF
--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -494,7 +494,7 @@ def _set_dig_kit(mrk, elp, hsp, auto_decimate=True):
         hsp = _read_dig_points(hsp)
     n_pts = len(hsp)
     if n_pts > KIT.DIG_POINTS:
-        hsp = _decimate_points(hsp, decim=5)
+        hsp = _decimate_points(hsp, res=5)
         n_new = len(hsp)
         msg = ("The selected head shape contained {n_in} points, which is "
                "more than recommended ({n_rec}), and was automatically "


### PR DESCRIPTION
Found a small bug in the kit module. The kwarg should be `res` (resolution) rather than `decim` (decimation). It passed by undetected because there isn't/can't be a test for it (our test hsp file is only 500 points to save space and this auto-decimation occurs in the script at 10k+). tested it on my box and it works.