### PR TITLE
[MRG+2] Refactor docstrings

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -379,7 +379,7 @@ class SetChannelsMixin(object):
         kind : str
             Whether to plot the sensors as 3d, topomap or as an interactive
             sensor selection dialog. Available options 'topomap', '3d',
-            'select'. If 'select', a set of channels can be selected
+            'select'.  If 'select', a set of channels can be selected
             interactively by using lasso selector or clicking while holding
             control key. The selected channels are returned along with the
             figure instance. Defaults to 'topomap'.
@@ -389,8 +389,8 @@ class SetChannelsMixin(object):
             eeg, seeg and ecog channels are plotted. If None (default), then
             channels are chosen in the order given above.
         title : str | None
-            Title for the figure. If None (default), equals to
-            ``'Sensor positions (%s)' % ch_type``.
+            Title for the figure. If None (default), equals to ``'Sensor
+            positions (%s)' % ch_type``.
         show_names : bool
             Whether to display all channel names. Defaults to False.
         ch_groups : 'position' | array of shape (ch_groups, picks) | None
@@ -420,6 +420,20 @@ class SetChannelsMixin(object):
         -------
         fig : instance of matplotlib figure
             Figure containing the sensor topography.
+        selection : list
+            A list of selected channels. Only returned if ``kind=='select'``.
+
+        See Also
+        --------
+        mne.viz.plot_layout
+
+        Notes
+        -----
+        This function plots the sensor locations from the info structure using
+        matplotlib. For drawing the sensors using mayavi see
+        :func:`mne.viz.plot_trans`.
+
+        .. versionadded:: 0.12.0
         """
         from ..viz.utils import plot_sensors
         return plot_sensors(self.info, kind=kind, ch_type=ch_type, title=title,
@@ -428,6 +442,7 @@ class SetChannelsMixin(object):
 
     @copy_function_doc_to_method_doc(anonymize_info)
     def anonymize(self):
+        """.. versionadded:: 0.13.0"""
         anonymize_info(self.info)
         return self
 
@@ -435,17 +450,79 @@ class SetChannelsMixin(object):
 class UpdateChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs, AverageTFR
     """
-    @copy_function_doc_to_method_doc(pick_types)
     def pick_types(self, meg=True, eeg=False, stim=False, eog=False,
                    ecg=False, emg=False, ref_meg='auto', misc=False,
                    resp=False, chpi=False, exci=False, ias=False, syst=False,
-                   seeg=False, bio=False, ecog=False, include=[],
-                   exclude='bads', selection=None):
+                   seeg=False, dipole=False, gof=False, bio=False, ecog=False,
+                   include=[], exclude='bads', selection=None):
+        """Pick some channels by type and names
+
+        Parameters
+        ----------
+        meg : bool | str
+            If True include all MEG channels. If False include None
+            If string it can be 'mag', 'grad', 'planar1' or 'planar2' to select
+            only magnetometers, all gradiometers, or a specific type of
+            gradiometer.
+        eeg : bool
+            If True include EEG channels.
+        stim : bool
+            If True include stimulus channels.
+        eog : bool
+            If True include EOG channels.
+        ecg : bool
+            If True include ECG channels.
+        emg : bool
+            If True include EMG channels.
+        ref_meg: bool | str
+            If True include CTF / 4D reference channels. If 'auto', the
+            reference channels are only included if compensations are present.
+        misc : bool
+            If True include miscellaneous analog channels.
+        resp : bool
+            If True include response-trigger channel. For some MEG systems this
+            is separate from the stim channel.
+        chpi : bool
+            If True include continuous HPI coil channels.
+        exci : bool
+            Flux excitation channel used to be a stimulus channel.
+        ias : bool
+            Internal Active Shielding data (maybe on Triux only).
+        syst : bool
+            System status channel information (on Triux systems only).
+        seeg : bool
+            Stereotactic EEG channels.
+        dipole : bool
+            Dipole time course channels.
+        gof : bool
+            Dipole goodness of fit channels.
+        bio : bool
+            Bio channels.
+        ecog : bool
+            Electrocorticography channels.
+        include : list of string
+            List of additional channels to include. If empty do not include
+            any.
+        exclude : list of string | str
+            List of channels to exclude. If 'bads' (default), exclude channels
+            in ``info['bads']``.
+        selection : list of string
+            Restrict sensor channels (MEG, EEG) to this list of channel names.
+
+        Returns
+        -------
+        inst : instance of Raw, Epochs, or Evoked
+            The modified instance.
+
+        Notes
+        -----
+        .. versionadded:: 0.9.0
+        """
         idx = pick_types(
             self.info, meg=meg, eeg=eeg, stim=stim, eog=eog, ecg=ecg, emg=emg,
             ref_meg=ref_meg, misc=misc, resp=resp, chpi=chpi, exci=exci,
-            ias=ias, syst=syst, seeg=seeg, bio=bio, ecog=ecog, include=include,
-            exclude=exclude, selection=selection)
+            ias=ias, syst=syst, seeg=seeg, dipole=dipole, gof=gof, bio=bio,
+            ecog=ecog, include=include, exclude=exclude, selection=selection)
         self._pick_drop_channels(idx)
         return self
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -379,7 +379,7 @@ class SetChannelsMixin(object):
         kind : str
             Whether to plot the sensors as 3d, topomap or as an interactive
             sensor selection dialog. Available options 'topomap', '3d',
-            'select'.  If 'select', a set of channels can be selected
+            'select'. If 'select', a set of channels can be selected
             interactively by using lasso selector or clicking while holding
             control key. The selected channels are returned along with the
             figure instance. Defaults to 'topomap'.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -442,7 +442,9 @@ class SetChannelsMixin(object):
 
     @copy_function_doc_to_method_doc(anonymize_info)
     def anonymize(self):
-        """.. versionadded:: 0.13.0"""
+        """
+        .. versionadded:: 0.13.0
+        """
         anonymize_info(self.info)
         return self
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -14,7 +14,7 @@ from scipy import sparse
 
 from ..externals.six import string_types
 
-from ..utils import verbose, logger, warn
+from ..utils import verbose, logger, warn, copy_function_doc_to_method_doc
 from ..io.compensator import get_current_comp
 from ..io.meas_info import anonymize_info
 from ..io.pick import (channel_type, pick_info, pick_types,
@@ -420,43 +420,14 @@ class SetChannelsMixin(object):
         -------
         fig : instance of matplotlib figure
             Figure containing the sensor topography.
-        selection : list
-            A list of selected channels. Only returned if ``kind=='select'``.
-
-        See Also
-        --------
-        mne.viz.plot_layout
-
-        Notes
-        -----
-        This function plots the sensor locations from the info structure using
-        matplotlib. For drawing the sensors using mayavi see
-        :func:`mne.viz.plot_trans`.
-
-        .. versionadded:: 0.12.0
-
         """
         from ..viz.utils import plot_sensors
         return plot_sensors(self.info, kind=kind, ch_type=ch_type, title=title,
                             show_names=show_names, ch_groups=ch_groups,
                             axes=axes, block=block, show=show)
 
+    @copy_function_doc_to_method_doc(anonymize_info)
     def anonymize(self):
-        """Anonymize measurement information in place by removing
-        'subject_info', 'meas_date', 'file_id', 'meas_id' if they exist in
-        ``info``.
-
-        Returns
-        -------
-        self : instance of Raw | Epochs | Evoked
-            The data container.
-
-        Notes
-        -----
-        Operates in place.
-
-        .. versionadded:: 0.13.0
-        """
         anonymize_info(self.info)
         return self
 
@@ -464,70 +435,12 @@ class SetChannelsMixin(object):
 class UpdateChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs, AverageTFR
     """
+    @copy_function_doc_to_method_doc(pick_types)
     def pick_types(self, meg=True, eeg=False, stim=False, eog=False,
                    ecg=False, emg=False, ref_meg='auto', misc=False,
                    resp=False, chpi=False, exci=False, ias=False, syst=False,
                    seeg=False, bio=False, ecog=False, include=[],
                    exclude='bads', selection=None):
-        """Pick some channels by type and names
-
-        Parameters
-        ----------
-        meg : bool | str
-            If True include all MEG channels. If False include None
-            If string it can be 'mag', 'grad', 'planar1' or 'planar2' to select
-            only magnetometers, all gradiometers, or a specific type of
-            gradiometer.
-        eeg : bool
-            If True include EEG channels.
-        stim : bool
-            If True include stimulus channels.
-        eog : bool
-            If True include EOG channels.
-        ecg : bool
-            If True include ECG channels.
-        emg : bool
-            If True include EMG channels.
-        ref_meg: bool | str
-            If True include CTF / 4D reference channels. If 'auto', the
-            reference channels are only included if compensations are present.
-        misc : bool
-            If True include miscellaneous analog channels.
-        resp : bool
-            If True include response-trigger channel. For some MEG systems this
-            is separate from the stim channel.
-        chpi : bool
-            If True include continuous HPI coil channels.
-        exci : bool
-            Flux excitation channel used to be a stimulus channel.
-        ias : bool
-            Internal Active Shielding data (maybe on Triux only).
-        syst : bool
-            System status channel information (on Triux systems only).
-        seeg : bool
-            Stereotactic EEG channels.
-        bio : bool
-            Bio channels.
-        ecog : bool
-            Electrocorticography channels.
-        include : list of string
-            List of additional channels to include. If empty do not include
-            any.
-        exclude : list of string | str
-            List of channels to exclude. If 'bads' (default), exclude channels
-            in ``info['bads']``.
-        selection : list of string
-            Restrict sensor channels (MEG, EEG) to this list of channel names.
-
-        Returns
-        -------
-        inst : instance of Raw, Epochs, or Evoked
-            The modified instance.
-
-        Notes
-        -----
-        .. versionadded:: 0.9.0
-        """
         idx = pick_types(
             self.info, meg=meg, eeg=eeg, stim=stim, eog=eog, ecg=ecg, emg=emg,
             ref_meg=ref_meg, misc=misc, resp=resp, chpi=chpi, exci=exci,

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -101,9 +101,7 @@ class Layout(object):
 
         Notes
         -----
-
         .. versionadded:: 0.12.0
-
         """
         from ..viz.topomap import plot_layout
         return plot_layout(self, show=show)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -31,8 +31,10 @@ from .defaults import _handle_default
 from .epochs import Epochs
 from .event import make_fixed_length_events
 from .utils import (check_fname, logger, verbose, estimate_rank,
-                    _compute_row_norms, check_version, _time_mask, warn)
+                    _compute_row_norms, check_version, _time_mask, warn,
+                    copy_doc, copy_function_doc_to_method_doc)
 from .fixes import in1d
+from . import viz
 
 from .externals.six.moves import zip
 from .externals.six import string_types
@@ -218,38 +220,11 @@ class Covariance(dict):
         return self
 
     @verbose
+    @copy_function_doc_to_method_doc(viz.misc.plot_cov)
     def plot(self, info, exclude=[], colorbar=True, proj=False, show_svd=True,
              show=True, verbose=None):
-        """Plot Covariance data.
-
-        Parameters
-        ----------
-        info: dict
-            Measurement info.
-        exclude : list of string | str
-            List of channels to exclude. If empty do not exclude any channel.
-            If 'bads', exclude info['bads'].
-        colorbar : bool
-            Show colorbar or not.
-        proj : bool
-            Apply projections or not.
-        show_svd : bool
-            Plot also singular values of the noise covariance for each sensor
-            type. We show square roots ie. standard deviations.
-        show : bool
-            Call pyplot.show() as the end or not.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-
-        Returns
-        -------
-        fig_cov : instance of matplotlib.pyplot.Figure
-            The covariance plot.
-        fig_svd : instance of matplotlib.pyplot.Figure | None
-            The SVD spectra plot of the covariance.
-        """
-        from .viz.misc import plot_cov
-        return plot_cov(self, info, exclude, colorbar, proj, show_svd, show)
+        return viz.misc.plot_cov(self, info, exclude, colorbar, proj, show_svd,
+                                 show, verbose)
 
 
 ###############################################################################
@@ -1960,38 +1935,9 @@ def _estimate_rank_meeg_signals(data, info, scalings, tol='auto',
     return out
 
 
+@copy_doc(_estimate_rank_meeg_signals)
 def _estimate_rank_meeg_cov(data, info, scalings, tol='auto',
                             return_singular=False):
-    """Estimate rank for M/EEG data.
-
-    Parameters
-    ----------
-    data : np.ndarray of float, shape (n_channels, n_channels)
-        The M/EEG covariance.
-    info : Info
-        The measurment info.
-    scalings : dict | 'norm' | np.ndarray | None
-        The rescaling method to be applied. If dict, it will override the
-        following default dict:
-
-            dict(mag=1e12, grad=1e11, eeg=1e5)
-
-        If 'norm' data will be scaled by channel-wise norms. If array,
-        pre-specified norms will be used. If None, no scaling will be applied.
-    tol : float | str
-        Tolerance. See ``estimate_rank``.
-    return_singular : bool
-        If True, also return the singular values that were used
-        to determine the rank.
-
-    Returns
-    -------
-    rank : int
-        Estimated rank of the data.
-    s : array
-        If return_singular is True, the singular values that were
-        thresholded to determine the rank are also returned.
-    """
     picks_list = _picks_by_type(info)
     scalings = _handle_default('scalings_cov_rank', scalings)
     _apply_scaling_cov(data, picks_list, scalings)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -32,7 +32,7 @@ from .epochs import Epochs
 from .event import make_fixed_length_events
 from .utils import (check_fname, logger, verbose, estimate_rank,
                     _compute_row_norms, check_version, _time_mask, warn,
-                    copy_doc, copy_function_doc_to_method_doc)
+                    copy_function_doc_to_method_doc)
 from .fixes import in1d
 from . import viz
 
@@ -1909,9 +1909,6 @@ def _estimate_rank_meeg_signals(data, info, scalings, tol='auto',
     return_singular : bool
         If True, also return the singular values that were used
         to determine the rank.
-    copy : bool
-        If False, values in data will be modified in-place during
-        rank estimation (saves memory).
 
     Returns
     -------
@@ -1935,9 +1932,38 @@ def _estimate_rank_meeg_signals(data, info, scalings, tol='auto',
     return out
 
 
-@copy_doc(_estimate_rank_meeg_signals)
 def _estimate_rank_meeg_cov(data, info, scalings, tol='auto',
                             return_singular=False):
+    """Estimate rank of M/EEG covariance data, given the covariance
+
+    Parameters
+    ----------
+    data : np.ndarray of float, shape (n_channels, n_channels)
+        The M/EEG covariance.
+    info : Info
+        The measurment info.
+    scalings : dict | 'norm' | np.ndarray | None
+        The rescaling method to be applied. If dict, it will override the
+        following default dict:
+
+            dict(mag=1e12, grad=1e11, eeg=1e5)
+
+        If 'norm' data will be scaled by channel-wise norms. If array,
+        pre-specified norms will be used. If None, no scaling will be applied.
+    tol : float | str
+        Tolerance. See ``estimate_rank``.
+    return_singular : bool
+        If True, also return the singular values that were used
+        to determine the rank.
+
+    Returns
+    -------
+    rank : int
+        Estimated rank of the data.
+    s : array
+        If return_singular is True, the singular values that were
+        thresholded to determine the rank are also returned.
+    """
     picks_list = _picks_by_type(info)
     scalings = _handle_default('scalings_cov_rank', scalings)
     _apply_scaling_cov(data, picks_list, scalings)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -761,40 +761,40 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return self.info['ch_names']
 
     @copy_function_doc_to_method_doc(plot_epochs)
-    def plot(self, picks=None, scalings=None, show=True,
-             block=False, n_epochs=20,
-             n_channels=20, title=None):
+    def plot(self, picks=None, scalings=None, n_epochs=20, n_channels=20,
+             title=None, show=True, block=False):
         return plot_epochs(self, picks=picks, scalings=scalings,
                            n_epochs=n_epochs, n_channels=n_channels,
                            title=title, show=show, block=block)
 
     @copy_function_doc_to_method_doc(plot_epochs_psd)
-    def plot_psd(self, fmin=0, fmax=np.inf, proj=False, bandwidth=None,
-                 adaptive=False, low_bias=True, normalization='length',
-                 picks=None, ax=None, color='black', area_mode='std',
-                 area_alpha=0.33, dB=True, n_jobs=1, verbose=None, show=True):
-        return plot_epochs_psd(self, fmin=fmin, fmax=fmax, proj=proj,
-                               bandwidth=bandwidth, adaptive=adaptive,
-                               low_bias=low_bias, normalization=normalization,
-                               picks=picks, ax=ax, color=color,
-                               area_mode=area_mode, area_alpha=area_alpha,
-                               dB=dB, n_jobs=n_jobs, verbose=None, show=show)
+    def plot_psd(self, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
+                 bandwidth=None, adaptive=False, low_bias=True,
+                 normalization='length', picks=None, ax=None, color='black',
+                 area_mode='std', area_alpha=0.33, dB=True, n_jobs=1,
+                 show=True, verbose=None):
+        return plot_epochs_psd(self, fmin=fmin, fmax=fmax, tmin=tmin,
+                               tmax=tmax, proj=proj, bandwidth=bandwidth,
+                               adaptive=adaptive, low_bias=low_bias,
+                               normalization=normalization, picks=picks, ax=ax,
+                               color=color, area_mode=area_mode,
+                               area_alpha=area_alpha, dB=dB, n_jobs=n_jobs,
+                               show=show, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_epochs_psd_topomap)
-    def plot_psd_topomap(self, bands=None, vmin=None, vmax=None, proj=False,
-                         bandwidth=None, adaptive=False, low_bias=True,
-                         normalization='length', ch_type=None,
+    def plot_psd_topomap(self, bands=None, vmin=None, vmax=None, tmin=None,
+                         tmax=None, proj=False, bandwidth=None, adaptive=False,
+                         low_bias=True, normalization='length', ch_type=None,
                          layout=None, cmap='RdBu_r', agg_fun=None, dB=True,
                          n_jobs=1, normalize=False, cbar_fmt='%0.3f',
                          outlines='head', axes=None, show=True, verbose=None):
         return plot_epochs_psd_topomap(
-            self, bands=bands, vmin=vmin, vmax=vmax, proj=proj,
-            bandwidth=bandwidth, adaptive=adaptive,
-            low_bias=low_bias, normalization=normalization,
-            ch_type=ch_type, layout=layout, cmap=cmap,
-            agg_fun=agg_fun, dB=dB, n_jobs=n_jobs, normalize=normalize,
-            cbar_fmt=cbar_fmt, outlines=outlines, axes=axes, show=show,
-            verbose=None)
+            self, bands=bands, vmin=vmin, vmax=vmax, tmin=tmin, tmax=tmax,
+            proj=proj, bandwidth=bandwidth, adaptive=adaptive,
+            low_bias=low_bias, normalization=normalization, ch_type=ch_type,
+            layout=layout, cmap=cmap, agg_fun=agg_fun, dB=dB, n_jobs=n_jobs,
+            normalize=normalize, cbar_fmt=cbar_fmt, outlines=outlines,
+            axes=axes, show=show, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_topo_image_epochs)
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,
@@ -896,11 +896,11 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def plot_image(self, picks=None, sigma=0., vmin=None,
                    vmax=None, colorbar=True, order=None, show=True,
                    units=None, scalings=None, cmap='RdBu_r',
-                   fig=None, overlay_times=None):
+                   fig=None, axes=None, overlay_times=None):
         return plot_epochs_image(self, picks=picks, sigma=sigma, vmin=vmin,
                                  vmax=vmax, colorbar=colorbar, order=order,
                                  show=show, units=units, scalings=scalings,
-                                 cmap=cmap, fig=fig,
+                                 cmap=cmap, fig=fig, axes=axes,
                                  overlay_times=overlay_times)
 
     @verbose

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -40,10 +40,10 @@ from .filter import resample, detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import in1d, _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
-                  plot_epochs_image, plot_topo_image_epochs)
+                  plot_epochs_image, plot_topo_image_epochs, plot_drop_log)
 from .utils import (check_fname, logger, verbose, _check_type_picks,
                     _time_mask, check_random_state, warn, _check_copy_dep,
-                    sizeof_fmt, SizeMixin)
+                    sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc)
 from .externals.six import iteritems, string_types
 from .externals.six.moves import zip
 
@@ -760,126 +760,19 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """Channel names"""
         return self.info['ch_names']
 
+    @copy_function_doc_to_method_doc(plot_epochs)
     def plot(self, picks=None, scalings=None, show=True,
              block=False, n_epochs=20,
              n_channels=20, title=None):
-        """Visualize epochs.
-
-        Bad epochs can be marked with a left click on top of the epoch. Bad
-        channels can be selected by clicking the channel name on the left side
-        of the main axes. Calling this function drops all the selected bad
-        epochs as well as bad epochs marked beforehand with rejection
-        parameters.
-
-        Parameters
-        ----------
-        picks : array-like of int | None
-            Channels to be included. If None only good data channels are used.
-            Defaults to None
-        scalings : dict | None
-            Scaling factors for the traces. If any fields in scalings are
-            'auto', the scaling factor is set to match the 99.5th percentile of
-            a subset of the corresponding data. If scalings == 'auto', all
-            scalings fields are set to 'auto'. If any fields are 'auto' and
-            data is not preloaded, a subset of epochs up to 100mb will be
-            loaded. If None, defaults to::
-
-                dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
-                     emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1,
-                     chpi=1e-4)
-
-        show : bool
-            Whether to show the figure or not.
-        block : bool
-            Whether to halt program execution until the figure is closed.
-            Useful for rejecting bad trials on the fly by clicking on a
-            sub plot.
-        n_epochs : int
-            The number of epochs per view.
-        n_channels : int
-            The number of channels per view on mne_browse_epochs. If trellis is
-            True, this parameter has no effect. Defaults to 20.
-        title : str | None
-            The title of the window. If None, epochs name will be displayed.
-            If trellis is True, this parameter has no effect.
-            Defaults to None.
-
-        Returns
-        -------
-        fig : Instance of matplotlib.figure.Figure
-            The figure.
-
-        Notes
-        -----
-        The arrow keys (up/down/left/right) can
-        be used to navigate between channels and epochs and the scaling can be
-        adjusted with - and + (or =) keys, but this depends on the backend
-        matplotlib is configured to use (e.g., mpl.use(``TkAgg``) should work).
-        Full screen mode can be toggled with f11 key. The amount of epochs
-        and channels per view can be adjusted with home/end and
-        page down/page up keys. Butterfly plot can be toggled with ``b`` key.
-        Right mouse click adds a vertical line to the plot.
-
-        .. versionadded:: 0.10.0
-        """
         return plot_epochs(self, picks=picks, scalings=scalings,
                            n_epochs=n_epochs, n_channels=n_channels,
                            title=title, show=show, block=block)
 
+    @copy_function_doc_to_method_doc(plot_epochs_psd)
     def plot_psd(self, fmin=0, fmax=np.inf, proj=False, bandwidth=None,
                  adaptive=False, low_bias=True, normalization='length',
                  picks=None, ax=None, color='black', area_mode='std',
                  area_alpha=0.33, dB=True, n_jobs=1, verbose=None, show=True):
-        """Plot the power spectral density across epochs
-
-        Parameters
-        ----------
-        fmin : float
-            Start frequency to consider.
-        fmax : float
-            End frequency to consider.
-        proj : bool
-            Apply projection.
-        bandwidth : float
-            The bandwidth of the multi taper windowing function in Hz.
-            The default value is a window half-bandwidth of 4.
-        adaptive : bool
-            Use adaptive weights to combine the tapered spectra into PSD
-            (slow, use n_jobs >> 1 to speed up computation).
-        low_bias : bool
-            Only use tapers with more than 90% spectral concentration within
-            bandwidth.
-        normalization : str
-            Either "full" or "length" (default). If "full", the PSD will
-            be normalized by the sampling rate as well as the length of
-            the signal (as in nitime).
-        picks : array-like of int | None
-            List of channels to use.
-        ax : instance of matplotlib Axes | None
-            Axes to plot into. If None, axes will be created.
-        color : str | tuple
-            A matplotlib-compatible color to use.
-        area_mode : str | None
-            Mode for plotting area. If 'std', the mean +/- 1 STD (across
-            channels) will be plotted. If 'range', the min and max (across
-            channels) will be plotted. Bad channels will be excluded from
-            these calculations. If None, no area will be plotted.
-        area_alpha : float
-            Alpha for the area.
-        dB : bool
-            If True, transform data to decibels.
-        n_jobs : int
-            Number of jobs to run in parallel.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-        show : bool
-            Show figure if True.
-
-        Returns
-        -------
-        fig : instance of matplotlib figure
-            Figure distributing one image per channel across sensor topography.
-        """
         return plot_epochs_psd(self, fmin=fmin, fmax=fmax, proj=proj,
                                bandwidth=bandwidth, adaptive=adaptive,
                                low_bias=low_bias, normalization=normalization,
@@ -887,106 +780,13 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                area_mode=area_mode, area_alpha=area_alpha,
                                dB=dB, n_jobs=n_jobs, verbose=None, show=show)
 
+    @copy_function_doc_to_method_doc(plot_epochs_psd_topomap)
     def plot_psd_topomap(self, bands=None, vmin=None, vmax=None, proj=False,
                          bandwidth=None, adaptive=False, low_bias=True,
                          normalization='length', ch_type=None,
                          layout=None, cmap='RdBu_r', agg_fun=None, dB=True,
                          n_jobs=1, normalize=False, cbar_fmt='%0.3f',
                          outlines='head', axes=None, show=True, verbose=None):
-        """Plot the topomap of the power spectral density across epochs
-
-        Parameters
-        ----------
-        bands : list of tuple | None
-            The lower and upper frequency and the name for that band. If None,
-            (default) expands to:
-
-            bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
-                     (12, 30, 'Beta'), (30, 45, 'Gamma')]
-
-        vmin : float | callable | None
-            The value specifying the lower bound of the color range.
-            If None, and vmax is None, -vmax is used. Else np.min(data).
-            If callable, the output equals vmin(data).
-        vmax : float | callable | None
-            The value specifying the upper bound of the color range.
-            If None, the maximum absolute value is used. If callable, the
-            output equals vmax(data). Defaults to None.
-        proj : bool
-            Apply projection.
-        bandwidth : float
-            The bandwidth of the multi taper windowing function in Hz.
-            The default value is a window half-bandwidth of 4 Hz.
-        adaptive : bool
-            Use adaptive weights to combine the tapered spectra into PSD
-            (slow, use n_jobs >> 1 to speed up computation).
-        low_bias : bool
-            Only use tapers with more than 90% spectral concentration within
-            bandwidth.
-        normalization : str
-            Either "full" or "length" (default). If "full", the PSD will
-            be normalized by the sampling rate as well as the length of
-            the signal (as in nitime).
-        ch_type : {None, 'mag', 'grad', 'planar1', 'planar2', 'eeg'}
-            The channel type to plot. For 'grad', the gradiometers are
-            collected in
-            pairs and the RMS for each pair is plotted. If None, defaults to
-            'mag' if MEG data are present and to 'eeg' if only EEG data are
-            present.
-        layout : None | Layout
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If possible, the correct layout
-            file is inferred from the data; if no appropriate layout file was
-            found, the layout is automatically generated from the sensor
-            locations.
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-            Colormap to use. If tuple, the first value indicates the colormap
-            to use and the second value is a boolean defining interactivity. In
-            interactive mode the colors are adjustable by clicking and dragging
-            the colorbar with left and right mouse button. Left mouse button
-            moves the scale up and down and right mouse button adjusts the
-            range. Hitting space bar resets the range. Up and down arrows can
-            be used to change the colormap. If None (default), 'Reds' is used
-            for all positive data, otherwise defaults to 'RdBu_r'. If
-            'interactive', translates to (None, True).
-        agg_fun : callable
-            The function used to aggregate over frequencies.
-            Defaults to np.sum. if normalize is True, else np.mean.
-        dB : bool
-            If True, transform data to decibels (with ``10 * np.log10(data)``)
-            following the application of `agg_fun`. Only valid if normalize
-            is False.
-        n_jobs : int
-            Number of jobs to run in parallel.
-        normalize : bool
-            If True, each band will be divided by the total power. Defaults to
-            False.
-        cbar_fmt : str
-            The colorbar format. Defaults to '%0.3f'.
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
-        axes : list of axes | None
-            List of axes to plot consecutive topographies to. If None the axes
-            will be created automatically. Defaults to None.
-        show : bool
-            Show figure if True.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-
-        Returns
-        -------
-        fig : instance of matplotlib figure
-            Figure distributing one image per channel across sensor topography.
-        """
         return plot_epochs_psd_topomap(
             self, bands=bands, vmin=vmin, vmax=vmax, proj=proj,
             bandwidth=bandwidth, adaptive=adaptive,
@@ -996,61 +796,12 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             cbar_fmt=cbar_fmt, outlines=outlines, axes=axes, show=show,
             verbose=None)
 
+    @copy_function_doc_to_method_doc(plot_topo_image_epochs)
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,
                         colorbar=True, order=None, cmap='RdBu_r',
                         layout_scale=.95, title=None, scalings=None,
                         border='none', fig_facecolor='k', fig_background=None,
                         font_color='w', show=True):
-        """Plot Event Related Potential / Fields image on topographies
-
-        Parameters
-        ----------
-        layout: instance of Layout
-            System specific sensor positions.
-        sigma : float
-            The standard deviation of the Gaussian smoothing to apply along the
-            epoch axis to apply in the image. If 0., no smoothing is applied.
-        vmin : float
-            The min value in the image. The unit is uV for EEG channels,
-            fT for magnetometers and fT/cm for gradiometers.
-        vmax : float
-            The max value in the image. The unit is uV for EEG channels,
-            fT for magnetometers and fT/cm for gradiometers.
-        colorbar : bool
-            Display or not a colorbar.
-        order : None | array of int | callable
-            If not None, order is used to reorder the epochs on the y-axis
-            of the image. If it's an array of int it should be of length
-            the number of good epochs. If it's a callable the arguments
-            passed are the times vector and the data as 2d array
-            (data.shape[1] == len(times)).
-        cmap : instance of matplotlib.pyplot.colormap
-            Colors to be mapped to the values.
-        layout_scale: float
-            scaling factor for adjusting the relative size of the layout
-            on the canvas.
-        title : str
-            Title of the figure.
-        scalings : dict | None
-            The scalings of the channel types to be applied for plotting. If
-            None, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
-        border : str
-            matplotlib borders style to be used for each sensor plot.
-        fig_facecolor : str | obj
-            The figure face color. Defaults to black.
-        fig_background : None | array
-            A background image for the figure. This must be a valid input to
-            `matplotlib.pyplot.imshow`. Defaults to None.
-        font_color : str | obj
-            The color of tick labels in the colorbar. Defaults to white.
-        show : bool
-            Show figure if True.
-
-        Returns
-        -------
-        fig : instance of matplotlib figure
-            Figure distributing one image per channel across sensor topography.
-        """
         return plot_topo_image_epochs(
             self, layout=layout, sigma=sigma, vmin=vmin, vmax=vmax,
             colorbar=colorbar, order=order, cmap=cmap,
@@ -1129,109 +880,23 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """
         return _drop_log_stats(self.drop_log, ignore)
 
+    @copy_function_doc_to_method_doc(plot_drop_log)
     def plot_drop_log(self, threshold=0, n_max_plot=20, subject='Unknown',
                       color=(0.9, 0.9, 0.9), width=0.8, ignore=('IGNORED',),
                       show=True):
-        """Show the channel stats based on a drop_log from Epochs
-
-        Parameters
-        ----------
-        threshold : float
-            The percentage threshold to use to decide whether or not to
-            plot. Default is zero (always plot).
-        n_max_plot : int
-            Maximum number of channels to show stats for.
-        subject : str
-            The subject name to use in the title of the plot.
-        color : tuple | str
-            Color to use for the bars.
-        width : float
-            Width of the bars.
-        ignore : list
-            The drop reasons to ignore.
-        show : bool
-            Show figure if True.
-
-        Returns
-        -------
-        perc : float
-            Total percentage of epochs dropped.
-        fig : Instance of matplotlib.figure.Figure
-            The figure.
-        """
         if not self._bad_dropped:
             raise ValueError("You cannot use plot_drop_log since bad "
                              "epochs have not yet been dropped. "
                              "Use epochs.drop_bad().")
-
-        from .viz import plot_drop_log
         return plot_drop_log(self.drop_log, threshold, n_max_plot, subject,
                              color=color, width=width, ignore=ignore,
                              show=show)
 
+    @copy_function_doc_to_method_doc(plot_epochs_image)
     def plot_image(self, picks=None, sigma=0., vmin=None,
                    vmax=None, colorbar=True, order=None, show=True,
                    units=None, scalings=None, cmap='RdBu_r',
                    fig=None, overlay_times=None):
-        """Plot Event Related Potential / Fields image
-
-        Parameters
-        ----------
-        picks : int | array-like of int | None
-            The indices of the channels to consider. If None, the first
-            five good channels are plotted.
-        sigma : float
-            The standard deviation of the Gaussian smoothing to apply along
-            the epoch axis to apply in the image. If 0., no smoothing is
-            applied.
-        vmin : float
-            The min value in the image. The unit is uV for EEG channels,
-            fT for magnetometers and fT/cm for gradiometers.
-        vmax : float
-            The max value in the image. The unit is uV for EEG channels,
-            fT for magnetometers and fT/cm for gradiometers.
-        colorbar : bool
-            Display or not a colorbar.
-        order : None | array of int | callable
-            If not None, order is used to reorder the epochs on the y-axis
-            of the image. If it's an array of int it should be of length
-            the number of good epochs. If it's a callable the arguments
-            passed are the times vector and the data as 2d array
-            (data.shape[1] == len(times).
-        show : bool
-            Show figure if True.
-        units : dict | None
-            The units of the channel types used for axes lables. If None,
-            defaults to `units=dict(eeg='uV', grad='fT/cm', mag='fT')`.
-        scalings : dict | None
-            The scalings of the channel types to be applied for plotting.
-            If None, defaults to `scalings=dict(eeg=1e6, grad=1e13, mag=1e15,
-            eog=1e6)`.
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive'
-            Colormap. If tuple, the first value indicates the colormap to use
-            and the second value is a boolean defining interactivity. In
-            interactive mode the colors are adjustable by clicking and dragging
-            the colorbar with left and right mouse button. Left mouse button
-            moves the scale up and down and right mouse button adjusts the
-            range. Hitting space bar resets the scale. Up and down arrows can
-            be used to change the colormap. If 'interactive', translates to
-            ('RdBu_r', True). Defaults to 'RdBu_r'.
-        fig : matplotlib figure | None
-            Figure instance to draw the image to. Figure must contain two
-            axes for drawing the single trials and evoked responses. If
-            None a new figure is created. Defaults to None.
-        overlay_times : array-like, shape (n_epochs,) | None
-            If not None the parameter is interpreted as time instants in
-            seconds and is added to the image. It is typically useful to
-            display reaction times. Note that it is defined with respect
-            to the order of epochs such that overlay_times[0] corresponds
-            to epochs[0].
-
-        Returns
-        -------
-        figs : list of matplotlib figures
-            One figure per channel displayed.
-        """
         return plot_epochs_image(self, picks=picks, sigma=sigma, vmin=vmin,
                                  vmax=vmax, colorbar=colorbar, order=order,
                                  show=show, units=units, scalings=scalings,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -303,6 +303,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                   proj=False, vline=[0.0], fig_facecolor='k',
                   fig_background=None, axis_facecolor='k', font_color='w',
                   merge_grads=False, show=True):
+        """
+
+        Notes
+        -----
+        .. versionadded:: 0.10.0
+        """
         return plot_evoked_topo(self, layout=layout, layout_scale=layout_scale,
                                 color=color, border=border, ylim=ylim,
                                 scalings=scalings, title=title, proj=proj,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -17,7 +17,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
 from .filter import resample, detrend, FilterMixin
 from .fixes import in1d
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
-                    deprecated, SizeMixin)
+                    deprecated, SizeMixin, copy_function_doc_to_method_doc)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import (_plot_evoked_white, plot_evoked_joint,
@@ -187,6 +187,16 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Start time of selection in seconds.
         tmax : float | None
             End time of selection in seconds.
+
+        Returns
+        -------
+        evoked : instance of Evoked
+            The cropped Evoked object.
+
+        Notes
+        -----
+        Unlike Python slices, MNE time intervals include both their end points;
+        crop(tmin, tmax) returns the interval tmin <= t <= tmax.
         """
         mask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'])
         self.times = self.times[mask]
@@ -266,94 +276,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self.times = np.arange(self.first, self.last + 1,
                                dtype=np.float) / sfreq
 
+    @copy_function_doc_to_method_doc(plot_evoked)
     def plot(self, picks=None, exclude='bads', unit=True, show=True, ylim=None,
              xlim='tight', proj=False, hline=None, units=None, scalings=None,
              titles=None, axes=None, gfp=False, window_title=None,
              spatial_colors=False, zorder='unsorted', selectable=True):
-        """Plot evoked data using butterfly plots
-
-        Left click to a line shows the channel name. Selecting an area by
-        clicking and holding left mouse button plots a topographic map of the
-        painted area.
-
-        Note: If bad channels are not excluded they are shown in red.
-
-        Parameters
-        ----------
-        picks : array-like of int | None
-            The indices of channels to plot. If None show all.
-        exclude : list of str | 'bads'
-            Channels names to exclude from being shown. If 'bads', the
-            bad channels are excluded.
-        unit : bool
-            Scale plot with channel (SI) unit.
-        show : bool
-            Call pyplot.show() at the end or not.
-        ylim : dict | None
-            ylim for plots (after scaling has been applied). The value
-            determines the upper and lower subplot limits. e.g.
-            ylim = dict(eeg=[-20, 20]). Valid keys are eeg, mag, grad. If None,
-            the ylim parameter for each channel is determined by the maximum
-            absolute peak.
-        xlim : 'tight' | tuple | None
-            xlim for plots.
-        proj : bool | 'interactive'
-            If true SSP projections are applied before display. If
-            'interactive', a check box for reversible selection of SSP
-            projection vectors will be shown.
-        hline : list of floats | None
-            The values at which show an horizontal line.
-        units : dict | None
-            The units of the channel types used for axes lables. If None,
-            defaults to `dict(eeg='uV', grad='fT/cm', mag='fT')`.
-        scalings : dict | None
-            The scalings of the channel types to be applied for plotting.
-            If None, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
-        titles : dict | None
-            The titles associated with the channels. If None, defaults to
-            `dict(eeg='EEG', grad='Gradiometers', mag='Magnetometers')`.
-        axes : instance of Axes | list | None
-            The axes to plot to. If list, the list must be a list of Axes of
-            the same length as the number of channel types. If instance of
-            Axes, there must be only one channel type plotted.
-        gfp : bool | 'only'
-            Plot GFP in green if True or "only". If "only", then the individual
-            channel traces will not be shown.
-        window_title : str | None
-            The title to put at the top of the figure window.
-        spatial_colors : bool
-            If True, the lines are color coded by mapping physical sensor
-            coordinates into color values. Spatially similar channels will have
-            similar colors. Bad channels will be dotted. If False, the good
-            channels are plotted black and bad channels red. Defaults to False.
-        zorder : str | callable
-            Which channels to put in the front or back. Only matters if
-            `spatial_colors` is used.
-            If str, must be `std` or `unsorted` (defaults to `unsorted`). If
-            `std`, data with the lowest standard deviation (weakest effects)
-            will be put in front so that they are not obscured by those with
-            stronger effects. If `unsorted`, channels are z-sorted as in the
-            evoked instance.
-            If callable, must take one argument: a numpy array of the same
-            dimensionality as the evoked raw data; and return a list of
-            unique integers corresponding to the number of channels.
-
-            .. versionadded:: 0.13.0
-
-        selectable : bool
-            Whether to use interactive features. If True (default), it is
-            possible to paint an area to draw topomaps. When False, the
-            interactive features are disabled. Disabling interactive features
-            reduces memory consumption and is useful when using ``axes``
-            parameter to draw multiaxes figures.
-
-            .. versionadded:: 0.13.0
-
-        Returns
-        -------
-        fig : instance of matplotlib.figure.Figure
-            Figure containing the butterfly plots.
-        """
         return plot_evoked(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             ylim=ylim, proj=proj, xlim=xlim, hline=hline, units=units,
@@ -361,129 +288,21 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             window_title=window_title, spatial_colors=spatial_colors,
             zorder=zorder, selectable=selectable)
 
+    @copy_function_doc_to_method_doc(plot_evoked_image)
     def plot_image(self, picks=None, exclude='bads', unit=True, show=True,
                    clim=None, xlim='tight', proj=False, units=None,
                    scalings=None, titles=None, axes=None, cmap='RdBu_r'):
-        """Plot evoked data as images
-
-        Parameters
-        ----------
-        picks : array-like of int | None
-            The indices of channels to plot. If None show all.
-        exclude : list of str | 'bads'
-            Channels names to exclude from being shown. If 'bads', the
-            bad channels are excluded.
-        unit : bool
-            Scale plot with channel (SI) unit.
-        show : bool
-            Call pyplot.show() at the end or not.
-        clim : dict
-            clim for images. e.g. clim = dict(eeg=[-200e-6, 200e6])
-            Valid keys are eeg, mag, grad
-        xlim : 'tight' | tuple | None
-            xlim for plots.
-        proj : bool | 'interactive'
-            If true SSP projections are applied before display. If
-            'interactive', a check box for reversible selection of SSP
-            projection vectors will be shown.
-        units : dict | None
-            The units of the channel types used for axes lables. If None,
-            defaults to `dict(eeg='uV', grad='fT/cm', mag='fT')`.
-        scalings : dict | None
-            The scalings of the channel types to be applied for plotting.
-            If None, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
-        titles : dict | None
-            The titles associated with the channels. If None, defaults to
-            `dict(eeg='EEG', grad='Gradiometers', mag='Magnetometers')`.
-        axes : instance of Axes | list | None
-            The axes to plot to. If list, the list must be a list of Axes of
-            the same length as the number of channel types. If instance of
-            Axes, there must be only one channel type plotted.
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive'
-            Colormap. If tuple, the first value indicates the colormap to use
-            and the second value is a boolean defining interactivity. In
-            interactive mode the colors are adjustable by clicking and dragging
-            the colorbar with left and right mouse button. Left mouse button
-            moves the scale up and down and right mouse button adjusts the
-            range. Hitting space bar resets the scale. Up and down arrows can
-            be used to change the colormap. If 'interactive', translates to
-            ('RdBu_r', True). Defaults to 'RdBu_r'.
-
-        Returns
-        -------
-        fig : instance of matplotlib.figure.Figure
-            Figure containing the images.
-        """
         return plot_evoked_image(self, picks=picks, exclude=exclude, unit=unit,
                                  show=show, clim=clim, proj=proj, xlim=xlim,
                                  units=units, scalings=scalings,
                                  titles=titles, axes=axes, cmap=cmap)
 
+    @copy_function_doc_to_method_doc(plot_evoked_topo)
     def plot_topo(self, layout=None, layout_scale=0.945, color=None,
                   border='none', ylim=None, scalings=None, title=None,
                   proj=False, vline=[0.0], fig_facecolor='k',
                   fig_background=None, axis_facecolor='k', font_color='w',
                   merge_grads=False, show=True):
-        """Plot 2D topography of evoked responses.
-
-        Clicking on the plot of an individual sensor opens a new figure showing
-        the evoked response for the selected sensor.
-
-        Parameters
-        ----------
-        layout : instance of Layout | None
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If possible, the correct layout is
-            inferred from the data.
-        layout_scale: float
-            Scaling factor for adjusting the relative size of the layout
-            on the canvas
-        color : list of color objects | color object | None
-            Everything matplotlib accepts to specify colors. If not list-like,
-            the color specified will be repeated. If None, colors are
-            automatically drawn.
-        border : str
-            matplotlib borders style to be used for each sensor plot.
-        ylim : dict | None
-            ylim for plots. The value determines the upper and lower subplot
-            limits. e.g. ylim = dict(eeg=[-20, 20]). Valid keys are eeg,
-            mag, grad, misc. If None, the ylim parameter for each channel is
-            determined by the maximum absolute peak.
-        scalings : dict | None
-            The scalings of the channel types to be applied for plotting. If
-            None, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
-        title : str
-            Title of the figure.
-        proj : bool | 'interactive'
-            If true SSP projections are applied before display. If
-            'interactive', a check box for reversible selection of SSP
-            projection vectors will be shown.
-        vline : list of floats | None
-            The values at which to show a vertical line.
-        fig_facecolor : str | obj
-            The figure face color. Defaults to black.
-        fig_background : None | numpy ndarray
-            A background image for the figure. This must work with a call to
-            plt.imshow. Defaults to None.
-        axis_facecolor : str | obj
-            The face color to be used for each sensor plot. Defaults to black.
-        font_color : str | obj
-            The color of text in the colorbar and title. Defaults to white.
-        merge_grads : bool
-            Whether to use RMS value of gradiometer pairs. Only works for
-            Neuromag data. Defaults to False.
-        show : bool
-            Show figure if True.
-
-        Returns
-        -------
-        fig : Instance of matplotlib.figure.Figure
-            Images of evoked responses at sensor locations
-
-        Notes
-        -----
-        .. versionadded:: 0.10.0
-        """
         return plot_evoked_topo(self, layout=layout, layout_scale=layout_scale,
                                 color=color, border=border, ylim=ylim,
                                 scalings=scalings, title=title, proj=proj,
@@ -493,6 +312,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                 font_color=font_color, merge_grads=merge_grads,
                                 show=show)
 
+    @copy_function_doc_to_method_doc(plot_evoked_topomap)
     def plot_topomap(self, times="auto", ch_type=None, layout=None, vmin=None,
                      vmax=None, cmap=None, sensors=True, colorbar=True,
                      scale=None, scale_time=1e3, unit=None, res=64, size=1,
@@ -501,134 +321,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                      mask_params=None, outlines='head', contours=6,
                      image_interp='bilinear', average=None, head_pos=None,
                      axes=None):
-        """Plot topographic maps of specific time points
-
-        Parameters
-        ----------
-        times : float | array of floats | "auto" | "peaks".
-            The time point(s) to plot. If "auto", the number of ``axes``
-            determines the amount of time point(s). If ``axes`` is also None,
-            10 topographies will be shown with a regular time spacing between
-            the first and last time instant. If "peaks", finds time points
-            automatically by checking for local maxima in Global Field Power.
-        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
-            The channel type to plot. For 'grad', the gradiometers are collec-
-            ted in pairs and the RMS for each pair is plotted.
-            If None, then first available channel type from order given
-            above is used. Defaults to None.
-        layout : None | Layout
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If possible, the correct
-            layout file is inferred from the data; if no appropriate layout
-            file was found, the layout is automatically generated from the
-            sensor locations.
-        vmin : float | callable
-            The value specfying the lower bound of the color range.
-            If None, and vmax is None, -vmax is used. Else np.min(data).
-            If callable, the output equals vmin(data).
-        vmax : float | callable
-            The value specfying the upper bound of the color range.
-            If None, the maximum absolute value is used. If vmin is None,
-            but vmax is not, defaults to np.max(data).
-            If callable, the output equals vmax(data).
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-            Colormap to use. If tuple, the first value indicates the colormap
-            to use and the second value is a boolean defining interactivity. In
-            interactive mode the colors are adjustable by clicking and dragging
-            the colorbar with left and right mouse button. Left mouse button
-            moves the scale up and down and right mouse button adjusts the
-            range. Hitting space bar resets the range. Up and down arrows can
-            be used to change the colormap. If None (default), 'Reds' is used
-            for all positive data, otherwise defaults to 'RdBu_r'. If
-            'interactive', translates to (None, True).
-
-            .. warning::  Interactive mode works smoothly only for a small
-                amount of topomaps.
-
-        sensors : bool | str
-            Add markers for sensor locations to the plot. Accepts matplotlib
-            plot format string (e.g., 'r+' for red plusses). If True, a circle
-            will be used (via .add_artist). Defaults to True.
-        colorbar : bool
-            Plot a colorbar.
-        scale : dict | float | None
-            Scale the data for plotting. If None, defaults to 1e6 for eeg, 1e13
-            for grad and 1e15 for mag.
-        scale_time : float | None
-            Scale the time labels. Defaults to 1e3 (ms).
-        unit : dict | str | None
-            The unit of the channel type used for colorbar label. If
-            scale is None the unit is automatically determined.
-        res : int
-            The resolution of the topomap image (n pixels along each side).
-        size : scalar
-            Side length of the topomaps in inches (only applies when plotting
-            multiple topomaps at a time).
-        cbar_fmt : str
-            String format for colorbar values.
-        time_format : str
-            String format for topomap values. Defaults to ``"%01d ms"``.
-        proj : bool | 'interactive'
-            If true SSP projections are applied before display. If
-            'interactive', a check box for reversible selection of SSP
-            projection vectors will be shown.
-        show : bool
-            Call pyplot.show() at the end.
-        show_names : bool | callable
-            If True, show channel names on top of the map. If a callable is
-            passed, channel names will be formatted using the callable; e.g.,
-            to delete the prefix 'MEG ' from all channel names, pass the
-            function
-            lambda x: x.replace('MEG ', ''). If `mask` is not None, only
-            significant sensors will be shown.
-        title : str | None
-            Title. If None (default), no title is displayed.
-        mask : ndarray of bool, shape (n_channels, n_times) | None
-            The channels to be marked as significant at a given time point.
-            Indices set to `True` will be considered. Defaults to None.
-        mask_params : dict | None
-            Additional plotting parameters for plotting significant sensors.
-            Default (None) equals:
-            ``dict(marker='o', markerfacecolor='w', markeredgecolor='k',
-            linewidth=0, markersize=4)``.
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
-        contours : int | False | None
-            The number of contour lines to draw. If 0, no contours will be
-            drawn.
-        image_interp : str
-            The image interpolation to be used. All matplotlib options are
-            accepted.
-        average : float | None
-            The time window around a given time to be used for averaging
-            (seconds). For example, 0.01 would translate into window that
-            starts 5 ms before and ends 5 ms after a given time point.
-            Defaults to None, which means no averaging.
-        head_pos : dict | None
-            If None (default), the sensors are positioned such that they span
-            the head circle. If dict, can have entries 'center' (tuple) and
-            'scale' (tuple) for what the center and scale of the head should be
-            relative to the electrode locations.
-        axes : instance of Axes | list | None
-            The axes to plot to. If list, the list must be a list of Axes of
-            the same length as ``times`` (unless ``times`` is None). If
-            instance of Axes, ``times`` must be a float or a list of one float.
-            Defaults to None.
-
-        Returns
-        -------
-        fig : instance of matplotlib.figure.Figure
-            Images of evoked responses at sensor locations
-        """
         return plot_evoked_topomap(self, times=times, ch_type=ch_type,
                                    layout=layout, vmin=vmin, vmax=vmax,
                                    cmap=cmap, sensors=sensors,
@@ -642,27 +334,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                    image_interp=image_interp, average=average,
                                    head_pos=head_pos, axes=axes)
 
+    @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',
                    n_jobs=1):
-        """Plot MEG/EEG fields on head surface and helmet in 3D
-
-        Parameters
-        ----------
-        surf_maps : list
-            The surface mapping information obtained with make_field_map.
-        time : float | None
-            The time point at which the field map shall be displayed. If None,
-            the average peak latency (across sensor types) is used.
-        time_label : str
-            How to print info about the time instant visualized.
-        n_jobs : int
-            Number of jobs to run in parallel.
-
-        Returns
-        -------
-        fig : instance of mlab.Figure
-            The mayavi figure.
-        """
         return plot_evoked_field(self, surf_maps, time=time,
                                  time_label=time_label, n_jobs=n_jobs)
 
@@ -706,53 +380,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return _plot_evoked_white(self, noise_cov=noise_cov, scalings=None,
                                   rank=None, show=show)
 
+    @copy_function_doc_to_method_doc(plot_evoked_joint)
     def plot_joint(self, times="peaks", title='', picks=None,
                    exclude='bads', show=True, ts_args=None,
                    topomap_args=None):
-        """Plot evoked data as butterfly plots and add topomaps for selected
-        time points.
-
-        Parameters
-        ----------
-        times : float | array of floats | "auto" | "peaks"
-            The time point(s) to plot. If "auto", 5 evenly spaced topographies
-            between the first and last time instant will be shown. If "peaks",
-            finds time points automatically by checking for 3 local
-            maxima in Global Field Power. Defaults to "peaks".
-        title : str
-            The title. If ``None``, suppress printing channel type. Defaults to
-            an empty string.
-        picks : array-like of int | None
-            The indices of channels to plot. If ``None``, show all. Defaults
-            to None.
-        exclude : list of str | 'bads'
-            Channels names to exclude from being shown. If 'bads', the
-            bad channels are excluded. Defaults to 'bads'.
-        show : bool
-            Show figure if True. Defaults to True.
-        ts_args : None | dict
-            A dict of `kwargs` that are forwarded to `evoked.plot` to
-            style the butterfly plot. `axes` and `show` are ignored.
-            If `spatial_colors` is not in this dict, `spatial_colors=True`,
-            and (if it is not in the dict) `zorder='std'` will be passed.
-            Beyond that, if `None`, no customizable arguments will be passed.
-        topomap_args : None | dict
-            A dict of `kwargs` that are forwarded to `evoked.plot_topomap`
-            to style the topomaps. `axes` and `show` are ignored. If `times`
-            is not in this dict, automatic peak detection is used. Beyond
-            that, if `None`, no customizable arguments will be passed.
-
-        Returns
-        -------
-        fig : instance of matplotlib.figure.Figure | list
-            The figure object containing the plot. If `evoked` has multiple
-            channel types, a list of figures, one for each channel type, is
-            returned.
-
-        Notes
-        -----
-        .. versionadded:: 0.12.0
-        """
         return plot_evoked_joint(self, times=times, title=title, picks=picks,
                                  exclude=exclude, show=show, ts_args=ts_args,
                                  topomap_args=topomap_args)
@@ -847,6 +478,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             a power-of-two size (can be much faster).
         window : string or tuple
             Window to use in resampling. See scipy.signal.resample.
+
+        Returns
+        -------
+        evoked : instance of mne.Evoked
+            The resampled evoked object.
         """
         sfreq = float(sfreq)
         o_sfreq = self.info['sfreq']
@@ -857,6 +493,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                       self.times[0])
         self.first = int(self.times[0] * self.info['sfreq'])
         self.last = len(self.times) + self.first - 1
+        return self
 
     def detrend(self, order=1, picks=None):
         """Detrend data
@@ -874,7 +511,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         Returns
         -------
         evoked : instance of Evoked
-            The evoked instance.
+            The detrended evoked object.
         """
         if picks is None:
             picks = _pick_data_channels(self.info)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1506,13 +1506,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,
                       n_fft=2048, n_overlap=0, layout=None, color='w',
                       fig_facecolor='k', axis_facecolor='k', dB=True,
-                      show=True, n_jobs=1, verbose=None):
+                      show=True, block=False, n_jobs=1, verbose=None):
         return plot_raw_psd_topo(self, tmin=tmin, tmax=tmax, fmin=fmin,
                                  fmax=fmax, proj=proj, n_fft=n_fft,
                                  n_overlap=n_overlap, layout=layout,
                                  color=color, fig_facecolor=fig_facecolor,
                                  axis_facecolor=axis_facecolor, dB=dB,
-                                 show=show, n_jobs=n_jobs, verbose=verbose)
+                                 show=show, block=block, n_jobs=n_jobs,
+                                 verbose=verbose)
 
     def estimate_rank(self, tstart=0.0, tstop=30.0, tol=1e-4,
                       return_singular=False, picks=None, scalings='norm'):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -17,7 +17,7 @@ import numpy as np
 from .constants import FIFF
 from .pick import pick_types, channel_type, pick_channels, pick_info
 from .pick import _pick_data_channels, _pick_data_or_ica
-from .meas_info import write_meas_info, anonymize_info
+from .meas_info import write_meas_info
 from .proj import setup_proj, activate_proj, _proj_equal, ProjMixin
 from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                  SetChannelsMixin, InterpolationMixin)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -35,7 +35,8 @@ from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_pandas_index_arguments, _check_copy_dep,
                      check_fname, _get_stim_channel,
-                     logger, verbose, _time_mask, warn, SizeMixin)
+                     logger, verbose, _time_mask, warn, SizeMixin,
+                     copy_function_doc_to_method_doc)
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
 from ..defaults import _handle_default
 from ..externals.six import string_types
@@ -1478,222 +1479,34 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                    start, stop, buffer_size, projector, drop_small_buffer,
                    split_size, 0, None)
 
+    @copy_function_doc_to_method_doc(plot_raw)
     def plot(self, events=None, duration=10.0, start=0.0, n_channels=20,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
              event_color='cyan', scalings=None, remove_dc=True, order='type',
              show_options=False, title=None, show=True, block=False,
              highpass=None, lowpass=None, filtorder=4, clipping=None):
-        """Plot raw data
-
-        Parameters
-        ----------
-        events : array | None
-            Events to show with vertical bars.
-        duration : float
-            Time window (sec) to plot in a given time.
-        start : float
-            Initial time to show (can be changed dynamically once plotted).
-        n_channels : int
-            Number of channels to plot at once. Defaults to 20. Has no effect
-            if ``order`` is 'position' or 'selection'.
-        bgcolor : color object
-            Color of the background.
-        color : dict | color object | None
-            Color for the data traces. If None, defaults to::
-
-                dict(mag='darkblue', grad='b', eeg='k', eog='k', ecg='r',
-                     emg='k', ref_meg='steelblue', misc='k', stim='k',
-                     resp='k', chpi='k')
-
-        bad_color : color object
-            Color to make bad channels.
-        event_color : color object
-            Color to use for events.
-        scalings : dict | None
-            Scaling factors for the traces. If any fields in scalings are
-            'auto', the scaling factor is set to match the 99.5th percentile of
-            a subset of the corresponding data. If scalings == 'auto', all
-            scalings fields are set to 'auto'. If any fields are 'auto' and
-            data is not preloaded, a subset of times up to 100mb will be
-            loaded. If None, defaults to::
-
-                dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
-                     emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,
-                     resp=1, chpi=1e-4)
-
-        remove_dc : bool
-            If True remove DC component when plotting data.
-        order : str | array of int
-            Order in which to plot data. 'type' groups by channel type,
-            'original' plots in the order of ch_names, 'selection' uses
-            Elekta's channel groupings (only works for Neuromag data),
-            'position' groups the channels by the positions of the sensors.
-            'selection' and 'position' modes allow custom selections by using
-            lasso selector on the topomap. Pressing ``ctrl`` key while
-            selecting allows appending to the current selection. If array, only
-            the channels in the array are plotted in the given order. Defaults
-            to 'type'.
-        show_options : bool
-            If True, a dialog for options related to projection is shown.
-        title : str | None
-            The title of the window. If None, and either the filename of the
-            raw object or '<unknown>' will be displayed as title.
-        show : bool
-            Show figures if True
-        block : bool
-            Whether to halt program execution until the figure is closed.
-            Useful for setting bad channels on the fly (click on line).
-            May not work on all systems / platforms.
-        highpass : float | None
-            Highpass to apply when displaying data.
-        lowpass : float | None
-            Lowpass to apply when displaying data.
-        filtorder : int
-            Filtering order. Note that for efficiency and simplicity,
-            filtering during plotting uses forward-backward IIR filtering,
-            so the effective filter order will be twice ``filtorder``.
-            Filtering the lines for display may also produce some edge
-            artifacts (at the left and right edges) of the signals
-            during display. Filtering requires scipy >= 0.10.
-        clipping : str | None
-            If None, channels are allowed to exceed their designated bounds in
-            the plot. If "clamp", then values are clamped to the appropriate
-            range for display, creating step-like artifacts. If "transparent",
-            then excessive values are not shown, creating gaps in the traces.
-
-        Returns
-        -------
-        fig : Instance of matplotlib.figure.Figure
-            Raw traces.
-
-        Notes
-        -----
-        The arrow keys (up/down/left/right) can typically be used to navigate
-        between channels and time ranges, but this depends on the backend
-        matplotlib is configured to use (e.g., mpl.use('TkAgg') should work).
-        The scaling can be adjusted with - and + (or =) keys. The viewport
-        dimensions can be adjusted with page up/page down and home/end keys.
-        Full screen mode can be to toggled with f11 key. To mark or un-mark a
-        channel as bad, click on the rather flat segments of a channel's time
-        series. The changes will be reflected immediately in the raw object's
-        ``raw.info['bads']`` entry.
-        """
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,
                         lowpass, filtorder, clipping)
 
     @verbose
+    @copy_function_doc_to_method_doc(plot_raw_psd)
     def plot_psd(self, tmin=0.0, tmax=60.0, fmin=0, fmax=np.inf,
                  proj=False, n_fft=2048, picks=None, ax=None,
                  color='black', area_mode='std', area_alpha=0.33,
                  n_overlap=0, dB=True, show=True, n_jobs=1, verbose=None):
-        """Plot the power spectral density across channels
-
-        Parameters
-        ----------
-        tmin : float
-            Start time for calculations.
-        tmax : float
-            End time for calculations.
-        fmin : float
-            Start frequency to consider.
-        fmax : float
-            End frequency to consider.
-        proj : bool
-            Apply projection.
-        n_fft : int
-            Number of points to use in Welch FFT calculations.
-        picks : array-like of int | None
-            List of channels to use. Cannot be None if `ax` is supplied. If
-            both `picks` and `ax` are None, separate subplots will be created
-            for each standard channel type (`mag`, `grad`, and `eeg`).
-        ax : instance of matplotlib Axes | None
-            Axes to plot into. If None, axes will be created.
-        color : str | tuple
-            A matplotlib-compatible color to use.
-        area_mode : str | None
-            How to plot area. If 'std', the mean +/- 1 STD (across channels)
-            will be plotted. If 'range', the min and max (across channels)
-            will be plotted. Bad channels will be excluded from these
-            calculations. If None, no area will be plotted.
-        area_alpha : float
-            Alpha for the area.
-        n_overlap : int
-            The number of points of overlap between blocks. The default value
-            is 0 (no overlap).
-        dB : bool
-            If True, transform data to decibels.
-        show : bool
-            Call pyplot.show() at the end.
-        n_jobs : int
-            Number of jobs to run in parallel.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-
-        Returns
-        -------
-        fig : instance of matplotlib figure
-            Figure with frequency spectra of the data channels.
-        """
         return plot_raw_psd(self, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax,
                             proj=proj, n_fft=n_fft, picks=picks, ax=ax,
                             color=color, area_mode=area_mode,
                             area_alpha=area_alpha, n_overlap=n_overlap,
                             dB=dB, show=show, n_jobs=n_jobs)
 
+    @copy_function_doc_to_method_doc(plot_raw_psd_topo)
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,
                       n_fft=2048, n_overlap=0, layout=None, color='w',
                       fig_facecolor='k', axis_facecolor='k', dB=True,
                       show=True, n_jobs=1, verbose=None):
-        """Function for plotting channel wise frequency spectra as topography.
-
-        Parameters
-        ----------
-        tmin : float
-            Start time for calculations. Defaults to zero.
-        tmax : float | None
-            End time for calculations. If None (default), the end of data is
-            used.
-        fmin : float
-            Start frequency to consider. Defaults to zero.
-        fmax : float
-            End frequency to consider. Defaults to 100.
-        proj : bool
-            Apply projection. Defaults to False.
-        n_fft : int
-            Number of points to use in Welch FFT calculations. Defaults to
-            2048.
-        n_overlap : int
-            The number of points of overlap between blocks. Defaults to 0
-            (no overlap).
-        layout : instance of Layout | None
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If None (default), the correct
-            layout is inferred from the data.
-        color : str | tuple
-            A matplotlib-compatible color to use for the curves. Defaults to
-            white.
-        fig_facecolor : str | tuple
-            A matplotlib-compatible color to use for the figure background.
-            Defaults to black.
-        axis_facecolor : str | tuple
-            A matplotlib-compatible color to use for the axis background.
-            Defaults to black.
-        dB : bool
-            If True, transform data to decibels. Defaults to True.
-        show : bool
-            Show figure if True. Defaults to True.
-        n_jobs : int
-            Number of jobs to run in parallel. Defaults to 1.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-
-        Returns
-        -------
-        fig : instance of matplotlib figure
-            Figure distributing one image per channel across sensor topography.
-        """
         return plot_raw_psd_topo(self, tmin=tmin, tmax=tmax, fmin=fmin,
                                  fmax=fmax, proj=proj, n_fft=n_fft,
                                  n_overlap=n_overlap, layout=layout,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -711,20 +711,6 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # set the data
         self._data[sel, start:stop] = value
 
-    def anonymize(self):
-        """Anonymize data.
-
-        This function will remove 'subject_info', 'meas_date', 'file_id',
-        'meas_id' if they exist in ``raw.info``.
-
-        Returns
-        -------
-        raw : instance of Raw
-            The raw object. Operates in place.
-        """
-        anonymize_info(self.info)
-        return self
-
     @verbose
     def apply_function(self, fun, picks, dtype, n_jobs, *args, **kwargs):
         """ Apply a function to a subset of channels.

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -24,7 +24,6 @@ from ..utils import _mult_cal_one
 from ...annotations import Annotations, _combine_annotations
 from ...externals.six import string_types
 from ...utils import check_fname, logger, verbose, warn
-from ...channels import fix_mag_coil_types
 
 
 class Raw(_BaseRaw):
@@ -433,7 +432,7 @@ class Raw(_BaseRaw):
                     break
 
     def fix_mag_coil_types(self):
-        """Fix magnetometer coil types
+        """Fix Elekta magnetometer coil types
 
         Returns
         -------
@@ -460,6 +459,7 @@ class Raw(_BaseRaw):
                   current estimates computed by the MNE software is very small.
                   Therefore the use of mne_fix_mag_coil_types is not mandatory.
         """
+        from ...channels import fix_mag_coil_types
         fix_mag_coil_types(self.info)
         return self
 

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -23,7 +23,9 @@ from ..utils import _mult_cal_one
 
 from ...annotations import Annotations, _combine_annotations
 from ...externals.six import string_types
-from ...utils import check_fname, logger, verbose, warn
+from ...utils import (check_fname, logger, verbose, warn,
+                      copy_function_doc_to_method_doc)
+from ...channels import fix_mag_coil_types
 
 
 class Raw(_BaseRaw):
@@ -431,35 +433,8 @@ class Raw(_BaseRaw):
                 if this['last'] >= stop:
                     break
 
+    @copy_function_doc_to_method_doc(fix_mag_coil_types)
     def fix_mag_coil_types(self):
-        """Fix Elekta magnetometer coil types
-
-        Returns
-        -------
-        raw : instance of Raw
-            The raw object. Operates in place.
-
-        Notes
-        -----
-        This function changes magnetometer coil types 3022 (T1: SQ20483N) and
-        3023 (T2: SQ20483-A) to 3024 (T3: SQ20950N) in the channel definition
-        records in the info structure.
-
-        Neuromag Vectorview systems can contain magnetometers with two
-        different coil sizes (3022 and 3023 vs. 3024). The systems
-        incorporating coils of type 3024 were introduced last and are used at
-        the majority of MEG sites. At some sites with 3024 magnetometers,
-        the data files have still defined the magnetometers to be of type
-        3022 to ensure compatibility with older versions of Neuromag software.
-        In the MNE software as well as in the present version of Neuromag
-        software coil type 3024 is fully supported. Therefore, it is now safe
-        to upgrade the data files to use the true coil type.
-
-        .. note:: The effect of the difference between the coil sizes on the
-                  current estimates computed by the MNE software is very small.
-                  Therefore the use of this function is not mandatory.
-        """
-        from ...channels import fix_mag_coil_types
         fix_mag_coil_types(self.info)
         return self
 

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -23,8 +23,7 @@ from ..utils import _mult_cal_one
 
 from ...annotations import Annotations, _combine_annotations
 from ...externals.six import string_types
-from ...utils import (check_fname, logger, verbose, warn,
-                      copy_function_doc_to_method_doc)
+from ...utils import check_fname, logger, verbose, warn
 from ...channels import fix_mag_coil_types
 
 
@@ -433,8 +432,34 @@ class Raw(_BaseRaw):
                 if this['last'] >= stop:
                     break
 
-    @copy_function_doc_to_method_doc(fix_mag_coil_types)
     def fix_mag_coil_types(self):
+        """Fix magnetometer coil types
+
+        Returns
+        -------
+        raw : instance of Raw
+            The raw object. Operates in place.
+
+        Notes
+        -----
+        This function changes magnetometer coil types 3022 (T1: SQ20483N) and
+        3023 (T2: SQ20483-A) to 3024 (T3: SQ20950N) in the channel definition
+        records in the info structure.
+
+        Neuromag Vectorview systems can contain magnetometers with two
+        different coil sizes (3022 and 3023 vs. 3024). The systems
+        incorporating coils of type 3024 were introduced last and are used at
+        the majority of MEG sites. At some sites with 3024 magnetometers,
+        the data files have still defined the magnetometers to be of type
+        3022 to ensure compatibility with older versions of Neuromag software.
+        In the MNE software as well as in the present version of Neuromag
+        software coil type 3024 is fully supported. Therefore, it is now safe
+        to upgrade the data files to use the true coil type.
+
+        .. note:: The effect of the difference between the coil sizes on the
+                  current estimates computed by the MNE software is very small.
+                  Therefore the use of mne_fix_mag_coil_types is not mandatory.
+        """
         fix_mag_coil_types(self.info)
         return self
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1570,7 +1570,8 @@ def _force_update_info(info_base, info_target):
 def anonymize_info(info):
     """Anonymize measurement information in place.
 
-    Reset 'subject_info', 'meas_date', 'file_id', and 'meas_id' keys.
+    Reset 'subject_info', 'meas_date', 'file_id', and 'meas_id' keys if they
+    exist in ``info``.
 
     Parameters
     ----------

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -188,7 +188,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     ----------
     info : dict
         The measurement info.
-    meg : bool or string
+    meg : bool | str
         If True include all MEG channels. If False include None
         If string it can be 'mag', 'grad', 'planar1' or 'planar2' to select
         only magnetometers, all gradiometers, or a specific type of
@@ -234,7 +234,7 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
         List of additional channels to include. If empty do not include any.
     exclude : list of string | str
         List of channels to exclude. If 'bads' (default), exclude channels
-        in info['bads'].
+        in ``info['bads']``.
     selection : list of string
         Restrict sensor channels (MEG, EEG) to this list of channel names.
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -45,7 +45,8 @@ from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state,
-                     _get_fast_dot, compute_corr)
+                     _get_fast_dot, compute_corr,
+                     copy_function_doc_to_method_doc)
 from ..fixes import _get_args
 from ..filter import band_pass_filter
 from .bads import find_outliers
@@ -1331,89 +1332,11 @@ class ICA(ContainsMixin):
         """
         return deepcopy(self)
 
+    @copy_function_doc_to_method_doc(plot_ica_components)
     def plot_components(self, picks=None, ch_type=None, res=64, layout=None,
                         vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                         colorbar=False, title=None, show=True, outlines='head',
                         contours=6, image_interp='bilinear', head_pos=None):
-        """Project unmixing matrix on interpolated sensor topography.
-
-        Parameters
-        ----------
-        picks : int | array-like | None
-            The indices of the sources to be plotted.
-            If None all are plotted in batches of 20.
-        ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
-            The channel type to plot. For 'grad', the gradiometers are
-            collected in pairs and the RMS for each pair is plotted.
-            If None, then first available channel type from order given
-            above is used. Defaults to None.
-        res : int
-            The resolution of the topomap image (n pixels along each side).
-        layout : None | Layout
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If possible, the correct layout is
-            inferred from the data.
-        vmin : float | callable
-            The value specfying the lower bound of the color range.
-            If None, and vmax is None, -vmax is used. Else np.min(data).
-            If callable, the output equals vmin(data).
-        vmax : float | callable
-            The value specfying the upper bound of the color range.
-            If None, the maximum absolute value is used. If vmin is None,
-            but vmax is not, defaults to np.min(data).
-            If callable, the output equals vmax(data).
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-            Colormap to use. If tuple, the first value indicates the colormap
-            to use and the second value is a boolean defining interactivity. In
-            interactive mode the colors are adjustable by clicking and dragging
-            the colorbar with left and right mouse button. Left mouse button
-            moves the scale up and down and right mouse button adjusts the
-            range. Hitting space bar resets the range. Up and down arrows can
-            be used to change the colormap. If None, 'Reds' is used for all
-            positive data, otherwise defaults to 'RdBu_r'. If 'interactive',
-            translates to (None, True). Defaults to 'RdBu_r'.
-
-            .. warning::  Interactive mode works smoothly only for a small
-                amount of topomaps.
-
-        sensors : bool | str
-            Add markers for sensor locations to the plot. Accepts matplotlib
-            plot format string (e.g., 'r+' for red plusses). If True, a circle
-            will be used (via .add_artist). Defaults to True.
-        colorbar : bool
-            Plot a colorbar.
-        title : str | None
-            Title to use.
-        show : bool
-            Call pyplot.show() at the end.
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
-        contours : int | False | None
-            The number of contour lines to draw. If 0, no contours will
-            be drawn.
-        image_interp : str
-            The image interpolation to be used. All matplotlib options are
-            accepted.
-        head_pos : dict | None
-            If None (default), the sensors are positioned such that they span
-            the head circle. If dict, can have entries 'center' (tuple) and
-            'scale' (tuple) for what the center and scale of the head should be
-            relative to the electrode locations.
-
-        Returns
-        -------
-        fig : instance of matplotlib.pyplot.Figure
-            The figure object.
-        """
         return plot_ica_components(self, picks=picks, ch_type=ch_type,
                                    res=res, layout=layout, vmin=vmin,
                                    vmax=vmax, cmap=cmap, sensors=sensors,
@@ -1422,192 +1345,34 @@ class ICA(ContainsMixin):
                                    image_interp=image_interp,
                                    head_pos=head_pos)
 
+    @copy_function_doc_to_method_doc(plot_ica_properties)
     def plot_properties(self, inst, picks=None, axes=None, dB=True,
                         plot_std=True, topomap_args=None, image_args=None,
                         psd_args=None, figsize=None, show=True):
-        """Display component properties: topography, epochs image, ERP,
-        power spectrum and epoch variance.
-
-        Parameters
-        ----------
-        inst: instance of Epochs or Raw
-            The data to use in plotting properties.
-        picks : int | array-like of int | None
-            The components to be displayed. If None, plot will show the first
-            five sources. If more than one components were chosen in the picks,
-            each one will be plotted in a separate figure. Defaults to None.
-        axes: list of matplotlib axes | None
-            List of five matplotlib axes to use in plotting: [topo_axis,
-            image_axis, erp_axis, spectrum_axis, variance_axis]. If None a new
-            figure with relevant axes is created. Defaults to None.
-        dB: bool
-            Whether to plot spectrum in dB. Defaults to True.
-        plot_std: bool | float
-            Whether to plot standard deviation in ERP/ERF and spectrum plots.
-            Defaults to True, which plots one standard deviation above/below.
-            If set to float allows to control how many standard deviations are
-            plotted. For example 2.5 will plot 2.5 standard deviation
-            above/below.
-        topomap_args : dict | None
-            Dictionary of arguments to ``plot_topomap``. If None, doesn't pass
-            any additional arguments. Defaults to None.
-        image_args : dict | None
-            Dictionary of arguments to ``plot_epochs_image``. If None, doesn't
-            pass any additional arguments. Defaults to None.
-        psd_args : dict | None
-            Dictionary of arguments to ``psd_multitaper``. If None, doesn't
-            pass any additional arguments. Defaults to None.
-        figsize : array-like of size (2,) | None
-            Allows to control size of the figure. If None the figure size
-            defauls to [7., 6.].
-        show : bool
-            Show figure if True.
-
-        Returns
-        -------
-        fig : list
-            List of matplotlib figures.
-
-        Notes
-        -----
-        .. versionadded:: 0.13
-        """
         return plot_ica_properties(inst, self, picks=picks, axes=axes,
                                    dB=dB, plot_std=plot_std,
                                    topomap_args=topomap_args,
                                    image_args=image_args, psd_args=psd_args,
                                    figsize=figsize, show=show)
 
+    @copy_function_doc_to_method_doc(plot_ica_sources)
     def plot_sources(self, inst, picks=None, exclude=None, start=None,
                      stop=None, title=None, show=True, block=False):
-        """Plot estimated latent sources given the unmixing matrix.
-
-        Typical usecases:
-
-        1. plot evolution of latent sources over time based on (Raw input)
-        2. plot latent source around event related time windows (Epochs input)
-        3. plot time-locking in ICA space (Evoked input)
-
-
-        Parameters
-        ----------
-        inst : instance of mne.io.Raw, mne.Epochs, mne.Evoked
-            The object to plot the sources from.
-        picks : ndarray | None.
-            The components to be displayed. If None, plot will show the
-            sources in the order as fitted.
-        exclude : array_like of int
-            The components marked for exclusion. If None (default), ICA.exclude
-            will be used.
-        start : int
-            X-axis start index. If None from the beginning.
-        stop : int
-            X-axis stop index. If None to the end.
-        title : str | None
-            The figure title. If None a default is provided.
-        show : bool
-            If True, all open plots will be shown.
-        block : bool
-            Whether to halt program execution until the figure is closed.
-            Useful for interactive selection of components in raw and epoch
-            plotter. For evoked, this parameter has no effect. Defaults to
-            False.
-
-        Returns
-        -------
-        fig : instance of pyplot.Figure
-            The figure.
-
-        Notes
-        -----
-        For raw and epoch instances, it is possible to select components for
-        exclusion by clicking on the line. The selected components are added to
-        ``ica.exclude`` on close. The independent components can be viewed as
-        topographies by clicking on the component name on the left of of the
-        main axes. The topography view tries to infer the correct electrode
-        layout from the data. This should work at least for Neuromag data.
-
-        .. versionadded:: 0.10.0
-        """
-
         return plot_ica_sources(self, inst=inst, picks=picks, exclude=exclude,
                                 title=title, start=start, stop=stop, show=show,
                                 block=block)
 
+    @copy_function_doc_to_method_doc(plot_ica_scores)
     def plot_scores(self, scores, exclude=None, labels=None, axhline=None,
                     title='ICA component scores', figsize=(12, 6),
                     show=True):
-        """Plot scores related to detected components.
-
-        Use this function to assess how well your score describes outlier
-        sources and how well you were detecting them.
-
-        Parameters
-        ----------
-        scores : array_like of float, shape (n ica components,) | list of array
-            Scores based on arbitrary metric to characterize ICA components.
-        exclude : array_like of int
-            The components marked for exclusion. If None (default), ICA.exclude
-            will be used.
-        labels : str | list | 'ecg' | 'eog' | None
-            The labels to consider for the axes tests. Defaults to None.
-            If list, should match the outer shape of `scores`.
-            If 'ecg' or 'eog', the ``labels_`` attributes will be looked up.
-            Note that '/' is used internally for sublabels specifying ECG and
-            EOG channels.
-        axhline : float
-            Draw horizontal line to e.g. visualize rejection threshold.
-        title : str
-            The figure title.
-        figsize : tuple of int
-            The figure size. Defaults to (12, 6).
-        show : bool
-            If True, all open plots will be shown.
-
-        Returns
-        -------
-        fig : instance of matplotlib.pyplot.Figure
-            The figure object.
-        """
         return plot_ica_scores(
             ica=self, scores=scores, exclude=exclude, labels=labels,
             axhline=axhline, title=title, figsize=figsize, show=show)
 
+    @copy_function_doc_to_method_doc(plot_ica_overlay)
     def plot_overlay(self, inst, exclude=None, picks=None, start=None,
                      stop=None, title=None, show=True):
-        """Overlay of raw and cleaned signals given the unmixing matrix.
-
-        This method helps visualizing signal quality and artifact rejection.
-
-        Parameters
-        ----------
-        inst : instance of mne.io.Raw or mne.Evoked
-            The signals to be compared given the ICA solution. If Raw input,
-            The raw data are displayed before and after cleaning. In a second
-            panel the cross channel average will be displayed. Since dipolar
-            sources will be canceled out this display is sensitive to
-            artifacts. If evoked input, butterfly plots for clean and raw
-            signals will be superimposed.
-        exclude : array_like of int
-            The components marked for exclusion. If None (default), ICA.exclude
-            will be used.
-        picks : array-like of int | None (default)
-            Indices of channels to include (if None, all channels
-            are used that were included on fitting).
-        start : int
-            X-axis start index. If None from the beginning.
-        stop : int
-            X-axis stop index. If None to the end.
-        title : str
-            The figure title.
-        show : bool
-            If True, all open plots will be shown.
-
-        Returns
-        -------
-        fig : instance of pyplot.Figure
-            The figure.
-        """
         return plot_ica_overlay(self, inst=inst, exclude=exclude, picks=picks,
                                 start=start, stop=stop, title=title, show=show)
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1349,7 +1349,7 @@ class ICA(ContainsMixin):
     def plot_properties(self, inst, picks=None, axes=None, dB=True,
                         plot_std=True, topomap_args=None, image_args=None,
                         psd_args=None, figsize=None, show=True):
-        return plot_ica_properties(inst, self, picks=picks, axes=axes,
+        return plot_ica_properties(self, inst, picks=picks, axes=axes,
                                    dB=dB, plot_std=plot_std,
                                    topomap_args=topomap_args,
                                    image_args=image_args, psd_args=psd_args,
@@ -1359,7 +1359,7 @@ class ICA(ContainsMixin):
     def plot_sources(self, inst, picks=None, exclude=None, start=None,
                      stop=None, title=None, show=True, block=False):
         return plot_ica_sources(self, inst=inst, picks=picks, exclude=exclude,
-                                title=title, start=start, stop=stop, show=show,
+                                start=start, stop=stop, title=title, show=show,
                                 block=block)
 
     @copy_function_doc_to_method_doc(plot_ica_scores)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -22,7 +22,7 @@ from .surface import (read_surface, _get_ico_surface, read_morph_map,
 from .source_space import (_ensure_src, _get_morph_src_reordering,
                            _ensure_src_subject, SourceSpaces)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose,
-                    _time_mask, warn as warn_)
+                    _time_mask, warn as warn_, copy_function_doc_to_method_doc)
 from .viz import plot_source_estimates
 from .fixes import in1d, sparse_block_diag
 from .io.base import ToDataFrameMixin, TimeMixin
@@ -1311,6 +1311,7 @@ class SourceEstimate(_BaseSourceEstimate):
         t = self.tmin + self.tstep * t_ind
         return vertex, hemi, t
 
+    @copy_function_doc_to_method_doc(plot_source_estimates)
     def plot(self, subject=None, surface='inflated', hemi='lh',
              colormap='auto', time_label='auto',
              smoothing_steps=10, transparent=None, alpha=1.0,
@@ -1318,101 +1319,6 @@ class SourceEstimate(_BaseSourceEstimate):
              figure=None, views='lat', colorbar=True, clim='auto',
              cortex="classic", size=800, background="black",
              foreground="white", initial_time=None, time_unit=None):
-        """Plot SourceEstimates with PySurfer
-
-        Note: PySurfer currently needs the SUBJECTS_DIR environment variable,
-        which will automatically be set by this function. Plotting multiple
-        SourceEstimates with different values for subjects_dir will cause
-        PySurfer to use the wrong FreeSurfer surfaces when using methods of
-        the returned Brain object. It is therefore recommended to set the
-        SUBJECTS_DIR environment variable or always use the same value for
-        subjects_dir (within the same Python session).
-
-        Parameters
-        ----------
-        subject : str | None
-            The subject name corresponding to FreeSurfer environment
-            variable SUBJECT. If None stc.subject will be used. If that
-            is None, the environment will be used.
-        surface : str
-            The type of surface (inflated, white etc.).
-        hemi : str, 'lh' | 'rh' | 'split' | 'both'
-            The hemisphere to display.
-        colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
-            Name of colormap to use or a custom look up table. If array, must
-            be (n x 3) or (n x 4) array for with RGB or RGBA values between
-            0 and 255. If 'auto', either 'hot' or 'mne' will be chosen
-            based on whether 'lims' or 'pos_lims' are specified in `clim`.
-        time_label : str | callable | None
-            Format of the time label (a format string, a function that maps
-            floating point time values to strings, or None for no label). The
-            default is ``time=%0.2f ms``.
-        smoothing_steps : int
-            The amount of smoothing.
-        transparent : bool | None
-            If True, use a linear transparency between fmin and fmid.
-            None will choose automatically based on colormap type.
-        alpha : float
-            Alpha value to apply globally to the overlay.
-        time_viewer : bool
-            Display time viewer GUI.
-        config_opts : dict
-            Deprecated parameter.
-        subjects_dir : str
-            The path to the FreeSurfer subjects reconstructions.
-            It corresponds to FreeSurfer environment variable SUBJECTS_DIR.
-        figure : instance of mayavi.core.scene.Scene | list | int | None
-            If None, a new figure will be created. If multiple views or a
-            split view is requested, this must be a list of the appropriate
-            length. If int is provided it will be used to identify the Mayavi
-            figure by it's id or create a new figure with the given id.
-        views : str | list
-            View to use. See surfer.Brain().
-        colorbar : bool
-            If True, display colorbar on scene.
-        clim : str | dict
-            Colorbar properties specification. If 'auto', set clim
-            automatically based on data percentiles. If dict, should contain:
-
-                kind : str
-                    Flag to specify type of limits. 'value' or 'percent'.
-                lims : list | np.ndarray | tuple of float, 3 elements
-                    Note: Only use this if 'colormap' is not 'mne'.
-                    Left, middle, and right bound for colormap.
-                pos_lims : list | np.ndarray | tuple of float, 3 elements
-                    Note: Only use this if 'colormap' is 'mne'.
-                    Left, middle, and right bound for colormap. Positive values
-                    will be mirrored directly across zero during colormap
-                    construction to obtain negative control points.
-
-        cortex : str or tuple
-            specifies how binarized curvature values are rendered.
-            either the name of a preset PySurfer cortex colorscheme (one of
-            'classic', 'bone', 'low_contrast', or 'high_contrast'), or the
-            name of mayavi colormap, or a tuple with values (colormap, min,
-            max, reverse) to fully specify the curvature colors.
-        size : float or pair of floats
-            The size of the window, in pixels. can be one number to specify
-            a square window, or the (width, height) of a rectangular window.
-        background : matplotlib color
-            Color of the background of the display window.
-        foreground : matplotlib color
-            Color of the foreground of the display window.
-        initial_time : float | None
-            The time to display on the plot initially. ``None`` to display the
-            first time sample (default).
-        time_unit : 's' | 'ms'
-            Whether time is represented in seconds (expected by PySurfer) or
-            milliseconds. The current default is 'ms', but will change to 's'
-            in MNE 0.14. To avoid a deprecation warning specify ``time_unit``
-            explicitly.
-
-
-        Returns
-        -------
-        brain : Brain
-            A instance of surfer.viz.Brain from PySurfer.
-        """
         brain = plot_source_estimates(self, subject, surface=surface,
                                       hemi=hemi, colormap=colormap,
                                       time_label=time_label,

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -701,7 +701,8 @@ def test_copy_function_doc_to_method_doc():
         def method_f3(self):
             pass
 
-    assert_equal(A.method_f1.__doc__,
+    assert_equal(
+        A.method_f1.__doc__,
         """Docstring for f1
 
         Parameters
@@ -710,16 +711,19 @@ def test_copy_function_doc_to_method_doc():
             Parameter a
         b : int
             Parameter b
-        """)
+        """
+    )
+
+    assert_equal(A.method_f2.__doc__, "Docstring for f2")
 
     assert_equal(
-        A.method_f2.__doc__,
-        """Docstring for f2
+        A.method_f3.__doc__,
+        """Docstring for f3
 
         Returns
         -------
         nothing.
-        method_f3 own docstring"""
+        """
     )
 
     assert_equal(A.method_f3.__doc__, 'Docstring for f3\n\n        ')

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -714,16 +714,14 @@ def test_copy_function_doc_to_method_doc():
         """
     )
 
-    assert_equal(A.method_f2.__doc__, "Docstring for f2")
-
     assert_equal(
-        A.method_f3.__doc__,
-        """Docstring for f3
+        A.method_f2.__doc__,
+        """Docstring for f2
 
         Returns
         -------
         nothing.
-        """
+        method_f3 own docstring"""
     )
 
     assert_equal(A.method_f3.__doc__, 'Docstring for f3\n\n        ')

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -862,6 +862,7 @@ def copy_function_doc_to_method_doc(source):
     --------
     >>> def plot_function(object, a, b):
     ...     '''Docstring for plotting function.
+    ...
     ...     Parameters
     ...     ----------
     ...     object : instance of object
@@ -880,6 +881,7 @@ def copy_function_doc_to_method_doc(source):
     ...         plot_function(self, a, b)
     >>> print(A.plot.__doc__)
     Docstring for plotting function.
+    <BLANKLINE>
         Parameters
         ----------
         a : int
@@ -891,8 +893,8 @@ def copy_function_doc_to_method_doc(source):
     Notes
     -----
     The parsing performed is very basic and will break easily on docstrings
-    that are not formatted exactly according to the basic MNE structure. Always
-    inspect the resulting docstring when using this decorator.
+    that are not formatted exactly according to the ``numpydoc`` standard.
+    Always inspect the resulting docstring when using this decorator.
     """
     def wrapper(func):
         doc = source.__doc__.split('\n')

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -891,7 +891,7 @@ def copy_function_doc_to_method_doc(source):
     Notes
     -----
     The parsing performed is very basic and will break easily on docstrings
-    that are not formatted exactly accoring to the basic MNE structure. Always
+    that are not formatted exactly according to the basic MNE structure. Always
     inspect the resulting docstring when using this decorator.
     """
     def wrapper(func):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -877,7 +877,11 @@ def copy_function_doc_to_method_doc(source):
     >>> class A:
     ...     @copy_function_doc_to_method_doc(plot_function)
     ...     def plot(self, a, b):
-    ...         '''.. versionadded:: 0.13.0'''
+    ...         '''
+    ...         Notes
+    ...         -----
+    ...         .. versionadded:: 0.13.0
+    ...         '''
     ...         plot_function(self, a, b)
     >>> print(A.plot.__doc__)
     Docstring for plotting function.
@@ -888,7 +892,11 @@ def copy_function_doc_to_method_doc(source):
             Some parameter
         b : int
             Some parameter
-        .. versionadded:: 0.13.0
+    <BLANKLINE>
+            Notes
+            -----
+            .. versionadded:: 0.13.0
+    <BLANKLINE>
 
     Notes
     -----

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -792,6 +792,167 @@ def requires_module(function, name, call=None):
     return dec
 
 
+def copy_doc(source):
+    """Decorator to copy the docstring from another function.
+
+    The docstring of the source function is prepepended to the docstring of the
+    function wrapped by this decorator.
+
+    This is useful when inheriting from a class and overloading a method. This
+    decorator can be used to copy the docstring of the original method.
+
+    Parameters
+    ----------
+    source : function
+        Function to copy the docstring from
+
+    Returns
+    -------
+    wrapper : function
+        The decorated function
+
+    Examples
+    --------
+    >>> class A:
+    ...     def m1():
+    ...         '''Docstring for m1'''
+    ...         pass
+    >>> class B (A):
+    ...     @copy_doc(A.m1)
+    ...     def m1():
+    ...         ''' this gets appended'''
+    ...         pass
+    >>> print(B.m1.__doc__)
+    Docstring for m1 this gets appended
+    """
+    def wrapper(func):
+        if source.__doc__ is None or len(source.__doc__) == 0:
+            raise ValueError('Cannot copy docstring: docstring was empty.')
+        doc = source.__doc__
+        if func.__doc__ is not None:
+            doc += func.__doc__
+        func.__doc__ = doc
+        return func
+    return wrapper
+
+
+def copy_function_doc_to_method_doc(source):
+    """Use the docstring from a function as docstring for a method.
+
+    The docstring of the source function is prepepended to the docstring of the
+    function wrapped by this decorator. Additionally, the first parameter
+    specified in the docstring of the source function is removed in the new
+    docstring.
+
+    This decorator is useful when implementing a method that just calls a
+    function.  This pattern is prevalent in for example the plotting functions
+    of MNE.
+
+    Parameters
+    ----------
+    source : function
+        Function to copy the docstring from
+
+    Returns
+    -------
+    wrapper : function
+        The decorated method
+
+    Examples
+    --------
+    >>> def plot_function(object, a, b):
+    ...     '''Docstring for plotting function.
+    ...     Parameters
+    ...     ----------
+    ...     object : instance of object
+    ...         The object to plot
+    ...     a : int
+    ...         Some parameter
+    ...     b : int
+    ...         Some parameter
+    ...     '''
+    ...     pass
+    ...
+    >>> class A:
+    ...     @copy_function_doc_to_method_doc(plot_function)
+    ...     def plot(self, a, b):
+    ...         '''.. versionadded:: 0.13.0'''
+    ...         plot_function(self, a, b)
+    >>> print(A.plot.__doc__)
+    Docstring for plotting function.
+        Parameters
+        ----------
+        a : int
+            Some parameter
+        b : int
+            Some parameter
+        .. versionadded:: 0.13.0
+
+    Notes
+    -----
+    The parsing performed is very basic and will break easily on docstrings
+    that are not formatted exactly accoring to the basic MNE structure. Always
+    inspect the resulting docstring when using this decorator.
+    """
+    def wrapper(func):
+        doc = source.__doc__.split('\n')
+
+        # Find parameter block
+        for line, text in enumerate(doc[:-2]):
+            if (text.strip() == 'Parameters' and
+                    doc[line + 1].strip() == '----------'):
+                parameter_block = line
+                break
+        else:
+            # No parameter block found
+            raise ValueError('Cannot copy function docstring: no parameter '
+                             'block found. To simply copy the docstring, use '
+                             'the @copy_doc decorator instead.')
+
+        # Find first parameter
+        for line, text in enumerate(doc[parameter_block:], parameter_block):
+            if ':' in text:
+                first_parameter = line
+                parameter_indentation = len(text) - len(text.lstrip(' '))
+                break
+        else:
+            raise ValueError('Cannot copy function docstring: no parameters '
+                             'found. To simply copy the docstring, use the '
+                             '@copy_doc decorator instead.')
+
+        # Find end of first parameter
+        for line, text in enumerate(doc[first_parameter + 1:],
+                                    first_parameter + 1):
+            # Ignore empty lines
+            if len(text.strip()) == 0:
+                continue
+
+            line_indentation = len(text) - len(text.lstrip(' '))
+            if line_indentation <= parameter_indentation:
+                # Reach end of first parameter
+                first_parameter_end = line
+
+                # Of only one parameter is defined, remove the Parameters
+                # heading as well
+                if ':' not in text:
+                    first_parameter = parameter_block
+
+                break
+        else:
+            # End of docstring reached
+            first_parameter_end = line
+            first_parameter = parameter_block
+
+        # Copy the docstring, but remove the first parameter
+        doc = ('\n'.join(doc[:first_parameter]) + '\n' +
+               '\n'.join(doc[first_parameter_end:]))
+        if func.__doc__ is not None:
+            doc += func.__doc__
+        func.__doc__ = doc
+        return func
+    return wrapper
+
+
 _pandas_call = """
 import pandas
 version = LooseVersion(pandas.__version__)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -438,6 +438,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20,
     with f11 key. The amount of epochs and channels per view can be adjusted
     with home/end and page down/page up keys. Butterfly plot can be toggled
     with ``b`` key. Right mouse click adds a vertical line to the plot.
+
+    .. versionadded:: 0.10.0
     """
     epochs.drop_bad()
     scalings = _compute_scalings(scalings, epochs)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -29,7 +29,7 @@ from ..time_frequency.psd import psd_multitaper
 
 
 def plot_ica_sources(ica, inst, picks=None, exclude=None, start=None,
-                     stop=None, show=True, title=None, block=False):
+                     stop=None, title=None, show=True, block=False):
     """Plot estimated latent sources given the unmixing matrix.
 
     Typical usecases:
@@ -56,10 +56,10 @@ def plot_ica_sources(ica, inst, picks=None, exclude=None, start=None,
     stop : int
         X-axis stop index. If None, next 20 are shown, in case of evoked to the
         end.
-    show : bool
-        Show figure if True.
     title : str | None
         The figure title. If None a default is provided.
+    show : bool
+        Show figure if True.
     block : bool
         Whether to halt program execution until the figure is closed.
         Useful for interactive selection of components in raw and epoch
@@ -123,7 +123,7 @@ def _create_properties_layout(figsize=None):
     return fig, ax
 
 
-def plot_ica_properties(inst, ica, picks=None, axes=None, dB=True,
+def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
                         plot_std=True, topomap_args=None, image_args=None,
                         psd_args=None, figsize=None, show=True):
     """Display component properties: topography, epochs image, ERP/ERF,
@@ -131,10 +131,10 @@ def plot_ica_properties(inst, ica, picks=None, axes=None, dB=True,
 
     Parameters
     ----------
-    inst: instance of Epochs or Raw
-        The data to use in plotting properties.
     ica : instance of mne.preprocessing.ICA
         The ICA solution.
+    inst: instance of Epochs or Raw
+        The data to use in plotting properties.
     picks : int | array-like of int | None
         The components to be displayed. If None, plot will show the first
         five sources. If more than one components were chosen in the picks,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1736,9 +1736,7 @@ def plot_layout(layout, show=True):
 
     Notes
     -----
-
     .. versionadded:: 0.12.0
-
     """
     import matplotlib.pyplot as plt
     fig = plt.figure()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1014,7 +1014,8 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
     res : int
         The resolution of the topomap image (n pixels along each side).
     size : float
-        Side length per topomap in inches.
+        Side length per topomap in inches (only applies when plotting multiple
+        topomaps at a time).
     cbar_fmt : str
         String format for colorbar values.
     show_names : bool | callable


### PR DESCRIPTION
There is a common pattern we employ where we have a function that does something:

    def plot_object(object):
        """Very long docstring, many parameters"""

and then we have a method that calls this function:

    class object:
        def plot(self):
             "Very long docstring, many parameters"""
             plot_object(self)

To have proper docstrings for both the function and the method, we copy/paste it. This is annoying, hard to read and prone to errors as we update one of the docstrings and not the other (see for example `mne.epochs.plot_drop_log` where the doc erroneously claims it returns a tuple).

This PR introduces two decorators to re-use a docstring:

    @copy_doc
    @copy_function_doc_to_method_doc

The first one simply copies the docstring from one function to another. This is useful when subclassing something and overloading a method.

The second one is a bit more clever and copies the docstring from a function and removes the first parameter from the parameter list. This covers the use case I described above, where we have a method calling a function with `self` as first parameter.

This PR is split into two commits: one adds the code and tests for the decorators, the other refactors the docstrings and contains all the glorious red lines.