### PR TITLE
Fix bug in set_bipolar_reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,8 @@ BUG
 
     - Fixed a bug where ``merge_grads=True`` causes :func:`mne.viz.plot_evoked_topo` to fail when plotting a list of evokeds by `Jaakko Leppakangas`_
 
+    - Fixed a bug when setting multiple bipolar references with :func:`mne.io.set_bipolar_reference` by `Marijn van Vliet`_.
+
 API
 ~~~
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -370,7 +370,6 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     # Perform bipolar referencing
     for an, ca, name, info in zip(anode, cathode, ch_name, new_ch_info):
-        print ca, an
         _apply_reference(inst, [ca], [an])
         an_idx = inst.ch_names.index(an)
         inst.info['chs'][an_idx] = info

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -370,12 +370,13 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     # Perform bipolar referencing
     for an, ca, name, info in zip(anode, cathode, ch_name, new_ch_info):
+        print ca, an
         _apply_reference(inst, [ca], [an])
         an_idx = inst.ch_names.index(an)
         inst.info['chs'][an_idx] = info
         inst.info['chs'][an_idx]['ch_name'] = name
         logger.info('Bipolar channel added as "%s".' % name)
-    inst.info._update_redundant()
+        inst.info._update_redundant()
 
     # Drop cathode channels
     inst.drop_channels(cathode)

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -192,7 +192,6 @@ def test_set_bipolar_reference():
     )
     a = raw.copy().pick_channels(['EEG 001', 'EEG 002', 'EEG 003', 'EEG 004'])
     a = np.array([a._data[0, :] - a._data[1, :], a._data[2, :] - a._data[3, :]])
-    print a.shape
     b = reref.copy().pick_channels(['bipolar1', 'bipolar2'])._data
     assert_allclose(a, b)
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -191,7 +191,8 @@ def test_set_bipolar_reference():
          {'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'}],
     )
     a = raw.copy().pick_channels(['EEG 001', 'EEG 002', 'EEG 003', 'EEG 004'])
-    a = np.array([a._data[0, :] - a._data[1, :], a._data[2, :] - a._data[3, :]])
+    a = np.array([a._data[0, :] - a._data[1, :],
+                  a._data[2, :] - a._data[3, :]])
     b = reref.copy().pick_channels(['bipolar1', 'bipolar2'])._data
     assert_allclose(a, b)
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -181,6 +181,21 @@ def test_set_bipolar_reference():
     reref = set_bipolar_reference(raw, 'EEG 001', 'EEG 002')
     assert_true('EEG 001-EEG 002' in reref.ch_names)
 
+    # Set multiple references at once
+    reref = set_bipolar_reference(
+        raw,
+        ['EEG 001', 'EEG 003'],
+        ['EEG 002', 'EEG 004'],
+        ['bipolar1', 'bipolar2'],
+        [{'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'},
+         {'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'}],
+    )
+    a = raw.copy().pick_channels(['EEG 001', 'EEG 002', 'EEG 003', 'EEG 004'])
+    a = np.array([a._data[0, :] - a._data[1, :], a._data[2, :] - a._data[3, :]])
+    print a.shape
+    b = reref.copy().pick_channels(['bipolar1', 'bipolar2'])._data
+    assert_allclose(a, b)
+
     # Test creating a bipolar reference that doesn't involve EEG channels:
     # it should not set the custom_ref_applied flag
     reref = set_bipolar_reference(raw, 'MEG 0111', 'MEG 0112',


### PR DESCRIPTION
Closes #3338

There was a test missing for setting multiple references with the `mne.io.set_bipolar_reference` function. With the back and forth on the `Info` object, this case therefore slipped through the regression testing. This PR adds the test and fixes the code.