### PR TITLE
MRG ENH: Center and allow ch_type=None

### DIFF
--- a/examples/datasets/plot_spm_faces_dataset.py
+++ b/examples/datasets/plot_spm_faces_dataset.py
@@ -18,7 +18,7 @@ fast machine it can take about 10 minutes to complete.
 #
 # License: BSD (3-clause)
 
-import os
+import os.path as op
 import matplotlib.pyplot as plt
 
 import mne
@@ -99,7 +99,7 @@ evoked[0].plot_field(maps, time=0.170)
 
 # Make source space
 src_fname = data_path + '/subjects/spm/bem/spm-oct-6-src.fif'
-if not os.path.isfile(src_fname):
+if not op.isfile(src_fname):
     src = mne.setup_source_space('spm', src_fname, spacing='oct6',
                                  subjects_dir=subjects_dir, overwrite=True)
 else:

--- a/examples/datasets/plot_spm_faces_dataset.py
+++ b/examples/datasets/plot_spm_faces_dataset.py
@@ -18,6 +18,7 @@ fast machine it can take about 10 minutes to complete.
 #
 # License: BSD (3-clause)
 
+import os
 import matplotlib.pyplot as plt
 
 import mne
@@ -97,8 +98,12 @@ evoked[0].plot_field(maps, time=0.170)
 # Compute forward model
 
 # Make source space
-src = mne.setup_source_space('spm', spacing='oct6', subjects_dir=subjects_dir,
-                             overwrite=True)
+src_fname = data_path + '/subjects/spm/bem/spm-oct-6-src.fif'
+if not os.path.isfile(src_fname):
+    src = mne.setup_source_space('spm', src_fname, spacing='oct6',
+                                 subjects_dir=subjects_dir, overwrite=True)
+else:
+    src = mne.read_source_spaces(src_fname)
 
 bem = data_path + '/subjects/spm/bem/spm-5120-5120-5120-bem-sol.fif'
 forward = mne.make_forward_solution(contrast.info, trans_fname, src, bem)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -7,4 +7,5 @@ from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, generate_2d_layout)
 from .montage import read_montage, read_dig_montage, Montage, DigMontage
 
-from .channels import (equalize_channels, rename_channels, read_ch_connectivity)
+from .channels import (equalize_channels, rename_channels,
+                       read_ch_connectivity, _get_ch_type)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -69,22 +69,28 @@ def _contains_ch_type(info, ch_type):
         raise ValueError('`ch_type` is of class {actual_class}. It must be '
                          '`str`'.format(actual_class=type(ch_type)))
 
-    valid_channel_types = ('grad mag planar1 planar2 eeg stim eog emg ecg '
-                           'ref_meg resp exci ias syst seeg misc').split()
+    valid_channel_types = ['grad', 'mag', 'planar1', 'planar2', 'eeg', 'stim',
+                           'eog', 'emg', 'ecg', 'ref_meg', 'resp', 'exci',
+                           'ias', 'syst', 'seeg', 'misc']
 
     if ch_type not in valid_channel_types:
-        msg = ('The ch_type passed ({passed}) is not valid. '
-               'it must be one of [{valid}]')
-        raise ValueError(msg.format(passed=ch_type,
-                                    valid=', '.join(valid_channel_types)))
+        raise ValueError('ch_type must be one of %s, not "%s"'
+                         % (valid_channel_types, ch_type))
+    if info is None:
+        raise ValueError('Cannot check for channels of type "%s" because info '
+                         'is None' % (ch_type,))
     return ch_type in [channel_type(info, ii) for ii in range(info['nchan'])]
 
 
-def _get_ch_type(info, ch_type):
-    """Helper to choose a singel channel type (usually for plotting)"""
+def _get_ch_type(inst, ch_type):
+    """Helper to choose a single channel type (usually for plotting)
+
+    Usually used in plotting to plot a single datatype, e.g. look for mags,
+    then grads, then ... to plot.
+    """
     if ch_type is None:
         for type_ in ['mag', 'grad', 'planar1', 'planar2', 'eeg']:
-            if _contains_ch_type(info, type_):
+            if type_ in inst:
                 ch_type = type_
                 break
         else:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -69,15 +69,27 @@ def _contains_ch_type(info, ch_type):
         raise ValueError('`ch_type` is of class {actual_class}. It must be '
                          '`str`'.format(actual_class=type(ch_type)))
 
-    valid_channel_types = ('grad mag eeg stim eog emg ecg ref_meg resp '
-                           'exci ias syst seeg misc').split()
+    valid_channel_types = ('grad mag planar1 planar2 eeg stim eog emg ecg '
+                           'ref_meg resp exci ias syst seeg misc').split()
 
     if ch_type not in valid_channel_types:
         msg = ('The ch_type passed ({passed}) is not valid. '
-               'it must be {valid}')
+               'it must be one of [{valid}]')
         raise ValueError(msg.format(passed=ch_type,
-                                    valid=' or '.join(valid_channel_types)))
+                                    valid=', '.join(valid_channel_types)))
     return ch_type in [channel_type(info, ii) for ii in range(info['nchan'])]
+
+
+def _get_ch_type(info, ch_type):
+    """Helper to choose a singel channel type (usually for plotting)"""
+    if ch_type is None:
+        for type_ in ['mag', 'grad', 'planar1', 'planar2', 'eeg']:
+            if _contains_ch_type(info, type_):
+                ch_type = type_
+                break
+        else:
+            raise RuntimeError('No plottable channel types found')
+    return ch_type
 
 
 @verbose

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -438,7 +438,7 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                                  units=units, scalings=scalings,
                                  titles=titles, axes=axes, cmap=cmap)
 
-    def plot_topomap(self, times=None, ch_type='mag', layout=None, vmin=None,
+    def plot_topomap(self, times=None, ch_type=None, layout=None, vmin=None,
                      vmax=None, cmap='RdBu_r', sensors=True, colorbar=True,
                      scale=None, scale_time=1e3, unit=None, res=64, size=1,
                      cbar_fmt="%3.1f", time_format='%01d ms', proj=False,
@@ -453,9 +453,10 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             The time point(s) to plot. If None, 10 topographies will be shown
             will a regular time spacing between the first and last time
             instant.
-        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg'
+        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
             The channel type to plot. For 'grad', the gradiometers are collec-
             ted in pairs and the RMS for each pair is plotted.
+            If None, then channels are chosen in the order given above.
         layout : None | Layout
             Layout instance specifying sensor positions (does not need to
             be specified for Neuromag data). If possible, the correct

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -444,7 +444,8 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                      cbar_fmt="%3.1f", time_format='%01d ms', proj=False,
                      show=True, show_names=False, title=None, mask=None,
                      mask_params=None, outlines='head', contours=6,
-                     image_interp='bilinear', average=None, format=None):
+                     image_interp='bilinear', average=None, head_pos=None,
+                     format=None):
         """Plot topographic maps of specific time points
 
         Parameters
@@ -540,6 +541,11 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             (seconds). For example, 0.01 would translate into window that
             starts 5 ms before and ends 5 ms after a given time point.
             Defaults to None, which means no averaging.
+        head_pos : dict | None
+            If None (default), the sensors are positioned such that they span
+            the head circle. If dict, can have entries 'center' (tuple) and
+            'scale' (tuple) for what the center and scale of the head should be
+            relative to the electrode locations.
         """
         return plot_evoked_topomap(self, times=times, ch_type=ch_type,
                                    layout=layout, vmin=vmin,
@@ -553,7 +559,8 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                                    mask_params=mask_params,
                                    outlines=outlines, contours=contours,
                                    image_interp=image_interp,
-                                   average=average, format=format)
+                                   average=average, head_pos=head_pos,
+                                   format=format)
 
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',
                    n_jobs=1):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1260,7 +1260,7 @@ class ICA(ContainsMixin):
 
         return self
 
-    def plot_components(self, picks=None, ch_type='mag', res=64, layout=None,
+    def plot_components(self, picks=None, ch_type=None, res=64, layout=None,
                         vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                         colorbar=False, title=None, show=True, outlines='head',
                         contours=6, image_interp='bilinear'):
@@ -1271,9 +1271,10 @@ class ICA(ContainsMixin):
         picks : int | array-like | None
             The indices of the sources to be plotted.
             If None all are plotted in batches of 20.
-        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg'
+        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
             The channel type to plot. For 'grad', the gradiometers are
             collected in pairs and the RMS for each pair is plotted.
+            If None, then channels are chosen in the order given above.
         res : int
             The resolution of the topomap image (n pixels along each side).
         layout : None | Layout

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1263,7 +1263,7 @@ class ICA(ContainsMixin):
     def plot_components(self, picks=None, ch_type=None, res=64, layout=None,
                         vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                         colorbar=False, title=None, show=True, outlines='head',
-                        contours=6, image_interp='bilinear'):
+                        contours=6, image_interp='bilinear', head_pos=None):
         """Project unmixing matrix on interpolated sensor topography.
 
         Parameters
@@ -1313,6 +1313,11 @@ class ICA(ContainsMixin):
         image_interp : str
             The image interpolation to be used. All matplotlib options are
             accepted.
+        head_pos : dict | None
+            If None (default), the sensors are positioned such that they span
+            the head circle. If dict, can have entries 'center' (tuple) and
+            'scale' (tuple) for what the center and scale of the head should be
+            relative to the electrode locations.
 
         Returns
         -------
@@ -1326,7 +1331,8 @@ class ICA(ContainsMixin):
                                    sensors=sensors, colorbar=colorbar,
                                    title=title, show=show,
                                    outlines=outlines, contours=contours,
-                                   image_interp=image_interp)
+                                   image_interp=image_interp,
+                                   head_pos=head_pos)
 
     def plot_sources(self, inst, picks=None, exclude=None, start=None,
                      stop=None, title=None, show=True):

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -204,7 +204,7 @@ def test_ica_core():
         with warnings.catch_warnings(record=True):
             ica.fit(raw, picks=pcks, start=start, stop=stop)
             repr(ica)  # to test repr
-        'mag' in ica  # should now work
+        assert_true('mag' in ica)  # should now work without error
 
         # test re-fit
         unmixing1 = ica.unmixing_matrix_

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -192,6 +192,7 @@ def test_ica_core():
         ica = ICA(noise_cov=n_cov, n_components=n_comp,
                   max_pca_components=max_n, n_pca_components=max_n,
                   random_state=0, method=method, max_iter=1)
+        assert_raises(ValueError, ica.__contains__, 'mag')
 
         print(ica)  # to test repr
 
@@ -203,6 +204,7 @@ def test_ica_core():
         with warnings.catch_warnings(record=True):
             ica.fit(raw, picks=pcks, start=start, stop=stop)
             repr(ica)  # to test repr
+        'mag' in ica  # should now work
 
         # test re-fit
         unmixing1 = ica.unmixing_matrix_

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -874,7 +874,8 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
                      layout=None, vmin=None, vmax=None, cmap='RdBu_r',
                      sensors=True, colorbar=True, unit=None, res=64, size=2,
                      cbar_fmt='%1.1e', show_names=False, title=None,
-                     axes=None, show=True, format=None, outlines='head'):
+                     axes=None, show=True, outlines='head', head_pos=None,
+                     format=None):
         """Plot topographic maps of time-frequency intervals of TFR data
 
         Parameters
@@ -963,6 +964,11 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
             points outside the outline. Moreover, a matplotlib patch object can
             be passed for advanced masking options, either directly or as a
             function that returns patches (required for multi-axis plots).
+        head_pos : dict | None
+            If None (default), the sensors are positioned such that they span
+            the head circle. If dict, can have entries 'center' (tuple) and
+            'scale' (tuple) for what the center and scale of the head should be
+            relative to the electrode locations.
 
         Returns
         -------
@@ -977,7 +983,8 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
                                 unit=unit, res=res, size=size,
                                 cbar_fmt=cbar_fmt, show_names=show_names,
                                 title=title, axes=axes, show=show,
-                                format=format, outlines=outlines)
+                                format=format, outlines=outlines,
+                                head_pos=head_pos)
 
     def save(self, fname, overwrite=False):
         """Save TFR object to hdf5 file

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -870,7 +870,7 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
         self.data = rescale(self.data, self.times, baseline, mode, copy=False)
 
     def plot_topomap(self, tmin=None, tmax=None, fmin=None, fmax=None,
-                     ch_type='mag', baseline=None, mode='mean',
+                     ch_type=None, baseline=None, mode='mean',
                      layout=None, vmin=None, vmax=None, cmap='RdBu_r',
                      sensors=True, colorbar=True, unit=None, res=64, size=2,
                      cbar_fmt='%1.1e', show_names=False, title=None,
@@ -891,9 +891,10 @@ class AverageTFR(ContainsMixin, PickDropChannelsMixin):
         fmax : None | float
             The last frequency to display. If None the last frequency
             available is used.
-        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg'
+        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
             The channel type to plot. For 'grad', the gradiometers are
             collected in pairs and the RMS for each pair is plotted.
+            If None, then channels are chosen in the order given above.
         baseline : tuple or list of length 2
             The time interval to apply rescaling / baseline correction.
             If None do not apply it. If baseline is (a, b)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -125,7 +125,6 @@ def test_limits_to_control_points():
 
     # Test for simple use cases
     from mayavi import mlab
-    mlab.close()
     stc.plot(clim='auto', subjects_dir=subjects_dir)
     stc.plot(clim=dict(pos_lims=(10, 50, 90)), subjects_dir=subjects_dir)
     stc.plot(clim=dict(kind='value', lims=(10, 50, 90)), figure=99,

--- a/mne/viz/tests/test_circle.py
+++ b/mne/viz/tests/test_circle.py
@@ -87,8 +87,8 @@ def test_plot_connectivity_circle():
                              node_angles=node_angles, title='test',
                              )
 
-    plt.close('all')
     assert_raises(ValueError, circular_layout, label_names, node_order,
                   group_boundaries=[-1])
     assert_raises(ValueError, circular_layout, label_names, node_order,
                   group_boundaries=[20, 0])
+    plt.close('all')

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -79,7 +79,7 @@ def test_gat_plot_times():
     gat.plot_times(gat.train_times['times_'])
     # test multiple colors
     n_times = len(gat.train_times['times_'])
-    colors = np.tile(['r', 'g', 'b'], np.ceil(n_times / 3))[:n_times]
+    colors = np.tile(['r', 'g', 'b'], int(np.ceil(n_times / 3)))[:n_times]
     gat.plot_times(gat.train_times['times_'], color=colors)
     # test invalid time point
     assert_raises(ValueError, gat.plot_times, -1.)

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -78,7 +78,9 @@ def test_plot_epochs():
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.plot([0, 1], picks=[0, 2, 3], scalings=None, title_str='%s')
+    plt.close('all')
     epochs[0].plot(picks=[0, 2, 3], scalings=None, title_str='%s')
+    plt.close('all')
     # test clicking: should increase coverage on
     # 3200-3226, 3235, 3237, 3239-3242, 3245-3255, 3260-3280
     fig = plt.gcf()
@@ -128,11 +130,13 @@ def test_plot_drop_log():
 def test_plot_psd_epochs():
     """Test plotting epochs psd (+topomap)
     """
+    import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.plot_psd()
     assert_raises(RuntimeError, epochs.plot_psd_topomap,
                   bands=[(0, 0.01, 'foo')])  # no freqs in range
     epochs.plot_psd_topomap()
+    plt.close('all')
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -63,8 +63,12 @@ def test_plot_topomap():
     ev_bad.pick_channels(ev_bad.ch_names[:2])
     ev_bad.plot_topomap()  # auto, should plot EEG
     assert_raises(ValueError, ev_bad.plot_topomap, ch_type='mag')
+    assert_raises(TypeError, ev_bad.plot_topomap, head_pos='foo')
+    assert_raises(KeyError, ev_bad.plot_topomap, head_pos=dict(foo='bar'))
+    assert_raises(ValueError, ev_bad.plot_topomap, head_pos=dict(center=0))
 
     evoked.plot_topomap(0.1, layout=layout, scale=dict(mag=0.1))
+    plt.close('all')
     mask = np.zeros_like(evoked.data, dtype=bool)
     mask[[1, 5], :] = True
     evoked.plot_topomap(None, ch_type='mag', outlines=None)
@@ -75,6 +79,7 @@ def test_plot_topomap():
     evoked.plot_topomap(times, ch_type='planar2', res=res)
     evoked.plot_topomap(times, ch_type='grad', mask=mask, res=res,
                         show_names=True, mask_params={'marker': 'x'})
+    plt.close('all')
     assert_raises(ValueError, evoked.plot_topomap, times, ch_type='eeg',
                   res=res, average=-1000)
     assert_raises(ValueError, evoked.plot_topomap, times, ch_type='eeg',
@@ -100,6 +105,7 @@ def test_plot_topomap():
     texts = get_texts(p)
     assert_equal(len(texts), 1)
     assert_equal(texts[0], 'Custom')
+    plt.close('all')
 
     # delaunay triangulation warning
     with warnings.catch_warnings(record=True):  # can't show
@@ -135,7 +141,7 @@ def test_plot_topomap():
     del evoked.info['dig'][85]
 
     pos = make_eeg_layout(evoked.info).pos
-    pos, outlines = _check_outlines(pos, outlines='head')
+    pos, outlines = _check_outlines(pos, 'head')
     # test 1: pass custom outlines without patch
 
     def patch():
@@ -149,11 +155,13 @@ def test_plot_topomap():
     evoked.info['dig'] = None
     assert_raises(RuntimeError, plot_evoked_topomap, evoked,
                   times, ch_type='eeg')
+    plt.close('all')
 
 
 def test_plot_tfr_topomap():
     """Test plotting of TFR data
     """
+    import matplotlib.pyplot as plt
     raw = _get_raw()
     times = np.linspace(-0.1, 0.1, 200)
     n_freqs = 3
@@ -163,6 +171,7 @@ def test_plot_tfr_topomap():
     tfr = AverageTFR(raw.info, data, times, np.arange(n_freqs), nave)
     tfr.plot_topomap(ch_type='mag', tmin=0.05, tmax=0.150, fmin=0, fmax=10,
                      res=16)
+    plt.close('all')
 
 
 def test_prepare_topo_plot():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -253,7 +253,7 @@ def _check_outlines(pos, outlines, head_pos=None):
         if 'center' not in head_pos:
             head_pos['center'] = 0.5 * (pos.max(axis=0) + pos.min(axis=0))
         if 'scale' not in head_pos:
-            head_pos['scale'] = 0.85 * (pos.max(axis=0) - pos.min(axis=0))
+            head_pos['scale'] = 0.85 / (pos.max(axis=0) - pos.min(axis=0))
         pos -= head_pos['center']
         pos *= head_pos['scale']
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -255,6 +255,7 @@ def _check_outlines(pos, outlines, head_pos=None):
         if 'scale' not in head_pos:
             # The default is to make the points occupy a slightly smaller
             # proportion (0.85) of the total width and height
+            # this number was empirically determined (seems to work well)
             head_pos['scale'] = 0.85 / (pos.max(axis=0) - pos.min(axis=0))
         pos -= head_pos['center']
         pos *= head_pos['scale']

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -224,7 +224,7 @@ def _check_outlines(pos, outlines, head_pos=None):
     """Check or create outlines for topoplot
     """
     pos = np.array(pos, float)[:, :2]  # ensure we have a copy
-    head_pos = {} if head_pos is None else head_pos
+    head_pos = dict() if head_pos is None else head_pos
     if not isinstance(head_pos, dict):
         raise TypeError('sensor_pos must be dict or None')
     head_pos = copy.deepcopy(head_pos)
@@ -253,6 +253,8 @@ def _check_outlines(pos, outlines, head_pos=None):
         if 'center' not in head_pos:
             head_pos['center'] = 0.5 * (pos.max(axis=0) + pos.min(axis=0))
         if 'scale' not in head_pos:
+            # The default is to make the points occupy a slightly smaller
+            # proportion (0.85) of the total width and height
             head_pos['scale'] = 0.85 / (pos.max(axis=0) - pos.min(axis=0))
         pos -= head_pos['center']
         pos *= head_pos['scale']

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -237,11 +237,11 @@ def _check_outlines(pos, outlines, head_scale=0.85):
                           -.1313, -.1384, -.1199])
         x, y = pos[:, :2].T
         x_range = max(x.max(), -x.min()) * 2.
-        y_range = y.max() - y.min()
+        y_range = max(y.max(), -y.min()) * 2.
 
         # shift and scale the electrode positions
-        pos[:, 0] = head_scale * ((pos[:, 0]) / x_range)
-        pos[:, 1] = head_scale * ((pos[:, 1] - y.min()) / y_range - 0.5)
+        pos[:, 0] = head_scale * (pos[:, 0] / x_range)
+        pos[:, 1] = head_scale * (pos[:, 1] / y_range)
 
         # Define the outline of the head, ears and nose
         if outlines is not None:
@@ -635,8 +635,8 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     from mpl_toolkits.axes_grid import make_axes_locatable
     from ..channels import _get_ch_type
 
-    ch_type = _get_ch_type(ica.info, ch_type)
     if picks is None:  # plot components by sets of 20
+        ch_type = _get_ch_type(ica, ch_type)
         n_components = ica.mixing_matrix_.shape[1]
         p = 20
         figs = []
@@ -653,6 +653,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         return figs
     elif np.isscalar(picks):
         picks = [picks]
+    ch_type = 'mag' if ch_type is None else ch_type
 
     data = np.dot(ica.mixing_matrix_[:, picks].T,
                   ica.pca_components_[:ica.n_components_])
@@ -809,7 +810,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         The figure containing the topography.
     """
     from ..channels import _get_ch_type
-    ch_type = _get_ch_type(tfr.info, ch_type)
+    ch_type = _get_ch_type(tfr, ch_type)
     if format is not None:
         cbar_fmt = format
         warnings.warn("The format parameter is deprecated and will be "
@@ -990,7 +991,7 @@ def plot_evoked_topomap(evoked, times=None, ch_type=None, layout=None,
         no averaging.
     """
     from ..channels import _get_ch_type
-    ch_type = _get_ch_type(evoked.info, ch_type)
+    ch_type = _get_ch_type(evoked, ch_type)
     if format is not None:
         cbar_fmt = format
         warnings.warn("The format parameter is deprecated and will be "
@@ -1244,7 +1245,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         Figure distributing one image per channel across sensor topography.
     """
     from ..channels import _get_ch_type
-    ch_type = _get_ch_type(epochs.info, ch_type)
+    ch_type = _get_ch_type(epochs, ch_type)
 
     picks, pos, merge_grads, names, ch_type = _prepare_topo_plot(
         epochs, ch_type, layout)


### PR DESCRIPTION
Closes #2113.
Closes #2027.

Example code:
```
import os.path as op
import mne
from mne.datasets.testing import data_path
evoked_fname = op.join(data_path(), 'MEG', 'sample', 'sample_audvis-ave.fif')
evoked = mne.read_evokeds(evoked_fname)[0]
evoked.pick_types(meg=False, eeg=True)
evoked.plot_topomap()
```
On current `master` this throws an error. This is what we now get on this PR:

![figure_1](https://cloud.githubusercontent.com/assets/2365790/7692756/88e9b2c0-fd7c-11e4-9d7b-98ef921ac8ce.png)

If change the last lines to select just the left EEG channels, with `ch_type='eeg'`:
```
left_ch = [ch['ch_name'] for ch in evoked.info['chs'] if ch['loc'][0] < 0]
evoked.pick_channels(left_ch)
evoked.plot_topomap()
```

On current master we get the left channels distributed all over the head, which is misleading:

![figure_2](https://cloud.githubusercontent.com/assets/2365790/7692767/cf12c93a-fd7c-11e4-8585-1c5af1539afa.png)

~~On this PR we get them staying on the left at least:~~

![figure_3](https://cloud.githubusercontent.com/assets/2365790/7692772/dd3c9f22-fd7c-11e4-9343-5236242f8223.png)

~~Not sure if we also want to do the same thing with the y coords, since those could also errantly get distributed. Maybe this should also be a controllable option. Thoughts?~~