### PR TITLE
[MRG+1]: Unify Raw and Epochs-based covariance

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,8 @@ Changelog
 
     - Add plotting RMS of gradiometer pairs in :func:`mne.viz.plot_evoked_topo` by `Jaakko Leppakangas`_
 
+    - Add regularization methods to :func:`mne.compute_raw_covariance` by `Eric Larson`_.
+
 BUG
 ~~~
 
@@ -77,6 +79,8 @@ API
     - The :func:`mne.bem.fit_sphere_to_headshape` now has a ``units`` argument that should be set explicitly. This will default to ``units='mm'`` in 0.12 for backward compatibility but change to ``units='m'`` in 0.13.
 
     - Added default parameters in Epochs class namely ``event_id=None``, ``tmin=-0.2`` and ``tmax=0.5``.
+
+    - To unify and extend the behavior of :func:`mne.comupute_raw_covariance` relative to :func:`mne.compute_covariance`, the default parameter ``tstep=0.2`` now discards any epochs at the end of the :class:`mne.io.Raw` instance that are not the full ``tstep`` duration. This will slighly change the computation of :func:`mne.compute_raw_covaraince`, but should only potentially have a big impact if the :class:`mne.io.Raw` instance is short relative to ``tstep`` and the last, too short (now discarded) epoch contained data inconsistent with the epochs that preceded it.
 
 .. _changes_0_11:
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -655,7 +655,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
     # check for baseline correction
     for epochs_t in epochs:
         if epochs_t.baseline is None and epochs_t.info['highpass'] < 0.5 and \
-               keep_sample_mean:
+                keep_sample_mean:
             warn('Epochs are not baseline corrected, covariance '
                  'matrix may be inaccurate')
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -486,26 +486,28 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
     when the stim onset is defined from events.
 
     If the covariance is computed for multiple event types (events
-    with different IDs), the following two options can be used and combined.
-    A) either an Epochs object for each event type is created and
-    a list of Epochs is passed to this function.
-    B) an Epochs object is created for multiple events and passed
-    to this function.
+    with different IDs), the following two options can be used and combined:
 
-    Note: Baseline correction should be used when creating the Epochs.
-          Otherwise the computed covariance matrix will be inaccurate.
+        1. either an Epochs object for each event type is created and
+           a list of Epochs is passed to this function.
+        2. an Epochs object is created for multiple events and passed
+           to this function.
 
-    Note: For multiple event types, it is also possible to create a
-          single Epochs object with events obtained using
-          merge_events(). However, the resulting covariance matrix
-          will only be correct if keep_sample_mean is True.
+    .. note:: Baseline correction should be used when creating the Epochs.
+              Otherwise the computed covariance matrix will be inaccurate.
 
-    Note: The covariance can be unstable if the number of samples is not
-          sufficient. In that case it is common to regularize a covariance
-          estimate. The ``method`` parameter of this function allows to
-          regularize the covariance in an automated way. It also allows
-          to select between different alternative estimation algorithms which
-          themselves achieve regularization. Details are described in [1].
+    .. note:: For multiple event types, it is also possible to create a
+              single Epochs object with events obtained using
+              merge_events(). However, the resulting covariance matrix
+              will only be correct if keep_sample_mean is True.
+
+    .. note:: The covariance can be unstable if the number of samples is
+              not sufficient. In that case it is common to regularize a
+              covariance estimate. The ``method`` parameter of this
+              function allows to regularize the covariance in an
+              automated way. It also allows to select between different
+              alternative estimation algorithms which themselves achieve
+              regularization. Details are described in [1]_.
 
     Parameters
     ----------
@@ -531,22 +533,30 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         set of the different methods.
         If 'auto' or a list of methods, the best estimator will be determined
         based on log-likelihood and cross-validation on unseen data as
-        described in ref. [1]. Valid methods are:
-        'empirical', the empirical or sample covariance,
-        'diagonal_fixed', a diagonal regularization as in mne.cov.regularize
-        (see MNE manual), 'ledoit_wolf', the Ledoit-Wolf estimator (see [2]),
-        'shrunk' like 'ledoit_wolf' with cross-validation for optimal alpha
-        (see scikit-learn documentation on covariance estimation), 'pca',
-        probabilistic PCA with low rank
-        (see [3]), and, 'factor_analysis', Factor Analysis with low rank
-        (see [4]). If 'auto', expands to::
+        described in [1]_. Valid methods are:
+
+            * ``'empirical'``: the empirical or sample covariance
+            * ``'diagonal_fixed'``: a diagonal regularization as in
+              mne.cov.regularize (see MNE manual)
+            * ``'ledoit_wolf'``: the Ledoit-Wolf estimator [2]_
+            * ``'shrunk'``: like 'ledoit_wolf' with cross-validation for
+              optimal alpha (see scikit-learn documentation on covariance
+              estimation)
+            * ``'pca'``: probabilistic PCA with low rank [3]_
+            * ``'factor_analysis'``: Factor Analysis with low rank [4]_
+
+        If ``'auto'``, this expands to::
 
              ['shrunk', 'diagonal_fixed', 'empirical', 'factor_analysis']
 
-        Note. 'ledoit_wolf' and 'pca' are similar to 'shrunk' and
-        'factor_analysis', respectively. They are not included to avoid
-        redundancy. In most cases 'shrunk' and 'factor_analysis' represent
-        more appropriate default choices.
+        .. note:: ``'ledoit_wolf'`` and ``'pca'`` are similar to
+           ``'shrunk'`` and ``'factor_analysis'``, respectively. They are not
+           included to avoid redundancy. In most cases ``'shrunk'`` and
+           ``'factor_analysis'`` represent more appropriate default
+           choices.
+
+        The ``'auto'`` mode is not recommended if there are many
+        segments of data, since computation can take a long time.
 
         .. versionadded:: 0.9.0
 
@@ -594,17 +604,17 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
 
     References
     ----------
-    [1] Engemann D. and Gramfort A. (2015) Automated model selection in
-        covariance estimation and spatial whitening of MEG and EEG signals,
-        vol. 108, 328-342, NeuroImage.
-    [2] Ledoit, O., Wolf, M., (2004). A well-conditioned estimator for
-        large-dimensional covariance matrices. Journal of Multivariate
-        Analysis 88 (2), 365 - 411.
-    [3] Tipping, M. E., Bishop, C. M., (1999). Probabilistic principal
-        component analysis. Journal of the Royal Statistical Society: Series
-        B (Statistical Methodology) 61 (3), 611 - 622.
-    [4] Barber, D., (2012). Bayesian reasoning and machine learning.
-        Cambridge University Press., Algorithm 21.1
+    .. [1] Engemann D. and Gramfort A. (2015) Automated model selection in
+           covariance estimation and spatial whitening of MEG and EEG
+           signals, vol. 108, 328-342, NeuroImage.
+    .. [2] Ledoit, O., Wolf, M., (2004). A well-conditioned estimator for
+           large-dimensional covariance matrices. Journal of Multivariate
+           Analysis 88 (2), 365 - 411.
+    .. [3] Tipping, M. E., Bishop, C. M., (1999). Probabilistic principal
+           component analysis. Journal of the Royal Statistical Society:
+           Series B (Statistical Methodology) 61 (3), 611 - 622.
+    .. [4] Barber, D., (2012). Bayesian reasoning and machine learning.
+           Cambridge University Press., Algorithm 21.1
     """
     accepted_methods = ('auto', 'empirical', 'diagonal_fixed', 'ledoit_wolf',
                         'shrunk', 'pca', 'factor_analysis',)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -5,10 +5,10 @@
 # License: BSD (3-clause)
 
 import copy as cp
-import os
-import itertools as itt
-from copy import deepcopy
 from distutils.version import LooseVersion
+import itertools as itt
+from math import log
+import os
 
 import numpy as np
 from scipy import linalg
@@ -159,7 +159,7 @@ class Covariance(dict):
         cov : instance of Covariance
             The copied object.
         """
-        return deepcopy(self)
+        return cp.deepcopy(self)
 
     def as_diag(self, copy=True):
         """Set covariance to be processed as being diagonal.
@@ -947,7 +947,7 @@ def _gaussian_loglik_scorer(est, X, y=None):
     n_samples, n_features = X.shape
     log_like = np.zeros(n_samples)
     log_like = -.5 * (X * (np.dot(X, precision))).sum(axis=1)
-    log_like -= .5 * (n_features * np.log(2. * np.pi) - _logdet(precision))
+    log_like -= .5 * (n_features * log(2. * np.pi) - _logdet(precision))
     out = np.mean(log_like)
     return out
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -354,7 +354,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
     It is typically useful to estimate a noise covariance from empty room
     data or time intervals before starting the stimulation.
 
-    .. note:: This function will will:
+    .. note:: This function will:
 
                   1. Partition the data into evenly spaced, equal-length
                      epochs.
@@ -366,8 +366,8 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
 
               This will produce a slightly different result compared to
               using :func:`make_fixed_length_events`, :class:`Epochs`, and
-              :func:`compute_covariance`, since that would (with the
-              recommended baseline correction) subtract the mean across
+              :func:`compute_covariance` directly, since that would (with
+              the recommended baseline correction) subtract the mean across
               time *for each epoch* (instead of across epochs) for each
               channel.
 
@@ -379,12 +379,11 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         Beginning of time interval in seconds
     tmax : float | None (default None)
         End of time interval in seconds
-    tstep : float
+    tstep : float (default 0.2)
         Length of data chunks for artefact rejection in seconds.
         Can also be None to use a single epoch of (tmax - tmin)
         duration. This can use a lot of memory for large ``Raw``
-        instances. The default behavior of MNE-C is equivalent to
-        using ``None`` (i.e., a single long interval).
+        instances.
     reject : dict | None (default None)
         Rejection parameters based on peak-to-peak amplitude.
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
@@ -460,7 +459,8 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
     tstep = tmax - tmin if tstep is None else float(tstep)
     tstep_m1 = tstep - 1. / raw.info['sfreq']  # inclusive!
     events = make_fixed_length_events(raw, 1, tmin, tmax, tstep)
-    logger.info('Using up to %s segments' % len(events))
+    pl = 's' if len(events) != 1 else ''
+    logger.info('Using up to %s segment%s' % (len(events), pl))
 
     # don't exclude any bad channels, inverses expect all channels present
     if picks is None:

--- a/mne/event.py
+++ b/mne/event.py
@@ -720,7 +720,8 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.):
         raise ValueError('id must be an integer')
     # Make sure we don't go out the end of the file:
     stop -= int(np.ceil(raw.info['sfreq'] * duration))
-    ts = np.arange(start, stop, raw.info['sfreq'] * duration).astype(int)
+    # This should be inclusive due to how we generally use start and stop...
+    ts = np.arange(start, stop + 1, raw.info['sfreq'] * duration).astype(int)
     n_events = len(ts)
     events = np.c_[ts, np.zeros(n_events, dtype=int),
                    id * np.ones(n_events, dtype=int)]

--- a/mne/tests/common.py
+++ b/mne/tests/common.py
@@ -5,6 +5,8 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 
+from scipy import linalg
+
 from .. import pick_types, Evoked
 from ..io import _BaseRaw
 from ..io.constants import FIFF
@@ -68,6 +70,14 @@ def assert_meg_snr(actual, desired, min_tol, med_tol=500., chpi_med_tol=500.,
     _check_snr(actual, desired, picks, min_tol, med_tol, msg, kind='MEG')
     if chpi_med_tol is not None and len(chpis) > 0:
         _check_snr(actual, desired, chpis, 0., chpi_med_tol, msg, kind='cHPI')
+
+
+def assert_snr(actual, desired, tol):
+    """Assert actual and desired arrays are within some SNR tolerance"""
+    from nose.tools import assert_true
+    snr = (linalg.norm(desired, ord='fro') /
+           linalg.norm(desired - actual, ord='fro'))
+    assert_true(snr >= tol, msg='%f < %f' % (snr, tol))
 
 
 def _dig_sort_key(dig):

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -136,8 +136,10 @@ def test_cov_estimation_on_raw_reg():
     cov_mne = read_cov(erm_cov_fname)
     with warnings.catch_warnings(record=True):  # too few samples
         warnings.simplefilter('always')
+        # Don't use "shrunk" here, for some reason it makes Travis 2.7 hang...
+        # "diagonal_fixed" is faster anyway.
         cov = compute_raw_covariance(raw, keep_sample_mean=True, tstep=5.,
-                                     method='shrunk')
+                                     method='diagonal_fixed')
     assert_snr(cov.data, cov_mne.data, 4)
 
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -22,7 +22,7 @@ from mne import (read_cov, write_cov, Epochs, merge_events,
                  compute_covariance, read_evokeds, compute_proj_raw,
                  pick_channels_cov, pick_channels, pick_types, pick_info,
                  make_ad_hoc_cov)
-from mne.io import Raw
+from mne.io import Raw, RawArray
 from mne.tests.common import assert_naming, assert_snr
 from mne.utils import (_TempDir, slow_test, requires_sklearn_0_15,
                        run_tests_if_main)
@@ -131,7 +131,8 @@ def test_cov_estimation_on_raw_reg():
     """Test estimation from raw with regularization
     """
     raw = Raw(raw_fname, preload=True)
-    raw.resample(10.)  # much faster computation below
+    raw.info['sfreq'] /= 10.
+    raw = RawArray(raw._data[:, ::10].copy(), raw.info)  # decimate for speed
     cov_mne = read_cov(erm_cov_fname)
     with warnings.catch_warnings(record=True):  # too few samples
         warnings.simplefilter('always')

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -3,7 +3,8 @@ import os
 
 from nose.tools import assert_true, assert_raises
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
 import warnings
 
 from mne import (read_events, write_events, make_fixed_length_events,
@@ -304,6 +305,10 @@ def test_make_fixed_length_events():
     raw = io.Raw(raw_fname)
     events = make_fixed_length_events(raw, id=1)
     assert_true(events.shape[1], 3)
+    tmin, tmax = raw.times[[0, -1]]
+    duration = tmax - tmin
+    events = make_fixed_length_events(raw, 1, tmin, tmax, duration)
+    assert_equal(events.shape[0], 1)
 
 
 def test_define_events():


### PR DESCRIPTION
Closes #2867. Related to #2448.

This simplifies our code a bit, and also shows how `compute_raw_covariance` differed from `compute_covariance` under the hood.

As shown in the code, `compute_raw_covariance` has (effectively) `keep_sample_mean=False` by default, whereas `compute_covariance` has `keep_sample_mean=True` by default. This makes me think we should have `keep_sample_mean=None` -> `False` with deprecation message saying it will change to `True` in 0.13. This would really unify the two functions. Thoughts?