### PR TITLE
[MRG] raw.plot_psd() with flat channel

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -575,6 +575,12 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         # Convert PSDs to dB
         if dB:
             psds = 10 * np.log10(psds)
+            if np.any(np.isinf(psds)):
+                where = np.flatnonzero(np.isinf(psds.min(1)))
+                chs = [raw.ch_names[i] for i in picks[where]]
+                raise ValueError("Infinite value in PSD for channel(s) %s. "
+                                 "These channels might be dead." %
+                                 ', '.join(chs))
             unit = 'dB'
         else:
             unit = 'power'

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -153,7 +153,7 @@ def test_plot_raw_psd():
     plt.close('all')
     # with a flat channel
     raw[5, :] = 0
-    raw.plot_psd()
+    assert_raises(ValueError, raw.plot_psd)
 
 
 def test_plot_sensors():

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -151,6 +151,9 @@ def test_plot_raw_psd():
     # topo psd
     raw.plot_psd_topo()
     plt.close('all')
+    # with a flat channel
+    raw[5, :] = 0
+    raw.plot_psd()
 
 
 def test_plot_sensors():


### PR DESCRIPTION
Currently when running `raw.plot_psd()` with data containing a dead channel an empty plot is created. Should the fix treat the dead channel like a normal channel or raise a warning or error?

![screen shot 2016-06-26 at 1 33 09 pm](https://cloud.githubusercontent.com/assets/145771/16363760/c8e25606-3ba2-11e6-9831-41ce6ba68a69.png)
 