### PR TITLE
adding a function to forcibly update measurement infos

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -560,7 +560,7 @@ class UpdateChannelsMixin(object):
         elif isinstance(self, Evoked):
             self.data = self.data.take(idx, axis=0)
 
-    def add_channels(self, add_list, force_update_info=False, copy=None):
+    def add_channels(self, add_list, copy=None, force_update_info=False):
         """Append new channels to the instance.
 
         Parameters
@@ -568,14 +568,16 @@ class UpdateChannelsMixin(object):
         add_list : list
             A list of objects to append to self. Must contain all the same
             type as the current object
-        force_update_info : bool
-            If True, force the info for objects to be appended to match the
-            values in `self`. This should generally only be used when adding
-            stim channels for which important metadata won't be overwritten.
         copy : bool
             This parameter has been deprecated and will be removed in 0.13.
             Use inst.copy() instead.
             Whether to return a new instance or modify in place.
+        force_update_info : bool
+            If True, force the info for objects to be appended to match the
+            values in `self`. This should generally only be used when adding
+            stim channels for which important metadata won't be overwritten.
+
+            .. versionadded:: 0.12
 
         Returns
         -------

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -584,9 +584,8 @@ class UpdateChannelsMixin(object):
         """
         out = _check_copy_dep(self, copy)
         # avoid circular imports
-        from ..io import _BaseRaw, _merge_info, _force_update_info
+        from ..io import _BaseRaw, _merge_info
         from ..epochs import _BaseEpochs
-        from copy import deepcopy
 
         if not isinstance(add_list, (list, tuple)):
             raise AssertionError('Input must be a list or tuple of objs')
@@ -618,11 +617,8 @@ class UpdateChannelsMixin(object):
 
         # Create final data / info objects
         data = np.concatenate(data, axis=con_axis)
-        infos_to_add = deepcopy([inst.info for inst in add_list])
-        if force_update_info is True:
-            _force_update_info(self.info, infos_to_add)
-        infos = [self.info] + infos_to_add
-        new_info = _merge_info(infos)
+        infos = [self.info] + [inst.info for inst in add_list]
+        new_info = _merge_info(infos, force_update_to_first=force_update_info)
 
         # Now update the attributes
         setattr(out, data_name, data)

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -7,7 +7,7 @@
 
 from .open import fiff_open, show_fiff, _fiff_get_fid
 from .meas_info import (read_fiducials, write_fiducials, read_info, write_info,
-                        _empty_info, _merge_info, Info)
+                        _empty_info, _merge_info, _force_update_info, Info)
 
 from .proj import make_eeg_average_ref_proj, Projection
 from .tag import _loc_to_coil_trans, _coil_trans_to_loc, _loc_to_eeg_loc

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1052,7 +1052,7 @@ def test_add_channels():
     raw_new = raw_meg.copy().add_channels([raw_eeg])
 
     # Testing force updates
-    raw_eeg_conf = deepcopy(raw_eeg)
+    raw_eeg_conf = raw_eeg.copy()
     raw_eeg_conf.info['sfreq'] = 1.
     assert_raises(RuntimeError, raw_meg.copy().add_channels, [raw_eeg_conf])
     raw_new = raw_meg.copy().add_channels([raw_eeg_conf],

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1051,6 +1051,15 @@ def test_add_channels():
     )
     raw_new = raw_meg.copy().add_channels([raw_eeg])
 
+    # Testing force updates
+    raw_eeg_conf = deepcopy(raw_eeg)
+    raw_eeg_conf.info['sfreq'] = 1.
+    assert_raises(RuntimeError, raw_meg.copy().add_channels, [raw_eeg_conf])
+    raw_new = raw_meg.copy().add_channels([raw_eeg_conf],
+                                          force_update_info=True)
+    assert_true(raw_eeg_conf.info['sfreq'] == 1.)
+    assert_true(raw_new.info['sfreq'] == raw_meg.info['sfreq'])
+
     assert_true(ch in raw_new.ch_names for ch in raw.ch_names)
     assert_array_equal(raw_new[:, :][0], raw_eeg_meg[:, :][0])
     assert_array_equal(raw_new[:, :][1], raw[:, :][1])

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1289,7 +1289,7 @@ def _merge_dict_values(dicts, key, verbose=None):
 
 
 @verbose
-def _merge_info(infos, verbose=None):
+def _merge_info(infos, force_update_to_first=False, verbose=None):
     """Merge multiple measurement info dictionaries.
 
      - Fields that are present in only one info object will be used in the
@@ -1305,6 +1305,10 @@ def _merge_info(infos, verbose=None):
     ----------
     infos | list of instance of Info
         Info objects to merge into one info object.
+    force_update_to_first : bool
+        If True, force the fields for objects in `info` will be updated
+        to match those in the first item. Use at your own risk, as this
+        may overwrite important metadata.
     verbose : bool, str, int, or NonIe
         If not None, override default verbose level (see mne.verbose).
 
@@ -1315,6 +1319,9 @@ def _merge_info(infos, verbose=None):
     """
     for info in infos:
         info._check_consistency()
+    if force_update_to_first is True:
+        infos = deepcopy(infos)
+        _force_update_info(infos[0], infos[1:])
     info = Info()
     info['chs'] = []
     for this_info in infos:

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1504,9 +1504,10 @@ def _force_update_info(info_base, info_target):
     exclude_keys = ['chs', 'ch_names', 'nchan']
     info_target = np.atleast_1d(info_target).ravel()
     all_infos = np.hstack([info_base, info_target])
-    msg = 'Inputs must be of type Info. Found type {0}'
-    if not all([isinstance(ii, Info) for ii in all_infos]):
-        raise ValueError(msg.format(type(ii)))
+    for ii in all_infos:
+        if not isinstance(ii, Info):
+            raise ValueError('Inputs must be of type Info. '
+                             'Found type %s' % type(ii))
     for key, val in info_base.items():
         if key in exclude_keys:
             continue

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1477,3 +1477,18 @@ def _empty_info(sfreq):
     info._update_redundant()
     info._check_consistency()
     return info
+
+
+def _force_update_info(info_base, info_target):
+    """Update target info objects with values from info base."""
+    exclude_keys = ['chs', 'ch_names', 'nchan']
+    info_target = np.atleast_1d(info_target)
+    if not isinstance(info_base, Info):
+        raise ValueError('info_base must be of type Info')
+    if not all([isinstance(ii, Info) for ii in info_target]):
+        raise ValueError('all target infos must both Info objects')
+    for key, val in info_base.items():
+        if key in exclude_keys:
+            continue
+        for i_targ in info_target:
+            i_targ[key] = val

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1487,13 +1487,26 @@ def _empty_info(sfreq):
 
 
 def _force_update_info(info_base, info_target):
-    """Update target info objects with values from info base."""
+    """Update target info objects with values from info base.
+
+    Note that values in info_target will be overwritten by those in info_base.
+    This will overwrite all fields except for: 'chs', 'ch_names', 'nchan'.
+
+    Parameters
+    ----------
+    info_base : mne.Info
+        The Info object you want to use for overwriting values
+        in target Info objects.
+    info_target : mne.Info | list of mne.Info
+        The Info object(s) you wish to overwrite using info_base. These objects
+        will be modified in-place.
+    """
     exclude_keys = ['chs', 'ch_names', 'nchan']
-    info_target = np.atleast_1d(info_target)
-    if not isinstance(info_base, Info):
-        raise ValueError('info_base must be of type Info')
-    if not all([isinstance(ii, Info) for ii in info_target]):
-        raise ValueError('all target infos must both Info objects')
+    info_target = np.atleast_1d(info_target).ravel()
+    all_infos = np.hstack([info_base, info_target])
+    msg = 'Inputs must be of type Info. Found type {0}'
+    if not all([isinstance(ii, Info) for ii in all_infos]):
+        raise ValueError(msg.format(type(ii)))
     for key, val in info_base.items():
         if key in exclude_keys:
             continue

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -269,6 +269,7 @@ def test_merge_info():
 
     # Testing for force updates before merging
     info_c = create_info(ch_names=['g', 'h', 'i'], sfreq=500., ch_types=None)
+    # This will break because sfreq is not equal
     assert_raises(RuntimeError, _merge_info, [info_a, info_c])
     _force_update_info(info_a, info_c)
     assert_true(info_c['sfreq'] == info_a['sfreq'])


### PR DESCRIPTION
In reference to #2948, this adds a function to forcible update parameters of target info objects using the values from a base info object. Generally meant to facilitate adding new channels that you created from RawArray. A couple thoughts worth mentioning:

* It hard-codes a few fields that it won't update `['chs', 'ch_names', and 'nchan']`. Is that OK and do you think I missed some?
* It will update the fields in target_info without copying first. I could do a deepcopy first and then return info objects, though that'll make it a little clunkier. I did make it so that using the force parameter in `add_channels` *will* deepcopy before updating the infos.
* In general, this is kind of a "dumb" implementation, so I tried to warn about potential ramifications in the doc for the "force" parameter in `add_channels`. I could also add more documentation to the _force_update... function itself.

WDYT? @Eric89GXL @kingjr @agramfort ?

EDIT by Eric89GXL:
Closes #2948.