### PR TITLE
[MRG+1] sort ica components by explained variance and add _get_inst_data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,7 +61,7 @@ Changelog
 
     - Added support for multiclass decoding in :class:`mne.decoding.CSP`, by `Jean-Remi King`_ and `Alexandre Barachant`_
 
-    - components obtained from :class:`mne.preprocessing.ICA` are now sorted by explained variance, by `Mikołaj Magnuski`_
+    - Components obtained from :class:`mne.preprocessing.ICA` are now sorted by explained variance, by `Mikołaj Magnuski`_
 
 
 BUG

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Changelog
 
     - Added support for multiclass decoding in :class:`mne.decoding.CSP`, by `Jean-Remi King`_ and `Alexandre Barachant`_
 
+    - components obtained from :class:`mne.preprocessing.ICA` are now sorted by explained variance, by `Mikołaj Magnuski`_
+
 
 BUG
 ~~~

--- a/examples/preprocessing/plot_run_ica.py
+++ b/examples/preprocessing/plot_run_ica.py
@@ -60,10 +60,10 @@ ica.plot_properties(epochs, picks=ecg_inds)
 # Mark EOG components for removal and compare evoked response before/after:
 
 ica.exclude = ecg_inds
-ica.plot_overlay(epochs)
+ica.plot_overlay(epochs.average())
 
 ###############################################################################
 # Although the epochs evoked response does not change much, we can see the
 # effects of component removal clearly on `ecg_epochs`:
 
-ica.plot_overlay(ecg_epochs)
+ica.plot_overlay(ecg_epochs.average())

--- a/examples/preprocessing/plot_run_ica.py
+++ b/examples/preprocessing/plot_run_ica.py
@@ -7,8 +7,6 @@ Compute ICA components on epochs
 ICA is fit to MEG raw data.
 We assume that the non-stationary EOG artifacts have already been removed.
 The sources matching the ECG are automatically found and displayed.
-Subsequently, artefact detection and rejection quality are assessed.
-Finally, the impact on the evoked ERF is visualized.
 
 Note that this example does quite a bit of processing, so even on a
 fast machine it can take about a minute to complete.
@@ -26,9 +24,12 @@ print(__doc__)
 
 ###############################################################################
 # Read and preprocess the data. Preprocessing consists of:
-# * meg channel selection
-# * 1 - 30 Hz band-pass IIR filter
-# * epoching -0.2 to 0.5 seconds with respect to events
+#
+# - meg channel selection
+#
+# - 1 - 30 Hz band-pass IIR filter
+#
+# - epoching -0.2 to 0.5 seconds with respect to events
 
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
@@ -55,15 +56,3 @@ ica.plot_components(ecg_inds)
 ###############################################################################
 # Plot properties of ECG components:
 ica.plot_properties(epochs, picks=ecg_inds)
-
-###############################################################################
-# Mark EOG components for removal and compare evoked response before/after:
-
-ica.exclude = ecg_inds
-ica.plot_overlay(epochs.average())
-
-###############################################################################
-# Although the epochs evoked response does not change much, we can see the
-# effects of component removal clearly on `ecg_epochs`:
-
-ica.plot_overlay(ecg_epochs.average())

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1633,7 +1633,7 @@ def _find_sources(sources, target, score_func):
 def _ica_explained_variance(ica, inst, normalize=False):
     """Checks variance accounted for by each component in supplied data.
 
-    parameters
+    Parameters
     ----------
     ica : ICA
         Instance of `mne.preprocessing.ICA`.
@@ -1642,7 +1642,7 @@ def _ica_explained_variance(ica, inst, normalize=False):
     normalize : bool
         Whether to normalize the variance.
 
-    returns
+    Returns
     -------
     var : array
         Variance explained by each component.

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -107,6 +107,7 @@ def test_object_size():
 
 def test_get_inst_data():
     from mne.epochs import _segment_raw
+    from mne.time_frequency import tfr_morlet
 
     raw = read_raw_fif(fname_raw)
     # chns = raw.ch_names[:5]
@@ -118,6 +119,13 @@ def test_get_inst_data():
 
     evoked = epochs.average()
     assert_equal(_get_inst_data(evoked), evoked.data)
+
+    evoked.crop(tmax=0.5)
+    picks = list(range(2))
+    freqs = np.array([15., 25.])
+    n_cycles = 3
+    tfr = tfr_morlet(evoked, freqs, n_cycles, return_itc=False, picks=picks)
+    assert_equal(_get_inst_data(tfr), tfr.data)
 
 
 def test_misc():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -10,7 +10,7 @@ import warnings
 from mne import read_evokeds
 from mne.datasets import testing
 from mne.externals.six.moves import StringIO
-from mne.io import show_fiff
+from mne.io import show_fiff, read_raw_fif
 from mne.utils import (set_log_level, set_log_file, _TempDir,
                        get_config, set_config, deprecated, _fetch_file,
                        sum_squared, estimate_rank,
@@ -23,8 +23,8 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        create_slices, _time_mask, random_permutation,
                        _get_call_line, compute_corr, sys_info, verbose,
                        check_fname, requires_ftp, get_config_path,
-                       object_size, buggy_mkl_svd, copy_doc,
-                       copy_function_doc_to_method_doc)
+                       object_size, buggy_mkl_svd, _get_inst_data,
+                       copy_doc, copy_function_doc_to_method_doc)
 
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -103,6 +103,21 @@ def test_object_size():
         size = object_size(obj)
         assert_true(lower < size < upper,
                     msg='%s < %s < %s:\n%s' % (lower, size, upper, obj))
+
+def test_get_inst_data():
+    from mne.epochs import _segment_raw
+
+    raw = read_raw_fif(fname_raw)
+    # chns = raw.ch_names[:5]
+    # raw.pick_channels(chns)
+    assert_equal(_get_inst_data(raw), raw._data)
+
+    epochs = _segment_raw(raw, 2.5)
+    assert_equal(_get_inst_data(epochs), epochs._data)
+
+    evoked = epochs.average()
+    assert_equal(_get_inst_data(evoked), evoked.data)
+
 
 
 def test_misc():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -104,6 +104,7 @@ def test_object_size():
         assert_true(lower < size < upper,
                     msg='%s < %s < %s:\n%s' % (lower, size, upper, obj))
 
+
 def test_get_inst_data():
     from mne.epochs import _segment_raw
 
@@ -117,7 +118,6 @@ def test_get_inst_data():
 
     evoked = epochs.average()
     assert_equal(_get_inst_data(evoked), evoked.data)
-
 
 
 def test_misc():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -11,6 +11,8 @@ from mne import read_evokeds
 from mne.datasets import testing
 from mne.externals.six.moves import StringIO
 from mne.io import show_fiff, read_raw_fif
+from mne.epochs import _segment_raw
+from mne.time_frequency import tfr_morlet
 from mne.utils import (set_log_level, set_log_file, _TempDir,
                        get_config, set_config, deprecated, _fetch_file,
                        sum_squared, estimate_rank,
@@ -106,12 +108,8 @@ def test_object_size():
 
 
 def test_get_inst_data():
-    from mne.epochs import _segment_raw
-    from mne.time_frequency import tfr_morlet
-
+    """Test _get_inst_data"""
     raw = read_raw_fif(fname_raw)
-    # chns = raw.ch_names[:5]
-    # raw.pick_channels(chns)
     assert_equal(_get_inst_data(raw), raw._data)
 
     epochs = _segment_raw(raw, 2.5)
@@ -126,6 +124,8 @@ def test_get_inst_data():
     n_cycles = 3
     tfr = tfr_morlet(evoked, freqs, n_cycles, return_itc=False, picks=picks)
     assert_equal(_get_inst_data(tfr), tfr.data)
+
+    assert_raises(TypeError, _get_inst_data, 'foo')
 
 
 def test_misc():

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -110,17 +110,19 @@ def test_object_size():
 def test_get_inst_data():
     """Test _get_inst_data"""
     raw = read_raw_fif(fname_raw)
+    raw.crop(tmax=1.)
     assert_equal(_get_inst_data(raw), raw._data)
+    raw.pick_channels(raw.ch_names[:2])
 
-    epochs = _segment_raw(raw, 2.5)
+    epochs = _segment_raw(raw, 0.5)
     assert_equal(_get_inst_data(epochs), epochs._data)
 
     evoked = epochs.average()
     assert_equal(_get_inst_data(evoked), evoked.data)
 
-    evoked.crop(tmax=0.5)
+    evoked.crop(tmax=0.1)
     picks = list(range(2))
-    freqs = np.array([15., 25.])
+    freqs = np.array([50., 55.])
     n_cycles = 3
     tfr = tfr_morlet(evoked, freqs, n_cycles, return_itc=False, picks=picks)
     assert_equal(_get_inst_data(tfr), tfr.data)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -526,6 +526,10 @@ def _get_inst_data(inst):
         return inst._data
     elif isinstance(inst, (Evoked, _BaseTFR)):
         return inst.data
+    else:
+        raise TypeError('The argument must be an instance of Raw, Epochs, '
+                        'Evoked, EpochsTFR or AverageTFR, got {}.'.format(
+                        type(inst)))
 
 
 class _FormatDict(dict):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -518,12 +518,13 @@ def _get_inst_data(inst):
     from .io.base import _BaseRaw
     from .epochs import _BaseEpochs
     from . import Evoked
+    from .time_frequency.tfr import _BaseTFR
 
     if isinstance(inst, (_BaseRaw, _BaseEpochs)):
         if not inst.preload:
             inst.load_data()
         return inst._data
-    elif isinstance(inst, Evoked):
+    elif isinstance(inst, (Evoked, _BaseTFR)):
         return inst.data
 
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -512,6 +512,21 @@ def _reject_data_segments(data, reject, flat, decim, info, tstep):
     return data, drop_inds
 
 
+def _get_inst_data(inst):
+    """get data from MNE object instance like Raw, Epochs or Evoked.
+    Returns a view, not a copy!"""
+    from .io.base import _BaseRaw
+    from .epochs import _BaseEpochs
+    from . import Evoked
+
+    if isinstance(inst, (_BaseRaw, _BaseEpochs)):
+        if not inst.preload:
+            inst.load_data()
+        return inst._data
+    elif isinstance(inst, Evoked):
+        return inst.data
+
+
 class _FormatDict(dict):
     """Helper for pformat()"""
     def __missing__(self, key):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -528,8 +528,8 @@ def _get_inst_data(inst):
         return inst.data
     else:
         raise TypeError('The argument must be an instance of Raw, Epochs, '
-                        'Evoked, EpochsTFR or AverageTFR, got {}.'.format(
-                        type(inst)))
+                        'Evoked, EpochsTFR or AverageTFR, got {0}.'.format(
+                            type(inst)))
 
 
 class _FormatDict(dict):

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -47,7 +47,7 @@ picks_meg = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,
 
 n_components = 25  # if float, select n_components by explained variance of PCA
 method = 'fastica'  # for comparison with EEGLAB try "extended-infomax" here
-decim = 3  # we need sufficient statistics, not all time points -> save time
+decim = 3  # we need sufficient statistics, not all time points -> saves time
 
 # we will also set state of the random number generator - ICA is a
 # non-deterministic algorithm, but we want to have the same decomposition
@@ -69,7 +69,7 @@ print(ica)
 ###############################################################################
 # Plot ICA components
 
-ica.plot_components()  # can you see some potential bad guys?
+ica.plot_components()  # can you spot some potential bad guys?
 
 
 ###############################################################################
@@ -138,7 +138,6 @@ ica.plot_overlay(eog_average, exclude=eog_inds, show=False)
 
 # to definitely register this component as a bad one to be removed
 # there is the ``ica.exclude`` attribute, a simple Python list
-
 ica.exclude.extend(eog_inds)
 
 # from now on the ICA will reject this component even if no exclude


### PR DESCRIPTION
I'll do docs clearing in a separate PR, this is just for ic sorting.
Currently it works this way:
```python
from mne.preprocessing.ica import _ica_explained_variance, _sort_components
var = _ica_explained_variance(ica, epochs)
var_ord = var.argsort()[::-1]
ica_sorted = _sort_components(ica, var_ord, copy=True)
```

The question I have is: should components be sorted by default? It makes sense to me to sort by default, but I have eeglab background so I am used to sorted components.
BTW - both infomax and fastica components are "unsorted", but I remember someone here saying fastica sorts components by exaplained variance?

If sorting shouldn't be made default then maybe a `sort` argument to `fit` method?