### PR TITLE
[MRG] FIX: Read units from .elc montage files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -101,6 +101,8 @@ BUG
 
     - Fixed bug with :func:`mne.realtime.FieldTripClient.get_data_as_epoch` when ``picks=None`` which crashed the function by `Mainak Jas`_
 
+    - Fixed reading of units in ``.elc`` montage files (from ``UnitsPosition`` field) so that these `mne.channels.Montage` objects are now returned with the ``pos`` attribute correctly in meters. by `Chris Mullins`_
+
 API
 ~~~
 
@@ -1725,3 +1727,5 @@ of commits):
 .. _Nick Foti: http://nfoti.github.io
 
 .. _Guillaume Dumas: http://www.extrospection.eu
+
+.. _Chris Mullins: http://crmullins.com

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -207,15 +207,13 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         pos = []
         with open(fname) as fid:
             # Default units are meters
-            scale_factor = 1.
             for line in fid:
                 if 'UnitPosition' in line:
                     units = line.split()[1]
-                    if units == 'm':
-                        break
-                    elif units == 'mm':
-                        scale_factor = 1. / 1000.
-                        break
+                    scale_factor=dict(m=1., mm=1e-3)[units]
+                    break
+                elif 'Positions\n' in line:
+                    raise RuntimeError('Could not detect units in file %s' % fname)
             for line in fid:
                 if 'Positions\n' in line:
                     break

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -210,10 +210,11 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
             for line in fid:
                 if 'UnitPosition' in line:
                     units = line.split()[1]
-                    scale_factor=dict(m=1., mm=1e-3)[units]
+                    scale_factor = dict(m=1., mm=1e-3)[units]
                     break
                 elif 'Positions\n' in line:
-                    raise RuntimeError('Could not detect units in file %s' % fname)
+                    raise RuntimeError(
+                        'Could not detect units in file %s' % fname)
             for line in fid:
                 if 'Positions\n' in line:
                     break

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -214,7 +214,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
                     if units == 'm':
                         break
                     elif units == 'mm':
-                        scale_factor = 1./1000.
+                        scale_factor = 1. / 1000.
                         break
             for line in fid:
                 if 'Positions\n' in line:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -206,6 +206,16 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         ch_names_ = []
         pos = []
         with open(fname) as fid:
+            # Default units are meters
+            scale_factor = 1.
+            for line in fid:
+                if 'UnitPosition' in line:
+                    units = line.split()[1]
+                    if units == 'm':
+                        break
+                    elif units == 'mm':
+                        scale_factor = 1./1000.
+                        break
             for line in fid:
                 if 'Positions\n' in line:
                     break
@@ -218,7 +228,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
                 if not line or not set(line) - set([' ']):
                     break
                 ch_names_.append(line.strip(' ').strip('\n'))
-        pos = np.array(pos)
+        pos = np.array(pos) * scale_factor
     elif ext == '.txt':
         # easycap
         try:  # newer version

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -212,9 +212,8 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
                     units = line.split()[1]
                     scale_factor = dict(m=1., mm=1e-3)[units]
                     break
-                elif 'Positions\n' in line:
-                    raise RuntimeError(
-                        'Could not detect units in file %s' % fname)
+            else:
+                raise RuntimeError('Could not detect units in file %s' % fname)
             for line in fid:
                 if 'Positions\n' in line:
                     break

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -90,8 +90,9 @@ def test_montage():
         if kind.endswith('elc'):
             # Make sure points are reasonable distance from geometric centroid
             centroid = np.sum(montage.pos, axis=0) / montage.pos.shape[0]
-            distance_from_centroid = np.apply_along_axis(np.linalg.norm, 1,
-                                                         montage.pos - centroid)
+            distance_from_centroid = np.apply_along_axis(
+                np.linalg.norm, 1,
+                montage.pos - centroid)
             assert_array_less(distance_from_centroid, 0.2)
             assert_array_less(0.01, distance_from_centroid)
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -90,8 +90,8 @@ def test_montage():
         if kind.endswith('elc'):
             # Make sure points are reasonable distance from geometric centroid
             centroid = np.sum(montage.pos, axis=0) / montage.pos.shape[0]
-            distance_from_centroid = np.linalg.norm(montage.pos - centroid,
-                                                    axis=1)
+            distance_from_centroid = np.apply_along_axis(np.linalg.norm, 1,
+                                                         montage.pos - centroid)
             assert_array_less(distance_from_centroid, 0.2)
             assert_array_less(0.01, distance_from_centroid)
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -9,7 +9,8 @@ from nose.tools import assert_equal, assert_true, assert_raises
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_almost_equal,
-                           assert_allclose, assert_array_almost_equal)
+                           assert_allclose, assert_array_almost_equal,
+                           assert_array_less)
 from mne.tests.common import assert_dig_allclose
 from mne.channels.montage import read_montage, _set_montage, read_dig_montage
 from mne.utils import _TempDir, run_tests_if_main
@@ -51,6 +52,10 @@ def test_montage():
         'NumberPositions=    68\nPositions\n-86.0761 -19.9897 -47.9860\n'
         '85.7939 -20.0093 -48.0310\n0.0083 86.8110 -39.9830\n'
         'Labels\nLPA\nRPA\nNz\n',
+        '# ASA electrode file\nReferenceLabel  avg\nUnitPosition    m\n'
+        'NumberPositions=    68\nPositions\n-.0860761 -.0199897 -.0479860\n'
+        '.0857939 -.0200093 -.0480310\n.0000083 .00868110 -.0399830\n'
+        'Labels\nLPA\nRPA\nNz\n',
         'Site  Theta  Phi\nFp1  -92    -72\nFp2   92     72\n'
         'very_very_very_long_name   -60    -51\n',
         '346\n'
@@ -59,8 +64,8 @@ def test_montage():
         'EEG	      F4	   62.01	  50.103	      85\n',
         'eeg Fp1 -95.0 -31.0 -3.0\neeg AF7 -81 -59 -3\neeg AF3 -87 -41 28\n'
     ]
-    kinds = ['test.sfp', 'test.csd', 'test.elc', 'test.txt', 'test.elp',
-             'test.hpts']
+    kinds = ['test.sfp', 'test.csd', 'test_mm.elc', 'test_m.elc', 'test.txt',
+             'test.elp', 'test.hpts']
     for kind, text in zip(kinds, input_str):
         fname = op.join(tempdir, kind)
         with open(fname, 'w') as fid:
@@ -82,6 +87,14 @@ def test_montage():
                 table = np.loadtxt(fname, skiprows=2, dtype=dtype)
             pos2 = np.c_[table['x'], table['y'], table['z']]
             assert_array_almost_equal(pos2, montage.pos, 4)
+        if kind.endswith('elc'):
+            # Make sure points are reasonable distance from geometric centroid
+            centroid = np.sum(montage.pos, axis=0) / montage.pos.shape[0]
+            distance_from_centroid = np.linalg.norm(montage.pos - centroid,
+                                                    axis=1)
+            assert_array_less(distance_from_centroid, 0.2)
+            assert_array_less(0.01, distance_from_centroid)
+
     # test transform
     input_str = """
     eeg Fp1 -95.0 -31.0 -3.0


### PR DESCRIPTION
Previously units were not read from .elc files. This caused all
units to be interpreted as meters.