### PR TITLE
MRG: Unify copy in methods

### DIFF
--- a/examples/datasets/plot_brainstorm_data.py
+++ b/examples/datasets/plot_brainstorm_data.py
@@ -59,7 +59,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
 evoked = epochs.average()
 
 # remove physiological artifacts (eyeblinks, heartbeats) using SSP on baseline
-evoked.add_proj(mne.compute_proj_evoked(evoked.crop(tmax=0, copy=True)))
+evoked.add_proj(mne.compute_proj_evoked(evoked.copy().crop(tmax=0)))
 evoked.apply_proj()
 
 # fix stim artifact

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -68,7 +68,7 @@ picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
 # Testing will be done with a running classifier
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
                 baseline=None, preload=True, add_eeg_ref=False)
-epochs_train = epochs.crop(tmin=1., tmax=2., copy=True)
+epochs_train = epochs.copy().crop(tmin=1., tmax=2.)
 labels = epochs.events[:, -1] - 2
 
 ###############################################################################

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -55,9 +55,9 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 labels = epochs.events[:, -1]
 
 # get MEG and EEG data
-meg_epochs = epochs.pick_types(meg=True, eeg=False, copy=True)
+meg_epochs = epochs.copy().pick_types(meg=True, eeg=False)
 meg_data = meg_epochs.get_data().reshape(len(labels), -1)
-eeg_epochs = epochs.pick_types(meg=False, eeg=True, copy=True)
+eeg_epochs = epochs.copy().pick_types(meg=False, eeg=True)
 eeg_data = eeg_epochs.get_data().reshape(len(labels), -1)
 
 ###############################################################################

--- a/examples/inverse/plot_covariance_whitening_dspm.py
+++ b/examples/inverse/plot_covariance_whitening_dspm.py
@@ -54,7 +54,7 @@ raw = io.read_raw_ctf(raw_fname % 1)  # Take first run
 # To save time and memory for this demo, we'll just use the first
 # 2.5 minutes (all we need to get 30 total events) and heavily
 # resample 480->60 Hz (usually you wouldn't do either of these!)
-raw.crop(0, 150., copy=False).load_data().resample(60, npad='auto')
+raw = raw.crop(0, 150.).load_data().resample(60, npad='auto')
 
 picks = mne.pick_types(raw.info, meg=True, exclude='bads')
 raw.filter(1, None, method='iir', n_jobs=1)

--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -44,7 +44,7 @@ raw.info['bads'] = ['MEG 2443']  # 1 bad MEG channel
 # but here we use raw.pick_types() to save memory.
 left_temporal_channels = mne.read_selection('Left-temporal')
 raw.pick_types(meg='mag', eeg=False, eog=False, stim=False, exclude='bads',
-               selection=left_temporal_channels, copy=False)
+               selection=left_temporal_channels)
 reject = dict(mag=4e-12)
 # Re-normalize our empty-room projectors, which should be fine after
 # subselection

--- a/examples/preprocessing/plot_resample.py
+++ b/examples/preprocessing/plot_resample.py
@@ -26,7 +26,7 @@ from mne.datasets import sample
 # Setting up data paths and loading raw data (skip some data for speed)
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
-raw = mne.io.read_raw_fif(raw_fname).crop(120, 240, copy=False).load_data()
+raw = mne.io.read_raw_fif(raw_fname).crop(120, 240).load_data()
 
 ###############################################################################
 # Since downsampling reduces the timing precision of events, we recommend
@@ -36,7 +36,7 @@ epochs = mne.Epochs(raw, events, event_id=2, tmin=-0.1, tmax=0.8, preload=True)
 
 # Downsample to 100 Hz
 print('Original sampling rate:', epochs.info['sfreq'], 'Hz')
-epochs_resampled = epochs.resample(100, npad='auto', copy=True)
+epochs_resampled = epochs.copy().resample(100, npad='auto')
 print('New sampling rate:', epochs_resampled.info['sfreq'], 'Hz')
 
 # Plot a piece of data to see the effects of downsampling
@@ -64,7 +64,7 @@ mne.viz.tight_layout()
 # can also be done on non-preloaded data.
 
 # Resample to 300 Hz
-raw_resampled = raw.resample(300, npad='auto', copy=True)
+raw_resampled = raw.copy().resample(300, npad='auto')
 
 ###############################################################################
 # Because resampling also affects the stim channels, some trigger onsets might
@@ -74,12 +74,12 @@ raw_resampled = raw.resample(300, npad='auto', copy=True)
 print('Number of events before resampling:', len(mne.find_events(raw)))
 
 # Resample to 100 Hz (generates warning)
-raw_resampled = raw.resample(100, npad='auto', copy=True)
+raw_resampled = raw.copy().resample(100, npad='auto')
 print('Number of events after resampling:',
       len(mne.find_events(raw_resampled)))
 
 # To avoid losing events, jointly resample the data and event matrix
 events = mne.find_events(raw)
-raw_resampled, events_resampled = raw.resample(100, npad='auto',
-                                               events=events, copy=True)
+raw_resampled, events_resampled = raw.copy().resample(
+    100, npad='auto', events=events)
 print('Number of events after resampling:', len(events_resampled))

--- a/examples/simulation/plot_simulate_raw_data.py
+++ b/examples/simulation/plot_simulate_raw_data.py
@@ -32,7 +32,7 @@ bem_fname = (data_path +
 
 # Load real data as the template
 raw = mne.io.read_raw_fif(raw_fname)
-raw = raw.crop(0., 30., copy=False)  # 30 sec is enough
+raw = raw.crop(0., 30.)  # 30 sec is enough
 
 ##############################################################################
 # Generate dipole time series

--- a/examples/time_frequency/plot_compute_raw_data_spectrum.py
+++ b/examples/time_frequency/plot_compute_raw_data_spectrum.py
@@ -30,12 +30,9 @@ proj_fname = data_path + '/MEG/sample/sample_audvis_eog-proj.fif'
 
 tmin, tmax = 0, 60  # use the first 60s of data
 
-# Setup for reading the raw data
-raw = io.read_raw_fif(raw_fname)
+# Setup for reading the raw data (to save memory, crop before loading)
+raw = io.read_raw_fif(raw_fname).crop(tmin, tmax).load_data()
 raw.info['bads'] += ['MEG 2443', 'EEG 053']  # bads + 2 more
-
-# To save memory, crop the raw data before loading data
-raw.crop(tmin, tmax, copy=False).load_data()
 
 # Add SSP projection vectors to reduce EOG and ECG artifacts
 projs = read_proj(proj_fname)

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-from .utils import logger, verbose
+from .utils import logger, verbose, _check_copy_dep
 
 
 def _log_rescale(baseline, mode='mean'):
@@ -24,7 +24,7 @@ def _log_rescale(baseline, mode='mean'):
 
 
 @verbose
-def rescale(data, times, baseline, mode='mean', copy=True, verbose=None):
+def rescale(data, times, baseline, mode='mean', copy=None, verbose=None):
     """Rescale aka baseline correct data
 
     Parameters
@@ -50,7 +50,9 @@ def rescale(data, times, baseline, mode='mean', copy=True, verbose=None):
         logratio is the same an mean but in log-scale, zlogratio is the
         same as zscore but data is rendered in log-scale first.
     copy : bool
-        Operate on a copy of the data, or in place.
+        This parameter has been deprecated and will be removed in 0.13.
+        Use data.copy() instead.
+        Whether to return a new instance or modify in place.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -59,9 +61,8 @@ def rescale(data, times, baseline, mode='mean', copy=True, verbose=None):
     data_scaled: array
         Array of same shape as data after rescaling.
     """
+    data = _check_copy_dep(data, copy, kind='data')
     _log_rescale(baseline, mode)
-    if copy:
-        data = data.copy()
     if baseline is None:
         return data
 

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -24,7 +24,7 @@ def _log_rescale(baseline, mode='mean'):
 
 
 @verbose
-def rescale(data, times, baseline, mode='mean', copy=None, verbose=None):
+def rescale(data, times, baseline, mode='mean', copy=True, verbose=None):
     """Rescale aka baseline correct data
 
     Parameters
@@ -50,8 +50,6 @@ def rescale(data, times, baseline, mode='mean', copy=None, verbose=None):
         logratio is the same an mean but in log-scale, zlogratio is the
         same as zscore but data is rendered in log-scale first.
     copy : bool
-        This parameter has been deprecated and will be removed in 0.13.
-        Use data.copy() instead.
         Whether to return a new instance or modify in place.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
@@ -61,7 +59,7 @@ def rescale(data, times, baseline, mode='mean', copy=None, verbose=None):
     data_scaled: array
         Array of same shape as data after rescaling.
     """
-    data = _check_copy_dep(data, copy, kind='data')
+    data = data.copy() if copy else data
     _log_rescale(baseline, mode)
     if baseline is None:
         return data

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-from .utils import logger, verbose, _check_copy_dep
+from .utils import logger, verbose
 
 
 def _log_rescale(baseline, mode='mean'):

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -185,7 +185,7 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
     # return without doing anything if there are no meg channels
     if len(picks_meg) == 0 or len(picks_bad) == 0:
         return
-    info_from = pick_info(inst.info, picks_good, copy=True)
-    info_to = pick_info(inst.info, picks_bad, copy=True)
+    info_from = pick_info(inst.info.copy(), picks_good)
+    info_to = pick_info(inst.info.copy(), picks_bad)
     mapping = _map_meg_channels(info_from, info_to, mode=mode)
     _do_interp_dots(inst, mapping, picks_good, picks_bad)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -185,7 +185,7 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
     # return without doing anything if there are no meg channels
     if len(picks_meg) == 0 or len(picks_bad) == 0:
         return
-    info_from = pick_info(inst.info.copy(), picks_good)
-    info_to = pick_info(inst.info.copy(), picks_bad)
+    info_from = pick_info(inst.info, picks_good)
+    info_to = pick_info(inst.info, picks_bad)
     mapping = _map_meg_channels(info_from, info_to, mode=mode)
     _do_interp_dots(inst, mapping, picks_good, picks_bad)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -329,7 +329,7 @@ def make_grid_layout(info, picks=None, n_col=None):
         if n_col * n_row < size:  # jump to the next full square
             n_row += 1
     else:
-        n_row = np.ceil(size / float(n_col))
+        n_row = int(np.ceil(size / float(n_col)))
 
     # setup position grid
     x, y = np.meshgrid(np.linspace(-0.5, 0.5, n_col),

--- a/mne/commands/mne_compute_proj_ecg.py
+++ b/mne/commands/mne_compute_proj_ecg.py
@@ -182,12 +182,11 @@ def run():
         raw_event = raw
 
     flat = None  # XXX : not exposed to the user
-    cpe = mne.preprocessing.compute_proj_ecg
-    projs, events = cpe(raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg,
-                        l_freq, h_freq, average, filter_length, n_jobs,
-                        ch_name, reject, flat, bads, avg_ref, no_proj,
-                        event_id, ecg_l_freq, ecg_h_freq, tstart,
-                        qrs_threshold, copy=False)
+    projs, events = mne.preprocessing.compute_proj_ecg(
+        raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg, l_freq, h_freq,
+        average, filter_length, n_jobs, ch_name, reject, flat, bads, avg_ref,
+        no_proj, event_id, ecg_l_freq, ecg_h_freq, tstart, qrs_threshold,
+        copy=False)
 
     raw.close()
 

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -60,7 +60,7 @@ def test_csp():
     sources = csp.transform(epochs_data)
     assert_true(sources.shape[1] == n_components)
 
-    epochs.pick_types(meg='mag', copy=False)
+    epochs.pick_types(meg='mag')
 
     # test plot patterns
     components = np.arange(n_components)

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -34,7 +34,7 @@ def test_ems():
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     assert_raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
-    epochs = epochs.equalize_event_counts(epochs.event_id)[0]
+    epochs = epochs.equalize_event_counts(epochs.event_id, copy=False)[0]
 
     assert_raises(KeyError, compute_ems, epochs, ['blah', 'hahah'])
     surrogates, filters, conditions = compute_ems(epochs)
@@ -44,7 +44,7 @@ def test_ems():
     event_id2 = dict(aud_l=1, aud_r=2, vis_l=3)
     epochs = Epochs(raw, events, event_id2, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    epochs = epochs.equalize_event_counts(epochs.event_id)[0]
+    epochs = epochs.equalize_event_counts(epochs.event_id, copy=False)[0]
 
     n_expected = sum([len(epochs[k]) for k in ['aud_l', 'vis_l']])
 

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -34,7 +34,7 @@ def test_ems():
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     assert_raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
-    epochs.equalize_event_counts(epochs.event_id)
+    epochs = epochs.equalize_event_counts(epochs.event_id)[0]
 
     assert_raises(KeyError, compute_ems, epochs, ['blah', 'hahah'])
     surrogates, filters, conditions = compute_ems(epochs)
@@ -44,7 +44,7 @@ def test_ems():
     event_id2 = dict(aud_l=1, aud_r=2, vis_l=3)
     epochs = Epochs(raw, events, event_id2, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    epochs.equalize_event_counts(epochs.event_id)
+    epochs = epochs.equalize_event_counts(epochs.event_id)[0]
 
     n_expected = sum([len(epochs[k]) for k in ['aud_l', 'vis_l']])
 

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -34,7 +34,7 @@ def test_ems():
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     assert_raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
-    epochs.equalize_event_counts(epochs.event_id, copy=False)
+    epochs.equalize_event_counts(epochs.event_id)
 
     assert_raises(KeyError, compute_ems, epochs, ['blah', 'hahah'])
     surrogates, filters, conditions = compute_ems(epochs)
@@ -44,7 +44,7 @@ def test_ems():
     event_id2 = dict(aud_l=1, aud_r=2, vis_l=3)
     epochs = Epochs(raw, events, event_id2, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    epochs.equalize_event_counts(epochs.event_id, copy=False)
+    epochs.equalize_event_counts(epochs.event_id)
 
     n_expected = sum([len(epochs[k]) for k in ['aud_l', 'vis_l']])
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -42,7 +42,8 @@ from .fixes import in1d, _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
                   plot_epochs_image, plot_topo_image_epochs)
 from .utils import (check_fname, logger, verbose, _check_type_picks,
-                    _time_mask, check_random_state, object_hash, warn)
+                    _time_mask, check_random_state, object_hash, warn,
+                    _check_copy_dep)
 from .utils import deprecated
 from .externals.six import iteritems, string_types
 from .externals.six.moves import zip
@@ -349,7 +350,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         assert self._data.shape[-1] == len(self.times)
         return self
 
-    def decimate(self, decim, copy=False, offset=0):
+    def decimate(self, decim, copy=None, offset=0):
         """Decimate the epochs
 
         Parameters
@@ -357,7 +358,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         decim : int
             The amount to decimate data.
         copy : bool
-            If True, operate on and return a copy of the Epochs object.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         offset : int
             Apply an offset to where the decimation starts relative to the
             sample corresponding to t=0. The offset is in samples at the
@@ -381,7 +384,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if decim < 1 or decim != int(decim):
             raise ValueError('decim must be an integer > 0')
         decim = int(decim)
-        epochs = self.copy() if copy else self
+        epochs = _check_copy_dep(self, copy)
         del self
 
         new_sfreq = epochs.info['sfreq'] / float(decim)
@@ -419,7 +422,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return epochs
 
     @verbose
-    def apply_baseline(self, baseline, copy=False, verbose=None):
+    def apply_baseline(self, baseline, copy=None, verbose=None):
         """Baseline correct epochs
 
         Parameters
@@ -431,8 +434,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             the interval. If baseline is equal to (None, None) all the time
             interval is used.
         copy : bool
-            Should the object be modified, or a copy? If ``False``, modify
-            in place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
 
@@ -451,14 +455,13 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             raise ValueError('`baseline=%s` is an invalid argument.'
                              % str(baseline))
 
-        epochs = self if not copy else self.copy()
+        epochs = _check_copy_dep(self, copy)
         picks = _pick_data_channels(epochs.info, exclude=[], with_ref_meg=True)
         picks_aux = _pick_aux_channels(epochs.info, exclude=[])
         picks = np.sort(np.concatenate((picks, picks_aux)))
 
         data = epochs._data
-        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline,
-                                    copy=False)
+        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline)
         epochs.baseline = baseline
 
         return epochs
@@ -575,7 +578,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, bio=True, ecog=True, exclude=[])
         epoch[picks] = rescale(epoch[picks], self._raw_times, self.baseline,
-                               copy=False, verbose=False)
+                               verbose=False)
 
         # handle offset
         if self._offset is not None:
@@ -1568,7 +1571,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                if v in epochs.events[:, 2])
         return epochs
 
-    def crop(self, tmin=None, tmax=None, copy=False):
+    def crop(self, tmin=None, tmax=None, copy=None):
         """Crops a time interval from epochs object.
 
         Parameters
@@ -1578,7 +1581,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         tmax : float | None
             End time of selection in seconds.
         copy : bool
-            If False epochs is cropped in place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
 
         Returns
         -------
@@ -1611,7 +1616,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             tmax = self.tmax
 
         tmask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'])
-        this_epochs = self if not copy else self.copy()
+        this_epochs = _check_copy_dep(self, copy)
         this_epochs.times = this_epochs.times[tmask]
         this_epochs._raw_times = this_epochs._raw_times[tmask]
         this_epochs._data = this_epochs._data[:, :, tmask]
@@ -1619,7 +1624,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @verbose
     def resample(self, sfreq, npad=None, window='boxcar', n_jobs=1,
-                 copy=False, verbose=None):
+                 copy=None, verbose=None):
         """Resample preloaded data
 
         Parameters
@@ -1635,8 +1640,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         n_jobs : int
             Number of jobs to run in parallel.
         copy : bool
-            Whether to operate on a copy of the data (True) or modify data
-            in-place (False). Defaults to False.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -1664,9 +1670,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             warn('npad is currently taken to be 100, but will be changed to '
                  '"auto" in 0.13. Please set the value explicitly.',
                  DeprecationWarning)
-
-        inst = self.copy() if copy else self
-
+        inst = _check_copy_dep(self, copy)
         o_sfreq = inst.info['sfreq']
         inst._data = resample(inst._data, sfreq, o_sfreq, npad, window=window,
                               n_jobs=n_jobs)
@@ -1722,7 +1726,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             this_epochs.event_id = self.event_id
             _save_split(this_epochs, fname, part_idx, n_parts)
 
-    def equalize_event_counts(self, event_ids, method='mintime', copy=True):
+    def equalize_event_counts(self, event_ids, method='mintime', copy=None):
         """Equalize the number of trials in each condition
 
         It tries to make the remaining epochs occurring as close as possible in
@@ -1753,8 +1757,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             list. If 'mintime', timing differences between each event list
             will be minimized.
         copy : bool
-            If True, a copy of epochs will be returned. Otherwise, the
-            function will operate in-place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
 
         Returns
         -------
@@ -1778,10 +1783,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         conditions will contribute evenly. E.g., it is possible to end up
         with 70 'Nonspatial' trials, 69 'Left' and 1 'Right'.
         """
-        if copy is True:
-            epochs = self.copy()
-        else:
-            epochs = self
+        epochs = _check_copy_dep(self, copy, default=True)
         if len(event_ids) == 0:
             raise ValueError('event_ids must have at least one element')
         if not epochs._bad_dropped:
@@ -2197,8 +2199,7 @@ def combine_event_ids(epochs, old_event_ids, new_event_id, copy=True):
         condition. Note that for safety, this cannot be any
         existing id (in epochs.event_id.values()).
     copy : bool
-        If True, a copy of epochs will be returned. Otherwise, the
-        function will operate in-place.
+        Whether to return a new instance or modify in place.
 
     Notes
     -----
@@ -2209,8 +2210,7 @@ def combine_event_ids(epochs, old_event_ids, new_event_id, copy=True):
     would create a 'Directional' entry in epochs.event_id replacing
     'Left' and 'Right' (combining their trials).
     """
-    if copy:
-        epochs = epochs.copy()
+    epochs = epochs.copy() if copy else epochs
     old_event_ids = np.asanyarray(old_event_ids)
     if isinstance(new_event_id, int):
         new_event_id = {str(new_event_id): new_event_id}

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -461,7 +461,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         picks = np.sort(np.concatenate((picks, picks_aux)))
 
         data = epochs._data
-        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline)
+        data[:, picks, :] = rescale(data[:, picks, :], self.times, baseline,
+                                    copy=False)
         epochs.baseline = baseline
 
         return epochs
@@ -578,7 +579,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                            ref_meg=True, eog=True, ecg=True, seeg=True,
                            emg=True, bio=True, ecog=True, exclude=[])
         epoch[picks] = rescale(epoch[picks], self._raw_times, self.baseline,
-                               verbose=False)
+                               copy=False, verbose=False)
 
         # handle offset
         if self._offset is not None:

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -15,7 +15,8 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 equalize_channels)
 from .filter import resample, detrend, FilterMixin
 from .fixes import in1d
-from .utils import check_fname, logger, verbose, object_hash, _time_mask, warn
+from .utils import (check_fname, logger, verbose, object_hash, _time_mask,
+                    warn, _check_copy_dep)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import (_plot_evoked_white, plot_evoked_joint,
@@ -112,7 +113,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # project and baseline correct
         if proj:
             self.apply_proj()
-        self.data = rescale(self.data, self.times, baseline, copy=False)
+        self.data = rescale(self.data, self.times, baseline)
 
     def save(self, fname):
         """Save dataset to file.
@@ -142,7 +143,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """Channel names"""
         return self.info['ch_names']
 
-    def crop(self, tmin=None, tmax=None, copy=False):
+    def crop(self, tmin=None, tmax=None, copy=None):
         """Crop data to a given time interval
 
         Parameters
@@ -152,9 +153,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         tmax : float | None
             End time of selection in seconds.
         copy : bool
-            If False epochs is cropped in place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         """
-        inst = self if not copy else self.copy()
+        inst = _check_copy_dep(self, copy)
         mask = _time_mask(inst.times, tmin, tmax, sfreq=self.info['sfreq'])
         inst.times = inst.times[mask]
         inst.first = int(inst.times[0] * inst.info['sfreq'])

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -113,7 +113,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # project and baseline correct
         if proj:
             self.apply_proj()
-        self.data = rescale(self.data, self.times, baseline)
+        self.data = rescale(self.data, self.times, baseline, copy=False)
 
     def save(self, fname):
         """Save dataset to file.

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -196,8 +196,8 @@ def _as_meg_type_evoked(evoked, ch_type='grad', mode='fast'):
                          ' locations of the destination channels will be used'
                          ' for interpolation.')
 
-    info_from = pick_info(evoked.info, pick_from, copy=True)
-    info_to = pick_info(evoked.info, pick_to, copy=True)
+    info_from = pick_info(evoked.info, pick_from)
+    info_to = pick_info(evoked.info, pick_to)
     mapping = _map_meg_channels(info_from, info_to, mode=mode)
 
     # compute evoked data by multiplying by the 'gain matrix' from
@@ -280,7 +280,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
         logger.info('Prepare EEG mapping...')
     if len(picks) == 0:
         raise RuntimeError('cannot map, no channels found')
-    chs = pick_info(info, picks, copy=True)['chs']
+    chs = pick_info(info, picks)['chs']
 
     # create coil defs in head coordinates
     if ch_type == 'meg':

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -42,7 +42,7 @@ from ..transforms import (transform_surface_to, invert_transform,
                           write_trans)
 from ..utils import (_check_fname, get_subjects_dir, has_mne_c, warn,
                      run_subprocess, check_fname, logger, verbose,
-                     deprecated, _check_copy_dep)
+                     deprecated)
 from ..label import Label
 
 

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -137,7 +137,7 @@ def test_make_field_map_meg():
     assert_raises(ValueError, _make_surface_mapping, info, surf, 'meg',
                   mode='foo')
     # no picks
-    evoked_eeg = evoked.pick_types(meg=False, eeg=True, copy=True)
+    evoked_eeg = evoked.copy().pick_types(meg=False, eeg=True)
     assert_raises(RuntimeError, _make_surface_mapping, evoked_eeg.info,
                   surf, 'meg')
     # bad surface def
@@ -219,14 +219,14 @@ def test_as_meg_type_evoked():
 
     # channel names
     ch_names = evoked.info['ch_names']
-    virt_evoked = evoked.pick_channels(ch_names=ch_names[:10:1], copy=True)
+    virt_evoked = evoked.copy().pick_channels(ch_names=ch_names[:10:1])
     virt_evoked.info.normalize_proj()
     virt_evoked = virt_evoked.as_type('mag')
     assert_true(all('_virtual' in ch for ch in virt_evoked.info['ch_names']))
 
     # pick from and to channels
-    evoked_from = evoked.pick_channels(ch_names=ch_names[2:10:3], copy=True)
-    evoked_to = evoked.pick_channels(ch_names=ch_names[0:10:3], copy=True)
+    evoked_from = evoked.copy().pick_channels(ch_names=ch_names[2:10:3])
+    evoked_to = evoked.copy().pick_channels(ch_names=ch_names[0:10:3])
 
     info_from, info_to = evoked_from.info, evoked_to.info
 

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -32,7 +32,7 @@ def test_array_raw():
     """
     import matplotlib.pyplot as plt
     # creating
-    raw = Raw(fif_fname).crop(2, 5, copy=False)
+    raw = Raw(fif_fname).crop(2, 5)
     data, times = raw[:, :]
     sfreq = raw.info['sfreq']
     ch_names = [(ch[4:] if 'STI' not in ch else ch)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1061,13 +1061,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Can also be "auto" to use a padding that will result in
             a power-of-two size (can be much faster).
         window : string or tuple
-            Window to use in resampling. See scipy.signal.resample.
+            Frequency-domain window to use in resampling.
+            See :func:`scipy.signal.resample`.
         stim_picks : array of int | None
             Stim channels. These channels are simply subsampled or
             supersampled (without applying any filtering). This reduces
             resampling artifacts in stim channels, but may lead to missing
             triggers. If None, stim channels are automatically chosen using
-            mne.pick_types(raw.info, meg=False, stim=True, exclude=[]).
+            :func:`mne.pick_types`.
         n_jobs : int | str
             Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
             is installed properly and CUDA is initialized.
@@ -1132,7 +1133,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         for ri in range(len(inst._raw_lengths)):
             data_chunk = inst._data[:, offsets[ri]:offsets[ri + 1]]
             new_data.append(resample(data_chunk, sfreq, o_sfreq, npad,
-                                     n_jobs=n_jobs))
+                                     window=window, n_jobs=n_jobs))
             new_ntimes = new_data[ri].shape[1]
 
             # In empirical testing, it was faster to resample all channels

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -35,7 +35,7 @@ from ..filter import (low_pass_filter, high_pass_filter, band_pass_filter,
 from ..fixes import in1d
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed,
-                     _check_pandas_index_arguments,
+                     _check_pandas_index_arguments, _check_copy_dep,
                      check_fname, _get_stim_channel, object_hash,
                      logger, verbose, _time_mask, warn, deprecated)
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
@@ -788,7 +788,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @verbose
     def filter(self, l_freq, h_freq, picks=None, filter_length='10s',
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5, n_jobs=1,
-               method='fft', iir_params=None, copy=False, verbose=None):
+               method='fft', iir_params=None, verbose=None):
         """Filter a subset of channels.
 
         Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
@@ -849,12 +849,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Dictionary of parameters to use for IIR filtering.
             See mne.filter.construct_iir_filter for details. If iir_params
             is None and method="iir", 4th order Butterworth will be used.
-        copy : bool
-            If ``True``, return a modified copy of original object. If
-            ``False`` modify in-place and return the original object.
-
-            .. versionadded:: 0.12.0
-
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -879,11 +873,9 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             l_freq = float(l_freq)
         if h_freq is not None and not isinstance(h_freq, float):
             h_freq = float(h_freq)
-
-        raw = self.copy() if copy else self
-        _check_preload(raw, 'raw.filter')
+        _check_preload(self, 'raw.filter')
         if picks is None:
-            picks = _pick_data_or_ica(raw.info)
+            picks = _pick_data_or_ica(self.info)
             # let's be safe.
             if len(picks) < 1:
                 raise RuntimeError('Could not find any valid channels for '
@@ -894,14 +886,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             # and it's not a band-stop filter
             if h_freq is not None:
                 if (l_freq is None or l_freq < h_freq) and \
-                   (raw.info["lowpass"] is None or
-                   h_freq < raw.info['lowpass']):
-                        raw.info['lowpass'] = h_freq
+                   (self.info["lowpass"] is None or
+                   h_freq < self.info['lowpass']):
+                        self.info['lowpass'] = h_freq
             if l_freq is not None:
                 if (h_freq is None or l_freq < h_freq) and \
-                   (raw.info["highpass"] is None or
-                   l_freq > raw.info['highpass']):
-                        raw.info['highpass'] = l_freq
+                   (self.info["highpass"] is None or
+                   l_freq > self.info['highpass']):
+                        self.info['highpass'] = l_freq
         else:
             if h_freq is not None or l_freq is not None:
                 logger.info('Filtering a subset of channels. The highpass and '
@@ -910,14 +902,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if l_freq is None and h_freq is not None:
             logger.info('Low-pass filtering at %0.2g Hz' % h_freq)
-            low_pass_filter(raw._data, fs, h_freq,
+            low_pass_filter(self._data, fs, h_freq,
                             filter_length=filter_length,
                             trans_bandwidth=h_trans_bandwidth, method=method,
                             iir_params=iir_params, picks=picks, n_jobs=n_jobs,
                             copy=False)
         if l_freq is not None and h_freq is None:
             logger.info('High-pass filtering at %0.2g Hz' % l_freq)
-            high_pass_filter(raw._data, fs, l_freq,
+            high_pass_filter(self._data, fs, l_freq,
                              filter_length=filter_length,
                              trans_bandwidth=l_trans_bandwidth, method=method,
                              iir_params=iir_params, picks=picks, n_jobs=n_jobs,
@@ -926,8 +918,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             if l_freq < h_freq:
                 logger.info('Band-pass filtering from %0.2g - %0.2g Hz'
                             % (l_freq, h_freq))
-                raw._data = band_pass_filter(
-                    raw._data, fs, l_freq, h_freq,
+                self._data = band_pass_filter(
+                    self._data, fs, l_freq, h_freq,
                     filter_length=filter_length,
                     l_trans_bandwidth=l_trans_bandwidth,
                     h_trans_bandwidth=h_trans_bandwidth,
@@ -936,21 +928,20 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             else:
                 logger.info('Band-stop filtering from %0.2g - %0.2g Hz'
                             % (h_freq, l_freq))
-                raw._data = band_stop_filter(
-                    raw._data, fs, h_freq, l_freq,
+                self._data = band_stop_filter(
+                    self._data, fs, h_freq, l_freq,
                     filter_length=filter_length,
                     l_trans_bandwidth=h_trans_bandwidth,
                     h_trans_bandwidth=l_trans_bandwidth, method=method,
                     iir_params=iir_params, picks=picks, n_jobs=n_jobs,
                     copy=False)
-
-        return raw
+        return self
 
     @verbose
     def notch_filter(self, freqs, picks=None, filter_length='10s',
                      notch_widths=None, trans_bandwidth=1.0, n_jobs=1,
                      method='fft', iir_params=None, mt_bandwidth=None,
-                     p_value=0.05, copy=False, verbose=None):
+                     p_value=0.05, verbose=None):
         """Notch filter a subset of channels.
 
         Applies a zero-phase notch filter to the channels selected by
@@ -1005,12 +996,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             sinusoidal components to remove when method='spectrum_fit' and
             freqs=None. Note that this will be Bonferroni corrected for the
             number of frequencies, so large p-values may be justified.
-        copy : bool
-            If ``True``, return a modified copy of original object. If
-            ``False`` modify in-place and return the original object.
-
-            .. versionadded:: 0.12.0
-
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -1028,26 +1013,25 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         -----
         For details, see :func:`mne.filter.notch_filter`.
         """
-        raw = self.copy() if copy else self
-        fs = float(raw.info['sfreq'])
+        fs = float(self.info['sfreq'])
         if picks is None:
-            picks = _pick_data_or_ica(raw.info)
+            picks = _pick_data_or_ica(self.info)
             # let's be safe.
             if len(picks) < 1:
                 raise RuntimeError('Could not find any valid channels for '
                                    'your Raw object. Please contact the '
                                    'MNE-Python developers.')
-        _check_preload(raw, 'raw.notch_filter')
-        raw._data = notch_filter(
-            raw._data, fs, freqs, filter_length=filter_length,
+        _check_preload(self, 'raw.notch_filter')
+        self._data = notch_filter(
+            self._data, fs, freqs, filter_length=filter_length,
             notch_widths=notch_widths, trans_bandwidth=trans_bandwidth,
             method=method, iir_params=iir_params, mt_bandwidth=mt_bandwidth,
             p_value=p_value, picks=picks, n_jobs=n_jobs, copy=False)
-        return raw
+        return self
 
     @verbose
     def resample(self, sfreq, npad=None, window='boxcar', stim_picks=None,
-                 n_jobs=1, events=None, copy=False, verbose=None):
+                 n_jobs=1, events=None, copy=None, verbose=None):
         """Resample all channels.
 
         The Raw object has to have the data loaded e.g. with ``preload=True``
@@ -1117,10 +1101,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             warn('npad is currently taken to be 100, but will be changed to '
                  '"auto" in 0.13. Please set the value explicitly.',
                  DeprecationWarning)
-        if not self.preload:
-            raise RuntimeError('Can only resample preloaded data')
-
-        inst = self.copy() if copy else self
+        _check_preload(self, 'raw.resample')
+        inst = _check_copy_dep(self, copy)
 
         # When no event object is supplied, some basic detection of dropped
         # events is performed to generate a warning. Finding events can fail
@@ -1197,14 +1179,13 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             )
             return inst, events
 
-    def crop(self, tmin=0.0, tmax=None, copy=True):
+    def crop(self, tmin=0.0, tmax=None, copy=None):
         """Crop raw data file.
 
         Limit the data from the raw file to go between specific times. Note
         that the new tmin is assumed to be t=0 for all subsequently called
         functions (e.g., time_as_index, or Epochs). New first_samp and
-        last_samp are set accordingly. And data are modified in-place when
-        called with copy=False.
+        last_samp are set accordingly.
 
         Parameters
         ----------
@@ -1213,14 +1194,16 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         tmax : float | None
             New end time in seconds of the data (cannot exceed data duration).
         copy : bool
-            If False Raw is cropped in place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
 
         Returns
         -------
         raw : instance of Raw
             The cropped raw object.
         """
-        raw = self.copy() if copy is True else self
+        raw = _check_copy_dep(self, copy, default=True)
         max_time = (raw.n_times - 1) / raw.info['sfreq']
         if tmax is None:
             tmax = max_time
@@ -1731,9 +1714,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         data = self[picks, tslice][0]
         out = _estimate_rank_meeg_signals(
             data, pick_info(self.info, picks),
-            scalings=scalings, tol=tol, return_singular=return_singular,
-            copy=False)
-
+            scalings=scalings, tol=tol, return_singular=return_singular)
         return out
 
     @property
@@ -2141,7 +2122,7 @@ def _start_writing_raw(name, info, sel=None, data_type=FIFF.FIFFT_FLOAT,
     #
     #    Measurement info
     #
-    info = pick_info(info, sel, copy=True)
+    info = pick_info(info, sel)
 
     #
     #  Create the file and save the essentials

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -62,7 +62,7 @@ def test_crop_append():
     y, t = raw[:]
     t0, t1 = 0.25 * t[-1], 0.75 * t[-1]
     mask = (t0 <= t) * (t <= t1)
-    raw_ = raw.crop(t0, t1)
+    raw_ = raw.copy().crop(t0, t1, copy=False)
     y_, _ = raw_[:]
     assert_true(y_.shape[1] == mask.sum())
     assert_true(y_.shape[0] == y.shape[0])

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -80,7 +80,7 @@ def test_concat():
     # we trim the file to save lots of memory and some time
     tempdir = _TempDir()
     raw = read_raw_fif(test_fif_fname)
-    raw = raw.crop(0, 2.)
+    raw.crop(0, 2., copy=False)
     test_name = op.join(tempdir, 'test_raw.fif')
     raw.save(test_name)
     # now run the standard test
@@ -93,9 +93,9 @@ def test_hash_raw():
     """
     raw = read_raw_fif(fif_fname)
     assert_raises(RuntimeError, raw.__hash__)
-    raw = Raw(fif_fname).crop(0, 0.5)
+    raw = Raw(fif_fname).crop(0, 0.5, copy=False)
     raw.load_data()
-    raw_2 = Raw(fif_fname).crop(0, 0.5)
+    raw_2 = Raw(fif_fname).crop(0, 0.5, copy=False)
     raw_2.load_data()
     assert_equal(hash(raw), hash(raw_2))
     # do NOT use assert_equal here, failing output is terrible
@@ -121,7 +121,7 @@ def test_subject_info():
     """Test reading subject information
     """
     tempdir = _TempDir()
-    raw = Raw(fif_fname).crop(0, 1)
+    raw = Raw(fif_fname).crop(0, 1, copy=False)
     assert_true(raw.info['subject_info'] is None)
     # fake some subject data
     keys = ['id', 'his_id', 'last_name', 'first_name', 'birthday', 'sex',
@@ -215,7 +215,7 @@ def test_output_formats():
     tols = [1e-4, 1e-7, 1e-7, 1e-15]
 
     # let's fake a raw file with different formats
-    raw = Raw(test_fif_fname).crop(0, 1)
+    raw = Raw(test_fif_fname).crop(0, 1, copy=False)
 
     temp_file = op.join(tempdir, 'raw.fif')
     for ii, (fmt, tol) in enumerate(zip(formats, tols)):
@@ -665,7 +665,7 @@ def test_proj():
 
     tempdir = _TempDir()
     out_fname = op.join(tempdir, 'test_raw.fif')
-    raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
+    raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002, copy=False)
     raw.pick_types(meg=False, eeg=True)
     raw.info['projs'] = [raw.info['projs'][-1]]
     raw._data.fill(0)
@@ -823,7 +823,7 @@ def test_crop():
     tmins /= sfreq
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
-        raws[ri] = raw.copy().crop(tmin, tmax)
+        raws[ri] = raw.copy().crop(tmin, tmax, copy=False)
     all_raw_2 = concatenate_raws(raws, preload=False)
     assert_equal(raw.first_samp, all_raw_2.first_samp)
     assert_equal(raw.last_samp, all_raw_2.last_samp)
@@ -837,11 +837,11 @@ def test_crop():
     # going in revere order so the last fname is the first file (need it later)
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
-        raws[ri] = raw.copy().crop(tmin, tmax)
+        raws[ri] = raw.copy().crop(tmin, tmax, copy=False)
     # test concatenation of split file
     all_raw_1 = concatenate_raws(raws, preload=False)
 
-    all_raw_2 = raw.copy().crop(0, None)
+    all_raw_2 = raw.copy().crop(0, None, copy=False)
     for ar in [all_raw_1, all_raw_2]:
         assert_equal(raw.first_samp, ar.first_samp)
         assert_equal(raw.last_samp, ar.last_samp)
@@ -852,7 +852,7 @@ def test_crop():
     info = create_info(1, 1000)
     raw = RawArray(data, info)
     for tmin in range(0, 1001, 100):
-        raw1 = raw.crop(tmin=tmin, tmax=tmin + 2)
+        raw1 = raw.copy().crop(tmin=tmin, tmax=tmin + 2, copy=False)
         assert_equal(raw1[:][0].shape, (1, 2001))
 
 
@@ -861,7 +861,7 @@ def test_resample():
     """Test resample (with I/O and multiple files)
     """
     tempdir = _TempDir()
-    raw = Raw(fif_fname).crop(0, 3)
+    raw = Raw(fif_fname).crop(0, 3, copy=False)
     raw.load_data()
     raw_resamp = raw.copy()
     sfreq = raw.info['sfreq']
@@ -1038,7 +1038,7 @@ def test_to_data_frame():
 def test_add_channels():
     """Test raw splitting / re-appending channel types
     """
-    raw = Raw(test_fif_fname).crop(0, 1).load_data()
+    raw = Raw(test_fif_fname).crop(0, 1, copy=False).load_data()
     raw_nopre = Raw(test_fif_fname, preload=False)
     raw_eeg_meg = raw.copy().pick_types(meg=True, eeg=True)
     raw_eeg = raw.copy().pick_types(meg=False, eeg=True)
@@ -1059,7 +1059,7 @@ def test_add_channels():
     # Now test errors
     raw_badsf = raw_eeg.copy()
     raw_badsf.info['sfreq'] = 3.1415927
-    raw_eeg = raw_eeg.crop(.5)
+    raw_eeg.crop(.5, copy=False)
 
     assert_raises(AssertionError, raw_meg.add_channels, [raw_nopre])
     assert_raises(RuntimeError, raw_meg.add_channels, [raw_badsf])

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -80,7 +80,7 @@ def test_concat():
     # we trim the file to save lots of memory and some time
     tempdir = _TempDir()
     raw = read_raw_fif(test_fif_fname)
-    raw.crop(0, 2., copy=False)
+    raw = raw.crop(0, 2.)
     test_name = op.join(tempdir, 'test_raw.fif')
     raw.save(test_name)
     # now run the standard test
@@ -93,9 +93,9 @@ def test_hash_raw():
     """
     raw = read_raw_fif(fif_fname)
     assert_raises(RuntimeError, raw.__hash__)
-    raw = Raw(fif_fname).crop(0, 0.5, False)
+    raw = Raw(fif_fname).crop(0, 0.5)
     raw.load_data()
-    raw_2 = Raw(fif_fname).crop(0, 0.5, False)
+    raw_2 = Raw(fif_fname).crop(0, 0.5)
     raw_2.load_data()
     assert_equal(hash(raw), hash(raw_2))
     # do NOT use assert_equal here, failing output is terrible
@@ -121,7 +121,7 @@ def test_subject_info():
     """Test reading subject information
     """
     tempdir = _TempDir()
-    raw = Raw(fif_fname).crop(0, 1, False)
+    raw = Raw(fif_fname).crop(0, 1)
     assert_true(raw.info['subject_info'] is None)
     # fake some subject data
     keys = ['id', 'his_id', 'last_name', 'first_name', 'birthday', 'sex',
@@ -215,7 +215,7 @@ def test_output_formats():
     tols = [1e-4, 1e-7, 1e-7, 1e-15]
 
     # let's fake a raw file with different formats
-    raw = Raw(test_fif_fname).crop(0, 1, copy=False)
+    raw = Raw(test_fif_fname).crop(0, 1)
 
     temp_file = op.join(tempdir, 'raw.fif')
     for ii, (fmt, tol) in enumerate(zip(formats, tols)):
@@ -243,7 +243,7 @@ def test_multiple_files():
     """
     # split file
     tempdir = _TempDir()
-    raw = Raw(fif_fname).crop(0, 10, False)
+    raw = Raw(fif_fname).crop(0, 10)
     raw.load_data()
     raw.load_data()  # test no operation
     split_size = 3.  # in seconds
@@ -444,7 +444,7 @@ def test_io_raw():
             assert_equal(desc1, desc2)
 
     # Let's construct a simple test for IO first
-    raw = Raw(fif_fname).crop(0, 3.5, False)
+    raw = Raw(fif_fname).crop(0, 3.5)
     raw.load_data()
     # put in some data that we know the values of
     data = rng.randn(raw._data.shape[0], raw._data.shape[1])
@@ -665,7 +665,7 @@ def test_proj():
 
     tempdir = _TempDir()
     out_fname = op.join(tempdir, 'test_raw.fif')
-    raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002, copy=False)
+    raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
     raw.pick_types(meg=False, eeg=True)
     raw.info['projs'] = [raw.info['projs'][-1]]
     raw._data.fill(0)
@@ -710,7 +710,7 @@ def test_preload_modify():
 def test_filter():
     """Test filtering (FIR and IIR) and Raw.apply_function interface
     """
-    raw = Raw(fif_fname).crop(0, 7, False)
+    raw = Raw(fif_fname).crop(0, 7)
     raw.load_data()
     sig_dec = 11
     sig_dec_notch = 12
@@ -718,11 +718,11 @@ def test_filter():
     picks_meg = pick_types(raw.info, meg=True, exclude='bads')
     picks = picks_meg[:4]
 
-    filter_params = dict(picks=picks, n_jobs=2, copy=True)
-    raw_lp = raw.filter(0., 4.0 - 0.25, **filter_params)
-    raw_hp = raw.filter(8.0 + 0.25, None, **filter_params)
-    raw_bp = raw.filter(4.0 + 0.25, 8.0 - 0.25, **filter_params)
-    raw_bs = raw.filter(8.0 + 0.25, 4.0 - 0.25, **filter_params)
+    filter_params = dict(picks=picks, n_jobs=2)
+    raw_lp = raw.copy().filter(0., 4.0 - 0.25, **filter_params)
+    raw_hp = raw.copy().filter(8.0 + 0.25, None, **filter_params)
+    raw_bp = raw.copy().filter(4.0 + 0.25, 8.0 - 0.25, **filter_params)
+    raw_bs = raw.copy().filter(8.0 + 0.25, 4.0 - 0.25, **filter_params)
 
     data, _ = raw[picks, :]
 
@@ -734,10 +734,11 @@ def test_filter():
     assert_array_almost_equal(data, lp_data + bp_data + hp_data, sig_dec)
     assert_array_almost_equal(data, bp_data + bs_data, sig_dec)
 
-    filter_params_iir = dict(picks=picks, n_jobs=2, copy=True, method='iir')
-    raw_lp_iir = raw.filter(0., 4.0, **filter_params_iir)
-    raw_hp_iir = raw.filter(8.0, None, **filter_params_iir)
-    raw_bp_iir = raw.filter(4.0, 8.0, **filter_params_iir)
+    filter_params_iir = dict(picks=picks, n_jobs=2, method='iir')
+    raw_lp_iir = raw.copy().filter(0., 4.0, **filter_params_iir)
+    raw_hp_iir = raw.copy().filter(8.0, None, **filter_params_iir)
+    raw_bp_iir = raw.copy().filter(4.0, 8.0, **filter_params_iir)
+    del filter_params_iir
     lp_data_iir, _ = raw_lp_iir[picks, :]
     hp_data_iir, _ = raw_hp_iir[picks, :]
     bp_data_iir, _ = raw_bp_iir[picks, :]
@@ -754,24 +755,24 @@ def test_filter():
 
     # ... and that inplace changes are inplace
     raw_copy = raw.copy()
-    raw_copy.filter(None, 20., picks=picks, n_jobs=2, copy=False)
+    raw_copy.filter(None, 20., picks=picks, n_jobs=2)
     assert_true(raw._data[0, 0] != raw_copy._data[0, 0])
-    assert_equal(raw.filter(None, 20., **filter_params)._data,
+    assert_equal(raw.copy().filter(None, 20., **filter_params)._data,
                  raw_copy._data)
 
     # do a very simple check on line filtering
     with warnings.catch_warnings(record=True):
         warnings.simplefilter('always')
-        raw_bs = raw.filter(60.0 + 0.5, 60.0 - 0.5, **filter_params)
+        raw_bs = raw.copy().filter(60.0 + 0.5, 60.0 - 0.5, **filter_params)
         data_bs, _ = raw_bs[picks, :]
-        raw_notch = raw.notch_filter(60.0, picks=picks, n_jobs=2,
-                                     method='fft', copy=True)
+        raw_notch = raw.copy().notch_filter(
+            60.0, picks=picks, n_jobs=2, method='fft')
     data_notch, _ = raw_notch[picks, :]
     assert_array_almost_equal(data_bs, data_notch, sig_dec_notch)
 
     # now use the sinusoidal fitting
-    raw_notch = raw.notch_filter(None, picks=picks, n_jobs=2,
-                                 method='spectrum_fit', copy=True)
+    raw_notch = raw.copy().notch_filter(
+        None, picks=picks, n_jobs=2, method='spectrum_fit')
     data_notch, _ = raw_notch[picks, :]
     data, _ = raw[picks, :]
     assert_array_almost_equal(data, data_notch, sig_dec_notch_fit)
@@ -790,7 +791,7 @@ def test_filter_picks():
     for ch_type in ('mag', 'grad', 'eeg', 'seeg', 'ecog'):
         picks = dict((ch, ch == ch_type) for ch in ch_types)
         picks['meg'] = ch_type if ch_type in ('mag', 'grad') else False
-        raw_ = raw.pick_types(copy=True, **picks)
+        raw_ = raw.copy().pick_types(**picks)
         # Avoid RuntimeWarning due to Attenuation
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
@@ -800,7 +801,7 @@ def test_filter_picks():
     # -- Error if no data channel
     for ch_type in ('misc', 'stim'):
         picks = dict((ch, ch == ch_type) for ch in ch_types)
-        raw_ = raw.pick_types(copy=True, **picks)
+        raw_ = raw.copy().pick_types(**picks)
         assert_raises(RuntimeError, raw_.filter, 10, 30)
 
 
@@ -822,7 +823,7 @@ def test_crop():
     tmins /= sfreq
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
-        raws[ri] = raw.crop(tmin, tmax, True)
+        raws[ri] = raw.copy().crop(tmin, tmax)
     all_raw_2 = concatenate_raws(raws, preload=False)
     assert_equal(raw.first_samp, all_raw_2.first_samp)
     assert_equal(raw.last_samp, all_raw_2.last_samp)
@@ -836,12 +837,11 @@ def test_crop():
     # going in revere order so the last fname is the first file (need it later)
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
-        raws[ri] = raw.copy()
-        raws[ri].crop(tmin, tmax, False)
+        raws[ri] = raw.copy().crop(tmin, tmax)
     # test concatenation of split file
     all_raw_1 = concatenate_raws(raws, preload=False)
 
-    all_raw_2 = raw.crop(0, None, True)
+    all_raw_2 = raw.copy().crop(0, None)
     for ar in [all_raw_1, all_raw_2]:
         assert_equal(raw.first_samp, ar.first_samp)
         assert_equal(raw.last_samp, ar.last_samp)
@@ -852,7 +852,7 @@ def test_crop():
     info = create_info(1, 1000)
     raw = RawArray(data, info)
     for tmin in range(0, 1001, 100):
-        raw1 = raw.crop(tmin=tmin, tmax=tmin + 2, copy=True)
+        raw1 = raw.crop(tmin=tmin, tmax=tmin + 2)
         assert_equal(raw1[:][0].shape, (1, 2001))
 
 
@@ -861,7 +861,7 @@ def test_resample():
     """Test resample (with I/O and multiple files)
     """
     tempdir = _TempDir()
-    raw = Raw(fif_fname).crop(0, 3, False)
+    raw = Raw(fif_fname).crop(0, 3)
     raw.load_data()
     raw_resamp = raw.copy()
     sfreq = raw.info['sfreq']
@@ -957,9 +957,9 @@ def test_resample():
     # test copy flag
     stim = [1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0]
     raw = RawArray([stim], create_info(1, len(stim), ['stim']))
-    raw_resampled = raw.resample(4., npad='auto', copy=True)
+    raw_resampled = raw.copy().resample(4., npad='auto')
     assert_true(raw_resampled is not raw)
-    raw_resampled = raw.resample(4., npad='auto', copy=False)
+    raw_resampled = raw.resample(4., npad='auto')
     assert_true(raw_resampled is raw)
 
     # resample should still work even when no stim channel is present
@@ -1040,16 +1040,16 @@ def test_add_channels():
     """
     raw = Raw(test_fif_fname).crop(0, 1).load_data()
     raw_nopre = Raw(test_fif_fname, preload=False)
-    raw_eeg_meg = raw.pick_types(meg=True, eeg=True, copy=True)
-    raw_eeg = raw.pick_types(meg=False, eeg=True, copy=True)
-    raw_meg = raw.pick_types(meg=True, eeg=False, copy=True)
-    raw_stim = raw.pick_types(meg=False, eeg=False, stim=True, copy=True)
-    raw_new = raw_meg.add_channels([raw_eeg, raw_stim], copy=True)
+    raw_eeg_meg = raw.copy().pick_types(meg=True, eeg=True)
+    raw_eeg = raw.copy().pick_types(meg=False, eeg=True)
+    raw_meg = raw.copy().pick_types(meg=True, eeg=False)
+    raw_stim = raw.copy().pick_types(meg=False, eeg=False, stim=True)
+    raw_new = raw_meg.copy().add_channels([raw_eeg, raw_stim])
     assert_true(
         all(ch in raw_new.ch_names
             for ch in list(raw_stim.ch_names) + list(raw_meg.ch_names))
     )
-    raw_new = raw_meg.add_channels([raw_eeg], copy=True)
+    raw_new = raw_meg.copy().add_channels([raw_eeg])
 
     assert_true(ch in raw_new.ch_names for ch in raw.ch_names)
     assert_array_equal(raw_new[:, :][0], raw_eeg_meg[:, :][0])
@@ -1180,7 +1180,7 @@ def test_drop_channels_mixin():
     ch_names = raw.ch_names[3:]
 
     ch_names_orig = raw.ch_names
-    dummy = raw.drop_channels(drop_ch, copy=True)
+    dummy = raw.copy().drop_channels(drop_ch)
     assert_equal(ch_names, dummy.ch_names)
     assert_equal(ch_names_orig, raw.ch_names)
     assert_equal(len(ch_names_orig), raw._data.shape[0])
@@ -1201,12 +1201,12 @@ def test_pick_channels_mixin():
     ch_names = raw.ch_names[:3]
 
     ch_names_orig = raw.ch_names
-    dummy = raw.pick_channels(ch_names, copy=True)  # copy is True
+    dummy = raw.copy().pick_channels(ch_names)
     assert_equal(ch_names, dummy.ch_names)
     assert_equal(ch_names_orig, raw.ch_names)
     assert_equal(len(ch_names_orig), raw._data.shape[0])
 
-    raw.pick_channels(ch_names, copy=False)  # copy is False
+    raw.pick_channels(ch_names)  # copy is False
     assert_equal(ch_names, raw.ch_names)
     assert_equal(len(ch_names), len(raw._cals))
     assert_equal(len(ch_names), raw._data.shape[0])

--- a/mne/io/matrix.py
+++ b/mne/io/matrix.py
@@ -10,19 +10,16 @@ from .write import (write_int, start_block, end_block, write_float_matrix,
 from ..utils import logger, verbose
 
 
-def _transpose_named_matrix(mat, copy=True):
-    """Transpose mat inplace (no copy)
-    """
-    if copy is True:
-        mat = mat.copy()
+def _transpose_named_matrix(mat):
+    """Transpose mat inplace (no copy)"""
     mat['nrow'], mat['ncol'] = mat['ncol'], mat['nrow']
     mat['row_names'], mat['col_names'] = mat['col_names'], mat['row_names']
     mat['data'] = mat['data'].T
-    return mat
 
 
 @verbose
-def _read_named_matrix(fid, node, matkind, indent='    ', verbose=None):
+def _read_named_matrix(fid, node, matkind, indent='    ', transpose=False,
+                       verbose=None):
     """Read named matrix from the given node
 
     Parameters
@@ -33,6 +30,8 @@ def _read_named_matrix(fid, node, matkind, indent='    ', verbose=None):
         The node in the tree.
     matkind : int
         The type of matrix.
+    transpose : bool
+        If True, transpose the matrix. Default is False.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -84,6 +83,8 @@ def _read_named_matrix(fid, node, matkind, indent='    ', verbose=None):
 
     mat = dict(nrow=nrow, ncol=ncol, row_names=row_names, col_names=col_names,
                data=data)
+    if transpose:
+        _transpose_named_matrix(mat)
     return mat
 
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -160,7 +160,7 @@ class Info(dict):
         info : instance of Info
             The copied info.
         """
-        return Info(super(Info, self).copy())
+        return Info(deepcopy(self))
 
     def normalize_proj(self):
         """(Re-)Normalize projection vectors after subselection

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -339,7 +339,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     return sel
 
 
-def pick_info(info, sel=[], copy=True):
+def pick_info(info, sel=(), copy=True):
     """Restrict an info structure to a selection of channels
 
     Parameters

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -98,7 +98,6 @@ def test_pick_seeg_ecog():
     types = 'mag mag eeg eeg seeg seeg ecog seeg ecog ecog'.split()
     info = create_info(names, 1024., types)
     idx = channel_indices_by_type(info)
-    print(idx)
     assert_array_equal(idx['mag'], [0, 1])
     assert_array_equal(idx['eeg'], [2, 3])
     assert_array_equal(idx['seeg'], [4, 5, 7])
@@ -110,7 +109,7 @@ def test_pick_seeg_ecog():
     events = np.array([[1, 0, 0], [2, 0, 0]])
     epochs = Epochs(raw, events, {'event': 0}, -1e-5, 1e-5)
     evoked = epochs.average(pick_types(epochs.info, meg=True, seeg=True))
-    e_seeg = evoked.pick_types(meg=False, seeg=True, copy=True)
+    e_seeg = evoked.copy().pick_types(meg=False, seeg=True)
     for l, r in zip(e_seeg.ch_names, [names[4], names[5], names[7]]):
         assert_equal(l, r)
     # Deal with constant debacle
@@ -185,9 +184,6 @@ def test_pick_forward_seeg_ecog():
     fwd_seeg = pick_types_forward(fwd, meg=False, seeg=True)
     assert_equal(fwd_seeg['sol']['row_names'], [seeg_name])
     assert_equal(fwd_seeg['info']['ch_names'], [seeg_name])
-    fwd_ecog = pick_types_forward(fwd, meg=False, ecog=True)
-    assert_equal(fwd_ecog['sol']['row_names'], [ecog_name])
-    assert_equal(fwd_ecog['info']['ch_names'], [ecog_name])
     # should work fine
     fwd_ = pick_types_forward(fwd, meg=True)
     _check_fwd_n_chan_consistent(fwd_, counts['meg'])

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -105,10 +105,10 @@ def _test_concat(reader, *args):
             for last_preload in (True, False):
                 t_crops = raw.times[np.argmin(np.abs(raw.times - 0.5)) +
                                     [0, 1]]
-                raw1 = raw.crop(0, t_crops[0])
+                raw1 = raw.copy().crop(0, t_crops[0], copy=False)
                 if preloads[0]:
                     raw1.load_data()
-                raw2 = raw.crop(t_crops[1], None)
+                raw2 = raw.copy().crop(t_crops[1], None, copy=False)
                 if preloads[1]:
                     raw2.load_data()
                 raw1.append(raw2)

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -76,8 +76,8 @@ def test_apply_reference():
     raw = Raw(fif_fname, preload=True)
 
     # Rereference raw data by creating a copy of original data
-    reref, ref_data = _apply_reference(raw, ref_from=['EEG 001', 'EEG 002'],
-                                       copy=True)
+    reref, ref_data = _apply_reference(
+        raw.copy(), ref_from=['EEG 001', 'EEG 002'])
     assert_true(reref.info['custom_ref_applied'])
     _test_reference(raw, reref, ref_data, ['EEG 001', 'EEG 002'])
 
@@ -89,8 +89,7 @@ def test_apply_reference():
     assert_array_equal(raw._data, reref._data)
 
     # Test that data is modified in place when copy=False
-    reref, ref_data = _apply_reference(raw, ['EEG 001', 'EEG 002'],
-                                       copy=False)
+    reref, ref_data = _apply_reference(raw, ['EEG 001', 'EEG 002'])
     assert_true(raw is reref)
 
     # Test re-referencing Epochs object
@@ -99,15 +98,15 @@ def test_apply_reference():
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True)
-    reref, ref_data = _apply_reference(epochs, ref_from=['EEG 001', 'EEG 002'],
-                                       copy=True)
+    reref, ref_data = _apply_reference(
+        epochs.copy(), ref_from=['EEG 001', 'EEG 002'])
     assert_true(reref.info['custom_ref_applied'])
     _test_reference(epochs, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # Test re-referencing Evoked object
     evoked = epochs.average()
-    reref, ref_data = _apply_reference(evoked, ref_from=['EEG 001', 'EEG 002'],
-                                       copy=True)
+    reref, ref_data = _apply_reference(
+        evoked.copy(), ref_from=['EEG 001', 'EEG 002'])
     assert_true(reref.info['custom_ref_applied'])
     _test_reference(evoked, reref, ref_data, ['EEG 001', 'EEG 002'])
 
@@ -154,9 +153,9 @@ def test_set_bipolar_reference():
     assert_true(reref.info['custom_ref_applied'])
 
     # Compare result to a manual calculation
-    a = raw.pick_channels(['EEG 001', 'EEG 002'], copy=True)
+    a = raw.copy().pick_channels(['EEG 001', 'EEG 002'])
     a = a._data[0, :] - a._data[1, :]
-    b = reref.pick_channels(['bipolar'], copy=True)._data[0, :]
+    b = reref.copy().pick_channels(['bipolar'])._data[0, :]
     assert_allclose(a, b)
 
     # Original channels should be replaced by a virtual one

--- a/mne/label.py
+++ b/mne/label.py
@@ -15,7 +15,8 @@ import numpy as np
 from scipy import linalg, sparse
 
 from .fixes import digitize, in1d
-from .utils import get_subjects_dir, _check_subject, logger, verbose, warn
+from .utils import (get_subjects_dir, _check_subject, logger, verbose, warn,
+                    _check_copy_dep)
 from .source_estimate import (morph_data, SourceEstimate,
                               spatial_src_connectivity)
 from .source_space import add_source_space_distances
@@ -452,7 +453,7 @@ class Label(object):
 
     @verbose
     def smooth(self, subject=None, smooth=2, grade=None,
-               subjects_dir=None, n_jobs=1, copy=True, verbose=None):
+               subjects_dir=None, n_jobs=1, copy=None, verbose=None):
         """Smooth the label
 
         Useful for filling in labels made in a
@@ -484,7 +485,9 @@ class Label(object):
         n_jobs : int
             Number of jobs to run in parallel
         copy : bool
-            If False, smoothing is done in-place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
             Defaults to self.verbose.
@@ -502,11 +505,11 @@ class Label(object):
         """
         subject = _check_subject(self.subject, subject)
         return self.morph(subject, subject, smooth, grade, subjects_dir,
-                          n_jobs, copy)
+                          n_jobs, copy=copy)
 
     @verbose
     def morph(self, subject_from=None, subject_to=None, smooth=5, grade=None,
-              subjects_dir=None, n_jobs=1, copy=True, verbose=None):
+              subjects_dir=None, n_jobs=1, copy=None, verbose=None):
         """Morph the label
 
         Useful for transforming a label from one subject to another.
@@ -538,7 +541,9 @@ class Label(object):
         n_jobs : int
             Number of jobs to run in parallel.
         copy : bool
-            If False, the morphing is done in-place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
 
@@ -578,10 +583,7 @@ class Label(object):
                          smooth=smooth, subjects_dir=subjects_dir,
                          warn=False, n_jobs=n_jobs)
         inds = np.nonzero(stc.data)[0]
-        if copy is True:
-            label = self.copy()
-        else:
-            label = self
+        label = _check_copy_dep(self, copy, default=True)
         label.values = stc.data[inds, :].ravel()
         label.pos = np.zeros((len(inds), 3))
         if label.hemi == 'lh':

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -380,9 +380,9 @@ def test_make_inverse_operator_diag():
     """Test MNE inverse computation with diagonal noise cov
     """
     evoked = _get_evoked()
-    noise_cov = read_cov(fname_cov)
+    noise_cov = read_cov(fname_cov).as_diag(copy=False)
     fwd_op = read_forward_solution(fname_fwd, surf_ori=True)
-    inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov.as_diag(),
+    inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                    loose=0.2, depth=0.8)
     _compare_io(inv_op)
     inverse_operator_diag = read_inverse_operator(fname_inv_meeg_diag)

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -141,7 +141,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
 
         # Run baseline correction
         power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                        verbose=False)
+                        copy=False, verbose=False)
 
         tmin = epochs.times[0]
         tstep = float(decim) / Fs
@@ -366,7 +366,8 @@ def source_induced_power(epochs, inverse_operator, frequencies, label=None,
                                                prepared=False)
 
     # Run baseline correction
-    power = rescale(power, epochs.times[::decim], baseline, baseline_mode)
+    power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
+                    copy=False)
     return power, plv
 
 

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -141,7 +141,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
 
         # Run baseline correction
         power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                        copy=False, verbose=False)
+                        verbose=False)
 
         tmin = epochs.times[0]
         tstep = float(decim) / Fs
@@ -366,9 +366,7 @@ def source_induced_power(epochs, inverse_operator, frequencies, label=None,
                                                prepared=False)
 
     # Run baseline correction
-    power = rescale(power, epochs.times[::decim], baseline, baseline_mode,
-                    copy=False)
-
+    power = rescale(power, epochs.times[::decim], baseline, baseline_mode)
     return power, plv
 
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -347,7 +347,7 @@ def _make_ecg(inst, start, stop, verbose=None):
     if isinstance(inst, _BaseRaw):
         ecg, times = inst[picks, start:stop]
     elif isinstance(inst, _BaseEpochs):
-        ecg = np.hstack(inst.crop(start, stop, copy=True).get_data())
+        ecg = np.hstack(inst.copy().crop(start, stop).get_data())
         times = inst.times
     elif isinstance(inst, Evoked):
         ecg = inst.data

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -9,6 +9,7 @@ from ..io import _BaseRaw
 from ..event import find_events
 
 from ..io.pick import pick_channels
+from ..utils import _check_copy_dep
 
 
 def _get_window(start, end):
@@ -43,7 +44,7 @@ def _fix_artifact(data, window, picks, first_samp, last_samp, mode):
 
 
 def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
-                      tmax=0.01, mode='linear', stim_channel=None, copy=False):
+                      tmax=0.01, mode='linear', stim_channel=None, copy=None):
     """Eliminate stimulation's artifacts from instance
 
     Parameters
@@ -75,9 +76,7 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
     """
     if mode not in ('linear', 'window'):
         raise ValueError("mode has to be 'linear' or 'window' (got %s)" % mode)
-
-    if copy:
-        inst = inst.copy()
+    inst = _check_copy_dep(inst, copy)
     s_start = int(np.ceil(inst.info['sfreq'] * tmin))
     s_end = int(np.ceil(inst.info['sfreq'] * tmax))
     if (mode == "window") and (s_end - s_start) < 4:

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -54,7 +54,7 @@ except:
 def test_ica_full_data_recovery():
     """Test recovery of full data when no source is rejected"""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop, False)
+    raw = Raw(raw_fname).crop(0.5, stop)
     raw.load_data()
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
@@ -113,7 +113,7 @@ def test_ica_full_data_recovery():
 def test_ica_rank_reduction():
     """Test recovery ICA rank reduction"""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop, False)
+    raw = Raw(raw_fname).crop(0.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
@@ -141,7 +141,7 @@ def test_ica_rank_reduction():
 @requires_sklearn
 def test_ica_reset():
     """Test ICA resetting"""
-    raw = Raw(raw_fname).crop(0.5, stop, False)
+    raw = Raw(raw_fname).crop(0.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
@@ -169,7 +169,7 @@ def test_ica_reset():
 @requires_sklearn
 def test_ica_core():
     """Test ICA on raw and epochs"""
-    raw = Raw(raw_fname).crop(1.5, stop, False)
+    raw = Raw(raw_fname).crop(1.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -274,7 +274,7 @@ def test_ica_additional():
     """Test additional ICA functionality"""
     tempdir = _TempDir()
     stop2 = 500
-    raw = Raw(raw_fname).crop(1.5, stop, False)
+    raw = Raw(raw_fname).crop(1.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -542,7 +542,7 @@ def test_ica_additional():
 @requires_sklearn
 def test_run_ica():
     """Test run_ica function"""
-    raw = Raw(raw_fname, preload=True).crop(0, stop, False).crop(1.5)
+    raw = Raw(raw_fname, preload=True).crop(1.5, stop)
     params = []
     params += [(None, -1, slice(2), [0, 1])]  # varicance, kurtosis idx
     params += [(None, 'MEG 1531')]  # ECG / EOG channel params
@@ -557,7 +557,7 @@ def test_run_ica():
 @requires_sklearn
 def test_ica_reject_buffer():
     """Test ICA data raw buffer rejection"""
-    raw = Raw(raw_fname).crop(1.5, stop, False)
+    raw = Raw(raw_fname).crop(1.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -575,7 +575,7 @@ def test_ica_reject_buffer():
 @requires_sklearn
 def test_ica_twice():
     """Test running ICA twice"""
-    raw = Raw(raw_fname).crop(1.5, stop, False)
+    raw = Raw(raw_fname).crop(1.5, stop)
     raw.load_data()
     picks = pick_types(raw.info, meg='grad', exclude='bads')
     n_components = 0.9

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -54,7 +54,7 @@ except:
 def test_ica_full_data_recovery():
     """Test recovery of full data when no source is rejected"""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop)
+    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
     raw.load_data()
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
@@ -113,7 +113,7 @@ def test_ica_full_data_recovery():
 def test_ica_rank_reduction():
     """Test recovery ICA rank reduction"""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop)
+    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
@@ -141,7 +141,7 @@ def test_ica_rank_reduction():
 @requires_sklearn
 def test_ica_reset():
     """Test ICA resetting"""
-    raw = Raw(raw_fname).crop(0.5, stop)
+    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
@@ -169,7 +169,7 @@ def test_ica_reset():
 @requires_sklearn
 def test_ica_core():
     """Test ICA on raw and epochs"""
-    raw = Raw(raw_fname).crop(1.5, stop)
+    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -274,7 +274,7 @@ def test_ica_additional():
     """Test additional ICA functionality"""
     tempdir = _TempDir()
     stop2 = 500
-    raw = Raw(raw_fname).crop(1.5, stop)
+    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -542,7 +542,7 @@ def test_ica_additional():
 @requires_sklearn
 def test_run_ica():
     """Test run_ica function"""
-    raw = Raw(raw_fname, preload=True).crop(1.5, stop)
+    raw = Raw(raw_fname, preload=True).crop(1.5, stop, copy=False)
     params = []
     params += [(None, -1, slice(2), [0, 1])]  # varicance, kurtosis idx
     params += [(None, 'MEG 1531')]  # ECG / EOG channel params
@@ -557,7 +557,7 @@ def test_run_ica():
 @requires_sklearn
 def test_ica_reject_buffer():
     """Test ICA data raw buffer rejection"""
-    raw = Raw(raw_fname).crop(1.5, stop)
+    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -575,7 +575,7 @@ def test_ica_reject_buffer():
 @requires_sklearn
 def test_ica_twice():
     """Test running ICA twice"""
-    raw = Raw(raw_fname).crop(1.5, stop)
+    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
     raw.load_data()
     picks = pick_types(raw.info, meg='grad', exclude='bads')
     n_components = 0.9

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -76,7 +76,7 @@ def test_ica_full_data_recovery():
                       method=method, max_iter=1)
             with warnings.catch_warnings(record=True):
                 ica.fit(raw, picks=list(range(n_channels)))
-            raw2 = ica.apply(raw, exclude=[], copy=True)
+            raw2 = ica.apply(raw.copy(), exclude=[])
             if ok:
                 assert_allclose(data[:n_channels], raw2._data[:n_channels],
                                 rtol=1e-10, atol=1e-15)
@@ -89,7 +89,7 @@ def test_ica_full_data_recovery():
                       n_pca_components=n_pca_components)
             with warnings.catch_warnings(record=True):
                 ica.fit(epochs, picks=list(range(n_channels)))
-            epochs2 = ica.apply(epochs, exclude=[], copy=True)
+            epochs2 = ica.apply(epochs.copy(), exclude=[])
             data2 = epochs2.get_data()[:, :n_channels]
             if ok:
                 assert_allclose(data_epochs[:, :n_channels], data2,
@@ -98,7 +98,7 @@ def test_ica_full_data_recovery():
                 diff = np.abs(data_epochs[:, :n_channels] - data2)
                 assert_true(np.max(diff) > 1e-14)
 
-            evoked2 = ica.apply(evoked, exclude=[], copy=True)
+            evoked2 = ica.apply(evoked.copy(), exclude=[])
             data2 = evoked2.data[:n_channels]
             if ok:
                 assert_allclose(data_evoked[:n_channels], data2,
@@ -129,7 +129,7 @@ def test_ica_rank_reduction():
 
         rank_before = raw.estimate_rank(picks=picks)
         assert_equal(rank_before, len(picks))
-        raw_clean = ica.apply(raw, copy=True)
+        raw_clean = ica.apply(raw.copy())
         rank_after = raw_clean.estimate_rank(picks=picks)
         # interaction between ICA rejection and PCA components difficult
         # to preduct. Rank_after often seems to be 1 higher then
@@ -255,7 +255,7 @@ def test_ica_core():
     # test for bug with whitener updating
     _pre_whitener = ica._pre_whitener.copy()
     epochs._data[:, 0, 10:15] *= 1e12
-    ica.apply(epochs, copy=True)
+    ica.apply(epochs.copy())
     assert_array_equal(_pre_whitener, ica._pre_whitener)
 
     # test expl. var threshold leading to empty sel

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -488,7 +488,7 @@ def test_spatiotemporal_maxwell():
         # onto the previous buffer if it's shorter than st_duration, we have to
         # crop the data here to compensate for Elekta's tSSS behavior.
         if st_duration == 10.:
-            tsss_bench.crop(0, st_duration, copy=False)
+            tsss_bench = tsss_bench.crop(0, st_duration)
 
         # Test sss computation at the standard head origin. Same cropping issue
         # as mentioned above.
@@ -666,7 +666,7 @@ def test_cross_talk():
     _assert_n_free(raw_sss, 68)
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04), ignore_ref=True)
     _assert_n_free(raw_sss, 70)
-    raw_missing = raw.crop(0, 0.1, copy=True).load_data().pick_channels(
+    raw_missing = raw.copy().crop(0, 0.1).load_data().pick_channels(
         [raw.ch_names[pi] for pi in pick_types(raw.info, meg=True,
                                                exclude=())[3:]])
     with warnings.catch_warnings(record=True) as w:
@@ -847,7 +847,7 @@ def test_all():
                mf_meg_origin,
                mf_head_origin)
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshield='yes').crop(0., 1., copy=False)
+        raw = Raw(rf, allow_maxshield='yes').crop(0., 1.)
         with warnings.catch_warnings(record=True):  # head fit off-center
             sss_py = maxwell_filter(
                 raw, calibration=fine_cals[ii], cross_talk=ctcs[ii],

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -348,7 +348,7 @@ def test_multipolar_bases():
 def test_basic():
     """Test Maxwell filter basic version"""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
     raw_err = Raw(raw_fname, proj=True, allow_maxshield='yes')
     raw_erm = Raw(erm_fname, allow_maxshield='yes')
     assert_raises(RuntimeError, maxwell_filter, raw_err)
@@ -422,7 +422,7 @@ def test_maxwell_filter_additional():
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
     # Use 2.0 seconds of data to get stable cov. estimate
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2.)
 
     # Get MEG channels, compute Maxwell filtered data
     raw.load_data()
@@ -458,7 +458,7 @@ def test_maxwell_filter_additional():
 @testing.requires_testing_data
 def test_bads_reconstruction():
     """Test Maxwell filter reconstruction of bad channels"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
     raw.info['bads'] = bads
     raw_sss = maxwell_filter(raw, origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
@@ -576,7 +576,7 @@ def test_fine_calibration():
     """Test Maxwell filter fine calibration"""
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
     sss_fine_cal = Raw(sss_fine_cal_fname)
 
     # Test 1D SSS fine calibration
@@ -619,7 +619,7 @@ def test_regularization():
                   sss_samp_reg_in_fname)
     comp_tols = [0, 1, 4]
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshield='yes').crop(0., 1., False)
+        raw = Raw(rf, allow_maxshield='yes').crop(0., 1.)
         sss_reg_in = Raw(sss_fnames[ii])
 
         # Test "in" regularization
@@ -646,7 +646,7 @@ def test_regularization():
 @testing.requires_testing_data
 def test_cross_talk():
     """Test Maxwell filter cross-talk cancellation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
     raw.info['bads'] = bads
     sss_ctc = Raw(sss_ctc_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
@@ -681,12 +681,12 @@ def test_cross_talk():
 @testing.requires_testing_data
 def test_head_translation():
     """Test Maxwell filter head translation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., False)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
     # First try with an unchanged destination
     raw_sss = maxwell_filter(raw, destination=raw_fname,
                              origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
-    assert_meg_snr(raw_sss, Raw(sss_std_fname).crop(0., 1., False), 200.)
+    assert_meg_snr(raw_sss, Raw(sss_std_fname).crop(0., 1.), 200.)
     # Now with default
     with warnings.catch_warnings(record=True):
         with catch_logging() as log:

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -107,7 +107,7 @@ def _assert_n_free(raw_sss, lower, upper=None):
 def test_movement_compensation():
     """Test movement compensation"""
     temp_dir = _TempDir()
-    lims = (0, 4)
+    lims = (0, 4, False)
     raw = Raw(raw_fname, allow_maxshield='yes', preload=True).crop(*lims)
     head_pos = read_head_pos(pos_fname)
 
@@ -348,7 +348,7 @@ def test_multipolar_bases():
 def test_basic():
     """Test Maxwell filter basic version"""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
     raw_err = Raw(raw_fname, proj=True, allow_maxshield='yes')
     raw_erm = Raw(erm_fname, allow_maxshield='yes')
     assert_raises(RuntimeError, maxwell_filter, raw_err)
@@ -422,7 +422,7 @@ def test_maxwell_filter_additional():
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
     # Use 2.0 seconds of data to get stable cov. estimate
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2.)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2., copy=False)
 
     # Get MEG channels, compute Maxwell filtered data
     raw.load_data()
@@ -488,7 +488,7 @@ def test_spatiotemporal_maxwell():
         # onto the previous buffer if it's shorter than st_duration, we have to
         # crop the data here to compensate for Elekta's tSSS behavior.
         if st_duration == 10.:
-            tsss_bench = tsss_bench.crop(0, st_duration)
+            tsss_bench.crop(0, st_duration, copy=False)
 
         # Test sss computation at the standard head origin. Same cropping issue
         # as mentioned above.
@@ -524,7 +524,8 @@ def test_spatiotemporal_maxwell():
 def test_spatiotemporal_only():
     """Test tSSS-only processing"""
     # Load raw testing data
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0, 2).load_data()
+    raw = Raw(raw_fname,
+              allow_maxshield='yes').crop(0, 2, copy=False).load_data()
     picks = pick_types(raw.info, meg='mag', exclude=())
     power = np.sqrt(np.sum(raw[picks][0] ** 2))
     # basics
@@ -576,7 +577,7 @@ def test_fine_calibration():
     """Test Maxwell filter fine calibration"""
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
     sss_fine_cal = Raw(sss_fine_cal_fname)
 
     # Test 1D SSS fine calibration
@@ -646,7 +647,7 @@ def test_regularization():
 @testing.requires_testing_data
 def test_cross_talk():
     """Test Maxwell filter cross-talk cancellation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
     raw.info['bads'] = bads
     sss_ctc = Raw(sss_ctc_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
@@ -681,7 +682,7 @@ def test_cross_talk():
 @testing.requires_testing_data
 def test_head_translation():
     """Test Maxwell filter head translation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
+    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
     # First try with an unchanged destination
     raw_sss = maxwell_filter(raw, destination=raw_fname,
                              origin=mf_head_origin, regularize=None,

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -20,7 +20,7 @@ eog_times = np.array([0.5, 2.3, 3.6, 14.5])
 
 def test_compute_proj_ecg():
     """Test computation of ECG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10, False)
+    raw = Raw(raw_fname).crop(0, 10)
     raw.load_data()
     for average in [False, True]:
         # For speed, let's not filter here (must also not reject then)
@@ -61,7 +61,7 @@ def test_compute_proj_ecg():
 
 def test_compute_proj_eog():
     """Test computation of EOG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10, False)
+    raw = Raw(raw_fname).crop(0, 10)
     raw.load_data()
     for average in [False, True]:
         n_projs_init = len(raw.info['projs'])
@@ -100,7 +100,7 @@ def test_compute_proj_eog():
 
 def test_compute_proj_parallel():
     """Test computation of ExG projectors using parallelization"""
-    raw_0 = Raw(raw_fname).crop(0, 10, False)
+    raw_0 = Raw(raw_fname).crop(0, 10)
     raw_0.load_data()
     raw = raw_0.copy()
     projs, _ = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -20,7 +20,7 @@ eog_times = np.array([0.5, 2.3, 3.6, 14.5])
 
 def test_compute_proj_ecg():
     """Test computation of ECG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10)
+    raw = Raw(raw_fname).crop(0, 10, copy=False)
     raw.load_data()
     for average in [False, True]:
         # For speed, let's not filter here (must also not reject then)
@@ -61,7 +61,7 @@ def test_compute_proj_ecg():
 
 def test_compute_proj_eog():
     """Test computation of EOG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10)
+    raw = Raw(raw_fname).crop(0, 10, copy=False)
     raw.load_data()
     for average in [False, True]:
         n_projs_init = len(raw.info['projs'])
@@ -100,7 +100,7 @@ def test_compute_proj_eog():
 
 def test_compute_proj_parallel():
     """Test computation of ExG projectors using parallelization"""
-    raw_0 = Raw(raw_fname).crop(0, 10)
+    raw_0 = Raw(raw_fname).crop(0, 10, copy=False)
     raw_0.load_data()
     raw = raw_0.copy()
     projs, _ = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -258,7 +258,7 @@ class FieldTripClient(object):
         # create epoch from data
         info = self.info
         if picks is not None:
-            info = pick_info(info, picks, copy=True)
+            info = pick_info(info, picks)
         epoch = EpochsArray(data[picks][np.newaxis], info, events)
 
         return epoch

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -131,13 +131,13 @@ def test_simulate_raw_sphere():
     del raw_sim_3, raw_sim_4
 
     # make sure it works with EEG-only and MEG-only
-    raw_sim_meg = simulate_raw(raw.pick_types(meg=True, eeg=False, copy=True),
+    raw_sim_meg = simulate_raw(raw.copy().pick_types(meg=True, eeg=False),
                                stc, trans, src, sphere, cov=None,
                                ecg=True, blink=True, random_state=seed)
-    raw_sim_eeg = simulate_raw(raw.pick_types(meg=False, eeg=True, copy=True),
+    raw_sim_eeg = simulate_raw(raw.copy().pick_types(meg=False, eeg=True),
                                stc, trans, src, sphere, cov=None,
                                ecg=True, blink=True, random_state=seed)
-    raw_sim_meeg = simulate_raw(raw.pick_types(meg=True, eeg=True, copy=True),
+    raw_sim_meeg = simulate_raw(raw.copy().pick_types(meg=True, eeg=True),
                                 stc, trans, src, sphere, cov=None,
                                 ecg=True, blink=True, random_state=seed)
     assert_allclose(np.concatenate((raw_sim_meg[:][0], raw_sim_eeg[:][0])),

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -55,7 +55,7 @@ def _make_stc(raw, src):
 def _get_data():
     """Helper to get some starting data"""
     # raw with ECG channel
-    raw = Raw(raw_fname).crop(0., 5.0).load_data()
+    raw = Raw(raw_fname).crop(0., 5.0, copy=False).load_data()
     data_picks = pick_types(raw.info, meg=True, eeg=True)
     other_picks = pick_types(raw.info, meg=False, stim=True, eog=True)
     picks = np.sort(np.concatenate((data_picks[::16], other_picks)))

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -281,7 +281,7 @@ def _prepare_rerp_data(raw, events, picks=None, decim=1):
     there for an explanation of parameters and output."""
     if picks is None:
         picks = pick_types(raw.info, meg=True, eeg=True, ref_meg=True)
-    info = pick_info(raw.info, picks, copy=True)
+    info = pick_info(raw.info, picks)
     decim = int(decim)
     info["sfreq"] /= decim
     data, times = raw[:]

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -164,7 +164,8 @@ def test_calculate_chpi_positions():
         assert_true('0/5 good' in line)
 
     # half the rate cuts off cHPI coils
-    raw.resample(300., npad='auto')
+    with warnings.catch_warnings(record=True):  # uint cast suggestion
+        raw.resample(300., npad='auto')
     assert_raises_regex(RuntimeError, 'above the',
                         _calculate_chpi_positions, raw)
 
@@ -192,7 +193,8 @@ def test_chpi_subtraction():
     #           -o test_move_anon_ds2_raw.fif
     # it can strip out some values of info, which we emulate here:
     raw = Raw(chpi_fif_fname, allow_maxshield='yes')
-    raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
+    with warnings.catch_warnings(record=True):  # uint cast suggestion
+        raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
     raw.info['buffer_size_sec'] = np.float64(2.)
     raw.info['lowpass'] = 200.
     del raw.info['maxshield']

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -155,7 +155,7 @@ def test_calculate_chpi_positions():
     for d in raw_bad.info['dig']:
         if d['kind'] == FIFF.FIFFV_POINT_HPI:
             d['r'] = np.ones(3)
-    raw_bad.crop(0, 1., copy=False)
+    raw_bad = raw_bad.crop(0, 1.)
     with warnings.catch_warnings(record=True):  # bad pos
         with catch_logging() as log_file:
             _calculate_chpi_positions(raw_bad, verbose=True)
@@ -177,10 +177,10 @@ def test_chpi_subtraction():
         filter_chpi(raw, include_line=False, verbose=True)
     assert_true('5 cHPI' in log.getvalue())
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
-    raw.crop(0, 16, copy=False)
-    raw_c = Raw(sss_hpisubt_fname, preload=True).crop(0, 16, copy=False)
-    raw_c.pick_types(meg=True, eeg=True, eog=True, ecg=True, stim=True,
-                     misc=True, copy=False)  # remove cHPI status chans
+    raw = raw.crop(0, 16)
+    # remove cHPI status chans
+    raw_c = Raw(sss_hpisubt_fname).crop(0, 16).load_data().pick_types(
+        meg=True, eeg=True, eog=True, ecg=True, stim=True, misc=True)
     assert_meg_snr(raw, raw_c, 143, 624)
 
     # Degenerate cases
@@ -192,8 +192,7 @@ def test_chpi_subtraction():
     #           -o test_move_anon_ds2_raw.fif
     # it can strip out some values of info, which we emulate here:
     raw = Raw(chpi_fif_fname, allow_maxshield='yes')
-    raw.crop(0, 1, copy=False).load_data()
-    raw.resample(600., npad='auto')
+    raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
     raw.info['buffer_size_sec'] = np.float64(2.)
     raw.info['lowpass'] = 200.
     del raw.info['maxshield']

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -155,7 +155,7 @@ def test_calculate_chpi_positions():
     for d in raw_bad.info['dig']:
         if d['kind'] == FIFF.FIFFV_POINT_HPI:
             d['r'] = np.ones(3)
-    raw_bad = raw_bad.crop(0, 1.)
+    raw_bad.crop(0, 1., copy=False)
     with warnings.catch_warnings(record=True):  # bad pos
         with catch_logging() as log_file:
             _calculate_chpi_positions(raw_bad, verbose=True)
@@ -178,9 +178,10 @@ def test_chpi_subtraction():
         filter_chpi(raw, include_line=False, verbose=True)
     assert_true('5 cHPI' in log.getvalue())
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
-    raw = raw.crop(0, 16)
+    raw.crop(0, 16, copy=False)
     # remove cHPI status chans
-    raw_c = Raw(sss_hpisubt_fname).crop(0, 16).load_data().pick_types(
+    raw_c = Raw(sss_hpisubt_fname).crop(0, 16, copy=False).load_data()
+    raw_c.pick_types(
         meg=True, eeg=True, eog=True, ecg=True, stim=True, misc=True)
     assert_meg_snr(raw, raw_c, 143, 624)
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -132,7 +132,7 @@ def test_cov_estimation_on_raw():
         cov = compute_raw_covariance(raw_pick, picks=picks, method=method)
         assert_snr(cov.data, cov_mne.data[picks][:, picks], 90)  # cutoff samps
         # make sure we get a warning with too short a segment
-        raw_2 = Raw(raw_fname).crop(0, 1)
+        raw_2 = Raw(raw_fname).crop(0, 1, copy=False)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             cov = compute_raw_covariance(raw_2, method=method)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -122,8 +122,8 @@ def test_cov_estimation_on_raw():
 
         # test with a subset of channels
         picks = pick_channels(raw.ch_names, include=raw.ch_names[:5])
-        raw_pick = raw.pick_channels([raw.ch_names[pick] for pick in picks],
-                                     copy=True)
+        raw_pick = raw.copy().pick_channels(
+            [raw.ch_names[pick] for pick in picks])
         raw_pick.info.normalize_proj()
         cov = compute_raw_covariance(raw_pick, picks=picks, tstep=None,
                                      method=method)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -166,7 +166,7 @@ def test_dipole_fitting_fixed():
     evoked = read_evokeds(fname_evo, baseline=(None, 0))[0]
     evoked.pick_types(meg=True, copy=False)
     t_idx = np.argmin(np.abs(tpeak - evoked.times))
-    evoked_crop = evoked.crop(tpeak, tpeak, copy=True)
+    evoked_crop = evoked.copy().crop(tpeak, tpeak, copy=False)
     assert_equal(len(evoked_crop.times), 1)
     cov = read_cov(fname_cov)
     dip_seq, resid = fit_dipole(evoked_crop, cov, sphere)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -43,7 +43,7 @@ def test_savgol_filter():
     match_mask = np.logical_and(freqs >= 0, freqs <= h_freq / 2.)
     mismatch_mask = np.logical_and(freqs >= h_freq * 2, freqs < 50.)
     assert_raises(ValueError, evoked.savgol_filter, evoked.info['sfreq'])
-    evoked_sg = evoked.savgol_filter(h_freq, copy=True)
+    evoked_sg = evoked.copy().savgol_filter(h_freq)
     data_filt = np.abs(fftpack.fft(evoked_sg.data))
     # decent in pass-band
     assert_allclose(np.mean(data[:, match_mask], 0),
@@ -308,7 +308,7 @@ def test_drop_channels_mixin():
     ch_names = evoked.ch_names[3:]
 
     ch_names_orig = evoked.ch_names
-    dummy = evoked.drop_channels(drop_ch, copy=True)
+    dummy = evoked.copy().drop_channels(drop_ch)
     assert_equal(ch_names, dummy.ch_names)
     assert_equal(ch_names_orig, evoked.ch_names)
     assert_equal(len(ch_names_orig), len(evoked.data))
@@ -325,7 +325,7 @@ def test_pick_channels_mixin():
     ch_names = evoked.ch_names[:3]
 
     ch_names_orig = evoked.ch_names
-    dummy = evoked.pick_channels(ch_names, copy=True)
+    dummy = evoked.copy().pick_channels(ch_names)
     assert_equal(ch_names, dummy.ch_names)
     assert_equal(ch_names_orig, evoked.ch_names)
     assert_equal(len(ch_names_orig), len(evoked.data))
@@ -477,14 +477,14 @@ def test_add_channels():
                  {'event_bits': np.array([256,   0, 256, 256])},
                  {'event_bits': np.array([512,   0, 512, 512])}]
     evoked.info['hpi_subsystem'] = dict(hpi_coils=hpi_coils, ncoil=2)
-    evoked_eeg = evoked.pick_types(meg=False, eeg=True, copy=True)
-    evoked_meg = evoked.pick_types(meg=True, copy=True)
-    evoked_stim = evoked.pick_types(meg=False, stim=True, copy=True)
-    evoked_eeg_meg = evoked.pick_types(meg=True, eeg=True, copy=True)
-    evoked_new = evoked_meg.add_channels([evoked_eeg, evoked_stim], copy=True)
+    evoked_eeg = evoked.copy().pick_types(meg=False, eeg=True)
+    evoked_meg = evoked.copy().pick_types(meg=True)
+    evoked_stim = evoked.copy().pick_types(meg=False, stim=True)
+    evoked_eeg_meg = evoked.copy().pick_types(meg=True, eeg=True)
+    evoked_new = evoked_meg.copy().add_channels([evoked_eeg, evoked_stim])
     assert_true(all(ch in evoked_new.ch_names
                     for ch in evoked_stim.ch_names + evoked_meg.ch_names))
-    evoked_new = evoked_meg.add_channels([evoked_eeg], copy=True)
+    evoked_new = evoked_meg.copy().add_channels([evoked_eeg])
 
     assert_true(ch in evoked_new.ch_names for ch in evoked.ch_names)
     assert_array_equal(evoked_new.data, evoked_eeg_meg.data)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -690,10 +690,8 @@ def test_morph():
         # this should throw an error because the label has all zero values
         assert_raises(ValueError, label.morph, 'sample', 'fsaverage')
         label.values.fill(1)
-        label.morph(None, 'fsaverage', 5, grade, subjects_dir, 1,
-                    copy=False)
-        label.morph('fsaverage', 'sample', 5, None, subjects_dir, 2,
-                    copy=False)
+        label = label.morph(None, 'fsaverage', 5, grade, subjects_dir, 1)
+        label = label.morph('fsaverage', 'sample', 5, None, subjects_dir, 2)
         assert_true(np.mean(in1d(label_orig.vertices, label.vertices)) == 1.0)
         assert_true(len(label.vertices) < 3 * len(label_orig.vertices))
         vals.append(label.vertices)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -201,7 +201,7 @@ def test_compute_proj_raw():
     tempdir = _TempDir()
     # Test that the raw projectors work
     raw_time = 2.5  # Do shorter amount for speed
-    raw = Raw(raw_fname).crop(0, raw_time, False)
+    raw = Raw(raw_fname).crop(0, raw_time)
     raw.load_data()
     for ii in (0.25, 0.5, 1, 2):
         with warnings.catch_warnings(record=True) as w:

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -344,14 +344,14 @@ def test_add_channels():
         1000., ['mag', 'mag', 'mag', 'eeg', 'eeg', 'stim'])
     tfr = AverageTFR(info, data=data, times=times, freqs=freqs,
                      nave=20, comment='test', method='crazy-tfr')
-    tfr_eeg = tfr.pick_types(meg=False, eeg=True, copy=True)
-    tfr_meg = tfr.pick_types(meg=True, copy=True)
-    tfr_stim = tfr.pick_types(meg=False, stim=True, copy=True)
-    tfr_eeg_meg = tfr.pick_types(meg=True, eeg=True, copy=True)
-    tfr_new = tfr_meg.add_channels([tfr_eeg, tfr_stim], copy=True)
+    tfr_eeg = tfr.copy().pick_types(meg=False, eeg=True)
+    tfr_meg = tfr.copy().pick_types(meg=True)
+    tfr_stim = tfr.copy().pick_types(meg=False, stim=True)
+    tfr_eeg_meg = tfr.copy().pick_types(meg=True, eeg=True)
+    tfr_new = tfr_meg.copy().add_channels([tfr_eeg, tfr_stim])
     assert_true(all(ch in tfr_new.ch_names
                     for ch in tfr_stim.ch_names + tfr_meg.ch_names))
-    tfr_new = tfr_meg.add_channels([tfr_eeg], copy=True)
+    tfr_new = tfr_meg.copy().add_channels([tfr_eeg])
 
     assert_true(ch in tfr_new.ch_names for ch in tfr.ch_names)
     assert_array_equal(tfr_new.data, tfr_eeg_meg.data)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -17,11 +17,11 @@ from scipy.fftpack import fftn, ifftn
 from ..fixes import partial
 from ..baseline import rescale
 from ..parallel import parallel_func
-from ..utils import logger, verbose, _time_mask, warn
+from ..utils import (logger, verbose, _time_mask, warn, check_fname,
+                     _check_copy_dep)
 from ..channels.channels import ContainsMixin, UpdateChannelsMixin
 from ..io.pick import pick_info, pick_types
 from ..io.meas_info import Info
-from ..utils import check_fname
 from .multitaper import dpss_windows
 from ..viz.utils import figure_nobar, plt_show
 from ..externals.h5io import write_hdf5, read_hdf5
@@ -435,7 +435,7 @@ def single_trial_power(data, sfreq, frequencies, use_fft=True, n_cycles=7,
     # needed.
     if times is not None:
         times = times[::decim]
-    power = rescale(power, times, baseline, baseline_mode, copy=False)
+    power = rescale(power, times, baseline, baseline_mode)
     return power
 
 
@@ -496,8 +496,9 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     """Aux Function to prepare tfr computation"""
     from ..viz.utils import _setup_vmin_vmax
 
-    copy = baseline is not None
-    data = rescale(data, times, baseline, mode, copy=copy)
+    if baseline is not None:
+        data = data.copy()
+    data = rescale(data, times, baseline, mode)
 
     # crop time
     itmin, itmax = None, None
@@ -589,7 +590,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
     def ch_names(self):
         return self.info['ch_names']
 
-    def crop(self, tmin=None, tmax=None, copy=False):
+    def crop(self, tmin=None, tmax=None, copy=None):
         """Crop data to a given time interval
 
         Parameters
@@ -599,9 +600,16 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         tmax : float | None
             End time of selection in seconds.
         copy : bool
-            If False epochs is cropped in place.
+            This parameter has been deprecated and will be removed in 0.13.
+            Use inst.copy() instead.
+            Whether to return a new instance or modify in place.
+
+        Returns
+        -------
+        inst : instance of AverageTFR
+            The modified instance.
         """
-        inst = self if not copy else self.copy()
+        inst = _check_copy_dep(inst, copy)
         mask = _time_mask(inst.times, tmin, tmax, sfreq=self.info['sfreq'])
         inst.times = inst.times[mask]
         inst.data = inst.data[:, :, mask]
@@ -926,7 +934,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
         """
-        self.data = rescale(self.data, self.times, baseline, mode, copy=False)
+        self.data = rescale(self.data, self.times, baseline, mode)
 
     def plot_topomap(self, tmin=None, tmax=None, fmin=None, fmax=None,
                      ch_type=None, baseline=None, mode='mean',

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -435,7 +435,7 @@ def single_trial_power(data, sfreq, frequencies, use_fft=True, n_cycles=7,
     # needed.
     if times is not None:
         times = times[::decim]
-    power = rescale(power, times, baseline, baseline_mode)
+    power = rescale(power, times, baseline, baseline_mode, copy=False)
     return power
 
 
@@ -496,9 +496,8 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     """Aux Function to prepare tfr computation"""
     from ..viz.utils import _setup_vmin_vmax
 
-    if baseline is not None:
-        data = data.copy()
-    data = rescale(data, times, baseline, mode)
+    copy = baseline is not None
+    data = rescale(data, times, baseline, mode, copy=copy)
 
     # crop time
     itmin, itmax = None, None
@@ -934,7 +933,8 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
         """
-        self.data = rescale(self.data, self.times, baseline, mode)
+        self.data = rescale(self.data, self.times, baseline, mode,
+                            copy=False)
 
     def plot_topomap(self, tmin=None, tmax=None, fmin=None, fmax=None,
                      ch_type=None, baseline=None, mode='mean',

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -609,7 +609,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
         inst : instance of AverageTFR
             The modified instance.
         """
-        inst = _check_copy_dep(inst, copy)
+        inst = _check_copy_dep(self, copy)
         mask = _time_mask(inst.times, tmin, tmax, sfreq=self.info['sfreq'])
         inst.times = inst.times[mask]
         inst.data = inst.data[:, :, mask]

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -67,8 +67,9 @@ def _check_copy_dep(inst, copy, kind='inst', default=False):
     """Check for copy deprecation for 0.13"""
     if copy is not None:
         warn('The copy parameter is deprecated and will be removed in 0.13, '
-             'and the behavior will be to operate in-place (like copy=False). '
-             'Use %s.copy() if necessary instead.' % kind, DeprecationWarning)
+             'where the behavior will be to operate in-place (like copy=False)'
+             '. In 0.12 the default is copy=%s. Use %s.copy() if necessary.'
+             % (kind, default), DeprecationWarning)
     else:
         copy = default
     return inst.copy() if copy else inst

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -64,12 +64,17 @@ def nottest(f):
 
 
 def _check_copy_dep(inst, copy, kind='inst', default=False):
-    """Check for copy deprecation for 0.13"""
+    """Check for copy deprecation for 0.13 and 0.14"""
+    # For methods with copy=False default, we only need one release cycle
+    # for deprecation (0.13). For copy=True, we first need to go to copy=False
+    # (one cycle; 0.13) then remove copy altogether (one cycle; 0.14).
     if copy or (copy is None and default is True):
-        warn('The copy parameter is deprecated and will be removed in 0.13, '
-             'where the behavior will be to operate in-place (like copy=False)'
-             '. In 0.12 the default is copy=%s. Use %s.copy() if necessary.'
-             % (default, kind), DeprecationWarning)
+        remove_version = '0.14' if default is True else '0.13'
+        warn('The copy parameter is deprecated and will be removed in %s. '
+             'In 0.13 the behavior will be to operate in-place '
+             '(like copy=False). In 0.12 the default is copy=%s. '
+             'Use %s.copy() if necessary.'
+             % (remove_version, default, kind), DeprecationWarning)
     if copy is None:
         copy = default
     return inst.copy() if copy else inst

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -65,12 +65,12 @@ def nottest(f):
 
 def _check_copy_dep(inst, copy, kind='inst', default=False):
     """Check for copy deprecation for 0.13"""
-    if copy is not None:
+    if copy or (copy is None and default is True):
         warn('The copy parameter is deprecated and will be removed in 0.13, '
              'where the behavior will be to operate in-place (like copy=False)'
              '. In 0.12 the default is copy=%s. Use %s.copy() if necessary.'
-             % (kind, default), DeprecationWarning)
-    else:
+             % (default, kind), DeprecationWarning)
+    if copy is None:
         copy = default
     return inst.copy() if copy else inst
 
@@ -403,10 +403,11 @@ def estimate_rank(data, tol='auto', return_singular=False,
     """
     if copy is not None:
         warn('copy is deprecated and ignored. It will be removed in 0.13.')
+    data = data.copy()  # operate on a copy
     if norm is True:
         norms = _compute_row_norms(data)
         data /= norms[:, np.newaxis]
-    s = linalg.svd(data, compute_uv=False, overwrite_a=False)
+    s = linalg.svd(data, compute_uv=False, overwrite_a=True)
     if isinstance(tol, string_types):
         if tol != 'auto':
             raise ValueError('tol must be "auto" or float')

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -772,7 +772,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
 
     picks = pick_types(evoked.info, meg=True, eeg=True, ref_meg=False,
                        exclude='bads')
-    evoked.copy().pick_channels([evoked.ch_names[k] for k in picks])
+    evoked.pick_channels([evoked.ch_names[k] for k in picks])
     # important to re-pick. will otherwise crash on systems with ref channels
     # as first sensor block
     picks = pick_types(evoked.info, meg=True, eeg=True, ref_meg=False,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -772,7 +772,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
 
     picks = pick_types(evoked.info, meg=True, eeg=True, ref_meg=False,
                        exclude='bads')
-    evoked.pick_channels([evoked.ch_names[k] for k in picks], copy=False)
+    evoked.copy().pick_channels([evoked.ch_names[k] for k in picks])
     # important to re-pick. will otherwise crash on systems with ref channels
     # as first sensor block
     picks = pick_types(evoked.info, meg=True, eeg=True, ref_meg=False,
@@ -1048,10 +1048,9 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
     if len(ch_types) > 1:
         figs = list()
         for t in ch_types:  # pick only the corresponding channel type
-            ev_ = evoked.pick_channels([info['ch_names'][idx]
-                                        for idx in range(info['nchan'])
-                                        if channel_type(info, idx) == t],
-                                       copy=True)
+            ev_ = evoked.copy().pick_channels(
+                [info['ch_names'][idx] for idx in range(info['nchan'])
+                 if channel_type(info, idx) == t])
             if len(set([channel_type(ev_.info, idx)
                         for idx in range(ev_.info['nchan'])
                         if channel_type(ev_.info, idx) in data_types])) > 1:

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -120,7 +120,7 @@ def plot_ica_sources(ica, inst, picks=None, exclude=None, start=None,
     elif isinstance(inst, Evoked):
         sources = ica.get_sources(inst)
         if start is not None or stop is not None:
-            inst = inst.crop(start, stop, copy=True)
+            inst = inst.copy().crop(start, stop)
         fig = _plot_ica_sources_evoked(
             evoked=sources, picks=picks, exclude=exclude, title=title,
             labels=getattr(ica, 'labels_', None), show=show)
@@ -473,18 +473,18 @@ def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
         start_compare, stop_compare = _check_start_stop(inst, start, stop)
         data, times = inst[picks, start_compare:stop_compare]
 
-        raw_cln = ica.apply(inst, exclude=exclude, start=start, stop=stop,
-                            copy=True)
+        raw_cln = ica.apply(inst.copy(), exclude=exclude,
+                            start=start, stop=stop)
         data_cln, _ = raw_cln[picks, start_compare:stop_compare]
         fig = _plot_ica_overlay_raw(data=data, data_cln=data_cln,
                                     times=times * 1e3, title=title,
                                     ch_types_used=ch_types_used, show=show)
     elif isinstance(inst, Evoked):
         if start is not None and stop is not None:
-            inst = inst.crop(start, stop, copy=True)
+            inst = inst.copy().crop(start, stop)
         if picks is not None:
             inst.pick_channels([inst.ch_names[p] for p in picks])
-        evoked_cln = ica.apply(inst, exclude=exclude, copy=True)
+        evoked_cln = ica.apply(inst.copy(), exclude=exclude)
         fig = _plot_ica_overlay_evoked(evoked=inst, evoked_cln=evoked_cln,
                                        title=title, show=show)
 

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -135,7 +135,7 @@ def test_plot_trans():
     plot_trans(info, None, meg_sensors=True, dig=True, coord_frame='head')
     # EEG only with strange options
     with warnings.catch_warnings(record=True) as w:
-        plot_trans(evoked.pick_types(meg=False, eeg=True, copy=True).info,
+        plot_trans(evoked.copy().pick_types(meg=False, eeg=True).info,
                    trans=trans_fname, meg_sensors=True)
     assert_true(['Cannot plot MEG' in str(ww.message) for ww in w])
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -52,6 +52,7 @@ def _get_picks(raw):
 
 def _get_epochs():
     raw = _get_raw()
+    raw.add_proj([], remove_existing=True)
     events = _get_events()
     picks = _get_picks(raw)
     # Use a subset of channels for plotting speed

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -76,9 +76,7 @@ def test_plot_ica_sources():
     """Test plotting of ICA panel
     """
     import matplotlib.pyplot as plt
-    raw = io.read_raw_fif(raw_fname, preload=False)
-    raw.crop(0, 1, copy=False)
-    raw.load_data()
+    raw = io.read_raw_fif(raw_fname, preload=False).crop(0, 1).load_data()
     picks = _get_picks(raw)
     epochs = _get_epochs()
     raw.pick_channels([raw.ch_names[k] for k in picks])

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -76,7 +76,8 @@ def test_plot_ica_sources():
     """Test plotting of ICA panel
     """
     import matplotlib.pyplot as plt
-    raw = io.read_raw_fif(raw_fname, preload=False).crop(0, 1).load_data()
+    raw = io.read_raw_fif(raw_fname,
+                          preload=False).crop(0, 1, copy=False).load_data()
     picks = _get_picks(raw)
     epochs = _get_epochs()
     raw.pick_channels([raw.ch_names[k] for k in picks])

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -84,8 +84,8 @@ def test_plot_topo():
                       topomap_args=dict(colorbar=True, times=[0.]))
 
     warnings.simplefilter('always', UserWarning)
-    picked_evoked = evoked.pick_channels(evoked.ch_names[:3], copy=True)
-    picked_evoked_eeg = evoked.pick_types(meg=False, eeg=True, copy=True)
+    picked_evoked = evoked.copy().pick_channels(evoked.ch_names[:3])
+    picked_evoked_eeg = evoked.copy().pick_types(meg=False, eeg=True)
     picked_evoked_eeg.pick_channels(picked_evoked_eeg.ch_names[:3])
 
     # test scaling

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -67,7 +67,7 @@ def test_plot_topomap():
     anim._func(1)  # _animate has to be tested separately on 'Agg' backend.
     plt.close('all')
 
-    ev_bad = evoked.pick_types(meg=False, eeg=True, copy=True)
+    ev_bad = evoked.copy().pick_types(meg=False, eeg=True)
     ev_bad.pick_channels(ev_bad.ch_names[:2])
     ev_bad.plot_topomap(times=ev_bad.times[:2] - 1e-6)  # auto, plots EEG
     assert_raises(ValueError, ev_bad.plot_topomap, ch_type='mag')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -967,7 +967,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         names = None
 
     data = tfr.data
-    data = rescale(data.copy(), tfr.times, baseline, mode)
+    data = rescale(data, tfr.times, baseline, mode, copy=True)
 
     # crop time
     itmin, itmax = None, None

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -967,7 +967,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         names = None
 
     data = tfr.data
-    data = rescale(data, tfr.times, baseline, mode, copy=True)
+    data = rescale(data.copy(), tfr.times, baseline, mode)
 
     # crop time
     itmin, itmax = None, None
@@ -1173,8 +1173,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     else:
         data = evoked.data
 
-    evoked = evoked.pick_channels([evoked.ch_names[pick] for pick in picks],
-                                  copy=True)
+    evoked = evoked.copy().pick_channels(
+        [evoked.ch_names[pick] for pick in picks])
 
     if axes is not None:
         if isinstance(axes, plt.Axes):

--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -23,7 +23,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
 proj_fname = data_path + '/MEG/sample/sample_audvis_eog_proj.fif'
 
-tmin, tmax = 0, 20  # use the first 60s of data
+tmin, tmax = 0, 20  # use the first 20s of data
 
 # Setup for reading the raw data (save memory by cropping the raw data
 # before loading it)

--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -25,12 +25,10 @@ proj_fname = data_path + '/MEG/sample/sample_audvis_eog_proj.fif'
 
 tmin, tmax = 0, 20  # use the first 60s of data
 
-# Setup for reading the raw data
-raw = mne.io.read_raw_fif(raw_fname)
+# Setup for reading the raw data (save memory by cropping the raw data
+# before loading it)
+raw = mne.io.read_raw_fif(raw_fname).crop(tmin, tmax).load_data()
 raw.info['bads'] = ['MEG 2443', 'EEG 053']  # bads + 2 more
-
-# To save memory, crop the raw data before loading data
-raw.crop(tmin, tmax, copy=False).load_data()
 
 fmin, fmax = 2, 300  # look at frequencies between 2 and 300Hz
 n_fft = 2048  # the FFT size (n_fft). Ideally a power of 2

--- a/tutorials/plot_ica_from_raw.py
+++ b/tutorials/plot_ica_from_raw.py
@@ -104,4 +104,4 @@ ica.plot_overlay(raw)  # EOG artifacts remain
 # read_ica('my_ica.fif')
 
 # Apply the solution to Raw, Epochs or Evoked like this:
-# ica.apply(epochs, copy=False)
+# ica.apply(epochs)

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -79,16 +79,16 @@ _ = plt.title('Sample channels')
 # channel names, types or time ranges.
 
 # Pull all MEG gradiometer channels:
-# Make sure to use copy==True or it will overwrite the data
-meg_only = raw.pick_types(meg=True, copy=True)
-eeg_only = raw.pick_types(meg=False, eeg=True, copy=True)
+# Make sure to use .copy() or it will overwrite the data
+meg_only = raw.copy().pick_types(meg=True)
+eeg_only = raw.copy().pick_types(meg=False, eeg=True)
 
 # The MEG flag in particular lets you specify a string for more specificity
-grad_only = raw.pick_types(meg='grad', copy=True)
+grad_only = raw.copy().pick_types(meg='grad')
 
 # Or you can use custom channel names
 pick_chans = ['MEG 0112', 'MEG 0111', 'MEG 0122', 'MEG 0123']
-specific_chans = raw.pick_channels(pick_chans, copy=True)
+specific_chans = raw.copy().pick_channels(pick_chans)
 print(meg_only, eeg_only, grad_only, specific_chans, sep='\n')
 
 ###############################################################################


### PR DESCRIPTION
This PR aims to deprecate `copy=` parameters in methods (while leaving `copy` parameters alone in functions).

Closes #3124.

One outstanding problem is the few methods (e.g., `raw.crop`) that have `copy=True` by default, users will have slightly awkward interactions with for a cycle. The behavior is currently:

1. For current `copy=False` default functions:
    1. If `copy=None` (default) or `copy=False`, interpret as `copy=False`
    2. If `copy=True`, give `DeprecationWarning` and interpret as `copy=True`.
2. For current `copy=True` default functions:
    1. If `copy=None` (default) or `copy=True`, interpret as `copy=True` and give a `DeprecationWarning`.
    2. If `copy=False`, interpret as `copy=False`.

Not sure if this is the best solution but I can't think of anything better right now.