### PR TITLE
[MRG] SSS: reconstruct bad channels

### DIFF
--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -182,10 +182,10 @@ def test_bads_reconstruction():
     raw_sss = maxwell.maxwell_filter(raw)
     meg_chs = pick_types(raw_sss.info)
 
-    assert_array_almost_equal(raw_sss._data[meg_chs, :],
-                              sss_bench._data[meg_chs, :], decimal=11,
-                              err_msg='Maxwell filtered data with '
-                              ' reconstructed bads is incorrect.')
+    # Some numerical imprecision since save uses 'single' fmt
+    assert_allclose(raw_sss._data[meg_chs, :], sss_bench._data[meg_chs, :],
+                    rtol=1e-12, atol=1e-4, err_msg='Maxwell filtered data '
+                    'with reconstructed bads is incorrect.')
 
     # Confirm SNR is above 1000
     bench_rms = np.sqrt(np.mean(raw_sss._data[meg_chs, :] ** 2, axis=1))

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -9,7 +9,7 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal)
 from nose.tools import assert_true, assert_raises
 
-from mne import compute_raw_data_covariance
+from mne import compute_raw_data_covariance, pick_types
 from mne.cov import _estimate_rank_meeg_cov
 from mne.datasets import testing
 from mne.forward._make_forward import _prep_meg_channels
@@ -25,6 +25,8 @@ sss_std_fname = op.join(data_path, 'SSS',
                         'test_move_anon_raw_simp_stdOrigin_sss.fif')
 sss_nonstd_fname = op.join(data_path, 'SSS',
                            'test_move_anon_raw_simp_nonStdOrigin_sss.fif')
+sss_bad_recon_fname = op.join(data_path, 'SSS',
+                              'test_move_anon_raw_bad_recon_sss.fif')
 
 
 @testing.requires_testing_data
@@ -156,5 +158,42 @@ def test_maxwell_filter_additional():
 
     assert_equal(cov_raw_rank, raw.info['nchan'])
     assert_equal(cov_sss_rank, maxwell.get_num_moments(int_order, 0))
+
+
+@testing.requires_testing_data
+def test_bads_reconstruction():
+    """Test reconstruction of channels marked as bad"""
+
+    with warnings.catch_warnings(record=True):  # maxshield, naming
+        sss_bench = Raw(sss_bad_recon_fname, preload=True, proj=False,
+                        allow_maxshield=True)
+
+    # Load testing data (raw, SSS std origin, SSS non-standard origin)
+    data_path = op.join(testing.data_path(download=False))
+
+    file_name = 'test_move_anon'
+    raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
+
+    with warnings.catch_warnings(record=True):  # maxshield
+        # Use 2.0 seconds of data to get stable cov. estimate
+        raw = Raw(raw_fname, preload=False, proj=False,
+                  allow_maxshield=True).crop(0., 2., False)
+
+    # Get MEG channels, compute Maxwell filtered data
+    raw.preload_data()
+    raw.info['bads'] = ['MEG0113', 'MEG0112', 'MEG0111']
+    raw_sss = maxwell.maxwell_filter(raw)
+    meg_picks = pick_types(raw_sss.info)
+
+    assert_array_almost_equal(raw_sss._data[meg_picks, :],
+                              sss_bench._data[meg_picks, :], decimal=11,
+                              err_msg='Maxwell filtered data with '
+                              ' reconstructed bads is incorrect.')
+
+    # Confirm SNR is above 1000
+    bench_rms = np.sqrt(np.mean(raw_sss._data[meg_picks, :] ** 2, axis=1))
+    error = raw_sss._data[meg_picks, :] - sss_bench._data[meg_picks, :]
+    error_rms = np.sqrt(np.mean(error ** 2, axis=1))
+    assert_true(np.mean(bench_rms / error_rms) >= 1000, 'SNR < 1000')
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -72,12 +72,6 @@ def test_maxwell_filter():
     assert_equal(S_out.shape, (ncoils, n_ext_bases),
                  'S_out has incorrect shape')
 
-    # Check normalization
-    assert_allclose(np.sum(S_in ** 2, axis=0), np.ones((S_in.shape[1])),
-                    rtol=1e-12, err_msg='S_in normalization error')
-    assert_allclose(np.sum(S_out ** 2, axis=0), np.ones((S_out.shape[1])),
-                    rtol=1e-12, err_msg='S_out normalization error')
-
     # Test sss computation at the standard head origin
     raw_sss = maxwell.maxwell_filter(raw, origin=[0., 0., 40.],
                                      int_order=int_order, ext_order=ext_order)
@@ -171,14 +165,20 @@ def test_bads_reconstruction():
     raw_fname = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
 
     with warnings.catch_warnings(record=True):  # maxshield
-        # Use 2.0 seconds of data to get stable cov. estimate
         raw = Raw(raw_fname, preload=False, proj=False,
                   allow_maxshield=True).crop(0., 1., False)
 
     raw.preload_data()
 
-    # Set bad MEG channels, compute Maxwell filtered data
-    raw.info['bads'] = raw.info['ch_names'][0:9]
+    # Set 30 random bad MEG channels (20 grad, 10 mag)
+    bads = ['MEG0912', 'MEG1722', 'MEG2213', 'MEG0132', 'MEG1312', 'MEG0432',
+            'MEG2433', 'MEG1022', 'MEG0442', 'MEG2332', 'MEG0633', 'MEG1043',
+            'MEG1713', 'MEG0422', 'MEG0932', 'MEG1622', 'MEG1343', 'MEG0943',
+            'MEG0643', 'MEG0143', 'MEG2142', 'MEG0813', 'MEG2143', 'MEG1323',
+            'MEG0522', 'MEG1123', 'MEG0423', 'MEG2122', 'MEG2532', 'MEG0812']
+    raw.info['bads'] = bads
+
+    # Compute Maxwell filtered data
     raw_sss = maxwell.maxwell_filter(raw)
     meg_chs = pick_types(raw_sss.info)
 


### PR DESCRIPTION
This PR allows the user to specify if bad channels should be reconstructed or not.

* [x] Add functionality to compute multipolar moments based only on good MEG channels
* [x] Add functionality to reconstruct all channels (good + bad) or only good channels depending on user's preference
* [x] Add tests for the above
* [x] Add new data to `MNE-testing-data`
* [x] Verify against Elekta's reconstructed data

Will require `MNE-testing-data` to be updated