### PR TITLE
MRG: Fix SEEG picking (again)

### DIFF
--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -253,6 +253,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
 
     for k in range(nchan):
         kind = info['chs'][k]['kind']
+        # XXX eventually we should de-duplicate this with channel_type!
         if kind == FIFF.FIFFV_MEG_CH:
             pick[k] = _triage_meg_pick(info['chs'][k], meg)
         elif kind == FIFF.FIFFV_EEG_CH and eeg:
@@ -273,8 +274,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
             pick[k] = True
         elif kind == FIFF.FIFFV_SYST_CH and syst:
             pick[k] = True
-        elif kind in [FIFF.FIFFV_SEEG_CH, 702] and seeg:
-            # Constant 702 was used before v0.11
+        elif kind == FIFF.FIFFV_SEEG_CH and seeg:
             pick[k] = True
         elif kind == FIFF.FIFFV_IAS_CH and ias:
             pick[k] = True

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -20,6 +20,7 @@ io_dir = op.join(op.dirname(inspect.getfile(inspect.currentframe())), '..')
 data_path = testing.data_path(download=False)
 fname_meeg = op.join(data_path, 'MEG', 'sample',
                      'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+fname_mc = op.join(data_path, 'SSS', 'test_move_anon_movecomp_raw_sss.fif')
 
 
 def test_pick_refs():
@@ -90,6 +91,7 @@ def test_pick_channels_regexp():
     assert_array_equal(pick_channels_regexp(ch_names, 'MEG *'), [0, 1, 2])
 
 
+@testing.requires_testing_data
 def test_pick_seeg():
     """Test picking with SEEG
     """
@@ -110,6 +112,9 @@ def test_pick_seeg():
     e_seeg = evoked.pick_types(meg=False, seeg=True, copy=True)
     for l, r in zip(e_seeg.ch_names, names[4:]):
         assert_equal(l, r)
+    # Deal with constant debacle
+    raw = Raw(fname_mc)
+    assert_equal(len(pick_types(raw.info, meg=False, seeg=True)), 0)
 
 
 def test_pick_chpi():


### PR DESCRIPTION
I missed a case in #2843. `pick_types` uses logic very similar to that of `channel_type` but not quite the same. At some point we should unify them.

This was breaking plotting with `raw.plot()` for files that had cHPI channels. This fixes it.