### PR TITLE
[MRG] Coregistration

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -73,7 +73,7 @@ def _find_head_bem(subject, subjects_dir, high_res=False):
 
 
 def coregister_fiducials(info, fiducials, tol=0.01):
-    """Create a head-MRI transform by aligning 3 fiducial points
+    """Create a head-MRI transform by aligning 3 fiducial points.
 
     Parameters
     ----------

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -94,11 +94,13 @@ def coregister_fiducials(info, fiducials, tol=0.01):
         fiducials, coord_frame_to = read_fiducials(fiducials)
     else:
         coord_frame_to = FIFF.FIFFV_COORD_MRI
-    coords_from, frames_from = _fiducial_coords(info['dig'])
-    if len(set(frames_from)) > 1:
+    frames_from = {d['coord_frame'] for d in info['dig']}
+    if len(frames_from) > 1:
         raise ValueError("info contains fiducials from different coordinate "
                          "frames")
-    coord_frame_from = frames_from[0]
+    else:
+        coord_frame_from = frames_from.pop()
+    coords_from = _fiducial_coords(info['dig'])
     coords_to = _fiducial_coords(fiducials, coord_frame_to)
     trans = fit_matched_points(coords_from, coords_to, tol=tol)
     return Transform(coord_frame_from, coord_frame_to, trans)

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -1,19 +1,45 @@
 from glob import glob
 import os
 
-from nose.tools import assert_raises, assert_true
+from nose.tools import assert_equal, assert_raises, assert_true
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_less
 
 import mne
-from mne.transforms import apply_trans, rotation, translation, scaling
+from mne.transforms import (Transform, apply_trans, rotation, translation,
+                            scaling)
 from mne.coreg import (fit_matched_points, fit_point_cloud,
                        _point_cloud_error, _decimate_points,
                        create_default_subject, scale_mri,
-                       _is_mri_subject, scale_labels, scale_source_space)
+                       _is_mri_subject, scale_labels, scale_source_space,
+                       coregister_fiducials)
+from mne.io.constants import FIFF
 from mne.utils import (requires_mne, requires_freesurfer, _TempDir,
                        run_tests_if_main, requires_version)
 from functools import reduce
+
+
+def test_coregister_fiducials():
+    """Test coreg.coregister_fiducials()"""
+    # prepare head and MRI fiducials
+    trans = Transform('head', 'mri',
+                      rotation(.4, .1, 0).dot(translation(.1, -.1, .1)))
+    coords_orig = np.array([[-0.08061612, -0.02908875, -0.04131077],
+                            [0.00146763, 0.08506715, -0.03483611],
+                            [0.08436285, -0.02850276, -0.04127743]])
+    coords_trans = apply_trans(trans, coords_orig)
+    def make_dig(coords, cf):
+        return ({'coord_frame': cf, 'ident': 1, 'kind': 1, 'r': coords[0]},
+                {'coord_frame': cf, 'ident': 2, 'kind': 1, 'r': coords[1]},
+                {'coord_frame': cf, 'ident': 3, 'kind': 1, 'r': coords[2]})
+    mri_fiducials = make_dig(coords_trans, FIFF.FIFFV_COORD_MRI)
+    info = {'dig': make_dig(coords_orig, FIFF.FIFFV_COORD_HEAD)}
+
+    # test coregister_fiducials()
+    trans_est = coregister_fiducials(info, mri_fiducials)
+    assert_equal(trans_est.from_str, trans.from_str)
+    assert_equal(trans_est.to_str, trans.to_str)
+    assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
 @requires_mne

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -28,10 +28,12 @@ def test_coregister_fiducials():
                             [0.00146763, 0.08506715, -0.03483611],
                             [0.08436285, -0.02850276, -0.04127743]])
     coords_trans = apply_trans(trans, coords_orig)
+
     def make_dig(coords, cf):
         return ({'coord_frame': cf, 'ident': 1, 'kind': 1, 'r': coords[0]},
                 {'coord_frame': cf, 'ident': 2, 'kind': 1, 'r': coords[1]},
                 {'coord_frame': cf, 'ident': 3, 'kind': 1, 'r': coords[2]})
+
     mri_fiducials = make_dig(coords_trans, FIFF.FIFFV_COORD_MRI)
     info = {'dig': make_dig(coords_orig, FIFF.FIFFV_COORD_HEAD)}
 

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -14,8 +14,8 @@ from mne.coreg import (fit_matched_points, fit_point_cloud,
                        _is_mri_subject, scale_labels, scale_source_space,
                        coregister_fiducials)
 from mne.io.constants import FIFF
-from mne.utils import (requires_mne, requires_freesurfer, _TempDir,
-                       run_tests_if_main, requires_version)
+from mne.utils import (requires_freesurfer, _TempDir, run_tests_if_main,
+                       requires_version)
 from functools import reduce
 
 
@@ -44,7 +44,6 @@ def test_coregister_fiducials():
     assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
-@requires_mne
 @requires_freesurfer
 @requires_version('scipy', '0.11')
 def test_scale_mri():

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -91,11 +91,12 @@ def test_scale_mri():
     # add distances to source space
     src = mne.read_source_spaces(path)
     mne.add_source_space_distances(src)
-    src.save(path)
+    src.save(path, overwrite=True)
 
     # scale with distances
     os.remove(src_path)
     scale_source_space('flachkopf', 'ico-0', subjects_dir=tempdir)
+    assert_true(os.path.exists(src_path), "Source space was not scaled")
 
 
 def test_fit_matched_points():

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -8,6 +8,7 @@ import os
 from os import path as op
 import glob
 import copy
+from numbers import Integral
 import numpy as np
 from numpy import sin, cos
 from scipy import linalg
@@ -63,7 +64,7 @@ def _to_const(cf):
         if cf not in _str_to_frame:
             raise ValueError('Unknown cf %s' % cf)
         cf = _str_to_frame[cf]
-    elif not isinstance(cf, (int, np.integer)):
+    elif not isinstance(cf, Integral):
         raise TypeError('cf must be str or int, not %s' % type(cf))
     return int(cf)
 

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -64,7 +64,7 @@ def _to_const(cf):
         if cf not in _str_to_frame:
             raise ValueError('Unknown cf %s' % cf)
         cf = _str_to_frame[cf]
-    elif not isinstance(cf, Integral):
+    elif not isinstance(cf, (Integral, np.int32)):
         raise TypeError('cf must be str or int, not %s' % type(cf))
     return int(cf)
 


### PR DESCRIPTION
@jona-sassenhagen the function is `mne.coreg.coregister_fiducials`. It currently has a scale parameter to use it with fsaverage, but this does not lead to satisfactory results and should be removed before merge.

The PR also contains some other small modifications. 
- Allow `viz.plot_trans` to plot fiducials
- Allow scaling MRI without label files
