### PR TITLE
plot_evoked_topomap colorbar in last subplot

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1232,12 +1232,13 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         plt.suptitle(title, verticalalignment='top', size='x-large')
 
     if colorbar:
-        cax = plt.subplot(1, n_times + 1, n_times + 1)
+        n_fig_axes = len(fig.get_axes())  # works when fig axes pre-defined
+        cax = plt.subplot(1, n_fig_axes + 1, n_fig_axes + 1)
         # resize the colorbar (by default the color fills the whole axes)
         cpos = cax.get_position()
         if size <= 1:
-            cpos.x0 = 1 - (.7 + .1 / size) / nax
-        cpos.x1 = cpos.x0 + .1 / nax
+            cpos.x0 = 1 - (.7 + .1 / size) / n_fig_axes
+        cpos.x1 = cpos.x0 + .1 / n_fig_axes
         cpos.y0 = .2
         cpos.y1 = .7
         cax.set_position(cpos)


### PR DESCRIPTION
When composing a custom topomap-layout and passing the axes-parameter to `plot_topomap`, it is assumed that is a colorbar is desired, it should be in the rightmost column.

Solves issue #2887 