### PR TITLE
MRG: allow an array as CORRMAP template

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2405,6 +2405,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
 
     all_maps = [_get_ica_map(ica) for ica in icas]
 
+    # check if template is an index to one IC in one ICA object, or an array
     if len(template) == 2:
         target = all_maps[template[0]][template[1]]
         is_subject = True
@@ -2417,13 +2418,13 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
 
     template_fig, labelled_ics = None, None
     if plot is True:
-        if is_subject:
+        if is_subject:  # plotting from an ICA object
             ttl = 'Template from subj. {0}'.format(str(template[0]))
             template_fig = icas[template[0]].plot_components(
                 picks=template[1], ch_type=ch_type, title=ttl,
                 outlines=outlines, cmap=cmap, contours=contours, layout=layout,
                 show=show)
-        else:
+        else:  # plotting an array
             template_fig = _plot_corrmap([template], [0], [0], ch_type,
                                          icas[0].copy(), "Template",
                                          outlines=outlines, cmap=cmap,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2308,7 +2308,7 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
 @verbose
 def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
             plot=True, show=True, verbose=None, outlines='head', layout=None,
-            sensors=True, contours=6, cmap='RdBu_r'):
+            sensors=True, contours=6, cmap=None):
     """Find similar Independent Components across subjects by map similarity.
 
     Corrmap (Viola et al. 2009 Clin Neurophysiol) identifies the best group
@@ -2369,8 +2369,9 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         Layout instance specifying sensor positions (does not need to be
         specified for Neuromag data). Or a list of Layout if projections
         are from different sensor types.
-    cmap : matplotlib colormap
-        Colormap.
+    cmap : None | matplotlib colormap
+        Colormap for the plot. If ``None``, defaults to 'Reds_r' for norm data,
+        otherwise to 'RdBu_r'.
     sensors : bool | str
         Add markers for sensor locations to the plot. Accepts matplotlib plot
         format string (e.g., 'r+' for red plusses). If True, a circle will be

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2251,11 +2251,12 @@ def _find_max_corrs(all_maps, target, threshold):
 def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
                   layout, cmap, contours, template=True):
     """Customized ica.plot_components for corrmap"""
-    title = 'Detected components'
-    if label is not None:
-        title += ' of type ' + label
     if not template:
-        title = "Template"
+        title = 'Detected components'
+        if label is not None:
+            title += ' of type ' + label
+    else:
+        title = "Supplied template"
 
     picks = list(range(len(data)))
 
@@ -2354,8 +2355,9 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         Defaults to "auto".
     label : None | str
         If not None, categorised ICs are stored in a dictionary "labels_" under
-        the given name. Preexisting entries will be appended to
-        (excluding repeats), not overwritten. If None, a dry run is performed.
+        the given name. Preexisting entries will be appended to (excluding
+        repeats), not overwritten. If None, a dry run is performed and
+        the supplied ICs are not changed.
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg'
             The channel type to plot. Defaults to 'eeg'.
     plot : bool
@@ -2426,7 +2428,6 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
                                          outlines=outlines, cmap=cmap,
                                          contours=contours, layout=layout,
                                          show=show, template=True)
-            template_fig.suptitle("Supplied template")
         template_fig.subplots_adjust(top=0.8)
         template_fig.canvas.draw()
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2254,7 +2254,7 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
     title = 'Detected components'
     if label is not None:
         title += ' of type ' + label
-    if template:
+    if not template:
         title = "Template"
 
     picks = list(range(len(data)))
@@ -2305,9 +2305,9 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
 
 
 @verbose
-def corrmap(icas, template, threshold="auto", label=None,
-            ch_type="eeg", plot=True, show=True, verbose=None, outlines='head',
-            layout=None, sensors=True, contours=6, cmap='RdBu_r'):
+def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
+            plot=True, show=True, verbose=None, outlines='head', layout=None,
+            sensors=True, contours=6, cmap='RdBu_r'):
     """Find similar Independent Components across subjects by map similarity.
 
     Corrmap (Viola et al. 2009 Clin Neurophysiol) identifies the best group

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2334,7 +2334,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     ----------
     icas : list of mne.preprocessing.ICA
         A list of fitted ICA objects.
-    template : tuple | ndarray
+    template : tuple | np.ndarray, shape (n_components,)
         Either a tuple with two elements (int, int) representing the list
         indices of the set from which the template should be chosen, and the
         template. E.g., if template=(1, 0), the first IC of the 2nd ICA object

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -20,7 +20,7 @@ from mne import Epochs, read_events, pick_types
 from mne.cov import read_cov
 from mne.preprocessing import (ICA, ica_find_ecg_events, ica_find_eog_events,
                                read_ica, run_ica)
-from mne.preprocessing.ica import get_score_funcs, corrmap
+from mne.preprocessing.ica import get_score_funcs, corrmap, _get_ica_map
 from mne.io import Raw, Info
 from mne.tests.common import assert_naming
 from mne.utils import (catch_logging, _TempDir, requires_sklearn, slow_test,
@@ -312,11 +312,16 @@ def test_ica_additional():
 
     # test corrmap
     ica2 = ica.copy()
+    ica3 = ica.copy()
     corrmap([ica, ica2], (0, 0), threshold='auto', label='blinks', plot=True,
             ch_type="mag")
     corrmap([ica, ica2], (0, 0), threshold=2, plot=False, show=False)
     assert_true(ica.labels_["blinks"] == ica2.labels_["blinks"])
     assert_true(0 in ica.labels_["blinks"])
+    template = _get_ica_map(ica)[0]
+    corrmap([ica, ica3], template, threshold='auto', label='blinks', plot=True,
+            ch_type="mag")
+    assert_true(ica2.labels_["blinks"] == ica3.labels_["blinks"])
     plt.close('all')
 
     # test warnings on bad filenames


### PR DESCRIPTION
Currently, the MNE version of CORRMAP (and the original) only allows to specify the template by referring to one component of those the algorithm is supposed to label. This allows to, alternatively, specify an array (an IC weight map) as a template. This allows in principle fully automatic usage, provided one has previously used the same montage. It's hopefully helpful for those who wish to preregister their analyses.

~~Missing a test.~~