### PR TITLE
Clean up infomax

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -158,6 +158,8 @@ API
 
     - Add argument ``mask_type`` to func:`mne.read_events` and func:`mne.find_events` to support MNE-C style of trigger masking by `Teon Brooks`_ and `Eric Larson`_
 
+    - Extended Infomax is now the new default in :func:`mne.preprocessing.infomax` (``extended=True``), by `Clemens Brunner`_
+
 .. _changes_0_12:
 
 Version 0.12

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -19,9 +19,6 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
             verbose=None):
     """Run (extended) Infomax ICA decomposition on raw data.
 
-    Based on the publications of Bell & Sejnowski, 1995 (Infomax)
-    and Lee, Girolami & Sejnowski, 1999 (extended Infomax).
-
     Parameters
     ----------
     data : np.ndarray, shape (n_samples, n_features)
@@ -31,11 +28,11 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
         Defaults to None, which means the identity matrix is used.
     l_rate : float
         This quantity indicates the relative size of the change in weights.
-        Note: Smaller learning rates will slow down the ICA procedure.
+        .. note:: Smaller learning rates will slow down the ICA procedure.
         Defaults to 0.01 / log(n_features ** 2).
     block : int
         The block size of randomly chosen data segments.
-        Defaults to floor(sqrt(n_times / 3)).
+        Defaults to floor(sqrt(n_times / 3.)).
     w_change : float
         The change at which to stop iteration. Defaults to 1e-12.
     anneal_deg : float
@@ -94,6 +91,15 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
     -------
     unmixing_matrix : np.ndarray, shape (n_features, n_features)
         The linear unmixing operator.
+
+    References
+    ----------
+    [1] A. J. Bell, T. J. Sejnowski. An information-maximization approach to
+        blind separation and bind deconvolution. Neural Computation, 7(6),
+        1129-1159, 1995.
+    [2] T. W. Lee, M. Girolami, T. J. Sejnowski. Independent component analysis
+        using an extended infomax algorithm for mixed subgaussian and
+        supergaussian sources. Neural Computation, 11(2), 417-441, 1999.
     """
     from scipy.stats import kurtosis
     rng = check_random_state(random_state)

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -13,94 +13,92 @@ from ..utils import logger, verbose, check_random_state, random_permutation
 
 @verbose
 def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
-            anneal_deg=60., anneal_step=0.9, extended=False, n_subgauss=1,
-            kurt_size=6000, ext_blocks=1, max_iter=200,
-            random_state=None, blowup=1e4, blowup_fac=0.5, n_small_angle=20,
-            use_bias=True, verbose=None):
-    """Run the (extended) Infomax ICA decomposition on raw data
+            anneal_deg=60., anneal_step=0.9, extended=True, n_subgauss=1,
+            kurt_size=6000, ext_blocks=1, max_iter=200, random_state=None,
+            blowup=1e4, blowup_fac=0.5, n_small_angle=20, use_bias=True,
+            verbose=None):
+    """Run (extended) Infomax ICA decomposition on raw data.
 
-    based on the publications of Bell & Sejnowski 1995 (Infomax)
-    and Lee, Girolami & Sejnowski, 1999 (extended Infomax)
+    Based on the publications of Bell & Sejnowski, 1995 (Infomax)
+    and Lee, Girolami & Sejnowski, 1999 (extended Infomax).
 
     Parameters
     ----------
     data : np.ndarray, shape (n_samples, n_features)
         The data to unmix.
-    w_init : np.ndarray, shape (n_features, n_features)
-        The initialized unmixing matrix. Defaults to None. If None, the
-        identity matrix is used.
+    weights : np.ndarray, shape (n_features, n_features)
+        The initialized unmixing matrix.
+        Defaults to None, which means the identity matrix is used.
     l_rate : float
         This quantity indicates the relative size of the change in weights.
-        Note. Smaller learining rates will slow down the procedure.
-        Defaults to 0.010d / alog(n_features ^ 2.0)
+        Note: Smaller learning rates will slow down the ICA procedure.
+        Defaults to 0.01 / log(n_features ** 2).
     block : int
-        The block size of randomly chosen data segment.
-        Defaults to floor(sqrt(n_times / 3d))
+        The block size of randomly chosen data segments.
+        Defaults to floor(sqrt(n_times / 3)).
     w_change : float
         The change at which to stop iteration. Defaults to 1e-12.
     anneal_deg : float
-        The angle at which (in degree) the learning rate will be reduced.
-        Defaults to 60.0
+        The angle (in degrees) at which the learning rate will be reduced.
+        Defaults to 60.0.
     anneal_step : float
         The factor by which the learning rate will be reduced once
         ``anneal_deg`` is exceeded:
             l_rate *= anneal_step
-        Defaults to 0.9
+        Defaults to 0.9.
     extended : bool
-        Wheather to use the extended infomax algorithm or not. Defaults to
-        True.
+        Whether to use the extended Infomax algorithm or not.
+        Defaults to True.
     n_subgauss : int
         The number of subgaussian components. Only considered for extended
-        Infomax.
+        Infomax. Defaults to 1.
     kurt_size : int
         The window size for kurtosis estimation. Only considered for extended
-        Infomax.
+        Infomax. Defaults to 6000.
     ext_blocks : int
-        Only considered for extended Infomax.
-        If positive, it denotes the number of blocks after which to recompute
-        the Kurtosis, which is used to estimate the signs of the sources.
-        In this case the number of sub-gaussian sources is automatically
-        determined.
+        Only considered for extended Infomax. If positive, denotes the number
+        of blocks after which to recompute the kurtosis, which is used to
+        estimate the signs of the sources. In this case, the number of
+        sub-gaussian sources is automatically determined.
         If negative, the number of sub-gaussian sources to be used is fixed
-        and equal to n_subgauss. In this case the Kurtosis is not estimated.
+        and equal to n_subgauss. In this case, the kurtosis is not estimated.
+        Defaults to 1.
     max_iter : int
         The maximum number of iterations. Defaults to 200.
     random_state : int | np.random.RandomState
-        If random_state is an int, use random_state as seed of the random
-        number generator.
-        If random_state is already a np.random.RandomState instance, use
-        random_state as random number generator.
+        If random_state is an int, use random_state to seed the random number
+        generator. If random_state is already a np.random.RandomState instance,
+        use random_state as random number generator.
     blowup : float
         The maximum difference allowed between two successive estimations of
-        the unmixing matrix. Defaults to 1e4
+        the unmixing matrix. Defaults to 10000.
     blowup_fac : float
-        The factor by which the learning rate will be reduced if the
-        difference between two successive estimations of the
-        unmixing matrix exceededs ``blowup``:
+        The factor by which the learning rate will be reduced if the difference
+        between two successive estimations of the unmixing matrix exceededs
+        ``blowup``:
             l_rate *= blowup_fac
-        Defaults to 0.5
+        Defaults to 0.5.
     n_small_angle : int | None
         The maximum number of allowed steps in which the angle between two
         successive estimations of the unmixing matrix is less than
-        ``anneal_deg``.
-        If None, this parameter is not taken into account to stop the
-        iterations.
-        Defaults to 20
+        ``anneal_deg``. If None, this parameter is not taken into account to
+        stop the iterations.
+        Defaults to 20.
     use_bias : bool
         This quantity indicates if the bias should be computed.
-        Defaults to True
+        Defaults to True.
     verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+        If not None, override default verbosity level (see mne.verbose).
 
     Returns
     -------
-    unmixing_matrix : np.ndarray of float, shape (n_features, n_features)
+    unmixing_matrix : np.ndarray, shape (n_features, n_features)
         The linear unmixing operator.
     """
     from scipy.stats import kurtosis
     rng = check_random_state(random_state)
 
-    # define some default parameter
+    # define some default parameters
     max_weight = 1e8
     restart_fac = 0.9
     min_l_rate = 1e-10
@@ -116,25 +114,22 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
     n_samples, n_features = data.shape
     n_features_square = n_features ** 2
 
-    # check input parameter
-    # heuristic default - may need adjustment for
-    # large or tiny data sets
+    # check input parameters
+    # heuristic default - may need adjustment for large or tiny data sets
     if l_rate is None:
         l_rate = 0.01 / math.log(n_features ** 2.0)
 
     if block is None:
         block = int(math.floor(math.sqrt(n_samples / 3.0)))
 
-    logger.info('computing%sInfomax ICA' % ' Extended ' if extended is True
-                else ' ')
+    logger.info('computing%sInfomax ICA' % ' Extended ' if extended else ' ')
 
-    # collect parameter
+    # collect parameters
     nblock = n_samples // block
     lastt = (nblock - 1) * block + 1
 
     # initialize training
     if weights is None:
-        # initialize weights as identity matrix
         weights = np.identity(n_features, dtype=np.float64)
 
     BI = block * np.identity(n_features, dtype=np.float64)
@@ -150,7 +145,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
     initial_ext_blocks = ext_blocks   # save the initial value in case of reset
 
     # for extended Infomax
-    if extended is True:
+    if extended:
         signs = np.ones(n_features)
 
         for k in range(n_subgauss):
@@ -173,7 +168,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
             u = np.dot(data[permute[t:t + block], :], weights)
             u += np.dot(bias, onesrow).T
 
-            if extended is True:
+            if extended:
                 # extended ICA update
                 y = np.tanh(u)
                 weights += l_rate * np.dot(weights,
@@ -206,10 +201,8 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
                 break
 
             # ICA kurtosis estimation
-            if extended is True:
-
+            if extended:
                 if ext_blocks > 0 and blockno % ext_blocks == 0:
-
                     if kurt_size < n_samples:
                         rp = np.floor(rng.uniform(0, 1, kurt_size) *
                                       (n_samples - 1))
@@ -239,8 +232,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
                         ext_blocks = np.fix(ext_blocks * signcount_step)
                         signcount = 0
 
-        # here we continue after the for
-        # loop over the ICA training blocks
+        # here we continue after the for loop over the ICA training blocks
         # if weights in bounds:
         if not wts_blowup:
             oldwtchange = weights - oldweights
@@ -262,10 +254,10 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
             oldweights = weights.copy()
             if angledelta > anneal_deg:
                 l_rate *= anneal_step    # anneal learning rate
-                # accumulate angledelta until anneal_deg reached l_rates
+                # accumulate angledelta until anneal_deg reaches l_rate
                 olddelta = delta
                 oldchange = change
-                count_small_angle = 0  # reset count when angle delta is large
+                count_small_angle = 0  # reset count when angledelta is large
             else:
                 if step == 1:  # on first step only
                     olddelta = delta  # initialize
@@ -282,8 +274,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
             elif change > blowup:
                 l_rate *= blowup_fac
 
-        # restart if weights blow up
-        # (for lowering l_rate)
+        # restart if weights blow up (for lowering l_rate)
         else:
             step = 0  # start again
             wts_blowup = 0  # re-initialize variables


### PR DESCRIPTION
Specifically, the `extended` argument now really defaults to `True` (the docstring claimed this before even though it was really `False`). I prettified the docstring and comments, added the defaults in the docstring, and replaced `if extended is True:` with `if extended:`.