### PR TITLE
[MRG] Kit2fiff GUI: Test event settings

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,8 @@ Changelog
 
     - Add support for \*.elp and \*.hsp files to the KIT2FIFF converter and :func:`mne.channels.read_dig_montage` by `Teon Brooks`_ and `Christian Brodbeck`_
 
+    - Add option to preview events in the KIT2FIFF GUI by `Christian Brodbeck`_
+
     - Add approximation of size of :class:`io.Raw`, :class:`Epochs`, and :class:`Evoked` in :func:`repr` by `Eric Larson`_
 
     - Add possibility to select a subset of sensors by lasso selector to :func:`mne.viz.plot_sensors` and :func:`mne.viz.plot_raw` when using order='selection' or order='position' by `Jaakko Leppakangas`_

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -118,13 +118,13 @@ class Kit2FiffModel(HasPrivateTraits):
     sqd_fname = Property(Str, depends_on='sqd_file')
     hsp_fname = Property(Str, depends_on='hsp_file')
     fid_fname = Property(Str, depends_on='fid_file')
-    can_save = Property(Bool, depends_on=['stim_chs_ok', 'sqd_file', 'fid',
+    can_save = Property(Bool, depends_on=['stim_chs_ok', 'fid',
                                           'elp', 'hsp', 'dev_head_trans'])
 
     @cached_property
     def _get_can_save(self):
         "Only allow saving when either all or no head shape elements are set."
-        if not self.stim_chs_ok or not self.sqd_file:
+        if not self.stim_chs_ok:
             return False
 
         has_all_hsp = (np.any(self.dev_head_trans) and np.any(self.hsp) and

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -20,7 +20,8 @@ from ..utils import logger
 try:
     from mayavi.core.ui.mayavi_scene import MayaviScene
     from mayavi.tools.mlab_scene_model import MlabSceneModel
-    from pyface.api import confirm, error, FileDialog, OK, YES, information
+    from pyface.api import (confirm, error, FileDialog, OK, YES, information,
+                            ProgressDialog)
     from traits.api import (HasTraits, HasPrivateTraits, cached_property,
                             Instance, Property, Bool, Button, Enum, File,
                             Float, Int, List, Str, Array, DelegatesTo)
@@ -263,7 +264,19 @@ class Kit2FiffModel(HasPrivateTraits):
     def _get_misc_data(self):
         if not self.raw:
             return
-        data, times = self.raw[self.misc_chs]
+        # progress dialog with indefinite progress bar
+        prog = ProgressDialog(title="Loading SQD data...",
+                              message="Loading stim channel data from SQD "
+                              "file ...")
+        prog.open()
+        prog.update(0)
+        try:
+            data, times = self.raw[self.misc_chs]
+        except Exception as err:
+            prog.close()
+            error(None, str(err), "Error Creating FsAverage")
+            raise
+        prog.close()
         return data
 
     @cached_property

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -544,11 +544,11 @@ class Kit2FiffPanel(HasPrivateTraits):
         # setup mayavi visualization
         m = self.model
         self.fid_obj = PointObject(scene=self.scene, color=(25, 225, 25),
-                                   point_scale=5e-3)
+                                   point_scale=5e-3, name='Fiducials')
         self.elp_obj = PointObject(scene=self.scene, color=(50, 50, 220),
-                                   point_scale=1e-2, opacity=.2)
+                                   point_scale=1e-2, opacity=.2, name='ELP')
         self.hsp_obj = PointObject(scene=self.scene, color=(200, 200, 200),
-                                   point_scale=2e-3)
+                                   point_scale=2e-3, name='HSP')
         if not _testing_mode():
             for name, obj in zip(['fid', 'elp', 'hsp'],
                                  [self.fid_obj, self.elp_obj, self.hsp_obj]):

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -333,10 +333,12 @@ class Kit2FiffModel(HasPrivateTraits):
     def _get_stim_chs_comment(self):
         if self.raw is None:
             return ""
-        elif self.stim_chs_array is None:
+        elif not self.stim_chs_ok:
             return "Invalid!"
+        elif not self.stim_chs.strip():
+            return "Default:  The first 8 MISC channels"
         else:
-            return "Ok: %i channels" % len(self.stim_chs_array)
+            return "Ok:  %i channels" % len(self.stim_chs_array)
 
     @cached_property
     def _get_stim_chs_ok(self):
@@ -492,7 +494,8 @@ class Kit2FiffPanel(HasPrivateTraits):
                            tooltip=tooltips["stim_chs"],
                            editor=TextEditor(evaluate_name='stim_chs_ok',
                                              auto_set=True)),
-                      Item('stim_chs_comment', label='>', style='readonly'),
+                      Item('stim_chs_comment', label='Evaluation',
+                           style='readonly', show_label=False),
                       Item('stim_threshold', label='Threshold',
                            tooltip=tooltips['stim_threshold']),
                       HGroup(Item('test_stim', enabled_when='can_test_stim',

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -438,6 +438,7 @@ class Kit2FiffPanel(HasPrivateTraits):
     misc_chs_desc = DelegatesTo('model')
     can_test_stim = DelegatesTo('model')
     test_stim = Button(label="Find Events")
+    plot_raw = Button(label="Plot Raw")
 
     # Source Files
     reset_dig = Button
@@ -494,8 +495,11 @@ class Kit2FiffPanel(HasPrivateTraits):
                       Item('stim_chs_comment', label='>', style='readonly'),
                       Item('stim_threshold', label='Threshold',
                            tooltip=tooltips['stim_threshold']),
-                      Item('test_stim', enabled_when='can_test_stim',
-                           show_label=False),
+                      HGroup(Item('test_stim', enabled_when='can_test_stim',
+                                  show_label=False),
+                             Item('plot_raw', enabled_when='can_test_stim',
+                                  show_label=False),
+                             show_labels=False),
                       label='Events', show_border=True),
                HGroup(Item('save_as', enabled_when='can_save'), spring,
                       'clear_all', show_labels=False),
@@ -559,6 +563,9 @@ class Kit2FiffPanel(HasPrivateTraits):
             return "Queue length: %i" % self.queue_len
         else:
             return ''
+
+    def _plot_raw_fired(self):
+        self.model.raw.plot()
 
     def _reset_dig_fired(self):
         self.reset_traits(['hsp_file', 'fid_file'])

--- a/mne/gui/tests/test_kit2fiff_gui.py
+++ b/mne/gui/tests/test_kit2fiff_gui.py
@@ -41,10 +41,17 @@ def test_kit2fiff_model():
     model.fid_file = fid_path
     assert_true(model.can_save)
 
+    # events
+    model.stim_slope = '+'
+    assert_equal(model.get_event_info(), {1: 2})
+    model.stim_slope = '-'
+    assert_equal(model.get_event_info(), {254: 2, 255: 2})
+
     # stim channels
     model.stim_chs = "181:184, 186"
     assert_array_equal(model.stim_chs_array, [181, 182, 183, 186])
     assert_true(model.stim_chs_ok)
+    assert_equal(model.get_event_info(), {})
     model.stim_chs = "181:184, bad"
     assert_false(model.stim_chs_ok)
     assert_false(model.can_save)

--- a/mne/gui/tests/test_kit2fiff_gui.py
+++ b/mne/gui/tests/test_kit2fiff_gui.py
@@ -33,9 +33,12 @@ def test_kit2fiff_model():
 
     model = Kit2FiffModel()
     assert_false(model.can_save)
+    assert_equal(model.misc_chs_desc, "No SQD file selected...")
+    assert_equal(model.stim_chs_comment, "")
     model.markers.mrk1.file = mrk_pre_path
     model.markers.mrk2.file = mrk_post_path
     model.sqd_file = sqd_path
+    assert_equal(model.misc_chs_desc, "160:192")
     model.hsp_file = hsp_path
     assert_false(model.can_save)
     model.fid_file = fid_path

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -250,11 +250,11 @@ class RawKIT(_BaseRaw):
 
                 # Create a synthetic stim channel
                 if stim is not None:
+                    params = self._raw_extras[fi]
                     stim_ch = _make_stim_channel(block[stim, :],
-                                        self._raw_extras[fi]['slope'],
-                                        self._raw_extras[fi]['stimthresh'],
-                                        self._raw_extras[fi]['stim_code'],
-                                        stim)
+                                                 params['slope'],
+                                                 params['stimthresh'],
+                                                 params['stim_code'], stim)
                     block = np.vstack((block, stim_ch))
 
                 _mult_cal_one(data_view, block, idx, None, mult)

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -179,8 +179,7 @@ class RawKIT(_BaseRaw):
 
         if stim is not None:
             if isinstance(stim, str):
-                picks = pick_types(info, meg=False, ref_meg=False,
-                                   misc=True, exclude=[])[:8]
+                picks = _default_stim_chs(info)
                 if stim == '<':
                     stim = picks[::-1]
                 elif stim == '>':
@@ -240,6 +239,7 @@ class RawKIT(_BaseRaw):
             data_offset = unpack('i', fid.read(KIT.INT))[0]
             pointer = start * nchan * KIT.SHORT
             fid.seek(data_offset + pointer)
+            stim = self._raw_extras[fi]['stim']
             for blk_start in np.arange(0, data_left, blk_size) // nchan:
                 blk_size = min(blk_size, data_left - blk_start * nchan)
                 block = np.fromfile(fid, dtype='h', count=blk_size)
@@ -248,28 +248,42 @@ class RawKIT(_BaseRaw):
                 data_view = data[:, blk_start:blk_stop]
                 block *= conv_factor[:, np.newaxis]
 
-                # Create a synthetic channel
-                if self._raw_extras[fi]['stim'] is not None:
-                    trig_chs = block[self._raw_extras[fi]['stim'], :]
-                    if self._raw_extras[fi]['slope'] == '+':
-                        trig_chs = trig_chs > self._raw_extras[0]['stimthresh']
-                    elif self._raw_extras[fi]['slope'] == '-':
-                        trig_chs = trig_chs < self._raw_extras[0]['stimthresh']
-                    else:
-                        raise ValueError("slope needs to be '+' or '-'")
-                    # trigger value
-                    if self._raw_extras[0]['stim_code'] == 'binary':
-                        ntrigchan = len(self._raw_extras[0]['stim'])
-                        trig_vals = np.array(2 ** np.arange(ntrigchan),
-                                             ndmin=2).T
-                    else:
-                        trig_vals = np.reshape(self._raw_extras[0]['stim'],
-                                               (-1, 1))
-                    trig_chs = trig_chs * trig_vals
-                    stim_ch = np.array(trig_chs.sum(axis=0), ndmin=2)
+                # Create a synthetic stim channel
+                if stim is not None:
+                    stim_ch = _make_stim_channel(block[stim, :],
+                                        self._raw_extras[fi]['slope'],
+                                        self._raw_extras[fi]['stimthresh'],
+                                        self._raw_extras[fi]['stim_code'],
+                                        stim)
                     block = np.vstack((block, stim_ch))
+
                 _mult_cal_one(data_view, block, idx, None, mult)
         # cals are all unity, so can be ignored
+
+
+def _default_stim_chs(info):
+    """Default stim channels for SQD files"""
+    return pick_types(info, meg=False, ref_meg=False, misc=True,
+                      exclude=[])[:8]
+
+
+def _make_stim_channel(trigger_chs, slope, threshold, stim_code,
+                       trigger_values):
+    """Create synthetic stim channel from multiple trigger channels"""
+    if slope == '+':
+        trig_chs_bin = trigger_chs > threshold
+    elif slope == '-':
+        trig_chs_bin = trigger_chs < threshold
+    else:
+        raise ValueError("slope needs to be '+' or '-'")
+    # trigger value
+    if stim_code == 'binary':
+        trigger_values = 2 ** np.arange(len(trigger_chs))
+    elif stim_code != 'channel':
+        raise ValueError("stim_code must be 'binary' or 'channel', got %s" %
+                         repr(stim_code))
+    trig_chs = trig_chs_bin * trigger_values[:, np.newaxis]
+    return np.array(trig_chs.sum(axis=0), ndmin=2)
 
 
 class EpochsKIT(_BaseEpochs):


### PR DESCRIPTION
Some enhancements to the KIT2FIFF GUI:

- button to preview the events: this is something I've wished for many times, makes it easier to make sure one has selected the right event settings
- button to plot raw (just uses `raw.plot()`). On my setup this works nicely with the traits gui.

<img width="629" alt="screen shot 2016-07-27 at 10 39 42 am" src="https://cloud.githubusercontent.com/assets/145771/17179235/73b3c848-53e6-11e6-807e-1716fda97d38.png">
