### PR TITLE
MRG: deprecated ConcatenateChannels and renamed EpochVectorizer

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,9 +45,9 @@ Changelog
 
     - Add support to append new channels to an object from a list of other objects by `Chris Holdgraf`_
 
-    - Deprecated :class: ConcatenateChannels and replaced by :class: EpochVectorizer by `Romain Trachel`_ 
+    - Deprecated :class: `mne.decoding.transformer.ConcatenateChannels` and replaced by :class: `mne.decoding.transformer.EpochsVectorizer` by `Romain Trachel`_ 
 
-    - Deprecated `lws` and renamed `ledoit_wolf` for the `reg` argument in :class:`mne.decoding.csp.CSP` and :class:`mne.preprocessing.Xdawn` by `Romain Trachel`_ 
+    - Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.csp.CSP` and :class:`mne.preprocessing.Xdawn` by `Romain Trachel`_ 
 
 
 BUG

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ Changelog
 
     - Add support to append new channels to an object from a list of other objects by `Chris Holdgraf`_
 
+    - Deprecated :class: ConcatenateChannels and replaced by :class: EpochVectorizer by `Romain Trachel`_ 
+
 
 BUG
 ~~~

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -34,7 +34,7 @@ from sklearn.preprocessing import MinMaxScaler
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
 from mne.preprocessing import Xdawn
-from mne.decoding import ConcatenateChannels
+from mne.decoding import EpochVectorizer
 from mne.viz import tight_layout
 
 
@@ -63,7 +63,7 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
 
 # Create classification pipeline
 clf = make_pipeline(Xdawn(n_components=3),
-                    ConcatenateChannels(),
+                    EpochVectorizer(),
                     MinMaxScaler(),
                     LogisticRegression(penalty='l1'))
 

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -34,7 +34,7 @@ from sklearn.preprocessing import MinMaxScaler
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
 from mne.preprocessing import Xdawn
-from mne.decoding import EpochVectorizer
+from mne.decoding import EpochsVectorizer
 from mne.viz import tight_layout
 
 
@@ -63,7 +63,7 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
 
 # Create classification pipeline
 clf = make_pipeline(Xdawn(n_components=3),
-                    EpochVectorizer(),
+                    EpochsVectorizer(),
                     MinMaxScaler(),
                     LogisticRegression(penalty='l1'))
 

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -55,14 +55,14 @@ from sklearn import preprocessing  # noqa
 from sklearn.svm import SVC  # noqa
 from sklearn.pipeline import Pipeline  # noqa
 from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
-from mne.decoding import EpochVectorizer, FilterEstimator  # noqa
+from mne.decoding import EpochsVectorizer, FilterEstimator  # noqa
 
 
 scores_x, scores, std_scores = [], [], []
 
 filt = FilterEstimator(rt_epochs.info, 1, 40)
 scaler = preprocessing.StandardScaler()
-vectorizer = EpochVectorizer()
+vectorizer = EpochsVectorizer()
 clf = SVC(C=1, kernel='linear')
 
 concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -55,17 +55,17 @@ from sklearn import preprocessing  # noqa
 from sklearn.svm import SVC  # noqa
 from sklearn.pipeline import Pipeline  # noqa
 from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
-from mne.decoding import ConcatenateChannels, FilterEstimator  # noqa
+from mne.decoding import EpochVectorizer, FilterEstimator  # noqa
 
 
 scores_x, scores, std_scores = [], [], []
 
 filt = FilterEstimator(rt_epochs.info, 1, 40)
 scaler = preprocessing.StandardScaler()
-concatenator = ConcatenateChannels()
+vectorizer = EpochVectorizer()
 clf = SVC(C=1, kernel='linear')
 
-concat_classifier = Pipeline([('filter', filt), ('concat', concatenator),
+concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),
                               ('scaler', scaler), ('svm', clf)])
 
 data_picks = mne.pick_types(rt_epochs.info, meg='grad', eeg=False, eog=True,

--- a/examples/realtime/rt_feedback_server.py
+++ b/examples/realtime/rt_feedback_server.py
@@ -43,7 +43,7 @@ import mne
 from mne.datasets import sample
 from mne.realtime import StimServer
 from mne.realtime import MockRtClient
-from mne.decoding import ConcatenateChannels, FilterEstimator
+from mne.decoding import EpochVectorizer, FilterEstimator
 
 print(__doc__)
 
@@ -66,10 +66,10 @@ with StimServer('localhost', port=4218) as stim_server:
     # Constructing the pipeline for classification
     filt = FilterEstimator(raw.info, 1, 40)
     scaler = preprocessing.StandardScaler()
-    concatenator = ConcatenateChannels()
+    vectorizer = EpochVectorizer()
     clf = SVC(C=1, kernel='linear')
 
-    concat_classifier = Pipeline([('filter', filt), ('concat', concatenator),
+    concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),
                                   ('scaler', scaler), ('svm', clf)])
 
     stim_server.start(verbose=True)

--- a/examples/realtime/rt_feedback_server.py
+++ b/examples/realtime/rt_feedback_server.py
@@ -43,7 +43,7 @@ import mne
 from mne.datasets import sample
 from mne.realtime import StimServer
 from mne.realtime import MockRtClient
-from mne.decoding import EpochVectorizer, FilterEstimator
+from mne.decoding import EpochsVectorizer, FilterEstimator
 
 print(__doc__)
 
@@ -66,7 +66,7 @@ with StimServer('localhost', port=4218) as stim_server:
     # Constructing the pipeline for classification
     filt = FilterEstimator(raw.info, 1, 40)
     scaler = preprocessing.StandardScaler()
-    vectorizer = EpochVectorizer()
+    vectorizer = EpochsVectorizer()
     clf = SVC(C=1, kernel='linear')
 
     concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -1,5 +1,5 @@
 from .transformer import Scaler, FilterEstimator
-from .transformer import PSDEstimator, EpochsVectorizer
+from .transformer import PSDEstimator, EpochsVectorizer, ConcatenateChannels
 from .mixin import TransformerMixin
 from .base import BaseEstimator, LinearModel
 from .csp import CSP

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -1,6 +1,5 @@
 from .transformer import Scaler, FilterEstimator
-from .transformer import PSDEstimator, ConcatenateChannels
-from .transformer import ConcatenateChannels as EpochVectorizer
+from .transformer import PSDEstimator, EpochVectorizer
 from .mixin import TransformerMixin
 from .base import BaseEstimator, LinearModel
 from .csp import CSP

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -1,5 +1,6 @@
 from .transformer import Scaler, FilterEstimator
 from .transformer import PSDEstimator, ConcatenateChannels
+from .transformer import ConcatenateChannels as EpochVectorizer
 from .mixin import TransformerMixin
 from .base import BaseEstimator, LinearModel
 from .csp import CSP

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -1,5 +1,5 @@
 from .transformer import Scaler, FilterEstimator
-from .transformer import PSDEstimator, EpochVectorizer
+from .transformer import PSDEstimator, EpochsVectorizer
 from .mixin import TransformerMixin
 from .base import BaseEstimator, LinearModel
 from .csp import CSP

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 from mne import io, read_events, Epochs, pick_types
 from mne.decoding import Scaler, FilterEstimator
-from mne.decoding import PSDEstimator, EpochVectorizer
+from mne.decoding import PSDEstimator, EpochsVectorizer
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -119,8 +119,8 @@ def test_psdestimator():
     assert_raises(ValueError, psd.transform, epochs, y)
 
 
-def test_epochvectorizer():
-    """Test methods of EpochVectorizer
+def test_epochs_vectorizer():
+    """Test methods of EpochsVectorizer
     """
     raw = io.Raw(raw_fname, preload=False)
     events = read_events(event_name)
@@ -131,7 +131,7 @@ def test_epochvectorizer():
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True)
     epochs_data = epochs.get_data()
-    vector = EpochVectorizer(epochs.info)
+    vector = EpochsVectorizer(epochs.info)
     y = epochs.events[:, -1]
     X = vector.fit_transform(epochs_data, y)
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -154,6 +154,8 @@ class ConcatenateChannels(TransformerMixin):
 
     Parameters
     ----------
+    info : instance of Info
+        The measurement info.
 
     Attributes
     ----------

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -147,108 +147,6 @@ class Scaler(TransformerMixin):
         return X
 
 
-@deprecated("Class 'ConcatenateChannels' has been renamed to "
-            "'EpochsVectorizer' and will be removed in release 0.11.")
-class ConcatenateChannels(TransformerMixin):
-    """Concatenates data from different channels into a single feature vector
-
-    Parameters
-    ----------
-    info : instance of Info
-        The measurement info.
-
-    Attributes
-    ----------
-    n_epochs : int
-        The number of epochs.
-    n_channels : int
-        The number of channels.
-    n_times : int
-        The number of time points.
-
-    """
-    def __init__(self, info=None):
-        self.info = info
-        self.n_epochs = None
-        self.n_channels = None
-        self.n_times = None
-
-    def fit(self, epochs_data, y):
-        """Concatenate different channels into a single feature vector
-
-        Parameters
-        ----------
-        epochs_data : array, shape (n_epochs, n_channels, n_times)
-            The data to concatenate channels.
-        y : array, shape (n_epochs,)
-            The label for each epoch.
-
-        Returns
-        -------
-        self : instance of ConcatenateChannels
-            returns the modified instance
-        """
-        if not isinstance(epochs_data, np.ndarray):
-            raise ValueError("epochs_data should be of type ndarray (got %s)."
-                             % type(epochs_data))
-
-        return self
-
-    def transform(self, epochs_data, y=None):
-        """Concatenates data from different channels into a single feature
-        vector
-
-        Parameters
-        ----------
-        epochs_data : array, shape (n_epochs, n_channels, n_times)
-            The data.
-        y : None | array, shape (n_epochs,)
-            The label for each epoch.
-            If None not used. Defaults to None.
-
-        Returns
-        -------
-        X : array, shape (n_epochs, n_channels * n_times)
-            The data concatenated over channels
-        """
-        if not isinstance(epochs_data, np.ndarray):
-            raise ValueError("epochs_data should be of type ndarray (got %s)."
-                             % type(epochs_data))
-
-        epochs_data = np.atleast_3d(epochs_data)
-
-        n_epochs, n_channels, n_times = epochs_data.shape
-        X = epochs_data.reshape(n_epochs, n_channels * n_times)
-        # save attributes for inverse_transform
-        self.n_epochs = n_epochs
-        self.n_channels = n_channels
-        self.n_times = n_times
-
-        return X
-
-    def inverse_transform(self, X, y=None):
-        """Reshape a feature vector into the original data shape
-
-        Parameters
-        ----------
-        X : array, shape (n_epochs, n_channels * n_times)
-            The feature vector concatenated over channels
-        y : None | array, shape (n_epochs,)
-            The label for each epoch.
-            If None not used. Defaults to None.
-
-        Returns
-        -------
-        epochs_data : array, shape (n_epochs, n_channels, n_times)
-            The original data
-        """
-        if not isinstance(X, np.ndarray):
-            raise ValueError("epochs_data should be of type ndarray (got %s)."
-                             % type(X))
-
-        return X.reshape(self.n_epochs, self.n_channels, self.n_times)
-
-
 class EpochsVectorizer(TransformerMixin):
     """EpochsVectorizer transforms epoch data to fit into a scikit-learn pipeline.
 
@@ -348,6 +246,12 @@ class EpochsVectorizer(TransformerMixin):
                              % type(X))
 
         return X.reshape(self.n_epochs, self.n_channels, self.n_times)
+
+
+@deprecated("Class 'ConcatenateChannels' has been renamed to "
+            "'EpochsVectorizer' and will be removed in release 0.11.")
+class ConcatenateChannels(EpochsVectorizer):
+    pass
 
 
 class PSDEstimator(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -148,7 +148,7 @@ class Scaler(TransformerMixin):
 
 
 @deprecated("Class 'ConcatenateChannels' has been renamed to "
-            "'EpochVectorizer' and will be removed in release 0.11.")
+            "'EpochsVectorizer' and will be removed in release 0.11.")
 class ConcatenateChannels(TransformerMixin):
     """Concatenates data from different channels into a single feature vector
 
@@ -249,8 +249,8 @@ class ConcatenateChannels(TransformerMixin):
         return X.reshape(self.n_epochs, self.n_channels, self.n_times)
 
 
-class EpochVectorizer(TransformerMixin):
-    """EpochVectorizer transforms epoch data to fit into a scikit-learn pipeline.
+class EpochsVectorizer(TransformerMixin):
+    """EpochsVectorizer transforms epoch data to fit into a scikit-learn pipeline.
 
     Parameters
     ----------

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -13,7 +13,7 @@ from ..filter import (low_pass_filter, high_pass_filter, band_pass_filter,
                       band_stop_filter)
 from ..time_frequency import multitaper_psd
 from ..externals import six
-from ..utils import _check_type_picks
+from ..utils import _check_type_picks, deprecated
 
 
 class Scaler(TransformerMixin):
@@ -147,6 +147,8 @@ class Scaler(TransformerMixin):
         return X
 
 
+@deprecated("Class 'ConcatenateChannels' has been renamed to "
+            "'EpochVectorizer' and will be removed in release 0.11.")
 class ConcatenateChannels(TransformerMixin):
     """Concatenates data from different channels into a single feature vector
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -249,6 +249,107 @@ class ConcatenateChannels(TransformerMixin):
         return X.reshape(self.n_epochs, self.n_channels, self.n_times)
 
 
+class EpochVectorizer(TransformerMixin):
+    """EpochVectorizer transforms epoch data to fit into a scikit-learn pipeline.
+
+    Parameters
+    ----------
+    info : instance of Info
+        The measurement info.
+
+    Attributes
+    ----------
+    n_epochs : int
+        The number of epochs.
+    n_channels : int
+        The number of channels.
+    n_times : int
+        The number of time points.
+
+    """
+    def __init__(self, info=None):
+        self.info = info
+        self.n_epochs = None
+        self.n_channels = None
+        self.n_times = None
+
+    def fit(self, epochs_data, y):
+        """For each epoch, concatenate data from different channels into a single
+        feature vector.
+
+        Parameters
+        ----------
+        epochs_data : array, shape (n_epochs, n_channels, n_times)
+            The data to concatenate channels.
+        y : array, shape (n_epochs,)
+            The label for each epoch.
+
+        Returns
+        -------
+        self : instance of ConcatenateChannels
+            returns the modified instance
+        """
+        if not isinstance(epochs_data, np.ndarray):
+            raise ValueError("epochs_data should be of type ndarray (got %s)."
+                             % type(epochs_data))
+
+        return self
+
+    def transform(self, epochs_data, y=None):
+        """For each epoch, concatenate data from different channels into a single
+        feature vector.
+
+        Parameters
+        ----------
+        epochs_data : array, shape (n_epochs, n_channels, n_times)
+            The data.
+        y : None | array, shape (n_epochs,)
+            The label for each epoch.
+            If None not used. Defaults to None.
+
+        Returns
+        -------
+        X : array, shape (n_epochs, n_channels * n_times)
+            The data concatenated over channels
+        """
+        if not isinstance(epochs_data, np.ndarray):
+            raise ValueError("epochs_data should be of type ndarray (got %s)."
+                             % type(epochs_data))
+
+        epochs_data = np.atleast_3d(epochs_data)
+
+        n_epochs, n_channels, n_times = epochs_data.shape
+        X = epochs_data.reshape(n_epochs, n_channels * n_times)
+        # save attributes for inverse_transform
+        self.n_epochs = n_epochs
+        self.n_channels = n_channels
+        self.n_times = n_times
+
+        return X
+
+    def inverse_transform(self, X, y=None):
+        """For each epoch, reshape a feature vector into the original data shape
+
+        Parameters
+        ----------
+        X : array, shape (n_epochs, n_channels * n_times)
+            The feature vector concatenated over channels
+        y : None | array, shape (n_epochs,)
+            The label for each epoch.
+            If None not used. Defaults to None.
+
+        Returns
+        -------
+        epochs_data : array, shape (n_epochs, n_channels, n_times)
+            The original data
+        """
+        if not isinstance(X, np.ndarray):
+            raise ValueError("epochs_data should be of type ndarray (got %s)."
+                             % type(X))
+
+        return X.reshape(self.n_epochs, self.n_channels, self.n_times)
+
+
 class PSDEstimator(TransformerMixin):
     """Compute power spectrum density (PSD) using a multi-taper method
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -154,8 +154,6 @@ class ConcatenateChannels(TransformerMixin):
 
     Parameters
     ----------
-    info : instance of Info
-        The measurement info.
 
     Attributes
     ----------

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -61,7 +61,8 @@ _deprecation_ignores = [
     'mne.fixes._in1d',  # fix function
     'mne.utils.plot_epochs_trellis',  # deprecated
     'mne.utils.write_bem_surface',  # deprecated
-    'mne.gui.coregistration'  # deprecated
+    'mne.gui.coregistration',  # deprecated
+    'mne.utils.ConcatenateChannels'  # deprecated
 ]
 
 

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -61,8 +61,7 @@ _deprecation_ignores = [
     'mne.fixes._in1d',  # fix function
     'mne.utils.plot_epochs_trellis',  # deprecated
     'mne.utils.write_bem_surface',  # deprecated
-    'mne.gui.coregistration',  # deprecated
-    'mne.utils.ConcatenateChannels'  # deprecated
+    'mne.gui.coregistration'  # deprecated
 ]
 
 


### PR DESCRIPTION
@agramfort @dengemann This PR addresses issue #2313 
Is it fine to import ConcatenateChannels as EpochVectorizer in the __init__ ??
or I should copy the code of ConcatenateChannels and name it class EpochVectorizer?