### PR TITLE
[MRG] Split labels into contiguous regions

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -167,7 +167,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.18', misc='0.1')
+    releases = dict(testing='0.19', misc='0.1')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -211,7 +211,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='1d5da3a809fded1ef5734444ab5bf857',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='f61041e3f3f2ba0def8a2ca71592cc41',
-        testing='f04a4937acb9982695e964126d4c62c6',
+        testing='77b2a435d80adb23cbe7e19144e7bc47'
     )
     folder_origs = dict(  # not listed means None
         misc='mne-misc-data-%s' % releases['misc'],

--- a/mne/label.py
+++ b/mne/label.py
@@ -962,13 +962,12 @@ def _split_label_contig(label_to_split, subject=None, subjects_dir=None):
     surf_path = op.join(subjects_dir, subject, 'surf', surf_fname)
     surface_points, surface_tris = read_surface(surf_path)
 
-    # Get vertices we want to keep
+    # Get vertices we want to keep and compute mesh edges
     verts_arr = label_to_split.vertices
-    # Compute edges on only upper triangle (since edges are binary)
-    edges_all = sparse.triu(mesh_edges(surface_tris), format='csr')
+    edges_all = mesh_edges(surface_tris)
 
     # Subselect rows and cols of vertices that belong to the label
-    select_edges = edges_all[verts_arr].tocsc()[:, verts_arr].tocoo()
+    select_edges = edges_all[verts_arr][:, verts_arr].tocoo()
 
     # Compute connected components and store as lists of vertex numbers
     comp_labels = _get_components(verts_arr, select_edges)

--- a/mne/label.py
+++ b/mne/label.py
@@ -623,16 +623,14 @@ class Label(object):
 
         Notes
         -----
-        If using 'contiguous' split, some small fringe labels may be returned
-        that are close (but not connected) to the large components.  Also,
-        ensure that the label being split is the same resolution as the surface
-        files in `subjects_dir`.
+        If using 'contiguous' split, you must ensure that the label being split
+        uses the same triangular resolution as the surface mesh files in
+        ``subjects_dir`` Also, some small fringe labels may be returned that
+        are close (but not connected) to the large components.
 
-        The spatial split works by finding the label's principal eigen-axis on
-        the spherical surface, projecting all label vertex coordinates onto
-        this axis and dividing them at regular spatial intervals. The
-        'contiguous' split works by finding all connected components with
-        scipy's `connected_components` algorithm.
+        The spatial split finds the label's principal eigen-axis on the
+        spherical surface, projects all label vertex coordinates onto this
+        axis, and divides them at regular spatial intervals.
         """
         if isinstance(parts, string_types) and parts == 'contiguous':
             return _split_label_contig(self, subject, subjects_dir)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -572,12 +572,16 @@ def test_write_labels_to_annot():
                   annot_fname=fnames[0])
 
 
+@slow_test
 @testing.requires_testing_data
 def test_split_label():
     """Test splitting labels"""
     aparc = read_labels_from_annot('fsaverage', 'aparc', 'lh',
                                    regexp='lingual', subjects_dir=subjects_dir)
     lingual = aparc[0]
+
+    # Test input error
+    assert_raises(ValueError, lingual.split, 'bad_input_string')
 
     # split with names
     parts = ('lingual_post', 'lingual_ant')
@@ -610,6 +614,14 @@ def test_split_label():
 
     # check default label name
     assert_equal(antmost.name, "lingual_div40-lh")
+
+    # Apply contiguous splitting to DMN label from parcellation in Yeo, 2011
+    label_DMN = read_label(op.join(subjects_dir, 'fsaverage', 'label',
+                                   'lh.7Networks_7.label'))
+    DMN_sublabels = label_DMN.split(parts='contiguous', subject='fsaverage',
+                                    subjects_dir=subjects_dir)
+    assert_equal([len(label.vertices) for label in DMN_sublabels],
+                 [16181, 7022, 5965, 5300, 823] + [1] * 23)
 
 
 @slow_test

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -572,6 +572,7 @@ def test_write_labels_to_annot():
                   annot_fname=fnames[0])
 
 
+@requires_sklearn
 @testing.requires_testing_data
 def test_split_label():
     """Test splitting labels"""

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -615,10 +615,11 @@ def test_split_label():
     assert_equal(antmost.name, "lingual_div40-lh")
 
     # Apply contiguous splitting to DMN label from parcellation in Yeo, 2011
-    label_DMN = read_label(op.join(subjects_dir, 'fsaverage', 'label',
-                                   'lh.7Networks_7.label'))
-    DMN_sublabels = label_DMN.split(parts='contiguous', subject='fsaverage',
-                                    subjects_dir=subjects_dir)
+    label_default_mode = read_label(op.join(subjects_dir, 'fsaverage', 'label',
+                                            'lh.7Networks_7.label'))
+    DMN_sublabels = label_default_mode.split(parts='contiguous',
+                                             subject='fsaverage',
+                                             subjects_dir=subjects_dir)
     assert_equal([len(label.vertices) for label in DMN_sublabels],
                  [16181, 7022, 5965, 5300, 823] + [1] * 23)
 

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -572,7 +572,6 @@ def test_write_labels_to_annot():
                   annot_fname=fnames[0])
 
 
-@slow_test
 @testing.requires_testing_data
 def test_split_label():
     """Test splitting labels"""


### PR DESCRIPTION
This adds functionality to take a label with non-contiguous regions and split it into its components. 

Example use case: resting state network parcellations [here](https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation_Yeo2011). The individual networks contain multiple components, and they need to be disconnected to more easily compute connectivity between the subparts.

- [x] implement ability to split labels
- [x] add helper function to reuse with existing `split_label` function
- [x] add tests
- [x] figure out how to handle isolated dipoles that end up as size 1 labels