### PR TITLE
MRG: Add fixed dipole pos mode

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,7 +12,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - Add `overlay_times` parameter to :func:`mne.viz.plot_epochs_image` to be able to display for example reaction times on top of the images, by `Alex Gramfort`_
+    - Add ``overlay_times`` parameter to :func:`mne.viz.plot_epochs_image` to be able to display for example reaction times on top of the images, by `Alex Gramfort`_
 
     - Animation for evoked topomap in :func:`mne.Evoked.animate_topomap` by `Jaakko Leppakangas`_
 
@@ -38,7 +38,7 @@ Changelog
 
     - Add creating forward operator for dipole object :func:`mne.make_forward_dipole` by `Chris Bailey`_
 
-    - Add reading of Elekta ``xfit`` fixed-position dipole time courses using :func:`mne.read_dipole` by `Eric Larson`_.
+    - Add reading and estimation of fixed-position dipole time courses (similar to Elekta ``xfit``) using :func:`mne.read_dipole` and :func:`mne.fit_dipole` by `Eric Larson`_.
 
     - Accept :class:`mne.decoding.GeneralizationAcrossTime`'s ``scorer`` parameter to be a string that refers to a scikit-learn metric scorer by `Asish Panda`_.
 
@@ -64,13 +64,11 @@ BUG
 
     - :func:`mne.Epochs.plot_psd` no longer calls a Welch PSD, and instead uses a Multitaper method which is more appropriate for epochs. Flags for this function are passed to :func:`mne.time_frequency.psd_multitaper` by `Chris Holdgraf`_
 
-    - Time-cropping functions (e.g., :func:`mne.Epochs.crop`, :func:`mne.Evoked.crop`, :func:`mne.io.Raw.crop`, :func:`mne.SourceEstimate.crop`) made consistent with behavior of ``tmin`` and ``tmax`` of :class:`mne.Epochs`, where nearest sample is kept. For example, for MGH data acquired with ``sfreq=600.614990234``, constructing ``Epochs(..., tmin=-1, tmax=1)`` has bounds ``+/-1.00064103``, and now ``epochs.crop(-1, 1)`` will also have these bounds (previously they would have been ``+/-0.99897607``). This also has minor effects on functions that use cropping under the hood, such as :func:`mne.compute_covariance` and :func:`mne.connectivity.spectral_connectivity`.
+    - Time-cropping functions (e.g., :func:`mne.Epochs.crop`, :func:`mne.Evoked.crop`, :func:`mne.io.Raw.crop`, :func:`mne.SourceEstimate.crop`) made consistent with behavior of ``tmin`` and ``tmax`` of :class:`mne.Epochs`, where nearest sample is kept. For example, for MGH data acquired with ``sfreq=600.614990234``, constructing ``Epochs(..., tmin=-1, tmax=1)`` has bounds ``+/-1.00064103``, and now ``epochs.crop(-1, 1)`` will also have these bounds (previously they would have been ``+/-0.99897607``). Time cropping functions also no longer use relative tolerances when determining the boundaries. These changes have minor effects on functions that use cropping under the hood, such as :func:`mne.compute_covariance` and :func:`mne.connectivity.spectral_connectivity`. Changes by `Jaakko Leppakangas`_ and `Eric Larson`_
 
     - Fix EEG spherical spline interpolation code to account for average reference by `Mainak Jas`_ (`#2758 <https://github.com/mne-tools/mne-python/pull/2758>`_)
 
     - MEG projectors are removed after Maxwell filtering by `Eric Larson`_
-
-    - Time cropping functions no longer use relative tolerances when determining the boundaries by `Jaakko Leppakangas`_
 
     - Fix :func:`mne.decoding.TimeDecoding` to allow specifying ``clf`` by `Jean-Remi King`_
 
@@ -140,7 +138,6 @@ API
     - The default ``picks=None`` in :func:`mne.io.Raw.filter` nows picks eeg, meg and seeg channels, by `Jean-Remi King`_
 
     - EOG, ECG and EMG channels are now plotted by default (if present in data) when using :func:`mne.viz.plot_evoked` by `Marijn van Vliet`_
-
 
     - Replace pseudoinverse-based solver with much faster Cholesky solver in :func:`mne.stats.linear_regression_raw`, by `Jona Sassenhagen`_.
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy import linalg
 
 from .cov import read_cov, _get_whitener_data
+from .io.constants import FIFF
 from .io.pick import pick_types, channel_type
 from .io.proj import make_projector, _needs_eeg_average_ref_proj
 from .bem import _fit_sphere
@@ -37,6 +38,9 @@ from .utils import logger, verbose, _time_mask, warn, _check_fname, check_fname
 class Dipole(object):
     """Dipole class for sequential dipole fits
 
+    .. note:: This class should usually not be instantiated directly,
+              instead :func:`mne.read_dipole` should be used.
+
     Used to store positions, orientations, amplitudes, times, goodness of fit
     of dipoles, typically obtained with Neuromag/xfit, mne_dipole_fit
     or certain inverse solvers. Note that dipole position vectors are given in
@@ -59,6 +63,7 @@ class Dipole(object):
 
     See Also
     --------
+    read_dipole
     DipoleFixed
 
     Notes
@@ -227,35 +232,68 @@ class Dipole(object):
         return self.pos.shape[0]
 
 
+def _read_dipole_fixed(fname):
+    """Helper to read a fixed dipole FIF file"""
+    logger.info('Reading %s ...' % fname)
+    _check_fname(fname, overwrite=True, must_exist=True)
+    info, nave, aspect_kind, first, last, comment, times, data = \
+        _read_evoked(fname)
+    return DipoleFixed(info, data, times, nave, aspect_kind, first, last,
+                       comment)
+
+
 class DipoleFixed(object):
     """Dipole class for fixed-position dipole fits
 
+    .. note:: This class should usually not be instantiated directly,
+              instead :func:`mne.read_dipole` should be used.
+
     Parameters
     ----------
-    fname : str
-        The file to load.
+    info : instance of io.Info
+        The measurement info.
+    data : array, shape (n_channels, n_times)
+        The dipole data.
+    times : array, shape (n_times,)
+        The time points.
+    nave : int
+        Number of averages.
+    aspect_kind : int
+        The kind of data.
+    first : int
+        First sample.
+    last : int
+        Last sample.
+    comment : str
+        The dipole comment.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
     See Also
     --------
+    read_dipole
     Dipole
 
     Notes
     -----
-    This class is for sequential dipole fits, where the position
-    changes as a function of time. For fixed dipole fits, where the
-    position is fixed as a function of time, use :class:`mne.DipoleFixed`.
+    This class is for fixed-position dipole fits, where the position
+    (and maybe orientation) is static over time. For sequential dipole fits,
+    where the position can change a function of time, use :class:`mne.Dipole`.
 
     .. versionadded:: 0.12
     """
     @verbose
-    def __init__(self, fname, verbose=None):
-        _check_fname(fname, overwrite=True, must_exist=True)
-        logger.info('Reading %s ...' % fname)
-        self.info, self.nave, self._aspect_kind, self.first, self.last, \
-            self.comment, self.times, self.data = _read_evoked(fname)
-        self.kind = _aspect_rev.get(str(self._aspect_kind), 'Unknown')
+    def __init__(self, info, data, times, nave, aspect_kind, first, last,
+                 comment, verbose=None):
+        self.info = info
+        self.nave = nave
+        self._aspect_kind = aspect_kind
+        self.kind = _aspect_rev.get(str(aspect_kind), 'Unknown')
+        self.first = first
+        self.last = last
+        self.comment = comment
+        self.times = times
+        self.data = data
         self.verbose = verbose
 
     @property
@@ -314,12 +352,17 @@ def read_dipole(fname, verbose=None):
 
     Returns
     -------
-    dipole : instance of Dipole
+    dipole : instance of Dipole or DipoleFixed
         The dipole.
+
+    See Also
+    --------
+    mne.Dipole
+    mne.DipoleFixed
     """
     _check_fname(fname, overwrite=True, must_exist=True)
     if fname.endswith('.fif') or fname.endswith('.fif.gz'):
-        return DipoleFixed(fname)
+        return _read_dipole_fixed(fname)
     try:
         data = np.loadtxt(fname, comments='%')
     except:
@@ -413,31 +456,56 @@ def _dipole_gof(uu, sing, vv, B, B2):
     return gof, one
 
 
-def _fit_Q(fwd_data, whitener, proj_op, B, B2, B_orig, rd):
+def _fit_Q(fwd_data, whitener, proj_op, B, B2, B_orig, rd, ori=None):
     """Fit the dipole moment once the location is known"""
-    fwd, fwd_orig, scales = _dipole_forwards(fwd_data, whitener,
-                                             rd[np.newaxis, :])
-    uu, sing, vv = linalg.svd(fwd, full_matrices=False)
-    gof, one = _dipole_gof(uu, sing, vv, B, B2)
-    ncomp = len(one)
-    # Counteract the effect of column normalization
-    Q = scales[0] * np.sum(uu.T[:ncomp] * (one / sing[:ncomp])[:, np.newaxis],
-                           axis=0)
-    # apply the projector to both elements
-    B_residual = np.dot(proj_op, B_orig) - np.dot(np.dot(Q, fwd_orig),
-                                                  proj_op.T)
+    if 'fwd' in fwd_data:
+        # should be a single precomputed "guess" (i.e., fixed position)
+        assert rd is None
+        fwd = fwd_data['fwd']
+        assert fwd.shape[0] == 3
+        fwd_orig = fwd_data['fwd_orig']
+        assert fwd_orig.shape[0] == 3
+        scales = fwd_data['scales']
+        assert scales.shape == (3,)
+        fwd_svd = fwd_data['fwd_svd'][0]
+    else:
+        fwd, fwd_orig, scales = _dipole_forwards(fwd_data, whitener,
+                                                 rd[np.newaxis, :])
+        fwd_svd = None
+    if ori is None:
+        if fwd_svd is None:
+            fwd_svd = linalg.svd(fwd, full_matrices=False)
+        uu, sing, vv = fwd_svd
+        gof, one = _dipole_gof(uu, sing, vv, B, B2)
+        ncomp = len(one)
+        # Counteract the effect of column normalization
+        Q = scales[0] * np.sum(uu.T[:ncomp] *
+                               (one / sing[:ncomp])[:, np.newaxis], axis=0)
+    else:
+        fwd = np.dot(ori[np.newaxis], fwd)
+        sing = np.linalg.norm(fwd)
+        one = np.dot(fwd / sing, B)
+        gof = (one * one)[0] / B2
+        Q = ori * (scales[0] * np.sum(one / sing))
+    B_residual = _compute_residual(proj_op, B_orig, fwd_orig, Q)
     return Q, gof, B_residual
 
 
-def _fit_dipoles(min_dist_to_inner_skull, data, times, guess_rrs,
-                 guess_fwd_svd, fwd_data, whitener, proj_op, n_jobs):
+def _compute_residual(proj_op, B_orig, fwd_orig, Q):
+    """Compute the residual"""
+    # apply the projector to both elements
+    return np.dot(proj_op, B_orig) - np.dot(np.dot(Q, fwd_orig), proj_op.T)
+
+
+def _fit_dipoles(fun, min_dist_to_inner_skull, data, times, guess_rrs,
+                 guess_data, fwd_data, whitener, proj_op, ori, n_jobs):
     """Fit a single dipole to the given whitened, projected data"""
     from scipy.optimize import fmin_cobyla
-    parallel, p_fun, _ = parallel_func(_fit_dipole, n_jobs)
+    parallel, p_fun, _ = parallel_func(fun, n_jobs)
     # parallel over time points
     res = parallel(p_fun(min_dist_to_inner_skull, B, t, guess_rrs,
-                         guess_fwd_svd, fwd_data, whitener, proj_op,
-                         fmin_cobyla)
+                         guess_data, fwd_data, whitener, proj_op,
+                         fmin_cobyla, ori)
                    for B, t in zip(data.T, times))
     pos = np.array([r[0] for r in res])
     amp = np.array([r[1] for r in res])
@@ -541,38 +609,42 @@ def _simplex_minimize(p, ftol, stol, fun, max_eval=1000):
 '''
 
 
+def _surface_constraint(rd, surf, min_dist_to_inner_skull):
+    """Surface fitting constraint"""
+    dist = _compute_nearest(surf['rr'], rd[np.newaxis, :],
+                            return_dists=True)[1][0]
+    if _points_outside_surface(rd[np.newaxis, :], surf, 1)[0]:
+        dist *= -1.
+    # Once we know the dipole is below the inner skull,
+    # let's check if its distance to the inner skull is at least
+    # min_dist_to_inner_skull. This can be enforced by adding a
+    # constrain proportional to its distance.
+    dist -= min_dist_to_inner_skull
+    return dist
+
+
+def _sphere_constraint(rd, r0, R_adj):
+    """Sphere fitting constraint"""
+    return R_adj - np.sqrt(np.sum((rd - r0) ** 2))
+
+
 def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
-                guess_fwd_svd, fwd_data, whitener, proj_op,
-                fmin_cobyla):
+                guess_data, fwd_data, whitener, proj_op,
+                fmin_cobyla, ori):
     """Fit a single bit of data"""
     B = np.dot(whitener, B_orig)
 
     # make constraint function to keep the solver within the inner skull
     if isinstance(fwd_data['inner_skull'], dict):  # bem
         surf = fwd_data['inner_skull']
-
-        def constraint(rd):
-
-            dist = _compute_nearest(surf['rr'], rd[np.newaxis, :],
-                                    return_dists=True)[1][0]
-
-            if _points_outside_surface(rd[np.newaxis, :], surf, 1)[0]:
-                dist *= -1.
-
-            # Once we know the dipole is below the inner skull,
-            # let's check if its distance to the inner skull is at least
-            # min_dist_to_inner_skull. This can be enforced by adding a
-            # constrain proportional to its distance.
-            dist -= min_dist_to_inner_skull
-            return dist
-
+        constraint = partial(_surface_constraint, surf=surf,
+                             min_dist_to_inner_skull=min_dist_to_inner_skull)
     else:  # sphere
         surf = None
         R, r0 = fwd_data['inner_skull']
-        R_adj = R - min_dist_to_inner_skull
-
-        def constraint(rd):
-            return R_adj - np.sqrt(np.sum((rd - r0) ** 2))
+        constraint = partial(_sphere_constraint, r0=r0,
+                             R_adj=R - min_dist_to_inner_skull)
+        del R, r0
 
     # Find a good starting point (find_best_guess in C)
     B2 = np.dot(B, B)
@@ -581,7 +653,7 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
         return np.zeros(3), 0, np.zeros(3), 0
 
     idx = np.argmin([_fit_eval(guess_rrs[[fi], :], B, B2, fwd_svd)
-                     for fi, fwd_svd in enumerate(guess_fwd_svd)])
+                     for fi, fwd_svd in enumerate(guess_data['fwd_svd'])])
     x0 = guess_rrs[idx]
     fun = partial(_fit_eval, B=B, B2=B2, fwd_data=fwd_data, whitener=whitener)
 
@@ -599,16 +671,15 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
     # Compute the dipole moment at the final point
     Q, gof, residual = _fit_Q(fwd_data, whitener, proj_op, B, B2, B_orig,
-                              rd_final)
+                              rd_final, ori=ori)
     amp = np.sqrt(np.dot(Q, Q))
     norm = 1. if amp == 0. else amp
     ori = Q / norm
 
     msg = '---- Fitted : %7.1f ms' % (1000. * t)
     if surf is not None:
-        dist_to_inner_skull = _compute_nearest(surf['rr'],
-                                               rd_final[np.newaxis, :],
-                                               return_dists=True)[1][0]
+        dist_to_inner_skull = _compute_nearest(
+            surf['rr'], rd_final[np.newaxis, :], return_dists=True)[1][0]
         msg += (", distance to inner skull : %2.4f mm"
                 % (dist_to_inner_skull * 1000.))
 
@@ -616,9 +687,31 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
     return rd_final, amp, ori, gof, residual
 
 
+def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
+                      guess_data, fwd_data, whitener, proj_op,
+                      fmin_cobyla, ori):
+    """Fit a data using a fixed position"""
+    B = np.dot(whitener, B_orig)
+    B2 = np.dot(B, B)
+    if B2 == 0:
+        warn('Zero field found for time %s' % t)
+        return np.zeros(3), 0, np.zeros(3), 0
+    # Compute the dipole moment
+    Q, gof, residual = _fit_Q(guess_data, whitener, proj_op, B, B2, B_orig,
+                              rd=None, ori=ori)
+    if ori is None:
+        amp = np.sqrt(np.dot(Q, Q))
+        norm = 1. if amp == 0. else amp
+        ori = Q / norm
+    else:
+        amp = np.dot(Q, ori)
+    # No corresponding 'logger' message here because it should go *very* fast
+    return guess_rrs[0], amp, ori, gof, residual
+
+
 @verbose
 def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
-               verbose=None):
+               pos=None, ori=None, verbose=None):
     """Fit a dipole
 
     Parameters
@@ -640,13 +733,32 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     n_jobs : int
         Number of jobs to run in parallel (used in field computation
         and fitting).
+    pos : ndarray, shape (3,) | None
+        Position of the dipole to use. If None (default), sequential
+        fitting (different position and orientation for each time instance)
+        is performed. If a position (in head coords) is given as an array,
+        the position is fixed during fitting.
+
+        .. versionadded:: 0.12
+
+    ori : ndarray, shape (3,) | None
+        Orientation of the dipole to use. If None (default), the
+        orientation is free to change as a function of time. If an
+        orientation (in head coordinates) is given as an array, ``pos``
+        must also be provided, and the routine computes the amplitude and
+        goodness of fit of the dipole at the given position and orientation
+        for each time instant.
+
+        .. versionadded:: 0.12
+
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
     Returns
     -------
-    dip : instance of Dipole
-        The dipole fits.
+    dip : instance of Dipole or DipoleFixed
+        The dipole fits. A :class:`mne.DipoleFixed` is returned if
+        ``pos`` and ``ori`` are both not None.
     residual : ndarray, shape (n_meeg_channels, n_times)
         The good M-EEG data channels with the fitted dipolar activity
         removed.
@@ -668,9 +780,10 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     if _needs_eeg_average_ref_proj(evoked.info):
         raise ValueError('EEG average reference is mandatory for dipole '
                          'fitting.')
-
     if min_dist < 0:
         raise ValueError('min_dist should be positive. Got %s' % min_dist)
+    if ori is not None and pos is None:
+        raise ValueError('pos must be provided if ori is not None')
 
     data = evoked.data
     info = evoked.info
@@ -684,13 +797,13 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # Figure out our inputs
     neeg = len(pick_types(info, meg=False, eeg=True, exclude=[]))
     if isinstance(bem, string_types):
-        logger.info('BEM              : %s' % bem)
+        logger.info('BEM               : %s' % bem)
     if trans is not None:
-        logger.info('MRI transform    : %s' % trans)
+        logger.info('MRI transform     : %s' % trans)
         mri_head_t, trans = _get_trans(trans)
     else:
         mri_head_t = Transform('head', 'mri', np.eye(4))
-    bem = _setup_bem(bem, bem, neeg, mri_head_t)
+    bem = _setup_bem(bem, bem, neeg, mri_head_t, verbose=False)
     if not bem['is_sphere']:
         if trans is None:
             raise ValueError('mri must not be None if BEM is provided')
@@ -700,12 +813,12 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         R, r0 = _fit_sphere(inner_skull['rr'], disp=False)
         # r0 back to head frame for logging
         r0 = apply_trans(mri_head_t['trans'], r0[np.newaxis, :])[0]
-        logger.info('Grid origin      : '
+        logger.info('Head origin       : '
                     '%6.1f %6.1f %6.1f mm rad = %6.1f mm.'
                     % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2], 1000 * R))
     else:
         r0 = bem['r0']
-        logger.info('Sphere model     : origin at (% 7.2f % 7.2f % 7.2f) mm'
+        logger.info('Sphere model      : origin at (% 7.2f % 7.2f % 7.2f) mm'
                     % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2]))
         if 'layers' in bem:
             R = bem['layers'][0]['rad']
@@ -714,23 +827,51 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         inner_skull = [R, r0]  # NB sphere model defined in head frame
     r0_mri = apply_trans(invert_transform(mri_head_t)['trans'],
                          r0[np.newaxis, :])[0]
+    accurate = False  # can be an option later (shouldn't make big diff)
 
-    # Eventually these could be parameters, but they are just used for
-    # the initial grid anyway
-    guess_grid = 0.02  # MNE-C uses 0.01, but this is faster w/similar perf
-    guess_mindist = max(0.005, min_dist_to_inner_skull)
-    guess_exclude = 0.02
-    accurate = False  # can be made an option later (shouldn't make big diff)
+    # Deal with DipoleFixed cases here
+    if pos is not None:
+        fixed_position = True
+        pos = np.array(pos, float)
+        if pos.shape != (3,):
+            raise ValueError('pos must be None or a 3-element array-like,'
+                             ' got %s' % (pos,))
+        logger.info('Fixed position    : %6.1f %6.1f %6.1f mm'
+                    % tuple(1000 * pos))
+        if ori is not None:
+            ori = np.array(ori, float)
+            if ori.shape != (3,):
+                raise ValueError('oris must be None or a 3-element array-like,'
+                                 ' got %s' % (ori,))
+            norm = np.sqrt(np.sum(ori * ori))
+            if not np.isclose(norm, 1):
+                raise ValueError('ori must be a unit vector, got length %s'
+                                 % (norm,))
+            logger.info('Fixed orientation  : %6.4f %6.4f %6.4f mm'
+                        % tuple(ori))
+        else:
+            logger.info('Free orientation   : <time-varying>')
+        fit_n_jobs = 1  # only use 1 job to do the guess fitting
+    else:
+        fixed_position = False
+        # Eventually these could be parameters, but they are just used for
+        # the initial grid anyway
+        guess_grid = 0.02  # MNE-C uses 0.01, but this is faster w/similar perf
+        guess_mindist = max(0.005, min_dist_to_inner_skull)
+        guess_exclude = 0.02
 
-    logger.info('Guess grid       : %6.1f mm' % (1000 * guess_grid,))
-    if guess_mindist > 0.0:
-        logger.info('Guess mindist    : %6.1f mm' % (1000 * guess_mindist,))
-    if guess_exclude > 0:
-        logger.info('Guess exclude    : %6.1f mm' % (1000 * guess_exclude,))
-    logger.info('Using %s MEG coil definitions.'
-                % ("accurate" if accurate else "standard"))
+        logger.info('Guess grid        : %6.1f mm' % (1000 * guess_grid,))
+        if guess_mindist > 0.0:
+            logger.info('Guess mindist     : %6.1f mm'
+                        % (1000 * guess_mindist,))
+        if guess_exclude > 0:
+            logger.info('Guess exclude     : %6.1f mm'
+                        % (1000 * guess_exclude,))
+        logger.info('Using %s MEG coil definitions.'
+                    % ("accurate" if accurate else "standard"))
+        fit_n_jobs = n_jobs
     if isinstance(cov, string_types):
-        logger.info('Noise covariance : %s' % (cov,))
+        logger.info('Noise covariance  : %s' % (cov,))
         cov = read_cov(cov, verbose=False)
     logger.info('')
 
@@ -773,42 +914,85 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     whitener = _get_whitener_data(info, cov, picks, verbose=False)
 
     # Proceed to computing the fits (make_guess_data)
-    logger.info('\n---- Computing the forward solution for the guesses...')
-    guess_src = _make_guesses(inner_skull, r0_mri,
-                              guess_grid, guess_exclude, guess_mindist,
-                              n_jobs=n_jobs)[0]
+    if fixed_position:
+        guess_src = dict(nuse=1, rr=pos[np.newaxis], inuse=np.array([True]))
+        logger.info('Compute forward for dipole location...')
+    else:
+        logger.info('\n---- Computing the forward solution for the guesses...')
+        guess_src = _make_guesses(inner_skull, r0_mri,
+                                  guess_grid, guess_exclude, guess_mindist,
+                                  n_jobs=n_jobs)[0]
+        # grid coordinates go from mri to head frame
+        transform_surface_to(guess_src, 'head', mri_head_t)
+        logger.info('Go through all guess source locations...')
 
-    # inner_skull and grid coordinates go from mri to head frame
+    # inner_skull goes from mri to head frame
     if isinstance(inner_skull, dict):
         transform_surface_to(inner_skull, 'head', mri_head_t)
-    transform_surface_to(guess_src, 'head', mri_head_t)
+    if fixed_position:
+        if isinstance(inner_skull, dict):
+            check = _surface_constraint(pos, inner_skull,
+                                        min_dist_to_inner_skull)
+        else:
+            check = _sphere_constraint(pos, r0,
+                                       R_adj=R - min_dist_to_inner_skull)
+        if check <= 0:
+            raise ValueError('fixed position is %0.1fmm outside the inner '
+                             'skull boundary' % (-1000 * check,))
 
-    # C code computes guesses using a sphere model for speed, don't bother here
-    logger.info('Go through all guess source locations...')
+    # C code computes guesses w/sphere model for speed, don't bother here
     fwd_data = dict(coils_list=[megcoils, eegels], infos=[meg_info, None],
                     ccoils_list=[compcoils, None], coil_types=['meg', 'eeg'],
                     inner_skull=inner_skull)
     # fwd_data['inner_skull'] in head frame, bem in mri, confusing...
     _prep_field_computation(guess_src['rr'], bem, fwd_data, n_jobs,
                             verbose=False)
-    guess_fwd = _dipole_forwards(fwd_data, whitener, guess_src['rr'],
-                                 n_jobs=n_jobs)[0]
+    guess_fwd, guess_fwd_orig, guess_fwd_scales = _dipole_forwards(
+        fwd_data, whitener, guess_src['rr'], n_jobs=fit_n_jobs)
     # decompose ahead of time
-    guess_fwd_svd = [linalg.svd(fwd, overwrite_a=True, full_matrices=False)
+    guess_fwd_svd = [linalg.svd(fwd, overwrite_a=False, full_matrices=False)
                      for fwd in np.array_split(guess_fwd,
                                                len(guess_src['rr']))]
-    del guess_fwd  # destroyed
-    logger.info('[done %d sources]' % guess_src['nuse'])
+    guess_data = dict(fwd=guess_fwd, fwd_svd=guess_fwd_svd,
+                      fwd_orig=guess_fwd_orig, scales=guess_fwd_scales)
+    del guess_fwd, guess_fwd_svd, guess_fwd_orig, guess_fwd_scales  # destroyed
+    pl = '' if guess_src['nuse'] == 1 else 's'
+    logger.info('[done %d source%s]' % (guess_src['nuse'], pl))
 
     # Do actual fits
     data = data[picks]
     ch_names = [info['ch_names'][p] for p in picks]
     proj_op = make_projector(info['projs'], ch_names, info['bads'])[0]
-    out = _fit_dipoles(min_dist_to_inner_skull, data, times, guess_src['rr'],
-                       guess_fwd_svd, fwd_data,
-                       whitener, proj_op, n_jobs)
-    dipoles = Dipole(times, out[0], out[1], out[2], out[3], comment)
+    fun = _fit_dipole_fixed if fixed_position else _fit_dipole
+    out = _fit_dipoles(
+        fun, min_dist_to_inner_skull, data, times, guess_src['rr'],
+        guess_data, fwd_data, whitener, proj_op, ori, n_jobs)
+    if fixed_position and ori is not None:
+        # DipoleFixed
+        data = np.array([out[1], out[3]])
+        out_info = deepcopy(info)
+        loc = np.concatenate([pos, ori, np.zeros(6)])
+        out_info['chs'] = [
+            dict(ch_name='dip 01', loc=loc, kind=FIFF.FIFFV_DIPOLE_WAVE,
+                 coord_frame=FIFF.FIFFV_COORD_UNKNOWN, unit=FIFF.FIFF_UNIT_AM,
+                 coil_type=FIFF.FIFFV_COIL_DIPOLE,
+                 unit_mul=0, range=1, cal=1., scanno=1, logno=1),
+            dict(ch_name='goodness', loc=np.zeros(12),
+                 kind=FIFF.FIFFV_GOODNESS_FIT, unit=FIFF.FIFF_UNIT_AM,
+                 coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
+                 coil_type=FIFF.FIFFV_COIL_NONE,
+                 unit_mul=0, range=1., cal=1., scanno=2, logno=100)]
+        for key in ['hpi_meas', 'hpi_results', 'projs']:
+            out_info[key] = list()
+        for key in ['acq_pars', 'acq_stim', 'description', 'dig',
+                    'experimenter', 'hpi_subsystem', 'proj_id', 'proj_name',
+                    'subject_info']:
+            out_info[key] = None
+        dipoles = DipoleFixed(out_info, data, times, evoked.nave,
+                              evoked._aspect_kind, evoked.first, evoked.last,
+                              comment)
+    else:
+        dipoles = Dipole(times, out[0], out[1], out[2], out[3], comment)
     residual = out[4]
-
-    logger.info('%d dipoles fitted' % len(dipoles.times))
+    logger.info('%d time points fitted' % len(dipoles.times))
     return dipoles, residual

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -181,7 +181,7 @@ def test_dipole_fitting_fixed():
     assert_allclose(np.tile(pos[np.newaxis], (len(evoked.times), 1)),
                     dip_free.pos)
     assert_allclose(ori, dip_free.ori[t_idx])  # should find same ori
-    assert_true(np.dot(dip_free.ori, ori).mean() < 0.1)  # but few the same
+    assert_true(np.dot(dip_free.ori, ori).mean() < 0.9)  # but few the same
     assert_allclose(gof, dip_free.gof[t_idx])  # ... same gof
     assert_allclose(amp, dip_free.amplitude[t_idx])  # and same amp
     assert_allclose(resid, resid_free[:, [t_idx]])

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -12,7 +12,7 @@ from mne import (read_dipole, read_forward_solution,
                  SourceEstimate, write_evokeds, fit_dipole,
                  transform_surface_to, make_sphere_model, pick_types,
                  pick_info, EvokedArray, read_source_spaces, make_ad_hoc_cov,
-                 make_forward_solution)
+                 make_forward_solution, Dipole, DipoleFixed)
 from mne.simulation import simulate_evoked
 from mne.datasets import testing
 from mne.utils import (run_tests_if_main, _TempDir, slow_test, requires_mne,
@@ -29,8 +29,8 @@ warnings.simplefilter('always')
 data_path = testing.data_path(download=False)
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
 fname_dip = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_set1.dip')
-fname_evo = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-ave.fif')
-fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-cov.fif')
+fname_evo = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
+fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis-cov.fif')
 fname_bem = op.join(data_path, 'subjects', 'sample', 'bem',
                     'sample-1280-1280-1280-bem-sol.fif')
 fname_src = op.join(data_path, 'subjects', 'sample', 'bem',
@@ -63,8 +63,7 @@ def _check_dipole(dip, n_dipoles):
 
 @testing.requires_testing_data
 def test_io_dipoles():
-    """Test IO for .dip files
-    """
+    """Test IO for .dip files"""
     tempdir = _TempDir()
     dipole = read_dipole(fname_dip)
     print(dipole)  # test repr
@@ -160,9 +159,52 @@ def test_dipole_fitting():
 
 
 @testing.requires_testing_data
+def test_dipole_fitting_fixed():
+    """Test dipole fitting with a fixed position"""
+    tpeak = 0.073
+    sphere = make_sphere_model(head_radius=0.1)
+    evoked = read_evokeds(fname_evo, baseline=(None, 0))[0]
+    evoked.pick_types(meg=True, copy=False)
+    t_idx = np.argmin(np.abs(tpeak - evoked.times))
+    evoked_crop = evoked.crop(tpeak, tpeak, copy=True)
+    assert_equal(len(evoked_crop.times), 1)
+    cov = read_cov(fname_cov)
+    dip_seq, resid = fit_dipole(evoked_crop, cov, sphere)
+    assert_true(isinstance(dip_seq, Dipole))
+    assert_equal(len(dip_seq.times), 1)
+    pos, ori, gof = dip_seq.pos[0], dip_seq.ori[0], dip_seq.gof[0]
+    amp = dip_seq.amplitude[0]
+    # Fix position, allow orientation to change
+    dip_free, resid_free = fit_dipole(evoked, cov, sphere, pos=pos)
+    assert_true(isinstance(dip_free, Dipole))
+    assert_allclose(dip_free.times, evoked.times)
+    assert_allclose(np.tile(pos[np.newaxis], (len(evoked.times), 1)),
+                    dip_free.pos)
+    assert_allclose(ori, dip_free.ori[t_idx])  # should find same ori
+    assert_true(np.dot(dip_free.ori, ori).mean() < 0.1)  # but few the same
+    assert_allclose(gof, dip_free.gof[t_idx])  # ... same gof
+    assert_allclose(amp, dip_free.amplitude[t_idx])  # and same amp
+    assert_allclose(resid, resid_free[:, [t_idx]])
+    # Fix position and orientation
+    dip_fixed, resid_fixed = fit_dipole(evoked, cov, sphere, pos=pos, ori=ori)
+    assert_true(isinstance(dip_fixed, DipoleFixed))
+    assert_allclose(dip_fixed.times, evoked.times)
+    assert_allclose(dip_fixed.info['chs'][0]['loc'][:3], pos)
+    assert_allclose(dip_fixed.info['chs'][0]['loc'][3:6], ori)
+    assert_allclose(dip_fixed.data[1, t_idx], gof)
+    assert_allclose(resid, resid_fixed[:, [t_idx]])
+    _check_roundtrip_fixed(dip_fixed)
+    # Degenerate conditions
+    assert_raises(ValueError, fit_dipole, evoked, cov, sphere, pos=[0])
+    assert_raises(ValueError, fit_dipole, evoked, cov, sphere, ori=[1, 0, 0])
+    assert_raises(ValueError, fit_dipole, evoked, cov, sphere, pos=[0, 0, 0],
+                  ori=[2, 0, 0])
+    assert_raises(ValueError, fit_dipole, evoked, cov, sphere, pos=[0.1, 0, 0])
+
+
+@testing.requires_testing_data
 def test_len_index_dipoles():
-    """Test len and indexing of Dipole objects
-    """
+    """Test len and indexing of Dipole objects"""
     dipole = read_dipole(fname_dip)
     d0 = dipole[0]
     d1 = dipole[:1]
@@ -225,8 +267,7 @@ def _compute_depth(dip, fname_bem, fname_trans, subject, subjects_dir):
 
 @testing.requires_testing_data
 def test_accuracy():
-    """Test dipole fitting to sub-mm accuracy
-    """
+    """Test dipole fitting to sub-mm accuracy"""
     evoked = read_evokeds(fname_evo)[0].crop(0., 0.,)
     evoked.pick_types(meg=True, eeg=False)
     evoked.pick_channels([c for c in evoked.ch_names[::4]])
@@ -268,8 +309,13 @@ def test_accuracy():
 @testing.requires_testing_data
 def test_dipole_fixed():
     """Test reading a fixed-position dipole (from Xfit)"""
-    tempdir = _TempDir()
     dip = read_dipole(fname_xfit_dip)
+    _check_roundtrip_fixed(dip)
+
+
+def _check_roundtrip_fixed(dip):
+    """Helper to test roundtrip IO for fixed dipoles"""
+    tempdir = _TempDir()
     dip.save(op.join(tempdir, 'test-dip.fif.gz'))
     dip_read = read_dipole(op.join(tempdir, 'test-dip.fif.gz'))
     assert_allclose(dip_read.data, dip_read.data)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -29,8 +29,8 @@ warnings.simplefilter('always')
 data_path = testing.data_path(download=False)
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
 fname_dip = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_set1.dip')
-fname_evo = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
-fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis-cov.fif')
+fname_evo = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-ave.fif')
+fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-cov.fif')
 fname_bem = op.join(data_path, 'subjects', 'sample', 'bem',
                     'sample-1280-1280-1280-bem-sol.fif')
 fname_src = op.join(data_path, 'subjects', 'sample', 'bem',

--- a/tutorials/plot_dipole_fit.py
+++ b/tutorials/plot_dipole_fit.py
@@ -45,13 +45,6 @@ evoked.crop(0.07, 0.08)
 # Fit a dipole
 dip = mne.fit_dipole(evoked, fname_cov, fname_bem, fname_trans)[0]
 
-# Estimate the time course of a single dipole (the one that maximized GOF)
-# over the entire interval
-best_idx = np.argmax(dip.gof)
-dip_fixed = mne.fit_dipole(evoked_full, fname_cov, fname_bem, fname_trans,
-                           pos=dip.pos[best_idx], ori=dip.ori[best_idx])[0]
-dip_fixed.plot()
-
 # Plot the result in 3D brain
 dip.plot_locations(fname_trans, 'sample', subjects_dir)
 
@@ -62,7 +55,8 @@ fwd, stc = make_forward_dipole(dip, fname_bem, evoked.info, fname_trans)
 pred_evoked = simulate_evoked(fwd, stc, evoked.info, None, snr=np.inf)
 
 # find time point with highes GOF to plot
-best_time = dip.times[np.argmax(dip.gof)]
+best_idx = np.argmax(dip.gof)
+best_time = dip.times[best_idx]
 # rememeber to create a subplot for the colorbar
 fig, axes = plt.subplots(nrows=1, ncols=4, figsize=[10., 3.4])
 vmin, vmax = -400, 400  # make sure each plot has same colour range
@@ -82,3 +76,10 @@ plot_params['colorbar'] = True
 diff.plot_topomap(time_format='Difference', axes=axes[2], **plot_params)
 plt.suptitle('Comparison of measured and predicted fields '
              'at {:.0f} ms'.format(best_time * 1000.), fontsize=16)
+
+###############################################################################
+# Estimate the time course of a single dipole with fixed position and
+# orientation (the one that maximized GOF)over the entire interval
+dip_fixed = mne.fit_dipole(evoked_full, fname_cov, fname_bem, fname_trans,
+                           pos=dip.pos[best_idx], ori=dip.ori[best_idx])[0]
+dip_fixed.plot()

--- a/tutorials/plot_dipole_fit.py
+++ b/tutorials/plot_dipole_fit.py
@@ -39,10 +39,18 @@ fname_surf_lh = op.join(subjects_dir, 'sample', 'surf', 'lh.white')
 evoked = mne.read_evokeds(fname_ave, condition='Right Auditory',
                           baseline=(None, 0))
 evoked.pick_types(meg=True, eeg=False)
+evoked_full = evoked.copy()
 evoked.crop(0.07, 0.08)
 
 # Fit a dipole
 dip = mne.fit_dipole(evoked, fname_cov, fname_bem, fname_trans)[0]
+
+# Estimate the time course of a single dipole (the one that maximized GOF)
+# over the entire interval
+best_idx = np.argmax(dip.gof)
+dip_fixed = mne.fit_dipole(evoked_full, fname_cov, fname_bem, fname_trans,
+                           pos=dip.pos[best_idx], ori=dip.ori[best_idx])[0]
+dip_fixed.plot()
 
 # Plot the result in 3D brain
 dip.plot_locations(fname_trans, 'sample', subjects_dir)


### PR DESCRIPTION
This is a feature of Xfit that would be nice to have -- constrain `pos` and `ori` when doing dipole fitting so time-courses can be obtained.