### PR TITLE
fix bug introduced by PR2888

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1232,7 +1232,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         plt.suptitle(title, verticalalignment='top', size='x-large')
 
     if colorbar:
-        n_fig_axes = len(fig.get_axes())  # works when fig axes pre-defined
+        # works both when fig axes pre-defined and when not
+        n_fig_axes = max(nax, len(fig.get_axes()))
         cax = plt.subplot(1, n_fig_axes + 1, n_fig_axes + 1)
         # resize the colorbar (by default the color fills the whole axes)
         cpos = cax.get_position()


### PR DESCRIPTION
@jaeilepp @agramfort @wmvanvliet I introduced a bug in PR2888 :-(
* when `axes` not given, new figure created on-the-fly
* topomap-axes created for each time point
* finally, colorbar-subplot created
* BUG: `len(fig.get_axes())` is one short and colorbar end up too far to left

FIX: take the max of `len(fig.get_axes())` and `nax` (`= n_times + bool(colorbar)`)