### PR TITLE
fix vmin vmax in plot_epochs_image when picks is more than one

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -177,14 +177,14 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             if colorbar:
                 ax3 = plt.subplot2grid((3, 10), (0, 9), colspan=1, rowspan=3)
         if scale_vmin:
-            vmin *= scalings[ch_type]
+            this_vmin = vmin * scalings[ch_type]
         if scale_vmax:
-            vmax *= scalings[ch_type]
+            this_vmax = vmax * scalings[ch_type]
         im = ax1.imshow(this_data,
                         extent=[1e3 * epochs.times[0], 1e3 * epochs.times[-1],
                                 0, len(data)],
                         aspect='auto', origin='lower', interpolation='nearest',
-                        vmin=vmin, vmax=vmax, cmap=cmap)
+                        vmin=this_vmin, vmax=this_vmax, cmap=cmap)
         if this_overlay_times is not None:
             plt.plot(1e3 * this_overlay_times, 0.5 + np.arange(len(this_data)),
                      'k', linewidth=2)


### PR DESCRIPTION
`vmin` and `vmax` were repeatedly scaled when picks were longer than one leading to almost all images except the first one being almost entirely white. This fixes the problem.

Before:
<img width="300" alt="before" src="https://cloud.githubusercontent.com/assets/8452354/16434519/ae88f504-3d90-11e6-9b56-75b78deb9e71.PNG">

After:
<img width="300" alt="after" src="https://cloud.githubusercontent.com/assets/8452354/16434523/b4f7bc36-3d90-11e6-8327-020d6a568bf2.PNG">

Currently, however, if vmin and vmax are None (default) - each epochs image plot will have it's own scale. I'm fine with that, but not sure about others.
This is a small change, do you think it requires test or could I leave it as it is now?