### PR TITLE
[MRG] ENH add explained_variance to PCA

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,8 @@ Changelog
     
     - Improve speed of generalization across time :class:`mne.decoding.GeneralizationAcrossTime` decoding up to a factor of seven by `Jean-Remi King`_ and `Federico Raimondo`_ and `Denis Engemann`_.
 
+    - Add the explained variance for each principal component, `explained_var`, key to the :class:`mne.io.proj.Projection` by `Teon Brooks`_
+
 BUG
 ~~~
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -424,7 +424,7 @@ def compute_raw_covariance(raw, tmin=None, tmax=None, tstep=0.2,
     info = pick_info(raw.info, picks)
     idx_by_type = channel_indices_by_type(info)
 
-    # Read data in chuncks
+    # Read data in chunks
     for first in range(start, stop, step):
         last = first + step
         if last >= stop:

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -343,7 +343,7 @@ def _read_proj(fid, node, verbose=None):
 
         tag = find_tag(fid, item, FIFF.FIFF_MNE_ICA_PCA_EXPLAINED_VAR)
         if tag is not None:
-            explained_var = bool(tag.data)
+            explained_var = tag.data
         else:
             explained_var = None
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -341,6 +341,12 @@ def _read_proj(fid, node, verbose=None):
         else:
             active = False
 
+        tag = find_tag(fid, item, FIFF.FIFF_MNE_ICA_PCA_EXPLAINED_VAR)
+        if tag is not None:
+            explained_var = bool(tag.data)
+        else:
+            explained_var = None
+
         # handle the case when data is transposed for some reason
         if data.shape[0] == len(names) and data.shape[1] == nvec:
             data = data.T
@@ -352,7 +358,8 @@ def _read_proj(fid, node, verbose=None):
         #   Use exactly the same fields in data as in a named matrix
         one = Projection(kind=kind, active=active, desc=desc,
                          data=dict(nrow=nvec, ncol=nchan, row_names=None,
-                                   col_names=names, data=data))
+                                   col_names=names, data=data),
+                         explained_var=explained_var)
 
         projs.append(one)
 
@@ -401,6 +408,9 @@ def _write_proj(fid, projs):
         write_int(fid, FIFF.FIFF_MNE_PROJ_ITEM_ACTIVE, proj['active'])
         write_float_matrix(fid, FIFF.FIFF_PROJ_ITEM_VECTORS,
                            proj['data']['data'])
+        if proj['explained_var'] is not None:
+            write_float(fid, FIFF.FIFF_MNE_ICA_PCA_EXPLAINED_VAR,
+                        proj['explained_var'])
         end_block(fid, FIFF.FIFFB_PROJ_ITEM)
 
     end_block(fid, FIFF.FIFFB_PROJ)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -637,11 +637,13 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
         raise ValueError('Cannot create EEG average reference projector '
                          '(no EEG data found)')
     vec = np.ones((1, n_eeg)) / n_eeg
+    explained_var = None
     eeg_proj_data = dict(col_names=eeg_names, row_names=None,
                          data=vec, nrow=1, ncol=n_eeg)
     eeg_proj = Projection(active=activate, data=eeg_proj_data,
                           desc='Average EEG reference',
-                          kind=FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF)
+                          kind=FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF,
+                          explained_var=explained_var)
     return eeg_proj
 
 

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -34,6 +34,17 @@ def test_compute_proj_ecg():
         # heart rate at least 0.5 Hz, but less than 3 Hz
         assert_true(events.shape[0] > 0.5 * dur_use and
                     events.shape[0] < 3 * dur_use)
+        ssp_ecg = [proj for proj in projs if proj['desc'].startswith('ECG')]
+        # check that the first principal component have a certain minimum
+        ssp_ecg = [proj for proj in ssp_ecg if 'PCA-01' in proj['desc']]
+        thresh_eeg, thresh_axial, thresh_planar = .9, .3, .1
+        for proj in ssp_ecg:
+            if 'planar' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_planar)
+            elif 'axial' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_axial)
+            elif 'eeg' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_eeg)
         # XXX: better tests
 
         # without setting a bad channel, this should throw a warning
@@ -62,6 +73,17 @@ def test_compute_proj_eog():
         assert_true(len(projs) == (7 + n_projs_init))
         assert_true(np.abs(events.shape[0] -
                     np.sum(np.less(eog_times, dur_use))) <= 1)
+        ssp_eog = [proj for proj in projs if proj['desc'].startswith('EOG')]
+        # check that the first principal component have a certain minimum
+        ssp_eog = [proj for proj in ssp_eog if 'PCA-01' in proj['desc']]
+        thresh_eeg, thresh_axial, thresh_planar = .9, .3, .1
+        for proj in ssp_eog:
+            if 'planar' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_planar)
+            elif 'axial' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_axial)
+            elif 'eeg' in proj['desc']:
+                assert_true(proj['explained_var'] > thresh_eeg)
         # XXX: better tests
 
         # This will throw a warning b/c simplefilter('always')

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -102,11 +102,10 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, n_epochs, desc_prefix,
         U, Sexp2, _ = linalg.svd(data_ind, full_matrices=False,
                                  overwrite_a=True)
         U = U[:, :n]
-        exp_var_ = Sexp2 / n_epochs
-        exp_var_ = exp_var_ / exp_var_.sum()
-        exp_var_ = exp_var_[:n]
-        exp_var = dict()
-        for k, temp in enumerate(zip(U.T, exp_var_)):
+        exp_var = Sexp2 / n_epochs
+        exp_var = exp_var / exp_var.sum()
+        exp_var = exp_var[:n]
+        for k, temp in enumerate(zip(U.T, exp_var)):
             u, var = temp
             proj_data = dict(col_names=names, row_names=None,
                              data=u[np.newaxis, :], nrow=1, ncol=u.size)

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -114,15 +114,15 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, n_epochs, desc_prefix,
             logger.info("Adding projection: %s" % this_desc)
             proj = Projection(active=False, data=proj_data,
                               desc=this_desc, kind=1)
+            proj.explained_variance_ = var
             projs.append(proj)
-            exp_var[this_desc] = var
 
-    return projs, exp_var
+    return projs
 
 
 @verbose
 def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
-                        desc_prefix=None, explained_variance, verbose=None):
+                        desc_prefix=None, verbose=None):
     """Compute SSP (spatial space projection) vectors on Epochs
 
     Parameters
@@ -140,9 +140,6 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
     desc_prefix : str | None
         The description prefix to use. If None, one will be created based on
         the event_id, tmin, and tmax.
-    explained_variance : bool
-        If True, this will return the percentage of explained variance in each
-        of the selected principal components.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -150,9 +147,6 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
     -------
     projs: list
         List of projection vectors
-    explained_variance: dict (optional)
-        A dict of principal components and the percentages of explained
-        variance. This is only returned if explained_variance is True.
 
     See Also
     --------
@@ -169,12 +163,8 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
         event_id = 'Multiple-events'
     if desc_prefix is None:
         desc_prefix = "%s-%-.3f-%-.3f" % (event_id, epochs.tmin, epochs.tmax)
-    if not explained_variance:
-        return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, n_epochs,
-                             desc_prefix)[0]
-    else:
-        return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, n_epochs,
-                             desc_prefix)
+    return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, n_epochs,
+                         desc_prefix)
 
 
 def _compute_cov_epochs(epochs, n_jobs):
@@ -206,9 +196,6 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2,
         Number of vectors for magnetometers
     n_eeg : int
         Number of vectors for EEG channels
-    explained_variance : bool
-        If True, this will return the percentage of explained variance in each
-        of the selected principal components.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -216,9 +203,6 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2,
     -------
     projs : list
         List of projection vectors
-    explained_variance: dict (optional)
-        A dict of principal components and the percentages of explained
-        variance. This is only returned if explained_variance is True.
 
     See Also
     --------
@@ -227,12 +211,8 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2,
     data = np.dot(evoked.data, evoked.data.T)  # compute data covariance
     n_epochs = 1
     desc_prefix = "%-.3f-%-.3f" % (evoked.times[0], evoked.times[-1])
-    if not explained_variance:
-        return _compute_proj(data, evoked.info, n_grad, n_mag, n_eeg, n_epochs,
-                             desc_prefix)[0]
-    else:
-        return _compute_proj(data, evoked.info, n_grad, n_mag, n_eeg, n_epochs,
-                             desc_prefix)
+    return _compute_proj(data, evoked.info, n_grad, n_mag, n_eeg, n_epochs,
+                         desc_prefix)
 
 
 @verbose
@@ -265,9 +245,6 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
         Epoch flat configuration (see Epochs).
     n_jobs : int
         Number of jobs to use to compute covariance.
-    explained_variance : bool
-        If True, this will return the percentage of explained variance in each
-        of the selected principal components.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -275,9 +252,6 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
     -------
     projs: list
         List of projection vectors
-    explained_variance: dict (optional)
-        A dict of principal components and the percentages of explained
-        variance. This is only returned if explained_variance is True.
 
     See Also
     --------
@@ -310,8 +284,6 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
     desc_prefix = "Raw-%-.3f-%-.3f" % (start, stop)
     projs = _compute_proj(data, info, n_grad, n_mag, n_eeg, n_epochs,
                           desc_prefix)
-    if not explained_variance:
-        projs = projs[0]
     return projs
 
 

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -113,8 +113,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, n_epochs, desc_prefix,
             this_desc = "%s-%s-PCA-%02d" % (desc, desc_prefix, k + 1)
             logger.info("Adding projection: %s" % this_desc)
             proj = Projection(active=False, data=proj_data,
-                              desc=this_desc, kind=1)
-            proj.explained_variance_ = var
+                              desc=this_desc, kind=1, explained_var=var)
             projs.append(proj)
 
     return projs

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -103,8 +103,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix, verbose=None):
         U = U[:, :n]
         exp_var = Sexp2 / Sexp2.sum()
         exp_var = exp_var[:n]
-        for k, temp in enumerate(zip(U.T, exp_var)):
-            u, var = temp
+        for k, (u, var) in enumerate(zip(U.T, exp_var)):
             proj_data = dict(col_names=names, row_names=None,
                              data=u[np.newaxis, :], nrow=1, ncol=u.size)
             this_desc = "%s-%s-PCA-%02d" % (desc, desc_prefix, k + 1)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -123,7 +123,8 @@ def test_compute_proj_epochs():
             corr = np.corrcoef(p1_data, p2_data)[0, 1]
             assert_array_almost_equal(corr, 1.0, 5)
             if p2['explained_var']:
-                assert_true(p1['explained_var'] == p2['explained_var'])
+                assert_array_almost_equal(p1['explained_var'],
+                                          p2['explained_var'])
 
     # test that you can compute the projection matrix
     projs = activate_proj(projs)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -122,6 +122,8 @@ def test_compute_proj_epochs():
                 p2_data = p2_data[:, mask]
             corr = np.corrcoef(p1_data, p2_data)[0, 1]
             assert_array_almost_equal(corr, 1.0, 5)
+            if p2['explained_var']:
+                assert_true(p1['explained_var'] == p2['explained_var'])
 
     # test that you can compute the projection matrix
     projs = activate_proj(projs)


### PR DESCRIPTION
closes #2341. this is written to return an optional `explained_variance`. I am not sure if this is pythonic. The other option would be to make a separate function but then it wouldn't be DRY.