### PR TITLE
Fix to colorbar in topomap.

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1263,7 +1263,6 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
 
     if title is not None:
         plt.suptitle(title, verticalalignment='top', size='x-large')
-        tight_layout(pad=size, fig=fig)
 
     if colorbar:
         cax = plt.subplot(1, n_times + 1, n_times + 1)


### PR DESCRIPTION
For me the colorbar works best when tight_layout is not used. I removed it, but this needs to be tested on macosx too. You can try ``plot_evoked_topomap`` and adding a title to one of the figures.
Closes https://github.com/mne-tools/mne-python/issues/2615.