### PR TITLE
[MRG] GAT cv scores

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,4 @@
+.. include:: links.inc
 .. _whats_new:
 
 What's new
@@ -40,7 +41,7 @@ Changelog
 
     - Add reading and estimation of fixed-position dipole time courses (similar to Elekta ``xfit``) using :func:`mne.read_dipole` and :func:`mne.fit_dipole` by `Eric Larson`_.
 
-    - Accept :class:`mne.decoding.GeneralizationAcrossTime`'s ``scorer`` parameter to be a string that refers to a scikit-learn metric scorer by `Asish Panda`_.
+    - Accept :class:`mne.decoding.GeneralizationAcrossTime`'s ``scorer`` parameter to be a string that refers to a scikit-learn_ metric scorer by `Asish Panda`_.
 
     - Add method :func:`mne.Epochs.plot_image` calling :func:`mne.viz.plot_epochs_image` for better usability by `Asish Panda`_.
 
@@ -121,7 +122,8 @@ BUG
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
 
-    - Change default scoring method of :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` to estimate the scores within the cross-validation as in scikit-learn. The method can be changed with the ``score_mode`` parameter by `Jean-Remi King`_
+    - Change default scoring method of :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` to estimate the scores within the cross-validation as in scikit-learn_ as opposed to across all cross-validated `y_pred`. The method can be changed with the ``score_mode`` parameter by `Jean-Remi King`_
+
 
 
 API

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -122,7 +122,7 @@ BUG
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
 
-    - Change default scoring method of :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` to estimate the scores within the cross-validation as in scikit-learn_ as opposed to across all cross-validated `y_pred`. The method can be changed with the ``score_mode`` parameter by `Jean-Remi King`_
+    - Change default scoring method of :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` to estimate the scores within the cross-validation as in scikit-learn_ as opposed to across all cross-validated ``y_pred``. The method can be changed with the ``score_mode`` parameter by `Jean-Remi King`_
 
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,9 @@ BUG
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
 
+    - Change default scoring method of :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` to estimate the scores within the cross-validation as in scikit-learn. The method can be changed with the ``score_mode`` parameter by `Jean-Remi King`_
+
+
 API
 ~~~
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -186,7 +186,7 @@ def test_generalization_across_time():
     gat.predict_mode = 'mean-prediction'
     with warnings.catch_warnings(record=True) as w:
         gat.score(epochs)
-        assert_true(w > 0)
+        assert_true(len(w) > 0)
         assert_true(any("score_mode changed from " in str(ww.message)
                         for ww in w))
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -186,7 +186,6 @@ def test_generalization_across_time():
     gat.predict_mode = 'mean-prediction'
     with warnings.catch_warnings(record=True) as w:
         gat.score(epochs)
-        assert_true(len(w) > 0)
         assert_true(any("score_mode changed from " in str(ww.message)
                         for ww in w))
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -177,7 +177,7 @@ def test_generalization_across_time():
     gat.score_mode = 'fold-wise'
     scores = gat.score(epochs)
     assert_array_equal(np.shape(scores), [15, 15, 5])
-    gat.score_mode = 'sample-wise'
+    gat.score_mode = 'mean-sample-wise'
     scores = gat.score(epochs)
     assert_array_equal(np.shape(scores), [15, 15])
     gat.score_mode = 'mean-fold-wise'

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -186,7 +186,7 @@ def test_generalization_across_time():
     gat.predict_mode = 'mean-prediction'
     with warnings.catch_warnings(record=True) as w:
         gat.score(epochs)
-        assert_true(len(w) > 0)
+        assert_true(w > 0)
         assert_true(any("score_mode changed from " in str(ww.message)
                         for ww in w))
 

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -187,7 +187,7 @@ def test_generalization_across_time():
     with warnings.catch_warnings(record=True) as w:
         gat.score(epochs)
         assert_true(len(w) > 0)
-        assert_true(any("`score_mode` changed from " in str(ww.message)
+        assert_true(any("score_mode changed from " in str(ww.message)
                         for ww in w))
 
     # Test longer time window

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -174,13 +174,13 @@ def test_generalization_across_time():
     # Test score_mode
     gat.score_mode = 'foo'
     assert_raises(ValueError, gat.score, epochs)
-    gat.score_mode = 'per-fold'
+    gat.score_mode = 'fold-wise'
     scores = gat.score(epochs)
     assert_array_equal(np.shape(scores), [15, 15, 5])
-    gat.score_mode = 'no-cv'
+    gat.score_mode = 'sample-wise'
     scores = gat.score(epochs)
     assert_array_equal(np.shape(scores), [15, 15])
-    gat.score_mode = 'mean-across-folds'
+    gat.score_mode = 'mean-fold-wise'
     scores = gat.score(epochs)
     assert_array_equal(np.shape(scores), [15, 15])
     gat.predict_mode = 'mean-prediction'

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -102,8 +102,9 @@ class _GeneralizationAcrossTime(object):
     def fit(self, epochs, y=None):
         """Train a classifier on each specified time slice.
 
-        .. note:: This function sets the ``picks_``, ``ch_names``, ``cv_``,
-        ``y_train``, ``train_times_`` and ``estimators_`` attributes.
+        .. note::
+            This function sets the ``picks_``, ``ch_names``, ``cv_``,
+            ``y_train``, ``train_times_`` and ``estimators_`` attributes.
 
         Parameters
         ----------
@@ -166,8 +167,8 @@ class _GeneralizationAcrossTime(object):
     def predict(self, epochs):
         """Classifiers' predictions on each specified testing time slice.
 
-        .. note:: This function sets the ``y_pred_`` and ``test_times_``
-                  attributes.
+        .. note::
+            This function sets the ``y_pred_`` and ``test_times_`` attributes.
 
         Parameters
         ----------
@@ -314,11 +315,13 @@ class _GeneralizationAcrossTime(object):
 
         Calls ``predict()`` if it has not been already.
 
-        .. note:: The function updates the ``scorer_``, ``scores_``, and
-        ``y_true_`` attributes.
+        .. note::
+            The function updates the ``scorer_``, ``scores_``, and
+            ``y_true_`` attributes.
 
-        .. note:: If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
-        automatically set to 'sample-wise'.
+        .. note::
+            If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
+            automatically set to 'sample-wise'.
 
         Parameters
         ----------
@@ -1357,8 +1360,9 @@ class TimeDecoding(_GeneralizationAcrossTime):
     def fit(self, epochs, y=None):
         """Train a classifier on each specified time slice.
 
-        .. note:: This function sets the ``picks_``, ``ch_names``, ``cv_``,
-        ``y_train``, ``train_times_`` and ``estimators_`` attributes.
+        .. note::
+            This function sets the ``picks_``, ``ch_names``, ``cv_``,
+            ``y_train``, ``train_times_`` and ``estimators_`` attributes.
 
         Parameters
         ----------
@@ -1388,8 +1392,8 @@ class TimeDecoding(_GeneralizationAcrossTime):
     def predict(self, epochs):
         """Test each classifier on each specified testing time slice.
 
-        .. note:: This function sets the ``y_pred_`` and ``test_times_``
-                  attributes.
+        .. note::
+            This function sets the ``y_pred_`` and ``test_times_`` attributes.
 
         Parameters
         ----------
@@ -1415,11 +1419,13 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
         Calls ``predict()`` if it has not been already.
 
-        .. note:: The function updates the ``scorer_``, ``scores_``, and
-        ``y_true_`` attributes.
+        .. note::
+            The function updates the ``scorer_``, ``scores_``, and
+            ``y_true_`` attributes.
 
-        .. note:: If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
-        automatically set to 'sample-wise'.
+        .. note::
+            If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
+            automatically set to 'sample-wise'.
 
         Parameters
         ----------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -888,19 +888,19 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     train_times : dict | None
         A dictionary to configure the training times:
 
-            ``slices`` : ndarray, shape (n_clfs,)
+            * ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
-            ``start`` : float
+            * ``start`` : float
                 Time at which to start decoding (in seconds).
                 Defaults to min(epochs.times).
-            ``stop`` : float
+            * ``stop`` : float
                 Maximal time at which to stop decoding (in seconds).
                 Defaults to max(times).
-            ``step`` : float
+            * ``step`` : float
                 Duration separating the start of subsequent classifiers (in
                 seconds). Defaults to one time sample.
-            ``length`` : float
+            * ``length`` : float
                 Duration of each classifier (in seconds).
                 Defaults to one time sample.
 
@@ -911,7 +911,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         each classifier is trained.
         If set to None, predictions are made at all time points.
         If set to dict, the dict should contain ``slices`` or be contructed in
-        a similar way to train_times::
+        a similar way to train_times:
 
             ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
@@ -927,12 +927,12 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         Indicates how predictions are achieved with regards to the cross-
         validation procedure:
 
-            ``cross-validation`` : estimates a single prediction per sample
+            * ``cross-validation`` : estimates a single prediction per sample
                 based on the unique independent classifier fitted in the
                 cross-validation.
 
-            ``mean-prediction`` : estimates k predictions per sample, based on
-                each of the k-fold cross-validation classifiers, and average
+            * ``mean-prediction`` : estimates k predictions per sample, based
+                on each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
 
         Defaults to 'cross-validation'.
@@ -942,11 +942,12 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 
-            ``per-fold`` : returns the score obtained in each fold.
+            * ``per-fold`` : returns the score obtained in each fold.
 
-            ``mean-across-folds`` : returns the average of the per-fold scores.
+            * ``mean-across-folds`` : returns the average of the per-fold
+                scores.
 
-            ``no-cv`` : returns score estimated across across all y_pred
+            * ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
                 than ``mean-across-folds`` but less conventional, use at your
                 own risk.
@@ -966,10 +967,11 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     train_times_ : dict
         A dictionary that configures the training times:
 
-            ``slices`` : ndarray, shape (n_clfs,)
+            * ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
-            ``times`` : ndarray, shape (n_clfs,)
+
+            * ``times`` : ndarray, shape (n_clfs,)
                 The training times (in seconds).
 
     test_times_ : dict
@@ -1246,12 +1248,12 @@ class TimeDecoding(_GeneralizationAcrossTime):
         Indicates how predictions are achieved with regards to the cross-
         validation procedure:
 
-            ``cross-validation`` : estimates a single prediction per sample
+            * ``cross-validation`` : estimates a single prediction per sample
                 based on the unique independent classifier fitted in the
                 cross-validation.
 
-            ``mean-prediction`` : estimates k predictions per sample, based on
-                each of the k-fold cross-validation classifiers, and average
+            * ``mean-prediction`` : estimates k predictions per sample, based
+                on each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
 
         Defaults to 'cross-validation'.
@@ -1261,11 +1263,12 @@ class TimeDecoding(_GeneralizationAcrossTime):
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 
-            ``per-fold`` : returns the score obtained in each fold.
+            * ``per-fold`` : returns the score obtained in each fold.
 
-            ``mean-across-folds`` : returns the average of the per-fold scores.
+            * ``mean-across-folds`` : returns the average of the per-fold
+                scores.
 
-            ``no-cv`` : returns score estimated across across all y_pred
+            * ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
                 than ``mean-across-folds`` but less conventional, use at your
                 own risk.
@@ -1285,10 +1288,11 @@ class TimeDecoding(_GeneralizationAcrossTime):
     times_ : dict
         A dictionary that configures the training times:
 
-            ``slices`` : ndarray, shape (n_clfs,)
+            * ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
-            ``times`` : ndarray, shape (n_clfs,)
+
+            * ``times`` : ndarray, shape (n_clfs,)
                 The training times (in seconds).
 
     cv_ : CrossValidation object

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -337,9 +337,9 @@ class _GeneralizationAcrossTime(object):
             The scores estimated by ``scorer_`` at each training time and each
             testing time (e.g. mean accuracy of ``predict(X)``). Note that the
             number of testing times per training time need not be regular;
-            else, np.shape(scores) = (n_train_time, n_test_time). If score_mode
-            is 'complete', np.shape(scores) = (n_train_time, n_test_time,
-            n_folds).
+            else, np.shape(scores) = (n_train_time, n_test_time). If
+            ``score_mode`` is 'complete', np.shape(scores) = (n_train_time,
+            n_test_time, n_folds).
         """
         import sklearn.metrics
         from sklearn.base import is_classifier
@@ -934,11 +934,10 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
                 each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
 
-        Default: 'cross-validation'
+        Defaults to 'cross-validation'.
     scorer : object | None | str
-        scikit-learn Scorer instance or str type indicating the name of
-        the scorer such as `accuracy`, `roc_auc`. If None, set to
-        accuracy_score.
+        scikit-learn Scorer instance or str type indicating the name of the
+        scorer such as `accuracy`, `roc_auc`. If None, set to accuracy_score.
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 
@@ -1014,11 +1013,13 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     """  # noqa
     def __init__(self, picks=None, cv=5, clf=None, train_times=None,
                  test_times=None, predict_method='predict',
-                 predict_mode='cross-validation', scorer=None, n_jobs=1):
+                 predict_mode='cross-validation', scorer=None,
+                 score_mode='mean-across-folds', n_jobs=1):
         super(GeneralizationAcrossTime, self).__init__(
             picks=picks, cv=cv, clf=clf, train_times=train_times,
             test_times=test_times, predict_method=predict_method,
-            predict_mode=predict_mode, scorer=scorer, n_jobs=n_jobs)
+            predict_mode=predict_mode, scorer=scorer, score_mode=score_mode,
+            n_jobs=n_jobs)
 
     def __repr__(self):
         s = ''
@@ -1245,11 +1246,10 @@ class TimeDecoding(_GeneralizationAcrossTime):
                 each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
 
-        Default: 'cross-validation'
+        Defaults to 'cross-validation'.
     scorer : object | None | str
-        scikit-learn Scorer instance or str type indicating the
-        name of the scorer such as `accuracy`, `roc_auc`. If None,
-        set to accuracy_score.
+        scikit-learn Scorer instance or str type indicating the name of the
+        scorer such as `accuracy`, `roc_auc`. If None, set to accuracy_score.
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -606,10 +606,10 @@ def _score_slices(y_true, list_y_pred, scorer, score_mode, cv):
                 scores_ = list()
                 for train, test in cv:
                     scores_.append(scorer(y_true[test], this_y_pred[test]))
+                scores_ = np.array(scores_)
                 # Summarize score as average across folds
                 if score_mode == 'mean-fold-wise':
-                    # Note that np.mean automatically squeezes the dimensions
-                    scores_ = np.mean(scores_, axis=0, keepdims=True)[0]
+                    scores_ = np.mean(scores_, axis=0)
             elif score_mode == 'sample-wise':
                 # Estimate score across all y_pred without cross-validation.
                 scores_ = scorer(y_true, this_y_pred)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -321,7 +321,7 @@ class _GeneralizationAcrossTime(object):
 
         .. note::
             If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
-            automatically set to 'sample-wise'.
+            automatically set to 'mean-sample-wise'.
 
         Parameters
         ----------
@@ -363,16 +363,16 @@ class _GeneralizationAcrossTime(object):
 
         # Check scorer
         if self.score_mode not in ('fold-wise', 'mean-fold-wise',
-                                   'sample-wise'):
+                                   'mean-sample-wise'):
             raise ValueError("score_mode must be 'fold-wise', "
-                             "'mean-fold-wise' or 'sample-wise'. "
+                             "'mean-fold-wise' or 'mean-sample-wise'. "
                              "Got %s instead'" % self.score_mode)
         score_mode = self.score_mode
         if (self.predict_mode == 'mean-prediction' and
-                self.score_mode != 'sample-wise'):
-            warn("score_mode changed from %s set to 'sample-wise' because "
-                 "predict_mode is 'mean-prediction'." % self.score_mode)
-            score_mode = 'sample-wise'
+                self.score_mode != 'mean-sample-wise'):
+            warn("score_mode changed from %s set to 'mean-sample-wise' because"
+                 " predict_mode is 'mean-prediction'." % self.score_mode)
+            score_mode = 'mean-sample-wise'
         self.scorer_ = self.scorer
         if self.scorer_ is None:
             # Try to guess which scoring metrics should be used
@@ -610,7 +610,7 @@ def _score_slices(y_true, list_y_pred, scorer, score_mode, cv):
                 # Summarize score as average across folds
                 if score_mode == 'mean-fold-wise':
                     scores_ = np.mean(scores_, axis=0)
-            elif score_mode == 'sample-wise':
+            elif score_mode == 'mean-sample-wise':
                 # Estimate score across all y_pred without cross-validation.
                 scores_ = scorer(y_true, this_y_pred)
             scores.append(scores_)
@@ -941,14 +941,14 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
     scorer : object | None | str
         scikit-learn Scorer instance or str type indicating the name of the
         scorer such as ``accuracy``, ``roc_auc``. If None, set to ``accuracy``.
-    score_mode : {'fold-wise', 'mean-fold-wise', 'sample-wise'}
+    score_mode : {'fold-wise', 'mean-fold-wise', 'mean-sample-wise'}
         Determines how the scorer is estimated:
 
             * ``fold-wise`` : returns the score obtained in each fold.
 
             * ``mean-fold-wise`` : returns the average of the fold-wise scores.
 
-            * ``sample-wise`` : returns score estimated across across all
+            * ``mean-sample-wise`` : returns score estimated across across all
                 y_pred independently of the cross-validation. This method is
                 faster than ``mean-fold-wise`` but less conventional, use at
                 your own risk.
@@ -1261,14 +1261,14 @@ class TimeDecoding(_GeneralizationAcrossTime):
     scorer : object | None | str
         scikit-learn Scorer instance or str type indicating the name of the
         scorer such as ``accuracy``, ``roc_auc``. If None, set to ``accuracy``.
-    score_mode : {'fold-wise', 'mean-fold-wise', 'sample-wise'}
+    score_mode : {'fold-wise', 'mean-fold-wise', 'mean-sample-wise'}
         Determines how the scorer is estimated:
 
             * ``fold-wise`` : returns the score obtained in each fold.
 
             * ``mean-fold-wise`` : returns the average of the fold-wise scores.
 
-            * ``sample-wise`` : returns score estimated across across all
+            * ``mean-sample-wise`` : returns score estimated across across all
                 y_pred independently of the cross-validation. This method is
                 faster than ``mean-fold-wise`` but less conventional, use at
                 your own risk.
@@ -1425,7 +1425,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
         .. note::
             If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
-            automatically set to 'sample-wise'.
+            automatically set to 'mean-sample-wise'.
 
         Parameters
         ----------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -102,7 +102,7 @@ class _GeneralizationAcrossTime(object):
     def fit(self, epochs, y=None):
         """Train a classifier on each specified time slice.
 
-        Note. This function sets the ``picks_``, ``ch_names``, ``cv_``,
+        .. note:: This function sets the ``picks_``, ``ch_names``, ``cv_``,
         ``y_train``, ``train_times_`` and ``estimators_`` attributes.
 
         Parameters
@@ -314,11 +314,11 @@ class _GeneralizationAcrossTime(object):
 
         Calls ``predict()`` if it has not been already.
 
-        Note. The function updates the ``scorer_``, ``scores_``, and
+        .. note:: The function updates the ``scorer_``, ``scores_``, and
         ``y_true_`` attributes.
 
-        Note. If `predict_mode` is 'mean-prediction', `score_mode` is
-        automatically set to `no-cv`.
+        .. note:: If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
+        automatically set to 'no-cv'.
 
         Parameters
         ----------
@@ -368,8 +368,8 @@ class _GeneralizationAcrossTime(object):
             (self.predict_mode == 'mean-prediction') and
             (self.score_mode != 'no-cv')
         ):
-            warn("`score_mode` changed from %s set to" % self.score_mode +
-                 "'no-cv' because `predict_mode` is 'mean-prediction'.")
+            warn("`score_mode` changed from %s set to 'no-cv' because "
+                 "`predict_mode` is 'mean-prediction'." % self.score_mode)
             score_mode = 'no-cv'
         self.scorer_ = self.scorer
         if self.scorer_ is None:
@@ -930,6 +930,7 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
             ``cross-validation`` : estimates a single prediction per sample
                 based on the unique independent classifier fitted in the
                 cross-validation.
+
             ``mean-prediction`` : estimates k predictions per sample, based on
                 each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
@@ -937,12 +938,14 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         Defaults to 'cross-validation'.
     scorer : object | None | str
         scikit-learn Scorer instance or str type indicating the name of the
-        scorer such as `accuracy`, `roc_auc`. If None, set to accuracy_score.
+        scorer such as ``accuracy``, ``roc_auc``. If None, set to ``accuracy``.
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 
             ``per-fold`` : returns the score obtained in each fold.
+
             ``mean-across-folds`` : returns the average of the per-fold scores.
+
             ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
                 than ``mean-across-folds`` but less conventional, use at your
@@ -1216,15 +1219,19 @@ class TimeDecoding(_GeneralizationAcrossTime):
             ``slices`` : ndarray, shape (n_clfs,)
                 Array of time slices (in indices) used for each classifier.
                 If not given, computed from 'start', 'stop', 'length', 'step'.
+
             ``start`` : float
                 Time at which to start decoding (in seconds). By default,
                 min(epochs.times).
+
             ``stop`` : float
                 Maximal time at which to stop decoding (in seconds). By
                 default, max(times).
+
             ``step`` : float
                 Duration separating the start of subsequent classifiers (in
                 seconds). By default, equals one time sample.
+
             ``length`` : float
                 Duration of each classifier (in seconds). By default, equals
                 one time sample.
@@ -1242,6 +1249,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
             ``cross-validation`` : estimates a single prediction per sample
                 based on the unique independent classifier fitted in the
                 cross-validation.
+
             ``mean-prediction`` : estimates k predictions per sample, based on
                 each of the k-fold cross-validation classifiers, and average
                 these predictions into a single estimate per sample.
@@ -1249,12 +1257,14 @@ class TimeDecoding(_GeneralizationAcrossTime):
         Defaults to 'cross-validation'.
     scorer : object | None | str
         scikit-learn Scorer instance or str type indicating the name of the
-        scorer such as `accuracy`, `roc_auc`. If None, set to accuracy_score.
+        scorer such as ``accuracy``, ``roc_auc``. If None, set to ``accuracy``.
     score_mode : {'per-fold', 'mean-across-folds', 'no-cv'}
         Determines how the scorer is estimated:
 
             ``per-fold`` : returns the score obtained in each fold.
+
             ``mean-across-folds`` : returns the average of the per-fold scores.
+
             ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
                 than ``mean-across-folds`` but less conventional, use at your
@@ -1346,7 +1356,7 @@ class TimeDecoding(_GeneralizationAcrossTime):
     def fit(self, epochs, y=None):
         """Train a classifier on each specified time slice.
 
-        Note. This function sets the ``picks_``, ``ch_names``, ``cv_``,
+        .. note:: This function sets the ``picks_``, ``ch_names``, ``cv_``,
         ``y_train``, ``train_times_`` and ``estimators_`` attributes.
 
         Parameters
@@ -1404,11 +1414,11 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
         Calls ``predict()`` if it has not been already.
 
-        Note. The function updates the ``scorer_``, ``scores_``, and
+        .. note:: The function updates the ``scorer_``, ``scores_``, and
         ``y_true_`` attributes.
 
-        Note. If `predict_mode` is 'mean-prediction', `score_mode` is
-        automatically set to `no-cv`.
+        .. note:: If ``predict_mode`` is 'mean-prediction', ``score_mode`` is
+        automatically set to 'no-cv'.
 
         Parameters
         ----------

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -943,12 +943,11 @@ class GeneralizationAcrossTime(_GeneralizationAcrossTime):
         Determines how the scorer is estimated:
 
             ``per-fold`` : returns the score obtained in each fold.
-            ``mean-across-folds`` : returns the average scores obtained in each
-                fold separately. This method is the most conventional.
+            ``mean-across-folds`` : returns the average of the per-fold scores.
             ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
-                but less conventional, and is not valid for estimating metrics
-                related to fold errors.
+                than ``mean-across-folds`` but less conventional, use at your
+                own risk.
 
         Defaults to 'mean-across-folds'.
     n_jobs : int
@@ -1255,12 +1254,11 @@ class TimeDecoding(_GeneralizationAcrossTime):
         Determines how the scorer is estimated:
 
             ``per-fold`` : returns the score obtained in each fold.
-            ``mean-across-folds`` : returns the average scores obtained in each
-                fold separately. This method is the most conventional.
+            ``mean-across-folds`` : returns the average of the per-fold scores.
             ``no-cv`` : returns score estimated across across all y_pred
                 independently of the cross-validation. This method is faster
-                but less conventional, and is not valid for estimating metrics
-                related to fold errors.
+                than ``mean-across-folds`` but less conventional, use at your
+                own risk.
 
         Defaults to 'mean-across-folds'.
     n_jobs : int

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -1307,13 +1307,15 @@ class TimeDecoding(_GeneralizationAcrossTime):
 
     def __init__(self, picks=None, cv=5, clf=None, times=None,
                  predict_method='predict', predict_mode='cross-validation',
-                 scorer=None, n_jobs=1):
+                 scorer=None, score_mode='mean-across-folds', n_jobs=1):
         super(TimeDecoding, self).__init__(picks=picks, cv=cv, clf=clf,
                                            train_times=times,
                                            test_times='diagonal',
                                            predict_method=predict_method,
                                            predict_mode=predict_mode,
-                                           scorer=scorer, n_jobs=n_jobs)
+                                           scorer=scorer,
+                                           score_mode=score_mode,
+                                           n_jobs=n_jobs)
         self._clean_times()
 
     def __repr__(self):

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -188,7 +188,7 @@ class _GeneralizationAcrossTime(object):
         # Check that classifier has predict_method (e.g. predict_proba is not
         # always available):
         if not hasattr(self.clf, self.predict_method):
-            raise NotImplementedError('%s does not have `%s`' % (
+            raise NotImplementedError('%s does not have "%s"' % (
                 self.clf, self.predict_method))
 
         # Check that at least one classifier has been trained
@@ -197,7 +197,7 @@ class _GeneralizationAcrossTime(object):
 
         # Check predict mode
         if self.predict_mode not in ['cross-validation', 'mean-prediction']:
-            raise ValueError('`predict_mode` must be a str, "mean-prediction" '
+            raise ValueError('predict_mode must be a str, "mean-prediction" '
                              'or "cross-validation"')
 
         # Check that training cv and predicting cv match
@@ -208,7 +208,7 @@ class _GeneralizationAcrossTime(object):
             mismatch_y = len(self.y_train_) != len(epochs)
             if heterogeneous_cv or mismatch_cv or mismatch_y:
                 raise ValueError(
-                    'When `predict_mode = "cross-validation"`, the training '
+                    'When predict_mode = "cross-validation", the training '
                     'and predicting cv schemes must be identical.')
 
         # Clean attributes
@@ -230,7 +230,7 @@ class _GeneralizationAcrossTime(object):
         elif isinstance(self.test_times, dict):
             test_times = copy.deepcopy(self.test_times)
         else:
-            raise ValueError('`test_times` must be a dict or "diagonal"')
+            raise ValueError('test_times must be a dict or "diagonal"')
 
         if 'slices' not in test_times:
             if 'length' not in self.train_times_.keys():
@@ -256,7 +256,7 @@ class _GeneralizationAcrossTime(object):
             # that the dimensionality of each estimator (i.e. training
             # time) corresponds to the dimensionality of each testing time)
             if not np.all([len(test) == len(train) for test in tests]):
-                raise ValueError('`train_times` and `test_times` must '
+                raise ValueError('train_times and test_times must '
                                  'have identical lengths')
 
         # Store all testing times parameters
@@ -364,14 +364,14 @@ class _GeneralizationAcrossTime(object):
         # Check scorer
         if self.score_mode not in ('fold-wise', 'mean-fold-wise',
                                    'sample-wise'):
-            raise ValueError("`score_mode` must be 'fold-wise', "
+            raise ValueError("score_mode must be 'fold-wise', "
                              "'mean-fold-wise' or 'sample-wise'. "
                              "Got %s instead'" % self.score_mode)
         score_mode = self.score_mode
         if (self.predict_mode == 'mean-prediction' and
                 self.score_mode != 'sample-wise'):
-            warn("`score_mode` changed from %s set to 'sample-wise' because "
-                 "`predict_mode` is 'mean-prediction'." % self.score_mode)
+            warn("score_mode changed from %s set to 'sample-wise' because "
+                 "predict_mode is 'mean-prediction'." % self.score_mode)
             score_mode = 'sample-wise'
         self.scorer_ = self.scorer
         if self.scorer_ is None:
@@ -387,11 +387,11 @@ class _GeneralizationAcrossTime(object):
                 self.scorer_ = getattr(sklearn.metrics, '%s_score' %
                                        self.scorer_)
             else:
-                raise KeyError("`{0} scorer` Doesn't appear to be valid a "
+                raise KeyError("{0} scorer Doesn't appear to be valid a "
                                "scikit-learn scorer.".format(self.scorer_))
         if not self.scorer_:
-            raise ValueError('Could not find a scoring metric for `clf=%s` '
-                             ' and `predict_method=%s`. Manually define scorer'
+            raise ValueError('Could not find a scoring metric for clf=%s '
+                             ' and predict_method=%s. Manually define scorer'
                              '.' % (self.clf, self.predict_method))
 
         # If no regressor is passed, use default epochs events
@@ -756,18 +756,18 @@ def _sliding_window(times, window, sfreq):
 
         if not (times[0] <= window['start'] <= times[-1]):
             raise ValueError(
-                '`start` (%.2f s) outside time range [%.2f, %.2f].' % (
+                'start (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['start'], times[0], times[-1]))
         if not (times[0] <= window['stop'] <= times[-1]):
             raise ValueError(
-                '`stop` (%.2f s) outside time range [%.2f, %.2f].' % (
+                'stop (%.2f s) outside time range [%.2f, %.2f].' % (
                     window['stop'], times[0], times[-1]))
         if window['step'] < 1. / sfreq:
-            raise ValueError('`step` must be >= 1 / sampling_frequency')
+            raise ValueError('step must be >= 1 / sampling_frequency')
         if window['length'] < 1. / sfreq:
-            raise ValueError('`length` must be >= 1 / sampling_frequency')
+            raise ValueError('length must be >= 1 / sampling_frequency')
         if window['length'] > np.ptp(times):
-            raise ValueError('`length` must be <= time range')
+            raise ValueError('length must be <= time range')
 
         # Convert seconds to index
 


### PR DESCRIPTION
* FIX: Addresses issue raised by @dengemann  in https://github.com/mne-tools/mne-python/issues/3125, related to the fact that the current behavior of the decoding algorithm is to apply the score outside the cross-validation, which is not the conventional sklearn way
* changes default scoring mode
* ENH: allows retrieving fold-specific scores

Some [empirical tests here](https://gist.github.com/kingjr/3827a326733204e6e6b8af58c831b12c ). tl;dr: At the exception of `f1_score` (for which I need to think a bit more, I actually never use this metrics), the scoring metrics, if anything, is overestimated when applied per fold (as compared to across trials) when there is information (there isn't a systematic bias when `X` can't predict `y`). Additional simulations could be done to test different `X` distributions.