### PR TITLE
MRG+1: Fix: Error message for missing event_id for tag event_id selection during event count equalization

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1601,7 +1601,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # deal with hierarchical tags
         ids = epochs.event_id
-        orig_ids = event_ids.copy()
+        orig_ids = list(event_ids)
         tagging = False
         if "/" in "".join(ids):
             # make string inputs a list of length 1

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1601,6 +1601,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # deal with hierarchical tags
         ids = epochs.event_id
+        orig_ids = event_ids.copy()
         tagging = False
         if "/" in "".join(ids):
             # make string inputs a list of length 1
@@ -1618,8 +1619,11 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          if all(id__ not in ids for id__ in id_)
                          else id_  # straight pass for non-tag inputs
                          for id_ in event_ids]
-            for id_ in event_ids:
-                if len(set([sub_id in ids for sub_id in id_])) != 1:
+            for ii, id_ in enumerate(event_ids):
+                if len(id_) == 0:
+                    err = "'{}' not found in the epoch object's event_id."
+                    raise ValueError(err.format(orig_ids[ii]))
+                elif len(set([sub_id in ids for sub_id in id_])) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
                            " like in \'%s\'." % ", ".join(id_))
                     raise ValueError(err)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1621,8 +1621,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          for id_ in event_ids]
             for ii, id_ in enumerate(event_ids):
                 if len(id_) == 0:
-                    err = "'{}' not found in the epoch object's event_id."
-                    raise ValueError(err.format(orig_ids[ii]))
+                    raise ValueError(orig_ids[ii] + "not found in the "
+                                     "epoch object's event_id.")
                 elif len(set([sub_id in ids for sub_id in id_])) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
                            " like in \'%s\'." % ", ".join(id_))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1621,8 +1621,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          for id_ in event_ids]
             for ii, id_ in enumerate(event_ids):
                 if len(id_) == 0:
-                    raise ValueError(orig_ids[ii] + "not found in the "
-                                     "epoch object's event_id.")
+                    raise KeyError(orig_ids[ii] + "not found in the "
+                                   "epoch object's event_id.")
                 elif len(set([sub_id in ids for sub_id in id_])) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
                            " like in \'%s\'." % ", ".join(id_))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1302,7 +1302,7 @@ def test_epoch_eq():
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
         assert_raises(ValueError, epochs.equalize_event_counts, c)
-    assert_raises(ValueError, epochs.equalize_event_counts,
+    assert_raises(KeyError, epochs.equalize_event_counts,
                   ["a/no_match", "b"])
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1302,6 +1302,7 @@ def test_epoch_eq():
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
         assert_raises(ValueError, epochs.equalize_event_counts, c)
+    assert_raises(ValueError, epochs.equalize_event_counts, ["a/no_match", "b"])
 
 
 def test_access_by_name():

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1302,7 +1302,8 @@ def test_epoch_eq():
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
         assert_raises(ValueError, epochs.equalize_event_counts, c)
-    assert_raises(ValueError, epochs.equalize_event_counts, ["a/no_match", "b"])
+    assert_raises(ValueError, epochs.equalize_event_counts,
+                  ["a/no_match", "b"])
 
 
 def test_access_by_name():


### PR DESCRIPTION
Currently, if one attempts to equalize event counts with hierarchical tags, one of which matches no event_ids, an unhelpful error is raised. This provides a better message.

~~Will do a test later.~~

*Possibly* addresses #2794.