### PR TITLE
adding basic auto-scaling functionality for raw and epochs classes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,8 @@ Changelog
 
     - Add option for ``first_samp`` in :func:`mne.make_fixed_length_events` by `Jon Houck`_
 
+    - Add ability to auto-scale channel types for `mne.viz.plot_raw` and `mne.viz.plot_epochs` and corresponding object plotting methods by `Chris Holdgraf`_
+
 BUG
 ~~~
 

--- a/examples/io/plot_objects_from_arrays.py
+++ b/examples/io/plot_objects_from_arrays.py
@@ -51,6 +51,11 @@ scalings = {'mag': 2, 'grad': 2}
 raw.plot(n_channels=4, scalings=scalings, title='Data from arrays',
          show=True, block=True)
 
+# It is also possible to auto-compute scalings
+scalings = 'auto'  # Could also pass a dictionary with some value == 'auto'
+raw.plot(n_channels=4, scalings=scalings, title='Auto-scaled Data from arrays',
+         show=True, block=True)
+
 
 ###############################################################################
 # EpochsArray
@@ -66,7 +71,6 @@ events = np.array([[200, 0, event_id],
 epochs_data = np.array([[sin[:700], cos[:700]],
                         [sin[1000:1700], cos[1000:1700]],
                         [sin[1800:2500], cos[1800:2500]]])
-epochs_data *= 1e-12  # Scale to match usual magnetometer amplitudes.
 
 ch_names = ['sin', 'cos']
 ch_types = ['mag', 'mag']
@@ -77,7 +81,7 @@ epochs = mne.EpochsArray(epochs_data, info=info, events=events,
 
 picks = mne.pick_types(info, meg=True, eeg=False, misc=False)
 
-epochs.plot(picks=picks, show=True, block=True)
+epochs.plot(picks=picks, scalings='auto', show=True, block=True)
 
 
 ###############################################################################

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -814,9 +814,17 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Channels to be included. If None only good data channels are used.
             Defaults to None
         scalings : dict | None
-            Scale factors for the traces. If None, defaults to
-            ``dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
-            emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1, chpi=1e-4)``.
+            Scaling factors for the traces. If any fields in scalings are
+            'auto', the scaling factor is set to match the 99.5th percentile of
+            a subset of the corresponding data. If scalings == 'auto', all
+            scalings fields are set to 'auto'. If any fields are 'auto' and
+            data is not preloaded, a subset of epochs up to 100mb will be
+            loaded. If None, defaults to::
+
+                dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
+                     emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1,
+                     chpi=1e-4)
+
         show : bool
             Whether to show the figure or not.
         block : bool

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1404,7 +1404,12 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         event_color : color object
             Color to use for events.
         scalings : dict | None
-            Scale factors for the traces. If None, defaults to::
+            Scaling factors for the traces. If any fields in scalings are
+            'auto', the scaling factor is set to match the 99.5th percentile of
+            a subset of the corresponding data. If scalings == 'auto', all
+            scalings fields are set to 'auto'. If any fields are 'auto' and
+            data is not preloaded, a subset of times up to 100mb will be
+            loaded. If None, defaults to::
 
                 dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
                      emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -365,8 +365,12 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
     picks : array-like of int | None
         Channels to be included. If None only good data channels are used.
         Defaults to None
-    scalings : dict | None
-        Scale factors for the traces. If None, defaults to::
+    scalings : dict | 'auto' | None
+        Scaling factors for the traces. If any fields in scalings are 'auto',
+        the scaling factor is set to match the 99.5th percentile of a subset of
+        the corresponding data. If scalings == 'auto', all scalings fields are
+        set to 'auto'. If any fields are 'auto' and data is not preloaded,
+        a subset of epochs up to 100mb will be loaded. If None, defaults to::
 
             dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
                  emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1, chpi=1e-4)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -21,7 +21,8 @@ from ..fixes import Counter, _in1d
 from ..time_frequency import psd_multitaper
 from .utils import (tight_layout, figure_nobar, _toggle_proj, _toggle_options,
                     _layout_figure, _setup_vmin_vmax, _channels_changed,
-                    _plot_raw_onscroll, _onclick_help, plt_show)
+                    _plot_raw_onscroll, _onclick_help, plt_show,
+                    compute_scalings)
 from ..defaults import _handle_default
 
 
@@ -400,6 +401,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
     with ``b`` key. Right mouse click adds a vertical line to the plot.
     """
     epochs.drop_bad()
+    scalings = compute_scalings(scalings, epochs)
     scalings = _handle_default('scalings_plot_raw', scalings)
 
     projs = epochs.info['projs']

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -22,7 +22,7 @@ from ..time_frequency import psd_multitaper
 from .utils import (tight_layout, figure_nobar, _toggle_proj, _toggle_options,
                     _layout_figure, _setup_vmin_vmax, _channels_changed,
                     _plot_raw_onscroll, _onclick_help, plt_show,
-                    compute_scalings)
+                    _compute_scalings)
 from ..defaults import _handle_default
 
 
@@ -401,7 +401,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
     with ``b`` key. Right mouse click adds a vertical line to the plot.
     """
     epochs.drop_bad()
-    scalings = compute_scalings(scalings, epochs)
+    scalings = _compute_scalings(scalings, epochs)
     scalings = _handle_default('scalings_plot_raw', scalings)
 
     projs = epochs.info['projs']

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -23,7 +23,7 @@ from .utils import (_toggle_options, _toggle_proj, tight_layout,
                     _layout_figure, _plot_raw_onkey, figure_nobar,
                     _plot_raw_onscroll, _mouse_click, plt_show,
                     _helper_raw_resize, _select_bads, _onclick_help,
-                    _setup_browser_offsets, compute_scalings)
+                    _setup_browser_offsets, _compute_scalings)
 from ..defaults import _handle_default
 from ..annotations import _onset_to_seconds
 
@@ -177,7 +177,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     import matplotlib as mpl
     from scipy.signal import butter
     color = _handle_default('color', color)
-    scalings = compute_scalings(scalings, raw)
+    scalings = _compute_scalings(scalings, raw)
     scalings = _handle_default('scalings_plot_raw', scalings)
 
     if clipping is not None and clipping not in ('clamp', 'transparent'):

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -117,7 +117,11 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         ``{event_number: color}`` pairings. Use ``event_number==-1`` for
         any event numbers in the events list that are not in the dictionary.
     scalings : dict | None
-        Scale factors for the traces. If None, defaults to::
+        Scaling factors for the traces. If any fields in scalings are 'auto',
+        the scaling factor is set to match the 99.5th percentile of a subset of
+        the corresponding data. If scalings == 'auto', all scalings fields are
+        set to 'auto'. If any fields are 'auto' and data is not preloaded, a
+        subset of times up to 100mb will be loaded. If None, defaults to::
 
             dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
                  emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -23,7 +23,7 @@ from .utils import (_toggle_options, _toggle_proj, tight_layout,
                     _layout_figure, _plot_raw_onkey, figure_nobar,
                     _plot_raw_onscroll, _mouse_click, plt_show,
                     _helper_raw_resize, _select_bads, _onclick_help,
-                    _setup_browser_offsets)
+                    _setup_browser_offsets, compute_scalings)
 from ..defaults import _handle_default
 from ..annotations import _onset_to_seconds
 
@@ -177,6 +177,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     import matplotlib as mpl
     from scipy.signal import butter
     color = _handle_default('color', color)
+    scalings = compute_scalings(scalings, raw)
     scalings = _handle_default('scalings_plot_raw', scalings)
 
     if clipping is not None and clipping not in ('clamp', 'transparent'):

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -110,9 +110,10 @@ def test_auto_scale():
         assert_true(scalings_new['eeg'] != 'auto')
 
     assert_raises(ValueError, _compute_scalings, scalings_def, rand_data)
+    epochs = epochs[0].load_data()
     epochs.pick_types(eeg=True, meg=False, copy=False)
     assert_raises(ValueError, _compute_scalings,
-                  dict([('grad', 'auto')]), epochs)
+                  dict(grad='auto'), epochs)
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -8,9 +8,12 @@ import numpy as np
 from nose.tools import assert_true, assert_raises
 from numpy.testing import assert_allclose
 
-from mne.viz.utils import compare_fiff, _fake_click
+from mne.viz.utils import compare_fiff, _fake_click, _compute_scalings
 from mne.viz import ClickableImage, add_background_image, mne_analyze_colormap
 from mne.utils import run_tests_if_main
+from mne.io import read_raw_fif
+from mne.event import read_events
+from mne.epochs import Epochs
 
 # Set our plotters to test mode
 import matplotlib
@@ -88,10 +91,6 @@ def test_add_background_image():
 
 def test_auto_scale():
     """Test auto-scaling of channels for quick plotting."""
-    from mne.io import read_raw_fif
-    from mne.event import read_events
-    from mne.epochs import Epochs
-    from ..utils import compute_scalings
     raw = read_raw_fif(raw_fname, preload=False)
     ev = read_events(ev_fname)
     epochs = Epochs(raw, ev)
@@ -103,16 +102,16 @@ def test_auto_scale():
 
         # Test for wrong inputs
         assert_raises(ValueError, inst.plot, scalings='foo')
-        assert_raises(ValueError, compute_scalings, 'foo', inst)
+        assert_raises(ValueError, _compute_scalings, 'foo', inst)
 
         # Make sure compute_scalings doesn't change anything not auto
-        scalings_new = compute_scalings(scalings_def, inst)
+        scalings_new = _compute_scalings(scalings_def, inst)
         assert_true(scale_grad == scalings_new['grad'])
         assert_true(scalings_new['eeg'] != 'auto')
 
-    assert_raises(ValueError, compute_scalings, scalings_def, rand_data)
+    assert_raises(ValueError, _compute_scalings, scalings_def, rand_data)
     epochs.pick_types(eeg=True, meg=False, copy=False)
-    assert_raises(ValueError, compute_scalings,
+    assert_raises(ValueError, _compute_scalings,
                   dict([('grad', 'auto')]), epochs)
 
 

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -99,7 +99,7 @@ def test_auto_scale():
 
     for inst in [raw, epochs]:
         scale_grad = 1e10
-        scalings_def = {'eeg': 'auto', 'grad': scale_grad}
+        scalings_def = dict([('eeg', 'auto'), ('grad', scale_grad)])
 
         # Test for wrong inputs
         assert_raises(ValueError, inst.plot, scalings='foo')
@@ -111,6 +111,9 @@ def test_auto_scale():
         assert_true(scalings_new['eeg'] != 'auto')
 
     assert_raises(ValueError, compute_scalings, scalings_def, rand_data)
+    epochs.pick_types(eeg=True, meg=False, copy=False)
+    assert_raises(ValueError, compute_scalings,
+                  dict([('grad', 'auto')]), epochs)
 
 
 run_tests_if_main()

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -30,6 +30,10 @@ from ..fixes import _get_argrelmax
 COLORS = ['b', 'g', 'r', 'c', 'm', 'y', 'k', '#473C8B', '#458B74',
           '#CD7F32', '#FF4040', '#ADFF2F', '#8E2323', '#FF1493']
 
+_channel_types = ['eeg', 'seeg', 'eog', 'ecg', 'emg', 'ref_meg', 'stim',
+                  'resp', 'misc', 'chpi', 'syst', 'ias', 'exci', 'bio']
+_meg_types = ['mag', 'grad']
+
 
 def _setup_vmin_vmax(data, vmin, vmax, norm=False):
     """Aux function to handle vmin and vmax parameters"""
@@ -1032,3 +1036,102 @@ def _plot_sensors(pos, colors, ch_names, title, show_names, show):
     fig.suptitle(title)
     plt_show(show)
     return fig
+
+
+def compute_scalings(scalings, inst):
+    """Compute scalings for each channel type automatically.
+
+    Parameters
+    ----------
+    scalings : dict
+        The scalings for each channel type. If any values are
+        'auto', this will automatically compute a reasonable
+        scaling for that channel type.
+    inst : instance of Raw or Epochs
+        The data you wish to compute scalings for. If Epochs,
+        data will be preloaded. If Raw, a window of max 20
+        seconds will be loaded from the middle of the data for
+        estimating scaling.
+
+    Returns
+    -------
+    scalings : dict
+        A scalings dictionary with updated scalings
+    """
+    from copy import deepcopy
+    from mne.io.base import _BaseRaw
+    from mne.epochs import _BaseEpochs
+    if not isinstance(inst, (_BaseRaw, _BaseEpochs)):
+        raise ValueError('Must supply either Raw or Epochs')
+
+    if scalings == 'auto':
+        # If we want to auto-compute everything
+        scalings = {i_type: 'auto' for i_type in _channel_types + _meg_types}
+    if not isinstance(scalings, dict):
+        raise ValueError('scalings must be a dictionary of ch_type: val pairs')
+    scalings = deepcopy(scalings)
+    ixs_types = _get_channel_types(inst)[1]
+
+    if inst.preload is False:
+        if isinstance(inst, _BaseRaw):
+            # Load a sample of data
+            n_secs = 20.
+            time_middle = np.mean(inst.times)
+            tmin = np.clip(time_middle - n_secs / 2., inst.times.min(), None)
+            tmax = np.clip(time_middle + n_secs / 2., None, inst.times.max())
+            data = inst._read_segment(tmin, tmax)
+        elif isinstance(inst, _BaseEpochs):
+            inst.load_data()
+    else:
+        data = inst._data
+    if isinstance(inst, _BaseEpochs):
+        data = np.hstack(inst._data)
+
+    # Arbitrary compression factor for scaling
+    scale_factor = 5. if isinstance(inst, _BaseRaw) else 10.
+
+    # Iterate through ch types and update scaling if 'auto'
+    for key, value in scalings.items():
+        if value != 'auto':
+            continue
+        this_ixs = [iix for iix in ixs_types[key]
+                    if iix not in inst.info['bads']]
+        if len(this_ixs) == 0:
+            scalings[key] = None
+            continue
+        this_data = data[this_ixs]
+        this_mad = _mad(this_data)
+        scalings[key] = this_mad * scale_factor  # Arbitrary compression factor
+    return scalings
+
+
+def _get_channel_types(inst):
+    """Return some objects that reveal channel types."""
+    from mne import pick_types
+    types = list()
+    inds = {}
+
+    # First MEG because there are special kws for it
+    for t in _meg_types:
+        this_inds = pick_types(inst.info, meg=t, ref_meg=False, exclude=[])
+        inds[t] = this_inds
+        types += [t] * len(this_inds)
+
+    # Now the rest
+    pick_kwargs = dict(meg=False, ref_meg=False, exclude=[])
+    for t in _channel_types:
+        pick_kwargs[t] = True
+        this_inds = pick_types(inst.info, **pick_kwargs)
+        inds[t] = this_inds
+        types += [t] * len(this_inds)
+        pick_kwargs[t] = False
+    return types, inds
+
+
+def _mad(x):
+    """Calculate the median absolute deviation of an array."""
+    x = x.astype(float)
+    grand_median = np.median(x)
+    deviation = x - grand_median
+    mad = np.median(np.abs(deviation))
+    return mad

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -35,10 +35,12 @@ raw.plot(block=True, events=events)
 # color coded gray. By clicking the lines or channel names on the left, you can
 # mark or unmark a bad channel interactively. You can use +/- keys to adjust
 # the scale (also = works for magnifying the data). Note that the initial
-# scaling factors can be set with parameter ``scalings``. With
-# ``pageup/pagedown`` and ``home/end`` keys you can adjust the amount of data
-# viewed at once. To see all the interactive features, hit ``?`` or click
-# ``help`` in the lower left corner of the browser window.
+# scaling factors can be set with parameter ``scalings``. If you don't know the
+# scaling factor for channels, you can automatically set them by passing
+# scalings='auto'. With ``pageup/pagedown`` and ``home/end`` keys you can
+# adjust the amount of data viewed at once. To see all the interactive
+# features, hit ``?`` or click ``help`` in the lower left corner of the
+# browser window.
 #
 # We read the events from a file and passed it as a parameter when calling the
 # method. The events are plotted as vertical lines so you can see how they


### PR DESCRIPTION
This is a first-pass PR at adding auto-scaling functionality for plotting raw / epoched data. The basic change is to include a "compute_scalings" function in the viz.utils module. This takes a scalings dictionary, and for any value that is 'auto', it will use the data instance provided to auto-calculate the scaling. Alternatively you can supply only the string "auto" and it'll auto-compute for all channel types in the data. Then it goes on to plotting as normal.

There are some weird things that I did to make iterating through channel types easier (e.g., I've got a hard-coded list of channel types but maybe that exists elsewhere, I also wrote a function to return a list of the channel type for all channels, as well as a dictionary of channel type: ixs, but maybe that's already been done elsewhere?)

Suggestions etc are welcome! Here's the basic idea of what this does:

```python
scalings_def = dict(eeg='auto', grad='auto')
scalings_raw = mne.viz.utils.compute_scalings(scalings_def, raw)
scalings_ep = mne.viz.utils.compute_scalings(scalings_def, epochs)
scalings_all = mne.viz.utils.compute_scalings('auto', raw)
print('{}\n\n{}\n\n{}\n\n{}'.format(scalings_def, scalings_raw, scalings_ep, scalings_all))
```
```
{'eeg': 'auto', 'grad': 'auto'}

{'eeg': 7.1589975858543653e-05, 'grad': 1.928710961556987e-11}

{'eeg': 3.6195661505710243e-05, 'grad': 3.506747202830885e-11}

{'ecg': None, 'bio': None, 'emg': None, 'stim': 0.0, 'eog': 1.7976379496076333e-05, 'ref_meg': None, 'resp': None, 'misc': None, 'seeg': None, 'chpi': None, 'mag': 1.3265991686001318e-12, 'syst': None, 'eeg': 7.1589975858543653e-05, 'grad': 1.928710961556987e-11, 'ias': None, 'exci': None}
```
originally comes from #2253 