### PR TITLE
MRG: Enforce ints for events

### DIFF
--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -361,8 +361,9 @@ def test_tf_lcmv():
     # the underlying raw object
     epochs_preloaded = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                                   baseline=(None, 0), preload=True)
-    assert_raises(ValueError, tf_lcmv, epochs_preloaded, forward, noise_covs,
-                  tmin, tmax, tstep, win_lengths, freq_bins)
+    with warnings.catch_warnings(record=True):  # not enough samples
+        assert_raises(ValueError, tf_lcmv, epochs_preloaded, forward,
+                      noise_covs, tmin, tmax, tstep, win_lengths, freq_bins)
 
     with warnings.catch_warnings(record=True):  # not enough samples
         # Pass only one epoch to test if subtracting evoked

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -128,8 +128,9 @@ def test_rap_music_simulated():
         _get_data()
 
     n_dipoles = 2
-    sim_evoked, stc = simu_data(evoked, forward_fixed, noise_cov, n_dipoles,
-                                evoked.times)
+    with warnings.catch_warnings(record=True):  # not positive semidef
+        sim_evoked, stc = simu_data(evoked, forward_fixed, noise_cov,
+                                    n_dipoles, evoked.times)
     # Check dipoles for fixed ori
     dipoles = rap_music(sim_evoked, forward_fixed, noise_cov,
                         n_dipoles=n_dipoles)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -49,7 +49,8 @@ def test_scaler():
     assert_array_equal(X2, X)
 
     # Test inverse_transform
-    Xi = scaler.inverse_transform(X, y)
+    with warnings.catch_warnings(record=True):  # invalid value in mult
+        Xi = scaler.inverse_transform(X, y)
     assert_array_equal(epochs_data, Xi)
 
     # Test init exception

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -179,9 +179,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if events is not None:  # RtEpochs can have events=None
 
-            if not np.array_equal(events, np.array(events, dtype=int)):
-                raise ValueError('events values be integers.')
-            events = np.array(events, dtype=int)
+            if events.dtype.kind != 'i':
+                raise ValueError('`events` needs to be an array of type int')
 
             for key, val in self.event_id.items():
                 if val not in events[:, 2]:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -178,6 +178,11 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         del event_id
 
         if events is not None:  # RtEpochs can have events=None
+
+            if not np.array_equal(events, np.array(events, dtype=int)):
+                raise ValueError('events values be integers.')
+            events = np.array(events, dtype=int)
+
             for key, val in self.event_id.items():
                 if val not in events[:, 2]:
                     msg = ('No matching events found for %s '
@@ -1548,7 +1553,7 @@ class Epochs(_BaseEpochs):
     ----------
     raw : Raw object
         An instance of Raw.
-    events : array, shape (n_events, 3)
+    events : array of int, shape (n_events, 3)
         The events typically returned by the read_events function.
         If some events don't match the events of interest as specified
         by event_id, they will be marked as 'IGNORED' in the drop log.
@@ -1820,8 +1825,6 @@ class EpochsArray(_BaseEpochs):
         if data.shape[0] != len(events):
             raise ValueError('The number of epochs and the number of events'
                              'must match')
-        if not np.array_equal(events, np.array(events, dtype=int)):
-            raise ValueError('events must be an array integers.')
         tmax = (data.shape[2] - 1) / info['sfreq'] + tmin
         if event_id is None:  # convert to int to make typing-checks happy
             event_id = dict((str(e), int(e)) for e in np.unique(events[:, 2]))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1751,7 +1751,7 @@ class EpochsArray(_BaseEpochs):
     info : instance of Info
         Info dictionary. Consider using ``create_info`` to populate
         this structure.
-    events : array, shape (n_events, 3)
+    events : array of int, shape (n_events, 3)
         The events typically returned by the read_events function.
         If some events don't match the events of interest as specified
         by event_id, they will be marked as 'IGNORED' in the drop log.
@@ -1820,6 +1820,8 @@ class EpochsArray(_BaseEpochs):
         if data.shape[0] != len(events):
             raise ValueError('The number of epochs and the number of events'
                              'must match')
+        if not np.array_equal(events, np.array(events, dtype=int)):
+            raise ValueError('events must be an array integers.')
         tmax = (data.shape[2] - 1) / info['sfreq'] + tmin
         if event_id is None:  # convert to int to make typing-checks happy
             event_id = dict((str(e), int(e)) for e in np.unique(events[:, 2]))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -180,7 +180,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if events is not None:  # RtEpochs can have events=None
 
             if events.dtype.kind not in ['i', 'u']:
-                raise ValueError('`events` needs to be an array of type int')
+                raise ValueError('events must be an array of type int')
+            if events.ndim != 2 or events.shape[1] != 3:
+                raise ValueError('events must be 2D with 3 columns')
 
             for key, val in self.event_id.items():
                 if val not in events[:, 2]:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -179,7 +179,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if events is not None:  # RtEpochs can have events=None
 
-            if events.dtype.kind != 'i':
+            if events.dtype.kind not in ['i', 'u']:
                 raise ValueError('`events` needs to be an array of type int')
 
             for key, val in self.event_id.items():

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -503,7 +503,10 @@ def construct_iir_filter(iir_params=dict(b=[1, 0], a=[1, 0], padlen=0),
     (array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]), [1, 0], 0)
 
     """  # noqa
-    from scipy.signal import filter_dict, iirfilter, iirdesign
+    from scipy.signal import iirfilter, iirdesign
+    known_filters = ('bessel', 'butter', 'butterworth', 'cauer', 'cheby1',
+                     'cheby2', 'chebyshev1', 'chebyshev2', 'chebyshevi',
+                     'chebyshevii', 'ellip', 'elliptic')
     a = None
     b = None
     # if the filter has been designed, we're good to go
@@ -515,7 +518,7 @@ def construct_iir_filter(iir_params=dict(b=[1, 0], a=[1, 0], padlen=0),
             raise RuntimeError('ftype must be an entry in iir_params if ''b'' '
                                'and ''a'' are not specified')
         ftype = iir_params['ftype']
-        if ftype not in filter_dict:
+        if ftype not in known_filters:
             raise RuntimeError('ftype must be in filter_dict from '
                                'scipy.signal (e.g., butter, cheby1, etc.) not '
                                '%s' % ftype)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -81,7 +81,7 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
 
 
 def test_magnetic_dipole():
-    """Basic test for magnetic dipole forward calculation
+    """Test basic magnetic dipole forward calculation
     """
     trans = {'to': FIFF.FIFFV_COORD_HEAD, 'from': FIFF.FIFFV_COORD_MRI,
              'trans': np.eye(4)}

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -15,6 +15,7 @@ from mne.io.constants import FIFF
 from mne.io import Raw
 from mne.datasets import testing
 from mne.forward.tests import test_forward
+from mne.utils import run_tests_if_main
 
 
 def test_pick_channels_regexp():
@@ -40,7 +41,7 @@ def test_pick_seeg():
     for i, t in enumerate(types):
         assert_equal(channel_type(info, i), types[i])
     raw = RawArray(np.zeros((len(names), 10)), info)
-    events = np.array([[1, 0, 0], [2, 0, 0]]).astype('d')
+    events = np.array([[1, 0, 0], [2, 0, 0]])
     epochs = Epochs(raw, events, {'event': 0}, -1e-5, 1e-5)
     evoked = epochs.average(pick_types(epochs.info, meg=True, seeg=True))
     e_seeg = evoked.pick_types(meg=False, seeg=True, copy=True)
@@ -168,3 +169,5 @@ def test_clean_info_bads():
 
     assert_equal(info_eeg['bads'], eeg_bad_ch)
     assert_equal(info_meg['bads'], meg_bad_ch)
+
+run_tests_if_main()

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -186,8 +186,9 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     logger.info("Number of ECG events detected : %d (average pulse %d / "
                 "min.)" % (n_events, average_pulse))
 
-    ecg_events = np.c_[ecg_events + raw.first_samp, np.zeros(n_events),
-                       event_id * np.ones(n_events)]
+    ecg_events = np.array([ecg_events + raw.first_samp,
+                           np.zeros(n_events, int),
+                           event_id * np.ones(n_events, int)]).T
     return ecg_events, idx_ecg, average_pulse
 
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -94,8 +94,9 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     eog_events += n_samples_start
     n_events = len(eog_events)
     logger.info("Number of EOG events detected : %d" % n_events)
-    eog_events = np.c_[eog_events + first_samp, np.zeros(n_events),
-                       event_id * np.ones(n_events)]
+    eog_events = np.array([eog_events + first_samp,
+                           np.zeros(n_events, int),
+                           event_id * np.ones(n_events, int)]).T
 
     return eog_events
 

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -5,9 +5,10 @@ from nose.tools import assert_true, assert_equal
 from numpy.testing import assert_array_almost_equal
 import numpy as np
 
-from ...io import Raw
-from ...io.proj import make_projector, activate_proj
-from ..ssp import compute_proj_ecg, compute_proj_eog
+from mne.io import Raw
+from mne.io.proj import make_projector, activate_proj
+from mne.preprocessing.ssp import compute_proj_ecg, compute_proj_eog
+from mne.utils import run_tests_if_main
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -98,3 +99,5 @@ def test_compute_proj_parallel():
     projs_2, _, _ = make_projector(projs_2, raw_2.info['ch_names'],
                                    bads=['MEG 2443'])
     assert_array_almost_equal(projs, projs_2, 10)
+
+run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1539,7 +1539,7 @@ def test_array_epochs():
     types = ['eeg'] * 20
     info = create_info(ch_names, sfreq, types)
     events = np.c_[np.arange(1, 600, 60),
-                   np.zeros(10),
+                   np.zeros(10, int),
                    [1, 2] * 5]
     event_id = {'a': 1, 'b': 2}
     epochs = EpochsArray(data, info, events, tmin, event_id)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1583,6 +1583,9 @@ def test_array_epochs():
     ep_data = epochs.get_data()
     assert_array_equal(np.zeros_like(ep_data), ep_data)
 
+    # events with non integers
+    assert_raises(ValueError, EpochsArray, data, info, events + .01)
+
 
 def test_concatenate_epochs():
     """Test concatenate epochs"""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -242,6 +242,10 @@ def test_base_epochs():
     epochs = _BaseEpochs(raw.info, None, np.ones((1, 3), int),
                          event_id, tmin, tmax)
     assert_raises(NotImplementedError, epochs.get_data)
+    # events with non integers
+    _BaseEpochs(raw.info, None, np.ones((1, 3), float), event_id, tmin, tmax)
+    assert_raises(ValueError, _BaseEpochs, raw.info, None,
+                  np.ones((1, 3)) + .01, event_id, tmin, tmax)
 
 
 @requires_scipy_version('0.14')
@@ -1582,9 +1586,6 @@ def test_array_epochs():
                          tmin=-.2, baseline=(None, 0))
     ep_data = epochs.get_data()
     assert_array_equal(np.zeros_like(ep_data), ep_data)
-
-    # events with non integers
-    assert_raises(ValueError, EpochsArray, data, info, events + .01)
 
 
 def test_concatenate_epochs():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -245,6 +245,8 @@ def test_base_epochs():
     # events with non integers
     assert_raises(ValueError, _BaseEpochs, raw.info, None,
                   np.ones((1, 3), float), event_id, tmin, tmax)
+    assert_raises(ValueError, _BaseEpochs, raw.info, None,
+                  np.ones((1, 3, 2), int), event_id, tmin, tmax)
 
 
 @requires_scipy_version('0.14')

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -243,9 +243,8 @@ def test_base_epochs():
                          event_id, tmin, tmax)
     assert_raises(NotImplementedError, epochs.get_data)
     # events with non integers
-    _BaseEpochs(raw.info, None, np.ones((1, 3), float), event_id, tmin, tmax)
     assert_raises(ValueError, _BaseEpochs, raw.info, None,
-                  np.ones((1, 3)) + .01, event_id, tmin, tmax)
+                  np.ones((1, 3), float), event_id, tmin, tmax)
 
 
 @requires_scipy_version('0.14')

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -150,7 +150,7 @@ def test_tfr_multitaper():
     dat = noise + signal
 
     reject = dict(grad=4000.)
-    events = np.empty((n_epochs, 3))
+    events = np.empty((n_epochs, 3), int)
     first_event_sample = 100
     event_id = dict(sin50hz=1)
     for k in range(n_epochs):

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -79,7 +79,8 @@ def test_gat_plot_times():
     gat.plot_times(gat.train_times_['times'])
     # test multiple colors
     n_times = len(gat.train_times_['times'])
-    colors = np.tile(['r', 'g', 'b'], np.ceil(n_times / 3))[:n_times]
+    colors = np.tile(['r', 'g', 'b'],
+                     int(np.ceil(n_times / 3)))[:n_times]
     gat.plot_times(gat.train_times_['times'], color=colors)
     # test invalid time point
     assert_raises(ValueError, gat.plot_times, -1.)


### PR DESCRIPTION
Fixes the six bugs we had not making `events` integers. Builds on #2411. Closes #2406.