### PR TITLE
ENH: from mne impose future (no depracation for epochs trellis plot)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -83,7 +83,7 @@ API
 
     - Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.csp.CSP` by `Romain Trachel`_ 
     
-    - Redesigned and rewrote mne.Epochs.plot (no backwards compatibility) during the GSOC 2015 by `Jaakko Leppakangas`_, `Mainak Jas`_ and `Denis Engemann`_
+    - Redesigned and rewrote mne.Epochs.plot (no backwards compatibility) during the GSOC 2015 by `Jaakko Leppakangas`_, `Mainak Jas`_, `Federico Raimondo`_ and `Denis Engemann`_
 
 .. _changes_0_9:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,7 +73,6 @@ BUG
 
     - Fix scaling in :func:``mne.viz.utils._setup_vmin_vmax`` by `Jaakko Leppakangas`_
 
-
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,7 @@ BUG
 
     - Fix scaling in :func:``mne.viz.utils._setup_vmin_vmax`` by `Jaakko Leppakangas`_
 
+
 API
 ~~~
 
@@ -81,6 +82,8 @@ API
     - Deprecated :class: `mne.decoding.transformer.ConcatenateChannels` and replaced by :class: `mne.decoding.transformer.EpochsVectorizer` by `Romain Trachel`_ 
 
     - Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.csp.CSP` by `Romain Trachel`_ 
+    
+    - Redesigned and rewrote mne.Epochs.plot (no backwards compatibility) during the GSOC 2015 by `Jaakko Leppakangas`_, `Mainak Jas`_ and `Denis Engemann`_
 
 .. _changes_0_9:
 

--- a/examples/plot_from_raw_to_epochs_to_evoked.py
+++ b/examples/plot_from_raw_to_epochs_to_evoked.py
@@ -50,7 +50,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     preload=True)
 
 # Plot epochs.
-epochs.plot(trellis=False, title='Auditory left/right')
+epochs.plot(title='Auditory left/right')
 
 # Look at channels that caused dropped events, showing that the subject's
 # blinks were likely to blame for most epochs being dropped

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -37,7 +37,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
 from .filter import resample, detrend, FilterMixin
 from .event import _read_events_fif
 from .fixes import in1d
-from .viz import (plot_epochs, _plot_epochs_trellis, _drop_log_stats,
+from .viz import (plot_epochs, _drop_log_stats,
                   plot_epochs_psd, plot_epochs_psd_topomap)
 from .utils import (check_fname, logger, verbose, _check_type_picks,
                     _time_mask, check_random_state, object_hash)
@@ -721,7 +721,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     def plot(self, epoch_idx=None, picks=None, scalings=None,
              title_str='#%003i', show=True, block=False, n_epochs=20,
-             n_channels=20, title=None, trellis=True):
+             n_channels=20, title=None):
         """Visualize epochs.
 
         Bad epochs can be marked with a left click on top of the epoch. Bad
@@ -760,10 +760,6 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             The title of the window. If None, epochs name will be displayed.
             If trellis is True, this parameter has no effect.
             Defaults to None.
-        trellis : bool
-            Whether to use Trellis plotting. If False, plotting is similar to
-            Raw plot methods, with epochs stacked horizontally.
-            Defaults to True.
 
         Returns
         -------
@@ -772,7 +768,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         Notes
         -----
-        With trellis set to False, the arrow keys (up/down/left/right) can
+        The arrow keys (up/down/left/right) can
         be used to navigate between channels and epochs and the scaling can be
         adjusted with - and + (or =) keys, but this depends on the backend
         matplotlib is configured to use (e.g., mpl.use(``TkAgg``) should work).
@@ -783,15 +779,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         .. versionadded:: 0.10.0
         """
-        if trellis is True:
-            return _plot_epochs_trellis(self, epoch_idx=epoch_idx, picks=picks,
-                                        scalings=scalings, title_str=title_str,
-                                        show=show, block=block,
-                                        n_epochs=n_epochs)
-        else:
-            return plot_epochs(self, picks=picks, scalings=scalings,
-                               n_epochs=n_epochs, n_channels=n_channels,
-                               title=title, show=show, block=block)
+        return plot_epochs(self, picks=picks, scalings=scalings,
+                           n_epochs=n_epochs, n_channels=n_channels,
+                           title=title, show=show, block=block)
 
     def plot_psd(self, fmin=0, fmax=np.inf, proj=False, n_fft=256,
                  picks=None, ax=None, color='black', area_mode='std',

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -719,8 +719,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """Channel names"""
         return self.info['ch_names']
 
-    def plot(self, epoch_idx=None, picks=None, scalings=None,
-             title_str='#%003i', show=True, block=False, n_epochs=20,
+    def plot(self, picks=None, scalings=None, show=True,
+             block=False, n_epochs=20,
              n_channels=20, title=None):
         """Visualize epochs.
 
@@ -732,9 +732,6 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         Parameters
         ----------
-        epoch_idx : array-like | int | None
-            The epochs to visualize. If None, the first 20 epochs are shown.
-            Defaults to None.
         picks : array-like of int | None
             Channels to be included. If None only good data channels are used.
             Defaults to None
@@ -742,9 +739,6 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Scale factors for the traces. If None, defaults to
             ``dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
             emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1, chpi=1e-4)``.
-        title_str : None | str
-            The string formatting to use for axes titles. If None, no titles
-            will be shown. Defaults expand to ``#001, #002, ...``.
         show : bool
             Whether to show the figure or not.
         block : bool

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1606,7 +1606,7 @@ def test_array_epochs():
     assert_array_equal(epochs.events, epochs2.events)
 
     # plotting
-    epochs[0].plot(trellis=False)
+    epochs[0].plot()
     plt.close('all')
 
     # indexing

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -16,8 +16,7 @@ from .evoked import (plot_evoked, plot_evoked_image, plot_evoked_white,
                      plot_snr_estimate, plot_evoked_topo)
 from .circle import plot_connectivity_circle, circular_layout
 from .epochs import (plot_image_epochs, plot_drop_log, plot_epochs,
-                     plot_epochs_trellis, _drop_log_stats, plot_epochs_psd,
-                     _plot_epochs_trellis)
+                     _drop_log_stats, plot_epochs_psd)
 from .raw import plot_raw, plot_raw_psd
 from .ica import plot_ica_scores, plot_ica_sources, plot_ica_overlay
 from .ica import _plot_sources_raw, _plot_sources_epochs

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -14,7 +14,7 @@ import copy
 
 import numpy as np
 
-from ..utils import verbose, get_config, deprecated, set_config
+from ..utils import verbose, get_config, set_config
 from ..utils import logger
 from ..io.pick import pick_types, channel_type
 from ..io.proj import setup_proj

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -82,7 +82,7 @@ def test_plot_epochs():
     fig = epochs[0].plot(picks=[0, 2, 3], scalings=None)
     fig.canvas.key_press_event('escape')
     plt.close('all')
-    fig = epochs.plot(trellis=False)
+    fig = epochs.plot()
     fig.canvas.key_press_event('left')
     fig.canvas.key_press_event('right')
     fig.canvas.scroll_event(0.5, 0.5, -0.5)  # scroll down
@@ -107,7 +107,7 @@ def test_plot_epochs():
     assert_raises(RuntimeError, epochs.plot, picks=[])
     plt.close('all')
     with warnings.catch_warnings(record=True):
-        fig = epochs.plot(trellis=False)
+        fig = epochs.plot()
         # test mouse clicks
         x = fig.get_axes()[0].get_xlim()[1] / 2
         y = fig.get_axes()[0].get_ylim()[0] / 2

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -8,7 +8,6 @@
 
 import os.path as op
 import warnings
-from collections import namedtuple
 from nose.tools import assert_raises
 
 import numpy as np
@@ -19,7 +18,7 @@ from mne import pick_types
 from mne.utils import run_tests_if_main, requires_scipy_version
 from mne.channels import read_layout
 
-from mne.viz import plot_drop_log, plot_image_epochs, _get_presser
+from mne.viz import plot_drop_log, plot_image_epochs
 from mne.viz.utils import _fake_click
 
 # Set our plotters to test mode
@@ -74,39 +73,13 @@ def _get_epochs_delayed_ssp():
     return epochs_delayed_ssp
 
 
-def test_plot_trellis():
-    """ Test plotting epochs using Trellis plot"""
-    import matplotlib.pyplot as plt
-    epochs = _get_epochs()
-    epochs.plot([0, 1], picks=[0, 2, 3], scalings=None, title_str='%s')
-    plt.close('all')
-    epochs[0].plot(picks=[0, 2, 3], scalings=None, title_str='%s')
-    plt.close('all')
-    # now let's add a bad channel
-    epochs.info['bads'] = [epochs.ch_names[0]]  # include a bad one
-    epochs.plot([0, 1], picks=[0, 2, 3], scalings=None, title_str='%s')
-    plt.close('all')
-    fig = epochs[0].plot(picks=[0, 2, 3], scalings=None, title_str='%s')
-    plt.close('all')
-    fig = epochs.plot([0, 1], picks=[0, 2, 3], scalings=None, title_str='%s')
-    # fake a click
-    event = namedtuple('Event', 'inaxes')
-    func = _get_presser(fig)
-    func(event(inaxes=fig.axes[0]))
-    # now do a click in the nav
-    nav_fig = func.keywords['params']['navigation']
-    func = _get_presser(nav_fig)
-    func(event(inaxes=nav_fig.axes[1]))
-    plt.close('all')
-
-
 def test_plot_epochs():
     """Test epoch plotting"""
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
-    epochs.plot(scalings=None, title='Epochs', trellis=False)
+    epochs.plot(scalings=None, title='Epochs')
     plt.close('all')
-    fig = epochs[0].plot(picks=[0, 2, 3], scalings=None, trellis=False)
+    fig = epochs[0].plot(picks=[0, 2, 3], scalings=None)
     fig.canvas.key_press_event('escape')
     plt.close('all')
     fig = epochs.plot(trellis=False)
@@ -131,7 +104,7 @@ def test_plot_epochs():
     fig.canvas.resize_event()
     fig.canvas.close_event()  # closing and epoch dropping
     plt.close('all')
-    assert_raises(RuntimeError, epochs.plot, picks=[], trellis=False)
+    assert_raises(RuntimeError, epochs.plot, picks=[])
     plt.close('all')
     with warnings.catch_warnings(record=True):
         fig = epochs.plot(trellis=False)


### PR DESCRIPTION
It's an exceptional move, but I feel it it's for a good reason.
As dicsussed with @agramfort and @mainakjas we're just removing the old viz code from epochs.plot.
As a nice side-effect: we've got many red lines.