### PR TITLE
ENH add button to GUI for allowing EEG as head points

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,9 +45,9 @@ Changelog
 
     - Add support to append new channels to an object from a list of other objects by `Chris Holdgraf`_
 
-    - Deprecated :class: `mne.decoding.transformer.ConcatenateChannels` and replaced by :class: `mne.decoding.transformer.EpochsVectorizer` by `Romain Trachel`_ 
+    - Deprecated :class: `mne.decoding.transformer.ConcatenateChannels` and replaced by :class: `mne.decoding.transformer.EpochsVectorizer` by `Romain Trachel`_
 
-    - Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.csp.CSP` by `Romain Trachel`_ 
+    - Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.csp.CSP` by `Romain Trachel`_
 
     - Add interactive plotting of topomap from time-frequency representation by `Jaakko Leppakangas`_
 
@@ -56,6 +56,8 @@ Changelog
     - Add fetcher :mod:`mne.datasets.brainstorm` for datasets used by Brainstorm in their tutorials by `Mainak Jas`_
 
     - Add interactive plotting of single trials by right clicking on channel name in epochs browser by `Jaakko Leppakangas`_
+
+    - Add possibility to use digitised EEG electrode locations as head shape points in :func:`mne.gui.coregistration` by `Chris Bailey`_
 
     - New logos and logo generation script by `Daniel McCloy`_
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -106,6 +106,8 @@ class CoregModel(HasPrivateTraits):
     has_fid_data = Property(Bool, depends_on=['mri_origin', 'hsp.nasion'],
                             desc="Required fiducials data is present.")
     has_pts_data = Property(Bool, depends_on=['mri.points', 'hsp.points'])
+    has_eegpts_data = Property(Bool, depends_on=['hsp.eeg_points'])
+    dig_points = Property(depends_on=['hsp.raw_points','hsp.has_eegpts_data','use_eeg_as_hsp'])
 
     # MRI dependent
     mri_origin = Property(depends_on=['mri.nasion', 'scale'],
@@ -169,6 +171,11 @@ class CoregModel(HasPrivateTraits):
     @cached_property
     def _get_has_pts_data(self):
         has = (np.any(self.mri.points) and np.any(self.hsp.points))
+        return has
+
+    @cached_property
+    def _get_has_eegpts_data(self):
+        has = np.any(self.hsp.eeg_points)
         return has
 
     @cached_property
@@ -1227,6 +1234,7 @@ class CoregFrame(HasTraits):
     hsp_nasion_obj = Instance(PointObject)
     hsp_rpa_obj = Instance(PointObject)
     hsp_visible = Property(depends_on=['hsp_always_visible', 'lock_fiducials'])
+    eeg_as_hsp = Property(depends_on=['use_eeg_as_hsp'])
 
     view_options = Button(label="View Options")
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -348,7 +348,7 @@ class CoregModel(HasPrivateTraits):
             Reset the filter before calculating new omission (default is
             False).
         use_eeg : bool
-            Sets EEG point selection on reset.
+            Check whether to use EEG electrodes (if present) as head points.
         """
         distance = float(distance)
         if reset:
@@ -380,6 +380,7 @@ class CoregModel(HasPrivateTraits):
         # set the filter
         with warnings.catch_warnings(record=True):  # comp to None in Traits
             self.hsp.points_filter = new_filter
+            self.select_eeg_points(use_eeg=use_eeg)
 
     def select_eeg_points(self, use_eeg=True):
         """Omit all EEG head shape points
@@ -1260,8 +1261,7 @@ class CoregFrame(HasTraits):
     hsp_nasion_obj = Instance(PointObject)
     hsp_rpa_obj = Instance(PointObject)
     hsp_visible = Property(depends_on=['hsp_always_visible', 'lock_fiducials'])
-    eeg_visible = Property(depends_on=['use_eeg_locations', 'omit_points',
-                                       'reset_omit_points'])
+    eeg_visible = Property(depends_on=['use_eeg_locations'])
 
     view_options = Button(label="View Options")
 
@@ -1397,10 +1397,11 @@ class CoregFrame(HasTraits):
 
     def _omit_points_fired(self):
         distance = self.distance / 1000.
-        self.model.omit_hsp_points(distance, use_eeg=self.use_eeg_locations)
+        self.model.omit_hsp_points(distance, reset=False)
 
     def _reset_omit_points_fired(self):
-        self.model.omit_hsp_points(0, True)
+        self.model.omit_hsp_points(0, reset=True,
+                                   use_eeg=self.use_eeg_locations)
 
     def _get_eeg_visible(self):
         return self.use_eeg_locations

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1139,6 +1139,9 @@ def _make_view(tabbed=False, split=False, scene_width=-1):
                                HGroup('hsp_always_visible',
                                       Label("Always Show Head Shape Points"),
                                       show_labels=False),
+                               HGroup('use_eeg_as_hsp',
+                                      Label("Use EEG Locations as Head Shape Points"),
+                                      show_labels=False),
                                Item('fid_panel', style='custom'),
                                label="MRI Fiducials", show_border=True,
                                show_labels=False),
@@ -1212,6 +1215,7 @@ class CoregFrame(HasTraits):
     fid_ok = DelegatesTo('model', 'mri.fid_ok')
     lock_fiducials = DelegatesTo('model')
     hsp_always_visible = Bool(False, label="Always Show Head Shape")
+    use_eeg_as_hsp = Bool(False, label="Use EEG Locations as Head Shape Points")
 
     # visualization
     hsp_obj = Instance(PointObject)
@@ -1346,6 +1350,10 @@ class CoregFrame(HasTraits):
     @cached_property
     def _get_hsp_visible(self):
         return self.hsp_always_visible or self.lock_fiducials
+
+    @cached_property
+    def _get_eeg_as_hsp(self):
+        return self.use_eeg_as_hsp
 
     @cached_property
     def _get_omitted_info(self):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1409,7 +1409,8 @@ class CoregFrame(HasTraits):
 
     @cached_property
     def _get_omitted_string(self):
-        if self.model.omitted_info['n_total'] == 0:
+        if (len(self.model.omitted_info.items()) == 0 or
+                self.model.omitted_info['n_total'] == 0):
             return "No points omitted"
         elif self.model.omitted_info['n_total'] == 1:
             omit_str = "1 point"

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -182,12 +182,6 @@ class CoregModel(HasPrivateTraits):
         else:
             return self.hsp.inst_points[self.points_filter]
 
-    def _get_points_filter(self):
-        if self.points_filter is None:
-            return self.hsp.inst_points
-        else:
-            return self.hsp.inst_points[self.points_filter]
-
     @cached_property
     def _get_omitted_info(self):
         if self.points_filter is None:

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -338,6 +338,9 @@ class CoregModel(HasPrivateTraits):
         elif 'fsaverage' in self.mri.subject_source.subjects:
             self.mri.subject = 'fsaverage'
 
+    def _use_eeg_locations_changed(self):
+        self.apply_eeg_filter()
+
     def apply_eeg_filter(self):
         """Either in- or exclude EEG locations in head shape points,
         depending on the setting of the tickbox."""
@@ -376,6 +379,7 @@ class CoregModel(HasPrivateTraits):
             logger.info("Coregistration: Reset excluded head shape points")
             with warnings.catch_warnings(record=True):  # Traits None comp
                 self.hsp.points_filter = None
+                self.apply_eeg_filter()  # Don't forget the EEG
 
         if distance <= 0:
             return
@@ -1398,10 +1402,6 @@ class CoregFrame(HasTraits):
 
     def _reset_omit_points_fired(self):
         self.model.omit_hsp_points(0, reset=True)
-        self.model.apply_eeg_filter()  # Don't forget the EEG
-
-    def _use_eeg_locations_fired(self):
-        self.model.apply_eeg_filter()
 
     @on_trait_change('model.mri.tris')
     def _on_mri_src_change(self):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -106,7 +106,6 @@ class CoregModel(HasPrivateTraits):
     has_fid_data = Property(Bool, depends_on=['mri_origin', 'hsp.nasion'],
                             desc="Required fiducials data is present.")
     has_pts_data = Property(Bool, depends_on=['mri.points', 'hsp.points'])
-    dig_points = Property(depends_on=['hsp.inst_points'])
 
     # MRI dependent
     mri_origin = Property(depends_on=['mri.nasion', 'scale'],
@@ -340,6 +339,8 @@ class CoregModel(HasPrivateTraits):
             self.mri.subject = 'fsaverage'
 
     def apply_eeg_filter(self):
+        """Either in- or exclude EEG locations in head shape points,
+        depending on the setting of the tickbox."""
         with warnings.catch_warnings(record=True):  # comp to None in Traits
             if self.hsp.points_filter is None:
                 self.hsp.points_filter = \
@@ -1381,9 +1382,15 @@ class CoregFrame(HasTraits):
         if self.model.hsp.n_omitted == 0:
             return "No points omitted"
         elif self.model.hsp.n_omitted == 1:
-            return "1 point omitted"
+            omit_str = "1 point"
         else:
-            return "%i points omitted" % self.model.hsp.n_omitted
+            omit_str = "%i points" % self.model.hsp.n_omitted
+
+        omit_str += " out of %d omitted (HSP: %d; EEG: %d)" % \
+                    (len(self.model.hsp.inst_points),
+                     self.model.hsp.n_omitted_types['HSP'],
+                     self.model.hsp.n_omitted_types['EEG'])
+        return omit_str
 
     def _omit_points_fired(self):
         distance = self.distance / 1000.

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1398,19 +1398,12 @@ class CoregFrame(HasTraits):
     def _reset_omit_points_fired(self):
         self.model.omit_hsp_points(0, True)
 
-    def _select_eeg_points_fired(self):
-        self.model.select_eeg_points(False)
-
-    def _reset_select_eeg_points_fired(self):
-        self.model.select_eeg_points(True)
-
     @cached_property
     def _get_eeg_visible(self):
         return self.use_eeg_locations
 
     def _eeg_visible_fired(self):
         self.model.select_eeg_points(use_eeg=self.use_eeg_locations)
-        self.model.omit_hsp_points(0, reset=self.use_eeg_locations)
 
     @on_trait_change('model.mri.tris')
     def _on_mri_src_change(self):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -107,7 +107,8 @@ class CoregModel(HasPrivateTraits):
                             desc="Required fiducials data is present.")
     has_pts_data = Property(Bool, depends_on=['mri.points', 'hsp.points'])
     has_eegpts_data = Property(Bool, depends_on=['hsp.eeg_points'])
-    dig_points = Property(depends_on=['hsp.raw_points','hsp.has_eegpts_data','use_eeg_as_hsp'])
+    dig_points = Property(depends_on=['hsp.raw_points', 'hsp.has_eegpts_data',
+                                      'use_eeg_as_hsp'])
 
     # MRI dependent
     mri_origin = Property(depends_on=['mri.nasion', 'scale'],
@@ -1147,7 +1148,8 @@ def _make_view(tabbed=False, split=False, scene_width=-1):
                                       Label("Always Show Head Shape Points"),
                                       show_labels=False),
                                HGroup('use_eeg_as_hsp',
-                                      Label("Use EEG Locations as Head Shape Points"),
+                                      Label("Use EEG Locations as "
+                                            "Head Shape Points"),
                                       show_labels=False),
                                Item('fid_panel', style='custom'),
                                label="MRI Fiducials", show_border=True,
@@ -1222,7 +1224,8 @@ class CoregFrame(HasTraits):
     fid_ok = DelegatesTo('model', 'mri.fid_ok')
     lock_fiducials = DelegatesTo('model')
     hsp_always_visible = Bool(False, label="Always Show Head Shape")
-    use_eeg_as_hsp = Bool(False, label="Use EEG Locations as Head Shape Points")
+    use_eeg_as_hsp = Bool(False, label="Use EEG Locations as "
+                                       "Head Shape Points")
 
     # visualization
     hsp_obj = Instance(PointObject)

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -173,11 +173,6 @@ class CoregModel(HasPrivateTraits):
         return has
 
     @cached_property
-    def _get_has_eegpts_data(self):
-        has = np.any(self.hsp.eeg_points)
-        return has
-
-    @cached_property
     def _get_has_fid_data(self):
         has = (np.any(self.mri_origin) and np.any(self.hsp.nasion))
         return has

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -371,7 +371,7 @@ class CoregModel(HasPrivateTraits):
         if old_filter is None:
             new_filter = new_sub_filter
         else:
-            new_filter = np.ones(len(self.hsp.raw_points), np.bool8)
+            new_filter = np.ones(len(self.hsp.inst_points), np.bool8)
             new_filter[old_filter] = new_sub_filter
 
         # set the filter

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -378,7 +378,7 @@ class CoregModel(HasPrivateTraits):
         with warnings.catch_warnings(record=True):  # comp to None in Traits
             self.hsp.points_filter = new_filter
 
-    def omit_eeg_points(self, use_eeg=True):
+    def select_eeg_points(self, use_eeg=True):
         """Omit all EEG head shape points
         """
 
@@ -1174,9 +1174,6 @@ def _make_view(tabbed=False, split=False, scene_width=-1):
                                HGroup(Item('distance', show_label=True),
                                       'omit_points', 'reset_omit_points',
                                       show_labels=False),
-                               HGroup('omit_eeg_points',
-                                      'reset_omit_eeg_points',
-                                      show_labels=False),
                                HGroup('use_eeg_locations',
                                       Label("Use EEG electrode locations "
                                             "as head shape points"),
@@ -1242,11 +1239,6 @@ class CoregFrame(HasTraits):
                          "procedure.")
     reset_omit_points = Button(label='Reset Omission', desc="Reset the "
                                "omission of head shape points to include all.")
-    omit_eeg_points = Button(label='Omit EEG', desc="Omit EEG "
-                             "points for the purpose of the automatic "
-                             "coregistration procedure.")
-    reset_omit_eeg_points = Button(label='Reset EEG', desc="Reset the "
-                                   "omission of EEG points to include all.")
     omitted_info = Property(Str, depends_on=['model.hsp.n_omitted'])
 
     fid_ok = DelegatesTo('model', 'mri.fid_ok')
@@ -1405,21 +1397,20 @@ class CoregFrame(HasTraits):
 
     def _reset_omit_points_fired(self):
         self.model.omit_hsp_points(0, True)
-        if not self.use_eeg_locations:
-            self.model.omit_eeg_points(omit=True)
 
-    def _omit_eeg_points_fired(self):
-        self.model.omit_eeg_points(False)
+    def _select_eeg_points_fired(self):
+        self.model.select_eeg_points(False)
 
-    def _reset_omit_eeg_points_fired(self):
-        self.model.omit_eeg_points(True)
+    def _reset_select_eeg_points_fired(self):
+        self.model.select_eeg_points(True)
 
     @cached_property
     def _get_eeg_visible(self):
         return self.use_eeg_locations
 
     def _eeg_visible_fired(self):
-        self.model.omit_eeg_points(use_eeg=self.use_eeg_locations)
+        self.model.select_eeg_points(use_eeg=self.use_eeg_locations)
+        self.model.omit_hsp_points(0, reset=self.use_eeg_locations)
 
     @on_trait_change('model.mri.tris')
     def _on_mri_src_change(self):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -134,7 +134,6 @@ class CoregModel(HasPrivateTraits):
     transformed_mri_points = Property(depends_on=['processed_mri_points',
                                                   'mri_scale_trans'])
     transformed_hsp_points = Property(depends_on=['hsp.points',
-                                                  'hsp.points_filter',
                                                   'head_mri_trans'])
     transformed_mri_lpa = Property(depends_on=['mri.lpa', 'mri_scale_trans'])
     transformed_hsp_lpa = Property(depends_on=['hsp.lpa', 'head_mri_trans'])

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -364,7 +364,7 @@ class InstSource(HasPrivateTraits):
     @cached_property
     def _get_points_type(self):
         if not self.inst:
-            return np.zeros((0, 3), dtype=np.int)  # FIFFV_POINTs are ints
+            return np.array([], dtype=np.int)  # FIFFV_POINTs are ints
 
         points_type = np.array([d['kind'] for d in self.inst['dig']
                                 if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -348,12 +348,11 @@ class InstSource(HasPrivateTraits):
     @cached_property
     def _get_points_type(self):
         if not self.inst:
-            return []
+            return np.zeros((1, 3))
 
-        points_type = [d['kind'] for d in self.inst['dig']
-                       if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
-                       d['kind'] == FIFF.FIFFV_POINT_EEG)]
-        print(points_type)
+        points_type = np.array([d['kind'] for d in self.inst['dig']
+                                if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
+                                d['kind'] == FIFF.FIFFV_POINT_EEG)])
         return points_type
 
     @cached_property

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -290,7 +290,11 @@ class InstSource(HasPrivateTraits):
     # head shape, where EEG is included but can be filtered out
     inst_points = Property(depends_on='inst', desc="Head shape points in the "
                            "inst file(n x 3 array)")
-    points = Property(depends_on=['inst_points', 'points_filter'], desc="Head "
+    points_type = Property(depends_on='inst',
+                           desc="A list of point types ('Extra', 'EEG', ...)"
+                           "(n x 3 array) from the inst file")
+    points = Property(depends_on=['inst_points', 'points_type',
+                      'points_filter'], desc="Head "
                       "shape points selected by the filter (n x 3 array)")
 
     # fiducials
@@ -340,6 +344,17 @@ class InstSource(HasPrivateTraits):
                            if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
                            d['kind'] == FIFF.FIFFV_POINT_EEG)])
         return points
+
+    @cached_property
+    def _get_points_type(self):
+        if not self.inst:
+            return []
+
+        points_type = [d['kind'] for d in self.inst['dig']
+                       if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
+                       d['kind'] == FIFF.FIFFV_POINT_EEG)]
+        print(points_type)
+        return points_type
 
     @cached_property
     def _get_points(self):

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -361,7 +361,6 @@ class InstSource(HasPrivateTraits):
         if self.points_filter is None:
             return self.inst_points
         else:
-            print('filtering inst points, sum', np.sum(self.points_filter))
             return self.inst_points[self.points_filter]
 
     @cached_property

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -287,7 +287,7 @@ class InstSource(HasPrivateTraits):
                         "points")
     n_omitted = Property(Int, depends_on=['points_filter'])
 
-    # head shape
+    # head shape, where EEG is included but can be filtered out
     inst_points = Property(depends_on='inst', desc="Head shape points in the "
                            "inst file(n x 3 array)")
     points = Property(depends_on=['inst_points', 'points_filter'], desc="Head "
@@ -337,16 +337,8 @@ class InstSource(HasPrivateTraits):
             return np.zeros((1, 3))
 
         points = np.array([d['r'] for d in self.inst['dig']
-                           if d['kind'] == FIFF.FIFFV_POINT_EXTRA])
-        return points
-
-    @cached_property
-    def _get_eeg_points(self):
-        if not self.raw:
-            return np.zeros((1, 3))
-
-        points = np.array([d['r'] for d in self.raw.info['dig']
-                           if d['kind'] == FIFF.FIFFV_POINT_EEG])
+                           if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
+                           d['kind'] == FIFF.FIFFV_POINT_EEG)])
         return points
 
     @cached_property

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -291,11 +291,10 @@ class InstSource(HasPrivateTraits):
     inst_points = Property(depends_on='inst', desc="Head shape points in the "
                            "inst file(n x 3 array)")
     # a property defining the type of each head shape point
-    points_type = Property(depends_on='inst',
+    points_type = Property(depends_on='inst_points',
                            desc="A list of point types ('Extra', 'EEG', ...)"
                            "(n x 3 array) from the inst file")
-    points = Property(depends_on=['inst_points', 'points_type',
-                      'points_filter'], desc="Head "
+    points = Property(depends_on=['inst_points', 'points_filter'], desc="Head "
                       "shape points selected by the filter (n x 3 array)")
 
     # fiducials
@@ -356,8 +355,9 @@ class InstSource(HasPrivateTraits):
                                 d['kind'] == FIFF.FIFFV_POINT_EEG)])
         return points_type
 
-    # @cached_property
+    @cached_property
     def _get_points(self):
+        print('Getting points again')
         if self.points_filter is None:
             return self.inst_points
         else:

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -341,6 +341,15 @@ class InstSource(HasPrivateTraits):
         return points
 
     @cached_property
+    def _get_eeg_points(self):
+        if not self.raw:
+            return np.zeros((1, 3))
+
+        points = np.array([d['r'] for d in self.raw.info['dig']
+                           if d['kind'] == FIFF.FIFFV_POINT_EEG])
+        return points
+
+    @cached_property
     def _get_points(self):
         if self.points_filter is None:
             return self.inst_points

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -357,7 +357,6 @@ class InstSource(HasPrivateTraits):
 
     @cached_property
     def _get_points(self):
-        print('Getting points again')
         if self.points_filter is None:
             return self.inst_points
         else:

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -290,6 +290,7 @@ class InstSource(HasPrivateTraits):
     # head shape, where EEG is included but can be filtered out
     inst_points = Property(depends_on='inst', desc="Head shape points in the "
                            "inst file(n x 3 array)")
+    # a property defining the type of each head shape point
     points_type = Property(depends_on='inst',
                            desc="A list of point types ('Extra', 'EEG', ...)"
                            "(n x 3 array) from the inst file")
@@ -338,7 +339,7 @@ class InstSource(HasPrivateTraits):
     @cached_property
     def _get_inst_points(self):
         if not self.inst:
-            return np.zeros((1, 3))
+            return np.zeros((1, 3))  # why not just None?
 
         points = np.array([d['r'] for d in self.inst['dig']
                            if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or
@@ -348,7 +349,7 @@ class InstSource(HasPrivateTraits):
     @cached_property
     def _get_points_type(self):
         if not self.inst:
-            return np.zeros((1, 3))
+            return np.zeros((1, 3))  # why not just None?
 
         points_type = np.array([d['kind'] for d in self.inst['dig']
                                 if (d['kind'] == FIFF.FIFFV_POINT_EXTRA or

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -356,11 +356,12 @@ class InstSource(HasPrivateTraits):
                                 d['kind'] == FIFF.FIFFV_POINT_EEG)])
         return points_type
 
-    @cached_property
+    # @cached_property
     def _get_points(self):
         if self.points_filter is None:
             return self.inst_points
         else:
+            print('filtering inst points, sum', np.sum(self.points_filter))
             return self.inst_points[self.points_filter]
 
     @cached_property

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -142,27 +142,31 @@ def test_coreg_model_with_fsaverage():
     nasion_distance = model.nasion_distance
     rpa_distance = model.rpa_distance
     avg_point_distance = np.mean(model.point_distance)
+    n_omitted = sum(model.omitted_info.values())
+    print(model.omitted_info.keys())
+    print(model.omitted_info.values())
+    print(n_omitted)
 
     # test hsp point omission
     model.trans_y = -0.008
     model.fit_auricular_points()
     model.omit_hsp_points(0.02)
-    assert_equal(model.n_omitted, 1)
+    assert_equal(sum(model.omitted_info.values()), 1)
     model.omit_hsp_points(reset=True)
-    assert_equal(model.n_omitted, 0)
+    assert_equal(sum(model.omitted_info.values()), 0)
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.n_omitted, 1)
+    assert_equal(sum(model.omitted_info.values()), 1)
 
     # test that omission also works then EEG locs are used,
     # and resetting the omission when EEG locs are NOT used
     # does NOT enable the EEG locs.
     model.use_eeg_locations = True
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.n_omitted, 1)
+    assert_equal(sum(model.omitted_info.values()), 1)
     model.use_eeg_locations = False
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.n_omitted_types['HSP'], 1)
-    assert_equal(model.n_omitted_types['EEG'], 61)
+    assert_equal(model.omitted_info['HSP'], 1)
+    assert_equal(model.omitted_info['EEG'], 61)
 
     # scale with 1 parameter
     model.n_scale_params = 1
@@ -195,12 +199,12 @@ def test_coreg_model_with_fsaverage():
     assert_true(np.mean(model.point_distance) < avg_point_distance_1param)
 
     # test switching raw disables point omission but leaves EEG selector as is
-    assert_equal(model.n_omitted, 62)  # 1 HSP due to dist and 61 EEG
+    assert_equal(sum(model.omitted_info.values()), 62)  # 1 HSP (dist), 61 EEG
     with warnings.catch_warnings(record=True):
         model.hsp.file = kit_raw_path  # KIT data has no EEG points
-    assert_equal(model.n_omitted, 0)  # all HSPs back on-line
+    assert_equal(sum(model.omitted_info.values()), 0)  # all HSPs back on-line
     model.hsp.file = raw_path  # back to sample data with EEG
-    assert_equal(model.n_omitted, 61)  # since EEG selector off
+    assert_equal(sum(model.omitted_info.values()), 61)  # EEG selector off
 
 
 run_tests_if_main()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -70,9 +70,9 @@ def test_coreg_model():
     assert_true(new_x < old_x)
 
     # By default, use_eeg_locations==True
-    assert_equal(len(model.hsp.points), 139)  # dipoints + EEG
+    assert_equal(len(model.points), 139)  # dipoints + EEG
     model.use_eeg_locations = False
-    assert_equal(len(model.hsp.points), 78)  # dipoints only
+    assert_equal(len(model.points), 78)  # dipoints only
 
     # Perform the fit test without EEG points only
     avg_point_distance = np.mean(model.point_distance)
@@ -147,22 +147,22 @@ def test_coreg_model_with_fsaverage():
     model.trans_y = -0.008
     model.fit_auricular_points()
     model.omit_hsp_points(0.02)
-    assert_equal(model.hsp.n_omitted, 1)
+    assert_equal(model.n_omitted, 1)
     model.omit_hsp_points(reset=True)
-    assert_equal(model.hsp.n_omitted, 0)
+    assert_equal(model.n_omitted, 0)
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.hsp.n_omitted, 1)
+    assert_equal(model.n_omitted, 1)
 
     # test that omission also works then EEG locs are used,
     # and resetting the omission when EEG locs are NOT used
     # does NOT enable the EEG locs.
     model.use_eeg_locations = True
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.hsp.n_omitted, 1)
+    assert_equal(model.n_omitted, 1)
     model.use_eeg_locations = False
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.hsp.n_omitted_types['HSP'], 1)
-    assert_equal(model.hsp.n_omitted_types['EEG'], 61)
+    assert_equal(model.n_omitted_types['HSP'], 1)
+    assert_equal(model.n_omitted_types['EEG'], 61)
 
     # scale with 1 parameter
     model.n_scale_params = 1
@@ -194,11 +194,13 @@ def test_coreg_model_with_fsaverage():
     model.fit_scale_hsp_points()
     assert_true(np.mean(model.point_distance) < avg_point_distance_1param)
 
-    # test switching raw disables point omission and possible disabling of EEG
-    assert_equal(model.hsp.n_omitted, 62)  # 1 HSP due to dist and 61 EEG
+    # test switching raw disables point omission but leaves EEG selector as is
+    assert_equal(model.n_omitted, 62)  # 1 HSP due to dist and 61 EEG
     with warnings.catch_warnings(record=True):
-        model.hsp.file = kit_raw_path
-    assert_equal(model.hsp.n_omitted, 0)
+        model.hsp.file = kit_raw_path  # KIT data has no EEG points
+    assert_equal(model.n_omitted, 0)  # all HSPs back on-line
+    model.hsp.file = raw_path  # back to sample data with EEG
+    assert_equal(model.n_omitted, 61)  # since EEG selector off
 
 
 run_tests_if_main()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -57,7 +57,6 @@ def test_coreg_model():
     lpa_distance = model.lpa_distance
     nasion_distance = model.nasion_distance
     rpa_distance = model.rpa_distance
-    avg_point_distance = np.mean(model.point_distance)
 
     model.fit_auricular_points()
     old_x = lpa_distance ** 2 + rpa_distance ** 2
@@ -70,6 +69,15 @@ def test_coreg_model():
              model.nasion_distance ** 2)
     assert_true(new_x < old_x)
 
+    # By default, use_eeg_locations==True
+    avg_point_distance = np.mean(model.point_distance)
+    model.fit_hsp_points()
+    assert_true(np.mean(model.point_distance) < avg_point_distance)
+
+    # Repeat test without EEG electrode locations
+    model.use_eeg_locations = False
+    model.apply_eeg_filter()
+    avg_point_distance = np.mean(model.point_distance)
     model.fit_hsp_points()
     assert_true(np.mean(model.point_distance) < avg_point_distance)
 

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -142,31 +142,27 @@ def test_coreg_model_with_fsaverage():
     nasion_distance = model.nasion_distance
     rpa_distance = model.rpa_distance
     avg_point_distance = np.mean(model.point_distance)
-    n_omitted = sum(model.omitted_info.values())
-    print(model.omitted_info.keys())
-    print(model.omitted_info.values())
-    print(n_omitted)
 
     # test hsp point omission
     model.trans_y = -0.008
     model.fit_auricular_points()
     model.omit_hsp_points(0.02)
-    assert_equal(sum(model.omitted_info.values()), 1)
+    assert_equal(model.omitted_info['n_total'], 1)
     model.omit_hsp_points(reset=True)
-    assert_equal(sum(model.omitted_info.values()), 0)
+    assert_equal(model.omitted_info['n_total'], 0)
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(sum(model.omitted_info.values()), 1)
+    assert_equal(model.omitted_info['n_total'], 1)
 
     # test that omission also works then EEG locs are used,
     # and resetting the omission when EEG locs are NOT used
     # does NOT enable the EEG locs.
     model.use_eeg_locations = True
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(sum(model.omitted_info.values()), 1)
+    assert_equal(model.omitted_info['n_total'], 1)
     model.use_eeg_locations = False
     model.omit_hsp_points(0.02, reset=True)
-    assert_equal(model.omitted_info['HSP'], 1)
-    assert_equal(model.omitted_info['EEG'], 61)
+    assert_equal(model.omitted_info['n_hsp'], 1)
+    assert_equal(model.omitted_info['n_eeg'], 61)
 
     # scale with 1 parameter
     model.n_scale_params = 1
@@ -199,12 +195,12 @@ def test_coreg_model_with_fsaverage():
     assert_true(np.mean(model.point_distance) < avg_point_distance_1param)
 
     # test switching raw disables point omission but leaves EEG selector as is
-    assert_equal(sum(model.omitted_info.values()), 62)  # 1 HSP (dist), 61 EEG
+    assert_equal(model.omitted_info['n_total'], 62)  # 1 HSP (dist), 61 EEG
     with warnings.catch_warnings(record=True):
         model.hsp.file = kit_raw_path  # KIT data has no EEG points
-    assert_equal(sum(model.omitted_info.values()), 0)  # all HSPs back on-line
+    assert_equal(model.omitted_info['n_total'], 0)  # all HSPs back on-line
     model.hsp.file = raw_path  # back to sample data with EEG
-    assert_equal(sum(model.omitted_info.values()), 61)  # EEG selector off
+    assert_equal(model.omitted_info['n_total'], 61)  # EEG selector off
 
 
 run_tests_if_main()


### PR DESCRIPTION
Thanks for the great GUI @christianbrodbeck 
I wonder if there's a reason not to include the option of using digitised EEG locations as head points during coregistration? I understand that this is conditional on the digitisation pen being stuck through the electrode ring all the way to the scalp, but would it make sense to allow the user to tick a box to use them?

I've made the few edits needed to expose the option in the GUI, but am having trouble understanding Traits. As far as I can tell, the points returned by _get_raw_points and the new _get_eeg_points could be concatenated and the rest of the code remain as-is. If you agree the feature might be useful, I'd appreciate some pointers on how to proceed, and perhaps a word on testing.