### PR TITLE
[WIP] no need to pass events to Epochs if they are present in raw.info

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2090,7 +2090,7 @@ class Epochs(_BaseEpochs):
         # proj is on when applied in Raw
         proj = proj or raw.proj
 
-        if events is None
+        if events is None:
             if isinstance(info['events'], np.ndarray):
                 events = info['events']
             else:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2077,7 +2077,7 @@ class Epochs(_BaseEpochs):
     :func:`mne.Epochs.__getitem__`.
     """
     @verbose
-    def __init__(self, raw, events, event_id=None, tmin=-0.2, tmax=0.5,
+    def __init__(self, raw, events=None, event_id=None, tmin=-0.2, tmax=0.5,
                  baseline=(None, 0), picks=None, name='Unknown', preload=False,
                  reject=None, flat=None, proj=True, decim=1, reject_tmin=None,
                  reject_tmax=None, detrend=None, add_eeg_ref=True,
@@ -2089,6 +2089,13 @@ class Epochs(_BaseEpochs):
 
         # proj is on when applied in Raw
         proj = proj or raw.proj
+
+        if events is None
+            if isinstance(info['events'], np.ndarray):
+                events = info['events']
+            else:
+                raise TypeError('events can be None only if raw.info contains'
+                                ' events.')
 
         self.reject_by_annotation = reject_by_annotation
         # call _BaseEpochs constructor


### PR DESCRIPTION
This is currently more of a feature request. 
I often read continuous data that were saved in eeglab format - so I get a `Raw` object with `info['events']` already filled. I thought in such cases it might be convenient to perform epoching without passing `raw.info['events']` but rather:
```python
epochs = mne.Epochs(raw, event_id=[1, 2], preload=True)
```

WDYT?