### PR TITLE
allow different channel ordering in fwd['sol'] and fwd['info']

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -22,6 +22,7 @@ BUG
 
     - Fix FFT filter artifacts when using short windows in overlap-add by `Eric Larson`_
 
+    - Fix picking channels from forward operator could return a channel ordering different from ``info['chs']`` by `Chris Bailey`_
 
 .. _changes_0_9:
 
@@ -1052,3 +1053,5 @@ of commits):
 .. _Mark Wronkiewicz: http://ilabs.washington.edu/graduate-students/bio/i-labs-mark-wronkiewicz
 
 .. _Sébastien Marti: http://www.researchgate.net/profile/Sebastien_Marti
+
+.. _Chris Bailey: https://github.com/cjayb

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -106,6 +106,7 @@ def _reapply_source_weighting(X, source_weighting, active_set,
 
 
 def _compute_residual(forward, evoked, X, active_set, info):
+    # OK, picking based on row_names is safe
     sel = [forward['sol']['row_names'].index(c) for c in info['ch_names']]
     residual = evoked.copy()
     residual = pick_channels_evoked(residual, include=info['ch_names'])

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -391,6 +391,8 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
 
     sel = pick_channels(orig['sol']['row_names'], include=include,
                         exclude=exclude)
+    sel_info = pick_channels(orig['info']['ch_names'], include=include,
+                        exclude=exclude)
 
     fwd = deepcopy(orig)
 
@@ -411,8 +413,8 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
     fwd['nchan'] = nuse
     fwd['sol']['row_names'] = ch_names
 
-    fwd['info']['ch_names'] = [fwd['info']['ch_names'][k] for k in sel]
-    fwd['info']['chs'] = [fwd['info']['chs'][k] for k in sel]
+    fwd['info']['ch_names'] = [fwd['info']['ch_names'][k] for k in sel_info]
+    fwd['info']['chs'] = [fwd['info']['chs'][k] for k in sel_info]
     fwd['info']['nchan'] = nuse
     fwd['info']['bads'] = [b for b in fwd['info']['bads'] if b in ch_names]
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -389,41 +389,49 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
     if len(include) == 0 and len(exclude) == 0:
         return orig
 
-    sel = pick_channels(orig['sol']['row_names'], include=include,
-                        exclude=exclude)
+    # Allow for possibility of channel ordering in forward solution being
+    # different from that of the M/EEG file it is based on.
+    sel_sol = pick_channels(orig['sol']['row_names'], include=include,
+                            exclude=exclude)
     sel_info = pick_channels(orig['info']['ch_names'], include=include,
-                        exclude=exclude)
+                             exclude=exclude)
 
     fwd = deepcopy(orig)
 
+    # Check that forward solution and original data file agree on #channels
+    if not len(sel_sol) == len(sel_info):
+        raise ValueError('Forward solution and functional data appear to'
+                         'have different channel names, please check.')
+
     #   Do we have something?
-    nuse = len(sel)
+    nuse = len(sel_sol)
     if nuse == 0:
         raise ValueError('Nothing remains after picking')
 
     logger.info('    %d out of %d channels remain after picking'
                 % (nuse, fwd['nchan']))
 
-    #   Pick the correct rows of the forward operator
-    fwd['sol']['data'] = fwd['sol']['data'][sel, :]
-    fwd['_orig_sol'] = fwd['_orig_sol'][sel, :]
+    #   Pick the correct rows of the forward operator using sel_sol
+    fwd['sol']['data'] = fwd['sol']['data'][sel_sol, :]
+    fwd['_orig_sol'] = fwd['_orig_sol'][sel_sol, :]
     fwd['sol']['nrow'] = nuse
 
-    ch_names = [fwd['sol']['row_names'][k] for k in sel]
+    ch_names = [fwd['sol']['row_names'][k] for k in sel_sol]
     fwd['nchan'] = nuse
     fwd['sol']['row_names'] = ch_names
 
+    # Pick the appropriate channel names from the info-dict using sel_info
     fwd['info']['ch_names'] = [fwd['info']['ch_names'][k] for k in sel_info]
     fwd['info']['chs'] = [fwd['info']['chs'][k] for k in sel_info]
     fwd['info']['nchan'] = nuse
     fwd['info']['bads'] = [b for b in fwd['info']['bads'] if b in ch_names]
 
     if fwd['sol_grad'] is not None:
-        fwd['sol_grad']['data'] = fwd['sol_grad']['data'][sel, :]
-        fwd['_orig_sol_grad'] = fwd['_orig_sol_grad'][sel, :]
+        fwd['sol_grad']['data'] = fwd['sol_grad']['data'][sel_sol, :]
+        fwd['_orig_sol_grad'] = fwd['_orig_sol_grad'][sel_sol, :]
         fwd['sol_grad']['nrow'] = nuse
         fwd['sol_grad']['row_names'] = [fwd['sol_grad']['row_names'][k]
-                                        for k in sel]
+                                        for k in sel_sol]
 
     return fwd
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -400,7 +400,7 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
 
     # Check that forward solution and original data file agree on #channels
     if not len(sel_sol) == len(sel_info):
-        raise ValueError('Forward solution and functional data appear to'
+        raise ValueError('Forward solution and functional data appear to '
                          'have different channel names, please check.')
 
     #   Do we have something?

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -399,7 +399,7 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
     fwd = deepcopy(orig)
 
     # Check that forward solution and original data file agree on #channels
-    if not len(sel_sol) == len(sel_info):
+    if len(sel_sol) != len(sel_info):
         raise ValueError('Forward solution and functional data appear to '
                          'have different channel names, please check.')
 

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1087,11 +1087,12 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
                      verbose=None):
     """Util function to prepare forward solution for inverse solvers
     """
-    fwd_ch_names = [c['ch_name'] for c in forward['info']['chs']]
+    # fwd['sol']['row_names'] may be different order from fwd['info']['chs']
+    fwd_sol_ch_names = forward['sol']['row_names']
     ch_names = [c['ch_name'] for c in info['chs']
                 if ((c['ch_name'] not in info['bads'] and
                      c['ch_name'] not in noise_cov['bads']) and
-                    (c['ch_name'] in fwd_ch_names and
+                    (c['ch_name'] in fwd_sol_ch_names and
                      c['ch_name'] in noise_cov.ch_names))]
 
     if not len(info['bads']) == len(noise_cov['bads']) or \
@@ -1124,8 +1125,12 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
 
     gain = forward['sol']['data']
 
-    fwd_idx = [fwd_ch_names.index(name) for name in ch_names]
+    # This actually reorders the gain matrix to conform to the info ch order
+    fwd_idx = [fwd_sol_ch_names.index(name) for name in ch_names]
     gain = gain[fwd_idx]
+    # Any function calling this helper will be using the returned fwd_info
+    # dict, so fwd['sol']['row_names'] becomes obsolete and is NOT re-ordered
+
     info_idx = [info['ch_names'].index(name) for name in ch_names]
     fwd_info = pick_info(info, info_idx)
 

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -30,7 +30,9 @@ def _prepare_info(inverse_operator):
 
 def _pick_leadfield(leadfield, forward, ch_names):
     """Helper to pick out correct lead field components"""
-    picks_fwd = pick_channels(forward['info']['ch_names'], ch_names)
+    # NB must pick from fwd['sol']['row_names'], not ['info']['ch_names'],
+    # because ['sol']['data'] may be ordered differently from functional data
+    picks_fwd = pick_channels(forward['sol']['row_names'], ch_names)
     return leadfield[picks_fwd]
 
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -221,7 +221,8 @@ def test_inverse_operator_channel_ordering():
     # Assume that a raw reordering applies to both evoked and noise_cov,
     # so we don't need to create those from scratch. Just reorder them,
     # then try to apply the original inverse operator
-    new_order = [375] + range(315, 375) + range(0, 306) + range(306, 315)
+    new_order = np.arange(len(evoked.info['ch_names']))
+    np.random.shuffle(new_order)
     evoked.data = evoked.data[new_order]
     evoked.info['ch_names'] = [evoked.info['ch_names'][n] for n in new_order]
     evoked.info['chs'] = [evoked.info['chs'][n] for n in new_order]

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -246,7 +246,7 @@ def test_inverse_operator_channel_ordering():
 
     assert_equal(stc_1.subject, stc_2.subject)
     assert_array_equal(stc_1.times, stc_2.times)
-    assert_allclose(stc_1.data, stc_2.data, rtol=1e-7, atol=1e-7)
+    assert_allclose(stc_1.data, stc_2.data, rtol=1e-5, atol=1e-5)
     assert_true(inv_orig['units'] == inv_reorder['units'])
 
     # Reload with original ordering & apply reordered inverse

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -254,7 +254,7 @@ def test_inverse_operator_channel_ordering():
     noise_cov = read_cov(fname_cov)
 
     stc_3 = apply_inverse(evoked, inv_reorder, lambda2, "dSPM")
-    assert_allclose(stc_1.data, stc_3.data, rtol=1e-7, atol=1e-7)
+    assert_allclose(stc_1.data, stc_3.data, rtol=1e-5, atol=1e-5)
 
 
 @slow_test


### PR DESCRIPTION
@Eric89GXL Here is the PR for the actual implementation. I've made a gist testing your suggested raw.info-reordering based on sample data:

https://gist.github.com/cjayb/60ce9a543a4665348ad4

The new ordering is based on the order I found in Triux raw files (EOG, EEG, MEG, STI), and reproduces the error. Having separate selections for sol and info dicts (@3ebdb09eba52ac7cd37089dc7d448f0b97c0bab8) indeed solves the situation, though I am a little uncertain about `fwd['_orig_sol']` and `fwd['_orig_sol_grad']`?

I tried to grasp the testing-structure, but feel I need your help to implement my gist as a proper test. Any pointers?

Closes #2223 