### PR TITLE
fix reading eeglab events if there is only one event in file

### DIFF
--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -525,8 +525,13 @@ def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
     if event_id is None:
         event_id = dict()
 
-    types = [event.type for event in eeg.event]
-    latencies = [event.latency for event in eeg.event]
+    try:
+        types = [event.type for event in eeg.event]
+        latencies = [event.latency for event in eeg.event]
+    except TypeError:
+        # only one event - TypeError: 'mat_struct' object is not iterable
+        types = [eeg.event.type]
+        latencies = [eeg.event.latency]
     if "boundary" in types and "boundary" not in event_id:
         warn("The data contains 'boundary' events, indicating data "
              "discontinuities. Be cautious of filtering and epoching around "

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -525,10 +525,10 @@ def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
     if event_id is None:
         event_id = dict()
 
-    try:
+    if isinstance(eeg.event, np.ndarray):
         types = [event.type for event in eeg.event]
         latencies = [event.latency for event in eeg.event]
-    except TypeError:
+    else:
         # only one event - TypeError: 'mat_struct' object is not iterable
         types = [eeg.event.type]
         latencies = [eeg.event.latency]

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -84,6 +84,22 @@ def test_io_set():
     assert_raises(ValueError, read_epochs_eeglab, epochs_fname,
                   epochs.events, None)
 
+    # test reading file with one event
+    eeg = io.loadmat(raw_fname, struct_as_record=False,
+                     squeeze_me=True)['EEG']
+    one_event_fname = op.join(temp_dir, 'test_one_event.set')
+    io.savemat(one_event_fname, {'EEG':
+               {'trials': eeg.trials, 'srate': eeg.srate,
+                'nbchan': eeg.nbchan, 'data': eeg.data,
+                'epoch': eeg.epoch, 'event': eeg.event[0],
+                'chanlocs': eeg.chanlocs}})
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
+                    op.join(temp_dir, 'test_one_event.fdt'))
+    event_id = {eeg.event[0].type: 1}
+    raw5 = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
+                               event_id=event_id, preload=True)
+
+
     # test if .dat file raises an error
     eeg = io.loadmat(epochs_fname, struct_as_record=False,
                      squeeze_me=True)['EEG']

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -96,9 +96,8 @@ def test_io_set():
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     op.join(temp_dir, 'test_one_event.fdt'))
     event_id = {eeg.event[0].type: 1}
-    raw5 = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
-                               event_id=event_id, preload=True)
-
+    read_raw_eeglab(input_fname=one_event_fname, montage=montage,
+                    event_id=event_id, preload=True)
 
     # test if .dat file raises an error
     eeg = io.loadmat(epochs_fname, struct_as_record=False,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -90,9 +90,9 @@ def test_io_set():
     one_event_fname = op.join(temp_dir, 'test_one_event.set')
     io.savemat(one_event_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
-                'nbchan': eeg.nbchan, 'data': eeg.data,
+                'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': eeg.event[0],
-                'chanlocs': eeg.chanlocs}})
+                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     op.join(temp_dir, 'test_one_event.fdt'))
     event_id = {eeg.event[0].type: 1}


### PR DESCRIPTION
Hey there,
I've just had a TypeError with the eeglab event reader with a file that contains only one event. In such case the list comprehension that gathers event types fails because `'mat_struct' object is not iterable`.
This small change fixes the problem.

This is my first PR to mne-python so please be merciful :) If I messed something up I'll be happy to clean up, add something etc.

And just BTW - thanks for your efforts with mne-python, really cool package!
