### PR TITLE
MRG Error for event latency overlap due to decim in rerps

### DIFF
--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -273,6 +273,12 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
     events = events.copy()
     events[:, 0] -= raw.first_samp
     events[:, 0] //= decim
+    if len(set(events[:, 0])) < len(events[:, 0]):
+        msg = ("After decimating, `events` contains duplicate time points. "
+                "This means some events are too closely spaced for the "
+                "requested decimation factor. Choose different events, "
+                "drop close events, or choose a different decimation factor.")
+        raise ValueError(msg)
 
     conds = list(event_id)
     if covariates is not None:

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -267,18 +267,19 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
     data = data[picks, ::decim]
     times = times[::decim]
     if len(set(events[:, 0])) < len(events[:, 0]):
-        msg = ("`events` contains duplicate time points. Make sure"
-               " all entries in the first column of `events` are unique.")
-        raise ValueError(msg)
+        raise ValueError("`events` contains duplicate time points. Make "
+                         "sure all entries in the first column of `events` "
+                         "are unique.")
+
     events = events.copy()
     events[:, 0] -= raw.first_samp
     events[:, 0] //= decim
     if len(set(events[:, 0])) < len(events[:, 0]):
-        msg = ("After decimating, `events` contains duplicate time points. "
-               "This means some events are too closely spaced for the "
-               "requested decimation factor. Choose different events, "
-               "drop close events, or choose a different decimation factor.")
-        raise ValueError(msg)
+        raise ValueError("After decimating, `events` contains duplicate time "
+                         "points. This means some events are too closely "
+                         "spaced for the requested decimation factor. Choose "
+                         "different events, drop close events, or choose a "
+                         "different decimation factor.")
 
     conds = list(event_id)
     if covariates is not None:

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -275,9 +275,9 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
     events[:, 0] //= decim
     if len(set(events[:, 0])) < len(events[:, 0]):
         msg = ("After decimating, `events` contains duplicate time points. "
-                "This means some events are too closely spaced for the "
-                "requested decimation factor. Choose different events, "
-                "drop close events, or choose a different decimation factor.")
+               "This means some events are too closely spaced for the "
+               "requested decimation factor. Choose different events, "
+               "drop close events, or choose a different decimation factor.")
         raise ValueError(msg)
 
     conds = list(event_id)

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -115,7 +115,7 @@ def test_continuous_regression_no_overlap():
                   raw, events, event_id, tmin, tmax)
 
     events[1, 0] = old_latency
-    events[:, 0] = range(len(events)
+    events[:, 0] = range(len(events))
     assert_raises(ValueError, linear_regression_raw,
                   raw, events, event_id, tmin, tmax,
                   decim=2)

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -103,14 +103,22 @@ def test_continuous_regression_no_overlap():
                                      tmin=tmin, tmax=tmax,
                                      reject=None)
 
-    events[1, 0] = events[0, 0]
-    assert_raises(ValueError, linear_regression_raw,
-                  raw, events, event_id, tmin, tmax)
-
+    # Check that evokeds and revokeds are nearly equivalent
     for cond in event_id.keys():
         assert_allclose(revokeds[cond].data,
                         epochs[cond].average().data)
 
+    # Test events that will lead to "duplicate" errors
+    old_latency = events[1, 0]
+    events[1, 0] = events[0, 0]
+    assert_raises(ValueError, linear_regression_raw,
+                  raw, events, event_id, tmin, tmax)
+
+    events[1, 0] = old_latency
+    events[:, 0] = range(len(events)
+    assert_raises(ValueError, linear_regression_raw,
+                  raw, events, event_id, tmin, tmax,
+                  decim=2)
 
 def test_continuous_regression_with_overlap():
     """Test regression with overlap correction"""

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -116,7 +116,7 @@ def test_continuous_regression_no_overlap():
 
     events[1, 0] = old_latency
     events[:, 0] = range(len(events))
-    assert_raises(ValueError, linear_regression_raw, raw, 
+    assert_raises(ValueError, linear_regression_raw, raw,
                   events, event_id, tmin, tmax, decim=2)
 
 

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -120,6 +120,7 @@ def test_continuous_regression_no_overlap():
                   raw, events, event_id, tmin, tmax,
                   decim=2)
 
+
 def test_continuous_regression_with_overlap():
     """Test regression with overlap correction"""
     signal = np.zeros(100000)

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -116,9 +116,8 @@ def test_continuous_regression_no_overlap():
 
     events[1, 0] = old_latency
     events[:, 0] = range(len(events))
-    assert_raises(ValueError, linear_regression_raw,
-                  raw, events, event_id, tmin, tmax,
-                  decim=2)
+    assert_raises(ValueError, linear_regression_raw, raw, 
+                  events, event_id, tmin, tmax, decim=2)
 
 
 def test_continuous_regression_with_overlap():


### PR DESCRIPTION
Currently, if events are tightly spaced and decimation is used for linear_regression_raw, it is possible overlapping events result and an unhelpful error is thrown. This replaces this with a hopefully *helpful* error.

Addresses #2790

Shoul I add a test?

@kingjr 