### PR TITLE
[MRG][FIX] Evoked topomap colors correspond to the colorbar.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,8 @@ BUG
 
     - Fixed channel selection order when MEG channels do not come first in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 
+    - Fixed color ranges to correspond the colors in colorbar when plotting several time instances with :func:`mne.viz.plot_evoked_topomap` by `Jaakko Leppakangas`_
+
 API
 ~~~
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1362,12 +1362,10 @@ class ICA(ContainsMixin):
         fig : instance of matplotlib.pyplot.Figure
             The figure object.
         """
-        return plot_ica_components(self, picks=picks,
-                                   ch_type=ch_type,
-                                   res=res, layout=layout, vmax=vmax,
-                                   cmap=cmap,
-                                   sensors=sensors, colorbar=colorbar,
-                                   title=title, show=show,
+        return plot_ica_components(self, picks=picks, ch_type=ch_type,
+                                   res=res, layout=layout, vmin=vmin,
+                                   vmax=vmax, cmap=cmap, sensors=sensors,
+                                   colorbar=colorbar, title=title, show=show,
                                    outlines=outlines, contours=contours,
                                    image_interp=image_interp,
                                    head_pos=head_pos)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -19,11 +19,12 @@ from mne.io.constants import FIFF
 from mne.channels import read_layout, make_eeg_layout
 from mne.datasets import testing
 from mne.time_frequency.tfr import AverageTFR
-from mne.utils import slow_test
+from mne.utils import slow_test, run_tests_if_main
 
 from mne.viz import plot_evoked_topomap, plot_projs_topomap
 from mne.viz.topomap import (_check_outlines, _onselect, plot_topomap)
 from mne.viz.utils import _find_peaks
+
 
 # Set our plotters to test mode
 import matplotlib
@@ -275,3 +276,6 @@ def test_plot_tfr_topomap():
     _onselect(eclick, erelease, tfr, pos, 'mag', 1, 3, 1, 3, 'RdBu_r', list())
     tfr._onselect(eclick, erelease, None, 'mean', None)
     plt.close('all')
+
+
+run_tests_if_main()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1263,6 +1263,10 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     else:
         image_mask = None
 
+    vlims = [_setup_vmin_vmax(data[:, i], vmin, vmax, norm=merge_grads)
+             for i in range(len(times))]
+    vmin = np.min(vlims)
+    vmax = np.max(vlims)
     for idx, time in enumerate(times):
         tp, cn = plot_topomap(data[:, idx], pos, vmin=vmin, vmax=vmax,
                               sensors=sensors, res=res, names=names,


### PR DESCRIPTION
Noticed that the color range is too large for small activations when using multiple ``times`` in evoked topomaps. This is because the full range is always used. This means that the colors in colorbar don't correspond to the colors in topomaps (except the one with highest activation).