### PR TITLE
Add unit test for _merge_info

### DIFF
--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -215,8 +215,7 @@ def test_merge_info():
     info_b = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None)
     info_merged = _merge_info([info_a, info_b])
     assert_equal(info_merged['nchan'], 6)
-    assert_equal(info_merged['ch_names'].to_list(), ['a', 'b', 'c', 'd', 'e',
-                                                     'f'])
+    assert_equal(info_merged['ch_names'], ['a', 'b', 'c', 'd', 'e', 'f'])
     assert_raises(ValueError, _merge_info, [info_a, info_a])
 
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -11,7 +11,7 @@ from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
                     _loc_to_coil_trans, Raw, read_info, write_info)
 from mne.io.constants import FIFF
 from mne.io.meas_info import (Info, create_info, _write_dig_points,
-                              _read_dig_points, _make_dig_points)
+                              _read_dig_points, _make_dig_points, _merge_info)
 from mne.utils import _TempDir, run_tests_if_main
 from mne.channels.montage import read_montage, read_dig_montage
 
@@ -207,5 +207,17 @@ def test_make_dig_points():
                   dig_points[:, :2])
     assert_raises(ValueError, _make_dig_points, None, None, None, None,
                   dig_points[:, :2])
+
+
+def test_merge_info():
+    """Test merging of multiple Info objects"""
+    info_a = create_info(ch_names=['a', 'b', 'c'], sfreq=1000., ch_types=None)
+    info_b = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None)
+    info_merged = _merge_info([info_a, info_b])
+    assert_equal(info_merged['nchan'], 6)
+    assert_equal(info_merged['ch_names'].to_list(), ['a', 'b', 'c', 'd', 'e',
+                                                     'f'])
+    assert_raises(ValueError, _merge_info, [info_a, info_a])
+
 
 run_tests_if_main()


### PR DESCRIPTION
There was no unit test for this method. This PR adds a small test. I'm currently not in the mood to write an exhaustive test, but this is better than no test at all.