### PR TITLE
[MRG] Vectorizer class to help chain MNE transformers by converting o/p into 2D

### DIFF
--- a/doc/manual/decoding.rst
+++ b/doc/manual/decoding.rst
@@ -29,7 +29,7 @@ To recover the original 3D data, an ``inverse_transform`` can be used. The ``epo
 
 Vectorizer
 ^^^^^^^^^^
-Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.pipeline.Pipeline`. We can construct decoding pipeline and perform cross-validation and grid-search. However scikit-Learn transformers and estimators generally expect 2D data (n_samples * n_features), MNE transformers typically output data with higher dimensionality (e.g. n_samples * n_channels * n_frequencies * n_times). A Vectorizer therefore needs to be applied between the MNE and the Scikit-Learn steps: e.g: make_pipeline(Xdawn(), Vectorizer(), LogisticRegression())
+Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.pipeline.Pipeline`. We can construct decoding pipeline and perform cross-validation and grid-search. However scikit-Learn transformers and estimators generally expect 2D data (n_samples * n_features), whereas MNE transformers typically output data with higher dimensionality (e.g. n_samples * n_channels * n_frequencies * n_times). A Vectorizer therefore needs to be applied between the MNE and the Scikit-Learn steps: e.g: make_pipeline(Xdawn(), Vectorizer(), LogisticRegression())
 
 PSDEstimator
 ^^^^^^^^^^^^

--- a/doc/manual/decoding.rst
+++ b/doc/manual/decoding.rst
@@ -29,7 +29,7 @@ To recover the original 3D data, an ``inverse_transform`` can be used. The ``epo
 
 Vectorizer
 ^^^^^^^^^^
-Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.pipeline.Pipeline`. We can construct decoding pipeline and perform cross-validation and grid-search. However scikit-Learn transformers and estimators generally expect 2D data (n_samples * n_features), whereas MNE transformers typically output data with higher dimensionality (e.g. n_samples * n_channels * n_frequencies * n_times). A Vectorizer therefore needs to be applied between the MNE and the Scikit-Learn steps: e.g: make_pipeline(Xdawn(), Vectorizer(), LogisticRegression())
+Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.pipeline.Pipeline`. We can construct decoding pipelines and perform cross-validation and grid-search. However scikit-learn transformers and estimators generally expect 2D data (n_samples * n_features), whereas MNE transformers typically output data with a higher dimensionality (e.g. n_samples * n_channels * n_frequencies * n_times). A Vectorizer therefore needs to be applied between the MNE and the scikit-learn steps: e.g: make_pipeline(Xdawn(), Vectorizer(), LogisticRegression())
 
 PSDEstimator
 ^^^^^^^^^^^^

--- a/doc/manual/decoding.rst
+++ b/doc/manual/decoding.rst
@@ -27,6 +27,10 @@ Scikit-learn API enforces the requirement that data arrays must be 2D. A common 
 
 To recover the original 3D data, an ``inverse_transform`` can be used. The ``epochs_vectorizer`` is particularly useful when constructing a pipeline object (used mainly for parameter search and cross validation). The ``epochs_vectorizer`` is the first estimator in the pipeline enabling estimators downstream to be more advanced estimators implemented in Scikit-learn. 
 
+Vectorizer
+^^^^^^^^^^
+Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.Pipeline`. We can apply MNE transformers in scikit-learn pipeline to chain them. Further it becomes useful for cross validation and grid search for parameters. Vectorizer is typically the last step(before the estimator in the pipeline) to convert higher dimensional data into two dimensional, compatible with the estimator.
+
 PSDEstimator
 ^^^^^^^^^^^^
 This estimator computes the power spectral density (PSD) using the multitaper method. It takes a 3D array as input, it into 2D and computes the PSD.

--- a/doc/manual/decoding.rst
+++ b/doc/manual/decoding.rst
@@ -29,7 +29,7 @@ To recover the original 3D data, an ``inverse_transform`` can be used. The ``epo
 
 Vectorizer
 ^^^^^^^^^^
-Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.Pipeline`. We can apply MNE transformers in scikit-learn pipeline to chain them. Further it becomes useful for cross validation and grid search for parameters. Vectorizer is typically the last step(before the estimator in the pipeline) to convert higher dimensional data into two dimensional, compatible with the estimator.
+Scikit-learn API provides functionality to chain transformers and estimators by using :class:`sklearn.pipeline.Pipeline`. We can construct decoding pipeline and perform cross-validation and grid-search. However scikit-Learn transformers and estimators generally expect 2D data (n_samples * n_features), MNE transformers typically output data with higher dimensionality (e.g. n_samples * n_channels * n_frequencies * n_times). A Vectorizer therefore needs to be applied between the MNE and the Scikit-Learn steps: e.g: make_pipeline(Xdawn(), Vectorizer(), LogisticRegression())
 
 PSDEstimator
 ^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -113,7 +113,7 @@ API
 
     - The ``compensation`` parameter in :func:`mne.io.read_raw_fif` has been deprecated in favor of the method :meth:`mne.io.Raw.apply_gradient_compensation` by `Eric Larson`_
 
-    - Added :class:`mne.decoding.Vectorizer` to convert the output of an MNE transformer into two dimensions so as to pipeline it to scikit-learn estimators by `Asish Panda`_
+    - :class:`mne.decoding.EpochsVectorizer` has been deprecated in favor of :class:`mne.decoding.Vectorizer` by `Asish Panda`_
 
 .. _changes_0_12:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -113,7 +113,7 @@ API
 
     - The ``compensation`` parameter in :func:`mne.io.read_raw_fif` has been deprecated in favor of the method :meth:`mne.io.Raw.apply_gradient_compensation` by `Eric Larson`_
 
-    -   -  Added :class:`mne.decoding.Vectorizer` to convert the output of an MNE transformer into two dimensions so as to pipeline it to scikit-learn estimators. By `Asish Panda`_
+    - Added :class:`mne.decoding.Vectorizer` to convert the output of an MNE transformer into two dimensions so as to pipeline it to scikit-learn estimators by `Asish Panda`_
 
 .. _changes_0_12:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -113,6 +113,8 @@ API
 
     - The ``compensation`` parameter in :func:`mne.io.read_raw_fif` has been deprecated in favor of the method :meth:`mne.io.Raw.apply_gradient_compensation` by `Eric Larson`_
 
+    -   -  Added :class:`mne.decoding.Vectorizer` to convert the output of an MNE transformer into two dimensions so as to pipeline it to scikit-learn estimators. By `Asish Panda`_
+
 .. _changes_0_12:
 
 Version 0.12

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -34,7 +34,7 @@ from sklearn.preprocessing import MinMaxScaler
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
 from mne.preprocessing import Xdawn
-from mne.decoding import EpochsVectorizer
+from mne.decoding import Vectorizer
 from mne.viz import tight_layout
 
 
@@ -63,7 +63,7 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
 
 # Create classification pipeline
 clf = make_pipeline(Xdawn(n_components=3),
-                    EpochsVectorizer(),
+                    Vectorizer(),
                     MinMaxScaler(),
                     LogisticRegression(penalty='l1'))
 

--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -17,7 +17,7 @@ from sklearn.preprocessing import label_binarize
 
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
-from mne.decoding import XdawnTransformer, EpochsVectorizer
+from mne.decoding import XdawnTransformer, Vectorizer
 
 data_path = sample.data_path()
 
@@ -43,7 +43,7 @@ X = epochs.get_data()
 y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 
 clf = make_pipeline(XdawnTransformer(n_components=3),
-                    EpochsVectorizer(),
+                    Vectorizer(),
                     LogisticRegression())
 score = cross_val_score(clf, X, y, cv=5)
 print(score)

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -55,14 +55,14 @@ from sklearn import preprocessing  # noqa
 from sklearn.svm import SVC  # noqa
 from sklearn.pipeline import Pipeline  # noqa
 from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
-from mne.decoding import EpochsVectorizer, FilterEstimator  # noqa
+from mne.decoding import Vectorizer, FilterEstimator  # noqa
 
 
 scores_x, scores, std_scores = [], [], []
 
 filt = FilterEstimator(rt_epochs.info, 1, 40)
 scaler = preprocessing.StandardScaler()
-vectorizer = EpochsVectorizer()
+vectorizer = Vectorizer()
 clf = SVC(C=1, kernel='linear')
 
 concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),

--- a/examples/realtime/rt_feedback_server.py
+++ b/examples/realtime/rt_feedback_server.py
@@ -43,7 +43,7 @@ import mne
 from mne.datasets import sample
 from mne.realtime import StimServer
 from mne.realtime import MockRtClient
-from mne.decoding import EpochsVectorizer, FilterEstimator
+from mne.decoding import Vectorizer, FilterEstimator
 
 print(__doc__)
 
@@ -66,7 +66,7 @@ with StimServer(port=4218) as stim_server:
     # Constructing the pipeline for classification
     filt = FilterEstimator(raw.info, 1, 40)
     scaler = preprocessing.StandardScaler()
-    vectorizer = EpochsVectorizer()
+    vectorizer = Vectorizer()
     clf = SVC(C=1, kernel='linear')
 
     concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -1,5 +1,5 @@
 from .transformer import Scaler, FilterEstimator
-from .transformer import PSDEstimator, EpochsVectorizer
+from .transformer import PSDEstimator, EpochsVectorizer, Vectorizer
 from .mixin import TransformerMixin
 from .base import BaseEstimator, LinearModel
 from .csp import CSP

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -168,11 +168,12 @@ def test_vectorizer():
     vect = Vectorizer()
     result = vect.fit_transform(data)
     assert_equal(result.ndim, 2)
-    # check inverse_trasnform
 
+    # check inverse_trasnform
     orig_data = vect.inverse_transform(result)
     assert_equal(orig_data.ndim, 3)
     assert_array_equal(orig_data, data)
+    asser_array_equal(vect.inverse_transform(esult[1:]), data[1:])
 
     # check with different shape
     assert_equal(vect.fit_transform(np.random.rand(150, 18, 6, 3)).shape,

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -8,11 +8,11 @@ import os.path as op
 import numpy as np
 
 from nose.tools import assert_true, assert_raises
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 from mne import io, read_events, Epochs, pick_types
 from mne.decoding import Scaler, FilterEstimator
-from mne.decoding import PSDEstimator, EpochsVectorizer
+from mne.decoding import PSDEstimator, EpochsVectorizer, Vectorizer
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -160,3 +160,18 @@ def test_epochs_vectorizer():
     # Test init exception
     assert_raises(ValueError, vector.fit, epochs, y)
     assert_raises(ValueError, vector.transform, epochs, y)
+
+
+def test_vectorizer():
+    """Test Vectorizer."""
+
+    raw = io.read_raw_fif(raw_fname, preload=False)
+    events = read_events(event_name)
+    picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
+                       eog=False, exclude='bads')
+    picks = picks[1:13:3]
+    epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                    baseline=(None, 0), preload=True)
+    epochs_data = epochs.get_data()
+    vector_data = Vectorizer().fit_transform(epochs._data)
+    assert_equal(vector_data.ndim, 2)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -172,6 +172,5 @@ def test_vectorizer():
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    epochs_data = epochs.get_data()
     vector_data = Vectorizer().fit_transform(epochs._data)
     assert_equal(vector_data.ndim, 2)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -170,12 +170,14 @@ def test_vectorizer():
     assert_equal(result.ndim, 2)
     # check inverse_trasnform
 
-    assert_equal(vect.inverse_transform(result).ndim, 3)
-    assert_array_equal(vect.inverse_transform(result), data)
+    orig_data = vect.inverse_transform(result)
+    assert_equal(orig_data.ndim, 3)
+    assert_array_equal(orig_data, data)
 
     # check with different shape
-    vect.fit_transform(np.random.rand(150, 18, 6, 3))
-    vect.fit_transform(data[1:])
+    assert_equal(vect.fit_transform(np.random.rand(150, 18, 6, 3)).shape,
+                 (150, 324))
+    assert_equal(vect.fit_transform(data[1:]).shape, (149, 108))
 
     # check if raised errors are working correctly
     vect.fit(np.random.rand(105, 12, 3))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -164,13 +164,6 @@ def test_epochs_vectorizer():
 
 def test_vectorizer():
     """Test Vectorizer."""
-
-    raw = io.read_raw_fif(raw_fname, preload=False)
-    events = read_events(event_name)
-    picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
-                       eog=False, exclude='bads')
-    picks = picks[1:13:3]
-    epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
-    vector_data = Vectorizer().fit_transform(epochs._data)
+    data = np.random.rand(150, 18, 6)
+    vector_data = Vectorizer().fit_transform(data)
     assert_equal(vector_data.ndim, 2)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -169,8 +169,16 @@ def test_vectorizer():
     result = vect.fit_transform(data)
     assert_equal(result.ndim, 2)
     # check inverse_trasnform
+
     assert_equal(vect.inverse_transform(result).ndim, 3)
     assert_array_equal(vect.inverse_transform(result), data)
+
     # check with different shape
     vect.fit_transform(np.random.rand(150, 18, 6, 3))
     vect.fit_transform(data[1:])
+    
+    # check if raised errors are working correctly
+    vect.fit(np.random.rand(105, 12, 3))
+    assert_raises(ValueError, vect.transform, np.random.rand(105, 12, 3, 1))
+    assert_raises(ValueError, vect.inverse_transform,
+                  np.random.rand(102, 12, 12))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -170,3 +170,7 @@ def test_vectorizer():
     assert_equal(result.ndim, 2)
     # check inverse_trasnform
     assert_equal(vect.inverse_transform(result).ndim, 3)
+    assert_array_equal(vect.inverse_transform(result), data)
+    # check with different shape
+    vect.fit_transform(np.random.rand(150, 18, 6, 3))
+    vect.fit_transform(data[1:])

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -173,7 +173,7 @@ def test_vectorizer():
     orig_data = vect.inverse_transform(result)
     assert_equal(orig_data.ndim, 3)
     assert_array_equal(orig_data, data)
-    asser_array_equal(vect.inverse_transform(esult[1:]), data[1:])
+    assert_array_equal(vect.inverse_transform(result[1:]), data[1:])
 
     # check with different shape
     assert_equal(vect.fit_transform(np.random.rand(150, 18, 6, 3)).shape,

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -176,7 +176,7 @@ def test_vectorizer():
     # check with different shape
     vect.fit_transform(np.random.rand(150, 18, 6, 3))
     vect.fit_transform(data[1:])
-    
+
     # check if raised errors are working correctly
     vect.fit(np.random.rand(105, 12, 3))
     assert_raises(ValueError, vect.transform, np.random.rand(105, 12, 3, 1))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -165,5 +165,8 @@ def test_epochs_vectorizer():
 def test_vectorizer():
     """Test Vectorizer."""
     data = np.random.rand(150, 18, 6)
-    vector_data = Vectorizer().fit_transform(data)
-    assert_equal(vector_data.ndim, 2)
+    vect = Vectorizer()
+    result = vect.fit_transform(data)
+    assert_equal(result.ndim, 2)
+    # check inverse_trasnform
+    assert_equal(vect.inverse_transform(result).ndim, 3)

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -258,7 +258,7 @@ class Vectorizer(TransformerMixin):
 
     Attributes
     ----------
-    ``shape_`` : array
+    ``features_shape_`` : tuple
          Stores the original shape of data.
     """
 
@@ -280,6 +280,7 @@ class Vectorizer(TransformerMixin):
         self : Instance of Vectorizer
             Return the modified instance.
         """
+        X = np.asarray(X)
         self.features_shape_ = X.shape[1:]
         return self
 
@@ -299,6 +300,10 @@ class Vectorizer(TransformerMixin):
         X : array, shape (n_trials, -1)
             The transformed data.
         """
+        X = np.asarray(X)
+        if X.shape[1:] != self.features_shape_:
+            raise ValueError("Shape of X used in fit and transform must be "
+                             "same")
         return X.reshape(len(X), -1)
 
     def fit_transform(self, X, y=None):
@@ -338,6 +343,10 @@ class Vectorizer(TransformerMixin):
             The data transformed into shape as used in fit. The first
             dimension is of length (n_samples).
         """
+        X = np.asarray(X)
+        if X.ndim != 2:
+            raise ValueError("X should be of 2 dimensions but given has %s "
+                             "dimension(s)" %X.ndim)
         return X.reshape((len(X),) + self.features_shape_)
 
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -346,7 +346,7 @@ class Vectorizer(TransformerMixin):
         X = np.asarray(X)
         if X.ndim != 2:
             raise ValueError("X should be of 2 dimensions but given has %s "
-                             "dimension(s)" %X.ndim)
+                             "dimension(s)" % X.ndim)
         return X.reshape((len(X),) + self.features_shape_)
 
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -274,7 +274,7 @@ class Vectorizer(TransformerMixin):
             least 2d. The first dimension must be of length n_samples, where
             samples are the independent samples used by the estimator
             (e.g. n_epochs for epoched data).
-        y : None
+        y : None | array, shape (n_samples,)
             Used for scikit-learn compatibility.
 
         Returns
@@ -318,7 +318,7 @@ class Vectorizer(TransformerMixin):
             least 2d. The first dimension must be of length n_samples, where
             samples are the independent samples used by the estimator
             (e.g. n_epochs for epoched data).
-        y : None
+        y : None | array, shape (n_samples,)
             Used for scikit-learn compatibility.
 
         Returns
@@ -333,15 +333,12 @@ class Vectorizer(TransformerMixin):
 
         Parameters
         ----------
-        X : array-like
-            The data to fit. Can be, for example a list, or an array of at
-            least 2d. The first dimension must be of length n_samples, where
-            samples are the independent samples used by the estimator
-            (e.g. n_epochs for epoched data).
+        X : array-like, shape (n_samples,  n_features)
+            Transform data back to original shape.
 
         Returns
         -------
-        X : array-like
+        X : array
             The data transformed into shape as used in fit. The first
             dimension is of length (n_samples).
         """

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -147,7 +147,8 @@ class Scaler(TransformerMixin):
         return X
 
 
-@deprecated("EpochsVectorizer will be deprecated; use Vectorizer instead")
+@deprecated("EpochsVectorizer will be deprecated in version 0.14; "
+            "use Vectorizer instead")
 class EpochsVectorizer(TransformerMixin):
     """EpochsVectorizer transforms epoch data to fit into a scikit-learn pipeline.
 
@@ -298,7 +299,7 @@ class Vectorizer(TransformerMixin):
 
         Returns
         -------
-        X : array, shape (n_trials, -1)
+        X : array, shape (n_samples, -1)
             The transformed data.
         """
         X = np.asarray(X)
@@ -322,7 +323,7 @@ class Vectorizer(TransformerMixin):
 
         Returns
         -------
-        X : array, shape (n_trials, -1)
+        X : array, shape (n_samples, -1)
             The transformed data.
         """
         return self.fit(X).transform(X)

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -269,7 +269,9 @@ class Vectorizer(TransformerMixin):
         ----------
         X : array-like
             The data to fit. Can be, for example a list, or an array of at
-            least 2d. The first dimension must be of length (n_samples).
+            least 2d. The first dimension must be of length n_samples, where
+            samples are the independent samples used by the estimator
+            (e.g. n_epochs for epoched data).
         y : None
             Used for scikit-learn compatibility.
 
@@ -287,13 +289,14 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an
-            array of at least 2d. The first dimension must be of
-            length (n_samples).
+            The data to fit. Can be, for example a list, or an array of at
+            least 2d. The first dimension must be of length n_samples, where
+            samples are the independent samples used by the estimator
+            (e.g. n_epochs for epoched data).
 
         Returns
         -------
-        X : array, shape (n_trials, n_chan * n_times)
+        X : array, shape (n_trials, -1)
             The transformed data.
         """
         return X.reshape(len(X), -1)
@@ -304,15 +307,16 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an
-            array of at least 2d. The first dimension must be of
-            length (n_samples).
+            The data to fit. Can be, for example a list, or an array of at
+            least 2d. The first dimension must be of length n_samples, where
+            samples are the independent samples used by the estimator
+            (e.g. n_epochs for epoched data).
         y : None
             Used for scikit-learn compatibility.
 
         Returns
         -------
-        X : array, shape (n_trials, n_chan * n_times)
+        X : array, shape (n_trials, -1)
             The transformed data.
         """
         return self.fit(X).transform(X)
@@ -323,9 +327,10 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an
-            array of at least 2d. The first dimension must be of
-            length (n_samples).
+            The data to fit. Can be, for example a list, or an array of at
+            least 2d. The first dimension must be of length n_samples, where
+            samples are the independent samples used by the estimator
+            (e.g. n_epochs for epoched data).
 
         Returns
         -------

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -13,7 +13,7 @@ from ..filter import (low_pass_filter, high_pass_filter, band_pass_filter,
                       band_stop_filter)
 from ..time_frequency.psd import _psd_multitaper
 from ..externals import six
-from ..utils import _check_type_picks
+from ..utils import _check_type_picks, deprecated
 
 
 class Scaler(TransformerMixin):
@@ -147,6 +147,7 @@ class Scaler(TransformerMixin):
         return X
 
 
+@deprecated("EpochsVectorizer will be deprecated; use Vectorizer instead")
 class EpochsVectorizer(TransformerMixin):
     """EpochsVectorizer transforms epoch data to fit into a scikit-learn pipeline.
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -246,9 +246,9 @@ class EpochsVectorizer(TransformerMixin):
 
 
 class Vectorizer(TransformerMixin):
-    """Transforms n-dimensional array into 2D array of n_sample by n_features.
+    """Transforms n-dimensional array into 2D array of n_samples by n_features.
 
-    This class reshapes an n-dimensional array into an n_sample * n_features
+    This class reshapes an n-dimensional array into an n_samples * n_features
     array, usable by the estimators and transformers of scikit-learn.
 
     Examples
@@ -259,17 +259,17 @@ class Vectorizer(TransformerMixin):
     Attributes
     ----------
     ``shape_`` : array
-         Stores the original dimension of data.
+         Stores the original shape of data.
     """
 
     def fit(self, X, y=None):
-        """Stores the shape of X.
+        """Stores the shape of the features of X.
 
         Parameters
         ----------
         X : array-like
             The data to fit. Can be, for example a list, or an array of at
-            least 2d. The first dimension must be of shape (n_samples).
+            least 2d. The first dimension must be of length (n_samples).
         y : None
             Used for scikit-learn compatibility.
 
@@ -278,18 +278,18 @@ class Vectorizer(TransformerMixin):
         self : Instance of Vectorizer
             Return the modified instance.
         """
-        self.shape_ = X.shape[1:]
+        self.features_shape_ = X.shape[1:]
         return self
 
     def transform(self, X):
-        """Convert matrix data into two dimensions.
+        """Convert given array into two dimensions.
 
         Parameters
         ----------
         X : array-like
             The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_samples).
+            length (n_samples).
 
         Returns
         -------
@@ -306,7 +306,7 @@ class Vectorizer(TransformerMixin):
         X : array-like
             The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_samples).
+            length (n_samples).
         y : None
             Used for scikit-learn compatibility.
 
@@ -325,15 +325,15 @@ class Vectorizer(TransformerMixin):
         X : array-like
             The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_samples).
+            length (n_samples).
 
         Returns
         -------
         X : array-like
             The data transformed into shape as used in fit. The first
-            dimension is of shape (n_samples).
+            dimension is of length (n_samples).
         """
-        return X.reshape(np.r_[len(X), self.shape_])
+        return X.reshape((len(X),) + self.features_shape_)
 
 
 class PSDEstimator(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -265,7 +265,7 @@ class Vectorizer(TransformerMixin):
         ----------
         X : numpy array, shape(n_epochs, n_chans, n_times) or
                               (n_epochs, n_chans * n_times) or
-                              (n_epochs, n_chans * n_times * n_freqs)
+                              (n_epochs, n_chans, n_times, n_freqs)
             The data to be transformed
         y : None
             Used for scikit-learn compatibility.
@@ -275,6 +275,7 @@ class Vectorizer(TransformerMixin):
         self : Instance of Vectorizer
             Return the modified instance.
         """
+        self.shape = X.shape
         return self
 
     def transform(self, X):
@@ -284,7 +285,7 @@ class Vectorizer(TransformerMixin):
         ----------
         X : numpy array, shape(n_epochs, n_chans, n_times) or
                               (n_epochs, n_chans * n_times)
-                              (n_epochs, n_chans * n_times * n_freqs)
+                              (n_epochs, n_chans, n_times, n_freqs)
             The data to be transformed.
 
         Returns
@@ -301,7 +302,7 @@ class Vectorizer(TransformerMixin):
         ----------
         X : numpy array, shape(n_epochs, n_chans, n_times) or
                               (n_epochs, n_chans * n_times)
-                              (n_epochs, n_chans * n_times * n_freqs)
+                              (n_epochs, n_chans, n_times, n_freqs)
             The data to be transformed.
         y : None
             Used for scikit-learn compatibility.
@@ -312,6 +313,22 @@ class Vectorizer(TransformerMixin):
             The transformed data.
         """
         return self.fit(X).transform(X)
+
+    def inverse_transform(self, X):
+        """Transform 2D data back to shape used in fit.
+
+        Parameters
+        ----------
+        X : numpy array, shape(n_epochs, n_chans * n_freqs) or
+                              (n_epochs, n_chans * n_times * n_freqs)
+
+        Returns
+        -------
+        X : numpy array, shape(n_epochs, n_chans, n_freqs)
+                              (n_epochs, n_chans * n_times) or
+                              (n_epochs, n_chans, n_times, n_freqs)
+        """
+        return X.reshape(self.shape)
 
 
 class PSDEstimator(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -248,23 +248,28 @@ class EpochsVectorizer(TransformerMixin):
 class Vectorizer(TransformerMixin):
     """Transforms n-dimensional array into 2D array of n_sample by n_features.
 
-    MNE transformer have three, four dimensional output. This class converts
-    them into two dimension so as to comply with scikit-learn API.
+    This class reshapes an n-dimensional array into an n_sample * n_features
+    array, usable by the estimators and transformers of scikit-learn.
 
     Examples
-    -------
+    --------
     clf = make_pipeline(SpatialFilter(), XdawnTransformer(), Vectorizer(),
                         LogisticRegression())
+
+    Attributes
+    ----------
+    ``shape_`` : array
+         Stores the original dimension of data.
     """
 
     def fit(self, X, y=None):
-        """Does nothing. Added for scikit-learn compatibility.
+        """Stores the shape of X.
 
         Parameters
         ----------
         X : array-like
             The data to fit. Can be, for example a list, or an array of at
-            least 2d. The first dimension must be of shape (n_sample).
+            least 2d. The first dimension must be of shape (n_samples).
         y : None
             Used for scikit-learn compatibility.
 
@@ -273,7 +278,7 @@ class Vectorizer(TransformerMixin):
         self : Instance of Vectorizer
             Return the modified instance.
         """
-        self.shape_ = X.shape
+        self.shape_ = X.shape[1:]
         return self
 
     def transform(self, X):
@@ -282,13 +287,13 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an 
+            The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_sample).
+            shape (n_samples).
 
         Returns
         -------
-        X : numpy ndarray of shape(n_trials, n_chan * n_times * n_freqs)
+        X : array, shape (n_trials, n_chan * n_times)
             The transformed data.
         """
         return X.reshape(len(X), -1)
@@ -299,36 +304,36 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an 
+            The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_sample).
+            shape (n_samples).
         y : None
             Used for scikit-learn compatibility.
 
         Returns
         -------
-        X : numpy ndarray of shape(n_trials, n_chan * n_times * n_freqs)
+        X : array, shape (n_trials, n_chan * n_times)
             The transformed data.
         """
         return self.fit(X).transform(X)
 
     def inverse_transform(self, X):
-        """Transform 2D data back to shape used in fit.
+        """Transform 2D data back to its original feature shape.
 
         Parameters
         ----------
         X : array-like
-            The data to be transformed. Can be, for example a list, or an 
+            The data to be transformed. Can be, for example a list, or an
             array of at least 2d. The first dimension must be of
-            shape (n_sample).
+            shape (n_samples).
 
         Returns
         -------
         X : array-like
             The data transformed into shape as used in fit. The first
-            dimension is of shape (n_sample).
+            dimension is of shape (n_samples).
         """
-        return X.reshape(self.shape_)
+        return X.reshape(np.r_[len(X), self.shape_])
 
 
 class PSDEstimator(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -251,7 +251,7 @@ class Vectorizer(TransformerMixin):
     MNE transformer have three, four dimensional output. This class converts
     them into two dimension so as to comply with scikit-learn API.
 
-    Example
+    Examples
     -------
     clf = make_pipeline(SpatialFilter(), XdawnTransforme(), Vectorizer(),
                         LogisticRegression())

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -246,16 +246,15 @@ class EpochsVectorizer(TransformerMixin):
 
 
 class Vectorizer(TransformerMixin):
-    """Class to chain MNE transformer output to scikit-learn estimators.
+    """Transforms n-dimensional array into 2D array of n_sample by n_features.
 
     MNE transformer have three, four dimensional output. This class converts
     them into two dimension so as to comply with scikit-learn API.
 
     Examples
     -------
-    clf = make_pipeline(SpatialFilter(), XdawnTransforme(), Vectorizer(),
+    clf = make_pipeline(SpatialFilter(), XdawnTransformer(), Vectorizer(),
                         LogisticRegression())
-    cross_val_score(clf)
     """
 
     def fit(self, X, y=None):
@@ -263,10 +262,9 @@ class Vectorizer(TransformerMixin):
 
         Parameters
         ----------
-        X : numpy array, shape(n_epochs, n_chans, n_times) or
-                              (n_epochs, n_chans * n_times) or
-                              (n_epochs, n_chans, n_times, n_freqs)
-            The data to be transformed
+        X : array-like
+            The data to fit. Can be, for example a list, or an array of at
+            least 2d. The first dimension must be of shape (n_sample).
         y : None
             Used for scikit-learn compatibility.
 
@@ -275,7 +273,7 @@ class Vectorizer(TransformerMixin):
         self : Instance of Vectorizer
             Return the modified instance.
         """
-        self.shape = X.shape
+        self.shape_ = X.shape
         return self
 
     def transform(self, X):
@@ -283,10 +281,10 @@ class Vectorizer(TransformerMixin):
 
         Parameters
         ----------
-        X : numpy array, shape(n_epochs, n_chans, n_times) or
-                              (n_epochs, n_chans * n_times)
-                              (n_epochs, n_chans, n_times, n_freqs)
-            The data to be transformed.
+        X : array-like
+            The data to be transformed. Can be, for example a list, or an 
+            array of at least 2d. The first dimension must be of
+            shape (n_sample).
 
         Returns
         -------
@@ -300,10 +298,10 @@ class Vectorizer(TransformerMixin):
 
         Parameters
         ----------
-        X : numpy array, shape(n_epochs, n_chans, n_times) or
-                              (n_epochs, n_chans * n_times)
-                              (n_epochs, n_chans, n_times, n_freqs)
-            The data to be transformed.
+        X : array-like
+            The data to be transformed. Can be, for example a list, or an 
+            array of at least 2d. The first dimension must be of
+            shape (n_sample).
         y : None
             Used for scikit-learn compatibility.
 
@@ -319,16 +317,18 @@ class Vectorizer(TransformerMixin):
 
         Parameters
         ----------
-        X : numpy array, shape(n_epochs, n_chans * n_freqs) or
-                              (n_epochs, n_chans * n_times * n_freqs)
+        X : array-like
+            The data to be transformed. Can be, for example a list, or an 
+            array of at least 2d. The first dimension must be of
+            shape (n_sample).
 
         Returns
         -------
-        X : numpy array, shape(n_epochs, n_chans, n_freqs)
-                              (n_epochs, n_chans * n_times) or
-                              (n_epochs, n_chans, n_times, n_freqs)
+        X : array-like
+            The data transformed into shape as used in fit. The first
+            dimension is of shape (n_sample).
         """
-        return X.reshape(self.shape)
+        return X.reshape(self.shape_)
 
 
 class PSDEstimator(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -299,7 +299,7 @@ class Vectorizer(TransformerMixin):
 
         Returns
         -------
-        X : array, shape (n_samples, -1)
+        X : array, shape (n_samples, n_features)
             The transformed data.
         """
         X = np.asarray(X)
@@ -334,13 +334,13 @@ class Vectorizer(TransformerMixin):
         Parameters
         ----------
         X : array-like, shape (n_samples,  n_features)
-            Transform data back to original shape.
+            Data to be transformed back to original shape.
 
         Returns
         -------
         X : array
             The data transformed into shape as used in fit. The first
-            dimension is of length (n_samples).
+            dimension is of length n_samples.
         """
         X = np.asarray(X)
         if X.ndim != 2:

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -245,6 +245,75 @@ class EpochsVectorizer(TransformerMixin):
         return X.reshape(-1, self.n_channels, self.n_times)
 
 
+class Vectorizer(TransformerMixin):
+    """Class to chain MNE transformer output to scikit-learn estimators.
+
+    MNE transformer have three, four dimensional output. This class converts
+    them into two dimension so as to comply with scikit-learn API.
+
+    Example
+    -------
+    clf = make_pipeline(SpatialFilter(), XdawnTransforme(), Vectorizer(),
+                        LogisticRegression())
+    cross_val_score(clf)
+    """
+
+    def fit(self, X, y=None):
+        """Does nothing. Added for scikit-learn compatibility.
+
+        Parameters
+        ----------
+        X : numpy array, shape(n_epochs, n_chans, n_times) or
+                              (n_epochs, n_chans * n_times) or
+                              (n_epochs, n_chans * n_times * n_freqs)
+            The data to be transformed
+        y : None
+            Used for scikit-learn compatibility.
+
+        Returns
+        -------
+        self : Instance of Vectorizer
+            Return the modified instance.
+        """
+        return self
+
+    def transform(self, X):
+        """Convert matrix data into two dimensions.
+
+        Parameters
+        ----------
+        X : numpy array, shape(n_epochs, n_chans, n_times) or
+                              (n_epochs, n_chans * n_times)
+                              (n_epochs, n_chans * n_times * n_freqs)
+            The data to be transformed.
+
+        Returns
+        -------
+        X : numpy ndarray of shape(n_trials, n_chan * n_times * n_freqs)
+            The transformed data.
+        """
+        return X.reshape(len(X), -1)
+
+    def fit_transform(self, X, y=None):
+        """Fit the data, then transform in one step.
+
+        Parameters
+        ----------
+        X : numpy array, shape(n_epochs, n_chans, n_times) or
+                              (n_epochs, n_chans * n_times)
+                              (n_epochs, n_chans * n_times * n_freqs)
+            The data to be transformed.
+        y : None
+            Used for scikit-learn compatibility.
+
+        Returns
+        -------
+        X : numpy ndarray of shape(n_trials, n_chan * n_times * n_freqs)
+            The transformed data.
+        """
+        return self.fit(X).transform(X)
+
+
 class PSDEstimator(TransformerMixin):
     """Compute power spectrum density (PSD) using a multi-taper method
 


### PR DESCRIPTION
This was previously on #3276. The idea is to support MNE transformers with scikit-learn pipeline and be compatible with `cross_val_score` and `grid_search` methods. Ideally this should be in the last step in a pipeline to convert higher dimension output into two dimension.
Example
```
clf = make_pipeline(SptialFilter(), XdawnTransformer(), Vectorizer(), LogisticRegression())
cross_val_score(clf)
```