### PR TITLE
[MRG+1]: vectorize predictions for the standard time gen case (window-size == 1)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
     - Add reader for CTF data in :func:`mne.io.read_raw_ctf` by `Eric Larson`_
 
     - Add support for Brainvision v2 by `Teon Brooks`_
+    
+    - Improve speed of generalization across time decoding up to a factor of seven by `Jean-Remi King`_ and `Federico Raimondo`_ and `Denis Engemann`_.
 
 BUG
 ~~~

--- a/examples/decoding/plot_decoding_time_generalization.py
+++ b/examples/decoding/plot_decoding_time_generalization.py
@@ -45,7 +45,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                     reject=dict(mag=1.5e-12), decim=decim, verbose=False)
 
 # Define decoder. The decision function is employed to use cross-validation
-gat = GeneralizationAcrossTime(predict_mode='cross-validation', n_jobs=2)
+gat = GeneralizationAcrossTime(predict_mode='cross-validation', n_jobs=1)
 
 # fit and score
 gat.fit(epochs)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -99,7 +99,6 @@ def test_generalization_across_time():
     assert_equal("<DecodingTime | start: -0.200 (s), stop: 0.499 (s), step: "
                  "0.050 (s), length: 0.050 (s), n_time_windows: 15 x 15>",
                  "%s" % gat.test_times_)
-
     # the y-check
     gat.predict_mode = 'mean-prediction'
     epochs2.events[:, 2] += 10
@@ -130,6 +129,7 @@ def test_generalization_across_time():
     assert_true(gat is gat2)  # return self
     assert_true(hasattr(gat2, 'cv_'))
     assert_true(gat2.cv_ != gat.cv)
+
     scores = gat.score(epochs)
     assert_true(isinstance(scores, list))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -99,6 +99,7 @@ def test_generalization_across_time():
     assert_equal("<DecodingTime | start: -0.200 (s), stop: 0.499 (s), step: "
                  "0.050 (s), length: 0.050 (s), n_time_windows: 15 x 15>",
                  "%s" % gat.test_times_)
+
     # the y-check
     gat.predict_mode = 'mean-prediction'
     epochs2.events[:, 2] += 10
@@ -129,7 +130,6 @@ def test_generalization_across_time():
     assert_true(gat is gat2)  # return self
     assert_true(hasattr(gat2, 'cv_'))
     assert_true(gat2.cv_ != gat.cv)
-
     scores = gat.score(epochs)
     assert_true(isinstance(scores, list))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -237,7 +237,9 @@ def test_generalization_across_time():
         gat.fit(epochs)
 
     gat.predict(epochs)
-    assert_raises(ValueError, gat.predict, epochs[:10])
+    assert_raises(IndexError, gat.predict, epochs[:10])
+
+    # TODO JRK: test GAT with non-exhaustive CV (eg. train on 80%, test on 10%)
 
     # Check that still works with classifier that output y_pred with
     # shape = (n_trials, 1) instead of (n_trials,)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -11,6 +11,7 @@ import copy
 from ..io.pick import pick_types
 from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
+from ..utils import logger
 
 
 class _DecodingTime(dict):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -362,7 +362,6 @@ def _predict_slices(X, estimators, cv, slices, predict_mode):
     return out
 
 
-#@profile
 def _predict_time_loop(X, estimators, cv, slices, predict_mode):
     """Aux function of GeneralizationAcrossTime
 
@@ -664,7 +663,7 @@ def _sliding_window(times, window_params, sfreq):
 
     return window_params
 
-#@profile
+
 def _predict(X, estimators, is_single_time_sample):
     """Aux function of GeneralizationAcrossTime
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -388,22 +388,20 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
                 these predictions into a single estimate per sample.
         Default: 'cross-validation'
     """
-    n_epochs = len(X)
+    n_epochs, _, n_times = X.shape
     y_pred = list()
 
     # check whether the GAT is based on window length = 1-time-sample
     # Note that we have to check i) that slices' step = 1 and ii) that slices
     # are consecutive.
-    expected_start = np.arange(len(slices))
-    is_single_time_sample = not(
-        any(len(s) != 1 for s in slices) or
-        not np.array_equal([sl[0] for sl in slices], expected_start) or
-        slices[-1][0] != X.shape[0])
-
+    expected_start = np.arange(n_times)
+    is_single_time_sample = np.array_equal([ii for sl in slices for ii in sl],
+                                           expected_start)
     msg = 'vectoring predictions across testing times'
     if is_single_time_sample:
         # in simple mode, we don't need to iterate over time slices
         slices = [slice(expected_start[0], expected_start[-1] + 1, 1)]
+    else:
         msg = 'not ' + msg + ', using a time window with length > 1'
     logger.info(msg)
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -421,13 +421,12 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
     expected_start = np.arange(n_times)
     is_single_time_sample = np.array_equal([ii for sl in slices for ii in sl],
                                            expected_start)
-    msg = 'vectoring predictions across testing times'
     if is_single_time_sample:
         # In simple mode, we avoid iterating over time slices.
         slices = [slice(expected_start[0], expected_start[-1] + 1, 1)]
     else:
-        msg = 'not ' + msg + ', using a time window with length > 1'
-    logger.info(msg)
+        logger.warning('not vectorizing predictions across testing times, '
+                       'using a time window with length > 1')
 
     # Iterate over testing times. If is_single_time_sample, then 1 iteration.
     y_pred = list()

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -389,23 +389,6 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
         Default: 'cross-validation'
     """
     n_epochs = len(X)
-    # Loop across testing slices
-
-    if predict_mode == 'cross-validation':
-        # Check that training cv and predicting cv match
-        if (len(estimators) != len(cv)) or (cv.n != n_epochs):
-            raise ValueError(
-                'When `predict_mode = "cross-validation"`, the training '
-                'and predicting cv schemes must be identical.')
-        all_test = np.concatenate(list(zip(*cv))[-1])
-        test_slices = []
-        start = 0
-        for _, test in cv:
-            l = len(test)
-            stop = start + l
-            test_slices.append(slice(start, stop, 1))
-            start += l
-
     y_pred = list()
 
     # check whether the GAT is based on window length = 1-time-sample
@@ -437,6 +420,20 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
             y_pred.append(_predict(X_pred, estimators,
                           is_single_time_sample=is_single_time_sample))
         elif predict_mode == 'cross-validation':
+            # Check that training cv and predicting cv match
+            if (len(estimators) != len(cv)) or (cv.n != n_epochs):
+                raise ValueError(
+                    'When `predict_mode = "cross-validation"`, the training '
+                    'and predicting cv schemes must be identical.')
+            all_test = np.concatenate(list(zip(*cv))[-1])
+            test_slices = []
+            start = 0
+            for _, test in cv:
+                l = len(test)
+                stop = start + l
+                test_slices.append(slice(start, stop, 1))
+                start += l
+
             X_t = X_pred[all_test]
             for k, (train, test) in enumerate(cv):
                 # Single trial predictions

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -396,7 +396,7 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
             raise ValueError(
                 'When `predict_mode = "cross-validation"`, the training '
                 'and predicting cv schemes must be identical.')
-        all_test = np.concatenate(zip(*cv)[-1])
+        all_test = np.concatenate(list(zip(*cv))[-1])
         test_slices = []
         start = 0
         for _, test in cv:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -424,11 +424,14 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode):
         is_single_time_sample = False
     elif slices[-1].stop != X.shape[-1]:
         is_single_time_sample = False
+
+    msg = 'vectoring predictions across times'
     if is_single_time_sample:
         # in simple mode, we don't need to iterate over time slices
         slices = [slice(expected_start[0], expected_stop[-1], 1)]
+        msg = 'not ' + msg + ', using a time window with length > 1'
+    logger.info(msg)
 
-    # XXX EHN: This loop should be parallelized in a similar way to fit()
     for t, indices in enumerate(slices):
         # Flatten features in case of multiple time samples given to the
         # estimators


### PR DESCRIPTION
Joint [pair programming](https://en.wikipedia.org/wiki/Pair_programming) work with @fraimondo and @kingjr to make the time-gen considerably faster.
It looks as if we managed to impose a performance function that scales linearly with n_times. On MNE-Examples with we observed 6 seconds instead of 50 seconds single CPU time.

cc @agramfort @jona-sassenhagen @cmoutard @jdsitt

Let's see what is left to be done.