### PR TITLE
BUG: no test_times_['times'] if test_time is 'diagonal'

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -156,6 +156,8 @@ def test_generalization_across_time():
     scores = gat.score()
     assert_true(scores is gat.scores_)
     assert_equal(np.shape(gat.scores_), (15, 1))
+    assert_true(np.all([tim for ttime in gat.test_times_['times']
+                        for tim in ttime] == gat.train_times_['times']))
 
     # Test generalization across conditions
     gat = GeneralizationAcrossTime(predict_mode='mean-prediction')

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -9,6 +9,7 @@ import os.path as op
 
 from nose.tools import assert_equal, assert_true, assert_raises
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_sklearn, slow_test
@@ -156,8 +157,8 @@ def test_generalization_across_time():
     scores = gat.score()
     assert_true(scores is gat.scores_)
     assert_equal(np.shape(gat.scores_), (15, 1))
-    assert_true(np.all([tim for ttime in gat.test_times_['times']
-                        for tim in ttime] == gat.train_times_['times']))
+    assert_array_equal([tim for ttime in gat.test_times_['times']
+                        for tim in ttime], gat.train_times_['times'])
 
     # Test generalization across conditions
     gat = GeneralizationAcrossTime(predict_mode='mean-prediction')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -356,6 +356,7 @@ class GeneralizationAcrossTime(object):
         if self.test_times == 'diagonal':
             test_times = _DecodingTime()
             test_times['slices'] = [[s] for s in self.train_times_['slices']]
+            test_times['times'] = [[s] for s in self.train_times_['times']]
         elif isinstance(self.test_times, dict):
             test_times = copy.deepcopy(self.test_times)
         else:


### PR DESCRIPTION
There was a missing key in the `test_times_` attribute if the param `test_times` is `'diagonal'`.