### PR TITLE
MRG: Add Evoked.decimate

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,8 @@ Changelog
 
     - Add order params 'selection' and 'position' for :func:`mne.viz.plot_raw` to allow plotting of specific brain regions by `Jaakko Leppakangas`_
 
+    - Added the ability to decimate :class:`mne.Evoked` objects with :func:`mne.Evoked.decimate` by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,8 @@ BUG
 
     - Added units to :func:`mne.io.read_raw_brainvision` for reading non-data channels and enable default behavior of inferring channel type by unit by `Jaakko Leppakangas`_ and `Pablo-Arias`_
 
+    - Fixed minor bugs with :func:`mne.Epochs.resample` and :func:`mne.Epochs.decimate` by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -340,6 +340,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def decimate(self, decim, offset=0):
         """Decimate the epochs
 
+        .. note:: No filtering is performed. To avoid aliasing, ensure
+                  your data are properly lowpassed.
+
         Parameters
         ----------
         decim : int
@@ -359,6 +362,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         See Also
         --------
         Evoked.decimate
+        Epochs.resample
+        Raw.resample
 
         Notes
         -----
@@ -1692,6 +1697,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self.info['sfreq'] = float(sfreq)
         self.times = (np.arange(self._data.shape[2], dtype=np.float) /
                       sfreq + self.times[0])
+        self._raw_times = self.times
         return self
 
     def copy(self):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -160,6 +160,44 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self.data = self.data[:, mask]
         return self
 
+    def decimate(self, decim, offset=0):
+        """Decimate the evoked data
+
+        Parameters
+        ----------
+        decim : int
+            The amount to decimate data.
+        offset : int
+            Apply an offset to where the decimation starts relative to the
+            sample corresponding to t=0. The offset is in samples at the
+            current sampling rate.
+
+        Returns
+        -------
+        evoked : instance of Evoked
+            The decimated Evoked object.
+
+        See Also
+        --------
+        Epochs.decimate
+
+        Notes
+        -----
+        Decimation can be done multiple times. For example,
+        ``evoked.decimate(2).decimate(2)`` will be the same as
+        ``evoked.decimate(4)``.
+
+        .. versionadded:: 0.13.0
+        """
+        decim, offset, new_sfreq = _check_decim(self.info, decim, offset)
+        start_idx = int(round(self.times[0] * (self.info['sfreq'] * decim)))
+        i_start = start_idx % decim + offset
+        decim_slice = slice(i_start, None, decim)
+        self.info['sfreq'] = new_sfreq
+        self.data = self.data[:, decim_slice].copy()
+        self.times = self.times[decim_slice].copy()
+        return self
+
     def shift_time(self, tshift, relative=True):
         """Shift time scale in evoked data
 
@@ -898,6 +936,30 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         return (ch_names[ch_idx],
                 time_idx if time_as_index else self.times[time_idx])
+
+
+def _check_decim(info, decim, offset):
+    """Helper to check decimation parameters"""
+    if decim < 1 or decim != int(decim):
+        raise ValueError('decim must be an integer > 0')
+    decim = int(decim)
+    new_sfreq = info['sfreq'] / float(decim)
+    lowpass = info['lowpass']
+    if decim > 1 and lowpass is None:
+        warn('The measurement information indicates data is not low-pass '
+             'filtered. The decim=%i parameter will result in a sampling '
+             'frequency of %g Hz, which can cause aliasing artifacts.'
+             % (decim, new_sfreq))
+    elif decim > 1 and new_sfreq < 2.5 * lowpass:
+        warn('The measurement information indicates a low-pass frequency '
+             'of %g Hz. The decim=%i parameter will result in a sampling '
+             'frequency of %g Hz, which can cause aliasing artifacts.'
+             % (lowpass, decim, new_sfreq))  # > 50% nyquist lim
+    offset = int(offset)
+    if not 0 <= offset < decim:
+        raise ValueError('decim must be at least 0 and less than %s, got '
+                         '%s' % (decim, offset))
+    return decim, offset, new_sfreq
 
 
 class EvokedArray(Evoked):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -163,6 +163,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def decimate(self, decim, offset=0):
         """Decimate the evoked data
 
+        .. note:: No filtering is performed. To avoid aliasing, ensure
+                  your data are properly lowpassed.
+
         Parameters
         ----------
         decim : int
@@ -180,6 +183,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         See Also
         --------
         Epochs.decimate
+        Epochs.resample
+        Raw.resample
 
         Notes
         -----

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -54,7 +54,7 @@ def test_decim():
     assert_array_equal(data_epochs, data_epochs_3)
 
     # Now let's do it with some real data
-    raw = io.Raw(raw_fname)
+    raw = io.read_raw_fif(raw_fname)
     events = read_events(event_name)
     sfreq_new = raw.info['sfreq'] / decim
     raw.info['lowpass'] = sfreq_new / 4.  # suppress aliasing warnings


### PR DESCRIPTION
Also fixes a bug with existing `Epochs.decimate` when the `offset` parameter is used.

Closes #3287.
Closes #3296.

Ready for review/merge from my end.