### PR TITLE
FIX:  kit2fiff GUI “clear all” command

### DIFF
--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -246,7 +246,7 @@ class Kit2FiffModel(HasPrivateTraits):
     def clear_all(self):
         """Clear all specified input parameters"""
         self.markers.clear = True
-        self.reset_traits(['sqd_file', 'hsp_file', 'fid_file'])
+        self.reset_traits(['sqd_file', 'hsp_file', 'fid_file', 'use_mrk'])
 
     def get_event_info(self):
         """

--- a/mne/gui/tests/test_kit2fiff_gui.py
+++ b/mne/gui/tests/test_kit2fiff_gui.py
@@ -89,6 +89,11 @@ def test_kit2fiff_model():
     events = mne.find_events(raw, stim_channel='STI 014')
     assert_array_equal(events, events_bin)
 
+    # test reset
+    model.clear_all()
+    assert_equal(model.use_mrk, [0, 1, 2, 3, 4])
+    assert_equal(model.sqd_file, "")
+
     os.environ['_MNE_GUI_TESTING_MODE'] = 'true'
     try:
         with warnings.catch_warnings(record=True):  # traits warnings


### PR DESCRIPTION
Just a small usability fix

Did not reset use_mrk trait, which could lead users to 
inadvertently not using a marker point in the next file they process