### PR TITLE
Fixes to nicolet. Added seeg to raw.plot.

### DIFF
--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -90,9 +90,9 @@ def _get_nicolet_info(fname, ch_type, eog, ecg, emg, misc):
     ch_names = header_info['elec_names']
     if eog == 'auto':
         eog = [idx for idx, ch in enumerate(ch_names) if ch.startswith('EOG')]
-    if ecg is 'auto':
+    if ecg == 'auto':
         ecg = [idx for idx, ch in enumerate(ch_names) if ch.startswith('ECG')]
-    if emg is 'auto':
+    if emg == 'auto':
         emg = [idx for idx, ch in enumerate(ch_names) if ch.startswith('EMG')]
 
     date, time = header_info['start_ts'].split()

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -13,8 +13,8 @@ from ..meas_info import _empty_info
 from ..constants import FIFF
 
 
-def read_raw_nicolet(input_fname, ch_type, montage=None, eog=[], ecg=[],
-                     emg=[], misc=[], preload=False, verbose=None):
+def read_raw_nicolet(input_fname, ch_type, montage=None, eog=(), ecg=(),
+                     emg=(), misc=(), preload=False, verbose=None):
     """Read Nicolet data as raw object
 
     Note: This reader takes data files with the extension ``.data`` as an
@@ -35,18 +35,18 @@ def read_raw_nicolet(input_fname, ch_type, montage=None, eog=[], ecg=[],
     eog : list | tuple | 'auto'
         Names of channels or list of indices that should be designated
         EOG channels. If 'auto', the channel names beginning with
-        ``EOG`` are used. Defaults to empty list.
+        ``EOG`` are used. Defaults to empty tuple.
     ecg : list or tuple | 'auto'
         Names of channels or list of indices that should be designated
         ECG channels. If 'auto', the channel names beginning with
-        ``ECG`` are used. Defaults to empty list.
+        ``ECG`` are used. Defaults to empty tuple.
     emg : list or tuple | 'auto'
         Names of channels or list of indices that should be designated
         EMG channels. If 'auto', the channel names beginning with
-        ``EMG`` are used. Defaults to empty list.
+        ``EMG`` are used. Defaults to empty tuple.
     misc : list or tuple
         Names of channels or list of indices that should be designated
-        MISC channels. Defaults to empty list.
+        MISC channels. Defaults to empty tuple.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires
@@ -163,18 +163,18 @@ class RawNicolet(_BaseRaw):
     eog : list | tuple | 'auto'
         Names of channels or list of indices that should be designated
         EOG channels. If 'auto', the channel names beginning with
-        ``EOG`` are used. Defaults to empty list.
+        ``EOG`` are used. Defaults to empty tuple.
     ecg : list or tuple | 'auto'
         Names of channels or list of indices that should be designated
         ECG channels. If 'auto', the channel names beginning with
-        ``ECG`` are used. Defaults to empty list.
+        ``ECG`` are used. Defaults to empty tuple.
     emg : list or tuple | 'auto'
         Names of channels or list of indices that should be designated
         EMG channels. If 'auto', the channel names beginning with
-        ``EMG`` are used. Defaults to empty list.
+        ``EMG`` are used. Defaults to empty tuple.
     misc : list or tuple
         Names of channels or list of indices that should be designated
-        MISC channels. Defaults to empty list.
+        MISC channels. Defaults to empty tuple.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires
@@ -188,8 +188,8 @@ class RawNicolet(_BaseRaw):
     --------
     mne.io.Raw : Documentation of attribute and methods.
     """
-    def __init__(self, input_fname, ch_type, montage=None, eog=[], ecg=[],
-                 emg=[], misc=[], preload=False, verbose=None):
+    def __init__(self, input_fname, ch_type, montage=None, eog=(), ecg=(),
+                 emg=(), misc=(), preload=False, verbose=None):
         input_fname = path.abspath(input_fname)
         info, header_info = _get_nicolet_info(input_fname, ch_type, eog, ecg,
                                               emg, misc)

--- a/mne/io/nicolet/tests/test_nicolet.py
+++ b/mne/io/nicolet/tests/test_nicolet.py
@@ -16,4 +16,5 @@ fname = op.join(base_dir, 'test_nicolet_raw.data')
 
 def test_data():
     """Test reading raw nicolet files."""
-    _test_raw_reader(read_raw_nicolet, input_fname=fname)
+    _test_raw_reader(read_raw_nicolet, input_fname=fname, ch_type='eeg',
+                     ecg='auto', eog='auto', emg='auto', misc=['PHO'])

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -235,7 +235,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         inds += [pick_types(info, meg=t, ref_meg=False, exclude=[])]
         types += [t] * len(inds[-1])
     pick_kwargs = dict(meg=False, ref_meg=False, exclude=[])
-    for t in ['eeg', 'eog', 'ecg', 'emg', 'ref_meg', 'stim', 'resp',
+    for t in ['eeg', 'seeg', 'eog', 'ecg', 'emg', 'ref_meg', 'stim', 'resp',
               'misc', 'chpi', 'syst', 'ias', 'exci']:
         pick_kwargs[t] = True
         inds += [pick_types(raw.info, **pick_kwargs)]


### PR DESCRIPTION
Related to discussion at https://github.com/mne-tools/mne-python/pull/2676.
Check if this is how you want it. Now nicolet reader has a mandatory field for setting channel type (accepts eeg and seeg). For eog, emg and ecg there is 'auto' option which tries to guess these channels.
Also, ``raw.plot`` now accepts seeg channels.