### PR TITLE
MRG: anonymize_info function

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,7 +13,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - 
+    -
 
 BUG
 ~~~
@@ -32,6 +32,9 @@ API
     - Added options for setting data and date formats manually in :func:`mne.io.read_raw_cnt` by `Jaakko Leppakangas`_
 
     - Now channels with units of 'C', 'µS', 'uS', 'ARU' and 'S' will be turned to misc by default in :func:`mne.io.read_raw_brainvision` by `Jaakko Leppakangas`_
+
+    - Add :func:`mne.io.anonymize_info` function to anonymize measurements and add methods to :class:`mne.io.Raw`, :class:`mne.Epochs` and :class:`mne.Evoked`, by `Jean-Remi King`_
+
 
 .. _changes_0_12:
 
@@ -153,7 +156,7 @@ BUG
     - Fix bug in source normal adjustment that occurred when 1) patch information is available (e.g., when distances have been calculated) and 2) points are excluded from the source space (by inner skull distance) by `Eric Larson`_
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
-    
+
     - The BTI/4D reader now considers user defined channel labels instead of the hard-ware names, however only for channels other than MEG. By `Denis Engemann`_ and `Alex Gramfort`_.
 
     - Fix bug in :func:`mne.compute_raw_covariance` where rejection by non-data channels (e.g. EOG) was not done properly by `Eric Larson`_.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -15,6 +15,7 @@ from scipy import sparse
 from ..externals.six import string_types
 
 from ..utils import verbose, logger, warn
+from ..io.meas_info import anonymize_info
 from ..io.pick import (channel_type, pick_info, pick_types,
                        _check_excludes_includes, _PICK_TYPES_KEYS)
 from ..io.constants import FIFF
@@ -401,6 +402,25 @@ class SetChannelsMixin(object):
         from ..viz.utils import plot_sensors
         return plot_sensors(self.info, kind=kind, ch_type=ch_type, title=title,
                             show_names=show_names, show=show)
+
+    def anonymize(self):
+        """Anonymize measurement information in place by removing
+        'subject_info', 'meas_date', 'file_id', 'meas_id' if they exist in
+        ``info``.
+
+        Returns
+        -------
+        inst : instance of Raw, Epochs or Evoked
+            The instance object.
+
+        Notes
+        -----
+        Operates in place.
+
+        .. versionadded:: 0.13.0
+        """
+        anonymize_info(self.info)
+        return self
 
 
 class UpdateChannelsMixin(object):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -410,8 +410,8 @@ class SetChannelsMixin(object):
 
         Returns
         -------
-        inst : instance of Raw, Epochs or Evoked
-            The instance object.
+        self : instance of Raw | Epochs | Evoked
+            The data container.
 
         Notes
         -----

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -7,7 +7,8 @@
 
 from .open import fiff_open, show_fiff, _fiff_get_fid
 from .meas_info import (read_fiducials, write_fiducials, read_info, write_info,
-                        _empty_info, _merge_info, _force_update_info, Info)
+                        _empty_info, _merge_info, _force_update_info, Info,
+                        anonymize_info)
 
 from .proj import make_eeg_average_ref_proj, Projection
 from .tag import _loc_to_coil_trans, _coil_trans_to_loc, _loc_to_eeg_loc

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -18,7 +18,7 @@ from scipy import linalg
 from .constants import FIFF
 from .pick import pick_types, channel_type, pick_channels, pick_info
 from .pick import _pick_data_channels, _pick_data_or_ica
-from .meas_info import write_meas_info
+from .meas_info import write_meas_info, anonymize_info
 from .proj import setup_proj, activate_proj, _proj_equal, ProjMixin
 from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                  SetChannelsMixin, InterpolationMixin)
@@ -675,7 +675,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         raw : instance of Raw
             The raw object. Operates in place.
         """
-        self.info._anonymize()
+        anonymize_info(self.info)
         return self
 
     @verbose

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -665,9 +665,10 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self._data[sel, start:stop] = value
 
     def anonymize(self):
-        """Anonymize data
+        """Anonymize data.
 
-        This function will remove ``raw.info['subject_info']`` if it exists.
+        This function will remove 'subject_info', 'meas_date', 'file_id',
+        'meas_id' if they exist in ``raw.info``.
 
         Returns
         -------

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -137,18 +137,6 @@ def test_subject_info():
     for key in keys:
         assert_equal(subject_info[key], raw_read.info['subject_info'][key])
     assert_equal(raw.info['meas_date'], raw_read.info['meas_date'])
-    raw.anonymize()
-    raw.save(out_fname, overwrite=True)
-    raw_read = Raw(out_fname)
-    for this_raw in (raw, raw_read):
-        assert_true(this_raw.info.get('subject_info') is None)
-        assert_equal(this_raw.info['meas_date'], [0, 0])
-    assert_equal(raw.info['file_id']['secs'], 0)
-    assert_equal(raw.info['meas_id']['secs'], 0)
-    # When we write out with raw.save, these get overwritten with the
-    # new save time
-    assert_true(raw_read.info['file_id']['secs'] > 0)
-    assert_true(raw_read.info['meas_id']['secs'] > 0)
 
 
 @testing.requires_testing_data

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1508,24 +1508,25 @@ def _force_update_info(info_base, info_target):
 
 
 def anonymize_info(info):
-    """Anonymize measurement information in place by removing 'subject_info',
-       'meas_date', 'file_id', 'meas_id' if they exist.
+    """Anonymize measurement information in place.
+
+    Reset 'subject_info', 'meas_date', 'file_id', and 'meas_id' keys.
 
     Parameters
     ----------
-        info : dict, instance of Info
+    info : dict, instance of Info
         Measurement information for the dataset.
 
     Returns
     -------
-        info : instance of Info
+    info : instance of Info
         Measurement information for the dataset.
 
     Notes
     -----
-        Operates in place.
+    Operates in place.
     """
-    if not isinstance(info, (dict, Info)):
+    if not isinstance(info, Info):
         raise ValueError('self must be an Info instance.')
     if info.get('subject_info') is not None:
         del info['subject_info']

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -226,14 +226,6 @@ class Info(dict):
         st %= non_empty
         return st
 
-    def _anonymize(self):
-        if self.get('subject_info') is not None:
-            del self['subject_info']
-        self['meas_date'] = [0, 0]
-        for key_1 in ('file_id', 'meas_id'):
-            for key_2 in ('secs', 'msecs', 'usecs'):
-                self[key_1][key_2] = 0
-
     def _check_consistency(self):
         """Do some self-consistency checks and datatype tweaks"""
         missing = [bad for bad in self['bads'] if bad not in self['ch_names']]
@@ -1513,3 +1505,32 @@ def _force_update_info(info_base, info_target):
             continue
         for i_targ in info_target:
             i_targ[key] = val
+
+
+def anonymize_info(info):
+    """Anonymize measurement information in place by removing 'subject_info',
+       'meas_date', 'file_id', 'meas_id' if they exist.
+
+    Parameters
+    ----------
+        info : dict, instance of Info
+        Measurement information for the dataset.
+
+    Returns
+    -------
+        info : instance of Info
+        Measurement information for the dataset.
+
+    Notes
+    -----
+        Operates in place.
+    """
+    if not isinstance(info, (dict, Info)):
+        raise ValueError('self must be an Info instance.')
+    if info.get('subject_info') is not None:
+        del info['subject_info']
+    info['meas_date'] = [0, 0]
+    for key_1 in ('file_id', 'meas_id'):
+        for key_2 in ('secs', 'msecs', 'usecs'):
+            info[key_1][key_2] = 0
+    return info

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -6,7 +6,6 @@ from nose.tools import assert_false, assert_equal, assert_raises, assert_true
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
-from mne.datasets import testing
 from mne import Epochs, read_events
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
                     _loc_to_coil_trans, Raw, read_info, write_info,
@@ -26,7 +25,6 @@ event_name = op.join(base_dir, 'test-eve.fif')
 kit_data_dir = op.join(op.dirname(__file__), '..', 'kit', 'tests', 'data')
 hsp_fname = op.join(kit_data_dir, 'test_hsp.txt')
 elp_fname = op.join(kit_data_dir, 'test_elp.txt')
-out_fname = op.join(_TempDir(), 'test_subj_info_raw.fif')
 
 
 def test_coil_trans():
@@ -328,7 +326,6 @@ def test_check_consistency():
     assert_raises(RuntimeError, info2._check_consistency)
 
 
-@testing.requires_testing_data
 def test_anonymize():
     # Checks that contains sensitive information
     assert_raises(ValueError, anonymize_info, 'foo')
@@ -355,6 +352,8 @@ def test_anonymize():
 
     # When we write out with raw.save, these get overwritten with the
     # new save time
+    tempdir = _TempDir()
+    out_fname = op.join(tempdir, 'test_subj_info_raw.fif')
     raw.save(out_fname, overwrite=True)
     raw = Raw(out_fname)
     assert_true(raw.info.get('subject_info') is None)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -327,7 +327,8 @@ def test_check_consistency():
 
 
 def test_anonymize():
-    # Checks that contains sensitive information
+    """Checks that sensitive information can be anonymized.
+    """
     assert_raises(ValueError, anonymize_info, 'foo')
 
     # Fake some subject data

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -336,11 +336,14 @@ def test_anonymize():
                                     first_name='bar', birthday=(1987, 4, 8),
                                     sex=0, hand=1)
 
+    orig_file_id = raw.info['file_id']['secs']
+    orig_meas_id = raw.info['meas_id']['secs']
     # Test instance method
     events = read_events(event_name)
     epochs = Epochs(raw, events[:1], 2, 0., 0.1)
     for inst in [raw, epochs]:
         assert_true('subject_info' in inst.info.keys())
+        assert_true(inst.info['subject_info'] is not None)
         assert_true(inst.info['file_id']['secs'] != 0)
         assert_true(inst.info['meas_id']['secs'] != 0)
         assert_true(np.any(inst.info['meas_date'] != [0, 0]))
@@ -357,9 +360,10 @@ def test_anonymize():
     raw.save(out_fname, overwrite=True)
     raw = Raw(out_fname)
     assert_true(raw.info.get('subject_info') is None)
-    assert_equal(raw.info['meas_date'], [0, 0])
-    assert_equal(raw.info['file_id']['secs'], 0)
-    assert_equal(raw.info['meas_id']['secs'], 0)
+    assert_array_equal(raw.info['meas_date'], [0, 0])
+    # XXX mne.io.write.write_id necessarily writes secs
+    assert_true(raw.info['file_id']['secs'] != orig_file_id)
+    assert_true(raw.info['meas_id']['secs'] != orig_meas_id)
 
 
 run_tests_if_main()


### PR DESCRIPTION
We currently could only anonymize `raw` data. This allow anonymizing any `Info`, and add the method to `Epochs` so that we can share already preprocessed data that happened not to be anonymized.