### PR TITLE
[MRG] better error msg for missing names for plot_topomap

### DIFF
--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -196,11 +196,11 @@ def test_plot_topomap():
     plt.close('all')
 
     # Error for missing names
+    data = np.ones(n_channels)
     assert_raises(ValueError, plot_topomap, data, pos, show_names=True)
 
     # Test error messages for invalid pos parameter
     n_channels = len(pos)
-    data = np.ones(n_channels)
     pos_1d = np.zeros(n_channels)
     pos_3d = np.zeros((n_channels, 2, 2))
     assert_raises(ValueError, plot_topomap, data, pos_1d)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -69,6 +69,7 @@ def test_plot_topomap():
     assert_raises(ValueError, ev_bad.plot_topomap, head_pos=dict(center=0))
     assert_raises(ValueError, ev_bad.plot_topomap, times=[-100])  # bad time
     assert_raises(ValueError, ev_bad.plot_topomap, times=[[0]])  # bad time
+    assert_raises(ValueError, ev_bad.plot_topomap, times=[[0]])  # bad time
 
     evoked.plot_topomap(0.1, layout=layout, scale=dict(mag=0.1))
     plt.close('all')
@@ -193,6 +194,9 @@ def test_plot_topomap():
     assert_raises(RuntimeError, plot_evoked_topomap, evoked,
                   times, ch_type='eeg')
     plt.close('all')
+
+    # Error for missing names
+    assert_raises(ValueError, plot_topomap, data, pos, show_names=True)
 
     # Test error messages for invalid pos parameter
     n_channels = len(pos)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -196,11 +196,11 @@ def test_plot_topomap():
     plt.close('all')
 
     # Error for missing names
+    n_channels = len(pos)
     data = np.ones(n_channels)
     assert_raises(ValueError, plot_topomap, data, pos, show_names=True)
 
     # Test error messages for invalid pos parameter
-    n_channels = len(pos)
     pos_1d = np.zeros(n_channels)
     pos_3d = np.zeros((n_channels, 2, 2))
     assert_raises(ValueError, plot_topomap, data, pos_1d)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -403,6 +403,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
         delete the prefix 'MEG ' from all channel names, pass the function
         lambda x: x.replace('MEG ', ''). If `mask` is not None, only
         significant sensors will be shown.
+        If `True`, a list of names must be provided (see `names` keyword).
     mask : ndarray of bool, shape (n_channels, n_times) | None
         The channels to be marked as significant at a given time point.
         Indices set to `True` will be considered. Defaults to None.
@@ -580,6 +581,9 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
             ax.plot(x, y, color='k', linewidth=linewidth, clip_on=False)
 
     if show_names:
+        if names is None:
+            raise ValueError("To show names, a list of names must be provided"
+                             " (see `names` keyword).")
         if show_names is True:
             def _show_names(x):
                 return x


### PR DESCRIPTION
A minor PR hopefully helpful for stupid people like me.

Currently, if you try `plot_topomap(..., show_names=True)` without supplying `names`, the following error is raised: `TypeError: object of type 'NoneType' has no len()`.
This adds the dependency of `show_names` on `names` to the doc, and gives a more meaningful error message when this is not done.