### PR TITLE
MRG: Ica inf values fix

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,8 @@ API
 
     - Now it is possible to plot only a subselection of channels in :func:`mne.viz.plot_raw` by using an array for order parameter by `Jaakko Leppakangas`_
 
+    - EOG channels can now be incuded when calling :funf:`mne.preprocessing.ICA.fit` and a proper error is raised when trying to include unsupported channels by `Alexander Rudiuk`_
+
 .. _changes_0_12:
 
 Version 0.12

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -475,7 +475,8 @@ class ICA(ContainsMixin):
                     elif ch_type == 'eog':
                         this_picks = pick_types(info, meg=False, eog=True)
                     else:
-                        raise RuntimeError('Unsupported channel {}'
+                        raise RuntimeError("""Should not be reached.
+                                           Unsupported channel {}"""
                                            .format(ch_type))
                     pre_whitener[this_picks] = np.std(data[this_picks])
             data /= pre_whitener

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -477,8 +477,8 @@ class ICA(ContainsMixin):
                     elif ch_type == 'eog':
                         this_picks = pick_types(info, meg=False, eog=True)
                     else:
-                        raise RuntimeError("""Should not be reached.
-                                           Unsupported channel {}"""
+                        raise RuntimeError('Should not be reached.'
+                                           'Unsupported channel {}'
                                            .format(ch_type))
                     pre_whitener[this_picks] = np.std(data[this_picks])
             data /= pre_whitener

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -101,11 +101,13 @@ def _check_for_unsupported_ica_channels(picks, info):
     elif len(picks) == 0:
         raise ValueError('No channels provided to ICA')
     types = _DATA_CH_TYPES_SPLIT + ['eog']
-    check = all([channel_type(info, j) in types for j in picks])
+    chs = list(set([channel_type(info, j) for j in picks]))
+    check = all([ch in types for ch in chs])
     if not check:
-        raise ValueError('Invalid channel type(s) passed for ICA.'
-                         'Only the following channels are supported {}'
-                         .format(types))
+        raise ValueError('Invalid channel type(s) passed for ICA.\n'
+                         'Only the following channels are supported {}\n'
+                         'Following types were passed {}\n'
+                         .format(types, chs))
 
 
 class ICA(ContainsMixin):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -272,11 +272,16 @@ class ICA(ContainsMixin):
         return '<ICA  |  %s>' % s
 
     def _check_for_unsupported_ica_channels(self, picks, info):
+        """Check for ica channels that are not considered
+        actual data channels. These prevents the program from
+        crashing without feedback when a bad channel is provided
+        to ICA whitening
+        """
         types = _DATA_CH_TYPES_SPLIT + ['eog']
-        n_chan = info['nchan']
         check = all([channel_type(info, j) in types for j in picks])
         if not check:
-            1 / 0
+            raise ValueError("""Invalid channel type(s) passed for ICA.
+             Only the following channels are supported {}""".format(types))
 
     @verbose
     def fit(self, inst, picks=None, start=None, stop=None, decim=None,
@@ -458,7 +463,7 @@ class ICA(ContainsMixin):
                         this_picks = pick_types(info, meg=False, ecog=True)
                     elif ch_type == 'eeg':
                         this_picks = pick_types(info, meg=False, eeg=True)
-                    elif ch_type == 'mag' or ch_type == 'grad':
+                    elif ch_type in ['mag', 'grad']:
                         this_picks = pick_types(info, meg=ch_type)
                     elif ch_type == 'eog':
                         this_picks = pick_types(info, meg=False, eog=True)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -636,8 +636,7 @@ def test_bad_channels():
 
 @requires_sklearn
 def test_eog_channel():
-    """Test if ICA works when EOG channel is included for raw
-    and epoched data"""
+    """Test that EOG channel is included when performing ICA"""
     raw = Raw(raw_fname, preload=True)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=True, ecg=False,
@@ -652,4 +651,6 @@ def test_eog_channel():
         picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
                             eog=True, exclude='bads')
         ica.fit(inst, picks=picks1, decim=decim)
+        assert_true(any('EOG' in ch for ch in ica.ch_names))
+
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -608,4 +608,32 @@ def test_fit_params():
     ICA(fit_params=fit_params)  # test no side effects
     assert_equal(fit_params, {})
 
+
+def test_bad_channels():
+    """Test if exception is raised when unsupported channels are used"""
+    """Test for raw and evoked data"""
+    raw = Raw(raw_fname)
+    raw.load_data()
+    events = read_events(event_name)
+    picks_bad1 = pick_types(raw.info, meg=False, stim=True, ecg=True,
+                            eog=False, exclude='bads')
+    picks_bad2 = pick_types(raw.info, meg=True, stim=True, ecg=True,
+                            eog=True, exclude='bads')
+    n_components = 0.9
+    decim = 3
+    ica = ICA(n_components=n_components)
+    assert_raises(ValueError, ica.fit, raw, picks=picks_bad1, decim=decim)
+    assert_raises(ValueError, ica.fit, raw, picks=picks_bad2, decim=decim)
+    picks = pick_types(raw.info, meg=True, stim=True, ecg=False,
+                       eog=True, exclude='bads')
+    epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
+                    baseline=(None, 0), preload=True)
+    picks_bad1 = pick_types(epochs.info, meg=False, stim=True, ecg=True,
+                            eog=False, exclude='bads')
+    picks_bad2 = pick_types(epochs.info, meg=True, stim=True, ecg=True,
+                            eog=True, exclude='bads')
+    assert_raises(ValueError, ica.fit, epochs, picks=picks_bad1, decim=decim)
+    assert_raises(ValueError, ica.fit, epochs, picks=picks_bad2, decim=decim)
+
+
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -9,7 +9,7 @@ import os
 import os.path as op
 import warnings
 
-from nose.tools import assert_true, assert_raises, assert_equal
+from nose.tools import assert_true, assert_raises, assert_equal, assert_false
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose)
@@ -646,11 +646,17 @@ def test_eog_channel():
     n_components = 0.9
     decim = 3
     ica = ICA(n_components=n_components)
+    # Test case for MEG and EOG data. Should have EOG channel
     for inst in [raw, epochs]:
-        # Test case for meg data and eog data
         picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
                             eog=True, exclude='bads')
         ica.fit(inst, picks=picks1, decim=decim)
         assert_true(any('EOG' in ch for ch in ica.ch_names))
+    # Test case for MEG data. Should have no EOG channel
+    for inst in [raw, epochs]:
+        picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
+                            eog=False, exclude='bads')
+        ica.fit(inst, picks=picks1, decim=decim)
+        assert_false(any('EOG' in ch for ch in ica.ch_names))
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -609,31 +609,26 @@ def test_fit_params():
     assert_equal(fit_params, {})
 
 
+@requires_sklearn
 def test_bad_channels():
-    """Test if exception is raised when unsupported channels are used"""
-    """Test for raw and evoked data"""
-    raw = Raw(raw_fname)
-    raw.load_data()
+    """Test if exception is raised when unsupported channels are used
+    Test for raw and evoked data"""
+    raw = Raw(raw_fname, preload=True)
     events = read_events(event_name)
-    picks_bad1 = pick_types(raw.info, meg=False, stim=True, ecg=True,
-                            eog=False, exclude='bads')
-    picks_bad2 = pick_types(raw.info, meg=True, stim=True, ecg=True,
-                            eog=True, exclude='bads')
-    n_components = 0.9
-    decim = 3
-    ica = ICA(n_components=n_components)
-    assert_raises(ValueError, ica.fit, raw, picks=picks_bad1, decim=decim)
-    assert_raises(ValueError, ica.fit, raw, picks=picks_bad2, decim=decim)
     picks = pick_types(raw.info, meg=True, stim=True, ecg=False,
                        eog=True, exclude='bads')
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    picks_bad1 = pick_types(epochs.info, meg=False, stim=True, ecg=True,
-                            eog=False, exclude='bads')
-    picks_bad2 = pick_types(epochs.info, meg=True, stim=True, ecg=True,
-                            eog=True, exclude='bads')
-    assert_raises(ValueError, ica.fit, epochs, picks=picks_bad1, decim=decim)
-    assert_raises(ValueError, ica.fit, epochs, picks=picks_bad2, decim=decim)
-
+    n_components = 0.9
+    decim = 3
+    ica = ICA(n_components=n_components)
+    for inst in [raw, epochs]:
+        picks_bad1 = pick_types(inst.info, meg=False, stim=True, ecg=True,
+                                eog=False, exclude='bads')
+        picks_bad2 = pick_types(inst.info, meg=True, stim=True, ecg=True,
+                                eog=True, exclude='bads')
+        assert_raises(ValueError, ica.fit, inst, picks=picks_bad1, decim=decim)
+        assert_raises(ValueError, ica.fit, inst, picks=picks_bad2, decim=decim)
+        assert_raises(ValueError, ica.fit, inst, picks=[], decim=decim)
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -625,15 +625,15 @@ def test_bad_channels():
     epochs = EpochsArray(data, info)
 
     n_components = 0.9
-    ica = ICA(n_components=n_components)
+    ica = ICA(n_components=n_components, method='fastica')
 
     for inst in [raw, epochs]:
         for ch in chs_bad:
             # Test case for only bad channels
-            picks_bad1 = pick_types(inst.info, exclude='bads',
+            picks_bad1 = pick_types(inst.info, meg=False,
                                     **{str(ch): True})
             # Test case for good and bad channels
-            picks_bad2 = pick_types(inst.info, exclude='bads',
+            picks_bad2 = pick_types(inst.info, meg=True,
                                     **{str(ch): True})
             assert_raises(ValueError, ica.fit, inst, picks=picks_bad1)
             assert_raises(ValueError, ica.fit, inst, picks=picks_bad2)
@@ -650,17 +650,20 @@ def test_eog_channel():
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
     n_components = 0.9
-    ica = ICA(n_components=n_components)
+    ica = ICA(n_components=n_components, method='fastica')
     # Test case for MEG and EOG data. Should have EOG channel
     for inst in [raw, epochs]:
-        picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
-                            eog=True, exclude='bads')
+        picks1a = pick_types(inst.info, meg=True, stim=False, ecg=False,
+                             eog=False, exclude='bads')[:4]
+        picks1b = pick_types(inst.info, meg=False, stim=False, ecg=False,
+                             eog=True, exclude='bads')
+        picks1 = np.append(picks1a, picks1b)
         ica.fit(inst, picks=picks1)
         assert_true(any('EOG' in ch for ch in ica.ch_names))
     # Test case for MEG data. Should have no EOG channel
     for inst in [raw, epochs]:
         picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
-                            eog=False, exclude='bads')
+                            eog=False, exclude='bads')[:4]
         ica.fit(inst, picks=picks1)
         assert_false(any('EOG' in ch for ch in ica.ch_names))
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -623,12 +623,33 @@ def test_bad_channels():
     decim = 3
     ica = ICA(n_components=n_components)
     for inst in [raw, epochs]:
+        # Test case for only bad channels
         picks_bad1 = pick_types(inst.info, meg=False, stim=True, ecg=True,
                                 eog=False, exclude='bads')
+        # Test case for good and bad channels
         picks_bad2 = pick_types(inst.info, meg=True, stim=True, ecg=True,
                                 eog=True, exclude='bads')
         assert_raises(ValueError, ica.fit, inst, picks=picks_bad1, decim=decim)
         assert_raises(ValueError, ica.fit, inst, picks=picks_bad2, decim=decim)
         assert_raises(ValueError, ica.fit, inst, picks=[], decim=decim)
 
+
+@requires_sklearn
+def test_eog_channel():
+    """Test if ICA works when EOG channel is included for raw
+    and epoched data"""
+    raw = Raw(raw_fname, preload=True)
+    events = read_events(event_name)
+    picks = pick_types(raw.info, meg=True, stim=True, ecg=False,
+                       eog=True, exclude='bads')
+    epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
+                    baseline=(None, 0), preload=True)
+    n_components = 0.9
+    decim = 3
+    ica = ICA(n_components=n_components)
+    for inst in [raw, epochs]:
+        # Test case for meg data and eog data
+        picks1 = pick_types(inst.info, meg=True, stim=False, ecg=False,
+                            eog=True, exclude='bads')
+        ica.fit(inst, picks=picks1, decim=decim)
 run_tests_if_main()


### PR DESCRIPTION
It seems like the error with #3267 is that the user can define channels which are not supported data channels.

In my current code I have added a simple method that crashes the program if there are unsupported channels defined by the user. I also added EOG as an acceptable channel. 
@agramfort @Eric89GXL any ideas on how to proceed? 

Two things that still need to be addressed in my eyes are: 1) should EOG be included as a supported channel? 2) how would I raise an appropriate error for bad channels being present?