### PR TITLE
MRG: Allow maxshield silently

### DIFF
--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -185,7 +185,7 @@ class Raw(_BaseRaw):
                     elif allow_maxshield:
                         info['maxshield'] = True
                         if not (isinstance(allow_maxshield, string_types) and
-                                allow_maxshield.startswith('y')):
+                                allow_maxshield == 'yes'):
                             warn(msg)
                     else:
                         msg += (' Use allow_maxshield=True if you are sure you'

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -23,6 +23,7 @@ from ..base import _BaseRaw, _RawShell, _check_raw_compatibility
 from ..utils import _mult_cal_one
 
 from ...annotations import Annotations, _combine_annotations
+from ...externals.six import string_types
 from ...utils import check_fname, logger, verbose, warn
 
 
@@ -37,10 +38,11 @@ class Raw(_BaseRaw):
         name of the first file has to be specified. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz,
         raw_tsss.fif or raw_tsss.fif.gz.
-    allow_maxshield : bool, (default False)
+    allow_maxshield : bool | str (default False)
         allow_maxshield if True, allow loading of data that has been
         processed with Maxshield. Maxshield-processed data should generally
         not be loaded directly, but should be processed using SSS first.
+        Can also be "yes" to load without eliciting a warning.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires
@@ -182,7 +184,9 @@ class Raw(_BaseRaw):
                         raise ValueError('No raw data in %s' % fname)
                     elif allow_maxshield:
                         info['maxshield'] = True
-                        warn(msg)
+                        if not (isinstance(allow_maxshield, string_types) and
+                                allow_maxshield.startswith('y')):
+                            warn(msg)
                     else:
                         msg += (' Use allow_maxshield=True if you are sure you'
                                 ' want to load the data despite this warning.')

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -108,8 +108,7 @@ def test_movement_compensation():
     """Test movement compensation"""
     temp_dir = _TempDir()
     lims = (0, 4)
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True, preload=True).crop(*lims)
+    raw = Raw(raw_fname, allow_maxshield='yes', preload=True).crop(*lims)
     head_pos = read_head_pos(pos_fname)
 
     #
@@ -163,7 +162,7 @@ def test_movement_compensation():
 
     # some degenerate cases
     with warnings.catch_warnings(record=True):  # maxshield
-        raw_erm = Raw(erm_fname, allow_maxshield=True)
+        raw_erm = Raw(erm_fname, allow_maxshied='yes')
     assert_raises(ValueError, maxwell_filter, raw_erm, coord_frame='meg',
                   head_pos=head_pos)  # can't do ERM file
     head_pos_bad = head_pos[:, :9]
@@ -350,10 +349,9 @@ def test_multipolar_bases():
 def test_basic():
     """Test Maxwell filter basic version"""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 1., False)
-        raw_err = Raw(raw_fname, proj=True, allow_maxshield=True)
-        raw_erm = Raw(erm_fname, allow_maxshield=True)
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
+    raw_err = Raw(raw_fname, proj=True, allow_maxshied='yes')
+    raw_erm = Raw(erm_fname, allow_maxshied='yes')
     assert_raises(RuntimeError, maxwell_filter, raw_err)
     assert_raises(TypeError, maxwell_filter, 1.)  # not a raw
     assert_raises(ValueError, maxwell_filter, raw, int_order=20)  # too many
@@ -424,9 +422,8 @@ def test_maxwell_filter_additional():
 
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
-    with warnings.catch_warnings(record=True):  # maxshield
-        # Use 2.0 seconds of data to get stable cov. estimate
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 2., False)
+    # Use 2.0 seconds of data to get stable cov. estimate
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 2., False)
 
     # Get MEG channels, compute Maxwell filtered data
     raw.load_data()
@@ -462,8 +459,7 @@ def test_maxwell_filter_additional():
 @testing.requires_testing_data
 def test_bads_reconstruction():
     """Test Maxwell filter reconstruction of bad channels"""
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
     raw.info['bads'] = bads
     raw_sss = maxwell_filter(raw, origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
@@ -475,8 +471,7 @@ def test_bads_reconstruction():
 def test_spatiotemporal_maxwell():
     """Test Maxwell filter (tSSS) spatiotemporal processing"""
     # Load raw testing data
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True)
+    raw = Raw(raw_fname, allow_maxshied='yes')
 
     # Test that window is less than length of data
     assert_raises(ValueError, maxwell_filter, raw, st_duration=1000.)
@@ -583,8 +578,7 @@ def test_fine_calibration():
     """Test Maxwell filter fine calibration"""
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
     sss_fine_cal = Raw(sss_fine_cal_fname)
 
     # Test 1D SSS fine calibration
@@ -627,8 +621,7 @@ def test_regularization():
                   sss_samp_reg_in_fname)
     comp_tols = [0, 1, 4]
     for ii, rf in enumerate(raw_fnames):
-        with warnings.catch_warnings(record=True):  # maxshield
-            raw = Raw(rf, allow_maxshield=True).crop(0., 1., False)
+        raw = Raw(rf, allow_maxshied='yes').crop(0., 1., False)
         sss_reg_in = Raw(sss_fnames[ii])
 
         # Test "in" regularization
@@ -655,8 +648,7 @@ def test_regularization():
 @testing.requires_testing_data
 def test_cross_talk():
     """Test Maxwell filter cross-talk cancellation"""
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
     raw.info['bads'] = bads
     sss_ctc = Raw(sss_ctc_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
@@ -691,8 +683,7 @@ def test_cross_talk():
 @testing.requires_testing_data
 def test_head_translation():
     """Test Maxwell filter head translation"""
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
     # First try with an unchanged destination
     raw_sss = maxwell_filter(raw, destination=raw_fname,
                              origin=mf_head_origin, regularize=None,
@@ -744,8 +735,7 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
 @testing.requires_testing_data
 def test_shielding_factor():
     """Test Maxwell filter shielding factor using empty room"""
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw_erm = Raw(erm_fname, allow_maxshield=True, preload=True)
+    raw_erm = Raw(erm_fname, allow_maxshied='yes', preload=True)
     picks = pick_types(raw_erm.info, meg='mag')
     erm_power = raw_erm[picks][0]
     erm_power = np.sqrt(np.sum(erm_power * erm_power))
@@ -859,8 +849,7 @@ def test_all():
                mf_meg_origin,
                mf_head_origin)
     for ii, rf in enumerate(raw_fnames):
-        with warnings.catch_warnings(record=True):  # maxshield
-            raw = Raw(rf, allow_maxshield=True).crop(0., 1., copy=False)
+        raw = Raw(rf, allow_maxshied='yes').crop(0., 1., copy=False)
         with warnings.catch_warnings(record=True):  # head fit off-center
             sss_py = maxwell_filter(
                 raw, calibration=fine_cals[ii], cross_talk=ctcs[ii],

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -162,7 +162,7 @@ def test_movement_compensation():
 
     # some degenerate cases
     with warnings.catch_warnings(record=True):  # maxshield
-        raw_erm = Raw(erm_fname, allow_maxshied='yes')
+        raw_erm = Raw(erm_fname, allow_maxshield='yes')
     assert_raises(ValueError, maxwell_filter, raw_erm, coord_frame='meg',
                   head_pos=head_pos)  # can't do ERM file
     head_pos_bad = head_pos[:, :9]
@@ -349,9 +349,9 @@ def test_multipolar_bases():
 def test_basic():
     """Test Maxwell filter basic version"""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
-    raw_err = Raw(raw_fname, proj=True, allow_maxshied='yes')
-    raw_erm = Raw(erm_fname, allow_maxshied='yes')
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw_err = Raw(raw_fname, proj=True, allow_maxshield='yes')
+    raw_erm = Raw(erm_fname, allow_maxshield='yes')
     assert_raises(RuntimeError, maxwell_filter, raw_err)
     assert_raises(TypeError, maxwell_filter, 1.)  # not a raw
     assert_raises(ValueError, maxwell_filter, raw, int_order=20)  # too many
@@ -423,7 +423,7 @@ def test_maxwell_filter_additional():
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
     # Use 2.0 seconds of data to get stable cov. estimate
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 2., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2., False)
 
     # Get MEG channels, compute Maxwell filtered data
     raw.load_data()
@@ -459,7 +459,7 @@ def test_maxwell_filter_additional():
 @testing.requires_testing_data
 def test_bads_reconstruction():
     """Test Maxwell filter reconstruction of bad channels"""
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
     raw.info['bads'] = bads
     raw_sss = maxwell_filter(raw, origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
@@ -471,7 +471,7 @@ def test_bads_reconstruction():
 def test_spatiotemporal_maxwell():
     """Test Maxwell filter (tSSS) spatiotemporal processing"""
     # Load raw testing data
-    raw = Raw(raw_fname, allow_maxshied='yes')
+    raw = Raw(raw_fname, allow_maxshield='yes')
 
     # Test that window is less than length of data
     assert_raises(ValueError, maxwell_filter, raw, st_duration=1000.)
@@ -578,7 +578,7 @@ def test_fine_calibration():
     """Test Maxwell filter fine calibration"""
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
     sss_fine_cal = Raw(sss_fine_cal_fname)
 
     # Test 1D SSS fine calibration
@@ -621,7 +621,7 @@ def test_regularization():
                   sss_samp_reg_in_fname)
     comp_tols = [0, 1, 4]
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshied='yes').crop(0., 1., False)
+        raw = Raw(rf, allow_maxshield='yes').crop(0., 1., False)
         sss_reg_in = Raw(sss_fnames[ii])
 
         # Test "in" regularization
@@ -648,7 +648,7 @@ def test_regularization():
 @testing.requires_testing_data
 def test_cross_talk():
     """Test Maxwell filter cross-talk cancellation"""
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
     raw.info['bads'] = bads
     sss_ctc = Raw(sss_ctc_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
@@ -683,7 +683,7 @@ def test_cross_talk():
 @testing.requires_testing_data
 def test_head_translation():
     """Test Maxwell filter head translation"""
-    raw = Raw(raw_fname, allow_maxshied='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
     # First try with an unchanged destination
     raw_sss = maxwell_filter(raw, destination=raw_fname,
                              origin=mf_head_origin, regularize=None,
@@ -735,7 +735,7 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
 @testing.requires_testing_data
 def test_shielding_factor():
     """Test Maxwell filter shielding factor using empty room"""
-    raw_erm = Raw(erm_fname, allow_maxshied='yes', preload=True)
+    raw_erm = Raw(erm_fname, allow_maxshield='yes', preload=True)
     picks = pick_types(raw_erm.info, meg='mag')
     erm_power = raw_erm[picks][0]
     erm_power = np.sqrt(np.sum(erm_power * erm_power))
@@ -849,7 +849,7 @@ def test_all():
                mf_meg_origin,
                mf_head_origin)
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshied='yes').crop(0., 1., copy=False)
+        raw = Raw(rf, allow_maxshield='yes').crop(0., 1., copy=False)
         with warnings.catch_warnings(record=True):  # head fit off-center
             sss_py = maxwell_filter(
                 raw, calibration=fine_cals[ii], cross_talk=ctcs[ii],

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -161,8 +161,7 @@ def test_movement_compensation():
     assert_meg_snr(raw_sss_mc, raw_sss_mv, 0.6, 1.4)
 
     # some degenerate cases
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw_erm = Raw(erm_fname, allow_maxshield='yes')
+    raw_erm = Raw(erm_fname, allow_maxshield='yes')
     assert_raises(ValueError, maxwell_filter, raw_erm, coord_frame='meg',
                   head_pos=head_pos)  # can't do ERM file
     head_pos_bad = head_pos[:, :9]
@@ -525,8 +524,7 @@ def test_spatiotemporal_maxwell():
 def test_spatiotemporal_only():
     """Test tSSS-only processing"""
     # Load raw testing data
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(raw_fname, allow_maxshield=True).crop(0, 2).load_data()
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0, 2).load_data()
     picks = pick_types(raw.info, meg='mag', exclude=())
     power = np.sqrt(np.sum(raw[picks][0] ** 2))
     # basics

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -107,8 +107,7 @@ def test_simulate_raw_sphere():
     test_outname = op.join(tempdir, 'sim_test_raw.fif')
     raw_sim.save(test_outname)
 
-    raw_sim_loaded = Raw(test_outname, preload=True, proj=False,
-                         allow_maxshield=True)
+    raw_sim_loaded = Raw(test_outname, preload=True, proj=False)
     assert_allclose(raw_sim_loaded[:][0], raw_sim[:][0], rtol=1e-6, atol=1e-20)
     del raw_sim, raw_sim_2
     # with no cov (no noise) but with artifacts, most time periods should match
@@ -212,8 +211,7 @@ def test_simulate_raw_bem():
 @testing.requires_testing_data
 def test_simulate_raw_chpi():
     """Test simulation of raw data with cHPI"""
-    with warnings.catch_warnings(record=True):  # MaxShield
-        raw = Raw(raw_chpi_fname, allow_maxshield=True)
+    raw = Raw(raw_chpi_fname, allow_maxshield='yes')
     sphere = make_sphere_model('auto', 'auto', raw.info)
     # make sparse spherical source space
     sphere_vol = tuple(sphere['r0'] * 1000.) + (sphere.radius * 1000.,)

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -87,14 +87,10 @@ def test_hpi_info():
     tempdir = _TempDir()
     temp_name = op.join(tempdir, 'temp_raw.fif')
     for fname in (chpi_fif_fname, sss_fif_fname):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always')
-            raw = Raw(fname, allow_maxshield=True)
+        raw = Raw(fname, allow_maxshield='yes')
         assert_true(len(raw.info['hpi_subsystem']) > 0)
         raw.save(temp_name, overwrite=True)
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always')
-            raw_2 = Raw(temp_name, allow_maxshield=True)
+        raw_2 = Raw(temp_name, allow_maxshield='yes')
         assert_equal(len(raw_2.info['hpi_subsystem']),
                      len(raw.info['hpi_subsystem']))
 
@@ -139,8 +135,7 @@ def test_calculate_chpi_positions():
     """Test calculation of cHPI positions
     """
     trans, rot, t = head_pos_to_trans_rot_t(read_head_pos(pos_fname))
-    with warnings.catch_warnings(record=True):
-        raw = Raw(chpi_fif_fname, allow_maxshield=True, preload=True)
+    raw = Raw(chpi_fif_fname, allow_maxshield='yes', preload=True)
     t -= raw.first_samp / raw.info['sfreq']
     quats = _calculate_chpi_positions(raw, verbose='debug')
     trans_est, rot_est, t_est = head_pos_to_trans_rot_t(quats)
@@ -171,8 +166,7 @@ def test_calculate_chpi_positions():
 @testing.requires_testing_data
 def test_chpi_subtraction():
     """Test subtraction of cHPI signals"""
-    with warnings.catch_warnings(record=True):  # maxshield
-        raw = Raw(chpi_fif_fname, allow_maxshield=True, preload=True)
+    raw = Raw(chpi_fif_fname, allow_maxshield='yes', preload=True)
     filter_chpi(raw, include_line=False)
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
     raw.crop(0, 16, copy=False)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -80,8 +80,7 @@ def test_average_movements():
     # usable data
     crop = 0., 10.
     origin = (0., 0., 0.04)
-    with warnings.catch_warnings(record=True):  # MaxShield
-        raw = Raw(fname_raw_move, allow_maxshield=True)
+    raw = Raw(fname_raw_move, allow_maxshield='yes')
     raw.info['bads'] += ['MEG2443']  # mark some bad MEG channel
     raw.crop(*crop, copy=False).load_data()
     raw.filter(None, 20, method='iir')


### PR DESCRIPTION
For people who record with MaxShield on and plan on running `maxwell_filter` on the data, it would be nice to be able to silently load data. Now `allow_maxshield='yes'` allows us to do that.