### PR TITLE
(bug?) The `brain_color` parameter of `plot_dipole_locations` seems unused

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,7 @@ API
 ~~~
 
     - The default `picks=None` in :func:`mne.viz.plot_epochs_image` now only plots the first 5 channels, not all channels, by `Jona Sassenhagen`_
+    - Deprecated `mesh_color` in `mne.viz.plot_dipole_locations` (use `brain_color`) by `Marijn van Vliet`_
 
 
 .. _changes_0_11:

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -829,7 +829,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
 def plot_dipole_locations(dipoles, trans, subject, subjects_dir=None,
                           bgcolor=(1, 1, 1), opacity=0.3,
-                          brain_color=(0.7, 0.7, 0.7), mesh_color=(1, 1, 0),
+                          brain_color=(1, 1, 0), mesh_color=None,
                           fig_name=None, fig_size=(600, 600), mode='cone',
                           scale_factor=0.1e-1, colors=None, verbose=None):
     """Plot dipole locations
@@ -856,7 +856,7 @@ def plot_dipole_locations(dipoles, trans, subject, subjects_dir=None,
     brain_color : tuple of length 3
         Brain color.
     mesh_color : tuple of length 3
-        Mesh color.
+        Deprecated: use brain_color instead.
     fig_name : str
         Mayavi figure name.
     fig_size : tuple of length 2
@@ -901,10 +901,14 @@ def plot_dipole_locations(dipoles, trans, subject, subjects_dir=None,
     if colors is None:
         colors = cycle(COLORS)
 
+    if mesh_color is not None:
+        brain_color = mesh_color
+        warnings.warn('mesh_color is deprecated. Use brain_color instead.')
+
     fig = mlab.figure(size=fig_size, bgcolor=bgcolor, fgcolor=(0, 0, 0))
     with warnings.catch_warnings(record=True):  # FutureWarning in traits
         mlab.triangular_mesh(points[:, 0], points[:, 1], points[:, 2],
-                             faces, color=mesh_color, opacity=opacity)
+                             faces, color=brain_color, opacity=opacity)
 
     for dip, color in zip(dipoles, colors):
         rgb_color = color_converter.to_rgb(color)


### PR DESCRIPTION
@Eric89GXL: what's up with the `brain_color` and `mesh_color` parameters of the `plot_dipole_locations` function? The former doesn't seem to be used. It seems to be copied from `plot_sparse_source_estimates`, where it is used to set the color of the glass mesh. In this function, the `mesh_color` parameter is used for this. Perhaps we should deprecate `mesh_color` and use `brain_color` in both functions?