### PR TITLE
BUG: seeg in psd

### DIFF
--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -126,8 +126,8 @@ def _check_psd_data(inst, tmin, tmax, picks, proj):
 
     time_mask = _time_mask(inst.times, tmin, tmax, sfreq=inst.info['sfreq'])
     if picks is None:
-        picks = pick_types(inst.info, meg=True, eeg=True, ref_meg=False,
-                           exclude='bads')
+        picks = pick_types(inst.info, meg=True, eeg=True, seeg=True,
+                           ref_meg=False, exclude='bads')
     if proj:
         # Copy first so it's not modified
         inst = inst.copy().apply_proj()
@@ -400,7 +400,7 @@ def compute_epochs_psd(epochs, picks=None, fmin=0, fmax=np.inf, tmin=None,
     Fs = epochs.info['sfreq']
     if picks is None:
         picks = pick_types(epochs.info, meg=True, eeg=True, ref_meg=False,
-                           exclude='bads')
+                           seeg=True, exclude='bads')
     n_fft, n_overlap = _check_nfft(len(epochs.times), n_fft, n_overlap)
 
     if tmin is not None or tmax is not None:

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from ..parallel import parallel_func
-from ..io.pick import pick_types, _pick_data_channels
+from ..io.pick import _pick_data_channels
 from ..utils import logger, verbose, deprecated, _time_mask
 from .multitaper import _psd_multitaper
 
@@ -126,7 +126,7 @@ def _check_psd_data(inst, tmin, tmax, picks, proj):
 
     time_mask = _time_mask(inst.times, tmin, tmax, sfreq=inst.info['sfreq'])
     if picks is None:
-        picks = _pick_data_channels(inst.info)
+        picks = _pick_data_channels(inst.info, with_ref_meg=False)
     if proj:
         # Copy first so it's not modified
         inst = inst.copy().apply_proj()
@@ -398,7 +398,7 @@ def compute_epochs_psd(epochs, picks=None, fmin=0, fmax=np.inf, tmin=None,
     n_fft = int(n_fft)
     Fs = epochs.info['sfreq']
     if picks is None:
-        picks = _pick_data_channels(epochs.info)
+        picks = _pick_data_channels(epochs.info, with_ref_meg=False)
     n_fft, n_overlap = _check_nfft(len(epochs.times), n_fft, n_overlap)
 
     if tmin is not None or tmax is not None:

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from ..parallel import parallel_func
-from ..io.pick import pick_types
+from ..io.pick import pick_types, _pick_data_channels
 from ..utils import logger, verbose, deprecated, _time_mask
 from .multitaper import _psd_multitaper
 
@@ -126,8 +126,7 @@ def _check_psd_data(inst, tmin, tmax, picks, proj):
 
     time_mask = _time_mask(inst.times, tmin, tmax, sfreq=inst.info['sfreq'])
     if picks is None:
-        picks = pick_types(inst.info, meg=True, eeg=True, seeg=True,
-                           ref_meg=False, exclude='bads')
+        picks = _pick_data_channels(inst.info)
     if proj:
         # Copy first so it's not modified
         inst = inst.copy().apply_proj()
@@ -399,8 +398,7 @@ def compute_epochs_psd(epochs, picks=None, fmin=0, fmax=np.inf, tmin=None,
     n_fft = int(n_fft)
     Fs = epochs.info['sfreq']
     if picks is None:
-        picks = pick_types(epochs.info, meg=True, eeg=True, ref_meg=False,
-                           seeg=True, exclude='bads')
+        picks = _pick_data_channels(epochs.info)
     n_fft, n_overlap = _check_nfft(len(epochs.times), n_fft, n_overlap)
 
     if tmin is not None or tmax is not None:


### PR DESCRIPTION
By default, the seeg channels are not included.

I didn't find a test of the pick types.

Besides this quick fix, I have the impression that a `_pick_data_channels(inst.info)` could be shared across many functions, and could be thus tested once only.