### PR TITLE
attempt to make cross links between examples and API work

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -302,3 +302,15 @@ sphinx_gallery_conf = {
     }
 
 numpydoc_class_members_toctree = False
+
+def touch_example_backreferences(app, what, name, obj, options, lines):
+    # generate empty examples files, so that we don't get
+    # inclusion errors if there are no examples for a class / module
+    examples_path = os.path.join(app.srcdir, "modules", "generated",
+                                 "%s.examples" % name)
+    if not os.path.exists(examples_path):
+        # touch file
+        open(examples_path, 'w').close()
+
+def setup(app):
+    app.connect('autodoc-process-docstring', touch_example_backreferences)


### PR DESCRIPTION
eg see for example:

http://nilearn.github.io/modules/generated/nilearn.image.high_variance_confounds.html

at bottom of the page. In our function.rst we have 

.. include:: {{module}}.{{objname}}.examples

so to me it should work.

@jaeilepp can you have a look?