### PR TITLE
MRG: Minor bug with dipole fitting

### DIFF
--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -242,7 +242,8 @@ def test_min_distance_fit_dipole():
 
     min_dist = 5.  # distance in mm
 
-    dip, residual = fit_dipole(evoked, cov, fname_bem, fname_trans,
+    bem = read_bem_solution(fname_bem)
+    dip, residual = fit_dipole(evoked, cov, bem, fname_trans,
                                min_dist=min_dist)
 
     dist = _compute_depth(dip, fname_bem, fname_trans, subject, subjects_dir)


### PR DESCRIPTION
Fixes a minor bug where `bem` could not be a `ConductorModel` (had to be string path). Also shows disappointing dipole fit quality with BEM, but MNE-C's dipole routines and Xfit's agree with ours. Not sure if it's a limitation of dipole fitting, or of our raw simulation. I'll keep looking into it, but in the meantime this should be good to go.