### PR TITLE
FIX: data.shape[2] may be wrongly estimated in _BaseEpochs.__init__()

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -278,7 +278,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         else:
             assert decim == 1
             if data.ndim != 3 or data.shape[2] != \
-                    round((tmax - tmin) * self.info['sfreq']) + 1:
+                    int((tmax - tmin) * self.info['sfreq']) + 1:
                 raise RuntimeError('bad data shape')
             self.preload = True
             self._data = data

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1895,7 +1895,7 @@ class EpochsArray(_BaseEpochs):
         if data.shape[0] != len(events):
             raise ValueError('The number of epochs and the number of events'
                              'must match')
-        tmax = (data.shape[2] - 1) / info['sfreq'] + tmin
+        tmax = float(data.shape[2] - 1) / info['sfreq'] + tmin
         if event_id is None:  # convert to int to make typing-checks happy
             event_id = dict((str(e), int(e)) for e in np.unique(events[:, 2]))
         super(EpochsArray, self).__init__(info, data, events, event_id, tmin,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -905,7 +905,7 @@ def test_crop():
     assert_array_equal(data3, data_normal[:, :, tmask])
 
     # test time info is correct
-    epochs = EpochsArray(np.zeros((1, 1, 1001)), create_info(1, 1000., 'eeg'),
+    epochs = EpochsArray(np.zeros((1, 1, 1000)), create_info(1, 1000., 'eeg'),
                          np.ones((1, 3), int), tmin=-0.2)
     epochs.crop(-.200, .700)
     last_time = epochs.times[-1]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -905,7 +905,7 @@ def test_crop():
     assert_array_equal(data3, data_normal[:, :, tmask])
 
     # test time info is correct
-    epochs = EpochsArray(np.zeros((1, 1, 1000)), create_info(1, 1000., 'eeg'),
+    epochs = EpochsArray(np.zeros((1, 1, 1001)), create_info(1, 1000., 'eeg'),
                          np.ones((1, 3), int), tmin=-0.2)
     epochs.crop(-.200, .700)
     last_time = epochs.times[-1]


### PR DESCRIPTION
In \__init\__() within _BaseEpochs, data.shape[2] is evaluated as follow :
```
round((tmax - tmin) * self.info['sfreq']) + 1
```

And if data.shape[2] is not egal to this estimation, it throws an error :
```
raise RuntimeError('bad data shape')
```

However, in some cases, I think the estimation is wrong. Here is an exemple :
Let's say that originally tmin=0.0 and tmax=0.009 (epochs lasting 9ms), and that self.info['sfreq'] was fixed to 500.
Then, after decimation, times and data.shape[2] would be : 

```
epochs.times = [0., 0.002, 0.004, 0.006, 0.008]        
data.shape[2] = 5
```

But :
```
(tmax - tmin) * self.info['sfreq'] = 0.009*500 = 4.5
round(4.5) = 5
```
So :
```
round((tmax - tmin) * self.info['sfreq']) + 1 = 6
```

\__init\__() in _BaseEpochs whould then throw an error while everything is fine.

To sum it up, when the first decimal of (tmax - tmin) * self.info['sfreq'] is >=5, the rounding and the +1 are redondant, making the estimate of data.shape[2] wrong.

I propose here to fix it by replacing _round_ by _int_, to floor the float and suppress the redondant increment. 

Btw, this issue is fairely related to another problem I met with tmin and tmax definition + decimation, which is still out there (see PR #2486, closed without being merged...).
