### PR TITLE
Sensitivity map for volume source estimate.

### DIFF
--- a/mne/proj.py
+++ b/mne/proj.py
@@ -386,14 +386,12 @@ def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
         sensitivity_map /= np.max(sensitivity_map)
 
     subject = _subject_from_forward(fwd)
-    if len(fwd['src']) == 1:  # volume source space
+    if fwd['src'][0]['type'] == 'vol':  # volume source space
         vertices = fwd['src'][0]['vertno']
-        stc = VolSourceEstimate(sensitivity_map[:, np.newaxis],
-                                vertices=vertices, tmin=0, tstep=1,
-                                subject=subject)
+        SEClass = VolSourceEstimate
     else:
         vertices = [fwd['src'][0]['vertno'], fwd['src'][1]['vertno']]
-        stc = SourceEstimate(sensitivity_map[:, np.newaxis],
-                             vertices=vertices, tmin=0, tstep=1,
-                             subject=subject)
+        SEClass = SourceEstimate
+    stc = SEClass(sensitivity_map[:, np.newaxis], vertices=vertices, tmin=0,
+                  tstep=1, subject=subject)
     return stc

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -14,9 +14,8 @@ from .parallel import parallel_func
 from .cov import _check_n_samples
 from .forward import (is_fixed_orient, _subject_from_forward,
                       convert_forward_solution)
-from .source_estimate import SourceEstimate
+from .source_estimate import SourceEstimate, VolSourceEstimate
 from .io.proj import make_projector, make_eeg_average_ref_proj
-from mne.source_estimate import VolSourceEstimate
 
 
 def read_proj(fname):

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -79,6 +79,10 @@ def test_sensitivity_maps():
     # test corner case for EEG
     stc = sensitivity_map(fwd, projs=[make_eeg_average_ref_proj(fwd['info'])],
                           ch_type='eeg', exclude='bads')
+    # test volume source space
+    fname = op.join(sample_path, 'sample_audvis_trunc-meg-vol-7-fwd.fif')
+    fwd = mne.read_forward_solution(fname)
+    sensitivity_map(fwd)
 
 
 def test_compute_proj_epochs():


### PR DESCRIPTION
I noticed when converting the mne-script https://github.com/mne-tools/mne-scripts/blob/master/sample-data/run_meg_volume_tutorial.sh, that the sensitivity maps cannot be made for volume source space in python. With this it is possible.