### PR TITLE
[MRG+1] Add eeglab event reader, 3rd try

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,9 @@ Changelog
 
     - Add ``decim`` parameter to :func:`mne.time_frequency.cwt_morlet`, by `Jean-Remi King`_
 
+    - Add the ability to read events when importing raw EEGLAB files, by `Jona Sassenhagen`_.
+
+
 BUG
 ~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -269,7 +269,8 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         pos = np.vstack((data['x'], data['y'], data['z'])).T
         ch_names_ = data['name'].astype(np.str)
     elif ext in ('.loc', '.locs', '.eloc'):
-        ch_names_ = np.loadtxt(fname, dtype='S4', usecols=[3]).tolist()
+        ch_names_ = np.loadtxt(fname, dtype='S4',
+                               usecols=[3]).astype(np.str).tolist()
         dtype = {'names': ('angle', 'radius'), 'formats': ('f4', 'f4')}
         angle, radius = np.loadtxt(fname, dtype=dtype, usecols=[1, 2],
                                    unpack=True)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -17,7 +17,7 @@ from ...utils import verbose, logger, warn
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..base import _BaseRaw, _check_update_montage
-from ..utils import _read_segments_file
+from ..utils import _read_segments_file, _synthesize_stim_channel
 
 from ...externals.six import StringIO
 from ...externals.six.moves import configparser
@@ -201,31 +201,6 @@ def _read_vmrk_events(fname, event_id=None, response_trig_shift=0):
 
     events = np.array(events).reshape(-1, 3)
     return events
-
-
-def _synthesize_stim_channel(events, n_samp):
-    """Synthesize a stim channel from events read from a vmrk file
-
-    Parameters
-    ----------
-    events : array, shape (n_events, 3)
-        Each row representing an event as (onset, duration, trigger) sequence
-        (the format returned by _read_vmrk_events).
-    n_samp : int
-        The number of samples.
-
-    Returns
-    -------
-    stim_channel : array, shape (n_samples,)
-        An array containing the whole recording's event marking
-    """
-    # select events overlapping buffer
-    onset = events[:, 0]
-    # create output buffer
-    stim_channel = np.zeros(n_samp, int)
-    for onset, duration, trigger in events:
-        stim_channel[onset:onset + duration] = trigger
-    return stim_channel
 
 
 def _check_hdr_version(header):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -140,7 +140,7 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
 
     event_id_func : None | str | callable
         What to do for events not found in ``event_id``. Must take one ``str``
-        argument and return an ``int``. If a string, must be 'strip-to-integer',
+        argument and return an ``int``. If string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
         Any event that is not in `event_id` and cannot be parsed with this
@@ -267,7 +267,7 @@ class RawEEGLAB(_BaseRaw):
 
     event_id_func : None | str | callable
         What to do for events not found in ``event_id``. Must take one ``str``
-        argument and return an ``int``. If a string, must be 'strip-to-integer',
+        argument and return an ``int``. If string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
         Any event that is not in `event_id` and cannot be parsed with this

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -136,7 +136,7 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
         Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
     event_id_func : callable
         What to do for events not found in `event_id`. Must
-        take one `str` argument and return an ìnt`. Currently defaults to
+        take one `str` argument and return an `int`. Currently defaults to
 
             `lambda t: int("".join([x for x in t if x.isdigit()]))`
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -6,7 +6,8 @@ import os.path as op
 
 import numpy as np
 
-from ..utils import _read_segments_file, _find_channels
+from ..utils import (_read_segments_file, _find_channels,
+                     _synthesize_stim_channel)
 from ..constants import FIFF
 from ..meas_info import _empty_info, create_info
 from ..base import _BaseRaw, _check_update_montage
@@ -15,6 +16,7 @@ from ...channels.montage import Montage
 from ...epochs import _BaseEpochs
 from ...event import read_events
 from ...externals.six import string_types
+#from mne.io.brainvision import _synthesize_stim_channel
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6
@@ -107,6 +109,7 @@ def _get_info(eeg, montage, eog=()):
 
 
 def read_raw_eeglab(input_fname, montage=None, preload=False, eog=(),
+                    event_id=dict(), event_id_func="strip-to-int",
                     verbose=None):
     """Read an EEGLAB .set file
 
@@ -131,6 +134,20 @@ def read_raw_eeglab(input_fname, montage=None, preload=False, eog=(),
         Names or indices of channels that should be designated
         EOG channels. If 'auto', the channel names containing
         ``EOG`` or ``EYE`` are used. Defaults to empty tuple.
+    event_id : dict | None
+        The ids of the events to consider. If None (default),
+        `event_id_func` (see below) is called on every event value. If dict,
+        the keys will be mapped to trigger values on the stimulus channel
+        Keys are case-sensitive.
+        Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+    event_id_func : callable | str | None
+        What to do for events not found in `event_id`. If callable, must
+        take one `str` argument and return an ìnt`. If a string, must be one
+        of the supported methods of parsing events. Currently, only
+        'strip-to-integer' is supported, which strips event codes such as
+        "D128" or "S  1" of their non-integer parts and returns the integer.
+        Any event that is not in `event_id` and cannot be parsed with this
+        function is dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -148,7 +165,8 @@ def read_raw_eeglab(input_fname, montage=None, preload=False, eog=(),
     mne.io.Raw : Documentation of attribute and methods.
     """
     return RawEEGLAB(input_fname=input_fname, montage=montage, preload=preload,
-                     eog=eog, verbose=verbose)
+                     eog=eog, event_id=event_id, event_id_func="strip-to-int",
+                     verbose=verbose)
 
 
 def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
@@ -225,6 +243,20 @@ class RawEEGLAB(_BaseRaw):
         Names or indices of channels that should be designated
         EOG channels. If 'auto', the channel names containing
         ``EOG`` or ``EYE`` are used. Defaults to empty tuple.
+    event_id : dict | None
+        The ids of the events to consider. If None (default),
+        `event_id_func` (see below) is called on every event value. If dict,
+        the keys will be mapped to trigger values on the stimulus channel
+        Keys are case-sensitive.
+        Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+    event_id_func : callable | str | None
+        What to do for events not found in `event_id`. If callable, must
+        take one `str` argument and return an ìnt`. If a string, must be one
+        of the supported methods of parsing events. Currently, only
+        'strip-to-integer' is supported, which strips event codes such as
+        "D128" or "S  1" of their non-integer parts and returns the integer.
+        Any event that is not in `event_id` and cannot be parsed with this
+        function is dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -243,7 +275,7 @@ class RawEEGLAB(_BaseRaw):
     """
     @verbose
     def __init__(self, input_fname, montage, preload=False, eog=(),
-                 verbose=None):
+                 event_id=dict(), event_id_func='strip-to-int', verbose=None):
         """Read EEGLAB .set file.
         """
         from scipy import io
@@ -258,6 +290,24 @@ class RawEEGLAB(_BaseRaw):
 
         last_samps = [eeg.pnts - 1]
         info = _get_info(eeg, montage, eog=eog)
+
+        n_chan = len(info["chs"])
+        stimchan = dict(ch_name='STI 014', coil_type=FIFF.FIFFV_COIL_NONE,
+                        kind=FIFF.FIFFV_STIM_CH, logno=n_chan + 1,
+                        scanno=n_chan + 1, cal=1., range=1., loc=np.zeros(12),
+                        unit=FIFF.FIFF_UNIT_NONE, unit_mul=0.,
+                        coord_frame=FIFF.FIFFV_COORD_HEAD)
+        info['chs'].append(stimchan)
+#        info["ch_names"].append("STI 014")
+#        info['nchan'] += 1
+        if event_id_func == 'strip-to-int':
+            event_id_func = _strip_non_int_event
+
+        self.preload = False  # so the event-setting works
+        events = _read_eeglab_events(eeg, event_id=event_id,
+                                     event_id_func=event_id_func)
+        self._create_event_ch(events, n_samp=eeg.pnts)
+
         # read the data
         if isinstance(eeg.data, string_types):
             data_fname = op.join(basedir, eeg.data)
@@ -269,9 +319,9 @@ class RawEEGLAB(_BaseRaw):
                 orig_format='double', verbose=verbose)
         else:
             if preload is False or isinstance(preload, string_types):
-                warn('Data will be preloaded. preload=False or a string '
-                     'preload is not supported when the data is stored in the '
-                     '.set file')
+                warnings.warn('Data will be preloaded. preload=False or a'
+                              ' string preload is not supported when the data'
+                              ' is stored in the .set file')
             # can't be done in standard way with preload=True because of
             # different reading path (.set file)
             data = eeg.data.reshape(eeg.nbchan, -1, order='F')
@@ -281,10 +331,29 @@ class RawEEGLAB(_BaseRaw):
                 info, data, last_samps=last_samps, orig_format='double',
                 verbose=verbose)
 
+    def _add_trigger_ch(self, block, start, stop, sample_start, sample_stop):
+        """Callback function for adding the trigger channel."""
+        stim_ch = self._event_ch[start:stop][sample_start:sample_stop]
+        return np.vstack((block, stim_ch))
+
+    def _create_event_ch(self, events, n_samp=None):
+        """Create the event channel"""
+        if n_samp is None:
+            n_samp = self.last_samp - self.first_samp + 1
+        events = np.array(events, int)
+        if events.ndim != 2 or events.shape[1] != 3:
+            raise ValueError("[n_events x 3] shaped array required")
+        # update events
+        self._event_ch = _synthesize_stim_channel(events, n_samp)
+        self._events = events
+        if self.preload:
+            self._data[-1] = self._event_ch
+
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data"""
         _read_segments_file(self, data, idx, fi, start, stop, cals, mult,
-                            dtype=np.float32)
+                            dtype=np.float32, trigger_ch=self._event_ch,
+                            n_channels=self.info['nchan'] - 1)
 
 
 class EpochsEEGLAB(_BaseEpochs):
@@ -443,3 +512,60 @@ class EpochsEEGLAB(_BaseEpochs):
             reject=reject, flat=flat, reject_tmin=reject_tmin,
             reject_tmax=reject_tmax, add_eeg_ref=False, verbose=verbose)
         logger.info('Ready.')
+
+
+def _strip_non_int_event(t):
+    """Strip every non-digit from the input string and return the
+    concatenated integer."""
+    return int("".join([x for x in t if x.isdigit()]))
+
+
+def _read_eeglab_events(eeg, event_id=dict(),
+                            event_id_func=_strip_non_int_event):
+    """Create events array from EEGLAB structure by looking them up in the
+    event_id, trying to reduce them to their integer part otherwise, and
+    entirely dropping them (with a warning) if this is impossible.
+    Returns a 3x3 array of zeros if no events are found."""
+    types = [event.type for event in eeg.event]
+    latencies = [event.latency for event in eeg.event]
+
+    not_in_event_id = set([x for x in types if x not in event_id])
+    not_purely_numeric = set([x for x in not_in_event_id if not x.isdigit()])
+    no_numbers = set([x for x in not_purely_numeric
+                      if not any([d.isdigit() for d in x])])
+    have_integers = set([x for x in not_purely_numeric
+                         if x not in no_numbers])
+    if len(not_purely_numeric) > 0:
+        basewarn = "Events like the following will be dropped"
+        n_no_numbers, n_have_integers = len(no_numbers), len(have_integers)
+        if n_no_numbers > 0:
+            nonumwarm = " entirely: {}, {} in total"
+            warnings.warn(basewarn + nonumwarm.format(list(no_numbers)[:5],
+                                                      n_no_numbers))
+        if n_have_integers > 0 and event_id_func is None:
+            intwarn = (", but could be reduced to their integer part "
+                       "instead with `event_id_func='strip-to-integer'`: "
+                       "{}, {} in total")
+            warnings.warn(basewarn + intwarn.format(list(have_integers)[:5],
+                                                    n_have_integers))
+
+    events = list()
+    for t, latency in zip(types, latencies):
+        try:
+            event_code = event_id[t] if t in event_id else event_id_func(t)
+            events.append([int(latency), 1, event_code])
+        except ValueError:
+            pass  # We're already raising warnings above
+
+    if len(events) < len(types):
+            warnings.warn("Some event codes could not be mapped to integers."
+                          " Use the `event_id` keyword to"
+                          " map such events to integers manually.")
+
+    if len(events) < 3:
+        warnings.warn("No events found, consider adding an `event_id`."
+                      " As-is, the event channel will consist entirely"
+                      " of zeros.")
+        return np.zeros((3, 3))
+    else:
+        return np.asarray(events)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -106,7 +106,7 @@ def _get_info(eeg, montage, eog=()):
     return info
 
 
-def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
+def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
                     event_id_func='strip_to_integer', preload=False,
                     verbose=None):
     """Read an EEGLAB .set file
@@ -124,10 +124,6 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    misc : list or tuple
-        Names of channels or list of indices that should be designated MISC
-        channels. Values should correspond to the electrodes in the .set file.
-        Default is ``()``.
     event_id : dict | None
         The ids of the events to consider. If None (default), an empty dict is
         used and ``event_id_func`` (see below) is called on every event value.
@@ -171,12 +167,12 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
     mne.io.Raw : Documentation of attribute and methods.
     """
     return RawEEGLAB(input_fname=input_fname, montage=montage, preload=preload,
-                     eog=eog, misc=misc, event_id=event_id,
-                     event_id_func=event_id_func, verbose=verbose)
+                     eog=eog, event_id=event_id, event_id_func=event_id_func,
+                     verbose=verbose)
 
 
 def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
-                       eog=(), misc=(), verbose=None):
+                       eog=(), verbose=None):
     """Reader function for EEGLAB epochs files
 
     Parameters
@@ -209,10 +205,6 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    misc : list or tuple
-        Names of channels or list of indices that should be designated MISC
-        channels. Values should correspond to the electrodes in the .set file.
-        Default is ``()``.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -231,8 +223,7 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
     mne.Epochs : Documentation of attribute and methods.
     """
     epochs = EpochsEEGLAB(input_fname=input_fname, events=events, eog=eog,
-                          misc=misc, event_id=event_id, montage=montage,
-                          verbose=verbose)
+                          event_id=event_id, montage=montage, verbose=verbose)
     return epochs
 
 
@@ -252,10 +243,6 @@ class RawEEGLAB(_BaseRaw):
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    misc : list or tuple
-        Names of channels or list of indices that should be designated MISC
-        channels. Values should correspond to the electrodes in the .set file.
-        Default is ``()``.
     event_id : dict | None
         The ids of the events to consider. If None (default), an empty dict is
         used and ``event_id_func`` (see below) is called on every event value.
@@ -297,7 +284,7 @@ class RawEEGLAB(_BaseRaw):
     mne.io.Raw : Documentation of attribute and methods.
     """
     @verbose
-    def __init__(self, input_fname, montage, eog=(), misc=(), event_id=None,
+    def __init__(self, input_fname, montage, eog=(), event_id=None,
                  event_id_func='strip_to_integer', preload=False,
                  verbose=None):
         """Read EEGLAB .set file.
@@ -430,10 +417,6 @@ class EpochsEEGLAB(_BaseEpochs):
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    misc : list or tuple
-        Names of channels or list of indices that should be designated MISC
-        channels. Values should correspond to the electrodes in the .set file.
-        Default is ``()``.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -448,8 +431,7 @@ class EpochsEEGLAB(_BaseEpochs):
     @verbose
     def __init__(self, input_fname, events=None, event_id=None, tmin=0,
                  baseline=None,  reject=None, flat=None, reject_tmin=None,
-                 reject_tmax=None, montage=None, eog=(), misc=(),
-                 verbose=None):
+                 reject_tmax=None, montage=None, eog=(), verbose=None):
         from scipy import io
         _check_mat_struct(input_fname)
         eeg = io.loadmat(input_fname, struct_as_record=False,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -139,8 +139,8 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
             {'SyncStatus': 1; 'Pulse Artifact': 3}
 
     event_id_func : None | str | callable
-        What to do for events not found in `event_id`. Must take one `str`
-        argument and return an `int`. If a string, must be 'strip-to-integer',
+        What to do for events not found in ``event_id``. Must take one ``str``
+        argument and return an ``int``. If a string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
         Any event that is not in `event_id` and cannot be parsed with this
@@ -266,8 +266,8 @@ class RawEEGLAB(_BaseRaw):
             {'SyncStatus': 1; 'Pulse Artifact': 3}
 
     event_id_func : None | str | callable
-        What to do for events not found in `event_id`. Must take one `str`
-        argument and return an `int`. If a string, must be 'strip-to-integer',
+        What to do for events not found in ``event_id``. Must take one ``str``
+        argument and return an ``int``. If a string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
         Any event that is not in `event_id` and cannot be parsed with this
@@ -391,7 +391,7 @@ class EpochsEEGLAB(_BaseEpochs):
         dict(auditory=1, visual=3). If int, a dict will be created with
         the id as string. If a list, all events with the IDs specified
         in the list are used. If None, the event_id is constructed from the
-        EEGLAB (.set) file with each descriptions copied from ``eventtype`.
+        EEGLAB (.set) file with each descriptions copied from ``eventtype``.
     tmin : float
         Start time before event.
     baseline : None or tuple of length 2 (default (None, 0))

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -83,7 +83,7 @@ def _get_info(eeg, montage, eog=()):
     elif isinstance(montage, string_types):
         path = op.dirname(montage)
     else:  # if eeg.chanlocs is empty, we still need default chan names
-        ch_names = ["EEG " + str(ii) for ii in range(eeg.nbchan)]
+        ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
 
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
@@ -349,11 +349,6 @@ class RawEEGLAB(_BaseRaw):
                 info, data, last_samps=last_samps, orig_format='double',
                 verbose=verbose)
 
-    def _add_trigger_ch(self, block, start, stop, sample_start, sample_stop):
-        """Callback function for adding the trigger channel."""
-        stim_ch = self._event_ch[start:stop][sample_start:sample_stop]
-        return np.vstack((block, stim_ch))
-
     def _create_event_ch(self, events, n_samples=None):
         """Create the event channel"""
         if n_samples is None:
@@ -534,8 +529,7 @@ class EpochsEEGLAB(_BaseEpochs):
         logger.info('Ready.')
 
 
-def _read_eeglab_events(eeg, event_id=None,
-                        event_id_func='strip_to_integer'):
+def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
     """Create events array from EEGLAB structure
 
     An event array is constructed by looking up events in the

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -3,7 +3,6 @@
 #
 # License: BSD (3-clause)
 
-from ...utils import warn
 import os.path as op
 
 import numpy as np
@@ -84,7 +83,7 @@ def _get_info(eeg, montage, eog=()):
     elif isinstance(montage, string_types):
         path = op.dirname(montage)
 
-    if montage is None:  # deal with missing ch_names
+    if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         _check_update_montage(info, montage, path=path,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -82,6 +82,8 @@ def _get_info(eeg, montage, eog=()):
             montage = Montage(np.array(pos), ch_names, kind, selection)
     elif isinstance(montage, string_types):
         path = op.dirname(montage)
+    else:  # if eeg.chanlocs is empty, we still need default chan names
+        ch_names = ["Channel " + str(ii) for ii in range(eeg.nbchan)]
 
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
@@ -316,7 +318,7 @@ class RawEEGLAB(_BaseRaw):
         if event_id is None:
             event_id = dict()
 
-        self.preload = False  # so the event-setting works
+#        self.preload = preload
         if event_id_func is None:
             event_id_func = _strip_to_integer
         events = _read_eeglab_events(eeg, event_id=event_id,
@@ -362,8 +364,6 @@ class RawEEGLAB(_BaseRaw):
             raise ValueError("[n_events x 3] shaped array required")
         # update events
         self._event_ch = _synthesize_stim_channel(events, n_samples)
-        if self.preload:
-            self._data[-1] = self._event_ch
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data"""

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -88,8 +88,8 @@ def _get_info(eeg, montage, eog=()):
     elif isinstance(montage, string_types):
         path = op.dirname(montage)
 
-    if montage is None:
-        info = create_info(ch_names, eeg.srate, ch_types='eeg')  # deal with missing ch_names
+    if montage is None:  # deal with missing ch_names
+        info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         _check_update_montage(info, montage, path=path,
                               update_ch_names=True)
@@ -293,15 +293,15 @@ class RawEEGLAB(_BaseRaw):
 
         n_chan = len(info["chs"])
         stim_chan = dict(ch_name='STI 014', coil_type=FIFF.FIFFV_COIL_NONE,
-                        kind=FIFF.FIFFV_STIM_CH, logno=n_chan + 1,
-                        scanno=n_chan + 1, cal=1., range=1., loc=np.zeros(12),
-                        unit=FIFF.FIFF_UNIT_NONE, unit_mul=0.,
-                        coord_frame=FIFF.FIFFV_COORD_HEAD)
+                         kind=FIFF.FIFFV_STIM_CH, logno=n_chan + 1,
+                         scanno=n_chan + 1, cal=1., range=1., loc=np.zeros(12),
+                         unit=FIFF.FIFF_UNIT_NONE, unit_mul=0.,
+                         coord_frame=FIFF.FIFFV_COORD_HEAD)
         info['chs'].append(stim_chan)
         if event_id is None:
             event_id = dict()
 
-        self.preload = False # so the event-setting works
+        self.preload = False  # so the event-setting works
         if event_id_func is None:
             event_id_func = strip_to_integer
         events = _read_eeglab_events(eeg, event_id=event_id,
@@ -557,8 +557,8 @@ def _read_eeglab_events(eeg, event_id=dict(), event_id_func=None):
 
     if len(events) < len(types):
         warnings.warn("Some event codes could not be mapped to integers."
-                          " Use the `event_id` parameter to"
-                          " map such events to integers manually.")
+                      " Use the `event_id` parameter to"
+                      " map such events to integers manually.")
 
     if len(events) < 3:
         warnings.warn("No events found, consider adding an `event_id`."

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -83,7 +83,7 @@ def _get_info(eeg, montage, eog=()):
     elif isinstance(montage, string_types):
         path = op.dirname(montage)
     else:  # if eeg.chanlocs is empty, we still need default chan names
-        ch_names = ["Channel " + str(ii) for ii in range(eeg.nbchan)]
+        ch_names = ["EEG " + str(ii) for ii in range(eeg.nbchan)]
 
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -2,6 +2,7 @@
 #
 # License: BSD (3-clause)
 
+import warnings
 import os.path as op
 
 import numpy as np

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -143,8 +143,9 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), misc=(), event_id=None,
         argument and return an ``int``. If string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
-        Any event that is not in `event_id` and cannot be parsed with this
-        function is dropped.
+        If the event is not in the ``event_id`` and calling ``event_id_func``
+        on it results in a ``TypeError`` (e.g. if ``event_id_func`` is
+        ``None``) or a ``ValueError``, the event is dropped.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires
@@ -270,8 +271,9 @@ class RawEEGLAB(_BaseRaw):
         argument and return an ``int``. If string, must be 'strip-to-integer',
         in which case it defaults to stripping event codes such as "D128" or
         "S  1" of their non-integer parts and returns the integer.
-        Any event that is not in `event_id` and cannot be parsed with this
-        function is dropped.
+        If the event is not in the ``event_id`` and calling ``event_id_func``
+        on it results in a ``TypeError`` (e.g. if ``event_id_func`` is
+        ``None``) or a ``ValueError``, the event is dropped.
     preload : bool or str (default False)
         Preload data into memory for data manipulation and faster indexing.
         If True, the data will be preloaded into memory (fast, requires large
@@ -573,7 +575,7 @@ def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
         try:  # look up the event in event_id and if not, try event_id_func
             event_code = event_id[tt] if tt in event_id else event_id_func(tt)
             events.append([int(latency), 1, event_code])
-        except ValueError:  # if event_id_func can't parse the event
+        except (ValueError, TypeError):  # if event_id_func fails
             pass  # We're already raising warnings above, so we just drop
 
     if len(events) < len(types):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -250,7 +250,7 @@ class RawEEGLAB(_BaseRaw):
         Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
     event_id_func : callable
         What to do for events not found in `event_id`. Must
-        take one `str` argument and return an ìnt`. Currently defaults to
+        take one `str` argument and return an `int`. Currently defaults to
 
             `lambda t: int("".join([x for x in t if x.isdigit()]))`
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -36,12 +36,10 @@ def test_io_set():
         warnings.simplefilter('always')
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
                          montage=montage)
-        raw = read_raw_eeglab(input_fname=raw_fname_onefile, montage=montage)
         # test finding events in continuous data
-        event_id={'rt':1, 'square':2}
+        event_id = {'rt': 1, 'square': 2}
         raw = read_raw_eeglab(input_fname=raw_fname_onefile, montage=montage,
                               event_id=event_id)
-        Epochs(raw, find_events(raw))  # without event_id
         epochs = Epochs(raw, find_events(raw), event_id)  # with event_id
         assert_equal(epochs["square"].average().nave, 80)
         raw2 = read_raw_eeglab(input_fname=raw_fname, montage=montage)

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -38,8 +38,8 @@ def test_io_set():
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
                          montage=montage)
         assert_equal(len(w1), 20)
-        # for preload_false and a lot for dropping events
-    with warnings.catch_warnings(record=True) as w2:
+        # f3 or preload_false and a lot for dropping events
+    with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         # test finding events in continuous data
         event_id = {'rt': 1, 'square': 2}
@@ -58,8 +58,8 @@ def test_io_set():
         assert_equal(epochs["square"].average().nave, 80)  # 80 with
         assert_array_equal(raw0[:][0], raw1[:][0], raw2[:][0], raw3[:][0])
         assert_array_equal(raw0[:][-1], raw1[:][-1], raw2[:][-1], raw3[:][-1])
-        assert_equal(len(w2), 4)
-        # for preload=False / str with fname_onefile, and for dropped events
+        assert_equal(len(w), 4)
+        # 1 for preload=False / str with fname_onefile, 3 for dropped events
         raw0.filter(1, None)  # test that preloading works
 
     with warnings.catch_warnings(record=True) as w:

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -40,6 +40,8 @@ def test_io_set():
     with warnings.catch_warnings(record=True) as w2:
         # test finding events in continuous data
         event_id = {'rt': 1, 'square': 2}
+        raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
+                               event_id=event_id, preload=True)
         raw1 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
                                event_id=event_id, preload=False)
         raw2 = read_raw_eeglab(input_fname=raw_fname_onefile, montage=montage,
@@ -50,10 +52,11 @@ def test_io_set():
         epochs = Epochs(raw1, find_events(raw1), event_id)
         assert_equal(len(find_events(raw4)), 0)  # no events without event_id
         assert_equal(epochs["square"].average().nave, 80)  # 80 with
-        assert_array_equal(raw1[:][0], raw2[:][0], raw3[:][0])
-        assert_array_equal(raw1[:][-1], raw2[:][-1], raw3[:][-1])
+        assert_array_equal(raw0[:][0], raw1[:][0], raw2[:][0], raw3[:][0])
+        assert_array_equal(raw0[:][-1], raw1[:][-1], raw2[:][-1], raw3[:][-1])
         assert_equal(len(w2), 4)
         # for preload=False / str with fname_onefile, and for dropped events
+        raw0.filter(1, None)  # test that preloading works
 
     with warnings.catch_warnings(record=True) as w:
         epochs = read_epochs_eeglab(epochs_fname)

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -31,6 +31,7 @@ def test_io_set():
     """Test importing EEGLAB .set files"""
     from scipy import io
     with warnings.catch_warnings(record=True) as w1:
+        warnings.simplefilter('always')
         # main tests, and test missing event_id
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname,
                          montage=montage)
@@ -38,6 +39,7 @@ def test_io_set():
                          montage=montage)
         assert_equal(len(w1), 20)  # for preload_false and dropping events
     with warnings.catch_warnings(record=True) as w2:
+        warnings.simplefilter('always')
         # test finding events in continuous data
         event_id = {'rt': 1, 'square': 2}
         raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
@@ -49,6 +51,7 @@ def test_io_set():
         raw3 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
                                event_id=event_id)
         raw4 = read_raw_eeglab(input_fname=raw_fname, montage=montage)
+        Epochs(raw0, find_events(raw0), event_id)
         epochs = Epochs(raw1, find_events(raw1), event_id)
         assert_equal(len(find_events(raw4)), 0)  # no events without event_id
         assert_equal(epochs["square"].average().nave, 80)  # 80 with
@@ -59,6 +62,7 @@ def test_io_set():
         raw0.filter(1, None)  # test that preloading works
 
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         epochs = read_epochs_eeglab(epochs_fname)
         epochs2 = read_epochs_eeglab(epochs_fname_onefile)
     # 3 warnings for each read_epochs_eeglab because there are 3 epochs
@@ -92,6 +96,7 @@ def test_io_set():
     shutil.copyfile(op.join(base_dir, 'test_epochs.fdt'),
                     op.join(temp_dir, 'test_epochs.dat'))
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         assert_raises(NotImplementedError, read_epochs_eeglab,
                       bad_epochs_fname)
     assert_equal(len(w), 3)

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -9,7 +9,7 @@ import warnings
 from nose.tools import assert_raises, assert_equal
 from numpy.testing import assert_array_equal
 
-from mne import write_events, read_epochs_eeglab
+from mne import write_events, read_epochs_eeglab, Epochs, find_events
 from mne.io import read_raw_eeglab
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
@@ -37,6 +37,13 @@ def test_io_set():
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
                          montage=montage)
         raw = read_raw_eeglab(input_fname=raw_fname_onefile, montage=montage)
+        # test finding events in continuous data
+        event_id={'rt':1, 'square':2}
+        raw = read_raw_eeglab(input_fname=raw_fname_onefile, montage=montage,
+                              event_id=event_id)
+        Epochs(raw, find_events(raw))  # without event_id
+        epochs = Epochs(raw, find_events(raw), event_id)  # with event_id
+        assert_equal(epochs["square"].average().nave, 80)
         raw2 = read_raw_eeglab(input_fname=raw_fname, montage=montage)
         assert_array_equal(raw[:][0], raw2[:][0])
     # one warning per each preload=False or str with raw_fname_onefile

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -37,7 +37,8 @@ def test_io_set():
                          montage=montage)
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
                          montage=montage)
-        assert_equal(len(w1), 20)  # for preload_false and dropping events
+        assert_equal(len(w1), 20)  # 3 for preload_false
+                                   # and a lot for dropping events
     with warnings.catch_warnings(record=True) as w2:
         warnings.simplefilter('always')
         # test finding events in continuous data

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -37,8 +37,8 @@ def test_io_set():
                          montage=montage)
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
                          montage=montage)
-        assert_equal(len(w1), 20)  # 3 for preload_false
-                                   # and a lot for dropping events
+        assert_equal(len(w1), 20)
+        # for preload_false and a lot for dropping events
     with warnings.catch_warnings(record=True) as w2:
         warnings.simplefilter('always')
         # test finding events in continuous data

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -48,8 +48,12 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
                        slice(0, bnd + 100)]
         other_raws = [reader(preload=buffer_fname, **kwargs),
                       reader(preload=False, **kwargs)]
-        for sl_time in slices:
-            for other_raw in other_raws:
+#        print(len(slices), len(other_raws), "hiiiiii")
+        for ii, sl_time in enumerate(slices):
+            for yy, other_raw in enumerate(other_raws):
+#                print(str(ii), str(yy), "_____________________________")
+#                print(raw[:][0].shape, picks, sl_time)
+#                print("_____________________________")
                 data1, times1 = raw[picks, sl_time]
                 data2, times2 = other_raw[picks, sl_time]
                 assert_allclose(data1, data2)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -48,8 +48,8 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
                        slice(0, bnd + 100)]
         other_raws = [reader(preload=buffer_fname, **kwargs),
                       reader(preload=False, **kwargs)]
-        for ii, sl_time in enumerate(slices):
-            for yy, other_raw in enumerate(other_raws):
+        for sl_time in slices:
+            for other_raw in other_raws:
                 data1, times1 = raw[picks, sl_time]
                 data2, times2 = other_raw[picks, sl_time]
                 assert_allclose(data1, data2)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -48,12 +48,8 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
                        slice(0, bnd + 100)]
         other_raws = [reader(preload=buffer_fname, **kwargs),
                       reader(preload=False, **kwargs)]
-#        print(len(slices), len(other_raws), "hiiiiii")
         for ii, sl_time in enumerate(slices):
             for yy, other_raw in enumerate(other_raws):
-#                print(str(ii), str(yy), "_____________________________")
-#                print(raw[:][0].shape, picks, sl_time)
-#                print("_____________________________")
                 data1, times1 = raw[picks, sl_time]
                 data2, times2 = other_raw[picks, sl_time]
                 assert_allclose(data1, data2)

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -220,12 +220,12 @@ def _synthesize_stim_channel(events, n_samp):
     events : array, shape (n_events, 3)
         Each row representing an event as (onset, duration, trigger) sequence
         (the format returned by `_read_vmrk_events` or `_read_eeglab_events).
-    n_samp : int
+    n_sample : int
         The number of samples.
 
     Returns
     -------
-    stim_channel : array, shape (n_samples,)
+    stim_channel : array, shape (n_sample,)
         An array containing the whole recording's event marking.
     """
     # select events overlapping buffer

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -210,3 +210,28 @@ def _create_chs(ch_names, cals, ch_coil, ch_kind, eog, ecg, emg, misc):
                      'coil_type': coil_type, 'kind': kind, 'loc': np.zeros(12)}
         chs.append(chan_info)
     return chs
+
+
+def _synthesize_stim_channel(events, n_samp):
+    """Synthesize a stim channel from events read from a vmrk file
+
+    Parameters
+    ----------
+    events : array, shape (n_events, 3)
+        Each row representing an event as (onset, duration, trigger) sequence
+        (the format returned by _read_vmrk_events).
+    n_samp : int
+        The number of samples.
+
+    Returns
+    -------
+    stim_channel : array, shape (n_samples,)
+        An array containing the whole recording's event marking
+    """
+    # select events overlapping buffer
+    onset = events[:, 0]
+    # create output buffer
+    stim_channel = np.zeros(n_samp, int)
+    for onset, duration, trigger in events:
+        stim_channel[onset:onset + duration] = trigger
+    return stim_channel

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -213,13 +213,13 @@ def _create_chs(ch_names, cals, ch_coil, ch_kind, eog, ecg, emg, misc):
 
 
 def _synthesize_stim_channel(events, n_samp):
-    """Synthesize a stim channel from events read from a vmrk file
+    """Synthesize a stim channel from events read from an event file
 
     Parameters
     ----------
     events : array, shape (n_events, 3)
         Each row representing an event as (onset, duration, trigger) sequence
-        (the format returned by _read_vmrk_events).
+        (the format returned by `_read_vmrk_events` or `_read_eeglab_events).
     n_samp : int
         The number of samples.
 

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -212,7 +212,7 @@ def _create_chs(ch_names, cals, ch_coil, ch_kind, eog, ecg, emg, misc):
     return chs
 
 
-def _synthesize_stim_channel(events, n_samp):
+def _synthesize_stim_channel(events, n_samples):
     """Synthesize a stim channel from events read from an event file
 
     Parameters

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -226,12 +226,12 @@ def _synthesize_stim_channel(events, n_samp):
     Returns
     -------
     stim_channel : array, shape (n_samples,)
-        An array containing the whole recording's event marking
+        An array containing the whole recording's event marking.
     """
     # select events overlapping buffer
     onset = events[:, 0]
     # create output buffer
-    stim_channel = np.zeros(n_samp, int)
+    stim_channel = np.zeros(n_sample, int)
     for onset, duration, trigger in events:
         stim_channel[onset:onset + duration] = trigger
     return stim_channel

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -219,19 +219,19 @@ def _synthesize_stim_channel(events, n_samp):
     ----------
     events : array, shape (n_events, 3)
         Each row representing an event as (onset, duration, trigger) sequence
-        (the format returned by `_read_vmrk_events` or `_read_eeglab_events).
-    n_sample : int
+        (the format returned by `_read_vmrk_events` or `_read_eeglab_events`).
+    n_samples : int
         The number of samples.
 
     Returns
     -------
-    stim_channel : array, shape (n_sample,)
+    stim_channel : array, shape (n_samples,)
         An array containing the whole recording's event marking.
     """
     # select events overlapping buffer
     onset = events[:, 0]
     # create output buffer
-    stim_channel = np.zeros(n_sample, int)
+    stim_channel = np.zeros(n_samples, int)
     for onset, duration, trigger in events:
         stim_channel[onset:onset + duration] = trigger
     return stim_channel


### PR DESCRIPTION
EEGLAB reader is missing the ability to read events, making it basically worthless as is. This adds the ability to read events (with a syntax for handling non-ints previously discussed with @agramfort , @teonlamont and @jasmainak).

~~WIP. It doesn't crash and it returns *something*, that's it for now.~~

Sorry for taking so long, I just really don't get file IO.

Thanks @jaeilepp for tips.

~~No test yet. Do we even have raw data with events?~~ 