### PR TITLE
MRG: Fix regression

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ BUG
 
     - Fix train and test time window-length in :class:`mne.decoding.GeneralizationAcrossTime` by `Jean-Remi King`_
 
-    - Added lower bound in :func:`mne.stats.linear_regression` on p-values ``p_val`` (and resulting ``mlog10_p_val``) using double floating point epsilon by `Eric Larson`_
+    - Added lower bound in :func:`mne.stats.linear_regression` on p-values ``p_val`` (and resulting ``mlog10_p_val``) using double floating point arithmetic limits by `Eric Larson`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ BUG
 
     - Fix train and test time window-length in :class:`mne.decoding.GeneralizationAcrossTime` by `Jean-Remi King`_
 
+    - Added lower bound in :func:`mne.stats.linear_regression` on p-values ``p_val`` (and resulting ``mlog10_p_val``) using double floating point epsilon by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -135,13 +135,20 @@ def _fit_lm(data, design_matrix, names):
         p_val[predictor] = np.empty_like(stderr[predictor])
         t_val[predictor] = np.empty_like(stderr[predictor])
 
-        pred_valid = (stderr[predictor] > 0)
-        t_val[predictor][pred_valid] = (beta[predictor][pred_valid] /
-                                        stderr[predictor][pred_valid])
-        cdf = stats.t.cdf(np.abs(t_val[predictor][pred_valid]), df)
-        p_val[predictor][pred_valid] = np.clip((1. - cdf) * 2., tiny, 1.)
-        t_val[predictor][~pred_valid] = np.inf
-        p_val[predictor][~pred_valid] = 1.
+        stderr_pos = (stderr[predictor] > 0)
+        beta_pos = (beta[predictor] > 0)
+        t_val[predictor][stderr_pos] = (beta[predictor][stderr_pos] /
+                                        stderr[predictor][stderr_pos])
+        cdf = stats.t.cdf(np.abs(t_val[predictor][stderr_pos]), df)
+        p_val[predictor][stderr_pos] = np.clip((1. - cdf) * 2., tiny, 1.)
+        # degenerate cases
+        mask = (~stderr_pos & beta_pos)
+        t_val[predictor][mask] = np.inf
+        p_val[predictor][mask] = tiny
+        # could do NaN here, but hopefully this is safe enough
+        mask = (~stderr_pos & ~beta_pos)
+        t_val[predictor][mask] = 0
+        p_val[predictor][mask] = 1.
         mlog10_p_val[predictor] = -np.log10(p_val[predictor])
 
     return beta, stderr, t_val, p_val, mlog10_p_val

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -143,7 +143,7 @@ def _fit_lm(data, design_matrix, names):
         p_val[predictor][stderr_pos] = np.clip((1. - cdf) * 2., tiny, 1.)
         # degenerate cases
         mask = (~stderr_pos & beta_pos)
-        t_val[predictor][mask] = np.inf
+        t_val[predictor][mask] = np.inf * np.sign(beta[predictor][mask])
         p_val[predictor][mask] = tiny
         # could do NaN here, but hopefully this is safe enough
         mask = (~stderr_pos & ~beta_pos)

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -127,7 +127,7 @@ def _fit_lm(data, design_matrix, names):
     sqrt_noise_var = np.sqrt(resid_sum_squares / df).reshape(data.shape[1:])
     design_invcov = linalg.inv(np.dot(design_matrix.T, design_matrix))
     unscaled_stderrs = np.sqrt(np.diag(design_invcov))
-    eps = np.finfo(np.float64).eps
+    tiny = np.finfo(np.float64).tiny
     beta, stderr, t_val, p_val, mlog10_p_val = (dict() for _ in range(5))
     for x, unscaled_stderr, predictor in zip(betas, unscaled_stderrs, names):
         beta[predictor] = x.reshape(data.shape[1:])
@@ -139,7 +139,7 @@ def _fit_lm(data, design_matrix, names):
         t_val[predictor][pred_valid] = (beta[predictor][pred_valid] /
                                         stderr[predictor][pred_valid])
         cdf = stats.t.cdf(np.abs(t_val[predictor][pred_valid]), df)
-        p_val[predictor][pred_valid] = np.clip((1. - cdf) * 2., eps, 1.)
+        p_val[predictor][pred_valid] = np.clip((1. - cdf) * 2., tiny, 1.)
         t_val[predictor][~pred_valid] = np.inf
         p_val[predictor][~pred_valid] = 1.
         mlog10_p_val[predictor] = -np.log10(p_val[predictor])


### PR DESCRIPTION
Closes #2056.
Closes #1917.

Gets rid of warnings about divide by zero and underflows in linear regression by protecting against `stderr == 0`. It effectively forces all values in mlog10_p_val to be in the range `[-9.64e-17, 0]` (i.e., `[np.log10(1. - np.finfo(np.float64).eps), 0]`).

@dengemann I'd like to also take care of #1917 with this, but practically I'm not sure if we should make any changes to the code -- it might be doing the right thing already. I think if you get a p-value of 1., you should get a `0` in your `mlog10_p_val` and `np.inf` in your `t_val`, and deal with it appropriately afterward. Do you agree, or is there some coding change to be made?