### PR TITLE
MRG: Add outline='skirt' option to plot_topomap

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -418,14 +418,14 @@ class LinearModel(BaseEstimator):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw.
             If 0, no contours will be drawn.
@@ -566,14 +566,14 @@ class LinearModel(BaseEstimator):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw.
             If 0, no contours will be drawn.

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -415,14 +415,15 @@ class LinearModel(BaseEstimator):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask.
-            If None, nothing will be drawn. Defaults to 'head'.
-            If dict, the 'autoshrink' (bool) field will trigger automated
-            shrinking of the positions due to points outside the outline.
-            Moreover, a matplotlib patch object can be passed for
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
             advanced masking options, either directly or as a function that
             returns patches (required for multi-axis plots).
         contours : int | False | None
@@ -562,14 +563,15 @@ class LinearModel(BaseEstimator):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask.
-            If None, nothing will be drawn. Defaults to 'head'.
-            If dict, the 'autoshrink' (bool) field will trigger automated
-            shrinking of the positions due to points outside the outline.
-            Moreover, a matplotlib patch object can be passed for
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
             advanced masking options, either directly or as a function that
             returns patches (required for multi-axis plots).
         contours : int | False | None

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -264,14 +264,15 @@ class CSP(TransformerMixin):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask.
-            If None, nothing will be drawn. Defaults to 'head'.
-            If dict, the 'autoshrink' (bool) field will trigger automated
-            shrinking of the positions due to points outside the outline.
-            Moreover, a matplotlib patch object can be passed for
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
             advanced masking options, either directly or as a function that
             returns patches (required for multi-axis plots).
         contours : int | False | None
@@ -407,14 +408,15 @@ class CSP(TransformerMixin):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask.
-            If None, nothing will be drawn. Defaults to 'head'.
-            If dict, the 'autoshrink' (bool) field will trigger automated
-            shrinking of the positions due to points outside the outline.
-            Moreover, a matplotlib patch object can be passed for
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
             advanced masking options, either directly or as a function that
             returns patches (required for multi-axis plots).
         contours : int | False | None

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -267,14 +267,14 @@ class CSP(TransformerMixin):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw.
             If 0, no contours will be drawn.
@@ -411,14 +411,14 @@ class CSP(TransformerMixin):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw.
             If 0, no contours will be drawn.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -894,15 +894,17 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             False.
         cbar_fmt : str
             The colorbar format. Defaults to '%0.3f'.
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask. If None, nothing
-            will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-            field will trigger automated shrinking of the positions due to
-            points outside the outline. Moreover, a matplotlib patch object can
-            be passed for advanced masking options, either directly or as a
-            function that returns patches (required for multi-axis plots).
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
+            advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots).
         show : bool
             Show figure if True.
         verbose : bool, str, int, or None

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -897,14 +897,14 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         show : bool
             Show figure if True.
         verbose : bool, str, int, or None

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -592,14 +592,14 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw. If 0, no contours will be
             drawn.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -589,15 +589,17 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Default (None) equals:
             ``dict(marker='o', markerfacecolor='w', markeredgecolor='k',
             linewidth=0, markersize=4)``.
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask. If None, nothing
-            will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-            field will trigger automated shrinking of the positions due to
-            points outside the outline. Moreover, a matplotlib patch object can
-            be passed for advanced masking options, either directly or as a
-            function that returns patches (required for multi-axis plots).
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
+            advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots).
         contours : int | False | None
             The number of contour lines to draw. If 0, no contours will be
             drawn.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1305,14 +1305,14 @@ class ICA(ContainsMixin):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         contours : int | False | None
             The number of contour lines to draw. If 0, no contours will
             be drawn.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1302,11 +1302,17 @@ class ICA(ContainsMixin):
             Title to use.
         show : bool
             Call pyplot.show() at the end.
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions. The
-            values in 'mask_pos' will serve as image mask. If None,
-            nothing will be drawn. Defaults to 'head'.
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
+            advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots).
         contours : int | False | None
             The number of contour lines to draw. If 0, no contours will
             be drawn.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1019,14 +1019,14 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         outlines : 'head' | 'skirt' | dict | None
             The outlines to be drawn. If 'head', the default head scheme will
             be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outsize of the head circle. If dict, each key
-            refers to a tuple of x and y positions. The values in 'mask_pos'
-            will serve as image mask. If None, nothing will be drawn.  Defaults
-            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the
-            outline. Moreover, a matplotlib patch object can be passed for
-            advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots).
+            allowed to be plotted outside of the head circle. If dict, each key
+            refers to a tuple of x and y positions, the values in 'mask_pos'
+            will serve as image mask, and the 'autoshrink' (bool) field will
+            trigger automated shrinking of the positions due to points outside
+            the outline. Alternatively, a matplotlib patch object can be passed
+            for advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots). If None, nothing
+            will be drawn. Defaults to 'head'.
         head_pos : dict | None
             If None (default), the sensors are positioned such that they span
             the head circle. If dict, can have entries 'center' (tuple) and

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1016,15 +1016,17 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             The axes to plot to. If None the axes is defined automatically.
         show : bool
             Call pyplot.show() at the end.
-        outlines : 'head' | dict | None
-            The outlines to be drawn. If 'head', a head scheme will be drawn.
-            If dict, each key refers to a tuple of x and y positions.
-            The values in 'mask_pos' will serve as image mask. If None, nothing
-            will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-            field will trigger automated shrinking of the positions due to
-            points outside the outline. Moreover, a matplotlib patch object can
-            be passed for advanced masking options, either directly or as a
-            function that returns patches (required for multi-axis plots).
+        outlines : 'head' | 'skirt' | dict | None
+            The outlines to be drawn. If 'head', the default head scheme will
+            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
+            allowed to be plotted outsize of the head circle. If dict, each key
+            refers to a tuple of x and y positions. The values in 'mask_pos'
+            will serve as image mask. If None, nothing will be drawn.  Defaults
+            to 'head'. If dict, the 'autoshrink' (bool) field will trigger
+            automated shrinking of the positions due to points outside the
+            outline. Moreover, a matplotlib patch object can be passed for
+            advanced masking options, either directly or as a function that
+            returns patches (required for multi-axis plots).
         head_pos : dict | None
             If None (default), the sensors are positioned such that they span
             the head circle. If dict, can have entries 'center' (tuple) and

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -9,7 +9,7 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_raises
+from numpy.testing import assert_raises, assert_array_equal
 
 from nose.tools import assert_true, assert_equal
 
@@ -152,15 +152,43 @@ def test_plot_topomap():
 
     pos = make_eeg_layout(evoked.info).pos
     pos, outlines = _check_outlines(pos, 'head')
-    # test 1: pass custom outlines without patch
+    assert_true('head' in outlines.keys())
+    assert_true('nose' in outlines.keys())
+    assert_true('ear_left' in outlines.keys())
+    assert_true('ear_right' in outlines.keys())
+    assert_true('autoshrink' in outlines.keys())
+    assert_true(outlines['autoshrink'])
+    assert_true('clip_radius' in outlines.keys())
+    assert_array_equal(outlines['clip_radius'], 0.5)
 
+    pos, outlines = _check_outlines(pos, 'skirt')
+    assert_true('head' in outlines.keys())
+    assert_true('nose' in outlines.keys())
+    assert_true('ear_left' in outlines.keys())
+    assert_true('ear_right' in outlines.keys())
+    assert_true('autoshrink' in outlines.keys())
+    assert_true(not outlines['autoshrink'])
+    assert_true('clip_radius' in outlines.keys())
+    assert_array_equal(outlines['clip_radius'], 0.625)
+
+    pos, outlines = _check_outlines(pos, 'skirt',
+                                    head_pos={'scale': [1.2, 1.2]})
+    assert_array_equal(outlines['clip_radius'], 0.75)
+
+    # Plot skirt
+    evoked.plot_topomap(times, ch_type='eeg', outlines='skirt')
+    
+    # Pass custom outlines without patch
+    evoked.plot_topomap(times, ch_type='eeg', outlines=outlines)
+    plt.close('all')
+
+    # Pass custom outlines with patch callable
     def patch():
         return Circle((0.5, 0.4687), radius=.46,
                       clip_on=True, transform=plt.gca().transAxes)
-
-    # test 2: pass custom outlines with patch callable
     outlines['patch'] = patch
-    plot_evoked_topomap(evoked, times, ch_type='eeg', outlines='head')
+    plot_evoked_topomap(evoked, times, ch_type='eeg', outlines=outlines)
+
     # Remove digitization points. Now topomap should fail
     evoked.info['dig'] = None
     assert_raises(RuntimeError, plot_evoked_topomap, evoked,

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -177,7 +177,7 @@ def test_plot_topomap():
 
     # Plot skirt
     evoked.plot_topomap(times, ch_type='eeg', outlines='skirt')
-    
+
     # Pass custom outlines without patch
     evoked.plot_topomap(times, ch_type='eeg', outlines=outlines)
     plt.close('all')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -244,7 +244,7 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
 
 
 def _check_outlines(pos, outlines, head_pos=None):
-    """Check or create outlines for 1opoplot
+    """Check or create outlines for topoplot
     """
     pos = np.array(pos, float)[:, :2]  # ensure we have a copy
     head_pos = dict() if head_pos is None else head_pos

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -146,15 +146,17 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
         multiple topomaps at a time).
     show : bool
         Show figure if True.
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn. If
-        dict, each key refers to a tuple of x and y positions. The values in
-        'mask_pos' will serve as image mask. If None, nothing will be drawn.
-        Defaults to 'head'. If dict, the 'autoshrink' (bool) field will
-        trigger automated shrinking of the positions due to points outside the
-        outline. Moreover, a matplotlib patch object can be passed for
-        advanced masking options, either directly or as a function that returns
-        patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -242,12 +244,12 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
 
 
 def _check_outlines(pos, outlines, head_pos=None):
-    """Check or create outlines for topoplot
+    """Check or create outlines for 1opoplot
     """
     pos = np.array(pos, float)[:, :2]  # ensure we have a copy
     head_pos = dict() if head_pos is None else head_pos
     if not isinstance(head_pos, dict):
-        raise TypeError('sensor_pos must be dict or None')
+        raise TypeError('head_pos must be dict or None')
     head_pos = copy.deepcopy(head_pos)
     for key in head_pos.keys():
         if key not in ('center', 'scale'):
@@ -258,7 +260,7 @@ def _check_outlines(pos, outlines, head_pos=None):
             raise ValueError('head_pos["%s"] must have shape (2,), not '
                              '%s' % (key, head_pos[key].shape))
 
-    if outlines in ('head', None):
+    if outlines in ('head', 'skirt', None):
         radius = 0.5
         l = np.linspace(0, 2 * np.pi, 101)
         head_x = np.cos(l) * radius
@@ -273,23 +275,42 @@ def _check_outlines(pos, outlines, head_pos=None):
         # shift and scale the electrode positions
         if 'center' not in head_pos:
             head_pos['center'] = 0.5 * (pos.max(axis=0) + pos.min(axis=0))
-        if 'scale' not in head_pos:
-            # The default is to make the points occupy a slightly smaller
-            # proportion (0.85) of the total width and height
-            # this number was empirically determined (seems to work well)
-            head_pos['scale'] = 0.85 / (pos.max(axis=0) - pos.min(axis=0))
         pos -= head_pos['center']
-        pos *= head_pos['scale']
 
-        # Define the outline of the head, ears and nose
-        outlines = dict()
         if outlines is not None:
-            outlines.update(head=(head_x, head_y), nose=(nose_x, nose_y),
-                            ear_left=(ear_x, ear_y),
-                            ear_right=(-ear_x, ear_y))
+            # Define the outline of the head, ears and nose
+            outlines_dict = dict(head=(head_x, head_y), nose=(nose_x, nose_y),
+                                 ear_left=(ear_x, ear_y),
+                                 ear_right=(-ear_x, ear_y))
+        else:
+            outlines_dict = dict()
 
-        outlines['mask_pos'] = head_x, head_y
-        outlines['autoshrink'] = True
+        if outlines == 'skirt':
+            if 'scale' not in head_pos:
+                # By default, fit electrodes inside the head circle
+                head_pos['scale'] = 1.0 / (pos.max(axis=0) - pos.min(axis=0))
+            pos *= head_pos['scale']
+
+            # Make the figure encompass slightly more than all points
+            mask_scale = 1.25 * (pos.max(axis=0) - pos.min(axis=0))
+
+            outlines_dict['autoshrink'] = False
+            outlines_dict['mask_pos'] = (mask_scale[0] * head_x,
+                                         mask_scale[1] * head_y)
+            outlines_dict['clip_radius'] = (mask_scale / 2)
+        else:
+            if 'scale' not in head_pos:
+                # The default is to make the points occupy a slightly smaller
+                # proportion (0.85) of the total width and height
+                # this number was empirically determined (seems to work well)
+                head_pos['scale'] = 0.85 / (pos.max(axis=0) - pos.min(axis=0))
+            pos *= head_pos['scale']
+            outlines_dict['autoshrink'] = True
+            outlines_dict['mask_pos'] = head_x, head_y
+            outlines_dict['clip_radius'] = (0.5, 0.5)
+
+        outlines = outlines_dict
+
     elif isinstance(outlines, dict):
         if 'mask_pos' not in outlines:
             raise ValueError('You must specify the coordinates of the image'
@@ -391,15 +412,17 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
            dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                 linewidth=0, markersize=4)
 
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn. If
-        dict, each key refers to a tuple of x and y positions. The values in
-        'mask_pos' will serve as image mask. If None, nothing will be drawn.
-        Defaults to 'head'. If dict, the 'autoshrink' (bool) field will
-        trigger automated shrinking of the positions due to points outside the
-        outline. Moreover, a matplotlib patch object can be passed for
-        advanced masking options, either directly or as a function that returns
-        patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     image_mask : ndarray of bool, shape (res, res) | None
         The image mask to cover the interpolated surface. If None, it will be
         computed from the outline.
@@ -511,10 +534,11 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
 
     if _is_default_outlines:
         from matplotlib import patches
-        # remove nose offset and tweak
-        patch_ = patches.Circle((0.5, 0.4687), radius=.46,
-                                clip_on=True,
-                                transform=ax.transAxes)
+        patch_ = patches.Ellipse((0, 0),
+                                 2 * outlines['clip_radius'][0],
+                                 2 * outlines['clip_radius'][1],
+                                 clip_on=True,
+                                 transform=ax.transData)
     if _is_default_outlines or patch is not None:
         im.set_clip_path(patch_)
         # ax.set_clip_path(patch_)
@@ -660,15 +684,17 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         Title to use.
     show : bool
         Show figure if True.
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn. If
-        dict, each key refers to a tuple of x and y positions. The values in
-        'mask_pos' will serve as image mask. If None, nothing will be drawn.
-        Defaults to 'head'. If dict, the 'autoshrink' (bool) field will
-        trigger automated shrinking of the positions due to points outside the
-        outline. Moreover, a matplotlib patch object can be passed for
-        advanced masking options, either directly or as a function that returns
-        patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -849,15 +875,17 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         The axes to plot to. If None the axes is defined automatically.
     show : bool
         Show figure if True.
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn.
-        If dict, each key refers to a tuple of x and y positions.
-        The values in 'mask_pos' will serve as image mask. If None, nothing
-        will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-        field will trigger automated shrinking of the positions due to
-        points outside the outline. Moreover, a matplotlib patch object can
-        be passed for advanced masking options, either directly or as a
-        function that returns patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     head_pos : dict | None
         If None (default), the sensors are positioned such that they span
         the head circle. If dict, can have entries 'center' (tuple) and
@@ -1036,15 +1064,17 @@ def plot_evoked_topomap(evoked, times=None, ch_type=None, layout=None,
             dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                  linewidth=0, markersize=4)
 
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn. If
-        dict, each key refers to a tuple of x and y positions. The values in
-        'mask_pos' will serve as image mask. If None, nothing will be drawn.
-        Defaults to 'head'. If dict, the 'autoshrink' (bool) field will
-        trigger automated shrinking of the positions due to points outside the
-        outline. Moreover, a matplotlib patch object can be passed for
-        advanced masking options, either directly or as a function that returns
-        patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -1324,15 +1354,17 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         False.
     cbar_fmt : str
         The colorbar format. Defaults to '%0.3f'.
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn.
-        If dict, each key refers to a tuple of x and y positions.
-        The values in 'mask_pos' will serve as image mask. If None, nothing
-        will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-        field will trigger automated shrinking of the positions due to
-        points outside the outline. Moreover, a matplotlib patch object can
-        be passed for advanced masking options, either directly or as a
-        function that returns patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     show : bool
         Show figure if True.
     verbose : bool, str, int, or None
@@ -1408,15 +1440,17 @@ def plot_psds_topomap(
         False.
     cbar_fmt : str
         The colorbar format. Defaults to '%0.3f'.
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn.
-        If dict, each key refers to a tuple of x and y positions.
-        The values in 'mask_pos' will serve as image mask. If None, nothing
-        will be drawn. Defaults to 'head'. If dict, the 'autoshrink' (bool)
-        field will trigger automated shrinking of the positions due to
-        points outside the outline. Moreover, a matplotlib patch object can
-        be passed for advanced masking options, either directly or as a
-        function that returns patches (required for multi-axis plots).
+    outlines : 'head' | 'skirt' | dict | None
+        The outlines to be drawn. If 'head', the default head scheme will be
+        drawn. If 'skirt' the head scheme will be drawn, but sensors are
+        allowed to be plotted outsize of the head circle. If dict, each key
+        refers to a tuple of x and y positions. The values in 'mask_pos' will
+        serve as image mask. If None, nothing will be drawn.  Defaults to
+        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
+        shrinking of the positions due to points outside the outline. Moreover,
+        a matplotlib patch object can be passed for advanced masking options,
+        either directly or as a function that returns patches (required for
+        multi-axis plots).
     show : bool
         Show figure if True.
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -149,14 +149,14 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -415,14 +415,14 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     image_mask : ndarray of bool, shape (res, res) | None
         The image mask to cover the interpolated surface. If None, it will be
         computed from the outline.
@@ -687,14 +687,14 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -878,14 +878,14 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     head_pos : dict | None
         If None (default), the sensors are positioned such that they span
         the head circle. If dict, can have entries 'center' (tuple) and
@@ -1067,14 +1067,14 @@ def plot_evoked_topomap(evoked, times=None, ch_type=None, layout=None,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     contours : int | False | None
         The number of contour lines to draw. If 0, no contours will be drawn.
     image_interp : str
@@ -1357,14 +1357,14 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     show : bool
         Show figure if True.
     verbose : bool, str, int, or None
@@ -1443,14 +1443,14 @@ def plot_psds_topomap(
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outsize of the head circle. If dict, each key
-        refers to a tuple of x and y positions. The values in 'mask_pos' will
-        serve as image mask. If None, nothing will be drawn.  Defaults to
-        'head'. If dict, the 'autoshrink' (bool) field will trigger automated
-        shrinking of the positions due to points outside the outline. Moreover,
-        a matplotlib patch object can be passed for advanced masking options,
-        either directly or as a function that returns patches (required for
-        multi-axis plots).
+        allowed to be plotted outside of the head circle. If dict, each key
+        refers to a tuple of x and y positions, the values in 'mask_pos' will
+        serve as image mask, and the 'autoshrink' (bool) field will trigger
+        automated shrinking of the positions due to points outside the outline.
+        Alternatively, a matplotlib patch object can be passed for advanced
+        masking options, either directly or as a function that returns patches
+        (required for multi-axis plots). If None, nothing will be drawn.
+        Defaults to 'head'.
     show : bool
         Show figure if True.
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -297,7 +297,7 @@ def _check_outlines(pos, outlines, head_pos=None):
             outlines_dict['autoshrink'] = False
             outlines_dict['mask_pos'] = (mask_scale[0] * head_x,
                                          mask_scale[1] * head_y)
-            outlines_dict['clip_radius'] = (mask_scale / 2)
+            outlines_dict['clip_radius'] = (mask_scale / 2.)
         else:
             if 'scale' not in head_pos:
                 # The default is to make the points occupy a slightly smaller


### PR DESCRIPTION
In some dense EEG montages, electrodes are at the side / underside of the
head. When making a topomap plot, it can help interpretation to place
these electrodes (and corresponding interpolated data) outside the head
circle. Setting outline='skirt' allows you to do this.

![figure_1](https://cloud.githubusercontent.com/assets/428273/9228533/99d240aa-4121-11e5-934d-054b24226181.png)

To see an example of the API:

https://gist.github.com/wmvanvliet/6d7c78ea329d4e9e1217
