### PR TITLE
FIX write_labels_to_annot():  List of RH labels only

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -1583,7 +1583,7 @@ def _get_annot_fname(annot_fname, subject, hemi, parc, subjects_dir):
 
         subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
         dst = op.join(subjects_dir, subject, 'label', '%%s.%s.annot' % parc)
-        annot_fname = [dst % hemi for hemi in hemis]
+        annot_fname = [dst % hemi_ for hemi_ in hemis]
 
     return annot_fname, hemis
 

--- a/mne/label.py
+++ b/mne/label.py
@@ -1581,12 +1581,9 @@ def _get_annot_fname(annot_fname, subject, hemi, parc, subjects_dir):
         else:
             hemis = [hemi]
 
-        annot_fname = list()
-        for hemi in hemis:
-            subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
-            fname = op.join(subjects_dir, subject, 'label',
-                            '%s.%s.annot' % (hemi, parc))
-            annot_fname.append(fname)
+        subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+        dst = op.join(subjects_dir, subject, 'label', '%%s.%s.annot' % parc)
+        annot_fname = [dst % hemi for hemi in hemis]
 
     return annot_fname, hemis
 

--- a/mne/label.py
+++ b/mne/label.py
@@ -1800,6 +1800,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
 
         if n_hemi_labels == 0:
             ctab = np.empty((0, 4), dtype=np.int32)
+            ctab_rgb = ctab[:, :3]
         else:
             hemi_labels.sort(key=lambda label: label.name)
 

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -435,9 +435,39 @@ def test_write_labels_to_annot():
 
     labels = read_labels_from_annot('sample', subjects_dir=subjects_dir)
 
-    # write left and right hemi labels:
-    fnames = ['%s/%s-myparc' % (tempdir, hemi) for hemi in ['lh', 'rh']]
+    # create temporary subjects-dir skeleton
+    surf_dir = op.join(subjects_dir, 'sample', 'surf')
+    temp_surf_dir = op.join(tempdir, 'sample', 'surf')
+    os.makedirs(temp_surf_dir)
+    shutil.copy(op.join(surf_dir, 'lh.white'), temp_surf_dir)
+    shutil.copy(op.join(surf_dir, 'rh.white'), temp_surf_dir)
+    os.makedirs(op.join(tempdir, 'sample', 'label'))
 
+    # test automatic filenames
+    dst = op.join(tempdir, 'sample', 'label', '%s.%s.annot')
+    write_labels_to_annot(labels, 'sample', 'test1', subjects_dir=tempdir)
+    assert_true(op.exists(dst % ('lh', 'test1')))
+    assert_true(op.exists(dst % ('rh', 'test1')))
+    # lh only
+    for label in labels:
+        if label.hemi == 'lh':
+            break
+    write_labels_to_annot([label], 'sample', 'test2', subjects_dir=tempdir)
+    assert_true(op.exists(dst % ('lh', 'test2')))
+    assert_true(op.exists(dst % ('rh', 'test2')))
+    # rh only
+    for label in labels:
+        if label.hemi == 'rh':
+            break
+    write_labels_to_annot([label], 'sample', 'test3', subjects_dir=tempdir)
+    assert_true(op.exists(dst % ('lh', 'test3')))
+    assert_true(op.exists(dst % ('rh', 'test3')))
+    # label alone
+    assert_raises(TypeError, write_labels_to_annot, labels[0], 'sample',
+                  'test4', subjects_dir=tempdir)
+
+    # write left and right hemi labels with filenames:
+    fnames = ['%s/%s-myparc' % (tempdir, hemi) for hemi in ['lh', 'rh']]
     for fname in fnames:
         write_labels_to_annot(labels, annot_fname=fname)
 


### PR DESCRIPTION
If a user tried to save an `annot` containing only RH-labels, `ctab_rgb` was not defined in the first (LH) iteration
