### PR TITLE
[MRG] ADD add'l bef setting

### DIFF
--- a/mne/io/kit/constants.py
+++ b/mne/io/kit/constants.py
@@ -33,8 +33,8 @@ KIT.UNIT_MUL = 0  # default is 0 mne_manual p.273
 
 # gain: 0:x1, 1:x2, 2:x5, 3:x10, 4:x20, 5:x50, 6:x100, 7:x200
 KIT.GAINS = [1, 2, 5, 10, 20, 50, 100, 200]
-# BEF options: 0:THRU, 1:50Hz, 2:60Hz
-KIT.BEFS = [0, 50, 60]
+# BEF options: 0:THRU, 1:50Hz, 2:60Hz, 3:50Hz
+KIT.BEFS = [0, 50, 60, 50]
 
 # coreg constants
 KIT.DIG_POINTS = 10000


### PR DESCRIPTION
The band-elimination filter values have changed. The unmasked value of 3 now maps to 50Hz. It is unclear that 1 still maps to 50Hz as well. This information is not incorporated into the `raw.info` but it does cause the file to be rendered properly.

side question: why don't we store notch filter settings in the info? historical reasons?