### PR TITLE
MRG: Check and warn for bad pos

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -750,6 +750,11 @@ def _check_pos(pos, head_frame, raw, st_fixed, sfreq):
         raise ValueError('Head position time points must be greater than '
                          'first sample offset, but found %0.4f < %0.4f'
                          % (t[0], t_off))
+    max_dist = np.linalg.norm(pos[:, 4:7], axis=1).max()
+    if max_dist > 1.:
+        warn('Found a distance greater than 1 m (%0.3g m) from the device '
+             'origin, positions may be invalid and Maxwell filtering could '
+             'fail' % (max_dist,))
     dev_head_ts = np.zeros((len(t), 4, 4))
     dev_head_ts[:, 3, 3] = 1.
     dev_head_ts[:, :3, 3] = pos[:, 4:7]

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -750,7 +750,7 @@ def _check_pos(pos, head_frame, raw, st_fixed, sfreq):
         raise ValueError('Head position time points must be greater than '
                          'first sample offset, but found %0.4f < %0.4f'
                          % (t[0], t_off))
-    max_dist = np.linalg.norm(pos[:, 4:7], axis=1).max()
+    max_dist = np.sqrt(np.sum(pos[:, 4:7] ** 2, axis=1)).max()
     if max_dist > 1.:
         warn('Found a distance greater than 1 m (%0.3g m) from the device '
              'origin, positions may be invalid and Maxwell filtering could '

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -186,7 +186,15 @@ def test_movement_compensation():
     head_pos_bad = head_pos.copy()
     head_pos_bad[0, 0] = raw.first_samp / raw.info['sfreq'] - 1e-2
     assert_raises(ValueError, maxwell_filter, raw, head_pos=head_pos_bad)
+
+    head_pos_bad = head_pos.copy()
+    head_pos_bad[0, 4] = 1.  # off by more than 1 m
+    with warnings.catch_warnings(record=True) as w:
+        maxwell_filter(raw, head_pos=head_pos_bad, bad_condition='ignore')
+    assert_true(any('greater than 1 m' in str(ww.message) for ww in w))
+
     # make sure numerical error doesn't screw it up, though
+    head_pos_bad = head_pos.copy()
     head_pos_bad[0, 0] = raw.first_samp / raw.info['sfreq'] - 5e-4
     raw_sss_tweak = maxwell_filter(raw, head_pos=head_pos_bad,
                                    origin=mf_head_origin)


### PR DESCRIPTION
Addresses cases where the `head_pos` argument are likely invalid, which can happen if MaxFilter's head position fitting routines fail badly.