### PR TITLE
MRG: Move Info to mne namespace

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -39,8 +39,8 @@ Classes
    BiHemiLabel
    Transform
    Report
-   io.Info
-   io.Projection
+   Info
+   Projection
    preprocessing.ICA
    decoding.CSP
    decoding.Scaler

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -90,7 +90,7 @@ BUG
 
     - Fix ``info['lowpass']`` value for downsampled raw data by `Eric Larson`_
 
-    - Remove measurement date from :class:`mne.io.Info` in :func:`mne.io.Raw.anonymize` by `Eric Larson`_
+    - Remove measurement date from :class:`mne.Info` in :func:`mne.io.Raw.anonymize` by `Eric Larson`_
 
     - Fix bug that caused synthetic ecg channel creation even if channel was specified for ECG peak detection in :func:`mne.preprocessing.create_ecg_epochs` by `Jaakko Leppakangas`_
 
@@ -143,7 +143,7 @@ API
 
     - CTF data reader now reads EEG locations from .pos file as HPI points by `Jaakko Leppakangas`_
 
-    - Subselecting channels can now emit a warning if many channels have been subselected from projection vectors. We recommend only computing projection vertors for and applying projectors to channels that will be used in the final analysis. However, after picking a subset of channels, projection vectors can be renormalized with :func:`mne.io.Info.normalize_proj` if necessary to avoid warnings about subselection. Changes by `Eric Larson`_ and `Alex Gramfort`_.
+    - Subselecting channels can now emit a warning if many channels have been subselected from projection vectors. We recommend only computing projection vertors for and applying projectors to channels that will be used in the final analysis. However, after picking a subset of channels, projection vectors can be renormalized with :func:`mne.Info.normalize_proj` if necessary to avoid warnings about subselection. Changes by `Eric Larson`_ and `Alex Gramfort`_.
 
 .. _changes_0_11:
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -29,7 +29,8 @@ from .io.pick import (pick_types, pick_channels,
                       pick_channels_evoked, pick_info)
 from .io.base import concatenate_raws
 from .chpi import get_chpi_positions
-from .io.meas_info import create_info
+from .io.meas_info import create_info, Info
+from .io.proj import Projection
 from .io.kit import read_epochs_kit
 from .io.eeglab import read_epochs_eeglab
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -706,7 +706,7 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
         If float, compute spherical shells for EEG using the given radius.
         If 'auto', estimate an approriate radius from the dig points in Info,
         If None, exclude shells.
-    info : instance of mne.io.meas_info.Info | None
+    info : instance of Info | None
         Measurement info. Only needed if ``r0`` or ``head_radius`` are
         ``'auto'``.
     relative_radii : array-like
@@ -808,7 +808,7 @@ def fit_sphere_to_headshape(info, dig_kinds='auto', units=None, verbose=None):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         Measurement info.
     dig_kinds : list of str | str
         Kind of digitization points to use in the fitting. These can be any

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -55,7 +55,7 @@ def _contains_ch_type(info, ch_type):
 
     Parameters
     ---------
-    info : instance of mne.io.Info
+    info : instance of Info
         The measurement information.
     ch_type : str
         the channel type to be checked for

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -215,7 +215,7 @@ def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads'):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         Measurement info (e.g., raw.info).
     radius : float
         Viewport radius as a fraction of main figure height. Defaults to 0.5.
@@ -290,7 +290,7 @@ def make_grid_layout(info, picks=None, n_col=None):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info | None
+    info : instance of Info | None
         Measurement info (e.g., raw.info). If None, default names will be
         employed.
     picks : array-like of int | None
@@ -365,7 +365,7 @@ def find_layout(info, ch_type=None, exclude='bads'):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     ch_type : {'mag', 'grad', 'meg', 'eeg'} | None
         The channel type for selecting single channel layouts.
@@ -554,7 +554,7 @@ def _find_topomap_coords(info, picks, layout=None):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         Measurement info.
     picks : list of int
         Channel indices to generate topomap coords for.
@@ -589,7 +589,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     picks : list of int
         The channel indices to generate topomap coords for.
@@ -710,7 +710,7 @@ def _pair_grad_sensors(info, layout=None, topomap_coords=True, exclude='bads'):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         An info dictionary containing channel information.
     layout : Layout | None
         The layout if available. Defaults to None.

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -301,7 +301,7 @@ def make_ad_hoc_cov(info, verbose=None):
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         Measurement info.
     verbose : bool, str, int, or None (default None)
         If not None, override default verbose level (see mne.verbose).
@@ -1886,7 +1886,7 @@ def _estimate_rank_meeg_signals(data, info, scalings, tol='auto',
     ----------
     data : np.ndarray of float, shape(n_channels, n_samples)
         The M/EEG signals.
-    info : mne.io.measurement_info.Info
+    info : Info
         The measurment info.
     scalings : dict | 'norm' | np.ndarray | None
         The rescaling method to be applied. If dict, it will override the
@@ -1935,7 +1935,7 @@ def _estimate_rank_meeg_cov(data, info, scalings, tol='auto',
     ----------
     data : np.ndarray of float, shape (n_channels, n_channels)
         The M/EEG covariance.
-    info : mne.io.measurement_info.Info
+    info : Info
         The measurment info.
     scalings : dict | 'norm' | np.ndarray | None
         The rescaling method to be applied. If dict, it will override the

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -250,7 +250,7 @@ class DipoleFixed(object):
 
     Parameters
     ----------
-    info : instance of io.Info
+    info : instance of Info
         The measurement info.
     data : array, shape (n_channels, n_times)
         The dipole data.

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -111,9 +111,9 @@ def _map_meg_channels(info_from, info_to, mode='fast', origin=(0., 0., 0.04)):
 
     Parameters
     ----------
-    info_from : mne.io.MeasInfo
+    info_from : instance of Info
         The measurement data to interpolate from.
-    info_to : mne.io.MeasInfo
+    info_to : instance of Info
         The measurement info to interpolate to.
     mode : str
         Either `'accurate'` or `'fast'`, determines the quality of the
@@ -222,7 +222,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
 
     Parameters
     ----------
-    info : instance of io.meas_info.Info
+    info : instance of Info
         Measurement info.
     surf : dict
         The surface to map the data to. The required fields are `'rr'`,

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -274,7 +274,7 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
         Information for each prepped MEG coil
     megnames : list of str
         Name of each prepped MEG coil
-    meginfo : Info
+    meginfo : instance of Info
         Information subselected for just the set of MEG coils
     """
 
@@ -489,7 +489,7 @@ def make_forward_solution(info, trans, src, bem, fname=None, meg=True,
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info | str
+    info : instance of mne.Info | str
         If str, then it should be a filename to a Raw, Epochs, or Evoked
         file with measurement information. If dict, should be an info
         dict (such as one from Raw, Epochs, or Evoked).

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -280,7 +280,7 @@ def _read_forward_meas_info(tree, fid):
 
     Returns
     -------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     """
     # This function assumes fid is being used as a context manager
@@ -862,7 +862,7 @@ def write_forward_meas_info(fid, info):
     ----------
     fid : file id
         The file id
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     """
     info._check_consistency()
@@ -1131,7 +1131,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None,
         Forward operator to use. Has to be fixed-orientation.
     stc : SourceEstimate
         The source estimate from which the sensor space data is computed.
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         Measurement info to generate the evoked.
     start : int, optional
         Index of first time sample (index not time is seconds).
@@ -1191,7 +1191,7 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
         Forward operator to use. Has to be fixed-orientation.
     stc : SourceEstimate
         The source estimate from which the sensor space data is computed.
-    info : Instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     start : int, optional
         Index of first time sample (index not time is seconds).

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -672,8 +672,8 @@ def read_info(fname, verbose=None):
 
     Returns
     -------
-    info : instance of mne.io.meas_info.Info
-       Info on dataset.
+    info : instance of Info
+       Measurement information for the dataset.
     """
     f, tree, _ = fiff_open(fname)
     with f as fid:
@@ -727,7 +727,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
 
     Returns
     -------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
        Info on dataset.
     meas : dict
         Node in tree that contains the info.
@@ -1111,7 +1111,7 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
     ----------
     fid : file
         Open file descriptor.
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info structure.
     data_type : int
         The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
@@ -1327,7 +1327,7 @@ def write_info(fname, info, data_type=None, reset_range=True):
     ----------
     fname : str
         The name of the file. Should end by -info.fif.
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info structure
     data_type : int
         The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -182,7 +182,7 @@ class ICA(ContainsMixin):
         .exclude attribute. When saving the ICA also the indices are restored.
         Hence, artifact components once identified don't have to be added
         again. To dump this 'artifact memory' say: ica.exclude = []
-    info : None | instance of mne.io.meas_info.Info
+    info : None | instance of Info
         The measurement info copied from the object fitted.
     `n_samples_` : int
         the number of samples used on fit.

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -105,7 +105,7 @@ def get_meg_helmet_surf(info, trans=None, verbose=None):
 
     Parameters
     ----------
-    info : instance of io.meas_info.Info
+    info : instance of Info
         Measurement info.
     trans : dict
         The head<->MRI transformation, usually obtained using

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -297,7 +297,7 @@ def test_io():
     tfr3 = read_tfrs(fname, condition='test-A')
     assert_equal(tfr.comment, tfr3.comment)
 
-    assert_true(isinstance(tfr.info, io.meas_info.Info))
+    assert_true(isinstance(tfr.info, mne.Info))
 
     tfrs = read_tfrs(fname, condition=None)
     assert_equal(len(tfrs), 2)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -38,7 +38,7 @@ def iter_topography(info, layout=None, on_pick=None, fig=None,
 
     Parameters
     ----------
-    info : instance of mne.io.meas_info.Info
+    info : instance of Info
         The measurement info.
     layout : instance of mne.layout.Layout | None
         The layout to use. If None, layout will be guessed

--- a/tutorials/plot_creating_data_structures.py
+++ b/tutorials/plot_creating_data_structures.py
@@ -13,13 +13,13 @@ import numpy as np
 
 ###############################################################################
 # ------------------------------------------------------
-# Creating :class:`Info <mne.io.Info>` objects
+# Creating :class:`Info <mne.Info>` objects
 # ------------------------------------------------------
 #
 # .. note:: for full documentation on the `Info` object, see
 #           :ref:`tut_info_objects`.
 #
-# Normally, :class:`mne.io.Info` objects are created by the various
+# Normally, :class:`mne.Info` objects are created by the various
 # :ref:`data import functions <ch_convert>`.
 # However, if you wish to create one from scratch, you can use the
 # :func:`mne.create_info` function to initialize the minimally required
@@ -62,7 +62,7 @@ print(info)
 
 ###############################################################################
 # .. note:: When assigning new values to the fields of an
-#           :class:`mne.io.Info` object, it is important that the
+#           :class:`mne.Info` object, it is important that the
 #           fields are consistent:
 #
 #           - The length of the channel information field `chs` must be
@@ -78,7 +78,7 @@ print(info)
 # To create a :class:`mne.io.Raw` object from scratch, you can use the
 # :class:`mne.io.RawArray` class, which implements raw data that is backed by a
 # numpy array.  Its constructor simply takes the data matrix and
-# :class:`mne.io.Info` object:
+# :class:`mne.Info` object:
 
 # Generate some random data
 data = np.random.randn(5, 1000)

--- a/tutorials/plot_info.py
+++ b/tutorials/plot_info.py
@@ -1,7 +1,7 @@
 """
 .. _tut_info_objects:
 
-The :class:`Info <mne.io.Info>` data structure
+The :class:`Info <mne.Info>` data structure
 ==============================================
 """
 
@@ -11,7 +11,7 @@ import mne
 import os.path as op
 
 ###############################################################################
-# The :class:`Info <mne.io.Info>` data object is typically created
+# The :class:`Info <mne.Info>` data object is typically created
 # when data is imported into MNE-Python and contains details such as:
 #
 #  - date, subject information, and other recording details
@@ -20,7 +20,7 @@ import os.path as op
 #  - digitized points
 #  - sensor–head coordinate transformation matrices
 #
-# and so forth. See the :class:`the API reference <mne.io.Info>`
+# and so forth. See the :class:`the API reference <mne.Info>`
 # for a complete list of all data fields. Once created, this object is passed
 # around throughout the data analysis pipeline.
 #
@@ -48,7 +48,7 @@ print(info['chs'][0])
 # -----------------------------
 #
 # There are a number of convenience functions to obtain channel indices, given
-# an :class:`mne.io.Info` object.
+# an :class:`mne.Info` object.
 
 ###############################################################################
 # Get channel indices by name

--- a/tutorials/plot_object_epochs.py
+++ b/tutorials/plot_object_epochs.py
@@ -59,7 +59,7 @@ print(epochs)
 
 ###############################################################################
 # Epochs behave similarly to :class:`mne.io.Raw` objects. They have an
-# :class:`info <mne.io.Info>` attribute that has all of the same
+# :class:`info <mne.Info>` attribute that has all of the same
 # information, as well as a number of attributes unique to the events contained
 # within the object.
 

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -30,7 +30,7 @@ print(evoked)
 
 ###############################################################################
 # If you're gone through the tutorials of raw and epochs datasets, you're
-# probably already familiar with the :class:`Info <mne.io.Info>` attribute.
+# probably already familiar with the :class:`Info <mne.Info>` attribute.
 # There is nothing new or special with the ``evoked.info``. All the relevant
 # info is still there.
 print(evoked.info)

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -14,7 +14,7 @@ from matplotlib import pyplot as plt
 ###############################################################################
 # Continuous data is stored in objects of type :class:`Raw <mne.io.RawFIF>`.
 # The core data structure is simply a 2D numpy array (channels × samples,
-# `._data`) combined with an :class:`Info <mne.io.Info>` object
+# `._data`) combined with an :class:`Info <mne.Info>` object
 # (`.info`) (:ref:`tut_info_objects`.
 #
 # The most common way to load continuous data is from a .fif file. For more
@@ -38,7 +38,7 @@ print('channels x samples:', raw._data.shape)
 
 ###############################################################################
 # Information about the channels contained in the :class:`Raw <mne.io.RawFIF>`
-# object is contained in the :class:`Info <mne.io.Info>` attribute.
+# object is contained in the :class:`Info <mne.Info>` attribute.
 # This is essentially a dictionary with a number of relevant fields (see
 # :ref:`tut_info_objects`).
 
@@ -121,7 +121,7 @@ print('Number of channels reduced from', raw.info['nchan'], 'to',
 # :class:`Raw <mne.io.RawFIF>` objects can be concatenated in time by using the
 # :func:`append <mne.io.RawFIF.append>` function. For this to work, they must
 # have the same number of channels and their :class:`Info
-# <mne.io.Info>` structures should be compatible.
+# <mne.Info>` structures should be compatible.
 
 # Create multiple :class:`Raw <mne.io.RawFIF>` objects
 raw1 = raw.copy().crop(0, 10)


### PR DESCRIPTION
Closes #3149.

95% docstring changes. Now that we have a tutorial for `mne.io.Info` and it's not only for raw io, it makes more sense to have it in the `mne` namespace.