### PR TITLE
MRG: phantom tutorials

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,15 +33,17 @@ dependencies:
         chmod +x ~/miniconda.sh;
         ~/miniconda.sh -b -p /home/ubuntu/miniconda;
         conda update --yes --quiet conda;
-        conda create -n circleenv --yes pip python=2.7 pip numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
+        conda create -n circleenv --yes pip python=2.7 pip;
         sed -i "s/ENABLE_USER_SITE = .*/ENABLE_USER_SITE = False/g" /home/ubuntu/miniconda/envs/circleenv/lib/python2.7/site.py;
       else
         echo "Conda already set up.";
       fi
-    # If we get "raise EOFError from Sphinx again, we can follow
+    # Te get around "raise EOFError" from Sphinx, we can follow
     # https://github.com/sphinx-doc/sphinx/issues/2670 and do:
-    # - conda remove -n circleenv --yes sphinx;
-    # - conda install -n circleenv --yes numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
+    - if conda list -n circleenv sphinx; then
+        conda remove -n circleenv --yes sphinx;
+      fi;
+    - conda install -n circleenv --yes numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
     - ls -al /home/ubuntu/miniconda;
     - ls -al /home/ubuntu/miniconda/bin;
     - echo $PATH;

--- a/circle.yml
+++ b/circle.yml
@@ -38,8 +38,10 @@ dependencies:
       else
         echo "Conda already set up.";
       fi
-    - conda remove -n circleenv --yes sphinx;
-    - conda install -n circleenv --yes numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
+    # If we get "raise EOFError from Sphinx again, we can follow
+    # https://github.com/sphinx-doc/sphinx/issues/2670 and do:
+    # - conda remove -n circleenv --yes sphinx;
+    # - conda install -n circleenv --yes numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
     - ls -al /home/ubuntu/miniconda;
     - ls -al /home/ubuntu/miniconda/bin;
     - echo $PATH;

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,8 @@ dependencies:
       else
         echo "Conda already set up.";
       fi
+    - conda remove -n circleenv --yes sphinx;
+    - conda install -n circleenv --yes numpy scipy scikit-learn mayavi matplotlib sphinx pillow six IPython pandas;
     - ls -al /home/ubuntu/miniconda;
     - ls -al /home/ubuntu/miniconda/bin;
     - echo $PATH;

--- a/circle.yml
+++ b/circle.yml
@@ -75,6 +75,12 @@ dependencies:
             if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_raw.*" | wc -l) -gt 0 ]]; then
               python -c "import mne; print(mne.datasets.brainstorm.bst_raw.data_path())" --accept-brainstorm-license;
             fi;
+            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_phantom_ctf.*" | wc -l) -gt 0 ]]; then
+              python -c "import mne; print(mne.datasets.brainstorm.bst_phantom_ctf.data_path())" --accept-brainstorm-license;
+            fi;
+            if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_phantom_elekta.*" | wc -l) -gt 0 ]]; then
+              python -c "import mne; print(mne.datasets.brainstorm.bst_phantom_elekta.data_path())" --accept-brainstorm-license;
+            fi;
           fi;
         done;
         echo PATTERN="$PATTERN";

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -113,3 +113,6 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) _build/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in _build/doctest/output.txt."
+
+view:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -748,6 +748,18 @@ Functions:
 
    fit_dipole
 
+:py:mod:`mne.dipole`:
+
+.. currentmodule:: mne.dipole
+
+Functions:
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   get_phantom_dipoles
+
 
 Source Space Data
 =================

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -134,6 +134,7 @@ For further reading:
     auto_tutorials/plot_mne_dspm_source_localization.rst
     auto_tutorials/plot_dipole_fit.rst
     auto_tutorials/plot_brainstorm_auditory.rst
+    auto_tutorials/plot_brainstorm_phantom_ctf.rst
     auto_tutorials/plot_brainstorm_phantom_elekta.rst
     auto_tutorials/plot_point_spread.rst
 

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -134,6 +134,7 @@ For further reading:
     auto_tutorials/plot_mne_dspm_source_localization.rst
     auto_tutorials/plot_dipole_fit.rst
     auto_tutorials/plot_brainstorm_auditory.rst
+    auto_tutorials/plot_brainstorm_phantom_elekta.rst
     auto_tutorials/plot_point_spread.rst
 
 .. container:: span box

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1653,13 +1653,17 @@ def _get_whitener_data(info, noise_cov, picks, diag=False, rank=None,
     """Get whitening matrix for a set of data."""
     ch_names = [info['ch_names'][k] for k in picks]
     noise_cov = pick_channels_cov(noise_cov, include=ch_names, exclude=[])
-    info = pick_info(info, picks)
+    if len(noise_cov['data']) != len(ch_names):
+        missing = list(set(ch_names) - set(noise_cov['names']))
+        raise RuntimeError('Not all channels present in noise covariance:\n%s'
+                           % missing)
     if diag:
         noise_cov = cp.deepcopy(noise_cov)
         noise_cov['data'] = np.diag(np.diag(noise_cov['data']))
 
     scalings = _handle_default('scalings_cov_rank', scalings)
-    W = compute_whitener(noise_cov, info, rank=rank, scalings=scalings)[0]
+    W = compute_whitener(noise_cov, info, picks=picks, rank=rank,
+                         scalings=scalings)[0]
     return W
 
 

--- a/mne/datasets/brainstorm/__init__.py
+++ b/mne/datasets/brainstorm/__init__.py
@@ -1,4 +1,5 @@
 """Brainstorm Dataset
 """
 
-from . import bst_raw, bst_resting, bst_auditory
+from . import (bst_raw, bst_resting, bst_auditory, bst_phantom_ctf,
+               bst_phantom_elekta)

--- a/mne/datasets/brainstorm/bst_phantom_ctf.py
+++ b/mne/datasets/brainstorm/bst_phantom_ctf.py
@@ -1,0 +1,50 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+
+from ...utils import verbose
+from ...fixes import partial
+from ..utils import (has_dataset, _data_path, _get_version, _version_doc,
+                     _data_path_doc)
+
+has_brainstorm_data = partial(has_dataset, name='brainstorm')
+
+
+_description = u"""
+URL: http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomCtf
+"""
+
+
+@verbose
+def data_path(path=None, force_update=False, update_path=True, download=True,
+              verbose=None):
+    archive_name = dict(brainstorm='bst_phantom_ctf.tar.gz')
+    data_path = _data_path(path=path, force_update=force_update,
+                           update_path=update_path, name='brainstorm',
+                           download=download, archive_name=archive_name)
+    if data_path != '':
+        return op.join(data_path, 'bst_phantom_ctf')
+    else:
+        return data_path
+
+_data_path_doc = _data_path_doc.format(name='brainstorm',
+                                       conf='MNE_DATASETS_BRAINSTORM_DATA'
+                                            '_PATH')
+_data_path_doc = _data_path_doc.replace('brainstorm dataset',
+                                        'brainstorm (bst_phantom_ctf) dataset')
+data_path.__doc__ = _data_path_doc
+
+
+def get_version():
+    return _get_version('brainstorm')
+
+get_version.__doc__ = _version_doc.format(name='brainstorm')
+
+
+def description():
+    """Get description of brainstorm (bst_phantom_ctf) dataset
+    """
+    for desc in _description.splitlines():
+        print(desc)

--- a/mne/datasets/brainstorm/bst_phantom_elekta.py
+++ b/mne/datasets/brainstorm/bst_phantom_elekta.py
@@ -1,0 +1,51 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+
+from ...utils import verbose
+from ...fixes import partial
+from ..utils import (has_dataset, _data_path, _get_version, _version_doc,
+                     _data_path_doc)
+
+has_brainstorm_data = partial(has_dataset, name='brainstorm')
+
+
+_description = u"""
+URL: http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomElekta
+"""
+
+
+@verbose
+def data_path(path=None, force_update=False, update_path=True, download=True,
+              verbose=None):
+    archive_name = dict(brainstorm='bst_phantom_elekta.tar.gz')
+    data_path = _data_path(path=path, force_update=force_update,
+                           update_path=update_path, name='brainstorm',
+                           download=download, archive_name=archive_name)
+    if data_path != '':
+        return op.join(data_path, 'bst_phantom_elekta')
+    else:
+        return data_path
+
+_data_path_doc = _data_path_doc.format(name='brainstorm',
+                                       conf='MNE_DATASETS_BRAINSTORM_DATA'
+                                            '_PATH')
+_data_path_doc = _data_path_doc.replace('brainstorm dataset',
+                                        'brainstorm (bst_phantom_elekta) '
+                                        'dataset')
+data_path.__doc__ = _data_path_doc
+
+
+def get_version():
+    return _get_version('brainstorm')
+
+get_version.__doc__ = _version_doc.format(name='brainstorm')
+
+
+def description():
+    """Get description of brainstorm (bst_phantom_elekta) dataset
+    """
+    for desc in _description.splitlines():
+        print(desc)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -69,10 +69,11 @@ tutorial, e.g. for research purposes, is prohibited without written consent
 from the MEG Lab.
 
 If you reference this dataset in your publications, please:
-1) aknowledge its authors: Elizabeth Bock, Esther Florin, Francois Tadel and
-Sylvain Baillet
-2) cite Brainstorm as indicated on the website:
-http://neuroimage.usc.edu/brainstorm
+
+    1) acknowledge its authors: Elizabeth Bock, Esther Florin, Francois Tadel
+       and Sylvain Baillet, and
+    2) cite Brainstorm as indicated on the website:
+       http://neuroimage.usc.edu/brainstorm
 
 For questions, please contact Francois Tadel (francois.tadel@mcgill.ca).
 """
@@ -370,6 +371,8 @@ def _download_all_example_data(verbose=True):
     try:
         brainstorm.bst_raw.data_path()
         brainstorm.bst_auditory.data_path()
+        brainstorm.bst_phantom_elekta.data_path()
+        brainstorm.bst_phantom_ctf.data_path()
     finally:
         sys.argv.pop(-1)
     megsim.load_data(condition='visual', data_format='single-trial',

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1088,6 +1088,8 @@ def get_phantom_dipoles(kind='elekta'):
             idx = np.setdiff1d(np.arange(3), idx[0])
             this_ori[idx] = (this_pos[idx][::-1] /
                              np.linalg.norm(this_pos[idx])) * [1, -1]
+            # Now we have this quality, which we could uncomment to
+            # double-check:
             # np.testing.assert_allclose(np.dot(this_ori, this_pos) /
             #                            np.linalg.norm(this_pos), 0,
             #                            atol=1e-15)

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -733,7 +733,7 @@ def _prep_field_computation(rr, bem, fwd_data, n_jobs, verbose=None):
                     # Compute solution for EEG sensor
                     solution = _bem_specify_els(bem, coils, mults)
             else:
-                solution = bem
+                solution = csolution = bem
                 if coil_type == 'eeg':
                     logger.info('Using the equivalent source approach in the '
                                 'homogeneous sphere for EEG')

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -313,7 +313,7 @@ def test_regularize_cov():
     assert_true(np.mean(noise_cov['data'] < reg_noise_cov['data']) < 0.08)
 
 
-def test_evoked_whiten():
+def test_whiten_evoked():
     """Test whitening of evoked data"""
     evoked = read_evokeds(ave_fname, condition=0, baseline=(None, 0),
                           proj=True)
@@ -332,6 +332,10 @@ def test_evoked_whiten():
     mean_baseline = np.mean(np.abs(whiten_baseline_data), axis=1)
     assert_true(np.all(mean_baseline < 1.))
     assert_true(np.all(mean_baseline > 0.2))
+
+    # degenerate
+    cov_bad = pick_channels_cov(cov, include=evoked.ch_names[:10])
+    assert_raises(RuntimeError, whiten_evoked, evoked, cov_bad, picks)
 
 
 @slow_test

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -24,7 +24,7 @@ if len(bad) > 0:
     out.append('Found un-nested scipy submodules: %s' % list(bad))
 
 # check sklearn and others
-_sklearn = _pandas = _nose = False
+_sklearn = _pandas = _nose = _mayavi = False
 for x in sys.modules.keys():
     if x.startswith('sklearn') and not _sklearn:
         out.append('Found un-nested sklearn import')
@@ -35,6 +35,9 @@ for x in sys.modules.keys():
     if x.startswith('nose') and not _nose:
         out.append('Found un-nested nose import')
         _nose = True
+    if x.startswith('mayavi') and not _mayavi:
+        out.append('Found un-nested mayavi import')
+        _mayavi = True
 if len(out) > 0:
     print('\\n' + '\\n'.join(out), end='')
     exit(1)

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -17,6 +17,7 @@ skip_files = (
     'FreeSurferColorLUT.txt',
     'test_edf_stim_channel.txt',
     'FieldTrip.py',
+    'license.txt',
 )
 
 
@@ -50,8 +51,7 @@ def _assert_line_endings(dir_):
 
 
 def test_line_endings():
-    """Test line endings of mne-python
-    """
+    """Test line endings of mne-python"""
     tempdir = _TempDir()
     with open(op.join(tempdir, 'foo'), 'wb') as fid:
         fid.write('bad\r\ngood\n'.encode('ascii'))

--- a/tutorials/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/plot_brainstorm_phantom_ctf.py
@@ -80,6 +80,10 @@ raw_erm = read_raw_ctf(erm_path)
 cov = mne.compute_raw_covariance(raw_erm)
 sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=None)
 dip = fit_dipole(evoked, cov, sphere)[0]
+
+###############################################################################
+# Compare the actual position with the estimated one.
+
 expected_pos = np.array([18., 0., 49.])
 diff = np.sqrt(np.sum((dip.pos[0] * 1000 - expected_pos) ** 2))
 print('Actual pos:     %s mm' % np.array_str(expected_pos, precision=1))

--- a/tutorials/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/plot_brainstorm_phantom_ctf.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+=======================================
+Brainstorm CTF phantom tutorial dataset
+=======================================
+
+Here we compute the evoked from raw for the Brainstorm CTF phantom
+tutorial dataset. For comparison, see [1]_ and:
+
+    http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomCtf
+
+References
+----------
+.. [1] Tadel F, Baillet S, Mosher JC, Pantazis D, Leahy RM.
+       Brainstorm: A User-Friendly Application for MEG/EEG Analysis.
+       Computational Intelligence and Neuroscience, vol. 2011, Article ID
+       879716, 13 pages, 2011. doi:10.1155/2011/879716
+"""
+
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+import numpy as np
+import matplotlib.pyplot as plt
+
+import mne
+from mne import fit_dipole
+from mne.datasets.brainstorm import bst_phantom_ctf
+from mne.io import read_raw_ctf
+
+print(__doc__)
+
+###############################################################################
+# The data were collected with a CTF system at 2400 Hz.
+data_path = bst_phantom_ctf.data_path()
+
+# Switch to these to use the higher-SNR data:
+# raw_path = op.join(data_path, 'phantom_200uA_20150709_01.ds')
+# dip_freq = 7.
+raw_path = op.join(data_path, 'phantom_20uA_20150603_03.ds')
+dip_freq = 23.
+erm_path = op.join(data_path, 'emptyroom_20150709_01.ds')
+raw = read_raw_ctf(raw_path, preload=True)
+
+###############################################################################
+# The sinusoidal signal is generated on channel HDAC006, so we can use
+# that to obtain precise timing.
+
+sinusoid, times = raw[raw.ch_names.index('HDAC006-4408')]
+plt.figure()
+plt.plot(times[times < 1.], sinusoid.T[times < 1.])
+
+###############################################################################
+# Let's create some events using this signal by thresholding the sinusoid.
+
+events = np.where(np.diff(sinusoid > 0.5) > 0)[1] + raw.first_samp
+events = np.vstack((events, np.zeros_like(events), np.ones_like(events))).T
+
+###############################################################################
+# Our choice of tmin and tmax should capture exactly one cycle, so
+# we can make the unusual choice of baselining using the entire epoch
+# when creating our evoked data. We also then crop to a single time point
+# (@t=0) because this is a peak in our signal.
+
+tmin = -0.5 / dip_freq
+tmax = -tmin
+epochs = mne.Epochs(raw, events, event_id=1, tmin=tmin, tmax=tmax,
+                    baseline=(None, None))
+evoked = epochs.average()
+evoked.plot()
+evoked.crop(0., 0.)
+
+###############################################################################
+# To do a dipole fit, let's use the covariance provided by the empty room
+# recording.
+
+raw_erm = read_raw_ctf(erm_path)
+cov = mne.compute_raw_covariance(raw_erm)
+sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=None)
+dip = fit_dipole(evoked, cov, sphere)[0]
+expected_pos = np.array([18., 0., 49.])
+diff = np.sqrt(np.sum((dip.pos[0] * 1000 - expected_pos) ** 2))
+print('Actual pos:     %s mm' % np.array_str(expected_pos, precision=1))
+print('Estimated pos:  %s mm' % np.array_str(dip.pos[0] * 1000, precision=1))
+print('Difference:     %0.1f mm' % diff)
+print('Amplitude:      %0.1f nAm' % (1e9 * dip.amplitude[0]))
+print('GOF:            %0.1f %%' % dip.gof[0])

--- a/tutorials/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/plot_brainstorm_phantom_elekta.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+==========================================
+Brainstorm Elekta phantom tutorial dataset
+==========================================
+
+Here we compute the evoked from raw for the Brainstorm Elekta phantom
+tutorial dataset. For comparison, see [1]_ and:
+
+    http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomElekta
+
+References
+----------
+.. [1] Tadel F, Baillet S, Mosher JC, Pantazis D, Leahy RM.
+       Brainstorm: A User-Friendly Application for MEG/EEG Analysis.
+       Computational Intelligence and Neuroscience, vol. 2011, Article ID
+       879716, 13 pages, 2011. doi:10.1155/2011/879716
+"""
+
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+import numpy as np
+
+import mne
+from mne import find_events, fit_dipole
+from mne.datasets.brainstorm import bst_phantom_elekta
+from mne.io import read_raw_fif
+
+print(__doc__)
+
+###############################################################################
+# The data were collected with an Elekta Neuromag VectorView system at 1000 Hz
+# and low-pass filtered at 330 Hz. Here the medium-amplitude (200 nAm) data
+# are read to construct instances of :class:`mne.io.Raw`.
+data_path = bst_phantom_elekta.data_path()
+
+raw_fname = op.join(data_path, 'kojak_all_200nAm_pp_no_chpi_no_ms_raw.fif')
+raw = read_raw_fif(raw_fname, preload=True)
+
+###############################################################################
+# Data channel array consisted of 204 MEG planor gradiometers,
+# 102 axial magnetometers, and 3 stimulus channels. Let's get the events
+# for the phantom, where each dipole (1-32) gets its own event:
+
+events = find_events(raw, 'STI201')
+raw.plot(events=events)
+raw.info['bads'] = ['MEG2421']
+
+###############################################################################
+# The data have strong line frequency (60 Hz and harmonics) and cHPI coil
+# noise (five peaks around 300 Hz):
+
+raw.plot_psd()
+
+###############################################################################
+# We know our phantom produces sinusoidal bursts below 25 Hz, so let's filter.
+
+raw.filter(None, 40., h_trans_bandwidth=10., filter_length='1s')
+raw.plot_psd()
+
+###############################################################################
+# The data are still a bit noisy, so let's use Maxwell filtering to clean it.
+# Ideally we would have the fine calibration and cross-talk information
+# for the site of interest, but we don't, so we just do:
+
+raw.fix_mag_coil_types()
+raw = mne.preprocessing.maxwell_filter(raw, origin=(0., 0., 0.))
+raw.plot(events=events)
+
+###############################################################################
+# Now we epoch our data, average it, and look at the first dipole response.
+# The first peak appears around 3 ms.
+
+tmin, tmax = -0.2, 0.2
+event_id = list(range(1, 33))
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, baseline=(None, -0.01))
+epochs['1'].average().plot()
+
+###############################################################################
+# Let's do some dipole fits. The phantom is properly modeled by a single-shell
+# sphere with origin (0., 0., 0.). We compute covariance, then do the fits.
+
+t_peak = 0.061  # 3 MS at largest peak
+sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=None)
+cov = mne.compute_covariance(epochs, tmax=0)
+data = []
+for ii in range(1, 33):
+    evoked = epochs[str(ii)].average().crop(t_peak, t_peak)
+    data.append(evoked.data[:, 0])
+evoked = mne.EvokedArray(np.array(data).T, evoked.info, tmin=0.)
+dip = fit_dipole(evoked, cov, sphere, n_jobs=2)[0]
+
+###############################################################################
+# Now we can compare to the actual locations, taking the difference in mm:
+
+actual_pos = mne.dipole.get_phantom_dipoles(kind='122')[0]
+diffs = 1000 * np.sqrt(np.sum((dip.pos - actual_pos) ** 2, axis=-1))
+print('Differences (mm):\n%s' % diffs[:, np.newaxis])


### PR DESCRIPTION
Tutorials for the [Elekta] (http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomElekta) and [CTF] (http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomCtf) phantoms from the Brainstorm datasets. Our localization is similar for CTF, and slightly better for Elekta because I applied `maxwell_filter` to it (and similar otherwise).

Closes #2937.