### PR TITLE
[MRG+1] ica.find_bads_ecg pass ch_name to create_ecg_epochs

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1032,6 +1032,7 @@ class ICA(ContainsMixin):
                 sources = self.get_sources(create_ecg_epochs(
                     inst, ch_name, keep_ecg=False,
                     reject_by_annotation=reject_by_annotation)).get_data()
+
                 if sources.shape[0] == 0:
                     warn('No ECG activity detected. Consider changing '
                          'the input parameters.')

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -315,8 +315,14 @@ def test_ica_additional():
     ica = ICA(n_components=3, max_pca_components=4,
               n_pca_components=4)
     assert_raises(RuntimeError, ica.save, '')
+
     with warnings.catch_warnings(record=True):
         ica.fit(raw, picks=[1, 2, 3, 4, 5], start=start, stop=stop2)
+
+    # check passing a ch_name to find_bads_ecg
+    _, scores_1 = ica.find_bads_ecg(raw)
+    _, scores_2 = ica.find_bads_ecg(raw, raw.ch_names[1])
+    assert_false(scores_1[0] == scores_2[0])
 
     # test corrmap
     ica2 = ica.copy()
@@ -503,9 +509,6 @@ def test_ica_additional():
                       method='ctps')
         assert_raises(ValueError, ica.find_bads_ecg, raw,
                       method='crazy-coupling')
-
-        # check passing a ch_name to find_bads_ecg
-        ica.find_bads_ecg(epochs, raw.ch_names[0], method='ctps')
 
         idx, scores = ica.find_bads_eog(raw)
         assert_equal(len(scores), ica.n_components_)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -461,7 +461,7 @@ def test_ica_additional():
         assert_array_almost_equal(_raw1[:, :][0], _raw2[:, :][0])
 
     os.remove(test_ica_fname)
-    # check scrore funcs
+    # check score funcs
     for name, func in get_score_funcs().items():
         if name in score_funcs_unsuited:
             continue
@@ -504,10 +504,8 @@ def test_ica_additional():
         assert_raises(ValueError, ica.find_bads_ecg, raw,
                       method='crazy-coupling')
 
-        # check that nonsense ecg ch_name means bad output -
-        # i.e., that find_bads_ecg recognizes the ch_name arg
-        idx2, _ = ica.find_bads_ecg(epochs, raw.ch_names[0], method='ctps')
-        assert_true(set(idx2) != set(idx))
+        # check passing a ch_name to find_bads_ecg
+        ica.find_bads_ecg(epochs, raw.ch_names[0], method='ctps')
 
         idx, scores = ica.find_bads_eog(raw)
         assert_equal(len(scores), ica.n_components_)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -497,11 +497,20 @@ def test_ica_additional():
         assert_equal(len(scores), ica.n_components_)
 
         idx, scores = ica.find_bads_ecg(epochs, method='ctps')
+
         assert_equal(len(scores), ica.n_components_)
         assert_raises(ValueError, ica.find_bads_ecg, epochs.average(),
                       method='ctps')
         assert_raises(ValueError, ica.find_bads_ecg, raw,
                       method='crazy-coupling')
+
+        # check that nonsense ecg ch_name means bad output -
+        # i.e., that find_bads_ecg recognizes the ch_name arg
+        idx2, _ = ica.find_bads_ecg(epochs, raw.ch_names[0], method='ctps')
+        assert_true(set(idx2) != set(idx))
+
+        idx, scores = ica.find_bads_eog(raw)
+        assert_equal(len(scores), ica.n_components_)
 
         raw.info['chs'][raw.ch_names.index('EOG 061') - 1]['kind'] = 202
         idx, scores = ica.find_bads_eog(raw)


### PR DESCRIPTION
Redo of #3169 because I'm terrible with Git.

> Currently, if you do something like
> 
> ica.find_bads_ecg(raw, "CUSTOM_ECG_NAME")
> 
> it will internally create ecg_epochs by calling create_ecg_epochs(inst). The problem with this is that if, for some reason, "CUSTOM_ECG_NAME" is not defined properly as the only ECG channel, it will pick the wrong channels, and possibly create bad ecg epochs.
> This PR should in principle be very rare (which is why it's not been discovered so far), but can happen for example with the HCP files.
> 
> This change passes the ch_name to the create_ecg_epochs call.
> 
> Still needs a test.

@dengemann do you agree that with the chance in line 944 because

> we don't return the created sources anyways. And there is no kwarg on the input side.
> ?
