### PR TITLE
adding background image to other topoplots

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1039,9 +1039,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             matplotlib borders style to be used for each sensor plot.
         fig_facecolor : str | obj
             The figure face color. Defaults to black.
-        fig_background : None | numpy ndarray
-            A background image for the figure. This must work with a call to
-            plt.imshow. Defaults to None.
+        fig_background : None | array
+            A background image for the figure. This must be a valid input to
+            `matplotlib.pyplot.imshow`. Defaults to None.
         font_color : str | obj
             The color of tick labels in the colorbar. Defaults to white.
         show : bool

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1000,8 +1000,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,
                         colorbar=True, order=None, cmap='RdBu_r',
                         layout_scale=.95, title=None, scalings=None,
-                        border='none', fig_facecolor='k', font_color='w',
-                        show=True):
+                        border='none', fig_facecolor='k', fig_background=None,
+                        font_color='w', show=True):
         """Plot Event Related Potential / Fields image on topographies
 
         Parameters
@@ -1039,6 +1039,9 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             matplotlib borders style to be used for each sensor plot.
         fig_facecolor : str | obj
             The figure face color. Defaults to black.
+        fig_background : None | numpy ndarray
+            A background image for the figure. This must work with a call to
+            plt.imshow. Defaults to None.
         font_color : str | obj
             The color of tick labels in the colorbar. Defaults to white.
         show : bool
@@ -1053,8 +1056,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self, layout=layout, sigma=sigma, vmin=vmin, vmax=vmax,
             colorbar=colorbar, order=order, cmap=cmap,
             layout_scale=layout_scale, title=title, scalings=scalings,
-            border=border, fig_facecolor=fig_facecolor, font_color=font_color,
-            show=show)
+            border=border, fig_facecolor=fig_facecolor,
+            fig_background=fig_background, font_color=font_color, show=show)
 
     @verbose
     def drop_bad(self, reject='existing', flat='existing', verbose=None):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -866,9 +866,9 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             matplotlib borders style to be used for each sensor plot.
         fig_facecolor : str | obj
             The figure face color. Defaults to black.
-        fig_background : None | numpy ndarray
-            A background image for the figure. This must work with a call to
-            plt.imshow. Defaults to None.
+        fig_background : None | array
+            A background image for the figure. This must be a valid input to
+            `matplotlib.pyplot.imshow`. Defaults to None.
         font_color: str | obj
             The color of tick labels in the colorbar. Defaults to white.
 
@@ -910,8 +910,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
                          fig_facecolor=fig_facecolor, font_color=font_color,
                          unified=True, img=True)
 
-        if fig_background is not None:
-            add_background_image(fig, fig_background)
+        add_background_image(fig, fig_background)
         plt_show(show)
         return fig
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -805,7 +805,8 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
                   tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
                   layout=None, cmap='RdBu_r', title=None, dB=False,
                   colorbar=True, layout_scale=0.945, show=True,
-                  border='none', fig_facecolor='k', font_color='w'):
+                  border='none', fig_facecolor='k', fig_background=None,
+                  font_color='w'):
         """Plot TFRs in a topography with images
 
         Parameters
@@ -865,6 +866,9 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             matplotlib borders style to be used for each sensor plot.
         fig_facecolor : str | obj
             The figure face color. Defaults to black.
+        fig_background : None | numpy ndarray
+            A background image for the figure. This must work with a call to
+            plt.imshow. Defaults to None.
         font_color: str | obj
             The color of tick labels in the colorbar. Defaults to white.
 
@@ -874,6 +878,7 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
             The figure containing the topography.
         """
         from ..viz.topo import _imshow_tfr, _plot_topo, _imshow_tfr_unified
+        from ..viz import add_background_image
         times = self.times.copy()
         freqs = self.freqs
         data = self.data
@@ -904,6 +909,9 @@ class AverageTFR(ContainsMixin, UpdateChannelsMixin):
                          x_label='Time (ms)', y_label='Frequency (Hz)',
                          fig_facecolor=fig_facecolor, font_color=font_color,
                          unified=True, img=True)
+
+        if fig_background is not None:
+            add_background_image(fig, fig_background)
         plt_show(show)
         return fig
 

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -89,6 +89,9 @@ def test_add_background_image():
     for ax in axs:
         assert_true(ax.get_aspect() == 'auto')
 
+    # Make sure passing None as image returns None
+    assert_true(add_background_image(f, None) is None)
+
 
 def test_auto_scale():
     """Test auto-scaling of channels for quick plotting."""

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -644,8 +644,8 @@ def _plot_update_evoked_topo_proj(params, bools):
 def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
                            vmax=None, colorbar=True, order=None, cmap='RdBu_r',
                            layout_scale=.95, title=None, scalings=None,
-                           border='none', fig_facecolor='k', font_color='w',
-                           show=True):
+                           border='none', fig_facecolor='k',
+                           fig_background=None, font_color='w', show=True):
     """Plot Event Related Potential / Fields image on topographies
 
     Parameters
@@ -685,6 +685,9 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         matplotlib borders style to be used for each sensor plot.
     fig_facecolor : str | obj
         The figure face color. Defaults to black.
+    fig_background : None | numpy ndarray
+        A background image for the figure. This must work with a call to
+        plt.imshow. Defaults to None.
     font_color : str | obj
         The color of tick labels in the colorbar. Defaults to white.
     show : bool
@@ -721,5 +724,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
                      fig_facecolor=fig_facecolor, font_color=font_color,
                      border=border, x_label='Time (s)', y_label='Epoch',
                      unified=True, img=True)
+    if fig_background is not None:
+        add_background_image(fig, fig_background)
     plt_show(show)
     return fig

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -474,9 +474,9 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
         The values at which to show a horizontal line.
     fig_facecolor : str | obj
         The figure face color. Defaults to black.
-    fig_background : None | numpy ndarray
-        A background image for the figure. This must work with a call to
-        plt.imshow. Defaults to None.
+    fig_background : None | array
+        A background image for the figure. This must be a valid input to
+        `matplotlib.pyplot.imshow`. Defaults to None.
     axis_facecolor : str | obj
         The face color to be used for each sensor plot. Defaults to black.
     font_color : str | obj
@@ -608,8 +608,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
                      axis_facecolor=axis_facecolor, title=title,
                      x_label='Time (s)', y_label=y_label, unified=True)
 
-    if fig_background is not None:
-        add_background_image(fig, fig_background)
+    add_background_image(fig, fig_background)
 
     if proj == 'interactive':
         for e in evoked:
@@ -685,9 +684,9 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         matplotlib borders style to be used for each sensor plot.
     fig_facecolor : str | obj
         The figure face color. Defaults to black.
-    fig_background : None | numpy ndarray
-        A background image for the figure. This must work with a call to
-        plt.imshow. Defaults to None.
+    fig_background : None | array
+        A background image for the figure. This must be a valid input to
+        `matplotlib.pyplot.imshow`. Defaults to None.
     font_color : str | obj
         The color of tick labels in the colorbar. Defaults to white.
     show : bool
@@ -724,7 +723,6 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
                      fig_facecolor=fig_facecolor, font_color=font_color,
                      border=border, x_label='Time (s)', y_label='Epoch',
                      unified=True, img=True)
-    if fig_background is not None:
-        add_background_image(fig, fig_background)
+    add_background_image(fig, fig_background)
     plt_show(show)
     return fig

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -994,10 +994,9 @@ def add_background_image(fig, im, set_ratios=None):
     ----------
     fig : plt.figure
         The figure you wish to add a bg image to.
-    im : ndarray
-        A numpy array that works with a call to
-        plt.imshow(im). This will be plotted
-        as the background of the figure.
+    im : array, shape (M, N, {3, 4})
+        A background image for the figure. This must be a valid input to
+        `matplotlib.pyplot.imshow`. Defaults to None.
     set_ratios : None | str
         Set the aspect ratio of any axes in fig
         to the value in set_ratios. Defaults to None,
@@ -1013,6 +1012,9 @@ def add_background_image(fig, im, set_ratios=None):
     .. versionadded:: 0.9.0
 
     """
+    if im is None:
+        # Don't do anything and return nothing
+        return None
     if set_ratios is not None:
         for ax in fig.axes:
             ax.set_aspect(set_ratios)


### PR DESCRIPTION
Exposes the `fig_background` kwarg to epochs image plots, as well as TFR plots. This had already been done for Evoked plots but not for these. If there are other plots that this would make sense for, I could do that too...