### PR TITLE
FIX: Faster read speed

### DIFF
--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1226,6 +1226,7 @@ def apply_forward_raw(fwd, stc, raw_template, start=None, stop=None,
     raw.info = _fill_measurement_info(raw.info, fwd, sfreq)
     raw.info['projs'] = []
     raw._projector = None
+    raw._update_times()
     return raw
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -233,7 +233,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                                    'not %s' % preload.dtype)
             self._data = preload
             self.preload = True
-            self._last_samps = np.array([self._data.shape[1] - 1])
+            last_samps = [self._data.shape[1] - 1]
             load_from_disk = False
         else:
             if last_samps is None:
@@ -246,7 +246,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                 raise ValueError('bad preload: %s' % preload)
             else:
                 load_from_disk = True
-            self._last_samps = np.array(last_samps)
+        self._last_samps = np.array(last_samps)
+        self._first_samps = np.array(first_samps)
         self.info = info
         cals = np.empty(info['nchan'])
         for k in range(info['nchan']):
@@ -257,13 +258,13 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         self.comp = comp
         self._orig_comp_grade = orig_comp_grade
         self._filenames = list(filenames)
-        self._first_samps = np.array(first_samps)
         self.orig_format = orig_format
         self._projectors = list()
         self._projector = None
         # If we have True or a string, actually do the preloading
         if load_from_disk:
             self._preload_data(preload)
+        self._update_times()
 
     def _read_segment(start, stop, sel, data_buffer, projector, verbose):
         """Read a chunk of raw data
@@ -320,6 +321,10 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         assert len(self._data) == self.info['nchan']
         self.preload = True
         self.close()
+
+    def _update_times(self):
+        """Helper to update times"""
+        self._times = np.arange(self.n_times) / float(self.info['sfreq'])
 
     @property
     def first_samp(self):
@@ -868,6 +873,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         # adjust affected variables
         self._data = np.concatenate(new_data, axis=1)
         self.info['sfreq'] = sfreq
+        self._update_times()
 
     def crop(self, tmin=0.0, tmax=None, copy=True):
         """Crop raw data file.
@@ -922,6 +928,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         if raw.preload:
             # slice and copy to avoid the reference to large array
             raw._data = raw._data[:, smin:smax + 1].copy()
+        raw._update_times()
         return raw
 
     @verbose
@@ -1355,7 +1362,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
     @property
     def times(self):
         """Time points"""
-        return np.arange(self.n_times) / float(self.info['sfreq'])
+        return self._times
 
     @property
     def n_times(self):
@@ -1477,6 +1484,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             self._last_samps = np.r_[self._last_samps, r._last_samps]
             self._rawdirs += r._rawdirs
             self._filenames += r._filenames
+        self._update_times()
 
     def close(self):
         """Clean up the object.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -325,6 +325,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
     def _update_times(self):
         """Helper to update times"""
         self._times = np.arange(self.n_times) / float(self.info['sfreq'])
+        # make it immutable
+        self._times.flags.writeable = False
 
     @property
     def first_samp(self):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -666,6 +666,7 @@ class ICA(ContainsMixin):
 
         out._projector = None
         self._export_info(out.info, raw, add_channels)
+        out._update_times()
 
         return out
 

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -86,6 +86,7 @@ def test_find_events():
     raw._data[stim_channel_idx, 520:530] = 6
     raw._data[stim_channel_idx, 530:532] = 5
     raw._data[stim_channel_idx, 540] = 6
+    raw._update_times()
 
     # consecutive=False
     find_events = dict(consecutive=False)

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -150,6 +150,7 @@ def test_find_events():
     # Reset some data for ease of comparison
     raw._first_samps[0] = 0
     raw.info['sfreq'] = 1000
+    raw._update_times()
 
     stim_channel = 'STI 014'
     stim_channel_idx = pick_channels(raw.info['ch_names'],


### PR DESCRIPTION
This speeds up Hari's example for me by a factor of ~400. Turns out `.times` was being created really often and bogging things down.

Closes #2049.