### PR TITLE
EHN: GAT parallel across chunks for predict & score

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_array_equal
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_sklearn, slow_test
 from mne.decoding import GeneralizationAcrossTime, TimeDecoding
-from mne import EpochsArray
 
 
 data_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -46,6 +45,7 @@ def test_generalization_across_time():
     """Test time generalization decoding
     """
     from sklearn.svm import SVC
+    from sklearn.linear_model import RANSACRegressor, LinearRegression
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
     from sklearn.cross_validation import LeaveOneLabelOut
@@ -214,14 +214,6 @@ def test_generalization_across_time():
     # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
-
-    # Test float arithmetic error
-    with warnings.catch_warnings(record=True):
-        epochs.decimate(3)
-    gat.fit(epochs)
-    0/0
-    epochs = EpochsArray(epochs._data, epochs.info, epochs.events, tmin=epochs.times[0])
-    gat.predict(epochs)
 
     svc = SVC(C=1, kernel='linear', probability=True)
     gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_array_equal
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_sklearn, slow_test
 from mne.decoding import GeneralizationAcrossTime, TimeDecoding
+from mne import EpochsArray
 
 
 data_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -45,7 +46,6 @@ def test_generalization_across_time():
     """Test time generalization decoding
     """
     from sklearn.svm import SVC
-    from sklearn.linear_model import RANSACRegressor, LinearRegression
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
     from sklearn.cross_validation import LeaveOneLabelOut
@@ -214,6 +214,14 @@ def test_generalization_across_time():
     # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
+
+    # Test float arithmetic error
+    with warnings.catch_warnings(record=True):
+        epochs.decimate(3)
+    gat.fit(epochs)
+    0/0
+    epochs = EpochsArray(epochs._data, epochs.info, epochs.events, tmin=epochs.times[0])
+    gat.predict(epochs)
 
     svc = SVC(C=1, kernel='linear', probability=True)
     gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -233,17 +233,39 @@ class _GeneralizationAcrossTime(object):
         # TODO: JRK: Chunking times points needs to be simplified
         parallel, p_time_gen, n_jobs = parallel_func(_predict_slices, n_jobs)
         n_estimators = len(self.train_times_['slices'])
-        n_chunks = min(n_estimators, n_jobs)
-        splits = np.array_split(self.test_times_['slices'], n_chunks)
-
         # Loop across estimators (i.e. training times)
-        y_pred = parallel(p_time_gen(
-            X,
-            [self.estimators_[t_train] for t_train in split * int(
-                n_chunks / n_estimators) + np.arange(len(slices))],
-            self.cv_, slices, self.predict_mode)
-            for split, slices in enumerate(splits))
-        self.y_pred_ = np.concatenate(y_pred, axis=1).tolist()
+        # 1. if all testing slices are identical, loop across data. This
+        # minimizes memory load, assuming that the data, when cloned in each
+        # chunk, is larger than the estimators, cloned in each chunk)
+        if np.all([np.array_equal(self.test_times_['slices'][0], this_slice)
+                   for this_slice in self.test_times_['slices']]):
+            n_chunks = min(n_estimators, n_jobs) + 1
+            splits = np.transpose([np.array_split(slices, n_chunks)
+                                   for slices in self.test_times_['slices']])
+
+            def chunk_X(X, slices):
+                """Smart chunking to avoid memory overload"""
+                slices = [sl for sl in slices]  # from object array to list
+                start = np.min(slices)
+                stop = np.max(slices) + 1
+                slices_ = np.array(slices) - start
+                X_ = X[:, :, start:stop]
+                return (X_, self.estimators_, self.cv_, slices_.tolist(),
+                        self.predict_mode)
+
+            y_pred = parallel(p_time_gen(*chunk_X(X, slices))
+                              for slices in splits)
+            self.y_pred_ = np.concatenate(y_pred, axis=1).tolist()
+        else:
+            # 2. If each classifier is used to predict different data slices
+            # we have no choice but to loop across classifiers.
+            # TODO: Use chunks and select X slices to avoid unnecessary
+            # overload.
+            self.y_pred_ = parallel(p_time_gen(X, [self.estimators_[t_train]],
+                                               self.cv_, slices,
+                                               self.predict_mode)
+                                    for t_train, slices in
+                                    enumerate(self.test_times_['slices']))
         return self.y_pred_
 
     def score(self, epochs=None, y=None):
@@ -328,7 +350,7 @@ class _GeneralizationAcrossTime(object):
             [self.y_pred_[t_train] for t_train in split * int(
                 n_chunks / n_estimators) + np.arange(len(slices))],
             slices, self.scorer_) for split, slices in enumerate(splits))
-        self.scores_ = np.concatenate(scores, axis=1).tolist()
+        self.scores_ = np.concatenate(scores, axis=0).tolist()
         return self.scores_
 
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -153,7 +153,7 @@ class _GeneralizationAcrossTime(object):
         # Parallel across training time
         # TODO: JRK: Chunking times points needs to be simplified
         parallel, p_time_gen, n_jobs = parallel_func(_fit_slices, n_jobs)
-        n_chunks = min(len(self.train_times_['slices']), n_jobs)
+        n_chunks = min(X.shape[2], n_jobs)
         splits = np.array_split(self.train_times_['slices'], n_chunks)
 
         def f(x):
@@ -212,19 +212,24 @@ class _GeneralizationAcrossTime(object):
             raise ValueError('`test_times` must be a dict or "diagonal"')
 
         if 'slices' not in test_times:
-            # Force same number of time sample in testing than in training
+            # Check that same number of time sample in testing than in training
             # (otherwise it won 't be the same number of features')
-            window_param = dict(length=self.train_times_['length'])
+            if 'length' not in test_times:
+                test_times['length'] = self.train_times_['length']
+            if test_times['length'] != self.train_times_['length']:
+                raise ValueError('`train_times` and `test_times` must have '
+                                 'identical `length` keys')
             # Make a sliding window for each training time.
             slices_list = list()
             times_list = list()
             for t in range(0, len(self.train_times_['slices'])):
-                test_times_ = _sliding_window(epochs.times, window_param)
+                test_times_ = _sliding_window(epochs.times, test_times)
                 times_list += [test_times_['times']]
                 slices_list += [test_times_['slices']]
             test_times = test_times_
             test_times['slices'] = slices_list
             test_times['times'] = times_list
+
 
         # Store all testing times parameters
         self.test_times_ = test_times
@@ -567,6 +572,23 @@ def _sliding_window(times, window_params):
             window_params['step'] = freq
         if 'length' not in window_params:
             window_params['length'] = freq
+
+        if (window_params['start'] < times[0] or
+                window_params['start'] > times[-1]):
+            raise ValueError(
+                '`start` (%.2f s) outside time range [%.2f, %.2f].' % (
+                    window_params['start'], times[0], times[-1]))
+        if (window_params['stop'] < times[0] or
+                window_params['stop'] > times[-1]):
+            raise ValueError(
+                '`stop` (%.2f s) outside time range [%.2f, %.2f].' % (
+                    window_params['stop'], times[0], times[-1]))
+        if window_params['step'] < freq:
+            raise ValueError('`step` must be >= 1 / sampling_frequency')
+        if window_params['length'] < freq:
+            raise ValueError('`length` must be >= 1 / sampling_frequency')
+        if window_params['length'] > np.ptp(times):
+            raise ValueError('`length` must be <= time range')
 
         # Convert seconds to index
 


### PR DESCRIPTION
@dengemann @jona-sassenhagen @cmoutard

The previous implementation was parallelized across time samples, which was highly suboptimal when dealing with simple classifiers (e.g. based on a low number of features, like with eeg) and a lot of time points, because of constant jumps across CPU threads.

With the current implementation, the `predict` and `score` parallelization is made with chunked data. This is analogous to the method used for `fit`, but the chunked data is across time (not estimators), which is slightly more difficult to follow, but allows dispatching `X` across threads, as opposed to copy it in each thread.

The cpu and memory gain is pretty high for large datasets. (@agramfort No, I haven't done the profiling, but I see it by eye ;))

I apologize in advance: the syntax remains quite hard to follow, most of the time because I made the stupid decision early on to accept irregular training and testing times (which can be useful, but not that often). There may be room for improvement and clarification (notably by using a single function to chunk and parallelize the data), but this will be for a later PR.

(Also: I've had problems with the git history, some old commits were omitted; I'm not sure why, I tried rebasing a few time, keeping silent features, checked the history,  etc; in vain. I think it's because i) I started this branch a while ago and/or ii) I continued from https://github.com/mne-tools/mne-python/pull/2398)

Let me know what you think.