### PR TITLE
MRG: deprecation warning removed for dawn

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ Changelog
 
     - Add support to append new channels to an object from a list of other objects by `Chris Holdgraf`_
 
-    - Deprecated `lws` and renamed `ledoit_wolf` for the `reg` argument in :class:`mne.decoding.csp.CSP` and :class:`mne.preprocessing.Xdawn` by `Romain Trachel`_ 
+    - Deprecated `lws` and renamed `ledoit_wolf` for the `reg` argument in :class:`mne.decoding.csp.CSP` by `Romain Trachel`_ 
 
 
 BUG

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -216,11 +216,6 @@ class Xdawn(TransformerMixin, ContainsMixin):
         """init xdawn."""
         self.n_components = n_components
         self.signal_cov = signal_cov
-        if reg == 'lws':
-            raise DeprecationWarning('`lws` has been deprecated for the `reg`'
-                                     ' argument. It will be removed in 0.11.'
-                                     ' Use `ledoit_wolf` instead.')
-            reg = 'ledoit_wolf'
         self.reg = reg
         self.filters_ = dict()
         self.patterns_ = dict()


### PR DESCRIPTION
This a short PR to remove deprecation warning from xdawn in PR #2352 (closed)