### PR TITLE
WIP: Pickle Evoked

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -135,9 +135,16 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                      'found datasets:\n  %s'
                                      % (condition, kind, t))
                 condition = found_cond[0]
+            elif condition is None:
+                if len(evoked_node) > 1:
+                    _, _, conditions = _get_entries(fid, evoked_node)
+                    raise TypeError("Evoked file has more than one conditions, "
+                                    "the condition parameters must be "
+                                    "specified as one of:\n%s" % conditions)
+                else:
+                    condition = 0
 
             if condition >= len(evoked_node) or condition < 0:
-                fid.close()
                 raise ValueError('Data set selector out of range')
 
             my_evoked = evoked_node[condition]

--- a/mne/io/_bytesio.py
+++ b/mne/io/_bytesio.py
@@ -1,0 +1,10 @@
+# Author: Christian Brodbeck <christianbrodbeck@nyu.edu>
+from io import BytesIO
+
+
+class PersistentBytesIO(BytesIO):
+
+    def close(self):
+        if not self.closed:
+            self.value = self.getvalue()
+            BytesIO.close(self)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -17,7 +17,7 @@ from nose.tools import assert_true, assert_raises, assert_not_equal
 
 from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
                  grand_average, combine_evoked)
-from mne.evoked import _get_peak, EvokedArray
+from mne.evoked import _get_peak, Evoked, EvokedArray
 from mne.epochs import EpochsArray
 
 from mne.utils import _TempDir, requires_pandas, slow_test, requires_version
@@ -125,6 +125,9 @@ def test_io_evoked():
         write_evokeds(fname2, ave)
         read_evokeds(fname2)
     assert_true(len(w) == 2)
+
+    # constructor
+    assert_raises(TypeError, Evoked, fname)
 
 
 def test_shift_time_evoked():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -101,10 +101,9 @@ def test_io_evoked():
     assert_array_almost_equal(ave.data, ave3.data, 19)
 
     # test read_evokeds and write_evokeds
-    types = ['Left Auditory', 'Right Auditory', 'Left visual', 'Right visual']
-    aves1 = read_evokeds(fname)
-    aves2 = read_evokeds(fname, [0, 1, 2, 3])
-    aves3 = read_evokeds(fname, types)
+    aves1 = read_evokeds(fname)[1::2]
+    aves2 = read_evokeds(fname, [1, 3])
+    aves3 = read_evokeds(fname, ['Right Auditory', 'Right visual'])
     write_evokeds(op.join(tempdir, 'evoked-ave.fif'), aves1)
     aves4 = read_evokeds(op.join(tempdir, 'evoked-ave.fif'))
     aves5 = [pickle.loads(pickle.dumps(av)) for av in aves1]

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -107,7 +107,8 @@ def test_io_evoked():
     aves3 = read_evokeds(fname, types)
     write_evokeds(op.join(tempdir, 'evoked-ave.fif'), aves1)
     aves4 = read_evokeds(op.join(tempdir, 'evoked-ave.fif'))
-    for aves in [aves2, aves3, aves4]:
+    aves5 = [pickle.loads(pickle.dumps(av)) for av in aves1]
+    for aves in [aves2, aves3, aves4, aves5]:
         for [av1, av2] in zip(aves1, aves):
             assert_array_almost_equal(av1.data, av2.data)
             assert_array_almost_equal(av1.times, av2.times)


### PR DESCRIPTION
This should make pickled Evoked objects compatible between mne versions by using a FIFF byte string as suggested a while ago by @mluessi. I noticed that file-like objects were already supported and very little has to be changed. 