### PR TITLE
WIP: ica.find_bads_ecg does not pass ch_name to create_ecg_epochs

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -42,9 +42,9 @@ from ..viz.topomap import (_prepare_topo_plot, _check_outlines,
 
 from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
-from ..utils import (check_version, logger, check_fname, verbose,
-                     _reject_data_segments, check_random_state, warn,
-                     _get_fast_dot, compute_corr)
+from ..utils import (check_version, logger, check_fname, verbose, warn,
+                     _reject_data_segments, check_random_state,
+                     _get_fast_dot, compute_corr, _check_copy_dep)
 from ..fixes import _get_args
 from ..filter import band_pass_filter
 from .bads import find_outliers

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -939,7 +939,7 @@ class ICA(ContainsMixin):
                 threshold = 0.25
             if isinstance(inst, _BaseRaw):
                 sources = self.get_sources(create_ecg_epochs(
-                  inst, ch_name, keep_ecg=True)).get_data()
+                    inst, ch_name, keep_ecg=True)).get_data()
             elif isinstance(inst, _BaseEpochs):
                 sources = self.get_sources(inst).get_data()
             else:

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -43,8 +43,8 @@ from ..viz.topomap import (_prepare_topo_plot, _check_outlines,
 from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
-                     _reject_data_segments, check_random_state,
-                     _get_fast_dot, compute_corr, warn)
+                     _reject_data_segments, check_random_state, warn,
+                     _get_fast_dot, compute_corr, _check_copy_dep)
 from ..fixes import _get_args
 from ..filter import band_pass_filter
 from .bads import find_outliers

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -44,7 +44,7 @@ from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state, warn,
-                     _get_fast_dot, compute_corr, _check_copy_dep)
+                     _get_fast_dot, compute_corr)
 from ..fixes import _get_args
 from ..filter import band_pass_filter
 from .bads import find_outliers

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -966,7 +966,7 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'labels_'):
             self.labels_ = dict()
         self.labels_['ecg'] = list(ecg_idx)
-        if ch_name == None:
+        if ch_name is None:
             ch_name = 'ECG-MAG'
         self.labels_['ecg/%s' % ch_name] = list(ecg_idx)
         return self.labels_['ecg'], scores

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -938,7 +938,8 @@ class ICA(ContainsMixin):
             if threshold is None:
                 threshold = 0.25
             if isinstance(inst, _BaseRaw):
-                sources = self.get_sources(create_ecg_epochs(inst)).get_data()
+                sources = self.get_sources(create_ecg_epochs(
+                  inst, ch_name)).get_data()
             elif isinstance(inst, _BaseEpochs):
                 sources = self.get_sources(inst).get_data()
             else:

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -44,7 +44,7 @@ from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state,
-                     _get_fast_dot, compute_corr)
+                     _get_fast_dot, compute_corr, warn)
 from ..fixes import _get_args
 from ..filter import band_pass_filter
 from .bads import find_outliers
@@ -923,7 +923,6 @@ class ICA(ContainsMixin):
             if verbose is not None:
                 verbose = self.verbose
             ecg, times = _make_ecg(inst, start, stop, verbose)
-            ch_name = 'ECG-MAG'
         else:
             ecg = inst.ch_names[idx_ecg]
 
@@ -940,6 +939,9 @@ class ICA(ContainsMixin):
             if isinstance(inst, _BaseRaw):
                 sources = self.get_sources(create_ecg_epochs(
                     inst, ch_name, keep_ecg=True)).get_data()
+                if sources.shape[0] == 0:
+                    warn('No ECG activity detected. Consider changing '
+                         'the input parameters.')
             elif isinstance(inst, _BaseEpochs):
                 sources = self.get_sources(inst).get_data()
             else:
@@ -964,6 +966,8 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'labels_'):
             self.labels_ = dict()
         self.labels_['ecg'] = list(ecg_idx)
+        if ch_name == None:
+            ch_name = 'ECG-MAG'
         self.labels_['ecg/%s' % ch_name] = list(ecg_idx)
         return self.labels_['ecg'], scores
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -939,7 +939,7 @@ class ICA(ContainsMixin):
                 threshold = 0.25
             if isinstance(inst, _BaseRaw):
                 sources = self.get_sources(create_ecg_epochs(
-                  inst, ch_name)).get_data()
+                  inst, ch_name, keep_ecg=True)).get_data()
             elif isinstance(inst, _BaseEpochs):
                 sources = self.get_sources(inst).get_data()
             else:


### PR DESCRIPTION
Currently, if you do something like

`ica.find_bads_ecg(raw, "CUSTOM_ECG_NAME")`

it will internally create ecg_epochs by calling `create_ecg_epochs(inst)`. The problem with this is that if, for some reason, "CUSTOM_ECG_NAME" is not defined properly as the only ECG channel, it will pick the wrong channels, and possibly create bad ecg epochs.
This should in principle be very rare (which is why it's not been discovered so far), but can happen for example with the HCP files.

This change passes the ch_name to the create_ecg_epochs call.

Still needs a test.

@dengemann makes sense?