### PR TITLE
[MRG] ENH add picks argument to tfr_morlet, tfr_multitaper

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -89,6 +89,8 @@ API
 
     - Deprecated and renamed :func:`mne.viz.plot_image_epochs` for :func:`mne.plot.plot_epochs_image` by `Teon Brooks`_
 
+    - `picks` argument has been added to :func:`mne.time_frequency.tfr_morlet`, :func:`mne.time_frequency.tfr_multitaper` by `Teon Brooks`_
+
 .. _changes_0_9:
 
 Version 0.9

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -55,7 +55,8 @@ def test_time_frequency():
     times = epochs.times
     nave = len(data)
 
-    epochs_picks = Epochs(raw, events, event_id, tmin, tmax, baseline=(None, 0))
+    epochs_picks = Epochs(raw, events, event_id, tmin, tmax,
+                          baseline=(None, 0))
 
     freqs = np.arange(6, 20, 5)  # define frequencies of interest
     n_cycles = freqs / 4.

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -55,8 +55,8 @@ def test_time_frequency():
     times = epochs.times
     nave = len(data)
 
-    epochs_picks = Epochs(raw, events, event_id, tmin, tmax,
-                          baseline=(None, 0))
+    epochs_nopicks = Epochs(raw, events, event_id, tmin, tmax,
+                            baseline=(None, 0))
 
     freqs = np.arange(6, 20, 5)  # define frequencies of interest
     n_cycles = freqs / 4.
@@ -72,7 +72,7 @@ def test_time_frequency():
     power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
     # Test picks argument
-    power_picks, itc_picks = tfr_morlet(epochs_picks, freqs=freqs,
+    power_picks, itc_picks = tfr_morlet(epochs_nopicks, freqs=freqs,
                                         n_cycles=n_cycles, use_fft=True,
                                         return_itc=True, picks=picks)
     # the actual data arrays here are equivalent, too...

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -55,7 +55,7 @@ def test_time_frequency():
     times = epochs.times
     nave = len(data)
 
-    epochs_full = Epochs(raw, events, event_id, tmin, tmax, baseline=(None, 0))
+    epochs_picks = Epochs(raw, events, event_id, tmin, tmax, baseline=(None, 0))
 
     freqs = np.arange(6, 20, 5)  # define frequencies of interest
     n_cycles = freqs / 4.
@@ -75,8 +75,8 @@ def test_time_frequency():
                                         n_cycles=n_cycles, use_fft=True,
                                         return_itc=True, picks=picks)
     # the actual data arrays here are equivalent, too...
-    assert_array_equal(power.data, power_picks.data)
-    assert_array_equal(itc.data, itc_picks.data)
+    assert_array_almost_equal(power.data, power_picks.data)
+    assert_array_almost_equal(itc.data, itc_picks.data)
     assert_array_almost_equal(power.data, power_evoked.data)
 
     print(itc)  # test repr
@@ -182,8 +182,8 @@ def test_tfr_multitaper():
                                   n_cycles=freqs / 2., time_bandwidth=4.0,
                                   return_itc=False)
     # test picks argument
-    assert_array_equal(power.data, power_picks.data)
-    assert_array_equal(itc.data, itc_picks.data)
+    assert_array_almost_equal(power.data, power_picks.data)
+    assert_array_almost_equal(itc.data, itc_picks.data)
     # one is squared magnitude of the average (evoked) and
     # the other is average of the squared magnitudes (epochs PSD)
     # so values shouldn't match, but shapes should

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1159,8 +1159,8 @@ def read_tfrs(fname, condition=None):
     return out
 
 
-def tfr_morlet(inst, freqs, n_cycles, picks=None, use_fft=False,
-               return_itc=True, decim=1, n_jobs=1):
+def tfr_morlet(inst, freqs, n_cycles, use_fft=False,
+               return_itc=True, decim=1, n_jobs=1, picks=None):
     """Compute Time-Frequency Representation (TFR) using Morlet wavelets
 
     Parameters
@@ -1171,9 +1171,6 @@ def tfr_morlet(inst, freqs, n_cycles, picks=None, use_fft=False,
         The frequencies in Hz.
     n_cycles : float | ndarray, shape (n_freqs,)
         The number of cycles globally or for each frequency.
-    picks : array-like of int | None
-        The indices of the channels to plot. If None all available
-        channels are displayed.
     use_fft : bool
         The fft based convolution or not.
     return_itc : bool
@@ -1183,6 +1180,9 @@ def tfr_morlet(inst, freqs, n_cycles, picks=None, use_fft=False,
         The decimation factor on the time axis. To reduce memory usage.
     n_jobs : int
         The number of jobs to run in parallel.
+    picks : array-like of int | None
+        The indices of the channels to plot. If None all available
+        channels are displayed.
 
     Returns
     -------
@@ -1294,8 +1294,9 @@ def _induced_power_mtm(data, sfreq, frequencies, time_bandwidth=4.0,
     return psd, itc
 
 
-def tfr_multitaper(inst, freqs, n_cycles, picks=None, time_bandwidth=4.0,
-                   use_fft=True, return_itc=True, decim=1, n_jobs=1):
+def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
+                   use_fft=True, return_itc=True, decim=1, n_jobs=1,
+                   picks=None):
     """Compute Time-Frequency Representation (TFR) using DPSS wavelets
 
     Parameters
@@ -1307,9 +1308,6 @@ def tfr_multitaper(inst, freqs, n_cycles, picks=None, time_bandwidth=4.0,
     n_cycles : float | ndarray, shape (n_freqs,)
         The number of cycles globally or for each frequency.
         The time-window length is thus T = n_cycles / freq.
-    picks : array-like of int | None
-        The indices of the channels to plot. If None all available
-        channels are displayed.
     time_bandwidth : float, (optional)
         Time x (Full) Bandwidth product. Should be >= 2.0.
         Choose this along with n_cycles to get desired frequency resolution.
@@ -1330,6 +1328,9 @@ def tfr_multitaper(inst, freqs, n_cycles, picks=None, time_bandwidth=4.0,
         Defaults to 1.
     n_jobs : int
         The number of jobs to run in parallel. Defaults to 1.
+    picks : array-like of int | None
+        The indices of the channels to plot. If None all available
+        channels are displayed.
 
     Returns
     -------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -696,7 +696,9 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
                          baseline, vmin, vmax, dB)
 
-        pick, info = _prepare_picks_info(picks, info)
+        info, picks = _prepare_picks_info(info, picks)
+        if not np.array_equal(picks, np.arange(len(data))):
+            data = data[picks]
 
         tmin, tmax = times[0], times[-1]
         if isinstance(axes, plt.Axes):
@@ -725,14 +727,6 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         if show:
             plt.show()
         return fig
-
-    def _prepare_picks_info(picks, info):
-        if picks is None:
-            picks = pick_types(info, meg=True, eeg=True, ref_meg=False,
-                               exclude='bads')
-            info = pick_info(info, picks)
-
-        return picks, info
 
     def _onselect(self, eclick, erelease, baseline, mode, layout):
         """Callback function called by rubber band selector in channel tfr."""
@@ -854,8 +848,8 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         data = self.data
         info = self.info
 
-        picks, info = _prepare_picks_info(picks, info)
-        if picks != np.arange(len(data)):
+        info, picks = _prepare_picks_info(info, picks)
+        if not np.array_equal(picks, np.arange(len(data))):
             data = data[picks]
 
         data, times, freqs, vmin, vmax = \
@@ -1198,8 +1192,8 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False,
     data = _get_data(inst, return_itc)
     info = inst.info
 
-    picks, info = _prepare_picks_info(picks, info)
-    if picks != np.arange(len(data)):
+    info, picks = _prepare_picks_info(info, picks)
+    if not np.array_equal(picks, np.arange(len(data))):
         data = data[:, picks, :]
 
     power, itc = _induced_power_cwt(data, sfreq=info['sfreq'],
@@ -1214,6 +1208,15 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False,
         out = (out, AverageTFR(info, itc, times, freqs, nave,
                                method='morlet-itc'))
     return out
+
+
+def _prepare_picks_info(info, picks):
+    if picks is None:
+        picks = pick_types(info, meg=True, eeg=True, ref_meg=False,
+                           exclude='bads')
+    info = pick_info(info, picks)
+
+    return info, picks
 
 
 @verbose
@@ -1347,8 +1350,8 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     data = _get_data(inst, return_itc)
     info = inst.info
 
-    picks, info = _prepare_picks_info(picks, info)
-    if picks != np.arange(len(data)):
+    info, picks = _prepare_picks_info(info, picks)
+    if not np.array_equal(picks, np.arange(len(data))):
         data = data[:, picks, :]
 
     power, itc = _induced_power_mtm(data, sfreq=info['sfreq'],

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1204,7 +1204,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False,
                            exclude='bads')
     picks = np.atleast_1d(picks)
 
-    data = data[picks]
+    data = data[:, picks, :]
     info = pick_info(info, picks)
 
     power, itc = _induced_power_cwt(data, sfreq=info['sfreq'],
@@ -1357,7 +1357,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
                            exclude='bads')
     picks = np.atleast_1d(picks)
 
-    data = data[picks]
+    data = data[:, picks, :]
     info = pick_info(info, picks)
     power, itc = _induced_power_mtm(data, sfreq=info['sfreq'],
                                     frequencies=freqs, n_cycles=n_cycles,


### PR DESCRIPTION
This is needed if you transform IC sources and try to look at their tfr because the source channels become misc, and our built-in default in these functions are `meg` and `eeg`.