### PR TITLE
[MRG] Fix logic checks in make_forward_solution

### DIFF
--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -239,7 +239,7 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
         If true (default) then use `accurate` coil definitions (more
         integration points)
     exclude : list of str | str
-        List of channels to exclude. If 'bads' (default), exclude channels in
+        List of channels to exclude. If 'bads', exclude channels in
         info['bads']
     ignore_ref : bool
         If true, ignore compensation coils
@@ -323,7 +323,7 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
 
 
 @verbose
-def _prep_eeg_channels(info, exclude='bads', verbose=None):
+def _prep_eeg_channels(info, exclude=(), verbose=None):
     """Prepare EEG electrode definitions for forward calculation
 
     Parameters
@@ -331,7 +331,7 @@ def _prep_eeg_channels(info, exclude='bads', verbose=None):
     info : instance of Info
         The measurement information dictionary
     exclude : list of str | str
-        List of channels to exclude. If 'bads' (default), exclude channels in
+        List of channels to exclude. If 'bads', exclude channels in
         info['bads']
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
@@ -520,10 +520,10 @@ def make_forward_solution(info, trans, src, bem, fname=None, meg=True,
     megcoils, compcoils, megnames, meg_info = [], [], [], []
     eegels, eegnames = [], []
 
-    if meg:
+    if meg and len(pick_types(info, ref_meg=False)) > 0:
         megcoils, compcoils, megnames, meg_info = \
             _prep_meg_channels(info, ignore_ref=ignore_ref, verbose=verbose)
-    if eeg:
+    if eeg and len(pick_types(info, meg=False, eeg=True, ref_meg=False)) > 0:
         eegels, eegnames = _prep_eeg_channels(info, verbose=verbose)
 
     # Check that some channels were found

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -148,7 +148,11 @@ def test_make_forward_solution_kit():
     assert_raises(NotImplementedError, make_forward_solution, raw_py.info,
                   src=src, eeg=False, meg=True,
                   bem=fname_bem_meg, trans=trans_path)
-    fwd_py = make_forward_solution(raw_py.info, src=src, eeg=False, meg=True,
+
+    # check that asking for eeg channels (even if they don't exist) is handled
+    meg_only_info = pick_info(raw_py.info, pick_types(raw_py.info, meg=True,
+                                                      eeg=False))
+    fwd_py = make_forward_solution(meg_only_info, src=src, meg=True, eeg=True,
                                    bem=fname_bem_meg, trans=trans_path,
                                    ignore_ref=True)
     _compare_forwards(fwd, fwd_py, 157, n_src,


### PR DESCRIPTION
Fix the error in `make_forward_solution` where user could erroneously ask for a solution with meg or eeg channels and the computation would bomb if those channels types weren't present.