### PR TITLE
MRG: Fix raw cov

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,8 @@ BUG
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
 
+    - Fix bug in :func:`mne.compute_raw_covariance` where rejection by non-data channels (e.g. EOG) was not done properly by `Eric Larson`_.
+
 API
 ~~~
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -18,7 +18,7 @@ from .io.proj import (make_projector, _proj_equal, activate_proj,
                       _needs_eeg_average_ref_proj)
 from .io import fiff_open
 from .io.pick import (pick_types, pick_channels_cov, pick_channels, pick_info,
-                      _picks_by_type)
+                      _picks_by_type, _pick_data_channels)
 
 from .io.constants import FIFF
 from .io.meas_info import read_bad_channels
@@ -401,8 +401,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         are floats that set the minimum acceptable peak-to-peak amplitude.
         If flat is None then no rejection is done.
     picks : array-like of int | None (default None)
-        Indices of channels to include (if None, all channels
-        except bad channels are used).
+        Indices of channels to include (if None, data channels are used).
     method : str | list | None (default 'empirical')
         The method used for covariance estimation.
         See :func:`mne.compute_covariance`.
@@ -464,18 +463,24 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
 
     # don't exclude any bad channels, inverses expect all channels present
     if picks is None:
-        picks = pick_types(raw.info, meg=True, eeg=True, eog=False,
-                           ref_meg=False, exclude=[])
+        # Need to include all channels e.g. if eog rejection is to be used
+        picks = np.arange(raw.info['nchan'])
+        data_mask = np.in1d(
+            picks, _pick_data_channels(raw.info, with_ref_meg=False))
+    else:
+        data_mask = slice(None)
     epochs = Epochs(raw, events, 1, 0, tstep_m1, baseline=None,
                     picks=picks, reject=reject, flat=flat, verbose=False,
                     preload=False, proj=False)
     if isinstance(method, string_types) and method == 'empirical':
         # potentially *much* more memory efficient to do it the iterative way
+        picks = picks[data_mask]
         data = 0
         n_samples = 0
         mu = 0
         # Read data in chunks
         for raw_segment in epochs:
+            raw_segment = raw_segment[data_mask]
             mu += raw_segment.sum(axis=1)
             data += np.dot(raw_segment, raw_segment.T)
             n_samples += raw_segment.shape[1]
@@ -489,6 +494,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         bads = [b for b in raw.info['bads'] if b in ch_names]
         projs = cp.deepcopy(raw.info['projs'])
         return Covariance(data, ch_names, bads, projs, nfree=n_samples)
+    del picks, data_mask
 
     # This makes it equivalent to what we used to do (and do above for
     # empirical mode), treating all epochs as if they were a single long one

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -137,6 +137,13 @@ def test_cov_estimation_on_raw():
             warnings.simplefilter('always')
             cov = compute_raw_covariance(raw_2, method=method)
         assert_true(any('Too few samples' in str(ww.message) for ww in w))
+        # no epochs found due to rejection
+        assert_raises(ValueError, compute_raw_covariance, raw, tstep=None,
+                      method='empirical', reject=dict(eog=200e-6))
+        # but this should work
+        cov = compute_raw_covariance(raw.copy().crop(0, 10., copy=False),
+                                     tstep=None, method=method,
+                                     reject=dict(eog=1000e-6))
 
 
 @slow_test


### PR DESCRIPTION
Found a bug in our raw covariance code. In previous versions (i.e., before my big changes a couple of months ago):

1. Docstring was wrong, it only used data channels (and included bads).

2. It didn't actually do e.g. EOG rejection before even if you supplied the keys. Now it does.

Now in `master` we get an error message if `picks is None` and we reject based on EOG. This makes it still do that rejection, but only compute the covariance for data channels, which I think is the default behavior we want actually.