### PR TITLE
FFT for one signal at a time.

### DIFF
--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -437,7 +437,9 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
 
     # remove mean (do not use in-place subtraction as it may modify input x)
     x = x - np.mean(x, axis=-1)[:, np.newaxis]
-    x_mt = fftpack.fft(x[:, np.newaxis, :] * dpss, n=n_fft)
+    x_mt = np.zeros((len(x), len(dpss), len(x[0])))
+    for idx, sig in enumerate(x):
+        x_mt[idx] = fftpack.fft(sig[np.newaxis, :] * dpss, n=n_fft)
 
     # only keep positive frequencies
     freqs = fftpack.fftfreq(n_fft, 1. / sfreq)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -437,7 +437,7 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
 
     # remove mean (do not use in-place subtraction as it may modify input x)
     x = x - np.mean(x, axis=-1)[:, np.newaxis]
-    x_mt = np.zeros((len(x), len(dpss), len(x[0])))
+    x_mt = np.zeros((len(x), len(dpss), x.shape[1]), dtype=complex)
     for idx, sig in enumerate(x):
         x_mt[idx] = fftpack.fft(sig[np.newaxis, :] * dpss, n=n_fft)
 


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/2967
Reduces memory consumption. In ``plot_epochs_spectra.py`` from over 2GB to ~1.2GB.
Also makes the spectra less smooth. See https://github.com/mne-tools/mne-python/issues/2967