### PR TITLE
FIX: ensure consistency in the GAT params and attributes

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -102,7 +102,7 @@ def test_generalization_across_time():
     gat.predict_mode = old_mode
 
     gat.score(epochs, y=epochs.events[:, 2])
-    assert_true("accuracy_score" in '%s' % gat.scorer_)
+    assert_true("accuracy_score" in '%s' % gat.scorer)
     epochs2 = epochs.copy()
 
     # check _DecodingTime class
@@ -238,6 +238,7 @@ def test_generalization_across_time():
             for n_class in n_classes:
                 y_ = y % n_class
                 with warnings.catch_warnings(record=True):
-                    gat = GeneralizationAcrossTime(cv=2, clf=clf)
+                    gat = GeneralizationAcrossTime(cv=2, clf=clf,
+                                                   scorer=scorer)
                     gat.fit(epochs, y=y_)
-                    gat.score(epochs, y=y_, scorer=scorer)
+                    gat.score(epochs, y=y_)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -81,7 +81,7 @@ def test_generalization_across_time():
         gat.fit(epochs, y=epochs.events[:, 2])
         # check optional y as list
         gat.fit(epochs, y=epochs.events[:, 2].tolist())
-    assert_equal(len(gat.picks), len(gat.ch_names), 1)
+    assert_equal(len(gat.picks_), len(gat.ch_names), 1)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)
@@ -104,16 +104,16 @@ def test_generalization_across_time():
     gat.predict_mode = old_mode
 
     gat.score(epochs, y=epochs.events[:, 2])
-    assert_true("accuracy_score" in '%s' % gat.scorer)
+    assert_true("accuracy_score" in '%s' % gat.scorer_)
     epochs2 = epochs.copy()
 
     # check _DecodingTime class
     assert_equal("<DecodingTime | start: -0.200 (s), stop: 0.499 (s), step: "
                  "0.047 (s), length: 0.047 (s), n_time_windows: 15>",
-                 "%s" % gat.train_times)
+                 "%s" % gat.train_times_)
     assert_equal("<DecodingTime | start: -0.200 (s), stop: 0.499 (s), step: "
                  "0.047 (s), length: 0.047 (s), n_time_windows: 15 x 15>",
-                 "%s" % gat.test_times)
+                 "%s" % gat.test_times_)
 
     # the y-check
     gat.predict_mode = 'mean-prediction'
@@ -130,12 +130,12 @@ def test_generalization_across_time():
     # ---  number of folds
     assert_true(np.shape(gat.estimators_)[1] == gat.cv)
     # ---  length training size
-    assert_true(len(gat.train_times['slices']) == 15 ==
+    assert_true(len(gat.train_times_['slices']) == 15 ==
                 np.shape(gat.estimators_)[0])
     # ---  length testing sizes
-    assert_true(len(gat.test_times['slices']) == 15 ==
+    assert_true(len(gat.test_times_['slices']) == 15 ==
                 np.shape(gat.scores_)[0])
-    assert_true(len(gat.test_times['slices'][0]) == 15 ==
+    assert_true(len(gat.test_times_['slices'][0]) == 15 ==
                 np.shape(gat.scores_)[1])
 
     # Test longer time window
@@ -149,7 +149,7 @@ def test_generalization_across_time():
     assert_true(isinstance(scores, list))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check
 
-    assert_equal(len(gat.test_times['slices'][0][0]), 2)
+    assert_equal(len(gat.test_times_['slices'][0][0]), 2)
     # Decim training steps
     gat = GeneralizationAcrossTime(train_times={'step': .100})
     with warnings.catch_warnings(record=True):
@@ -168,8 +168,8 @@ def test_generalization_across_time():
         gat.fit(epochs)
     gat.score(epochs)
     assert_equal(len(gat.scores_), 4)
-    assert_equal(gat.train_times['times_'][0], epochs.times[6])
-    assert_equal(gat.train_times['times_'][-1], epochs.times[9])
+    assert_equal(gat.train_times_['times'][0], epochs.times[6])
+    assert_equal(gat.train_times_['times'][-1], epochs.times[9])
 
     # Test score without passing epochs & Test diagonal decoding
     gat = GeneralizationAcrossTime(test_times='diagonal')

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -69,17 +69,19 @@ def test_generalization_across_time():
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True, decim=decim)
     # Test default running
-    gat = GeneralizationAcrossTime()
+    gat = GeneralizationAcrossTime(picks='foo')
     assert_equal("<GAT | no fit, no prediction, no score>", "%s" % gat)
-    assert_raises(ValueError, gat.fit, epochs, picks='foo')
+    assert_raises(ValueError, gat.fit, epochs)
     with warnings.catch_warnings(record=True):
         # check classic fit + check manual picks
-        gat.fit(epochs, picks=[0])
+        gat.picks = [0]
+        gat.fit(epochs)
         # check optional y as array
+        gat.picks = None
         gat.fit(epochs, y=epochs.events[:, 2])
         # check optional y as list
         gat.fit(epochs, y=epochs.events[:, 2].tolist())
-    assert_equal(len(gat.picks_), len(gat.ch_names), 1)
+    assert_equal(len(gat.picks), len(gat.ch_names), 1)
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -290,7 +290,7 @@ class GeneralizationAcrossTime(object):
         """ Test each classifier on each specified testing time slice.
 
         Note. This function sets and updates the ``y_pred_`` and the
-        ``test_times`` attribute.
+        ``test_times`` attributes.
 
         Parameters
         ----------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -169,7 +169,7 @@ class GeneralizationAcrossTime(object):
     scorer_ : object
         scikit-learn Scorer instance.
     scores_ : list of lists of float
-        The scores estimated by self.scorer at each training time and each
+        The scores estimated by self.scorer_ at each training time and each
         testing time (e.g. mean accuracy of self.predict(X)). Note that the
         number of testing times per training time need not be regular;
         else, np.shape(scores) = [n_train_time, n_test_time].

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -156,7 +156,9 @@ class GeneralizationAcrossTime(object):
 
         Jean-Remi King, Alexandre Gramfort, Aaron Schurger, Lionel Naccache
         and Stanislas Dehaene, "Two distinct dynamic modes subtend the
-        detection of unexpected sounds", PLOS ONE, 2013
+        detection of unexpected sounds", PLoS ONE, 2014
+        DOI: 10.1371/journal.pone.0085791
+
 
     .. versionadded:: 0.9.0
     """  # noqa

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -149,7 +149,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
     # Find and plot chance level
     if chance is not False:
         if chance is True:
-            chance = _get_chance_level(gat.scorer_, gat.y_train_)
+            chance = _get_chance_level(gat.scorer, gat.y_train_)
         ax.axhline(float(chance), color='k', linestyle='--',
                    label="Chance level")
     ax.axvline(0, color='k', label='')
@@ -179,7 +179,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
         ax.set_xlabel('Time (s)')
     if ylabel is True:
         ax.set_ylabel('Classif. score ({0})'.format(
-                      'AUC' if 'roc' in repr(gat.scorer_) else r'%'))
+                      'AUC' if 'roc' in repr(gat.scorer) else r'%'))
     if legend is True:
         ax.legend(loc='best')
     if show is True:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -204,7 +204,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
                 lag = test_times - train_time
                 test_idx = np.abs(lag).argmin()
                 # check that not more than 1 classifier away
-                if np.abs(lag[test_idx]) > gat.train_times['step']:
+                if np.abs(lag[test_idx]) > gat.train_times_['step']:
                     score = np.nan
                 else:
                     score = gat.scores_[train_idx][test_idx]
@@ -212,7 +212,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
     elif isinstance(train_time, float):
         train_times = gat.train_times_['times']
         idx = np.abs(train_times - train_time).argmin()
-        if train_times[idx] - train_time > gat.train_times['step']:
+        if train_times[idx] - train_time > gat.train_times_['step']:
             raise ValueError("No classifier trained at %s " % train_time)
         scores = gat.scores_[idx]
     else:

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -64,7 +64,7 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
     # Define time limits
     if tlim is None:
         tt_times = gat.train_times['times_']
-        tn_times = gat.test_times_['times_']
+        tn_times = gat.test_times['times_']
         tlim = [tn_times[0][0], tn_times[-1][-1], tt_times[0], tt_times[-1]]
 
     # Plot scores
@@ -192,14 +192,14 @@ def _plot_gat_time(gat, train_time, ax, color, label):
 
     Plots a unique score 1d array"""
     # Detect whether gat is a full matrix or just its diagonal
-    if np.all(np.unique([len(t) for t in gat.test_times_['times_']]) == 1):
+    if np.all(np.unique([len(t) for t in gat.test_times['times_']]) == 1):
         scores = gat.scores_
     elif train_time == 'diagonal':
         # Get scores from identical training and testing times even if GAT
         # is not square.
         scores = np.zeros(len(gat.scores_))
         for train_idx, train_time in enumerate(gat.train_times['times_']):
-            for test_times in gat.test_times_['times_']:
+            for test_times in gat.test_times['times_']:
                 # find closest testing time from train_time
                 lag = test_times - train_time
                 test_idx = np.abs(lag).argmin()

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -63,8 +63,8 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
 
     # Define time limits
     if tlim is None:
-        tt_times = gat.train_times['times_']
-        tn_times = gat.test_times['times_']
+        tt_times = gat.train_times_['times']
+        tn_times = gat.test_times_['times']
         tlim = [tn_times[0][0], tn_times[-1][-1], tt_times[0], tt_times[-1]]
 
     # Plot scores
@@ -149,7 +149,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
     # Find and plot chance level
     if chance is not False:
         if chance is True:
-            chance = _get_chance_level(gat.scorer, gat.y_train_)
+            chance = _get_chance_level(gat.scorer_, gat.y_train_)
         ax.axhline(float(chance), color='k', linestyle='--',
                    label="Chance level")
     ax.axvline(0, color='k', label='')
@@ -179,7 +179,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
         ax.set_xlabel('Time (s)')
     if ylabel is True:
         ax.set_ylabel('Classif. score ({0})'.format(
-                      'AUC' if 'roc' in repr(gat.scorer) else r'%'))
+                      'AUC' if 'roc' in repr(gat.scorer_) else r'%'))
     if legend is True:
         ax.legend(loc='best')
     if show is True:
@@ -192,14 +192,14 @@ def _plot_gat_time(gat, train_time, ax, color, label):
 
     Plots a unique score 1d array"""
     # Detect whether gat is a full matrix or just its diagonal
-    if np.all(np.unique([len(t) for t in gat.test_times['times_']]) == 1):
+    if np.all(np.unique([len(t) for t in gat.test_times_['times']]) == 1):
         scores = gat.scores_
     elif train_time == 'diagonal':
         # Get scores from identical training and testing times even if GAT
         # is not square.
         scores = np.zeros(len(gat.scores_))
-        for train_idx, train_time in enumerate(gat.train_times['times_']):
-            for test_times in gat.test_times['times_']:
+        for train_idx, train_time in enumerate(gat.train_times_['times']):
+            for test_times in gat.test_times_['times']:
                 # find closest testing time from train_time
                 lag = test_times - train_time
                 test_idx = np.abs(lag).argmin()
@@ -210,7 +210,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
                     score = gat.scores_[train_idx][test_idx]
                 scores[train_idx] = score
     elif isinstance(train_time, float):
-        train_times = gat.train_times['times_']
+        train_times = gat.train_times_['times']
         idx = np.abs(train_times - train_time).argmin()
         if train_times[idx] - train_time > gat.train_times['step']:
             raise ValueError("No classifier trained at %s " % train_time)
@@ -220,7 +220,7 @@ def _plot_gat_time(gat, train_time, ax, color, label):
     kwargs = dict()
     if color is not None:
         kwargs['color'] = color
-    ax.plot(gat.train_times['times_'], scores, label=str(label), **kwargs)
+    ax.plot(gat.train_times_['times'], scores, label=str(label), **kwargs)
 
 
 def _get_chance_level(scorer, y_train):

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -74,13 +74,13 @@ def test_gat_plot_times():
     """Test GAT times plot"""
     gat = _get_data()
     # test one line
-    gat.plot_times(gat.train_times['times_'][0])
+    gat.plot_times(gat.train_times_['times'][0])
     # test multiple lines
-    gat.plot_times(gat.train_times['times_'])
+    gat.plot_times(gat.train_times_['times'])
     # test multiple colors
-    n_times = len(gat.train_times['times_'])
-    colors = np.tile(['r', 'g', 'b'], int(np.ceil(n_times / 3)))[:n_times]
-    gat.plot_times(gat.train_times['times_'], color=colors)
+    n_times = len(gat.train_times_['times'])
+    colors = np.tile(['r', 'g', 'b'], np.ceil(n_times / 3))[:n_times]
+    gat.plot_times(gat.train_times_['times'], color=colors)
     # test invalid time point
     assert_raises(ValueError, gat.plot_times, -1.)
     # test float type

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -45,9 +45,9 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     epochs = concatenate_epochs(epochs_list)
 
     # Test default running
-    gat = GeneralizationAcrossTime()
+    gat = GeneralizationAcrossTime(test_times=test_times)
     gat.fit(epochs)
-    gat.score(epochs, test_times=test_times)
+    gat.score(epochs)
     return gat
 
 


### PR DESCRIPTION
The PR aims at adopting a stricter design close to sklearn and numpy: all params are set at the ```__init__``` time, as opposed to setting each of them at ```__init__()```, ```fit()```, ```predict()``` and/or ```score()```. 

These functions update the attributes corresponding to  each params (e.g. `pick` is set at `init` and`picks_` is updated at ```fit()``` because it requires epochs to be defined)

As ```picks```, ```test_times```, ```predict_mode``` and ```scorer``` are params, the corresponding attributes are not saved with an extra ```_``` (e.g. ```self.scorer_``` becomes ```self.scorer```).

See issue: https://github.com/mne-tools/mne-python/issues/2119#issuecomment-103539540