### PR TITLE
More fixes to examples.

### DIFF
--- a/examples/realtime/plot_compute_rt_average.py
+++ b/examples/realtime/plot_compute_rt_average.py
@@ -55,6 +55,7 @@ for ii, ev in enumerate(rt_epochs.iter_evoked()):
         evoked = ev
     else:
         evoked += ev
+    evoked.pick_types(meg=True, eog=False)  # leave out the eog channel
     plt.clf()  # clear canvas
     evoked.plot(axes=plt.gca())  # plot on current figure
     plt.pause(0.05)

--- a/examples/visualization/plot_evoked_erf_erp.py
+++ b/examples/visualization/plot_evoked_erf_erp.py
@@ -23,12 +23,10 @@ fname = path + '/MEG/sample/sample_audvis-ave.fif'
 condition = 'Left Auditory'
 evoked = read_evokeds(fname, condition=condition, baseline=(None, 0))
 
-exclude = evoked.info['bads']
-exclude.append('EOG 061')  # Exlude EOG channel.
 # Plot the evoked response with spatially color coded lines.
 # Note: You can paint the area with left mouse button to show the topographic
 # map of the N100.
-evoked.plot(spatial_colors=True, exclude=exclude)
+evoked.plot(spatial_colors=True)
 
 ###############################################################################
 # Or plot manually after extracting peak latency

--- a/examples/visualization/plot_evoked_erf_erp.py
+++ b/examples/visualization/plot_evoked_erf_erp.py
@@ -23,10 +23,12 @@ fname = path + '/MEG/sample/sample_audvis-ave.fif'
 condition = 'Left Auditory'
 evoked = read_evokeds(fname, condition=condition, baseline=(None, 0))
 
+exclude = evoked.info['bads']
+exclude.append('EOG 061')  # Exlude EOG channel.
 # Plot the evoked response with spatially color coded lines.
 # Note: You can paint the area with left mouse button to show the topographic
 # map of the N100.
-evoked.plot(spatial_colors=True)
+evoked.plot(spatial_colors=True, exclude=exclude)
 
 ###############################################################################
 # Or plot manually after extracting peak latency

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -283,7 +283,10 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
                         locs3d = np.array([ch['loc'][:3] for ch in chs])
                         x, y, z = locs3d.T
                         colors = _rgb(info, x, y, z)
-                        layout = find_layout(info, ch_type=t, exclude=[])
+                        if t in ('meg', 'mag', 'grad', 'eeg'):
+                            layout = find_layout(info, ch_type=t, exclude=[])
+                        else:
+                            layout = find_layout(info, None, exclude=[])
                         # drop channels that are not in the data
 
                         used_nm = np.array(_clean_names(info['ch_names']))[idx]


### PR DESCRIPTION
It seems that some recent changes the behavior so that eog channels are included in the evoked object. This causes a couple of our examples to fail. I can't remember a recent PR that would change the behavior of evoked.
I'm wondering if this is an unintended side effect of some other fix. This seems like an API change, and before fixing the examples, maybe we should figure out why this happens. Any ideas?
This first commit includes a fix to ``plot_evoked_erf_erp`` that is broken because of this. Another one is ``plot_compute_rt_average``.