### PR TITLE
MRG: Allow skipping FTP tests

### DIFF
--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -424,7 +424,7 @@ def test_fetch_file_html():
 @requires_good_network
 def test_fetch_file_ftp():
     """Test file downloading over ftp"""
-    _test_fetch('ftp://ftp.openbsd.org/pub/OpenBSD/README')
+    _test_fetch('ftp://speedtest.tele2.net/1KB.zip')
 
 
 def test_sum_squared():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -787,6 +787,10 @@ requires_good_network = partial(
     requires_module, name='good network connection',
     call='if int(os.environ.get("MNE_SKIP_NETWORK_TESTS", 0)):\n'
          '    raise ImportError')
+requires_ftp = partial(
+    requires_module, name='ftp downloading capability',
+    call='if int(os.environ.get("MNE_SKIP_FTP_TESTS", 0)):\n'
+         '    raise ImportError')
 requires_nitime = partial(requires_module, name='nitime',
                           call='import nitime')
 requires_traits = partial(requires_module, name='traits',
@@ -1175,6 +1179,8 @@ known_config_types = (
     'MNE_DATASETS_TESTING_PATH',
     'MNE_LOGGING_LEVEL',
     'MNE_MEMMAP_MIN_SIZE',
+    'MNE_SKIP_FTP_TESTS',
+    'MNE_SKIP_NETWORK_TESTS',
     'MNE_SKIP_TESTING_DATASET_TESTS',
     'MNE_STIM_CHANNEL',
     'MNE_USE_CUDA',


### PR DESCRIPTION
Closes #3113.

@jjnurminen you should be able to do `mne.set_config('MNE_SKIP_FTP_TESTS', 'true')` and have it not run those tests. Can you try it?