### PR TITLE
MRG: Set env vars in set_config

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -103,6 +103,8 @@ API
 
     - The default dataset location has been changed from ``examples/`` in the MNE-Python root directory to ``~/mne_data`` in the user's home directory, by `Eric Larson`_
 
+    - A new option ``set_env`` has been added to :func:`mne.set_config` that defaults to ``False`` in 0.13 but will change to ``True`` in 0.14, by `Eric Larson`_
+
 .. _changes_0_12:
 
 Version 0.12

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -142,7 +142,7 @@ def _do_path_update(path, update_path, key, name):
             update_path = False
 
     if update_path is True:
-        set_config(key, path)
+        set_config(key, path, set_env=False)
     return path
 
 

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -92,7 +92,7 @@ def _get_root_home(cfg, name, check_fun):
             root = dlg.path
             problem = check_fun(root)
             if problem is None:
-                set_config(cfg, root)
+                set_config(cfg, root, set_env=False)
         else:
             return None
     return root

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -352,15 +352,20 @@ def test_config():
     assert_true(len(set_config(None, None)) > 10)  # tuple of valid keys
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        set_config(key, None, home_dir=tempdir)
+        set_config(key, None, home_dir=tempdir, set_env=False)
     assert_true(len(w) == 1)
     assert_true(get_config(key, home_dir=tempdir) is None)
     assert_raises(KeyError, get_config, key, raise_error=True)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter('always')
-        set_config(key, value, home_dir=tempdir)
+        assert_true(key not in os.environ)
+        set_config(key, value, home_dir=tempdir, set_env=True)
+        assert_true(key in os.environ)
         assert_true(get_config(key, home_dir=tempdir) == value)
-        set_config(key, None, home_dir=tempdir)
+        set_config(key, None, home_dir=tempdir, set_env=True)
+        assert_true(key not in os.environ)
+        set_config(key, None, home_dir=tempdir, set_env=True)
+        assert_true(key not in os.environ)
     if old_val is not None:
         os.environ[key] = old_val
     # Check if get_config with no input returns all config

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1393,7 +1393,7 @@ def _close_event(event, params):
 def _resize_event(event, params):
     """Function to handle resize event"""
     size = ','.join([str(s) for s in params['fig'].get_size_inches()])
-    set_config('MNE_BROWSE_RAW_SIZE', size)
+    set_config('MNE_BROWSE_RAW_SIZE', size, set_env=False)
     _layout_figure(params)
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -534,7 +534,7 @@ def figure_nobar(*args, **kwargs):
 def _helper_raw_resize(event, params):
     """Helper for resizing"""
     size = ','.join([str(s) for s in params['fig'].get_size_inches()])
-    set_config('MNE_BROWSE_RAW_SIZE', size)
+    set_config('MNE_BROWSE_RAW_SIZE', size, set_env=False)
     _layout_figure(params)
 
 

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -103,7 +103,7 @@ mne.set_log_level('INFO')
 # You can set the default level by setting the environment variable
 # "MNE_LOGGING_LEVEL", or by having mne-python write preferences to a file:
 
-mne.set_config('MNE_LOGGING_LEVEL', 'WARNING')
+mne.set_config('MNE_LOGGING_LEVEL', 'WARNING', set_env=True)
 
 ##############################################################################
 # Note that the location of the mne-python preferences file (for easier manual
@@ -170,7 +170,7 @@ print(events[:5])
 # system (e.g., a newer system that uses channel 'STI101' by default), you can
 # use the following to set the default stim channel to use for finding events:
 
-mne.set_config('MNE_STIM_CHANNEL', 'STI101')
+mne.set_config('MNE_STIM_CHANNEL', 'STI101', set_env=True)
 
 ##############################################################################
 # Events are stored as 2D numpy array where the first column is the time


### PR DESCRIPTION
Closes #3274.

Changes `set_config(..., set_env=True)` in 0.14, so that setting config updates `os.environ`, too, by default.