### PR TITLE
MRG fix eeglab single integer event

### DIFF
--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -530,7 +530,7 @@ def _read_eeglab_events(eeg, event_id=None, event_id_func='strip_to_integer'):
         latencies = [event.latency for event in eeg.event]
     else:
         # only one event - TypeError: 'mat_struct' object is not iterable
-        types = [eeg.event.type]
+        types = [str(eeg.event.type)]
         latencies = [eeg.event.latency]
     if "boundary" in types and "boundary" not in event_id:
         warn("The data contains 'boundary' events, indicating data "

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -69,6 +69,8 @@ def test_io_set():
     for event in eeg.event:  # old version allows integer events
         event.type = 1
     assert_equal(_read_eeglab_events(eeg)[-1, -1], 1)
+    eeg.event = eeg.event[0]  # single event
+    assert_equal(_read_eeglab_events(eeg)[-1, -1], 1)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')


### PR DESCRIPTION
We recently fixed old EEGLAB versions that could store events as integers. However, we only fixed it for the multi-event case. This takes care of the single-event case.