### PR TITLE
FIX: remove replacegeom option?

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -944,7 +944,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                     subject + '_outer_skin_surface']
         for s in surfaces:
             cmd = ['mne_convert_surface', '--surf', s, '--mghmri', T1_mgz,
-                   '--surfout', s, "--replacegeom"]
+                   '--surfout', s]
             run_subprocess(cmd, env=env, stdout=sys.stdout)
     os.chdir(bem_dir)
     if op.isfile(subject + '-head.fif'):


### PR DESCRIPTION
See https://github.com/mne-tools/mne-python/commit/81cd080083db6a04e04bf8a26baf4233963c09e2

I'm not sure whether this is a correct change/fix: the "--replacegeom" option doesn't seem to work on my computer (ubuntu, with mne stable or dev nightly 2.7.3)

I've removed it and it works, and passes the tests, so I'd like to see whether travis has something to say about it.
