### PR TITLE
MRG minor tutorials spelling and formatting

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -63,11 +63,11 @@ To get started with MNE, visit the installation instructions for
 What can you do with MNE using Python?
 --------------------------------------
 
-   - **Raw data visualization** to visualize recordings (see
-   :ref:`general_examples` for more).
+   - **Raw data visualization** to visualize recordings
+     (see :ref:`general_examples` for more).
    - **Epoching**: Define epochs, baseline correction, handle conditions etc.
    - **Averaging** to get Evoked data.
-   - **Compute SSP pojectors** to remove ECG and EOG artifacts.
+   - **Compute SSP projectors** to remove ECG and EOG artifacts.
    - **Compute ICA** to remove artifacts or select latent sources.
    - **Maxwell filtering** to remove environmental noise.
    - **Boundary Element Modeling**: single and three-layer BEM model

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -8,8 +8,8 @@ Basic MEG and EEG data processing
 MNE-Python reimplements most of MNE-C's (the original MNE command line utils)
 functionality and offers transparent scripting.
 On top of that it extends MNE-C's functionality considerably
-(customize events, compute contrasts, group statistics, time-frequency analysis,
-EEG-sensor space analyses, etc.) It uses the same files as standard
+(customize events, compute contrasts, group statistics, time-frequency
+analysis, EEG-sensor space analyses, etc.) It uses the same files as standard
 MNE unix commands: no need to convert your files to a new system or database.
 
 What you can do with MNE Python

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -7,11 +7,10 @@ Basic MEG and EEG data processing
 
 MNE-Python reimplements most of MNE-C's (the original MNE command line utils)
 functionality and offers transparent scripting.
-On top of that it extends MNE-C's functionality considerably (customize events,
-compute
-contrasts, group statistics, time-frequency analysis, EEG-sensor space analyses
-, etc.) It uses the same files as standard MNE unix commands:
-no need to convert your files to a new system or database.
+On top of that it extends MNE-C's functionality considerably
+(customize events, compute contrasts, group statistics, time-frequency analysis,
+EEG-sensor space analyses, etc.) It uses the same files as standard
+MNE unix commands: no need to convert your files to a new system or database.
 
 What you can do with MNE Python
 -------------------------------
@@ -20,7 +19,7 @@ What you can do with MNE Python
      *mne_browse_raw* for extended functionality (see :ref:`ch_browse`)
    - **Epoching**: Define epochs, baseline correction, handle conditions etc.
    - **Averaging** to get Evoked data
-   - **Compute SSP pojectors** to remove ECG and EOG artifacts
+   - **Compute SSP projectors** to remove ECG and EOG artifacts
    - **Compute ICA** to remove artifacts or select latent sources.
    - **Maxwell filtering** to remove environmental noise.
    - **Boundary Element Modeling**: single and three-layer BEM model


### PR DESCRIPTION
Currently, tutorials render like this due to brackets:

![screen shot 2016-04-24 at 18 49 29](https://cloud.githubusercontent.com/assets/4321826/14768917/a85698ce-0a4d-11e6-8171-ee78bb16bb1a.png)

Also, fun fact: Po means butt in German.