### PR TITLE
Fix examples pick channels

### DIFF
--- a/examples/preprocessing/plot_eog_artifact_histogram.py
+++ b/examples/preprocessing/plot_eog_artifact_histogram.py
@@ -40,7 +40,7 @@ event_ids = {'AudL': 1, 'AudR': 2, 'VisL': 3, 'VisR': 4}
 epochs = mne.Epochs(raw, events, event_ids, tmin, tmax, picks=picks)
 
 # Get the stim channel data
-pick_ch = mne.pick_channels(epochs.ch_names, 'STI 014')[0]
+pick_ch = mne.pick_channels(epochs.ch_names, ['STI 014'])[0]
 data = epochs.get_data()[:, pick_ch, :].astype(int)
 data = np.sum((data.astype(int) & 512) == 512, axis=0)
 

--- a/examples/preprocessing/plot_shift_evoked.py
+++ b/examples/preprocessing/plot_shift_evoked.py
@@ -25,7 +25,7 @@ evoked = mne.read_evokeds(fname, condition=condition, baseline=(None, 0),
                           proj=True)
 
 ch_names = evoked.info['ch_names']
-picks = mne.pick_channels(ch_names=ch_names, include="MEG 2332", exclude="bad")
+picks = mne.pick_channels(ch_names=ch_names, include=["MEG 2332"])
 
 # Create subplots
 f, (ax1, ax2, ax3) = plt.subplots(3)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -585,8 +585,8 @@ def _check_excludes_includes(chs, info=None, allow_bads=False):
     ----------
     chs : any input, should be list, tuple, string
         The channels passed to include or exclude.
-    allow_strs : list of strings
-        Optional strings to allow.
+    allow_bads : bool
+        Allow the user to supply "bads" as a string for auto exclusion.
 
     Returns
     -------


### PR DESCRIPTION
Suggestion from #2410 

I removed the `exclude="bads"` string from `pick_channels` because this doesn't make sense if we don't supply an info object, which the function `pick_channels` doesn't include.