### PR TITLE
FIX: FFT length for overlap-add filtering when using CUDA

### DIFF
--- a/mne/filter.py
+++ b/mne/filter.py
@@ -136,7 +136,10 @@ def _overlap_add_filter(x, h, n_fft=None, zero_phase=True, picks=None,
 def _1d_overlap_filter(x, h_fft, n_h, n_edge, zero_phase, cuda_dict):
     """Do one-dimensional overlap-add FFT FIR filtering"""
     # pad to reduce ringing
-    n_fft = len(h_fft)
+    if cuda_dict['use_cuda']:
+        n_fft = cuda_dict['x'].size  # account for CUDA's modification of h_fft
+    else:
+        n_fft = len(h_fft)
     x_ext = _smart_pad(x, n_edge)
     n_x = len(x_ext)
     filter_input = x_ext


### PR DESCRIPTION
The fft length was being ascertained from the length of `h_fft`, but CUDA filtering only uses the left side of the Fourier transform, meaning that `h_fft` did not have a length of `n_fft`. This was resulting in the following error that was not picked up by the tests, since CUDA is not a part of them:

```python
Test our private overlap-add filtering function ... time: 1 sec
Test CUDA-based filtering ... Traceback (most recent call last):
  File ".../mne-python/mne/tests/test_filter.py", line 339, in <module>
    run_tests_if_main()
  File ".../mne-python/mne/utils.py", line 1660, in run_tests_if_main
    val()
  File ".../mne-python/mne/tests/test_filter.py", line 297, in test_cuda
    filter_length=fl, verbose='INFO')
  File "<string>", line 2, in band_pass_filter
  File ".../mne-python/mne/utils.py", line 537, in verbose
    return function(*args, **kwargs)
  File ".../mne-python/mne/filter.py", line 651, in band_pass_filter
    xf = _filter(x, Fs, freq, gain, filter_length, picks, n_jobs, copy)
  File ".../mne-python/mne/filter.py", line 359, in _filter
    n_jobs=n_jobs)
  File ".../mne-python/mne/filter.py", line 130, in _overlap_add_filter
    cuda_dict)
  File ".../mne-python/mne/filter.py", line 176, in _1d_overlap_filter
    prod = fft_multiply_repeated(h_fft, seg, cuda_dict)
  File ".../mne-python/mne/cuda.py", line 196, in fft_multiply_repeated
    cuda_dict['x'].set(x.astype(np.float64))
  File "/usr/lib/python2.7/dist-packages/pycuda/gpuarray.py", line 217, in set
    assert ary.size == self.size
AssertionError
```