### PR TITLE
EDF Import: invalid char & overlapping annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,7 +79,7 @@ BUG
     - Fixed a bug with channel order determination that could lead to an ``AssertionError`` when using :class:`mne.Covariance` matrices by `Eric Larson`_
 
     - Fixed the check for CTF gradient compensation in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
-    - Fixed the import of EDF files with encoding characters in :func:`edf.py` by `Guillaume Dumas`_
+    - Fixed the import of EDF files with encoding characters in :func:`mne.io.edf.edf.py` by `Guillaume Dumas`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -80,7 +80,7 @@ BUG
 
     - Fixed the check for CTF gradient compensation in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 
-    - Fixed the import of EDF files with encoding characters in :func:`mne.io.edf.edf.py` by `Guillaume Dumas`_
+    - Fixed the import of EDF files with encoding characters in :func:`mne.io.read_raw_edf` by `Guillaume Dumas`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,7 @@ BUG
     - Fixed a bug with channel order determination that could lead to an ``AssertionError`` when using :class:`mne.Covariance` matrices by `Eric Larson`_
 
     - Fixed the check for CTF gradient compensation in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
+    - Fixed the import of EDF files with encoding characters in :func:`edf.py` by `Guillaume Dumas`_
 
 API
 ~~~
@@ -1691,3 +1692,5 @@ of commits):
 .. _Felix Raimundo: https://github.com/gamazeps
 
 .. _Nick Foti: http://nfoti.github.io
+
+.. _Guillaume Dumas: http://www.extrospection.eu

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,7 @@ BUG
     - Fixed a bug with channel order determination that could lead to an ``AssertionError`` when using :class:`mne.Covariance` matrices by `Eric Larson`_
 
     - Fixed the check for CTF gradient compensation in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
+
     - Fixed the import of EDF files with encoding characters in :func:`mne.io.edf.edf.py` by `Guillaume Dumas`_
 
 API

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -208,7 +208,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='1d5da3a809fded1ef5734444ab5bf857',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='f61041e3f3f2ba0def8a2ca71592cc41',
-        testing='566d9e97421972c874fe8a76a837c6ed'
+        testing='217aed43e361c86b622dc0363ae3cef4'
     )
     folder_origs = dict(  # not listed means None
         misc='mne-misc-data-%s' % releases['misc'],

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -164,7 +164,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.24', misc='0.1')
+    releases = dict(testing='0.25', misc='0.1')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -204,8 +204,7 @@ class RawEDF(_BaseRaw):
                     # make sure events without duration get one sample
                     n_stop = n_stop if n_stop > n_start else n_start + 1
                     if any(stim[n_start:n_stop]):
-                        raise NotImplementedError('EDF+ with overlapping '
-                                                  'events not supported.')
+                        warn('EDF+ with overlapping events not supported.')
                     stim[n_start:n_stop] = evid
                 data[stim_channel_idx, :] = stim[start:stop]
             else:
@@ -255,7 +254,11 @@ def _parse_tal_channel(tal_channel_data):
     tals = bytearray()
     for s in tal_channel_data:
         i = int(s)
-        tals.extend([i % 256, i // 256])
+        i0, i1 = i % 256, i // 256
+        if  0 <= i0 < 128 and 0 <= i1 < 128:
+            tals.extend([i0, i1])
+        else:
+            warn('Skipped invalid caracters...')
 
     regex_tal = '([+-]\d+\.?\d*)(\x15(\d+\.?\d*))?(\x14.*?)\x14\x00'
     tal_list = re.findall(regex_tal, tals.decode('ascii'))

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -204,7 +204,7 @@ class RawEDF(_BaseRaw):
                     # make sure events without duration get one sample
                     n_stop = n_stop if n_stop > n_start else n_start + 1
                     if any(stim[n_start:n_stop]):
-                        warn('EDF+ with overlapping events not supported.')
+                        warn('EDF+ with overlapping events are not fully supported.')
                     stim[n_start:n_stop] = evid
                 data[stim_channel_idx, :] = stim[start:stop]
             else:
@@ -258,7 +258,7 @@ def _parse_tal_channel(tal_channel_data):
         if  0 <= i0 < 128 and 0 <= i1 < 128:
             tals.extend([i0, i1])
         else:
-            warn('Skipped invalid caracters...')
+            warn('Skipped invalid character...')
 
     regex_tal = '([+-]\d+\.?\d*)(\x15(\d+\.?\d*))?(\x14.*?)\x14\x00'
     tal_list = re.findall(regex_tal, tals.decode('ascii'))

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -204,7 +204,8 @@ class RawEDF(_BaseRaw):
                     # make sure events without duration get one sample
                     n_stop = n_stop if n_stop > n_start else n_start + 1
                     if any(stim[n_start:n_stop]):
-                        warn('EDF+ with overlapping events are not fully supported.')
+                        warn('EDF+ with overlapping events'
+                             ' are not fully supported')
                     stim[n_start:n_stop] = evid
                 data[stim_channel_idx, :] = stim[start:stop]
             else:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -255,7 +255,7 @@ def _parse_tal_channel(tal_channel_data):
     for s in tal_channel_data:
         i = int(s)
         i0, i1 = i % 256, i // 256
-        if  0 <= i0 < 128 and 0 <= i1 < 128:
+        if 0 <= i0 < 128 and 0 <= i1 < 128:
             tals.extend([i0, i1])
         else:
             warn('Skipped invalid character...')

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -255,11 +255,7 @@ def _parse_tal_channel(tal_channel_data):
     tals = bytearray()
     for s in tal_channel_data:
         i = int(s)
-        i0, i1 = i % 256, i // 256
-        if 0 <= i0 < 128 and 0 <= i1 < 128:
-            tals.extend([i0, i1])
-        else:
-            warn('Skipped invalid character...')
+        tals.extend(np.uint8([i % 256, i // 256]))
 
     regex_tal = '([+-]\d+\.?\d*)(\x15(\d+\.?\d*))?(\x14.*?)\x14\x00'
     # use of latin-1 because characters are only encoded for the first 256

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -262,7 +262,10 @@ def _parse_tal_channel(tal_channel_data):
             warn('Skipped invalid character...')
 
     regex_tal = '([+-]\d+\.?\d*)(\x15(\d+\.?\d*))?(\x14.*?)\x14\x00'
-    tal_list = re.findall(regex_tal, tals.decode('ascii'))
+    # use of latin-1 because characters are only encoded for the first 256
+    # code points and utf-8 can triggers an "invalid continuation byte" error
+    tal_list = re.findall(regex_tal, tals.decode('latin-1'))
+
     events = []
     for ev in tal_list:
         onset = float(ev[0])

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -43,6 +43,8 @@ edf_txt_stim_channel_path = op.join(data_dir, 'test_edf_stim_channel.txt')
 
 data_path = testing.data_path(download=False)
 edf_stim_resamp_path = op.join(data_path, 'EDF', 'test_edf_stim_resamp.edf')
+edf_overlap_annot_path = op.join(data_path, 'EDF',
+                                 'test_edf_overlapping_annotations.edf')
 
 
 eog = ['REOG', 'LEOG', 'IEOG']
@@ -68,6 +70,14 @@ def test_bdf_data():
     assert_true((raw_py.info['chs'][0]['loc']).any())
     assert_true((raw_py.info['chs'][25]['loc']).any())
     assert_true((raw_py.info['chs'][63]['loc']).any())
+
+
+def test_edf_overlapping_annotations():
+    n_warning = 2
+    with warnings.catch_warnings(record=True) as w:
+        read_raw_edf(edf_overlap_annot_path, verbose=True)
+        assert_equal(sum('overlapping' in str(ww.message) for ww in w),
+                     n_warning)
 
 
 def test_edf_data():


### PR DESCRIPTION
Relate to the issue: https://github.com/mne-tools/mne-python/issues/3420
- skip invalid characters in EDF file annotations
- warn for not implementation of overlapping annotations instead of raising an error