### PR TITLE
Implement basic version of sklearn estimator API

### DIFF
--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -10,6 +10,7 @@ import copy as cp
 
 import numpy as np
 from scipy import linalg
+import six
 
 from .mixin import TransformerMixin, EstimatorMixin
 from ..cov import _regularized_covariance

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -10,13 +10,12 @@ import copy as cp
 
 import numpy as np
 from scipy import linalg
-import six
 
-from .mixin import TransformerMixin
+from .mixin import TransformerMixin, EstimatorMixin
 from ..cov import _regularized_covariance
 
 
-class CSP(TransformerMixin):
+class CSP(TransformerMixin, EstimatorMixin):
     """M/EEG signal decomposition using the Common Spatial Patterns (CSP).
 
     This object can be used as a supervised decomposition to estimate
@@ -76,33 +75,6 @@ class CSP(TransformerMixin):
                   "reg": self.reg,
                   "log": self.log}
         return params
-
-    def set_params(self, **params):
-        """Set parameters (mimics sklearn API)."""
-        if not params:
-            return self
-        valid_params = self.get_params(deep=True)
-        for key, value in six.iteritems(params):
-            split = key.split('__', 1)
-            if len(split) > 1:
-                # nested objects case
-                name, sub_name = split
-                if name not in valid_params:
-                    raise ValueError('Invalid parameter %s for estimator %s. '
-                                     'Check the list of available parameters '
-                                     'with `estimator.get_params().keys()`.' %
-                                     (name, self))
-                sub_object = valid_params[name]
-                sub_object.set_params(**{sub_name: value})
-            else:
-                # simple objects case
-                if key not in valid_params:
-                    raise ValueError('Invalid parameter %s for estimator %s. '
-                                     'Check the list of available parameters '
-                                     'with `estimator.get_params().keys()`.' %
-                                     (key, self.__class__.__name__))
-                setattr(self, key, value)
-        return self
 
     def fit(self, epochs_data, y):
         """Estimate the CSP decomposition on epochs.

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -70,7 +70,14 @@ class CSP(TransformerMixin, EstimatorMixin):
         self.std_ = None
 
     def get_params(self, deep=True):
-        """Return all parameters (mimics sklearn API)."""
+        """Return all parameters (mimics sklearn API).
+
+        Parameters
+        ----------
+        deep: boolean, optional
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+        """
         params = {"n_components": self.n_components,
                   "reg": self.reg,
                   "log": self.log}

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -10,7 +10,6 @@ import copy as cp
 
 import numpy as np
 from scipy import linalg
-import six
 
 from .mixin import TransformerMixin, EstimatorMixin
 from ..cov import _regularized_covariance

--- a/mne/decoding/mixin.py
+++ b/mne/decoding/mixin.py
@@ -1,3 +1,6 @@
+from ..externals import six
+
+
 class TransformerMixin(object):
     """Mixin class for all transformers in scikit-learn"""
 
@@ -28,3 +31,37 @@ class TransformerMixin(object):
         else:
             # fit method of arity 2 (supervised transformation)
             return self.fit(X, y, **fit_params).transform(X)
+
+
+class EstimatorMixin(object):
+    """Mixin class for estimators."""
+
+    def get_params(self):
+        pass
+
+    def set_params(self, **params):
+        """Set parameters (mimics sklearn API)."""
+        if not params:
+            return self
+        valid_params = self.get_params(deep=True)
+        for key, value in six.iteritems(params):
+            split = key.split('__', 1)
+            if len(split) > 1:
+                # nested objects case
+                name, sub_name = split
+                if name not in valid_params:
+                    raise ValueError('Invalid parameter %s for estimator %s. '
+                                     'Check the list of available parameters '
+                                     'with `estimator.get_params().keys()`.' %
+                                     (name, self))
+                sub_object = valid_params[name]
+                sub_object.set_params(**{sub_name: value})
+            else:
+                # simple objects case
+                if key not in valid_params:
+                    raise ValueError('Invalid parameter %s for estimator %s. '
+                                     'Check the list of available parameters '
+                                     'with `estimator.get_params().keys()`.' %
+                                     (key, self.__class__.__name__))
+                setattr(self, key, value)
+        return self

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -8,6 +8,8 @@ import os.path as op
 from nose.tools import assert_true, assert_raises
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from sklearn.svm import SVC
+from sklearn.pipeline import Pipeline
 
 from mne import io, Epochs, read_events, pick_types
 from mne.decoding.csp import CSP
@@ -106,3 +108,12 @@ def test_regularized_csp():
         csp.n_components = n_components
         sources = csp.transform(epochs_data)
         assert_true(sources.shape[1] == n_components)
+
+
+@requires_sklearn
+def test_csp_pipeline():
+    csp = CSP(reg=1)
+    svc = SVC()
+    pipe = Pipeline([("CSP", csp), ("SVC", svc)])
+    pipe.set_params(CSP__reg=0.2)
+    assert_true(pipe.get_params()["CSP__reg"] == 0.2)

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -112,6 +112,8 @@ def test_regularized_csp():
 
 @requires_sklearn
 def test_csp_pipeline():
+    """Test if CSP works in a pipeline
+    """
     csp = CSP(reg=1)
     svc = SVC()
     pipe = Pipeline([("CSP", csp), ("SVC", svc)])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -8,8 +8,6 @@ import os.path as op
 from nose.tools import assert_true, assert_raises
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from sklearn.svm import SVC
-from sklearn.pipeline import Pipeline
 
 from mne import io, Epochs, read_events, pick_types
 from mne.decoding.csp import CSP
@@ -114,6 +112,8 @@ def test_regularized_csp():
 def test_csp_pipeline():
     """Test if CSP works in a pipeline
     """
+    from sklearn.svm import SVC
+    from sklearn.pipeline import Pipeline
     csp = CSP(reg=1)
     svc = SVC()
     pipe = Pipeline([("CSP", csp), ("SVC", svc)])


### PR DESCRIPTION
Addresses #2589. It is as simple as possible, but not simpler (I use `six` in order to keep the `sklearn` implementation of `set_params`).