### PR TITLE
MRG: Fix paths

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,14 +45,7 @@ dependencies:
     - cd /home/ubuntu/mne-python && python setup.py develop;
     - if [ "$CIRCLE_BRANCH" == "master" ]; then
         mkdir -p ~/mne_data;
-        python -c "import mne; mne.datasets.sample.data_path(verbose=True);";
-        python -c "import mne; mne.datasets.testing.data_path(verbose=True);";
-        python -c "import mne; mne.datasets.misc.data_path(verbose=True);";
-        python -c "import mne; mne.datasets.spm_face.data_path(verbose=True);";
-        python -c "import mne; mne.datasets.somato.data_path(verbose=True);";
-        python -c "import mne; mne.datasets.brainstorm.bst_raw.data_path(verbose=True); mne.datasets.brainstorm.bst_auditory.data_path(verbose=True);" --accept-brainstorm-license;
-        python -c "from mne.datasets.megsim import load_data; load_data(condition='visual', data_format='single-trial', data_type='simulation', verbose=True); load_data(condition='visual', data_format='raw', data_type='experimental', verbose=True); load_data(condition='visual', data_format='evoked', data_type='simulation', verbose=True);" --update-dataset-path;
-        python -c "import mne; mne.datasets.eegbci.data_path('http://www.physionet.org/physiobank/database/eegmmidb/S001/S001R06.edf', update_path=True, verbose=True);";
+        python -c "import mne; mne.datasets._download_all_example_data()";
       fi
     - python -c "import mne; mne.sys_info()";
     - >

--- a/mne/datasets/__init__.py
+++ b/mne/datasets/__init__.py
@@ -10,3 +10,4 @@ from . import somato
 from . import spm_face
 from . import testing
 from . import _fake
+from .utils import _download_all_example_data

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -12,7 +12,7 @@ import stat
 import sys
 
 from .. import __version__ as mne_version
-from ..utils import get_config, set_config, _fetch_file, logger, warn
+from ..utils import get_config, set_config, _fetch_file, logger, warn, verbose
 from ..externals.six import string_types
 from ..externals.six.moves import input
 
@@ -351,3 +351,36 @@ def has_dataset(name):
     dp = _data_path(download=False, name=name, check_version=False,
                     archive_name=archive_name)
     return dp.endswith(endswith)
+
+
+@verbose
+def _download_all_example_data(verbose=True):
+    """Helper to download all datasets used in examples and tutorials"""
+    # This function is designed primarily to be used by CircleCI. It has
+    # verbose=True by default so we get nice status messages
+    from . import (sample, testing, misc, spm_face, somato, brainstorm, megsim,
+                   eegbci)
+    sample.data_path()
+    testing.data_path()
+    misc.data_path()
+    spm_face.data_path()
+    somato.data_path()
+    sys.argv += ['--accept-brainstorm-license']
+    try:
+        brainstorm.bst_raw.data_path()
+    finally:
+        sys.argv.pop(-1)
+    sys.argv += ['--update-dataset-path']
+    try:
+        megsim.load_data(condition='visual', data_format='single-trial',
+                         data_type='simulation')
+        megsim.load_data(condition='visual', data_format='raw',
+                         data_type='experimental')
+        megsim.load_data(condition='visual', data_format='evoked',
+                         data_type='simulation')
+    finally:
+        sys.argv.pop(-1)
+    url_root = 'http://www.physionet.org/physiobank/database/eegmmidb/'
+    eegbci.data_path(url_root + 'S001/S001R06.edf', update_path=True)
+    eegbci.data_path(url_root + 'S001/S001R10.edf', update_path=True)
+    eegbci.data_path(url_root + 'S001/S001R14.edf', update_path=True)


### PR DESCRIPTION
We were missing a couple EEGBCI data files in our CircleCI downloads. This also moves the downloading code to Python land, which is hopefully a little bit cleaner, as the next time someone uses a new dataset in an example we can tell them to modify a Python function instead of CI code.

Ready for review/merge from my end.