### PR TITLE
sane exception on IAS-enabled raw with allow_maxshield=False

### DIFF
--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -161,15 +161,16 @@ class RawFIF(_BaseRaw):
                     if (len(raw_node) == 0):
                         raise ValueError('No raw data in %s' % fname)
                     elif allow_maxshield:
-                        msg = ('This file contains raw Internal Active Shielding '
-                               'data. It may be distorted. Elekta recommends it be'
-                               ' run through MaxFilter to produce reliable '
-                               'results. Consider closing the file and running '
-                               'MaxFilter on the data.')
+                        msg = ('This file contains raw Internal Active '
+                               'Shielding data. It may be distorted. Elekta '
+                               'recommends it be run through MaxFilter to '
+                               'produce reliable results. Consider closing '
+                               'the file and running MaxFilter on the data.')
                         info['maxshield'] = True
                         warnings.warn(msg)
                     else:
-                        raise ValueError('IAS detected, but allow_maxshield=False')
+                        raise ValueError('IAS detected, '
+                                         'but allow_maxshield=False')
 
             if len(raw_node) == 1:
                 raw_node = raw_node[0]

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -158,19 +158,20 @@ class RawFIF(_BaseRaw):
                 raw_node = dir_tree_find(meas, FIFF.FIFFB_CONTINUOUS_DATA)
                 if (len(raw_node) == 0):
                     raw_node = dir_tree_find(meas, FIFF.FIFFB_SMSH_RAW_DATA)
+                    msg = ('This file contains raw Internal Active '
+                           'Shielding data. It may be distorted. Elekta '
+                           'recommends it be run through MaxFilter to '
+                           'produce reliable results. Consider closing '
+                           'the file and running MaxFilter on the data.')
                     if (len(raw_node) == 0):
                         raise ValueError('No raw data in %s' % fname)
                     elif allow_maxshield:
-                        msg = ('This file contains raw Internal Active '
-                               'Shielding data. It may be distorted. Elekta '
-                               'recommends it be run through MaxFilter to '
-                               'produce reliable results. Consider closing '
-                               'the file and running MaxFilter on the data.')
                         info['maxshield'] = True
                         warnings.warn(msg)
                     else:
-                        raise ValueError('IAS detected, '
-                                         'but allow_maxshield=False')
+                        msg += (' Use allow_maxshield=True if you are sure you'
+                                ' want to load the data despite this warning.')
+                        raise ValueError(msg)
 
             if len(raw_node) == 1:
                 raw_node = raw_node[0]

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -156,18 +156,20 @@ class RawFIF(_BaseRaw):
             raw_node = dir_tree_find(meas, FIFF.FIFFB_RAW_DATA)
             if len(raw_node) == 0:
                 raw_node = dir_tree_find(meas, FIFF.FIFFB_CONTINUOUS_DATA)
-                if (len(raw_node) == 0) and allow_maxshield:
+                if (len(raw_node) == 0):
                     raw_node = dir_tree_find(meas, FIFF.FIFFB_SMSH_RAW_DATA)
-                    msg = ('This file contains raw Internal Active Shielding '
-                           'data. It may be distorted. Elekta recommends it be'
-                           ' run through MaxFilter to produce reliable '
-                           'results. Consider closing the file and running '
-                           'MaxFilter on the data.')
-                    info['maxshield'] = True
-                    warnings.warn(msg)
-
-            if len(raw_node) == 0:
-                raise ValueError('No raw data in %s' % fname)
+                    if (len(raw_node) == 0):
+                        raise ValueError('No raw data in %s' % fname)
+                    elif allow_maxshield:
+                        msg = ('This file contains raw Internal Active Shielding '
+                               'data. It may be distorted. Elekta recommends it be'
+                               ' run through MaxFilter to produce reliable '
+                               'results. Consider closing the file and running '
+                               'MaxFilter on the data.')
+                        info['maxshield'] = True
+                        warnings.warn(msg)
+                    else:
+                        raise ValueError('IAS detected, but allow_maxshield=False')
 
             if len(raw_node) == 1:
                 raw_node = raw_node[0]


### PR DESCRIPTION
Previously, trying to read a raw FIF with IAS data resulted in a `ValueError('No raw data in`. IMHO this is misleading, though I respect the need to throw an exception in case the user does not know what they are doing.

This PR changes the behaviour of `mne.io.Raw()` to yield
* `ValueError "No data"` if FIF is neither RAW, CONTINUOUS or SMSH (maxshield)
* `ValueError "IAS detected..."` if FIF is SMSH, but `allow_maxshield=False` (default)
* `UserWarning "This file contains IAS..."` if FIF is SMSH and `allow_maxshield=True`