### PR TITLE
MRG: Allow MF to run on other systems

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -10,7 +10,6 @@ import os
 import os.path as op
 import shutil
 import glob
-import warnings
 
 import numpy as np
 from scipy import linalg
@@ -854,8 +853,12 @@ def fit_sphere_to_headshape(info, dig_kinds=(FIFF.FIFFV_POINT_EXTRA,),
     # i.e. 108mm "radius", so let's go with 110mm
     # en.wikipedia.org/wiki/Human_head#/media/File:HeadAnthropometry.JPG
     if radius > 110.:
-        warnings.warn('Estimated head size (%0.1f mm) exceeded 99th '
-                      'percentile for adult head size' % (radius,))
+        logger.warning('Estimated head size (%0.1f mm) exceeded 99th '
+                       'percentile for adult head size' % (radius,))
+    # > 2 cm away from head center in X or Y is strange
+    if np.sqrt(np.sum(origin_head[:2] ** 2)) > 20:
+        logger.warning('(X, Y) fit (%0.1f, %0.1f) more than 20 mm from '
+                       'head frame origin' % tuple(origin_head[:2]))
     logger.info('Origin head coordinates:'.ljust(30) +
                 '%0.1f %0.1f %0.1f mm' % tuple(origin_head))
     logger.info('Origin device coordinates:'.ljust(30) +

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2605,7 +2605,7 @@ def concatenate_epochs(epochs_list):
 @verbose
 def average_movements(epochs, pos, orig_sfreq=None, picks=None, origin='auto',
                       weight_all=True, int_order=8, ext_order=3,
-                      return_mapping=False, verbose=None):
+                      ignore_ref=False, return_mapping=False, verbose=None):
     """Average data using Maxwell filtering, transforming using head positions
 
     Parameters
@@ -2639,6 +2639,10 @@ def average_movements(epochs, pos, orig_sfreq=None, picks=None, origin='auto',
         Basis regularization type, must be "in" or None.
         See :func:`mne.preprocessing.maxwell_filter` for details.
         Regularization is chosen based only on the destination position.
+    ignore_ref : bool
+        If True, do not include reference channels in compensation. This
+        option should be True for KIT files, since Maxwell filtering
+        with reference channels is not currently supported.
     return_mapping : bool
         If True, return the mapping matrix.
     verbose : bool, str, int, or None
@@ -2692,7 +2696,7 @@ def average_movements(epochs, pos, orig_sfreq=None, picks=None, origin='auto',
     logger.info('Aligning and averaging up to %s epochs'
                 % (len(epochs.events)))
     meg_picks, _, _, good_picks, coil_scale = \
-        _get_mf_picks(epochs.info, int_order, ext_order)
+        _get_mf_picks(epochs.info, int_order, ext_order, ignore_ref)
     n_channels, n_times = len(epochs.ch_names), len(epochs.times)
     other_picks = np.setdiff1d(np.arange(n_channels), meg_picks)
     data = np.zeros((n_channels, n_times))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2695,7 +2695,7 @@ def average_movements(epochs, pos, orig_sfreq=None, picks=None, origin='auto',
 
     logger.info('Aligning and averaging up to %s epochs'
                 % (len(epochs.events)))
-    meg_picks, _, _, good_picks, coil_scale = \
+    meg_picks, _, _, good_picks, coil_scale, _ = \
         _get_mf_picks(epochs.info, int_order, ext_order, ignore_ref)
     n_channels, n_times = len(epochs.ch_names), len(epochs.times)
     other_picks = np.setdiff1d(np.arange(n_channels), meg_picks)
@@ -2766,8 +2766,8 @@ def average_movements(epochs, pos, orig_sfreq=None, picks=None, origin='auto',
         # so we do not provide the option here.
         S_recon /= coil_scale
         # Invert
-        pS_ave = _col_norm_pinv(S_decomp)[:n_in]
-        pS_ave *= coil_scale[good_picks].T
+        pS_ave = _col_norm_pinv(S_decomp)[0][:n_in]
+        pS_ave *= decomp_coil_scale.T
         # Get mapping matrix
         mapping = np.dot(S_recon, pS_ave)
         # Apply mapping

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -38,6 +38,9 @@ def _read_coil_defs(elekta_defs=False, verbose=None):
     elekta_defs : bool
         If true, prepend Elekta's coil definitions for numerical
         integration (from Abramowitz and Stegun section 25.4.62).
+        Note that this will likely cause duplicate coil definitions,
+        so the first matching coil should be selected for optimal
+        integration parameters.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
         Defaults to raw.verbose.

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -30,16 +30,14 @@ _accuracy_dict = dict(normal=FIFF.FWD_COIL_ACCURACY_NORMAL,
 
 
 @verbose
-def _read_coil_defs(fname=None, elekta_defs=False, verbose=None):
+def _read_coil_defs(elekta_defs=False, verbose=None):
     """Read a coil definition file.
 
     Parameters
     ----------
-    fname : str
-        The name of the file from which coil definitions are read.
     elekta_defs : bool
-        If true, use Elekta's coil definitions for numerical integration
-        (from Abramowitz and Stegun section 25.4.62).
+        If true, prepend Elekta's coil definitions for numerical
+        integration (from Abramowitz and Stegun section 25.4.62).
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
         Defaults to raw.verbose.
@@ -53,58 +51,61 @@ def _read_coil_defs(fname=None, elekta_defs=False, verbose=None):
         cosmag contains the direction of the coils and rmag contains the
         position vector.
     """
-    if fname is None:
-        if not elekta_defs:
-            fname = op.join(op.split(__file__)[0], '..', 'data',
-                            'coil_def.dat')
-        else:
-            fname = op.join(op.split(__file__)[0], '..', 'data',
-                            'coil_def_Elekta.dat')
+    coil_dir = op.join(op.split(__file__)[0], '..', 'data')
+    coils = list()
+    if elekta_defs:
+        coils += _read_coil_def_file(op.join(coil_dir, 'coil_def_Elekta.dat'))
+    coils += _read_coil_def_file(op.join(coil_dir, 'coil_def.dat'))
+    return coils
+
+
+def _read_coil_def_file(fname):
+    """Helper to read a coil def file"""
     big_val = 0.5
+    coils = list()
     with open(fname, 'r') as fid:
         lines = fid.readlines()
-        res = dict(coils=list())
-        lines = lines[::-1]
-        while len(lines) > 0:
-            line = lines.pop()
-            if line[0] != '#':
-                vals = np.fromstring(line, sep=' ')
-                assert len(vals) in (6, 7)  # newer numpy can truncate comment
-                start = line.find('"')
-                end = len(line.strip()) - 1
-                assert line.strip()[end] == '"'
-                desc = line[start:end]
-                npts = int(vals[3])
-                coil = dict(coil_type=vals[1], coil_class=vals[0], desc=desc,
-                            accuracy=vals[2], size=vals[4], base=vals[5])
-                # get parameters of each component
-                rmag = list()
-                cosmag = list()
-                w = list()
-                for p in range(npts):
-                    # get next non-comment line
+    lines = lines[::-1]
+    while len(lines) > 0:
+        line = lines.pop()
+        if line[0] != '#':
+            vals = np.fromstring(line, sep=' ')
+            assert len(vals) in (6, 7)  # newer numpy can truncate comment
+            start = line.find('"')
+            end = len(line.strip()) - 1
+            assert line.strip()[end] == '"'
+            desc = line[start:end]
+            npts = int(vals[3])
+            coil = dict(coil_type=vals[1], coil_class=vals[0], desc=desc,
+                        accuracy=vals[2], size=vals[4], base=vals[5])
+            # get parameters of each component
+            rmag = list()
+            cosmag = list()
+            w = list()
+            for p in range(npts):
+                # get next non-comment line
+                line = lines.pop()
+                while(line[0] == '#'):
                     line = lines.pop()
-                    while(line[0] == '#'):
-                        line = lines.pop()
-                    vals = np.fromstring(line, sep=' ')
-                    assert len(vals) == 7
-                    # Read and verify data for each integration point
-                    w.append(vals[0])
-                    rmag.append(vals[[1, 2, 3]])
-                    cosmag.append(vals[[4, 5, 6]])
-                w = np.array(w)
-                rmag = np.array(rmag)
-                cosmag = np.array(cosmag)
-                size = np.sqrt(np.sum(cosmag ** 2, axis=1))
-                if np.any(np.sqrt(np.sum(rmag ** 2, axis=1)) > big_val):
-                    raise RuntimeError('Unreasonable integration point')
-                if np.any(size <= 0):
-                    raise RuntimeError('Unreasonable normal')
-                cosmag /= size[:, np.newaxis]
-                coil.update(dict(w=w, cosmag=cosmag, rmag=rmag))
-                res['coils'].append(coil)
-    logger.info('%d coil definitions read', len(res['coils']))
-    return res
+                vals = np.fromstring(line, sep=' ')
+                assert len(vals) == 7
+                # Read and verify data for each integration point
+                w.append(vals[0])
+                rmag.append(vals[[1, 2, 3]])
+                cosmag.append(vals[[4, 5, 6]])
+            w = np.array(w)
+            rmag = np.array(rmag)
+            cosmag = np.array(cosmag)
+            size = np.sqrt(np.sum(cosmag ** 2, axis=1))
+            if np.any(np.sqrt(np.sum(rmag ** 2, axis=1)) > big_val):
+                raise RuntimeError('Unreasonable integration point')
+            if np.any(size <= 0):
+                raise RuntimeError('Unreasonable normal')
+            cosmag /= size[:, np.newaxis]
+            coil.update(dict(w=w, cosmag=cosmag, rmag=rmag))
+            coils.append(coil)
+    logger.info('%d coil definitions read', len(coils))
+    return coils
 
 
 def _create_meg_coil(coilset, ch, acc, t):
@@ -117,7 +118,7 @@ def _create_meg_coil(coilset, ch, acc, t):
         raise RuntimeError('%s is not a MEG channel' % ch['ch_name'])
 
     # Simple linear search from the coil definitions
-    for coil in coilset['coils']:
+    for coil in coilset:
         if coil['coil_type'] == (ch['coil_type'] & 0xFFFF) and \
                 coil['accuracy'] == acc:
             break
@@ -278,10 +279,10 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
                         % (ncomp, info_extra))
             # We need to check to make sure these are NOT KIT refs
             if _has_kit_refs(info, picks):
-                err = ('Cannot create forward solution with KIT reference '
-                       'channels. Consider using "ignore_ref=True" in '
-                       'calculation')
-                raise NotImplementedError(err)
+                raise NotImplementedError(
+                    'Cannot create forward solution with KIT reference '
+                    'channels. Consider using "ignore_ref=True" in '
+                    'calculation')
     else:
         ncomp = 0
 

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -18,6 +18,7 @@ from mne.io.bti.bti import (_read_config, _process_bti_headshape,
                             _read_bti_header, _get_bti_dev_t,
                             _correct_trans, _get_bti_info)
 from mne.io.tests.test_raw import _test_raw_reader
+from mne.tests.common import assert_dig_allclose
 from mne.io.pick import pick_info
 from mne.io.constants import FIFF
 from mne import pick_types
@@ -105,9 +106,7 @@ def test_raw():
         assert_equal(ex.ch_names[:NCH], ra.ch_names[:NCH])
         assert_array_almost_equal(ex.info['dev_head_t']['trans'],
                                   ra.info['dev_head_t']['trans'], 7)
-        dig1, dig2 = [np.array([d['r'] for d in r_.info['dig']])
-                      for r_ in (ra, ex)]
-        assert_array_almost_equal(dig1, dig2, 18)
+        assert_dig_allclose(ex.info, ra.info)
         coil1, coil2 = [np.concatenate([d['loc'].flatten()
                         for d in r_.info['chs'][:NCH]])
                         for r_ in (ra, ex)]

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -11,6 +11,7 @@ from nose.tools import assert_raises, assert_true
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
 from mne import pick_types
+from mne.tests.common import assert_dig_allclose
 from mne.transforms import apply_trans
 from mne.io import Raw, read_raw_ctf
 from mne.io.tests.test_raw import _test_raw_reader
@@ -135,8 +136,7 @@ def test_read_ctf():
             for key in ('loc', 'cal'):
                 assert_allclose(c1[key], c2[key], atol=1e-6, rtol=1e-4,
                                 err_msg='raw.info["chs"][%d][%s]' % (ii, key))
-        for d, d_c in zip(raw.info['dig'], raw_c.info['dig']):
-            assert_allclose(d['r'], d_c['r'], atol=1e-5)
+        assert_dig_allclose(raw.info, raw_c.info)
 
         # check data match
         raw_c.save(out_fname, overwrite=True, buffer_size_sec=1.)

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -13,9 +13,9 @@ from nose.tools import assert_raises, assert_true
 import scipy.io
 
 from mne import pick_types, Epochs, find_events, read_events
+from mne.tests.common import assert_dig_allclose
 from mne.utils import run_tests_if_main
-from mne.io import Raw
-from mne.io import read_raw_kit, read_epochs_kit
+from mne.io import Raw, read_raw_kit, read_epochs_kit
 from mne.io.kit.coreg import read_sns
 from mne.io.tests.test_raw import _test_raw_reader
 
@@ -138,6 +138,6 @@ def test_ch_loc():
     # test when more than one marker file provided
     mrks = [mrk_path, mrk2_path, mrk3_path]
     read_raw_kit(sqd_path, mrks, elp_path, hsp_path, preload=False)
-
+    assert_dig_allclose(raw_py.info, raw_bin.info)
 
 run_tests_if_main()

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -138,6 +138,9 @@ def test_ch_loc():
     # test when more than one marker file provided
     mrks = [mrk_path, mrk2_path, mrk3_path]
     read_raw_kit(sqd_path, mrks, elp_path, hsp_path, preload=False)
+    # this dataset does not have the equivalent set of points :(
+    raw_bin.info['dig'] = raw_bin.info['dig'][:8]
+    raw_py.info['dig'] = raw_py.info['dig'][:8]
     assert_dig_allclose(raw_py.info, raw_bin.info)
 
 run_tests_if_main()

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -8,8 +8,7 @@ from __future__ import print_function
 import os.path as op
 import inspect
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_raises, assert_true
 import scipy.io
 

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 import os.path as op
 import inspect
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
 from nose.tools import assert_raises, assert_true
 import scipy.io
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -382,16 +382,6 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
         List of digitizer points to be added to the info['dig'].
     """
     dig = []
-    if nasion is not None:
-        nasion = np.asarray(nasion)
-        if nasion.shape == (3,):
-            dig.append({'r': nasion, 'ident': FIFF.FIFFV_POINT_NASION,
-                        'kind': FIFF.FIFFV_POINT_CARDINAL,
-                        'coord_frame':  FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('Nasion should have the shape (3,) instead of %s'
-                   % (nasion.shape,))
-            raise ValueError(msg)
     if lpa is not None:
         lpa = np.asarray(lpa)
         if lpa.shape == (3,):
@@ -401,6 +391,16 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
         else:
             msg = ('LPA should have the shape (3,) instead of %s'
                    % (lpa.shape,))
+            raise ValueError(msg)
+    if nasion is not None:
+        nasion = np.asarray(nasion)
+        if nasion.shape == (3,):
+            dig.append({'r': nasion, 'ident': FIFF.FIFFV_POINT_NASION,
+                        'kind': FIFF.FIFFV_POINT_CARDINAL,
+                        'coord_frame':  FIFF.FIFFV_COORD_HEAD})
+        else:
+            msg = ('Nasion should have the shape (3,) instead of %s'
+                   % (nasion.shape,))
             raise ValueError(msg)
     if rpa is not None:
         rpa = np.asarray(rpa)
@@ -416,7 +416,7 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
         hpi = np.asarray(hpi)
         if hpi.shape[1] == 3:
             for idx, point in enumerate(hpi):
-                dig.append({'r': point, 'ident': idx,
+                dig.append({'r': point, 'ident': idx + 1,
                             'kind': FIFF.FIFFV_POINT_HPI,
                             'coord_frame': FIFF.FIFFV_COORD_HEAD})
         else:
@@ -427,7 +427,7 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
         dig_points = np.asarray(dig_points)
         if dig_points.shape[1] == 3:
             for idx, point in enumerate(dig_points):
-                dig.append({'r': point, 'ident': idx,
+                dig.append({'r': point, 'ident': idx + 1,
                             'kind': FIFF.FIFFV_POINT_EXTRA,
                             'coord_frame': FIFF.FIFFV_COORD_HEAD})
         else:

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -157,7 +157,7 @@ def _triage_meg_pick(ch, meg):
 def _check_meg_type(meg, allow_auto=False):
     """Helper to ensure a valid meg type"""
     if isinstance(meg, string_types):
-        allowed_types = ['grad', 'mag']
+        allowed_types = ['grad', 'mag', 'planar1', 'planar2']
         allowed_types += ['auto'] if allow_auto else []
         if meg not in allowed_types:
             raise ValueError('meg value must be one of %s or bool, not %s'
@@ -191,7 +191,8 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
         If True include EMG channels.
     ref_meg: bool | str
         If True include CTF / 4D reference channels. If 'auto', the reference
-        channels are only included if compensations are present.
+        channels are only included if compensations are present. Can also be
+        the string options from `meg`.
     misc : bool
         If True include miscellaneous analog channels.
     resp : bool

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -138,6 +138,32 @@ def pick_channels_regexp(ch_names, regexp):
     return [k for k, name in enumerate(ch_names) if r.match(name)]
 
 
+def _triage_meg_pick(ch, meg):
+    """Helper to triage an MEG pick type"""
+    if meg is True:
+        return True
+    elif ch['unit'] == FIFF.FIFF_UNIT_T_M:
+        if meg == 'grad':
+            return True
+        elif meg == 'planar1' and ch['ch_name'].endswith('2'):
+            return True
+        elif meg == 'planar2' and ch['ch_name'].endswith('3'):
+            return True
+    elif (meg == 'mag' and ch['unit'] == FIFF.FIFF_UNIT_T):
+        return True
+    return False
+
+
+def _check_meg_type(meg, allow_auto=False):
+    """Helper to ensure a valid meg type"""
+    if isinstance(meg, string_types):
+        allowed_types = ['grad', 'mag']
+        allowed_types += ['auto'] if allow_auto else []
+        if meg not in allowed_types:
+            raise ValueError('meg value must be one of %s or bool, not %s'
+                             % (allowed_types, meg))
+
+
 def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
                emg=False, ref_meg='auto', misc=False, resp=False, chpi=False,
                exci=False, ias=False, syst=False, seeg=False,
@@ -213,28 +239,16 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
                          ' If only one channel is to be excluded, use '
                          '[ch_name] instead of passing ch_name.')
 
-    if isinstance(ref_meg, string_types):
-        if ref_meg != 'auto':
-            raise ValueError('ref_meg has to be either a bool or \'auto\'')
-
+    _check_meg_type(ref_meg, allow_auto=True)
+    _check_meg_type(meg)
+    if isinstance(ref_meg, string_types) and ref_meg == 'auto':
         ref_meg = ('comps' in info and info['comps'] is not None and
                    len(info['comps']) > 0)
 
     for k in range(nchan):
         kind = info['chs'][k]['kind']
         if kind == FIFF.FIFFV_MEG_CH:
-            if meg is True:
-                pick[k] = True
-            elif info['chs'][k]['unit'] == FIFF.FIFF_UNIT_T_M:
-                if meg == 'grad':
-                    pick[k] = True
-                elif meg == 'planar1' and info['ch_names'][k].endswith('2'):
-                    pick[k] = True
-                elif meg == 'planar2' and info['ch_names'][k].endswith('3'):
-                    pick[k] = True
-            elif (meg == 'mag' and
-                  info['chs'][k]['unit'] == FIFF.FIFF_UNIT_T):
-                pick[k] = True
+            pick[k] = _triage_meg_pick(info['chs'][k], meg)
         elif kind == FIFF.FIFFV_EEG_CH and eeg:
             pick[k] = True
         elif kind == FIFF.FIFFV_STIM_CH and stim:
@@ -248,7 +262,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
         elif kind == FIFF.FIFFV_MISC_CH and misc:
             pick[k] = True
         elif kind == FIFF.FIFFV_REF_MEG_CH and ref_meg:
-            pick[k] = True
+            pick[k] = _triage_meg_pick(info['chs'][k], ref_meg)
         elif kind == FIFF.FIFFV_RESP_CH and resp:
             pick[k] = True
         elif kind == FIFF.FIFFV_SYST_CH and syst:

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -1,21 +1,82 @@
+import os.path as op
+import inspect
+
 from nose.tools import assert_equal, assert_raises
 from numpy.testing import assert_array_equal
 import numpy as np
-import os.path as op
 
 from mne import (pick_channels_regexp, pick_types, Epochs,
                  read_forward_solution, rename_channels,
                  pick_info, pick_channels, __file__, create_info)
-from mne.io import Raw, RawArray
+from mne.io import Raw, RawArray, read_raw_bti, read_raw_kit
 from mne.io.pick import (channel_indices_by_type, channel_type,
                          pick_types_forward, _picks_by_type)
 from mne.io.constants import FIFF
 from mne.datasets import testing
 from mne.utils import run_tests_if_main
 
+io_dir = op.join(op.dirname(inspect.getfile(inspect.currentframe())), '..')
 data_path = testing.data_path(download=False)
 fname_meeg = op.join(data_path, 'MEG', 'sample',
                      'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+
+
+def test_pick_refs():
+    """Test picking of reference sensors
+    """
+    infos = list()
+    # KIT
+    kit_dir = op.join(io_dir, 'kit', 'tests', 'data')
+    sqd_path = op.join(kit_dir, 'test.sqd')
+    mrk_path = op.join(kit_dir, 'test_mrk.sqd')
+    elp_path = op.join(kit_dir, 'test_elp.txt')
+    hsp_path = op.join(kit_dir, 'test_hsp.txt')
+    raw_kit = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path)
+    infos.append(raw_kit.info)
+    # BTi
+    bti_dir = op.join(io_dir, 'bti', 'tests', 'data')
+    bti_pdf = op.join(bti_dir, 'test_pdf_linux')
+    bti_config = op.join(bti_dir, 'test_config_linux')
+    bti_hs = op.join(bti_dir, 'test_hs_linux')
+    raw_bti = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
+    infos.append(raw_bti.info)
+    # CTF
+    fname_ctf_raw = op.join(io_dir, 'tests', 'data', 'test_ctf_comp_raw.fif')
+    raw_ctf = Raw(fname_ctf_raw, compensation=2)
+    infos.append(raw_ctf.info)
+    for info in infos:
+        info['bads'] = []
+        assert_raises(ValueError, pick_types, info, meg='foo')
+        assert_raises(ValueError, pick_types, info, ref_meg='foo')
+        picks_meg_ref = pick_types(info, meg=True, ref_meg=True)
+        picks_meg = pick_types(info, meg=True, ref_meg=False)
+        picks_ref = pick_types(info, meg=False, ref_meg=True)
+        assert_array_equal(picks_meg_ref,
+                           np.sort(np.concatenate([picks_meg, picks_ref])))
+        picks_grad = pick_types(info, meg='grad', ref_meg=False)
+        picks_ref_grad = pick_types(info, meg=False, ref_meg='grad')
+        picks_meg_ref_grad = pick_types(info, meg='grad', ref_meg='grad')
+        assert_array_equal(picks_meg_ref_grad,
+                           np.sort(np.concatenate([picks_grad,
+                                                   picks_ref_grad])))
+        picks_mag = pick_types(info, meg='mag', ref_meg=False)
+        picks_ref_mag = pick_types(info, meg=False, ref_meg='mag')
+        picks_meg_ref_mag = pick_types(info, meg='mag', ref_meg='mag')
+        assert_array_equal(picks_meg_ref_mag,
+                           np.sort(np.concatenate([picks_mag,
+                                                   picks_ref_mag])))
+        assert_array_equal(picks_meg,
+                           np.sort(np.concatenate([picks_mag, picks_grad])))
+        assert_array_equal(picks_ref,
+                           np.sort(np.concatenate([picks_ref_mag,
+                                                   picks_ref_grad])))
+        assert_array_equal(picks_meg_ref, np.sort(np.concatenate(
+            [picks_grad, picks_mag, picks_ref_grad, picks_ref_mag])))
+        for pick in (picks_meg_ref, picks_meg, picks_ref,
+                     picks_grad, picks_ref_grad, picks_meg_ref_grad,
+                     picks_mag, picks_ref_mag, picks_meg_ref_mag):
+            if len(pick) > 0:
+                pick_info(info, pick)
 
 
 def test_pick_channels_regexp():

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -113,7 +113,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
     Returns
     -------
     raw_sss : instance of mne.io.Raw
-        The raw data with Maxwell filtering applied
+        The raw data with Maxwell filtering applied.
 
     See Also
     --------
@@ -123,19 +123,17 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
     -----
     .. versionadded:: 0.11
 
-    Equation numbers refer to Taulu and Kajola, 2005 [1]_ unless otherwise
-    noted.
-
     Some of this code was adapted and relicensed (with BSD form) with
-    permission from Jussi Nurminen.
+    permission from Jussi Nurminen. These algorithms are based on work
+    from [1]_ and [2]_.
 
-    Compared to Elekta's MaxFilter™ software, our algorithm
-    currently provides the following features:
+    Compared to Elekta's MaxFilter™ software, our Maxwell filtering
+    algorithm currently provides the following features:
 
-        * Basic Maxwell filtering
-        * Cross-talk cancellation
-        * tSSS
         * Bad channel reconstruction
+        * Cross-talk cancellation
+        * Fine calibration correction
+        * tSSS
         * Coordinate frame translation
         * Regularization of internal components using information theory
 
@@ -150,11 +148,11 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
 
         * Double floating point precision
         * Handling of 3D (in additon to 1D) fine calibration files
-        * **Experimental** processing of data from (un-compensated)
-          non-Elekta systems
         * Automated processing of split (-1.fif) and concatenated files
         * Epoch-based movement compensation as described in [1]_ through
           :func:`mne.epochs.average_movements`
+        * **Experimental** processing of data from (un-compensated)
+          non-Elekta systems
 
     Use of Maxwell filtering routines with non-Elekta systems is currently
     **experimental**. Worse results for non-Elekta systems are expected due

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -110,15 +110,15 @@ def test_aaother_systems():
     hsp_path = op.join(kit_dir, 'test_hsp.txt')
     raw_kit = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path)
     assert_raises(RuntimeError, maxwell_filter, raw_kit)
-    raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04),
-                             ignore_ref=True)
+    raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04), ignore_ref=True)
     _assert_n_free(raw_sss, 65)
     # XXX this KIT origin fit is terrible! Need to fix it before release :(
     with catch_logging() as log_file:
         assert_raises(RuntimeError, maxwell_filter, raw_kit,
                       ignore_ref=True, regularize=None)  # bad condition
         raw_sss = maxwell_filter(raw_kit, origin='auto',
-                                 ignore_ref=True, bad_condition='warning')
+                                 ignore_ref=True, bad_condition='warning',
+                                 verbose='warning')
     log_file = log_file.getvalue()
     assert_true('badly conditioned' in log_file)
     assert_true('more than 20 mm from' in log_file)
@@ -127,14 +127,14 @@ def test_aaother_systems():
     with catch_logging() as log_file:
         raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04),
                                  ignore_ref=True, bad_condition='warning',
-                                 regularize=None)
+                                 regularize=None, verbose='warning')
     log_file = log_file.getvalue()
     assert_true('badly conditioned' in log_file)
     _assert_n_free(raw_sss, 80)
     # Now with reg
     with catch_logging() as log_file:
         raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04),
-                                 ignore_ref=True)
+                                 ignore_ref=True, verbose=True)
     log_file = log_file.getvalue()
     assert_true('badly conditioned' not in log_file)
     _assert_n_free(raw_sss, 65)
@@ -144,21 +144,20 @@ def test_aaother_systems():
     bti_pdf = op.join(bti_dir, 'test_pdf_linux')
     bti_config = op.join(bti_dir, 'test_config_linux')
     bti_hs = op.join(bti_dir, 'test_hs_linux')
-    raw_bti = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False,
-                           verbose='error')
+    raw_bti = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
     raw_sss = maxwell_filter(raw_bti)
-    _assert_n_free(raw_sss, 70)
-    raw_sss = maxwell_filter(raw_bti, ignore_ref=True)
     _assert_n_free(raw_sss, 70)
 
     # CTF
     fname_ctf_raw = op.join(io_dir, 'tests', 'data', 'test_ctf_comp_raw.fif')
     raw_ctf = Raw(fname_ctf_raw, compensation=2)
-    assert_raises(RuntimeError, maxwell_filter, raw_ctf)
+    assert_raises(RuntimeError, maxwell_filter, raw_ctf)  # compensated
     raw_ctf = Raw(fname_ctf_raw)
     assert_raises(ValueError, maxwell_filter, raw_ctf)  # cannot fit headshape
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04))
     _assert_n_free(raw_sss, 68)
+    raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04), ignore_ref=True)
+    _assert_n_free(raw_sss, 70)
 
 
 def test_spherical_harmonics():
@@ -532,14 +531,14 @@ def test_head_translation():
     with catch_logging() as log:
         raw_sss = maxwell_filter(raw, destination=mf_head_origin,
                                  origin=mf_head_origin, regularize=None,
-                                 bad_condition='ignore')
+                                 bad_condition='ignore', verbose='warning')
     assert_true('over 25 mm' in log.getvalue())
     assert_meg_snr(raw_sss, Raw(sss_trans_default_fname), 125.)
     # Now to sample's head pos
     with catch_logging() as log:
         raw_sss = maxwell_filter(raw, destination=sample_fname,
                                  origin=mf_head_origin, regularize=None,
-                                 bad_condition='ignore')
+                                 bad_condition='ignore', verbose='warning')
     assert_true('= 25.6 mm' in log.getvalue())
     assert_meg_snr(raw_sss, Raw(sss_trans_sample_fname), 350.)
     # Degenerate cases

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -96,10 +96,9 @@ def _assert_n_free(raw_sss, lower, upper=None):
 
 
 @slow_test
-def test_aaother_systems():
+def test_other_systems():
     """Test Maxwell filtering on KIT, BTI, and CTF files
     """
-    # XXX remove "aa" from start once debugging is done...
     io_dir = op.join(op.dirname(__file__), '..', '..', 'io')
 
     # KIT
@@ -112,7 +111,8 @@ def test_aaother_systems():
     assert_raises(RuntimeError, maxwell_filter, raw_kit)
     raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04), ignore_ref=True)
     _assert_n_free(raw_sss, 65)
-    # XXX this KIT origin fit is terrible! Need to fix it before release :(
+    # XXX this KIT origin fit is terrible! Eventually we should get a
+    # corrected HSP file with proper coverage
     with catch_logging() as log_file:
         assert_raises(RuntimeError, maxwell_filter, raw_kit,
                       ignore_ref=True, regularize=None)  # bad condition

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -122,7 +122,7 @@ def test_other_systems():
     log_file = log_file.getvalue()
     assert_true('badly conditioned' in log_file)
     assert_true('more than 20 mm from' in log_file)
-    _assert_n_free(raw_sss, 28)  # bad origin == brutal reg
+    _assert_n_free(raw_sss, 28, 32)  # bad origin == brutal reg
     # Let's set the origin
     with catch_logging() as log_file:
         raw_sss = maxwell_filter(raw_kit, origin=(0., 0., 0.04),

--- a/mne/tests/common.py
+++ b/mne/tests/common.py
@@ -3,10 +3,11 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from .. import pick_types, Evoked
 from ..io import _BaseRaw
+from ..bem import fit_sphere_to_headshape
 
 
 def _get_data(x, ch_idx):
@@ -46,3 +47,17 @@ def assert_meg_snr(actual, desired, min_tol, med_tol=500., msg=None):
     snr = np.median(snrs)
     assert_true(snr >= med_tol, 'SNR median %0.2f < %0.2f%s'
                 % (snr, med_tol, msg))
+
+
+def assert_dig_allclose(info_py, info_bin):
+    # test dig positions
+    dig_py = info_py['dig']
+    dig_bin = info_bin['dig']
+    assert_equal(len(dig_py), len(dig_bin))
+    for d_py, d_bin in zip(dig_py, dig_bin):
+        raise RuntimeError
+    R_bin, o_head_bin, o_dev_bin = fit_sphere_to_headshape(info_bin)
+    R_py, o_head_py, o_dev_py = fit_sphere_to_headshape(info_py)
+    assert_allclose(R_py, R_bin)
+    assert_allclose(o_dev_py, o_dev_bin)
+    assert_allclose(o_head_py, o_head_bin)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -149,6 +149,8 @@ def test_average_movements():
     ts -= 10.
     assert_raises(TypeError, average_movements, 'foo', pos=pos)
     assert_raises(RuntimeError, average_movements, epochs_proj, pos=pos)  # prj
+    epochs.info['comps'].append([0])
+    assert_raises(RuntimeError, average_movements, epochs, pos=pos)
 
 
 def test_reject():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -92,7 +92,8 @@ def test_average_movements():
                     preload=True)
     epochs_proj = Epochs(raw, events[:1], event_id, tmin, tmax, picks=picks,
                          proj=True, preload=True)
-    raw_sss_stat = maxwell_filter(raw, origin=origin, regularize=None)
+    raw_sss_stat = maxwell_filter(raw, origin=origin, regularize=None,
+                                  bad_condition='ignore')
     del raw
     epochs_sss_stat = Epochs(raw_sss_stat, events, event_id, tmin, tmax,
                              picks=picks, proj=False)


### PR DESCRIPTION
Relates to #2112.

Many chanegs to make MF run on other systems:

- [x] Error, warn, or ignore bad SSS matrix condition.

- [x] Regularize "out" components e.g. if grads only exist, the first external degree components must be omitted

- ~~[ ] Fix head shape calculation for KIT data.~~

@kingjr can you try this branch on your data?