### PR TITLE
[MRG] expose uint16_codec in eeglab reader (+ minor fixes)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -168,6 +168,9 @@ API
 
     - Extended Infomax is now the new default in :func:`mne.preprocessing.infomax` (``extended=True``), by `Clemens Brunner`_
 
+    - :func:`mne.io.read_raw_eeglab` and :func:`mne.io.read_epochs_eeglab` now take additional argument ``uint16_codec`` that allows to define the encoding of character arrays in set file. This helps in rare cases when reading a set file fails with ``TypeError: buffer is too small for requested array``. By `Mikołaj Magnuski`_
+
+
 .. _changes_0_12:
 
 Version 0.12

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -152,7 +152,11 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
     verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
     uint16_codec : str | None
-        Codec to use for uint16 char arrays (defaults to system default codec).
+        If your *.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
 
     Returns
     -------
@@ -209,7 +213,11 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
     verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
     uint16_codec : str | None
-        Codec to use for uint16 char arrays (defaults to system default codec).
+        If your *.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
 
     Returns
     -------
@@ -274,7 +282,11 @@ class RawEEGLAB(_BaseRaw):
     verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
     uint16_codec : str | None
-        mne.io.read_raw_eeglab(os.path.join(data_dir, set_fls[1]))
+        If your *.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
 
     Returns
     -------
@@ -427,7 +439,11 @@ class EpochsEEGLAB(_BaseEpochs):
     verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
     uint16_codec : str | None
-        Codec to use for uint16 char arrays (defaults to system default codec).
+        If your *.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
 
     Notes
     -----

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -107,7 +107,7 @@ def _get_info(eeg, montage, eog=()):
 
 def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
                     event_id_func='strip_to_integer', preload=False,
-                    verbose=None):
+                    verbose=None, uint16_codec=None):
     """Read an EEGLAB .set file
 
     Parameters
@@ -149,8 +149,10 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
         on the hard drive (slower, requires less memory). Note that
         preload=False will be effective only if the data is stored in a
         separate binary file.
-    verbose : bool, str, int, or None
+    verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
+    uint16_codec : str | None
+        Codec to use for uint16 char arrays (defaults to system default codec).
 
     Returns
     -------
@@ -167,11 +169,11 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), event_id=None,
     """
     return RawEEGLAB(input_fname=input_fname, montage=montage, preload=preload,
                      eog=eog, event_id=event_id, event_id_func=event_id_func,
-                     verbose=verbose)
+                     verbose=verbose, uint16_codec=uint16_codec)
 
 
 def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
-                       eog=(), verbose=None):
+                       eog=(), verbose=None, uint16_codec=None):
     """Reader function for EEGLAB epochs files
 
     Parameters
@@ -204,8 +206,10 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    verbose : bool, str, int, or None
+    verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
+    uint16_codec : str | None
+        Codec to use for uint16 char arrays (defaults to system default codec).
 
     Returns
     -------
@@ -222,7 +226,8 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
     mne.Epochs : Documentation of attribute and methods.
     """
     epochs = EpochsEEGLAB(input_fname=input_fname, events=events, eog=eog,
-                          event_id=event_id, montage=montage, verbose=verbose)
+                          event_id=event_id, montage=montage, verbose=verbose,
+                          uint16_codec=uint16_codec)
     return epochs
 
 
@@ -266,8 +271,10 @@ class RawEEGLAB(_BaseRaw):
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard
         drive (slower, requires less memory).
-    verbose : bool, str, int, or None
+    verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
+    uint16_codec : str | None
+        mne.io.read_raw_eeglab(os.path.join(data_dir, set_fls[1]))
 
     Returns
     -------
@@ -285,14 +292,14 @@ class RawEEGLAB(_BaseRaw):
     @verbose
     def __init__(self, input_fname, montage, eog=(), event_id=None,
                  event_id_func='strip_to_integer', preload=False,
-                 verbose=None):
+                 verbose=None, uint16_codec=None):
         """Read EEGLAB .set file.
         """
         from scipy import io
         basedir = op.dirname(input_fname)
         _check_mat_struct(input_fname)
         eeg = io.loadmat(input_fname, struct_as_record=False,
-                         squeeze_me=True)['EEG']
+                         squeeze_me=True, uint16_codec=uint16_codec)['EEG']
         if eeg.trials != 1:
             raise TypeError('The number of trials is %d. It must be 1 for raw'
                             ' files. Please use `mne.io.read_epochs_eeglab` if'
@@ -417,8 +424,10 @@ class EpochsEEGLAB(_BaseEpochs):
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    verbose : bool, str, int, or None
+    verbose : bool | str | int | None
         If not None, override default verbose level (see mne.verbose).
+    uint16_codec : str | None
+        Codec to use for uint16 char arrays (defaults to system default codec).
 
     Notes
     -----
@@ -431,11 +440,12 @@ class EpochsEEGLAB(_BaseEpochs):
     @verbose
     def __init__(self, input_fname, events=None, event_id=None, tmin=0,
                  baseline=None,  reject=None, flat=None, reject_tmin=None,
-                 reject_tmax=None, montage=None, eog=(), verbose=None):
+                 reject_tmax=None, montage=None, eog=(), verbose=None,
+                 uint16_codec=None):
         from scipy import io
         _check_mat_struct(input_fname)
         eeg = io.loadmat(input_fname, struct_as_record=False,
-                         squeeze_me=True)['EEG']
+                         squeeze_me=True, uint16_codec=uint16_codec)['EEG']
 
         if not ((events is None and event_id is None) or
                 (events is not None and event_id is not None)):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -64,6 +64,9 @@ def _get_info(eeg, montage, eog=()):
 
     # add the ch_names and info['chs'][idx]['loc']
     path = None
+    if not isinstance(eeg.chanlocs, np.ndarray) and eeg.nbchan == 1:
+            eeg.chanlocs = [eeg.chanlocs]
+
     if len(eeg.chanlocs) > 0:
         ch_names, pos = list(), list()
         kind = 'user_defined'
@@ -348,7 +351,10 @@ class RawEEGLAB(_BaseRaw):
                      'the .set file')
             # can't be done in standard way with preload=True because of
             # different reading path (.set file)
-            n_chan, n_times = eeg.data.shape
+            if eeg.nbchan == 1 and len(eeg.data.shape) == 1:
+                n_chan, n_times = [1, eeg.data.shape[0]]
+            else:
+                n_chan, n_times = eeg.data.shape
             data = np.empty((n_chan + 1, n_times), dtype=np.double)
             data[:-1] = eeg.data
             data *= CAL
@@ -533,6 +539,9 @@ class EpochsEEGLAB(_BaseEpochs):
                                     order="F")
         else:
             data = eeg.data
+
+        if eeg.nbchan == 1 and len(data.shape) == 2:
+            data = data[np.newaxis, :]
         data = data.transpose((2, 0, 1)).astype('double')
         data *= CAL
         assert data.shape == (eeg.trials, eeg.nbchan, eeg.pnts)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -456,6 +456,7 @@ class EpochsEEGLAB(_BaseEpochs):
             # first extract the events and construct an event_id dict
             event_name, event_latencies, unique_ev = list(), list(), list()
             ev_idx = 0
+            warn_multiple_events = False
             for ep in eeg.epoch:
                 if not isinstance(ep.eventtype, string_types):
                     event_type = '/'.join(ep.eventtype.tolist())
@@ -463,8 +464,7 @@ class EpochsEEGLAB(_BaseEpochs):
                     # store latency of only first event
                     event_latencies.append(eeg.event[ev_idx].latency)
                     ev_idx += len(ep.eventtype)
-                    warn('An epoch has multiple events. Only the latency of '
-                         'the first event will be retained.')
+                    warn_multiple_events = True
                 else:
                     event_type = ep.eventtype
                     event_name.append(ep.eventtype)
@@ -477,6 +477,12 @@ class EpochsEEGLAB(_BaseEpochs):
                 # invent event dict but use id > 0 so you know its a trigger
                 event_id = dict((ev, idx + 1) for idx, ev
                                 in enumerate(unique_ev))
+
+            # warn about multiple events in epoch if necessary
+            if warn_multiple_events:
+                warn('At least one epoch has multiple events. Only the latency'
+                     ' of the first event will be retained.')
+
             # now fill up the event array
             events = np.zeros((eeg.trials, 3), dtype=int)
             for idx in range(0, eeg.trials):

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -7,6 +7,7 @@ import shutil
 
 import warnings
 from nose.tools import assert_raises, assert_equal
+import numpy as np
 from numpy.testing import assert_array_equal
 
 from mne import write_events, read_epochs_eeglab, Epochs, find_events
@@ -114,6 +115,21 @@ def test_io_set():
     event_id = {eeg.event[0].type: 1}
     read_raw_eeglab(input_fname=one_event_fname, montage=montage,
                     event_id=event_id, preload=True)
+
+    # test reading file with one channel
+    one_chan_fname = op.join(temp_dir, 'test_one_channel.set')
+    io.savemat(one_chan_fname, {'EEG':
+               {'trials': eeg.trials, 'srate': eeg.srate,
+                'nbchan': 1, 'data': np.random.random((1, 3)),
+                'epoch': eeg.epoch, 'event': eeg.epoch,
+                'chanlocs': {'labels': 'E1', 'Y': -6.6069,
+                             'X': 6.3023, 'Z': -2.9423},
+                'times': eeg.times[:3], 'pnts': 3}})
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        read_raw_eeglab(input_fname=one_chan_fname, preload=True)
+    # one warning for 'no events fond'
+    assert_equal(len(w), 1)
 
     # test if .dat file raises an error
     eeg = io.loadmat(epochs_fname, struct_as_record=False,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -64,6 +64,11 @@ def test_io_set():
         raw0.filter(1, None, l_trans_bandwidth='auto', filter_length='auto',
                     phase='zero')  # test that preloading works
 
+    # test that using uin16_codec does not break stuff
+    raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
+                           event_id=event_id, preload=False,
+                           uint16_codec='ascii')
+
     # test old EEGLAB version event import
     eeg = io.loadmat(raw_fname, struct_as_record=False,
                      squeeze_me=True)['EEG']

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -126,6 +126,6 @@ def test_io_set():
         warnings.simplefilter('always')
         assert_raises(NotImplementedError, read_epochs_eeglab,
                       bad_epochs_fname)
-    assert_equal(len(w), 3)
+    assert_equal(len(w), 1)
 
 run_tests_if_main()

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -77,9 +77,9 @@ def test_io_set():
         warnings.simplefilter('always')
         epochs = read_epochs_eeglab(epochs_fname)
         epochs2 = read_epochs_eeglab(epochs_fname_onefile)
-    # 3 warnings for each read_epochs_eeglab because there are 3 epochs
+    # one warning for each read_epochs_eeglab because both files have epochs
     # associated with multiple events
-    assert_equal(len(w), 6)
+    assert_equal(len(w), 2)
     assert_array_equal(epochs.get_data(), epochs2.get_data())
 
     # test different combinations of events and event_ids


### PR DESCRIPTION
@agramfort 
Sorry it took so long, forgot about that. 

Now `read_epochs_eeglab` and `read_raw_eeglab` expose `uint16_codec`.
Additional changes:
* the warning when multiple events are found in an epoch - is now raised only once, not for each epoch.
* minor fixes to the docstrings - `verbose` arg didn't use `|` when listing possible input types
* fixes reading one channel set files

TODO:
- [x] test for `uint16_codec`
- [x] maybe a better description of that argument in the docstring - when it's useful etc.
- [x] update what's new
- [x] fix for reading one-channel files
- [x] test for reading one-channels files