### PR TITLE
ENH pass allow_maxshield to Raw when loading digpoints

### DIFF
--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -317,7 +317,7 @@ class RawSource(HasPrivateTraits):
     @cached_property
     def _get_raw(self):
         if self.file:
-            return Raw(self.file)
+            return Raw(self.file, allow_maxshield=True)
 
     @cached_property
     def _get_raw_dir(self):


### PR DESCRIPTION
Allow the use of Neuromag raw data files with IAS turned on,
i.e., don't require first Maxfiltering the data.

I haven't come up with a scenario in which this would cause a problem, but perhaps others can?