### PR TITLE
MRG+1: Add reference without digization points (bugfix)

### DIFF
--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -205,9 +205,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
     else:
         # we should actually be able to do this from the montage, but
         # it looks like the montage isn't stored, so we can't extract
-        # this information. The user will just have to call set_montag()
-        warn('No digitization found, location of new reference channel '
-             'set to zero')
+        # this information. The user will just have to call set_montage()
         # by setting this to zero, we fall back to the old behavior
         # when missing digitisation
         ref_dig_array = np.zeros(12)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -187,7 +187,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
     nchan = len(inst.info['ch_names'])
 
     # only do this if we actually have digitisation points
-    if 'dig' in inst.info and inst.info['dig'] is not None:
+    if inst.info.get('dig', None) is not None:
         # "zeroth" EEG electrode dig points is reference
         ref_dig_loc = [dl for dl in inst.info['dig'] if (
                        dl['kind'] == FIFF.FIFFV_POINT_EEG and

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -187,7 +187,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
     nchan = len(inst.info['ch_names'])
 
     # only do this if we actually have digitisation points
-    if 'dig' in inst.info and inst.info['dig']:
+    if 'dig' in inst.info and inst.info['dig'] is not None:
         # "zeroth" EEG electrode dig points is reference
         ref_dig_loc = [dl for dl in inst.info['dig'] if (
                        dl['kind'] == FIFF.FIFFV_POINT_EEG and

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -187,7 +187,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
     nchan = len(inst.info['ch_names'])
 
     # only do this if we actually have digitisation points
-    if 'dig' in inst.info:
+    if 'dig' in inst.info and inst.info['dig']:
         # "zeroth" EEG electrode dig points is reference
         ref_dig_loc = [dl for dl in inst.info['dig'] if (
                        dl['kind'] == FIFF.FIFFV_POINT_EEG and

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -266,10 +266,8 @@ def test_add_reference():
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     del raw.info['dig']
 
-    with warnings.catch_warnings(record=True) as w:
-        raw_ref = add_reference_channels(raw, 'Ref', copy=True)
+    raw_ref = add_reference_channels(raw, 'Ref', copy=True)
 
-    assert_true('No digitization found' in str(ww.message) for ww in w)
     assert_equal(raw_ref._data.shape[0], raw._data.shape[0] + 1)
     assert_array_equal(raw._data[picks_eeg, :], raw_ref._data[picks_eeg, :])
     _check_channel_names(raw_ref, 'Ref')

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -258,11 +258,8 @@ def test_add_reference():
     ref_data, _ = raw[ref_idx]
     assert_array_equal(ref_data, 0)
 
-    raw = Raw(fif_fname, preload=True)
-    picks_eeg = pick_types(raw.info, meg=False, eeg=True)
-
     # add reference channel to Raw when no digitization points exist
-    raw = Raw(fif_fname, preload=True)
+    raw = Raw(fif_fname).crop(0, 1).load_data()
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     del raw.info['dig']
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -265,7 +265,11 @@ def test_add_reference():
     raw = Raw(fif_fname, preload=True)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     del raw.info['dig']
-    raw_ref = add_reference_channels(raw, 'Ref', copy=True)
+
+    with warnings.catch_warnings(record=True) as w:
+        raw_ref = add_reference_channels(raw, 'Ref', copy=True)
+
+    assert_true('No digitization found' in str(ww.message) for ww in w)
     assert_equal(raw_ref._data.shape[0], raw._data.shape[0] + 1)
     assert_array_equal(raw._data[picks_eeg, :], raw_ref._data[picks_eeg, :])
     _check_channel_names(raw_ref, 'Ref')

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -261,6 +261,21 @@ def test_add_reference():
     raw = Raw(fif_fname, preload=True)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
 
+    # add reference channel to Raw when no digitization points exist
+    raw = Raw(fif_fname, preload=True)
+    picks_eeg = pick_types(raw.info, meg=False, eeg=True)
+    del raw.info['dig']
+    raw_ref = add_reference_channels(raw, 'Ref', copy=True)
+    assert_equal(raw_ref._data.shape[0], raw._data.shape[0] + 1)
+    assert_array_equal(raw._data[picks_eeg, :], raw_ref._data[picks_eeg, :])
+    _check_channel_names(raw_ref, 'Ref')
+
+    orig_nchan = raw.info['nchan']
+    raw = add_reference_channels(raw, 'Ref', copy=False)
+    assert_array_equal(raw._data, raw_ref._data)
+    assert_equal(raw.info['nchan'], orig_nchan + 1)
+    _check_channel_names(raw, 'Ref')
+
     # Test adding an existing channel as reference channel
     assert_raises(ValueError, add_reference_channels, raw,
                   raw.info['ch_names'][0])


### PR DESCRIPTION
This fixes a new bug where adding a reference channel without digization points fails. I've included a test that fails without the fix.