### PR TITLE
MRG: Allow setting mag_scale in maxwell_filter

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2983,8 +2983,9 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
         The magenetometer scale-factor used to bring the magnetometers
         to approximately the same order of magnitude as the gradiometers
         (default 100.), as they have different units (T vs T/m).
-        Can be ``'auto'`` to use the reciprocal of the gradiometer
-        baseline (e.g., 0.0168 m yields 59.5 for VectorView).
+        Can be ``'auto'`` to use the reciprocal of the physical distance
+        between the gradiometer pickup loops (e.g., 0.0168 m yields
+        59.5 for VectorView).
 
         .. versionadded:: 0.13
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2927,7 +2927,7 @@ def concatenate_epochs(epochs_list):
 def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
                       origin='auto', weight_all=True, int_order=8, ext_order=3,
                       destination=None, ignore_ref=False, return_mapping=False,
-                      verbose=None):
+                      mag_scale=100., verbose=None):
     """Average data using Maxwell filtering, transforming using head positions
 
     Parameters
@@ -2979,6 +2979,15 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
         with reference channels is not currently supported.
     return_mapping : bool
         If True, return the mapping matrix.
+    mag_scale : float | str
+        The magenetometer scale-factor used to bring the magnetometers
+        to approximately the same order of magnitude as the gradiometers
+        (default 100.), as they have different units (T vs T/m).
+        Can be ``'auto'`` to use the reciprocal of the gradiometer
+        baseline (e.g., 0.0168 m yields 59.5 for VectorView).
+
+        .. versionadded:: 0.13
+
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -3019,7 +3028,7 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
                                         _check_usable, _col_norm_pinv,
                                         _get_n_moments, _get_mf_picks,
                                         _prep_mf_coils, _check_destination,
-                                        _remove_meg_projs)
+                                        _remove_meg_projs, _get_coil_scale)
     if head_pos is None:
         raise TypeError('head_pos must be provided and cannot be None')
     from .chpi import head_pos_to_trans_rot_t
@@ -3040,8 +3049,10 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
                 % (len(epochs.events)))
     if not np.array_equal(epochs.events[:, 0], np.unique(epochs.events[:, 0])):
         raise RuntimeError('Epochs must have monotonically increasing events')
-    meg_picks, _, _, good_picks, coil_scale, _ = \
+    meg_picks, mag_picks, grad_picks, good_picks, _ = \
         _get_mf_picks(epochs.info, int_order, ext_order, ignore_ref)
+    coil_scale, mag_scale = _get_coil_scale(
+        meg_picks, mag_picks, grad_picks, mag_scale, epochs.info)
     n_channels, n_times = len(epochs.ch_names), len(epochs.times)
     other_picks = np.setdiff1d(np.arange(n_channels), meg_picks)
     data = np.zeros((n_channels, n_times))

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -308,6 +308,7 @@ def _safe_svd(A, **kwargs):
     try:
         return linalg.svd(A, **kwargs)
     except np.linalg.LinAlgError as exp:
+        from .utils import warn
         if 'lapack_driver' in _get_args(linalg.svd):
             warn('SVD error (%s), attempting to use GESVD instead of GESDD'
                  % (exp,))

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -141,8 +141,9 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         The magenetometer scale-factor used to bring the magnetometers
         to approximately the same order of magnitude as the gradiometers
         (default 100.), as they have different units (T vs T/m).
-        Can be ``'auto'`` to use the reciprocal of the gradiometer
-        baseline (e.g., 0.0168 m yields 59.5 for VectorView).
+        Can be ``'auto'`` to use the reciprocal of the physical distance
+        between the gradiometer pickup loops (e.g., 0.0168 m yields
+        59.5 for VectorView).
 
         .. versionadded:: 0.13
 
@@ -529,19 +530,20 @@ def _get_coil_scale(meg_picks, mag_picks, grad_picks, mag_scale, info):
             logger.info('    Setting mag_scale=%0.2f because only one '
                         'coil type is present' % mag_scale)
         else:
-            # Find our gradiometer baseline
+            # Find our physical distance between gradiometer pickup loops
+            # ("base line")
             coils = _create_meg_coils(pick_info(info, meg_picks)['chs'],
                                       'accurate')
             grad_base = set(coils[pick]['base'] for pick in grad_picks)
             if len(grad_base) != 1 or list(grad_base)[0] <= 0:
                 raise RuntimeError('Could not automatically determine '
                                    'mag_scale, could not find one '
-                                   'proper baseline value from: %s'
+                                   'proper gradiometer distance from: %s'
                                    % list(grad_base))
             grad_base = list(grad_base)[0]
             mag_scale = 1. / grad_base
             logger.info('    Setting mag_scale=%0.2f based on gradiometer '
-                        'baseline %0.2f mm' % (mag_scale, 1000 * grad_base))
+                        'distance %0.2f mm' % (mag_scale, 1000 * grad_base))
     mag_scale = float(mag_scale)
     coil_scale = np.ones((len(meg_picks), 1))
     coil_scale[mag_picks] = mag_scale


### PR DESCRIPTION
From talking to @staulu this seems like a better / more principled way to set `mag_scale` in Maxwell filtering. This should help remove some of the mystery from the 100 value that used to be there.

@wronk can you have a look and see if it makes sense to you?