### PR TITLE
MRG: Dont require TVTK

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,8 @@ Changelog
 
     - Add the ``--filterchpi`` option to :ref:`mne browse_raw <gen_mne_browse_raw>`, by `Felix Raimundo`_
 
+    - Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` to skip the high-resolution surface decimation step, by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/mne/commands/mne_make_scalp_surfaces.py
+++ b/mne/commands/mne_make_scalp_surfaces.py
@@ -44,7 +44,9 @@ def run():
                       help='Print the debug messages.')
     parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
                       help="Subjects directory", default=subjects_dir)
-
+    parser.add_option("-n", "--no-decimate", dest="no_decimate",
+                      help="Disable medium and sparse decimations "
+                      "(dense only)", action='store_true')
     options, args = parser.parse_args()
 
     subject = vars(options).get('subject', os.getenv('SUBJECT'))
@@ -52,12 +54,13 @@ def run():
     if subject is None or subjects_dir is None:
         parser.print_help()
         sys.exit(1)
+    print(options.no_decimate)
     _run(subjects_dir, subject, options.force, options.overwrite,
-         options.verbose)
+         options.no_decimate, options.verbose)
 
 
 @verbose
-def _run(subjects_dir, subject, force, overwrite, verbose=None):
+def _run(subjects_dir, subject, force, overwrite, no_decimate, verbose=None):
     this_env = copy.copy(os.environ)
     this_env['SUBJECTS_DIR'] = subjects_dir
     this_env['SUBJECT'] = subject
@@ -115,7 +118,7 @@ def _run(subjects_dir, subject, force, overwrite, verbose=None):
                     '--fif', dense_fname], env=this_env)
     levels = 'medium', 'sparse'
     my_surf = mne.read_bem_surfaces(dense_fname)[0]
-    tris = [30000, 2500]
+    tris = [] if no_decimate else [30000, 2500]
     if os.getenv('_MNE_TESTING_SCALP', 'false') == 'true':
         tris = [len(my_surf['tris'])]  # don't actually decimate
     for ii, (n_tri, level) in enumerate(zip(tris, levels), 3):

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -123,7 +123,8 @@ def test_make_scalp_surfaces():
     surf_path_new = op.join(tempdir, 'sample', 'surf')
     os.mkdir(op.join(tempdir, 'sample'))
     os.mkdir(surf_path_new)
-    os.mkdir(op.join(tempdir, 'sample', 'bem'))
+    subj_dir = op.join(tempdir, 'sample', 'bem')
+    os.mkdir(subj_dir)
     shutil.copy(op.join(surf_path, 'lh.seghead'), surf_path_new)
 
     orig_fs = os.getenv('FREESURFER_HOME', None)
@@ -140,6 +141,8 @@ def test_make_scalp_surfaces():
             assert_raises(RuntimeError, mne_make_scalp_surfaces.run)
             os.environ['MNE_ROOT'] = orig_mne
             mne_make_scalp_surfaces.run()
+            assert_true(op.isfile(op.join(subj_dir, 'sample-head-dense.fif')))
+            assert_true(op.isfile(op.join(subj_dir, 'sample-head-medium.fif')))
             assert_raises(IOError, mne_make_scalp_surfaces.run)  # no overwrite
     finally:
         if orig_fs is not None:


### PR DESCRIPTION
Closes #3435.

Adds an option not to decimate. @dengemann what do you use the other decimations (medium, sparse) for? I don't think they're part of the standard processing scheme...?