### PR TITLE
Added epoch-based covariance estimation method

### DIFF
--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -73,8 +73,8 @@ def test_csp():
     # test covariance estimation methods (results should be roughly equal)
     csp_epochs = CSP(cov_est="epoch")
     csp_epochs.fit(epochs_data, y)
-    assert_array_almost_equal(csp.filters_, csp_epochs.filters_, 0)
-    assert_array_almost_equal(csp.patterns_, csp_epochs.patterns_, 0)
+    assert_array_almost_equal(csp.filters_, csp_epochs.filters_, -1)
+    assert_array_almost_equal(csp.patterns_, csp_epochs.patterns_, -1)
 
     # make sure error is raised for undefined estimation method
     csp_fail = CSP(cov_est="undefined")

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -70,6 +70,15 @@ def test_csp():
     csp.plot_filters(epochs.info, components=components, res=12,
                      show=False)
 
+    # test covariance estimation methods (results should be roughly equal)
+    csp_epochs = CSP(cov_est="epoch")
+    csp_epochs.fit(epochs_data, y)
+    assert_array_almost_equal(csp.filters_, csp_epochs.filters_, 0)
+    assert_array_almost_equal(csp.patterns_, csp_epochs.patterns_, 0)
+
+    # make sure error is raised for undefined estimation method
+    csp_fail = CSP(cov_est="undefined")
+    assert_raises(ValueError, csp_fail.fit, epochs_data, y)
 
 @requires_sklearn
 def test_regularized_csp():

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -80,6 +80,7 @@ def test_csp():
     csp_fail = CSP(cov_est="undefined")
     assert_raises(ValueError, csp_fail.fit, epochs_data, y)
 
+
 @requires_sklearn
 def test_regularized_csp():
     """Test Common Spatial Patterns algorithm using regularized covariance


### PR DESCRIPTION
Following the discussion in https://github.com/scot-dev/scot/issues/64, I added a second way to estimate the two covariance matrices. By default, the previous method (`concat`) is used, but maybe this should be changed to the new method (`epoch`) in a future release because that's how most papers describe CSP.