### PR TITLE
MRG: Add decorator for MKL errors in tests

### DIFF
--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -24,7 +24,7 @@ from mne.preprocessing.maxwell import (
     _bases_real_to_complex, _sph_harm, _prep_mf_coils)
 from mne.tests.common import assert_meg_snr
 from mne.utils import (_TempDir, run_tests_if_main, slow_test, catch_logging,
-                       requires_version, object_diff, buggy_mkl_test)
+                       requires_version, object_diff, buggy_mkl_svd)
 from mne.externals.six import PY3
 
 warnings.simplefilter('always')  # Always throw warnings
@@ -760,7 +760,7 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
                 'Shielding factor %0.3f < %0.3f' % (factor, shielding_factor))
 
 
-@buggy_mkl_test
+@buggy_mkl_svd
 @slow_test
 @requires_svd_convergence
 @testing.requires_testing_data

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -24,7 +24,7 @@ from mne.preprocessing.maxwell import (
     _bases_real_to_complex, _sph_harm, _prep_mf_coils)
 from mne.tests.common import assert_meg_snr
 from mne.utils import (_TempDir, run_tests_if_main, slow_test, catch_logging,
-                       requires_version, object_diff)
+                       requires_version, object_diff, buggy_mkl_test)
 from mne.externals.six import PY3
 
 warnings.simplefilter('always')  # Always throw warnings
@@ -760,6 +760,7 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
                 'Shielding factor %0.3f < %0.3f' % (factor, shielding_factor))
 
 
+@buggy_mkl_test
 @slow_test
 @requires_svd_convergence
 @testing.requires_testing_data

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -23,7 +23,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        create_slices, _time_mask, random_permutation,
                        _get_call_line, compute_corr, sys_info, verbose,
                        check_fname, requires_ftp, get_config_path,
-                       object_size, buggy_mkl_test)
+                       object_size, buggy_mkl_svd)
 
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -48,12 +48,12 @@ def test_buggy_mkl():
     """Test decorator for buggy MKL issues"""
     from nose.plugins.skip import SkipTest
 
-    @buggy_mkl_test
+    @buggy_mkl_svd
     def foo(a, b):
         raise np.linalg.LinAlgError('SVD did not converge')
     assert_raises(SkipTest, foo, 1, 2)
 
-    @buggy_mkl_test
+    @buggy_mkl_svd
     def bar(c, d, e):
         raise RuntimeError('SVD did not converge')
     assert_raises(RuntimeError, bar, 1, 2, 3)

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -23,7 +23,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        create_slices, _time_mask, random_permutation,
                        _get_call_line, compute_corr, sys_info, verbose,
                        check_fname, requires_ftp, get_config_path,
-                       object_size)
+                       object_size, buggy_mkl_test)
 
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -42,6 +42,21 @@ fname_fsaverage_trans = op.join(data_path, 'subjects', 'fsaverage', 'bem',
 def clean_lines(lines=[]):
     # Function to scrub filenames for checking logging output (in test_logging)
     return [l if 'Reading ' not in l else 'Reading test file' for l in lines]
+
+
+def test_buggy_mkl():
+    """Test decorator for buggy MKL issues"""
+    from nose.plugins.skip import SkipTest
+
+    @buggy_mkl_test
+    def foo():
+        raise np.linalg.LinAlgError('SVD did not converge')
+    assert_raises(SkipTest, foo)
+
+    @buggy_mkl_test
+    def bar():
+        raise RuntimeError('SVD did not converge')
+    assert_raises(RuntimeError, bar)
 
 
 def test_sys_info():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -49,14 +49,14 @@ def test_buggy_mkl():
     from nose.plugins.skip import SkipTest
 
     @buggy_mkl_test
-    def foo():
+    def foo(a, b):
         raise np.linalg.LinAlgError('SVD did not converge')
-    assert_raises(SkipTest, foo)
+    assert_raises(SkipTest, foo, 1, 2)
 
     @buggy_mkl_test
-    def bar():
+    def bar(c, d, e):
         raise RuntimeError('SVD did not converge')
-    assert_raises(RuntimeError, bar)
+    assert_raises(RuntimeError, bar, 1, 2, 3)
 
 
 def test_sys_info():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -742,7 +742,7 @@ def requires_nibabel(vox2ras_tkr=False):
                                  'Requires nibabel%s' % extra)
 
 
-def buggy_mkl_test(function):
+def buggy_mkl_svd(function):
     """Decorator for tests that make calls to SVD and intermittently fail"""
     @wraps(function)
     def dec(*args, **kwargs):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -742,6 +742,21 @@ def requires_nibabel(vox2ras_tkr=False):
                                  'Requires nibabel%s' % extra)
 
 
+def buggy_mkl_test(function, *args, **kwargs):
+    """Decorator for tests that make calls to SVD and intermittently fail"""
+    @wraps(function)
+    def dec():
+        try:
+            return function(*args, **kwargs)
+        except np.linalg.LinAlgError as exp:
+            if 'SVD did not converge' in str(exp):
+                from nose.plugins.skip import SkipTest
+                raise SkipTest('Intel MKL SVD convergence error detected,'
+                               'skipping test')
+            raise
+    return dec
+
+
 def requires_version(library, min_version):
     """Helper for testing"""
     return np.testing.dec.skipif(not check_version(library, min_version),

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -742,10 +742,10 @@ def requires_nibabel(vox2ras_tkr=False):
                                  'Requires nibabel%s' % extra)
 
 
-def buggy_mkl_test(function, *args, **kwargs):
+def buggy_mkl_test(function):
     """Decorator for tests that make calls to SVD and intermittently fail"""
     @wraps(function)
-    def dec():
+    def dec(*args, **kwargs):
         try:
             return function(*args, **kwargs)
         except np.linalg.LinAlgError as exp:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -751,8 +751,9 @@ def buggy_mkl_test(function):
         except np.linalg.LinAlgError as exp:
             if 'SVD did not converge' in str(exp):
                 from nose.plugins.skip import SkipTest
-                raise SkipTest('Intel MKL SVD convergence error detected,'
-                               'skipping test')
+                msg = 'Intel MKL SVD convergence error detected, skipping test'
+                warn(msg)
+                raise SkipTest(msg)
             raise
     return dec
 


### PR DESCRIPTION
@kingjr recently hit the dreaded MKL bug. The next time it happens, this can allow us to avoid holding up a PR.