### PR TITLE
MRG + 1: Add sys_info

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -68,6 +68,7 @@ Logging and Configuration
    set_log_level
    set_log_file
    set_config
+   sys_info
 
 :py:mod:`mne.cuda`:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ Changelog
 
     - Add reading of .fif file montages by `Eric Larson`_
 
+    - Add system config utility :func:`mne.sys_info` by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -22,7 +22,7 @@ __version__ = '0.12.dev0'
 # have to import verbose first since it's needed by many things
 from .utils import (set_log_level, set_log_file, verbose, set_config,
                     get_config, get_config_path, set_cache_dir,
-                    set_memmap_min_size, grand_average)
+                    set_memmap_min_size, grand_average, sys_info)
 from .io.pick import (pick_types, pick_channels,
                       pick_channels_regexp, pick_channels_forward,
                       pick_types_forward, pick_channels_cov,

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -17,7 +17,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        _check_mayavi_version, requires_mayavi,
                        set_memmap_min_size, _get_stim_channel, _check_fname,
                        create_slices, _time_mask, random_permutation,
-                       _get_call_line, compute_corr, verbose)
+                       _get_call_line, compute_corr, sys_info, verbose)
 from mne.io import show_fiff
 from mne import Evoked
 from mne.externals.six.moves import StringIO
@@ -35,6 +35,15 @@ fname_log_2 = op.join(base_dir, 'test-ave-2.log')
 def clean_lines(lines=[]):
     # Function to scrub filenames for checking logging output (in test_logging)
     return [l if 'Reading ' not in l else 'Reading test file' for l in lines]
+
+
+def test_sys_info():
+    """Test info-showing utility
+    """
+    out = StringIO()
+    sys_info(fid=out)
+    out = out.getvalue()
+    assert_true('numpy:' in out)
 
 
 def test_get_call_line():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 # License: BSD (3-clause)
 
 import warnings
-import importlib
 import logging
 import time
 import platform
@@ -2068,7 +2067,7 @@ def sys_info(fid=None, show_paths=False):
             continue
         out += ('%s:' % mod_name).ljust(ljust)
         try:
-            mod = importlib.import_module(mod_name)
+            mod = __import__(mod_name)
         except Exception:
             out += 'Not found\n'
         else:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -7,8 +7,10 @@ from __future__ import print_function
 # License: BSD (3-clause)
 
 import warnings
+import importlib
 import logging
 import time
+import platform
 from distutils.version import LooseVersion
 import os
 import os.path as op
@@ -2038,3 +2040,41 @@ def _get_root_dir():
             op.isdir(op.join(up_dir, x)) for x in ('mne', 'examples', 'doc')):
         root_dir = op.abspath(up_dir)
     return root_dir
+
+
+def sys_info(fid=None, show_paths=False):
+    """Print the system information for debugging
+
+    Parameters
+    ----------
+    fid : file-like | None
+        The file to write to. Will be passed to :func:`print()`.
+        Can be None to use ``sys.stdout``.
+    show_paths : bool
+        If True, print paths for each module.
+    """
+    from numpy.distutils import misc_util
+    ljust = 15
+    out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'
+    out += 'Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n'
+    out += 'Executable:'.ljust(ljust) + sys.executable + '\n\n'
+    bld = misc_util.get_build_architecture()
+    version_texts = dict(pycuda='VERSION_TEXT')
+    for mod_name in ('mne', 'numpy', 'scipy', 'matplotlib', '',
+                     'sklearn', 'nibabel', 'nitime', 'mayavi', 'nose',
+                     'pandas', 'pycuda', 'skcuda'):
+        if mod_name == '':
+            out += '\n'
+            continue
+        out += ('%s:' % mod_name).ljust(ljust)
+        try:
+            mod = importlib.import_module(mod_name)
+        except Exception:
+            out += 'Not found\n'
+        else:
+            version = getattr(mod, version_texts.get(mod_name, '__version__'))
+            extra = (' (%s)' % op.dirname(mod.__file__)) if show_paths else ''
+            if mod_name == 'numpy':
+                extra = ' (%s)%s' % (bld, extra)
+            out += '%s%s\n' % (version, extra)
+    print(out, end='', file=fid)


### PR DESCRIPTION
Should make things like #2834 a bit easier. Example output from doing `$ python -c "import mne; mne.sys_info()"` on my system:
```
Platform:      Linux-4.2.0-25-generic-x86_64-with-Ubuntu-15.10-wily
Python:        2.7.10 (default, Oct 14 2015, 16:09:02)  [GCC 5.2.1 20151010]
Executable:    /usr/bin/python

mne:           0.12.dev0
numpy:         1.12.0.dev0+d5cef01 (Intel)
scipy:         0.18.0.dev0+fe694ea
matplotlib:    1.5.1+1107.g1fa2697

sklearn:       0.18.dev0
nibabel:       2.1.0dev
nitime:        0.6.dev
mayavi:        4.3.1
nose:          1.3.7
pandas:        0.17.1+25.g547750a
pycuda:        2015.1.3
skcuda:        0.5.1
```