### PR TITLE
fix long sfp chan names

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -192,7 +192,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
 
         ch_names_, pos = [], []
         for line in lines:
-            line = line.lstrip().rstrip().split()
+            line = line.strip().split()
             if len(line) > 0:  # skip empty lines
                 name, x, y, z = line
                 ch_names_.append(name)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -196,8 +196,8 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
             if len(line) > 0:  # skip empty lines
                 if len(line) != 4:  # name, x, y, z
                     raise ValueError("Malformed .sfp file in line " + str(ii))
-                name, x, y, z = line
-                ch_names_.append(name)
+                this_name, x, y, z = line
+                ch_names_.append(this_name)
                 pos.append([float(cord) for cord in (x, y, z)])
         pos = np.asarray(pos)
     elif ext == '.elc':

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -191,12 +191,14 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
             lines = f.read().replace('\t', ' ').split("\n")
 
         ch_names_, pos = [], []
-        for line in lines:
+        for ii, line in enumerate(lines):
             line = line.strip().split()
             if len(line) > 0:  # skip empty lines
-                name, x, y, z = line
+                if len(line) != 4:  # name, x, y, z
+                    raise ValueError("Malformed .sfp file in line " + str(ii))
+                name, *coords = line
                 ch_names_.append(name)
-                pos.append([np.float(cord) for cord in (x, y, z)])
+                pos.append([np.float(cord) for cord in coords])
         pos = np.asarray(pos)
     elif ext == '.elc':
         # 10-5 system

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -196,9 +196,9 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
             if len(line) > 0:  # skip empty lines
                 if len(line) != 4:  # name, x, y, z
                     raise ValueError("Malformed .sfp file in line " + str(ii))
-                name, *coords = line
+                name, x, y, z = line
                 ch_names_.append(name)
-                pos.append([np.float(cord) for cord in coords])
+                pos.append([float(cord) for cord in (x, y, z)])
         pos = np.asarray(pos)
     elif ext == '.elc':
         # 10-5 system

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -187,10 +187,17 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
 
     if ext == '.sfp':
         # EGI geodesic
-        dtype = np.dtype('S4, f8, f8, f8')
-        data = np.loadtxt(fname, dtype=dtype)
-        pos = np.c_[data['f1'], data['f2'], data['f3']]
-        ch_names_ = data['f0'].astype(np.str)
+        with open(fname, 'r') as f:
+            lines = f.read().replace('\t', ' ').split("\n")
+
+        ch_names_, pos = [], []
+        for line in lines:
+            line = line.lstrip().rstrip().split()
+            if len(line) > 0:  # skip empty lines
+                name, x, y, z = line
+                ch_names_.append(name)
+                pos.append([np.float(cord) for cord in (x, y, z)])
+        pos = np.asarray(pos)
     elif ext == '.elc':
         # 10-5 system
         ch_names_ = []

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -41,7 +41,7 @@ def test_montage():
     # no pep8
     input_str = ["""FidNz 0.00000 10.56381 -2.05108
     FidT9 -7.82694 0.45386 -3.76056
-    FidT10_very_very_long_name 7.82694 0.45386 -3.76056""",
+    very_very_very_long_name 7.82694 0.45386 -3.76056""",
     """// MatLab   Sphere coordinates [degrees]         Cartesian coordinates
     // Label       Theta       Phi    Radius         X         Y         Z       off sphere surface
       E1      37.700     -14.000       1.000    0.7677    0.5934   -0.2419  -0.00000000000000011
@@ -63,7 +63,7 @@ def test_montage():
     """Site  Theta  Phi
     Fp1  -92    -72
     Fp2   92     72
-    F3_very_very_long_name   -60    -51
+    very_very_very_long_name   -60    -51
     """,
     """346
      EEG	      F3	 -62.027	 -50.053	      85
@@ -73,7 +73,7 @@ def test_montage():
     """
     eeg Fp1 -95.0 -31.0 -3.0
     eeg AF7 -81 -59 -3
-    eeg_very_very_long_name AF3 -87 -41 28
+    eeg AF3 -87 -41 28
     """]
     kinds = ['test.sfp', 'test.csd', 'test.elc', 'test.txt', 'test.elp',
              'test.hpts']
@@ -82,6 +82,8 @@ def test_montage():
         with open(fname, 'w') as fid:
             fid.write(text)
         montage = read_montage(fname)
+        if ".sfp" in kind or ".txt" in kind:
+            assert_true('very_very_very_long_name' in montage.ch_names)
         assert_equal(len(montage.ch_names), 3)
         assert_equal(len(montage.ch_names), len(montage.pos))
         assert_equal(montage.pos.shape, (3, 3))

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -41,7 +41,7 @@ def test_montage():
     # no pep8
     input_str = ["""FidNz 0.00000 10.56381 -2.05108
     FidT9 -7.82694 0.45386 -3.76056
-    FidT10 7.82694 0.45386 -3.76056""",
+    FidT10_very_very_long_name 7.82694 0.45386 -3.76056""",
     """// MatLab   Sphere coordinates [degrees]         Cartesian coordinates
     // Label       Theta       Phi    Radius         X         Y         Z       off sphere surface
       E1      37.700     -14.000       1.000    0.7677    0.5934   -0.2419  -0.00000000000000011
@@ -63,7 +63,7 @@ def test_montage():
     """Site  Theta  Phi
     Fp1  -92    -72
     Fp2   92     72
-    F3   -60    -51
+    F3_very_very_long_name   -60    -51
     """,
     """346
      EEG	      F3	 -62.027	 -50.053	      85
@@ -73,7 +73,7 @@ def test_montage():
     """
     eeg Fp1 -95.0 -31.0 -3.0
     eeg AF7 -81 -59 -3
-    eeg AF3 -87 -41 28
+    eeg_very_very_long_name AF3 -87 -41 28
     """]
     kinds = ['test.sfp', 'test.csd', 'test.elc', 'test.txt', 'test.elp',
              'test.hpts']


### PR DESCRIPTION
Replace file parser for .sfp files. Less efficient, but should not choke on long channel names.

~~Missing dedicated test for the specific scenario this is aimed to fix.~~

Closes #3385