### PR TITLE
[MRG]: check estimator / transformer

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -709,14 +709,12 @@ def _set_cv(cv, estimator=None, X=None, y=None):
 def _check_estimator(estimator, get_params=True):
     """Check whether an object has the fit, transform, fit_transform and
     get_params methods required by scikit-learn"""
-    err = True
-    for attr in ('predict', 'transform', 'predict_proba', 'decision_function'):
-        if hasattr(estimator, attr):
-            err = False
-    if not hasattr(estimator, 'fit'):
-        err = True
-
-    if err:
+    valid_methods = ('predict', 'transform', 'predict_proba',
+                     'decision_function')
+    if (
+        (not hasattr(estimator, 'fit')) or
+        (not np.any([hasattr(estimator, method) for method in valid_methods]))
+    ):
         raise ValueError('estimator must be a scikit-learn transformer or '
                          'an estimator with the fit and a predict-like (e.g. '
                          'predict_proba) or a transform method.')

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -709,11 +709,19 @@ def _set_cv(cv, estimator=None, X=None, y=None):
 def _check_estimator(estimator, get_params=True):
     """Check whether an object has the fit, transform, fit_transform and
     get_params methods required by scikit-learn"""
-    for attr in ('fit', 'transform', 'fit_transform'):
-        if not hasattr(estimator, attr):
-            raise ValueError('estimator must be a scikit-learn transformer or '
-                             'an estimator with the %s method' % attr)
-    if get_params and not hasattr(estimator, attr):
+    err = True
+    for attr in ('predict', 'transform', 'predict_proba', 'decision_function'):
+        if hasattr(estimator, attr):
+            err = False
+    if not hasattr(estimator, 'fit'):
+        err = True
+
+    if err:
+        raise ValueError('estimator must be a scikit-learn transformer or '
+                         'an estimator with the fit and a predict-like (e.g. '
+                         'predict_proba) or a transform method.')
+
+    if get_params and not hasattr(estimator, 'get_params'):
         raise ValueError('estimator must be a scikit-learn transformer or an '
                          'estimator with the get_params method that allows '
                          'cloning.')

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -713,7 +713,7 @@ def _check_estimator(estimator, get_params=True):
                      'decision_function')
     if (
         (not hasattr(estimator, 'fit')) or
-        (not any([hasattr(estimator, method) for method in valid_methods]))
+        (not any(hasattr(estimator, method) for method in valid_methods))
     ):
         raise ValueError('estimator must be a scikit-learn transformer or '
                          'an estimator with the fit and a predict-like (e.g. '

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -713,7 +713,7 @@ def _check_estimator(estimator, get_params=True):
                      'decision_function')
     if (
         (not hasattr(estimator, 'fit')) or
-        (not np.any([hasattr(estimator, method) for method in valid_methods]))
+        (not any([hasattr(estimator, method) for method in valid_methods]))
     ):
         raise ValueError('estimator must be a scikit-learn transformer or '
                          'an estimator with the fit and a predict-like (e.g. '

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -23,14 +23,15 @@ def make_data():
 
 @requires_sklearn
 def test_searchlight():
-    from sklearn.linear_model import LogisticRegression
+    from sklearn.linear_model import Ridge, LogisticRegression
     from sklearn.pipeline import make_pipeline
     X, y = make_data()
     n_epochs, _, n_time = X.shape
     # init
     assert_raises(ValueError, SearchLight, 'foo')
-    # fit
+    sl = SearchLight(Ridge())
     sl = SearchLight(LogisticRegression())
+    # fit
     assert_equal(sl.__repr__()[:13], '<SearchLight(')
     sl.fit(X, y)
     assert_equal(sl.__repr__()[-28:], ', fitted with 10 estimators>')


### PR DESCRIPTION
Init was throwing an error at search light init because Ridge doesn't have a transform method, although SearchLight should accept both estimators and transformers

```
from sklearn.linear_model import Ridge
from mne.decoding import SearchLight
SearchLight(Ridge())
````