### PR TITLE
MRG: Change evoked arithmetic

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -49,7 +49,7 @@ html_dev:
 	@echo "Build finished. The HTML pages are in _build/html"
 
 html_dev-pattern:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=1 -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -b html $(ALLSPHINXOPTS) _build/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=1 -D raise_gallery=1 -D abort_on_example_error=1 -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -b html $(ALLSPHINXOPTS) _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html"
 

--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -4,7 +4,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :special-members: __contains__,__getitem__,__iter__,__len__
+   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__hash__
 
    {% block methods %}
    {% endblock %}

--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -4,7 +4,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__hash__
+   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__,__hash__
 
    {% block methods %}
    {% endblock %}

--- a/doc/manual/pitfalls.rst
+++ b/doc/manual/pitfalls.rst
@@ -8,19 +8,6 @@
 Pitfalls
 ########
 
-Evoked Arithmetic
-=================
-
-Two evoked objects can be contrasted using::
-
-	>>> evoked = evoked_cond1 - evoked_cond2
-
-Note, however that the number of trials used to obtain the averages for
-``evoked_cond1`` and ``evoked_cond2`` are taken into account when computing
-``evoked``. That is, what you get is a weighted average, not a simple
-element-by-element subtraction. To do a uniform (not weighted) average, use
-the function :func:`mne.combine_evoked`.
-
 Float64 vs float32
 ==================
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -104,6 +104,8 @@ API
 
     - Adds :func:`mne.time_frequency.csd_epochs` to replace :func:`mne.time_frequency.csd_compute_epochs` for naming consistency. :func:`mne.time_frequency.csd_compute_epochs` is now deprecated and will be removed in mne 0.14, by `Nick Foti`_
 
+    - Weighted addition and subtraction of :class:`Evoked` as ``ev1 + ev2`` and ``ev1 - ev2`` have been deprecated, use explicit :func:`mne.combine_evoked` instead by `Eric Larson`_
+
     - Deprecated support for passing a lits of filenames to :class:`mne.io.Raw` constructor, use :func:`mne.io.read_raw_fif` and :func:`mne.concatenate_raws` instead by `Eric Larson`_
 
     - Added options for setting data and date formats manually in :func:`mne.io.read_raw_cnt` by `Jaakko Leppakangas`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -104,7 +104,7 @@ API
 
     - Adds :func:`mne.time_frequency.csd_epochs` to replace :func:`mne.time_frequency.csd_compute_epochs` for naming consistency. :func:`mne.time_frequency.csd_compute_epochs` is now deprecated and will be removed in mne 0.14, by `Nick Foti`_
 
-    - Weighted addition and subtraction of :class:`Evoked` as ``ev1 + ev2`` and ``ev1 - ev2`` have been deprecated, use explicit :func:`mne.combine_evoked` instead by `Eric Larson`_
+    - Weighted addition and subtraction of :class:`Evoked` as ``ev1 + ev2`` and ``ev1 - ev2`` have been deprecated, use explicit :func:`mne.combine_evoked(..., weights='nave') <mne.combine_evoked>` instead by `Eric Larson`_
 
     - Deprecated support for passing a lits of filenames to :class:`mne.io.Raw` constructor, use :func:`mne.io.read_raw_fif` and :func:`mne.concatenate_raws` instead by `Eric Larson`_
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -907,7 +907,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @deprecated('ev1 + ev2 weighted summation has been deprecated and will be '
                 'removed in 0.14, use combine_evoked([ev1, ev2],'
-                'weight="nave") instead')
+                'weights="nave") instead')
     def __add__(self, evoked):
         """Add evoked taking into account number of epochs
 
@@ -918,12 +918,13 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         --------
         mne.combine_evoked
         """
-        out = combine_evoked([self, evoked])
+        out = combine_evoked([self, evoked], weights='nave')
         out.comment = self.comment + " + " + evoked.comment
         return out
 
     @deprecated('ev1 - ev2 weighted subtraction has been deprecated and will '
-                'be removed in 0.14, use combine_evoked instead')
+                'be removed in 0.14, use combine_evoked([ev1, -ev2], '
+                'weights="nave") instead')
     def __sub__(self, evoked):
         """Subtract evoked taking into account number of epochs
 
@@ -936,7 +937,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """
         this_evoked = deepcopy(evoked)
         this_evoked.data *= -1.
-        out = combine_evoked([self, this_evoked])
+        out = combine_evoked([self, this_evoked], weights='nave')
         if self.comment is None or this_evoked.comment is None:
             warn('evoked.comment expects a string but is None')
             out.comment = 'unknown'
@@ -1205,7 +1206,7 @@ def grand_average(all_evoked, interpolate_bads=True):
     return grand_average
 
 
-def combine_evoked(all_evoked, weights='nave'):
+def combine_evoked(all_evoked, weights=None):
     """Merge evoked data by weighted addition or subtraction
 
     Data should have the same channels and the same time instants.
@@ -1229,6 +1230,11 @@ def combine_evoked(all_evoked, weights='nave'):
     -----
     .. versionadded:: 0.9.0
     """
+    if weights is None:
+        weights = 'nave'
+        warn('In 0.13 the default weights="nave", but in 0.14 the default '
+             'will be removed and it will have to be explicitly set',
+             DeprecationWarning)
     evoked = all_evoked[0].copy()
     if isinstance(weights, string_types):
         if weights not in ('nave', 'equal'):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -935,14 +935,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         --------
         mne.combine_evoked
         """
-        this_evoked = deepcopy(evoked)
-        this_evoked.data *= -1.
-        out = combine_evoked([self, this_evoked], weights='nave')
-        if self.comment is None or this_evoked.comment is None:
+        out = combine_evoked([self, -evoked], weights='nave')
+        if self.comment is None or evoked.comment is None:
             warn('evoked.comment expects a string but is None')
             out.comment = 'unknown'
         else:
-            out.comment = self.comment + " - " + this_evoked.comment
+            out.comment = self.comment + " - " + evoked.comment
         return out
 
     def get_peak(self, ch_type=None, tmin=None, tmax=None, mode='abs',

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -902,7 +902,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """
         out = self.copy()
         out.data *= -1
-        out.comment = '-' + out.comment
+        out.comment = '-' + (out.comment or 'unknown')
         return out
 
     @deprecated('ev1 + ev2 weighted summation has been deprecated and will be '
@@ -1232,7 +1232,7 @@ def combine_evoked(all_evoked, weights=None):
     """
     if weights is None:
         weights = 'nave'
-        warn('In 0.13 the default weights="nave", but in 0.14 the default '
+        warn('In 0.13 the default is weights="nave", but in 0.14 the default '
              'will be removed and it will have to be explicitly set',
              DeprecationWarning)
     evoked = all_evoked[0].copy()
@@ -1280,6 +1280,8 @@ def combine_evoked(all_evoked, weights=None):
     # And our resulting nave is the reciprocal of this:
     evoked.nave = max(int(round(
         1. / sum(w ** 2 / e.nave for w, e in zip(weights, all_evoked)))), 1)
+    evoked.comment = ' + '.join('%0.3f * %s' % (w, e.comment or 'unknown')
+                                for w, e in zip(weights, all_evoked))
     return evoked
 
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -15,8 +15,8 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 equalize_channels)
 from .filter import resample, detrend, FilterMixin
 from .fixes import in1d
-from .utils import check_fname, logger, verbose, _time_mask, warn, sizeof_fmt
-from .utils import SizeMixin
+from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
+                    deprecated, SizeMixin)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import (_plot_evoked_white, plot_evoked_joint,
@@ -890,6 +890,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         evoked = deepcopy(self)
         return evoked
 
+    @deprecated('ev1 + ev2 weighted summation has been deprecated and will be '
+                'removed in 0.14, use combine_evoked([ev1, ev2],'
+                'weight="nave") instead')
     def __add__(self, evoked):
         """Add evoked taking into account number of epochs
 
@@ -904,6 +907,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         out.comment = self.comment + " + " + evoked.comment
         return out
 
+    @deprecated('ev1 - ev2 weighted subtraction has been deprecated and will '
+                'be removed in 0.14, use combine_evoked instead')
     def __sub__(self, evoked):
         """Subtract evoked taking into account number of epochs
 
@@ -1186,7 +1191,7 @@ def grand_average(all_evoked, interpolate_bads=True):
 
 
 def combine_evoked(all_evoked, weights='nave'):
-    """Merge evoked data by weighted addition
+    """Merge evoked data by weighted addition or subtraction
 
     Data should have the same channels and the same time instants.
     Subtraction can be performed by passing negative weights (e.g., [1, -1]).

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1238,7 +1238,8 @@ def _is_equal_dict(dicts):
                 is_equal.append((k0 == k) and _is_equal_dict(v))
         else:
             is_equal.append(all(np.all(k == k0) and
-                            np.all(v == v0) for k, v in d))
+                            (np.array_equal(v, v0) if isinstance(v, np.ndarray)
+                             else np.all(v == v0)) for k, v in d))
     return all(is_equal)
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -19,7 +19,8 @@ import matplotlib
 
 from mne import (Epochs, Annotations, read_events, pick_events, read_epochs,
                  equalize_channels, pick_types, pick_channels, read_evokeds,
-                 write_evokeds, create_info, make_fixed_length_events)
+                 write_evokeds, create_info, make_fixed_length_events,
+                 combine_evoked)
 from mne.baseline import rescale
 from mne.preprocessing import maxwell_filter
 from mne.epochs import (
@@ -833,11 +834,11 @@ def test_evoked_arithmetic():
     epochs = Epochs(raw, events[:8], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0))
     evoked = epochs.average()
-    evoked_sum = evoked1 + evoked2
+    evoked_sum = combine_evoked([evoked1, evoked2])
     assert_array_equal(evoked.data, evoked_sum.data)
     assert_array_equal(evoked.times, evoked_sum.times)
-    assert_true(evoked_sum.nave == (evoked1.nave + evoked2.nave))
-    evoked_diff = evoked1 - evoked1
+    assert_equal(evoked_sum.nave, evoked1.nave + evoked2.nave)
+    evoked_diff = combine_evoked([evoked1, evoked1], weights=[1, -1])
     assert_array_equal(np.zeros_like(evoked.data), evoked_diff.data)
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -834,7 +834,7 @@ def test_evoked_arithmetic():
     epochs = Epochs(raw, events[:8], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0))
     evoked = epochs.average()
-    evoked_sum = combine_evoked([evoked1, evoked2])
+    evoked_sum = combine_evoked([evoked1, evoked2], weights='nave')
     assert_array_equal(evoked.data, evoked_sum.data)
     assert_array_equal(evoked.times, evoked_sum.times)
     assert_equal(evoked_sum.nave, evoked1.nave + evoked2.nave)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -396,7 +396,8 @@ def test_evoked_arithmetic():
     # combine_evoked([ev1, ev2]) should be the same as ev1 + ev2:
     # data should be added according to their `nave` weights
     # nave = ev1.nave + ev2.nave
-    ev = combine_evoked([ev1, ev2])
+    with warnings.catch_warnings(record=True):  # deprceation no weights
+        ev = combine_evoked([ev1, ev2])
     assert_equal(ev.nave, ev1.nave + ev2.nave)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -396,7 +396,7 @@ def test_arithmetic():
     # combine_evoked([ev1, ev2]) should be the same as ev1 + ev2:
     # data should be added according to their `nave` weights
     # nave = ev1.nave + ev2.nave
-    with warnings.catch_warnings(record=True):  # deprceation no weights
+    with warnings.catch_warnings(record=True):  # deprecation no weights
         ev = combine_evoked([ev1, ev2])
     assert_equal(ev.nave, ev1.nave + ev2.nave)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -75,8 +75,7 @@ def test_decim():
 
 @requires_version('scipy', '0.14')
 def test_savgol_filter():
-    """Test savgol filtering
-    """
+    """Test savgol filtering"""
     h_freq = 10.
     evoked = read_evokeds(fname, 0)
     freqs = fftpack.fftfreq(len(evoked.times), 1. / evoked.info['sfreq'])
@@ -98,8 +97,7 @@ def test_savgol_filter():
 
 
 def test_hash_evoked():
-    """Test evoked hashing
-    """
+    """Test evoked hashing"""
     ave = read_evokeds(fname, 0)
     ave_2 = read_evokeds(fname, 0)
     assert_equal(hash(ave), hash(ave_2))
@@ -112,8 +110,7 @@ def test_hash_evoked():
 
 @slow_test
 def test_io_evoked():
-    """Test IO for evoked data (fif + gz) with integer and str args
-    """
+    """Test IO for evoked data (fif + gz) with integer and str args"""
     tempdir = _TempDir()
     ave = read_evokeds(fname, 0)
 
@@ -172,8 +169,7 @@ def test_io_evoked():
 
 
 def test_shift_time_evoked():
-    """ Test for shifting of time scale
-    """
+    """ Test for shifting of time scale"""
     tempdir = _TempDir()
     # Shift backward
     ave = read_evokeds(fname, 0)
@@ -213,8 +209,7 @@ def test_shift_time_evoked():
 
 
 def test_evoked_resample():
-    """Test for resampling of evoked data
-    """
+    """Test for resampling of evoked data"""
     tempdir = _TempDir()
     # upsample, write it out, read it in
     ave = read_evokeds(fname, 0)
@@ -245,8 +240,7 @@ def test_evoked_resample():
 
 
 def test_evoked_detrend():
-    """Test for detrending evoked data
-    """
+    """Test for detrending evoked data"""
     ave = read_evokeds(fname, 0)
     ave_normal = read_evokeds(fname, 0)
     ave.detrend(0)
@@ -270,8 +264,7 @@ def test_to_data_frame():
 
 
 def test_evoked_proj():
-    """Test SSP proj operations
-    """
+    """Test SSP proj operations"""
     for proj in [True, False]:
         ave = read_evokeds(fname, condition=0, proj=proj)
         assert_true(all(p['active'] == proj for p in ave.info['projs']))
@@ -299,8 +292,7 @@ def test_evoked_proj():
 
 
 def test_get_peak():
-    """Test peak getter
-    """
+    """Test peak getter"""
 
     evoked = read_evokeds(fname, condition=0, proj=True)
     assert_raises(ValueError, evoked.get_peak, ch_type='mag', tmin=1)
@@ -342,8 +334,7 @@ def test_get_peak():
 
 
 def test_drop_channels_mixin():
-    """Test channels-dropping functionality
-    """
+    """Test channels-dropping functionality"""
     evoked = read_evokeds(fname, condition=0, proj=True)
     drop_ch = evoked.ch_names[:3]
     ch_names = evoked.ch_names[3:]
@@ -360,8 +351,7 @@ def test_drop_channels_mixin():
 
 
 def test_pick_channels_mixin():
-    """Test channel-picking functionality
-    """
+    """Test channel-picking functionality"""
     evoked = read_evokeds(fname, condition=0, proj=True)
     ch_names = evoked.ch_names[:3]
 
@@ -385,8 +375,7 @@ def test_pick_channels_mixin():
 
 
 def test_equalize_channels():
-    """Test equalization of channels
-    """
+    """Test equalization of channels"""
     evoked1 = read_evokeds(fname, condition=0, proj=True)
     evoked2 = evoked1.copy()
     ch_names = evoked1.ch_names[2:]
@@ -399,8 +388,7 @@ def test_equalize_channels():
 
 
 def test_evoked_arithmetic():
-    """Test evoked arithmetic
-    """
+    """Test evoked arithmetic"""
     ev = read_evokeds(fname, condition=0)
     ev1 = EvokedArray(np.ones_like(ev.data), ev.info, ev.times[0], nave=20)
     ev2 = EvokedArray(-np.ones_like(ev.data), ev.info, ev.times[0], nave=10)
@@ -411,6 +399,19 @@ def test_evoked_arithmetic():
     ev = combine_evoked([ev1, ev2])
     assert_equal(ev.nave, ev1.nave + ev2.nave)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
+
+    # with same trial counts, a bunch of things should be equivalent
+    for weights in ('nave', 'equal', [0.5, 0.5]):
+        print(weights)
+        ev = combine_evoked([ev1, ev1], weights=weights)
+        assert_allclose(ev.data, ev1.data)
+        assert_equal(ev.nave, 2 * ev1.nave)
+        ev = combine_evoked([ev1, -ev1], weights=weights)
+        assert_allclose(ev.data, 0., atol=1e-20)
+        assert_equal(ev.nave, 2 * ev1.nave)
+    ev = combine_evoked([ev1, ev1], weights=[0.5, -0.5])
+    assert_allclose(ev.data, 0., atol=1e-20)
+    assert_equal(ev.nave, 2 * ev1.nave)
 
     # default comment behavior if evoked.comment is None
     old_comment1 = ev1.comment
@@ -450,8 +451,7 @@ def test_evoked_arithmetic():
 
 
 def test_array_epochs():
-    """Test creating evoked from array
-    """
+    """Test creating evoked from array"""
     tempdir = _TempDir()
 
     # creating

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -416,10 +416,8 @@ def test_evoked_arithmetic():
     old_comment1 = ev1.comment
     old_comment2 = ev2.comment
     ev1.comment = None
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter('always')
-        ev = ev1 - ev2
-        assert_equal(ev.comment, 'unknown')
+    ev = combine_evoked([ev1, ev2], weights=[1, -1])
+    assert_true(ev.comment is None)
     ev1.comment = old_comment1
     ev2.comment = old_comment2
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -408,13 +408,9 @@ def test_evoked_arithmetic():
     # combine_evoked([ev1, ev2]) should be the same as ev1 + ev2:
     # data should be added according to their `nave` weights
     # nave = ev1.nave + ev2.nave
-    ev = ev1 + ev2
+    ev = combine_evoked([ev1, ev2])
     assert_equal(ev.nave, ev1.nave + ev2.nave)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
-    ev = ev1 - ev2
-    assert_equal(ev.nave, ev1.nave + ev2.nave)
-    assert_equal(ev.comment, ev1.comment + ' - ' + ev2.comment)
-    assert_allclose(ev.data, np.ones_like(ev1.data))
 
     # default comment behavior if evoked.comment is None
     old_comment1 = ev1.comment

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -454,6 +454,7 @@ def test_arithmetic():
     assert_equal(gave.data.shape, [len(ch_names), evoked1.data.shape[1]])
     assert_equal(ch_names, gave.ch_names)
     assert_equal(gave.nave, 2)
+    assert_raises(ValueError, grand_average, [1, evoked1])
 
 
 def test_array_epochs():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -402,7 +402,6 @@ def test_evoked_arithmetic():
 
     # with same trial counts, a bunch of things should be equivalent
     for weights in ('nave', 'equal', [0.5, 0.5]):
-        print(weights)
         ev = combine_evoked([ev1, ev1], weights=weights)
         assert_allclose(ev.data, ev1.data)
         assert_equal(ev.nave, 2 * ev1.nave)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -59,10 +59,12 @@ def nottest(f):
     return f
 
 
+# # # WARNING # # #
 # This list must also be updated in doc/_templates/class.rst if it is
 # changed here!
 _doc_special_members = ('__contains__', '__getitem__', '__iter__', '__len__',
-                        '__call__')
+                        '__call__', '__add__', '__sub__', '__mul__', '__div__',
+                        '__hash__')
 
 ###############################################################################
 # RANDOM UTILITIES

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -64,7 +64,7 @@ def nottest(f):
 # changed here!
 _doc_special_members = ('__contains__', '__getitem__', '__iter__', '__len__',
                         '__call__', '__add__', '__sub__', '__mul__', '__div__',
-                        '__hash__')
+                        '__neg__', '__hash__')
 
 ###############################################################################
 # RANDOM UTILITIES

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1746,6 +1746,13 @@ class SizeMixin(object):
         return size
 
     def __hash__(self):
+        """Hash the object
+
+        Returns
+        -------
+        hash : int
+            The hash
+        """
         from .evoked import Evoked
         from .epochs import _BaseEpochs
         from .io.base import _BaseRaw

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2208,8 +2208,7 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     from .evoked import Evoked
     from .time_frequency import AverageTFR
     from .channels.channels import equalize_channels
-    if not any([(all(isinstance(inst, t) for inst in all_inst)
-                for t in (Evoked, AverageTFR))]):
+    if not all(isinstance(inst, (Evoked, AverageTFR)) for inst in all_inst):
         raise ValueError("Not all input elements are Evoked or AverageTFR")
 
     # Copy channels to leave the original evoked datasets intact.
@@ -2222,7 +2221,7 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
                         else inst for inst in all_inst]
         equalize_channels(all_inst)  # apply equalize_channels
         from .evoked import combine_evoked as combine
-    elif isinstance(all_inst[0], AverageTFR):
+    else:  # isinstance(all_inst[0], AverageTFR):
         from .time_frequency.tfr import combine_tfr as combine
 
     if drop_bads:

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -287,7 +287,7 @@ evoked_dev.plot_topomap(times=times, title='Deviant')
 # We can see the MMN effect more clearly by looking at the difference between
 # the two conditions. P50 and N100 are no longer visible, but MMN/P200 and
 # P300 are emphasised.
-evoked_difference = combine_evoked([evoked_dev, evoked_std], weights=[1, -1])
+evoked_difference = combine_evoked([evoked_dev, -evoked_std], weights='equal')
 evoked_difference.plot(window_title='Difference', gfp=True)
 
 ###############################################################################

--- a/tutorials/plot_dipole_fit.py
+++ b/tutorials/plot_dipole_fit.py
@@ -71,7 +71,7 @@ pred_evoked.plot_topomap(time_format='Predicted field', axes=axes[1],
                          **plot_params)
 
 # Subtract predicted from measured data (apply equal weights)
-diff = combine_evoked([evoked, pred_evoked], [1, -1])
+diff = combine_evoked([evoked, -pred_evoked], weights='equal')
 plot_params['colorbar'] = True
 diff.plot_topomap(time_format='Difference', axes=axes[2], **plot_params)
 plt.suptitle('Comparison of measured and predicted fields '

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -172,7 +172,8 @@ all_evokeds = [aud_l, aud_r, vis_l, vis_r]
 # all_evokeds = [epochs[cond] for cond in event_id]
 
 # Then, we construct and plot an unweighted average of left vs. right trials.
-mne.combine_evoked(all_evokeds, weights=(1, -1, 1, -1)).plot_joint()
+mne.combine_evoked(all_evokeds,
+                   weights=(0.25, -0.25, 0.25, -0.25)).plot_joint()
 
 ###############################################################################
 # Often, it makes sense to store Evoked objects in a dictionary or a list -

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -172,7 +172,7 @@ print(all_evokeds)
 
 ###############################################################################
 # This can be simplified with a Python list comprehension:
-all_evokeds = [epochs[cond] for cond in sorted(event_id.keys())]
+all_evokeds = [epochs[cond].average() for cond in sorted(event_id.keys())]
 print(all_evokeds)
 
 # Then, we construct and plot an unweighted average of left vs. right trials

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -152,13 +152,14 @@ print(epochs)
 
 left, right = epochs["left"].average(), epochs["right"].average()
 
-(left - right).plot_joint()  # create and plot difference ERP
+# create and plot difference ERP
+mne.combine_evoked([left, -right], weights='equal').plot_joint()
 
 ###############################################################################
-# Note that by default, this is a trial-weighted average. If you have
-# imbalanced trial numbers, consider either equalizing the number of events per
-# condition (using ``Epochs.equalize_event_counts``), or the ``combine_evoked``
-# function.
+# This is an equal-weighting difference. If you have imbalanced trial numbers,
+# you could also consider either equalizing the number of events per
+# condition (using
+# :meth:``epochs.equalize_epochs_counts <mne.Epochs.equalize_event_counts`).
 # As an example, first, we create individual ERPs for each condition.
 
 aud_l = epochs["auditory", "left"].average()
@@ -167,11 +168,15 @@ vis_l = epochs["visual", "left"].average()
 vis_r = epochs["visual", "right"].average()
 
 all_evokeds = [aud_l, aud_r, vis_l, vis_r]
+print(all_evokeds)
 
-# This could have been much simplified with a list comprehension:
-# all_evokeds = [epochs[cond] for cond in event_id]
+###############################################################################
+# This can be simplified with a Python list comprehension:
+all_evokeds = [epochs[cond] for cond in sorted(event_id.keys())]
+print(all_evokeds)
 
-# Then, we construct and plot an unweighted average of left vs. right trials.
+# Then, we construct and plot an unweighted average of left vs. right trials
+# this way, too:
 mne.combine_evoked(all_evokeds,
                    weights=(0.25, -0.25, 0.25, -0.25)).plot_joint()
 

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -276,10 +276,39 @@ evoked2 = mne.read_evokeds(
     evoked_fname, condition='Right Auditory', baseline=(None, 0), proj=True)
 
 ##############################################################################
-# Compute a contrast:
+# Two evoked objects can be contrasted using :func:`mne.combine_evoked`.
+# By default, this function uses ``weights='nave'``, which means that the
+# number of trials used to obtain the averages for ``evoked1`` and ``evoked2``
+# are taken into account when computing the resulting ``contrast``. That is,
+# the following provides a weighted difference here, not a simple
+# element-by-element subtraction:
+
+contrast = mne.combine_evoked([evoked1, -evoked2])
+print(contrast)
+
+##############################################################################
+# To do a an unweighted difference, you can use either of the following, but
+# note that the resulting estimated number of averages might not be correct,
+# so it is not well suited to use in inverses:
 
 contrast = mne.combine_evoked([evoked1, evoked2], weights=[1, -1])
+contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
 print(contrast)
+
+##############################################################################
+# Instead of dealing with mismatches in the number of averages, we can use
+# trial-count equalization before computing a contrast, which is recommended
+# for inverse imaging (note that here the ``weights='nave'`` default will
+# give the same result as ``weights='equal'`` here):
+
+epochs_eq = epochs.copy().equalize_event_counts(['aud_l', 'aud_r'])[0]
+evoked1, evoked2 = epochs_eq['aud_l'].average(), epochs_eq['aud_r'].average()
+print(evoked1)
+print(evoked2)
+contrast = mne.combine_evoked([evoked1, -evoked2])
+contrast.comment = 'aud_l - aud_r'
+print(contrast)
+raise RuntimeError
 
 ##############################################################################
 # Time-Frequency: Induced power and inter trial coherence

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -277,38 +277,35 @@ evoked2 = mne.read_evokeds(
 
 ##############################################################################
 # Two evoked objects can be contrasted using :func:`mne.combine_evoked`.
-# By default, this function uses ``weights='nave'``, which means that the
+# This function can use ``weights='nave'``, which means that the
 # number of trials used to obtain the averages for ``evoked1`` and ``evoked2``
 # are taken into account when computing the resulting ``contrast``. That is,
 # the following provides a weighted difference here, not a simple
 # element-by-element subtraction:
 
-contrast = mne.combine_evoked([evoked1, -evoked2])
+contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
 print(contrast)
 
 ##############################################################################
-# To do a an unweighted difference, you can use either of the following, but
-# note that the resulting estimated number of averages might not be correct,
-# so it is not well suited to use in inverses:
+# To do a an unweighted difference, you can use either of the following:
 
-contrast = mne.combine_evoked([evoked1, evoked2], weights=[1, -1])
+contrast = mne.combine_evoked([evoked1, evoked2], weights=[0.5, -0.5])
 contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
 print(contrast)
 
 ##############################################################################
 # Instead of dealing with mismatches in the number of averages, we can use
 # trial-count equalization before computing a contrast, which is recommended
-# for inverse imaging (note that here the ``weights='nave'`` default will
+# for most cases for inverse imaging (note that here ``weights='nave'`` will
 # give the same result as ``weights='equal'`` here):
 
 epochs_eq = epochs.copy().equalize_event_counts(['aud_l', 'aud_r'])[0]
 evoked1, evoked2 = epochs_eq['aud_l'].average(), epochs_eq['aud_r'].average()
 print(evoked1)
 print(evoked2)
-contrast = mne.combine_evoked([evoked1, -evoked2])
+contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
 contrast.comment = 'aud_l - aud_r'
 print(contrast)
-raise RuntimeError
 
 ##############################################################################
 # Time-Frequency: Induced power and inter trial coherence

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -294,7 +294,7 @@ print(contrast)
 
 average = mne.combine_evoked([evoked1, evoked2], weights='nave')
 print(contrast)
-raise RuntimeError
+
 ##############################################################################
 # Instead of dealing with mismatches in the number of averages, we can use
 # trial-count equalization before computing a contrast, which can have some

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -277,34 +277,35 @@ evoked2 = mne.read_evokeds(
 
 ##############################################################################
 # Two evoked objects can be contrasted using :func:`mne.combine_evoked`.
-# This function can use ``weights='nave'``, which means that the
-# number of trials used to obtain the averages for ``evoked1`` and ``evoked2``
-# are taken into account when computing the resulting ``contrast``. That is,
-# the following provides a weighted difference here, not a simple
-# element-by-element subtraction:
-
-contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
-print(contrast)
-
-##############################################################################
-# To do a an unweighted difference, you can use either of the following:
+# This function can use ``weights='equal'``, which provides a simple
+# element-by-element subtraction (and sets the
+# :attr:`mne.Evoked.nave` attribute properly based on the underlying number
+# of trials) using either equivalent call:
 
 contrast = mne.combine_evoked([evoked1, evoked2], weights=[0.5, -0.5])
 contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
 print(contrast)
 
 ##############################################################################
+# To do a weighted sum based on the number of averages, which will give
+# you what you would have gotten from pooling all trials together in
+# :class:`mne.Epochs` before creating the :class:`mne.Evoked` instance,
+# you can use ``weights='nave'``:
+
+average = mne.combine_evoked([evoked1, evoked2], weights='nave')
+print(contrast)
+raise RuntimeError
+##############################################################################
 # Instead of dealing with mismatches in the number of averages, we can use
-# trial-count equalization before computing a contrast, which is recommended
-# for most cases for inverse imaging (note that here ``weights='nave'`` will
-# give the same result as ``weights='equal'`` here):
+# trial-count equalization before computing a contrast, which can have some
+# benefits in inverse imaging (note that here ``weights='nave'`` will
+# give the same result as ``weights='equal'``):
 
 epochs_eq = epochs.copy().equalize_event_counts(['aud_l', 'aud_r'])[0]
 evoked1, evoked2 = epochs_eq['aud_l'].average(), epochs_eq['aud_r'].average()
 print(evoked1)
 print(evoked2)
 contrast = mne.combine_evoked([evoked1, -evoked2], weights='equal')
-contrast.comment = 'aud_l - aud_r'
 print(contrast)
 
 ##############################################################################

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -278,7 +278,7 @@ evoked2 = mne.read_evokeds(
 ##############################################################################
 # Compute a contrast:
 
-contrast = evoked1 - evoked2
+contrast = mne.combine_evoked([evoked1, evoked2], weights=[1, -1])
 print(contrast)
 
 ##############################################################################


### PR DESCRIPTION
I think this is the API we talked about in #3363.

~~There is a backward-incompatible change -- `combine_evokeds(..., weights='equal')` or `combine_evokeds(..., weights=ndarray)` used to set `out.nave` using some simple computations, but according to our discussion it's safer for inverse modeling not to do that. So this makes it `out.nave = None`.~~

~~Labeled as WIP because I need to clean it up a little bit (see below) before merge, but we need to agree on the API before I do that.~~

~~I don't like the name I chose `summation_weights`, so feel free to suggest others.~~

~~Once we converge, I still need to:~~

* [ ] ~~check/fix doc rendering~~
* [ ] ~~update whats_new.py~~
* [ ] ~~squash warnings in **many** of places by setting `summation_weights=...` explicitly.~~