### PR TITLE
MRG: Actually do projection

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,8 @@ BUG
 
     - Fix drop percentages to take into account ``ignore`` option in :func:`mne.viz.plot_drop_log` and :func:`mne.Epochs.plot_drop_log` by `Eric Larson`_.
 
+    - :class:`mne.EpochsArray` no longer has an average EEG reference silently added (but not applied to the data) by default. Use :func:`mne.EpochsArray.add_eeg_ref` to properly add one.
+
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,8 @@ Changelog
 
     - Add the explained variance for each principal component, ``explained_var``, key to the :class:`mne.io.Projection` by `Teon Brooks`_
 
+    - Added methods :func:`mne.Epochs.add_eeg_ref`, :func:`mne.io.Raw.add_eeg_ref`, and :func:`mne.Evoked.add_eeg_ref` to add an average EEG reference.
+
 BUG
 ~~~
 
@@ -59,6 +61,10 @@ API
 ~~~
 
     - :func:`mne.io.read_raw_brainvision` now has ``event_id`` argument to assign non-standard trigger events to a trigger value by `Teon Brooks`_
+
+    - :func:`mne.read_epochs` now has ``add_eeg_ref=False`` by default, since average EEG reference can be added before writing or after reading using the method :func:`mne.Epochs.add_eeg_ref`.
+
+    - :class:`mne.EpochsArray` no longer has an average EEG reference silently added (but not applied to the data) by default. Use :func:`mne.EpochsArray.add_eeg_ref` to properly add one.
 
 
 .. _changes_0_10:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Changelog
 
     - Add the explained variance for each principal component, ``explained_var``, key to the :class:`mne.io.Projection` by `Teon Brooks`_
 
-    - Added methods :func:`mne.Epochs.add_eeg_ref`, :func:`mne.io.Raw.add_eeg_ref`, and :func:`mne.Evoked.add_eeg_ref` to add an average EEG reference.
+    - Added methods :func:`mne.Epochs.add_eeg_average_proj`, :func:`mne.io.Raw.add_eeg_average_proj`, and :func:`mne.Evoked.add_eeg_average_proj` to add an average EEG reference.
 
 BUG
 ~~~

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -71,10 +71,12 @@ def test_set_channel_types():
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
     assert_raises(ValueError, raw.set_channel_types, mapping)
-    # Test type change
-    raw2 = Raw(raw_fname)
-    raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
+    # Test changing type if in proj (avg eeg ref here)
     mapping = {'EEG 060': 'eog', 'EEG 059': 'ecg', 'EOG 061': 'seeg'}
+    assert_raises(RuntimeError, raw.set_channel_types, mapping)
+    # Test type change
+    raw2 = Raw(raw_fname, add_eeg_ref=False)
+    raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     raw2.set_channel_types(mapping)
     info = raw2.info
     assert_true(info['chs'][374]['ch_name'] == 'EEG 060')

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -17,7 +17,7 @@ from scipy import linalg
 
 from .io.write import start_file, end_file
 from .io.proj import (make_projector, _proj_equal, activate_proj,
-                      _has_eeg_average_ref_proj)
+                      _needs_eeg_average_ref_proj)
 from .io import fiff_open
 from .io.pick import (pick_types, channel_indices_by_type, pick_channels_cov,
                       pick_channels, pick_info, _picks_by_type)
@@ -1223,11 +1223,11 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
             rank_eeg = _estimate_rank_meeg_cov(C_eeg, this_info, scalings)
         C_eeg_eig, C_eeg_eigvec = _get_ch_whitener(C_eeg, False, 'EEG',
                                                    rank_eeg)
-        if not _has_eeg_average_ref_proj(info['projs']):
-            warnings.warn('No average EEG reference present in info["projs"], '
-                          'covariance may be adversely affected. Consider '
-                          'recomputing covariance using a raw file with an '
-                          'average eeg reference projector added.')
+    if _needs_eeg_average_ref_proj(info):
+        warnings.warn('No average EEG reference present in info["projs"], '
+                      'covariance may be adversely affected. Consider '
+                      'recomputing covariance using a raw file with an '
+                      'average eeg reference projector added.')
 
     n_chan = len(ch_names)
     eigvec = np.zeros((n_chan, n_chan), dtype=np.float)

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -10,7 +10,7 @@ import re
 
 from .cov import read_cov, _get_whitener_data
 from .io.pick import pick_types, channel_type
-from .io.proj import make_projector, _has_eeg_average_ref_proj
+from .io.proj import make_projector, _needs_eeg_average_ref_proj
 from .bem import _fit_sphere
 from .transforms import (_print_coord_trans, _coord_frame_name,
                          apply_trans, invert_transform, Transform)
@@ -575,7 +575,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     evoked = evoked.copy()
 
     # Determine if a list of projectors has an average EEG ref
-    if "eeg" in evoked and not _has_eeg_average_ref_proj(evoked.info['projs']):
+    if _needs_eeg_average_ref_proj(evoked.info):
         raise ValueError('EEG average reference is mandatory for dipole '
                          'fitting.')
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2268,7 +2268,7 @@ def _read_one_epoch_file(f, tree, fname, preload):
 
 
 @verbose
-def read_epochs(fname, proj=True, add_eeg_ref=True, preload=True,
+def read_epochs(fname, proj=True, add_eeg_ref=False, preload=True,
                 verbose=None):
     """Read epochs from a fif file
 

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -9,7 +9,7 @@ from ..io.constants import FIFF
 from ..io.pick import pick_types, pick_info
 from ..surface import get_head_surf, get_meg_helmet_surf
 
-from ..io.proj import _has_eeg_average_ref_proj, make_projector
+from ..io.proj import _needs_eeg_average_ref_proj, make_projector
 from ..transforms import transform_surface_to, read_trans, _find_trans
 from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
@@ -100,7 +100,7 @@ def _compute_mapping_matrix(fmd, info):
 
     # Optionally apply the average electrode reference to the final field map
     if fmd['kind'] == 'eeg':
-        if _has_eeg_average_ref_proj(projs):
+        if _needs_eeg_average_ref_proj(info):
             logger.info('    The map will have average electrode reference')
             mapping_mat -= np.mean(mapping_mat, axis=0)[np.newaxis, :]
     return mapping_mat

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -9,7 +9,7 @@ from ..io.constants import FIFF
 from ..io.pick import pick_types, pick_info
 from ..surface import get_head_surf, get_meg_helmet_surf
 
-from ..io.proj import _needs_eeg_average_ref_proj, make_projector
+from ..io.proj import _has_eeg_average_ref_proj, make_projector
 from ..transforms import transform_surface_to, read_trans, _find_trans
 from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
@@ -100,7 +100,7 @@ def _compute_mapping_matrix(fmd, info):
 
     # Optionally apply the average electrode reference to the final field map
     if fmd['kind'] == 'eeg':
-        if _needs_eeg_average_ref_proj(info):
+        if _has_eeg_average_ref_proj(projs):
             logger.info('    The map will have average electrode reference')
             mapping_mat -= np.mean(mapping_mat, axis=0)[np.newaxis, :]
     return mapping_mat

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -100,6 +100,13 @@ class ProjMixin(object):
 
         return self
 
+    def add_eeg_ref(self):
+        """Add an average EEG reference projector if one does not exist
+        """
+        if _needs_eeg_average_ref_proj(self.info):
+            eeg_proj = make_eeg_average_ref_proj(self.info, activate=True)
+            self.add_proj(eeg_proj)
+
     def apply_proj(self):
         """Apply the signal space projection (SSP) operators to the data.
 
@@ -152,7 +159,6 @@ class ProjMixin(object):
             logger.info('The projections don\'t apply to these data.'
                         ' Doing nothing.')
             return self
-
         self._projector, self.info = _projector, info
         if isinstance(self, _BaseRaw):
             if self.preload:
@@ -694,7 +700,7 @@ def setup_proj(info, add_eeg_ref=True, activate=True,
         The modified measurement info (Warning: info is modified inplace).
     """
     # Add EEG ref reference proj if necessary
-    if _needs_eeg_average_ref_proj(info) and add_eeg_ref:
+    if add_eeg_ref and _needs_eeg_average_ref_proj(info):
         eeg_proj = make_eeg_average_ref_proj(info, activate=activate)
         info['projs'].append(eeg_proj)
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -100,12 +100,14 @@ class ProjMixin(object):
 
         return self
 
-    def add_eeg_ref(self):
+    def add_eeg_average_proj(self):
         """Add an average EEG reference projector if one does not exist
         """
         if _needs_eeg_average_ref_proj(self.info):
-            eeg_proj = make_eeg_average_ref_proj(self.info, activate=True)
+            # Don't set as active, since we haven't applied it
+            eeg_proj = make_eeg_average_ref_proj(self.info, activate=False)
             self.add_proj(eeg_proj)
+        return self
 
     def apply_proj(self):
         """Apply the signal space projection (SSP) operators to the data.

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -16,7 +16,7 @@ from ..io.tag import find_tag
 from ..io.matrix import (_read_named_matrix, _transpose_named_matrix,
                          write_named_matrix)
 from ..io.proj import _read_proj, make_projector, _write_proj
-from ..io.proj import _has_eeg_average_ref_proj
+from ..io.proj import _needs_eeg_average_ref_proj
 from ..io.tree import dir_tree_find
 from ..io.write import (write_int, write_float_matrix, start_file,
                         start_block, end_block, end_file, write_float,
@@ -710,7 +710,7 @@ def _check_ori(pick_ori):
 
 def _check_reference(inst):
     """Aux funcion"""
-    if "eeg" in inst and not _has_eeg_average_ref_proj(inst.info['projs']):
+    if _needs_eeg_average_ref_proj(inst):
         raise ValueError('EEG average reference is mandatory for inverse '
                          'modeling.')
     if inst.info['custom_ref_applied']:

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -712,7 +712,7 @@ def _check_reference(inst):
     """Aux funcion"""
     if _needs_eeg_average_ref_proj(inst.info):
         raise ValueError('EEG average reference is mandatory for inverse '
-                         'modeling.')
+                         'modeling, use add_eeg_ref method.')
     if inst.info['custom_ref_applied']:
         raise ValueError('Custom EEG reference is not allowed for inverse '
                          'modeling.')

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -710,7 +710,7 @@ def _check_ori(pick_ori):
 
 def _check_reference(inst):
     """Aux funcion"""
-    if _needs_eeg_average_ref_proj(inst):
+    if _needs_eeg_average_ref_proj(inst.info):
         raise ValueError('EEG average reference is mandatory for inverse '
                          'modeling.')
     if inst.info['custom_ref_applied']:

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -739,16 +739,19 @@ def test_epochs_proj():
     assert_equal(len(epochs), 7)  # sufficient for testing
     temp_fname = 'test.fif'
     epochs.save(temp_fname)
-    epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=True)
-    assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
-    epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=False)
-    assert_raises(AssertionError, assert_allclose,
-                  epochs.get_data().mean(axis=1), 0., atol=1e-15)
-    epochs.add_eeg_ref()
-    assert_raises(AssertionError, assert_allclose,
-                  epochs.get_data().mean(axis=1), 0., atol=1e-15)
-    epochs.apply_proj()
-    assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
+    for preload in (True, False):
+        epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=True,
+                             preload=preload)
+        assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
+        epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=False,
+                             preload=preload)
+        assert_raises(AssertionError, assert_allclose,
+                      epochs.get_data().mean(axis=1), 0., atol=1e-15)
+        epochs.add_eeg_average_proj()
+        assert_raises(AssertionError, assert_allclose,
+                      epochs.get_data().mean(axis=1), 0., atol=1e-15)
+        epochs.apply_proj()
+        assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
 
 
 def test_evoked_arithmetic():


### PR DESCRIPTION
@agramfort it's probably good to take a look at this one now, esp. how `test_epochs.py` had to be changed. Writing out `EpochsArray` and reading it back by default will have avg ref added and applied.

The least intrusive change might actually be to have `add_eeg_ref=False` in `read_epochs`. If people have been using FIF, they've presumably already added the ref by that stage (during `Epochs` construction), and it avoids breaking people's `EpochsArray` use.