### PR TITLE
fix nan in filters for egi

### DIFF
--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -4,6 +4,7 @@
 
 import os.path as op
 import warnings
+import math
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -48,6 +49,9 @@ def test_io_egi():
     data2, times2 = raw2[:10, :]
     assert_array_almost_equal(data1, data2, 9)
     assert_array_almost_equal(times1, times2)
+
+    assert_true(not math.isnan(raw2.info['highpass']))
+    assert_true(not math.isnan(raw2.info['lowpass']))
 
     eeg_chan = [c for c in raw.ch_names if 'EEG' in c]
     assert_equal(len(eeg_chan), 256)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -862,7 +862,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
 
     info['nchan'] = nchan
     info['sfreq'] = sfreq
-    info['highpass'] = highpass if highpass is not None else 0
+    info['highpass'] = highpass if highpass is not None else 0.
     info['lowpass'] = lowpass if lowpass is not None else info['sfreq'] / 2.0
     info['line_freq'] = line_freq
 
@@ -1044,8 +1044,10 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         write_int(fid, FIFF.FIFF_MEAS_DATE, info['meas_date'])
     write_int(fid, FIFF.FIFF_NCHAN, info['nchan'])
     write_float(fid, FIFF.FIFF_SFREQ, info['sfreq'])
-    write_float(fid, FIFF.FIFF_LOWPASS, info['lowpass'])
-    write_float(fid, FIFF.FIFF_HIGHPASS, info['highpass'])
+    if info['lowpass'] is not None:
+        write_float(fid, FIFF.FIFF_LOWPASS, info['lowpass'])
+    if info['highpass'] is not None:
+        write_float(fid, FIFF.FIFF_HIGHPASS, info['highpass'])
     if info.get('line_freq') is not None:
         write_float(fid, FIFF.FIFF_LINE_FREQ, info['line_freq'])
     if data_type is not None:


### PR DESCRIPTION
closes #2652

it seems the readers are not consistent with highpass and lowpass. EGI returns None if not present while FIF sets it to 0 and sfreq / 2 if not available.

thoughts?