### PR TITLE
MRG: Reduce memory usage for compute_raw_covariance

### DIFF
--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -100,37 +100,43 @@ def test_cov_estimation_on_raw():
     raw = Raw(raw_fname, preload=True)
     cov_mne = read_cov(erm_cov_fname)
 
-    cov = compute_raw_covariance(raw, tstep=None)
-    assert_equal(cov.ch_names, cov_mne.ch_names)
-    assert_equal(cov.nfree, cov_mne.nfree)
-    assert_snr(cov.data, cov_mne.data, 1e4)
+    # The pure-string uses the more efficient numpy-based method, the
+    # the list gets triaged to compute_covariance (should be equivalent
+    # but use more memory)
+    for method in ('empirical', ['empirical']):
+        cov = compute_raw_covariance(raw, tstep=None, method=method)
+        assert_equal(cov.ch_names, cov_mne.ch_names)
+        assert_equal(cov.nfree, cov_mne.nfree)
+        assert_snr(cov.data, cov_mne.data, 1e4)
 
-    cov = compute_raw_covariance(raw)  # tstep=0.2 (default)
-    assert_equal(cov.nfree, cov_mne.nfree - 119)  # cutoff some samples
-    assert_snr(cov.data, cov_mne.data, 1e2)
+        cov = compute_raw_covariance(raw, method=method)  # tstep=0.2 (default)
+        assert_equal(cov.nfree, cov_mne.nfree - 119)  # cutoff some samples
+        assert_snr(cov.data, cov_mne.data, 1e2)
 
-    # test IO when computation done in Python
-    cov.save(op.join(tempdir, 'test-cov.fif'))  # test saving
-    cov_read = read_cov(op.join(tempdir, 'test-cov.fif'))
-    assert_true(cov_read.ch_names == cov.ch_names)
-    assert_true(cov_read.nfree == cov.nfree)
-    assert_array_almost_equal(cov.data, cov_read.data)
+        # test IO when computation done in Python
+        cov.save(op.join(tempdir, 'test-cov.fif'))  # test saving
+        cov_read = read_cov(op.join(tempdir, 'test-cov.fif'))
+        assert_true(cov_read.ch_names == cov.ch_names)
+        assert_true(cov_read.nfree == cov.nfree)
+        assert_array_almost_equal(cov.data, cov_read.data)
 
-    # test with a subset of channels
-    picks = pick_channels(raw.ch_names, include=raw.ch_names[:5])
-    raw.pick_channels([raw.ch_names[pick] for pick in picks])
-    raw.info.normalize_proj()
-    cov = compute_raw_covariance(raw, picks=picks, tstep=None)
-    assert_true(cov_mne.ch_names[:5] == cov.ch_names)
-    assert_snr(cov.data, cov_mne.data[picks][:, picks], 1e4)
-    cov = compute_raw_covariance(raw, picks=picks)
-    assert_snr(cov.data, cov_mne.data[picks][:, picks], 90)  # cutoff samps
-    # make sure we get a warning with too short a segment
-    raw_2 = Raw(raw_fname).crop(0, 1)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        cov = compute_raw_covariance(raw_2)
-    assert_true(any('Too few samples' in str(ww.message) for ww in w))
+        # test with a subset of channels
+        picks = pick_channels(raw.ch_names, include=raw.ch_names[:5])
+        raw_pick = raw.pick_channels([raw.ch_names[pick] for pick in picks],
+                                     copy=True)
+        raw_pick.info.normalize_proj()
+        cov = compute_raw_covariance(raw_pick, picks=picks, tstep=None,
+                                     method=method)
+        assert_true(cov_mne.ch_names[:5] == cov.ch_names)
+        assert_snr(cov.data, cov_mne.data[picks][:, picks], 1e4)
+        cov = compute_raw_covariance(raw_pick, picks=picks, method=method)
+        assert_snr(cov.data, cov_mne.data[picks][:, picks], 90)  # cutoff samps
+        # make sure we get a warning with too short a segment
+        raw_2 = Raw(raw_fname).crop(0, 1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            cov = compute_raw_covariance(raw_2, method=method)
+        assert_true(any('Too few samples' in str(ww.message) for ww in w))
 
 
 @slow_test


### PR DESCRIPTION
Looks like the unification I did of `compute_raw_covariance` can lead to some harsh memory requirements. Currently a copy of the raw data is made 1) when constructing epochs and then again 2) inside `compute_covariance`, tripling memory requirements. This brings it back down to where it used to be.