### PR TITLE
Sort CSP filters differently (0, -1, 1, -2, 2, -3, ...)

### DIFF
--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -133,7 +133,6 @@ class CSP(TransformerMixin):
         ind = np.argsort(vals)[::-1]
         vecs = vecs[:, ind]
         # re-order (first, last, second, second last, third, ...)
-        ind = np.empty_like(ind)
         ind[::2] = np.arange(0, np.ceil(len(ind)/2))
         ind[1::2] = np.arange(len(ind) - 1, int(len(ind)/2) - 1, -1)
         vecs = vecs[:, ind]

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -135,7 +135,7 @@ class CSP(TransformerMixin):
         # re-order (first, last, second, second last, third, ...)
         n_vals = len(ind)
         ind[::2] = np.arange(0, int(np.ceil(n_vals/2)))
-        ind[1::2] = np.arange(n_vals - 1, n_vals//2 - 1, -1)
+        ind[1::2] = np.arange(n_vals - 1, int(np.ceil(n_vals/2)) - 1, -1)
         vecs = vecs[:, ind]
         # and project
         w = np.dot(vecs.T, p)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -133,8 +133,9 @@ class CSP(TransformerMixin):
         ind = np.argsort(vals)[::-1]
         vecs = vecs[:, ind]
         # re-order (first, last, second, second last, third, ...)
-        ind[::2] = np.arange(0, np.ceil(len(ind)/2))
-        ind[1::2] = np.arange(len(ind) - 1, int(len(ind)/2) - 1, -1)
+        n_vals = len(ind)
+        ind[::2] = np.arange(0, int(np.ceil(n_vals/2)))
+        ind[1::2] = np.arange(n_vals - 1, n_vals//2 - 1, -1)
         vecs = vecs[:, ind]
         # and project
         w = np.dot(vecs.T, p)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -134,8 +134,8 @@ class CSP(TransformerMixin):
         vecs = vecs[:, ind]
         # re-order (first, last, second, second last, third, ...)
         n_vals = len(ind)
-        ind[::2] = np.arange(0, int(np.ceil(n_vals/2)))
-        ind[1::2] = np.arange(n_vals - 1, int(np.ceil(n_vals/2)) - 1, -1)
+        ind[::2] = np.arange(0, int(np.ceil(n_vals / 2.0)))
+        ind[1::2] = np.arange(n_vals - 1, int(np.ceil(n_vals / 2.0)) - 1, -1)
         vecs = vecs[:, ind]
         # and project
         w = np.dot(vecs.T, p)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -129,8 +129,13 @@ class CSP(TransformerMixin):
         w_b = np.dot(np.dot(p, cov_b), p.T)
         # and solve it
         vals, vecs = linalg.eigh(w_a, w_b)
-        # sort vectors by discriminative power using eigen values
-        ind = np.argsort(np.maximum(vals, 1. / vals))[::-1]
+        # sort vectors by discriminative power using eigenvalues
+        ind = np.argsort(vals)[::-1]
+        vecs = vecs[:, ind]
+        # re-order (first, last, second, second last, third, ...)
+        ind = np.empty_like(ind)
+        ind[::2] = np.arange(0, np.ceil(len(ind)/2))
+        ind[1::2] = np.arange(len(ind) - 1, int(len(ind)/2) - 1, -1)
         vecs = vecs[:, ind]
         # and project
         w = np.dot(vecs.T, p)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -94,7 +94,7 @@ def test_spherical_harmonics():
     """Test spherical harmonic functions"""
     from scipy.special import sph_harm
     az, pol = np.meshgrid(np.linspace(0, 2 * np.pi, 30),
-                          np.linspace(0, np.pi, 20), indexing='ij')
+                          np.linspace(0, np.pi, 20))
     # As of Oct 16, 2015, Anancoda has a bug in scipy due to old compilers (?):
     # https://github.com/ContinuumIO/anaconda-issues/issues/479
     if (PY3 and
@@ -114,7 +114,7 @@ def test_spherical_conversions():
     """Test spherical harmonic conversions"""
     # Test our real<->complex conversion functions
     az, pol = np.meshgrid(np.linspace(0, 2 * np.pi, 30),
-                          np.linspace(0, np.pi, 20), indexing='ij')
+                          np.linspace(0, np.pi, 20))
     for degree in range(1, int_order):
         for order in range(0, degree + 1):
             sph = _sph_harm(order, degree, az, pol)


### PR DESCRIPTION
I think the order of the CSP filters might not be correct. When we select `n_components` components, we usually pick the first, the last, the second, the second last, ... components until we have the desired number (@kazemakase and I do that in our SCoT implementation).