### PR TITLE
ENH: GAT refactor _predict, model_selection

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,10 @@ Changelog
 
     - Add system config utility :func:`mne.sys_info` by `Eric Larson`_
 
+    - Automatic cross-validation and scoring metrics in :func:`mne.decoding.GeneralizationAcrossTime`, by `Jean-Remi King`_
+
+    - :func:`mne.decoding.GeneralizationAcrossTime` accepts non-deterministic cross-validations, by `Jean-Remi King`_
+
 BUG
 ~~~
 
@@ -47,6 +51,9 @@ BUG
 
     - Fix bug in rank calculation of :func:`mne.utils.estimate_rank`, :func:`mne.io.Raw.estimate_rank`, and covariance functions where the tolerance was set to slightly too small a value, new 'auto' mode uses values from ``scipy.linalg.orth`` by `Eric Larson`_.
 
+    - Fix bug when specifying irregular ``train_times['slices']`` in :func:`mne.decoding.GeneralizationAcrossTime`, by `Jean-Remi King`_
+
+
 API
 ~~~
 
@@ -58,6 +65,8 @@ API
     - Deprecated function :func:`mne.time_frequency.multitaper_psd` and replaced by :func:`mne.time_frequency.psd_multitaper` by `Chris Holdgraf`_
 
     - The `'ch_names'` and `'nchan'` fields of the :class:`mne.io.Info` class are now read-only and are automatically updated to accommodate changes in the `'chs'` field, by `Marijn van Vliet`_
+
+    - The ``y_pred`` attribute in :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` is now a numpy array, by `Jean-Remi King`_
 
 .. _changes_0_11:
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -48,6 +48,8 @@ def test_generalization_across_time():
     """Test time generalization decoding
     """
     from sklearn.svm import SVC
+    # KernelRidge is used for testing 1) regression analyses 2) n-dimensional
+    # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
@@ -288,7 +290,7 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(clf=KernelRidge(), cv=2)
     epochs.crop(None, epochs.times[2])
     gat.fit(epochs)
-    # Xith regression the default cv is KFold and not StratifiedKFold
+    # With regression the default cv is KFold and not StratifiedKFold
     assert_true(gat.cv_.__class__ == KFold)
     gat.predict(epochs)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -178,8 +178,11 @@ def test_generalization_across_time():
     y_4classes = np.hstack((epochs.events[:7, 2], epochs.events[7:, 2] + 1))
     train_times = dict(start=0.090, stop=0.250)
     if check_version('sklearn', '0.18'):
-        # cv = LeaveOneLabelOut()  # XXX wait for sklearn issue #6304
-        cv = None
+        cv = LeaveOneLabelOut()
+        # XXX we cannot pass any other parameters than X and y to cv.split
+        # so we have to build it before hand
+        cv = [(train, test) for train, test in cv.split(
+            X=y_4classes, y=y_4classes, labels=y_4classes)]
     else:
         cv = LeaveOneLabelOut(y_4classes)
     gat = GeneralizationAcrossTime(cv=cv, train_times=train_times)
@@ -207,7 +210,7 @@ def test_generalization_across_time():
     from mne.utils import set_log_level
     set_log_level('error')
     # Test generalization across conditions
-    gat = GeneralizationAcrossTime(predict_mode='mean-prediction')
+    gat = GeneralizationAcrossTime(predict_mode='mean-prediction', cv=2)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs[0:6])
     with warnings.catch_warnings(record=True):
@@ -296,7 +299,6 @@ def test_generalization_across_time():
         cv = ShuffleSplit(len(epochs))
     gat = GeneralizationAcrossTime(cv=cv)
     gat.fit(epochs)
-    gat = GeneralizationAcrossTime()
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -52,7 +52,7 @@ def test_generalization_across_time():
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
-    from sklearn.metrics import roc_auc_score
+    from sklearn.metrics import roc_auc_score, mean_squared_error
 
     epochs = make_epochs()
     y_4classes = np.hstack((epochs.events[:7, 2], epochs.events[7:, 2] + 1))
@@ -344,7 +344,7 @@ def test_generalization_across_time():
         roc_auc_score(y_true, y_pred[:, 0])
 
     # We re testing 3 scenario: default, classifier + predict_proba, regressor
-    scorers = [None, scorer_proba, None]
+    scorers = [None, scorer_proba, mean_squared_error]
     predict_methods = [None, 'predict_proba', None]
     clfs = [svc, svc, reg]
     # Test all combinations

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -273,6 +273,9 @@ def test_generalization_across_time():
     gat.score(epochs)
     assert_array_equal(np.shape(gat.y_pred_[0]), [1, len(epochs), 1])
     assert_array_equal(np.shape(gat.y_pred_[1]), [2, len(epochs), 1])
+    # check cannot Automatically infer testing times for adhoc training times
+    gat.test_times = None
+    assert_raises(ValueError, gat.predict, epochs)
 
     svc = SVC(C=1, kernel='linear', probability=True)
     gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -52,7 +52,7 @@ def test_generalization_across_time():
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
-    from sklearn.metrics import mean_squared_error
+    from sklearn.metrics import accuracy_score, mean_squared_error
     try:
         from sklearn.model_selection import (KFold, StratifiedKFold,
                                              ShuffleSplit, LeaveOneLabelOut)
@@ -100,6 +100,14 @@ def test_generalization_across_time():
                  "predicted 14 epochs, no score>",
                  "%s" % gat)
     gat.score(epochs)
+    assert_true(gat.scorer_.__name__ == 'accuracy_score')
+    # check clf / predict_method combinations for which the scoring metrics
+    # cannot be inferred.
+    gat.scorer = None
+    gat.predict_method = 'decision_function'
+    assert_raises(ValueError, gat.score, epochs)
+    # Check specifying y manually
+    gat.predict_method = 'predict'
     gat.score(epochs, y=epochs.events[:, 2])
     gat.score(epochs, y=epochs.events[:, 2].tolist())
     assert_equal("<GAT | fitted, start : -0.200 (s), stop : 0.499 (s), "
@@ -307,7 +315,9 @@ def test_generalization_across_time():
     gat.fit(epochs)
     # With regression the default cv is KFold and not StratifiedKFold
     assert_true(gat.cv_.__class__ == KFold)
-    gat.predict(epochs)
+    gat.score(epochs)
+    # with regression the default scoring metrics is mean squared error
+    assert_true(gat.scorer_.__name__ == 'mean_squared_error')
 
     # Test combinations of complex scenarios
     # 2 or more distinct classes

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -52,7 +52,7 @@ def test_generalization_across_time():
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
-    from sklearn.metrics import mean_squared_error, roc_auc_score
+    from sklearn.metrics import roc_auc_score
     if check_version('sklearn', '0.18'):
         from sklearn.model_selection import (KFold, StratifiedKFold,
                                              ShuffleSplit, LeaveOneLabelOut)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -52,7 +52,7 @@ def test_generalization_across_time():
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
     from sklearn.cross_validation import LeaveOneLabelOut
-    from sklearn.model_selection import ShuffleSplit
+    from sklearn.model_selection import KFold, StratifiedKFold, ShuffleSplit
 
     epochs = make_epochs()
 
@@ -76,6 +76,8 @@ def test_generalization_across_time():
     # test different predict function:
     gat = GeneralizationAcrossTime(predict_method='decision_function')
     gat.fit(epochs)
+    # With classifier, the default cv is StratifiedKFold
+    assert_true(gat.cv_.__name__ == StratifiedKFold)
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
     gat.predict_method = 'predict_proba'
@@ -300,6 +302,8 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(clf=KernelRidge(), cv=2)
     epochs.crop(None, epochs.times[2])
     gat.fit(epochs)
+    # Xith regression the default cv is KFold and not StratifiedKFold
+    assert_true(gat.cv_.__name__ == KFold)
     gat.predict(epochs)
 
     # Test combinations of complex scenarios

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -263,7 +263,7 @@ def test_generalization_across_time():
         gat.fit(epochs)
 
     gat.predict(epochs)
-    assert_raises(IndexError, gat.predict, epochs[:10])
+    assert_raises(ValueError, gat.predict, epochs[:10])
 
     # TODO JRK: test GAT with non-exhaustive CV (eg. train on 80%, test on 10%)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -47,17 +47,18 @@ def make_epochs():
 def test_generalization_across_time():
     """Test time generalization decoding
     """
+    from mne.utils import check_version
     from sklearn.svm import SVC
     # KernelRidge is used for testing 1) regression analyses 2) n-dimensional
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
-    try:
+    if check_version('sklearn', '0.18'):
         from sklearn.model_selection import (KFold, StratifiedKFold,
                                              ShuffleSplit, LeaveOneLabelOut)
         sklearn_version = 'new'
-    except ImportError:  # XXX sklearn < 0.18
+    else:
         from sklearn.cross_validation import (KFold, StratifiedKFold,
                                               ShuffleSplit, LeaveOneLabelOut)
         sklearn_version = 'old'

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -165,13 +165,11 @@ def test_generalization_across_time():
         scores = gat.score(epochs)
     assert_true(isinstance(scores, list))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check
-
     assert_equal(len(gat.test_times_['slices'][0][0]), 2)
     # Decim training steps
     gat = GeneralizationAcrossTime(train_times={'step': .100})
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)
-
     gat.score(epochs)
     assert_true(len(gat.scores_) == len(gat.estimators_) == 8)  # training time
     assert_equal(len(gat.scores_[0]), 15)  # testing time
@@ -268,7 +266,8 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(train_times=train_times,
                                    test_times=test_times)
     gat.fit(epochs)
-    gat.score(epochs)
+    with warnings.catch_warnings(record=True):  # not vectorizing
+        gat.score(epochs)
     assert_array_equal(np.shape(gat.y_pred_[0]), [1, len(epochs), 1])
     assert_array_equal(np.shape(gat.y_pred_[1]), [2, len(epochs), 1])
     # check cannot Automatically infer testing times for adhoc training times

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -265,11 +265,8 @@ def test_generalization_across_time():
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
     # --- irregular length training and testing times TODO XXX
-    # gat.train_times = dict(slices=[[0], [1, 2]])
-    # gat.test_times = dict(slices=[[[0], [1]], [[0, 1], [1, 2], [2, 3]]])
-    # --- each training time is used to predict different testing times
-    gat = GeneralizationAcrossTime(train_times=dict(slices=[[0], [1]]),
-                                   test_times=dict(slices=[[[0]], [[0], [1]]]))
+    gat = GeneralizationAcrossTime(train_times=dict(slices=[[0, 1], [1]]),
+                                   test_times=dict(slices=[[[0, 1]], [[0], [1]]]))
     gat.fit(epochs)
     gat.score(epochs)
     assert_array_equal(np.shape(gat.y_pred_[0]), [1, len(epochs), 1])

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -163,7 +163,7 @@ def test_generalization_across_time():
     assert_true(gat2.cv_ != gat.cv)
     with warnings.catch_warnings(record=True):  # not vectorizing
         scores = gat.score(epochs)
-    assert_true(isinstance(scores, list))  # type check
+    assert_true(isinstance(scores, np.ndarray))  # type check
     assert_equal(len(scores[0]), len(scores))  # shape check
     assert_equal(len(gat.test_times_['slices'][0][0]), 2)
     # Decim training steps
@@ -287,7 +287,6 @@ def test_generalization_across_time():
     # and http://bit.ly/1u7t8UT
     assert_raises(ValueError, gat.score, epochs2)
     gat.score(epochs)
-    scores = sum(scores, [])  # flatten
     assert_true(0.0 <= np.min(scores) <= 1.0)
     assert_true(0.0 <= np.max(scores) <= 1.0)
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -52,6 +52,7 @@ def test_generalization_across_time():
     from sklearn.preprocessing import LabelEncoder
     from sklearn.metrics import mean_squared_error
     from sklearn.cross_validation import LeaveOneLabelOut
+    from sklearn.model_selection import ShuffleSplit
 
     epochs = make_epochs()
 
@@ -258,6 +259,8 @@ def test_generalization_across_time():
 
     # Test that gets error if train on one dataset, test on another, and don't
     # specify appropriate cv:
+    gat = GeneralizationAcrossTime(cv=ShuffleSplit())
+    gat.fit(epochs)
     gat = GeneralizationAcrossTime()
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -264,9 +264,11 @@ def test_generalization_across_time():
     # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
-    # --- irregular length training and testing times TODO XXX
-    gat = GeneralizationAcrossTime(train_times=dict(slices=[[0, 1], [1]]),
-                                   test_times=dict(slices=[[[0, 1]], [[0], [1]]]))
+    # --- irregular length training and testing times
+    train_times = dict(slices=[[0, 1], [1]])
+    test_times = dict(slices=[[[0, 1]], [[0], [1]]])
+    gat = GeneralizationAcrossTime(train_times=train_times,
+                                   test_times=test_times)
     gat.fit(epochs)
     gat.score(epochs)
     assert_array_equal(np.shape(gat.y_pred_[0]), [1, len(epochs), 1])
@@ -303,7 +305,7 @@ def test_generalization_across_time():
 
     # Make CV with some empty train and test folds:
     # --- empty test fold(s) should warn when gat.predict()
-    gat._splits[0] = [gat._splits[0][0], np.empty(0)]
+    gat._cv_splits[0] = [gat._cv_splits[0][0], np.empty(0)]
     with warnings.catch_warnings(record=True):
         gat.predict(epochs)
         assert_true(len(w) > 0)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -317,14 +317,15 @@ def test_generalization_across_time():
 
     # Check that still works with classifier that output y_pred with
     # shape = (n_trials, 1) instead of (n_trials,)
-    gat = GeneralizationAcrossTime(clf=KernelRidge(), cv=2)
-    epochs.crop(None, epochs.times[2])
-    gat.fit(epochs)
-    # With regression the default cv is KFold and not StratifiedKFold
-    assert_true(gat.cv_.__class__ == KFold)
-    gat.score(epochs)
-    # with regression the default scoring metrics is mean squared error
-    assert_true(gat.scorer_.__name__ == 'mean_squared_error')
+    if check_version('sklearn', '0.17'):  # no is_regressor before v0.17
+        gat = GeneralizationAcrossTime(clf=KernelRidge(), cv=2)
+        epochs.crop(None, epochs.times[2])
+        gat.fit(epochs)
+        # With regression the default cv is KFold and not StratifiedKFold
+        assert_true(gat.cv_.__class__ == KFold)
+        gat.score(epochs)
+        # with regression the default scoring metrics is mean squared error
+        assert_true(gat.scorer_.__name__ == 'mean_squared_error')
 
     # Test combinations of complex scenarios
     # 2 or more distinct classes

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -307,7 +307,7 @@ def test_generalization_across_time():
     # Make CV with some empty train and test folds:
     # --- empty test fold(s) should warn when gat.predict()
     gat._cv_splits[0] = [gat._cv_splits[0][0], np.empty(0)]
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings(record=True) as w:
         gat.predict(epochs)
         assert_true(len(w) > 0)
         assert_true(any('do not have any test epochs' in str(ww.message)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -264,7 +264,11 @@ def test_generalization_across_time():
     gat.test_times = dict(length=.150)
     assert_raises(ValueError, gat.predict, epochs)
     # --- irregular length training and testing times
+    # 2 estimators, the first one is trained on two successive time samples
+    # whereas the second one is trained on a single time sample.
     train_times = dict(slices=[[0, 1], [1]])
+    # The first estimator is tested once, the second estimator is tested on
+    # two successive time samples.
     test_times = dict(slices=[[[0, 1]], [[0], [1]]])
     gat = GeneralizationAcrossTime(train_times=train_times,
                                    test_times=test_times)

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import (requires_sklearn, requires_sklearn_0_15, slow_test,
-                       run_tests_if_main)
+                       run_tests_if_main, check_version)
 from mne.decoding import GeneralizationAcrossTime, TimeDecoding
 
 
@@ -47,7 +47,6 @@ def make_epochs():
 def test_generalization_across_time():
     """Test time generalization decoding
     """
-    from mne.utils import check_version
     from sklearn.svm import SVC
     # KernelRidge is used for testing 1) regression analyses 2) n-dimensional
     # predictions.
@@ -57,11 +56,9 @@ def test_generalization_across_time():
     if check_version('sklearn', '0.18'):
         from sklearn.model_selection import (KFold, StratifiedKFold,
                                              ShuffleSplit, LeaveOneLabelOut)
-        sklearn_version = 'new'
     else:
         from sklearn.cross_validation import (KFold, StratifiedKFold,
                                               ShuffleSplit, LeaveOneLabelOut)
-        sklearn_version = 'old'
 
     epochs = make_epochs()
 
@@ -182,7 +179,7 @@ def test_generalization_across_time():
     # Test start stop training & test cv without n_fold params
     y_4classes = np.hstack((epochs.events[:7, 2], epochs.events[7:, 2] + 1))
     train_times = dict(start=0.090, stop=0.250)
-    if sklearn_version == 'new':
+    if check_version('sklearn', '0.18'):
         # cv = LeaveOneLabelOut()  # XXX wait for sklearn issue #6304
         cv = None
     else:
@@ -294,7 +291,7 @@ def test_generalization_across_time():
 
     # Test that gets error if train on one dataset, test on another, and don't
     # specify appropriate cv:
-    if sklearn_version == 'new':
+    if check_version('sklearn', '0.18'):
         cv = ShuffleSplit()
     else:  # XXX sklearn < 0.18
         cv = ShuffleSplit(len(epochs))

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -77,7 +77,7 @@ def test_generalization_across_time():
     gat = GeneralizationAcrossTime(predict_method='decision_function')
     gat.fit(epochs)
     # With classifier, the default cv is StratifiedKFold
-    assert_true(gat.cv_.__name__ == StratifiedKFold)
+    assert_true(gat.cv_.__class__ == StratifiedKFold)
     gat.predict(epochs)
     assert_array_equal(np.shape(gat.y_pred_), (15, 15, 14, 1))
     gat.predict_method = 'predict_proba'
@@ -274,20 +274,7 @@ def test_generalization_across_time():
 
     # Make CV with some empty train and test folds:
     # --- empty test fold(s) should warn when gat.predict()
-
-    class adhoc_cv():
-        def __init__(self):
-            self.folds = [(train, test) for train, test in
-                          gat.cv_.split(range(len(epochs)))]
-            self.folds[-1] = (train, np.empty(0))  # empty test fold
-
-        def split(self, X, y=None):
-            return self.folds
-
-        def get_n_splits(self):
-            return 5
-
-    gat.cv_ = adhoc_cv()
+    gat._splits[0] = [gat._splits[0][0], np.empty(0)]
     with warnings.catch_warnings(record=True):
         gat.predict(epochs)
         assert_true(len(w) > 0)
@@ -303,7 +290,7 @@ def test_generalization_across_time():
     epochs.crop(None, epochs.times[2])
     gat.fit(epochs)
     # Xith regression the default cv is KFold and not StratifiedKFold
-    assert_true(gat.cv_.__name__ == KFold)
+    assert_true(gat.cv_.__class__ == KFold)
     gat.predict(epochs)
 
     # Test combinations of complex scenarios

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -242,9 +242,8 @@ def test_generalization_across_time():
     assert_raises(RuntimeError, gat.score)
     # --- unmatched length between training and testing time
     gat.test_times = dict(length=.150)
-    with warnings.catch_warnings(record=True):  # no test epochs
-        assert_raises(ValueError, gat.predict, epochs)
-
+    assert_raises(ValueError, gat.predict, epochs)
+    # --- XXX irregular length training times: this got lost in the API!
     svc = SVC(C=1, kernel='linear', probability=True)
     gat = GeneralizationAcrossTime(clf=svc, predict_mode='mean-prediction')
     with warnings.catch_warnings(record=True):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -49,11 +49,11 @@ class _DecodingTime(dict):
             depth = [len(ii) for ii in self["slices"]]
             if len(np.unique(depth)) == 1:  # if all slices have same depth
                 if depth[0] == 1:  # if depth is one
-                    s += ", n_t_windows: %s" % (len(depth))
+                    s += ", n_time_windows: %s" % (len(depth))
                 else:
-                    s += ", n_t_windows: %s x %s" % (len(depth), depth[0])
+                    s += ", n_time_windows: %s x %s" % (len(depth), depth[0])
             else:
-                s += (", n_t_windows: %s x [%s, %s]" %
+                s += (", n_time_windows: %s x [%s, %s]" %
                       (len(depth),
                        min([len(ii) for ii in depth]),
                        max(([len(ii) for ii in depth]))))
@@ -719,7 +719,7 @@ def _sliding_window(times, window, sfreq):
     window = _DecodingTime(copy.deepcopy(window))
 
     # Default values
-    time_slices = window.get(['slices'], None)
+    time_slices = window.get('slices', None)
     # If the users hasn't manually defined the time slices, we'll defined
     # them with start, stop, step and length parameters.
     if time_slices is None:
@@ -728,11 +728,11 @@ def _sliding_window(times, window, sfreq):
         window['step'] = window.get('step', 1. / sfreq)
         window['length'] = window.get('length', 1. / sfreq)
 
-        if times[0] < window['start'] < times[-1]:
+        if not(times[0] <= window['start'] <= times[-1]):
             raise ValueError(
                 '`start` (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['start'], times[0], times[-1]))
-        if (window['stop'] < times[0] or window['stop'] > times[-1]):
+        if not(times[0] <= window['stop'] <= times[-1]):
             raise ValueError(
                 '`stop` (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['stop'], times[0], times[-1]))

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -466,7 +466,10 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
                 these predictions into a single estimate per sample.
         Default: 'cross-validation'
     n_orig_epochs : int
-        Original number of predicted epochs before slice definition.
+        Original number of predicted epochs before slice definition. Note
+        that the number of epochs may have been cropped if the cross validation
+        is not deterministic (e.g. with ShuffleSplit, we may only predict a
+        subset of epochs).
     test_epochs : list of slices
         List of slices to select the tested epoched in the cv.
     """

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -767,8 +767,8 @@ def _sliding_window(times, window, sfreq):
 
 def _set_window_time(slices, times):
     """Defines time as the last training time point"""
-    t_inds_ = [t[-1] for t in slices]
-    return times[t_inds_]
+    t_idx_ = [t[-1] for t in slices]
+    return times[t_idx_]
 
 
 def _predict(X, estimators, vectorize_times, predict_method):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1142,7 +1142,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         fig : instance of matplotlib.figure.Figure
             The figure.
         """
-        if np.array(train_time) == np.dtype('float'):
+        if not np.array(train_time).dtype is np.dtype('float'):
             raise ValueError('train_time must be float | list or array of '
                              'floats. Got %s.' % type(train_time))
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1263,8 +1263,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
         s = ''
         if hasattr(self, "estimators_"):
             s += "fitted, start : %0.3f (s), stop : %0.3f (s)" % (
-                self.times_.gat('start', np.nan),
-                self.times_.gat('stop', np.nan))
+                self.times_.get('start', np.nan),
+                self.times_.get('stop', np.nan))
         else:
             s += 'no fit'
         if hasattr(self, 'y_pred_'):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -813,7 +813,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        Defaults to 5.
+        The `cv.random_state` is set to 0 by default. Defaults to 5.
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including
@@ -1124,7 +1124,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        Defaults to 5.
+        The `cv.random_state` is set to 0 by default. Defaults to 5.
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -482,7 +482,7 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
         expected_start = np.arange(n_times)
         contiguous_start = np.array_equal([sl[0] for sl in test_times],
                                           expected_start)
-        window_lengths = np.unique([len(sl) for sel in test_times])
+        window_lengths = np.unique([len(sl) for sl in test_times])
         vectorize_times = (window_lengths == 1) and contiguous_start
         if vectorize_times:
             # In vectorize mode, we avoid iterating over time test_times.

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -322,8 +322,7 @@ class _GeneralizationAcrossTime(object):
 
         # Concatenate chunks across test time dimension.
         n_tests = [len(sl) for sl in self.test_times_['slices']]
-        is_matrix = len(set(n_tests)) == 1
-        if is_matrix:
+        if len(set(n_tests)) == 1:  # does GAT deal with a regular array/matrix
             self.y_pred_ = np.concatenate(y_pred, axis=1)
         else:
             # Non regular testing times, y_pred is an array of arrays with
@@ -1472,7 +1471,13 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
 
 def _chunk_X(X, slices, gat, n_orig_epochs, test_epochs):
-    """Smart chunking to avoid memory overload"""
+    """Smart chunking to avoid memory overload.
+    The parallization is performed across time samples. To avoid overheads, the
+    X data is splitted into large chunks of different time sizes. To avoid
+    duplicating the memory load to each core, we only pass the time samples
+    that are required by each core. The indices of the training times must be
+    adjusted accordingly.
+    """
     # from object array to list
     slices = [sl for sl in slices if len(sl)]
     selected_times = np.hstack([np.ravel(sl) for sl in slices])

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -486,15 +486,14 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
         # Checks whether predict is based on contiguous windows of lengths = 1
         # time-sample, ranging across the entire times. In this case, we will
         # be able to vectorize the testing times samples.
-        expected_start = np.arange(n_times)
-        contiguous_start = np.array_equal([sl[0] for sl in test_t_idxs],
-                                          expected_start)
+        # Set expected start time if window length == 1
+        start = np.arange(n_times)
+        contiguous_start = np.array_equal([sl[0] for sl in test_t_idxs], start)
         window_lengths = np.unique([len(sl) for sl in test_t_idxs])
         vectorize_times = (window_lengths == 1) and contiguous_start
         if vectorize_times:
             # In vectorize mode, we avoid iterating over time test time indices
-            test_t_idxs = [slice(expected_start[0],
-                                 expected_start[-1] + 1, 1)]
+            test_t_idxs = [slice(start[0], start[-1] + 1, 1)]
         elif _warn_once.get('vectorization', True):
             warn('not vectorizing predictions across testing times, using a '
                  'time window with length > 1')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -200,10 +200,10 @@ class _GeneralizationAcrossTime(object):
         # Check that training cv and predicting cv match
         if self.predict_mode == 'cross-validation':
             n_est_cv = [len(estimator) for estimator in self.estimators_]
-            inconsistent_splits = len(set(n_est_cv)) != 1
-            mismatching_splits = n_est_cv[0] != len(self._cv_splits)
-            mismatching_y = len(self.y_train_) != len(epochs)
-            if inconsistent_splits or mismatching_splits or mismatching_y:
+            heterogeneous_cv = len(set(n_est_cv)) != 1
+            mismatch_cv = n_est_cv[0] != len(self._cv_splits)
+            mismatch_y = len(self.y_train_) != len(epochs)
+            if heterogeneous_cv or mismatch_cv or mismatch_y:
                 raise ValueError(
                     'When `predict_mode = "cross-validation"`, the training '
                     'and predicting cv schemes must be identical.')

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -217,8 +217,7 @@ class _GeneralizationAcrossTime(object):
                     'When `predict_mode = "cross-validation"`, the training '
                     'and predicting cv schemes must be identical.')
 
-
-        # clean attributes
+        # Clean attributes
         for att in ['y_pred_', 'test_times_', 'scores_', 'scorer_', 'y_true_']:
             if hasattr(self, att):
                 delattr(self, att)
@@ -443,8 +442,7 @@ def _predict_slices(X, estimators, cv, train_t_slices, predict_mode,
         # can't know whether it is a a categorical output or a set of
         # probabilistic estimates.
         # If all train time points have the same number of testing time
-        # points, then y_pred is a matrix. Else it is an array of
-        # arrays.
+        # points, then y_pred is a matrix. Else it is an array of arrays.
         n_train = len(estimators)
         n_test = [len(test_time_slices) for test_time_slices in train_t_slices]
         if len(set(n_test)) == 1:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -509,7 +509,7 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
                                              n_dim)
                     if vectorize_times:
                         # When vectorizing, we predict multiple time points at
-                        # once to gain speed. The utput predictions thus
+                        # once to gain speed. The output predictions thus
                         # correspond to different test_t_idx columns.
                         y_pred[train_t_idx][test_t_idx, test, ...] = y_pred_
                     else:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -813,7 +813,9 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        The `cv.random_state` is set to 0 by default. Defaults to 5.
+        The `cv.random_state` is set to 0 by default.
+        If clf is a classifier, defaults to KFold(n_folds=5), else defaults to
+        StratifiedKFold(n_folds=5).
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including
@@ -1124,7 +1126,9 @@ class TimeDecoding(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        The `cv.random_state` is set to 0 by default. Defaults to 5.
+        The `cv.random_state` is set to 0 by default.
+        If clf is a classifier, defaults to KFold(n_folds=5), else defaults to
+        StratifiedKFold(n_folds=5).
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -466,10 +466,12 @@ def _predict_slices(X, train_times, estimators, cv_splits, predict_mode,
             # In vectorize mode, we avoid iterating over time test time indices
             test_t_idxs = [slice(start[0], start[-1] + 1, 1)]
         elif _warn_once.get('vectorization', True):
-            warn('Due to a time window with length > 1, unable to vectorize '
-                 'across testing times. This leads to slower predictions '
-                 'compared to the length == 1 case.')
-            _warn_once['vectorization'] = False
+            # Only warn if multiple testing time
+            if len(test_t_idxs) > 1:
+                warn('Due to a time window with length > 1, unable to '
+                     ' vectorize across testing times. This leads to slower '
+                     'predictions compared to the length == 1 case.')
+                _warn_once['vectorization'] = False
 
         # Iterate over testing times. If vectorize_times: 1 iteration.
         for ii, test_t_idx in enumerate(test_t_idxs):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -169,7 +169,7 @@ class _GeneralizationAcrossTime(object):
             # XXX support sklearn < 0.18
             self._cv_splits = [(train, test) for train, test in cv]
 
-        if not np.all([len(train) for train, __ in self._cv_splits]):
+        if not np.all([len(train) for train, _ in self._cv_splits]):
             raise ValueError('Some folds do not have any train epochs.')
 
         self.y_train_ = y
@@ -246,7 +246,7 @@ class _GeneralizationAcrossTime(object):
                 delattr(self, att)
         _warn_once.clear()  # reset self-baked warning tracker
 
-        X, y, __ = _check_epochs_input(epochs, None, self.picks_)
+        X, y, _ = _check_epochs_input(epochs, None, self.picks_)
 
         if not np.all([len(test) for train, test in self._cv_splits]):
             warn('Some folds do not have any test epochs.')
@@ -270,7 +270,7 @@ class _GeneralizationAcrossTime(object):
                                                   self.train_times_['length'])
             # Make a sliding window for each training time.
             slices_list = list()
-            for __ in range(0, len(self.train_times_['slices'])):
+            for _ in range(0, len(self.train_times_['slices'])):
                 test_times_ = _sliding_window(epochs.times, test_times,
                                               epochs.info['sfreq'])
                 slices_list += [test_times_['slices']]
@@ -291,20 +291,20 @@ class _GeneralizationAcrossTime(object):
         # Store all testing times parameters
         self.test_times_ = test_times
 
-        n_orig_epochs, __, n_times = X.shape
+        n_orig_epochs, _, n_times = X.shape
 
         # Subselects the to-be-predicted epochs so as to manipulate a
         # contiguous array X by using slices rather than indices.
         test_epochs = []
         if self.predict_mode == 'cross-validation':
-            all_test = [ii for train, test in self._cv_splits for ii in test]
+            test_idxs = [ii for train, test in self._cv_splits for ii in test]
             start = 0
-            for __, test in self._cv_splits:
+            for _, test in self._cv_splits:
                 n_test_epochs = len(test)
                 stop = start + n_test_epochs
                 test_epochs.append(slice(start, stop, 1))
                 start += n_test_epochs
-            X = X[all_test]
+            X = X[test_idxs]
 
         # Prepare parallel predictions across testing time points
         # FIXME Note that this means that TimeDecoding.predict isn't parallel
@@ -472,7 +472,7 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
     """
 
     # Check inputs
-    n_epochs, __, n_times = X.shape
+    n_epochs, _, n_times = X.shape
     n_train = len(estimators)
     n_test = [len(test_times) for test_times in train_times]
 
@@ -822,7 +822,7 @@ def _predict(X, estimators, vectorize_times, predict_method):
     # XXX need API to identify how multiple predictions can be combined?
     if fold > 0:
         if is_classifier(clf) and (predict_method == 'predict'):
-            y_pred, __ = stats.mode(y_pred, axis=2)
+            y_pred, _ = stats.mode(y_pred, axis=2)
         else:
             y_pred = np.mean(y_pred, axis=2, keepdims=True)
     y_pred = y_pred[:, :, 0]

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -122,11 +122,12 @@ class _GeneralizationAcrossTime(object):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        from mne.utils import check_version
         from sklearn.base import clone, is_classifier
-        try:
+        if check_version('sklearn', '0.18'):
             from sklearn.model_selection import (check_cv, StratifiedKFold,
                                                  KFold)
-        except ImportError:  # XXX support sklearn < 0.18
+        else:
             from sklearn.cross_validation import (check_cv, StratifiedKFold,
                                                   KFold)
 
@@ -146,19 +147,19 @@ class _GeneralizationAcrossTime(object):
         cv = self.cv
         if isinstance(cv, (int, np.int)):
             # Automatically chose StratifiedKFold if classification else KFold
-            try:
+            if check_version('sklearn', '0.18'):
                 XFold = StratifiedKFold if is_classifier(self.clf) else KFold
                 cv = XFold(n_folds=cv)
-            except TypeError:  # XXX sklearn < 0.18
+            else:
                 if is_classifier(self.clf):
                     cv = StratifiedKFold(y=y, n_folds=cv)
                 else:
                     cv = KFold(n=len(y), n_folds=cv)
-        try:
-            cv = check_cv(cv=cv, X=X, y=y, classifier=is_classifier(self.clf))
-        except TypeError:
-            # XXX sklearn API change from 0.18: see sklearn issue #6300
+        if check_version('sklearn', '0.18'):
             cv = check_cv(cv=cv, y=y, classifier=is_classifier(self.clf))
+        else:
+            # XXX sklearn API change from 0.18: see sklearn issue #6300
+            cv = check_cv(cv=cv, X=X, y=y, classifier=is_classifier(self.clf))
         self.cv_ = cv
 
         # Keep cv splits to retrieve them at predict()

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1150,8 +1150,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        If clf is a classifier, defaults to KFold(n_folds=5), else defaults to
-        StratifiedKFold(n_folds=5).
+        If clf is a classifier, defaults to StratifiedKFold(n_folds=5), else
+        defaults to KFold(n_folds=5).
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -838,7 +838,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     cv : int | object
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
-        scikit-learn.cross_validation module for the list of possible objects.
+        scikit-learn.model_selection module for the list of possible objects.
         If clf is a classifier, defaults to StratifiedKFold(n_folds=5), else
         defaults to KFold(n_folds=5).
     clf : object | None
@@ -1149,7 +1149,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
     cv : int | object
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
-        scikit-learn.cross_validation module for the list of possible objects.
+        scikit-learn.model_selection module for the list of possible objects.
         If clf is a classifier, defaults to StratifiedKFold(n_folds=5), else
         defaults to KFold(n_folds=5).
     clf : object | None

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -331,13 +331,7 @@ class _GeneralizationAcrossTime(object):
                           for slices in splits)
 
         # Concatenate chunks across test time dimension.
-        n_test_times = [len(ii) for ii in test_times['slices']]
-        if len(set(n_test_times)) == 1:
-            self.y_pred_ = np.concatenate(y_pred, axis=1)
-        else:
-            self.y_pred_ = [[test for chunk in train for test in chunk]
-                            for train in map(list, zip(*y_pred))]
-
+        self.y_pred_ = np.concatenate(y_pred, axis=1)
         _warn_once.clear()  # reset self-baked warning tracker
         return self.y_pred_
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -148,7 +148,10 @@ class _GeneralizationAcrossTime(object):
             XFold = StratifiedKFold
 
         if isinstance(cv, (int, np.int)):
-            cv = XFold(n_folds=cv)
+            try:
+                cv = XFold(n_folds=cv)
+            except TypeError:  # XXX sklearn < 0.18
+                cv = XFold(n=cv)
         try:
             cv = check_cv(cv=cv, X=X, y=y, classifier=is_classifier(self.clf))
         except TypeError:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -11,7 +11,7 @@ import copy
 from ..io.pick import pick_types
 from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
-from ..utils import _traverse_warn
+from ..utils import warn
 
 
 class _DecodingTime(dict):
@@ -250,7 +250,7 @@ class _GeneralizationAcrossTime(object):
         X, y, __ = _check_epochs_input(epochs, None, self.picks_)
 
         if not np.all([len(test) for train, test in self._cv_splits]):
-            _traverse_warn('Some folds do not have any test epochs.')
+            warn('Some folds do not have any test epochs.')
 
         # Define testing sliding window
         if self.test_times == 'diagonal':
@@ -488,8 +488,8 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
             # In vectorize mode, we avoid iterating over time test_times.
             test_times = [slice(expected_start[0], expected_start[-1] + 1, 1)]
         elif _warn_once.get('vectorization', True):
-            _traverse_warn('not vectorizing predictions across testing times, '
-                           'using a time window with length > 1')
+            warn('not vectorizing predictions across testing times, using a '
+                 'time window with length > 1')
             _warn_once['vectorization'] = False
 
         # Iterate over testing times. If vectorize_times: 1 iteration.

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -494,8 +494,9 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
             # In vectorize mode, we avoid iterating over time test time indices
             test_t_idxs = [slice(start[0], start[-1] + 1, 1)]
         elif _warn_once.get('vectorization', True):
-            warn('not vectorizing predictions across testing times, using a '
-                 'time window with length > 1')
+            warn('Due to a time window with length > 1, unable to vectorize '
+                 'across testing times. This leads to slower predictions '
+                 'compared to the length == 1 case.')
             _warn_once['vectorization'] = False
 
         # Iterate over testing times. If vectorize_times: 1 iteration.
@@ -855,8 +856,8 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         If an integer is passed, it is the number of folds.
         Specific cross-validation objects can be passed, see
         scikit-learn.cross_validation module for the list of possible objects.
-        If clf is a classifier, defaults to KFold(n_folds=5), else defaults to
-        StratifiedKFold(n_folds=5).
+        If clf is a classifier, defaults to StratifiedKFold(n_folds=5), else
+        defaults to KFold(n_folds=5).
     clf : object | None
         An estimator compliant with the scikit-learn API (fit & predict).
         If None the classifier will be a standard pipeline including

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -381,16 +381,15 @@ class _GeneralizationAcrossTime(object):
 
         # Check scorer
         self.scorer_ = self.scorer
-        if self.scorer_ is not None:
-            if is_classifier(self.clf) and self.predict_method == 'predict':
+        if self.predict_method == "predict":
+            if is_classifier(self.clf):
                 self.scorer_ = accuracy_score
-            elif is_regressor(self.clf) and self.predict_method == 'predict':
+            elif is_regressor(self.clf):
                 self.scorer_ = mean_squared_error
-            else:
-                raise ValueError('Could not find a scoring metrics for '
-                                 '`clf=%s` and `predict_method=%s`. Manually'
-                                 ' define scorer. ' % (self.clf,
-                                                       self.predict_method))
+        if not self.scorer_:
+            raise ValueError('Could not find a scoring metrics for `clf=%s` '
+                             ' and `predict_method=%s`. Manually define scorer'
+                             '.' % (self.clf, self.predict_method))
 
         # If no regressor is passed, use default epochs events
         if y is None:

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -11,7 +11,7 @@ import copy
 from ..io.pick import pick_types
 from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
-from ..utils import warn
+from ..utils import _traverse_warn
 
 
 class _DecodingTime(dict):
@@ -250,7 +250,7 @@ class _GeneralizationAcrossTime(object):
         X, y, __ = _check_epochs_input(epochs, None, self.picks_)
 
         if not np.all([len(test) for train, test in self._cv_splits]):
-            warnings.warn('Some folds do not have any test epochs.')
+            _traverse_warn('Some folds do not have any test epochs.')
 
         # Define testing sliding window
         if self.test_times == 'diagonal':
@@ -488,7 +488,7 @@ def _predict_slices(X, estimators, splits, train_times, predict_mode,
             # In vectorize mode, we avoid iterating over time test_times.
             test_times = [slice(expected_start[0], expected_start[-1] + 1, 1)]
         elif _warn_once.get('vectorization', True):
-            logger.warning('not vectorizing predictions across testing times, '
+            _traverse_warn('not vectorizing predictions across testing times, '
                            'using a time window with length > 1')
             _warn_once['vectorization'] = False
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -11,7 +11,7 @@ import copy
 from ..io.pick import pick_types
 from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
-from ..utils import warn
+from ..utils import warn, check_version
 
 
 class _DecodingTime(dict):
@@ -122,7 +122,6 @@ class _GeneralizationAcrossTime(object):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
-        from mne.utils import check_version
         from sklearn.base import clone, is_classifier
         if check_version('sklearn', '0.18'):
             from sklearn.model_selection import (check_cv, StratifiedKFold,
@@ -364,7 +363,12 @@ class _GeneralizationAcrossTime(object):
             number of testing times per training time need not be regular;
             else, np.shape(scores) = (n_train_time, n_test_time).
         """
-        from sklearn.base import is_classifier, is_regressor
+        from sklearn.base import is_classifier
+        if check_version('sklearn', '0.17'):
+            from sklearn.base import is_regressor
+        else:
+            def is_regressor(clf):
+                return False
         from sklearn.metrics import accuracy_score, mean_squared_error
 
         # Run predictions if not already done

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -354,7 +354,7 @@ class _GeneralizationAcrossTime(object):
             elif is_regressor(self.clf):
                 self.scorer_ = mean_squared_error
         if not self.scorer_:
-            raise ValueError('Could not find a scoring metrics for `clf=%s` '
+            raise ValueError('Could not find a scoring metric for `clf=%s` '
                              ' and `predict_method=%s`. Manually define scorer'
                              '.' % (self.clf, self.predict_method))
 
@@ -698,19 +698,19 @@ def _sliding_window(times, window, sfreq):
 
     # Default values
     time_slices = window.get('slices', None)
-    # If the users hasn't manually defined the time slices, we'll defined
-    # them with start, stop, step and length parameters.
+    # If the user hasn't manually defined the time slices, we'll define them
+    # with ``start``, ``stop``, ``step`` and ``length`` parameters.
     if time_slices is None:
         window['start'] = window.get('start', times[0])
         window['stop'] = window.get('stop', times[-1])
         window['step'] = window.get('step', 1. / sfreq)
         window['length'] = window.get('length', 1. / sfreq)
 
-        if not(times[0] <= window['start'] <= times[-1]):
+        if not (times[0] <= window['start'] <= times[-1]):
             raise ValueError(
                 '`start` (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['start'], times[0], times[-1]))
-        if not(times[0] <= window['stop'] <= times[-1]):
+        if not (times[0] <= window['stop'] <= times[-1]):
             raise ValueError(
                 '`stop` (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['stop'], times[0], times[-1]))
@@ -1453,8 +1453,8 @@ def _chunk_data(X, slices, gat, n_orig_epochs, test_epochs):
 
     The parallelization is performed across time samples. To avoid overheads,
     the X data is splitted into large chunks of different time sizes. To
-    avoid duplicating the memory load to each core, we only pass the time
-    samples that are required by each core. The indices of the training times
+    avoid duplicating the memory load to each job, we only pass the time
+    samples that are required by each job. The indices of the training times
     must be adjusted accordingly.
     """
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1133,11 +1133,12 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             The figure.
         """
         not_float = not isinstance(train_time, float)
-        not_array = not (isinstance(train_time, (list, np.ndarray)))
-        all_float = np.all([isinstance(time, float) for time in train_time])
-        if (not_float and not_array and all_float):
-            raise ValueError('train_time must be float | list or array of '
-                             'floats. Got %s.' % type(train_time))
+        if not_float:
+            # Check that train_time is an array of floats
+            if not (isinstance(train_time, (list, np.ndarray)) and
+                    np.all([isinstance(ii, float) for ii in train_time])):
+                raise ValueError('train_time must be float | list or array of '
+                                 'floats. Got %s.' % type(train_time))
 
         return plot_gat_times(self, train_time=train_time, title=title,
                               xmin=xmin, xmax=xmax,

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -285,7 +285,7 @@ class _GeneralizationAcrossTime(object):
         chunks = map(list, zip(*chunks))
 
         # To minimize memory during parallelization, we apply a some chunking
-        y_pred = parallel(p_func(*_chunk_X(
+        y_pred = parallel(p_func(*_chunk_data(
             X, chunk, self, n_orig_epochs, test_epochs)) for chunk in chunks)
 
         # Concatenate chunks across test time dimension.
@@ -1448,7 +1448,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
             self.scores_ = [score[0] for score in self.scores_]
 
 
-def _chunk_X(X, slices, gat, n_orig_epochs, test_epochs):
+def _chunk_data(X, slices, gat, n_orig_epochs, test_epochs):
     """Smart chunking to avoid memory overload.
 
     The parallelization is performed across time samples. To avoid overheads,

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1488,18 +1488,6 @@ def _set_cv(cv, clf=None, X=None, y=None):
                 cv = StratifiedKFold(y=y, n_folds=cv)
             else:
                 cv = KFold(n=len(y), n_folds=cv)
-
-    # If cv is only defined in terms of n_folds
-    if isinstance(cv, (int, np.int)):
-        # Automatically chose StratifiedKFold if classification else KFold
-        if check_version('sklearn', '0.18'):
-            XFold = StratifiedKFold if is_classifier(clf) else KFold
-            cv = XFold(n_folds=cv)
-        else:
-            if is_classifier(clf):
-                cv = StratifiedKFold(y=y, n_folds=cv)
-            else:
-                cv = KFold(n=len(y), n_folds=cv)
         cv = check_cv(cv=cv, X=X, y=y, classifier=is_classifier(clf))
 
     # Extract train and test set to retrieve them at predict time

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -126,7 +126,7 @@ class _GeneralizationAcrossTime(object):
         try:
             from sklearn.model_selection import (check_cv, StratifiedKFold,
                                                  KFold)
-        except Exception:  # XXX support sklearn < 0.18
+        except ImportError:  # XXX support sklearn < 0.18
             from sklearn.cross_validation import (check_cv, StratifiedKFold,
                                                   KFold)
 
@@ -149,9 +149,9 @@ class _GeneralizationAcrossTime(object):
                 cv = XFold(n_folds=cv)
             except TypeError:  # XXX sklearn < 0.18
                 if is_classifier(self.clf):
-                    cv = KFold(n=len(y), n_folds=cv)
-                else:
                     cv = StratifiedKFold(y=y, n_folds=cv)
+                else:
+                    cv = KFold(n=len(y), n_folds=cv)
         try:
             cv = check_cv(cv=cv, X=X, y=y, classifier=is_classifier(self.clf))
         except TypeError:


### PR DESCRIPTION
* `gat.y_pred_` and `gat.scores_` are now a np.array, with same dimensionalities as before (when it used to be a list of list). np array can be irregular too, and the data reading and writing is now much faster.
* cleanup the `predict` function: put all test as early as possible, segment `X` only once, before the parallel processing (some speed gain here)
* accepts sklearn new model_selection cv. Closes https://github.com/mne-tools/mne-python/issues/2820
* accepts non deterministic cv objects (e.g. shufflesplit @teonlamont ). Closes https://github.com/mne-tools/mne-python/issues/2596 
* automatically sets cv to `KFold` and not `StratifiedKfold`in case of regression and not classification. Closes bug noted in https://github.com/mne-tools/mne-python/pull/2833.
* automatically sets scoring metrics. ENH to close https://github.com/mne-tools/mne-python/issues/2176 should be an easy PR.
* add test for irregular train test times definition. Here the API was actually broken (the lack of complains suggests that I am the only one who used this function...). 

This last feature (having irregular training and testing time points) is one of the main factor responsible for the script complexity. I have now fixed the API, but I think we we eventually go for refactoring, we may want to just remove this option. 

As discussed below, the other factors are 
* parallel jobs are performed across time chunks to optimize speed and  memory: this makes the CV an inside loop (unlike sklearn), and complexifies the code (we chunk the data, adjust the selected time samples accordingly etc)
* we now accept other methods than `predict`. This is because most users do use `predict_proba`, so this option facilitate their work, but it is a deep departure from sklearn.