### PR TITLE
MRG: Allow use of layer-free model in MEG dipole fitting

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -736,7 +736,15 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
             if param != 'auto':
                 raise ValueError('%s, if str, must be "auto" not "%s"'
                                  % (name, param))
-
+    relative_radii = np.array(relative_radii, float).ravel()
+    sigmas = np.array(sigmas, float).ravel()
+    if len(relative_radii) != len(sigmas):
+        raise ValueError('relative_radii length (%s) must match that of '
+                         'sigmas (%s)' % (len(relative_radii),
+                                          len(sigmas)))
+    if len(sigmas) == 0 and head_radius is not None:
+            raise ValueError('sigmas must be supplied if head_radius is not '
+                             'None')
     if (isinstance(r0, string_types) and r0 == 'auto') or \
        (isinstance(head_radius, string_types) and head_radius == 'auto'):
         if info is None:
@@ -786,7 +794,7 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
                            sphere['lambda'][k]))
         logger.info('Set up EEG sphere model with scalp radius %7.1f mm\n'
                     % (1000 * head_radius,))
-    return ConductorModel(sphere)
+    return sphere
 
 
 # #############################################################################

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -419,6 +419,7 @@ def _make_guesses(surf_or_rad, r0, grid, exclude, mindist, n_jobs):
                        _coord_frame_name(surf['coord_frame'])))
     else:
         radius = surf_or_rad[0]
+        radius = 0.1 if not np.isfinite(radius) else radius
         logger.info('Making a spherical guess space with radius %7.1f mm...'
                     % (1000 * radius))
         surf = _get_ico_surface(3)
@@ -820,7 +821,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         r0 = bem['r0']
         logger.info('Sphere model      : origin at (% 7.2f % 7.2f % 7.2f) mm'
                     % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2]))
-        if 'layers' in bem:
+        if len(bem.get('layers', [])) > 0:
             R = bem['layers'][0]['rad']
         else:
             R = np.inf

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -830,7 +830,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
             if len(R) == 0:
                 raise RuntimeError('No MEG channels found, but MEG-only '
                                    'sphere model used')
-            R = np.min(np.linalg.norm(R, axis=1))  # use dist to sensors
+            R = np.min(np.sqrt(np.sum(R * R, axis=1)))  # use dist to sensors
             kind = 'max_rad'
         logger.info('Sphere model      : origin at (% 7.2f % 7.2f % 7.2f) mm, '
                     '%s = %6.1f mm'

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -419,7 +419,6 @@ def _make_guesses(surf_or_rad, r0, grid, exclude, mindist, n_jobs):
                        _coord_frame_name(surf['coord_frame'])))
     else:
         radius = surf_or_rad[0]
-        radius = 0.1 if not np.isfinite(radius) else radius
         logger.info('Making a spherical guess space with radius %7.1f mm...'
                     % (1000 * radius))
         surf = _get_ico_surface(3)
@@ -819,12 +818,23 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
                     % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2], 1000 * R))
     else:
         r0 = bem['r0']
-        logger.info('Sphere model      : origin at (% 7.2f % 7.2f % 7.2f) mm'
-                    % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2]))
         if len(bem.get('layers', [])) > 0:
             R = bem['layers'][0]['rad']
-        else:
-            R = np.inf
+            kind = 'rad'
+        else:  # MEG-only
+            # Use the minimum distance to the MEG sensors as the radius then
+            R = np.dot(linalg.inv(info['dev_head_t']['trans']),
+                       np.hstack([r0, [1.]]))[:3]  # r0 -> device
+            R = R - [info['chs'][pick]['loc'][:3]
+                     for pick in pick_types(info, meg=True, exclude=[])]
+            if len(R) == 0:
+                raise RuntimeError('No MEG channels found, but MEG-only '
+                                   'sphere model used')
+            R = np.min(np.linalg.norm(R, axis=1))  # use dist to sensors
+            kind = 'max_rad'
+        logger.info('Sphere model      : origin at (% 7.2f % 7.2f % 7.2f) mm, '
+                    '%s = %6.1f mm'
+                    % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2], kind, R))
         inner_skull = [R, r0]  # NB sphere model defined in head frame
     r0_mri = apply_trans(invert_transform(mri_head_t)['trans'],
                          r0[np.newaxis, :])[0]

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -220,8 +220,9 @@ def _setup_bem(bem, bem_extra, neeg, mri_head_t, verbose=None):
         raise TypeError('bem must be a string or ConductorModel')
     if bem['is_sphere']:
         logger.info('Using the sphere model.\n')
-        if len(bem['layers']) == 0:
-            raise RuntimeError('Spherical model has zero layers')
+        if len(bem['layers']) == 0 and neeg > 0:
+            raise RuntimeError('Spherical model has zero shells, cannot use '
+                               'with EEG data')
         if bem['coord_frame'] != FIFF.FIFFV_COORD_HEAD:
             raise RuntimeError('Spherical model is not in head coordinates')
     else:

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -94,6 +94,10 @@ def test_make_sphere_model():
     info = read_info(fname_raw)
     assert_raises(ValueError, make_sphere_model, 'foo', 'auto', info)
     assert_raises(ValueError, make_sphere_model, 'auto', 'auto', None)
+    assert_raises(ValueError, make_sphere_model, 'auto', 'auto', info,
+                  relative_radii=(), sigmas=())
+    assert_raises(ValueError, make_sphere_model, 'auto', 'auto', info,
+                  relative_radii=(1,))  # wrong number of radii
     # here we just make sure it works -- the functionality is actually
     # tested more extensively e.g. in the forward and dipole code
     bem = make_sphere_model('auto', 'auto', info)


### PR DESCRIPTION
Found a small bug where we couldn't actually use a sphere model with no shells (i.e., just origin) in dipole fitting with MEG data only.

Ready for review/merge from my end.