### PR TITLE
FIX zorder

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -732,7 +732,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             A dict of `kwargs` that are forwarded to `evoked.plot` to
             style the butterfly plot. `axes` and `show` are ignored.
             If `spatial_colors` is not in this dict, `spatial_colors=True`,
-            and (if it is not in the dict) `zorder='std'` will be passed.
+            and (if it is not in the dict) `zorder='unsorted'` will be passed.
             Beyond that, if `None`, no customizable arguments will be passed.
         topomap_args : None | dict
             A dict of `kwargs` that are forwarded to `evoked.plot_topomap`

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1140,7 +1140,7 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
     ts_args_def = dict(picks=None, unit=True, ylim=None, xlim='tight',
                        proj=False, hline=None, units=None, scalings=None,
                        titles=None, gfp=False, window_title=None,
-                       spatial_colors=True, zorder='std')
+                       spatial_colors=True, zorder='unsorted')
     for key in ts_args_def:
         if key not in ts_args:
             ts_args_pass[key] = ts_args_def[key]


### PR DESCRIPTION
The default is `unsorted` for `evoked.plot()` so it's confusing when `std` is the default for `evoked.plot_joint()` without any documentation of this change. This PR fixes it