### PR TITLE
[FIX] Add warning for non-unique time points in `events`

### DIFF
--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -230,7 +230,7 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
         Either a function which takes as its inputs the sparse predictor
         matrix X and the observation matrix Y, and returns the coefficient
         matrix b; or a string (for now, only 'pinv'), in which case the
-        solver used is dot(scipy.linalg.pinv(dot(X.T, X)), dot(X.T, Y.T)).T.
+        solver used is `dot(scipy.linalg.pinv(dot(X.T, X)), dot(X.T, Y.T)).T`.
 
     Returns
     -------
@@ -266,6 +266,10 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
     data, times = raw[:]
     data = data[picks, ::decim]
     times = times[::decim]
+    if len(set(events[:, 0])) < len(events[:, 0]):
+        msg = ("`events` contains duplicate time points. Make sure"
+               " all entries in the first column of `events` are unique.")
+        raise ValueError(msg)
     events = events.copy()
     events[:, 0] -= raw.first_samp
     events[:, 0] //= decim

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -103,6 +103,10 @@ def test_continuous_regression_no_overlap():
                                      tmin=tmin, tmax=tmax,
                                      reject=None)
 
+    events[1, 0] = events[0, 0]
+    assert_raises(ValueError, linear_regression_raw,
+                  raw, events, event_id, tmin, tmax)
+
     for cond in event_id.keys():
         assert_allclose(revokeds[cond].data,
                         epochs[cond].average().data)


### PR DESCRIPTION
The previous warning message for non-unique time points was a bit cryptic.
@kingjr