### PR TITLE
[MRG] Fix to info merging.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -117,6 +117,8 @@ BUG
 
     - Fix bug in source normal adjustment that occurred when 1) patch information is available (e.g., when distances have been calculated) and 2) points are excluded from the source space (by inner skull distance) by `Eric Larson`_
 
+    - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
+
 API
 ~~~
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1195,8 +1195,12 @@ def _is_equal_dict(dicts):
     is_equal = []
     for d in tests:
         k0, v0 = d[0]
-        is_equal.append(all(np.all(k == k0) and
-                        np.all(v == v0) for k, v in d))
+        if isinstance(v0, list) and isinstance(v0[0], dict):
+            for k, v in d:
+                is_equal.append((k0 == k) and _is_equal_dict(v))
+        else:
+            is_equal.append(all(np.all(k == k0) and
+                            np.all(v == v0) for k, v in d))
     return all(is_equal)
 
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1195,7 +1195,8 @@ def _is_equal_dict(dicts):
     is_equal = []
     for d in tests:
         k0, v0 = d[0]
-        if isinstance(v0, list) and isinstance(v0[0], dict):
+        if (isinstance(v0, (list, np.ndarray)) and len(v0) > 0 and
+                isinstance(v0[0], dict)):
             for k, v in d:
                 is_equal.append((k0 == k) and _is_equal_dict(v))
         else:

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -473,7 +473,8 @@ def test_add_channels():
     """Test evoked splitting / re-appending channel types"""
     evoked = read_evokeds(fname, condition=0)
     evoked.info['buffer_size_sec'] = None
-    hpi_coils = [{'event_bits': np.array([256,   0, 256, 256])},
+    hpi_coils = [{'event_bits': []},
+                 {'event_bits': np.array([256,   0, 256, 256])},
                  {'event_bits': np.array([512,   0, 512, 512])}]
     evoked.info['hpi_subsystem'] = dict(hpi_coils=hpi_coils, ncoil=2)
     evoked_eeg = evoked.pick_types(meg=False, eeg=True, copy=True)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -20,7 +20,8 @@ from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
 from mne.evoked import _get_peak, Evoked, EvokedArray
 from mne.epochs import EpochsArray
 from mne.tests.common import assert_naming
-from mne.utils import _TempDir, requires_pandas, slow_test, requires_version
+from mne.utils import (_TempDir, requires_pandas, slow_test, requires_version,
+                       run_tests_if_main)
 from mne.externals.six.moves import cPickle as pickle
 
 warnings.simplefilter('always')
@@ -472,6 +473,9 @@ def test_add_channels():
     """Test evoked splitting / re-appending channel types"""
     evoked = read_evokeds(fname, condition=0)
     evoked.info['buffer_size_sec'] = None
+    hpi_coils = [{'event_bits': np.array([256,   0, 256, 256])},
+                 {'event_bits': np.array([512,   0, 512, 512])}]
+    evoked.info['hpi_subsystem'] = dict(hpi_coils=hpi_coils, ncoil=2)
     evoked_eeg = evoked.pick_types(meg=False, eeg=True, copy=True)
     evoked_meg = evoked.pick_types(meg=True, copy=True)
     evoked_stim = evoked.pick_types(meg=False, stim=True, copy=True)
@@ -495,3 +499,6 @@ def test_add_channels():
     assert_raises(AssertionError, evoked_meg.add_channels, [evoked_eeg])
     assert_raises(ValueError, evoked_meg.add_channels, [evoked_meg])
     assert_raises(AssertionError, evoked_meg.add_channels, evoked_badsf)
+
+
+run_tests_if_main()


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3175
I was able to reproduce the described bug with my own data. The problem occurs when trying to merge infos with list of dicts. In my case it was the hpi info that caused the crash. Fixed by making recursive calls to compare the dicts.
Ready for merge if tests pass.