### PR TITLE
MRG: Add check for line endings

### DIFF
--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -1,0 +1,53 @@
+# Adapted from vispy
+#
+# License: BSD (3-clause)
+
+import os
+from nose.plugins.skip import SkipTest
+from os import path as op
+import sys
+
+import mne
+from mne.utils import run_tests_if_main
+
+
+known_crlf = (
+    'FreeSurferColorLUT.txt',
+    'test_edf_stim_channel.txt',
+    'FieldTrip.py',
+)
+
+
+def test_line_endings():
+    """Test files in the repository for CR characters
+    """
+    if sys.platform == 'win32':
+        raise SkipTest('Skipping line endings check on Windows')
+    sys.stdout.flush()
+    report = []
+    import_dir = mne.__path__[0]
+    for dirpath, dirnames, filenames in os.walk(import_dir):
+        for fname in filenames:
+            if op.splitext(fname)[1] in ('.pyc', '.pyo'):
+                continue
+            # Get filename
+            filename = op.join(dirpath, fname)
+            relfilename = op.relpath(filename, import_dir)
+            # Open and check
+            try:
+                with open(filename, 'rb') as fid:
+                    text = fid.read().decode('utf-8')
+            except UnicodeDecodeError:
+                continue  # Probably a binary file
+            crcount = text.count('\r')
+            if crcount and op.basename(fname) not in known_crlf:
+                lfcount = text.count('\n')
+                report.append('In %s found %i/%i CR/LF' %
+                              (relfilename, crcount, lfcount))
+
+    # Process result
+    if len(report) > 0:
+        raise AssertionError('Found %s files with incorrect endings:\n%s'
+                             % (len(report), '\n'.join(report)))
+
+run_tests_if_main()

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -34,12 +34,8 @@ def _assert_line_endings(dir_):
                 continue
             filename = op.join(dirpath, fname)
             relfilename = op.relpath(filename, dir_)
-            try:
-                with open(filename, 'rb') as fid:
-                    text = fid.read().decode('utf-8')
-            except:
-                print(fname)
-                raise
+            with open(filename, 'rb') as fid:
+                text = fid.read().decode('utf-8')
             crcount = text.count('\r')
             if crcount:
                 report.append('In %s found %i/%i CR/LF' %

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -34,8 +34,12 @@ def _assert_line_endings(dir_):
                 continue
             filename = op.join(dirpath, fname)
             relfilename = op.relpath(filename, dir_)
-            with open(filename, 'rb') as fid:
-                text = fid.read().decode('utf-8')
+            try:
+                with open(filename, 'rb') as fid:
+                    text = fid.read().decode('utf-8')
+            except UnicodeDecodeError:
+                print(filename)
+                raise
             crcount = text.count('\r')
             if crcount:
                 report.append('In %s found %i/%i CR/LF' %

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -27,7 +27,7 @@ def _assert_line_endings(dir_):
     report = list()
     good_exts = ('.py', '.dat', '.sel', '.lout', '.css', '.js', '.lay', '.txt',
                  '.elc', '.csd', '.sfp', '.json', '.hpts', '.vmrk', '.vhdr',
-                 '.head', '.eve', '.ave', '.cov', '.sh', '.label')
+                 '.head', '.eve', '.ave', '.cov', '.label')
     for dirpath, dirnames, filenames in os.walk(dir_):
         for fname in filenames:
             if op.splitext(fname)[1] not in good_exts or fname in skip_files:
@@ -38,12 +38,12 @@ def _assert_line_endings(dir_):
                 with open(filename, 'rb') as fid:
                     text = fid.read().decode('utf-8')
             except UnicodeDecodeError:
-                print(filename)
-                raise
-            crcount = text.count('\r')
-            if crcount:
-                report.append('In %s found %i/%i CR/LF' %
-                              (relfilename, crcount, text.count('\n')))
+                report.append('In %s found non-decodable bytes' % relfilename)
+            else:
+                crcount = text.count('\r')
+                if crcount:
+                    report.append('In %s found %i/%i CR/LF' %
+                                  (relfilename, crcount, text.count('\n')))
     if len(report) > 0:
         raise AssertionError('Found %s files with incorrect endings:\n%s'
                              % (len(report), '\n'.join(report)))
@@ -56,7 +56,10 @@ def test_line_endings():
     with open(op.join(tempdir, 'foo'), 'wb') as fid:
         fid.write('bad\r\ngood\n'.encode('ascii'))
     _assert_line_endings(tempdir)
-    with open(op.join(tempdir, 'foo.py'), 'wb') as fid:
+    with open(op.join(tempdir, 'bad.py'), 'wb') as fid:
+        fid.write(b'\x97')
+    assert_raises(AssertionError, _assert_line_endings, tempdir)
+    with open(op.join(tempdir, 'bad.py'), 'wb') as fid:
         fid.write('bad\r\ngood\n'.encode('ascii'))
     assert_raises(AssertionError, _assert_line_endings, tempdir)
     # now check mne

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1985,3 +1985,13 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     # change comment field
     grand_average.comment = "Grand average (n = %d)" % grand_average.nave
     return grand_average
+
+
+def _get_root_dir():
+    """Helper to get as close to the repo root as possible"""
+    root_dir = op.abspath(op.dirname(__file__))
+    up_dir = op.join(root_dir, '..')
+    if op.isfile(op.join(up_dir, 'setup.py')) and all(
+            op.isdir(op.join(up_dir, x)) for x in ('mne', 'examples', 'doc')):
+        root_dir = op.abspath(up_dir)
+    return root_dir


### PR DESCRIPTION
Adds a check for line endings being correct. `vispy` has used something similar for a while.