### PR TITLE
MRG: Revert to using dict subclass for Info

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -123,8 +123,6 @@ API
 
     - Deprecated function :func:`mne.time_frequency.multitaper_psd` and replaced by :func:`mne.time_frequency.psd_multitaper` by `Chris Holdgraf`_
 
-    - The `'ch_names'` and `'nchan'` fields of the :class:`mne.io.Info` class are now read-only and are automatically updated to accommodate changes in the `'chs'` field, by `Marijn van Vliet`_
-
     - The ``y_pred`` attribute in :func:`mne.decoding.GeneralizationAcrossTime` and :func:`mne.decoding.TimeDecoding` is now a numpy array, by `Jean-Remi King`_
 
     - The :func:`mne.bem.fit_sphere_to_headshape` function now default to ``dig_kinds='auto'`` which will use extra digitization points, falling back to extra plus eeg digitization points if there not enough extra points are available.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -703,6 +703,7 @@ def rename_channels(info, mapping):
     info['bads'] = bads
     for ch, ch_name in zip(info['chs'], ch_names):
         ch['ch_name'] = ch_name
+    info._update_redundant()
     info._check_consistency()
 
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -627,6 +627,7 @@ def _set_montage(info, montage, update_ch_names=False):
                            'coord_frame': FIFF.FIFFV_COORD_HEAD,
                            'coil_type': FIFF.FIFFV_COIL_EEG}
                 info['chs'].append(ch_info)
+            info._update_redundant()
 
         if not _contains_ch_type(info, 'eeg'):
             raise ValueError('No EEG channels found.')

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -45,45 +45,25 @@ fname_ctf_raw = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
 fname_kit_157 = op.join(op.dirname(__file__), '..', '..',  'io', 'kit',
                         'tests', 'data', 'test.sqd')
 
-test_info = _empty_info(1000)
-test_info.update({
-    'chs': [{'cal': 1,
-             'ch_name': 'ICA 001',
-             'coil_type': 0,
-             'coord_Frame': 0,
-             'kind': 502,
-             'loc': np.array([0., 0., 0., 1., 0., 0., 0., 1., 0., 0., 0., 1.],
-                             dtype=np.float32),
-             'logno': 1,
-             'range': 1.0,
-             'scanno': 1,
-             'unit': -1,
-             'unit_mul': 0},
-            {'cal': 1,
-             'ch_name': 'ICA 002',
-             'coil_type': 0,
-             'coord_Frame': 0,
-             'kind': 502,
-             'loc': np.array([0., 0., 0., 1., 0., 0., 0., 1., 0., 0., 0., 1.],
-                             dtype=np.float32),
-             'logno': 2,
-             'range': 1.0,
-             'scanno': 2,
-             'unit': -1,
-             'unit_mul': 0},
-            {'cal': 0.002142000012099743,
-             'ch_name': 'EOG 061',
-             'coil_type': 1,
-             'coord_frame': 0,
-             'kind': 202,
-             'loc': np.array([0., 0., 0., 1., 0., 0., 0., 1., 0., 0., 0., 1.],
-                             dtype=np.float32),
-             'logno': 61,
-             'range': 1.0,
-             'scanno': 376,
-             'unit': 107,
-             'unit_mul': 0}],
-})
+
+def _get_test_info():
+    """Helper to make test info"""
+    test_info = _empty_info(1000)
+    loc = np.array([0., 0., 0., 1., 0., 0., 0., 1., 0., 0., 0., 1.],
+                   dtype=np.float32)
+    test_info['chs'] = [
+        {'cal': 1, 'ch_name': 'ICA 001', 'coil_type': 0, 'coord_Frame': 0,
+         'kind': 502, 'loc': loc.copy(), 'logno': 1, 'range': 1.0, 'scanno': 1,
+         'unit': -1, 'unit_mul': 0},
+        {'cal': 1, 'ch_name': 'ICA 002', 'coil_type': 0, 'coord_Frame': 0,
+         'kind': 502, 'loc': loc.copy(), 'logno': 2, 'range': 1.0, 'scanno': 2,
+         'unit': -1, 'unit_mul': 0},
+        {'cal': 0.002142000012099743, 'ch_name': 'EOG 061', 'coil_type': 1,
+         'coord_frame': 0, 'kind': 202, 'loc': loc.copy(), 'logno': 61,
+         'range': 1.0, 'scanno': 376, 'unit': 107, 'unit_mul': 0}]
+    test_info._update_redundant()
+    test_info._check_consistency()
+    return test_info
 
 
 def test_io_layout_lout():
@@ -198,7 +178,7 @@ def test_make_grid_layout():
     tmp_name = 'bar'
     lout_name = 'test_ica'
     lout_orig = read_layout(kind=lout_name, path=lout_path)
-    layout = make_grid_layout(test_info)
+    layout = make_grid_layout(_get_test_info())
     layout.save(op.join(tempdir, tmp_name + '.lout'))
     lout_new = read_layout(kind=tmp_name, path=tempdir)
     assert_array_equal(lout_new.kind, tmp_name)
@@ -206,7 +186,7 @@ def test_make_grid_layout():
     assert_array_equal(lout_orig.names, lout_new.names)
 
     # Test creating grid layout with specified number of columns
-    layout = make_grid_layout(test_info, n_col=2)
+    layout = make_grid_layout(_get_test_info(), n_col=2)
     # Vertical positions should be equal
     assert_true(layout.pos[0, 1] == layout.pos[1, 1])
     # Horizontal positions should be unequal
@@ -218,7 +198,7 @@ def test_make_grid_layout():
 def test_find_layout():
     """Test finding layout"""
     import matplotlib.pyplot as plt
-    assert_raises(ValueError, find_layout, test_info, ch_type='meep')
+    assert_raises(ValueError, find_layout, _get_test_info(), ch_type='meep')
 
     sample_info = Raw(fif_fname).info
     grads = pick_types(sample_info, meg='grad')

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -988,6 +988,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
                     'experimenter', 'hpi_subsystem', 'proj_id', 'proj_name',
                     'subject_info']:
             out_info[key] = None
+        out_info._update_redundant()
+        out_info._check_consistency()
         dipoles = DipoleFixed(out_info, data, times, evoked.nave,
                               evoked._aspect_kind, evoked.first, evoked.last,
                               comment)

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -211,7 +211,8 @@ def _as_meg_type_evoked(evoked, ch_type='grad', mode='fast'):
     # change channel names to emphasize they contain interpolated data
     for ch in evoked.info['chs']:
         ch['ch_name'] += '_virtual'
-
+    evoked.info._update_redundant()
+    evoked.info._check_consistency()
     return evoked
 
 

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -431,6 +431,8 @@ def _prepare_for_forward(src, mri_head_t, info, bem, mindist, n_jobs,
                 dev_head_t=info['dev_head_t'], mri_file=trans, mri_id=mri_id,
                 meas_file=info_extra, meas_id=None, working_dir=os.getcwd(),
                 command_line=cmd, bads=info['bads'], mri_head_t=mri_head_t)
+    info._update_redundant()
+    info._check_consistency()
     logger.info('')
 
     megcoils, compcoils, megnames, meg_info = [], [], [], []

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -317,6 +317,7 @@ def _read_forward_meas_info(tree, fid):
             tag = read_tag(fid, pos)
             chs.append(tag.data)
     info['chs'] = chs
+    info._update_redundant()
 
     #   Get the MRI <-> head coordinate transformation
     tag = find_tag(fid, parent_mri, FIFF.FIFF_COORD_TRANS)

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -38,7 +38,6 @@ class RawArray(_BaseRaw):
         if not isinstance(info, Info):
             raise TypeError('info must be an instance of Info, got %s'
                             % type(info))
-        info._check_consistency()  # make sure it's valid
         dtype = np.complex128 if np.any(np.iscomplex(data)) else np.float64
         data = np.asanyarray(data, dtype=dtype)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2339,8 +2339,8 @@ def _check_update_montage(info, montage, path=None, update_ch_names=False):
 
             # raise error if positions are missing
             if missing_positions:
-                err = ("The following positions are missing from the montage "
-                       "definitions: %s. If those channels lack positions "
-                       "because they are EOG channels use the eog parameter."
-                       % str(missing_positions))
-                raise KeyError(err)
+                raise KeyError(
+                    "The following positions are missing from the montage "
+                    "definitions: %s. If those channels lack positions "
+                    "because they are EOG channels use the eog parameter."
+                    % str(missing_positions))

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -462,6 +462,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
 
     # for stim channel
     mrk_fname = os.path.join(path, cfg.get('Common Infos', 'MarkerFile'))
+    info._update_redundant()
     info._check_consistency()
     return info, fmt, order, mrk_fname, montage
 

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1301,6 +1301,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
              'the 4D "print_table" routine.')
 
     # check that the info is complete
+    info._update_redundant()
     info._check_consistency()
     return info, bti_info
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -249,7 +249,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc):
     info.update(filename=input_fname, meas_date=np.array([meas_date, 0]),
                 description=str(session_label), buffer_size_sec=10., bads=bads,
                 subject_info=subject_info, chs=chs)
-    info._check_consistency()
+    info._update_redundant()
     return info, cnt_info
 
 

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -410,5 +410,5 @@ def _compose_meas_info(res4, coils, trans, eeg):
         eeg = _pick_eeg_pos(info)
     _add_eeg_pos(eeg, trans, info)
     logger.info('    Measurement info composed.')
-    info._check_consistency()
+    info._update_redundant()
     return info

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -464,7 +464,7 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, eog, misc, preload):
     if stim_channel is not None and not (annot and annotmap) and \
             tal_channel is None and n_samps[stim_channel] != int(max_samp):
         warn('Interpolating stim channel. Events may jitter.')
-
+    info._update_redundant()
     return info, edf_info
 
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -102,7 +102,6 @@ def _get_info(eeg, montage, eog=()):
         if ch['ch_name'] in eog or idx in eog:
             ch['coil_type'] = FIFF.FIFFV_COIL_NONE
             ch['kind'] = FIFF.FIFFV_EOG_CH
-
     return info
 
 
@@ -308,6 +307,7 @@ class RawEEGLAB(_BaseRaw):
                          loc=np.zeros(12), unit=FIFF.FIFF_UNIT_NONE,
                          unit_mul=0., coord_frame=FIFF.FIFFV_COORD_UNKNOWN)
         info['chs'].append(stim_chan)
+        info._update_redundant()
 
         events = _read_eeglab_events(eeg, event_id=event_id,
                                      event_id_func=event_id_func)

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -267,6 +267,7 @@ class RawEGI(_BaseRaw):
                              'coil_type': FIFF.FIFFV_COIL_NONE,
                              'unit': FIFF.FIFF_UNIT_NONE})
         info['chs'] = chs
+        info._update_redundant()
         _check_update_montage(info, montage)
         super(RawEGI, self).__init__(
             info, preload, orig_format=egi_info['orig_format'],

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -208,6 +208,7 @@ class RawKIT(_BaseRaw):
             chan_info['loc'] = np.zeros(12)
             chan_info['kind'] = FIFF.FIFFV_STIM_CH
             info['chs'].append(chan_info)
+            info._update_redundant()
         if self.preload:
             err = "Can't change stim channel after preloading data"
             raise NotImplementedError(err)
@@ -734,7 +735,7 @@ def get_kit_info(rawfile):
             chan_info['loc'] = np.zeros(12)
             chan_info['kind'] = FIFF.FIFFV_MISC_CH
             info['chs'].append(chan_info)
-
+    info._update_redundant()
     return info, sqd
 
 

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -121,7 +121,7 @@ def _get_nicolet_info(fname, ch_type, eog, ecg, emg, misc):
                               misc)
     info['highpass'] = 0.
     info['lowpass'] = info['sfreq'] / 2.0
-
+    info._update_redundant()
     return info, header_info
 
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -359,6 +359,7 @@ def pick_info(info, sel=[], copy=True):
         raise ValueError('No channels match the selection.')
 
     info['chs'] = [info['chs'][k] for k in sel]
+    info._update_redundant()
     info['bads'] = [ch for ch in info['bads'] if ch in info['ch_names']]
 
     comps = deepcopy(info['comps'])
@@ -372,7 +373,7 @@ def pick_info(info, sel=[], copy=True):
         c['data']['row_names'] = row_names
         c['data']['data'] = c['data']['data'][row_idx]
     info['comps'] = comps
-
+    info._check_consistency()
     return info
 
 
@@ -493,6 +494,7 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
 
     # Pick the appropriate channel names from the info-dict using sel_info
     fwd['info']['chs'] = [fwd['info']['chs'][k] for k in sel_info]
+    fwd['info']._update_redundant()
     fwd['info']['bads'] = [b for b in fwd['info']['bads'] if b in ch_names]
 
     if fwd['sol_grad'] is not None:
@@ -649,8 +651,8 @@ def _check_excludes_includes(chs, info=None, allow_bads=False):
         Channels to be excluded/excluded. If allow_bads, and chs=="bads",
         this will be the bad channels found in 'info'.
     """
-    from .meas_info import Info, _ChannelNameList
-    if not isinstance(chs, (list, tuple, np.ndarray, _ChannelNameList)):
+    from .meas_info import Info
+    if not isinstance(chs, (list, tuple, np.ndarray)):
         if allow_bads is True:
             if not isinstance(info, Info):
                 raise ValueError('Supply an info object if allow_bads is true')

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -198,9 +198,10 @@ def add_reference_channels(inst, ref_channels, copy=True):
                      'coord_frame': FIFF.FIFFV_COORD_HEAD,
                      'loc': np.zeros(12)}
         inst.info['chs'].append(chan_info)
+        inst.info._update_redundant()
     if isinstance(inst, _BaseRaw):
         inst._cals = np.hstack((inst._cals, [1] * len(ref_channels)))
-
+    inst.info._check_consistency()
     return inst
 
 
@@ -377,6 +378,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info['chs'][an_idx] = info
         inst.info['chs'][an_idx]['ch_name'] = name
         logger.info('Bipolar channel added as "%s".' % name)
+    inst.info._update_redundant()
 
     # Drop cathode channels
     inst.drop_channels(cathode)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -143,44 +143,22 @@ def test_info():
     assert_equal(info['nchan'], nchan)
     assert_equal(list(info['ch_names']), ch_names)
 
-    def _assignment_to_nchan(info):
-        info['nchan'] = 42
-    assert_raises(ValueError, _assignment_to_nchan, info)
-
-    def _assignment_to_ch_names(info):
-        info['ch_names'] = ['foo', 'bar']
-    assert_raises(ValueError, _assignment_to_ch_names, info)
-
-    def _del_nchan(info):
-        del info['nchan']
-    assert_raises(ValueError, _del_nchan, info)
-
-    def _del_ch_names(info):
-        del info['ch_names']
-    assert_raises(ValueError, _del_ch_names, info)
-
     # Deleting of regular fields should work
     info['foo'] = 'bar'
     del info['foo']
 
-    # Passing read only fields to the constructor
-    assert_raises(ValueError, Info, nchan=42)
-    assert_raises(ValueError, Info, ch_names=['foo', 'bar'])
-
-    # Test automatic updating of read-only fields
+    # Test updating of fields
     del info['chs'][-1]
+    info._update_redundant()
     assert_equal(info['nchan'], nchan - 1)
     assert_equal(list(info['ch_names']), ch_names[:-1])
 
     info['chs'][0]['ch_name'] = 'foo'
+    info._update_redundant()
     assert_equal(info['ch_names'][0], 'foo')
 
     # Test casting to and from a dict
     info_dict = dict(info)
-    info2 = Info(info_dict)
-    assert_equal(info, info2)
-
-    info_dict = info.to_dict()
     info2 = Info(info_dict)
     assert_equal(info, info2)
 
@@ -260,8 +238,8 @@ def test_make_dig_points():
                   dig_points[:, :2])
 
 
-def test_channel_name_list():
-    """Test the _ChannelNamesList object"""
+def test_redundant():
+    """Test some of the redundant properties of info"""
     # Indexing
     info = create_info(ch_names=['a', 'b', 'c'], sfreq=1000., ch_types=None)
     assert_equal(info['ch_names'][0], 'a')
@@ -278,29 +256,6 @@ def test_channel_name_list():
 
     # List should be read-only
     info = create_info(ch_names=['a', 'b', 'c'], sfreq=1000., ch_types=None)
-
-    def _test_assignment():
-        info['ch_names'][0] = 'foo'
-    assert_raises(RuntimeError, _test_assignment)
-
-    def _test_concatenation():
-        info['ch_names'] += ['foo']
-    assert_raises(RuntimeError, _test_concatenation)
-
-    def _test_appending():
-        info['ch_names'].append('foo')
-    assert_raises(RuntimeError, _test_appending)
-
-    def _test_removal():
-        del info['ch_names'][0]
-    assert_raises(AttributeError, _test_removal)
-
-    # Concatenation
-    assert_equal(info['ch_names'] + ['d'], ['a', 'b', 'c', 'd'])
-
-    # Representation
-    assert_equal(repr(info['ch_names']),
-                 "<ChannelNameList | 3 channels | a, b, c>")
 
 
 def test_merge_info():

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -227,6 +227,8 @@ def test_inverse_operator_channel_ordering():
     randomiser.shuffle(new_order)
     evoked.data = evoked.data[new_order]
     evoked.info['chs'] = [evoked.info['chs'][n] for n in new_order]
+    evoked.info._update_redundant()
+    evoked.info._check_consistency()
 
     cov_ch_reorder = [c for c in evoked.info['ch_names']
                       if (c in noise_cov.ch_names)]

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -750,6 +750,8 @@ class ICA(ContainsMixin):
                         add_channels]
         info['bads'] = [ch_names[k] for k in self.exclude]
         info['projs'] = []  # make sure projections are removed.
+        info._update_redundant()
+        info._check_consistency()
 
     @verbose
     def score_sources(self, inst, target=None, score_func='pearsonr',

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -655,6 +655,7 @@ def _copy_preload_add_channels(raw, add_channels):
                  cal=1e-4, coil_type=FIFF.FWD_COIL_UNKNOWN, loc=np.zeros(12))
             for ii in range(len(kinds))]
         raw.info['chs'].extend(chpi_chs)
+        raw.info._update_redundant()
         raw.info._check_consistency()
         assert raw._data.shape == (raw.info['nchan'], len(raw.times))
         # Return the pos picks

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -197,6 +197,8 @@ class FieldTripClient(object):
                 this_info['unit_mul'] = 0
 
                 info['chs'].append(this_info)
+                info._update_redundant()
+                info._check_consistency()
 
         else:
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1792,6 +1792,7 @@ def test_add_channels_epochs():
                   [epochs_meg, epochs_eeg[:2]])
 
     epochs_meg.info['chs'].pop(0)
+    epochs_meg.info._update_redundant()
     assert_raises(RuntimeError, add_channels_epochs,
                   [epochs_meg, epochs_eeg])
 
@@ -1807,6 +1808,7 @@ def test_add_channels_epochs():
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['chs'][1]['ch_name'] = epochs_meg2.info['ch_names'][0]
+    epochs_meg2.info._update_redundant()
     assert_raises(RuntimeError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1063,7 +1063,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
 def _prepare_write_tfr(tfr, condition):
     """Aux function"""
     return (condition, dict(times=tfr.times, freqs=tfr.freqs,
-                            data=tfr.data, info=tfr.info.to_dict(),
+                            data=tfr.data, info=tfr.info,
                             nave=tfr.nave, comment=tfr.comment,
                             method=tfr.method))
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -61,7 +61,8 @@ def _update_raw_data(params):
         data[di] /= params['scalings'][params['types'][di]]
         # stim channels should be hard limited
         if params['types'][di] == 'stim':
-            data[di] /= float(max(data[di]))
+            norm = float(max(data[di]))
+            data[di] /= norm if norm > 0 else 1.
     # clip
     if params['clipping'] == 'transparent':
         data[np.logical_or(data > 1, data < -1)] = np.nan

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -57,8 +57,9 @@ def _get_epochs():
     # Use a subset of channels for plotting speed
     picks = picks[np.round(np.linspace(0, len(picks) - 1, n_chan)).astype(int)]
     picks[0] = 2  # make sure we have a magnetometer
-    epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+    with warnings.catch_warnings(record=True):  # proj
+        epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
+                        baseline=(None, 0))
     epochs.info['bads'] = [epochs.ch_names[-1]]
     return epochs
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -56,7 +56,7 @@ def _get_epochs():
     picks = _get_picks(raw)
     with warnings.catch_warnings(record=True):  # bad proj
         epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0))
+                        baseline=(None, 0), verbose='error')
     return epochs
 
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -520,6 +520,8 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
             chs.append(ch)
         info['chs'] = chs
         info['bads'] = list()  # bads dropped on pair_grad_sensors
+        info._update_redundant()
+        info._check_consistency()
         new_picks = list()
         for e in evoked:
             data = _merge_grad_data(e.data[picks]) * scalings['grad']

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -41,6 +41,8 @@ def _prepare_topo_plot(inst, ch_type, layout):
     clean_ch_names = _clean_names(info['ch_names'])
     for ii, this_ch in enumerate(info['chs']):
         this_ch['ch_name'] = clean_ch_names[ii]
+    info._update_redundant()
+    info._check_consistency()
 
     # special case for merging grad channels
     if (ch_type == 'grad' and FIFF.FIFFV_COIL_VV_PLANAR_T1 in


### PR DESCRIPTION
Resets us to using `dict` subclass for `Info` for 0.12 before we tackle #2860 for 0.13 (or later).

Ready for review/merge from my end.