### PR TITLE
FIX, WIP: auto select ch_type when plotting ica components with picks

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -691,7 +691,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         return figs
     elif np.isscalar(picks):
         picks = [picks]
-    ch_type = 'mag' if ch_type is None else ch_type
+    ch_type = _get_ch_type(ica, ch_type)
 
     data = np.dot(ica.mixing_matrix_[:, picks].T,
                   ica.pca_components_[:ica.n_components_])


### PR DESCRIPTION
Closes #2333 

It's really trivial, I think somebody just forgot to turn on the routine for the case of less than 20 components to pick. Should I make a test still?