### PR TITLE
MRG: Add st_only option for temporal projection

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -397,7 +397,9 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
 
         # Get original data
         orig_data = raw_sss._data[good_picks, start:stop]
-        out_meg_data = orig_data.copy()
+        # This could just be np.empty if not st_only, but shouldn't be slow
+        # this way so might as well just always take the original data
+        out_meg_data = raw_sss._data[meg_picks, start:stop]
         # Apply cross-talk correction
         if cross_talk is not None:
             orig_data = ctc.dot(orig_data)
@@ -1510,13 +1512,13 @@ def _update_sss_info(raw, origin, int_order, ext_order, nchan, coord_frame,
     else:
         max_info_dict.update(sss_info=sss_info_dict, sss_cal=sss_cal,
                              sss_ctc=sss_ctc)
+        # Reset 'bads' for any MEG channels since they've been reconstructed
+        _reset_meg_bads(raw.info)
     block_id = _generate_meas_id()
     proc_block = dict(max_info=max_info_dict, block_id=block_id,
                       creator='mne-python v%s' % __version__,
                       date=_date_now(), experimentor='')
     raw.info['proc_history'] = [proc_block] + raw.info.get('proc_history', [])
-    # Reset 'bads' for any MEG channels since they've been reconstructed
-    _reset_meg_bads(raw.info)
 
 
 def _reset_meg_bads(info):

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -130,7 +130,9 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         but the ouptut MEG data will *only* have temporal projections
         performed. Noise reduction from SSS basis multiplication,
         cross-talk cancellation, movement compensation, and so forth
-        will not be applied to the data.
+        will not be applied to the data. This is useful, for example, when
+        evoked movement compensation will be performed with
+        :func:`mne.epochs.average_movements`.
 
         .. versionadded:: 0.12
 

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -564,11 +564,17 @@ def test_spatiotemporal_only():
     raw_tsss = maxwell_filter(raw_tsss)
     raw_tsss_2 = maxwell_filter(raw, st_duration=1.)
     assert_meg_snr(raw_tsss, raw_tsss_2, 1e5)
-    # now also with head movement
+    # now also with head movement, and a bad MEG channel
+    assert_equal(len(raw.info['bads']), 0)
+    raw.info['bads'] = ['EEG001', 'MEG2623']
     raw_tsss = maxwell_filter(raw, st_duration=1., st_only=True,
                               head_pos=head_pos)
+    assert_equal(raw.info['bads'], ['EEG001', 'MEG2623'])
+    assert_equal(raw_tsss.info['bads'], ['EEG001', 'MEG2623'])  # don't reset
     raw_tsss = maxwell_filter(raw_tsss, head_pos=head_pos)
+    assert_equal(raw_tsss.info['bads'], ['EEG001'])  # do reset MEG bads
     raw_tsss_2 = maxwell_filter(raw, st_duration=1., head_pos=head_pos)
+    assert_equal(raw_tsss_2.info['bads'], ['EEG001'])
     assert_meg_snr(raw_tsss, raw_tsss_2, 1e5)
 
 


### PR DESCRIPTION
This allows using `maxwell_filter` in a temporal-projection-only (tSSS only) mode.