### PR TITLE
Fix to create_ecg_epochs.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -85,6 +85,8 @@ BUG
 
     - Remove measurement date from :class:`mne.io.Info` in :func:`mne.io.Raw.anonymize` by `Eric Larson`_
 
+    - Fix bug that caused synthetic ecg channel creation even if channel was specified for ECG peak detection in :func:`mne.preprocessing.create_ecg_epochs` by `Jaakko Leppakangas`_
+
 API
 ~~~
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -289,7 +289,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None,
     ecg_epochs : instance of Epochs
         Data epoched around ECG r-peaks.
     """
-    not_has_ecg = 'ecg' not in raw
+    not_has_ecg = 'ecg' not in raw and ch_name is None
     if not_has_ecg:
         ecg, times = _make_ecg(raw, None, None, verbose)
 


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3038

The function tried to create the synthetic channel even if channel was provided.