### PR TITLE
[MRG] Rounding with raw.time_as_index()

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1705,7 +1705,7 @@ def _allocate_data(data, data_buffer, data_shape, dtype):
     return data
 
 
-def _time_as_index(times, first_samp=0, use_first_samp=False,
+def _time_as_index(times, sfreq, first_samp=0, use_first_samp=False,
                    use_rounding=False):
     """Convert time to indices
 
@@ -1713,6 +1713,8 @@ def _time_as_index(times, first_samp=0, use_first_samp=False,
     ----------
     times : list-like | float | int
         List of numbers or a number representing points in time.
+    sfreq : float | int
+        Sample frequency.
     first_samp : int
        Index to use as first time point.
     use_first_samp : boolean
@@ -1726,11 +1728,16 @@ def _time_as_index(times, first_samp=0, use_first_samp=False,
     -------
     index : ndarray
         Indices corresponding to the times supplied.
+
+    Notes
+    -----
+    np.around will return the nearest even number for values exactly between
+        two integers.
     """
     index = np.atleast_1d(times) * sfreq
     index -= (first_samp if use_first_samp else 0)
 
-    # TODO: is rounding func okay here? np.around(2.5) returns 2.0
+    # Round or truncate time indices
     if use_rounding:
         return np.around(index).astype(int)
     else:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1368,7 +1368,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
                             area_alpha=area_alpha, n_overlap=n_overlap,
                             dB=dB, show=show, n_jobs=n_jobs)
 
-    def time_as_index(self, times, use_first_samp=False):
+    def time_as_index(self, times, use_first_samp=False, use_rounding=False):
         """Convert time to indices
 
         Parameters
@@ -1378,6 +1378,9 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
         use_first_samp : boolean
             If True, time is treated as relative to the session onset, else
             as relative to the recording onset.
+        use_rounding : boolean
+            If True, use rounding (instead of truncation) when converting
+            times to indicies. This can help avoid non-unique indices.
 
         Returns
         -------
@@ -1385,7 +1388,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, PickDropChannelsMixin,
             Indices corresponding to the times supplied.
         """
         return _time_as_index(times, self.info['sfreq'], self.first_samp,
-                              use_first_samp)
+                              use_first_samp, use_rounding=use_rounding)
 
     def index_as_time(self, index, use_first_samp=False):
         """Convert indices to time
@@ -1702,16 +1705,22 @@ def _allocate_data(data, data_buffer, data_shape, dtype):
     return data
 
 
-def _time_as_index(times, sfreq, first_samp=0, use_first_samp=False):
+def _time_as_index(times, first_samp=0, use_first_samp=False,
+                   use_rounding=False):
     """Convert time to indices
 
     Parameters
     ----------
     times : list-like | float | int
         List of numbers or a number representing points in time.
+    first_samp : int
+       Index to use as first time point.
     use_first_samp : boolean
         If True, time is treated as relative to the session onset, else
         as relative to the recording onset.
+    use_rounding : boolean
+        If True, use rounding (instead of truncation) when converting times to
+        indicies. This can help avoid non-unique indices.
 
     Returns
     -------
@@ -1720,7 +1729,12 @@ def _time_as_index(times, sfreq, first_samp=0, use_first_samp=False):
     """
     index = np.atleast_1d(times) * sfreq
     index -= (first_samp if use_first_samp else 0)
-    return index.astype(int)
+
+    # TODO: is rounding func okay here? np.around(2.5) returns 2.0
+    if use_rounding:
+        return np.around(index).astype(int)
+    else:
+        return index.astype(int)
 
 
 def _index_as_time(index, sfreq, first_samp=0, use_first_samp=False):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1731,7 +1731,7 @@ def _time_as_index(times, sfreq, first_samp=0, use_first_samp=False,
 
     Notes
     -----
-    np.around will return the nearest even number for values exactly between
+    np.round will return the nearest even number for values exactly between
         two integers.
     """
     index = np.atleast_1d(times) * sfreq
@@ -1739,7 +1739,7 @@ def _time_as_index(times, sfreq, first_samp=0, use_first_samp=False,
 
     # Round or truncate time indices
     if use_rounding:
-        return np.around(index).astype(int)
+        return np.round(index).astype(int)
     else:
         return index.astype(int)
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -1,5 +1,9 @@
 # Generic tests that all raw classes should run
+from os import path as op
 from numpy.testing import assert_allclose
+
+from mne.datasets import testing
+from mne.io import Raw
 
 
 def _test_concat(reader, *args):
@@ -29,3 +33,19 @@ def _test_concat(reader, *args):
                 if last_preload:
                     raw1.preload_data()
                 assert_allclose(data, raw1[:, :][0])
+
+
+@testing.requires_testing_data
+def test_time_index():
+    """Test indexing of raw times"""
+    raw_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
+                        'data', 'test_raw.fif')
+    raw = Raw(raw_fname)
+
+    # Test original (non-rounding) indexing behavior
+    orig_inds = raw.time_as_index(raw.times)
+    assert(len(set(orig_inds)) != len(orig_inds))
+
+    # Test new (rounding) indexing behavior
+    new_inds = raw.time_as_index(raw.times, use_rounding=True)
+    assert(len(set(new_inds)) == len(new_inds))


### PR DESCRIPTION
This adds an option to round the indices returned by raw.time_as_index(). The original formulation truncates decimals after it calculates an index, which can lead to non-unique indices when doing: `raw.time_as_index(raw.times)`