### PR TITLE
FIX: GAT y_pred error when inconsistent axis

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -241,8 +241,7 @@ def test_generalization_across_time():
     # shape = (n_trials, 1) instead of (n_trials,)
     gat = GeneralizationAcrossTime(clf=RANSACRegressor(LinearRegression()),
                                    cv=2)
-    epochs._data = epochs._data[:, :, :2]
-    epochs.times = epochs.times[:2]
+    epochs.crop(None, epochs.times[2])
     gat.fit(epochs)
     gat.predict(epochs)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -2,7 +2,6 @@
 #          Jean-Remi King <jeanremi.king@gmail.com>
 #
 # License: BSD (3-clause)
-
 import warnings
 import copy
 import os.path as op
@@ -240,7 +239,10 @@ def test_generalization_across_time():
 
     # Check that still works with classifier that output y_pred with
     # shape = (n_trials, 1) instead of (n_trials,)
-    gat = GeneralizationAcrossTime(clf=RANSACRegressor(LinearRegression()))
+    gat = GeneralizationAcrossTime(clf=RANSACRegressor(LinearRegression()),
+                                   cv=2)
+    epochs._data = epochs._data[:, :, :2]
+    epochs.times = epochs.times[:2]
     gat.fit(epochs)
     gat.predict(epochs)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -46,6 +46,7 @@ def test_generalization_across_time():
     """Test time generalization decoding
     """
     from sklearn.svm import SVC
+    from sklearn.linear_model import RANSACRegressor, LinearRegression
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
     from sklearn.cross_validation import LeaveOneLabelOut
@@ -236,6 +237,12 @@ def test_generalization_across_time():
         gat.fit(epochs)
     gat.predict(epochs)
     assert_raises(ValueError, gat.predict, epochs[:10])
+
+    # Check that still works with classifier that output y_pred with
+    # shape = (n_trials, 1) instead of (n_trials,)
+    gat = GeneralizationAcrossTime(clf=RANSACRegressor(LinearRegression()))
+    gat.fit(epochs)
+    gat.predict(epochs)
 
     # Test combinations of complex scenarios
     # 2 or more distinct classes

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -609,14 +609,14 @@ def _predict(X, estimators):
     # if independent, estimators = all folds
     for fold, clf in enumerate(estimators):
         _y_pred = clf.predict(X)
+        # See inconsistency in dimensionality: scikit-learn/scikit-learn#5058
+        if _y_pred.ndim == 1:
+            _y_pred = _y_pred[:, None]
         # initialize predict_results array
         if fold == 0:
-            predict_size = _y_pred.shape[1] if _y_pred.ndim > 1 else 1
+            predict_size = _y_pred.shape[1]
             y_pred = np.ones((n_epochs, predict_size, n_clf))
-        if predict_size == 1:
-            y_pred[:, 0, fold] = np.squeeze(_y_pred)
-        else:
-            y_pred[:, :, fold] = _y_pred
+        y_pred[:, :, fold] = _y_pred
 
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -614,7 +614,7 @@ def _predict(X, estimators):
             predict_size = _y_pred.shape[1] if _y_pred.ndim > 1 else 1
             y_pred = np.ones((n_epochs, predict_size, n_clf))
         if predict_size == 1:
-            y_pred[:, 0, fold] = _y_pred
+            y_pred[:, 0, fold] = np.squeeze(_y_pred)
         else:
             y_pred[:, :, fold] = _y_pred
 


### PR DESCRIPTION
Some sklearn classifiers can predict y_pred_ with shape (n_trials, 1) instead of (n_trials,)