### PR TITLE
[MRG] Automatic peak finder

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ Changelog
 
     - Add support for drawing topomaps by selecting an area in :func:`mne.Evoked.plot` by `Jaakko Leppakangas`_
 
+    - Add support for finding peaks in evoked data in :func:`mne.Evoked.plot_topomap` by `Jona Sassenhagen`_ and `Jaakko Leppakangas`_
+
 BUG
 ~~~
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -509,7 +509,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                 axis_facecolor=axis_facecolor,
                                 font_color=font_color, show=show)
 
-    def plot_topomap(self, times=None, ch_type=None, layout=None, vmin=None,
+    def plot_topomap(self, times="auto", ch_type=None, layout=None, vmin=None,
                      vmax=None, cmap='RdBu_r', sensors=True, colorbar=True,
                      scale=None, scale_time=1e3, unit=None, res=64, size=1,
                      cbar_fmt="%3.1f", time_format='%01d ms', proj=False,
@@ -521,11 +521,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         Parameters
         ----------
-        times : float | array of floats | None.
-            The time point(s) to plot. If None, the number of ``axes``
+        times : float | array of floats | "auto" | "peaks".
+            The time point(s) to plot. If "auto", the number of ``axes``
             determines the amount of time point(s). If ``axes`` is also None,
             10 topographies will be shown with a regular time spacing between
-            the first and last time instant.
+            the first and last time instant. If "peaks", finds time points
+            automatically by checking for local maxima in Global Field Power.
         ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
             The channel type to plot. For 'grad', the gradiometers are collec-
             ted in pairs and the RMS for each pair is plotted.

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -101,7 +101,6 @@ def test_plot_topomap():
     assert_true(all('MEG' not in x.get_text()
                     for x in subplot.get_children()
                     if isinstance(x, matplotlib.text.Text)))
-    _find_peaks(evoked)
 
     # Test title
     def get_texts(p):
@@ -216,13 +215,17 @@ def test_plot_topomap():
     plt.close('all')
 
     # Test peak finder
+    axes = [plt.subplot(131), plt.subplot(132)]
+    evoked.plot_topomap(times='peaks', axes=axes)
+    plt.close('all')
     evoked.data = np.zeros(evoked.data.shape)
     evoked.data[50][1] = 1
-    assert_array_equal(_find_peaks(evoked), evoked.times[1])
+    assert_array_equal(_find_peaks(evoked, 10), evoked.times[1])
     evoked.data[80][100] = 1
-    assert_array_equal(_find_peaks(evoked), evoked.times[[1, 100]])
+    assert_array_equal(_find_peaks(evoked, 10), evoked.times[[1, 100]])
     evoked.data[2][95] = 2
-    assert_array_equal(_find_peaks(evoked), evoked.times[[1, 95]])
+    assert_array_equal(_find_peaks(evoked, 10), evoked.times[[1, 95]])
+    assert_array_equal(_find_peaks(evoked, 1), evoked.times[95])
 
 
 def test_plot_tfr_topomap():

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -78,7 +78,7 @@ def test_plot_topomap():
     plt.close('all')
     mask = np.zeros_like(evoked.data, dtype=bool)
     mask[[1, 5], :] = True
-    evoked.plot_topomap(None, ch_type='mag', outlines=None)
+    evoked.plot_topomap(ch_type='mag', outlines=None)
     times = [0.1]
     evoked.plot_topomap(times, ch_type='eeg', res=res, scale=1)
     evoked.plot_topomap(times, ch_type='grad', mask=mask, res=res)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -86,6 +86,7 @@ def test_plot_topomap():
     evoked.plot_topomap(times, ch_type='planar2', res=res)
     evoked.plot_topomap(times, ch_type='grad', mask=mask, res=res,
                         show_names=True, mask_params={'marker': 'x'})
+    evoked.plot_topomap("peaks")
     plt.close('all')
     assert_raises(ValueError, evoked.plot_topomap, times, ch_type='eeg',
                   res=res, average=-1000)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1145,7 +1145,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
             peaks = peaks[np.sort((-peaks).argsort()[:10])]
         times = evoked.times[peaks]
         if len(times) == 0:
-            times = "auto"
+            times = evoked.times[gfp.argmax()]
 
     if times == "auto":
         if axes is None:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -14,7 +14,7 @@ import copy
 from functools import partial
 
 import numpy as np
-from scipy import linalg, signal
+from scipy import linalg
 
 from ..baseline import rescale
 from ..io.constants import FIFF
@@ -1141,9 +1141,13 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         else:
             times = np.linspace(evoked.times[0], evoked.times[-1], len(axes))
     elif times == "peaks":
+        from scipy.signal import argrelmax
         gfp = evoked.data.std(axis=0)
         order = int(evoked.info["sfreq"] / 5.)
-        times = evoked.times[signal.argrelmax(gfp, order=order)]
+        peaks = argrelmax(gfp, order=order)
+        if len(peaks) > 10:  # max 10 peaks
+            peaks = peaks[np.sort((-gfp[peaks]).argsort()[:10])]
+        times = evoked.times[peaks]
     elif np.isscalar(times):
         times = [times]
     times = np.array(times)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1601,7 +1601,7 @@ def _find_peaks(evoked):
     """
     from scipy.signal import argrelmax
     gfp = evoked.data.std(axis=0)
-    order = len(evoked.times) / 30
+    order = len(evoked.times) // 30
     if order < 1:
         order = 1
     peaks = argrelmax(gfp, order=order, axis=0)[0]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1140,6 +1140,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         from scipy.signal import argrelmax
         gfp = evoked.data.std(axis=0)
         order = len(evoked.times) / 30
+        if order < 1:
+            order = 1
         peaks = argrelmax(gfp, order=order, axis=0)[0]
         if len(peaks) > 10:  # Find the largest 10 peaks
             max_indices = np.argsort([gfp[idx] for idx in peaks])[-10:]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1141,6 +1141,10 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
             times = np.linspace(evoked.times[0], evoked.times[-1], 10)
         else:
             times = np.linspace(evoked.times[0], evoked.times[-1], len(axes))
+    elif times == "peaks":
+        gfp = evoked.data.std(axis=0)
+        order = int(evoked.info["sfreq"] / 5.)
+        times = evoked.times[argrelmax(gfp, order=order)]
     elif np.isscalar(times):
         times = [times]
     times = np.array(times)
@@ -1149,11 +1153,6 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     if len(times) > 20:
         raise RuntimeError('Too many plots requested. Please pass fewer '
                            'than 20 time instants.')
-
-    if times == "peaks":
-        gfp = evoked.data.std(axis=0)
-        order = int(evoked.info["sfreq"] / 5.)
-        times = evoked.times[argrelmax(gfp, order=order)]
 
     n_times = len(times)
     nax = n_times + bool(colorbar)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1139,10 +1139,11 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     if times == "peaks":
         from scipy.signal import argrelmax
         gfp = evoked.data.std(axis=0)
-        order = int(evoked.info["sfreq"] / 5.)
-        peaks = argrelmax(gfp, order=order)
-        if len(peaks) > 10:
-            peaks = peaks[np.sort((-peaks).argsort()[:10])]
+        order = len(evoked.times) / 30
+        peaks = argrelmax(gfp, order=order, axis=0)[0]
+        if len(peaks) > 10:  # Find the largest 10 peaks
+            max_indices = np.argsort([gfp[idx] for idx in peaks])[-10:]
+            peaks = np.sort(peaks[max_indices])
         times = evoked.times[peaks]
         if len(times) == 0:
             times = evoked.times[gfp.argmax()]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -15,7 +15,7 @@ from functools import partial
 
 import numpy as np
 from scipy import linalg
-from scipy.signal import argrelmax
+from scipy import signal
 
 from ..baseline import rescale
 from ..io.constants import FIFF

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1144,7 +1144,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     elif times == "peaks":
         gfp = evoked.data.std(axis=0)
         order = int(evoked.info["sfreq"] / 5.)
-        times = evoked.times[argrelmax(gfp, order=order)]
+        times = evoked.times[signal.argrelmax(gfp, order=order)]
     elif np.isscalar(times):
         times = [times]
     times = np.array(times)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1137,7 +1137,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         axes = [axes]
 
     if times == "peaks":
-        times = _find_peaks(evoked)
+        npeaks = 10 if axes is None else len(axes)
+        times = _find_peaks(evoked, npeaks)
     elif times == "auto":
         if axes is None:
             times = np.linspace(evoked.times[0], evoked.times[-1], 10)
@@ -1595,9 +1596,9 @@ def _onselect(eclick, erelease, tfr, pos, ch_type, itmin, itmax, ifmin, ifmax,
     plt.show()
 
 
-def _find_peaks(evoked):
-    """Helper function for finding peaks from evoked data.
-    Returns max 10 peaks as a list of time points.
+def _find_peaks(evoked, npeaks):
+    """Helper function for finding peaks from evoked data
+    Returns ``npeaks`` biggest peaks as a list of time points.
     """
     from scipy.signal import argrelmax
     gfp = evoked.data.std(axis=0)
@@ -1605,8 +1606,8 @@ def _find_peaks(evoked):
     if order < 1:
         order = 1
     peaks = argrelmax(gfp, order=order, axis=0)[0]
-    if len(peaks) > 10:  # Find the largest 10 peaks
-        max_indices = np.argsort(gfp[peaks])[-10:]
+    if len(peaks) > npeaks:
+        max_indices = np.argsort(gfp[peaks])[-npeaks:]
         peaks = np.sort(peaks[max_indices])
     times = evoked.times[peaks]
     if len(times) == 0:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -14,8 +14,7 @@ import copy
 from functools import partial
 
 import numpy as np
-from scipy import linalg
-from scipy import signal
+from scipy import linalg, signal
 
 from ..baseline import rescale
 from ..io.constants import FIFF

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1019,8 +1019,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         The time point(s) to plot. If "auto", the number of ``axes`` determines
         the amount of time point(s). If ``axes`` is also None, 10 topographies
         will be shown with a regular time spacing between the first and last
-        time instant. If "peaks", finds time points automatically by checking for
-        local maxima in Global Field Power.
+        time instant. If "peaks", finds time points automatically by checking 
+        for local maxima in Global Field Power.
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
         The channel type to plot. For 'grad', the gradiometers are collected in
         pairs and the RMS for each pair is plotted.
@@ -1135,22 +1135,28 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
 
     if isinstance(axes, plt.Axes):
         axes = [axes]
-    if times is "auto":
-        if axes is None:
-            times = np.linspace(evoked.times[0], evoked.times[-1], 10)
-        else:
-            times = np.linspace(evoked.times[0], evoked.times[-1], len(axes))
-    elif times == "peaks":
+
+    if times == "peaks":
         from scipy.signal import argrelmax
         gfp = evoked.data.std(axis=0)
         order = int(evoked.info["sfreq"] / 5.)
         peaks = argrelmax(gfp, order=order)
-        if len(peaks) > 10:  # max 10 peaks
-            peaks = peaks[np.sort((-gfp[peaks]).argsort()[:10])]
+        if len(peaks) > 10:
+            peaks = peaks[np.sort((-peaks).argsort()[:10])]
         times = evoked.times[peaks]
+        if len(times) == 0:
+            times = "auto"
+
+    if times == "auto":
+        if axes is None:
+            times = np.linspace(evoked.times[0], evoked.times[-1], 10)
+        else:
+            times = np.linspace(evoked.times[0], evoked.times[-1], len(axes))
     elif np.isscalar(times):
         times = [times]
+
     times = np.array(times)
+
     if times.ndim != 1:
         raise ValueError('times must be 1D, got %d dimensions' % times.ndim)
     if len(times) > 20:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1019,7 +1019,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         The time point(s) to plot. If "auto", the number of ``axes`` determines
         the amount of time point(s). If ``axes`` is also None, 10 topographies
         will be shown with a regular time spacing between the first and last
-        time instant. If "peaks", finds time points automatically by checking 
+        time instant. If "peaks", finds time points automatically by checking
         for local maxima in Global Field Power.
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
         The channel type to plot. For 'grad', the gradiometers are collected in


### PR DESCRIPTION
Take over from https://github.com/mne-tools/mne-python/pull/2506.
Now it calculates the ``order`` from number of samples. If more than 10 peaks are found, the largest 10 peaks are shown. With ``order = len(evoked.times) / 30`` it seems to find a bit less than 10 peaks per dataset (exactly 10 with somato).
Sample:
![sample](https://cloud.githubusercontent.com/assets/3456414/10429076/38cfa6b2-70f6-11e5-8b3e-98f8520569b1.png)
Somato:
![somato](https://cloud.githubusercontent.com/assets/3456414/10429079/3e37017c-70f6-11e5-8bc6-96496928d763.png)
Spm_faces:
![spm_face](https://cloud.githubusercontent.com/assets/3456414/10429083/46dcc866-70f6-11e5-880e-a58bb61b9f66.png)

