### PR TITLE
MRG: Clearer compensation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,8 @@ BUG
 
     - Fixed a bug with channel order determination that could lead to an ``AssertionError`` when using :class:`mne.Covariance` matrices by `Eric Larson`_
 
+    - Fixed the check for CTF gradient compensation in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
+
 API
 ~~~
 
@@ -104,6 +106,8 @@ API
     - The default dataset location has been changed from ``examples/`` in the MNE-Python root directory to ``~/mne_data`` in the user's home directory, by `Eric Larson`_
 
     - A new option ``set_env`` has been added to :func:`mne.set_config` that defaults to ``False`` in 0.13 but will change to ``True`` in 0.14, by `Eric Larson`_
+
+    - The ``compensation`` parameter in :func:`mne.io.read_raw_fif` has been deprecated in favor of the method :meth:`mne.io.Raw.apply_gradient_compensation` by `Eric Larson`_
 
 .. _changes_0_12:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ BUG
 API
 ~~~
 
+    - When CTF gradient compensation is applied to raw data, it is no longer reverted on save of :meth:`mne.io.Raw.save` by `Eric Larson`_
+
     - Adds :func:`mne.time_frequency.csd_epochs` to replace :func:`mne.time_frequency.csd_compute_epochs` for naming consistency. :func:`mne.time_frequency.csd_compute_epochs` is now deprecated and will be removed in mne 0.14, by `Nick Foti`_
 
     - Deprecated support for passing a lits of filenames to :class:`mne.io.Raw` constructor, use :func:`mne.io.read_raw_fif` and :func:`mne.concatenate_raws` instead by `Eric Larson`_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -15,6 +15,7 @@ from scipy import sparse
 from ..externals.six import string_types
 
 from ..utils import verbose, logger, warn
+from ..io.compensator import get_current_comp
 from ..io.meas_info import anonymize_info
 from ..io.pick import (channel_type, pick_info, pick_types,
                        _check_excludes_includes, _PICK_TYPES_KEYS)
@@ -174,6 +175,12 @@ class ContainsMixin(object):
         else:
             has_ch_type = _contains_ch_type(self.info, ch_type)
         return has_ch_type
+
+    @property
+    def compensation_grade(self):
+        """The current gradient compensation grade"""
+        return get_current_comp(self.info)
+
 
 # XXX Eventually de-duplicate with _kind_dict of mne/io/meas_info.py
 _human2fiff = {'ecg': FIFF.FIFFV_ECG_CH,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -26,6 +26,7 @@ def _get_meg_system(info):
     system = '306m'
     for ch in info['chs']:
         if ch['kind'] == FIFF.FIFFV_MEG_CH:
+            # Only take first 16 bits, as higher bits store CTF grad comp order
             coil_type = ch['coil_type'] & 0xFFFF
             if coil_type == FIFF.FIFFV_COIL_NM_122:
                 system = '122m'

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -387,7 +387,8 @@ def find_layout(info, ch_type=None, exclude='bads'):
                          '`ch_type` must be %s' % (ch_type, our_types))
 
     chs = info['chs']
-    coil_types = set([ch['coil_type'] for ch in chs])
+    # Only take first 16 bits, as higher bits store CTF comp order
+    coil_types = set([ch['coil_type'] & 0xFFFF for ch in chs])
     channel_types = set([ch['kind'] for ch in chs])
 
     has_vv_mag = any(k in coil_types for k in
@@ -409,7 +410,8 @@ def find_layout(info, ch_type=None, exclude='bads'):
                     (FIFF.FIFFV_MEG_CH in channel_types and
                      any(k in ctf_other_types for k in coil_types)))
     # hack due to MNE-C bug in IO of CTF
-    n_kit_grads = sum(ch['coil_type'] == FIFF.FIFFV_COIL_KIT_GRAD
+    # only take first 16 bits, as higher bits store CTF comp order
+    n_kit_grads = sum(ch['coil_type'] & 0xFFFF == FIFF.FIFFV_COIL_KIT_GRAD
                       for ch in chs)
 
     has_any_meg = any([has_vv_mag, has_vv_grad, has_4D_mag, has_CTF_grad,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -377,8 +377,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             # Figure out what operator to use (varies depending on preload)
             from_comp = current_comp if self.preload else self._read_comp_grade
             comp = make_compensator(self.info, from_comp, grade)
-            logger.info('Compensator constructed to change %d -> %d (%d)'
-                        % (current_comp, grade, from_comp))
+            logger.info('Compensator constructed to change %d -> %d'
+                        % (current_comp, grade))
             set_current_comp(self.info, grade)
             # We might need to apply it to our data now
             if self.preload:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -13,7 +13,6 @@ import os
 import os.path as op
 
 import numpy as np
-from scipy import linalg
 
 from .constants import FIFF
 from .pick import pick_types, channel_type, pick_channels, pick_info
@@ -23,7 +22,7 @@ from .proj import setup_proj, activate_proj, _proj_equal, ProjMixin
 from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                  SetChannelsMixin, InterpolationMixin)
 from ..channels.montage import read_montage, _set_montage, Montage
-from .compensator import get_current_comp, set_current_comp, make_compensator
+from .compensator import set_current_comp, make_compensator
 from .write import (start_file, end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
@@ -329,11 +328,11 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self._raw_extras = list(raw_extras)
         # deal with compensation (only relevant for CTF data, either CTF
         # reader or MNE-C converted CTF->FIF files)
-        comp_grade = get_current_comp(info)
-        if comp_grade is not None:
-            logger.info('Current compensation grade : %d' % comp_grade)
-        self.comp = None
-        self._orig_comp_grade = comp_grade
+        self._read_comp_grade = self.compensation_grade  # read property
+        if self._read_comp_grade is not None:
+            logger.info('Current compensation grade : %d'
+                        % self._read_comp_grade)
+        self._comp = None
         self._filenames = list(filenames)
         self.orig_format = orig_format
         self._projectors = list()
@@ -345,26 +344,50 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if load_from_disk:
             self._preload_data(preload)
 
-    def apply_gradient_compensation(self, grade):
+    @verbose
+    def apply_gradient_compensation(self, grade, verbose=None):
         """Apply CTF gradient compensation
+
+        .. warning:: The compensation matrices are stored with single
+                     precision, so repeatedly switching between different
+                     of compensation (e.g., 0->1->3->2) can increase
+                     numerical noise. It is thus best to only use a single
+                     gradient compensation level in final analyses,
+                     and if possible.
 
         Parameters
         ----------
         grade : int
             CTF gradient compensation level.
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see mne.verbose).
 
         Returns
         -------
         raw : instance of Raw
             The modified Raw instance. Works in-place.
         """
-        current_comp = get_current_comp(self.info)
-        self.comp = make_compensator(self.info, current_comp, grade)
-        if self.comp is not None:
-            logger.info('Appropriate compensator added to change to '
-                        'grade %d.' % (grade,))
-            self._orig_comp_grade = current_comp
+        grade = int(grade)
+        current_comp = self.compensation_grade
+        if current_comp != grade:
+            # Figure out what operator to use (varies depending on preload)
+            from_comp = current_comp if self.preload else self._read_comp_grade
+            comp = make_compensator(self.info, from_comp, grade)
+            logger.info('Compensator constructed to change %d -> %d (%d)'
+                        % (current_comp, grade, from_comp))
             set_current_comp(self.info, grade)
+            # We might need to apply it to our data now
+            if self.preload:
+                logger.info('Applying compensator to loaded data')
+                # XXX do we need to make sure this is done before any
+                # projectors are applied (i.e., raise error here sometimes)?
+                lims = np.concatenate([np.arange(0, len(self.times), 10000),
+                                       [len(self.times)]])
+                for start, stop in zip(lims[:-1], lims[1:]):
+                    self._data[:, start:stop] = np.dot(
+                        comp, self._data[:, start:stop])
+            else:
+                self._comp = comp  # store it for later use
         return self
 
     @property
@@ -438,12 +461,12 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # set up cals and mult (cals, compensation, and projector)
         cals = self._cals.ravel()[np.newaxis, :]
-        if self.comp is not None:
+        if self._comp is not None:
             if projector is not None:
-                mult = self.comp * cals
+                mult = self._comp * cals
                 mult = np.dot(projector[idx], mult)
             else:
-                mult = self.comp[idx] * cals
+                mult = self._comp[idx] * cals
         elif projector is not None:
             mult = projector[idx] * cals
         else:
@@ -569,6 +592,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self._data = self._read_segment(data_buffer=data_buffer)
         assert len(self._data) == self.info['nchan']
         self.preload = True
+        self._comp = None  # no longer needed
         self.close()
 
     def _update_times(self):
@@ -1393,12 +1417,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             info = self.info
             projector = None
 
-        # set the correct compensation grade and make inverse compensator
-        inv_comp = None
-        if self.comp is not None:
-            inv_comp = linalg.inv(self.comp)
-            set_current_comp(info, self._orig_comp_grade)
-
         #
         #   Set up the reading parameters
         #
@@ -1416,8 +1434,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # write the raw file
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
-                   start, stop, buffer_size, projector, inv_comp,
-                   drop_small_buffer, split_size, 0, None)
+                   start, stop, buffer_size, projector, drop_small_buffer,
+                   split_size, 0, None)
 
     def plot(self, events=None, duration=10.0, start=0.0, n_channels=20,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
@@ -2007,7 +2025,7 @@ class _RawShell():
 ###############################################################################
 # Writing
 def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
-               stop, buffer_size, projector, inv_comp, drop_small_buffer,
+               stop, buffer_size, projector, drop_small_buffer,
                split_size, part_idx, prev_fname):
     """Write raw file with splitting
     """
@@ -2065,7 +2083,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                         '[done]')
             break
         logger.info('Writing ...')
-        _write_raw_buffer(fid, data, cals, fmt, inv_comp)
+        _write_raw_buffer(fid, data, cals, fmt)
 
         pos = fid.tell()
         this_buff_size_bytes = pos - pos_prev
@@ -2088,7 +2106,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             next_fname, next_idx = _write_raw(
                 fname, raw, info, picks, fmt,
                 data_type, reset_range, first + buffer_size, stop, buffer_size,
-                projector, inv_comp, drop_small_buffer, split_size,
+                projector, drop_small_buffer, split_size,
                 part_idx + 1, use_fname)
 
             start_block(fid, FIFF.FIFFB_REF)
@@ -2193,7 +2211,7 @@ def _start_writing_raw(name, info, sel=None, data_type=FIFF.FIFFT_FLOAT,
     return fid, cals
 
 
-def _write_raw_buffer(fid, buf, cals, fmt, inv_comp):
+def _write_raw_buffer(fid, buf, cals, fmt):
     """Write raw buffer
 
     Parameters
@@ -2208,9 +2226,6 @@ def _write_raw_buffer(fid, buf, cals, fmt, inv_comp):
         'short', 'int', 'single', or 'double' for 16/32 bit int or 32/64 bit
         float for each item. This will be doubled for complex datatypes. Note
         that short and int formats cannot be used for complex data.
-    inv_comp : array | None
-        The CTF compensation matrix used to revert compensation
-        change when reading.
     """
     if buf.shape[0] != len(cals):
         raise ValueError('buffer and calibration sizes do not match')
@@ -2236,11 +2251,7 @@ def _write_raw_buffer(fid, buf, cals, fmt, inv_comp):
             raise ValueError('only "single" and "double" supported for '
                              'writing complex data')
 
-    if inv_comp is not None:
-        buf = np.dot(inv_comp / np.ravel(cals)[:, None], buf)
-    else:
-        buf = buf / np.ravel(cals)[:, None]
-
+    buf = buf / np.ravel(cals)[:, None]
     write_function(fid, FIFF.FIFF_DATA_BUFFER, buf)
 
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -18,6 +18,7 @@ from nose.tools import assert_true, assert_raises, assert_not_equal
 from mne.datasets import testing
 from mne.io.constants import FIFF
 from mne.io import Raw, RawArray, concatenate_raws, read_raw_fif
+from mne.io.compensator import get_current_comp
 from mne.io.tests.test_raw import _test_concat, _test_raw_reader
 from mne import (concatenate_events, find_events, equalize_channels,
                  compute_proj_raw, pick_types, pick_channels, create_info)
@@ -1190,39 +1191,62 @@ def test_with_statement():
 def test_compensation_raw():
     """Test Raw compensation"""
     tempdir = _TempDir()
-    raw1 = Raw(ctf_comp_fname, compensation=None)
-    assert_true(raw1.comp is None)
+    raw = Raw(ctf_comp_fname)
+    assert_equal(get_current_comp(raw.info), 3)
+    assert_true(raw.comp is None)
+    data, times = raw[:, :]
+
+    # data come with grade 3
+    raw1 = raw.copy().apply_gradient_compensation(3)
+    assert_equal(get_current_comp(raw1.info), 3)
     data1, times1 = raw1[:, :]
-    raw2 = Raw(ctf_comp_fname, compensation=3)
+    assert_true(raw1.comp is None)  # unchanged (data come with grade 3)
+    assert_array_equal(times, times1)
+    assert_array_equal(data, data1)
+    # deprecated way
+    raw2 = Raw(ctf_comp_fname, compensation=3, verbose='error')
+    assert_equal(get_current_comp(raw2.info), 3)
     data2, times2 = raw2[:, :]
     assert_true(raw2.comp is None)  # unchanged (data come with grade 3)
-    assert_array_equal(times1, times2)
-    assert_array_equal(data1, data2)
-    raw3 = Raw(ctf_comp_fname, compensation=1)
+    assert_array_equal(times, times2)
+    assert_array_equal(data, data2)
+
+    # change to grade 1
+    raw3 = raw.copy().apply_gradient_compensation(1)
+    assert_equal(get_current_comp(raw3.info), 1)
     data3, times3 = raw3[:, :]
     assert_true(raw3.comp is not None)
-    assert_array_equal(times1, times3)
-    # make sure it's different with a different compensation:
+    assert_array_equal(times, times3)
     assert_true(np.mean(np.abs(data1 - data3)) > 1e-12)
     assert_raises(ValueError, Raw, ctf_comp_fname, compensation=33)
+    # deprecated way
+    raw4 = Raw(ctf_comp_fname, compensation=1, verbose='error')
+    assert_equal(get_current_comp(raw4.info), 1)
+    data4, times4 = raw4[:, :]
+    assert_true(raw4.comp is not None)
+    assert_array_equal(times, times4)
+    assert_true(np.mean(np.abs(data1 - data3)) > 1e-12)
+    assert_raises(ValueError, Raw, ctf_comp_fname, compensation=33)
+    assert_allclose(data3, data4)
 
     # Try IO with compensation
     temp_file = op.join(tempdir, 'raw.fif')
-
     raw1.save(temp_file, overwrite=True)
-    raw4 = Raw(temp_file)
-    data4, times4 = raw4[:, :]
-    assert_array_equal(times1, times4)
-    assert_array_equal(data1, data4)
+    raw5 = Raw(temp_file)
+    assert_equal(get_current_comp(raw5.info), 3)
+    data5, times5 = raw5[:, :]
+    assert_array_equal(times, times5)
+    assert_allclose(data, data5, rtol=1e-12, atol=1e-22)
 
     # Now save the file that has modified compensation
     # and make sure we can the same data as input ie. compensation
     # is undone
     raw3.save(temp_file, overwrite=True)
-    raw5 = Raw(temp_file)
-    data5, times5 = raw5[:, :]
-    assert_array_equal(times1, times5)
-    assert_allclose(data1, data5, rtol=1e-12, atol=1e-22)
+    raw6 = Raw(temp_file)
+    assert_equal(get_current_comp(raw6.info), 3)
+    data6, times6 = raw6[:, :]
+    assert_array_equal(times, times6)
+    assert_allclose(data, data6, rtol=1e-12, atol=1e-22)
 
 
 @requires_mne

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -34,8 +34,10 @@ def test_compensation():
                 continue
             comp1 = make_compensator(raw.info, from_, to)
             comp2 = make_compensator(raw.info, to, from_)
-            assert_allclose(np.dot(comp1, comp2), desired, atol=1e-6)
-            assert_allclose(np.dot(comp2, comp1), desired, atol=1e-6)
+            # To get 1e-12 here (instead of 1e-6) we must use the linalg.inv
+            # method mentioned in compensator.py
+            assert_allclose(np.dot(comp1, comp2), desired, atol=1e-12)
+            assert_allclose(np.dot(comp2, comp1), desired, atol=1e-12)
 
     # make sure that changing the comp doesn't modify the original data
     raw2 = Raw(ctf_comp_fname).apply_gradient_compensation(2)

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -26,16 +26,30 @@ def test_compensation():
     comp2 = make_compensator(raw.info, 3, 1, exclude_comp_chs=True)
     assert_true(comp2.shape == (311, 340))
 
+    # round-trip
+    desired = np.eye(340)
+    for from_ in range(3):
+        for to in range(3):
+            if from_ == to:
+                continue
+            comp1 = make_compensator(raw.info, from_, to)
+            comp2 = make_compensator(raw.info, to, from_)
+            assert_allclose(np.dot(comp1, comp2), desired, atol=1e-6)
+            assert_allclose(np.dot(comp2, comp1), desired, atol=1e-6)
+
     # make sure that changing the comp doesn't modify the original data
     raw2 = Raw(ctf_comp_fname).apply_gradient_compensation(2)
     assert_equal(get_current_comp(raw2.info), 2)
     fname = op.join(tempdir, 'ctf-raw.fif')
     raw2.save(fname)
     raw2 = Raw(fname)
-    assert_equal(get_current_comp(raw2.info), 3)
+    assert_equal(raw2.compensation_grade, 2)
+    raw2.apply_gradient_compensation(3)
+    assert_equal(raw2.compensation_grade, 3)
     data, _ = raw[:, :]
     data2, _ = raw2[:, :]
-    assert_allclose(data, data2, rtol=1e-9, atol=1e-20)
+    # channels have norm ~1e-12
+    assert_allclose(data, data2, rtol=1e-9, atol=1e-18)
     for ch1, ch2 in zip(raw.info['chs'], raw2.info['chs']):
         assert_true(ch1['coil_type'] == ch2['coil_type'])
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -20,7 +20,6 @@ from ..transforms import (_str_to_frame, _get_trans, Transform, apply_trans,
 from ..forward import _concatenate_coils, _prep_meg_channels, _create_meg_coils
 from ..surface import _normalize_vectors
 from ..io.constants import FIFF
-from ..io.compensator import get_current_comp
 from ..io.proc_history import _read_ctc
 from ..io.write import _generate_meas_id, _date_now
 from ..io import _loc_to_coil_trans, _BaseRaw
@@ -896,8 +895,8 @@ def _check_usable(inst):
     """Helper to ensure our data are clean"""
     if inst.proj:
         raise RuntimeError('Projectors cannot be applied to data.')
-    current_comp = get_current_comp(inst.info)
-    if current_comp != 0:
+    current_comp = inst.compensation_grade
+    if current_comp not in (0, None):
             raise RuntimeError('Maxwell filter cannot be done on compensated '
                                'channels, but data have been compensated with '
                                'grade %s.' % current_comp)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -19,7 +19,6 @@ from mne.cov import _estimate_rank_meeg_cov
 from mne.datasets import testing
 from mne.io import (Raw, proc_history, read_info, read_raw_bti, read_raw_kit,
                     _BaseRaw)
-from mne.io.compensator import get_current_comp
 from mne.preprocessing.maxwell import (
     maxwell_filter, _get_n_moments, _sss_basis_basic, _sh_complex_to_real,
     _sh_real_to_complex, _sh_negate, _bases_complex_to_real, _trans_sss_basis,
@@ -260,7 +259,7 @@ def test_other_systems():
 
     # CTF
     raw_ctf = Raw(fname_ctf_raw)
-    assert_equal(get_current_comp(raw_ctf.info), 3)
+    assert_equal(raw_ctf.compensation_grade, 3)
     assert_raises(RuntimeError, maxwell_filter, raw_ctf)  # compensated
     raw_ctf.apply_gradient_compensation(0)
     assert_raises(ValueError, maxwell_filter, raw_ctf)  # cannot fit headshape

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -17,7 +17,9 @@ from mne.chpi import read_head_pos, filter_chpi
 from mne.forward import _prep_meg_channels
 from mne.cov import _estimate_rank_meeg_cov
 from mne.datasets import testing
-from mne.io import Raw, proc_history, read_info, read_raw_bti, read_raw_kit
+from mne.io import (Raw, proc_history, read_info, read_raw_bti, read_raw_kit,
+                    _BaseRaw)
+from mne.io.compensator import get_current_comp
 from mne.preprocessing.maxwell import (
     maxwell_filter, _get_n_moments, _sss_basis_basic, _sh_complex_to_real,
     _sh_real_to_complex, _sh_negate, _bases_complex_to_real, _trans_sss_basis,
@@ -194,8 +196,7 @@ def test_movement_compensation():
 
 @slow_test
 def test_other_systems():
-    """Test Maxwell filtering on KIT, BTI, and CTF files
-    """
+    """Test Maxwell filtering on KIT, BTI, and CTF files"""
     # KIT
     kit_dir = op.join(io_dir, 'kit', 'tests', 'data')
     sqd_path = op.join(kit_dir, 'test.sqd')
@@ -258,14 +259,17 @@ def test_other_systems():
     _assert_shielding(raw_sss_auto, power, 0.7)
 
     # CTF
-    raw_ctf = Raw(fname_ctf_raw, compensation=2)
-    assert_raises(RuntimeError, maxwell_filter, raw_ctf)  # compensated
     raw_ctf = Raw(fname_ctf_raw)
+    assert_equal(get_current_comp(raw_ctf.info), 3)
+    assert_raises(RuntimeError, maxwell_filter, raw_ctf)  # compensated
+    raw_ctf.apply_gradient_compensation(0)
     assert_raises(ValueError, maxwell_filter, raw_ctf)  # cannot fit headshape
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04))
     _assert_n_free(raw_sss, 68)
+    _assert_shielding(raw_sss, raw_ctf, 1.8)
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04), ignore_ref=True)
     _assert_n_free(raw_sss, 70)
+    _assert_shielding(raw_sss, raw_ctf, 12)
     raw_sss_auto = maxwell_filter(raw_ctf, origin=(0., 0., 0.04),
                                   ignore_ref=True, mag_scale='auto')
     assert_allclose(raw_sss._data, raw_sss_auto._data)
@@ -424,10 +428,6 @@ def test_basic():
                  proc_history._get_sss_rank(sss_info))
 
     # Degenerate cases
-    raw_bad = raw.copy()
-    raw_bad.comp = True
-    assert_raises(RuntimeError, maxwell_filter, raw_bad)
-    del raw_bad
     assert_raises(ValueError, maxwell_filter, raw, coord_frame='foo')
     assert_raises(ValueError, maxwell_filter, raw, origin='foo')
     assert_raises(ValueError, maxwell_filter, raw, origin=[0] * 4)
@@ -627,7 +627,7 @@ def test_fine_calibration():
                                 origin=mf_head_origin, regularize=None,
                                 bad_condition='ignore')
     assert_meg_snr(raw_sss_3D, sss_fine_cal, 1.0, 6.)
-    raw_ctf = Raw(fname_ctf_raw)
+    raw_ctf = Raw(fname_ctf_raw).apply_gradient_compensation(0)
     assert_raises(RuntimeError, maxwell_filter, raw_ctf, origin=(0., 0., 0.04),
                   calibration=fine_cal_fname)
 
@@ -692,7 +692,7 @@ def test_cross_talk():
     mf_ctc = sss_ctc.info['proc_history'][0]['max_info']['sss_ctc']
     del mf_ctc['block_id']  # we don't write this
     assert_equal(object_diff(py_ctc, mf_ctc), '')
-    raw_ctf = Raw(fname_ctf_raw)
+    raw_ctf = Raw(fname_ctf_raw).apply_gradient_compensation(0)
     assert_raises(ValueError, maxwell_filter, raw_ctf)  # cannot fit headshape
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04))
     _assert_n_free(raw_sss, 68)
@@ -752,7 +752,11 @@ def test_head_translation():
 
 def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
     """Helper to assert a minimum shielding factor using empty-room power"""
-    picks = pick_types(raw_sss.info, meg=meg)
+    picks = pick_types(raw_sss.info, meg=meg, ref_meg=False)
+    if isinstance(erm_power, _BaseRaw):
+        picks_erm = pick_types(raw_sss.info, meg=meg, ref_meg=False)
+        assert_allclose(picks, picks_erm)
+        erm_power = np.sqrt((erm_power[picks_erm][0] ** 2).sum())
     sss_power = raw_sss[picks][0].ravel()
     sss_power = np.sqrt(np.sum(sss_power * sss_power))
     factor = erm_power / sss_power

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -165,9 +165,6 @@ def test_average_movements():
     assert_raises(TypeError, average_movements, 'foo', head_pos=head_pos)
     assert_raises(RuntimeError, average_movements, epochs_proj,
                   head_pos=head_pos)  # prj
-    epochs.info['comps'].append([0])
-    assert_raises(RuntimeError, average_movements, epochs, head_pos=head_pos)
-    epochs.info['comps'].pop()
 
 
 def test_reject():

--- a/tutorials/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/plot_brainstorm_phantom_ctf.py
@@ -59,6 +59,21 @@ events = np.where(np.diff(sinusoid > 0.5) > 0)[1] + raw.first_samp
 events = np.vstack((events, np.zeros_like(events), np.ones_like(events))).T
 
 ###############################################################################
+# The CTF software compensation works reasonably well:
+
+raw.plot()
+
+###############################################################################
+# But here we can get slightly better noise suppression, lower localization
+# bias, and a better dipole goodness of fit with spatio-temporal (tSSS)
+# Maxwell filtering:
+
+raw.apply_gradient_compensation(0)  # must un-do software compensation first
+raw = mne.preprocessing.maxwell_filter(
+    raw, origin=(0., 0., 0.), st_duration=10.)
+raw.plot()
+
+###############################################################################
 # Our choice of tmin and tmax should capture exactly one cycle, so
 # we can make the unusual choice of baselining using the entire epoch
 # when creating our evoked data. We also then crop to a single time point

--- a/tutorials/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/plot_brainstorm_phantom_ctf.py
@@ -69,8 +69,8 @@ raw.plot()
 # Maxwell filtering:
 
 raw.apply_gradient_compensation(0)  # must un-do software compensation first
-raw = mne.preprocessing.maxwell_filter(
-    raw, origin=(0., 0., 0.), st_duration=10.)
+mf_kwargs = dict(origin=(0., 0., 0.), st_duration=10.)
+raw = mne.preprocessing.maxwell_filter(raw, **mf_kwargs)
 raw.plot()
 
 ###############################################################################
@@ -86,13 +86,17 @@ epochs = mne.Epochs(raw, events, event_id=1, tmin=tmin, tmax=tmax,
 evoked = epochs.average()
 evoked.plot()
 evoked.crop(0., 0.)
+del raw, epochs
 
 ###############################################################################
 # To do a dipole fit, let's use the covariance provided by the empty room
 # recording.
 
-raw_erm = read_raw_ctf(erm_path)
+raw_erm = read_raw_ctf(erm_path).apply_gradient_compensation(0)
+raw_erm = mne.preprocessing.maxwell_filter(raw_erm, coord_frame='meg',
+                                           **mf_kwargs)
 cov = mne.compute_raw_covariance(raw_erm)
+del raw_erm
 sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=None)
 dip = fit_dipole(evoked, cov, sphere)[0]
 


### PR DESCRIPTION
Closes #3071.

Makes our compensation a bit clearer, and should fix a couple of small bugs related to it in `maxwell_filter` and some `mne.layout` functions.

Also deprecates the `compensation` parameter of `read_raw_fif` in favor of `raw.apply_gradient_compensation`, since really it 1) should be done separately, 2) should be able to be applied multiple times, and 3) be doable both for `Raw` and `RawCTF` (i.e., moved to `_BaseRaw` as a method).