### PR TITLE
FIX: Raw.filter() picks=None include seeg

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,7 +86,7 @@ API
 
     - To unify and extend the behavior of :func:`mne.comupute_raw_covariance` relative to :func:`mne.compute_covariance`, the default parameter ``tstep=0.2`` now discards any epochs at the end of the :class:`mne.io.Raw` instance that are not the full ``tstep`` duration. This will slighly change the computation of :func:`mne.compute_raw_covaraince`, but should only potentially have a big impact if the :class:`mne.io.Raw` instance is short relative to ``tstep`` and the last, too short (now discarded) epoch contained data inconsistent with the epochs that preceded it.
 
-    - The default `picks=None` in :func:`mne.io.raw.filter` nows picks eeg, meg and seeg channels, by `Jean-Remi King`_
+    - The default ``picks=None`` in :func:`mne.io.Raw.filter` nows picks eeg, meg and seeg channels, by `Jean-Remi King`_
 
 .. _changes_0_11:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,6 +86,8 @@ API
 
     - To unify and extend the behavior of :func:`mne.comupute_raw_covariance` relative to :func:`mne.compute_covariance`, the default parameter ``tstep=0.2`` now discards any epochs at the end of the :class:`mne.io.Raw` instance that are not the full ``tstep`` duration. This will slighly change the computation of :func:`mne.compute_raw_covaraince`, but should only potentially have a big impact if the :class:`mne.io.Raw` instance is short relative to ``tstep`` and the last, too short (now discarded) epoch contained data inconsistent with the epochs that preceded it.
 
+    - The default `picks=None` in :func:`mne.io.raw.filter` nows picks eeg, meg and seeg channels, by `Jean-Remi King`_
+
 .. _changes_0_11:
 
 Version 0.11

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -621,7 +621,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             raise RuntimeError('Raw data needs to be preloaded. Use '
                                'preload=True (or string) in the constructor.')
         if picks is None:
-            picks = pick_types(self.info, meg=True, eeg=True, exclude=[])
+            picks = pick_types(self.info, meg=True, eeg=True, seeg=True,
+                               exclude=[])
 
         if not callable(fun):
             raise ValueError('fun needs to be a function')
@@ -803,7 +804,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             if 'ICA ' in ','.join(self.ch_names):
                 pick_parameters = dict(misc=True, ref_meg=False)
             else:
-                pick_parameters = dict(meg=True, eeg=True, ref_meg=False)
+                pick_parameters = dict(meg=True, eeg=True, seeg=True,
+                                       ref_meg=False)
             picks = pick_types(self.info, exclude=[], **pick_parameters)
             # let's be safe.
             if len(picks) < 1:
@@ -931,7 +933,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             if 'ICA ' in ','.join(self.ch_names):
                 pick_parameters = dict(misc=True)
             else:
-                pick_parameters = dict(meg=True, eeg=True)
+                pick_parameters = dict(meg=True, eeg=True, seeg=True)
             picks = pick_types(self.info, exclude=[], **pick_parameters)
             # let's be safe.
             if len(picks) < 1:
@@ -1597,8 +1599,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             stop = min(self.n_times - 1, self.time_as_index(tstop)[0])
         tslice = slice(start, stop + 1)
         if picks is None:
-            picks = pick_types(self.info, meg=True, eeg=True, ref_meg=False,
-                               exclude='bads')
+            picks = pick_types(self.info, meg=True, eeg=True, seeg=True,
+                               ref_meg=False, exclude='bads')
         # ensure we don't get a view of data
         if len(picks) == 1:
             return 1.0, 1.0

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -782,9 +782,10 @@ def test_filter_picks():
 
     # -- Filter data channels
     for ch_type in ('mag', 'grad', 'eeg', 'seeg'):
-        picks = {ch: ch == ch_type for ch in ch_types}
+        picks = dict((ch, ch == ch_type) for ch in ch_types)
         picks['meg'] = ch_type if ch_type in ('mag', 'grad') else False
         raw_ = raw.pick_types(copy=True, **picks)
+        # Avoid RuntimeWarning due to Attenuation
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             raw_.filter(10, 30)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -771,6 +771,32 @@ def test_filter():
     assert_array_almost_equal(data, data_notch, sig_dec_notch_fit)
 
 
+def test_filter_picks():
+    """Test filtering default channel picks"""
+    ch_types = ['mag', 'grad', 'eeg', 'seeg', 'misc', 'stim']
+    info = create_info(ch_names=ch_types, ch_types=ch_types, sfreq=256)
+    raw = RawArray(data=np.zeros((len(ch_types), 1000)), info=info)
+
+    # -- Deal with meg mag grad exception
+    ch_types = ('misc', 'stim', 'meg', 'eeg', 'seeg')
+
+    # -- Filter data channels
+    for ch_type in ('mag', 'grad', 'eeg', 'seeg'):
+        picks = {ch: ch == ch_type for ch in ch_types}
+        picks['meg'] = ch_type if ch_type in ('mag', 'grad') else False
+        raw_ = raw.pick_types(copy=True, **picks)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            raw_.filter(10, 30)
+            assert_true(len(w) == 1)
+
+    # -- Error if no data channel
+    for ch_type in ('misc', 'stim'):
+        picks = {ch: ch == ch_type for ch in ch_types}
+        raw_ = raw.pick_types(copy=True, **picks)
+        assert_raises(RuntimeError, raw_.filter, 10, 30)
+
+
 @testing.requires_testing_data
 def test_crop():
     """Test cropping raw files


### PR DESCRIPTION
The previous raw.filter did not include seeg channels by default, and I didn't find any test of the picking behavior.