### PR TITLE
[MRG] Grey hline when spatial_colors=True

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -358,7 +358,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
 
             if (plot_type == 'butterfly') and (hline is not None):
                 for h in hline:
-                    ax.axhline(h, color='r', linestyle='--', linewidth=2)
+                    ax.axhline(h, color=('r' if not spatial_colors else 'grey'),
+                               linestyle='--', linewidth=2)
         lines.append(line_list)
     if plot_type == 'butterfly':
         params = dict(axes=axes, texts=texts, lines=lines,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -358,8 +358,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
 
             if (plot_type == 'butterfly') and (hline is not None):
                 for h in hline:
-                    ax.axhline(h, color=('r' if not spatial_colors else 'grey'),
-                               linestyle='--', linewidth=2)
+                    c = ('r' if not spatial_colors else 'grey')
+                    ax.axhline(h, linestyle='--', linewidth=2, color=c)
         lines.append(line_list)
     if plot_type == 'butterfly':
         params = dict(axes=axes, texts=texts, lines=lines,


### PR DESCRIPTION
The horizontal line for butterfly plots is in red. This looks silly (and is potentially confusing) for plots with spatial colors (see below).

![unknown-45](https://cloud.githubusercontent.com/assets/4321826/11935399/f736273c-a807-11e5-9f1a-88e9bb1cbfa7.png)

This PR makes it grey for spatial_colors, but leaves it red for black plots.

Furthermore, how about a vline option..?