### PR TITLE
MRG: More strict check in simulation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,8 @@ BUG
 
     - Fixed minor bugs with :func:`mne.Epochs.resample` and :func:`mne.Epochs.decimate` by `Eric Larson`_
 
+    - Fixed a bug where duplicate vertices were not strictly checked by :func:`mne.simulation.simulate_stc` by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -201,6 +201,11 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None):
         elif len(vertno[idx]) == 1:
             vertno[idx] = vertno[idx][0]
     vertno = [np.array(v) for v in vertno]
+    for v, hemi in zip(vertno, ('left', 'right')):
+        d = len(v) - len(np.unique(v))
+        if d > 0:
+            raise RuntimeError('Labels had %s overlaps in the %s hemisphere, '
+                               'they must be non-overlapping' % (d, hemi))
 
     # the data is in the order left, right
     data = list()

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -2,7 +2,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_raises
 
 from mne.datasets import testing
 from mne import read_label, read_forward_solution, pick_types_forward
@@ -83,6 +83,15 @@ def test_simulate_stc():
 
         res = ((2. * i) ** 2.) * np.ones((len(idx), n_times))
         assert_array_almost_equal(stc.data[idx], res)
+
+    # degenerate conditions
+    label_subset = mylabels[:2]
+    data_subset = stc_data[:2]
+    stc = simulate_stc(fwd['src'], label_subset, data_subset, tmin, tstep, fun)
+    assert_raises(ValueError, simulate_stc, fwd['src'],
+                  label_subset, data_subset[:-1], tmin, tstep, fun)
+    assert_raises(RuntimeError, simulate_stc, fwd['src'], label_subset * 2,
+                  np.concatenate([data_subset] * 2, axis=0), tmin, tstep, fun)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Adds a check that labels in `simulate_stc` do not overlap. If they did, in `master` the error would be cryptic:
```
  File "/home/larsoner/custombuilds/mne-python/mne/simulation/source.py", line 219, in simulate_stc
    stc = SourceEstimate(data, vertices=vertno, tmin=tmin, tstep=tstep)
  File "<string>", line 2, in __init__
  File "/home/larsoner/custombuilds/mne-python/mne/utils.py", line 629, in verbose
    return function(*args, **kwargs)
  File "/home/larsoner/custombuilds/mne-python/mne/source_estimate.py", line 975, in __init__
    verbose=verbose)
  File "<string>", line 2, in __init__
  File "/home/larsoner/custombuilds/mne-python/mne/utils.py", line 629, in verbose
    return function(*args, **kwargs)
  File "/home/larsoner/custombuilds/mne-python/mne/source_estimate.py", line 443, in __init__
    raise ValueError('Vertices must be ordered in increasing '
```
Now it's:
```
  File "/home/larsoner/custombuilds/mne-python/mne/simulation/source.py", line 208, in simulate_stc
    'they must be non-overlapping' % (d, hemi))
RuntimeError: Labels had 100 overlaps in the right hemisphere, they must be non-overlapping
```