### PR TITLE
MRG: Set subject when simulating source

### DIFF
--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -18,6 +18,13 @@ def simulate_evoked(fwd, stc, info, cov, snr=3., tmin=None, tmax=None,
                     iir_filter=None, random_state=None, verbose=None):
     """Generate noisy evoked data
 
+    .. note:: No projections from ``info`` will be present in the
+              output ``evoked``. You can use e.g.
+              :func:`evoked.add_proj <mne.Evoked.add_proj>` or
+              :func:`evoked.add_eeg_average_proj
+              <mne.Evoked.add_eeg_average_proj>`
+              to add them afterward as necessary.
+
     Parameters
     ----------
     fwd : dict

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -86,6 +86,7 @@ def simulate_sparse_stc(src, n_dipoles, times,
     """
     rng = check_random_state(random_state)
     src = _ensure_src(src, verbose=False)
+    subject = src[0].get('subject_his_id')
     data = np.zeros((n_dipoles, len(times)))
     for i_dip in range(n_dipoles):
         data[i_dip, :] = data_fun(times)
@@ -131,7 +132,7 @@ def simulate_sparse_stc(src, n_dipoles, times,
     tmin, tstep = times[0], np.diff(times[:2])[0]
     assert datas.shape == data.shape
     cls = SourceEstimate if len(vs) == 2 else VolSourceEstimate
-    stc = cls(datas, vertices=vs, tmin=tmin, tstep=tstep)
+    stc = cls(datas, vertices=vs, tmin=tmin, tstep=tstep, subject=subject)
     return stc
 
 
@@ -154,7 +155,7 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None):
 
     Parameters
     ----------
-    src : list of dict
+    src : instance of SourceSpaces
         The source space
     labels : list of Labels
         The labels
@@ -221,5 +222,7 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None):
 
     data = np.concatenate(data)
 
-    stc = SourceEstimate(data, vertices=vertno, tmin=tmin, tstep=tstep)
+    subject = src[0].get('subject_his_id')
+    stc = SourceEstimate(data, vertices=vertno, tmin=tmin, tstep=tstep,
+                         subject=subject)
     return stc

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -2,7 +2,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import assert_true, assert_raises
+from nose.tools import assert_true, assert_raises, assert_equal
 
 from mne.datasets import testing
 from mne import read_label, read_forward_solution, pick_types_forward
@@ -46,6 +46,7 @@ def test_simulate_stc():
 
     stc_data = np.ones((len(labels), n_times))
     stc = simulate_stc(fwd['src'], mylabels, stc_data, tmin, tstep)
+    assert_equal(stc.subject, 'sample')
 
     for label in labels:
         if label.hemi == 'lh':
@@ -108,6 +109,7 @@ def test_simulate_sparse_stc():
 
     stc_1 = simulate_sparse_stc(fwd['src'], len(labels), times,
                                 labels=labels, random_state=0)
+    assert_equal(stc_1.subject, 'sample')
 
     assert_true(stc_1.data.shape[0] == len(labels))
     assert_true(stc_1.data.shape[1] == n_times)


### PR DESCRIPTION
@nfoti I think removing the projections is a reasonable thing to do. Would this docstring have saved you a bit of annoyance when using `simulate_evoked`?

Note I also added auto `stc.subject` setting in `simulate*_stc`.