### PR TITLE
adding support for other channel types with auto-scale

### DIFF
--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -98,7 +98,8 @@ def test_auto_scale():
 
     for inst in [raw, epochs]:
         scale_grad = 1e10
-        scalings_def = dict([('eeg', 'auto'), ('grad', scale_grad)])
+        scalings_def = dict([('eeg', 'auto'), ('grad', scale_grad),
+                             ('stim', 'auto')])
 
         # Test for wrong inputs
         assert_raises(ValueError, inst.plot, scalings='foo')


### PR DESCRIPTION
This is a quick extension of #3198. I realized that the function would only pull eeg or meg channels when computing the auto-scaling, but we probably want auto-scaling to work for any channel types. This should add support for the remaining channel types.