### PR TITLE
MRG: Add memory usage to primary objects

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,8 @@ What's new
     Note, we are now using links to highlight new functions and classes.
     Please be sure to follow the examples below like :func:`mne.stats.f_mway_rm`, so the whats_new page will have a link to the function/class documentation.
 
+.. currentmodule:: mne
+
 Current
 -------
 
@@ -31,7 +33,7 @@ Changelog
 
     - Add support for the University of Maryland KIT system by `Christian Brodbeck`_
 
-    - Add approximation of size of :class:`Raw`, :class:`Epochs`, and :class:`Evoked` in :func:`repr` by `Eric Larson`_
+    - Add approximation of size of :class:`io.Raw`, :class:`Epochs`, and :class:`Evoked` in :func:`repr` by `Eric Larson`_
 
 BUG
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 
     - Add support for the University of Maryland KIT system by `Christian Brodbeck`_
 
+    - Add approximation of size of :class:`Raw`, :class:`Epochs`, and :class:`Evoked` in :func:`repr` by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1519,7 +1519,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         s += ', tmin : %s (s)' % self.tmin
         s += ', tmax : %s (s)' % self.tmax
         s += ', baseline : %s' % str(self.baseline)
-        s += ' (~%s)' % (sizeof_fmt(self._size),)
+        s += ', ~%s' % (sizeof_fmt(self._size),)
+        s += ', data%s loaded' % ('' if self.preload else ' not')
         if len(self.event_id) > 1:
             counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
                       for k, v in sorted(self.event_id.items())]

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -15,8 +15,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 equalize_channels)
 from .filter import resample, detrend, FilterMixin
 from .fixes import in1d
-from .utils import (check_fname, logger, verbose, object_hash, _time_mask,
-                    warn)
+from .utils import check_fname, logger, verbose, _time_mask, warn, sizeof_fmt
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import (_plot_evoked_white, plot_evoked_joint,
@@ -34,7 +33,7 @@ from .io.proj import ProjMixin
 from .io.write import (start_file, start_block, end_file, end_block,
                        write_int, write_string, write_float_matrix,
                        write_id)
-from .io.base import ToDataFrameMixin, TimeMixin
+from .io.base import ToDataFrameMixin, TimeMixin, SizeMixin
 
 _aspect_dict = {'average': FIFF.FIFFV_ASPECT_AVERAGE,
                 'standard_error': FIFF.FIFFV_ASPECT_STD_ERR}
@@ -44,7 +43,7 @@ _aspect_rev = {str(FIFF.FIFFV_ASPECT_AVERAGE): 'average',
 
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
              SetChannelsMixin, InterpolationMixin, FilterMixin,
-             ToDataFrameMixin, TimeMixin):
+             ToDataFrameMixin, TimeMixin, SizeMixin):
     """Evoked data
 
     Parameters
@@ -169,6 +168,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         s += ", time : [%f, %f]" % (self.times[0], self.times[-1])
         s += ", n_epochs : %d" % self.nave
         s += ", n_channels x n_times : %s x %s" % self.data.shape
+        s += " (~%s)" % (sizeof_fmt(self._size),)
         return "<Evoked  |  %s>" % s
 
     @property
@@ -922,9 +922,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         else:
             out.comment = self.comment + " - " + this_evoked.comment
         return out
-
-    def __hash__(self):
-        return object_hash(dict(info=self.info, data=self.data))
 
     def get_peak(self, ch_type=None, tmin=None, tmax=None, mode='abs',
                  time_as_index=False):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -168,7 +168,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         s += ", time : [%f, %f]" % (self.times[0], self.times[-1])
         s += ", n_epochs : %d" % self.nave
         s += ", n_channels x n_times : %s x %s" % self.data.shape
-        s += " (~%s)" % (sizeof_fmt(self._size),)
+        s += ", ~%s" % (sizeof_fmt(self._size),)
         return "<Evoked  |  %s>" % s
 
     @property

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1864,7 +1864,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def __repr__(self):
         name = self._filenames[0]
         name = 'None' if name is None else op.basename(name)
-        size_str = sizeof_fmt(self._size)
+        size_str = str(sizeof_fmt(self._size))  # str in case it fails -> None
         size_str += ', data%s loaded' % ('' if self.preload else ' not')
         s = ('%s, n_channels x n_times : %s x %s (%0.1f sec), ~%s'
              % (name, len(self.ch_names), self.n_times, self.times[-1],

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1864,9 +1864,11 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def __repr__(self):
         name = self._filenames[0]
         name = 'None' if name is None else op.basename(name)
-        s = ('%s, n_channels x n_times : %s x %s (%0.1f sec, ~%s)'
+        size_str = sizeof_fmt(self._size)
+        size_str += ', data%s loaded' % ('' if self.preload else ' not')
+        s = ('%s, n_channels x n_times : %s x %s (%0.1f sec), ~%s'
              % (name, len(self.ch_names), self.n_times, self.times[-1],
-                sizeof_fmt(self._size)))
+                size_str))
         return "<%s  |  %s>" % (self.__class__.__name__, s)
 
     def add_events(self, events, stim_channel=None):

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -90,7 +90,10 @@ def test_hash_raw():
     raw = read_raw_fif(fif_fname)
     assert_raises(RuntimeError, raw.__hash__)
     raw = Raw(fif_fname).crop(0, 0.5, copy=False)
+    raw_size = raw._size
     raw.load_data()
+    raw_load_size = raw._size
+    assert_true(raw_size < raw_load_size)
     raw_2 = Raw(fif_fname).crop(0, 0.5, copy=False)
     raw_2.load_data()
     assert_equal(hash(raw), hash(raw_2))

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -75,7 +75,7 @@ def test_object_size():
     """Test object size estimation"""
     assert_true(object_size(np.ones(10, np.float32)) <
                 object_size(np.ones(10, np.float64)))
-    for lower, upper, obj in ((0, 50, ''),
+    for lower, upper, obj in ((0, 60, ''),
                               (0, 30, 1),
                               (0, 30, 1.),
                               (0, 60, 'foo'),
@@ -85,7 +85,7 @@ def test_object_size():
                               (400, 1000, dict(a=np.ones(50)))):
         size = object_size(obj)
         assert_true(lower < size < upper,
-                    msg='%s < %s < %s' % (lower, size, upper))
+                    msg='%s < %s < %s:\n%s' % (lower, size, upper, obj))
 
 
 def test_misc():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -80,6 +80,7 @@ def test_object_size():
                               (0, 30, 1.),
                               (0, 60, 'foo'),
                               (0, 150, np.ones(0)),
+                              (0, 150, np.int32(1)),
                               (150, 500, np.ones(20)),
                               (100, 400, dict()),
                               (400, 1000, dict(a=np.ones(50)))):

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -22,7 +22,8 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        set_memmap_min_size, _get_stim_channel, _check_fname,
                        create_slices, _time_mask, random_permutation,
                        _get_call_line, compute_corr, sys_info, verbose,
-                       check_fname, requires_ftp, get_config_path)
+                       check_fname, requires_ftp, get_config_path,
+                       object_size)
 
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -68,6 +69,23 @@ def test_get_call_line():
 
     my_line = bar()  # testing more
     assert_equal(my_line, 'my_line = bar()  # testing more')
+
+
+def test_object_size():
+    """Test object size estimation"""
+    assert_true(object_size(np.ones(10, np.float32)) <
+                object_size(np.ones(10, np.float64)))
+    for lower, upper, obj in ((0, 50, ''),
+                              (0, 30, 1),
+                              (0, 30, 1.),
+                              (0, 60, 'foo'),
+                              (0, 150, np.ones(0)),
+                              (150, 500, np.ones(20)),
+                              (100, 400, dict()),
+                              (400, 1000, dict(a=np.ones(50)))):
+        size = object_size(obj)
+        assert_true(lower < size < upper,
+                    msg='%s < %s < %s' % (lower, size, upper))
 
 
 def test_misc():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -163,12 +163,16 @@ def object_size(x):
     size : int
         The estimated size in bytes of the object.
     """
+    # Note: this will not process object arrays properly (since those only)
+    # hold references
     if isinstance(x, (bytes, string_types, int, float, type(None))):
         size = sys.getsizeof(x)
     elif isinstance(x, np.ndarray):
         # On newer versions of NumPy, just doing sys.getsizeof(x) works,
         # but on older ones you always get something small :(
         size = sys.getsizeof(np.array([])) + x.nbytes
+    elif isinstance(x, np.generic):
+        size = x.nbytes
     elif isinstance(x, dict):
         size = sys.getsizeof(x)
         for key, value in x.items():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -163,9 +163,12 @@ def object_size(x):
     size : int
         The estimated size in bytes of the object.
     """
-    if isinstance(x, (bytes, string_types, int, float, type(None),
-                  np.ndarray)):
+    if isinstance(x, (bytes, string_types, int, float, type(None))):
         size = sys.getsizeof(x)
+    elif isinstance(x, np.ndarray):
+        # On newer versions of NumPy, just doing sys.getsizeof(x) works,
+        # but on older ones you always get something small :(
+        size = sys.getsizeof(np.array([])) + x.nbytes
     elif isinstance(x, dict):
         size = sys.getsizeof(x)
         for key, value in x.items():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -148,6 +148,36 @@ def object_hash(x, h=None):
     return int(h.hexdigest(), 16)
 
 
+def object_size(x):
+    """Estimate the size of a reasonable python object
+
+    Parameters
+    ----------
+    x : object
+        Object to approximate the size of.
+        Can be anything comprised of nested versions of:
+        {dict, list, tuple, ndarray, str, bytes, float, int, None}.
+
+    Returns
+    -------
+    size : int
+        The estimated size in bytes of the object.
+    """
+    if isinstance(x, (bytes, string_types, int, float, type(None),
+                  np.ndarray)):
+        size = sys.getsizeof(x)
+    elif isinstance(x, dict):
+        size = sys.getsizeof(x)
+        for key, value in x.items():
+            size += object_size(key)
+            size += object_size(value)
+    elif isinstance(x, (list, tuple)):
+        size = sys.getsizeof(x) + sum(object_size(xx) for xx in x)
+    else:
+        raise RuntimeError('unsupported type: %s (%s)' % (type(x), x))
+    return size
+
+
 def object_diff(a, b, pre=''):
     """Compute all differences between two python variables
 


### PR DESCRIPTION
Closes #3401.

For example:
```Python
>>> print(mne.io.read_raw_fif('sample_audvis_raw.fif'))
<Raw  |  sample_audvis_raw.fif, n_channels x n_times : 376 x 166800 (277.7 sec), ~3.8 MB>
>>> print(mne.io.read_raw_fif('sample_audvis_raw.fif', preload=True))
<Raw  |  sample_audvis_raw.fif, n_channels x n_times : 376 x 166800 (277.7 sec), ~482.3 MB>
>>> print(mne.read_epochs('sample-epo.fif', preload=False))
<EpochsFIF  |  n_events : 121 (all good), tmin : -0.0998976065792 (s), tmax : 1.0006410259 (s), baseline : (-0.0998976081609726, 0.0), ~3.8 MB,
 u'Auditory/Left': 57, u'Auditory/Right': 64>
>>> print(mne.read_epochs('sample-epo.fif'))
<EpochsFIF  |  n_events : 121 (all good), tmin : -0.0998976065792 (s), tmax : 1.0006410259 (s), baseline : (-0.0998976081609726, 0.0), ~233.6 MB,
 u'Auditory/Left': 57, u'Auditory/Right': 64>
>>> print(mne.read_evokeds('sample_audvis-ave.fif')[0])
<Evoked  |  comment : 'Left Auditory', kind : average, time : [-0.199795, 0.499488], n_epochs : 55, n_channels x n_times : 376 x 421, ~4.9 MB>
```
@jona-sassenhagen is that what you had in mind?