### PR TITLE
MRG: Refactor Epochs classes

### DIFF
--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -56,8 +56,8 @@ tmin, tmax = -0.55, 0.75  # s
 tmin_plot, tmax_plot = -0.3, 0.5  # s
 
 # Read epochs. Note that preload is set to False to enable tf_lcmv to read the
-# underlying raw object from epochs.raw, which would be set to None during
-# preloading. Filtering is then performed on raw data in tf_lcmv and the epochs
+# underlying raw object.
+# Filtering is then performed on raw data in tf_lcmv and the epochs
 # parameters passed here are used to create epochs from filtered data. However,
 # reading epochs without preloading means that bad epoch rejection is delayed
 # until later. To perform bad epoch rejection based on the reject parameter

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -708,7 +708,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                          'window lengths')
 
     # Extract raw object from the epochs object
-    raw = epochs.raw
+    raw = epochs._raw
     if raw is None:
         raise ValueError('The provided epochs object does not contain the '
                          'underlying raw object. Please use preload=False '

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -114,11 +114,11 @@ def equalize_channels(candidates, verbose=None):
     This function operates inplace.
     """
     from ..io.base import _BaseRaw
-    from ..epochs import Epochs
+    from ..epochs import _BaseEpochs
     from ..evoked import Evoked
     from ..time_frequency import AverageTFR
 
-    if not all(isinstance(c, (_BaseRaw, Epochs, Evoked, AverageTFR))
+    if not all(isinstance(c, (_BaseRaw, _BaseEpochs, Evoked, AverageTFR))
                for c in candidates):
         valid = ['Raw', 'Epochs', 'Evoked', 'AverageTFR']
         raise ValueError('candidates must be ' + ' or '.join(valid))
@@ -433,11 +433,11 @@ class PickDropChannelsMixin(object):
     def _pick_drop_channels(self, idx):
         # avoid circular imports
         from ..io.base import _BaseRaw
-        from ..epochs import Epochs
+        from ..epochs import _BaseEpochs
         from ..evoked import Evoked
         from ..time_frequency import AverageTFR
 
-        if isinstance(self, (_BaseRaw, Epochs)):
+        if isinstance(self, (_BaseRaw, _BaseEpochs)):
             if not self.preload:
                 raise RuntimeError('Raw data must be preloaded to drop or pick'
                                    ' channels')
@@ -458,7 +458,7 @@ class PickDropChannelsMixin(object):
 
         if isinstance(self, _BaseRaw) and inst_has('_data'):
             self._data = self._data.take(idx, axis=0)
-        elif isinstance(self, Epochs) and inst_has('_data'):
+        elif isinstance(self, _BaseEpochs) and inst_has('_data'):
             self._data = self._data.take(idx, axis=1)
         elif isinstance(self, AverageTFR) and inst_has('data'):
             self.data = self.data.take(idx, axis=0)

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -20,8 +20,8 @@ from mne.channels.layout import (_box_size, _auto_topomap_coords,
                                  generate_2d_layout)
 from mne.utils import run_tests_if_main
 from mne import pick_types, pick_info
-from mne.io import Raw
-from mne.io import read_raw_kit
+from mne.io import Raw, read_raw_kit
+from mne.io.meas_info import Info
 from mne.io.constants import FIFF
 from mne.preprocessing.maxfilter import fit_sphere_to_headshape
 from mne.utils import _TempDir
@@ -43,7 +43,7 @@ fname_ctf_raw = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
 fname_kit_157 = op.join(op.dirname(__file__), '..', '..',  'io', 'kit',
                         'tests', 'data', 'test.sqd')
 
-test_info = {
+test_info = Info({
     'ch_names': ['ICA 001', 'ICA 002', 'EOG 061'],
     'chs': [{'cal': 1,
              'ch_name': 'ICA 001',
@@ -87,7 +87,7 @@ test_info = {
              'scanno': 376,
              'unit': 107,
              'unit_mul': 0}],
-    'nchan': 3}
+    'nchan': 3})
 
 
 def test_io_layout_lout():

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -965,8 +965,12 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                     data[n_out] = epoch
                     n_out += 1
 
-            self.selection = self.selection[good_events]
-            self.events = np.atleast_2d(self.events[good_events])
+            if len(good_events) == 0:  # silly fix for old numpy index error
+                self.selection = np.array([], int)
+                self.events = np.empty((0, 3))
+            else:
+                self.selection = self.selection[good_events]
+                self.events = np.atleast_2d(self.events[good_events])
             self._bad_dropped = True
             logger.info("%d bad epochs dropped"
                         % (n_events - len(good_events)))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -327,8 +327,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             # restrictive
             old_reject = self.reject if self.reject is not None else dict()
             new_reject = reject if reject is not None else dict()
-            new_flat = flat if flat is not None else dict()
             old_flat = self.flat if self.flat is not None else dict()
+            new_flat = flat if flat is not None else dict()
             bad_msg = ('{kind}["{key}"] == {new} {op} {old} (old value), new '
                        '{kind} values must be at least as stringent as '
                        'previous ones')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1012,7 +1012,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         if self._delayed_proj:
             data = np.zeros_like(data_)
             for ii, e in enumerate(data_):
-                data[ii] = self._preprocess(e.copy(), self.verbose)
+                data[ii] = self._preprocess(e.copy())
         else:
             data = data_.copy()
         return data
@@ -1055,7 +1055,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                 raise StopIteration
             epoch = self._data[self._current]
             if self._delayed_proj:
-                epoch = self._preprocess(epoch.copy(), self.verbose)
+                epoch = self._preprocess(epoch.copy())
             self._current += 1
         else:
             is_good = False
@@ -1068,7 +1068,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                 is_good, _ = self._is_good_epoch(epoch)
             # If delayed-ssp mode, pass 'virgin' data after rejection decision.
             if self._delayed_proj:
-                epoch = self._preprocess(epoch_raw, self.verbose)
+                epoch = self._preprocess(epoch_raw)
 
         if not return_event_id:
             return epoch
@@ -1669,7 +1669,7 @@ class EpochsArray(_BaseEpochs):
             raise ValueError('The events must only contain event numbers from '
                              'event_id')
         for ii, e in enumerate(self._data):
-            self._preprocess(e, self.verbose)
+            self._preprocess(e)
         self.drop_bad_epochs()
 
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1206,7 +1206,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         epochs.selection = key_selection
         epochs.events = np.atleast_2d(epochs.events[select])
         if epochs.preload:
-            epochs._data = epochs._data[select]
+            # ensure that each Epochs instance owns its own data so we can
+            # resize later if necessary
+            epochs._data = np.require(epochs._data[select], requirements=['O'])
         # update event id to reflect new content of epochs
         epochs.event_id = dict((k, v) for k, v in epochs.event_id.items()
                                if v in epochs.events[:, 2])

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -222,7 +222,12 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             self.preload_data()
 
     def preload_data(self):
-        """Preload the data"""
+        """Preload the data if not already preloaded
+
+        Notes
+        -----
+        .. versionadded:: 0.10.0
+        """
         if self.preload:
             return
         self._data = self._get_data()
@@ -252,7 +257,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         ``epochs.decimate(2).decimate(2)`` will be the same as
         ``epochs.decimate(4)``.
 
-        .. versionadded:: 0.10
+        .. versionadded:: 0.10.0
         """
         if decim < 1 or decim != int(decim):
             raise ValueError('decim must be an integer > 0')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -115,7 +115,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             self.events = events
             del events
         else:
-            self.drop_log = []
+            self.drop_log = list()
             self.selection = np.array([], int)
             # do not set self.events here, let subclass do it
 
@@ -224,8 +224,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
     def preload_data(self):
         """Preload the data if not already preloaded
 
+        Returns
+        -------
+        epochs : instance of Epochs
+            The epochs object.
+
         Notes
         -----
+        This function operates inplace.
+
         .. versionadded:: 0.10.0
         """
         if self.preload:
@@ -235,6 +242,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         self._decim_slice = slice(None, None, None)
         self._decim = 1
         self._raw_times = self.times
+        return self
 
     def decimate(self, decim, copy=False):
         """Decimate the epochs
@@ -789,7 +797,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         Should be used before slicing operations.
 
         .. Warning:: Operation is slow since all epochs have to be read from
-            disk. To avoid reading epochs form disk multiple times, initialize
+            disk. To avoid reading epochs from disk multiple times, initialize
             Epochs object with preload=True.
 
         Dropping bad epochs with different rejection and flat parameters
@@ -1395,7 +1403,7 @@ class Epochs(_BaseEpochs):
         by event_id, they will be marked as 'IGNORED' in the drop log.
     event_id : int | list of int | dict | None
         The id of the event to consider. If dict,
-        the keys can later be used to acces associated events. Example:
+        the keys can later be used to access associated events. Example:
         dict(auditory=1, visual=3). If int, a dict will be created with
         the id as string. If a list, all events with the IDs specified
         in the list are used. If None, all events will be used with
@@ -1418,7 +1426,7 @@ class Epochs(_BaseEpochs):
     picks : array-like of int | None (default)
         Indices of channels to include (if None, all channels are used).
     name : string
-        Comment that describes the Evoked data created.
+        Comment that describes the Epochs data created.
     preload : boolean
         Load all epochs from disk when creating the object
         or wait before accessing each epoch (more memory
@@ -1487,9 +1495,9 @@ class Epochs(_BaseEpochs):
     info: dict
         Measurement info.
     event_id : dict
-        Names of  of conditions corresponding to event_ids.
+        Names of conditions corresponding to event_ids.
     ch_names : list of string
-        List of channels' names.
+        List of channel names.
     selection : array
         List of indices of selected events (not dropped or ignored etc.). For
         example, if the original event array had 4 events and the second event
@@ -1600,7 +1608,7 @@ class EpochsArray(_BaseEpochs):
         Start time before event.
     event_id : int | list of int | dict | None
         The id of the event to consider. If dict,
-        the keys can later be used to acces associated events. Example:
+        the keys can later be used to access associated events. Example:
         dict(auditory=1, visual=3). If int, a dict will be created with
         the id as string. If a list, all events with the IDs specified
         in the list are used. If None, all events will be used with
@@ -2059,7 +2067,7 @@ def add_channels_epochs(epochs_list, name='Unknown', add_eeg_ref=True,
     epochs_list : list of Epochs
         Epochs object to concatenate.
     name : str
-        Comment that describes the Evoked data created.
+        Comment that describes the Epochs data created.
     add_eeg_ref : bool
         If True, an EEG average reference will be added (unless there is no
         EEG in the data).

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -114,6 +114,10 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                 raise ValueError('No desired events found.')
             self.events = events
             del events
+        else:
+            self.drop_log = []
+            self.selection = np.array([], int)
+            # do not set self.events here, let subclass do it
 
         # check reject_tmin and reject_tmax
         if (reject_tmin is not None) and (reject_tmin < tmin):
@@ -184,6 +188,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         self._raw_times = np.arange(start_idx,
                                     int(round(self.tmax * sfreq)) + 1) / sfreq
         self._decim = 1
+        # this method sets the self.times property
         self.decimate(decim)
 
         # setup epoch rejection
@@ -787,6 +792,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         re-calling this function.
         """
         self._bad_dropped = False
+        self._reject_setup()
         self._get_data(out=False)
 
     def drop_log_stats(self, ignore=['IGNORED']):
@@ -1492,10 +1498,10 @@ class Epochs(_BaseEpochs):
         a list of the reasons the event is not longer in the selection, e.g.:
 
         'IGNORED' if it isn't part of the current subset defined by the user;
-        'NO DATA' or 'TOO SHORT' if epoch didn't contain enough data;
+        'NO_DATA' or 'TOO_SHORT' if epoch didn't contain enough data;
         names of channels that exceeded the amplitude threshold;
         'EQUALIZED_COUNTS' (see equalize_event_counts);
-        or user-defined reasons (see drop_epochs).
+        or 'USER' for user-defined reasons (see drop_epochs).
     verbose : bool, str, int, or None
         See above.
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -34,10 +34,10 @@ from .io.write import (start_file, start_block, end_file, end_block,
                        write_id)
 from .io.base import ToDataFrameMixin
 
-aspect_dict = {'average': FIFF.FIFFV_ASPECT_AVERAGE,
-               'standard_error': FIFF.FIFFV_ASPECT_STD_ERR}
-aspect_rev = {str(FIFF.FIFFV_ASPECT_AVERAGE): 'average',
-              str(FIFF.FIFFV_ASPECT_STD_ERR): 'standard_error'}
+_aspect_dict = {'average': FIFF.FIFFV_ASPECT_AVERAGE,
+                'standard_error': FIFF.FIFFV_ASPECT_STD_ERR}
+_aspect_rev = {str(FIFF.FIFFV_ASPECT_AVERAGE): 'average',
+               str(FIFF.FIFFV_ASPECT_STD_ERR): 'standard_error'}
 
 
 class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
@@ -121,13 +121,13 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
 
             # find string-based entry
             if isinstance(condition, string_types):
-                if kind not in aspect_dict.keys():
+                if kind not in _aspect_dict.keys():
                     raise ValueError('kind must be "average" or '
                                      '"standard_error"')
 
                 comments, aspect_kinds, t = _get_entries(fid, evoked_node)
                 goods = np.logical_and(in1d(comments, [condition]),
-                                       in1d(aspect_kinds, [aspect_dict[kind]]))
+                                       in1d(aspect_kinds, [_aspect_dict[kind]]))
                 found_cond = np.where(goods)[0]
                 if len(found_cond) != 1:
                     raise ValueError('condition "%s" (%s) not found, out of '
@@ -258,7 +258,7 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         # Put the rest together all together
         self.nave = nave
         self._aspect_kind = aspect_kind
-        self.kind = aspect_rev.get(str(self._aspect_kind), 'Unknown')
+        self.kind = _aspect_rev.get(str(self._aspect_kind), 'Unknown')
         self.first = first
         self.last = last
         self.comment = comment
@@ -852,9 +852,9 @@ class EvokedArray(Evoked):
         self.verbose = verbose
         self._projector = None
         if self.kind == 'average':
-            self._aspect_kind = aspect_dict['average']
+            self._aspect_kind = _aspect_dict['average']
         else:
-            self._aspect_kind = aspect_dict['standard_error']
+            self._aspect_kind = _aspect_dict['standard_error']
 
 
 def _get_entries(fid, evoked_node):
@@ -881,7 +881,7 @@ def _get_entries(fid, evoked_node):
         fid.close()
         raise ValueError('Dataset names in FIF file '
                          'could not be found.')
-    t = [aspect_rev.get(str(a), 'Unknown') for a in aspect_kinds]
+    t = [_aspect_rev.get(str(a), 'Unknown') for a in aspect_kinds]
     t = ['"' + c + '" (' + tt + ')' for tt, c in zip(t, comments)]
     t = '  ' + '\n  '.join(t)
     return comments, aspect_kinds, t

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -127,7 +127,8 @@ class Evoked(ProjMixin, ContainsMixin, PickDropChannelsMixin,
 
                 comments, aspect_kinds, t = _get_entries(fid, evoked_node)
                 goods = np.logical_and(in1d(comments, [condition]),
-                                       in1d(aspect_kinds, [_aspect_dict[kind]]))
+                                       in1d(aspect_kinds,
+                                            [_aspect_dict[kind]]))
                 found_cond = np.where(goods)[0]
                 if len(found_cond) != 1:
                     raise ValueError('condition "%s" (%s) not found, out of '

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -841,9 +841,8 @@ class EvokedArray(Evoked):
         # XXX: this should use round and be tested
         self.first = int(tmin * info['sfreq'])
         self.last = self.first + np.shape(data)[-1] - 1
-        self.times = np.arange(self.first, self.last + 1, dtype=np.float)
-        self.times /= info['sfreq']
-
+        self.times = np.arange(self.first, self.last + 1,
+                               dtype=np.float) / info['sfreq']
         self.info = info
         self.nave = nave
         self.kind = kind

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -12,6 +12,7 @@ import numpy as np
 from .. import pick_types, pick_info
 from ..io.pick import _has_kit_refs
 from ..io import read_info
+from ..io.meas_info import Info
 from ..io.constants import FIFF
 from .forward import Forward, write_forward_solution, _merge_meg_eeg_fwds
 from ._compute_forward import _compute_forwards
@@ -436,7 +437,7 @@ def make_forward_solution(info, trans, src, bem, fname=None, meg=True,
 
     # make a new dict with the relevant information
     mri_id = dict(machid=np.zeros(2, np.int32), version=0, secs=0, usecs=0)
-    info = dict(nchan=info['nchan'], chs=info['chs'], comps=info['comps'],
+    info = Info(nchan=info['nchan'], chs=info['chs'], comps=info['comps'],
                 ch_names=info['ch_names'], dev_head_t=info['dev_head_t'],
                 mri_file=trans, mri_id=mri_id, meas_file=info_extra_long,
                 meas_id=None, working_dir=os.getcwd(),

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -29,6 +29,7 @@ fif_fname = op.join(base_dir, 'test_raw.fif')
 def test_array_raw():
     """Test creating raw from array
     """
+    import matplotlib.pyplot as plt
     tempdir = _TempDir()
     # creating
     raw = Raw(fif_fname).crop(2, 5, copy=False)
@@ -97,6 +98,7 @@ def test_array_raw():
     # plotting
     raw2.plot()
     raw2.plot_psd()
+    plt.close('all')
 
     # epoching
     events = find_events(raw2, stim_channel='STI 014')
@@ -104,6 +106,9 @@ def test_array_raw():
     assert_true(len(events) > 2)
     epochs = Epochs(raw2, events, 1, -0.2, 0.4, preload=True)
     epochs.plot_drop_log()
-    epochs.plot()
+    with warnings.catch_warnings(record=True):  # deprecation
+        warnings.simplefilter('always')
+        epochs.plot()
     evoked = epochs.average()
     evoked.plot()
+    plt.close('all')

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -928,12 +928,16 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
 
         The Raw object has to be constructed using preload=True (or string).
 
-        WARNING: The intended purpose of this function is primarily to speed
-        up computations (e.g., projection calculation) when precise timing
-        of events is not required, as downsampling raw data effectively
-        jitters trigger timings. It is generally recommended not to epoch
-        downsampled data, but instead epoch and then downsample, as epoching
-        downsampled data jitters triggers.
+        .. warning:: The intended purpose of this function is primarily to
+                     speed up computations (e.g., projection calculation) when
+                     precise timing of events is not required, as downsampling
+                     raw data effectively jitters trigger timings. It is
+                     generally recommended not to epoch downsampled data,
+                     but instead epoch and then downsample, as epoching
+                     downsampled data jitters triggers. See here for an
+                     example:
+
+                         https://gist.github.com/Eric89GXL/01642cb3789992fbca59
 
         Parameters
         ----------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -51,6 +51,16 @@ class Info(dict):
     """ Info class to nicely represent info dicts
     """
 
+    def copy(self):
+        """Copy the instance
+
+        Returns
+        -------
+        info : instance of Info
+            The copied info.
+        """
+        return Info(super(Info, self).copy())
+
     def __repr__(self):
         """Summarize info instead of printing all"""
         strs = ['<Info | %s non-empty fields']

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -190,7 +190,8 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     # PickChannelsMixin
     from .meas_info import Info
     if not isinstance(info, Info):
-        raise TypeError('info must be an instance of Info, not %s' % info)
+        raise TypeError('info must be an instance of Info, not %s'
+                        % type(info))
     nchan = info['nchan']
     pick = np.zeros(nchan, dtype=np.bool)
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -188,6 +188,9 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     """
     # NOTE: Changes to this function's signature should also be changed in
     # PickChannelsMixin
+    from .meas_info import Info
+    if not isinstance(info, Info):
+        raise TypeError('info must be an instance of Info, not %s' % info)
     nchan = info['nchan']
     pick = np.zeros(nchan, dtype=np.bool)
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -134,9 +134,9 @@ class ProjMixin(object):
             return self
 
         # Exit delayed mode if you apply proj
-        if hasattr(self, '_delayed_proj'):
+        if getattr(self, '_delayed_proj', False):
             logger.info('Leaving delayed SSP mode.')
-            del self._delayed_proj
+            self._delayed_proj = False
 
         if all(p['active'] for p in self.info['projs']):
             logger.info('Projections have already been applied. '

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -683,7 +683,7 @@ class ICA(ContainsMixin):
 
         self._export_info(out.info, epochs, add_channels)
         out.preload = True
-        out.raw = None
+        out._raw = None
         out._projector = None
 
         return out

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -506,7 +506,7 @@ def test_ica_additional():
     ica_chans = [ch for ch in ica_epochs.ch_names if 'ICA' in ch]
     assert_true(ica.n_components_ == len(ica_chans))
     assert_true(ica.n_components_ == ica_epochs.get_data().shape[1])
-    assert_true(ica_epochs.raw is None)
+    assert_true(ica_epochs._raw is None)
     assert_true(ica_epochs.preload is True)
 
     # test float n pca components

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -14,7 +14,6 @@ from .. import pick_channels
 from ..utils import logger, verbose
 from ..epochs import _BaseEpochs
 from ..event import _find_events
-from ..io.proj import setup_proj
 
 
 class RtEpochs(_BaseEpochs):
@@ -148,13 +147,10 @@ class RtEpochs(_BaseEpochs):
 
         # call _BaseEpochs constructor
         super(RtEpochs, self).__init__(
-            info, event_id, tmin, tmax, baseline=baseline, picks=picks,
+            info, None, None, event_id, tmin, tmax, baseline, picks=picks,
             name=name, reject=reject, flat=flat, decim=decim,
             reject_tmin=reject_tmin, reject_tmax=reject_tmax, detrend=detrend,
-            add_eeg_ref=add_eeg_ref, verbose=verbose)
-
-        self._projector, self.info = setup_proj(self.info, add_eeg_ref,
-                                                activate=proj)
+            add_eeg_ref=add_eeg_ref, verbose=verbose, proj=True)
 
         self._client = client
 
@@ -289,7 +285,7 @@ class RtEpochs(_BaseEpochs):
                 raise RuntimeError('Not enough epochs in queue and currently '
                                    'not receiving epochs, cannot get epochs!')
 
-    def _get_data_from_disk(self):
+    def _get_data(self):
         """Return the data for n_epochs epochs"""
 
         epochs = list()

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 
 from ..io.constants import FIFF
-from ..io.meas_info import Info
+from ..io.meas_info import _empty_info
 from ..epochs import EpochsArray
 from ..utils import logger
 from ..externals.FieldTrip import Client as FtClient
@@ -138,7 +138,7 @@ class FieldTripClient(object):
             warnings.warn('Info dictionary not provided. Trying to guess it '
                           'from FieldTrip Header object')
 
-            info = Info()  # create info dictionary
+            info = _empty_info()  # create info dictionary
 
             # modify info attributes according to the FieldTrip Header object
             info['nchan'] = self.ft_header.nChannels
@@ -254,17 +254,15 @@ class FieldTripClient(object):
         events = np.expand_dims(np.array([start, 1, 1]), axis=0)
 
         # get the data
-        data = self.ft_client.getData([start, stop]).transpose()
-        data = np.expand_dims(data, axis=0)
+        data = self.ft_client.getData([start, stop]).transpose()[np.newaxis]
 
         # create epoch from data
-        epoch = EpochsArray(data, info=self.info,
-                            events=events, tmin=0)
+        epoch = EpochsArray(data, self.info, events)
 
         # pick channels
         if picks is not None:
             ch_names = [self.info['ch_names'][k] for k in picks]
-            epoch = epoch.pick_channels(ch_names=ch_names, copy=True)
+            epoch.pick_channels(ch_names=ch_names, copy=False)
 
         return epoch
 

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -9,7 +9,7 @@ import subprocess
 import warnings
 import os.path as op
 
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_equal
 
 import mne
 from mne.utils import requires_neuromag2ft, run_tests_if_main
@@ -69,12 +69,12 @@ def test_fieldtrip_client():
                 picks = mne.pick_types(raw_info, meg='grad', eeg=False,
                                        stim=False, eog=False)
                 epoch = rt_client.get_data_as_epoch(n_samples=5, picks=picks)
-                _, n_channels, n_samples = epoch.get_data().shape
+                n_channels, n_samples = epoch.get_data().shape[1:]
 
         assert_true(tmin_samp2 > tmin_samp1)
         assert_true(len(w) >= 1)
-        assert_true(n_samples == 5)
-        assert_true(n_channels == len(picks))
+        assert_equal(n_samples, 5)
+        assert_equal(n_channels, len(picks))
         kill_signal.put(False)  # stop the buffer
     except:
         kill_signal.put(False)  # stop the buffer even if tests fail

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -127,7 +127,7 @@ def test_reject():
             assert_array_equal(epochs.drop_log, drop_log)
             assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
-            # ensure that thresholds must be come more stringent, not less
+            # ensure that thresholds must become more stringent, not less
             assert_raises(ValueError, epochs.drop_bad_epochs, reject_part)
             assert_equal(len(epochs), len(events) - 4)
             assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -127,6 +127,15 @@ def test_reject():
             assert_array_equal(epochs.drop_log, drop_log)
             assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
+            # ensure that thresholds must be come more stringent, not less
+            assert_raises(ValueError, epochs.drop_bad_epochs, reject_part)
+            assert_equal(len(epochs), len(events) - 4)
+            assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
+            epochs.drop_bad_epochs(flat=dict(mag=1.))
+            assert_equal(len(epochs), 0)
+            assert_raises(ValueError, epochs.drop_bad_epochs,
+                          flat=dict(mag=0.))
+
 
 def test_decim():
     """Test epochs decimation

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -80,7 +80,7 @@ def test_reject():
     data_7 = dict()
     keep_idx = [0, 1, 2]
     for preload in (True, False):
-        for proj in (True, False):
+        for proj in (True, False, 'delayed'):
             # no rejection
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                             preload=preload)
@@ -1166,7 +1166,7 @@ def test_epochs_proj_mixin():
     for preload in [True, False]:
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), proj='delayed', preload=preload,
-                        add_eeg_ref=True, verbose=True, reject=reject)
+                        add_eeg_ref=True, reject=reject)
         epochs2 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                          baseline=(None, 0), proj=True, preload=preload,
                          add_eeg_ref=True, reject=reject)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -31,8 +31,7 @@ from mne.io.meas_info import create_info
 from mne.io.proj import _has_eeg_average_ref_proj
 from mne.event import merge_events
 from mne.io.constants import FIFF
-from mne.externals.six.moves import zip
-from mne.externals.six.moves import cPickle as pickle
+from mne.externals.six.moves import zip, cPickle as pickle
 
 matplotlib.use('Agg')  # for testing don't use X server
 
@@ -1293,6 +1292,7 @@ def test_add_channels_epochs():
 def test_array_epochs():
     """Test creating epochs from array
     """
+    import matplotlib.pyplot as plt
     tempdir = _TempDir()
 
     # creating
@@ -1321,6 +1321,7 @@ def test_array_epochs():
 
     # plotting
     epochs[0].plot()
+    plt.close('all')
 
     # indexing
     assert_array_equal(np.unique(epochs['a'].events[:, 2]), np.array([1]))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -65,10 +65,9 @@ def test_base_epochs():
     """Test base epochs class
     """
     raw = _get_data()[0]
-    epochs = _BaseEpochs(raw.info, event_id, tmin, tmax)
+    epochs = _BaseEpochs(raw.info, None, np.ones((1, 3), int),
+                         event_id, tmin, tmax)
     assert_raises(NotImplementedError, epochs.get_data)
-    assert_raises(NotImplementedError, epochs.__next__)
-    assert_equal(epochs.__iter__()._current, 0)
 
 
 @requires_scipy_version('0.14')

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -77,52 +77,55 @@ def test_reject():
     assert_raises(KeyError, Epochs, raw, events, event_id, tmin, tmax,
                   picks=picks, preload=False, reject=dict(foo=1.))
 
-    data_7 = None
+    data_7 = dict()
     keep_idx = [0, 1, 2]
     for preload in (True, False):
-        # no rejection
-        epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        preload=preload)
-        assert_raises(ValueError, epochs.drop_bad_epochs, reject='foo')
-        epochs.drop_bad_epochs()
-        assert_equal(len(epochs), len(events))
-        assert_array_equal(epochs.selection, np.arange(len(events)))
-        assert_array_equal(epochs.drop_log, [[]] * 7)
-        data_7 = epochs.get_data() if data_7 is None else data_7
+        for proj in (True, False):
+            # no rejection
+            epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                            preload=preload)
+            assert_raises(ValueError, epochs.drop_bad_epochs, reject='foo')
+            epochs.drop_bad_epochs()
+            assert_equal(len(epochs), len(events))
+            assert_array_equal(epochs.selection, np.arange(len(events)))
+            assert_array_equal(epochs.drop_log, [[]] * 7)
+            if proj not in data_7:
+                data_7[proj] = epochs.get_data()
+            assert_array_equal(epochs.get_data(), data_7[proj])
 
-        # with rejection
-        epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        reject=reject, preload=preload)
-        epochs.drop_bad_epochs()
-        assert_equal(len(epochs), len(events) - 4)
-        assert_array_equal(epochs.selection, selection)
-        assert_array_equal(epochs.drop_log, drop_log)
-        assert_array_equal(epochs.get_data(), data_7[keep_idx])
+            # with rejection
+            epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                            reject=reject, preload=preload)
+            epochs.drop_bad_epochs()
+            assert_equal(len(epochs), len(events) - 4)
+            assert_array_equal(epochs.selection, selection)
+            assert_array_equal(epochs.drop_log, drop_log)
+            assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
-        # rejection post-hoc
-        epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        preload=preload)
-        epochs.drop_bad_epochs()
-        assert_equal(len(epochs), len(events))
-        assert_array_equal(epochs.get_data(), data_7)
-        epochs.drop_bad_epochs(reject)
-        assert_equal(len(epochs), len(events) - 4)
-        assert_equal(len(epochs), len(epochs.get_data()))
-        assert_array_equal(epochs.selection, selection)
-        assert_array_equal(epochs.drop_log, drop_log)
-        assert_array_equal(epochs.get_data(), data_7[keep_idx])
+            # rejection post-hoc
+            epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                            preload=preload)
+            epochs.drop_bad_epochs()
+            assert_equal(len(epochs), len(events))
+            assert_array_equal(epochs.get_data(), data_7[proj])
+            epochs.drop_bad_epochs(reject)
+            assert_equal(len(epochs), len(events) - 4)
+            assert_equal(len(epochs), len(epochs.get_data()))
+            assert_array_equal(epochs.selection, selection)
+            assert_array_equal(epochs.drop_log, drop_log)
+            assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
-        # rejection twice
-        reject_part = dict(grad=1100e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
-        epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        reject=reject_part, preload=preload)
-        epochs.drop_bad_epochs()
-        assert_equal(len(epochs), len(events) - 1)
-        epochs.drop_bad_epochs(reject)
-        assert_equal(len(epochs), len(events) - 4)
-        assert_array_equal(epochs.selection, selection)
-        assert_array_equal(epochs.drop_log, drop_log)
-        assert_array_equal(epochs.get_data(), data_7[keep_idx])
+            # rejection twice
+            reject_part = dict(grad=1100e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
+            epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                            reject=reject_part, preload=preload)
+            epochs.drop_bad_epochs()
+            assert_equal(len(epochs), len(events) - 1)
+            epochs.drop_bad_epochs(reject)
+            assert_equal(len(epochs), len(events) - 4)
+            assert_array_equal(epochs.selection, selection)
+            assert_array_equal(epochs.drop_log, drop_log)
+            assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
 
 def test_decim():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -136,6 +136,15 @@ def test_reject():
             assert_raises(ValueError, epochs.drop_bad_epochs,
                           flat=dict(mag=0.))
 
+            # rejection of subset of trials (ensure array ownership)
+            reject_part = dict(grad=1100e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
+            epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                            reject=None, preload=preload)
+            epochs = epochs[:-1]
+            epochs.drop_bad_epochs(reject=reject)
+            assert_equal(len(epochs), len(events) - 4)
+            assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
+
 
 def test_decim():
     """Test epochs decimation

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -64,7 +64,7 @@ def test_reject():
     """Test epochs rejection
     """
     raw, events, picks = _get_data()
-    # cull the list just to contain the relevent event
+    # cull the list just to contain the relevant event
     events = events[events[:, 2] == event_id, :]
     selection = np.arange(3)
     drop_log = [[]] * 3 + [['MEG 2443']] * 4

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -110,7 +110,6 @@ def test_reject():
         assert_equal(len(epochs), len(epochs.get_data()))
         assert_array_equal(epochs.selection, selection)
         assert_array_equal(epochs.drop_log, drop_log)
-        print(preload)
         assert_array_equal(epochs.get_data(), data_7[keep_idx])
 
         # rejection twice

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -233,10 +233,11 @@ def test_read_write_epochs():
         raw.info['lowpass'] = lowpass
 
     data_dec = epochs_dec.get_data()
-    assert_array_equal(data[:, :, epochs_dec._decim_idx], data_dec)
+    assert_array_equal(data[:, :, epochs_dec._decim_slice], data_dec)
 
     evoked_dec = epochs_dec.average()
-    assert_array_equal(evoked.data[:, epochs_dec._decim_idx], evoked_dec.data)
+    assert_array_equal(evoked.data[:, epochs_dec._decim_slice],
+                       evoked_dec.data)
 
     n = evoked.data.shape[1]
     n_dec = evoked_dec.data.shape[1]
@@ -289,6 +290,7 @@ def test_read_write_epochs():
     epochs.save(op.join(tempdir, 'test-epo.fif'))
     epochs_read5 = read_epochs(op.join(tempdir, 'test-epo.fif'))
     assert_array_equal(epochs_read5.selection, epochs.selection)
+    assert_equal(len(epochs_read5.selection), len(epochs_read5.events))
     assert_array_equal(epochs_read5.drop_log, epochs.drop_log)
 
     # Test that one can drop channels on read file
@@ -1320,7 +1322,7 @@ def test_array_epochs():
     assert_array_equal(epochs.events, epochs2.events)
 
     # plotting
-    epochs[0].plot()
+    epochs[0].plot(trellis=False)
     plt.close('all')
 
     # indexing
@@ -1335,7 +1337,8 @@ def test_array_epochs():
                          reject_tmin=0.1, reject_tmax=0.2)
     assert_equal(len(epochs), len(events) - 2)
     assert_equal(epochs.drop_log[0], ['EEG 006'])
-    assert_equal(len(events), len(epochs.selection))
+    print(epochs.drop_log)
+    assert_equal(len(epochs.events), len(epochs.selection))
 
     # baseline
     data = np.ones((10, 20, 300))
@@ -1346,8 +1349,7 @@ def test_array_epochs():
 
 
 def test_concatenate_epochs():
-    """test concatenate epochs"""
-
+    """Test concatenate epochs"""
     raw, events, picks = _get_data()
     epochs = Epochs(
         raw=raw, events=events, event_id=event_id, tmin=tmin, tmax=tmax,
@@ -1377,7 +1379,7 @@ def test_concatenate_epochs():
         ValueError,
         concatenate_epochs, [epochs, epochs2])
 
-    assert_equal(epochs_conc.raw, None)
+    assert_equal(epochs_conc._raw, None)
 
 
 run_tests_if_main()

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -28,11 +28,11 @@ from .._hdf5 import write_hdf5, read_hdf5
 
 def _get_data(inst, return_itc):
     """Get data from Epochs or Evoked instance as epochs x ch x time"""
-    from ..epochs import Epochs
+    from ..epochs import _BaseEpochs
     from ..evoked import Evoked
-    if not isinstance(inst, (Epochs, Evoked)):
+    if not isinstance(inst, (_BaseEpochs, Evoked)):
         raise TypeError('inst must be Epochs or Evoked')
-    if isinstance(inst, Epochs):
+    if isinstance(inst, _BaseEpochs):
         data = inst.get_data()
     else:
         if return_itc:


### PR DESCRIPTION
Not working yet. I hope to keep this more red than green. To-do list:

* [x] Move methods to `_BaseEpochs`
* [x] Make `EpochsArray` subclass `_BaseEpochs` instead of `Epochs`
* [x] Refactor how projection is done (move to `_BaseEpochs` constructor; #2200)
* [x] Refactor how decimation is done (add method, call it in constructor; #2178)
* [x] Refactor how rejection/dropping is done (add method; #1893)
* [x] Get EpochsArray working again
* [x] Fix RtEpochs
* [x] Fix EpochsKit, make it subclass `_BaseEpochs` instead of `EpochsArray` (which in turn had been subclassing `Epochs`)
* [x] Add stronger docstring note about raw resampling / epoch decimation.
* [x] Add test of proj (#2200)
* [x] Add tests of EpochsArray mentioned in #1963
* [x] Add tests of repeated decimation (#2178)
* [x] Add tests of repeated dropping (#1893)

Closes #2225.
Closes #2200.
Closes #2178.
Closes #1982.
Closes #1893.