### PR TITLE
Fix issue 2256

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -1888,6 +1888,13 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
 
         hemi_names = [label.name for label in hemi_labels]
 
+        if None in hemi_names:
+            msg = ("Found %i labels with no name. Writing annotation file"
+                   "requires all labels named" % (hemi_names.count(None))
+            # raise the error immediately rather than crash with an
+            # uninformative error later (e.g. cannot join NoneType)
+            raise ValueError(msg)
+
         # Assign unlabeled vertices to an "unknown" label
         unlabeled = (annot == -1)
         if np.any(unlabeled):

--- a/mne/label.py
+++ b/mne/label.py
@@ -1890,7 +1890,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
 
         if None in hemi_names:
             msg = ("Found %i labels with no name. Writing annotation file"
-                   "requires all labels named" % (hemi_names.count(None))
+                   "requires all labels named" % (hemi_names.count(None)))
             # raise the error immediately rather than crash with an
             # uninformative error later (e.g. cannot join NoneType)
             raise ValueError(msg)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -564,6 +564,7 @@ def test_write_labels_to_annot():
     assert_raises(ValueError, write_labels_to_annot, labels4,
                   annot_fname=fnames[0])
 
+
 @testing.requires_testing_data
 def test_split_label():
     """Test splitting labels"""

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -558,7 +558,7 @@ def test_write_labels_to_annot():
     assert_equal(label1.name, "unknown-lh")
     assert_true(np.all(in1d(label0.vertices, label1.vertices)))
 
-    #unnamed labels
+    # unnamed labels
     labels4 = labels[:]
     labels4[0].name = None
     assert_raises(ValueError, write_labels_to_annot, labels4,

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -558,6 +558,11 @@ def test_write_labels_to_annot():
     assert_equal(label1.name, "unknown-lh")
     assert_true(np.all(in1d(label0.vertices, label1.vertices)))
 
+    #unnamed labels
+    labels4 = labels[:]
+    labels4[0].name = None
+    assert_raises(ValueError, write_labels_to_annot, labels4,
+                  annot_fname=fnames[0])
 
 @testing.requires_testing_data
 def test_split_label():


### PR DESCRIPTION
many of the other error messages fail with uninformative errors when `names = [None, None .... ]` such as `could not .join NoneType`. Now crashes cleanly with a useful error message.