### PR TITLE
MRG: Fix Xdawn example using EpochsVectorizer and y.ravel()

### DIFF
--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -40,9 +40,10 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
                 add_eeg_ref=False, verbose=False)
 
 X = epochs.get_data()
-y = label_binarize(epochs.events[:, 2], classes=[1, 3])
+y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 
 clf = make_pipeline(XdawnTransformer(n_components=3),
+                    Vectorizer(),
                     LogisticRegression())
 score = cross_val_score(clf, X, y, cv=5)
 print(score)

--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -17,7 +17,7 @@ from sklearn.preprocessing import label_binarize
 
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
-from mne.decoding.xdawn import XdawnTransformer
+from mne.decoding import XdawnTransformer, EpochsVectorizer
 
 data_path = sample.data_path()
 
@@ -43,7 +43,7 @@ X = epochs.get_data()
 y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 
 clf = make_pipeline(XdawnTransformer(n_components=3),
-                    Vectorizer(),
+                    EpochsVectorizer(),
                     LogisticRegression())
 score = cross_val_score(clf, X, y, cv=5)
 print(score)


### PR DESCRIPTION
closes https://github.com/mne-tools/mne-python/issues/3433

@kaichogami in the future please check that your new examples are working. There were two bugs in this one.

Also note that you'll have to change the missing `EpochsVectorizer` by a `Vectorizer` in #3409