### PR TITLE
Update spectral connectivity to check _BaseEpochs

### DIFF
--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -13,7 +13,7 @@ from .utils import check_indices
 from ..fixes import tril_indices, partial, _get_args
 from ..parallel import parallel_func
 from ..source_estimate import _BaseSourceEstimate
-from .. import Epochs
+from ..epochs import _BaseEpochs
 from ..time_frequency.multitaper import (dpss_windows, _mt_spectra,
                                          _psd_from_mt, _csd_from_mt,
                                          _psd_from_mt_adaptive)
@@ -755,7 +755,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
     # if none of the comp_con functions needs the PSD, we don't estimate it
     accumulate_psd = any(n == 5 for n in n_comp_args)
 
-    if isinstance(data, Epochs):
+    if isinstance(data, _BaseEpochs):
         times_in = data.times  # input times for Epochs input type
         sfreq = data.info['sfreq']
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -12,6 +12,7 @@ from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_array_equal, assert_allclose
 
 from mne import pick_channels, pick_types, Evoked, Epochs, read_events
+from mne.epochs import _BaseEpochs
 from mne.io.constants import FIFF
 from mne.io import (set_eeg_reference, set_bipolar_reference,
                     add_reference_channels)
@@ -59,7 +60,7 @@ def _test_reference(raw, reref, ref_data, ref_from):
     reref_other_data = _reref[..., picks_other, :]
 
     # Undo rereferencing of EEG channels
-    if isinstance(raw, Epochs):
+    if isinstance(raw, _BaseEpochs):
         unref_eeg_data = reref_eeg_data + ref_data[:, np.newaxis, :]
     else:
         unref_eeg_data = reref_eeg_data + ref_data

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -5,7 +5,7 @@
 import numpy as np
 from ..evoked import Evoked
 from ..epochs import _BaseEpochs
-from ..io import Raw
+from ..io import _BaseRaw
 from ..event import find_events
 
 from ..io.pick import pick_channels
@@ -89,7 +89,7 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
     ch_names = inst.info['ch_names']
     picks = pick_channels(ch_names, ch_names)
 
-    if isinstance(inst, Raw):
+    if isinstance(inst, _BaseRaw):
         _check_preload(inst)
         if events is None:
             events = find_events(inst, stim_channel=stim_channel)


### PR DESCRIPTION
Right now in calculating times it's checking `isinstance(Epochs)` rather than `_BaseEpochs`. So if you supply `EpochsArray` it doesn't catch it. This is a switch to use `_BaseEpochs`