### PR TITLE
MRG: Fix hpi filtering after MF downsample

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,6 +77,8 @@ BUG
 
     - Fix bug in :func:`mne.io.read_raw_ctf`, when omitting samples at the end by `Jaakko Leppakangas`_
 
+    - Fix ``info['lowpass']`` value for downsampled raw data by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1065,6 +1065,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         inst._data = np.concatenate(new_data, axis=1)
         inst.info['sfreq'] = sfreq
+        if inst.info.get('lowpass') is not None:
+            inst.info['lowpass'] = min(inst.info['lowpass'], sfreq / 2.)
         inst._update_times()
 
         # See the comment above why we ignore all errors here.

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -958,7 +958,9 @@ def test_resample():
 
     # resample should still work even when no stim channel is present
     raw = RawArray(np.random.randn(1, 100), create_info(1, 100, ['eeg']))
+    raw.info['lowpass'] = 50.
     raw.resample(10, npad='auto')
+    assert_equal(raw.info['lowpass'], 5.)
     assert_equal(len(raw), 10)
 
 

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -164,7 +164,7 @@ def test_calculate_chpi_positions():
 
     # half the rate cuts off cHPI coils
     raw.resample(300., npad='auto')
-    assert_raises_regex(RuntimeError, 'above the Nyquist',
+    assert_raises_regex(RuntimeError, 'above the',
                         _calculate_chpi_positions, raw)
 
 
@@ -200,6 +200,6 @@ def test_chpi_subtraction():
     del raw.info['hpi_subsystem']['event_channel']
     with catch_logging() as log:
         filter_chpi(raw, verbose=True)
-    assert_true('4 cHPI' in log.getvalue())
+    assert_true('2 cHPI' in log.getvalue())
 
 run_tests_if_main()

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -4,7 +4,7 @@
 
 import os.path as op
 import numpy as np
-from numpy.testing import assert_allclose, assert_raises_regex
+from numpy.testing import assert_allclose
 from nose.tools import assert_raises, assert_equal, assert_true
 import warnings
 
@@ -13,6 +13,7 @@ from mne.io.constants import FIFF
 from mne.chpi import (get_chpi_positions, _calculate_chpi_positions,
                       head_pos_to_trans_rot_t, read_head_pos,
                       write_head_pos, filter_chpi)
+from mne.fixes import assert_raises_regex
 from mne.transforms import rot_to_quat, quat_to_rot, _angle_between_quats
 from mne.utils import (run_tests_if_main, _TempDir, slow_test, catch_logging,
                        requires_version)

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -4,7 +4,7 @@
 
 import os.path as op
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_raises_regex
 from nose.tools import assert_raises, assert_equal, assert_true
 import warnings
 
@@ -162,12 +162,19 @@ def test_calculate_chpi_positions():
     for line in log_file.getvalue().strip().split('\n')[4:-1]:
         assert_true('0/5 good' in line)
 
+    # half the rate cuts off cHPI coils
+    raw.resample(300., npad='auto')
+    assert_raises_regex(RuntimeError, 'above the Nyquist',
+                        _calculate_chpi_positions, raw)
+
 
 @testing.requires_testing_data
 def test_chpi_subtraction():
     """Test subtraction of cHPI signals"""
     raw = Raw(chpi_fif_fname, allow_maxshield='yes', preload=True)
-    filter_chpi(raw, include_line=False)
+    with catch_logging() as log:
+        filter_chpi(raw, include_line=False, verbose=True)
+    assert_true('5 cHPI' in log.getvalue())
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
     raw.crop(0, 16, copy=False)
     raw_c = Raw(sss_hpisubt_fname, preload=True).crop(0, 16, copy=False)
@@ -178,5 +185,21 @@ def test_chpi_subtraction():
     # Degenerate cases
     raw_nohpi = Raw(test_fif_fname, preload=True)
     assert_raises(RuntimeError, filter_chpi, raw_nohpi)
+
+    # When MaxFliter downsamples, like::
+    #     $ maxfilter -nosss -ds 2 -f test_move_anon_raw.fif \
+    #           -o test_move_anon_ds2_raw.fif
+    # it can strip out some values of info, which we emulate here:
+    raw = Raw(chpi_fif_fname, allow_maxshield='yes')
+    raw.crop(0, 1, copy=False).load_data()
+    raw.resample(600., npad='auto')
+    raw.info['buffer_size_sec'] = np.float64(2.)
+    raw.info['lowpass'] = 200.
+    del raw.info['maxshield']
+    del raw.info['hpi_results'][0]['moments']
+    del raw.info['hpi_subsystem']['event_channel']
+    with catch_logging() as log:
+        filter_chpi(raw, verbose=True)
+    assert_true('4 cHPI' in log.getvalue())
 
 run_tests_if_main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,5 @@ doctest-fixtures = _fixture
 #doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
 
 [flake8]
-exclude = __init__.py,*externals*,constants.py
+exclude = __init__.py,*externals*,constants.py,fixes.py
 ignore = E241


### PR DESCRIPTION
Fixes a bug with `chpi` filtering after MaxFilter's downsampling (and ours, even, really).

Ready for review/merge from my end. Hopefully the test comments and code make it clear why this is necessary.