### PR TITLE
MRG: implement fully generalized M-way rANOVA in parametric.py

### DIFF
--- a/doc/source/python_reference.rst
+++ b/doc/source/python_reference.rst
@@ -787,6 +787,7 @@ Statistics
    spatio_temporal_cluster_1samp_test
    ttest_1samp_no_p
    linear_regression
+   f_mway_rm
 
 Functions to compute connectivity (adjacency) matrices for cluster-level statistics
 

--- a/examples/stats/plot_cluster_stats_spatio_temporal_repeated_measures_anova.py
+++ b/examples/stats/plot_cluster_stats_spatio_temporal_repeated_measures_anova.py
@@ -27,8 +27,8 @@ import matplotlib.pyplot as plt
 import mne
 from mne import (io, spatial_tris_connectivity, compute_morph_matrix,
                  grade_to_tris)
-from mne.stats import (spatio_temporal_cluster_test, f_threshold_twoway_rm,
-                       f_twoway_rm, summarize_clusters_stc)
+from mne.stats import (spatio_temporal_cluster_test, f_threshold_mway_rm,
+                       f_mway_rm, summarize_clusters_stc)
 
 from mne.minimum_norm import apply_inverse, read_inverse_operator
 from mne.datasets import sample
@@ -168,8 +168,8 @@ def stat_fun(*args):
     # subjects X conditions X observations (optional).
     # The following expression catches the list input
     # and swaps the first and the second dimension, and finally calls ANOVA.
-    return f_twoway_rm(np.swapaxes(args, 1, 0), factor_levels=factor_levels,
-                       effects=effects, return_pvals=return_pvals)[0]
+    return f_mway_rm(np.swapaxes(args, 1, 0), factor_levels=factor_levels,
+                     effects=effects, return_pvals=return_pvals)[0]
     # get f-values only.
     # Note. for further details on this ANOVA function consider the
     # corresponding time frequency example.
@@ -189,7 +189,7 @@ connectivity = spatial_tris_connectivity(lh_source_space)
 #    Now let's actually do the clustering. Please relax, on a small
 #    notebook and one single thread only this will take a couple of minutes ...
 pthresh = 0.0005
-f_thresh = f_threshold_twoway_rm(n_subjects, factor_levels, effects, pthresh)
+f_thresh = f_threshold_mway_rm(n_subjects, factor_levels, effects, pthresh)
 
 #    To speed things up a bit we will ...
 n_permutations = 128  # ... run fewer permutations (reduces sensitivity)

--- a/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
+++ b/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
@@ -30,10 +30,8 @@ import matplotlib.pyplot as plt
 import mne
 from mne import io
 from mne.time_frequency import single_trial_power
-from mne.stats import f_threshold_twoway_rm, f_twoway_rm, fdr_correction
-from mne.datasets import sample
-
-print(__doc__)
+from mne.stats import f_threshold_mway_rm, f_mway_rm, fdr_correction
+from mne.datasets import sample      rint(__doc__)
 
 ###############################################################################
 # Set parameters
@@ -128,9 +126,9 @@ print(data.shape)
 #
 # Now we're ready to run our repeated measures ANOVA.
 
-fvals, pvals = f_twoway_rm(data, factor_levels, effects=effects)
+fvals, pvals = f_mway_rm(data, factor_levels, effects=effects)
 
-effect_labels = ['modality', 'location', 'modality by location']
+fect_labels = ['modality', 'location', 'modality by location']
 
 # let's visualize our effects by computing f-images
 for effect, sig, effect_label in zip(fvals, pvals, effect_labels):
@@ -173,14 +171,14 @@ def stat_fun(*args):
     # subjects X conditions X observations (optional).
     # The following expression catches the list input and swaps the first and
     # the second dimension and finally calls the ANOVA function.
-    return f_twoway_rm(np.swapaxes(args, 1, 0), factor_levels=factor_levels,
-                       effects=effects, return_pvals=False)[0]
+    return f_mway_rm(np.swapaxes(args, 1, 0), factor_levels=factor_levels,
+                     effects=effects, return_pvals=False)[0]
     # The ANOVA returns a tuple f-values and p-values, we will pick the former.
 
 
 pthresh = 0.00001  # set threshold rather high to save some time
-f_thresh = f_threshold_twoway_rm(n_replications, factor_levels, effects,
-                                 pthresh)
+f_thresh = f_threshold_mway_rm(n_replications, factor_levels, effects,
+                               pthresh)
 tail = 1  # f-test, so tail > 0
 n_permutations = 256  # Save some time (the test won't be too sensitive ...)
 T_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(

--- a/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
+++ b/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
@@ -130,7 +130,7 @@ print(data.shape)
 
 fvals, pvals = f_mway_rm(data, factor_levels, effects=effects)
 
-fect_labels = ['modality', 'location', 'modality by location']
+effect_labels = ['modality', 'location', 'modality by location']
 
 # let's visualize our effects by computing f-images
 for effect, sig, effect_label in zip(fvals, pvals, effect_labels):

--- a/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
+++ b/examples/stats/plot_cluster_stats_time_frequency_repeated_measures_anova.py
@@ -31,7 +31,9 @@ import mne
 from mne import io
 from mne.time_frequency import single_trial_power
 from mne.stats import f_threshold_mway_rm, f_mway_rm, fdr_correction
-from mne.datasets import sample      rint(__doc__)
+from mne.datasets import sample
+
+print(__doc__)
 
 ###############################################################################
 # Set parameters

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -1,6 +1,7 @@
 """Functions for statistical analysis"""
 
-from .parametric import f_threshold_twoway_rm, f_twoway_rm
+from .parametric import (
+    f_threshold_twoway_rm, f_threshold_mway_rm, f_twoway_rm f_mway_rm) 
 from .permutations import permutation_t_test
 from .cluster_level import (permutation_cluster_test,
                             permutation_cluster_1samp_test,

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -1,7 +1,7 @@
 """Functions for statistical analysis"""
 
 from .parametric import (
-    f_threshold_twoway_rm, f_threshold_mway_rm, f_twoway_rm f_mway_rm) 
+    f_threshold_twoway_rm, f_threshold_mway_rm, f_twoway_rm, f_mway_rm) 
 from .permutations import permutation_t_test
 from .cluster_level import (permutation_cluster_test,
                             permutation_cluster_1samp_test,

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -7,22 +7,15 @@
 import numpy as np
 from ..fixes import matrix_rank
 from functools import reduce
-
-defaults_twoway_rm = {
-    'parse': {
-        'A': [0],
-        'B': [1],
-        'A+B': [0, 1],
-        'A:B': [2],
-        'A*B': [0, 1, 2]
-    },
-    'iter_contrasts': np.array([(1, 0, 1), (0, 1, 1), (1, 1, 1)])
-}
-
+from string import ascii_uppercase
+from mne.externals.six import string_types
+from mne.utils import deprecated
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
 # copy the data while keeping the inputs unchanged.
+
+
 def _f_oneway(*args):
     """
     Performs a 1-way ANOVA.
@@ -101,20 +94,76 @@ def f_oneway(*args):
     return _f_oneway(*args)[0]
 
 
-def _check_effects(effects):
-    """ Aux Function """
-    if effects.upper() not in defaults_twoway_rm['parse']:
-        raise ValueError('The value passed for `effects` is not supported. '
-                         'Please consider the documentation.')
+def _map_effects(n_factors, effects):
+    """Map effects to indices"""
+    if n_factors > len(ascii_uppercase):
+        raise ValueError('Maximum number of factors supported is 26')
 
-    return defaults_twoway_rm['parse'][effects]
+    factor_names = list(ascii_uppercase[:n_factors])
+
+    if isinstance(effects, string_types):
+        if '*' in effects and ':' in effects:
+            raise ValueError('Not "*" and ":" permitted in effects')
+        elif '+' in effects and ':' in effects:
+            raise ValueError('Not "+" and ":" permitted in effects')
+        elif effects == 'all':
+            effects = None
+        elif len(effects) == 1 or ':' in effects:
+            effects = [effects]
+        elif '+' in effects:
+            # all main effects
+            effects = effects.split('+')
+        elif '*' in effects:
+            pass  # handle later
+        else:
+            raise ValueError('"{0}" is not a valid option for "effects"'
+                             .format(effects))
+    if isinstance(effects, list):
+        bad_names = [e for e in effects if e not in factor_names]
+        if len(bad_names) > 1:
+            raise ValueError('Effect names: {0} are not valid. They should '
+                             'the first `n_factors` ({1}) characters from the'
+                             'alphabet'.format(bad_names, n_factors))
+
+    indices = list(np.arange(2 ** n_factors - 1))
+    names = list()
+    for this_effect in indices:
+        contrast_idx = _get_contrast_indices(this_effect + 1, n_factors)
+        this_code = (n_factors - 1) - np.where(contrast_idx == 1)[0]
+        this_name = [factor_names[e] for e in this_code]
+        this_name.sort()
+        names.append(':'.join(this_name))
+
+    if effects is None or isinstance(effects, string_types):
+        effects_ = names
+    else:
+        effects_ = effects
+
+    selection = [names.index(sel) for sel in effects_]
+    names = [names[sel] for sel in selection]
+
+    if isinstance(effects, string_types):
+        if '*' in effects:
+            # hierarchical order of effects
+            # the * based effect can be used as stop index
+            sel_ind = names.index(effects.replace('*', ':')) + 1
+            names = names[:sel_ind]
+            selection = selection[:sel_ind]
+
+    return selection, names
+
+
+def _get_contrast_indices(effect_idx, n_factors):
+    """Henson's factor coding, see num2binvec"""
+    binrepr = np.binary_repr(effect_idx, n_factors)
+    return np.array([int(i) for i in binrepr], dtype=int)
 
 
 def _iter_contrasts(n_subjects, factor_levels, effect_picks):
     """ Aux Function: Setup contrasts """
     from scipy.signal import detrend
-    sc, sy, = [], []
-
+    sc = []
+    n_factors = len(factor_levels)
     # prepare computation of Kronecker products
     for n_levels in factor_levels:
         # for each factor append
@@ -124,16 +173,13 @@ def _iter_contrasts(n_subjects, factor_levels, effect_picks):
         # main + interaction effects for contrasts
         sc.append([np.ones([n_levels, 1]),
                    detrend(np.eye(n_levels), type='constant')])
-        # main + interaction effects for component means
-        sy.append([np.ones([n_levels, 1]) / n_levels, np.eye(n_levels)])
-        # XXX component means not returned at the moment
 
-    for (c1, c2, c3) in defaults_twoway_rm['iter_contrasts'][effect_picks]:
-        # c1 selects the first factors' level in the column vector
-        # c3 selects the actual factor
-        # c2 selects either its column vector or diag matrix
-        c_ = np.kron(sc[0][c1], sc[c3][c2])
-        # for 3 way anova accumulation of c_ across factors required
+    for this_effect in effect_picks:
+        contrast_idx = _get_contrast_indices(this_effect + 1, n_factors)
+        c_ = sc[0][contrast_idx[n_factors - 1]]
+        for i_contrast in range(1, n_factors):
+            this_contrast = contrast_idx[(n_factors - 1) - i_contrast]
+            c_ = np.kron(c_, sc[i_contrast][this_contrast])
         df1 = matrix_rank(c_)
         df2 = df1 * (n_subjects - 1)
         yield c_, df1, df2
@@ -167,7 +213,7 @@ def f_threshold_twoway_rm(n_subjects, factor_levels, effects='A*B',
         requested > 2, else float.
     """
     from scipy.stats import f
-    effect_picks = _check_effects(effects)
+    effect_picks, _ = _map_effects(len(factor_levels), effects)
 
     f_threshold = []
     for _, df1, df2 in _iter_contrasts(n_subjects, factor_levels,
@@ -179,9 +225,19 @@ def f_threshold_twoway_rm(n_subjects, factor_levels, effects='A*B',
 
 # The following functions based on MATLAB code by Rik Henson
 # and Python code from the pvttble toolbox by Roger Lew.
+@deprecated('"f_twoway_rm" is deprecated and will be removed in MNE 0.11."'
+            " Please use f_mway_rm instead")
 def f_twoway_rm(data, factor_levels, effects='A*B', alpha=0.05,
                 correction=False, return_pvals=True):
-    """2-way repeated measures ANOVA for fully balanced designs
+    """This function is deprecated, use `f_mway_rm` instead"""
+    return f_mway_rm(data=data, factor_levels=factor_levels, effects=effects,
+                     alpha=alpha, correction=correction,
+                     return_pvals=return_pvals)
+
+
+def f_mway_rm(data, factor_levels, effects='all', alpha=0.05,
+              correction=False, return_pvals=True):
+    """M-way repeated measures ANOVA for fully balanced designs
 
     Parameters
     ----------
@@ -200,14 +256,17 @@ def f_twoway_rm(data, factor_levels, effects='A*B', alpha=0.05,
         for mass univariate analysis.
     factor_levels : list-like
         The number of levels per factor.
-    effects : str
+    effects : str | list
         A string denoting the effect to be returned. The following
-        mapping is currently supported:
+        mapping is currently supported (example with 2 factors):
             'A': main effect of A
             'B': main effect of B
             'A:B': interaction effect
             'A+B': both main effects
             'A*B': all three effects
+            'all': all effects (equals 'A*B' in a 2 way design)
+        if list, effect names are used:
+            ['A', 'B', 'A:B']
     alpha : float
         The significance threshold.
     correction : bool
@@ -233,7 +292,7 @@ def f_twoway_rm(data, factor_levels, effects='A*B', alpha=0.05,
         data = data.reshape(data.shape[0], data.shape[1],
                             np.prod(data.shape[2:]))
 
-    effect_picks = _check_effects(effects)
+    effect_picks, _ = _map_effects(len(factor_levels), effects)
     n_obs = data.shape[2]
     n_replications = data.shape[0]
 

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -8,8 +8,8 @@ import numpy as np
 from ..fixes import matrix_rank
 from functools import reduce
 from string import ascii_uppercase
-from mne.externals.six import string_types
-from mne.utils import deprecated
+from ..externals.six import string_types
+from ..utils import deprecated
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
@@ -185,8 +185,17 @@ def _iter_contrasts(n_subjects, factor_levels, effect_picks):
         yield c_, df1, df2
 
 
+@deprecated('"f_threshold_twoway_rm" is deprecated and will be removed in'
+            'MNE-0.11. Please use f_threshold_mway_rm instead')
 def f_threshold_twoway_rm(n_subjects, factor_levels, effects='A*B',
                           pvalue=0.05):
+    return f_threshold_mway_rm(
+        n_subjects=n_subjects, factor_levels=factor_levels,
+        effects=effects, pvalue=pvalue)
+
+
+def f_threshold_mway_rm(n_subjects, factor_levels, effects='A*B',
+                        pvalue=0.05):
     """ Compute f-value thesholds for a two-way ANOVA
 
     Parameters
@@ -289,8 +298,8 @@ def f_mway_rm(data, factor_levels, effects='all', alpha=0.05,
     if data.ndim == 2:  # general purpose support, e.g. behavioural data
         data = data[:, :, np.newaxis]
     elif data.ndim > 3:  # let's allow for some magic here.
-        data = data.reshape(data.shape[0], data.shape[1],
-                            np.prod(data.shape[2:]))
+        data = data.reshape(
+            data.shape[0], data.shape[1], np.prod(data.shape[2:]))
 
     effect_picks, _ = _map_effects(len(factor_levels), effects)
     n_obs = data.shape[2]

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -5,11 +5,12 @@
 # License: Simplified BSD
 
 import numpy as np
-from ..fixes import matrix_rank
 from functools import reduce
 from string import ascii_uppercase
+
 from ..externals.six import string_types
 from ..utils import deprecated
+from ..fixes import matrix_rank
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not

--- a/mne/stats/tests/test_parametric.py
+++ b/mne/stats/tests/test_parametric.py
@@ -1,6 +1,6 @@
 from itertools import product
-from ..parametric import (f_mway_rm, f_threshold_twoway_rm,
-                          _map_effects)
+from mne.stats.parametric import (f_mway_rm, f_threshold_mway_rm,
+                                  _map_effects)
 from nose.tools import assert_raises, assert_true
 from numpy.testing import assert_array_almost_equal
 
@@ -18,7 +18,7 @@ test_external = {
     'r_pvals_uncorrected': np.array([0.12557, 0.78776, 0.1864]),
     # and https://gist.github.com/dengemann/5539403
     'r_fvals_3way': np.array([
-        0.74783999999999995,   # A  #noqua
+        0.74783999999999995,   # A
         0.20895,               # B
         0.21378,               # A:B
         0.99404000000000003,   # C
@@ -79,7 +79,7 @@ def test_f_twoway_rm():
         if n_effects == 1:  # test for principle of least surprise ...
             assert_true(fvals.ndim == 1)
 
-        fvals_ = f_threshold_twoway_rm(n_subj, _effects[n_levels], effects)
+        fvals_ = f_threshold_mway_rm(n_subj, _effects[n_levels], effects)
         assert_true((fvals_ >= 0).all())
         assert_true(fvals_.size == n_effects)
 
@@ -107,6 +107,5 @@ def test_f_twoway_rm():
     fvals, _ = f_mway_rm(test_data, [2, 2, 2])
     assert_array_almost_equal(fvals, test_external['r_fvals_3way'], 5)
 
-    test_data = generate_data(n_subjects=20, n_conditions=8)
     fvals, _ = f_mway_rm(test_data, [8], 'A')
     assert_array_almost_equal(fvals, test_external['r_fvals_1way'], 5)

--- a/mne/stats/tests/test_parametric.py
+++ b/mne/stats/tests/test_parametric.py
@@ -15,46 +15,45 @@ test_external = {
     # R 15.2
     # data generated using this code http://goo.gl/7UcKb
     'r_fvals': np.array([2.567619, 0.24006, 1.756380]),
-    'r_pvals_uncorrected': np.array([0.12557, 0.78776, 0.1864])
+    'r_pvals_uncorrected': np.array([0.12557, 0.78776, 0.1864]),
+    # and https://gist.github.com/dengemann/5539403
+    'r_fvals_3way': np.array([
+        0.74783999999999995,   # A  #noqua
+        0.20895,               # B
+        0.21378,               # A:B
+        0.99404000000000003,   # C
+        0.094039999999999999,  # A:C
+        0.11685,               # B:C
+        2.78749]),              # A:B:C
+    'r_fvals_1way': np.array([0.67571999999999999])
 }
 
-#  generated using this expression: `np.random.RandomState(42).randn(20, 6)`
-test_data = np.array(
-[[0.49671415, -0.1382643, 0.64768854, 1.52302986, -0.23415337, -0.23413696],  # noqa
- [1.57921282, 0.76743473, -0.46947439, 0.54256004, -0.46341769, -0.46572975],
- [0.24196227, -1.91328024, -1.72491783, -0.56228753, -1.01283112, 0.31424733],
- [-0.90802408, -1.4123037, 1.46564877, -0.2257763, 0.0675282, -1.42474819],
- [-0.54438272, 0.11092259, -1.15099358, 0.37569802, -0.60063869, -0.29169375],
- [-0.60170661, 1.85227818, -0.01349722, -1.05771093, 0.82254491, -1.22084365],
- [0.2088636, -1.95967012, -1.32818605, 0.19686124, 0.73846658, 0.17136828],
- [-0.11564828, -0.3011037, -1.47852199, -0.71984421, -0.46063877, 1.05712223],
- [0.34361829, -1.76304016, 0.32408397, -0.38508228, -0.676922, 0.61167629],
- [1.03099952, 0.93128012, -0.83921752, -0.30921238, 0.33126343, 0.97554513],
- [-0.47917424, -0.18565898, -1.10633497, -1.19620662, 0.81252582, 1.35624003],
- [-0.07201012, 1.0035329, 0.36163603, -0.64511975, 0.36139561, 1.53803657],
- [-0.03582604, 1.56464366, -2.6197451, 0.8219025, 0.08704707, -0.29900735],
- [0.09176078, -1.98756891, -0.21967189, 0.35711257, 1.47789404, -0.51827022],
- [-0.8084936, -0.50175704, 0.91540212, 0.32875111, -0.5297602, 0.51326743],
- [0.09707755, 0.96864499, -0.70205309, -0.32766215, -0.39210815, -1.46351495],
- [0.29612028, 0.26105527, 0.00511346, -0.23458713, -1.41537074, -0.42064532],
- [-0.34271452, -0.80227727, -0.16128571, 0.40405086, 1.8861859, 0.17457781],
- [0.25755039, -0.07444592, -1.91877122, -0.02651388, 0.06023021, 2.46324211],
- [-0.19236096, 0.30154734, -0.03471177, -1.16867804, 1.14282281, 0.75193303]])
+
+def generate_data(n_subjects, n_conditions):
+    """generate testing data"""
+    rng = np.random.RandomState(42)
+    data = rng.randn(n_subjects * n_conditions).reshape(
+        n_subjects, n_conditions)
+    return data
 
 
-def test_parametric_utils():
-    """ Test ANOVA private functions """
-    selection, names = _map_effects(2, 'A')
+def test_map_effects():
+    """ Test ANOVA effects parsing"""
+    selection, names = _map_effects(n_factors=2, effects='A')
     assert_true(names, ['A'])
-    selection, names = _map_effects(2, ['A', 'A:B'])
+
+    selection, names = _map_effects(n_factors=2, effects=['A', 'A:B'])
     assert_true(names, ['A', 'A:B'])
-    selection, names = _map_effects(3, 'A*B')
+
+    selection, names = _map_effects(n_factors=3, effects='A*B')
     assert_true(names, ['A', 'B', 'A:B'])
-    selection, names = _map_effects(3, 'A*C')
+
+    selection, names = _map_effects(n_factors=3, effects='A*C')
     assert_true(names, ['A', 'B', 'A:B', 'C', 'A:C', 'B:C', 'A:B:C'])
 
-    assert_raises(ValueError, _map_effects, 2, 'C')
-    assert_raises(ValueError, _map_effects, 27, 'all')
+    assert_raises(ValueError, _map_effects, n_factors=2, effects='C')
+
+    assert_raises(ValueError, _map_effects, n_factors=27, effects='all')
 
 
 def test_f_twoway_rm():
@@ -92,6 +91,7 @@ def test_f_twoway_rm():
     f_mway_rm(data, _effects[n_levels], effects, correction=correction)
 
     # now check against external software results
+    test_data = generate_data(n_subjects=20, n_conditions=6)
     fvals, pvals = f_mway_rm(test_data, [2, 3])
 
     assert_array_almost_equal(fvals, test_external['spss_fvals'], 3)
@@ -102,3 +102,11 @@ def test_f_twoway_rm():
 
     _, pvals = f_mway_rm(test_data, [2, 3], correction=True)
     assert_array_almost_equal(pvals, test_external['spss_pvals_corrected'], 3)
+
+    test_data = generate_data(n_subjects=20, n_conditions=8)
+    fvals, _ = f_mway_rm(test_data, [2, 2, 2])
+    assert_array_almost_equal(fvals, test_external['r_fvals_3way'], 5)
+
+    test_data = generate_data(n_subjects=20, n_conditions=8)
+    fvals, _ = f_mway_rm(test_data, [8], 'A')
+    assert_array_almost_equal(fvals, test_external['r_fvals_1way'], 5)


### PR DESCRIPTION
Adresses #590

Implemented the missing parts of the Rick Henson code and extended the contrasts API.
With this modifcation M-way repeated measures models can be computed on data with mutliple observations per sample and per condition.

Tests need to be updated to incorporate 1way and 3way results.

cc @virvw @kingjr @Eric89GXL @josef-pkt @agramfort 
