### PR TITLE
FIX: concatenate with almost equal times

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2881,7 +2881,7 @@ def _concatenate_epochs(epochs_list, with_data=True):
     selection = out.selection
     for ii, epochs in enumerate(epochs_list[1:]):
         _compare_epochs_infos(epochs.info, info, ii)
-        if not np.array_equal(epochs.times, epochs_list[0].times):
+        if not np.allclose(epochs.times, epochs_list[0].times):
             raise ValueError('Epochs must have same times')
 
         if epochs.baseline != baseline:


### PR DESCRIPTION
closes https://github.com/mne-tools/mne-python/issues/3478

I didn't manage to reproduce it with made up data :/

Shall I update whatsnew?