### PR TITLE
MRG: Fix raw repr

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1779,10 +1779,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def __repr__(self):
         name = self._filenames[0]
         name = 'None' if name is None else op.basename(name)
-        s = ', '.join(('%r' % name, "n_channels x n_times : %s x %s"
-                       % (len(self.ch_names), self.n_times)))
-        s = "n_channels x n_times : %s x %s" % (len(self.info['ch_names']),
-                                                self.n_times)
+        s = ('%s, n_channels x n_times : %s x %s (%0.1f sec)'
+             % (name, len(self.ch_names), self.n_times, self.times[-1]))
         return "<%s  |  %s>" % (self.__class__.__name__, s)
 
     def add_events(self, events, stim_channel=None):

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -428,6 +428,7 @@ def test_io_raw():
     for chars in [b'\xc3\xa4\xc3\xb6\xc3\xa9', b'a']:
         with Raw(fif_fname) as r:
             assert_true('Raw' in repr(r))
+            assert_true(op.basename(fif_fname) in repr(r))
             desc1 = r.info['description'] = chars.decode('utf-8')
             temp_file = op.join(tempdir, 'raw.fif')
             r.save(temp_file, overwrite=True)


### PR DESCRIPTION
Somewhere along the way our raw `__repr__` got broken. On `master` it is:
```
<Raw  |  n_channels x n_times : 326 x 61500>
```
On this PR it is:
```
<Raw  |  phantom_moving_raw.fif, n_channels x n_times : 326 x 61500 (30.7 sec)>
```