### PR TITLE
Fix to test and travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     # Conda currently has packaging bug with mayavi/traits/numpy where 1.10 can't be used
     # but breaks scipy; hopefully eventually the NUMPY=1.9 on 2.7 full can be removed
     - PYTHON=2.7 DEPS=full TEST_LOCATION=src NUMPY="=1.9" SCIPY="=0.16"
-    - PYTHON=2.7 DEPS=nodata TEST_LOCATION=src MNE_DONTWRITE_HOME=true  # also runs flake8
+    - PYTHON=2.7 DEPS=nodata TEST_LOCATION=src MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1  # also runs flake8
     - PYTHON=3.5 DEPS=full TEST_LOCATION=install MNE_STIM_CHANNEL=STI101
     - PYTHON=2.6 DEPS=full TEST_LOCATION=src NUMPY="=1.7" SCIPY="=0.11" MPL="=1.1" LIBPNG="=1.5" SKLEARN="=0.11" PANDAS="=0.8"
     - PYTHON=2.7 DEPS=minimal TEST_LOCATION=src

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -123,9 +123,9 @@ def test_notch_filters():
 
         if lf is None:
             out = log_file.getvalue().split('\n')[:-1]
-            if len(out) != 2:
+            if len(out) != 2 and len(out) != 3:  # force_serial: len(out) == 3
                 raise ValueError('Detected frequencies not logged properly')
-            out = np.fromstring(out[1], sep=', ')
+            out = np.fromstring(out[-1], sep=', ')
             assert_array_almost_equal(out, freqs)
         new_power = np.sqrt(sum_squared(b) / b.size)
         assert_almost_equal(new_power, orig_power, tol)


### PR DESCRIPTION
I encountered a failure in tests when doing the packaging. It was caused by using ``force_serial``, which caused the log to contain 3 lines instead of 2.