### PR TITLE
FIX: Fix filtering

### DIFF
--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -361,7 +361,11 @@ def fft_resample(x, W, new_len, npad, to_remove,
 def _smart_pad(x, n_pad):
     """Pad vector x
     """
+    if n_pad == 0:
+        return x
+    elif n_pad < 0:
+        raise RuntimeError('n_pad must be non-negative')
     # need to pad with zeros if len(x) <= npad
     z_pad = np.zeros(max(n_pad - len(x) + 1, 0), dtype=x.dtype)
-    return np.r_[z_pad, 2 * x[0] - x[n_pad:0:-1], x,
-                 2 * x[-1] - x[-2:-n_pad - 2:-1], z_pad]
+    return np.concatenate([z_pad, 2 * x[0] - x[n_pad:0:-1], x,
+                           2 * x[-1] - x[-2:-n_pad - 2:-1], z_pad])


### PR DESCRIPTION
Looks like we had a strange bug in filtering caused by our normalization of the frequency-domain components we get from the FFT of the filter returned by `firwin2`. Doing the `sqrt` normalization of the gains themselves, before constructing the `firwin` filter, fixes the issue. I'm not sure how prevalent this will have been in people's data. It seems to be more common for short filter lengths than long ones.