### PR TITLE
Implementation of RAAA method for EOG correction

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,6 +63,8 @@ Changelog
 
     - Add ``preload`` argument to :func:`mne.read_epochs` to enable on-demand reads from disk by `Eric Larson`_
 
+    - Add :func:`mne.preprocessing.eog_regression` function to remove the influence of EOG on the EEG signal using RAAA by `Marijn van Vliet`_
+
 BUG
 ~~~
 

--- a/examples/preprocessing/plot_eog_regression.py
+++ b/examples/preprocessing/plot_eog_regression.py
@@ -29,7 +29,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.Raw(raw_fname, preload=True)
 events = mne.find_events(raw, 'STI 014')
 
-# Bandpass filter the EEG and EOG 
+# Bandpass filter the EEG and EOG
 picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True)
 raw.filter(0.3, 30, method='iir', picks=picks)
 
@@ -56,13 +56,13 @@ raw_clean, weights = mne.preprocessing.eog_regression(raw, blink_epochs)
 picks = mne.pick_types(raw_clean.info, meg=False, eeg=True)
 tmin, tmax = -0.2, 0.5
 event_ids = {'AudL': 1, 'AudR': 2, 'VisL': 3, 'VisR': 4}
-epochs_after = mne.Epochs(raw_clean, events, event_ids, tmin, tmax, picks=picks,
-                          preload=True)
+epochs_after = mne.Epochs(raw_clean, events, event_ids, tmin, tmax,
+                          picks=picks, preload=True)
 evoked_after = epochs_after.average()
 
 # Show the filter weights in a topomap
 l = mne.channels.make_eeg_layout(raw.info)
-mne.viz.plot_topomap(weights[0], l.pos[:, :2]);
+mne.viz.plot_topomap(weights[0], l.pos[:, :2])
 plt.title('Regression weights')
 
 # Plot the evoked before and after EOG regression

--- a/examples/preprocessing/plot_eog_regression.py
+++ b/examples/preprocessing/plot_eog_regression.py
@@ -1,0 +1,75 @@
+# ========================
+# EOG regression
+# ========================
+#
+# Reduce EOG artifacts by regressing the EOG channels onto the rest of the
+# signal.
+#
+# References
+# ----------
+# [1] Croft, R. J., & Barry, R. J. (2000). Removal of ocular artifact from
+# the EEG: a review. Clinical Neurophysiology, 30(1), 5-19.
+# http://doi.org/10.1016/S0987-7053(00)00055-1
+#
+# Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
+#
+# License: BSD (3-clause)
+
+import mne
+from mne.datasets import sample
+from matplotlib import pyplot as plt
+
+print(__doc__)
+
+data_path = sample.data_path()
+
+raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+
+# Read raw data
+raw = mne.io.Raw(raw_fname, preload=True)
+events = mne.find_events(raw, 'STI 014')
+
+# Bandpass filter the EEG and EOG 
+picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True)
+raw.filter(0.3, 30, method='iir', picks=picks)
+
+# Create evokeds before EOG correction
+picks = mne.pick_types(raw.info, meg=False, eeg=True)
+tmin, tmax = -0.2, 0.5
+event_ids = {'AudL': 1, 'AudR': 2, 'VisL': 3, 'VisR': 4}
+epochs_before = mne.Epochs(raw, events, event_ids, tmin, tmax, picks=picks,
+                           preload=True)
+evoked_before = epochs_before.average()
+
+
+# Estimate blink onsets and create blink epochs
+eog_event_id = 512
+eog_events = mne.preprocessing.find_eog_events(raw, eog_event_id)
+picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True)
+blink_epochs = mne.Epochs(raw, eog_events, eog_event_id, tmin=-0.5, tmax=0.5,
+                          picks=picks, baseline=(-0.5, -0.3), preload=True)
+
+# Perform regression and remove EOG
+raw_clean, weights = mne.preprocessing.eog_regression(raw, blink_epochs)
+
+# Create epochs after EOG correction
+picks = mne.pick_types(raw_clean.info, meg=False, eeg=True)
+tmin, tmax = -0.2, 0.5
+event_ids = {'AudL': 1, 'AudR': 2, 'VisL': 3, 'VisR': 4}
+epochs_after = mne.Epochs(raw_clean, events, event_ids, tmin, tmax, picks=picks,
+                          preload=True)
+evoked_after = epochs_after.average()
+
+# Show the filter weights in a topomap
+l = mne.channels.make_eeg_layout(raw.info)
+mne.viz.plot_topomap(weights[0], l.pos[:, :2]);
+plt.title('Regression weights')
+
+# Plot the evoked before and after EOG regression
+evoked_before.plot()
+plt.ylim(-6, 6)
+plt.title('Before EOG regression')
+
+evoked_after.plot()
+plt.ylim(-6, 6)
+plt.title('After EOG regression')

--- a/mne/preprocessing/__init__.py
+++ b/mne/preprocessing/__init__.py
@@ -9,7 +9,7 @@
 
 from .maxfilter import apply_maxfilter
 from .ssp import compute_proj_ecg, compute_proj_eog
-from .eog import find_eog_events, create_eog_epochs
+from .eog import find_eog_events, create_eog_epochs, eog_regression
 from .ecg import find_ecg_events, create_ecg_epochs
 from .ica import (ICA, ica_find_eog_events, ica_find_ecg_events,
                   get_score_funcs, read_ica, run_ica)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -335,4 +335,4 @@ def eog_regression(raw, blink_epochs, saccade_epochs=None, reog=None,
     raw._data[picks, :] -= np.dot(weights[:, weight_ch_ind].T,
                                   raw._data[raw_eog_ind, :])
 
-    return raw, weights
+    return raw, weights[:, weight_ch_ind]

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -1,10 +1,13 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Denis Engemann <denis.engemann@gmail.com>
 #          Eric Larson <larson.eric.d@gmail.com>
+#          Marijn van Vliet <w.m.vanvliet@gmail.com>
 #
 # License: BSD (3-clause)
 
 import numpy as np
+
+from scipy.linalg import lstsq
 
 from .peak_finder import peak_finder
 from .. import pick_types, pick_channels
@@ -204,3 +207,132 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None,
                         flat=flat, picks=picks, baseline=baseline,
                         preload=True)
     return eog_epochs
+
+
+def eog_regression(raw, blink_epochs, saccade_epochs=None, reog=None,
+                   picks=None, copy=False):
+    """Remove EOG signals from the EEG channels by regression.
+
+    It employes the RAAA (recommended aligned-artifact average) procedure
+    described by Croft & Barry [1].
+
+    Parameters
+    ----------
+    raw : Instance of Raw
+        The raw data on which the EOG correction produce should be performed.
+    blink_epochs : Instance of Epochs
+        Epochs cut around blink events. We recommend cutting a window from -0.5
+        to 0.5 seconds relative to the onset of the blink.
+    saccade_epochs : Instance of Epochs
+        Epochs cut around saccade events. We recommend cutting a window from -1
+        to 1.5 seconds relative to the onset of the saccades, and providing
+        separate events for "up", "down", "left" and "right" saccades.
+        By default, no saccade information is taken into account.
+    reog : str
+        The name of the rEOG channel, if present. If an rEOG channel is
+        available as well as saccade data, the accuracy of the estimation of
+        the weights can be improved. By default, no rEOG channel is assumed to
+        be present.
+    picks : list of int
+        Indices of the channels in the Raw instance for which to apply the EOG
+        correction procedure. By default, the correction is applied to EEG
+        channels only.
+    copy : bool
+        If True, a copy of the Raw instance will be made before applying the
+        EOG correction procedure. Defaults to False, which will perform the
+        operation in-place.
+
+
+    References
+    ----------
+    [1] Croft, R. J., & Barry, R. J. (2000). Removal of ocular artifact from
+    the EEG: a review. Clinical Neurophysiology, 30(1), 5-19.
+    http://doi.org/10.1016/S0987-7053(00)00055-1
+    """
+
+    if picks is None:
+        picks = pick_types(raw.info, meg=False, ref_meg=False, eeg=True)
+
+    if copy:
+        raw = raw.copy()
+
+    # Compute channel indices for the EOG channels
+    raw_eog_ind = pick_types(raw.info, meg=False, ref_meg=False, eog=True)
+    ev_eog_ind = pick_types(blink_epochs.info, meg=False, ref_meg=False,
+                            eog=True)
+
+    blink_evoked = [
+        blink_epochs[cl].average(range(blink_epochs.info['nchan']))
+        for cl in blink_epochs.event_id.keys()
+    ]
+    blink_data = np.hstack([ev.data for ev in blink_evoked])
+
+    if saccade_epochs is None:
+        # Calculate EOG weights
+        v = np.vstack((
+            np.ones(blink_data.shape[1]),
+            blink_data[ev_eog_ind]
+        )).T
+        weights = lstsq(v, blink_data.T)[0][1:]
+    else:
+        saccade_evoked = [
+            saccade_epochs[cl].average(range(saccade_epochs.info['nchan']))
+            for cl in saccade_epochs.event_id.keys()
+        ]
+        saccade_data = np.hstack([ev.data for ev in saccade_evoked])
+
+        if reog is None:
+            # If no rEOG data is present, just concatenate the saccade data
+            # to the blink data and treat it as one
+            blink_sac_data = np.c_[blink_data, saccade_data]
+            v = np.vstack((
+                np.ones(blink_sac_data.shape[1]),
+                blink_sac_data[np.r_[ev_eog_ind]]
+            )).T
+            weights = lstsq(v, blink_sac_data.T)[0][1:]
+        else:
+            # If rEOG data is present, use the saccade data to compute the
+            # weights for all non-rEOG channels. The blink data will be used
+            # for the rEOG channel weight.
+
+            # Isolate the rEOG channel from the other EOG channels
+            if reog is not None:
+                raw_reog_ind = raw.ch_names.index(reog)
+                raw_non_reog_ind = np.setdiff1d(raw_eog_ind, raw_reog_ind)
+                ev_reog_ind = blink_epochs.ch_names.index(reog)
+                ev_non_reog_ind = np.setdiff1d(ev_eog_ind, ev_reog_ind)
+
+            # Compute non-rEOG weights on the saccade data
+            v1 = np.vstack((
+                np.ones(saccade_data.shape[1]),
+                saccade_data[ev_non_reog_ind, :],
+            )).T
+            weights_sac = lstsq(v1, saccade_data.T)[0][1:]
+
+            # Remove saccades from blink data
+            blink_data -= weights_sac.T.dot(blink_data[ev_non_reog_ind, :])
+
+            # Compute rEOG weights on the blink data
+            v2 = np.vstack((
+                np.ones(blink_data.shape[1]),
+                blink_data[ev_reog_ind, :]
+            )).T
+            weights_blink = lstsq(v2, blink_data.T)[0][[1]]
+
+            # Remove non-EOG channels from rEOG channel
+            raw._data[raw_reog_ind, :] -= np.dot(
+                weights_sac[:, ev_reog_ind].T, raw._data[raw_non_reog_ind, :])
+
+            # Compile the EOG weights
+            weights = np.vstack((weights_sac, weights_blink))
+
+    # Create a mapping between the picked channels of the raw instance and the
+    # EOG weights
+    weight_names = blink_epochs.ch_names
+    weight_ch_ind = [weight_names.index(raw.ch_names[ch]) for ch in picks]
+
+    # Remove EOG from raw channels
+    raw._data[picks, :] -= np.dot(weights[:, weight_ch_ind].T,
+                                  raw._data[raw_eog_ind, :])
+
+    return raw, weights

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -223,17 +223,17 @@ def eog_regression(raw, blink_epochs, saccade_epochs=None, reog=None,
     blink_epochs : Instance of Epochs
         Epochs cut around blink events. We recommend cutting a window from -0.5
         to 0.5 seconds relative to the onset of the blink.
-    saccade_epochs : Instance of Epochs
+    saccade_epochs : Instance of Epochs | None
         Epochs cut around saccade events. We recommend cutting a window from -1
         to 1.5 seconds relative to the onset of the saccades, and providing
         separate events for "up", "down", "left" and "right" saccades.
         By default, no saccade information is taken into account.
-    reog : str
+    reog : str | None
         The name of the rEOG channel, if present. If an rEOG channel is
         available as well as saccade data, the accuracy of the estimation of
         the weights can be improved. By default, no rEOG channel is assumed to
         be present.
-    picks : list of int
+    picks : list of int | None
         Indices of the channels in the Raw instance for which to apply the EOG
         correction procedure. By default, the correction is applied to EEG
         channels only.


### PR DESCRIPTION
I've been using this method of EOG correction for a few years now with great succes. Thought I'd share.

This is a method of removing EOG artefacts that does not rely on blind source separation. It performs a linear regression of the EOG channels onto the EEG (and/or MEG) and removes it. Like SSP and ICA, it has its own up- and downsides.

Normally you would use this with a small calibration session at the start of your experiment. You make the subject follow an icon across the screen to capture saccades and make the subject blink a few times. Then, you can construct clean epochs around these events and estimate the linear relationship between the EOG sensors and the rest of the signal. Bonus points if you also record rEOG. You can read the entire story here:

Croft, R. J., & Barry, R. J. (2000). Removal of ocular artifact from the
EEG: a review. Clinical Neurophysiology, 30(1), 5-19.
http://doi.org/10.1016/S0987-7053(00)00055-1