### PR TITLE
FIX realtime example for eog channel

### DIFF
--- a/examples/realtime/ftclient_rt_average.py
+++ b/examples/realtime/ftclient_rt_average.py
@@ -70,6 +70,7 @@ with FieldTripClient(host='localhost', port=1972,
     for ii, ev in enumerate(rt_epochs.iter_evoked()):
         print("Just got epoch %d" % (ii + 1))
 
+        ev.pick_types(meg=True, eog=False)
         if ii == 0:
             evoked = ev
         else:


### PR DESCRIPTION
This was broken when eog channel was made a default when using `plot_evoked`.  @jaeilepp suggested adding `plot_` in front of this example so we add this to continuous integration ...