### PR TITLE
BUG: automatic assignement of gat scorer even if scorer is passed

### DIFF
--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -53,7 +53,7 @@ def test_generalization_across_time():
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
     from sklearn.preprocessing import LabelEncoder
-    from sklearn.metrics import roc_auc_score, mean_squared_error
+    from sklearn.metrics import roc_auc_score
 
     epochs = make_epochs()
     y_4classes = np.hstack((epochs.events[:7, 2], epochs.events[7:, 2] + 1))

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -352,11 +352,13 @@ class _GeneralizationAcrossTime(object):
 
         # Check scorer
         self.scorer_ = self.scorer
-        if self.predict_method == "predict":
-            if is_classifier(self.clf):
-                self.scorer_ = accuracy_score
-            elif is_regressor(self.clf):
-                self.scorer_ = mean_squared_error
+        if self.scorer_ is None:
+            # Try to guess which scoring metrics should be used
+            if self.predict_method == "predict":
+                if is_classifier(self.clf):
+                    self.scorer_ = accuracy_score
+                elif is_regressor(self.clf):
+                    self.scorer_ = mean_squared_error
         if not self.scorer_:
             raise ValueError('Could not find a scoring metric for `clf=%s` '
                              ' and `predict_method=%s`. Manually define scorer'


### PR DESCRIPTION
https://github.com/mne-tools/mne-python/pull/2856 had assigned `scorer_` as a function of `clf` and `predict_method` even when the user had already defined it:

e.g.
```
gat = GeneralizationAcrossTime(scorer=my_scorer)
gat.fit(epochs)
gat.score(epochs)
gat.scorer_ != my_scorer
```

This is corrected, with an additional test.