### PR TITLE
[FIX] Fix to cmap on interactive topomap.

### DIFF
--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -710,7 +710,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
                 ax = axes[idx]
                 fig = ax.get_figure()
             onselect_callback = partial(self._onselect, baseline=baseline,
-                                        mode=mode, layout=layout, cmap=cmap)
+                                        mode=mode, layout=layout)
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
                         ylim=None, tfr=data[idx: idx + 1], freq=freqs,
                         x_label='Time (ms)', y_label='Frequency (Hz)',
@@ -722,7 +722,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             plt.show()
         return fig
 
-    def _onselect(self, eclick, erelease, baseline, mode, layout, cmap):
+    def _onselect(self, eclick, erelease, baseline, mode, layout):
         """Callback function called by rubber band selector in channel tfr."""
         import matplotlib.pyplot as plt
         from ..viz import plot_tfr_topomap
@@ -759,7 +759,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             ax = plt.subplot(1, len(types), idx + 1)
             plot_tfr_topomap(self, ch_type=ch_type, tmin=tmin, tmax=tmax,
                              fmin=fmin, fmax=fmax, layout=layout,
-                             baseline=baseline, mode=mode, cmap=cmap,
+                             baseline=baseline, mode=mode, cmap=None,
                              title=ch_type, vmin=None, vmax=None,
                              axes=ax)
 
@@ -854,7 +854,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             from mne import find_layout
             layout = find_layout(self.info)
         onselect_callback = partial(self._onselect, baseline=baseline,
-                                    mode=mode, layout=layout, cmap=cmap)
+                                    mode=mode, layout=layout)
         imshow = partial(_imshow_tfr, tfr=data, freq=freqs, cmap=cmap,
                          onselect=onselect_callback)
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -194,7 +194,7 @@ def test_plot_tfr_topomap():
     erelease.ydata = 0.2
     pos = [[0.11, 0.11], [0.25, 0.5], [0.0, 0.2], [0.2, 0.39]]
     _onselect(eclick, erelease, tfr, pos, 'mag', 1, 3, 1, 3, 'RdBu_r', list())
-    tfr._onselect(eclick, erelease, None, 'mean', None, 'RdBu_r')
+    tfr._onselect(eclick, erelease, None, 'mean', None)
     plt.close('all')
 
 


### PR DESCRIPTION
I noticed that when using the interactive topomap feature by selecting a rectangle in TFR plot, the color maps aren't always right.
![screenshot from 2015-08-10 15 09 56](https://cloud.githubusercontent.com/assets/3456414/9191629/48d4353e-400c-11e5-967c-c9722ffcf01b.png)

I fixed it, but the downside is that now the user has no control over the color maps on the interactive plot.
![screenshot from 2015-08-11 09 32 11](https://cloud.githubusercontent.com/assets/3456414/9191645/63bcd838-400c-11e5-9c9a-21a2be79345f.png)

