### PR TITLE
MRG: Deprecate list to Raw constructor

### DIFF
--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -13,6 +13,7 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_report, mne_surf2bem, mne_watershed_bem,
                           mne_compare_fiff, mne_flash_bem, mne_show_fiff,
                           mne_show_info)
+from mne import concatenate_raws
 from mne.utils import (run_tests_if_main, _TempDir, requires_mne, requires_PIL,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
                        ArgvSetter, slow_test, ultra_slow_test)
@@ -67,7 +68,7 @@ def test_clean_eog_ecg():
     """Test mne clean_eog_ecg"""
     check_usage(mne_clean_eog_ecg)
     tempdir = _TempDir()
-    raw = Raw([raw_fname, raw_fname, raw_fname])
+    raw = concatenate_raws([Raw(f) for f in [raw_fname, raw_fname, raw_fname]])
     raw.info['bads'] = ['MEG 2443']
     use_fname = op.join(tempdir, op.basename(raw_fname))
     raw.save(use_fname)

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -32,10 +32,9 @@ class Raw(_BaseRaw):
 
     Parameters
     ----------
-    fnames : list, or string
-        A list of the raw files to treat as a Raw instance, or a single
-        raw file. For files that have automatically been split, only the
-        name of the first file has to be specified. Filenames should end
+    fname : str
+        The raw file to load. For files that have automatically been split,
+        the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz,
         raw_tsss.fif or raw_tsss.fif.gz.
     allow_maxshield : bool | str (default False)
@@ -63,6 +62,8 @@ class Raw(_BaseRaw):
     add_eeg_ref : bool
         If True, add average EEG reference projector (if it's not already
         present).
+    fnames : list or str
+        Deprecated.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -80,12 +81,22 @@ class Raw(_BaseRaw):
         See above.
     """
     @verbose
-    def __init__(self, fnames, allow_maxshield=False, preload=False,
+    def __init__(self, fname, allow_maxshield=False, preload=False,
                  proj=False, compensation=None, add_eeg_ref=True,
-                 verbose=None):
-
+                 fnames=None, verbose=None):
+        dep = ('Supplying a list of filenames with "fnames" to the Raw class '
+               'has been deprecated and will be removed in 0.13. Use multiple '
+               'calls to read_raw_fif with the "fname" argument followed by '
+               'and concatenate_raws instead.')
+        if fnames is not None:
+            warn(dep, DeprecationWarning)
+        else:
+            fnames = fname
+        del fname
         if not isinstance(fnames, list):
             fnames = [fnames]
+        else:
+            warn(dep, DeprecationWarning)
         fnames = [op.realpath(f) for f in fnames]
         split_fnames = []
 
@@ -473,17 +484,16 @@ def _check_entry(first, nent):
         raise IOError('Could not read data, perhaps this is a corrupt file')
 
 
-def read_raw_fif(fnames, allow_maxshield=False, preload=False,
+def read_raw_fif(fname, allow_maxshield=False, preload=False,
                  proj=False, compensation=None, add_eeg_ref=True,
-                 verbose=None):
+                 fnames=None, verbose=None):
     """Reader function for Raw FIF data
 
     Parameters
     ----------
-    fnames : list, or string
-        A list of the raw files to treat as a Raw instance, or a single
-        raw file. For files that have automatically been split, only the
-        name of the first file has to be specified. Filenames should end
+    fname : str
+        The raw file to load. For files that have automatically been split,
+        the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz,
         raw_tsss.fif or raw_tsss.fif.gz.
     allow_maxshield : bool, (default False)
@@ -510,6 +520,8 @@ def read_raw_fif(fnames, allow_maxshield=False, preload=False,
     add_eeg_ref : bool
         If True, add average EEG reference projector (if it's not already
         present).
+    fnames : list or str
+        Deprecated.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -522,6 +534,6 @@ def read_raw_fif(fnames, allow_maxshield=False, preload=False,
     -----
     .. versionadded:: 0.9.0
     """
-    return Raw(fnames=fnames, allow_maxshield=allow_maxshield,
+    return Raw(fname=fname, allow_maxshield=allow_maxshield,
                preload=preload, proj=proj, compensation=compensation,
-               add_eeg_ref=add_eeg_ref, verbose=verbose)
+               add_eeg_ref=add_eeg_ref, fnames=fnames, verbose=verbose)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -294,14 +294,18 @@ def test_multiple_files():
     # add potentially problematic points
     times.extend([n_times - 1, n_times, 2 * n_times - 1])
 
-    raw_combo0 = Raw([fif_fname, fif_fname], preload=True)
+    raw_combo0 = concatenate_raws([Raw(f) for f in [fif_fname, fif_fname]],
+                                  preload=True)
     _compare_combo(raw, raw_combo0, times, n_times)
-    raw_combo = Raw([fif_fname, fif_fname], preload=False)
+    raw_combo = concatenate_raws([Raw(f) for f in [fif_fname, fif_fname]],
+                                 preload=False)
     _compare_combo(raw, raw_combo, times, n_times)
-    raw_combo = Raw([fif_fname, fif_fname], preload='memmap8.dat')
+    raw_combo = concatenate_raws([Raw(f) for f in [fif_fname, fif_fname]],
+                                 preload='memmap8.dat')
     _compare_combo(raw, raw_combo, times, n_times)
-    assert_raises(ValueError, Raw, [fif_fname, ctf_fname])
-    assert_raises(ValueError, Raw, [fif_fname, fif_bad_marked_fname])
+    with warnings.catch_warnings(record=True):  # deprecated
+        assert_raises(ValueError, Raw, [fif_fname, ctf_fname])
+        assert_raises(ValueError, Raw, [fif_fname, fif_bad_marked_fname])
     assert_equal(raw[:, :][0].shape[1] * 2, raw_combo0[:, :][0].shape[1])
     assert_equal(raw_combo0[:, :][0].shape[1], raw_combo0.n_times)
 
@@ -385,7 +389,7 @@ def test_split_files():
     fnames.extend(sorted(glob.glob(op.join(tempdir, 'split_raw-*.fif'))))
     with warnings.catch_warnings(record=True):
         warnings.simplefilter('always')
-        raw_2 = Raw(fnames)
+        raw_2 = Raw(fnames)  # uses deprecated list pattern
     data_2, times_2 = raw_2[:, :]
     assert_array_equal(data_1, data_2)
     assert_array_equal(times_1, times_2)
@@ -614,7 +618,7 @@ def test_io_complex():
     tempdir = _TempDir()
     dtypes = [np.complex64, np.complex128]
 
-    raw = _test_raw_reader(Raw, fnames=fif_fname)
+    raw = _test_raw_reader(Raw, fname=fif_fname)
     picks = np.arange(5)
     start, stop = raw.time_as_index([0, 5])
 
@@ -875,7 +879,7 @@ def test_crop():
     """Test cropping raw files
     """
     # split a concatenated file to test a difficult case
-    raw = Raw([fif_fname, fif_fname], preload=False)
+    raw = concatenate_raws([Raw(f) for f in [fif_fname, fif_fname]])
     split_size = 10.  # in seconds
     sfreq = raw.info['sfreq']
     nsamp = (raw.last_samp - raw.first_samp + 1)


### PR DESCRIPTION
As pointed out in #2808, `Raw` is the only class that accepts a list of filenames. The proper way to do it would be to use `concatenate_raws` like every other type of reader, so we should get rid of the list support. This PR deprecates it.

Closes #2808.