### PR TITLE
MRG robustness to old EEGLAB versions

### DIFF
--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -526,7 +526,7 @@ def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
         event_id = dict()
 
     if isinstance(eeg.event, np.ndarray):
-        types = [event.type for event in eeg.event]
+        types = [str(event.type) for event in eeg.event]
         latencies = [event.latency for event in eeg.event]
     else:
         # only one event - TypeError: 'mat_struct' object is not iterable

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 from mne import write_events, read_epochs_eeglab, Epochs, find_events
 from mne.io import read_raw_eeglab
 from mne.io.tests.test_raw import _test_raw_reader
+from mne.io.eeglab.eeglab import _read_eeglab_events
 from mne.datasets import testing
 from mne.utils import _TempDir, run_tests_if_main, requires_version
 
@@ -61,6 +62,15 @@ def test_io_set():
         assert_equal(len(w), 4)
         # 1 for preload=False / str with fname_onefile, 3 for dropped events
         raw0.filter(1, None)  # test that preloading works
+
+    # test old EEGLAB version event import
+    eeg = io.loadmat(raw_fname, struct_as_record=False,
+                     squeeze_me=True)['EEG']
+    events1 = _read_eeglab_events(eeg)
+    for event in eeg.event:  # old version allows integer events
+        event.type = int(event.type)
+    events2 = _read_eeglab_events(eeg)
+    assert_array_equal(events1, events2)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -66,11 +66,9 @@ def test_io_set():
     # test old EEGLAB version event import
     eeg = io.loadmat(raw_fname, struct_as_record=False,
                      squeeze_me=True)['EEG']
-    events1 = _read_eeglab_events(eeg)
     for event in eeg.event:  # old version allows integer events
-        event.type = int(event.type)
-    events2 = _read_eeglab_events(eeg)
-    assert_array_equal(events1, events2)
+        event.type = 1
+    assert_equal(_read_eeglab_events(eeg)[-1, -1], 1)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')


### PR DESCRIPTION
Old EEGLAB versions seemingly allow integer event codes.
closes #3264

Not sure how to test - we probably don't want to add another test file just for this.