### PR TITLE
[MRG] set vmin, vmax after smoothing in plot_epochs_image

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -118,7 +118,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     data = epochs.get_data()[:, picks, :]
     scale_vmin = True if vmin is None else False
     scale_vmax = True if vmax is None else False
-    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
 
     if overlay_times is not None and len(overlay_times) != len(data):
         raise ValueError('size of overlay_times parameter (%s) do not '
@@ -146,7 +145,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if ch_type not in scalings:
             # We know it's not in either scalings or units since keys match
             raise KeyError('%s type not in scalings and units' % ch_type)
-        this_data *= scalings[ch_type]
 
         this_order = order
         if callable(order):
@@ -170,6 +168,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if sigma > 0.:
             this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma,
                                                   axis=0)
+        vmin, vmax = _setup_vmin_vmax(this_data, vmin, vmax)
+        this_data *= scalings[ch_type]
+
         plt.figure(this_fig.number)
         if axes is None:
             ax1 = plt.subplot2grid((3, 10), (0, 0), colspan=9, rowspan=2)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -116,13 +116,21 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             ax3 = axes[-1]
     evoked = epochs.average(picks)
     data = epochs.get_data()[:, picks, :]
+    n_epochs = len(data)
+    data = np.swapaxes(data, 0, 1)
+    if sigma > 0.:
+        for k in range(len(picks)):
+            data[k, :] = ndimage.gaussian_filter1d(
+                data[k, :], sigma=sigma, axis=0)
+
     scale_vmin = True if vmin is None else False
     scale_vmax = True if vmax is None else False
+    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
 
-    if overlay_times is not None and len(overlay_times) != len(data):
+    if overlay_times is not None and len(overlay_times) != n_epochs:
         raise ValueError('size of overlay_times parameter (%s) do not '
                          'match the number of epochs (%s).'
-                         % (len(overlay_times), len(data)))
+                         % (len(overlay_times), n_epochs))
 
     if overlay_times is not None:
         overlay_times = np.array(overlay_times)
@@ -134,7 +142,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                  % (epochs.tmin, epochs.tmax))
 
     figs = list()
-    for i, (this_data, idx) in enumerate(zip(np.swapaxes(data, 0, 1), picks)):
+    for i, (this_data, idx) in enumerate(zip(data, picks)):
         if fig is None:
             this_fig = plt.figure()
         else:
@@ -145,6 +153,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         if ch_type not in scalings:
             # We know it's not in either scalings or units since keys match
             raise KeyError('%s type not in scalings and units' % ch_type)
+        this_data *= scalings[ch_type]
 
         this_order = order
         if callable(order):
@@ -165,12 +174,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             if this_overlay_times is not None:
                 this_overlay_times = this_overlay_times[this_order]
 
-        if sigma > 0.:
-            this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma,
-                                                  axis=0)
-        vmin, vmax = _setup_vmin_vmax(this_data, vmin, vmax)
-        this_data *= scalings[ch_type]
-
         plt.figure(this_fig.number)
         if axes is None:
             ax1 = plt.subplot2grid((3, 10), (0, 0), colspan=9, rowspan=2)
@@ -183,7 +186,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             vmax *= scalings[ch_type]
         im = ax1.imshow(this_data,
                         extent=[1e3 * epochs.times[0], 1e3 * epochs.times[-1],
-                                0, len(data)],
+                                0, n_epochs],
                         aspect='auto', origin='lower', interpolation='nearest',
                         vmin=vmin, vmax=vmax, cmap=cmap)
         if this_overlay_times is not None:


### PR DESCRIPTION
Another small change to `plot_epochs_image` - I made it separate from the other PR, because it is not necessarily a bug.
Currently `vmin` and `vmax` are set before smoothing (using `sigma`) so if one uses `sigma` the colorscale is not fully used (smoothed data will have lower min and max values etc.).
You can see the difference here:
*Before*:
<img width="300" alt="before_02" src="https://cloud.githubusercontent.com/assets/8452354/16435741/6e2c6ac4-3d98-11e6-9306-878f1e131455.PNG">

*After*:
<img width="300" alt="after_02" src="https://cloud.githubusercontent.com/assets/8452354/16435747/77e06b2e-3d98-11e6-8dff-c06687b1adee.PNG">

:warning: 
Now the vmin, vmax are not set based on the whole data, but based on the first smoothed channel (out of those in picks). I could move smoothing out of the figure-loop - so that all picks are smoothed before the loop and vmin, vmax are set based on the whole smoothed data.