### PR TITLE
requires_tvtk -> requires_mayavi.

### DIFF
--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -13,7 +13,7 @@ from mne import read_surface, write_surface, decimate_surface
 from mne.surface import (read_morph_map, _compute_nearest,
                          fast_cross_3d, get_head_surf, read_curvature,
                          get_meg_helmet_surf)
-from mne.utils import _TempDir, requires_tvtk, run_tests_if_main, slow_test
+from mne.utils import _TempDir, requires_mayavi, run_tests_if_main, slow_test
 from mne.io import read_info
 from mne.transforms import _get_trans
 
@@ -145,7 +145,7 @@ def test_read_curv():
     assert_true(np.logical_or(bin_curv == 0, bin_curv == 1).all())
 
 
-@requires_tvtk
+@requires_mayavi
 def test_decimate_surface():
     """Test triangular surface decimation
     """


### PR DESCRIPTION
This test fails on some env. I fixed this on debian branch by changing to ``requires_mayavi``, but now looking into it maybe it should be ``requires_traits``. I'm not too familiar with traits though, but in my environment the call to ``QuadricDecimation`` links to mayavi.