### PR TITLE
Add custom_randperm function which outputs the same random numbers than matlab's randperm function

### DIFF
--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -16,7 +16,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        ArgvSetter, _memory_usage, check_random_state,
                        _check_mayavi_version, requires_mayavi,
                        set_memmap_min_size, _get_stim_channel, _check_fname,
-                       create_slices, _time_mask, custom_randperm)
+                       create_slices, _time_mask, random_permutation)
 from mne.io import show_fiff
 from mne import Evoked
 from mne.externals.six.moves import StringIO
@@ -460,13 +460,12 @@ def test_time_mask():
     assert_equal(_time_mask(x - 1e-10, 0, N - 1, strict=True).sum(), N - 1)
 
 
-def test_custom_randperm():
-    """Test custom randperm function
+def test_random_permutation():
+    """Test random permutation function
     """
-    n = 10
-    random_seed = 42
-    rng = np.random.RandomState(random_seed)
-    python_randperm = custom_randperm(n, rng)
+    n_samples = 10
+    random_state = 42
+    python_randperm = random_permutation(n_samples, random_state)
 
     # matlab output when we execute rng(42), randperm(10)
     matlab_randperm = np.array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -16,7 +16,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        ArgvSetter, _memory_usage, check_random_state,
                        _check_mayavi_version, requires_mayavi,
                        set_memmap_min_size, _get_stim_channel, _check_fname,
-                       create_slices, _time_mask)
+                       create_slices, _time_mask, custom_randperm)
 from mne.io import show_fiff
 from mne import Evoked
 from mne.externals.six.moves import StringIO
@@ -458,5 +458,20 @@ def test_time_mask():
     assert_equal(_time_mask(x, 0, N - 1).sum(), N)
     assert_equal(_time_mask(x - 1e-10, 0, N - 1).sum(), N)
     assert_equal(_time_mask(x - 1e-10, 0, N - 1, strict=True).sum(), N - 1)
+
+
+def test_custom_randperm():
+    """Test custom randperm function
+    """
+    n = 10
+    random_seed = 42
+    rng = np.random.RandomState(random_seed)
+    python_randperm = custom_randperm(n, rng)
+
+    # matlab output when we execute rng(42), randperm(10)
+    matlab_randperm = np.array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])
+
+    assert_array_equal(python_randperm, matlab_randperm - 1)
+
 
 run_tests_if_main()

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1808,14 +1808,6 @@ def random_permutation(n_samples, random_state=None):
     -------
     randperm : ndarray, int
         Randomly permuted sequence between 0 and n-1.
-
-    Example
-    -------
-    >>> n_samples=10
-    >>> random_state=42
-    >>> p = random_permutation(n_samples, random_state) # doctest: +SKIP
-    >>> p
-    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1])
     """
     rng = check_random_state(random_state)
     idx = rng.rand(n_samples)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1815,7 +1815,7 @@ def random_permutation(n_samples, random_state=None):
     >>> random_state=42
     >>> p = random_permutation(n_samples, random_state)
     >>> p
-    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1])
+    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1], dtype=int64)
     """
     rng = check_random_state(random_state)
     idx = rng.rand(n_samples)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1779,29 +1779,30 @@ def _time_mask(times, tmin=None, tmax=None, strict=False):
     return mask
 
 
-def custom_randperm(n, rng):
+def random_permutation(n_samples, random_state=None):
     """Helper to emulate the randperm matlab function.
 
     It returns a vector containing a random permutation of the
-    integers between 0 and n-1. It returns the same random numbers
-    than randperm matlab function whenever the calling random number
-    generator (rng) uses the same matlab's random seed.
+    integers between 0 and n_samples-1. It returns the same random numbers
+    than randperm matlab function whenever the random_state is the same
+    as the matlab's random seed.
 
     This function is useful for comparing against matlab scripts
     which use the randperm function.
 
-    Note: randperm(n) matlab function generates a random sequence between
-    1 and n, whereas custom_randperm(n, rng) function generates a random
-    sequence between 0 and n-1, that is:
-    randperm(n) = custom_randperm(n, rng) - 1
+    Note: the randperm(n_samples) matlab function generates a random
+    sequence between 1 and n_samples, whereas
+    random_permutation(n_samples, random_state) function generates
+    a random sequence between 0 and n_samples-1, that is:
+    randperm(n_samples) = random_permutation(n_samples, random_state) - 1
 
     Parameters
     ----------
-    n : int
+    n_samples : int
         End point of the sequence to be permuted (excluded, i.e., the end point
-        is equal to n-1)
-    rng : np.random.RandomState
-        Pseudo-random number generator used to generate the random sequence.
+        is equal to n_samples-1)
+    random_state : int | None
+        Random seed for initializing the pseudo-random number generator.
 
     Returns
     -------
@@ -1810,12 +1811,14 @@ def custom_randperm(n, rng):
 
     Example
     -------
-    >>> rng = np.random.RandomState(42)
-    >>> p = custom_randperm(10, rng)  # permuted sequence between 0 and 9
+    >>> n_samples=10
+    >>> random_state=42
+    >>> p = random_permutation(n_samples, random_state)
     >>> p
-    array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])
+    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1])
     """
-    idx = rng.rand(n)
+    rng = check_random_state(random_state)
+    idx = rng.rand(n_samples)
 
     randperm = np.argsort(idx)
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1781,39 +1781,40 @@ def _time_mask(times, tmin=None, tmax=None, strict=False):
 
 def custom_randperm(n, rng):
     """Helper to emulate the randperm matlab function.
+
     It returns a vector containing a random permutation of the
-    integers between 0 and n-1.
-    It returns the same random numbers than randperm
-    matlab function whenever the calling random number generator (rng)
-    uses the same matlab's random seed.
+    integers between 0 and n-1. It returns the same random numbers
+    than randperm matlab function whenever the calling random number
+    generator (rng) uses the same matlab's random seed.
+
     This function is useful for comparing against matlab scripts
     which use the randperm function.
+
     Note: randperm(n) matlab function generates a random sequence between
     1 and n, whereas custom_randperm(n, rng) function generates a random
     sequence between 0 and n-1, that is:
     randperm(n) = custom_randperm(n, rng) - 1
 
     Parameters
-        ----------
-        n : int
+    ----------
+    n : int
         End point of the sequence to be permuted (excluded, i.e., the end point
         is equal to n-1)
-        rng : np.random.RandomState
+    rng : np.random.RandomState
         Pseudo-random number generator used to generate the random sequence.
 
-        Returns
-        -------
-        randperm : ndarray, int
+    Returns
+    -------
+    randperm : ndarray, int
         Randomly permuted sequence between 0 and n-1.
 
-        Example
-        -----
-        >>> rng = np.random.RandomState(42)
-        >>> p = custom_randperm(10, rng)  # permuted sequence between 0 and 9
-        >>> p
-        array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])
-
-     """
+    Example
+    -------
+    >>> rng = np.random.RandomState(42)
+    >>> p = custom_randperm(10, rng)  # permuted sequence between 0 and 9
+    >>> p
+    array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])
+    """
     idx = rng.rand(n)
 
     randperm = np.argsort(idx)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1777,3 +1777,45 @@ def _time_mask(times, tmin=None, tmax=None, strict=False):
         mask |= isclose(times, tmin)
         mask |= isclose(times, tmax)
     return mask
+
+
+def custom_randperm(n, rng):
+    """Helper to emulate the randperm matlab function.
+    It returns a vector containing a random permutation of the
+    integers between 0 and n-1.
+    It returns the same random numbers than randperm
+    matlab function whenever the calling random number generator (rng)
+    uses the same matlab's random seed.
+    This function is useful for comparing against matlab scripts
+    which use the randperm function.
+    Note: randperm(n) matlab function generates a random sequence between
+    1 and n, whereas custom_randperm(n, rng) function generates a random
+    sequence between 0 and n-1, that is:
+    randperm(n) = custom_randperm(n, rng) - 1
+
+    Parameters
+        ----------
+        n : int
+        End point of the sequence to be permuted (excluded, i.e., the end point
+        is equal to n-1)
+        rng : np.random.RandomState
+        Pseudo-random number generator used to generate the random sequence.
+
+        Returns
+        -------
+        randperm : ndarray, int
+        Randomly permuted sequence between 0 and n-1.
+
+        Example
+        -----
+        >>> rng = np.random.RandomState(42)
+        >>> p = custom_randperm(10, rng)  # permuted sequence between 0 and 9
+        >>> p
+        array([7, 6, 5, 1, 4, 9, 10, 3, 8, 2])
+
+     """
+    idx = rng.rand(n)
+
+    randperm = np.argsort(idx)
+
+    return randperm

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1813,9 +1813,9 @@ def random_permutation(n_samples, random_state=None):
     -------
     >>> n_samples=10
     >>> random_state=42
-    >>> p = random_permutation(n_samples, random_state)
+    >>> p = random_permutation(n_samples, random_state) # doctest: +SKIP
     >>> p
-    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1], dtype=int64)
+    array([6, 5, 4, 0, 3, 8, 9, 2, 7, 1])
     """
     rng = check_random_state(random_state)
     idx = rng.rand(n_samples)


### PR DESCRIPTION
Helper function to emulate the same behavior than matlab's randperm function.
This function is useful for comparing against matlab scripts which use the randperm function, for instance, for comparison against the eeglab infomax code.
