### PR TITLE
More robust find_layout for kit.

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -419,9 +419,9 @@ def find_layout(info, ch_type=None, exclude='bads'):
         layout_name = 'magnesWH3600'
     elif has_CTF_grad:
         layout_name = 'CTF-275'
-    elif n_kit_grads == 157:
+    elif n_kit_grads <= 157:
         layout_name = 'KIT-157'
-    elif n_kit_grads == 208:
+    elif n_kit_grads > 157:
         layout_name = 'KIT-AD'
     else:
         return None


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/2805

Made ``find_layout`` more robust by allowing removing channels from kit data. I'm not sure we want it like this, but if there are only two types of layouts for kit, this should work just fine.