### PR TITLE
FIX merge_events when replace_events=False

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -656,6 +656,7 @@ def merge_events(events, ids, new_id, replace_events=True):
             where = (events[:, col] == i)
             events_out[where, col] = new_id
     if not replace_events:
+        events_out = events_out[where]
         events_out = np.concatenate((events_out, events), axis=0)
         events_out = events_out[np.argsort(events_out[:, 0])]
     return events_out


### PR DESCRIPTION
this was brought on the listserv by Lucy MacGregor.
When we create the merged events, we don't get rid of the redundant copy when `replace_events=False`.

Below you can replicate the error. 

```python
"""
========================================================
Sample script to merge events
========================================================

Reads sample data, finds events from event file, merges events to create new events whilst retaining the originals.

Desired behaviour: create *multiple* new event codes whilst retaining originals.

Current behaviour:  If 1 new event is created, for every sample point there are now 2 events: in
cases where original event is merged this results in 1 original and 1 new event as expected. However, in cases
where the original event code isn't merged there is a repetition of the original event code. If
n new events are created, for every sample point there are now n^2 events (presumably because
replace_events=False). 

8.3.2016
Lucy.MacGregor@mrc-cbu.cam.ac.uk

"""

import mne
from mne import io
from mne.datasets import sample

print(__doc__)

data_path = sample.data_path()

###############################################################################
# Set parameters
raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'


#   Setup for reading the raw data
raw = io.Raw(raw_fname)
events = mne.read_events(event_fname)

# merge events
events=mne.event.merge_events(events, [1,2], 12, replace_events=False)
events=mne.event.merge_events(events, [3,4], 34, replace_events=False)
events=mne.event.merge_events(events, [1,2,3,4], 1234, replace_events=False)


event_id = dict(A= 1, B= 2, C=3, D=4, E=5, F=12, G=34, H=1234)
```