### PR TITLE
MRG: Only warn using given verbose level

### DIFF
--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -63,13 +63,14 @@ def test_csp():
     epochs.pick_types(meg='mag')
 
     # test plot patterns
+    cmap = ('RdBu', True)
     components = np.arange(n_components)
     csp.plot_patterns(epochs.info, components=components, res=12,
-                      show=False)
+                      show=False, cmap=cmap)
 
     # test plot filters
     csp.plot_filters(epochs.info, components=components, res=12,
-                     show=False)
+                     show=False, cmap=cmap)
 
     # test covariance estimation methods (results should be roughly equal)
     csp_epochs = CSP(cov_est="epoch")

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import (requires_sklearn, requires_sklearn_0_15, slow_test,
-                       run_tests_if_main, check_version)
+                       run_tests_if_main, check_version, use_log_level)
 from mne.decoding import GeneralizationAcrossTime, TimeDecoding
 
 
@@ -152,7 +152,8 @@ def test_generalization_across_time():
     gat.predict_mode = 'mean-prediction'
     epochs2.events[:, 2] += 10
     gat_ = copy.deepcopy(gat)
-    assert_raises(ValueError, gat_.score, epochs2)
+    with use_log_level('error'):
+        assert_raises(ValueError, gat_.score, epochs2)
     gat.predict_mode = 'cross-validation'
 
     # Test basics
@@ -234,8 +235,6 @@ def test_generalization_across_time():
     assert_equal(np.shape(gat.scores_), (15, 1))
     assert_array_equal([tim for ttime in gat.test_times_['times']
                         for tim in ttime], gat.train_times_['times'])
-    from mne.utils import set_log_level
-    set_log_level('error')
     # Test generalization across conditions
     gat = GeneralizationAcrossTime(predict_mode='mean-prediction', cv=2)
     with warnings.catch_warnings(record=True):
@@ -249,7 +248,8 @@ def test_generalization_across_time():
     gat_ = copy.deepcopy(gat)
     # --- start stop outside time range
     gat_.train_times = dict(start=-999.)
-    assert_raises(ValueError, gat_.fit, epochs)
+    with use_log_level('error'):
+        assert_raises(ValueError, gat_.fit, epochs)
     gat_.train_times = dict(start=999.)
     assert_raises(ValueError, gat_.fit, epochs)
     # --- impossible slices
@@ -316,8 +316,9 @@ def test_generalization_across_time():
     # sklearn needs it: c.f.
     # https://github.com/scikit-learn/scikit-learn/issues/2723
     # and http://bit.ly/1u7t8UT
-    assert_raises(ValueError, gat.score, epochs2)
-    gat.score(epochs)
+    with use_log_level('error'):
+        assert_raises(ValueError, gat.score, epochs2)
+        gat.score(epochs)
     assert_true(0.0 <= np.min(scores) <= 1.0)
     assert_true(0.0 <= np.max(scores) <= 1.0)
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -82,8 +82,8 @@ def test_cov_order():
     ch_names = [info['ch_names'][pick]
                 for pick in pick_types(info, meg=False, eeg=True)]
     cov = read_cov(cov_fname)
-    with warnings.catch_warnings(record=True):  # no avg ref present
-        prepare_noise_cov(cov, info, ch_names, verbose='error')
+    # no avg ref present warning
+    prepare_noise_cov(cov, info, ch_names, verbose='error')
 
 
 def test_ad_hoc_cov():

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -560,9 +560,9 @@ def test_combine_source_spaces():
 
     # unrecognized file type
     bad_image_fname = op.join(tempdir, 'temp-image.png')
-    with warnings.catch_warnings(record=True):  # vertices outside vol space
-        assert_raises(ValueError, src.export_volume, bad_image_fname,
-                      verbose='error')
+    # vertices outside vol space warning
+    assert_raises(ValueError, src.export_volume, bad_image_fname,
+                  verbose='error')
 
     # mixed coordinate frames
     disc3 = disc.copy()

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -337,7 +337,9 @@ def warn(message, category=RuntimeWarning):
             last_fname = fname
             continue
         # treat tests as scripts
-        if not fname.startswith(root_dir) or \
+        # and don't capture unittest/case.py (assert_raises)
+        if not (fname.startswith(root_dir) or
+                ('unittest' in fname and 'case' in fname)) or \
                 op.basename(op.dirname(fname)) == 'tests':
             stacklevel = fi + 1
             break

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -343,7 +343,8 @@ def warn(message, category=RuntimeWarning):
             break
         last_fname = op.basename(fname)
     del stack
-    warnings.warn(message, category, stacklevel=stacklevel)
+    if logger.level <= logging.WARN:
+        warnings.warn(message, category, stacklevel=stacklevel)
     logger.warning(message)
 
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -54,9 +54,9 @@ def _get_epochs():
     raw = _get_raw()
     events = _get_events()
     picks = _get_picks(raw)
-    with warnings.catch_warnings(record=True):  # bad proj
-        epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), verbose='error')
+    # bad proj warning
+    epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
+                    baseline=(None, 0), verbose='error')
     return epochs
 
 


### PR DESCRIPTION
It occurred to me that we might not want to omit warnings if people have `verbose='error'`