### PR TITLE
MRG: Cleaner logging of baselines

### DIFF
--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -7,11 +7,19 @@
 
 import numpy as np
 
-from .utils import logger, verbose
+from .utils import logger
 
 
-@verbose
-def rescale(data, times, baseline, mode, verbose=None, copy=True):
+def _log_rescale(baseline, mode='mean'):
+    """Helper to log the rescaling method"""
+    if baseline is not None:
+        msg = 'Applying baseline correction (mode: %s)' % mode
+    else:
+        msg = 'No baseline correction applied'
+    logger.info(msg)
+
+
+def _rescale(data, times, baseline, mode='mean', copy=True):
     """Rescale aka baseline correct data
 
     Parameters
@@ -36,8 +44,6 @@ def rescale(data, times, baseline, mode, verbose=None, copy=True):
         power = [power - mean(power_baseline)] / std(power_baseline)).
         logratio is the same an mean but in log-scale, zlogratio is the
         same as zscore but data is rendered in log-scale first.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
     copy : bool
         Operate on a copy of the data, or in place.
 
@@ -55,7 +61,6 @@ def rescale(data, times, baseline, mode, verbose=None, copy=True):
         raise Exception('mode should be any of : %s' % (valid_modes, ))
 
     if baseline is not None:
-        logger.info("Applying baseline correction ... (mode: %s)" % mode)
         bmin, bmax = baseline
         if bmin is None:
             imin = 0
@@ -90,8 +95,5 @@ def rescale(data, times, baseline, mode, verbose=None, copy=True):
             data = np.log10(data)
             std = np.std(data[..., imin:imax], axis=-1)[..., None]
             data /= std
-
-    else:
-        logger.info("No baseline correction applied...")
 
     return data

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-from .utils import logger
+from .utils import logger, verbose
 
 
 def _log_rescale(baseline, mode='mean'):
@@ -19,7 +19,8 @@ def _log_rescale(baseline, mode='mean'):
     logger.info(msg)
 
 
-def _rescale(data, times, baseline, mode='mean', copy=True):
+@verbose
+def rescale(data, times, baseline, mode='mean', copy=True, verbose=None):
     """Rescale aka baseline correct data
 
     Parameters
@@ -46,6 +47,8 @@ def _rescale(data, times, baseline, mode='mean', copy=True):
         same as zscore but data is rendered in log-scale first.
     copy : bool
         Operate on a copy of the data, or in place.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
 
     Returns
     -------
@@ -60,6 +63,7 @@ def _rescale(data, times, baseline, mode='mean', copy=True):
     if mode not in valid_modes:
         raise Exception('mode should be any of : %s' % (valid_modes, ))
 
+    _log_rescale(baseline, mode)
     if baseline is not None:
         bmin, bmax = baseline
         if bmin is None:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -32,7 +32,7 @@ from .io.proj import setup_proj, ProjMixin, _proj_equal
 from .io.base import _BaseRaw, ToDataFrameMixin
 from .bem import _check_origin
 from .evoked import EvokedArray, _aspect_rev
-from .baseline import _log_rescale, _rescale
+from .baseline import rescale, _log_rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
 from .filter import resample, detrend, FilterMixin
@@ -439,9 +439,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         picks = pick_types(self.info, meg=True, eeg=True, stim=False,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, exclude=[])
-        _log_rescale(baseline)
-        data[:, picks, :] = _rescale(data[:, picks, :], self.times, baseline,
-                                     copy=False)
+        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline,
+                                    copy=False)
         self.baseline = baseline
 
     def _reject_setup(self, reject, flat):
@@ -551,8 +550,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         picks = pick_types(self.info, meg=True, eeg=True, stim=False,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, exclude=[])
-        epoch[picks] = _rescale(epoch[picks], self._raw_times, self.baseline,
-                                'mean', copy=False)
+        epoch[picks] = rescale(epoch[picks], self._raw_times, self.baseline,
+                               copy=False, verbose=False)
 
         # handle offset
         if self._offset is not None:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1165,6 +1165,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         else:
             # we start out with an empty array, allocate only if necessary
             data = np.empty((0, len(self.info['ch_names']), len(self.times)))
+            logger.info('Loading data from for %s events and %s original time '
+                        'points ...' % (n_events, len(self._raw_times)))
         if self._bad_dropped:
             if not out:
                 return

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1165,7 +1165,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         else:
             # we start out with an empty array, allocate only if necessary
             data = np.empty((0, len(self.info['ch_names']), len(self.times)))
-            logger.info('Loading data from for %s events and %s original time '
+            logger.info('Loading data for %s events and %s original time '
                         'points ...' % (n_events, len(self._raw_times)))
         if self._bad_dropped:
             if not out:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -32,7 +32,7 @@ from .io.proj import setup_proj, ProjMixin, _proj_equal
 from .io.base import _BaseRaw, ToDataFrameMixin
 from .bem import _check_origin
 from .evoked import EvokedArray, _aspect_rev
-from .baseline import rescale
+from .baseline import _log_rescale, _rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
 from .filter import resample, detrend, FilterMixin
@@ -252,7 +252,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                     raise ValueError(err)
         if tmin > tmax:
             raise ValueError('tmin has to be less than or equal to tmax')
-
+        _log_rescale(baseline)
         self.baseline = baseline
         self.reject_tmin = reject_tmin
         self.reject_tmax = reject_tmax
@@ -439,8 +439,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         picks = pick_types(self.info, meg=True, eeg=True, stim=False,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, exclude=[])
-        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline,
-                                    'mean', copy=False)
+        _log_rescale(baseline)
+        data[:, picks, :] = _rescale(data[:, picks, :], self.times, baseline,
+                                     copy=False)
         self.baseline = baseline
 
     def _reject_setup(self, reject, flat):
@@ -550,8 +551,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         picks = pick_types(self.info, meg=True, eeg=True, stim=False,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, exclude=[])
-        epoch[picks] = rescale(epoch[picks], self._raw_times, self.baseline,
-                               'mean', copy=False, verbose=verbose)
+        epoch[picks] = _rescale(epoch[picks], self._raw_times, self.baseline,
+                                'mean', copy=False)
 
         # handle offset
         if self._offset is not None:

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 import numpy as np
 
-from .baseline import rescale
+from .baseline import _log_rescale, _rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin,
                                 equalize_channels)
@@ -278,7 +278,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if proj:
             self.apply_proj()
         # Run baseline correction
-        self.data = rescale(self.data, times, baseline, 'mean', copy=False)
+        _log_rescale(baseline)
+        self.data = _rescale(self.data, times, baseline, copy=False)
 
     def save(self, fname):
         """Save dataset to file.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 import numpy as np
 
-from .baseline import _log_rescale, _rescale
+from .baseline import rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin,
                                 equalize_channels)
@@ -278,8 +278,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if proj:
             self.apply_proj()
         # Run baseline correction
-        _log_rescale(baseline)
-        self.data = _rescale(self.data, times, baseline, copy=False)
+        self.data = rescale(self.data, times, baseline, copy=False)
 
     def save(self, fname):
         """Save dataset to file.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -323,10 +323,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if start >= stop:
             raise ValueError('No data in this range')
 
-        logger.info('Reading %d ... %d  =  %9.3f ... %9.3f secs...' %
-                    (start, stop - 1, start / float(self.info['sfreq']),
-                     (stop - 1) / float(self.info['sfreq'])))
-
         #  Initialize the data and calibration vector
         n_sel_channels = self.info['nchan'] if sel is None else len(sel)
         # convert sel to a slice if possible for efficiency
@@ -439,10 +435,12 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return self
 
     @verbose
-    def _preload_data(self, preload, verbose=False):
+    def _preload_data(self, preload, verbose=None):
         """This function actually preloads the data"""
         data_buffer = preload if isinstance(preload, (string_types,
                                                       np.ndarray)) else None
+        logger.info('Reading %d ... %d  =  %9.3f ... %9.3f secs...' %
+                    (0, len(self.times) - 1, 0., self.times[-1]))
         self._data = self._read_segment(data_buffer=data_buffer)
         assert len(self._data) == self.info['nchan']
         self.preload = True

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -386,8 +386,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                     int(start_file), int(stop_file),
                                     cals, mult)
             offset += n_read
-
-        logger.info('[done]')
         return data
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -11,7 +11,7 @@ from ..source_estimate import _make_stc
 from ..time_frequency.tfr import cwt, morlet
 from ..time_frequency.multitaper import (dpss_windows, _psd_from_mt,
                                          _psd_from_mt_adaptive, _mt_spectra)
-from ..baseline import _log_rescale, _rescale
+from ..baseline import rescale, _log_rescale
 from .inverse import (combine_xyz, prepare_inverse_operator, _assemble_kernel,
                       _pick_channels_inverse_operator, _check_method,
                       _check_ori, _subject_from_inverse)
@@ -142,8 +142,8 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
         power = np.mean(powers[:, idx, :], axis=1)
 
         # Run baseline correction
-        power = _rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                         copy=False)
+        power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
+                        copy=False, verbose=False)
 
         tmin = epochs.times[0]
         tstep = float(decim) / Fs
@@ -368,9 +368,8 @@ def source_induced_power(epochs, inverse_operator, frequencies, label=None,
                                                prepared=False)
 
     # Run baseline correction
-    _log_rescale(baseline)
-    power = _rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                     copy=False)
+    power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
+                    copy=False)
 
     return power, plv
 

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -11,7 +11,7 @@ from ..source_estimate import _make_stc
 from ..time_frequency.tfr import cwt, morlet
 from ..time_frequency.multitaper import (dpss_windows, _psd_from_mt,
                                          _psd_from_mt_adaptive, _mt_spectra)
-from ..baseline import rescale
+from ..baseline import _log_rescale, _rescale
 from .inverse import (combine_xyz, prepare_inverse_operator, _assemble_kernel,
                       _pick_channels_inverse_operator, _check_method,
                       _check_ori, _subject_from_inverse)
@@ -134,6 +134,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
     stcs = dict()
 
     subject = _subject_from_inverse(inverse_operator)
+    _log_rescale(baseline, baseline_mode)
     for name, band in six.iteritems(bands):
         idx = [k for k, f in enumerate(frequencies) if band[0] <= f <= band[1]]
 
@@ -141,8 +142,8 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
         power = np.mean(powers[:, idx, :], axis=1)
 
         # Run baseline correction
-        power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                        copy=False)
+        power = _rescale(power, epochs.times[::decim], baseline, baseline_mode,
+                         copy=False)
 
         tmin = epochs.times[0]
         tstep = float(decim) / Fs
@@ -367,9 +368,9 @@ def source_induced_power(epochs, inverse_operator, frequencies, label=None,
                                                prepared=False)
 
     # Run baseline correction
-    if baseline is not None:
-        power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                        copy=False)
+    _log_rescale(baseline)
+    power = _rescale(power, epochs.times[::decim], baseline, baseline_mode,
+                     copy=False)
 
     return power, plv
 

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -17,7 +17,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        _check_mayavi_version, requires_mayavi,
                        set_memmap_min_size, _get_stim_channel, _check_fname,
                        create_slices, _time_mask, random_permutation,
-                       _get_call_line, compute_corr, sys_info, verbose)
+                       _get_call_line, compute_corr, sys_info, verbose, logger)
 from mne.io import show_fiff
 from mne import Evoked
 from mne.externals.six.moves import StringIO
@@ -248,6 +248,13 @@ def test_logging():
         old_lines = clean_lines(old_log_file.readlines())
     with open(fname_log_2, 'r') as old_log_file_2:
         old_lines_2 = clean_lines(old_log_file_2.readlines())
+    # we changed our logging a little bit
+    old_lines = [o.replace('No baseline correction applied...',
+                           'No baseline correction applied')
+                 for o in old_lines]
+    old_lines_2 = [o.replace('No baseline correction applied...',
+                             'No baseline correction applied')
+                   for o in old_lines_2]
 
     if op.isfile(test_name):
         os.remove(test_name)
@@ -276,6 +283,7 @@ def test_logging():
 
     # now go the other way (printing default on)
     set_log_file(test_name)
+    assert_equal(len(logger.handlers), 2)  # stream, file
     set_log_level('INFO')
     # should NOT print
     evoked = Evoked(fname_evoked, condition=1, verbose='WARNING')
@@ -298,6 +306,7 @@ def test_logging():
         assert_equal(len(w), 0)
         set_log_file(test_name)
     assert_equal(len(w), 1)
+    assert_equal(len(logger.handlers), 2)  # stream, file
     assert_true('test_utils.py' in w[0].filename)
     evoked = Evoked(fname_evoked, condition=1)
     with open(test_name, 'r') as new_log_file:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -970,7 +970,7 @@ def set_log_file(fname=None, output_format='%(message)s', overwrite=None):
             https://docs.python.org/dev/howto/logging.html
 
         e.g., "%(asctime)s - %(levelname)s - %(message)s".
-    overwrite : bool, or None
+    overwrite : bool | None
         Overwrite the log file (if it exists). Otherwise, statements
         will be appended to the log (default). None is the same as False,
         but additionally raises a warning to notify the user that log
@@ -979,9 +979,11 @@ def set_log_file(fname=None, output_format='%(message)s', overwrite=None):
     logger = logging.getLogger('mne')
     handlers = logger.handlers
     for h in handlers:
-        if isinstance(h, logging.FileHandler):
-            h.close()
-        logger.removeHandler(h)
+        # only remove our handlers (get along nicely with nose)
+        if isinstance(h, (logging.FileHandler, logging.StreamHandler)):
+            if isinstance(h, logging.FileHandler):
+                h.close()
+            logger.removeHandler(h)
     if fname is not None:
         if op.isfile(fname) and overwrite is None:
             # Don't use warn() here because we just want to

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -16,7 +16,7 @@ from functools import partial
 import numpy as np
 from scipy import linalg
 
-from ..baseline import rescale
+from ..baseline import _log_rescale, _rescale
 from ..io.constants import FIFF
 from ..io.pick import pick_types, _picks_by_type
 from ..utils import _clean_names, _time_mask, verbose, logger, warn
@@ -923,9 +923,8 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         names = None
 
     data = tfr.data
-
-    if mode is not None and baseline is not None:
-        data = rescale(data, tfr.times, baseline, mode, copy=True)
+    _log_rescale(baseline, mode)
+    data = _rescale(data, tfr.times, baseline, mode, copy=True)
 
     # crop time
     itmin, itmax = None, None

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -16,7 +16,7 @@ from functools import partial
 import numpy as np
 from scipy import linalg
 
-from ..baseline import _log_rescale, _rescale
+from ..baseline import rescale
 from ..io.constants import FIFF
 from ..io.pick import pick_types, _picks_by_type
 from ..utils import _clean_names, _time_mask, verbose, logger, warn
@@ -923,8 +923,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         names = None
 
     data = tfr.data
-    _log_rescale(baseline, mode)
-    data = _rescale(data, tfr.times, baseline, mode, copy=True)
+    data = rescale(data, tfr.times, baseline, mode, copy=True)
 
     # crop time
     itmin, itmax = None, None


### PR DESCRIPTION
Closes #2236.

Streamlines our logging messages about baselines a bit. Now it's done once per object, during instantiation / creation.