### PR TITLE
[MRG+1] Add fiff eeg ref dig

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - Adds automatic determiniation of FIR filter parameters ``filter_length``, ``l_trans_bandwidth``, and ``h_trans_bandwidth`` and adds ``phase`` argument in e.g. in :meth:`mne.io.Raw.filter` by `Eric Larson`_
+    - Adds automatic determination of FIR filter parameters ``filter_length``, ``l_trans_bandwidth``, and ``h_trans_bandwidth`` and adds ``phase`` argument in e.g. in :meth:`mne.io.Raw.filter` by `Eric Larson`_
 
     - Adds faster ``n_fft='auto'`` option to :meth:`mne.io.Raw.apply_hilbert` by `Eric Larson`_
 
@@ -61,6 +61,7 @@ Changelog
 
     - Added support for multiclass decoding in :class:`mne.decoding.CSP`, by `Jean-Remi King`_ and `Alexandre Barachant`_
 
+    - Added obtain digitized location of EEG Reference channel when creating it as a new data channel using :func:`mne.io.add_reference_channels` by `Chris Bailey`_
 
 BUG
 ~~~

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -112,6 +112,11 @@ class ProjMixin(object):
             # Don't set as active, since we haven't applied it
             eeg_proj = make_eeg_average_ref_proj(self.info, activate=False)
             self.add_proj(eeg_proj)
+        elif self.info.get('custom_ref_applied', False):
+            raise RuntimeError('Cannot add an average EEG reference '
+                               'projection since a custom reference has been '
+                               'applied to the data earlier.')
+
         return self
 
     def apply_proj(self):
@@ -696,12 +701,17 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
     return eeg_proj
 
 
-def _has_eeg_average_ref_proj(projs):
-    """Determine if a list of projectors has an average EEG ref"""
+def _has_eeg_average_ref_proj(projs, check_active=False):
+    """Determine if a list of projectors has an average EEG ref
+
+    Optionally, set check_active=True to additionally check if the CAR
+    has already been applied.
+    """
     for proj in projs:
         if (proj['desc'] == 'Average EEG reference' or
                 proj['kind'] == FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF):
-            return True
+            if not check_active or proj['active']:
+                return True
     return False
 
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -249,6 +249,11 @@ def test_add_reference():
     assert_equal(raw.info['nchan'], orig_nchan + 1)
     _check_channel_names(raw, 'Ref')
 
+    # for Neuromag fif's, the reference electrode location is placed in
+    # elements [3:6] of each "data" electrode location
+    assert_allclose(raw.info['chs'][-1]['loc'][:3],
+                    raw.info['chs'][picks_eeg[0]]['loc'][3:6], 1e-6)
+
     ref_idx = raw.ch_names.index('Ref')
     ref_data, _ = raw[ref_idx]
     assert_array_equal(ref_data, 0)
@@ -280,7 +285,16 @@ def test_add_reference():
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True)
+    # default: proj=True, after which adding a Ref channel is prohibited
+    assert_raises(RuntimeError, add_reference_channels, epochs, 'Ref')
+
+    # create epochs in delayed mode, allowing removal of CAR when re-reffing
+    epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
+                    picks=picks_eeg, preload=True, proj='delayed')
     epochs_ref = add_reference_channels(epochs, 'Ref', copy=True)
+    # CAR after custom reference is an Error
+    assert_raises(RuntimeError, epochs_ref.add_eeg_average_proj)
+
     assert_equal(epochs_ref._data.shape[1], epochs._data.shape[1] + 1)
     _check_channel_names(epochs_ref, 'Ref')
     ref_idx = epochs_ref.ch_names.index('Ref')
@@ -294,8 +308,9 @@ def test_add_reference():
     raw = Raw(fif_fname, preload=True)
     events = read_events(eve_fname)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
+    # create epochs in delayed mode, allowing removal of CAR when re-reffing
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
-                    picks=picks_eeg, preload=True)
+                    picks=picks_eeg, preload=True, proj='delayed')
     epochs_ref = add_reference_channels(epochs, ['M1', 'M2'], copy=True)
     assert_equal(epochs_ref._data.shape[1], epochs._data.shape[1] + 2)
     _check_channel_names(epochs_ref, ['M1', 'M2'])
@@ -313,8 +328,9 @@ def test_add_reference():
     raw = Raw(fif_fname, preload=True)
     events = read_events(eve_fname)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
+    # create epochs in delayed mode, allowing removal of CAR when re-reffing
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
-                    picks=picks_eeg, preload=True)
+                    picks=picks_eeg, preload=True, proj='delayed')
     evoked = epochs.average()
     evoked_ref = add_reference_channels(evoked, 'Ref', copy=True)
     assert_equal(evoked_ref.data.shape[0], evoked.data.shape[0] + 1)
@@ -330,8 +346,9 @@ def test_add_reference():
     raw = Raw(fif_fname, preload=True)
     events = read_events(eve_fname)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
+    # create epochs in delayed mode, allowing removal of CAR when re-reffing
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
-                    picks=picks_eeg, preload=True)
+                    picks=picks_eeg, preload=True, proj='delayed')
     evoked = epochs.average()
     evoked_ref = add_reference_channels(evoked, ['M1', 'M2'], copy=True)
     assert_equal(evoked_ref.data.shape[0], evoked.data.shape[0] + 2)


### PR DESCRIPTION
Just stumbled on `mne.io.add_reference_channels`, which is great for our custom Easycaps with reference at FCz. Now we can easily re-create the "missing" channel, particularly favoured by auditory researchers :)

This PR adds the location of the Ref channels to `info['chs']`, which is good for topographic plots. Neuromag EEG digitisation starts with the Ref and gets the identity `0`, which is what this code is based on. I'm not sure how that would translate to non-Neuromag systems? I'm hoping the test for `len(dig_loc)==1` will at least not cause bugs for them.