### PR TITLE
FIX: Xdawn with shuffled epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,8 @@ BUG
 
     - Fix to image scaling in :func:`mne.viz.plot_epochs_image` when plotting more than one channel by `Jaakko Leppakangas`_
 
+    - Fix :class:`mne.preprocessing.Xdawn` to fit shuffled epochs, , by `Jean-Remi King`_
+
 API
 ~~~
 

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -98,7 +98,7 @@ def test_xdawn_apply_transform():
     # apply on raw
     xd.apply(raw)
     # apply on epochs
-    xd.apply(epochs)
+    denoise = xd.apply(epochs)
     # apply on evoked
     xd.apply(epochs.average())
     # apply on other thing should raise an error
@@ -110,6 +110,13 @@ def test_xdawn_apply_transform():
     xd.transform(epochs._data)
     # transform on someting else
     assert_raises(ValueError, xd.transform, 42)
+
+    # check numerical results with shuffled epochs
+    idx = np.arange(len(epochs))
+    np.random.shuffle(idx)
+    xd.fit(epochs[idx])
+    denoise_shfl = xd.apply(epochs)
+    assert_array_equal(denoise['cond2']._data, denoise_shfl['cond2']._data)
 
 
 @requires_sklearn

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -243,7 +243,8 @@ class Xdawn(TransformerMixin, ContainsMixin):
         """
 
         # Ensure epochs order
-        epochs = epochs[np.argsort(epochs.events[:, 0])]
+        if np.any(np.diff(epochs.events[:, 0].astype(int)) < 0):
+            epochs = epochs[np.argsort(epochs.events[:, 0])]
 
         if self.correct_overlap == 'auto':
             self.correct_overlap = _check_overlapp(epochs)

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -241,6 +241,10 @@ class Xdawn(TransformerMixin, ContainsMixin):
         self : Xdawn instance
             The Xdawn instance.
         """
+
+        # Ensure epochs order
+        epochs = epochs[np.argsort(epochs.events[:, 0])]
+
         if self.correct_overlap == 'auto':
             self.correct_overlap = _check_overlapp(epochs)
 


### PR DESCRIPTION
`sklearn.cross_validation.ShuffleSplit` shuffle the epochs order and broke Xdawn.

cc @kaichogami @alexandrebarachant 