### PR TITLE
[WIP] Enhance `pick_channels` and optimize channel selection code

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -16,7 +16,7 @@ import os.path as op
 import numpy as np
 
 from ..transforms import _polar_to_cartesian, _cartesian_to_sphere
-from ..io.pick import pick_types
+from ..io.pick import pick_types, pick_channels
 from ..io.constants import FIFF
 from ..utils import _clean_names
 from ..externals.six.moves import map
@@ -689,7 +689,7 @@ def _pair_grad_sensors(info, layout=None, topomap_coords=True, exclude='bads'):
     # find the picks corresponding to the grad channels
     grad_chs = sum(pairs, [])
     ch_names = info['ch_names']
-    picks = [ch_names.index(c['ch_name']) for c in grad_chs]
+    picks = pick_channels(ch_names, grad_chs, order='include', strict=True)
 
     if topomap_coords:
         shape = (len(pairs), 2, -1)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -308,6 +308,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         pos = apply_trans(neuromag_trans, pos)
 
     if ch_names is not None:
+        ch_names = set(ch_names)
         sel, ch_names_ = zip(*[(i, e) for i, e in enumerate(ch_names_)
                              if e in ch_names])
         sel = list(sel)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1174,7 +1174,8 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
     """
-    C_ch_idx = [noise_cov.ch_names.index(c) for c in ch_names]
+    C_ch_idx = pick_channels(noise_cov.ch_names, ch_names, order='include',
+                             strict=True)
     if noise_cov['diag'] is False:
         C = noise_cov.data[np.ix_(C_ch_idx, C_ch_idx)]
     else:
@@ -1317,9 +1318,9 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
                           exclude=exclude)
 
     info_ch_names = info['ch_names']
-    ch_names_eeg = [info_ch_names[i] for i in sel_eeg]
-    ch_names_mag = [info_ch_names[i] for i in sel_mag]
-    ch_names_grad = [info_ch_names[i] for i in sel_grad]
+    ch_names_eeg = set([info_ch_names[i] for i in sel_eeg])
+    ch_names_mag = set([info_ch_names[i] for i in sel_mag])
+    ch_names_grad = set([info_ch_names[i] for i in sel_grad])
 
     # This actually removes bad channels from the cov, which is not backward
     # compatible, so let's leave all channels in

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -617,7 +617,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if len(picks) < len(self.ch_names):
             sel_ch = [evoked.ch_names[ii] for ii in picks]
             diff_ch = list(set(self.ch_names).difference(sel_ch))
-            diff_idx = [self.ch_names.index(ch) for ch in diff_ch]
+            diff_idx = pick_channels(self.ch_names, diff_ch, order='include',
+                                     strict=True)
             diff_types = [channel_type(self.info, idx) for idx in diff_idx]
             bad_idx = [diff_types.index(t) for t in diff_types if t in
                        ['grad', 'mag', 'eeg', 'seeg']]
@@ -641,7 +642,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             evoked = evoked.copy().apply_proj()
 
         # find the indices of the channels to use in Epochs
-        ep_picks = [self.ch_names.index(evoked.ch_names[ii]) for ii in picks]
+        ep_picks = pick_channels(self.ch_names,
+                                 [evoked.ch_names[ii] for ii in picks],
+                                 order='include', strict=True)
 
         # do the subtraction
         if self.preload:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -349,7 +349,8 @@ def _read_forward_meas_info(tree, fid):
 
     info['bads'] = read_bad_channels(fid, parent_meg)
     # clean up our bad list, old versions could have non-existent bads
-    info['bads'] = [bad for bad in info['bads'] if bad in info['ch_names']]
+    ch_names = set(info['ch_names'])
+    info['bads'] = [bad for bad in info['bads'] if bad in ch_names]
 
     # Check if a custom reference has been applied
     tag = find_tag(fid, parent_mri, FIFF.FIFF_MNE_CUSTOM_REF)
@@ -1153,8 +1154,9 @@ def apply_forward(fwd, stc, info, start=None, stop=None,
     apply_forward_raw: Compute sensor space data and return a Raw object.
     """
     # make sure evoked_template contains all channels in fwd
+    ch_names = set(info['ch_names'])
     for ch_name in fwd['sol']['row_names']:
-        if ch_name not in info['ch_names']:
+        if ch_name not in ch_names:
             raise ValueError('Channel %s of forward operator not present in '
                              'evoked_template.' % ch_name)
 
@@ -1213,8 +1215,9 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
     apply_forward: Compute sensor space data and return an Evoked object.
     """
     # make sure info contains all channels in fwd
+    ch_names = info['ch_names']
     for ch_name in fwd['sol']['row_names']:
-        if ch_name not in info['ch_names']:
+        if ch_name not in ch_names:
             raise ValueError('Channel %s of forward operator not present in '
                              'info.' % ch_name)
 

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -10,6 +10,7 @@ from ..forward import is_fixed_orient, _to_fixed_ori
 
 from ..minimum_norm.inverse import _check_reference
 from ..utils import logger, verbose
+from ..io.pick import pick_channels
 from ..externals.six.moves import xrange as range
 from .mxne_inverse import (_make_sparse_stc, _prepare_gain,
                            _reapply_source_weighting, _compute_residual)
@@ -251,7 +252,8 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
         forward, evoked.info, noise_cov, pca, depth, loose, None, None)
 
     # get the data
-    sel = [evoked.ch_names.index(name) for name in gain_info['ch_names']]
+    sel = pick_channels(evoked.ch_names, gain_info['ch_names'],
+                        order='include', strict=True)
     M = evoked.data[sel]
 
     # whiten the data

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -11,7 +11,7 @@ from ..source_estimate import SourceEstimate
 from ..minimum_norm.inverse import combine_xyz, _prepare_forward
 from ..minimum_norm.inverse import _check_reference
 from ..forward import compute_orient_prior, is_fixed_orient, _to_fixed_ori
-from ..io.pick import pick_channels_evoked
+from ..io.pick import pick_channels_evoked, pick_channels
 from ..io.proj import deactivate_proj
 from ..utils import logger, verbose
 from ..externals.six.moves import xrange as range
@@ -268,7 +268,8 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
         forward, evoked[0].info, noise_cov, pca, depth, loose, weights,
         weights_min)
 
-    sel = [all_ch_names.index(name) for name in gain_info['ch_names']]
+    sel = pick_channels(all_ch_names, gain_info['ch_names'], order='include',
+                        strict=True)
     M = np.concatenate([e.data[sel] for e in evoked], axis=1)
 
     # Whiten data
@@ -483,7 +484,8 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     if window is not None:
         evoked = _window_evoked(evoked, window)
 
-    sel = [all_ch_names.index(name) for name in gain_info["ch_names"]]
+    sel = pick_channels(all_ch_names, gain_info['ch_names'], order='include',
+                        strict=True)
     M = evoked.data[sel]
 
     # Whiten data

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .constants import FIFF
 from .proj import _has_eeg_average_ref_proj, make_eeg_average_ref_proj
-from .pick import pick_types
+from .pick import pick_types, pick_channels
 from .base import _BaseRaw
 from ..evoked import Evoked
 from ..epochs import _BaseEpochs
@@ -98,8 +98,9 @@ def _apply_reference(inst, ref_from, ref_to=None, copy=True):
                 inst.apply_proj()
             break
 
-    ref_from = [inst.ch_names.index(ch) for ch in ref_from]
-    ref_to = [inst.ch_names.index(ch) for ch in ref_to]
+    ref_from = pick_channels(inst.ch_names, ref_from, order='include',
+                             strict=True)
+    ref_to = pick_channels(inst.ch_names, ref_to, order='include', strict=True)
 
     if isinstance(inst, Evoked):
         data = inst.data
@@ -157,8 +158,9 @@ def add_reference_channels(inst, ref_channels, copy=True):
     elif not isinstance(ref_channels, list):
         raise ValueError("`ref_channels` should be either str or list of str. "
                          "%s was provided." % type(ref_channels))
+    ch_names_set = set(inst.info['ch_names'])
     for ch in ref_channels:
-        if ch in inst.info['ch_names']:
+        if ch in ch_names_set:
             raise ValueError("Channel %s already specified in inst." % ch)
 
     if copy:
@@ -343,8 +345,9 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     # Check for duplicate channel names (it is allowed to give the name of the
     # anode or cathode channel, as they will be replaced).
+    ch_names_set = set(inst.ch_names)
     for ch, a, c in zip(ch_name, anode, cathode):
-        if ch not in [a, c] and ch in inst.ch_names:
+        if ch not in [a, c] and ch in ch_names_set:
             raise ValueError('There is already a channel named "%s", please '
                              'specify a different name for the bipolar '
                              'channel using the ch_name parameter.' % ch)

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -22,7 +22,7 @@ from ..io.write import (write_int, write_float_matrix, start_file,
                         start_block, end_block, end_file, write_float,
                         write_coord_trans, write_string)
 
-from ..io.pick import channel_type, pick_info, pick_types
+from ..io.pick import channel_type, pick_info, pick_types, pick_channels
 from ..cov import prepare_noise_cov, _read_cov, _write_cov, Covariance
 from ..forward import (compute_depth_prior, _read_forward_meas_info,
                        write_forward_meas_info, is_fixed_orient,
@@ -1143,12 +1143,14 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
     gain = forward['sol']['data']
 
     # This actually reorders the gain matrix to conform to the info ch order
-    fwd_idx = [fwd_sol_ch_names.index(name) for name in ch_names]
+    fwd_idx = pick_channels(fwd_sol_ch_names, ch_names, order='include',
+                            strict=True)
     gain = gain[fwd_idx]
     # Any function calling this helper will be using the returned fwd_info
     # dict, so fwd['sol']['row_names'] becomes obsolete and is NOT re-ordered
 
-    info_idx = [info['ch_names'].index(name) for name in ch_names]
+    info_idx = pick_channels(info['ch_names'], ch_names, order='include',
+                             strict=True)
     fwd_info = pick_info(info, info_idx)
 
     logger.info('Total rank is %d' % n_nzero)

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -207,7 +207,8 @@ def _get_ecg_channel_index(ch_name, inst):
                              eog=False, ecg=True, emg=False, ref_meg=False,
                              exclude='bads')
     else:
-        if ch_name not in inst.ch_names:
+        ch_names_set = set(inst.ch_names)
+        if ch_name not in ch_names_set:
             raise ValueError('%s not in channel list (%s)' %
                              (ch_name, inst.ch_names))
         ecg_idx = pick_channels(inst.ch_names, include=[ch_name])

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -677,7 +677,8 @@ class ICA(ContainsMixin):
         out = epochs.copy()
         sources = self._transform_epochs(epochs, concatenate)
         if add_channels is not None:
-            picks = [epochs.ch_names.index(k) for k in add_channels]
+            picks = pick_channels(epochs.ch_names, add_channels,
+                                  order='include', strict=True)
         else:
             picks = []
         out._data = np.concatenate([sources, epochs.get_data()[:, picks]],
@@ -694,7 +695,8 @@ class ICA(ContainsMixin):
         """Aux method
         """
         if add_channels is not None:
-            picks = [evoked.ch_names.index(k) for k in add_channels]
+            picks = pick_channels(evoked.ch_names, add_channels,
+                                  order='include', strict=True)
         else:
             picks = []
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1417,7 +1417,7 @@ def _check_raw(raw):
         for msg, key in (('SSS', 'sss_info'),
                          ('tSSS', 'max_st'),
                          ('fine calibration', 'sss_cal'),
-                         ('cross-talk cancellation',  'sss_ctc')):
+                         ('cross-talk cancellation', 'sss_ctc')):
             if len(ent['max_info'][key]) > 0:
                 raise RuntimeError('Maxwell filtering %s step has already '
                                    'been applied' % msg)
@@ -1471,9 +1471,11 @@ def _update_sss_info(raw, origin, int_order, ext_order, nchan, coord_frame,
 
 def _reset_meg_bads(info):
     """Helper to reset MEG bads"""
-    meg_picks = pick_types(info, meg=True, exclude=[])
-    info['bads'] = [bad for bad in info['bads']
-                    if info['ch_names'].index(bad) not in meg_picks]
+    meg_picks = set(pick_types(info, meg=True, exclude=[]))
+    bad_idx = pick_channels(info['ch_names'], info['bads'], order='include',
+                            strict=True)
+    info['bads'] = [bad for bad, bad_i in zip(info['bads'], bad_idx)
+                    if bad_i not in meg_picks]
 
 
 check_disable = dict()  # not available on really old versions of SciPy

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from ..io.pick import channel_type, pick_types, _picks_by_type
+from ..io.pick import channel_type, pick_types, _picks_by_type, pick_channels
 from ..externals.six import string_types
 from ..defaults import _handle_default
 from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
@@ -189,14 +189,14 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
     if picks is None:
         picks = list(range(info['nchan']))
 
-    bad_ch_idx = [info['ch_names'].index(ch) for ch in info['bads']
-                  if ch in info['ch_names']]
+    bad_ch_idx = pick_channels(info['ch_names'], info['bads'], order='include')
     if len(exclude) > 0:
         if isinstance(exclude, string_types) and exclude == 'bads':
             exclude = bad_ch_idx
         elif (isinstance(exclude, list) and
               all(isinstance(ch, string_types) for ch in exclude)):
-            exclude = [info['ch_names'].index(ch) for ch in exclude]
+            exclude = pick_channels(info['ch_names'], exclude, order='include',
+                                    strict=True)
         else:
             raise ValueError('exclude has to be a list of channel names or '
                              '"bads"')
@@ -1006,8 +1006,9 @@ def _joint_plot(evoked, times="peaks", title='', picks=None, exclude=None,
         pick_names = [evoked.info['ch_names'][pick] for pick in picks]
         evoked.pick_channels(pick_names)
     if exclude == 'bads':
+        ch_names_set = set(evoked.info['ch_names'])
         exclude = [ch for ch in evoked.info['bads']
-                   if ch in evoked.info['ch_names']]
+                   if ch in ch_names_set]
     if exclude is not None:
         evoked.drop_channels(exclude)
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -22,7 +22,7 @@ from .topomap import _prepare_topo_plot, plot_topomap
 from ..utils import logger
 from ..defaults import _handle_default
 from ..io.meas_info import create_info
-from ..io.pick import pick_types
+from ..io.pick import pick_types, pick_channels
 from ..externals.six import string_types
 
 
@@ -461,7 +461,8 @@ def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
     if title is None:
         title = 'Signals before (red) and after (black) cleaning'
     if picks is None:
-        picks = [inst.ch_names.index(k) for k in ica.ch_names]
+        picks = pick_channels(inst.ch_names, ica.ch_names, order='include',
+                              strict=True)
     if exclude is None:
         exclude = ica.exclude
     if isinstance(inst, _BaseRaw):
@@ -771,8 +772,9 @@ def _update_epoch_data(params):
 def _close_epochs_event(events, params):
     """Function for excluding the selected components on close."""
     info = params['info']
-    exclude = [info['ch_names'].index(x) for x in info['bads']
-               if x.startswith('ICA')]
+    exclude = pick_channels(info['ch_names'],
+                            [x for x in info['bads'] if x.startswith('ICA')],
+                            order='include', strict=True)
     params['ica'].exclude = exclude
 
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -23,7 +23,7 @@ from scipy import linalg
 from ..surface import read_surface
 from ..io.proj import make_projector
 from ..utils import logger, verbose, get_subjects_dir
-from ..io.pick import pick_types
+from ..io.pick import pick_types, pick_channels
 from .utils import tight_layout, COLORS, _prepare_trellis, plt_show
 
 
@@ -63,7 +63,8 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
     if exclude == 'bads':
         exclude = info['bads']
     ch_names = [n for n in cov.ch_names if n not in exclude]
-    ch_idx = [cov.ch_names.index(n) for n in ch_names]
+    ch_idx = pick_channels(cov.ch_names, ch_names, order='include',
+                           strict=True)
     info_ch_names = info['ch_names']
     sel_eeg = pick_types(info, meg=False, eeg=True, ref_meg=False,
                          exclude=exclude)
@@ -71,12 +72,9 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
                          exclude=exclude)
     sel_grad = pick_types(info, meg='grad', eeg=False, ref_meg=False,
                           exclude=exclude)
-    idx_eeg = [ch_names.index(info_ch_names[c])
-               for c in sel_eeg if info_ch_names[c] in ch_names]
-    idx_mag = [ch_names.index(info_ch_names[c])
-               for c in sel_mag if info_ch_names[c] in ch_names]
-    idx_grad = [ch_names.index(info_ch_names[c])
-                for c in sel_grad if info_ch_names[c] in ch_names]
+    idx_eeg = pick_channels(ch_names, [info_ch_names[c] for c in sel_eeg])
+    idx_mag = pick_channels(ch_names, [info_ch_names[c] for c in sel_mag])
+    idx_grad = pick_channels(ch_names, [info_ch_names[c] for c in sel_grad])
 
     idx_names = [(idx_eeg, 'EEG covariance', 'uV', 1e6),
                  (idx_grad, 'Gradiometers', 'fT/cm', 1e13),

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -15,7 +15,7 @@ from functools import partial
 
 import numpy as np
 
-from ..io.pick import channel_type, pick_types
+from ..io.pick import channel_type, pick_types, pick_channels
 from ..fixes import normalize_colors
 from ..utils import _clean_names
 
@@ -333,8 +333,9 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
 
     # XXX. at the moment we are committed to 1- / 2-sensor-types layouts
     chs_in_layout = set(layout.names) & set(ch_names)
-    types_used = set(channel_type(info, ch_names.index(ch))
-                     for ch in chs_in_layout)
+    types_used = set(channel_type(info, ch)
+                     for ch in pick_channels(ch_names, chs_in_layout,
+                                             order='include', strict=True))
     # remove possible reference meg channels
     types_used = set.difference(types_used, set('ref_meg'))
     # one check for all vendors

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -642,6 +642,7 @@ def _select_bads(event, params, bads):
     # however for clean data don't click on peaks but on flat segments
     def f(x, y):
         return y(np.mean(x), x.std() * 2)
+    ch_names_set = set(params['info']['ch_names'])
     lines = event.inaxes.lines
     for line in lines:
         ydata = line.get_ydata()
@@ -649,7 +650,7 @@ def _select_bads(event, params, bads):
             ymin, ymax = f(ydata, np.subtract), f(ydata, np.add)
             if ymin <= event.ydata <= ymax:
                 this_chan = vars(line)['ch_name']
-                if this_chan in params['info']['ch_names']:
+                if this_chan in ch_names_set:
                     ch_idx = params['ch_start'] + lines.index(line)
                     if this_chan not in bads:
                         bads.append(this_chan)


### PR DESCRIPTION
This PR gives more power to the `pick_channels` function, so it can be more widely used throughout the codebase. The resulting code is more DRY and performs better. The performance improvements will be more relevant if and when #2765 gets merged.

Take the following scenario:

    ch_names = ['CH%03d' % x for x in range(400)]
    info = mne.create_info(ch_names, 1000.)
    ch_sel = list(ch_names)  # select all channels

Common channel selection idiom 1:

    [info['ch_names'].index(ch) for ch in ch_sel]
    >>> 100 loops, best of 3: 2.87 ms per loop

Propose to change to:

    mne.pick_channels(info['ch_names'], include=ch_sel, order='include', strict=True)
    >>> 1000 loops, best of 3: 235 µs per loop

Common channel selection idiom 2:

    [info['ch_names'].index(ch) for ch in ch_sel if ch in info['ch_names']]
    >>> 100 loops, best of 3: 5.59 ms per loop

Propose to change to:

    mne.pick_channels(info['ch_names'], include=ch_sel, order='include')
    >>> 1000 loops, best of 3: 236 µs per loop

Common channel selection idiom 3:

    [ch for ch in ch_sel if ch in info['ch_names']]
    >>> 100 loops, best of 3: 2.75 ms per loop

Propose to change to:

    ch_names = set(info['ch_names'])
    [ch for ch in ch_sel if ch in ch_names]
    >> 10000 loops, best of 3: 49.9 µs per loop