### PR TITLE
MRG: Fix dtype

### DIFF
--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -425,7 +425,7 @@ def _read_old_pack(fid, tag, shape, rlims):
     """Read old pack tag"""
     offset = float(np.fromstring(fid.read(4), dtype=">f4"))
     scale = float(np.fromstring(fid.read(4), dtype=">f4"))
-    data = np.fromstring(fid.read(tag.size - 8), dtype=">h2")
+    data = np.fromstring(fid.read(tag.size - 8), dtype=">i2")
     data = data * scale  # to float64
     data += offset
     return data


### PR DESCRIPTION
Looks like back in 2012 I missed one:

https://github.com/mne-tools/mne-python/commit/b1634cd3a602643138161e37d83effd079a7a8ce

Ready for review/merge from my end. It wasn't caught by tests because we don't have any files that use it. I got a hold of a file that did (exported from xplotter I think?) but it's too big (13 MB) to justify adding.