### PR TITLE
FIX: when n_jobs > n_test_times in GAT, remove empty jobs

### DIFF
--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -155,6 +155,7 @@ class _GeneralizationAcrossTime(object):
         parallel, p_time_gen, n_jobs = parallel_func(_fit_slices, n_jobs)
         n_chunks = min(X.shape[2], n_jobs)
         splits = np.array_split(self.train_times_['slices'], n_chunks)
+        splits = [split for split in splits if len(split)]
 
         def f(x):
             return np.unique(np.concatenate(x))

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -153,9 +153,8 @@ class _GeneralizationAcrossTime(object):
         # Parallel across training time
         # TODO: JRK: Chunking times points needs to be simplified
         parallel, p_time_gen, n_jobs = parallel_func(_fit_slices, n_jobs)
-        n_chunks = min(X.shape[2], n_jobs)
+        n_chunks = min(len(self.train_times_['slices']), n_jobs)
         splits = np.array_split(self.train_times_['slices'], n_chunks)
-        splits = [split for split in splits if len(split)]
 
         def f(x):
             return np.unique(np.concatenate(x))


### PR DESCRIPTION
There's a bug when n_jobs > n_testing_times and if the total number of time point is larger than the number of jobs because it tries to run some empty chunks.