### PR TITLE
MRG: Better error message for morph

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2219,7 +2219,7 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
     ----------
     subject : str
         Name of the subject
-    grade : int
+    grade : int | list
         Resolution of the icosahedral mesh (typically 5). If None, all
         vertices will be used (potentially filling the surface). If a list,
         then values will be morphed to the set of vertices specified in
@@ -2276,7 +2276,8 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
                     raise ValueError(
                         'Cannot use icosahedral grade %s with subject %s, '
                         'mapping %s vertices onto the high-resolution mesh '
-                        'yields repeated vertices'
+                        'yields repeated vertices, use a lower grade or a '
+                        'list of vertices from an existing source space'
                         % (grade, subject, len(verts)))
     else:  # potentially fill the surface
         vertices = [np.arange(lhs.shape[0]), np.arange(rhs.shape[0])]

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2271,6 +2271,13 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
                                 for xhs in [lhs, rhs])
             # Make sure the vertices are ordered
             vertices = [np.sort(verts) for verts in vertices]
+            for verts in vertices:
+                if (np.diff(verts) == 0).any():
+                    raise ValueError(
+                        'Cannot use icosahedral grade %s with subject %s, '
+                        'mapping %s vertices onto the high-resolution mesh '
+                        'yields repeated vertices'
+                        % (grade, subject, len(verts)))
     else:  # potentially fill the surface
         vertices = [np.arange(lhs.shape[0]), np.arange(rhs.shape[0])]
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -49,7 +49,7 @@ rng = np.random.RandomState(0)
 
 
 @testing.requires_testing_data
-def test_aaspatial_inter_hemi_connectivity():
+def test_spatial_inter_hemi_connectivity():
     """Test spatial connectivity between hemispheres"""
     # trivial cases
     conn = spatial_inter_hemi_connectivity(fname_src_3, 5e-6)
@@ -441,6 +441,11 @@ def test_morph_data():
     stc_to1 = stc_from.morph(subject_to, grade=3, smooth=12, buffer_size=1000,
                              subjects_dir=subjects_dir)
     stc_to1.save(op.join(tempdir, '%s_audvis-meg' % subject_to))
+    # Morphing to a density that is too high should raise an informative error
+    # (here we need to push to grade=6, but for some subjects even grade=5
+    # will break)
+    assert_raises(ValueError, stc_to1.morph, subject_from, grade=6,
+                  subjects_dir=subjects_dir)
     # make sure we can specify vertices
     vertices_to = grade_to_vertices(subject_to, grade=3,
                                     subjects_dir=subjects_dir)


### PR DESCRIPTION
Gives a more informative error message when users request a `grade` that can't be constructed for a subject. Previously they would get an error about vertices needing to be in ascending order, now they get a more informative message like "Cannot use icosahedral grade 6 with subject sample, mapping 40962 vertices onto the high-resolution mesh yields repeated vertices".

Apparently @nfoti is hitting a lot of corner cases for us :)

Ready for review/merge from my end.