### PR TITLE
MRG: Fix time mask

### DIFF
--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -510,11 +510,20 @@ def test_time_mask():
     N = 10
     x = np.arange(N).astype(float)
     assert_equal(_time_mask(x, 0, N - 1).sum(), N)
-    assert_equal(_time_mask(x - 1e-10, 0, N - 1).sum(), N)
-    assert_equal(_time_mask(x - 1e-10, None, N - 1).sum(), N)
-    assert_equal(_time_mask(x - 1e-10, None, None).sum(), N)
-    assert_equal(_time_mask(x - 1e-10, -np.inf, None).sum(), N)
-    assert_equal(_time_mask(x - 1e-10, None, np.inf).sum(), N)
+    assert_equal(_time_mask(x - 1e-10, 0, N - 1, sfreq=1000.).sum(), N)
+    assert_equal(_time_mask(x - 1e-10, None, N - 1, sfreq=1000.).sum(), N)
+    assert_equal(_time_mask(x - 1e-10, None, None, sfreq=1000.).sum(), N)
+    assert_equal(_time_mask(x - 1e-10, -np.inf, None, sfreq=1000.).sum(), N)
+    assert_equal(_time_mask(x - 1e-10, None, np.inf, sfreq=1000.).sum(), N)
+    # non-uniformly spaced inputs
+    x = np.array([4, 10])
+    assert_equal(_time_mask(x[:1], tmin=10, sfreq=1).sum(), 0)
+    assert_equal(_time_mask(x, tmin=10, sfreq=1).sum(), 1)
+    assert_equal(_time_mask(x, tmin=6, sfreq=1).sum(), 1)
+    assert_equal(_time_mask(x, tmin=5, sfreq=1).sum(), 1)
+    assert_equal(_time_mask(x, tmin=4.5001, sfreq=1).sum(), 1)
+    assert_equal(_time_mask(x, tmin=4.4999, sfreq=1).sum(), 2)
+    assert_equal(_time_mask(x, tmin=4, sfreq=1).sum(), 2)
 
 
 def test_random_permutation():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1928,13 +1928,10 @@ def _time_mask(times, tmin=None, tmax=None, sfreq=None):
     if not np.isfinite(tmax):
         tmax = times[-1]
     if sfreq is not None:
-        # Push to nearest sample first
-        tmin = round(tmin * sfreq) / sfreq
-        tmax = round(tmax * sfreq) / sfreq
-    deltas = np.abs(times - tmax)  # Find nearest times
-    tmax = times[np.where(deltas == deltas.min())[0]][-1]
-    deltas = np.abs(times - tmin)
-    tmin = times[np.where(deltas == deltas.min())[0]][-1]
+        # Push to a bit past the nearest sample boundary first
+        sfreq = float(sfreq)
+        tmin = int(round(tmin * sfreq)) / sfreq - 0.5 / sfreq
+        tmax = int(round(tmax * sfreq)) / sfreq + 0.5 / sfreq
     mask = (times >= tmin)
     mask &= (times <= tmax)
     return mask


### PR DESCRIPTION
@jaeilepp see if you agree with the fix.

The critical thing I think is that we should only try to fudge the limits if `sfreq` is provided. If it is not, then we have no way of knowing how far apart from `tmin` and `tmax` are from the true original time values. Thinking about what to do with e.g. `_time_mask(np.array([1.], tmin=1.001, sfreq=None)` should hopefully make this clear. If in the original data had `sfreq=100.`, then the extra `0.001` is probably numerical error, and the point should be included, if `sfreq=10000.` then it probably isn't, and the point should be excluded. So in the `sfreq=None` case, which is hopefully very rare, we stay fairly strict. If this causes failures (e.g. it might for `SourceEstimate` since we have no `sfreq` there), we might need to make ad-hoc solutions like trying to estimate the sample rate, as your code originally did.

Closes #2928.