### PR TITLE
MRG: Fix use of verbose

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1186,8 +1186,7 @@ class ICA(ContainsMixin):
         else:
             exclude = list(set(self.exclude + list(exclude)))
 
-        _n_pca_comp = _check_n_pca_components(self, self.n_pca_components,
-                                              self.verbose)
+        _n_pca_comp = self._check_n_pca_components(self.n_pca_components)
 
         if not(self.n_components_ <= _n_pca_comp <= self.max_pca_components):
             raise ValueError('n_pca_components must be >= '
@@ -1557,22 +1556,21 @@ class ICA(ContainsMixin):
 
         return self
 
+    @verbose
+    def _check_n_pca_components(self, _n_pca_comp, verbose=None):
+        """Aux function"""
+        if isinstance(_n_pca_comp, float):
+            _n_pca_comp = ((self.pca_explained_variance_ /
+                           self.pca_explained_variance_.sum()).cumsum() <=
+                           _n_pca_comp).sum()
+            logger.info('Selected %i PCA components by explained '
+                        'variance' % _n_pca_comp)
+        elif _n_pca_comp is None:
+            _n_pca_comp = self.max_pca_components
+        elif _n_pca_comp < self.n_components_:
+            _n_pca_comp = self.n_components_
 
-@verbose
-def _check_n_pca_components(ica, _n_pca_comp, verbose=None):
-    """Aux function"""
-    if isinstance(_n_pca_comp, float):
-        _n_pca_comp = ((ica.pca_explained_variance_ /
-                       ica.pca_explained_variance_.sum()).cumsum() <=
-                       _n_pca_comp).sum()
-        logger.info('Selected %i PCA components by explained '
-                    'variance' % _n_pca_comp)
-    elif _n_pca_comp is None:
-        _n_pca_comp = ica.max_pca_components
-    elif _n_pca_comp < ica.n_components_:
-        _n_pca_comp = ica.n_components_
-
-    return _n_pca_comp
+        return _n_pca_comp
 
 
 def _check_start_stop(raw, start, stop):

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -21,7 +21,7 @@ from mne import io, Epochs, read_events, pick_types
 from mne.cov import read_cov
 from mne.preprocessing import (ICA, ica_find_ecg_events, ica_find_eog_events,
                                read_ica, run_ica)
-from mne.preprocessing.ica import get_score_funcs, _check_n_pca_components
+from mne.preprocessing.ica import get_score_funcs
 from mne.io.meas_info import Info
 from mne.utils import set_log_file, _TempDir, requires_sklearn, slow_test
 
@@ -513,7 +513,7 @@ def test_ica_additional():
     ica.pca_explained_variance_ = np.array([0.2] * 5)
     ica.n_components_ = 0
     for ncomps, expected in [[0.3, 1], [0.9, 4], [1, 1]]:
-        ncomps_ = _check_n_pca_components(ica, ncomps)
+        ncomps_ = ica._check_n_pca_components(ncomps)
         assert_true(ncomps_ == expected)
 
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1135,7 +1135,7 @@ class Report(object):
         else:
             fname = op.realpath(fname)
 
-        self._render_toc(verbose=self.verbose)
+        self._render_toc()
 
         html = footer_template.substitute(date=time.strftime("%B %d, %Y"))
         self.html.append(html)


### PR DESCRIPTION
No need to pass `self.verbose` to classes when calling methods, the verbose decorator automatically checks to see if the first arg is `self` and if so checks for `self.verbose` and uses it.