### PR TITLE
FIX: GAT times params + add tests

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -173,13 +173,43 @@ def test_generalization_across_time():
     gat.predict(epochs[7:])
     gat.score(epochs[7:])
 
+    # Test training time parameters
+    gat_ = copy.deepcopy(gat)
+    # --- start stop outside time range
+    gat_.train_times = dict(start=-999.)
+    assert_raises(ValueError, gat_.fit, epochs)
+    gat_.train_times = dict(start=999.)
+    assert_raises(ValueError, gat_.fit, epochs)
+    # --- impossible slices
+    gat_.train_times = dict(step=.000001)
+    assert_raises(ValueError, gat_.fit, epochs)
+    gat_.train_times = dict(length=.000001)
+    assert_raises(ValueError, gat_.fit, epochs)
+    gat_.train_times = dict(length=999.)
+    assert_raises(ValueError, gat_.fit, epochs)
+
     # Test testing time parameters
+    # --- outside time range
+    gat.test_times = dict(start=-999.)
+    assert_raises(ValueError, gat.predict, epochs)
+    gat.test_times = dict(start=999.)
+    assert_raises(ValueError, gat.predict, epochs)
+    # --- impossible slices
+    gat.test_times = dict(step=.000001)
+    assert_raises(ValueError, gat.predict, epochs)
+    gat_ = copy.deepcopy(gat)
+    gat_.train_times_['length'] = .000001
+    gat_.test_times = dict(length=.000001)
+    assert_raises(ValueError, gat_.predict, epochs)
+    # --- test time region of interest
     gat.test_times = dict(step=.150)
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 5, 14, 1))
+    # --- silly value
     gat.test_times = 'foo'
     assert_raises(ValueError, gat.predict, epochs)
     assert_raises(RuntimeError, gat.score)
+    # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -173,10 +173,15 @@ def test_generalization_across_time():
     gat.predict(epochs[7:])
     gat.score(epochs[7:])
 
-    # Test wrong testing time
+    # Test testing time parameters
+    gat.test_times = dict(step=.150)
+    gat.predict(epochs)
+    assert_array_equal(np.shape(gat.y_pred_), (15, 5, 14, 1))
     gat.test_times = 'foo'
     assert_raises(ValueError, gat.predict, epochs)
     assert_raises(RuntimeError, gat.score)
+    gat.test_times = dict(length=.150)
+    assert_raises(ValueError, gat.predict, epochs)
 
     svc = SVC(C=1, kernel='linear', probability=True)
     gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -212,14 +212,18 @@ class _GeneralizationAcrossTime(object):
             raise ValueError('`test_times` must be a dict or "diagonal"')
 
         if 'slices' not in test_times:
-            # Force same number of time sample in testing than in training
+            # Check that same number of time sample in testing than in training
             # (otherwise it won 't be the same number of features')
-            window_param = dict(length=self.train_times_['length'])
+            if 'length' not in test_times:
+                test_times['length'] = self.train_times_['length']
+            if test_times['length'] != self.train_times_['length']:
+                raise ValueError('`train_times` and `test_times` must have '
+                                 'identical `length` keys')
             # Make a sliding window for each training time.
             slices_list = list()
             times_list = list()
             for t in range(0, len(self.train_times_['slices'])):
-                test_times_ = _sliding_window(epochs.times, window_param)
+                test_times_ = _sliding_window(epochs.times, test_times)
                 times_list += [test_times_['times']]
                 slices_list += [test_times_['slices']]
             test_times = test_times_

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -541,6 +541,23 @@ def _sliding_window(times, window_params):
         if 'length' not in window_params:
             window_params['length'] = freq
 
+        if (window_params['start'] < times[0] or
+                window_params['start'] > times[-1]):
+            raise ValueError(
+                '`start` (%.2f s) outside time range [%.2f, %.2f].' % (
+                    window_params['start'], times[0], times[-1]))
+        if (window_params['stop'] < times[0] or
+                window_params['stop'] > times[-1]):
+            raise ValueError(
+                '`stop` (%.2f s) outside time range [%.2f, %.2f].' % (
+                    window_params['stop'], times[0], times[-1]))
+        if window_params['step'] < freq:
+            raise ValueError('`step` must be >= 1 / sampling_frequency')
+        if window_params['length'] < freq:
+            raise ValueError('`length` must be >= 1 / sampling_frequency')
+        if window_params['length'] > np.ptp(times):
+            raise ValueError('`length` must be <= time range')
+
         # Convert seconds to index
 
         def find_time_idx(t):  # find closest time point


### PR DESCRIPTION
The params of `test_times` were not taken into account when only partially provided (instead the GAT was computed on all test_times points).

I also added more tests to prevent the user to try meaningless time parameters.