### PR TITLE
ENH : add show_times parameter to plot_epochs_image

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,7 +10,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - Add `show_times` parameter to :func:`mne.viz.plot_epochs_image` to be able to display for example reaction times on top of the images, by `Alex Gramfort`_
+    - Add `overlay_times` parameter to :func:`mne.viz.plot_epochs_image` to be able to display for example reaction times on top of the images, by `Alex Gramfort`_
 
 BUG
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,7 +10,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    -
+    - Add `show_times` parameter to :func:`mne.viz.plot_epochs_image` to be able to display for example reaction times on top of the images, by `Alex Gramfort`_
 
 BUG
 ~~~

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -133,6 +133,11 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if callable(order):
             this_order = order(epochs.times, this_data)
 
+        if this_order is not None and (len(this_order) != len(this_data)):
+            raise ValueError('size of order parameter (%s) does not '
+                             'match the number of epochs (%s).'
+                             % (len(this_order), len(this_data)))
+
         this_overlay_times = None
         if overlay_times is not None:
             this_overlay_times = overlay_times

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -28,7 +28,7 @@ from ..defaults import _handle_default
 def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                       vmax=None, colorbar=True, order=None, show=True,
                       units=None, scalings=None, cmap='RdBu_r',
-                      fig=None, show_times=None):
+                      fig=None, overlay_times=None):
     """Plot Event Related Potential / Fields image
 
     Parameters
@@ -70,7 +70,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         Figure instance to draw the image to. Figure must contain two axes for
         drawing the single trials and evoked responses. If None a new figure is
         created. Defaults to None.
-    show_times : array-like, shape (n_epochs,) | None
+    overlay_times : array-like, shape (n_epochs,) | None
         If not None the parameter is interpreted as time instants in seconds
         and is added to the image. It is typically useful to display reaction
         times.
@@ -101,10 +101,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     scale_vmax = True if vmax is None else False
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
 
-    if show_times is not None and len(show_times) != len(data):
-        raise ValueError('size of show_times parameter (%s) do not '
+    if overlay_times is not None and len(overlay_times) != len(data):
+        raise ValueError('size of overlay_times parameter (%s) do not '
                          'match the number of epochs (%s).'
-                         % (len(show_times), len(data)))
+                         % (len(overlay_times), len(data)))
 
     figs = list()
     for i, (this_data, idx) in enumerate(zip(np.swapaxes(data, 0, 1), picks)):
@@ -125,11 +125,12 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             this_order = order(epochs.times, this_data)
 
         if this_order is not None:
+            this_order = np.asarray(this_order)
             this_data = this_data[this_order]
 
-        this_show_times = None
-        if show_times is not None and this_order is not None:
-            this_show_times = show_times[this_order]
+        this_overlay_times = None
+        if overlay_times is not None and this_order is not None:
+            this_overlay_times = np.array(overlay_times)[this_order]
 
         if sigma > 0.:
             this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma,
@@ -145,8 +146,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                                 0, len(data)],
                         aspect='auto', origin='lower', interpolation='nearest',
                         vmin=vmin, vmax=vmax, cmap=cmap)
-        if this_show_times is not None:
-            plt.plot(1e3 * this_show_times, 0.5 + np.arange(len(this_data)),
+        if this_overlay_times is not None:
+            plt.plot(1e3 * this_overlay_times, 0.5 + np.arange(len(this_data)),
                      'k', linewidth=2)
         ax2 = plt.subplot2grid((3, 10), (2, 0), colspan=9, rowspan=1)
         if colorbar:

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -74,7 +74,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     overlay_times : array-like, shape (n_epochs,) | None
         If not None the parameter is interpreted as time instants in seconds
         and is added to the image. It is typically useful to display reaction
-        times.
+        times. Note that it is defined with respect to the order
+        of epochs such that overlay_times[0] corresponds to epochs[0].
 
     Returns
     -------

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -27,7 +27,8 @@ from ..defaults import _handle_default
 
 def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                       vmax=None, colorbar=True, order=None, show=True,
-                      units=None, scalings=None, cmap='RdBu_r', fig=None):
+                      units=None, scalings=None, cmap='RdBu_r',
+                      fig=None, show_times=None):
     """Plot Event Related Potential / Fields image
 
     Parameters
@@ -69,6 +70,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         Figure instance to draw the image to. Figure must contain two axes for
         drawing the single trials and evoked responses. If None a new figure is
         created. Defaults to None.
+    show_times : array-like, shape (n_epochs,) | None
+        If not None the parameter is interpreted as time instants in seconds
+        and is added to the image. It is typically useful to display reaction
+        times.
 
     Returns
     -------
@@ -96,6 +101,11 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     scale_vmax = True if vmax is None else False
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
 
+    if show_times is not None and len(show_times) != len(data):
+        raise ValueError('size of show_times parameter (%s) do not '
+                         'match the number of epochs (%s).'
+                         % (len(show_times), len(data)))
+
     figs = list()
     for i, (this_data, idx) in enumerate(zip(np.swapaxes(data, 0, 1), picks)):
         if fig is None:
@@ -117,6 +127,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if this_order is not None:
             this_data = this_data[this_order]
 
+        this_show_times = None
+        if show_times is not None and this_order is not None:
+            this_show_times = show_times[this_order]
+
         if sigma > 0.:
             this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma,
                                                   axis=0)
@@ -131,6 +145,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                                 0, len(data)],
                         aspect='auto', origin='lower', interpolation='nearest',
                         vmin=vmin, vmax=vmax, cmap=cmap)
+        if this_show_times is not None:
+            plt.plot(1e3 * this_show_times, 0.5 + np.arange(len(this_data)),
+                     'k', linewidth=2)
         ax2 = plt.subplot2grid((3, 10), (2, 0), colspan=9, rowspan=1)
         if colorbar:
             ax3 = plt.subplot2grid((3, 10), (0, 9), colspan=1, rowspan=3)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -109,8 +109,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
 
     if overlay_times is not None:
         overlay_times = np.array(overlay_times)
-        if ((np.min(overlay_times) < epochs.tmin)
-                or (np.max(overlay_times) > epochs.tmax)):
+        times_min = np.min(overlay_times)
+        times_max = np.max(overlay_times)
+        if ((times_min < epochs.tmin) or (times_max > epochs.tmax)):
             warnings.warn('Some values in overlay_times fall outside of '
                           'the epochs time interval (between %s s and %s s)' %
                           (epochs.tmin, epochs.tmax))

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -11,6 +11,7 @@
 
 from functools import partial
 import copy
+import warnings
 
 import numpy as np
 
@@ -106,6 +107,14 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                          'match the number of epochs (%s).'
                          % (len(overlay_times), len(data)))
 
+    if overlay_times is not None:
+        overlay_times = np.array(overlay_times)
+        if ((np.min(overlay_times) < epochs.tmin)
+                or (np.max(overlay_times) > epochs.tmax)):
+            warnings.warn('Some values in overlay_times fall outside of '
+                          'the epochs time interval (between %s s and %s s)' %
+                          (epochs.tmin, epochs.tmax))
+
     figs = list()
     for i, (this_data, idx) in enumerate(zip(np.swapaxes(data, 0, 1), picks)):
         if fig is None:
@@ -124,13 +133,15 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if callable(order):
             this_order = order(epochs.times, this_data)
 
+        this_overlay_times = None
+        if overlay_times is not None:
+            this_overlay_times = overlay_times
+
         if this_order is not None:
             this_order = np.asarray(this_order)
             this_data = this_data[this_order]
-
-        this_overlay_times = None
-        if overlay_times is not None and this_order is not None:
-            this_overlay_times = np.array(overlay_times)[this_order]
+            if this_overlay_times is not None:
+                this_overlay_times = this_overlay_times[this_order]
 
         if sigma > 0.:
             this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma,

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -136,6 +136,8 @@ def test_plot_epochs_image():
     plot_epochs_image(epochs, overlay_times=overlay_times)
     assert_raises(ValueError, plot_epochs_image, epochs,
                   overlay_times=[0.1, 0.2])
+    assert_raises(ValueError, plot_epochs_image, epochs,
+                  order=[0, 1])
     with warnings.catch_warnings(record=True) as w:
         plot_epochs_image(epochs, overlay_times=[1.1])
         warnings.simplefilter('always')

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -133,6 +133,8 @@ def test_plot_epochs_image():
     plot_epochs_image(epochs, picks=[1, 2])
     overlay_times = [0.1]
     plot_epochs_image(epochs, order=[0], overlay_times=overlay_times)
+    assert_raises(ValueError, plot_epochs_image, epochs,
+                  overlay_times=[0.1, 0.2])
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -11,7 +11,7 @@ import warnings
 from nose.tools import assert_raises
 
 import numpy as np
-
+from numpy.testing import assert_equal
 
 from mne import io, read_events, Epochs
 from mne import pick_types
@@ -133,8 +133,14 @@ def test_plot_epochs_image():
     plot_epochs_image(epochs, picks=[1, 2])
     overlay_times = [0.1]
     plot_epochs_image(epochs, order=[0], overlay_times=overlay_times)
+    plot_epochs_image(epochs, overlay_times=overlay_times)
     assert_raises(ValueError, plot_epochs_image, epochs,
                   overlay_times=[0.1, 0.2])
+    with warnings.catch_warnings(record=True) as w:
+        plot_epochs_image(epochs, overlay_times=[1.1])
+        warnings.simplefilter('always')
+    assert_equal(len(w), 1)
+
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -131,6 +131,8 @@ def test_plot_epochs_image():
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
     plot_epochs_image(epochs, picks=[1, 2])
+    show_times = [0.1]
+    plot_epochs_image(epochs, order=[0], show_times=show_times)
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -131,8 +131,8 @@ def test_plot_epochs_image():
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
     plot_epochs_image(epochs, picks=[1, 2])
-    show_times = [0.1]
-    plot_epochs_image(epochs, order=[0], show_times=show_times)
+    overlay_times = [0.1]
+    plot_epochs_image(epochs, order=[0], overlay_times=overlay_times)
     plt.close('all')
 
 


### PR DESCRIPTION
here is a new parameter to display eg reaction times on top of ERP/ERF image.

For @bburle
```
import numpy as np
import mne

epochs = mne.read_epochs('test-epo.fif')
reaction_times = epochs.events[:, 1] / epochs.info['sfreq']
order = np.argsort(reaction_times)
mne.viz.plot_epochs_image(epochs, picks=[0],
                          order=order, show_times=reaction_times)

```

it gives


![figure_1](https://cloud.githubusercontent.com/assets/161052/12208270/2ce0f770-b64c-11e5-8dff-4a3753b85819.png)
