### PR TITLE
ENH: enable a jitter in decimation of epochs + update tmin & tmax

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -343,15 +343,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         assert self._data.shape[-1] == len(self.times)
         return self
 
-    def decimate(self, decim, jitter=0, copy=False):
+    def decimate(self, decim, offset=0, copy=False):
         """Decimate the epochs
 
         Parameters
         ----------
         decim : int
             The amount to decimate data.
-        jitter : int
-            Apply a jitter to where the decimation starts
+        offset : int
+            Apply an offset to where the decimation starts. The offset is in samples, at the original sampling rate.
         copy : bool
             If True, operate on and return a copy of the Epochs object.
 
@@ -388,16 +388,16 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                           'result in a sampling frequency of %g Hz, which can '
                           'cause aliasing artifacts.'
                           % (lowpass, decim, new_sfreq))  # > 50% nyquist limit
-        if jitter >= decim:
-            warnings.warn('The jitter=%i is not lower than the decim=%i '
-                          'parameter. Some decimated samples will be lost'
-                          % (jitter, decim))
+        if offset >= decim:
+            raise ValueError('The offset=%i should be lower than the decim=%i '
+                             'parameter, to avoid loosing decimated samples.'
+                             % (offset, decim))
 
         epochs._decim *= decim
         start_idx = int(round(epochs._raw_times[0] * (epochs.info['sfreq'] *
                                                       epochs._decim)))
         i_start = start_idx % epochs._decim
-        decim_slice = slice(i_start + jitter, len(epochs._raw_times),
+        decim_slice = slice(i_start + offset, len(epochs._raw_times),
                             epochs._decim)
         epochs.info['sfreq'] = new_sfreq
         if epochs.preload:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -343,13 +343,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         assert self._data.shape[-1] == len(self.times)
         return self
 
-    def decimate(self, decim, copy=False):
+    def decimate(self, decim, jitter=0, copy=False):
         """Decimate the epochs
 
         Parameters
         ----------
         decim : int
             The amount to decimate data.
+        jitter : int
+            Apply a jitter to where the decimation starts
         copy : bool
             If True, operate on and return a copy of the Epochs object.
 
@@ -386,12 +388,17 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                           'result in a sampling frequency of %g Hz, which can '
                           'cause aliasing artifacts.'
                           % (lowpass, decim, new_sfreq))  # > 50% nyquist limit
+        if jitter >= decim:
+            warnings.warn('The jitter=%i is not lower than the decim=%i '
+                          'parameter. Some decimated samples will be lost'
+                          % (jitter, decim))
 
         epochs._decim *= decim
         start_idx = int(round(epochs._raw_times[0] * (epochs.info['sfreq'] *
                                                       epochs._decim)))
         i_start = start_idx % epochs._decim
-        decim_slice = slice(i_start, len(epochs._raw_times), epochs._decim)
+        decim_slice = slice(i_start + jitter, len(epochs._raw_times),
+                            epochs._decim)
         epochs.info['sfreq'] = new_sfreq
         if epochs.preload:
             epochs._data = epochs._data[:, :, decim_slice].copy()
@@ -402,6 +409,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         else:
             epochs._decim_slice = decim_slice
             epochs.times = epochs._raw_times[epochs._decim_slice]
+        epochs.tmin = epochs.times[0]
+        epochs.tmax = epochs.times[-1]
         return epochs
 
     @verbose

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -351,7 +351,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         decim : int
             The amount to decimate data.
         offset : int
-            Apply an offset to where the decimation starts. The offset is in samples, at the original sampling rate.
+            Apply an offset to where the decimation starts.
+            The offset is in samples, at the original sampling rate.
         copy : bool
             If True, operate on and return a copy of the Epochs object.
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -163,8 +163,10 @@ def test_decim():
     epochs = EpochsArray(data, info, events)
     data_epochs = epochs.decimate(decim, copy=True).get_data()
     data_epochs_2 = epochs.decimate(dec_1).decimate(dec_2).get_data()
+    data_epochs_3 = epochs.decimate(decim, offset=1, copy=True).get_data()
     assert_array_equal(data_epochs, data[:, :, ::decim])
     assert_array_equal(data_epochs, data_epochs_2)
+    assert_array_equal(data_epochs_3, data[:, :, 1::decim])
 
     # Now let's do it with some real data
     raw, events, picks = _get_data()
@@ -173,6 +175,7 @@ def test_decim():
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     preload=False)
     assert_raises(ValueError, epochs.decimate, -1)
+    assert_raises(ValueError, epochs.decimate, 1, 2)
     expected_data = epochs.get_data()[:, :, ::decim]
     expected_times = epochs.times[::decim]
     for preload in (True, False):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -162,11 +162,11 @@ def test_decim():
     info['lowpass'] = sfreq_new / float(decim)
     epochs = EpochsArray(data, info, events)
     data_epochs = epochs.decimate(decim, copy=True).get_data()
-    data_epochs_2 = epochs.decimate(dec_1).decimate(dec_2).get_data()
-    data_epochs_3 = epochs.decimate(decim, offset=1, copy=True).get_data()
+    data_epochs_2 = epochs.decimate(decim, offset=1, copy=True).get_data()
+    data_epochs_3 = epochs.decimate(dec_1).decimate(dec_2).get_data()
     assert_array_equal(data_epochs, data[:, :, ::decim])
-    assert_array_equal(data_epochs, data_epochs_2)
-    assert_array_equal(data_epochs_3, data[:, :, 1::decim])
+    assert_array_equal(data_epochs_2, data[:, :, 1::decim])
+    assert_array_equal(data_epochs, data_epochs_3)
 
     # Now let's do it with some real data
     raw, events, picks = _get_data()


### PR DESCRIPTION
Decimation starts always with the first sample of the data.
It may be useful to have the option to add an offset to the starting point of the decimation.
Indeed, one may want to time-lock the decimation to t=0 which may not be the first sample of the data (in case of baseline...).

Exemple: 

epochs.info['sfreq'] = 1000
epochs.times = [-0.002, -0.001, 0.0, 0.001, 0.002,...]
epochs.decimate(4)
epochs.times = [-0.002, 0.002,...]

=> here the sample associated to times=0.0 is lost.

This PR implementes an offset so that the decimation may be time-lock to any time point.

----------------------------------------------------------------------------------------

This PR also includes a small fix.
epochs.tmin and epochs.tmax are not updated in the decimation.
If epochs.times is not a multiple of decim, the shape of the decimated epochs may not be well tested in the \__init\__(), and may throw an error with the following lines of code:

```
if data.ndim != 3 or data.shape[2] != \
                    round((tmax - tmin) * self.info['sfreq']) + 1:
                raise RuntimeError('bad data shape')
```

Exemple:

```
epochs.times = [0, 0.001, 0.002]
epochs.info['sfreq'] = 1000
epochs.tmin = 0
epochs.tmax = 0.002

# Decimation is performed
epochs.decimate(4)
epochs.times = [0]
epochs.info['sfreq'] = 250
```
Let's compare what it gives in the test mentioned above in \__init\__():
```
epochs._data.shape[2] = 1
```
BUT 
```
round((epochs.tmax - epochs.tmin) * self.info['sfreq']) + 1 = 2
```

Then an error is thrown...