### PR TITLE
BUG: FIX empty slice error + add test

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -253,6 +253,10 @@ def test_generalization_across_time():
 
     # TODO JRK: test GAT with non-exhaustive CV (eg. train on 80%, test on 10%)
 
+    # Make CV with some empty tests to ensure that the folds are passed
+    gat.cv_.test_folds[gat.cv_.test_folds == 1] = 0
+    gat.predict(epochs)
+
     # Check that still works with classifier that output y_pred with
     # shape = (n_trials, 1) instead of (n_trials,)
     gat = GeneralizationAcrossTime(clf=RANSACRegressor(LinearRegression()),

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -36,9 +36,10 @@ def make_epochs():
     decim = 30
 
     # Test on time generalization within one condition
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings(record=True) as w:
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True, decim=decim)
+        assert_equal(len(w), 1)
     return epochs
 
 
@@ -136,17 +137,13 @@ def test_generalization_across_time():
 
     # Test longer time window
     gat = GeneralizationAcrossTime(train_times={'length': .100})
-    with warnings.catch_warnings(record=True) as w:
-        # Warning is thrown when window duration is not 1 time sample
-        # XXX
-        gat2 = gat.fit(epochs)
+    gat2 = gat.fit(epochs)  # FIXME need to catch warning from logger
 
     assert_true(gat is gat2)  # return self
     assert_true(hasattr(gat2, 'cv_'))
     assert_true(gat2.cv_ != gat.cv)
-    with warnings.catch_warnings(record=True) as w:
-        # Warning is thrown when window duration is not 1 time sample
-        scores = gat.score(epochs)
+    scores = gat.score(epochs)  # FIXME need to catch warning from logger
+
     assert_true(isinstance(scores, list))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check
 
@@ -175,8 +172,7 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(test_times='diagonal')
     gat.fit(epochs)
     assert_raises(RuntimeError, gat.score)
-    with warnings.catch_warnings(record=True) as w:
-        gat.predict(epochs)
+    gat.predict(epochs)  # FIXME need to catch warning from logger
     scores = gat.score()
     assert_true(scores is gat.scores_)
     assert_equal(np.shape(gat.scores_), (15, 1))

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -253,9 +253,14 @@ def test_generalization_across_time():
 
     # TODO JRK: test GAT with non-exhaustive CV (eg. train on 80%, test on 10%)
 
-    # Make CV with some empty tests to ensure that the folds are passed
+    # Make CV with some empty train and test folds:
+    # --- empty test fold(s) should warn when gat.predict()
     gat.cv_.test_folds[gat.cv_.test_folds == 1] = 0
-    gat.predict(epochs)
+    with warnings.catch_warnings(record=True):
+        gat.predict(epochs)
+    # --- empty train fold(s) should raise when gat.fit()
+    gat = GeneralizationAcrossTime(cv=[([0], [1]), ([], [0])])
+    assert_raises(ValueError, gat.fit, epochs[:2])
 
     # Check that still works with classifier that output y_pred with
     # shape = (n_trials, 1) instead of (n_trials,)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -184,7 +184,6 @@ def test_generalization_across_time():
     with warnings.catch_warnings(record=True) as w:
         # This scenario use has len(y) < n_folds and thus throws a warning
         gat.fit(epochs[0:6])
-        print(w[0].message)
         # This scenario introduces empty slices and thus throws warnings
         gat.predict(epochs[7:])
         gat.score(epochs[7:])

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -91,8 +91,7 @@ def test_generalization_across_time():
     gat.score(epochs, y=epochs.events[:, 2])
     gat.score(epochs, y=epochs.events[:, 2].tolist())
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
-                 "predicted 14 epochs,\n scored "
-                 "(accuracy_score)>", "%s" % gat)
+                 "predicted 14 epochs,\n scored (accuracy_score)>", "%s" % gat)
     gat.fit(epochs, y=epochs.events[:, 2])
 
     old_mode = gat.predict_mode

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -37,6 +37,7 @@ def make_epochs():
 
     # Test on time generalization within one condition
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True, decim=decim)
         assert_equal(len(w), 1)
@@ -182,6 +183,7 @@ def test_generalization_across_time():
     # Test generalization across conditions
     gat = GeneralizationAcrossTime(predict_mode='mean-prediction')
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         # This scenario use has len(y) < n_folds and thus throws a warning
         gat.fit(epochs[0:6])
         # This scenario introduces empty slices and thus throws warnings
@@ -207,6 +209,7 @@ def test_generalization_across_time():
     # Test testing time parameters
     # --- outside time range
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         # This scenario use has len(y) < n_folds and thus throws a warning
         gat.test_times = dict(start=-999.)
         assert_raises(ValueError, gat.predict, epochs)
@@ -216,29 +219,34 @@ def test_generalization_across_time():
     # --- impossible slices
     gat.test_times = dict(step=.000001)
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         assert_raises(ValueError, gat.predict, epochs)
         assert_equal(len(w), 1)
     gat_ = copy.deepcopy(gat)
     gat_.train_times_['length'] = .000001
     gat_.test_times = dict(length=.000001)
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         assert_raises(ValueError, gat_.predict, epochs)
         assert_equal(len(w), 1)
     # --- test time region of interest
     gat.test_times = dict(step=.150)
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         gat.predict(epochs)
         assert_equal(len(w), 1)
     assert_array_equal(np.shape(gat.y_pred_), (15, 5, 14, 1))
     # --- silly value
     gat.test_times = 'foo'
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         assert_raises(ValueError, gat.predict, epochs)
         assert_equal(len(w), 1)
     assert_raises(RuntimeError, gat.score)
     # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         assert_raises(ValueError, gat.predict, epochs)
         assert_equal(len(w), 1)
 
@@ -268,6 +276,7 @@ def test_generalization_across_time():
     # --- empty test fold(s) should warn when gat.predict()
     gat.cv_.test_folds[gat.cv_.test_folds == 1] = 0
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         gat.predict(epochs)
         assert_equal(len(w), 1)
     # --- empty train fold(s) should raise when gat.fit()

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -185,8 +185,10 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(predict_mode='mean-prediction')
     with warnings.catch_warnings(record=True):
         gat.fit(epochs[0:6])
-    gat.predict(epochs[7:])
-    gat.score(epochs[7:])
+    with warnings.catch_warnings(record=True):
+        # There are some empty test folds because of n_trials
+        gat.predict(epochs[7:])
+        gat.score(epochs[7:])
 
     # Test training time parameters
     gat_ = copy.deepcopy(gat)
@@ -256,8 +258,10 @@ def test_generalization_across_time():
     # Make CV with some empty train and test folds:
     # --- empty test fold(s) should warn when gat.predict()
     gat.cv_.test_folds[gat.cv_.test_folds == 1] = 0
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         gat.predict(epochs)
+        # FIXME assert_true('Some folds do not have any test epochs.' in w)
     # --- empty train fold(s) should raise when gat.fit()
     gat = GeneralizationAcrossTime(cv=[([0], [1]), ([], [0])])
     assert_raises(ValueError, gat.fit, epochs[:2])

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -460,6 +460,8 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode,
         elif predict_mode == 'cross-validation':
             # Predict with the estimator trained on the separate training set.
             for k, (train, test) in enumerate(cv):
+                if not np.any(test):
+                    continue
                 # Single trial predictions
                 X_pred_t = X_pred[test_epochs_slices[k]]
                 # If is_single_time_sample, we are predicting each time sample

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -142,6 +142,8 @@ class _GeneralizationAcrossTime(object):
             cv = StratifiedKFold(y, cv)
         cv = check_cv(cv, X, y, classifier=True)
         self.cv_ = cv  # update CV
+        if not np.all([len(train) for train, _ in self.cv_]):
+            raise ValueError('Some folds do not have any train epochs.')
 
         self.y_train_ = y
 
@@ -209,6 +211,9 @@ class _GeneralizationAcrossTime(object):
         n_jobs = self.n_jobs
 
         X, y, _ = _check_epochs_input(epochs, None, self.picks_)
+
+        if not np.all([len(test) for train, test in self.cv_]):
+            logger.warning('Some folds do not have any test epochs.')
 
         # Define testing sliding window
         if self.test_times == 'diagonal':

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -465,7 +465,7 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode,
         elif predict_mode == 'cross-validation':
             # Predict with the estimator trained on the separate training set.
             for k, (train, test) in enumerate(cv):
-                if not np.any(test):
+                if np.asarray(test).size == 0:
                     continue
                 # Single trial predictions
                 X_pred_t = X_pred[test_epochs_slices[k]]

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -5,6 +5,7 @@
 #
 # License: BSD (3-clause)
 
+import warnings
 import numpy as np
 import copy
 
@@ -213,7 +214,7 @@ class _GeneralizationAcrossTime(object):
         X, y, _ = _check_epochs_input(epochs, None, self.picks_)
 
         if not np.all([len(test) for train, test in self.cv_]):
-            logger.warning('Some folds do not have any test epochs.')
+            warnings.warn('Some folds do not have any test epochs.')
 
         # Define testing sliding window
         if self.test_times == 'diagonal':
@@ -465,7 +466,7 @@ def _predict_time_loop(X, estimators, cv, slices, predict_mode,
         elif predict_mode == 'cross-validation':
             # Predict with the estimator trained on the separate training set.
             for k, (train, test) in enumerate(cv):
-                if np.asarray(test).size == 0:
+                if test.size == 0:
                     continue
                 # Single trial predictions
                 X_pred_t = X_pred[test_epochs_slices[k]]


### PR DESCRIPTION
A bug was introduced in the previous optimization [PR](https://github.com/mne-tools/mne-python/pull/2673) if the cross val object had some empty `test` it generates an empty slide an do not have anything to predict anymore.

If possible, backpropagate (that's not the right term...) this to the stable version?