### PR TITLE
DOC:  Forward solution is `Forward` instead of `dict`

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -32,6 +32,7 @@ Classes
    Epochs
    Evoked
    SourceSpaces
+   Forward
    SourceEstimate
    VolSourceEstimate
    MixedSourceEstimate

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -41,7 +41,7 @@ from .event import (read_events, write_events, find_events, merge_events,
                     pick_events, make_fixed_length_events, concatenate_events,
                     find_stim_steps)
 from .forward import (read_forward_solution, apply_forward, apply_forward_raw,
-                      average_forward_solutions,
+                      average_forward_solutions, Forward,
                       write_forward_solution, make_forward_solution,
                       convert_forward_solution, make_field_map,
                       make_forward_dipole)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -577,7 +577,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         The forward solution to modify.
     surf_ori : bool, optional (default False)
         Use surface-based source coordinate system? Note that force_fixed=True
@@ -591,7 +591,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     Returns
     -------
-    fwd : dict
+    fwd : Forward
         The modified forward solution.
     """
     fwd = fwd.copy() if copy else fwd
@@ -694,7 +694,7 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
     fname : str
         File name to save the forward solution to. It should end with -fwd.fif
         or -fwd.fif.gz.
-    fwd : dict
+    fwd : Forward
         Forward solution.
     overwrite : bool
         If True, overwrite destination file (if it exists).
@@ -1130,7 +1130,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None,
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         Forward operator to use. Has to be fixed-orientation.
     stc : SourceEstimate
         The source estimate from which the sensor space data is computed.
@@ -1190,7 +1190,7 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         Forward operator to use. Has to be fixed-orientation.
     stc : SourceEstimate
         The source estimate from which the sensor space data is computed.
@@ -1240,7 +1240,7 @@ def restrict_forward_to_stc(fwd, stc):
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         Forward operator.
     stc : SourceEstimate
         Source estimate.
@@ -1287,7 +1287,7 @@ def restrict_forward_to_label(fwd, labels):
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         Forward operator.
     labels : label object | list
         Label object or list of label objects.
@@ -1432,7 +1432,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
 
     Returns
     -------
-    fwd : dict
+    fwd : Forward
         The generated forward solution.
     """
     if not has_mne_c():
@@ -1578,7 +1578,7 @@ def average_forward_solutions(fwds, weights=None):
 
     Parameters
     ----------
-    fwds : list of dict
+    fwds : list of Forward
         Forward solutions to average. Each entry (dict) should be a
         forward solution.
     weights : array | None
@@ -1588,7 +1588,7 @@ def average_forward_solutions(fwds, weights=None):
 
     Returns
     -------
-    fwd : dict
+    fwd : Forward
         The averaged forward solution.
     """
     # check for fwds being a list

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -285,7 +285,7 @@ def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         The forward operator.
     projs : list
         List of projection vectors.

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -27,7 +27,7 @@ def simulate_evoked(fwd, stc, info, cov, snr=3., tmin=None, tmax=None,
 
     Parameters
     ----------
-    fwd : dict
+    fwd : Forward
         a forward solution.
     stc : SourceEstimate object
         The source time courses.


### PR DESCRIPTION
Wonder if this should be changed, even though `Forward` is a `dict` subclass, to make it consistent with `read_forward_solution` which is said to return `Forward`