### PR TITLE
BF: use tvtk.configure_input instead of direct input=src

### DIFF
--- a/mne/surface.py
+++ b/mne/surface.py
@@ -717,6 +717,7 @@ def _decimate_surface(points, triangles, reduction):
         os.environ['ETS_TOOLKIT'] = 'null'
     try:
         from tvtk.api import tvtk
+        from tvtk.common import configure_input
     except ImportError:
         raise ValueError('This function requires the TVTK package to be '
                          'installed')
@@ -724,7 +725,8 @@ def _decimate_surface(points, triangles, reduction):
         raise ValueError('The triangles refer to undefined points. '
                          'Please check your mesh.')
     src = tvtk.PolyData(points=points, polys=triangles)
-    decimate = tvtk.QuadricDecimation(input=src, target_reduction=reduction)
+    decimate = tvtk.QuadricDecimation(target_reduction=reduction)
+    configure_input(decimate, src)
     decimate.update()
     out = decimate.output
     tris = out.polys.to_array()


### PR DESCRIPTION
Trying to resolve error during testing on Debian sid, see
http://stackoverflow.com/a/35131392 for origin for the "fix".
Closes #2648 

I have little to no clue in tvtk etc, just nearly blindly following the recipe from stackoverflow  which seems to avoid error during testing at least on debian sid.  Will try now across releases