### PR TITLE
Fix error message for auto EEG coords

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -636,7 +636,7 @@ def _auto_topomap_coords(info, picks):
     dist = pdist(locs3d)
     if np.min(dist) < 1e-10:
         problematic_electrodes = [
-            info['ch_names'][elec_i]
+            chs[elec_i]['ch_name']
             for elec_i in squareform(dist < 1e-10).any(axis=0).nonzero()[0]
         ]
 


### PR DESCRIPTION
When computing 2D EEG locations for topo plotting, there is an error
message when multiple sensors have the same location. However, this
message shows the wrong sensor names when picks are provided.