### PR TITLE
Add some error messages to `viz.plot_topomap`

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -460,8 +460,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
 
     # Give a helpful error message for common mistakes regarding the position
     # matrix.
-    pos_help = ("Electrode positions should be specified as a matrix with "
-                "shape (#channels, 2). Each row in this matrix contains the "
+    pos_help = ("Electrode positions should be specified as a 2D array with "
+                "shape (n_channels, 2). Each row in this matrix contains the "
                 "(x, y) position of an electrode.")
     if pos.ndim != 2:
         error = ("{ndim}D array supplied as electrode positions, where a 2D "


### PR DESCRIPTION
The `pos` parameter of the `viz.plot_topomap` function expects a matrix
with shape (#nchannels, 2). It used to silently accept other dimensions
as well by selecting `pos[:, :2]`. This means 3D coordinates, such as the
ones provided by Montage objects are accepted and lead to strange
results. See issue #2389.

This PR adds error messages when a matrix with invalid dimensions is
specified as `pos` argument. To keep backwards compatibility, matrices
with shape (#nchannels, 4) are allowed, meaning a user can still pass a
`layout.pos` matrix, even though `layout.pos[:, :2]` would be more
explicit and thus preferred.