### PR TITLE
ENH: Improvement over the Xdawn Transformer example

### DIFF
--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
 from sklearn.pipeline import make_pipeline
-from sklearn.svm import SVC  # noqa
+from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import label_binarize
 from sklearn.preprocessing import StandardScaler
 
@@ -36,10 +36,10 @@ event_id = dict(aud_l=1, vis_l=3)
 
 # Setup for reading the raw data
 raw = io.read_raw_fif(raw_fname, preload=True)
-raw.filter(2, None, method='iir')
+raw.filter(2., None, method='iir')
 events = read_events(event_fname)
 
-picks = pick_types(raw.info, meg='grad', eeg=False, stim=False, eog=False,
+picks = pick_types(raw.info, meg='mag', eeg=False, stim=False, eog=False,
                    exclude='bads')
 
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
@@ -51,7 +51,7 @@ y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 clf = make_pipeline(XdawnTransformer(n_components=2),
                     Vectorizer(),
                     StandardScaler(),
-                    SVC(C=1, kernel='linear'))
+                    LogisticRegression())
 
 # Define a monte-carlo cross-validation generator (reduce variance):
 cv = ShuffleSplit(len(y), 10, test_size=0.2, random_state=42)

--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -12,6 +12,7 @@ Here the classifier is applied to features extracted on Xdawn filtered signals.
 #
 # License: BSD (3-clause)
 import numpy as np
+import matplotlib.pyplot as plt
 
 from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
 from sklearn.pipeline import make_pipeline
@@ -24,8 +25,6 @@ from mne.viz import plot_topomap
 from mne.datasets import sample
 from mne.decoding import Vectorizer
 from mne.preprocessing import XdawnTransformer
-
-import matplotlib.pyplot as plt
 
 data_path = sample.data_path()
 

--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -1,52 +1,77 @@
 """
 ====================================================================
-Minimal example for using scikit-learn pipeline
+Decoding in sensor space data using the Xdawn Transformer
 ====================================================================
 
-This example creates a scikit-learn pipeline with mne transformers.
+Decoding applied to MEG data in sensor space decomposed using Xdawn.
+Here the classifier is applied to features extracted on Xdawn filtered signals.
 
 """
 # Authors: Asish Panda <asishrocks95@gmail.com>
+#          Alexandre Barachant <alexandre.barachant@gmail.com>
 #
 # License: BSD (3-clause)
+import numpy as np
 
-from sklearn.cross_validation import cross_val_score
+from sklearn.cross_validation import cross_val_score, ShuffleSplit  # noqa
 from sklearn.pipeline import make_pipeline
-from sklearn.linear_model import LogisticRegression
+from sklearn.svm import SVC  # noqa
 from sklearn.preprocessing import label_binarize
 from sklearn.preprocessing import StandardScaler
 
 from mne import io, pick_types, read_events, Epochs
+from mne.viz import plot_topomap
 from mne.datasets import sample
 from mne.decoding import Vectorizer
 from mne.preprocessing import XdawnTransformer
 
-data_path = sample.data_path()
+import matplotlib.pyplot as plt
 
+data_path = sample.data_path()
 
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
-tmin, tmax = -0.1, 0.3
+tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
 
 # Setup for reading the raw data
 raw = io.read_raw_fif(raw_fname, preload=True)
-raw.filter(1, 20, method='iir')
+raw.filter(2, None, method='iir')
 events = read_events(event_fname)
 
-picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
+picks = pick_types(raw.info, meg='grad', eeg=False, stim=False, eog=False,
                    exclude='bads')
 
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
-                picks=picks, baseline=None, preload=True,
-                add_eeg_ref=False, verbose=False)
+                picks=picks, baseline=None, preload=True, verbose=False)
 
 X = epochs.get_data()
 y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 
-clf = make_pipeline(XdawnTransformer(n_components=3),
+clf = make_pipeline(XdawnTransformer(n_components=2),
                     Vectorizer(),
                     StandardScaler(),
-                    LogisticRegression())
-score = cross_val_score(clf, X, y, cv=5)
-print(score)
+                    SVC(C=1, kernel='linear'))
+
+# Define a monte-carlo cross-validation generator (reduce variance):
+cv = ShuffleSplit(len(y), 10, test_size=0.2, random_state=42)
+
+scores = cross_val_score(clf, X, y, cv=cv)
+
+class_balance = np.mean(y == y[0])
+class_balance = max(class_balance, 1. - class_balance)
+print("Classification accuracy: %f / Chance level: %f" % (np.mean(scores),
+                                                          class_balance))
+
+###############################################################################
+# plot Xdawn patterns estimated on full data for visualization
+
+xdawn = XdawnTransformer(n_components=2)
+xdawn.fit(X, y)
+data = xdawn.patterns_
+fig, axes = plt.subplots(1, 4)
+for idx in range(4):
+    plot_topomap(data[idx], epochs.info, axes=axes[idx], show=False)
+fig.suptitle('Xdawn patterns')
+fig.tight_layout()
+plt.show()

--- a/examples/decoding/plot_decoding_xdawn_transformer.py
+++ b/examples/decoding/plot_decoding_xdawn_transformer.py
@@ -14,6 +14,7 @@ from sklearn.cross_validation import cross_val_score
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import label_binarize
+from sklearn.preprocessing import StandardScaler
 
 from mne import io, pick_types, read_events, Epochs
 from mne.datasets import sample
@@ -45,6 +46,7 @@ y = label_binarize(epochs.events[:, 2], classes=[1, 3]).ravel()
 
 clf = make_pipeline(XdawnTransformer(n_components=3),
                     Vectorizer(),
+                    StandardScaler(),
                     LogisticRegression())
 score = cross_val_score(clf, X, y, cv=5)
 print(score)


### PR DESCRIPTION
This PR is an improvement of the Xdawn transformer example. It is made to replace the `plot_decoding_csp_space.py` example. Decoding accuracy is now 99.6% instead of 90.3% for the CSP example.

Using CSP for decoding of evoked potential (with log-variance as feature) is both conceptually wrong and inefficient in practice. I suggest we remove the CSP example. MNE should not showcase bad habits. the `plot_decoding_csp_eeg.py` example is already covering the correct way to use CSP (to decode induced activity).