### PR TITLE
[MRG] viz.plot_bem():  include brain surfaces

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,8 @@ Changelog
 
     - Add possibility to select a subset of sensors by lasso selector to :func:`mne.viz.plot_sensors` and :func:`mne.viz.plot_raw` when using order='selection' or order='position' by `Jaakko Leppakangas`_
 
+    - Add the option to plot brain surfaces to :func:`viz.plot_bem` by `Christian Brodbeck`_
+
     - Add the ``--filterchpi`` option to :ref:`mne browse_raw <gen_mne_browse_raw>`, by `Felix Raimundo`_
 
     - Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` to skip the high-resolution surface decimation step, by `Eric Larson`_

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -369,12 +369,14 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
         raise IOError('Subject bem directory "%s" does not exist' % bem_path)
 
     surfaces = {}
-    for surf_name in ['*inner_skull', '*outer_skull', '*outer_skin']:
+    for surf_name, color in (('*inner_skull', '#FF0000'),
+                             ('*outer_skull', '#FFFF00'),
+                             ('*outer_skin', '#FFAA80')):
         surf_fname = glob(op.join(bem_path, surf_name + '.surf'))
         if len(surf_fname) > 0:
             surf_fname = surf_fname[0]
             logger.info("Using surface: %s" % surf_fname)
-            surfaces[surf_fname] = 'yellow'
+            surfaces[surf_fname] = color
 
     if brain_surfaces is not None:
         if isinstance(brain_surfaces, string_types):
@@ -384,7 +386,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
                 surf_fname = op.join(subjects_dir, subject, 'surf',
                                      hemi + '.' + surf_name)
                 if op.exists(surf_fname):
-                    surfaces[surf_fname] = 'red'
+                    surfaces[surf_fname] = '#00DD00'
                 else:
                     raise IOError("Surface %s does not exist." % surf_fname)
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -246,9 +246,9 @@ def _plot_mri_contours(mri_fname, surfaces, orientation='coronal',
     ----------
     mri_fname : str
         The name of the file containing anatomical data.
-    surfaces : dict
-        A {filename: color} dictionary for the BEM surfaces to plot. Colors
-        should be matplotlib-compatible.
+    surfaces : list of (str, str) tuples
+        A list containing the BEM surfaces to plot as (filename, color) tuples.
+        Colors should be matplotlib-compatible.
     orientation : str
         'coronal' or 'axial' or 'sagittal'
     slices : list of int
@@ -288,9 +288,9 @@ def _plot_mri_contours(mri_fname, surfaces, orientation='coronal',
     # XXX : next line is a hack don't ask why
     trans[:3, -1] = [n_sag // 2, n_axi // 2, n_cor // 2]
 
-    for surf_fname, color in surfaces.items():
+    for file_name, color in surfaces:
         surf = dict()
-        surf['rr'], surf['tris'] = read_surface(surf_fname)
+        surf['rr'], surf['tris'] = read_surface(file_name)
         # move back surface to MRI coordinate system
         surf['rr'] = nib.affines.apply_affine(trans, surf['rr'])
         surfs.append((surf, color))
@@ -349,8 +349,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
         Slice indices.
     brain_surfaces : None | str | list of str
         One or more brain surface to plot (optional). Entries should correspond
-        to files in the subject's ``surf`` directory, e.g., ``"white"`` will
-        plot ``<subject>/surf/lh.white`` and ``<subject>/surf/rh.white``.
+        to files in the subject's ``surf`` directory (e.g. ``"white"``).
     show : bool
         Show figure if True.
 
@@ -372,7 +371,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
     if not op.isdir(bem_path):
         raise IOError('Subject bem directory "%s" does not exist' % bem_path)
 
-    surfaces = {}
+    surfaces = []
     for surf_name, color in (('*inner_skull', '#FF0000'),
                              ('*outer_skull', '#FFFF00'),
                              ('*outer_skin', '#FFAA80')):
@@ -380,7 +379,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
         if len(surf_fname) > 0:
             surf_fname = surf_fname[0]
             logger.info("Using surface: %s" % surf_fname)
-            surfaces[surf_fname] = color
+            surfaces.append((surf_fname, color))
 
     if brain_surfaces is not None:
         if isinstance(brain_surfaces, string_types):
@@ -390,7 +389,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
                 surf_fname = op.join(subjects_dir, subject, 'surf',
                                      hemi + '.' + surf_name)
                 if op.exists(surf_fname):
-                    surfaces[surf_fname] = '#00DD00'
+                    surfaces.append((surf_fname, '#00DD00'))
                 else:
                     raise IOError("Surface %s does not exist." % surf_fname)
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -247,8 +247,8 @@ def _plot_mri_contours(mri_fname, surfaces, orientation='coronal',
     mri_fname : str
         The name of the file containing anatomical data.
     surfaces : dict
-        The filenames for the BEM surfaces in the format
-        ['inner_skull.surf', 'outer_skull.surf', 'outer_skin.surf'].
+        A {filename: color} dictionary for the BEM surfaces to plot. Colors
+        should be matplotlib-compatible.
     orientation : str
         'coronal' or 'axial' or 'sagittal'
     slices : list of int
@@ -347,6 +347,10 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
         'coronal' or 'axial' or 'sagittal'.
     slices : list of int
         Slice indices.
+    brain_surfaces : None | str | list of str
+        One or more brain surface to plot (optional). Entries should correspond
+        to files in the subject's ``surf`` directory, e.g., ``"white"`` will
+        plot ``<subject>/surf/lh.white`` and ``<subject>/surf/rh.white``.
     show : bool
         Show figure if True.
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -20,6 +20,7 @@ import numpy as np
 from scipy import linalg
 
 from ..surface import read_surface
+from ..externals.six import string_types
 from ..io.proj import make_projector
 from ..utils import logger, verbose, get_subjects_dir, warn
 from ..io.pick import pick_types
@@ -237,7 +238,7 @@ def plot_source_spectrogram(stcs, freq_bins, tmin=None, tmax=None,
     return fig
 
 
-def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
+def _plot_mri_contours(mri_fname, surfaces, orientation='coronal',
                        slices=None, show=True):
     """Plot BEM contours on anatomical slices.
 
@@ -245,7 +246,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
     ----------
     mri_fname : str
         The name of the file containing anatomical data.
-    surf_fnames : list of str
+    surfaces : dict
         The filenames for the BEM surfaces in the format
         ['inner_skull.surf', 'outer_skull.surf', 'outer_skin.surf'].
     orientation : str
@@ -287,12 +288,12 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
     # XXX : next line is a hack don't ask why
     trans[:3, -1] = [n_sag // 2, n_axi // 2, n_cor // 2]
 
-    for surf_fname in surf_fnames:
+    for surf_fname, color in surfaces.items():
         surf = dict()
         surf['rr'], surf['tris'] = read_surface(surf_fname)
         # move back surface to MRI coordinate system
         surf['rr'] = nib.affines.apply_affine(trans, surf['rr'])
-        surfs.append(surf)
+        surfs.append((surf, color))
 
     fig, axs = _prepare_trellis(len(slices), 4)
 
@@ -311,19 +312,19 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
         ax.axis('off')
 
         # and then plot the contours on top
-        for surf in surfs:
+        for surf, color in surfs:
             if orientation == 'coronal':
                 ax.tricontour(surf['rr'][:, 0], surf['rr'][:, 1],
                               surf['tris'], surf['rr'][:, 2],
-                              levels=[sl], colors='yellow', linewidths=2.0)
+                              levels=[sl], colors=color, linewidths=2.0)
             elif orientation == 'axial':
                 ax.tricontour(surf['rr'][:, 2], surf['rr'][:, 0],
                               surf['tris'], surf['rr'][:, 1],
-                              levels=[sl], colors='yellow', linewidths=2.0)
+                              levels=[sl], colors=color, linewidths=2.0)
             elif orientation == 'sagittal':
                 ax.tricontour(surf['rr'][:, 2], surf['rr'][:, 1],
                               surf['tris'], surf['rr'][:, 0],
-                              levels=[sl], colors='yellow', linewidths=2.0)
+                              levels=[sl], colors=color, linewidths=2.0)
 
     plt.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,
                         hspace=0.)
@@ -332,7 +333,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
 
 
 def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
-             slices=None, show=True):
+             slices=None, brain_surfaces=None, show=True):
     """Plot BEM contours on anatomical slices.
 
     Parameters
@@ -367,20 +368,32 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
     if not op.isdir(bem_path):
         raise IOError('Subject bem directory "%s" does not exist' % bem_path)
 
-    surf_fnames = []
+    surfaces = {}
     for surf_name in ['*inner_skull', '*outer_skull', '*outer_skin']:
         surf_fname = glob(op.join(bem_path, surf_name + '.surf'))
         if len(surf_fname) > 0:
             surf_fname = surf_fname[0]
             logger.info("Using surface: %s" % surf_fname)
-            surf_fnames.append(surf_fname)
+            surfaces[surf_fname] = 'yellow'
 
-    if len(surf_fnames) == 0:
+    if brain_surfaces is not None:
+        if isinstance(brain_surfaces, string_types):
+            brain_surfaces = (brain_surfaces,)
+        for surf_name in brain_surfaces:
+            for hemi in ('lh', 'rh'):
+                surf_fname = op.join(subjects_dir, subject, 'surf',
+                                     hemi + '.' + surf_name)
+                if op.exists(surf_fname):
+                    surfaces[surf_fname] = 'red'
+                else:
+                    raise IOError("Surface %s does not exist." % surf_fname)
+
+    if len(surfaces) == 0:
         raise IOError('No surface files found. Surface files must end with '
                       'inner_skull.surf, outer_skull.surf or outer_skin.surf')
 
     # Plot the contours
-    return _plot_mri_contours(mri_fname, surf_fnames, orientation=orientation,
+    return _plot_mri_contours(mri_fname, surfaces, orientation=orientation,
                               slices=slices, show=show)
 
 

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -68,6 +68,9 @@ def test_plot_bem():
                   subjects_dir=subjects_dir, orientation='bad-ori')
     plot_bem(subject='sample', subjects_dir=subjects_dir,
              orientation='sagittal', slices=[25, 50])
+    plot_bem(subject='sample', subjects_dir=subjects_dir,
+             orientation='coronal', slices=[25, 50],
+             brain_surfaces='white')
 
 
 def test_plot_events():


### PR DESCRIPTION
I wanted to plot a brain (white matter) surface along with the other bem surfaces, to this end I modified `viz.plot_bem` by adding a `brain_surfaces` argument. If this is generally useful (and there isn't already another preferred way to do this) and you agree with the API I will document it and make this PR ready.

`mne.viz.plot_bem(subject, subjects_dir, brain_surfaces='white')`
 
![00dd00](https://cloud.githubusercontent.com/assets/145771/16952389/fce41a24-4d96-11e6-8ef5-9d2ad5151a92.png)
(updated)