### PR TITLE
FIX: don't always overwrite blit to True

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1892,7 +1892,7 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
         raise ValueError('All times must be inside the evoked time series.')
     frames = [np.abs(evoked.times - time).argmin() for time in times]
 
-    blit = False if plt.get_backend() == 'MacOSX' else True
+    blit = False if plt.get_backend() == 'MacOSX' else blit
     picks, pos, merge_grads, _, ch_type = _prepare_topo_plot(evoked,
                                                              ch_type=ch_type,
                                                              layout=None)


### PR DESCRIPTION
When saving an animation to use with `HTML(anim.to_html5_video())` in
ipython notebooks it seems necessary to disable blit manually.