### PR TITLE
BUG with FilterEstimator [DONT MERGE]

### DIFF
--- a/examples/realtime/rt_feedback_server.py
+++ b/examples/realtime/rt_feedback_server.py
@@ -43,7 +43,7 @@ import mne
 from mne.datasets import sample
 from mne.realtime import StimServer
 from mne.realtime import MockRtClient
-from mne.decoding import EpochsVectorizer, FilterEstimator
+from mne.decoding import EpochsVectorizer
 
 print(__doc__)
 
@@ -64,12 +64,11 @@ with StimServer('localhost', port=4218) as stim_server:
     rt_client = MockRtClient(raw)
 
     # Constructing the pipeline for classification
-    filt = FilterEstimator(raw.info, 1, 40)
     scaler = preprocessing.StandardScaler()
     vectorizer = EpochsVectorizer()
     clf = SVC(C=1, kernel='linear')
 
-    concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),
+    concat_classifier = Pipeline([('vector', vectorizer),
                                   ('scaler', scaler), ('svm', clf)])
 
     stim_server.start(verbose=True)


### PR DESCRIPTION
this is more a bug report than a pull request. This is the traceback I get when I try to run the example in master:

``` py
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-7-fdb46b81d8af> in <module>()
----> 1 y_pred = concat_classifier.fit(X_train, y_train).predict(X_test)

/home/mainak/anaconda2/lib/python2.7/site-packages/sklearn/pipeline.pyc in fit(self, X, y, **fit_params)
    162             the pipeline.
    163         """
--> 164         Xt, fit_params = self._pre_transform(X, y, **fit_params)
    165         self.steps[-1][-1].fit(Xt, y, **fit_params)
    166         return self

/home/mainak/anaconda2/lib/python2.7/site-packages/sklearn/pipeline.pyc in _pre_transform(self, X, y, **fit_params)
    143         for name, transform in self.steps[:-1]:
    144             if hasattr(transform, "fit_transform"):
--> 145                 Xt = transform.fit_transform(Xt, y, **fit_params_steps[name])
    146             else:
    147                 Xt = transform.fit(Xt, y, **fit_params_steps[name]) \

/home/mainak/Desktop/projects/github_repos/mne-python/mne/decoding/mixin.pyc in fit_transform(self, X, y, **fit_params)
     31         else:
     32             # fit method of arity 2 (supervised transformation)
---> 33             return self.fit(X, y, **fit_params).transform(X)
     34 
     35 

/home/mainak/Desktop/projects/github_repos/mne-python/mne/decoding/transformer.pyc in transform(self, epochs_data, y)
    508                                      iir_params=self.iir_params,
    509                                      picks=self.picks, n_jobs=self.n_jobs,
--> 510                                      copy=False, verbose=False)
    511             else:
    512                 epochs_data = \

/home/mainak/Desktop/projects/github_repos/mne-python/mne/filter.pyc in band_pass_filter(x, Fs, Fp1, Fp2, filter_length, l_trans_bandwidth, h_trans_bandwidth, method, iir_params, picks, n_jobs, copy, verbose)

/home/mainak/Desktop/projects/github_repos/mne-python/mne/utils.pyc in verbose(function, *args, **kwargs)
    600         # set it back if we get an exception
    601         with use_log_level(verbose_level):
--> 602             return function(*args, **kwargs)
    603     return function(*args, **kwargs)
    604 

/home/mainak/Desktop/projects/github_repos/mne-python/mne/filter.pyc in band_pass_filter(x, Fs, Fp1, Fp2, filter_length, l_trans_bandwidth, h_trans_bandwidth, method, iir_params, picks, n_jobs, copy, verbose)
    671         freq = [0, Fs1, Fp1, Fp2, Fs2, Fs / 2]
    672         gain = [0, 0, 1, 1, 0, 0]
--> 673         xf = _filter(x, Fs, freq, gain, filter_length, picks, n_jobs, copy)
    674     else:
    675         iir_params = construct_iir_filter(iir_params, [Fp1, Fp2],

/home/mainak/Desktop/projects/github_repos/mne-python/mne/filter.pyc in _filter(x, Fs, freq, gain, filter_length, picks, n_jobs, copy)
    341         if n_jobs == 1:
    342             for p in picks:
--> 343                 x[p] = _1d_fftmult_ext(x[p], B, extend_x, cuda_dict)
    344         else:
    345             parallel, p_fun, _ = parallel_func(_1d_fftmult_ext, n_jobs)

IndexError: index 180624 is out of bounds for axis 0 with size 180624
```

I'm not sure who to ping. Maybe @Eric89GXL @kingjr @kaichogami ? `FilterEstimator` worked before ...
