### PR TITLE
MRG: Allow '/'-split tags for equalize_event_counts

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1566,8 +1566,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          for x in event_ids]
             for ids_ in event_ids:  # check if tagging is attempted
               for id_ in ids_:
-                if any(id_ not in ids):
-                  tagging = True
+                  if any(id_ not in ids):
+                      tagging = True
             # 1. treat everything that's not in event_id as a tag
             # 2a. for tags, find all the event_ids matched by the tags
             # 2b. for non-tag ids, just pass them directly

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1568,9 +1568,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             # 2b. for non-tag ids, just pass them directly
             # 3. do this for every input
             event_ids = [[k for k in ids if all((tag in k.split("/")
-                         for tag in id_))]
+                         for tag in id_))]  # find ids matching all tags
                          if all(id__ not in ids for id__ in id_)
-                         else id_
+                         else id_  # straight pass for non-tag inputs
                          for id_ in event_ids]
             for id_ in event_ids:
                 if len(set([sub_id in ids for sub_id in id_])) != 1:
@@ -1578,13 +1578,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                            " like in \'%s\'." % ", ".join(id_))
                     raise ValueError(err)
 
-            # deal with non-orthogonal tags
-            events_ = [set(epochs[x].events[:, 0]) for x in event_ids]
-            doubles = events_[0].intersection(events_[1])
-            if len(doubles):
-                raise ValueError("The two sets of epochs are "
-                                 "overlapping. Provide an "
-                                 "orthogonal selection.")
+            # raise for non-orthogonal tags
+            if any([id_ not in ids for id_ in
+                    [id_ for sublist in event_ids for id_ in sublist]]):
+                events_ = [set(epochs[x].events[:, 0]) for x in event_ids]
+                doubles = events_[0].intersection(events_[1])
+                if len(doubles):
+                    raise ValueError("The two sets of epochs are "
+                                     "overlapping. Provide an "
+                                     "orthogonal selection.")
 
         for eq in event_ids:
             eq = np.atleast_1d(eq)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1511,8 +1511,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             a str (single event) or a list of str. In the case where one of
             the entries is a list of str, event_ids in that list will be
             grouped together before equalizing trial counts across conditions.
-            In the case where partial matching (using event_ids with '/') is
-            used, processing works as if the event_ids matched by the provided
+            In the case where partial matching is used (using '/' in `event_ids`),
+            `event_ids` will be matched according to the provided tags, that is,
+            processing works as if the event_ids matched by the provided
             tags had been supplied instead.
             The event_ids must identify nonoverlapping subsets of the epochs.
         method : str

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1565,9 +1565,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             event_ids = [[x] if isinstance(x, string_types) else x
                          for x in event_ids]
             for ids_ in event_ids:  # check if tagging is attempted
-                for id_ in ids_:
-                    if any(id_ not in ids):
-                        tagging = True
+                if any([id_ not in ids for id_ in ids_]):
+                    tagging = True
             # 1. treat everything that's not in event_id as a tag
             # 2a. for tags, find all the event_ids matched by the tags
             # 2b. for non-tag ids, just pass them directly

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1560,10 +1560,10 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          if all(id__ not in ids for id__ in id_)
                          else id_
                          for id_ in event_ids]
-            for id in event_ids:
-                if len(set([id_ in ids for id_ in id])) != 1:
+            for id_ in event_ids:
+                if len(set([sub_id in ids for sub_id in id_])) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
-                           " like in \'%s\'." % ", ".join(id))
+                           " like in \'%s\'." % ", ".join(id_))
                     raise KeyError(err)
 
             # deal with non-orthogonal tags

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1511,15 +1511,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             a str (single event) or a list of str. In the case where one of
             the entries is a list of str, event_ids in that list will be
             grouped together before equalizing trial counts across conditions.
-            In the case where partial matching is used (using '/' in `event_ids`),
-            `event_ids` will be matched according to the provided tags, that is,
-            processing works as if the event_ids matched by the provided
-            tags had been supplied instead.
+            In the case where partial matching is used (using '/' in
+            `event_ids`), `event_ids` will be matched according to the
+            provided tags, that is, processing works as if the event_ids
+            matched by the provided tags had been supplied instead.
             The event_ids must identify nonoverlapping subsets of the epochs.
         method : str
             If 'truncate', events will be truncated from the end of each event
-            list. If 'mintime', timing differences between each event list will
-            be minimized.
+            list. If 'mintime', timing differences between each event list
+            will be minimized.
         copy : bool
             If True, a copy of epochs will be returned. Otherwise, the
             function will operate in-place.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1560,8 +1560,13 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # deal with hierarchical tags
         ids = epochs.event_id
         if "/" in "".join(ids):
+            # make string inputs a list of length 1
             event_ids = [[x] if isinstance(x, string_types) else x
                          for x in event_ids]
+            # 1. treat everything that's not in event_id as a tag
+            # 2a. for tags, find all the event_ids matched by the tags
+            # 2b. for non-tag ids, just pass them directly
+            # 3. do this for every input
             event_ids = [[k for k in ids if all((tag in k.split("/")
                          for tag in id_))]
                          if all(id__ not in ids for id__ in id_)
@@ -1571,13 +1576,13 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 if len(set([sub_id in ids for sub_id in id_])) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
                            " like in \'%s\'." % ", ".join(id_))
-                    raise KeyError(err)
+                    raise ValueError(err)
 
             # deal with non-orthogonal tags
             events_ = [set(epochs[x].events[:, 0]) for x in event_ids]
             doubles = events_[0].intersection(events_[1])
             if len(doubles):
-                raise ValueError("Warning: the two sets of epochs are "
+                raise ValueError("The two sets of epochs are "
                                  "overlapping. Provide an "
                                  "orthogonal selection.")
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1559,10 +1559,15 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # deal with hierarchical tags
         ids = epochs.event_id
+        tagging = False
         if "/" in "".join(ids):
             # make string inputs a list of length 1
             event_ids = [[x] if isinstance(x, string_types) else x
                          for x in event_ids]
+            for ids_ in event_ids:  # check if tagging is attempted
+              for id_ in ids_:
+                if any(id_ not in ids):
+                  tagging = True
             # 1. treat everything that's not in event_id as a tag
             # 2a. for tags, find all the event_ids matched by the tags
             # 2b. for non-tag ids, just pass them directly
@@ -1579,8 +1584,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                     raise ValueError(err)
 
             # raise for non-orthogonal tags
-            if any([id_ not in ids for id_ in
-                    [id_ for sublist in event_ids for id_ in sublist]]):
+            if tagging is True:
                 events_ = [set(epochs[x].events[:, 0]) for x in event_ids]
                 doubles = events_[0].intersection(events_[1])
                 if len(doubles):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1565,9 +1565,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             event_ids = [[x] if isinstance(x, string_types) else x
                          for x in event_ids]
             for ids_ in event_ids:  # check if tagging is attempted
-              for id_ in ids_:
-                  if any(id_ not in ids):
-                      tagging = True
+                for id_ in ids_:
+                    if any(id_ not in ids):
+                        tagging = True
             # 1. treat everything that's not in event_id as a tag
             # 2a. for tags, find all the event_ids matched by the tags
             # 2b. for non-tag ids, just pass them directly

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1539,8 +1539,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         would equalize the number of trials in the 'Nonspatial' condition with
         the total number of trials in the 'Left' and 'Right' conditions.
-        
-        If multiple indices are provided (e.g. 'Left' and 'Right' in the 
+
+        If multiple indices are provided (e.g. 'Left' and 'Right' in the
         example above), it is not guaranteed that after equalization, the
         conditions will contribute evenly. E.g., it is possible to end up
         with 70 'Nonspatial' trials, 69 'Left' and 1 'Right'.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1514,6 +1514,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             In the case where partial matching (using event_ids with '/') is
             used, processing works as if the event_ids matched by the provided
             tags had been supplied instead.
+            The event_ids must identify nonoverlapping subsets of the epochs.
         method : str
             If 'truncate', events will be truncated from the end of each event
             list. If 'mintime', timing differences between each event list will
@@ -1538,6 +1539,11 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         would equalize the number of trials in the 'Nonspatial' condition with
         the total number of trials in the 'Left' and 'Right' conditions.
+        
+        If multiple indices are provided (e.g. 'Left' and 'Right' in the 
+        example above), it is not guaranteed that after equalization, the
+        conditions will contribute evenly. E.g., it is possible to end up
+        with 70 'Nonspatial' trials, 69 'Left' and 1 'Right'.
         """
         if copy is True:
             epochs = self.copy()
@@ -1570,12 +1576,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             events_ = [set(epochs[x].events[:, 0]) for x in event_ids]
             doubles = events_[0].intersection(events_[1])
             if len(doubles):
-                warnings.warn("Warning: the two sets of epochs are "
-                              "overlapping. The %s overlapping epochs will"
-                              " be dropped." % len(doubles))
-                drop_ids = [ii for ii, t in enumerate(epochs.events[:, 0])
-                            if t in doubles]
-                epochs.drop_epochs(drop_ids, reason='EQUALIZED_COUNT')
+                raise ValueError("Warning: the two sets of epochs are "
+                                 "overlapping. Provide an "
+                                 "orthogonal selection.")
 
         for eq in event_ids:
             eq = np.atleast_1d(eq)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1154,6 +1154,13 @@ def test_epoch_eq():
     assert_true(epochs['ab'].events.shape[0] == old_shapes[0] + old_shapes[1])
     assert_true(epochs['ab'].events.shape[0] == epochs['cd'].events.shape[0])
 
+    # equalizing with hierarchical tags
+    epochs = Epochs(raw, events, {'a/x': 1, 'b/x': 2, 'a/y': 3, 'b/y': 4},
+                    tmin, tmax, picks=picks, reject=reject)
+    cond1, cond2 = ['a', ['b/x', 'b/y']], [['a/x', 'a/y'], 'b']
+    es = (epochs.equalize_event_counts[c] for c in (cond1, cond2))
+    assert_true(set(es[0].events[:, 0]) == set(es[1].events[:, 0]))
+
 
 def test_access_by_name():
     """Test accessing epochs by event name and on_missing for rare events

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1159,10 +1159,11 @@ def test_epoch_eq():
                     tmin, tmax, picks=picks, reject=reject)
     cond1, cond2 = ['a', ['b/x', 'b/y']], [['a/x', 'a/y'], 'b']
     es = [epochs.equalize_event_counts(c)[0] for c in (cond1, cond2)]
-    assert_equal(es[0].events[:, 0], es[1].events[:, 0])
+    assert_array_equal(es[0].events[:, 0], es[1].events[:, 0])
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
       assert_raises(ValueError, epochs.equalize_event_counts, c)
+
 
 def test_access_by_name():
     """Test accessing epochs by event name and on_missing for rare events

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1162,7 +1162,7 @@ def test_epoch_eq():
     assert_array_equal(es[0].events[:, 0], es[1].events[:, 0])
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
-      assert_raises(ValueError, epochs.equalize_event_counts, c)
+        assert_raises(ValueError, epochs.equalize_event_counts, c)
 
 
 def test_access_by_name():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1158,7 +1158,7 @@ def test_epoch_eq():
     epochs = Epochs(raw, events, {'a/x': 1, 'b/x': 2, 'a/y': 3, 'b/y': 4},
                     tmin, tmax, picks=picks, reject=reject)
     cond1, cond2 = ['a', ['b/x', 'b/y']], [['a/x', 'a/y'], 'b']
-    es = (epochs.equalize_event_counts[c] for c in (cond1, cond2))
+    es = [epochs.equalize_event_counts(c)[0] for c in (cond1, cond2)]
     assert_true(set(es[0].events[:, 0]) == set(es[1].events[:, 0]))
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1159,8 +1159,10 @@ def test_epoch_eq():
                     tmin, tmax, picks=picks, reject=reject)
     cond1, cond2 = ['a', ['b/x', 'b/y']], [['a/x', 'a/y'], 'b']
     es = [epochs.equalize_event_counts(c)[0] for c in (cond1, cond2)]
-    assert_true(set(es[0].events[:, 0]) == set(es[1].events[:, 0]))
-
+    assert_equal(es[0].events[:, 0], es[1].events[:, 0])
+    cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
+    for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
+      assert_raises(ValueError, epochs.equalize_event_counts, c)
 
 def test_access_by_name():
     """Test accessing epochs by event name and on_missing for rare events


### PR DESCRIPTION
See #2521 

~~Todo: a test~~

~~Note: this patch will induce a bit of unnecessary overhead if you use hierarchical tags in your event_ids, regardless of if you use them in the particular epoch selection.~~