### PR TITLE
WIP: initialize mklfft

### DIFF
--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -3,9 +3,8 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy.fftpack import fft, ifft
 
-from .utils import sizeof_fmt, logger, get_config
+from .utils import sizeof_fmt, logger, get_config, fft, ifft
 
 
 # Support CUDA for FFTs; requires scikits.cuda and pycuda

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 
-from .utils import sizeof_fmt, logger, get_config, fft, ifft
+from .utils import sizeof_fmt, logger, get_config, fft
+from scipy.fftpack import ifft
 
 
 # Support CUDA for FFTs; requires scikits.cuda and pycuda

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -4,8 +4,7 @@
 
 import numpy as np
 
-from .utils import sizeof_fmt, logger, get_config, fft
-from scipy.fftpack import ifft
+from .utils import sizeof_fmt, logger, get_config, fft, ifft
 
 
 # Support CUDA for FFTs; requires scikits.cuda and pycuda
@@ -200,7 +199,7 @@ def fft_multiply_repeated(h_fft, x, cuda_dict=dict(use_cuda=False)):
     """
     if not cuda_dict['use_cuda']:
         # do the fourier-domain operations
-        x = np.real(ifft(h_fft * fft(x), overwrite_x=True)).ravel()
+        x = np.real(ifft(h_fft * fft(x))).ravel()
     else:
         cudafft = _get_cudafft()
         # do the fourier-domain operations, results in second param
@@ -335,7 +334,7 @@ def fft_resample(x, W, new_len, npad, to_remove,
         y_fft[sl_1] = x_fft[sl_1]
         sl_2 = slice(-(N - 1) // 2, None)
         y_fft[sl_2] = x_fft[sl_2]
-        y = np.real(ifft(y_fft, overwrite_x=True)).ravel()
+        y = np.real(ifft(y_fft)).ravel()
     else:
         cudafft = _get_cudafft()
         cuda_dict['x'].set(np.concatenate((x, np.zeros(max(new_len - old_len,

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -4,10 +4,6 @@ from .externals.six import string_types, integer_types
 import warnings
 import numpy as np
 from scipy.fftpack import ifftshift, fftfreq
-#try:
-#    from mklfft.fftpack import fft
-#except ImportError:
-#    from scipy.fftpack import fft
 
 from copy import deepcopy
 
@@ -16,7 +12,7 @@ from .time_frequency.multitaper import dpss_windows, _mt_spectra
 from .parallel import parallel_func, check_n_jobs
 from .cuda import (setup_cuda_fft_multiply_repeated, fft_multiply_repeated,
                    setup_cuda_fft_resample, fft_resample, _smart_pad)
-from .utils import logger, verbose, sum_squared, check_version, _get_mkl_fft
+from .utils import logger, verbose, sum_squared, check_version, fft
 
 
 def is_power2(num):
@@ -125,7 +121,6 @@ def _overlap_add_filter(x, h, n_fft=None, zero_phase=True, picks=None,
         warnings.warn("FFT length is not a power of 2. Can be slower.")
 
     # Filter in frequency domain
-    fft = _get_mkl_fft("fft", n_jobs)
     h_fft = fft(np.concatenate([h, np.zeros(n_fft - n_h, dtype=h.dtype)]))
     assert(len(h_fft) == n_fft)
 
@@ -339,8 +334,7 @@ def _filter(x, Fs, freq, gain, filter_length='10s', picks=None, n_jobs=1,
                           '%0.1fdB.' % (att_freq, att_db))
 
         # Make zero-phase filter function
-        fft = _get_mkl_fft("fft", n_jobs)
-        B = np.abs(fft(h)).ravel()
+            B = np.abs(fft(h)).ravel()
 
         # Figure out if we should use CUDA
         n_jobs, cuda_dict, B = setup_cuda_fft_multiply_repeated(n_jobs, B)
@@ -1340,7 +1334,6 @@ def resample(x, up, down, npad=100, axis=-1, window='boxcar', n_jobs=1,
                 window.shape == (orig_len,):
             W = window
         else:
-            ifftshift = _get_mkl_fft("ifftshift")
             W = ifftshift(get_window(window, orig_len))
     else:
         W = np.ones(orig_len)

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -6,7 +6,8 @@
 from warnings import warn
 
 import numpy as np
-from scipy import linalg, fftpack
+from scipy import linalg
+from scipy.fftpack import fftfreq
 import warnings
 
 from ..io.constants import FIFF
@@ -19,7 +20,7 @@ from .inverse import (combine_xyz, prepare_inverse_operator, _assemble_kernel,
                       _pick_channels_inverse_operator, _check_method,
                       _check_ori, _subject_from_inverse)
 from ..parallel import parallel_func
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fft
 from ..externals import six
 
 
@@ -449,7 +450,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
     n_fft = int(n_fft)
     Fs = raw.info['sfreq']
     window = hanning(n_fft)
-    freqs = fftpack.fftfreq(n_fft, 1. / Fs)
+    freqs = fftfreq(n_fft, 1. / Fs)
     freqs_mask = (freqs >= 0) & (freqs >= fmin) & (freqs <= fmax)
     freqs = freqs[freqs_mask]
     fstep = np.mean(np.diff(freqs))
@@ -467,7 +468,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
 
         data *= window[None, :]
 
-        data_fft = fftpack.fft(data)[:, freqs_mask]
+        data_fft = fft(data)[:, freqs_mask]
         sol = np.dot(K, data_fft)
 
         if is_free_ori and pick_ori is None:

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 import numpy as np
 import copy as cp
 import warnings
-from scipy import fftpack
+from scipy.fftpack import fftfreq
 import matplotlib
 
 from mne import (io, Epochs, read_events, pick_events, read_epochs,
@@ -25,7 +25,7 @@ from mne.epochs import (
     EpochsArray, concatenate_epochs, _BaseEpochs)
 from mne.utils import (_TempDir, requires_pandas, slow_test,
                        clean_warning_registry, run_tests_if_main,
-                       requires_version)
+                       requires_version, fft)
 
 from mne.io.meas_info import create_info
 from mne.io.proj import _has_eeg_average_ref_proj
@@ -258,12 +258,12 @@ def test_savgol_filter():
     epochs = Epochs(raw, events, event_id, tmin, tmax)
     assert_raises(RuntimeError, epochs.savgol_filter, 10.)
     epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
-    freqs = fftpack.fftfreq(len(epochs.times), 1. / epochs.info['sfreq'])
-    data = np.abs(fftpack.fft(epochs.get_data()))
+    freqs = fftfreq(len(epochs.times), 1. / epochs.info['sfreq'])
+    data = np.abs(fft(epochs.get_data()))
     match_mask = np.logical_and(freqs >= 0, freqs <= h_freq / 2.)
     mismatch_mask = np.logical_and(freqs >= h_freq * 2, freqs < 50.)
     epochs.savgol_filter(h_freq)
-    data_filt = np.abs(fftpack.fft(epochs.get_data()))
+    data_filt = np.abs(fft(epochs.get_data()))
     # decent in pass-band
     assert_allclose(np.mean(data[:, :, match_mask], 0),
                     np.mean(data_filt[:, :, match_mask], 0),

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import warnings
 
 import numpy as np
-from scipy import fftpack
+from scipy.fftpack import fftfreq
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_array_equal, assert_allclose)
 from nose.tools import assert_true, assert_raises, assert_not_equal
@@ -20,7 +20,8 @@ from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
 from mne.evoked import _get_peak, Evoked, EvokedArray
 from mne.epochs import EpochsArray
 
-from mne.utils import _TempDir, requires_pandas, slow_test, requires_version
+from mne.utils import (_TempDir, requires_pandas, slow_test, requires_version,
+                       fft)
 
 from mne.io.meas_info import create_info
 from mne.externals.six.moves import cPickle as pickle
@@ -39,13 +40,13 @@ def test_savgol_filter():
     """
     h_freq = 10.
     evoked = read_evokeds(fname, 0)
-    freqs = fftpack.fftfreq(len(evoked.times), 1. / evoked.info['sfreq'])
-    data = np.abs(fftpack.fft(evoked.data))
+    freqs = fftfreq(len(evoked.times), 1. / evoked.info['sfreq'])
+    data = np.abs(fft(evoked.data))
     match_mask = np.logical_and(freqs >= 0, freqs <= h_freq / 2.)
     mismatch_mask = np.logical_and(freqs >= h_freq * 2, freqs < 50.)
     assert_raises(ValueError, evoked.savgol_filter, evoked.info['sfreq'])
     evoked.savgol_filter(h_freq)
-    data_filt = np.abs(fftpack.fft(evoked.data))
+    data_filt = np.abs(fft(evoked.data))
     # decent in pass-band
     assert_allclose(np.mean(data[:, match_mask], 0),
                     np.mean(data_filt[:, match_mask], 0),

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -8,8 +8,6 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 
-from scipy.fftpack import fft
-
 from mne.datasets import testing
 from mne import (stats, SourceEstimate, VolSourceEstimate, Label,
                  read_source_spaces, MixedSourceEstimate)
@@ -22,7 +20,7 @@ from mne.source_estimate import (spatio_temporal_tris_connectivity,
 from mne.minimum_norm import read_inverse_operator
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (_TempDir, requires_pandas, requires_sklearn,
-                       requires_h5py, run_tests_if_main, slow_test)
+                       requires_h5py, run_tests_if_main, slow_test, fft)
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -42,7 +42,7 @@ def _check_input_st(x_in, n_fft):
 
 def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
     """Precompute stockwell gausian windows (in the freq domain)"""
-    tw = fftpack.fftfreq(n_samp, 1. / sfreq) / n_samp
+    tw = fftfreq(n_samp, 1. / sfreq) / n_samp
     tw = np.r_[tw[:1], tw[1:][::-1]]
 
     k = width  # 1 for classical stowckwell transform
@@ -55,7 +55,7 @@ def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
             window = ((f / (np.sqrt(2. * np.pi) * k)) *
                       np.exp(-0.5 * (1. / k ** 2.) * (f ** 2.) * tw ** 2.))
         window /= window.sum()  # normalisation
-        windows[i_f] = fftpack.fft(window)
+        windows[i_f] = fft(window)
     return windows
 
 
@@ -64,11 +64,11 @@ def _st(x, start_f, windows):
     n_samp = x.shape[-1]
     ST = np.empty(x.shape[:-1] + (len(windows), n_samp), dtype=np.complex)
     # do the work
-    Fx = fftpack.fft(x)
+    Fx = fft(x)
     XF = np.concatenate([Fx, Fx], axis=-1)
     for i_f, window in enumerate(windows):
         f = start_f + i_f
-        ST[..., i_f, :] = fftpack.ifft(XF[..., f:f + n_samp] * window)
+        ST[..., i_f, :] = ifft(XF[..., f:f + n_samp] * window)
     return ST
 
 
@@ -79,11 +79,11 @@ def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     n_out = n_out // decim + bool(n_out % decim)
     psd = np.empty((len(W), n_out))
     itc = np.empty_like(psd) if compute_itc else None
-    X = fftpack.fft(x)
+    X = fft(x)
     XX = np.concatenate([X, X], axis=-1)
     for i_f, window in enumerate(W):
         f = start_f + i_f
-        ST = fftpack.ifft(XX[:, f:f + n_samp] * window)
+        ST = ifft(XX[:, f:f + n_samp] * window)
         TFR = ST[:, :-zero_pad:decim]
         TFR_abs = np.abs(TFR)
         if compute_itc:
@@ -158,7 +158,7 @@ def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
     n_out = data.shape[2] // decim + bool(data.shape[2] % decim)
     data, n_fft_, zero_pad = _check_input_st(data, n_fft)
 
-    freqs = fftpack.fftfreq(n_fft_, 1. / sfreq)
+    freqs = fftfreq(n_fft_, 1. / sfreq)
     if fmin is None:
         fmin = freqs[freqs > 0][0]
     if fmax is None:

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -6,11 +6,11 @@
 from copy import deepcopy
 import math
 import numpy as np
-from scipy import fftpack
+from scipy.fftpack import fftfreq
 # XXX explore cuda optimazation at some point.
 
 from ..io.pick import pick_types, pick_info
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fft, ifft
 from ..parallel import parallel_func, check_n_jobs
 from .tfr import AverageTFR, _get_data
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -5,11 +5,12 @@
 from warnings import warn
 
 import numpy as np
-from scipy import fftpack, linalg
+from scipy import linalg
+from scipy.fftpack import fftfreq
 import warnings
 
 from ..parallel import parallel_func
-from ..utils import verbose, sum_squared
+from ..utils import verbose, sum_squared, fft, ifft
 
 
 def tridisolve(d, e, b, overwrite_b=True):

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -232,8 +232,8 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
     # compute autocorr using FFT (same as nitime.utils.autocorr(dpss) * N)
     rxx_size = 2 * N - 1
     n_fft = 2 ** int(np.ceil(np.log2(rxx_size)))
-    dpss_fft = fftpack.fft(dpss, n_fft)
-    dpss_rxx = np.real(fftpack.ifft(dpss_fft * dpss_fft.conj()))
+    dpss_fft = fft(dpss, n_fft)
+    dpss_rxx = np.real(ifft(dpss_fft * dpss_fft.conj()))
     dpss_rxx = dpss_rxx[:, :N]
 
     r = 4 * W * np.sinc(2 * W * nidx)
@@ -440,10 +440,10 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
 
     # remove mean (do not use in-place subtraction as it may modify input x)
     x = x - np.mean(x, axis=-1)[:, np.newaxis]
-    x_mt = fftpack.fft(x[:, np.newaxis, :] * dpss, n=n_fft)
+    x_mt = fft(x[:, np.newaxis, :] * dpss, n=n_fft)
 
     # only keep positive frequencies
-    freqs = fftpack.fftfreq(n_fft, 1. / sfreq)
+    freqs = fftfreq(n_fft, 1. / sfreq)
     freq_mask = (freqs >= 0)
 
     x_mt = x_mt[:, :, freq_mask]

--- a/mne/time_frequency/stft.py
+++ b/mne/time_frequency/stft.py
@@ -1,8 +1,8 @@
 from math import ceil
 import numpy as np
-from scipy.fftpack import fft, ifft, fftfreq
+from scipy.fftpack import fftfreq
 
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fft, ifft
 
 
 @verbose

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -8,12 +8,13 @@ import os.path as op
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from nose.tools import assert_true, assert_equal
 
-from scipy import fftpack
+from scipy.fftpack import fftfreq
 
 from mne import io, read_events, Epochs, pick_types
 from mne.time_frequency._stockwell import (tfr_stockwell, _st,
                                            _precompute_st_windows)
 from mne.time_frequency.tfr import AverageTFR
+from mne.utils import fft
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -46,7 +47,7 @@ def test_stockwell_core():
     pulse[int(offset * sfreq):] = 0.         # and zero after our desired pulse
 
     width = 0.5
-    freqs = fftpack.fftfreq(len(pulse), 1. / sfreq)
+    freqs = fftfreq(len(pulse), 1. / sfreq)
     fmin, fmax = 1.0, 100.0
     start_f, stop_f = [np.abs(freqs - f).argmin() for f in (fmin, fmax)]
     W = _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width)
@@ -68,7 +69,7 @@ def test_stockwell_core():
     W = _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width)
     y = _st(pulse, start_f, W)
     # invert stockwell
-    y_inv = fftpack.ifft(np.sum(y, axis=1)).real
+    y_inv = ifft(np.sum(y, axis=1)).real
     assert_array_almost_equal(pulse, y_inv)
 
 

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -14,7 +14,7 @@ from mne import io, read_events, Epochs, pick_types
 from mne.time_frequency._stockwell import (tfr_stockwell, _st,
                                            _precompute_st_windows)
 from mne.time_frequency.tfr import AverageTFR
-from mne.utils import fft
+from mne.utils import ifft
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -12,7 +12,6 @@ from math import sqrt
 from copy import deepcopy
 import numpy as np
 from scipy import linalg
-from scipy.fftpack import fftn, ifftn
 
 from ..fixes import partial
 from ..baseline import rescale
@@ -21,7 +20,7 @@ from ..utils import logger, verbose, _time_mask
 from ..channels.channels import ContainsMixin, UpdateChannelsMixin
 from ..io.pick import pick_info, pick_types
 from ..io.meas_info import Info
-from ..utils import check_fname
+from ..utils import check_fname, fftn, ifftn
 from .multitaper import dpss_windows
 from ..viz.utils import figure_nobar
 from ..externals.h5io import write_hdf5, read_hdf5

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -52,7 +52,7 @@ try:
 except ImportError:
     from scipy.fftpack import fft, ifft, fftn, ifftn
 
-for f in (fft, ifft, fftn, ifftn):
+for f in (fft, ifft, fftn, ifftn, mkl):
     assert f  # to avoid pyflakes complaining about unused imports
 
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -30,11 +30,6 @@ import atexit
 import numpy as np
 from scipy import linalg, sparse
 
-try:
-    from mkl.fftpack import fft, ifft, fftn, ifftn
-except ImportError:
-    from scipy.fftpack import fft, ifft, fftn, ifftn
-
 from .externals.six.moves import urllib
 from .externals.six import string_types, StringIO, BytesIO
 from .externals.decorator import decorator
@@ -44,6 +39,18 @@ from .fixes import isclose, _get_args
 logger = logging.getLogger('mne')  # one selection here used across mne-python
 logger.propagate = False  # don't propagate (in case of multiple imports)
 
+try:
+    from mklfft.fftpack import fft, ifft, fftn, ifftn
+    try:
+        import mkl
+    except ImportError:
+        warnings.warn("`mklfft` found, but `mkl` could not be loaded. Not able"
+                      " to set the number of threads via mkl.set_num_threads."
+                      " Note that single-threaded `mklfft` is not expected to"
+                      " be faster than Scipy's regular FFT.")
+    logger.info("Using `mklfft` for FFT.")
+except ImportError:
+    from scipy.fftpack import fft, ifft, fftn, ifftn
 
 def _memory_usage(*args, **kwargs):
     if isinstance(args[0], tuple):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -40,10 +40,9 @@ logger = logging.getLogger('mne')  # one selection here used across mne-python
 logger.propagate = False  # don't propagate (in case of multiple imports)
 
 try:
-    from mklfft.fftpack import fft, ifft, fftn, ifftn
+    from mklfft.fftpack import fft, ifft, fftn, ifftn  # noqa
     try:
-        import mkl
-        assert mkl
+        import mkl  # noqa
     except ImportError:
         warnings.warn("`mklfft` found, but `mkl` could not be loaded. Not able"
                       " to set the number of threads via mkl.set_num_threads."
@@ -51,10 +50,7 @@ try:
                       " be faster than Scipy's regular FFT.")
     logger.info("Using `mklfft` for FFT.")
 except ImportError:
-    from scipy.fftpack import fft, ifft, fftn, ifftn
-
-for f in (fft, ifft, fftn, ifftn):
-    assert f  # to avoid pyflakes complaining about unused imports
+    from scipy.fftpack import fft, ifft, fftn, ifftn  # noqa
 
 
 def _memory_usage(*args, **kwargs):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1985,3 +1985,25 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     # change comment field
     grand_average.comment = "Grand average (n = %d)" % grand_average.nave
     return grand_average
+
+
+def _get_mkl_fft(f, n_jobs):
+    if isinstance(n_jobs, int):
+        try:
+            import mklfft.fftpack as fftpack
+            try:
+                import mkl
+                mkl.set_num_threads(n_jobs)
+            except ImportError:
+                m = ("Trying to use mklfft, but mkl-service is not available. "
+                     "Can't set number of threads. Try installing mkl-service."
+                     )
+                raise ImportError(m)
+            if n_jobs < 2:
+                m = "Using mklfft, but only 1 job selected. No speedup."
+                warnings.warn(m)
+        except ImportError:
+            import scipy.fftpack as fftpack
+    else:
+        import scipy.fftpack as fftpack
+    return getattr(fftpack, f)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -43,6 +43,7 @@ try:
     from mklfft.fftpack import fft, ifft, fftn, ifftn
     try:
         import mkl
+        assert mkl
     except ImportError:
         warnings.warn("`mklfft` found, but `mkl` could not be loaded. Not able"
                       " to set the number of threads via mkl.set_num_threads."
@@ -52,7 +53,7 @@ try:
 except ImportError:
     from scipy.fftpack import fft, ifft, fftn, ifftn
 
-for f in (fft, ifft, fftn, ifftn, mkl):
+for f in (fft, ifft, fftn, ifftn):
     assert f  # to avoid pyflakes complaining about unused imports
 
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -30,6 +30,11 @@ import atexit
 import numpy as np
 from scipy import linalg, sparse
 
+try:
+    from mkl.fftpack import fft, ifft, fftn, ifftn
+except ImportError:
+    from scipy.fftpack import fft, ifft, fftn, ifftn
+
 from .externals.six.moves import urllib
 from .externals.six import string_types, StringIO, BytesIO
 from .externals.decorator import decorator
@@ -1985,25 +1990,3 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     # change comment field
     grand_average.comment = "Grand average (n = %d)" % grand_average.nave
     return grand_average
-
-
-def _get_mkl_fft(f, n_jobs):
-    if isinstance(n_jobs, int):
-        try:
-            import mklfft.fftpack as fftpack
-            try:
-                import mkl
-                mkl.set_num_threads(n_jobs)
-            except ImportError:
-                m = ("Trying to use mklfft, but mkl-service is not available. "
-                     "Can't set number of threads. Try installing mkl-service."
-                     )
-                raise ImportError(m)
-            if n_jobs < 2:
-                m = "Using mklfft, but only 1 job selected. No speedup."
-                warnings.warn(m)
-        except ImportError:
-            import scipy.fftpack as fftpack
-    else:
-        import scipy.fftpack as fftpack
-    return getattr(fftpack, f)


### PR DESCRIPTION
My attempt at #1916

Please check if the general approach seems okay.
Basically, there is a function in mne.utils, `_get_mkl_fft`, that takes as arguments a string and `n_jobs`. If `n_jobs` isn't CUDA, it tries to import the function denoted by the string from `mklfft.fftpack`. It will also try to import mkl from mkl-service and set the number of threads to n_jobs.
Otherwise, it returns the corresponding function from `scipy.fftpack`.