### PR TITLE
FIX: Fix some test warnings, DRY code

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -34,7 +34,7 @@ from ..io.base import _BaseRaw
 from ..epochs import _BaseEpochs
 from ..viz import (plot_ica_components, plot_ica_scores,
                    plot_ica_sources, plot_ica_overlay)
-from ..viz.utils import (_prepare_trellis, tight_layout,
+from ..viz.utils import (_prepare_trellis, tight_layout, plt_show,
                          _setup_vmin_vmax)
 from ..viz.topomap import (_prepare_topo_plot, _check_outlines,
                            plot_topomap)
@@ -2249,8 +2249,6 @@ def _find_max_corrs(all_maps, target, threshold):
 def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
                   layout, cmap, contours):
     """Customized ica.plot_components for corrmap"""
-    import matplotlib.pyplot as plt
-
     title = 'Detected components'
     if label is not None:
         title += ' of type ' + label
@@ -2297,8 +2295,7 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
     tight_layout(fig=fig)
     fig.subplots_adjust(top=0.8)
     fig.canvas.draw()
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig
 
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -166,7 +166,7 @@ def compute_epochs_psd(epochs, picks=None, fmin=0, fmax=np.inf, tmin=None,
     if tmin is not None or tmax is not None:
         time_mask = _time_mask(epochs.times, tmin, tmax)
     else:
-        time_mask = Ellipsis
+        time_mask = slice(None)
 
     data = epochs.get_data()[:, picks][..., time_mask]
     if proj:

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -23,7 +23,7 @@ from ..io.pick import pick_info, pick_types
 from ..io.meas_info import Info
 from ..utils import check_fname
 from .multitaper import dpss_windows
-from ..viz.utils import figure_nobar
+from ..viz.utils import figure_nobar, plt_show
 from ..externals.h5io import write_hdf5, read_hdf5
 from ..externals.six import string_types
 
@@ -725,8 +725,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             if title:
                 fig.suptitle(title)
             colorbar = False  # only one colorbar for multiple axes
-        if show:
-            plt.show()
+        plt_show(show)
         return fig
 
     def _onselect(self, eclick, erelease, baseline, mode, layout):
@@ -843,7 +842,6 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             The figure containing the topography.
         """
         from ..viz.topo import _imshow_tfr, _plot_topo
-        import matplotlib.pyplot as plt
         times = self.times.copy()
         freqs = self.freqs
         data = self.data
@@ -870,10 +868,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
                          title=title, border=border, x_label='Time (ms)',
                          y_label='Frequency (Hz)', fig_facecolor=fig_facecolor,
                          font_color=font_color)
-
-        if show:
-            plt.show()
-
+        plt_show(show)
         return fig
 
     def _check_compat(self, tfr):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -31,7 +31,7 @@ from ..transforms import (read_trans, _find_trans, apply_trans,
 from ..utils import get_subjects_dir, logger, _check_subject, verbose
 from ..fixes import _get_args
 from ..defaults import _handle_default
-from .utils import mne_analyze_colormap, _prepare_trellis, COLORS
+from .utils import mne_analyze_colormap, _prepare_trellis, COLORS, plt_show
 from ..externals.six import BytesIO
 
 
@@ -262,8 +262,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
     if show:
         plt.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,
                             hspace=0.)
-        plt.show()
-
+    plt_show(show)
     return fig if img_output is None else outs
 
 
@@ -820,9 +819,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
     if fig_name is not None:
         plt.title(fig_name)
-
-    if show:
-        plt.show()
+    plt_show(show)
 
     surface.actor.property.backface_culling = True
     surface.actor.property.shading = True

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -14,6 +14,7 @@ from functools import partial
 
 import numpy as np
 
+from .utils import plt_show
 from ..externals.six import string_types
 from ..fixes import tril_indices, normalize_colors
 
@@ -409,6 +410,5 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
 
         fig.canvas.mpl_connect('button_press_event', callback)
 
-    if show:
-        plt.show()
+    plt_show(show)
     return fig, axes

--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -11,6 +11,8 @@ from __future__ import print_function
 import numpy as np
 import warnings
 
+from .utils import plt_show
+
 
 def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
                     ax=None, cmap='RdBu_r', show=True, colorbar=True,
@@ -82,8 +84,7 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
     ax.set_ylim(tlim[2:])
     if colorbar is True:
         plt.colorbar(im, ax=ax)
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig if ax is None else ax.get_figure()
 
 
@@ -182,8 +183,7 @@ def plot_gat_times(gat, train_time='diagonal', title=None, xmin=None,
                       'AUC' if 'roc' in repr(gat.scorer_) else r'%'))
     if legend is True:
         ax.legend(loc='best')
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig if ax is None else ax.get_figure()
 
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -463,7 +463,6 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     fig : instance of matplotlib figure
         Figure distributing one image per channel across sensor topography.
     """
-    import matplotlib.pyplot as plt
     from .raw import _set_psd_plot_params
     fig, picks_list, titles_list, ax_list, make_label = _set_psd_plot_params(
         epochs.info, proj, picks, ax, area_mode)
@@ -507,7 +506,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
             ax.set_xlim(freqs[0], freqs[-1])
     if make_label:
         tight_layout(pad=0.1, h_pad=0.1, w_pad=0.1, fig=fig)
-    plt.show(show)
+    plt_show(show)
     return fig
 
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -14,15 +14,14 @@ import copy
 
 import numpy as np
 
-from ..utils import verbose, get_config, set_config
-from ..utils import logger
+from ..utils import verbose, get_config, set_config, logger
 from ..io.pick import pick_types, channel_type
 from ..io.proj import setup_proj
 from ..fixes import Counter, _in1d
 from ..time_frequency import compute_epochs_psd
-from .utils import tight_layout, figure_nobar, _toggle_proj
-from .utils import _toggle_options, _layout_figure, _setup_vmin_vmax
-from .utils import _channels_changed, _plot_raw_onscroll, _onclick_help
+from .utils import (tight_layout, figure_nobar, _toggle_proj, _toggle_options,
+                    _layout_figure, _setup_vmin_vmax, _channels_changed,
+                    _plot_raw_onscroll, _onclick_help, plt_show)
 from ..defaults import _handle_default
 
 
@@ -156,9 +155,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             plt.colorbar(im, cax=ax3)
             tight_layout(fig=this_fig)
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return figs
 
 
@@ -238,10 +235,7 @@ def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject='Unknown',
     plt.ylabel('% of epochs rejected')
     plt.xlim((-width / 2.0, (n_plot - 1) + width * 3 / 2))
     plt.grid(True, axis='y')
-
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -390,7 +384,6 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
     with home/end and page down/page up keys. Butterfly plot can be toggled
     with ``b`` key. Right mouse click adds a vertical line to the plot.
     """
-    import matplotlib.pyplot as plt
     epochs.drop_bad_epochs()
     scalings = _handle_default('scalings_plot_raw', scalings)
 
@@ -409,11 +402,10 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
 
     callback_close = partial(_close_event, params=params)
     params['fig'].canvas.mpl_connect('close_event', callback_close)
-    if show:
-        try:
-            plt.show(block=block)
-        except TypeError:  # not all versions have this
-            plt.show()
+    try:
+        plt_show(show, block=block)
+    except TypeError:  # not all versions have this
+        plt_show(show)
 
     return params['fig']
 
@@ -515,8 +507,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
             ax.set_xlim(freqs[0], freqs[-1])
     if make_label:
         tight_layout(pad=0.1, h_pad=0.1, w_pad=0.1, fig=fig)
-    if show:
-        plt.show()
+    plt.show(show)
     return fig
 
 
@@ -1437,7 +1428,7 @@ def _open_options(params):
     params['fig_options'].canvas.mpl_connect('close_event', close_callback)
     try:
         params['fig_options'].canvas.draw()
-        params['fig_options'].show()
+        params['fig_options'].show(warn=False)
         if params['fig_proj'] is not None:
             params['fig_proj'].canvas.draw()
     except Exception:
@@ -1495,7 +1486,7 @@ def _plot_histogram(params):
     params['histogram'].suptitle('Peak-to-peak histogram', y=0.99)
     params['histogram'].subplots_adjust(hspace=0.6)
     try:
-        params['histogram'].show()
+        params['histogram'].show(warn=False)
     except:
         pass
     if params['fig_proj'] is not None:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -799,5 +799,5 @@ def plot_snr_estimate(evoked, inv, show=True):
     if evoked.comment is not None:
         ax.set_title(evoked.comment)
     plt.draw()
-    plt.show(show)
+    plt_show(show)
     return fig

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -16,7 +16,8 @@ import numpy as np
 from ..io.pick import channel_type, pick_types, _picks_by_type
 from ..externals.six import string_types
 from ..defaults import _handle_default
-from .utils import _draw_proj_checkbox, tight_layout, _check_delayed_ssp
+from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
+                    plt_show)
 from ..utils import logger
 from ..fixes import partial
 from ..io.pick import pick_info
@@ -99,7 +100,7 @@ def _butterfly_onselect(xmin, xmax, ch_types, evoked, text=None):
     fig.suptitle('Average over %.2fs - %.2fs' % (xmin, xmax), fontsize=15,
                  y=0.1)
     tight_layout(pad=2.0, fig=fig)
-    plt.show()
+    plt_show()
     if text is not None:
         text.set_visible(False)
         close_callback = partial(_topo_closed, ax=ax, lines=vert_lines,
@@ -314,9 +315,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
                       plot_type=plot_type)
         _draw_proj_checkbox(None, params)
 
-    if show and plt.get_backend() != 'agg':
-        plt.show()
-        fig.canvas.draw()  # for axes plots update axes.
+    plt_show(show)
+    fig.canvas.draw()  # for axes plots update axes.
     tight_layout(fig=fig)
 
     return fig
@@ -756,8 +756,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
         fig.subplots_adjust(**params)
     fig.canvas.draw()
 
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig
 
 
@@ -800,6 +799,5 @@ def plot_snr_estimate(evoked, inv, show=True):
     if evoked.comment is not None:
         ax.set_title(evoked.comment)
     plt.draw()
-    if show:
-        plt.show()
+    plt.show(show)
     return fig

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -12,9 +12,9 @@ from functools import partial
 
 import numpy as np
 
-from .utils import tight_layout, _prepare_trellis, _select_bads
-from .utils import _layout_figure, _plot_raw_onscroll, _mouse_click
-from .utils import _helper_raw_resize, _plot_raw_onkey
+from .utils import (tight_layout, _prepare_trellis, _select_bads,
+                    _layout_figure, _plot_raw_onscroll, _mouse_click,
+                    _helper_raw_resize, _plot_raw_onkey, plt_show)
 from .raw import _prepare_mne_browse_raw, _plot_raw_traces
 from .epochs import _prepare_mne_browse_epochs
 from .evoked import _butterfly_on_button_press, _butterfly_onpick
@@ -194,10 +194,7 @@ def _plot_ica_grid(sources, start, stop,
     # register callback
     callback = partial(_ica_plot_sources_onpick_, sources=sources, ylims=ylims)
     fig.canvas.mpl_connect('pick_event', callback)
-
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -307,9 +304,7 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, labels=None):
     fig.canvas.mpl_connect('button_press_event',
                            partial(_butterfly_on_button_press,
                                    params=params))
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -409,9 +404,7 @@ def plot_ica_scores(ica, scores,
     tight_layout(fig=fig)
     if len(axes) > 1:
         plt.subplots_adjust(top=0.9)
-
-    if show:
-        plt.show()
+    plt.show(show)
     return fig
 
 
@@ -536,10 +529,7 @@ def _plot_ica_overlay_raw(data, data_cln, times, title, ch_types_used, show):
 
     fig.subplots_adjust(top=0.90)
     fig.canvas.draw()
-
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -583,17 +573,13 @@ def _plot_ica_overlay_evoked(evoked, evoked_cln, title, show):
 
     fig.subplots_adjust(top=0.90)
     fig.canvas.draw()
-
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
 def _plot_sources_raw(ica, raw, picks, exclude, start, stop, show, title,
                       block):
     """Function for plotting the ICA components as raw array."""
-    import matplotlib.pyplot as plt
     color = _handle_default('color', (0., 0., 0.))
     orig_data = ica._transform_raw(raw, 0, len(raw.times)) * 0.2
     if picks is None:
@@ -669,12 +655,10 @@ def _plot_sources_raw(ica, raw, picks, exclude, start, stop, show, title,
     params['event_times'] = None
     params['update_fun']()
     params['plot_fun']()
-    if show:
-        try:
-            plt.show(block=block)
-        except TypeError:  # not all versions have this
-            plt.show()
-
+    try:
+        plt_show(show, block=block)
+    except TypeError:  # not all versions have this
+        plt_show(show)
     return params['fig']
 
 
@@ -706,7 +690,6 @@ def _close_event(events, params):
 def _plot_sources_epochs(ica, epochs, picks, exclude, start, stop, show,
                          title, block):
     """Function for plotting the components as epochs."""
-    import matplotlib.pyplot as plt
     data = ica._transform_epochs(epochs, concatenate=True)
     eog_chs = pick_types(epochs.info, meg=False, eog=True, ref_meg=False)
     ecg_chs = pick_types(epochs.info, meg=False, ecg=True, ref_meg=False)
@@ -760,12 +743,10 @@ def _plot_sources_epochs(ica, epochs, picks, exclude, start, stop, show,
     params['hsel_patch'].set_x(params['t_start'])
     callback_close = partial(_close_epochs_event, params=params)
     params['fig'].canvas.mpl_connect('close_event', callback_close)
-    if show:
-        try:
-            plt.show(block=block)
-        except TypeError:  # not all versions have this
-            plt.show()
-
+    try:
+        plt_show(show, block=block)
+    except TypeError:  # not all versions have this
+        plt_show(show)
     return params['fig']
 
 
@@ -834,5 +815,4 @@ def _label_clicked(pos, params):
     tight_layout(fig=fig)
     fig.subplots_adjust(top=0.95)
     fig.canvas.draw()
-
-    plt.show()
+    plt_show(True)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -404,7 +404,7 @@ def plot_ica_scores(ica, scores,
     tight_layout(fig=fig)
     if len(axes) > 1:
         plt.subplots_adjust(top=0.9)
-    plt.show(show)
+    plt_show(show)
     return fig
 
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -24,7 +24,7 @@ from ..surface import read_surface
 from ..io.proj import make_projector
 from ..utils import logger, verbose, get_subjects_dir
 from ..io.pick import pick_types
-from .utils import tight_layout, COLORS, _prepare_trellis
+from .utils import tight_layout, COLORS, _prepare_trellis, plt_show
 
 
 @verbose
@@ -124,9 +124,7 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
             plt.title(name)
             tight_layout(fig=fig_svd)
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig_cov, fig_svd
 
 
@@ -236,9 +234,7 @@ def plot_source_spectrogram(stcs, freq_bins, tmin=None, tmax=None,
         plt.barh(lower_bound, time_bounds[-1] - time_bounds[0], upper_bound -
                  lower_bound, time_bounds[0], color='#666666')
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -332,9 +328,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
 
     plt.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,
                         hspace=0.)
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -524,9 +518,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         fig.canvas.draw()
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -576,5 +568,5 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
     ax.set_xlabel('Time (sec)')
     ax.set_ylabel('Amplitude (nAm)')
     if show:
-        fig.show()
+        fig.show(warn=False)
     return fig

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -2,6 +2,8 @@
 """
 import numpy as np
 
+from .utils import plt_show
+
 
 def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
     """Plot a montage
@@ -52,7 +54,5 @@ def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
     ax.set_ylabel('y')
     ax.set_zlabel('z')
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -18,10 +18,10 @@ from ..io.proj import setup_proj
 from ..utils import verbose, get_config
 from ..time_frequency import compute_raw_psd
 from .topo import _plot_topo, _plot_timeseries
-from .utils import _toggle_options, _toggle_proj, tight_layout
-from .utils import _layout_figure, _plot_raw_onkey, figure_nobar
-from .utils import _plot_raw_onscroll, _mouse_click
-from .utils import _helper_raw_resize, _select_bads, _onclick_help
+from .utils import (_toggle_options, _toggle_proj, tight_layout,
+                    _layout_figure, _plot_raw_onkey, figure_nobar,
+                    _plot_raw_onscroll, _mouse_click, plt_show,
+                    _helper_raw_resize, _select_bads, _onclick_help)
 from ..defaults import _handle_default
 
 
@@ -332,11 +332,10 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=None,
     if show_options is True:
         _toggle_options(None, params)
 
-    if show:
-        try:
-            plt.show(block=block)
-        except TypeError:  # not all versions have this
-            plt.show()
+    try:
+        plt_show(show, block=block)
+    except TypeError:  # not all versions have this
+        plt_show(show)
 
     return params['fig']
 
@@ -464,7 +463,6 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
     fig : instance of matplotlib figure
         Figure with frequency spectra of the data channels.
     """
-    import matplotlib.pyplot as plt
     fig, picks_list, titles_list, ax_list, make_label = _set_psd_plot_params(
         raw.info, proj, picks, ax, area_mode)
 
@@ -503,8 +501,7 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
             ax.set_xlim(freqs[0], freqs[-1])
     if make_label:
         tight_layout(pad=0.1, h_pad=0.1, w_pad=0.1, fig=fig)
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig
 
 
@@ -724,8 +721,6 @@ def plot_raw_psd_topo(raw, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,
     fig : instance of matplotlib figure
         Figure distributing one image per channel across sensor topography.
     """
-    import matplotlib.pyplot as plt
-
     if layout is None:
         from ..channels.layout import find_layout
         layout = find_layout(raw.info)
@@ -746,6 +741,5 @@ def plot_raw_psd_topo(raw, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,
                      fig_facecolor=fig_facecolor, x_label='Frequency (Hz)',
                      y_label=y_label)
 
-    if show:
-        plt.show()
+    plt_show(show)
     return fig

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -21,7 +21,7 @@ from ..utils import _clean_names
 
 from ..defaults import _handle_default
 from .utils import (_check_delayed_ssp, COLORS, _draw_proj_checkbox,
-                    add_background_image)
+                    add_background_image, plt_show)
 
 
 def iter_topography(info, layout=None, on_pick=None, fig=None,
@@ -299,8 +299,6 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
     fig : Instance of matplotlib.figure.Figure
         Images of evoked responses at sensor locations
     """
-    import matplotlib.pyplot as plt
-
     if not type(evoked) in (tuple, list):
         evoked = [evoked]
 
@@ -401,9 +399,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
                       projs=evoked[0].info['projs'], fig=fig)
         _draw_proj_checkbox(None, params)
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -523,7 +519,6 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     fig : instance of matplotlib figure
         Figure distributing one image per channel across sensor topography.
     """
-    import matplotlib.pyplot as plt
     scalings = _handle_default('scalings', scalings)
     data = epochs.get_data()
     if vmin is None:
@@ -545,6 +540,5 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
                      fig_facecolor=fig_facecolor,
                      font_color=font_color, border=border,
                      x_label='Time (s)', y_label='Epoch')
-    if show:
-        plt.show()
+    plt_show(show)
     return fig

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -21,7 +21,8 @@ from ..io.constants import FIFF
 from ..io.pick import pick_types
 from ..utils import _clean_names, _time_mask, verbose, logger
 from .utils import (tight_layout, _setup_vmin_vmax, _prepare_trellis,
-                    _check_delayed_ssp, _draw_proj_checkbox, figure_nobar)
+                    _check_delayed_ssp, _draw_proj_checkbox, figure_nobar,
+                    plt_show)
 from ..time_frequency import compute_epochs_psd
 from ..defaults import _handle_default
 from ..channels.layout import _find_topomap_coords
@@ -238,9 +239,7 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
             raise RuntimeError('Cannot find a proper layout for projection %s'
                                % proj['desc'])
     tight_layout(fig=axes[0].get_figure())
-    if show and plt.get_backend() != 'agg':
-        plt.show()
-
+    plt_show(show)
     return axes[0].get_figure()
 
 
@@ -604,8 +603,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
 
     if onselect is not None:
         ax.RS = RectangleSelector(ax, onselect=onselect)
-    if show:
-        plt.show()
+    plt_show(show)
     return im, cont
 
 
@@ -805,9 +803,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     tight_layout(fig=fig)
     fig.subplots_adjust(top=0.95)
     fig.canvas.draw()
-
-    if show is True:
-        plt.show()
+    plt_show(show)
     return fig
 
 
@@ -995,9 +991,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         cbar.ax.tick_params(labelsize=12)
         cbar.ax.set_title('AU')
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -1288,9 +1282,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
                       plot_update_proj_callback=_plot_update_evoked_topomap)
         _draw_proj_checkbox(None, params)
 
-    if show:
-        plt.show()
-
+    plt_show(show)
     return fig
 
 
@@ -1531,8 +1523,7 @@ def plot_psds_topomap(
                                  colorbar=True, unit=unit, cbar_fmt=cbar_fmt)
     tight_layout(fig=fig)
     fig.canvas.draw()
-    if show:
-        plt.show()
+    plt_show(show)
     return fig
 
 
@@ -1599,7 +1590,7 @@ def _onselect(eclick, erelease, tfr, pos, ch_type, itmin, itmax, ifmin, ifmax,
         fig[0].get_axes()[1].cbar.on_mappable_changed(mappable=img)
     fig[0].canvas.draw()
     plt.figure(fig[0].number)
-    plt.show()
+    plt_show(True)
 
 
 def _find_peaks(evoked, npeaks):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -27,6 +27,7 @@ from ..time_frequency import compute_epochs_psd
 from ..defaults import _handle_default
 from ..channels.layout import _find_topomap_coords
 from ..fixes import _get_argrelmax
+from ..externals.six import string_types
 
 
 def _prepare_topo_plot(inst, ch_type, layout):
@@ -222,7 +223,7 @@ def plot_projs_topomap(projs, layout=None, cmap='RdBu_r', sensors=True,
             pos = l.pos[idx]
             if is_vv and grad_pairs:
                 from ..channels.layout import _merge_grad_data
-                shape = (len(idx) / 2, 2, -1)
+                shape = (len(idx) // 2, 2, -1)
                 pos = pos.reshape(shape).mean(axis=1)
                 data = _merge_grad_data(data[grad_pairs]).ravel()
 
@@ -1131,14 +1132,16 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     if isinstance(axes, plt.Axes):
         axes = [axes]
 
-    if times == "peaks":
-        npeaks = 10 if axes is None else len(axes)
-        times = _find_peaks(evoked, npeaks)
-    elif times == "auto":
-        if axes is None:
-            times = np.linspace(evoked.times[0], evoked.times[-1], 10)
-        else:
-            times = np.linspace(evoked.times[0], evoked.times[-1], len(axes))
+    if isinstance(times, string_types):
+        if times == "peaks":
+            npeaks = 10 if axes is None else len(axes)
+            times = _find_peaks(evoked, npeaks)
+        elif times == "auto":
+            if axes is None:
+                times = np.linspace(evoked.times[0], evoked.times[-1], 10)
+            else:
+                times = np.linspace(evoked.times[0], evoked.times[-1],
+                                    len(axes))
     elif np.isscalar(times):
         times = [times]
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -49,6 +49,13 @@ def _setup_vmin_vmax(data, vmin, vmax, norm=False):
     return vmin, vmax
 
 
+def plt_show(show=True, **kwargs):
+    """Helper to show a figure while suppressing warnings"""
+    import matplotlib.pyplot as plt
+    if show:
+        plt.show(warn=False, **kwargs)
+
+
 def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
     """ Adjust subplot parameters to give specified padding.
 
@@ -358,7 +365,7 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
     # this should work for non-test cases
     try:
         fig_proj.canvas.draw()
-        fig_proj.show()
+        fig_proj.show(warn=False)
     except Exception:
         pass
 
@@ -691,7 +698,7 @@ def _onclick_help(event, params):
     # this should work for non-test cases
     try:
         fig_help.canvas.draw()
-        fig_help.show()
+        fig_help.show(warn=False)
     except Exception:
         pass
 
@@ -724,7 +731,7 @@ class ClickableImage(object):
 
     def __init__(self, imdata, **kwargs):
         """Display the image for clicking."""
-        from matplotlib.pyplot import figure, show
+        from matplotlib.pyplot import figure
         self.coords = []
         self.imdata = imdata
         self.fig = figure()
@@ -736,7 +743,7 @@ class ClickableImage(object):
                                  picker=True, **kwargs)
         self.ax.axis('off')
         self.fig.canvas.mpl_connect('pick_event', self.onclick)
-        show()
+        plt_show()
 
     def onclick(self, event):
         """Mouse click handler.
@@ -757,7 +764,7 @@ class ClickableImage(object):
         **kwargs : dict
             Arguments are passed to imshow in displaying the bg image.
         """
-        from matplotlib.pyplot import subplots, show
+        from matplotlib.pyplot import subplots
         f, ax = subplots()
         ax.imshow(self.imdata, extent=(0, self.xmax, 0, self.ymax), **kwargs)
         xlim, ylim = [ax.get_xlim(), ax.get_ylim()]
@@ -768,7 +775,7 @@ class ClickableImage(object):
             ax.annotate(txt, coord, fontsize=20, color='r')
         ax.set_xlim(xlim)
         ax.set_ylim(ylim)
-        show()
+        plt_show()
 
     def to_layout(self, **kwargs):
         """Turn coordinates into an MNE Layout object.


### PR DESCRIPTION
Some tweaks to make the code more DRY and silence some test warnings that have cropped up. If the `warn=False` is for too recent `numpy`, I can change it to use a backend-lookup pattern.