### PR TITLE
Fix to empty fields in info.

### DIFF
--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -98,8 +98,8 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc):
         patient_id = int(patient_id) if patient_id.isdigit() else 0
         fid.seek(121)
         patient_name = read_str(fid, 20).split()
-        last_name = patient_name[0] if len(patient_name) > 0 else 'Unknown'
-        first_name = patient_name[-1] if len(patient_name) > 0 else 'Unknown'
+        last_name = patient_name[0] if len(patient_name) > 0 else ''
+        first_name = patient_name[-1] if len(patient_name) > 0 else ''
         fid.seek(2, 1)
         sex = read_str(fid, 1)
         if sex == 'M':
@@ -117,7 +117,6 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc):
             hand = None
         fid.seek(205)
         session_label = read_str(fid, 20)
-        session_label = 'CNT' if len(session_label) == 0 else session_label
         session_date = read_str(fid, 10)
         time = read_str(fid, 12)
         date = session_date.split('/')

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -823,7 +823,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
 
     # Check that we have everything we need
     if nchan is None:
-        raise ValueError('Number of channels in not defined')
+        raise ValueError('Number of channels is not defined')
 
     if sfreq is None:
         raise ValueError('Sampling frequency is not defined')

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -9,7 +9,7 @@ from nose.tools import assert_equal, assert_true
 from mne import concatenate_raws
 from mne.datasets import testing
 from mne.io import Raw
-from mne.utils import _TempDir
+from mne.utils import _TempDir, string_types
 
 
 def _test_raw_reader(reader, test_preloading=True, **kwargs):
@@ -35,6 +35,9 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
     rng = np.random.RandomState(0)
     if test_preloading:
         raw = reader(preload=True, **kwargs)
+        for value in raw.info.values():
+            if isinstance(value, string_types):
+                assert_true(len(value) != 0)
         # don't assume the first is preloaded
         buffer_fname = op.join(tempdir, 'buffer')
         picks = rng.permutation(np.arange(len(raw.ch_names) - 1))[:10]

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -9,7 +9,7 @@ from nose.tools import assert_equal, assert_true
 from mne import concatenate_raws
 from mne.datasets import testing
 from mne.io import Raw
-from mne.utils import _TempDir, string_types
+from mne.utils import _TempDir
 
 
 def _test_raw_reader(reader, test_preloading=True, **kwargs):
@@ -35,9 +35,6 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
     rng = np.random.RandomState(0)
     if test_preloading:
         raw = reader(preload=True, **kwargs)
-        for value in raw.info.values():
-            if isinstance(value, string_types):
-                assert_true(len(value) != 0)
         # don't assume the first is preloaded
         buffer_fname = op.join(tempdir, 'buffer')
         picks = rng.permutation(np.arange(len(raw.ch_names) - 1))[:10]

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -98,11 +98,11 @@ def write_julian(fid, kind, data):
 
 def write_string(fid, kind, data):
     """Writes a string tag"""
-
     str_data = data.encode('utf-8')  # Use unicode or bytes depending on Py2/3
     data_size = len(str_data)  # therefore compute size here
     my_dtype = '>a'  # py2/3 compatible on writing -- don't ask me why
-    _write(fid, str_data, kind, data_size, FIFF.FIFFT_STRING, my_dtype)
+    if data_size > 0:
+        _write(fid, str_data, kind, data_size, FIFF.FIFFT_STRING, my_dtype)
 
 
 def write_name_list(fid, kind, data):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -815,8 +815,10 @@ def test_evoked_io_from_epochs():
                         picks=picks, baseline=(None, 0), decim=5)
     assert_true(len(w) == 1)
     evoked = epochs.average()
+    evoked.info['proj_name'] = ''  # Test that empty string shortcuts to None.
     evoked.save(op.join(tempdir, 'evoked-ave.fif'))
     evoked2 = read_evokeds(op.join(tempdir, 'evoked-ave.fif'))[0]
+    assert_equal(evoked2.info['proj_name'], None)
     assert_allclose(evoked.data, evoked2.data, rtol=1e-4, atol=1e-20)
     assert_allclose(evoked.times, evoked2.times, rtol=1e-4,
                     atol=1 / evoked.info['sfreq'])


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3130.
FIFF tree structure somehow breaks if empty strings are included in some fields. I didn't want to go and check every field at save stage. I think we should instead make sure that these don't exist in the info structure in the first place.