### PR TITLE
[MRG] Options for setting data and date formats for cnt data.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,8 @@ API
 
     - Deprecated support for passing a lits of filenames to :class:`mne.io.Raw` constructor, use :func:`mne.io.read_raw_fif` and :func:`mne.concatenate_raws` instead by `Eric Larson`_
 
+    - Added options for setting data and date formats manually in :func:`mne.io.read_raw_cnt` by `Jaakko Leppakangas`_
+
 .. _changes_0_12:
 
 Version 0.12

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -143,7 +143,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, n_bytes, date_format):
                     date[0], date[1] = date[1], date[0]
                 else:
                     raise ValueError("Only date formats 'mm/dd/yy' and "
-                                     "'dd/mm/yy' supported")
+                        "'dd/mm/yy' supported. Got '%s'." % date_format)
                 # Assuming mm/dd/yy
                 date = datetime.datetime(int(date[2]), int(date[0]),
                                          int(date[1]), int(time[0]),

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -26,7 +26,8 @@ def test_data():
     with warnings.catch_warnings(record=True) as w:
         raw = _test_raw_reader(read_raw_cnt, montage=None, input_fname=fname,
                                eog='auto', misc=['NA1', 'LEFT_EAR'])
-    assert_true(all('meas date' in str(ww.message) for ww in w))
+    assert_true(all('meas date' in str(ww.message) or
+                    'number of bytes' in str(ww.message) for ww in w))
     eog_chs = mne.pick_types(raw.info, eog=True, exclude=[])
     assert_equal(len(eog_chs), 2)  # test eog='auto'
     assert_equal(raw.info['bads'], ['LEFT_EAR', 'VEOGR'])  # test bads

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -8,7 +8,7 @@ import warnings
 
 from nose.tools import assert_equal, assert_true
 
-import mne
+from mne import pick_types
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
@@ -28,7 +28,7 @@ def test_data():
                                eog='auto', misc=['NA1', 'LEFT_EAR'])
     assert_true(all('meas date' in str(ww.message) or
                     'number of bytes' in str(ww.message) for ww in w))
-    eog_chs = mne.pick_types(raw.info, eog=True, exclude=[])
+    eog_chs = pick_types(raw.info, eog=True, exclude=[])
     assert_equal(len(eog_chs), 2)  # test eog='auto'
     assert_equal(raw.info['bads'], ['LEFT_EAR', 'VEOGR'])  # test bads
 


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3232.
This allows reading cnt data in int32. The data itself has no information about the data format, so I added a parameter.
Also added a param to define the date format.