### PR TITLE
MRG: Fix covariance order

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -328,6 +328,7 @@ Functions:
    plot_evoked_white
    plot_ica_sources
    plot_ica_components
+   plot_ica_properties
    plot_ica_scores
    plot_ica_overlay
    plot_epochs_image

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Changelog
 
     - Add label center of mass function :func:`mne.Label.center_of_mass` by `Eric Larson`_
 
-    - Added :func:`mne.viz.ica.plot_ica_properties` that allows ploting of independent component properties similar to ``pop_prop`` in EEGLAB. Also :class:`mne.preprocessing.ica.ICA` has :func:`mne.preprocessing.ica.ICA.plot_properties` method now. Added by `Mikołaj Magnuski`_
+    - Added :func:`mne.viz.plot_ica_properties` that allows ploting of independent component properties similar to ``pop_prop`` in EEGLAB. Also :class:`mne.preprocessing.ICA` has :func:`mne.preprocessing.ICA.plot_properties` method now. Added by `Mikołaj Magnuski`_
 
     - Add second-order sections (instead of ``(b, a)`` form) IIR filtering for reduced numerical error by `Eric Larson`_
 
@@ -48,9 +48,11 @@ BUG
 
     - Fixed a bug when setting multiple bipolar references with :func:`mne.io.set_bipolar_reference` by `Marijn van Vliet`_.
 
-    - Fix to image scaling in :func:`mne.viz.plot_epochs_image` when plotting more than one channel by `Jaakko Leppakangas`_
+    - Fixed image scaling in :func:`mne.viz.plot_epochs_image` when plotting more than one channel by `Jaakko Leppakangas`_
 
-    - Fix :class:`mne.preprocessing.Xdawn` to fit shuffled epochs, , by `Jean-Remi King`_
+    - Fixed :class:`mne.preprocessing.Xdawn` to fit shuffled epochs by `Jean-Remi King`_
+
+    - Fixed a bug with channel order determination that could lead to an ``AssertionError`` when using :class:`mne.Covariance` matrices by `Eric Larson`_
 
 API
 ~~~
@@ -1617,3 +1619,7 @@ of commits):
 .. _Jon Houck: http://www.unm.edu/~jhouck/
 
 .. _Pablo-Arias: https://github.com/Pablo-Arias
+
+.. _Alexander Rudiuk: https://github.com/ARudiuk
+
+.. _Mikołaj Magnuski: https://github.com/mmagnuski

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1458,6 +1458,10 @@ class ICA(ContainsMixin):
         -------
         fig : list
             List of matplotlib figures.
+
+        Notes
+        -----
+        .. versionadded:: 0.13
         """
         return plot_ica_properties(inst, self, picks=picks, axes=axes,
                                    dB=dB, plot_std=plot_std,

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -23,7 +23,7 @@ from mne import (read_cov, write_cov, Epochs, merge_events,
                  compute_covariance, read_evokeds, compute_proj_raw,
                  pick_channels_cov, pick_channels, pick_types, pick_info,
                  make_ad_hoc_cov)
-from mne.io import read_raw_fif, RawArray
+from mne.io import read_raw_fif, RawArray, read_info
 from mne.tests.common import assert_naming, assert_snr
 from mne.utils import (_TempDir, slow_test, requires_sklearn_0_15,
                        run_tests_if_main)
@@ -71,6 +71,19 @@ def test_cov_mismatch():
     epochs.info['dev_head_t'] = None
     epochs_2.info['dev_head_t'] = None
     compute_covariance([epochs, epochs_2])
+
+
+def test_cov_order():
+    """Test covariance ordering"""
+    info = read_info(raw_fname)
+    # add MEG channel with low enough index number to affect EEG if
+    # order is incorrect
+    info['bads'] += ['MEG 0113']
+    ch_names = [info['ch_names'][pick]
+                for pick in pick_types(info, meg=False, eeg=True)]
+    cov = read_cov(cov_fname)
+    with warnings.catch_warnings(record=True):  # no avg ref present
+        prepare_noise_cov(cov, info, ch_names, verbose='error')
 
 
 def test_ad_hoc_cov():

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -18,7 +18,7 @@ from .circle import plot_connectivity_circle, circular_layout
 from .epochs import (plot_drop_log, plot_epochs, plot_epochs_psd,
                      plot_epochs_image)
 from .raw import plot_raw, plot_raw_psd, plot_raw_psd_topo
-from .ica import plot_ica_scores, plot_ica_sources, plot_ica_overlay
-from .ica import _plot_sources_raw, _plot_sources_epochs
+from .ica import (plot_ica_scores, plot_ica_sources, plot_ica_overlay,
+                  _plot_sources_raw, _plot_sources_epochs, plot_ica_properties)
 from .montage import plot_montage
 from .decoding import plot_gat_matrix, plot_gat_times

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -169,6 +169,10 @@ def plot_ica_properties(inst, ica, picks=None, axes=None, dB=True,
     -------
     fig : list
         List of matplotlib figures.
+
+    Notes
+    -----
+    .. versionadded:: 0.13
     """
     from ..io.base import _BaseRaw
     from ..epochs import _BaseEpochs


### PR DESCRIPTION
Fixes a bug where the channel order / indexing in `prepare_noise_cov` could lead to `AssertionError` or (worse) silent errant selection of channels.