### PR TITLE
[MRG] Add warnings for EEG electrodes not in montage

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -638,9 +638,9 @@ def _auto_topomap_coords(info, picks):
             for elec_i in np.unique(squareform(dist < 1e-10).nonzero()[0])
         ]
 
-        raise ValueError('The following electrodes have the same position:\n' +
-                         '    ' + str(problematic_electrodes) + '\nThis causes'
-                         ' problems during visualization.')
+        raise ValueError('The following electrodes have overlapping positions:'
+                         '\n    ' + str(problematic_electrodes) + '\nThis '
+                         'causes problems during visualization.')
 
     x, y, z = locs3d.T
     az, el, r = _cartesian_to_sphere(x, y, z)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -573,7 +573,7 @@ def _auto_topomap_coords(info, picks):
     locs : array, shape = (n_sensors, 2)
         An array of positions of the 2 dimensional map.
     """
-    from scipy.spatial.distance import pdist
+    from scipy.spatial.distance import pdist, squareform
 
     chs = [info['chs'][i] for i in picks]
 
@@ -631,8 +631,16 @@ def _auto_topomap_coords(info, picks):
         locs3d = np.array([eeg_ch_locs[ch['ch_name']] for ch in chs])
 
     # Duplicate points cause all kinds of trouble during visualization
-    if np.min(pdist(locs3d)) < 1e-10:
-        raise ValueError('Electrode positions must be unique.')
+    dist = pdist(locs3d)
+    if np.min(dist) < 1e-10:
+        problematic_electrodes = [
+            info['ch_names'][elec_i]
+            for elec_i in np.unique(squareform(dist < 1e-10).nonzero()[0])
+        ]
+
+        raise ValueError('The following electrodes have the same position:\n' +
+                         '    ' + str(problematic_electrodes) + '\nThis causes'
+                         ' problems during visualization.')
 
     x, y, z = locs3d.T
     az, el, r = _cartesian_to_sphere(x, y, z)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -635,7 +635,7 @@ def _auto_topomap_coords(info, picks):
     if np.min(dist) < 1e-10:
         problematic_electrodes = [
             info['ch_names'][elec_i]
-            for elec_i in np.unique(squareform(dist < 1e-10).nonzero()[0])
+            for elec_i in squareform(dist < 1e-10).any(axis=0).nonzero()[0]
         ]
 
         raise ValueError('The following electrodes have overlapping positions:'

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -540,7 +540,7 @@ def _set_montage(info, montage):
             not_found_names = [info['ch_names'][ch] for ch in not_found]
             warnings.warn('The following EEG sensors did not have a position '
                           'specified in the selected montage: ' +
-                          str(not_found_names) +'. Their position has been '
+                          str(not_found_names) + '. Their position has been '
                           'left untouched.')
 
     elif isinstance(montage, DigMontage):

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -11,6 +11,7 @@
 
 import os
 import os.path as op
+import warnings
 
 import numpy as np
 
@@ -19,6 +20,7 @@ from .channels import _contains_ch_type
 from ..transforms import (_sphere_to_cartesian, apply_trans,
                           get_ras_to_neuromag_trans)
 from ..io.meas_info import _make_dig_points, _read_dig_points
+from ..io.pick import pick_types
 from ..externals.six import string_types
 from ..externals.six.moves import map
 
@@ -490,7 +492,7 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
 
 
 def _set_montage(info, montage):
-    """Apply montage to data.
+    """Apply montage to data
 
     With a Montage, this function will replace the EEG channel names and
     locations with the values specified for the particular montage.
@@ -498,20 +500,25 @@ def _set_montage(info, montage):
     With a DigMontage, this function will replace the digitizer info with
     the values specified for the particular montage.
 
-    Note: This function will change the info variable in place.
+    Usually, a montage is expected to contain the positions of all EEG
+    electrodes and a warning is raised when this is not the case.
 
     Parameters
     ----------
     info : instance of Info
         The measurement info to update.
-    montage : instance of Montage
+    montage : instance of Montage | instance of DigMontage
         The montage to apply.
+
+    Notes
+    -----
+    This function will change the info variable in place.
     """
     if isinstance(montage, Montage):
         if not _contains_ch_type(info, 'eeg'):
             raise ValueError('No EEG channels found.')
 
-        sensors_found = False
+        sensors_found = []
         for pos, ch_name in zip(montage.pos, montage.ch_names):
             if ch_name not in info['ch_names']:
                 continue
@@ -519,12 +526,23 @@ def _set_montage(info, montage):
             ch_idx = info['ch_names'].index(ch_name)
             info['ch_names'][ch_idx] = ch_name
             info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
-            sensors_found = True
+            sensors_found.append(ch_idx)
 
-        if not sensors_found:
+        if len(sensors_found) == 0:
             raise ValueError('None of the sensors defined in the montage were '
                              'found in the info structure. Check the channel '
                              'names.')
+
+        eeg_sensors = pick_types(info, meg=False, ref_meg=False, eeg=True,
+                                 exclude=[])
+        not_found = np.setdiff1d(eeg_sensors, sensors_found)
+        if len(not_found) > 0:
+            not_found_names = [info['ch_names'][ch] for ch in not_found]
+            warnings.warn('The following EEG sensors did not have a position '
+                          'specified in the selected montage: ' +
+                          str(not_found_names) +'. Their position has been '
+                          'left untouched.')
+
     elif isinstance(montage, DigMontage):
         dig = _make_dig_points(nasion=montage.nasion, lpa=montage.lpa,
                                rpa=montage.rpa, hpi=montage.hpi,

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -3,8 +3,9 @@
 # License: BSD (3-clause)
 
 import os.path as op
+import warnings
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_almost_equal,
@@ -138,6 +139,12 @@ def test_montage():
     assert_array_equal(pos3, montage.pos)
     assert_equal(montage.ch_names, evoked.info['ch_names'])
 
+    # Warning should be raised when some EEG are not specified in the montage
+    with warnings.catch_warnings(record=True) as w:
+        info = create_info(montage.ch_names + ['foo', 'bar'], 1e3,
+                           ['eeg'] * (len(montage.ch_names) + 2))
+        _set_montage(info, montage)
+        assert_true(len(w) == 1)
 
 def test_read_dig_montage():
     """Test read_dig_montage"""

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -146,6 +146,7 @@ def test_montage():
         _set_montage(info, montage)
         assert_true(len(w) == 1)
 
+
 def test_read_dig_montage():
     """Test read_dig_montage"""
     names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']


### PR DESCRIPTION
When a montage is applied, it is assumed that all the EEG channels in
the data have position information specified in the montage file. Raise
a warning if this is not the case.

Furthermore, the warning raised in `_auto_topomap_coords` when multiple
channels have the same position, has been extended to list the offending
channels.