### PR TITLE
temp file filename in do_forward_solution

### DIFF
--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1461,7 +1461,7 @@ def do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
         raise ValueError('meas must be string, Raw, Epochs, or Evoked')
 
     if meas_data is not None:
-        meas = op.join(temp_dir, 'evoked.fif')
+        meas = op.join(temp_dir, 'evoked-ave.fif')
         write_evokeds(meas, meas_data)
 
     # deal with trans/mri


### PR DESCRIPTION
Currently, calling do_forward_solution with a raw or epochs inst will raise a warning:
```
RuntimeWarning: This filename (/tmp/tmpcku0pbm5/evoked.fif) does not conform to MNE naming conventions. All evoked files should end with -ave.fif or -ave.fif.gz
```

This changes the name for the default evoked file accordingly.