### PR TITLE
FIX: symbolic links on non NTFS partition

### DIFF
--- a/doc/manual/appendix/bem_model.rst
+++ b/doc/manual/appendix/bem_model.rst
@@ -78,9 +78,9 @@ following steps:
 - Inspecting the meshes with tkmedit, see :ref:`BABHJBED`.
 
 .. note:: Different methods can be employed for the creation of the
-          individual surfaces. For example, it may turn out that the 
+          individual surfaces. For example, it may turn out that the
           watershed algorithm produces are better quality skin surface than
-          the segmentation approach based on the FLASH images. If this is 
+          the segmentation approach based on the FLASH images. If this is
           the case, ``outer_skin.surf`` can set to point to the corresponding
           watershed output file while the other surfaces can be picked from
           the FLASH segmentation data.
@@ -158,6 +158,12 @@ Before running mne_flash_bem do the following:
   - ``ln -s``  <*FLASH 5 series dir*> ``flash05``
 
   - ``ln -s``  <*FLASH 30 series dir*> ``flash30``
+
+- Some partition formats (e.g. FAT32) do not support symbolic links. In this case, copy the file to the appropriate series:
+
+  - ``cp`` <*FLASH 5 series dir*> ``flash05``
+
+  - ``cp`` <*FLASH 30 series dir*> ``flash30``
 
 - Set the ``SUBJECTS_DIR`` and ``SUBJECT`` environment
   variables

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1642,7 +1642,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
 
 @verbose
 def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
-                   verbose=None, force_copy=False):
+                   verbose=None):
     """Create 3-Layer BEM model from prepared flash MRI images
 
     Parameters
@@ -1657,10 +1657,6 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
         Path to SUBJECTS_DIR if it is not set in the environment.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
-    force_copy : bool
-        Hard-copy files instead of making symbolic links. This parameter needs
-        to be applied on partitions, such as FAT32, that do not support
-        symbolic links.
 
     Notes
     -----

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1078,7 +1078,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
             else:
                 if op.exists(surf_out):
                     os.remove(surf_out)
-                os.symlink(surf_ws_out, surf_out)
+                _symlink(surf_ws_out, surf_out)
                 skip_symlink = False
 
         if skip_symlink:
@@ -1768,7 +1768,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
         else:
             if op.exists(surf):
                 os.remove(surf)
-            os.symlink(op.join('flash', surf), op.join(surf))
+            _symlink(op.join('flash', surf), op.join(surf))
             skip_symlink = False
     if skip_symlink:
         logger.info("Unable to create all symbolic links to .surf files "
@@ -1788,3 +1788,12 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
 
     # Go back to initial directory
     os.chdir(curdir)
+
+
+def _symlink(src, dest):
+    try:
+        os.symlink(src, dest)
+    except OSError:
+        shutil.copy(src, dest)
+        logger.warning('Could not create symbolic link because %f' % dest
+                       + 'is not on an NTFS partition. Copied file instead.')

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1795,5 +1795,5 @@ def _symlink(src, dest):
         os.symlink(src, dest)
     except OSError:
         shutil.copy(src, dest)
-        logger.warning('Could not create symbolic link because %s' % dest
-                       + 'is not on an NTFS partition. Copied file instead.')
+        logger.warning('Could not create symbolic link because is not on an '
+                       'NTFS partition. Copied %f instead.' % dest)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1536,6 +1536,10 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
            appropriate series:
            $ ln -s <FLASH 5 series dir> flash05
            $ ln -s <FLASH 30 series dir> flash30
+           Some partition formats (e.g. FAT32) do not support symbolic links.
+           In this case, copy the file to the appropriate series:
+           $ cp <FLASH 5 series dir> flash05
+           $ cp <FLASH 30 series dir> flash30
         4. cd to the directory where flash05 and flash30 links are
         5. Set SUBJECTS_DIR and SUBJECT environment variables appropriately
         6. Run this script

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1795,5 +1795,5 @@ def _symlink(src, dest):
         os.symlink(src, dest)
     except OSError:
         shutil.copy(src, dest)
-        logger.warning('Could not create symbolic link because %f' % dest
+        logger.warning('Could not create symbolic link because %s' % dest
                        + 'is not on an NTFS partition. Copied file instead.')

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -23,6 +23,10 @@ Before running this script do the following:
        appropriate series:
        $ ln -s <FLASH 5 series dir> flash05
        $ ln -s <FLASH 30 series dir> flash30
+       Some partition formats (e.g. FAT32) do not support symbolic links.
+       In this case, copy the file to the appropriate series:
+       $ cp <FLASH 5 series dir> flash05
+       $ cp <FLASH 30 series dir> flash30
     4. cd to the directory where flash05 and flash30 links are
     5. Set SUBJECTS_DIR and SUBJECT environment variables appropriately
     6. Run this script


### PR DESCRIPTION
When analyzing data on FAT32, I encountered a non-explicit error with `mne_watershed_bem` as it attemps to create a symbolic link, which isn' possible on all types of partitions.