### PR TITLE
Minor FIX for topomap outlines:  set clip_on=False

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -562,7 +562,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
         for k, (x, y) in outlines_.items():
             if 'mask' in k:
                 continue
-            ax.plot(x, y, color='k', linewidth=linewidth)
+            ax.plot(x, y, color='k', linewidth=linewidth, clip_on=False)
 
     if show_names:
         if show_names is True:


### PR DESCRIPTION
I've noticed that the outlines on topomaps go right to the edge of the axes, which leads to the lines being cut off slightly. Setting clip_on=False is one possible solution, another would be increasing the axes limits, I am not sure if there are arguments against one or the other.

![ref cluster topo b](https://cloud.githubusercontent.com/assets/145771/9695682/596c71fc-5332-11e5-9cf0-e96ebcf5ffeb.png)
![ref cluster topo](https://cloud.githubusercontent.com/assets/145771/9695683/5c5c78bc-5332-11e5-8d90-e4f8cd3a5614.png)
