### PR TITLE
Fix add_reference not setting correctly nchan

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -9,6 +9,10 @@ Changelog
 ~~~~~~~~~
     - Add support for generalized M-way repeated measures ANOVA for fully balanced designs by `Denis Engemann`_
 
+BUG
+~~~
+
+    - Fix ``mne.io.add_reference_channels`` not setting ``info[nchan]`` correctly by `Federico Raimondo`_
 
 .. _changes_0_9:
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -200,6 +200,8 @@ def add_reference_channels(inst, ref_channels, copy=True):
                      'loc': np.zeros(12)}
         inst.info['chs'].append(chan_info)
     inst.info['ch_names'].extend(ref_channels)
+    nchan = len(inst.info['ch_names'])
+    inst.info['nchan'] = nchan
     if isinstance(inst, _BaseRaw):
         inst._cals = np.hstack((inst._cals, [1] * len(ref_channels)))
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -200,8 +200,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
                      'loc': np.zeros(12)}
         inst.info['chs'].append(chan_info)
     inst.info['ch_names'].extend(ref_channels)
-    nchan = len(inst.info['ch_names'])
-    inst.info['nchan'] = nchan
+    inst.info['nchan'] = len(inst.info['ch_names'])
     if isinstance(inst, _BaseRaw):
         inst._cals = np.hstack((inst._cals, [1] * len(ref_channels)))
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -213,8 +213,10 @@ def test_add_reference():
     assert_equal(raw_ref._data.shape[0], raw._data.shape[0] + 1)
     assert_array_equal(raw._data[picks_eeg, :], raw_ref._data[picks_eeg, :])
 
+    orig_nchan = raw.info['nchan']
     raw = add_reference_channels(raw, 'Ref', copy=False)
     assert_array_equal(raw._data, raw_ref._data)
+    assert_equal(raw.info['nchan'], orig_nchan + 1)
 
     ref_idx = raw.ch_names.index('Ref')
     ref_data, _ = raw[ref_idx]


### PR DESCRIPTION
After calling `mne.io.add_reference_channels` the number of channels in the instance is not changed.

This fixes this issue.