### PR TITLE
Fix the handling of first_samp in make_fixed_length_events

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -729,8 +729,8 @@ def shift_time_events(events, ids, tshift, sfreq):
     return events
 
 
-def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., 
-                            first_samp=True):
+def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.,
+                             first_samp=True):
     """Make a set of events separated by a fixed duration
 
     Parameters
@@ -758,16 +758,16 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.,
     new_events : array
         The new events.
     """
-    start = raw.time_as_index(start)
+    start = raw.time_as_index(start)[0]
     if stop is not None:
-        stop = raw.time_as_index(stop)
+        stop = raw.time_as_index(stop)[0]
     else:
-        stop = [raw.last_samp + 1]
+        stop = raw.last_samp + 1
     if first_samp:
-        start = start[0] + raw.first_samp
-        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])
+        start = start + raw.first_samp
+        stop = min([stop + raw.first_samp, raw.last_samp + 1])
     else:
-        stop = min([stop[0], len(raw.times)])
+        stop = min([stop, len(raw.times)])
     if not isinstance(id, int):
         raise ValueError('id must be an integer')
     # Make sure we don't go out the end of the file:
@@ -777,7 +777,7 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.,
     n_events = len(ts)
     if n_events == 0:
         raise ValueError('No events produced, check the values of start, '
-                        'stop, and duration')
+                         'stop, and duration')
     events = np.c_[ts, np.zeros(n_events, dtype=int),
                    id * np.ones(n_events, dtype=int)]
     return events

--- a/mne/event.py
+++ b/mne/event.py
@@ -746,9 +746,9 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     duration: float
         The duration to separate events by.
     first_samp: bool
-        If True (default), times will have raw.first_samp added to them,
-        as in :func:`mne.find_events`. This behavior is not desirable if 
-        the returned events will be combined with event times that already 
+        If True (default), times will have raw.first_samp added to them, as
+        in :func:`mne.find_events`. This behavior is not desirable if the 
+        returned events will be combined with event times that already 
         have ``raw.first_samp`` added to them, e.g. event times that come 
         from :func:`mne.find_events`.
 
@@ -758,13 +758,15 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
         The new events.
     """
     start = raw.time_as_index(start)
-    if first_samp:
-        start = start[0] + raw.first_samp
     if stop is not None:
         stop = raw.time_as_index(stop)
-        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])
     else:
-        stop = raw.last_samp + 1
+        stop = raw.last_samp + 1    
+    if first_samp:
+        start = start[0] + raw.first_samp
+        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])  
+    else:
+        stop = min([stop[0], len(raw.times)])
     if not isinstance(id, int):
         raise ValueError('id must be an integer')
     # Make sure we don't go out the end of the file:
@@ -772,6 +774,8 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     # This should be inclusive due to how we generally use start and stop...
     ts = np.arange(start, stop + 1, raw.info['sfreq'] * duration).astype(int)
     n_events = len(ts)
+    if n_events == 0:
+        raise ValueError('No events produced, check the values of start, stop, and duration') 
     events = np.c_[ts, np.zeros(n_events, dtype=int),
                    id * np.ones(n_events, dtype=int)]
     return events

--- a/mne/event.py
+++ b/mne/event.py
@@ -729,7 +729,8 @@ def shift_time_events(events, ids, tshift, sfreq):
     return events
 
 
-def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_samp=True):
+def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., 
+                            first_samp=True):
     """Make a set of events separated by a fixed duration
 
     Parameters
@@ -747,9 +748,9 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
         The duration to separate events by.
     first_samp: bool
         If True (default), times will have raw.first_samp added to them, as
-        in :func:`mne.find_events`. This behavior is not desirable if the 
-        returned events will be combined with event times that already 
-        have ``raw.first_samp`` added to them, e.g. event times that come 
+        in :func:`mne.find_events`. This behavior is not desirable if the
+        returned events will be combined with event times that already
+        have ``raw.first_samp`` added to them, e.g. event times that come
         from :func:`mne.find_events`.
 
     Returns
@@ -761,10 +762,10 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     if stop is not None:
         stop = raw.time_as_index(stop)
     else:
-        stop = [raw.last_samp + 1]    
+        stop = [raw.last_samp + 1]
     if first_samp:
         start = start[0] + raw.first_samp
-        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])  
+        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])
     else:
         stop = min([stop[0], len(raw.times)])
     if not isinstance(id, int):
@@ -775,7 +776,8 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     ts = np.arange(start, stop + 1, raw.info['sfreq'] * duration).astype(int)
     n_events = len(ts)
     if n_events == 0:
-        raise ValueError('No events produced, check the values of start, stop, and duration') 
+        raise ValueError('No events produced, check the values of start, '
+                        'stop, and duration')
     events = np.c_[ts, np.zeros(n_events, dtype=int),
                    id * np.ones(n_events, dtype=int)]
     return events

--- a/mne/event.py
+++ b/mne/event.py
@@ -761,7 +761,7 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     if stop is not None:
         stop = raw.time_as_index(stop)
     else:
-        stop = raw.last_samp + 1    
+        stop = [raw.last_samp + 1]    
     if first_samp:
         start = start[0] + raw.first_samp
         stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])  

--- a/mne/event.py
+++ b/mne/event.py
@@ -729,7 +729,7 @@ def shift_time_events(events, ids, tshift, sfreq):
     return events
 
 
-def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.):
+def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_samp=True):
     """Make a set of events separated by a fixed duration
 
     Parameters
@@ -745,6 +745,11 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.):
         of the recording.
     duration: float
         The duration to separate events by.
+    first_samp: bool
+        If True (default), times will be adjusted for first_samp. The default
+        behavior is desirable if times are arbitrary, as in resting data. Use 
+        False if times are based on events from find_events, as these have already 
+        been adjusted for first_samp.
 
     Returns
     -------
@@ -752,7 +757,8 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.):
         The new events.
     """
     start = raw.time_as_index(start)
-    start = start[0] + raw.first_samp
+    if first_samp:
+        start = start[0] + raw.first_samp
     if stop is not None:
         stop = raw.time_as_index(stop)
         stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])

--- a/mne/event.py
+++ b/mne/event.py
@@ -746,10 +746,11 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     duration: float
         The duration to separate events by.
     first_samp: bool
-        If True (default), times will be adjusted for first_samp. The default
-        behavior is desirable if times are arbitrary, as in resting data. Use 
-        False if times are based on events from find_events, as these have already 
-        been adjusted for first_samp.
+        If True (default), times will have raw.first_samp added to them,
+        as in :func:`mne.find_events`. This behavior is not desirable if 
+        the returned events will be combined with event times that already 
+        have ``raw.first_samp`` added to them, e.g. event times that come 
+        from :func:`mne.find_events`.
 
     Returns
     -------


### PR DESCRIPTION
Addresses issue #3160 to make the handling of first_samp explicit in make_fixed_length_events. 