### PR TITLE
FIX/ENH: use channel labels

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1169,7 +1169,9 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
     info['lowpass'] = lp
     chs = []
 
-    bti_ch_names = [ch['name'] for ch in bti_info['chs']]
+    # Note that 'name' and 'chan_label' are not the same.
+    # We want the configured label if out IO parsed it.
+    bti_ch_names = [c.get('chan_label', c['name']) for c in bti_info['chs']]
     neuromag_ch_names = _rename_channels(
         bti_ch_names, ecg_ch=ecg_ch, eog_ch=eog_ch)
     ch_mapping = zip(bti_ch_names, neuromag_ch_names)

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -203,11 +203,13 @@ def test_info_no_rename_no_reorder_no_pdf():
         # just check reading data | corner case
         raw2 = read_raw_bti(
             pdf_fname=pdf, config_fname=config, head_shape_fname=None,
+            rename_channels=False,
             sort_by_ch_name=True, preload=True)
 
     sort_idx = [raw1.bti_ch_labels.index(ch) for ch in raw2.bti_ch_labels]
     raw1._data = raw1._data[sort_idx]
     assert_array_equal(raw1._data, raw2._data)
+    assert_array_equal(raw2.bti_ch_labels, raw2.ch_names)
 
 
 def test_no_conversion():


### PR DESCRIPTION
Currently no failing test is possible as in our test files these fields don't differ. More later.