### PR TITLE
EHN: allows predict_proba and decision_function

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -71,16 +71,16 @@ def test_generalization_across_time():
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)
     # test different predict function:
-    gat = GeneralizationAcrossTime(predict_function='decision_function')
+    gat = GeneralizationAcrossTime(predict_method='decision_function')
     gat.fit(epochs)
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
-    gat.predict_function = 'predict_proba'
+    gat.predict_method = 'predict_proba'
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 2))
-    gat.predict_function = 'foo'
+    gat.predict_method = 'foo'
     assert_raises(NotImplementedError, gat.predict, epochs)
-    gat.predict_function = 'predict'
+    gat.predict_method = 'predict'
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -71,12 +71,16 @@ def test_generalization_across_time():
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)
     # test different predict function:
-    gat.decision_function(epochs)
+    gat = GeneralizationAcrossTime(predict_function='decision_function')
+    gat.fit(epochs)
+    gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
-    gat.predict_proba(epochs)
+    gat.predict_function = 'predict_proba'
+    gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 2))
-    assert_raises(NotImplementedError, gat._predict, epochs,
-                  predict_function='foo')
+    gat.predict_function = 'foo'
+    assert_raises(NotImplementedError, gat.predict, epochs)
+    gat.predict_function = 'predict'
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -70,7 +70,15 @@ def test_generalization_across_time():
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), no "
                  "prediction, no score>", '%s' % gat)
     assert_equal(gat.ch_names, epochs.ch_names)
+    # test different predict function:
+    gat.decision_function(epochs)
+    assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
+    gat.predict_proba(epochs)
+    assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 2))
+    assert_raises(NotImplementedError, gat._predict, epochs,
+                  predict_function='foo')
     gat.predict(epochs)
+    assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
                  "predicted 14 epochs, no score>",
                  "%s" % gat)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -284,12 +284,14 @@ def test_generalization_across_time():
     for clf, scorer in zip(clfs, scorers):
         for y in ys:
             for n_class in n_classes:
-                y_ = y % n_class
-                with warnings.catch_warnings(record=True):
-                    gat = GeneralizationAcrossTime(cv=2, clf=clf,
-                                                   scorer=scorer)
-                    gat.fit(epochs, y=y_)
-                    gat.score(epochs, y=y_)
+                for predict_mode in ['cross-validation', 'mean-prediction']:
+                    y_ = y % n_class
+                    with warnings.catch_warnings(record=True):
+                        gat = GeneralizationAcrossTime(
+                            cv=2, clf=clf, scorer=scorer,
+                            predict_mode=predict_mode)
+                        gat.fit(epochs, y=y_)
+                        gat.score(epochs, y=y_)
 
 
 @requires_sklearn

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -727,7 +727,7 @@ def _predict(X, estimators, is_single_time_sample, predict_method):
     # Collapse y_pred across folds if necessary (i.e. if independent)
     if fold > 0:
         # XXX need API to identify how multiple predictions can be combined?
-        if is_classifier(clf):
+        if is_classifier(clf) and (predict_method == 'predict'):
             y_pred, _ = stats.mode(y_pred, axis=2)
         else:
             y_pred = np.mean(y_pred, axis=2)


### PR DESCRIPTION
This allows using `predict_proba` and `decision_function` for clf that allow for it, (instead of the dirty hack meta class that I proposed earlier).

Note that when shortcutting prediction with e.g. `gat.score(epochs)` this will by default use `gat.predict(epochs)`.

@dengemann @jona-sassenhagen @choldgraf

Note that, to score a probabilistic output, you still need to make an home made scorer (see example below). @agramfort you [mentionned](https://github.com/mne-tools/mne-python/issues/2176) that sklearn has an automatic way of dealing with this? To-be-dealt in another PR?

```
import mne
from mne.datasets import spm_face
from mne.decoding import GeneralizationAcrossTime

# Preprocess data
data_path = spm_face.data_path()
raw_fname = data_path + '/MEG/spm/SPM_CTF_MEG_example_faces%d_3D_raw.fif'
raw = mne.io.Raw(raw_fname % 1, preload=True)  # Take first run
picks = mne.pick_types(raw.info, meg=True, exclude='bads')
raw.filter(1, 30, method='iir')
events = mne.find_events(raw, stim_channel='UPPT001')
event_id = {"faces": 1, "scrambled": 2}
tmin, tmax = -0.1, 0.5
decim = 4  # decimate to make the example faster to run
epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                    picks=picks, baseline=None, preload=True,
                    reject=dict(mag=1.5e-12), decim=decim, verbose=False)

# Define decoding params


def auc_scorer(y_true, y_pred):
    """ roc_auc_score only takes 1 dimensional prediction, so we need to
    subselect one of the two categories.
    """
    from sklearn.metrics import roc_auc_score
    from sklearn.preprocessing import LabelBinarizer
    le = LabelBinarizer()
    y_true = le.fit_transform(y_true)
    return roc_auc_score(y_true, y_pred[:, 1])

gat = GeneralizationAcrossTime(scorer=auc_scorer, n_jobs=-1)
gat.fit(epochs)
y_pred = gat.predict_proba(epochs)
gat.score()
gat.plot()

```