### PR TITLE
[MRG+1]: Deprecate add_eeg_ref parameters

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ dependencies:
     - pip install --upgrade pyface;
     - git clone https://github.com/sphinx-gallery/sphinx-gallery.git;
     - cd sphinx-gallery && pip install -r requirements.txt && python setup.py develop;
-    - pip install sphinx_bootstrap_theme PySurfer nilearn neo numpydoc;
+    - pip install sphinx_bootstrap_theme git+git://github.com/nipy/PySurfer.git nilearn neo numpydoc;
 
   override:
     # Figure out if we should run a full, pattern, or noplot version

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -354,12 +354,12 @@ It creates a BrainVision ``vhdr`` file and calls :ref:`mne_brain_vision2fiff`.
 Setting EEG references
 ######################
 
-The preferred method for creating an average EEG reference in MNE is
+The preferred method for applying an EEG reference in MNE is
 :func:`mne.set_eeg_reference`, or equivalent instance methods like
-:meth:`raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>`. Instead
-of applying the average reference to the data directly, an average EEG
-reference projector is created that is applied like any other SSP projection
-operator.
+:meth:`raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>`. By default,
+an average reference is used. Instead of applying the average reference to
+the data directly, an average EEG reference projector is created that is
+applied like any other SSP projection operator.
 
 There are also other functions that can be useful for other referencing
 operations. See :func:`mne.set_bipolar_reference` and

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -46,9 +46,11 @@ Neuromag Raw FIF files can be loaded using :func:`mne.io.read_raw_fif`.
     ``mne.io.read_raw_fif(..., allow_maxshield=True)``.
 
 .. note::
-    This file format also supports EEG data. An average reference will be added
-    by default on reading EEG data. To change this behavior call the readers
-    like this: ``mne.io.read_raw_fif(..., add_eeg_ref=False)``
+    This file format also supports EEG data. In 0.13, an average reference
+    will be added by default on reading EEG data. To change this behavior,
+    use the argument ``add_eeg_ref=False``, which will become the default
+    in 0.14. The argument will be removed in 0.15 in favor of
+    :func:`mne.set_eeg_reference` and :meth:`mne.io.Raw.set_eeg_reference`.
 
 
 Importing 4-D Neuroimaging / BTI data
@@ -348,6 +350,20 @@ EEG data from the Nexstim eXimia system can be converted
 to the fif format with help of the :ref:`mne_eximia2fiff` script.
 It creates a BrainVision ``vhdr`` file and calls :ref:`mne_brain_vision2fiff`.
 
+
+Setting EEG references
+######################
+
+The preferred method for creating an average EEG reference in MNE is
+:func:`mne.set_eeg_reference`, or equivalent instance methods like
+:meth:`raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>`. Instead
+of applying the average reference to the data directly, an average EEG
+reference projector is created that is applied like any other SSP projection
+operator.
+
+There are also other functions that can be useful for other referencing
+operations. See :func:`mne.set_bipolar_reference` and
+:func:`mne.add_reference_channels` for more information.
 
 
 Reading Electrode locations and Headshapes for EEG recordings

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -444,7 +444,7 @@ Functions:
 
 EEG referencing:
 
-.. currentmodule:: mne.io
+.. currentmodule:: mne
 
 .. autosummary::
    :toctree: generated/

--- a/examples/connectivity/plot_mne_inverse_coherence_epochs.py
+++ b/examples/connectivity/plot_mne_inverse_coherence_epochs.py
@@ -36,7 +36,7 @@ method = "dSPM"  # use dSPM method (could also be MNE or sLORETA)
 # Load data
 inverse_operator = read_inverse_operator(fname_inv)
 label_lh = mne.read_label(fname_label_lh)
-raw = mne.io.read_raw_fif(fname_raw)
+raw = mne.io.read_raw_fif(fname_raw, add_eeg_ref=False)
 events = mne.read_events(fname_event)
 
 # Add a bad channel
@@ -48,8 +48,8 @@ picks = mne.pick_types(raw.info, meg=True, eeg=False, stim=False, eog=True,
 
 # Read epochs
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), reject=dict(mag=4e-12, grad=4000e-13,
-                                                    eog=150e-6))
+                    add_eeg_ref=False, baseline=(None, 0),
+                    reject=dict(mag=4e-12, grad=4000e-13, eog=150e-6))
 
 # First, we find the most active vertex in the left auditory cortex, which
 # we will later use as seed for the connectivity computation

--- a/examples/decoding/plot_decoding_spatio_temporal_source.py
+++ b/examples/decoding/plot_decoding_spatio_temporal_source.py
@@ -148,6 +148,5 @@ stc_feat = mne.SourceEstimate(feature_weights, vertices=vertices,
                               tmin=stc.tmin, tstep=stc.tstep,
                               subject='sample')
 
-brain = stc_feat.plot()
-brain.set_time(100)
-brain.show_view('l')  # take the medial view to further explore visual areas
+brain = stc_feat.plot(hemi='split', views=['lat', 'med'], transparent=True,
+                      initial_time=0.1, time_unit='s')

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -32,6 +32,8 @@ from .io.meas_info import create_info, Info
 from .io.proj import Projection
 from .io.kit import read_epochs_kit
 from .io.eeglab import read_epochs_eeglab
+from .io.reference import (set_eeg_reference, set_bipolar_reference,
+                           add_reference_channels)
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -40,7 +40,7 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
     """
     label = mne.read_label(fname_label)
     events = mne.read_events(fname_event)[:10]
-    raw = mne.io.read_raw_fif(fname_raw, preload=False)
+    raw = mne.io.read_raw_fif(fname_raw, preload=False, add_eeg_ref=False)
     raw.add_proj([], remove_existing=True)  # we'll subselect so remove proj
     forward = mne.read_forward_solution(fname_fwd)
     if read_all_forward:
@@ -67,7 +67,8 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
     # Read epochs
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                         picks=picks, baseline=(None, 0), preload=True,
-                        reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
+                        reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6),
+                        add_eeg_ref=False)
     epochs.resample(200, npad=0, n_jobs=2)
     evoked = epochs.average()
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -40,7 +40,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     """
     label = mne.read_label(fname_label)
     events = mne.read_events(fname_event)
-    raw = mne.io.read_raw_fif(fname_raw, preload=True)
+    raw = mne.io.read_raw_fif(fname_raw, preload=True, add_eeg_ref=False)
     forward = mne.read_forward_solution(fname_fwd)
     if all_forward:
         forward_surf_ori = read_forward_solution_meg(fname_fwd, surf_ori=True)
@@ -69,7 +69,8 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
         epochs = mne.Epochs(
             raw, events, event_id, tmin, tmax, proj=True,
             baseline=(None, 0), preload=epochs_preload,
-            reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
+            reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6),
+            add_eeg_ref=False)
         if epochs_preload:
             epochs.resample(200, npad=0, n_jobs=2)
         evoked = epochs.average()
@@ -267,7 +268,7 @@ def test_tf_lcmv():
     """
     label = mne.read_label(fname_label)
     events = mne.read_events(fname_event)
-    raw = mne.io.read_raw_fif(fname_raw, preload=True)
+    raw = mne.io.read_raw_fif(fname_raw, preload=True, add_eeg_ref=False)
     forward = mne.read_forward_solution(fname_fwd)
 
     event_id, tmin, tmax = 1, -0.2, 0.2
@@ -287,7 +288,8 @@ def test_tf_lcmv():
     # Read epochs
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                         baseline=None, preload=False,
-                        reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
+                        reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6),
+                        add_eeg_ref=False)
     epochs.drop_bad()
 
     freq_bins = [(4, 12), (15, 40)]
@@ -304,7 +306,7 @@ def test_tf_lcmv():
                         iir_params=dict(output='ba'))
         epochs_band = mne.Epochs(
             raw_band, epochs.events, epochs.event_id, tmin=tmin, tmax=tmax,
-            baseline=None, proj=True)
+            baseline=None, proj=True, add_eeg_ref=False)
         with warnings.catch_warnings(record=True):  # not enough samples
             noise_cov = compute_covariance(epochs_band, tmin=tmin, tmax=tmin +
                                            win_length)
@@ -365,7 +367,8 @@ def test_tf_lcmv():
     # Test correct detection of preloaded epochs objects that do not contain
     # the underlying raw object
     epochs_preloaded = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
-                                  baseline=(None, 0), preload=True)
+                                  baseline=(None, 0), preload=True,
+                                  add_eeg_ref=False)
     epochs_preloaded._raw = None
     with warnings.catch_warnings(record=True):  # not enough samples
         assert_raises(ValueError, tf_lcmv, epochs_preloaded, forward,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -16,10 +16,10 @@ from ..externals.six import string_types
 
 from ..utils import verbose, logger, warn, copy_function_doc_to_method_doc
 from ..io.compensator import get_current_comp
+from ..io.constants import FIFF
 from ..io.meas_info import anonymize_info
 from ..io.pick import (channel_type, pick_info, pick_types,
                        _check_excludes_includes, _PICK_TYPES_KEYS)
-from ..io.constants import FIFF
 
 
 def _get_meg_system(info):
@@ -228,8 +228,52 @@ def _check_set(ch, projs, ch_type):
 
 
 class SetChannelsMixin(object):
-    """Mixin class for Raw, Evoked, Epochs
-    """
+    """Mixin class for Raw, Evoked, Epochs."""
+
+    def set_eeg_reference(self, ref_channels=None):
+        """Rereference EEG channels to new reference channel(s).
+
+        If multiple reference channels are specified, they will be averaged. If
+        no reference channels are specified, an average reference will be
+        applied.
+
+        Parameters
+        ----------
+        ref_channels : list of str | None
+            The names of the channels to use to construct the reference. If
+            None (default), an average reference will be added as an SSP
+            projector but not immediately applied to the data. If an empty list
+            is specified, the data is assumed to already have a proper
+            reference and MNE will not attempt any re-referencing of the data.
+            Defaults to an average reference (None).
+
+        Returns
+        -------
+        inst : instance of Raw | Epochs | Evoked
+            Data with EEG channels re-referenced. For ``ref_channels=None``,
+            an average projector will be added instead of directly subtarcting
+            data.
+
+        Notes
+        -----
+        1. If a reference is requested that is not the average reference, this
+           function removes any pre-existing average reference projections.
+
+        2. During source localization, the EEG signal should have an average
+           reference.
+
+        3. In order to apply a reference other than an average reference, the
+           data must be preloaded.
+
+        .. versionadded:: 0.13.0
+
+        See Also
+        --------
+        mne.set_bipolar_reference
+        """
+        from ..io.reference import set_eeg_reference
+        return set_eeg_reference(self, ref_channels, copy=False)[0]
+
     def _get_channel_positions(self, picks=None):
         """Gets channel locations from info
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -16,7 +16,7 @@ from nose.tools import assert_raises, assert_true, assert_equal
 
 from mne.channels import rename_channels, read_ch_connectivity
 from mne.channels.channels import _ch_neighbor_connectivity
-from mne.io import read_info, Raw
+from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
 from mne.utils import _TempDir, run_tests_if_main
 from mne import pick_types, pick_channels
@@ -28,8 +28,7 @@ warnings.simplefilter('always')
 
 
 def test_rename_channels():
-    """Test rename channels
-    """
+    """Test rename channels"""
     info = read_info(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
@@ -65,9 +64,8 @@ def test_rename_channels():
 
 
 def test_set_channel_types():
-    """Test set_channel_types
-    """
-    raw = Raw(raw_fname)
+    """Test set_channel_types"""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
@@ -80,7 +78,7 @@ def test_set_channel_types():
                'EOG 061': 'seeg', 'MEG 2441': 'eeg', 'MEG 2443': 'eeg'}
     assert_raises(RuntimeError, raw.set_channel_types, mapping)
     # Test type change
-    raw2 = Raw(raw_fname, add_eeg_ref=False)
+    raw2 = read_raw_fif(raw_fname, add_eeg_ref=False)
     raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     with warnings.catch_warnings(record=True):  # MEG channel change
         assert_raises(RuntimeError, raw2.set_channel_types, mapping)  # has prj
@@ -119,7 +117,7 @@ def test_set_channel_types():
 
 
 def test_read_ch_connectivity():
-    "Test reading channel connectivity templates"
+    """Test reading channel connectivity templates"""
     tempdir = _TempDir()
     a = partial(np.array, dtype='<U7')
     # no pep8
@@ -160,9 +158,8 @@ def test_read_ch_connectivity():
 
 
 def test_get_set_sensor_positions():
-    """Test get/set functions for sensor positions
-    """
-    raw1 = Raw(raw_fname)
+    """Test get/set functions for sensor positions"""
+    raw1 = read_raw_fif(raw_fname, add_eeg_ref=False)
     picks = pick_types(raw1.info, meg=False, eeg=True)
     pos = np.array([ch['loc'][:3] for ch in raw1.info['chs']])[picks]
     raw_pos = raw1._get_channel_positions(picks=picks)
@@ -170,7 +167,7 @@ def test_get_set_sensor_positions():
 
     ch_name = raw1.info['ch_names'][13]
     assert_raises(ValueError, raw1._set_channel_positions, [1, 2], ['name'])
-    raw2 = Raw(raw_fname)
+    raw2 = read_raw_fif(raw_fname, add_eeg_ref=False)
     raw2.info['chs'][13]['loc'][:3] = np.array([1, 2, 3])
     raw1._set_channel_positions([[1, 2, 3]], [ch_name])
     assert_array_equal(raw1.info['chs'][13]['loc'],

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -22,7 +22,7 @@ from mne.channels.layout import (_box_size, _auto_topomap_coords,
                                  generate_2d_layout)
 from mne.utils import run_tests_if_main
 from mne import pick_types, pick_info
-from mne.io import Raw, read_raw_kit, _empty_info
+from mne.io import read_raw_kit, _empty_info, read_info
 from mne.io.constants import FIFF
 from mne.bem import fit_sphere_to_headshape
 from mne.utils import _TempDir
@@ -85,7 +85,7 @@ def test_io_layout_lay():
 
 def test_auto_topomap_coords():
     """Test mapping of coordinates in 3D space to 2D"""
-    info = Raw(fif_fname).info.copy()
+    info = read_info(fif_fname)
     picks = pick_types(info, meg=False, eeg=True, eog=False, stim=False)
 
     # Remove extra digitization point, so EEG digitization points match up
@@ -145,7 +145,7 @@ def test_make_eeg_layout():
     tmp_name = 'foo'
     lout_name = 'test_raw'
     lout_orig = read_layout(kind=lout_name, path=lout_path)
-    info = Raw(fif_fname).info
+    info = read_info(fif_fname)
     info['bads'].append(info['ch_names'][360])
     layout = make_eeg_layout(info, exclude=[])
     assert_array_equal(len(layout.names), len([ch for ch in info['ch_names']
@@ -193,7 +193,7 @@ def test_find_layout():
     import matplotlib.pyplot as plt
     assert_raises(ValueError, find_layout, _get_test_info(), ch_type='meep')
 
-    sample_info = Raw(fif_fname).info
+    sample_info = read_info(fif_fname)
     grads = pick_types(sample_info, meg='grad')
     sample_info2 = pick_info(sample_info, grads)
 
@@ -247,11 +247,11 @@ def test_find_layout():
     assert_equal(lout.kind, 'EEG')
     # no common layout, 'meg' option not supported
 
-    lout = find_layout(Raw(fname_ctf_raw).info)
+    lout = find_layout(read_info(fname_ctf_raw))
     assert_equal(lout.kind, 'CTF-275')
 
     fname_bti_raw = op.join(bti_dir, 'exported4D_linux_raw.fif')
-    lout = find_layout(Raw(fname_bti_raw).info)
+    lout = find_layout(read_info(fname_bti_raw))
     assert_equal(lout.kind, 'magnesWH3600')
 
     raw_kit = read_raw_kit(fname_kit_157)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -6,6 +6,7 @@ import glob
 import warnings
 from nose.tools import assert_true, assert_raises
 
+from mne import concatenate_raws
 from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_compute_proj_ecg, mne_compute_proj_eog,
                           mne_coreg, mne_kit2fiff,
@@ -13,12 +14,11 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_report, mne_surf2bem, mne_watershed_bem,
                           mne_compare_fiff, mne_flash_bem, mne_show_fiff,
                           mne_show_info)
-from mne import concatenate_raws
+from mne.datasets import testing, sample
+from mne.io import read_raw_fif
 from mne.utils import (run_tests_if_main, _TempDir, requires_mne, requires_PIL,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
                        ArgvSetter, slow_test, ultra_slow_test)
-from mne.io import Raw
-from mne.datasets import testing, sample
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -42,22 +42,22 @@ def check_usage(module, force_help=False):
 
 @slow_test
 def test_browse_raw():
-    """Test mne browse_raw"""
+    """Test mne browse_raw."""
     check_usage(mne_browse_raw)
 
 
 def test_bti2fiff():
-    """Test mne bti2fiff"""
+    """Test mne bti2fiff."""
     check_usage(mne_bti2fiff)
 
 
 def test_compare_fiff():
-    """Test mne compare_fiff"""
+    """Test mne compare_fiff."""
     check_usage(mne_compare_fiff)
 
 
 def test_show_fiff():
-    """Test mne compare_fiff"""
+    """Test mne compare_fiff."""
     check_usage(mne_show_fiff)
     with ArgvSetter((raw_fname,)):
         mne_show_fiff.run()
@@ -65,10 +65,11 @@ def test_show_fiff():
 
 @requires_mne
 def test_clean_eog_ecg():
-    """Test mne clean_eog_ecg"""
+    """Test mne clean_eog_ecg."""
     check_usage(mne_clean_eog_ecg)
     tempdir = _TempDir()
-    raw = concatenate_raws([Raw(f) for f in [raw_fname, raw_fname, raw_fname]])
+    raw = concatenate_raws([read_raw_fif(f, add_eeg_ref=False)
+                            for f in [raw_fname, raw_fname, raw_fname]])
     raw.info['bads'] = ['MEG 2443']
     use_fname = op.join(tempdir, op.basename(raw_fname))
     raw.save(use_fname)
@@ -82,7 +83,7 @@ def test_clean_eog_ecg():
 
 @slow_test
 def test_compute_proj_ecg_eog():
-    """Test mne compute_proj_ecg/eog"""
+    """Test mne compute_proj_ecg/eog."""
     for fun in (mne_compute_proj_ecg, mne_compute_proj_eog):
         check_usage(fun)
         tempdir = _TempDir()
@@ -101,12 +102,12 @@ def test_compute_proj_ecg_eog():
 
 
 def test_coreg():
-    """Test mne coreg"""
+    """Test mne coreg."""
     assert_true(hasattr(mne_coreg, 'run'))
 
 
 def test_kit2fiff():
-    """Test mne kit2fiff"""
+    """Test mne kit2fiff."""
     # Can't check
     check_usage(mne_kit2fiff, force_help=True)
 
@@ -115,7 +116,7 @@ def test_kit2fiff():
 @requires_mne
 @testing.requires_testing_data
 def test_make_scalp_surfaces():
-    """Test mne make_scalp_surfaces"""
+    """Test mne make_scalp_surfaces."""
     check_usage(mne_make_scalp_surfaces)
     # Copy necessary files to avoid FreeSurfer call
     tempdir = _TempDir()
@@ -152,7 +153,7 @@ def test_make_scalp_surfaces():
 
 
 def test_maxfilter():
-    """Test mne maxfilter"""
+    """Test mne maxfilter."""
     check_usage(mne_maxfilter)
     with ArgvSetter(('-i', raw_fname, '--st', '--movecomp', '--linefreq', '60',
                      '--trans', raw_fname)) as out:
@@ -173,7 +174,7 @@ def test_maxfilter():
 @requires_PIL
 @testing.requires_testing_data
 def test_report():
-    """Test mne report"""
+    """Test mne report."""
     check_usage(mne_report)
     tempdir = _TempDir()
     use_fname = op.join(tempdir, op.basename(raw_fname))
@@ -186,7 +187,7 @@ def test_report():
 
 
 def test_surf2bem():
-    """Test mne surf2bem"""
+    """Test mne surf2bem."""
     check_usage(mne_surf2bem)
 
 
@@ -194,7 +195,7 @@ def test_surf2bem():
 @requires_freesurfer
 @testing.requires_testing_data
 def test_watershed_bem():
-    """Test mne watershed bem"""
+    """Test mne watershed bem."""
     check_usage(mne_watershed_bem)
     # Copy necessary files to tempdir
     tempdir = _TempDir()
@@ -218,7 +219,7 @@ def test_watershed_bem():
 @requires_freesurfer
 @sample.requires_sample_data
 def test_flash_bem():
-    """Test mne flash_bem"""
+    """Test mne flash_bem."""
     check_usage(mne_flash_bem, force_help=True)
     # Using the sample dataset
     subjects_dir = op.join(sample.data_path(download=False), 'subjects')
@@ -247,7 +248,7 @@ def test_flash_bem():
 
 
 def test_show_info():
-    """Test mne show_info"""
+    """Test mne show_info."""
     check_usage(mne_show_info)
     with ArgvSetter((raw_fname,)):
         mne_show_info.run()

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -453,8 +453,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
             data += np.dot(raw_segment, raw_segment.T)
             n_samples += raw_segment.shape[1]
         _check_n_samples(n_samples, len(picks))
-        mu /= n_samples
-        data -= n_samples * mu[:, None] * mu[None, :]
+        data -= mu[:, None] * (mu[None, :] / n_samples)
         data /= (n_samples - 1.0)
         logger.info("Number of samples used : %d" % n_samples)
         logger.info('[done]')

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -437,7 +437,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         pick_mask = slice(None)
     epochs = Epochs(raw, events, 1, 0, tstep_m1, baseline=None,
                     picks=picks, reject=reject, flat=flat, verbose=False,
-                    preload=False, proj=False)
+                    preload=False, proj=False, add_eeg_ref=False)
     if method is None:
         method = 'empirical'
     if isinstance(method, string_types) and method == 'empirical':

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -27,14 +27,15 @@ start, stop = 0, 8
 def test_csp():
     """Test Common Spatial Patterns algorithm on epochs
     """
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[2:12:3]  # subselect channels -> disable proj!
     raw.add_proj([], remove_existing=True)
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True, proj=False)
+                    baseline=(None, 0), preload=True, proj=False,
+                    add_eeg_ref=False)
     epochs_data = epochs.get_data()
     n_channels = epochs_data.shape[1]
     y = epochs.events[:, -1]
@@ -91,7 +92,8 @@ def test_csp():
     # Test with more than 2 classes
     epochs = Epochs(raw, events, tmin=tmin, tmax=tmax, picks=picks,
                     event_id=dict(aud_l=1, aud_r=2, vis_l=3, vis_r=4),
-                    baseline=(None, 0), proj=False, preload=True)
+                    baseline=(None, 0), proj=False, preload=True,
+                    add_eeg_ref=False)
     epochs_data = epochs.get_data()
     n_channels = epochs_data.shape[1]
 
@@ -137,13 +139,13 @@ def test_csp():
 def test_regularized_csp():
     """Test Common Spatial Patterns algorithm using regularized covariance
     """
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
     n_channels = epochs_data.shape[1]
 

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -24,7 +24,7 @@ event_id = dict(aud_l=1, vis_l=3)
 @requires_sklearn_0_15
 def test_ems():
     """Test event-matched spatial filters"""
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
 
     # create unequal number of events
     events = read_events(event_name)
@@ -33,7 +33,7 @@ def test_ems():
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     assert_raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
     epochs = epochs.equalize_event_counts(epochs.event_id, copy=False)[0]
 
@@ -44,7 +44,7 @@ def test_ems():
     events = read_events(event_name)
     event_id2 = dict(aud_l=1, aud_r=2, vis_l=3)
     epochs = Epochs(raw, events, event_id2, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs = epochs.equalize_event_counts(epochs.event_id, copy=False)[0]
 
     n_expected = sum([len(epochs[k]) for k in ['aud_l', 'vis_l']])

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -28,7 +28,7 @@ warnings.simplefilter('always')
 
 
 def make_epochs():
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg='mag', stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -38,7 +38,8 @@ def make_epochs():
     # Test on time generalization within one condition
     with warnings.catch_warnings(record=True):
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), preload=True, decim=decim)
+                        baseline=(None, 0), preload=True, decim=decim,
+                        add_eeg_ref=False)
     return epochs
 
 

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -29,15 +29,15 @@ event_name = op.join(data_dir, 'test-eve.fif')
 
 
 def test_scaler():
-    """Test methods of Scaler"""
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    """Test methods of Scaler."""
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
 
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
     scaler = Scaler(epochs.info)
     y = epochs.events[:, -1]
@@ -61,14 +61,14 @@ def test_scaler():
 
 
 def test_filterestimator():
-    """Test methods of FilterEstimator"""
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    """Test methods of FilterEstimator."""
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
 
     # Add tests for different combinations of l_freq and h_freq
@@ -105,15 +105,14 @@ def test_filterestimator():
 
 
 def test_psdestimator():
-    """Test methods of PSDEstimator
-    """
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    """Test methods of PSDEstimator."""
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
     psd = PSDEstimator(2 * np.pi, 0, np.inf)
     y = epochs.events[:, -1]
@@ -128,16 +127,15 @@ def test_psdestimator():
 
 
 def test_epochs_vectorizer():
-    """Test methods of EpochsVectorizer
-    """
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    """Test methods of EpochsVectorizer."""
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     with warnings.catch_warnings(record=True):
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), preload=True)
+                        baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
     vector = EpochsVectorizer(epochs.info)
     y = epochs.events[:, -1]
@@ -196,15 +194,17 @@ def test_vectorizer():
 
 @requires_sklearn_0_15
 def test_unsupervised_spatial_filter():
+    """Test unsupervised spatial filter."""
     from sklearn.decomposition import PCA
     from sklearn.kernel_ridge import KernelRidge
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = io.read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, baseline=None, verbose=False)
+                    preload=True, baseline=None, verbose=False,
+                    add_eeg_ref=False)
 
     # Test estimator
     assert_raises(ValueError, UnsupervisedSpatialFilter, KernelRidge(2))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -137,7 +137,8 @@ def test_epochs_vectorizer():
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), preload=True, add_eeg_ref=False)
     epochs_data = epochs.get_data()
-    vector = EpochsVectorizer(epochs.info)
+    with warnings.catch_warnings(record=True):  # deprecation
+        vector = EpochsVectorizer(epochs.info)
     y = epochs.events[:, -1]
     X = vector.fit_transform(epochs_data, y)
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -297,11 +297,10 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             logger.info('Entering delayed SSP mode.')
         else:
             self._do_delayed_proj = False
-
+        add_eeg_ref = _dep_eeg_ref(add_eeg_ref) if 'eeg' in self else False
         activate = False if self._do_delayed_proj else proj
         self._projector, self.info = setup_proj(self.info, add_eeg_ref,
                                                 activate=activate)
-
         if preload_at_end:
             assert self._data is None
             assert self.preload is False
@@ -1776,7 +1775,6 @@ class Epochs(_BaseEpochs):
         if not isinstance(raw, _BaseRaw):
             raise ValueError('The first argument to `Epochs` must be an '
                              'instance of `mne.io.Raw`')
-        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
         info = deepcopy(raw.info)
 
         # proj is on when applied in Raw
@@ -2333,8 +2331,6 @@ class EpochsFIF(_BaseEpochs):
     def __init__(self, fname, proj=True, add_eeg_ref=None, preload=True,
                  verbose=None):
         check_fname(fname, 'epochs', ('-epo.fif', '-epo.fif.gz'))
-        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
-
         fnames = [fname]
         ep_list = list()
         raw = list()

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1604,19 +1604,19 @@ def _drop_log_stats(drop_log, ignore=('IGNORED',)):
 
 
 def _dep_eeg_ref(add_eeg_ref, current_default=True):
-    """Helper for deprecation"""
+    """Helper for deprecation add_eeg_ref -> False"""
     if current_default is True:
         if add_eeg_ref is None:
             add_eeg_ref = True
             warn('add_eeg_ref will default to True in 0.13 and False in 0.14, '
                  'and will be removed in 0.15. We recommend to use '
-                 'add_eeg_ref=False and raw.set_eeg_reference() instead.',
+                 'add_eeg_ref=False and mne.set_eeg_reference() instead.',
                  DeprecationWarning)
     # current_default is False
     elif add_eeg_ref is None:
         add_eeg_ref = False
     else:
-        warn('add_eeg_ref will be removed in 0.14, use raw.set_eeg_reference()'
+        warn('add_eeg_ref will be removed in 0.14, use mne.set_eeg_reference()'
              ' instead', DeprecationWarning)
     return add_eeg_ref
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1608,15 +1608,15 @@ def _dep_eeg_ref(add_eeg_ref, current_default=True):
     if current_default is True:
         if add_eeg_ref is None:
             add_eeg_ref = True
-            warn('add_eeg_ref will default to True in 0.13 and False in 0.14, '
-                 'and will be removed in 0.15. We recommend to use '
-                 'add_eeg_ref=False and mne.set_eeg_reference() instead.',
+            warn('add_eeg_ref defaults to True in 0.13, will default to '
+                 'False in 0.14, and will be removed in 0.15. We recommend '
+                 'to use add_eeg_ref=False and set_eeg_reference() instead.',
                  DeprecationWarning)
     # current_default is False
     elif add_eeg_ref is None:
         add_eeg_ref = False
     else:
-        warn('add_eeg_ref will be removed in 0.14, use mne.set_eeg_reference()'
+        warn('add_eeg_ref will be removed in 0.14, use set_eeg_reference()'
              ' instead', DeprecationWarning)
     return add_eeg_ref
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -151,7 +151,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  baseline=(None, 0), raw=None,
                  picks=None, name='Unknown', reject=None, flat=None,
                  decim=1, reject_tmin=None, reject_tmax=None, detrend=None,
-                 add_eeg_ref=True, proj=True, on_missing='error',
+                 add_eeg_ref=False, proj=True, on_missing='error',
                  preload_at_end=False, selection=None, drop_log=None,
                  verbose=None):
 
@@ -1198,8 +1198,7 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                       for k, v in sorted(self.event_id.items())]
             s += ',\n %s' % ', '.join(counts)
         class_name = self.__class__.__name__
-        if class_name == '_BaseEpochs':
-            class_name = 'Epochs'
+        class_name = 'Epochs' if class_name == '_BaseEpochs' else class_name
         return '<%s  |  %s>' % (class_name, s)
 
     def _key_match(self, key):
@@ -1604,6 +1603,24 @@ def _drop_log_stats(drop_log, ignore=('IGNORED',)):
     return perc
 
 
+def _dep_eeg_ref(add_eeg_ref, current_default=True):
+    """Helper for deprecation"""
+    if current_default is True:
+        if add_eeg_ref is None:
+            add_eeg_ref = True
+            warn('add_eeg_ref will default to True in 0.13 and False in 0.14, '
+                 'and will be removed in 0.15. We recommend to use '
+                 'add_eeg_ref=False and raw.set_eeg_reference() instead.',
+                 DeprecationWarning)
+    # current_default is False
+    elif add_eeg_ref is None:
+        add_eeg_ref = False
+    else:
+        warn('add_eeg_ref will be removed in 0.14, use raw.set_eeg_reference()'
+             ' instead', DeprecationWarning)
+    return add_eeg_ref
+
+
 class Epochs(_BaseEpochs):
     """Epochs extracted from a Raw instance
 
@@ -1691,7 +1708,9 @@ class Epochs(_BaseEpochs):
         (will yield equivalent results but be slower).
     add_eeg_ref : bool
         If True, an EEG average reference will be added (unless one
-        already exists).
+        already exists). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     on_missing : str
         What to do if one or several event ids are not found in the recording.
         Valid keys are 'error' | 'warning' | 'ignore'
@@ -1752,11 +1771,12 @@ class Epochs(_BaseEpochs):
     def __init__(self, raw, events, event_id=None, tmin=-0.2, tmax=0.5,
                  baseline=(None, 0), picks=None, name='Unknown', preload=False,
                  reject=None, flat=None, proj=True, decim=1, reject_tmin=None,
-                 reject_tmax=None, detrend=None, add_eeg_ref=True,
+                 reject_tmax=None, detrend=None, add_eeg_ref=None,
                  on_missing='error', reject_by_annotation=True, verbose=None):
         if not isinstance(raw, _BaseRaw):
             raise ValueError('The first argument to `Epochs` must be an '
                              'instance of `mne.io.Raw`')
+        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
         info = deepcopy(raw.info)
 
         # proj is on when applied in Raw
@@ -1894,7 +1914,7 @@ class EpochsArray(_BaseEpochs):
                                           tmax, baseline, reject=reject,
                                           flat=flat, reject_tmin=reject_tmin,
                                           reject_tmax=reject_tmax, decim=1,
-                                          add_eeg_ref=False, proj=proj)
+                                          proj=proj)
         if len(events) != np.in1d(self.events[:, 2],
                                   list(self.event_id.values())).sum():
             raise ValueError('The events must only contain event numbers from '
@@ -2221,7 +2241,7 @@ def _read_one_epoch_file(f, tree, fname, preload):
 
 
 @verbose
-def read_epochs(fname, proj=True, add_eeg_ref=False, preload=True,
+def read_epochs(fname, proj=True, add_eeg_ref=None, preload=True,
                 verbose=None):
     """Read epochs from a fif file
 
@@ -2242,7 +2262,8 @@ def read_epochs(fname, proj=True, add_eeg_ref=False, preload=True,
         recommended value if SSPs are not used for cleaning the data.
     add_eeg_ref : bool
         If True, an EEG average reference will be added (unless one
-        already exists).
+        already exists). This parameter is deprecated and will be
+        removed in 0.14, use :func:`mne.set_eeg_reference` instead.
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
@@ -2255,6 +2276,7 @@ def read_epochs(fname, proj=True, add_eeg_ref=False, preload=True,
     epochs : instance of Epochs
         The epochs
     """
+    add_eeg_ref = _dep_eeg_ref(add_eeg_ref, False)
     return EpochsFIF(fname, proj, add_eeg_ref, preload, verbose)
 
 
@@ -2291,7 +2313,9 @@ class EpochsFIF(_BaseEpochs):
         recommended value if SSPs are not used for cleaning the data.
     add_eeg_ref : bool
         If True, an EEG average reference will be added (unless one
-        already exists).
+        already exists). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
@@ -2306,9 +2330,10 @@ class EpochsFIF(_BaseEpochs):
     mne.Epochs.equalize_event_counts
     """
     @verbose
-    def __init__(self, fname, proj=True, add_eeg_ref=True, preload=True,
+    def __init__(self, fname, proj=True, add_eeg_ref=None, preload=True,
                  verbose=None):
         check_fname(fname, 'epochs', ('-epo.fif', '-epo.fif.gz'))
+        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
 
         fnames = [fname]
         ep_list = list()
@@ -2325,7 +2350,7 @@ class EpochsFIF(_BaseEpochs):
             epoch = _BaseEpochs(
                 info, data, events, event_id, tmin, tmax, baseline,
                 on_missing='ignore', selection=selection, drop_log=drop_log,
-                add_eeg_ref=False, proj=False, verbose=False)
+                proj=False, verbose=False)
             ep_list.append(epoch)
             if not preload:
                 # store everything we need to index back to the original data
@@ -2436,7 +2461,7 @@ def _check_merge_epochs(epochs_list):
 
 
 @verbose
-def add_channels_epochs(epochs_list, name='Unknown', add_eeg_ref=True,
+def add_channels_epochs(epochs_list, name='Unknown', add_eeg_ref=None,
                         verbose=None):
     """Concatenate channels, info and data from two Epochs objects
 
@@ -2447,8 +2472,10 @@ def add_channels_epochs(epochs_list, name='Unknown', add_eeg_ref=True,
     name : str
         Comment that describes the Epochs data created.
     add_eeg_ref : bool
-        If True, an EEG average reference will be added (unless there is no
-        EEG in the data).
+        If True, an EEG average reference will be added (unless there is
+        no EEG in the data). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
         Defaults to True if any of the input epochs have verbose=True.
@@ -2458,6 +2485,7 @@ def add_channels_epochs(epochs_list, name='Unknown', add_eeg_ref=True,
     epochs : instance of Epochs
         Concatenated epochs.
     """
+    add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
     if not all(e.preload for e in epochs_list):
         raise ValueError('All epochs must be preloaded.')
 
@@ -2574,10 +2602,10 @@ def _finish_concat(info, data, events, event_id, tmin, tmax, baseline,
     """Helper to finish concatenation for epochs not read from disk"""
     events[:, 0] = np.arange(len(events))  # arbitrary after concat
     selection = np.where([len(d) == 0 for d in drop_log])[0]
-    out = _BaseEpochs(info, data, events, event_id, tmin, tmax,
-                      baseline=baseline, add_eeg_ref=False,
-                      selection=selection, drop_log=drop_log,
-                      proj=False, on_missing='ignore', verbose=verbose)
+    out = _BaseEpochs(
+        info, data, events, event_id, tmin, tmax, baseline=baseline,
+        selection=selection, drop_log=drop_log, proj=False,
+        on_missing='ignore', verbose=verbose)
     out.drop_bad()
     return out
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2870,4 +2870,4 @@ def _segment_raw(raw, segment_length=1., verbose=None, **kwargs):
     """
     events = make_fixed_length_events(raw, 1, duration=segment_length)
     return Epochs(raw, events, event_id=[1], tmin=0., tmax=segment_length,
-                  verbose=verbose, baseline=None, **kwargs)
+                  verbose=verbose, baseline=None, add_eeg_ref=False, **kwargs)

--- a/mne/event.py
+++ b/mne/event.py
@@ -678,8 +678,8 @@ def _mask_trigs(events, mask, mask_type):
 
     if mask is not None:
         if mask_type is None:
-            warn("The default setting will change from 'not_and' "
-                 "to 'and' in v0.14.", DeprecationWarning)
+            warn("The default setting for mask_type will change from "
+                 "'not and' to 'and' in v0.14.", DeprecationWarning)
             mask_type = 'not_and'
         if mask_type == 'not_and':
             mask = np.bitwise_not(mask)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
 
 from mne.datasets import testing
-from mne.io import Raw, read_raw_kit, read_raw_bti, read_info
+from mne.io import read_raw_fif, read_raw_kit, read_raw_bti, read_info
 from mne.io.constants import FIFF
 from mne import (read_forward_solution, make_forward_solution,
                  convert_forward_solution, setup_volume_source_space,
@@ -190,7 +190,8 @@ def test_make_forward_solution_kit():
     _compare_forwards(fwd, fwd_py, 274, n_src)
 
     # CTF with compensation changed in python
-    ctf_raw = Raw(fname_ctf_raw).apply_gradient_compensation(2)
+    ctf_raw = read_raw_fif(fname_ctf_raw, add_eeg_ref=False)
+    ctf_raw.apply_gradient_compensation(2)
 
     fwd_py = make_forward_solution(ctf_raw.info, fname_trans, src,
                                    fname_bem_meg, eeg=False, meg=True)

--- a/mne/gui/tests/test_kit2fiff_gui.py
+++ b/mne/gui/tests/test_kit2fiff_gui.py
@@ -11,7 +11,7 @@ from nose.tools import assert_true, assert_false, assert_equal
 
 import mne
 from mne.io.kit.tests import data_dir as kit_data_dir
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.utils import _TempDir, requires_traits, run_tests_if_main
 
 mrk_pre_path = os.path.join(kit_data_dir, 'test_mrk_pre.sqd')
@@ -26,7 +26,7 @@ warnings.simplefilter('always')
 
 @requires_traits
 def test_kit2fiff_model():
-    """Test CombineMarkersModel Traits Model"""
+    """Test CombineMarkersModel Traits Model."""
     from mne.gui._kit2fiff_gui import Kit2FiffModel, Kit2FiffPanel
     tempdir = _TempDir()
     tgt_fname = os.path.join(tempdir, 'test-raw.fif')
@@ -54,10 +54,10 @@ def test_kit2fiff_model():
     # export raw
     raw_out = model.get_raw()
     raw_out.save(tgt_fname)
-    raw = Raw(tgt_fname)
+    raw = read_raw_fif(tgt_fname, add_eeg_ref=False)
 
     # Compare exported raw with the original binary conversion
-    raw_bin = Raw(fif_path)
+    raw_bin = read_raw_fif(fif_path, add_eeg_ref=False)
     trans_bin = raw.info['dev_head_t']['trans']
     want_keys = list(raw_bin.info.keys())
     assert_equal(sorted(want_keys), sorted(list(raw.info.keys())))

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -32,7 +32,7 @@ def test_array_raw():
     """
     import matplotlib.pyplot as plt
     # creating
-    raw = read_raw_fif(fif_fname).crop(2, 5)
+    raw = read_raw_fif(fif_fname, add_eeg_ref=False).crop(2, 5)
     data, times = raw[:, :]
     sfreq = raw.info['sfreq']
     ch_names = [(ch[4:] if 'STI' not in ch else ch)
@@ -99,7 +99,8 @@ def test_array_raw():
     events = find_events(raw2, stim_channel='STI 014')
     events[:, 2] = 1
     assert_true(len(events) > 2)
-    epochs = Epochs(raw2, events, 1, -0.2, 0.4, preload=True)
+    epochs = Epochs(raw2, events, 1, -0.2, 0.4, preload=True,
+                    add_eeg_ref=False)
     epochs.plot_drop_log()
     epochs.plot()
     evoked = epochs.average()

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -17,7 +17,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 from mne.utils import _TempDir, run_tests_if_main
 from mne import pick_types, find_events
 from mne.io.constants import FIFF
-from mne.io import Raw, read_raw_brainvision
+from mne.io import read_raw_fif, read_raw_brainvision
 from mne.io.tests.test_raw import _test_raw_reader
 
 FILE = inspect.getfile(inspect.currentframe())
@@ -56,7 +56,7 @@ warnings.simplefilter('always')
 
 
 def test_brainvision_data_highpass_filters():
-    """Test reading raw Brain Vision files with amplifier HP filter settings"""
+    """Test reading raw Brain Vision files with amplifier filter settings."""
     # Homogeneous highpass in seconds (default measurement unit)
     with warnings.catch_warnings(record=True) as w:  # event parsing
         raw = _test_raw_reader(
@@ -208,7 +208,7 @@ def test_brainvision_data_partially_disabled_hw_filters():
 
 
 def test_brainvision_data_software_filters_latin1_global_units():
-    """Test reading raw Brain Vision files"""
+    """Test reading raw Brain Vision files."""
     with warnings.catch_warnings(record=True) as w:  # event parsing
         raw = _test_raw_reader(
             read_raw_brainvision, vhdr_fname=vhdr_old_path,
@@ -220,7 +220,7 @@ def test_brainvision_data_software_filters_latin1_global_units():
 
 
 def test_brainvision_data():
-    """Test reading raw Brain Vision files"""
+    """Test reading raw Brain Vision files."""
     assert_raises(IOError, read_raw_brainvision, vmrk_path)
     assert_raises(ValueError, read_raw_brainvision, vhdr_path, montage,
                   preload=True, scale="foo")
@@ -240,7 +240,7 @@ def test_brainvision_data():
     data_py, times_py = raw_py[picks]
 
     # compare with a file that was generated using MNE-C
-    raw_bin = Raw(eeg_bin, preload=True)
+    raw_bin = read_raw_fif(eeg_bin, preload=True, add_eeg_ref=False)
     picks = pick_types(raw_py.info, meg=False, eeg=True, exclude='bads')
     data_bin, times_bin = raw_bin[picks]
 
@@ -271,7 +271,7 @@ def test_brainvision_data():
 
 
 def test_events():
-    """Test reading and modifying events"""
+    """Test reading and modifying events."""
     tempdir = _TempDir()
 
     # check that events are read and stim channel is synthesized correcly

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -13,7 +13,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose)
 from nose.tools import assert_true, assert_raises, assert_equal
 
-from mne.io import Raw, read_raw_bti
+from mne.io import read_raw_fif, read_raw_bti
 from mne.io.bti.bti import (_read_config, _process_bti_headshape,
                             _read_bti_header, _get_bti_dev_t,
                             _correct_trans, _get_bti_info)
@@ -43,7 +43,7 @@ NCH = 248
 
 
 def test_read_config():
-    """ Test read bti config file """
+    """Test read bti config file."""
     # for config in config_fname, config_solaris_fname:
     for config in config_fnames:
         cfg = _read_config(config)
@@ -52,7 +52,7 @@ def test_read_config():
 
 
 def test_crop_append():
-    """ Test crop and append raw """
+    """Test crop and append raw."""
     with warnings.catch_warnings(record=True):  # preload warning
         warnings.simplefilter('always')
         raw = _test_raw_reader(
@@ -68,7 +68,7 @@ def test_crop_append():
 
 
 def test_transforms():
-    """ Test transformations """
+    """Test transformations."""
     bti_trans = (0.0, 0.02, 0.11)
     bti_dev_t = Transform('ctf_meg', 'meg', _get_bti_dev_t(0.0, bti_trans))
     for pdf, config, hs, in zip(pdf_fnames, config_fnames, hs_fnames):
@@ -91,7 +91,7 @@ def test_transforms():
 
 
 def test_raw():
-    """ Test bti conversion to Raw object """
+    """Test bti conversion to Raw object."""
     for pdf, config, hs, exported in zip(pdf_fnames, config_fnames, hs_fnames,
                                          exported_fnames):
         # rx = 2 if 'linux' in pdf else 0
@@ -100,7 +100,7 @@ def test_raw():
                       preload=False)
         if op.exists(tmp_raw_fname):
             os.remove(tmp_raw_fname)
-        ex = Raw(exported, preload=True)
+        ex = read_raw_fif(exported, preload=True, add_eeg_ref=False)
         with warnings.catch_warnings(record=True):  # weight tables
             ra = read_raw_bti(pdf, config, hs, preload=False)
         assert_true('RawBTi' in repr(ra))
@@ -137,7 +137,7 @@ def test_raw():
                                     ra.info[key][ent])
 
         ra.save(tmp_raw_fname)
-        re = Raw(tmp_raw_fname)
+        re = read_raw_fif(tmp_raw_fname, add_eeg_ref=False)
         print(re)
         for key in ('dev_head_t', 'dev_ctf_t', 'ctf_head_t'):
             assert_true(isinstance(re.info[key], dict))
@@ -149,7 +149,7 @@ def test_raw():
 
 
 def test_info_no_rename_no_reorder_no_pdf():
-    """ Test private renaming, reordering and partial construction option """
+    """Test private renaming, reordering and partial construction option."""
     for pdf, config, hs in zip(pdf_fnames, config_fnames, hs_fnames):
         with warnings.catch_warnings(record=True):  # weight tables
             info, bti_info = _get_bti_info(
@@ -212,8 +212,7 @@ def test_info_no_rename_no_reorder_no_pdf():
 
 
 def test_no_conversion():
-    """ Test bti no-conversion option """
-
+    """Test bti no-conversion option."""
     get_info = partial(
         _get_bti_info,
         rotation_x=0.0, translation=(0.0, 0.02, 0.11), convert=False,
@@ -272,7 +271,7 @@ def test_no_conversion():
 
 
 def test_bytes_io():
-    """ Test bti bytes-io API """
+    """Test bti bytes-io API."""
     for pdf, config, hs in zip(pdf_fnames, config_fnames, hs_fnames):
         with warnings.catch_warnings(record=True):  # weight tables
             raw = read_raw_bti(pdf, config, hs, convert=True, preload=False)
@@ -290,7 +289,7 @@ def test_bytes_io():
 
 
 def test_setup_headshape():
-    """ Test reading bti headshape """
+    """Test reading bti headshape."""
     for hs in hs_fnames:
         dig, t = _process_bti_headshape(hs)
         expected = set(['kind', 'ident', 'r'])

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -21,10 +21,10 @@ import numpy as np
 from mne import pick_types
 from mne.datasets import testing
 from mne.externals.six import iterbytes
-from mne.utils import _TempDir, run_tests_if_main, requires_pandas
-from mne.io import read_raw_edf, Raw
+from mne.utils import run_tests_if_main, requires_pandas
+from mne.io import read_raw_edf
 from mne.io.tests.test_raw import _test_raw_reader
-import mne.io.edf.edf as edfmodule
+from mne.io.edf.edf import _parse_tal_channel
 from mne.event import find_events
 
 warnings.simplefilter('always')
@@ -52,7 +52,7 @@ misc = ['EXG1', 'EXG5', 'EXG8', 'M1', 'M2']
 
 
 def test_bdf_data():
-    """Test reading raw bdf files"""
+    """Test reading raw bdf files."""
     raw_py = _test_raw_reader(read_raw_edf, input_fname=bdf_path,
                               montage=montage_path, eog=eog, misc=misc)
     assert_true('RawEDF' in repr(raw_py))
@@ -74,6 +74,7 @@ def test_bdf_data():
 
 @testing.requires_testing_data
 def test_edf_overlapping_annotations():
+    """Test EDF with overlapping annotations."""
     n_warning = 2
     with warnings.catch_warnings(record=True) as w:
         read_raw_edf(edf_overlap_annot_path, preload=True, verbose=True)
@@ -82,15 +83,10 @@ def test_edf_overlapping_annotations():
 
 
 def test_edf_data():
-    """Test edf files"""
+    """Test edf files."""
     _test_raw_reader(read_raw_edf, input_fname=edf_path, stim_channel=None)
     raw_py = read_raw_edf(edf_path, preload=True)
     # Test saving and loading when annotations were parsed.
-    tempdir = _TempDir()
-    raw_file = op.join(tempdir, 'test-raw.fif')
-    raw_py.save(raw_file, overwrite=True, buffer_size_sec=1)
-    Raw(raw_file, preload=True)
-
     edf_events = find_events(raw_py, output='step', shortest_event=0,
                              stim_channel='STI 014')
 
@@ -118,7 +114,7 @@ def test_edf_data():
 
 @testing.requires_testing_data
 def test_stim_channel():
-    """Test reading raw edf files with stim channel"""
+    """Test reading raw edf files with stim channel."""
     raw_py = read_raw_edf(edf_path, misc=range(-4, 0), stim_channel=139,
                           preload=True)
 
@@ -163,8 +159,7 @@ def test_stim_channel():
 
 
 def test_parse_annotation():
-    """Test parsing the tal channel"""
-
+    """Test parsing the tal channel."""
     # test the parser
     annot = (b'+180\x14Lights off\x14Close door\x14\x00\x00\x00\x00\x00'
              b'+180\x14Lights off\x14\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -175,18 +170,14 @@ def test_parse_annotation():
     annot = [a for a in iterbytes(annot)]
     annot[1::2] = [a * 256 for a in annot[1::2]]
     tal_channel = map(sum, zip(annot[0::2], annot[1::2]))
-    events = edfmodule._parse_tal_channel(tal_channel)
-    assert_equal(events, [[180.0, 0, 'Lights off'],
-                          [180.0, 0, 'Close door'],
-                          [180.0, 0, 'Lights off'],
-                          [180.0, 0, 'Close door'],
-                          [3.14, 4.2, 'nothing'],
-                          [1800.2, 25.5, 'Apnea']])
+    assert_equal(_parse_tal_channel(tal_channel),
+                 [[180.0, 0, 'Lights off'], [180.0, 0, 'Close door'],
+                  [180.0, 0, 'Lights off'], [180.0, 0, 'Close door'],
+                  [3.14, 4.2, 'nothing'], [1800.2, 25.5, 'Apnea']])
 
 
 def test_edf_annotations():
     """Test if events are detected correctly in a typical MNE workflow."""
-
     # test an actual file
     raw = read_raw_edf(edf_path, preload=True)
     edf_events = find_events(raw, output='step', shortest_event=0,
@@ -215,7 +206,7 @@ def test_edf_annotations():
 
 
 def test_edf_stim_channel():
-    """Test stim channel for edf file"""
+    """Test stim channel for edf file."""
     raw = read_raw_edf(edf_stim_channel_path, preload=True,
                        stim_channel=-1)
     true_data = np.loadtxt(edf_txt_stim_channel_path).T
@@ -233,7 +224,7 @@ def test_edf_stim_channel():
 
 @requires_pandas
 def test_to_data_frame():
-    """Test edf Raw Pandas exporter"""
+    """Test edf Raw Pandas exporter."""
     for path in [edf_path, bdf_path]:
         raw = read_raw_edf(path, stim_channel=None, preload=True)
         _, times = raw[0, :10]

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -54,8 +54,8 @@ def test_io_set():
         raw3 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
                                event_id=event_id)
         raw4 = read_raw_eeglab(input_fname=raw_fname, montage=montage)
-        Epochs(raw0, find_events(raw0), event_id)
-        epochs = Epochs(raw1, find_events(raw1), event_id)
+        Epochs(raw0, find_events(raw0), event_id, add_eeg_ref=False)
+        epochs = Epochs(raw1, find_events(raw1), event_id, add_eeg_ref=False)
         assert_equal(len(find_events(raw4)), 0)  # no events without event_id
         assert_equal(epochs["square"].average().nave, 80)  # 80 with
         assert_array_equal(raw0[:][0], raw1[:][0], raw2[:][0], raw3[:][0])

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -48,20 +48,18 @@ class Raw(_BaseRaw):
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
     proj : bool
-        Apply the signal space projection (SSP) operators present in
-        the file to the data. Note: Once the projectors have been
-        applied, they can no longer be removed. It is usually not
-        recommended to apply the projectors at this point as they are
-        applied automatically later on (e.g. when computing inverse
-        solutions).
+        Deprecated. Use :meth:`raw.apply_proj() <mne.io.Raw.apply_proj>`
+        instead.
     compensation : None | int
         Deprecated. Use :meth:`mne.io.Raw.apply_gradient_compensation`
         instead.
     add_eeg_ref : bool
-        If True, add average EEG reference projector (if it's not already
-        present).
+        If True, an EEG average reference will be added (unless one
+        already exists). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     fnames : list or str
-        Deprecated.
+        Deprecated. Use :func:`mne.concatenate_raws` instead.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -80,12 +78,19 @@ class Raw(_BaseRaw):
     """
     @verbose
     def __init__(self, fname, allow_maxshield=False, preload=False,
-                 proj=False, compensation=None, add_eeg_ref=True,
+                 proj=None, compensation=None, add_eeg_ref=None,
                  fnames=None, verbose=None):
+        if proj is None:
+            proj = False
+        else:
+            warn('The proj parameter has been dprecated and will be removed '
+                 'in 0.14. Use raw.apply_proj() instead.', DeprecationWarning)
         dep = ('Supplying a list of filenames with "fnames" to the Raw class '
                'has been deprecated and will be removed in 0.13. Use multiple '
                'calls to read_raw_fif with the "fname" argument followed by '
-               'and concatenate_raws instead.')
+               'concatenate_raws instead.')
+        from ...epochs import _dep_eeg_ref
+        add_eeg_ref = _dep_eeg_ref(add_eeg_ref, True)
         if fnames is not None:
             warn(dep, DeprecationWarning)
         else:
@@ -471,7 +476,7 @@ def _check_entry(first, nent):
 
 
 def read_raw_fif(fname, allow_maxshield=False, preload=False,
-                 proj=False, compensation=None, add_eeg_ref=True,
+                 proj=False, compensation=None, add_eeg_ref=None,
                  fnames=None, verbose=None):
     """Reader function for Raw FIF data
 
@@ -493,20 +498,18 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False,
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
     proj : bool
-        Apply the signal space projection (SSP) operators present in
-        the file to the data. Note: Once the projectors have been
-        applied, they can no longer be removed. It is usually not
-        recommended to apply the projectors at this point as they are
-        applied automatically later on (e.g. when computing inverse
-        solutions).
+        Deprecated. Use :meth:`raw.apply_proj() <mne.io.Raw.apply_proj>`
+        instead.
     compensation : None | int
         Deprecated. Use :meth:`mne.io.Raw.apply_gradient_compensation`
         instead.
     add_eeg_ref : bool
-        If True, add average EEG reference projector (if it's not already
-        present).
+        If True, an EEG average reference will be added (unless one
+        already exists). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     fnames : list or str
-        Deprecated.
+        Deprecated. Use :func:`mne.concatenate_raws` instead.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -80,7 +80,7 @@ class Raw(_BaseRaw):
     def __init__(self, fname, allow_maxshield=False, preload=False,
                  proj=None, compensation=None, add_eeg_ref=None,
                  fnames=None, verbose=None):
-        if proj is None:
+        if not proj:
             proj = False
         else:
             warn('The proj parameter has been dprecated and will be removed '

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -89,8 +89,6 @@ class Raw(_BaseRaw):
                'has been deprecated and will be removed in 0.13. Use multiple '
                'calls to read_raw_fif with the "fname" argument followed by '
                'concatenate_raws instead.')
-        from ...epochs import _dep_eeg_ref
-        add_eeg_ref = _dep_eeg_ref(add_eeg_ref, True)
         if fnames is not None:
             warn(dep, DeprecationWarning)
         else:
@@ -133,6 +131,9 @@ class Raw(_BaseRaw):
             [r.first_samp for r in raws], [r.last_samp for r in raws],
             [r.filename for r in raws], [r._raw_extras for r in raws],
             raws[0].orig_format, None, verbose=verbose)
+        if 'eeg' in self:
+            from ...epochs import _dep_eeg_ref
+            add_eeg_ref = _dep_eeg_ref(add_eeg_ref, True)
 
         # combine information from each raw file to construct self
         if add_eeg_ref and _needs_eeg_average_ref_proj(self.info):

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -17,7 +17,7 @@ from mne import pick_types, Epochs, find_events, read_events
 from mne.transforms import apply_trans
 from mne.tests.common import assert_dig_allclose
 from mne.utils import run_tests_if_main
-from mne.io import Raw, read_raw_kit, read_epochs_kit
+from mne.io import read_raw_fif, read_raw_kit, read_epochs_kit
 from mne.io.kit.coreg import read_sns
 from mne.io.kit.constants import KIT, KIT_CONSTANTS, KIT_NY, KIT_UMD_2014
 from mne.io.tests.test_raw import _test_raw_reader
@@ -39,8 +39,7 @@ hsp_path = op.join(data_dir, 'test.hsp')
 
 
 def test_data():
-    """Test reading raw kit files
-    """
+    """Test reading raw kit files."""
     assert_raises(TypeError, read_raw_kit, epochs_path)
     assert_raises(TypeError, read_epochs_kit, sqd_path)
     assert_raises(ValueError, read_raw_kit, sqd_path, mrk_path, elp_txt_path)
@@ -72,7 +71,7 @@ def test_data():
     # Binary file only stores the sensor channels
     py_picks = pick_types(raw_py.info, exclude='bads')
     raw_bin = op.join(data_dir, 'test_bin_raw.fif')
-    raw_bin = Raw(raw_bin, preload=True)
+    raw_bin = read_raw_fif(raw_bin, preload=True, add_eeg_ref=False)
     bin_picks = pick_types(raw_bin.info, stim=True, exclude='bads')
     data_bin, _ = raw_bin[bin_picks]
     data_py, _ = raw_py[py_picks]
@@ -97,11 +96,11 @@ def test_data():
 
 
 def test_epochs():
-    """Test reading epoched SQD file
-    """
+    """Test reading epoched SQD file."""
     raw = read_raw_kit(sqd_path, stim=None)
     events = read_events(events_path)
-    raw_epochs = Epochs(raw, events, None, tmin=0, tmax=.099, baseline=None)
+    raw_epochs = Epochs(raw, events, None, tmin=0, tmax=.099, baseline=None,
+                        add_eeg_ref=False)
     data1 = raw_epochs.get_data()
     epochs = read_epochs_kit(epochs_path, events_path)
     data11 = epochs.get_data()
@@ -109,8 +108,7 @@ def test_epochs():
 
 
 def test_raw_events():
-    """Test creating stim channel from raw SQD file
-    """
+    """Test creating stim channel from raw SQD file."""
     def evts(a, b, c, d, e, f=None):
         out = [[269, a, b], [281, b, c], [1552, c, d], [1564, d, e]]
         if f is not None:
@@ -135,11 +133,11 @@ def test_raw_events():
 
 
 def test_ch_loc():
-    """Test raw kit loc
-    """
+    """Test raw kit loc."""
     raw_py = read_raw_kit(sqd_path, mrk_path, elp_txt_path, hsp_txt_path,
                           stim='<')
-    raw_bin = Raw(op.join(data_dir, 'test_bin_raw.fif'))
+    raw_bin = read_raw_fif(op.join(data_dir, 'test_bin_raw.fif'),
+                           add_eeg_ref=False)
 
     ch_py = raw_py._raw_extras[0]['sensor_locs'][:, :5]
     # ch locs stored as m, not mm
@@ -164,8 +162,7 @@ def test_ch_loc():
 
 
 def test_hsp_elp():
-    """Test KIT usage of *.elp and *.hsp files against *.txt files
-    """
+    """Test KIT usage of *.elp and *.hsp files against *.txt files."""
     raw_txt = read_raw_kit(sqd_path, mrk_path, elp_txt_path, hsp_txt_path)
     raw_elp = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path)
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -18,7 +18,7 @@ from .constants import FIFF
 from .pick import pick_types
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
-from ..utils import logger, verbose, warn
+from ..utils import logger, verbose, warn, deprecated
 from ..externals.six import string_types
 
 
@@ -105,9 +105,10 @@ class ProjMixin(object):
                                              check_active=False, sort=False)
         return self
 
+    @deprecated('This function is deprecated and will be removed in 0.14. '
+                'Use set_eeg_reference() instead.')
     def add_eeg_average_proj(self):
-        """Add an average EEG reference projector if one does not exist
-        """
+        """Add an average EEG reference projector if one does not exist."""
         if _needs_eeg_average_ref_proj(self.info):
             # Don't set as active, since we haven't applied it
             eeg_proj = make_eeg_average_ref_proj(self.info, activate=False)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -242,11 +242,12 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
     inst : instance of Raw | Epochs | Evoked
         Instance of Raw or Epochs with EEG channels and reference channel(s).
     ref_channels : list of str | None
-        The names of the channels to use to construct the reference. If None is
-        specified here, an average reference will be applied in the form of an
-        SSP projector. If an empty list is specified, the data is assumed to
-        already have a proper reference and MNE will not attempt any
-        re-referencing of the data. Defaults to an average reference (None).
+        The names of the channels to use to construct the reference. If
+        None (default), an average reference will be added as an SSP
+        projector but not immediately applied to the data. If an empty list
+        is specified, the data is assumed to already have a proper reference
+        and MNE will not attempt any re-referencing of the data. Defaults
+        to an average reference (None).
     copy : bool
         Specifies whether the data will be copied (True) or modified in place
         (False). Defaults to True.
@@ -254,9 +255,12 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
     Returns
     -------
     inst : instance of Raw | Epochs | Evoked
-        Data with EEG channels re-referenced.
+        Data with EEG channels re-referenced. For ``ref_channels=None``,
+        an average projector will be added instead of directly subtarcting
+        data.
     ref_data : array
-        Array of reference data subtracted from EEG channels.
+        Array of reference data subtracted from EEG channels. This will
+        be None for an average reference.
 
     Notes
     -----

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -287,7 +287,6 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
                  'has been left untouched.')
             return inst, None
         else:
-            inst.info['custom_ref_applied'] = False
             inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
             return inst, None
     else:

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_allclose, assert_equal
 from mne import Epochs, read_evokeds, pick_types
 from mne.io.compensator import make_compensator, get_current_comp
 from mne.io import read_raw_fif
-from mne.utils import _TempDir, requires_mne, run_subprocess
+from mne.utils import _TempDir, requires_mne, run_subprocess, run_tests_if_main
 
 base_dir = op.join(op.dirname(__file__), 'data')
 ctf_comp_fname = op.join(base_dir, 'test_ctf_comp_raw.fif')
@@ -70,7 +70,7 @@ def test_compensation_mne():
         picks = pick_types(raw.info, meg=True, ref_meg=True)
         events = np.array([[0, 0, 1]], dtype=np.int)
         evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks,
-                        add_eeg_ref=False).set_eeg_reference().average()
+                        add_eeg_ref=False).average()
         return evoked
 
     def compensate_mne(fname, comp):
@@ -96,3 +96,5 @@ def test_compensation_mne():
         chs_c = [evoked_c.info['chs'][ii] for ii in picks_c]
         for ch_py, ch_c in zip(chs_py, chs_c):
             assert_equal(ch_py['coil_type'], ch_c['coil_type'])
+
+run_tests_if_main()

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -63,15 +63,18 @@ def test_compensation_mne():
     tempdir = _TempDir()
 
     def make_evoked(fname, comp):
+        """Make evoked data."""
         raw = read_raw_fif(fname, add_eeg_ref=False)
         if comp is not None:
             raw.apply_gradient_compensation(comp)
         picks = pick_types(raw.info, meg=True, ref_meg=True)
         events = np.array([[0, 0, 1]], dtype=np.int)
-        evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks).average()
+        evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks,
+                        add_eeg_ref=False).set_eeg_reference().average()
         return evoked
 
     def compensate_mne(fname, comp):
+        """Compensate using MNE-C."""
         tmp_fname = '%s-%d-ave.fif' % (fname[:-4], comp)
         cmd = ['mne_compensate_data', '--in', fname,
                '--out', tmp_fname, '--grad', str(comp)]

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 
 from mne import Epochs, read_events
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
-                    _loc_to_coil_trans, Raw, read_info, write_info,
+                    _loc_to_coil_trans, read_raw_fif, read_info, write_info,
                     anonymize_info)
 from mne.io.constants import FIFF
 from mne.io.meas_info import (Info, create_info, _write_dig_points,
@@ -28,7 +28,7 @@ elp_fname = op.join(kit_data_dir, 'test_elp.txt')
 
 
 def test_coil_trans():
-    """Test loc<->coil_trans functions"""
+    """Test loc<->coil_trans functions."""
     rng = np.random.RandomState(0)
     x = rng.randn(4, 4)
     x[3] = [0, 0, 0, 1]
@@ -38,8 +38,7 @@ def test_coil_trans():
 
 
 def test_make_info():
-    """Test some create_info properties
-    """
+    """Test some create_info properties."""
     n_ch = 1
     info = create_info(n_ch, 1000., 'eeg')
     assert_equal(sorted(info.keys()), sorted(RAW_INFO_FIELDS))
@@ -88,7 +87,7 @@ def test_make_info():
 
 
 def test_fiducials_io():
-    """Test fiducials i/o"""
+    """Test fiducials i/o."""
     tempdir = _TempDir()
     pts, coord_frame = read_fiducials(fiducials_fname)
     assert_equal(pts[0]['coord_frame'], FIFF.FIFFV_COORD_MRI)
@@ -110,13 +109,13 @@ def test_fiducials_io():
 
 
 def test_info():
-    """Test info object"""
-    raw = Raw(raw_fname)
+    """Test info object."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     event_id, tmin, tmax = 1, -0.2, 0.5
     events = read_events(event_name)
     event_id = int(events[0, 2])
     epochs = Epochs(raw, events[:1], event_id, tmin, tmax, picks=None,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
 
     evoked = epochs.average()
 
@@ -164,8 +163,7 @@ def test_info():
 
 
 def test_read_write_info():
-    """Test IO of info
-    """
+    """Test IO of info."""
     tempdir = _TempDir()
     info = read_info(raw_fname)
     temp_file = op.join(tempdir, 'info.fif')
@@ -191,7 +189,7 @@ def test_read_write_info():
 
 
 def test_io_dig_points():
-    """Test Writing for dig files"""
+    """Test Writing for dig files."""
     tempdir = _TempDir()
     points = _read_dig_points(hsp_fname)
 
@@ -210,7 +208,7 @@ def test_io_dig_points():
 
 
 def test_make_dig_points():
-    """Test application of Polhemus HSP to info"""
+    """Test application of Polhemus HSP to info."""
     dig_points = _read_dig_points(hsp_fname)
     info = create_info(ch_names=['Test Ch'], sfreq=1000., ch_types=None)
     assert_false(info['dig'])
@@ -239,7 +237,7 @@ def test_make_dig_points():
 
 
 def test_redundant():
-    """Test some of the redundant properties of info"""
+    """Test some of the redundant properties of info."""
     # Indexing
     info = create_info(ch_names=['a', 'b', 'c'], sfreq=1000., ch_types=None)
     assert_equal(info['ch_names'][0], 'a')
@@ -259,7 +257,7 @@ def test_redundant():
 
 
 def test_merge_info():
-    """Test merging of multiple Info objects"""
+    """Test merging of multiple Info objects."""
     info_a = create_info(ch_names=['a', 'b', 'c'], sfreq=1000., ch_types=None)
     info_b = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None)
     info_merged = _merge_info([info_a, info_b])
@@ -289,7 +287,7 @@ def test_merge_info():
 
 
 def test_check_consistency():
-    """Test consistency check of Info objects"""
+    """Test consistency check of Info objects."""
     info = create_info(ch_names=['a', 'b', 'c'], sfreq=1000.)
 
     # This should pass
@@ -334,12 +332,11 @@ def test_check_consistency():
 
 
 def test_anonymize():
-    """Checks that sensitive information can be anonymized.
-    """
+    """Checks that sensitive information can be anonymized."""
     assert_raises(ValueError, anonymize_info, 'foo')
 
     # Fake some subject data
-    raw = Raw(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     raw.info['subject_info'] = dict(id=1, his_id='foobar', last_name='bar',
                                     first_name='bar', birthday=(1987, 4, 8),
                                     sex=0, hand=1)
@@ -348,7 +345,7 @@ def test_anonymize():
     orig_meas_id = raw.info['meas_id']['secs']
     # Test instance method
     events = read_events(event_name)
-    epochs = Epochs(raw, events[:1], 2, 0., 0.1)
+    epochs = Epochs(raw, events[:1], 2, 0., 0.1, add_eeg_ref=False)
     for inst in [raw, epochs]:
         assert_true('subject_info' in inst.info.keys())
         assert_true(inst.info['subject_info'] is not None)
@@ -366,7 +363,7 @@ def test_anonymize():
     tempdir = _TempDir()
     out_fname = op.join(tempdir, 'test_subj_info_raw.fif')
     raw.save(out_fname, overwrite=True)
-    raw = Raw(out_fname)
+    raw = read_raw_fif(out_fname, add_eeg_ref=False)
     assert_true(raw.info.get('subject_info') is None)
     assert_array_equal(raw.info['meas_date'], [0, 0])
     # XXX mne.io.write.write_id necessarily writes secs

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -9,7 +9,8 @@ import numpy as np
 from mne import (pick_channels_regexp, pick_types, Epochs,
                  read_forward_solution, rename_channels,
                  pick_info, pick_channels, __file__, create_info)
-from mne.io import Raw, RawArray, read_raw_bti, read_raw_kit, read_info
+from mne.io import (read_raw_fif, RawArray, read_raw_bti, read_raw_kit,
+                    read_info)
 from mne.io.pick import (channel_indices_by_type, channel_type,
                          pick_types_forward, _picks_by_type)
 from mne.io.constants import FIFF
@@ -45,7 +46,8 @@ def test_pick_refs():
     infos.append(raw_bti.info)
     # CTF
     fname_ctf_raw = op.join(io_dir, 'tests', 'data', 'test_ctf_comp_raw.fif')
-    raw_ctf = Raw(fname_ctf_raw).apply_gradient_compensation(2)
+    raw_ctf = read_raw_fif(fname_ctf_raw, add_eeg_ref=False)
+    raw_ctf.apply_gradient_compensation(2)
     infos.append(raw_ctf.info)
     for info in infos:
         info['bads'] = []
@@ -107,13 +109,14 @@ def test_pick_seeg_ecog():
         assert_equal(channel_type(info, i), types[i])
     raw = RawArray(np.zeros((len(names), 10)), info)
     events = np.array([[1, 0, 0], [2, 0, 0]])
-    epochs = Epochs(raw, events, {'event': 0}, -1e-5, 1e-5)
+    epochs = Epochs(raw, events, {'event': 0}, -1e-5, 1e-5, add_eeg_ref=False)
     evoked = epochs.average(pick_types(epochs.info, meg=True, seeg=True))
     e_seeg = evoked.copy().pick_types(meg=False, seeg=True)
     for l, r in zip(e_seeg.ch_names, [names[4], names[5], names[7]]):
         assert_equal(l, r)
     # Deal with constant debacle
-    raw = Raw(op.join(io_dir, 'tests', 'data', 'test_chpi_raw_sss.fif'))
+    raw = read_raw_fif(op.join(io_dir, 'tests', 'data',
+                               'test_chpi_raw_sss.fif'), add_eeg_ref=False)
     assert_equal(len(pick_types(raw.info, meg=False, seeg=True, ecog=True)), 0)
 
 
@@ -245,7 +248,7 @@ def test_clean_info_bads():
 
     raw_file = op.join(op.dirname(__file__), 'io', 'tests', 'data',
                        'test_raw.fif')
-    raw = Raw(raw_file)
+    raw = read_raw_fif(raw_file, add_eeg_ref=False)
 
     # select eeg channels
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)

--- a/mne/io/tests/test_proc_history.py
+++ b/mne/io/tests/test_proc_history.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import os.path as op
-from mne import io
+from mne.io import read_info
 from mne.io.constants import FIFF
 from mne.io.proc_history import _get_sss_rank
 from nose.tools import assert_true, assert_equal
@@ -14,9 +14,9 @@ raw_fname = op.join(base_dir, 'test_chpi_raw_sss.fif')
 
 
 def test_maxfilter_io():
-    """test maxfilter io"""
-    raw = io.read_raw_fif(raw_fname)
-    mf = raw.info['proc_history'][1]['max_info']
+    """Test maxfilter io."""
+    info = read_info(raw_fname)
+    mf = info['proc_history'][1]['max_info']
 
     assert_true(mf['sss_info']['frame'], FIFF.FIFFV_COORD_HEAD)
     # based on manual 2.0, rev. 5.0 page 23
@@ -24,7 +24,7 @@ def test_maxfilter_io():
     assert_true(mf['sss_info']['out_order'] <= 5)
     assert_true(mf['sss_info']['nchan'] > len(mf['sss_info']['components']))
 
-    assert_equal(raw.ch_names[:mf['sss_info']['nchan']],
+    assert_equal(info['ch_names'][:mf['sss_info']['nchan']],
                  mf['sss_ctc']['proj_items_chs'])
     assert_equal(mf['sss_ctc']['decoupler'].shape,
                  (mf['sss_info']['nchan'], mf['sss_info']['nchan']))
@@ -39,9 +39,8 @@ def test_maxfilter_io():
 
 
 def test_maxfilter_get_rank():
-    """test maxfilter rank lookup"""
-    raw = io.read_raw_fif(raw_fname)
-    mf = raw.info['proc_history'][0]['max_info']
+    """Test maxfilter rank lookup."""
+    mf = read_info(raw_fname)['proc_history'][0]['max_info']
     rank1 = mf['sss_info']['nfree']
     rank2 = _get_sss_rank(mf)
     assert_equal(rank1, rank2)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -8,7 +8,7 @@ from nose.tools import assert_equal, assert_true
 
 from mne import concatenate_raws
 from mne.datasets import testing
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.utils import _TempDir
 
 
@@ -64,7 +64,7 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
     # Test saving and reading
     out_fname = op.join(tempdir, 'test_raw.fif')
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
-    raw3 = Raw(out_fname)
+    raw3 = read_raw_fif(out_fname, add_eeg_ref=False)
     assert_equal(set(raw.info.keys()), set(raw3.info.keys()))
     assert_allclose(raw3[0:20][0], full_data[0:20], rtol=1e-6,
                     atol=1e-20)  # atol is very small but > 0
@@ -88,7 +88,7 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
 
 
 def _test_concat(reader, *args):
-    """Test concatenation of raw classes that allow not preloading"""
+    """Test concatenation of raw classes that allow not preloading."""
     data = None
 
     for preload in (True, False):
@@ -121,10 +121,10 @@ def _test_concat(reader, *args):
 
 @testing.requires_testing_data
 def test_time_index():
-    """Test indexing of raw times"""
+    """Test indexing of raw times."""
     raw_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
                         'data', 'test_raw.fif')
-    raw = Raw(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
 
     # Test original (non-rounding) indexing behavior
     orig_inds = raw.time_as_index(raw.times)

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -11,15 +11,16 @@ import numpy as np
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_array_equal, assert_allclose
 
-from mne import pick_channels, pick_types, Evoked, Epochs, read_events
+from mne import (pick_channels, pick_types, Evoked, Epochs, read_events,
+                 set_eeg_reference, set_bipolar_reference,
+                 add_reference_channels)
 from mne.epochs import _BaseEpochs
+from mne.io import read_raw_fif
 from mne.io.constants import FIFF
-from mne.io import (set_eeg_reference, set_bipolar_reference,
-                    add_reference_channels)
 from mne.io.proj import _has_eeg_average_ref_proj
 from mne.io.reference import _apply_reference
 from mne.datasets import testing
-from mne.io import read_raw_fif
+from mne.utils import run_tests_if_main
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -309,7 +310,7 @@ def test_add_reference():
                     add_eeg_ref=False)
     epochs_ref = add_reference_channels(epochs, 'Ref', copy=True)
     # CAR after custom reference is an Error
-    assert_raises(RuntimeError, epochs_ref.add_eeg_average_proj)
+    assert_raises(RuntimeError, epochs_ref.set_eeg_reference)
 
     assert_equal(epochs_ref._data.shape[1], epochs._data.shape[1] + 1)
     _check_channel_names(epochs_ref, 'Ref')
@@ -386,3 +387,5 @@ def test_add_reference():
     raw_np = read_raw_fif(fif_fname, preload=False, add_eeg_ref=False)
     assert_raises(RuntimeError, add_reference_channels, raw_np, ['Ref'])
     assert_raises(ValueError, add_reference_channels, raw, 1)
+
+run_tests_if_main()

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -16,7 +16,7 @@ from mne.source_estimate import read_source_estimate, VolSourceEstimate
 from mne import (read_cov, read_forward_solution, read_evokeds, pick_types,
                  pick_types_forward, make_forward_solution,
                  convert_forward_solution, Covariance)
-from mne.io import Raw, Info
+from mne.io import read_raw_fif, Info
 from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       apply_inverse_raw, apply_inverse_epochs,
                                       make_inverse_operator,
@@ -60,24 +60,28 @@ last_keys = [None] * 10
 
 
 def read_forward_solution_meg(*args, **kwargs):
+    """Read MEG forward."""
     fwd = read_forward_solution(*args, **kwargs)
     fwd = pick_types_forward(fwd, meg=True, eeg=False)
     return fwd
 
 
 def read_forward_solution_eeg(*args, **kwargs):
+    """Read EEG forward."""
     fwd = read_forward_solution(*args, **kwargs)
     fwd = pick_types_forward(fwd, meg=False, eeg=True)
     return fwd
 
 
 def _get_evoked():
+    """Get evoked data."""
     evoked = read_evokeds(fname_data, condition=0, baseline=(None, 0))
     evoked.crop(0, 0.2)
     return evoked
 
 
 def _compare(a, b):
+    """Compare two python objects."""
     global last_keys
     skip_types = ['whitener', 'proj', 'reginv', 'noisenorm', 'nchan',
                   'command_line', 'working_dir', 'mri_file', 'mri_id']
@@ -115,6 +119,7 @@ def _compare(a, b):
 
 def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,
                              check_depth=True):
+    """Compare inverses."""
     # depth prior
     if check_depth:
         if inv_1['depth_prior'] is not None:
@@ -148,6 +153,7 @@ def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,
 
 
 def _compare_io(inv_op, out_file_ext='.fif'):
+    """Compare inverse IO."""
     tempdir = _TempDir()
     if out_file_ext == '.fif':
         out_file = op.join(tempdir, 'test-inv.fif')
@@ -165,8 +171,7 @@ def _compare_io(inv_op, out_file_ext='.fif'):
 
 @testing.requires_testing_data
 def test_warn_inverse_operator():
-    """Test MNE inverse warning without average EEG projection
-    """
+    """Test MNE inverse warning without average EEG projection."""
     bad_info = copy.deepcopy(_get_evoked().info)
     bad_info['projs'] = list()
     fwd_op = read_forward_solution(fname_fwd, surf_ori=True)
@@ -464,11 +469,10 @@ def test_io_inverse_operator():
 
 @testing.requires_testing_data
 def test_apply_mne_inverse_raw():
-    """Test MNE with precomputed inverse operator on Raw
-    """
+    """Test MNE with precomputed inverse operator on Raw."""
     start = 3
     stop = 10
-    raw = Raw(fname_raw)
+    raw = read_raw_fif(fname_raw, add_eeg_ref=False)
     label_lh = read_label(fname_label % 'Aud-lh')
     _, times = raw[0, start:stop]
     inverse_operator = read_inverse_operator(fname_full)
@@ -498,9 +502,8 @@ def test_apply_mne_inverse_raw():
 
 @testing.requires_testing_data
 def test_apply_mne_inverse_fixed_raw():
-    """Test MNE with fixed-orientation inverse operator on Raw
-    """
-    raw = Raw(fname_raw)
+    """Test MNE with fixed-orientation inverse operator on Raw."""
+    raw = read_raw_fif(fname_raw, add_eeg_ref=False)
     start = 3
     stop = 10
     _, times = raw[0, start:stop]
@@ -538,13 +541,12 @@ def test_apply_mne_inverse_fixed_raw():
 
 @testing.requires_testing_data
 def test_apply_mne_inverse_epochs():
-    """Test MNE with precomputed inverse operator on Epochs
-    """
+    """Test MNE with precomputed inverse operator on Epochs."""
     inverse_operator = read_inverse_operator(fname_full)
     label_lh = read_label(fname_label % 'Aud-lh')
     label_rh = read_label(fname_label % 'Aud-rh')
     event_id, tmin, tmax = 1, -0.2, 0.5
-    raw = Raw(fname_raw)
+    raw = read_raw_fif(fname_raw, add_eeg_ref=False)
 
     picks = pick_types(raw.info, meg=True, eeg=False, stim=True, ecg=True,
                        eog=True, include=['STI 014'], exclude='bads')
@@ -553,7 +555,8 @@ def test_apply_mne_inverse_epochs():
 
     events = read_events(fname_event)[:15]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), reject=reject, flat=flat)
+                    baseline=(None, 0), reject=reject, flat=flat,
+                    add_eeg_ref=False)
     stcs = apply_inverse_epochs(epochs, inverse_operator, lambda2, "dSPM",
                                 label=label_lh, pick_ori="normal")
     inverse_operator = prepare_inverse_operator(inverse_operator, nave=1,
@@ -603,8 +606,7 @@ def test_apply_mne_inverse_epochs():
 
 @testing.requires_testing_data
 def test_make_inverse_operator_bads():
-    """Test MNE inverse computation given a mismatch of bad channels
-    """
+    """Test MNE inverse computation given a mismatch of bad channels."""
     fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)

--- a/mne/minimum_norm/tests/test_time_frequency.py
+++ b/mne/minimum_norm/tests/test_time_frequency.py
@@ -6,7 +6,8 @@ from nose.tools import assert_true
 import warnings
 
 from mne.datasets import testing
-from mne import io, find_events, Epochs, pick_types
+from mne import find_events, Epochs, pick_types
+from mne.io import read_raw_fif
 from mne.utils import run_tests_if_main
 from mne.label import read_label
 from mne.minimum_norm.inverse import (read_inverse_operator,
@@ -31,12 +32,11 @@ warnings.simplefilter('always')
 
 @testing.requires_testing_data
 def test_tfr_with_inverse_operator():
-    """Test time freq with MNE inverse computation"""
-
+    """Test time freq with MNE inverse computation."""
     tmin, tmax, event_id = -0.2, 0.5, 1
 
     # Setup for reading the raw data
-    raw = io.read_raw_fif(fname_data)
+    raw = read_raw_fif(fname_data, add_eeg_ref=False)
     events = find_events(raw, stim_channel='STI 014')
     inverse_operator = read_inverse_operator(fname_inv)
     inv = prepare_inverse_operator(inverse_operator, nave=1,
@@ -53,7 +53,7 @@ def test_tfr_with_inverse_operator():
     events3 = events[:3]  # take 3 events to keep the computation time low
     epochs = Epochs(raw, events3, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), reject=dict(grad=4000e-13, eog=150e-6),
-                    preload=True)
+                    preload=True, add_eeg_ref=False)
 
     # Compute a source estimate per frequency band
     bands = dict(alpha=[10, 10])
@@ -78,7 +78,7 @@ def test_tfr_with_inverse_operator():
     # Compute a source estimate per frequency band
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), reject=dict(grad=4000e-13, eog=150e-6),
-                    preload=True)
+                    preload=True, add_eeg_ref=False)
 
     frequencies = np.arange(7, 30, 2)  # define frequencies of interest
     power, phase_lock = source_induced_power(epochs, inv,
@@ -94,8 +94,8 @@ def test_tfr_with_inverse_operator():
 
 @testing.requires_testing_data
 def test_source_psd():
-    """Test source PSD computation in label"""
-    raw = io.read_raw_fif(fname_data)
+    """Test source PSD computation in label."""
+    raw = read_raw_fif(fname_data, add_eeg_ref=False)
     inverse_operator = read_inverse_operator(fname_inv)
     label = read_label(fname_label)
     tmin, tmax = 0, 20  # seconds
@@ -114,9 +114,8 @@ def test_source_psd():
 
 @testing.requires_testing_data
 def test_source_psd_epochs():
-    """Test multi-taper source PSD computation in label from epochs"""
-
-    raw = io.read_raw_fif(fname_data)
+    """Test multi-taper source PSD computation in label from epochs."""
+    raw = read_raw_fif(fname_data, add_eeg_ref=False)
     inverse_operator = read_inverse_operator(fname_inv)
     label = read_label(fname_label)
 
@@ -132,7 +131,7 @@ def test_source_psd_epochs():
 
     events = find_events(raw, stim_channel='STI 014')
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), reject=reject)
+                    baseline=(None, 0), reject=reject, add_eeg_ref=False)
 
     # only look at one epoch
     epochs.drop_bad()

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -319,7 +319,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     ecg_epochs = Epochs(raw, events=events, event_id=event_id,
                         tmin=tmin, tmax=tmax, proj=False, flat=flat,
                         picks=picks, reject=reject, baseline=baseline,
-                        verbose=verbose, preload=preload)
+                        verbose=verbose, preload=preload, add_eeg_ref=False)
 
     if not has_ecg:
         raw.drop_channels(['ECG-SYN'])

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -208,5 +208,5 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None,
     eog_epochs = Epochs(raw, events=events, event_id=event_id,
                         tmin=tmin, tmax=tmax, proj=False, reject=reject,
                         flat=flat, picks=picks, baseline=baseline,
-                        preload=preload)
+                        preload=preload, add_eeg_ref=False)
     return eog_epochs

--- a/mne/preprocessing/maxfilter.py
+++ b/mne/preprocessing/maxfilter.py
@@ -9,7 +9,7 @@ import os
 
 
 from ..bem import fit_sphere_to_headshape
-from ..io import Raw
+from ..io import read_raw_fif
 from ..utils import logger, verbose, warn
 from ..externals.six.moves import map
 
@@ -136,7 +136,7 @@ def apply_maxfilter(in_fname, out_fname, origin=None, frame='device',
     # determine the head origin if necessary
     if origin is None:
         logger.info('Estimating head origin from headshape points..')
-        raw = Raw(in_fname)
+        raw = read_raw_fif(in_fname, add_eeg_ref=False)
         r, o_head, o_dev = fit_sphere_to_headshape(raw.info, units='mm')
         raw.close()
         logger.info('[done]')

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -185,7 +185,8 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
                phase='zero-double')
 
     epochs = Epochs(raw, events, None, tmin, tmax, baseline=None, preload=True,
-                    picks=picks, reject=reject, flat=flat, proj=True)
+                    picks=picks, reject=reject, flat=flat, proj=True,
+                    add_eeg_ref=False)
 
     epochs.drop_bad()
     if epochs.events.shape[0] < 1:

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -2,7 +2,7 @@ import os.path as op
 
 from nose.tools import assert_true, assert_equal
 
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne import pick_types
 from mne.preprocessing.ecg import find_ecg_events, create_ecg_epochs
 from mne.utils import run_tests_if_main
@@ -14,8 +14,8 @@ proj_fname = op.join(data_path, 'test-proj.fif')
 
 
 def test_find_ecg():
-    """Test find ECG peaks"""
-    raw = Raw(raw_fname)
+    """Test find ECG peaks."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
 
     # once with mag-trick
     # once with characteristic channel

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -1,4 +1,5 @@
 import os.path as op
+import warnings
 
 from nose.tools import assert_true, assert_equal
 
@@ -49,8 +50,9 @@ def test_find_ecg():
 
     # test with user provided ecg channel
     raw.info['projs'] = list()
-    raw.set_channel_types({'MEG 2641': 'ecg'})
+    with warnings.catch_warnings(record=True) as w:
+        raw.set_channel_types({'MEG 2641': 'ecg'})
+    assert_true(len(w) == 1 and 'unit for channel' in str(w[0].message))
     create_ecg_epochs(raw)
-
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_eeglab_infomax.py
+++ b/mne/preprocessing/tests/test_eeglab_infomax.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_almost_equal
 from scipy.linalg import svd, pinv
 import scipy.io as sio
 
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne import pick_types
 from mne.preprocessing.infomax_ import infomax
 from mne.utils import random_permutation, slow_test
@@ -17,11 +17,12 @@ base_dir = op.join(op.dirname(__file__), 'data')
 
 
 def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
+    """Generate data."""
 
     data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
     raw_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 
-    raw = Raw(raw_fname, preload=True)
+    raw = read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
 
     if ch_type == 'eeg':
         picks = pick_types(raw.info, meg=False, eeg=True, exclude='bads')

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -1,7 +1,7 @@
 import os.path as op
 from nose.tools import assert_true
 
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.preprocessing.eog import find_eog_events
 
 data_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -11,8 +11,8 @@ proj_fname = op.join(data_path, 'test-proj.fif')
 
 
 def test_find_eog():
-    """Test find EOG peaks"""
-    raw = Raw(raw_fname)
+    """Test find EOG peaks."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     events = find_eog_events(raw)
     n_events = len(events)
     assert_true(n_events == 4)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -22,7 +22,7 @@ from mne.preprocessing import (ICA, ica_find_ecg_events, ica_find_eog_events,
                                read_ica, run_ica)
 from mne.preprocessing.ica import (get_score_funcs, corrmap, _get_ica_map,
                                    _ica_explained_variance, _sort_components)
-from mne.io import Raw, Info, RawArray
+from mne.io import read_raw_fif, Info, RawArray
 from mne.io.meas_info import _kind_dict
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
 from mne.tests.common import assert_naming
@@ -54,16 +54,16 @@ except:
 
 @requires_sklearn
 def test_ica_full_data_recovery():
-    """Test recovery of full data when no source is rejected"""
+    """Test recovery of full data when no source is rejected."""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
-    raw.load_data()
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(0.5, stop, copy=False).load_data()
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
     with warnings.catch_warnings(record=True):  # bad proj
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), preload=True)
+                        baseline=(None, 0), preload=True, add_eeg_ref=False)
     evoked = epochs.average()
     n_channels = 5
     data = raw._data[:n_channels].copy()
@@ -113,10 +113,10 @@ def test_ica_full_data_recovery():
 
 @requires_sklearn
 def test_ica_rank_reduction():
-    """Test recovery ICA rank reduction"""
+    """Test recovery ICA rank reduction."""
     # Most basic recovery
-    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
-    raw.load_data()
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(0.5, stop, copy=False).load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
     n_components = 5
@@ -142,9 +142,9 @@ def test_ica_rank_reduction():
 
 @requires_sklearn
 def test_ica_reset():
-    """Test ICA resetting"""
-    raw = Raw(raw_fname).crop(0.5, stop, copy=False)
-    raw.load_data()
+    """Test ICA resetting."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(0.5, stop, copy=False).load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')[:10]
 
@@ -170,9 +170,9 @@ def test_ica_reset():
 
 @requires_sklearn
 def test_ica_core():
-    """Test ICA on raw and epochs"""
-    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
-    raw.load_data()
+    """Test ICA on raw and epochs."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(1.5, stop, copy=False).load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     # XXX. The None cases helped revealing bugs but are time consuming.
@@ -181,7 +181,7 @@ def test_ica_core():
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     noise_cov = [None, test_cov]
     # removed None cases to speed up...
     n_components = [2, 1.0]  # for future dbg add cases
@@ -273,11 +273,11 @@ def test_ica_core():
 @slow_test
 @requires_sklearn
 def test_ica_additional():
-    """Test additional ICA functionality"""
+    """Test additional ICA functionality."""
     tempdir = _TempDir()
     stop2 = 500
-    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
-    raw.load_data()
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(1.5, stop, copy=False).load_data()
     # XXX This breaks the tests :(
     # raw.info['bads'] = [raw.ch_names[1]]
     test_cov = read_cov(test_cov_name)
@@ -285,7 +285,7 @@ def test_ica_additional():
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     # test if n_components=None works
     with warnings.catch_warnings(record=True):
         ica = ICA(n_components=None,
@@ -296,7 +296,7 @@ def test_ica_additional():
     picks2 = pick_types(raw.info, meg=True, stim=False, ecg=False,
                         eog=True, exclude='bads')
     epochs_eog = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks2,
-                        baseline=(None, 0), preload=True)
+                        baseline=(None, 0), preload=True, add_eeg_ref=False)
 
     test_cov2 = test_cov.copy()
     ica = ICA(noise_cov=test_cov2, n_components=3, max_pca_components=4,
@@ -537,7 +537,7 @@ def test_ica_additional():
     test_ica_fname = op.join(op.abspath(op.curdir), 'test-ica_raw.fif')
     ica.n_components = np.int32(ica.n_components)
     ica_raw.save(test_ica_fname, overwrite=True)
-    ica_raw2 = Raw(test_ica_fname, preload=True)
+    ica_raw2 = read_raw_fif(test_ica_fname, preload=True, add_eeg_ref=False)
     assert_allclose(ica_raw._data, ica_raw2._data, rtol=1e-5, atol=1e-4)
     ica_raw2.close()
     os.remove(test_ica_fname)
@@ -561,8 +561,9 @@ def test_ica_additional():
 
 @requires_sklearn
 def test_run_ica():
-    """Test run_ica function"""
-    raw = Raw(raw_fname, preload=True).crop(1.5, stop, copy=False)
+    """Test run_ica function."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(1.5, stop, copy=False).load_data()
     params = []
     params += [(None, -1, slice(2), [0, 1])]  # varicance, kurtosis idx
     params += [(None, 'MEG 1531')]  # ECG / EOG channel params
@@ -576,9 +577,9 @@ def test_run_ica():
 
 @requires_sklearn
 def test_ica_reject_buffer():
-    """Test ICA data raw buffer rejection"""
-    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
-    raw.load_data()
+    """Test ICA data raw buffer rejection."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(1.5, stop, copy=False).load_data()
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     ica = ICA(n_components=3, max_pca_components=4, n_pca_components=4)
@@ -594,9 +595,9 @@ def test_ica_reject_buffer():
 
 @requires_sklearn
 def test_ica_twice():
-    """Test running ICA twice"""
-    raw = Raw(raw_fname).crop(1.5, stop, copy=False)
-    raw.load_data()
+    """Test running ICA twice."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(1.5, stop, copy=False).load_data()
     picks = pick_types(raw.info, meg='grad', exclude='bads')
     n_components = 0.9
     max_pca_components = None
@@ -617,7 +618,7 @@ def test_ica_twice():
 
 @requires_sklearn
 def test_fit_params():
-    """Test fit_params for ICA"""
+    """Test fit_params for ICA."""
     assert_raises(ValueError, ICA, fit_params=dict(extended=True))
     fit_params = {}
     ICA(fit_params=fit_params)  # test no side effects
@@ -626,8 +627,7 @@ def test_fit_params():
 
 @requires_sklearn
 def test_bad_channels():
-    """Test if exception is raised when unsupported channels are used.
-    Test for raw and evoked data"""
+    """Test exception when unsupported channels are used."""
     chs = [i for i in _kind_dict]
     data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
     chs_bad = list(set(chs) - set(data_chs))
@@ -655,13 +655,14 @@ def test_bad_channels():
 
 @requires_sklearn
 def test_eog_channel():
-    """Test that EOG channel is included when performing ICA"""
-    raw = Raw(raw_fname, preload=True)
+    """Test that EOG channel is included when performing ICA."""
+    raw = read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, stim=True, ecg=False,
                        eog=True, exclude='bads')
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True,
+                    add_eeg_ref=False)
     n_components = 0.9
     ica = ICA(n_components=n_components, method='fastica')
     # Test case for MEG and EOG data. Should have EOG channel

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -17,8 +17,8 @@ from mne.chpi import read_head_pos, filter_chpi
 from mne.forward import _prep_meg_channels
 from mne.cov import _estimate_rank_meeg_cov
 from mne.datasets import testing
-from mne.io import (Raw, proc_history, read_info, read_raw_bti, read_raw_kit,
-                    _BaseRaw)
+from mne.io import (read_raw_fif, proc_history, read_info, read_raw_bti,
+                    read_raw_kit, _BaseRaw)
 from mne.preprocessing.maxwell import (
     maxwell_filter, _get_n_moments, _sss_basis_basic, _sh_complex_to_real,
     _sh_real_to_complex, _sh_negate, _bases_complex_to_real, _trans_sss_basis,
@@ -110,20 +110,26 @@ bads = ['MEG0912', 'MEG1722', 'MEG2213', 'MEG0132', 'MEG1312', 'MEG0432',
 
 
 def _assert_n_free(raw_sss, lower, upper=None):
-    """Helper to check the DOF"""
+    """Check the DOF."""
     upper = lower if upper is None else upper
     n_free = raw_sss.info['proc_history'][0]['max_info']['sss_info']['nfree']
     assert_true(lower <= n_free <= upper,
                 'nfree fail: %s <= %s <= %s' % (lower, n_free, upper))
 
 
+def read_crop(fname, lims=(0, None)):
+    """Read and crop."""
+    return read_raw_fif(fname, allow_maxshield='yes',
+                        add_eeg_ref=False).crop(*lims)
+
+
 @slow_test
 @testing.requires_testing_data
 def test_movement_compensation():
-    """Test movement compensation"""
+    """Test movement compensation."""
     temp_dir = _TempDir()
     lims = (0, 4, False)
-    raw = Raw(raw_fname, allow_maxshield='yes', preload=True).crop(*lims)
+    raw = read_crop(raw_fname, lims).load_data()
     head_pos = read_head_pos(pos_fname)
 
     #
@@ -131,20 +137,20 @@ def test_movement_compensation():
     #
     raw_sss = maxwell_filter(raw, head_pos=head_pos, origin=mf_head_origin,
                              regularize=None, bad_condition='ignore')
-    assert_meg_snr(raw_sss, Raw(sss_movecomp_fname).crop(*lims),
+    assert_meg_snr(raw_sss, read_crop(sss_movecomp_fname, lims),
                    4.6, 12.4, chpi_med_tol=58)
     # IO
     temp_fname = op.join(temp_dir, 'test_raw_sss.fif')
     raw_sss.save(temp_fname)
-    raw_sss = Raw(temp_fname)
-    assert_meg_snr(raw_sss, Raw(sss_movecomp_fname).crop(*lims),
+    raw_sss = read_crop(temp_fname)
+    assert_meg_snr(raw_sss, read_crop(sss_movecomp_fname, lims),
                    4.6, 12.4, chpi_med_tol=58)
 
     #
     # Movement compensation,    regularization, no tSSS
     #
     raw_sss = maxwell_filter(raw, head_pos=head_pos, origin=mf_head_origin)
-    assert_meg_snr(raw_sss, Raw(sss_movecomp_reg_in_fname).crop(*lims),
+    assert_meg_snr(raw_sss, read_crop(sss_movecomp_reg_in_fname, lims),
                    0.5, 1.9, chpi_med_tol=121)
 
     #
@@ -158,25 +164,25 @@ def test_movement_compensation():
     assert_equal(len(w), 1)
     assert_true('is untested' in str(w[0].message))
     # Neither match is particularly good because our algorithm actually differs
-    assert_meg_snr(raw_sss_mv, Raw(sss_movecomp_reg_in_st4s_fname).crop(*lims),
+    assert_meg_snr(raw_sss_mv, read_crop(sss_movecomp_reg_in_st4s_fname, lims),
                    0.6, 1.3)
     tSSS_fname = op.join(sss_path, 'test_move_anon_st4s_raw_sss.fif')
-    assert_meg_snr(raw_sss_mv, Raw(tSSS_fname).crop(*lims),
+    assert_meg_snr(raw_sss_mv, read_crop(tSSS_fname, lims),
                    0.6, 1.0, chpi_med_tol=None)
-    assert_meg_snr(Raw(sss_movecomp_reg_in_st4s_fname), Raw(tSSS_fname),
-                   0.8, 1.0, chpi_med_tol=None)
+    assert_meg_snr(read_crop(sss_movecomp_reg_in_st4s_fname),
+                   read_crop(tSSS_fname), 0.8, 1.0, chpi_med_tol=None)
 
     #
     # Movement compensation,    regularization,    tSSS at the beginning
     #
     raw_sss_mc = maxwell_filter(raw_nohpi, head_pos=head_pos, st_duration=4.,
                                 origin=mf_head_origin)
-    assert_meg_snr(raw_sss_mc, Raw(tSSS_fname).crop(*lims),
+    assert_meg_snr(raw_sss_mc, read_crop(tSSS_fname, lims),
                    0.6, 1.0, chpi_med_tol=None)
     assert_meg_snr(raw_sss_mc, raw_sss_mv, 0.6, 1.4)
 
     # some degenerate cases
-    raw_erm = Raw(erm_fname, allow_maxshield='yes')
+    raw_erm = read_crop(erm_fname)
     assert_raises(ValueError, maxwell_filter, raw_erm, coord_frame='meg',
                   head_pos=head_pos)  # can't do ERM file
     assert_raises(ValueError, maxwell_filter, raw,
@@ -203,7 +209,7 @@ def test_movement_compensation():
 
 @slow_test
 def test_other_systems():
-    """Test Maxwell filtering on KIT, BTI, and CTF files"""
+    """Test Maxwell filtering on KIT, BTI, and CTF files."""
     # KIT
     kit_dir = op.join(io_dir, 'kit', 'tests', 'data')
     sqd_path = op.join(kit_dir, 'test.sqd')
@@ -266,7 +272,7 @@ def test_other_systems():
     _assert_shielding(raw_sss_auto, power, 0.7)
 
     # CTF
-    raw_ctf = Raw(fname_ctf_raw)
+    raw_ctf = read_crop(fname_ctf_raw)
     assert_equal(raw_ctf.compensation_grade, 3)
     assert_raises(RuntimeError, maxwell_filter, raw_ctf)  # compensated
     raw_ctf.apply_gradient_compensation(0)
@@ -283,7 +289,7 @@ def test_other_systems():
 
 
 def test_spherical_harmonics():
-    """Test spherical harmonic functions"""
+    """Test spherical harmonic functions."""
     from scipy.special import sph_harm
     az, pol = np.meshgrid(np.linspace(0, 2 * np.pi, 30),
                           np.linspace(0, np.pi, 20))
@@ -303,7 +309,7 @@ def test_spherical_harmonics():
 
 
 def test_spherical_conversions():
-    """Test spherical harmonic conversions"""
+    """Test spherical harmonic conversions."""
     # Test our real<->complex conversion functions
     az, pol = np.meshgrid(np.linspace(0, 2 * np.pi, 30),
                           np.linspace(0, np.pi, 20))
@@ -322,7 +328,7 @@ def test_spherical_conversions():
 
 @testing.requires_testing_data
 def test_multipolar_bases():
-    """Test multipolar moment basis calculation using sensor information"""
+    """Test multipolar moment basis calculation using sensor information."""
     from scipy.io import loadmat
     # Test our basis calculations
     info = read_info(raw_fname)
@@ -382,11 +388,11 @@ def test_multipolar_bases():
 
 @testing.requires_testing_data
 def test_basic():
-    """Test Maxwell filter basic version"""
+    """Test Maxwell filter basic version."""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
-    raw_err = Raw(raw_fname, proj=True, allow_maxshield='yes')
-    raw_erm = Raw(erm_fname, allow_maxshield='yes')
+    raw = read_crop(raw_fname, (0., 1.))
+    raw_err = read_crop(raw_fname).apply_proj()
+    raw_erm = read_crop(erm_fname)
     assert_raises(RuntimeError, maxwell_filter, raw_err)
     assert_raises(TypeError, maxwell_filter, 1.)  # not a raw
     assert_raises(ValueError, maxwell_filter, raw, int_order=20)  # too many
@@ -404,7 +410,7 @@ def test_basic():
                              bad_condition='ignore')
     assert_equal(len(raw_sss.info['projs']), 1)  # avg EEG
     assert_equal(raw_sss.info['projs'][0]['desc'], 'Average EEG reference')
-    assert_meg_snr(raw_sss, Raw(sss_std_fname), 200., 1000.)
+    assert_meg_snr(raw_sss, read_crop(sss_std_fname), 200., 1000.)
     py_cal = raw_sss.info['proc_history'][0]['max_info']['sss_cal']
     assert_equal(len(py_cal), 0)
     py_ctc = raw_sss.info['proc_history'][0]['max_info']['sss_ctc']
@@ -416,10 +422,10 @@ def test_basic():
     # Test SSS computation at non-standard head origin
     raw_sss = maxwell_filter(raw, origin=[0., 0.02, 0.02], regularize=None,
                              bad_condition='ignore')
-    assert_meg_snr(raw_sss, Raw(sss_nonstd_fname), 250., 700.)
+    assert_meg_snr(raw_sss, read_crop(sss_nonstd_fname), 250., 700.)
 
     # Test SSS computation at device origin
-    sss_erm_std = Raw(sss_erm_std_fname)
+    sss_erm_std = read_crop(sss_erm_std_fname)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg',
                              origin=mf_meg_origin, regularize=None,
                              bad_condition='ignore')
@@ -443,7 +449,7 @@ def test_basic():
 
 @testing.requires_testing_data
 def test_maxwell_filter_additional():
-    """Test processing of Maxwell filtered data"""
+    """Test processing of Maxwell filtered data."""
 
     # TODO: Future tests integrate with mne/io/tests/test_proc_history
 
@@ -455,7 +461,7 @@ def test_maxwell_filter_additional():
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
     # Use 2.0 seconds of data to get stable cov. estimate
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 2., copy=False)
+    raw = read_crop(raw_fname, (0., 2.))
 
     # Get MEG channels, compute Maxwell filtered data
     raw.load_data()
@@ -468,7 +474,7 @@ def test_maxwell_filter_additional():
     tempdir = _TempDir()
     test_outname = op.join(tempdir, 'test_raw_sss.fif')
     raw_sss.save(test_outname)
-    raw_sss_loaded = Raw(test_outname, preload=True)
+    raw_sss_loaded = read_crop(test_outname).load_data()
 
     # Some numerical imprecision since save uses 'single' fmt
     assert_allclose(raw_sss_loaded[:][0], raw_sss[:][0],
@@ -490,20 +496,20 @@ def test_maxwell_filter_additional():
 @slow_test
 @testing.requires_testing_data
 def test_bads_reconstruction():
-    """Test Maxwell filter reconstruction of bad channels"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1.)
+    """Test Maxwell filter reconstruction of bad channels."""
+    raw = read_crop(raw_fname, (0., 1.))
     raw.info['bads'] = bads
     raw_sss = maxwell_filter(raw, origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
-    assert_meg_snr(raw_sss, Raw(sss_bad_recon_fname), 300.)
+    assert_meg_snr(raw_sss, read_crop(sss_bad_recon_fname), 300.)
 
 
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_spatiotemporal_maxwell():
-    """Test Maxwell filter (tSSS) spatiotemporal processing"""
+    """Test Maxwell filter (tSSS) spatiotemporal processing."""
     # Load raw testing data
-    raw = Raw(raw_fname, allow_maxshield='yes')
+    raw = read_crop(raw_fname)
 
     # Test that window is less than length of data
     assert_raises(ValueError, maxwell_filter, raw, st_duration=1000.)
@@ -516,7 +522,7 @@ def test_spatiotemporal_maxwell():
         # Load tSSS data depending on st_duration and get data
         tSSS_fname = op.join(sss_path,
                              'test_move_anon_st%0ds_raw_sss.fif' % st_duration)
-        tsss_bench = Raw(tSSS_fname)
+        tsss_bench = read_crop(tSSS_fname)
         # Because Elekta's tSSS sometimes(!) lumps the tail window of data
         # onto the previous buffer if it's shorter than st_duration, we have to
         # crop the data here to compensate for Elekta's tSSS behavior.
@@ -555,10 +561,9 @@ def test_spatiotemporal_maxwell():
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_spatiotemporal_only():
-    """Test tSSS-only processing"""
+    """Test tSSS-only processing."""
     # Load raw testing data
-    raw = Raw(raw_fname,
-              allow_maxshield='yes').crop(0, 2, copy=False).load_data()
+    raw = read_crop(raw_fname, (0, 2)).load_data()
     picks = pick_types(raw.info, meg='mag', exclude=())
     power = np.sqrt(np.sum(raw[picks][0] ** 2))
     # basics
@@ -607,11 +612,11 @@ def test_spatiotemporal_only():
 
 @testing.requires_testing_data
 def test_fine_calibration():
-    """Test Maxwell filter fine calibration"""
+    """Test Maxwell filter fine calibration."""
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
-    sss_fine_cal = Raw(sss_fine_cal_fname)
+    raw = read_crop(raw_fname, (0., 1.))
+    sss_fine_cal = read_crop(sss_fine_cal_fname)
 
     # Test 1D SSS fine calibration
     raw_sss = maxwell_filter(raw, calibration=fine_cal_fname,
@@ -634,7 +639,7 @@ def test_fine_calibration():
                                 origin=mf_head_origin, regularize=None,
                                 bad_condition='ignore')
     assert_meg_snr(raw_sss_3D, sss_fine_cal, 1.0, 6.)
-    raw_ctf = Raw(fname_ctf_raw).apply_gradient_compensation(0)
+    raw_ctf = read_crop(fname_ctf_raw).apply_gradient_compensation(0)
     assert_raises(RuntimeError, maxwell_filter, raw_ctf, origin=(0., 0., 0.04),
                   calibration=fine_cal_fname)
 
@@ -642,7 +647,7 @@ def test_fine_calibration():
 @slow_test
 @testing.requires_testing_data
 def test_regularization():
-    """Test Maxwell filter regularization"""
+    """Test Maxwell filter regularization."""
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
     min_tols = (100., 2.6, 1.0)
     med_tols = (1000., 21.4, 3.7)
@@ -653,8 +658,8 @@ def test_regularization():
                   sss_samp_reg_in_fname)
     comp_tols = [0, 1, 4]
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshield='yes').crop(0., 1.)
-        sss_reg_in = Raw(sss_fnames[ii])
+        raw = read_crop(rf, (0., 1.))
+        sss_reg_in = read_crop(sss_fnames[ii])
 
         # Test "in" regularization
         raw_sss = maxwell_filter(raw, coord_frame=coord_frames[ii],
@@ -666,7 +671,7 @@ def test_regularization():
 
 
 def _check_reg_match(sss_py, sss_mf, comp_tol):
-    """Helper to check regularization"""
+    """Helper to check regularization."""
     info_py = sss_py.info['proc_history'][0]['max_info']['sss_info']
     assert_true(info_py is not None)
     assert_true(len(info_py) > 0)
@@ -684,10 +689,10 @@ def _check_reg_match(sss_py, sss_mf, comp_tol):
 
 @testing.requires_testing_data
 def test_cross_talk():
-    """Test Maxwell filter cross-talk cancellation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
+    """Test Maxwell filter cross-talk cancellation."""
+    raw = read_crop(raw_fname, (0., 1.))
     raw.info['bads'] = bads
-    sss_ctc = Raw(sss_ctc_fname)
+    sss_ctc = read_crop(sss_ctc_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
                              origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
@@ -699,7 +704,7 @@ def test_cross_talk():
     mf_ctc = sss_ctc.info['proc_history'][0]['max_info']['sss_ctc']
     del mf_ctc['block_id']  # we don't write this
     assert_equal(object_diff(py_ctc, mf_ctc), '')
-    raw_ctf = Raw(fname_ctf_raw).apply_gradient_compensation(0)
+    raw_ctf = read_crop(fname_ctf_raw).apply_gradient_compensation(0)
     assert_raises(ValueError, maxwell_filter, raw_ctf)  # cannot fit headshape
     raw_sss = maxwell_filter(raw_ctf, origin=(0., 0., 0.04))
     _assert_n_free(raw_sss, 68)
@@ -719,13 +724,13 @@ def test_cross_talk():
 
 @testing.requires_testing_data
 def test_head_translation():
-    """Test Maxwell filter head translation"""
-    raw = Raw(raw_fname, allow_maxshield='yes').crop(0., 1., copy=False)
+    """Test Maxwell filter head translation."""
+    raw = read_crop(raw_fname, (0., 1.))
     # First try with an unchanged destination
     raw_sss = maxwell_filter(raw, destination=raw_fname,
                              origin=mf_head_origin, regularize=None,
                              bad_condition='ignore')
-    assert_meg_snr(raw_sss, Raw(sss_std_fname).crop(0., 1.), 200.)
+    assert_meg_snr(raw_sss, read_crop(sss_std_fname, (0., 1.)), 200.)
     # Now with default
     with warnings.catch_warnings(record=True):
         with catch_logging() as log:
@@ -733,7 +738,7 @@ def test_head_translation():
                                      origin=mf_head_origin, regularize=None,
                                      bad_condition='ignore', verbose='warning')
     assert_true('over 25 mm' in log.getvalue())
-    assert_meg_snr(raw_sss, Raw(sss_trans_default_fname), 125.)
+    assert_meg_snr(raw_sss, read_crop(sss_trans_default_fname), 125.)
     destination = np.eye(4)
     destination[2, 3] = 0.04
     assert_allclose(raw_sss.info['dev_head_t']['trans'], destination)
@@ -744,7 +749,7 @@ def test_head_translation():
                                      origin=mf_head_origin, regularize=None,
                                      bad_condition='ignore', verbose='warning')
     assert_true('= 25.6 mm' in log.getvalue())
-    assert_meg_snr(raw_sss, Raw(sss_trans_sample_fname), 350.)
+    assert_meg_snr(raw_sss, read_crop(sss_trans_sample_fname), 350.)
     assert_allclose(raw_sss.info['dev_head_t']['trans'],
                     read_info(sample_fname)['dev_head_t']['trans'])
     # Degenerate cases
@@ -758,7 +763,7 @@ def test_head_translation():
 # http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=1495874
 
 def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
-    """Helper to assert a minimum shielding factor using empty-room power"""
+    """Helper to assert a minimum shielding factor using empty-room power."""
     picks = pick_types(raw_sss.info, meg=meg, ref_meg=False)
     if isinstance(erm_power, _BaseRaw):
         picks_erm = pick_types(raw_sss.info, meg=meg, ref_meg=False)
@@ -776,8 +781,8 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_shielding_factor():
-    """Test Maxwell filter shielding factor using empty room"""
-    raw_erm = Raw(erm_fname, allow_maxshield='yes', preload=True)
+    """Test Maxwell filter shielding factor using empty room."""
+    raw_erm = read_crop(erm_fname).load_data()
     picks = pick_types(raw_erm.info, meg='mag')
     erm_power = raw_erm[picks][0]
     erm_power = np.sqrt(np.sum(erm_power * erm_power))
@@ -785,7 +790,7 @@ def test_shielding_factor():
     erm_power_grad = np.sqrt(np.sum(erm_power * erm_power))
 
     # Vanilla SSS (second value would be for meg=True instead of meg='mag')
-    _assert_shielding(Raw(sss_erm_std_fname), erm_power, 10)  # 1.5)
+    _assert_shielding(read_crop(sss_erm_std_fname), erm_power, 10)  # 1.5)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None)
     _assert_shielding(raw_sss, erm_power, 12)  # 1.5)
     _assert_shielding(raw_sss, erm_power_grad, 0.45, 'grad')  # 1.5)
@@ -805,14 +810,14 @@ def test_shielding_factor():
     _assert_shielding(raw_sss, erm_power_grad, 0.1, 'grad')
 
     # Fine cal
-    _assert_shielding(Raw(sss_erm_fine_cal_fname), erm_power, 12)  # 2.0)
+    _assert_shielding(read_crop(sss_erm_fine_cal_fname), erm_power, 12)  # 2.0)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None,
                              origin=mf_meg_origin,
                              calibration=fine_cal_fname)
     _assert_shielding(raw_sss, erm_power, 12)  # 2.0)
 
     # Crosstalk
-    _assert_shielding(Raw(sss_erm_ctc_fname), erm_power, 12)  # 2.1)
+    _assert_shielding(read_crop(sss_erm_ctc_fname), erm_power, 12)  # 2.1)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None,
                              origin=mf_meg_origin,
                              cross_talk=ctc_fname)
@@ -826,7 +831,7 @@ def test_shielding_factor():
     _assert_shielding(raw_sss, erm_power, 13)  # 2.2)
 
     # tSSS
-    _assert_shielding(Raw(sss_erm_st_fname), erm_power, 37)  # 5.8)
+    _assert_shielding(read_crop(sss_erm_st_fname), erm_power, 37)  # 5.8)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None,
                              origin=mf_meg_origin, st_duration=1.)
     _assert_shielding(raw_sss, erm_power, 37)  # 5.8)
@@ -844,7 +849,7 @@ def test_shielding_factor():
     _assert_shielding(raw_sss, erm_power, 38)  # 5.98)
 
     # Fine cal + Crosstalk + tSSS
-    _assert_shielding(Raw(sss_erm_st1FineCalCrossTalk_fname),
+    _assert_shielding(read_crop(sss_erm_st1FineCalCrossTalk_fname),
                       erm_power, 39)  # 6.07)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None,
                              calibration=fine_cal_fname, origin=mf_meg_origin,
@@ -852,8 +857,8 @@ def test_shielding_factor():
     _assert_shielding(raw_sss, erm_power, 39)  # 6.05)
 
     # Fine cal + Crosstalk + tSSS + Reg-in
-    _assert_shielding(Raw(sss_erm_st1FineCalCrossTalkRegIn_fname), erm_power,
-                      57)  # 6.97)
+    _assert_shielding(read_crop(sss_erm_st1FineCalCrossTalkRegIn_fname),
+                      erm_power, 57)  # 6.97)
     raw_sss = maxwell_filter(raw_erm, calibration=fine_cal_fname,
                              cross_talk=ctc_fname, st_duration=1.,
                              origin=mf_meg_origin,
@@ -894,7 +899,7 @@ def test_shielding_factor():
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_all():
-    """Test maxwell filter using all options"""
+    """Test maxwell filter using all options."""
     raw_fnames = (raw_fname, raw_fname, erm_fname, sample_fname)
     sss_fnames = (sss_st1FineCalCrossTalkRegIn_fname,
                   sss_st1FineCalCrossTalkRegInTransSample_fname,
@@ -915,13 +920,13 @@ def test_all():
                mf_meg_origin,
                mf_head_origin)
     for ii, rf in enumerate(raw_fnames):
-        raw = Raw(rf, allow_maxshield='yes').crop(0., 1.)
+        raw = read_crop(rf, (0., 1.))
         with warnings.catch_warnings(record=True):  # head fit off-center
             sss_py = maxwell_filter(
                 raw, calibration=fine_cals[ii], cross_talk=ctcs[ii],
                 st_duration=st_durs[ii], coord_frame=coord_frames[ii],
                 destination=destinations[ii], origin=origins[ii])
-        sss_mf = Raw(sss_fnames[ii])
+        sss_mf = read_crop(sss_fnames[ii])
         assert_meg_snr(sss_py, sss_mf, mins[ii], meds[ii], msg=rf)
 
 
@@ -929,41 +934,41 @@ def test_all():
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_triux():
-    """Test TRIUX system support"""
-    raw = Raw(tri_fname).crop(0, 0.999)
+    """Test TRIUX system support."""
+    raw = read_crop(tri_fname, (0, 0.999))
     raw.fix_mag_coil_types()
     # standard
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize=None)
-    assert_meg_snr(sss_py, Raw(tri_sss_fname), 37, 700)
+    assert_meg_snr(sss_py, read_crop(tri_sss_fname), 37, 700)
     # cross-talk
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize=None,
                             cross_talk=tri_ctc_fname)
-    assert_meg_snr(sss_py, Raw(tri_sss_ctc_fname), 35, 700)
+    assert_meg_snr(sss_py, read_crop(tri_sss_ctc_fname), 35, 700)
     # fine cal
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize=None,
                             calibration=tri_cal_fname)
-    assert_meg_snr(sss_py, Raw(tri_sss_cal_fname), 31, 360)
+    assert_meg_snr(sss_py, read_crop(tri_sss_cal_fname), 31, 360)
     # ctc+cal
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize=None,
                             calibration=tri_cal_fname,
                             cross_talk=tri_ctc_fname)
-    assert_meg_snr(sss_py, Raw(tri_sss_ctc_cal_fname), 31, 350)
+    assert_meg_snr(sss_py, read_crop(tri_sss_ctc_cal_fname), 31, 350)
     # regularization
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize='in')
-    sss_mf = Raw(tri_sss_reg_fname)
+    sss_mf = read_crop(tri_sss_reg_fname)
     assert_meg_snr(sss_py, sss_mf, 0.6, 9)
     _check_reg_match(sss_py, sss_mf, 1)
     # all three
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize='in',
                             calibration=tri_cal_fname,
                             cross_talk=tri_ctc_fname)
-    sss_mf = Raw(tri_sss_ctc_cal_reg_in_fname)
+    sss_mf = read_crop(tri_sss_ctc_cal_reg_in_fname)
     assert_meg_snr(sss_py, sss_mf, 0.6, 9)
     _check_reg_match(sss_py, sss_mf, 1)
     # tSSS
-    raw = Raw(tri_fname).fix_mag_coil_types()
+    raw = read_crop(tri_fname).fix_mag_coil_types()
     sss_py = maxwell_filter(raw, coord_frame='meg', regularize=None,
                             st_duration=4., verbose=True)
-    assert_meg_snr(sss_py, Raw(tri_sss_st4_fname), 700., 1600)
+    assert_meg_snr(sss_py, read_crop(tri_sss_st4_fname), 700., 1600)
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -5,7 +5,7 @@ from nose.tools import assert_true, assert_equal
 from numpy.testing import assert_array_almost_equal
 import numpy as np
 
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.io.proj import make_projector, activate_proj
 from mne.preprocessing.ssp import compute_proj_ecg, compute_proj_eog
 from mne.utils import run_tests_if_main
@@ -19,8 +19,8 @@ eog_times = np.array([0.5, 2.3, 3.6, 14.5])
 
 
 def test_compute_proj_ecg():
-    """Test computation of ECG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10, copy=False)
+    """Test computation of ECG SSP projectors."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False).crop(0, 10, copy=False)
     raw.load_data()
     for average in [False, True]:
         # For speed, let's not filter here (must also not reject then)
@@ -61,8 +61,8 @@ def test_compute_proj_ecg():
 
 
 def test_compute_proj_eog():
-    """Test computation of EOG SSP projectors"""
-    raw = Raw(raw_fname).crop(0, 10, copy=False)
+    """Test computation of EOG SSP projectors."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False).crop(0, 10, copy=False)
     raw.load_data()
     for average in [False, True]:
         n_projs_init = len(raw.info['projs'])
@@ -101,8 +101,8 @@ def test_compute_proj_eog():
 
 
 def test_compute_proj_parallel():
-    """Test computation of ExG projectors using parallelization"""
-    raw_0 = Raw(raw_fname).crop(0, 10, copy=False)
+    """Test computation of ExG projectors using parallelization."""
+    raw_0 = read_raw_fif(raw_fname, add_eeg_ref=False).crop(0, 10, copy=False)
     raw_0.load_data()
     raw = raw_0.copy()
     projs, _ = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,

--- a/mne/preprocessing/tests/test_stim.py
+++ b/mne/preprocessing/tests/test_stim.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_true, assert_raises
 
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.io.pick import pick_types
 from mne.event import read_events
 from mne.epochs import Epochs
@@ -20,20 +20,20 @@ event_fname = op.join(data_path, 'test-eve.fif')
 
 
 def test_fix_stim_artifact():
-    """Test fix stim artifact"""
+    """Test fix stim artifact."""
     events = read_events(event_fname)
 
-    raw = Raw(raw_fname, preload=False)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     assert_raises(RuntimeError, fix_stim_artifact, raw)
 
-    raw = Raw(raw_fname, preload=True)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=True)
 
     # use window before stimulus in epochs
     tmin, tmax, event_id = -0.2, 0.5, 1
     picks = pick_types(raw.info, meg=True, eeg=True,
                        eog=True, stim=False, exclude='bads')
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, reject=None)
+                    preload=True, reject=None, add_eeg_ref=False)
     e_start = int(np.ceil(epochs.info['sfreq'] * epochs.tmin))
     tmin, tmax = -0.045, -0.015
     tmin_samp = int(-0.035 * epochs.info['sfreq']) - e_start
@@ -72,7 +72,8 @@ def test_fix_stim_artifact():
     # get epochs from raw with fixed data
     tmin, tmax, event_id = -0.2, 0.5, 1
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, reject=None, baseline=None)
+                    preload=True, reject=None, baseline=None,
+                    add_eeg_ref=False)
     e_start = int(np.ceil(epochs.info['sfreq'] * epochs.tmin))
     tmin_samp = int(-0.035 * epochs.info['sfreq']) - e_start
     tmax_samp = int(-0.015 * epochs.info['sfreq']) - e_start

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -7,8 +7,8 @@ import numpy as np
 import os.path as op
 from nose.tools import assert_equal, assert_raises, assert_true
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from mne import (io, Epochs, read_events, pick_types,
-                 compute_raw_covariance)
+from mne import Epochs, read_events, pick_types, compute_raw_covariance
+from mne.io import read_raw_fif
 from mne.utils import requires_sklearn, run_tests_if_main
 from mne.preprocessing.xdawn import Xdawn, XdawnTransformer
 
@@ -21,8 +21,9 @@ event_id = dict(cond2=2, cond3=3)
 
 
 def _get_data():
-    raw = io.read_raw_fif(raw_fname, add_eeg_ref=False, verbose=False,
-                          preload=True)
+    """Get data."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, verbose=False,
+                       preload=True)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=False, eeg=True, stim=False,
                        ecg=False, eog=False,
@@ -43,7 +44,8 @@ def test_xdawn_fit():
     # Get data
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, baseline=None, verbose=False)
+                    preload=True, baseline=None, verbose=False,
+                    add_eeg_ref=False)
     # =========== Basic Fit test =================
     # Test base xdawn
     xd = Xdawn(n_components=2, correct_overlap='auto')
@@ -79,7 +81,8 @@ def test_xdawn_fit():
     # error
     # XXX This is a buggy test, the epochs here don't overlap
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, baseline=(None, 0), verbose=False)
+                    preload=True, baseline=(None, 0), verbose=False,
+                    add_eeg_ref=False)
 
     xd = Xdawn(n_components=2, correct_overlap=True)
     assert_raises(ValueError, xd.fit, epochs)
@@ -127,7 +130,8 @@ def test_xdawn_regularization():
     # Get data
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, baseline=None, verbose=False)
+                    preload=True, baseline=None, verbose=False,
+                    add_eeg_ref=False)
 
     # Test with overlapping events.
     # modify events to simulate one overlap
@@ -156,11 +160,12 @@ def test_xdawn_regularization():
 
 @requires_sklearn
 def test_xdawntransformer():
-    """Test XdawnTransformer"""
+    """Test XdawnTransformer."""
     # Get data
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    preload=True, baseline=None, verbose=False)
+                    preload=True, baseline=None, verbose=False,
+                    add_eeg_ref=False)
     X = epochs._data
     y = epochs.events[:, -1]
     # Fit

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -253,7 +253,7 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
                         picks=pick_types(raw.info, meg=True, eeg=True,
                                          eog=True, ecg=True, emg=True,
                                          exclude='bads'),
-                        reject=reject, flat=flat)
+                        reject=reject, flat=flat, add_eeg_ref=False)
         data = _compute_cov_epochs(epochs, n_jobs)
         info = epochs.info
         if not stop:

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .. import pick_channels
 from ..utils import logger, verbose
-from ..epochs import _BaseEpochs, _dep_eeg_ref
+from ..epochs import _BaseEpochs
 from ..event import _find_events
 
 
@@ -138,8 +138,6 @@ class RtEpochs(_BaseEpochs):
                  name='Unknown', reject=None, flat=None, proj=True,
                  decim=1, reject_tmin=None, reject_tmax=None, detrend=None,
                  add_eeg_ref=None, isi_max=2., find_events=None, verbose=None):
-        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
-
         info = client.get_measurement_info()
 
         # the measurement info of the data as we receive it

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .. import pick_channels
 from ..utils import logger, verbose
-from ..epochs import _BaseEpochs
+from ..epochs import _BaseEpochs, _dep_eeg_ref
 from ..event import _find_events
 
 
@@ -100,7 +100,9 @@ class RtEpochs(_BaseEpochs):
         (will yield equivalent results but be slower).
     add_eeg_ref : bool
         If True, an EEG average reference will be added (unless one
-        already exists).
+        already exists). The default value of True in 0.13 will change to
+        False in 0.14, and the parameter will be removed in 0.15. Use
+        :func:`mne.set_eeg_reference` instead.
     isi_max : float
         The maximmum time in seconds between epochs. If no epoch
         arrives in the next isi_max seconds the RtEpochs stops.
@@ -135,7 +137,8 @@ class RtEpochs(_BaseEpochs):
                  sleep_time=0.1, baseline=(None, 0), picks=None,
                  name='Unknown', reject=None, flat=None, proj=True,
                  decim=1, reject_tmin=None, reject_tmax=None, detrend=None,
-                 add_eeg_ref=True, isi_max=2., find_events=None, verbose=None):
+                 add_eeg_ref=None, isi_max=2., find_events=None, verbose=None):
+        add_eeg_ref = _dep_eeg_ref(add_eeg_ref)
 
         info = client.get_measurement_info()
 

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -18,19 +18,21 @@ events = read_events(event_name)
 def test_mockclient():
     """Test the RtMockClient."""
 
-    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
+    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False,
+                              add_eeg_ref=False)
     picks = mne.pick_types(raw.info, meg='grad', eeg=False, eog=True,
                            stim=True, exclude=raw.info['bads'])
 
     event_id, tmin, tmax = 1, -0.2, 0.5
 
     epochs = Epochs(raw, events[:7], event_id=event_id, tmin=tmin, tmax=tmax,
-                    picks=picks, baseline=(None, 0), preload=True)
+                    picks=picks, baseline=(None, 0), preload=True,
+                    add_eeg_ref=False)
     data = epochs.get_data()
 
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
-                         isi_max=0.5)
+                         isi_max=0.5, add_eeg_ref=False)
 
     rt_epochs.start()
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
@@ -44,14 +46,15 @@ def test_mockclient():
 def test_get_event_data():
     """Test emulation of realtime data stream."""
 
-    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
+    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False,
+                              add_eeg_ref=False)
     picks = mne.pick_types(raw.info, meg='grad', eeg=False, eog=True,
                            stim=True, exclude=raw.info['bads'])
 
     event_id, tmin, tmax = 2, -0.1, 0.3
     epochs = Epochs(raw, events, event_id=event_id,
                     tmin=tmin, tmax=tmax, picks=picks, baseline=None,
-                    preload=True, proj=False)
+                    preload=True, proj=False, add_eeg_ref=False)
 
     data = epochs.get_data()[0, :, :]
 
@@ -66,7 +69,8 @@ def test_get_event_data():
 def test_find_events():
     """Test find_events in rt_epochs."""
 
-    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
+    raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False,
+                              add_eeg_ref=False)
     picks = mne.pick_types(raw.info, meg='grad', eeg=False, eog=True,
                            stim=True, exclude=raw.info['bads'])
 
@@ -94,7 +98,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, add_eeg_ref=False)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6]
@@ -107,7 +111,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, add_eeg_ref=False)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 6]
@@ -120,7 +124,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, add_eeg_ref=False)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5]
@@ -133,7 +137,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, add_eeg_ref=False)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 0, 6, 0]

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -14,7 +14,7 @@ from mne.datasets import testing
 from mne import read_forward_solution
 from mne.simulation import simulate_sparse_stc, simulate_evoked
 from mne import read_cov
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne import pick_types_forward, read_evokeds
 from mne.utils import run_tests_if_main
 
@@ -33,9 +33,9 @@ cov_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
 
 @testing.requires_testing_data
 def test_simulate_evoked():
-    """ Test simulation of evoked data """
+    """Test simulation of evoked data."""
 
-    raw = Raw(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     fwd = read_forward_solution(fwd_fname, force_fixed=True)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -21,7 +21,7 @@ from mne.chpi import (_calculate_chpi_positions, read_head_pos,
 from mne.tests.test_chpi import _compare_positions
 from mne.datasets import testing
 from mne.simulation import simulate_sparse_stc, simulate_raw
-from mne.io import Raw, RawArray
+from mne.io import read_raw_fif, RawArray
 from mne.time_frequency import psd_welch
 from mne.utils import _TempDir, run_tests_if_main, requires_version, slow_test
 
@@ -44,7 +44,7 @@ pos_fname = op.join(data_path, 'SSS', 'test_move_anon_raw_subsampled.pos')
 
 
 def _make_stc(raw, src):
-    """Helper to make a STC"""
+    """Helper to make a STC."""
     seed = 42
     sfreq = raw.info['sfreq']  # Hz
     tstep = 1. / sfreq
@@ -55,9 +55,10 @@ def _make_stc(raw, src):
 
 
 def _get_data():
-    """Helper to get some starting data"""
+    """Helper to get some starting data."""
     # raw with ECG channel
-    raw = Raw(raw_fname).crop(0., 5.0, copy=False).load_data()
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    raw.crop(0., 5.0, copy=False).load_data()
     data_picks = pick_types(raw.info, meg=True, eeg=True)
     other_picks = pick_types(raw.info, meg=False, stim=True, eog=True)
     picks = np.sort(np.concatenate((data_picks[::16], other_picks)))
@@ -79,7 +80,7 @@ def _get_data():
 
 @testing.requires_testing_data
 def test_simulate_raw_sphere():
-    """Test simulation of raw data with sphere model"""
+    """Test simulation of raw data with sphere model."""
     seed = 42
     raw, src, stc, trans, sphere = _get_data()
     assert_true(len(pick_types(raw.info, meg=False, ecg=True)) == 1)
@@ -110,7 +111,8 @@ def test_simulate_raw_sphere():
     test_outname = op.join(tempdir, 'sim_test_raw.fif')
     raw_sim.save(test_outname)
 
-    raw_sim_loaded = Raw(test_outname, preload=True, proj=False)
+    raw_sim_loaded = read_raw_fif(test_outname, preload=True, proj=False,
+                                  add_eeg_ref=False)
     assert_allclose(raw_sim_loaded[:][0], raw_sim[:][0], rtol=1e-6, atol=1e-20)
     del raw_sim, raw_sim_2
     # with no cov (no noise) but with artifacts, most time periods should match
@@ -194,7 +196,7 @@ def test_simulate_raw_sphere():
 
 @testing.requires_testing_data
 def test_simulate_raw_bem():
-    """Test simulation of raw data with BEM"""
+    """Test simulation of raw data with BEM."""
     raw, src, stc, trans, sphere = _get_data()
     src = setup_source_space('sample', None, 'oct1', subjects_dir=subjects_dir)
     # use different / more complete STC here
@@ -224,7 +226,8 @@ def test_simulate_raw_bem():
                               (raw_sim_bem, bem_fname, 28)):
         events = find_events(use_raw, 'STI 014')
         assert_equal(len(locs), 12)  # oct1 count
-        evoked = Epochs(use_raw, events, 1, 0, tmax, baseline=None).average()
+        evoked = Epochs(use_raw, events, 1, 0, tmax, baseline=None,
+                        add_eeg_ref=False).average()
         assert_equal(len(evoked.times), len(locs))
         fits = fit_dipole(evoked, cov, bem, trans, min_dist=1.)[0].pos
         diffs = np.sqrt(np.sum((locs - fits) ** 2, axis=-1)) * 1000
@@ -236,8 +239,9 @@ def test_simulate_raw_bem():
 @requires_version('scipy', '0.12')
 @testing.requires_testing_data
 def test_simulate_raw_chpi():
-    """Test simulation of raw data with cHPI"""
-    raw = Raw(raw_chpi_fname, allow_maxshield='yes')
+    """Test simulation of raw data with cHPI."""
+    raw = read_raw_fif(raw_chpi_fname, allow_maxshield='yes',
+                       add_eeg_ref=False)
     sphere = make_sphere_model('auto', 'auto', raw.info)
     # make sparse spherical source space
     sphere_vol = tuple(sphere['r0'] * 1000.) + (sphere.radius * 1000.,)

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -31,16 +31,15 @@ event_fname = data_path + '/MEG/sample/sample_audvis_trunc_raw-eve.fif'
 
 @testing.requires_testing_data
 def test_regression():
-    """Test Ordinary Least Squares Regression
-    """
+    """Test Ordinary Least Squares Regression."""
     tmin, tmax = -0.2, 0.5
     event_id = dict(aud_l=1, aud_r=2)
 
     # Setup for reading the raw data
-    raw = mne.io.read_raw_fif(raw_fname)
+    raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
     events = mne.read_events(event_fname)[:10]
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
-                        baseline=(None, 0))
+                        baseline=(None, 0), add_eeg_ref=False)
     picks = np.arange(len(epochs.ch_names))
     evoked = epochs.average(picks=picks)
     design_matrix = epochs.events[:, 1:].astype(np.float64)
@@ -87,10 +86,10 @@ def test_regression():
 
 @testing.requires_testing_data
 def test_continuous_regression_no_overlap():
-    """Test regression without overlap correction, on real data"""
+    """Test regression without overlap correction, on real data."""
     tmin, tmax = -.1, .5
 
-    raw = mne.io.read_raw_fif(raw_fname, preload=True)
+    raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
     raw.apply_proj()
     events = mne.read_events(event_fname)
     event_id = dict(audio_l=1, audio_r=2)
@@ -98,7 +97,7 @@ def test_continuous_regression_no_overlap():
     raw = raw.pick_channels(raw.ch_names[:2])
 
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
-                        baseline=None, reject=None)
+                        baseline=None, reject=None, add_eeg_ref=False)
 
     revokeds = linear_regression_raw(raw, events, event_id,
                                      tmin=tmin, tmax=tmax,
@@ -122,7 +121,7 @@ def test_continuous_regression_no_overlap():
 
 
 def test_continuous_regression_with_overlap():
-    """Test regression with overlap correction"""
+    """Test regression with overlap correction."""
     signal = np.zeros(100000)
     times = [1000, 2500, 3000, 5000, 5250, 7000, 7250, 8000]
     events = np.zeros((len(times), 3), int)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from mne import create_info
 from mne.utils import run_tests_if_main
-from mne.io import Raw, RawArray, concatenate_raws
+from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.annotations import Annotations
 from mne.datasets import testing
 
@@ -22,7 +22,7 @@ fif_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 @testing.requires_testing_data
 def test_annotations():
     """Test annotation class."""
-    raw = Raw(fif_fname)
+    raw = read_raw_fif(fif_fname, add_eeg_ref=False)
     onset = np.array(range(10))
     duration = np.ones(10)
     description = np.repeat('test', 10)

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -37,8 +37,9 @@ warnings.simplefilter('always')
 
 @testing.requires_testing_data
 def test_chpi_adjust():
-    """Test cHPI logging and adjustment"""
-    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
+    """Test cHPI logging and adjustment."""
+    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes',
+                       add_eeg_ref=False)
     with catch_logging() as log:
         _get_hpi_info(raw.info, adjust=True, verbose='debug')
 
@@ -75,7 +76,7 @@ def test_chpi_adjust():
 
 @testing.requires_testing_data
 def test_read_write_head_pos():
-    """Test reading and writing head position quaternion parameters"""
+    """Test reading and writing head position quaternion parameters."""
     tempdir = _TempDir()
     temp_name = op.join(tempdir, 'temp.pos')
     # This isn't a 100% valid quat matrix but it should be okay for tests
@@ -96,20 +97,21 @@ def test_read_write_head_pos():
 
 @testing.requires_testing_data
 def test_hpi_info():
-    """Test getting HPI info"""
+    """Test getting HPI info."""
     tempdir = _TempDir()
     temp_name = op.join(tempdir, 'temp_raw.fif')
     for fname in (chpi_fif_fname, sss_fif_fname):
-        raw = read_raw_fif(fname, allow_maxshield='yes')
+        raw = read_raw_fif(fname, allow_maxshield='yes', add_eeg_ref=False)
         assert_true(len(raw.info['hpi_subsystem']) > 0)
         raw.save(temp_name, overwrite=True)
-        raw_2 = read_raw_fif(temp_name, allow_maxshield='yes')
+        raw_2 = read_raw_fif(temp_name, allow_maxshield='yes',
+                             add_eeg_ref=False)
         assert_equal(len(raw_2.info['hpi_subsystem']),
                      len(raw.info['hpi_subsystem']))
 
 
 def _compare_positions(a, b, max_dist=0.003, max_angle=5.):
-    """Compare estimated cHPI positions"""
+    """Compare estimated cHPI positions."""
     from scipy.interpolate import interp1d
     trans, rot, t = a
     trans_est, rot_est, t_est = b
@@ -145,16 +147,17 @@ def _compare_positions(a, b, max_dist=0.003, max_angle=5.):
 @requires_version('scipy', '0.11')
 @requires_version('numpy', '1.7')
 def test_calculate_chpi_positions():
-    """Test calculation of cHPI positions"""
+    """Test calculation of cHPI positions."""
     trans, rot, t = head_pos_to_trans_rot_t(read_head_pos(pos_fname))
-    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True)
+    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True,
+                       add_eeg_ref=False)
     t -= raw.first_samp / raw.info['sfreq']
     quats = _calculate_chpi_positions(raw, verbose='debug')
     trans_est, rot_est, t_est = head_pos_to_trans_rot_t(quats)
     _compare_positions((trans, rot, t), (trans_est, rot_est, t_est), 0.003)
 
     # degenerate conditions
-    raw_no_chpi = read_raw_fif(test_fif_fname)
+    raw_no_chpi = read_raw_fif(test_fif_fname, add_eeg_ref=False)
     assert_raises(RuntimeError, _calculate_chpi_positions, raw_no_chpi)
     raw_bad = raw.copy()
     for d in raw_bad.info['dig']:
@@ -182,8 +185,9 @@ def test_calculate_chpi_positions():
 
 @testing.requires_testing_data
 def test_chpi_subtraction():
-    """Test subtraction of cHPI signals"""
-    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True)
+    """Test subtraction of cHPI signals."""
+    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True,
+                       add_eeg_ref=False)
     raw.info['bads'] = ['MEG0111']
     with catch_logging() as log:
         filter_chpi(raw, include_line=False, verbose=True)
@@ -191,20 +195,22 @@ def test_chpi_subtraction():
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
     raw.crop(0, 16, copy=False)
     # remove cHPI status chans
-    raw_c = read_raw_fif(sss_hpisubt_fname).crop(0, 16, copy=False).load_data()
+    raw_c = read_raw_fif(sss_hpisubt_fname,
+                         add_eeg_ref=False).crop(0, 16, copy=False).load_data()
     raw_c.pick_types(
         meg=True, eeg=True, eog=True, ecg=True, stim=True, misc=True)
     assert_meg_snr(raw, raw_c, 143, 624)
 
     # Degenerate cases
-    raw_nohpi = read_raw_fif(test_fif_fname, preload=True)
+    raw_nohpi = read_raw_fif(test_fif_fname, preload=True, add_eeg_ref=False)
     assert_raises(RuntimeError, filter_chpi, raw_nohpi)
 
     # When MaxFliter downsamples, like::
     #     $ maxfilter -nosss -ds 2 -f test_move_anon_raw.fif \
     #           -o test_move_anon_ds2_raw.fif
     # it can strip out some values of info, which we emulate here:
-    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
+    raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes',
+                       add_eeg_ref=False)
     with warnings.catch_warnings(record=True):  # uint cast suggestion
         raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
     raw.info['buffer_size_sec'] = np.float64(2.)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -48,7 +48,7 @@ subjects_dir = op.join(data_path, 'subjects')
 
 
 def _compare_dipoles(orig, new):
-    """Compare dipole results for equivalence"""
+    """Compare dipole results for equivalence."""
     assert_allclose(orig.times, new.times, atol=1e-3, err_msg='times')
     assert_allclose(orig.pos, new.pos, err_msg='pos')
     assert_allclose(orig.amplitude, new.amplitude, err_msg='amplitude')
@@ -58,6 +58,7 @@ def _compare_dipoles(orig, new):
 
 
 def _check_dipole(dip, n_dipoles):
+    """Check dipole sizes."""
     assert_equal(len(dip), n_dipoles)
     assert_equal(dip.pos.shape, (n_dipoles, 3))
     assert_equal(dip.ori.shape, (n_dipoles, 3))
@@ -67,7 +68,7 @@ def _check_dipole(dip, n_dipoles):
 
 @testing.requires_testing_data
 def test_io_dipoles():
-    """Test IO for .dip files"""
+    """Test IO for .dip files."""
     tempdir = _TempDir()
     dipole = read_dipole(fname_dip)
     print(dipole)  # test repr
@@ -79,10 +80,11 @@ def test_io_dipoles():
 
 @testing.requires_testing_data
 def test_dipole_fitting_ctf():
-    """Test dipole fitting with CTF data"""
-    raw_ctf = read_raw_ctf(fname_ctf)
+    """Test dipole fitting with CTF data."""
+    raw_ctf = read_raw_ctf(fname_ctf).set_eeg_reference()
     events = make_fixed_length_events(raw_ctf, 1)
-    evoked = Epochs(raw_ctf, events, 1, 0, 0, baseline=None).average()
+    evoked = Epochs(raw_ctf, events, 1, 0, 0, baseline=None,
+                    add_eeg_ref=False).average()
     cov = make_ad_hoc_cov(evoked.info)
     sphere = make_sphere_model((0., 0., 0.))
     # XXX Eventually we should do some better checks about accuracy, but
@@ -96,7 +98,7 @@ def test_dipole_fitting_ctf():
 @testing.requires_testing_data
 @requires_mne
 def test_dipole_fitting():
-    """Test dipole fitting"""
+    """Test dipole fitting."""
     amp = 10e-9
     tempdir = _TempDir()
     rng = np.random.RandomState(0)
@@ -179,7 +181,7 @@ def test_dipole_fitting():
 
 @testing.requires_testing_data
 def test_dipole_fitting_fixed():
-    """Test dipole fitting with a fixed position"""
+    """Test dipole fitting with a fixed position."""
     tpeak = 0.073
     sphere = make_sphere_model(head_radius=0.1)
     evoked = read_evokeds(fname_evo, baseline=(None, 0))[0]
@@ -223,7 +225,7 @@ def test_dipole_fitting_fixed():
 
 @testing.requires_testing_data
 def test_len_index_dipoles():
-    """Test len and indexing of Dipole objects"""
+    """Test len and indexing of Dipole objects."""
     dipole = read_dipole(fname_dip)
     d0 = dipole[0]
     d1 = dipole[:1]
@@ -239,9 +241,9 @@ def test_len_index_dipoles():
 
 @testing.requires_testing_data
 def test_min_distance_fit_dipole():
-    """Test dipole min_dist to inner_skull"""
+    """Test dipole min_dist to inner_skull."""
     subject = 'sample'
-    raw = read_raw_fif(fname_raw, preload=True)
+    raw = read_raw_fif(fname_raw, preload=True, add_eeg_ref=False)
 
     # select eeg data
     picks = pick_types(raw.info, meg=False, eeg=True, exclude='bads')
@@ -275,7 +277,7 @@ def test_min_distance_fit_dipole():
 
 
 def _compute_depth(dip, fname_bem, fname_trans, subject, subjects_dir):
-    """Compute dipole depth"""
+    """Compute dipole depth."""
     trans = _get_trans(fname_trans)[0]
     bem = read_bem_solution(fname_bem)
     surf = _bem_find_surface(bem, 'inner_skull')
@@ -287,7 +289,7 @@ def _compute_depth(dip, fname_bem, fname_trans, subject, subjects_dir):
 
 @testing.requires_testing_data
 def test_accuracy():
-    """Test dipole fitting to sub-mm accuracy"""
+    """Test dipole fitting to sub-mm accuracy."""
     evoked = read_evokeds(fname_evo)[0].crop(0., 0.,)
     evoked.pick_types(meg=True, eeg=False)
     evoked.pick_channels([c for c in evoked.ch_names[::4]])
@@ -330,7 +332,7 @@ def test_accuracy():
 
 @testing.requires_testing_data
 def test_dipole_fixed():
-    """Test reading a fixed-position dipole (from Xfit)"""
+    """Test reading a fixed-position dipole (from Xfit)."""
     dip = read_dipole(fname_xfit_dip)
     _check_roundtrip_fixed(dip)
     with warnings.catch_warnings(record=True) as w:  # unused fields
@@ -344,7 +346,7 @@ def test_dipole_fixed():
 
 
 def _check_roundtrip_fixed(dip):
-    """Helper to test roundtrip IO for fixed dipoles"""
+    """Helper to test roundtrip IO for fixed dipoles."""
     tempdir = _TempDir()
     dip.save(op.join(tempdir, 'test-dip.fif.gz'))
     dip_read = read_dipole(op.join(tempdir, 'test-dip.fif.gz'))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -30,7 +30,7 @@ from mne.utils import (_TempDir, requires_pandas, slow_test,
                        run_tests_if_main, requires_version)
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 
-from mne.io import RawArray, Raw
+from mne.io import RawArray, read_raw_fif
 from mne.io.proj import _has_eeg_average_ref_proj
 from mne.event import merge_events
 from mne.io.constants import FIFF
@@ -60,7 +60,8 @@ rng = np.random.RandomState(42)
 
 
 def _get_data(preload=False):
-    raw = Raw(raw_fname, preload=preload, add_eeg_ref=False, proj=False)
+    """Get data."""
+    raw = read_raw_fif(raw_fname, preload=preload, add_eeg_ref=False)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg=True, eeg=True, stim=True,
                        ecg=True, eog=True, include=['STI 014'],
@@ -74,12 +75,12 @@ flat = dict(grad=1e-15, mag=1e-15)
 @slow_test
 @testing.requires_testing_data
 def test_average_movements():
-    """Test movement averaging algorithm
-    """
+    """Test movement averaging algorithm."""
     # usable data
     crop = 0., 10.
     origin = (0., 0., 0.04)
-    raw = Raw(fname_raw_move, allow_maxshield='yes')
+    raw = read_raw_fif(fname_raw_move, allow_maxshield='yes',
+                       add_eeg_ref=False)
     raw.info['bads'] += ['MEG2443']  # mark some bad MEG channel
     raw.crop(*crop, copy=False).load_data()
     raw.filter(None, 20, method='iir')
@@ -87,14 +88,14 @@ def test_average_movements():
     picks = pick_types(raw.info, meg=True, eeg=True, stim=True,
                        ecg=True, eog=True, exclude=())
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks, proj=False,
-                    preload=True)
+                    preload=True, add_eeg_ref=False)
     epochs_proj = Epochs(raw, events[:1], event_id, tmin, tmax, picks=picks,
-                         proj=True, preload=True)
+                         proj=True, preload=True, add_eeg_ref=False)
     raw_sss_stat = maxwell_filter(raw, origin=origin, regularize=None,
                                   bad_condition='ignore')
     del raw
     epochs_sss_stat = Epochs(raw_sss_stat, events, event_id, tmin, tmax,
-                             picks=picks, proj=False)
+                             picks=picks, proj=False, add_eeg_ref=False)
     evoked_sss_stat = epochs_sss_stat.average()
     del raw_sss_stat, epochs_sss_stat
     head_pos = read_head_pos(fname_raw_move_pos)
@@ -124,13 +125,14 @@ def test_average_movements():
     assert_allclose(evoked_move_non.data[meg_picks],
                     evoked_move_all.data[meg_picks], atol=1e-20)
     # compare to averaged movecomp version (should be fairly similar)
-    raw_sss = Raw(fname_raw_movecomp_sss).crop(*crop, copy=False).load_data()
+    raw_sss = read_raw_fif(fname_raw_movecomp_sss, add_eeg_ref=False)
+    raw_sss.crop(*crop, copy=False).load_data()
     raw_sss.filter(None, 20, method='iir')
     picks_sss = pick_types(raw_sss.info, meg=True, eeg=True, stim=True,
                            ecg=True, eog=True, exclude=())
     assert_array_equal(picks, picks_sss)
     epochs_sss = Epochs(raw_sss, events, event_id, tmin, tmax,
-                        picks=picks_sss, proj=False)
+                        picks=picks_sss, proj=False, add_eeg_ref=False)
     evoked_sss = epochs_sss.average()
     assert_equal(evoked_std.nave, evoked_sss.nave)
     # this should break the non-MEG channels
@@ -166,7 +168,7 @@ def test_average_movements():
 
 
 def test_reject():
-    """Test epochs rejection"""
+    """Test epochs rejection."""
     raw, events, picks = _get_data()
     # cull the list just to contain the relevant event
     events = events[events[:, 2] == event_id, :]
@@ -175,19 +177,22 @@ def test_reject():
     assert_raises(TypeError, pick_types, raw)
     picks_meg = pick_types(raw.info, meg=True, eeg=False)
     assert_raises(TypeError, Epochs, raw, events, event_id, tmin, tmax,
-                  picks=picks, preload=False, reject='foo')
+                  picks=picks, preload=False, reject='foo',
+                  add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
-                  picks=picks_meg, preload=False, reject=dict(eeg=1.))
+                  picks=picks_meg, preload=False, reject=dict(eeg=1.),
+                  add_eeg_ref=False)
     # this one is okay because it's not actually requesting rejection
     Epochs(raw, events, event_id, tmin, tmax, picks=picks_meg,
-           preload=False, reject=dict(eeg=np.inf))
+           preload=False, reject=dict(eeg=np.inf), add_eeg_ref=False)
     for val in (None, -1):  # protect against older MNE-C types
         for kwarg in ('reject', 'flat'):
             assert_raises(ValueError, Epochs, raw, events, event_id,
                           tmin, tmax, picks=picks_meg, preload=False,
-                          **{kwarg: dict(grad=val)})
+                          add_eeg_ref=False, **{kwarg: dict(grad=val)})
     assert_raises(KeyError, Epochs, raw, events, event_id, tmin, tmax,
-                  picks=picks, preload=False, reject=dict(foo=1.))
+                  picks=picks, preload=False, reject=dict(foo=1.),
+                  add_eeg_ref=False)
 
     data_7 = dict()
     keep_idx = [0, 1, 2]
@@ -195,7 +200,7 @@ def test_reject():
         for proj in (True, False, 'delayed'):
             # no rejection
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            preload=preload)
+                            preload=preload, add_eeg_ref=False)
             assert_raises(ValueError, epochs.drop_bad, reject='foo')
             epochs.drop_bad()
             assert_equal(len(epochs), len(events))
@@ -207,7 +212,7 @@ def test_reject():
 
             # with rejection
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            reject=reject, preload=preload)
+                            reject=reject, preload=preload, add_eeg_ref=False)
             epochs.drop_bad()
             assert_equal(len(epochs), len(events) - 4)
             assert_array_equal(epochs.selection, selection)
@@ -216,7 +221,7 @@ def test_reject():
 
             # rejection post-hoc
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            preload=preload)
+                            preload=preload, add_eeg_ref=False)
             epochs.drop_bad()
             assert_equal(len(epochs), len(events))
             assert_array_equal(epochs.get_data(), data_7[proj])
@@ -230,7 +235,8 @@ def test_reject():
             # rejection twice
             reject_part = dict(grad=1100e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            reject=reject_part, preload=preload)
+                            reject=reject_part, preload=preload,
+                            add_eeg_ref=False)
             epochs.drop_bad()
             assert_equal(len(epochs), len(events) - 1)
             epochs.drop_bad(reject)
@@ -251,7 +257,8 @@ def test_reject():
             # rejection of subset of trials (ensure array ownership)
             reject_part = dict(grad=1100e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            reject=None, preload=preload)
+                            reject=None, preload=preload,
+                            add_eeg_ref=False)
             epochs = epochs[:-1]
             epochs.drop_bad(reject=reject)
             assert_equal(len(epochs), len(events) - 4)
@@ -261,7 +268,8 @@ def test_reject():
             raw.annotations = Annotations([(events[0][0] - raw.first_samp) /
                                            raw.info['sfreq']], [1], ['BAD'])
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=[0],
-                            reject=None, preload=preload)
+                            reject=None, preload=preload,
+                            add_eeg_ref=False)
             epochs.drop_bad()
             assert_equal(len(events) - 1, len(epochs.events))
             assert_equal(epochs.drop_log[0][0], 'BAD')
@@ -269,8 +277,7 @@ def test_reject():
 
 
 def test_decim():
-    """Test epochs decimation
-    """
+    """Test epochs decimation."""
     # First with EpochsArray
     dec_1, dec_2 = 2, 3
     decim = dec_1 * dec_2
@@ -303,7 +310,7 @@ def test_decim():
     for this_offset in range(decim):
         epochs = Epochs(raw, events, event_id,
                         tmin=-this_offset / raw.info['sfreq'],
-                        tmax=tmax, preload=False)
+                        tmax=tmax, preload=False, add_eeg_ref=False)
         idx_offsets = np.arange(decim) + this_offset
         for offset, idx_offset in zip(np.arange(decim), idx_offsets):
             expected_times = epochs.times[idx_offset::decim]
@@ -317,13 +324,14 @@ def test_decim():
             assert_equal(ep_decim.info['sfreq'], sfreq_new)
 
     # More complex cases
-    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=False)
+    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=False,
+                    add_eeg_ref=False)
     expected_data = epochs.get_data()[:, :, ::decim]
     expected_times = epochs.times[::decim]
     for preload in (True, False):
         # at init
         epochs = Epochs(raw, events, event_id, tmin, tmax, decim=decim,
-                        preload=preload)
+                        preload=preload, add_eeg_ref=False)
         assert_allclose(epochs.get_data(), expected_data)
         assert_allclose(epochs.get_data(), expected_data)
         assert_equal(epochs.info['sfreq'], sfreq_new)
@@ -331,13 +339,13 @@ def test_decim():
 
         # split between init and afterward
         epochs = Epochs(raw, events, event_id, tmin, tmax, decim=dec_1,
-                        preload=preload).decimate(dec_2)
+                        preload=preload, add_eeg_ref=False).decimate(dec_2)
         assert_allclose(epochs.get_data(), expected_data)
         assert_allclose(epochs.get_data(), expected_data)
         assert_equal(epochs.info['sfreq'], sfreq_new)
         assert_array_equal(epochs.times, expected_times)
         epochs = Epochs(raw, events, event_id, tmin, tmax, decim=dec_2,
-                        preload=preload).decimate(dec_1)
+                        preload=preload, add_eeg_ref=False).decimate(dec_1)
         assert_allclose(epochs.get_data(), expected_data)
         assert_allclose(epochs.get_data(), expected_data)
         assert_equal(epochs.info['sfreq'], sfreq_new)
@@ -345,7 +353,7 @@ def test_decim():
 
         # split between init and afterward, with preload in between
         epochs = Epochs(raw, events, event_id, tmin, tmax, decim=dec_1,
-                        preload=preload)
+                        preload=preload, add_eeg_ref=False)
         epochs.load_data()
         epochs = epochs.decimate(dec_2)
         assert_allclose(epochs.get_data(), expected_data)
@@ -353,7 +361,7 @@ def test_decim():
         assert_equal(epochs.info['sfreq'], sfreq_new)
         assert_array_equal(epochs.times, expected_times)
         epochs = Epochs(raw, events, event_id, tmin, tmax, decim=dec_2,
-                        preload=preload)
+                        preload=preload, add_eeg_ref=False)
         epochs.load_data()
         epochs = epochs.decimate(dec_1)
         assert_allclose(epochs.get_data(), expected_data)
@@ -363,7 +371,7 @@ def test_decim():
 
         # decimate afterward
         epochs = Epochs(raw, events, event_id, tmin, tmax,
-                        preload=preload).decimate(decim)
+                        preload=preload, add_eeg_ref=False).decimate(decim)
         assert_allclose(epochs.get_data(), expected_data)
         assert_allclose(epochs.get_data(), expected_data)
         assert_equal(epochs.info['sfreq'], sfreq_new)
@@ -371,7 +379,7 @@ def test_decim():
 
         # decimate afterward, with preload in between
         epochs = Epochs(raw, events, event_id, tmin, tmax,
-                        preload=preload)
+                        preload=preload, add_eeg_ref=False)
         epochs.load_data()
         epochs.decimate(decim)
         assert_allclose(epochs.get_data(), expected_data)
@@ -381,8 +389,7 @@ def test_decim():
 
 
 def test_base_epochs():
-    """Test base epochs class
-    """
+    """Test base epochs class."""
     raw = _get_data()[0]
     epochs = _BaseEpochs(raw.info, None, np.ones((1, 3), int),
                          event_id, tmin, tmax)
@@ -396,13 +403,13 @@ def test_base_epochs():
 
 @requires_version('scipy', '0.14')
 def test_savgol_filter():
-    """Test savgol filtering
-    """
+    """Test savgol filtering."""
     h_freq = 10.
     raw, events = _get_data()[:2]
-    epochs = Epochs(raw, events, event_id, tmin, tmax)
+    epochs = Epochs(raw, events, event_id, tmin, tmax, add_eeg_ref=False)
     assert_raises(RuntimeError, epochs.savgol_filter, 10.)
-    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
+    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True,
+                    add_eeg_ref=False)
     freqs = fftpack.fftfreq(len(epochs.times), 1. / epochs.info['sfreq'])
     data = np.abs(fftpack.fft(epochs.get_data()))
     match_mask = np.logical_and(freqs >= 0, freqs <= h_freq / 2.)
@@ -419,14 +426,16 @@ def test_savgol_filter():
 
 
 def test_epochs_hash():
-    """Test epoch hashing
-    """
+    """Test epoch hashing."""
     raw, events = _get_data()[:2]
-    epochs = Epochs(raw, events, event_id, tmin, tmax)
+    epochs = Epochs(raw, events, event_id, tmin, tmax,
+                    add_eeg_ref=False)
     assert_raises(RuntimeError, epochs.__hash__)
-    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
+    epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True,
+                    add_eeg_ref=False)
     assert_equal(hash(epochs), hash(epochs))
-    epochs_2 = Epochs(raw, events, event_id, tmin, tmax, preload=True)
+    epochs_2 = Epochs(raw, events, event_id, tmin, tmax, preload=True,
+                      add_eeg_ref=False)
     assert_equal(hash(epochs), hash(epochs_2))
     # do NOT use assert_equal here, failing output is terrible
     assert_true(pickle.dumps(epochs) == pickle.dumps(epochs_2))
@@ -444,22 +453,28 @@ def test_event_ordering():
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             Epochs(raw, eve, event_id, tmin, tmax,
-                   baseline=(None, 0), reject=reject, flat=flat)
+                   baseline=(None, 0), reject=reject, flat=flat,
+                   add_eeg_ref=False)
             assert_equal(len(w), ii)
             if ii > 0:
                 assert_true('chronologically' in '%s' % w[-1].message)
 
 
 def test_epochs_bad_baseline():
-    """Test Epochs initialization with bad baseline parameters
-    """
+    """Test Epochs initialization with bad baseline parameters."""
     raw, events = _get_data()[:2]
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (-0.2, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0, 0.4))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0.1, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, 0.1, 0.3, (None, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.3, -0.1, (0, None))
-    epochs = Epochs(raw, events, None, 0.1, 0.3, baseline=None)
+    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (-0.2, 0),
+                  add_eeg_ref=False)
+    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0, 0.4),
+                  add_eeg_ref=False)
+    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0.1, 0),
+                  add_eeg_ref=False)
+    assert_raises(ValueError, Epochs, raw, events, None, 0.1, 0.3, (None, 0),
+                  add_eeg_ref=False)
+    assert_raises(ValueError, Epochs, raw, events, None, -0.3, -0.1, (0, None),
+                  add_eeg_ref=False)
+    epochs = Epochs(raw, events, None, 0.1, 0.3, baseline=None,
+                    add_eeg_ref=False)
     assert_raises(RuntimeError, epochs.apply_baseline, (0.1, 0.2))
     epochs.load_data()
     assert_raises(ValueError, epochs.apply_baseline, (None, 0))
@@ -473,12 +488,11 @@ def test_epochs_bad_baseline():
 
 
 def test_epoch_combine_ids():
-    """Test combining event ids in epochs compared to events
-    """
+    """Test combining event ids in epochs compared to events."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a': 1, 'b': 2, 'c': 3,
                                   'd': 4, 'e': 5, 'f': 32},
-                    tmin, tmax, picks=picks, preload=False)
+                    tmin, tmax, picks=picks, preload=False, add_eeg_ref=False)
     events_new = merge_events(events, [1, 2], 12)
     epochs_new = combine_event_ids(epochs, ['a', 'b'], {'ab': 12})
     assert_equal(epochs_new['ab'].name, 'ab')
@@ -487,29 +501,29 @@ def test_epoch_combine_ids():
 
 
 def test_epoch_multi_ids():
-    """Test epoch selection via multiple/partial keys
-    """
+    """Test epoch selection via multiple/partial keys."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a/b/a': 1, 'a/b/b': 2, 'a/c': 3,
                                   'b/d': 4, 'a_b': 5},
-                    tmin, tmax, picks=picks, preload=False)
+                    tmin, tmax, picks=picks, preload=False, add_eeg_ref=False)
     epochs_regular = epochs[['a', 'b']]
     epochs_multi = epochs[['a/b/a', 'a/b/b']]
     assert_array_equal(epochs_regular.events, epochs_multi.events)
 
 
 def test_read_epochs_bad_events():
-    """Test epochs when events are at the beginning or the end of the file
-    """
+    """Test epochs when events are at the beginning or the end of the file."""
     raw, events, picks = _get_data()
     # Event at the beginning
     epochs = Epochs(raw, np.array([[raw.first_samp, 0, event_id]]),
-                    event_id, tmin, tmax, picks=picks, baseline=(None, 0))
+                    event_id, tmin, tmax, picks=picks, baseline=(None, 0),
+                    add_eeg_ref=False)
     with warnings.catch_warnings(record=True):
         evoked = epochs.average()
 
     epochs = Epochs(raw, np.array([[raw.first_samp, 0, event_id]]),
-                    event_id, tmin, tmax, picks=picks, baseline=(None, 0))
+                    event_id, tmin, tmax, picks=picks, baseline=(None, 0),
+                    add_eeg_ref=False)
     assert_true(repr(epochs))  # test repr
     epochs.drop_bad()
     assert_true(repr(epochs))
@@ -518,7 +532,8 @@ def test_read_epochs_bad_events():
 
     # Event at the end
     epochs = Epochs(raw, np.array([[raw.last_samp, 0, event_id]]),
-                    event_id, tmin, tmax, picks=picks, baseline=(None, 0))
+                    event_id, tmin, tmax, picks=picks, baseline=(None, 0),
+                    add_eeg_ref=False)
 
     with warnings.catch_warnings(record=True):
         evoked = epochs.average()
@@ -528,18 +543,17 @@ def test_read_epochs_bad_events():
 
 @slow_test
 def test_read_write_epochs():
-    """Test epochs from raw files with IO as fif file
-    """
+    """Test epochs from raw files with IO as fif file."""
     raw, events, picks = _get_data(preload=True)
     tempdir = _TempDir()
     temp_fname = op.join(tempdir, 'test-epo.fif')
     temp_fname_no_bl = op.join(tempdir, 'test_no_bl-epo.fif')
     baseline = (None, 0)
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=baseline, preload=True)
+                    baseline=baseline, preload=True, add_eeg_ref=False)
     epochs_orig = epochs.copy()
     epochs_no_bl = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                          baseline=None, preload=True)
+                          baseline=None, preload=True, add_eeg_ref=False)
     assert_true(epochs_no_bl.baseline is None)
     evoked = epochs.average()
     data = epochs.get_data()
@@ -550,7 +564,7 @@ def test_read_write_epochs():
 
     epochs_no_id = Epochs(raw, pick_events(events, include=event_id),
                           None, tmin, tmax, picks=picks,
-                          baseline=(None, 0))
+                          baseline=(None, 0), add_eeg_ref=False)
     assert_array_equal(data, epochs_no_id.get_data())
 
     eog_picks = pick_types(raw.info, meg=False, eeg=False, stim=False,
@@ -567,7 +581,7 @@ def test_read_write_epochs():
         # decim with lowpass
         warnings.simplefilter('always')
         epochs_dec = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            baseline=(None, 0), decim=2)
+                            baseline=(None, 0), decim=2, add_eeg_ref=False)
         assert_equal(len(w), 1)
 
         # decim without lowpass
@@ -602,7 +616,8 @@ def test_read_write_epochs():
     for proj in (True, 'delayed', False):
         epochs = Epochs(raw, events, event_ids, tmin, tmax, picks=picks,
                         baseline=(None, 0), proj=proj, reject=reject,
-                        add_eeg_ref=True)
+                        add_eeg_ref=False)
+        epochs.set_eeg_reference()
         assert_equal(epochs.proj, proj if proj != 'delayed' else False)
         data1 = epochs.get_data()
         epochs2 = epochs.copy().apply_proj()
@@ -670,7 +685,8 @@ def test_read_write_epochs():
 
         # add reject here so some of the epochs get dropped
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), reject=reject)
+                        baseline=(None, 0), reject=reject,
+                        add_eeg_ref=False)
         epochs.save(temp_fname)
         # ensure bad events are not saved
         epochs_read3 = read_epochs(temp_fname, preload=preload)
@@ -705,7 +721,8 @@ def test_read_write_epochs():
 
         # test loading epochs with missing events
         epochs = Epochs(raw, events, dict(foo=1, bar=999), tmin, tmax,
-                        picks=picks, on_missing='ignore')
+                        picks=picks, on_missing='ignore',
+                        add_eeg_ref=False)
         epochs.save(temp_fname)
         epochs_read = read_epochs(temp_fname, preload=preload)
         assert_allclose(epochs.get_data(), epochs_read.get_data(), **tols)
@@ -732,23 +749,23 @@ def test_read_write_epochs():
 
 
 def test_epochs_proj():
-    """Test handling projection (apply proj in Raw or in Epochs)
-    """
+    """Test handling projection (apply proj in Raw or in Epochs)."""
     tempdir = _TempDir()
     raw, events, picks = _get_data()
     exclude = raw.info['bads'] + ['MEG 2443', 'EEG 053']  # bads + 2 more
     this_picks = pick_types(raw.info, meg=True, eeg=False, stim=True,
                             eog=True, exclude=exclude)
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
-                    baseline=(None, 0), proj=True)
+                    baseline=(None, 0), proj=True, add_eeg_ref=False)
     assert_true(all(p['active'] is True for p in epochs.info['projs']))
     evoked = epochs.average()
     assert_true(all(p['active'] is True for p in evoked.info['projs']))
     data = epochs.get_data()
 
-    raw_proj = Raw(raw_fname, proj=True)
+    raw_proj = read_raw_fif(raw_fname, add_eeg_ref=False).apply_proj()
     epochs_no_proj = Epochs(raw_proj, events[:4], event_id, tmin, tmax,
-                            picks=this_picks, baseline=(None, 0), proj=False)
+                            picks=this_picks, baseline=(None, 0), proj=False,
+                            add_eeg_ref=False)
 
     data_no_proj = epochs_no_proj.get_data()
     assert_true(all(p['active'] is True for p in epochs_no_proj.info['projs']))
@@ -762,7 +779,8 @@ def test_epochs_proj():
     this_picks = pick_types(raw.info, meg=True, eeg=True, stim=True,
                             eog=True, exclude=exclude)
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
-                    baseline=(None, 0), proj=True, add_eeg_ref=True)
+                    baseline=(None, 0), proj=True, add_eeg_ref=False)
+    epochs.set_eeg_reference().apply_proj()
     assert_true(_has_eeg_average_ref_proj(epochs.info['projs']))
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     baseline=(None, 0), proj=True, add_eeg_ref=False)
@@ -771,14 +789,14 @@ def test_epochs_proj():
     # make sure we don't add avg ref when a custom ref has been applied
     raw.info['custom_ref_applied'] = True
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
-                    baseline=(None, 0), proj=True)
+                    baseline=(None, 0), proj=True, add_eeg_ref=False)
     assert_true(not _has_eeg_average_ref_proj(epochs.info['projs']))
 
     # From GH#2200:
     # This has no problem
     proj = raw.info['projs']
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
-                    baseline=(None, 0), proj=False)
+                    baseline=(None, 0), proj=False, add_eeg_ref=False)
     epochs.info['projs'] = []
     data = epochs.copy().add_proj(proj).apply_proj().get_data()
     # save and reload data
@@ -791,7 +809,7 @@ def test_epochs_proj():
     assert_allclose(data, data_2, atol=1e-15, rtol=1e-3)
 
     # adding EEG ref (GH #2727)
-    raw = Raw(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     raw.add_proj([], remove_existing=True)
     raw.info['bads'] = ['MEG 2443', 'EEG 053']
     picks = pick_types(raw.info, meg=False, eeg=True, stim=True, eog=False,
@@ -803,11 +821,11 @@ def test_epochs_proj():
     temp_fname = op.join(tempdir, 'test-epo.fif')
     epochs.save(temp_fname)
     for preload in (True, False):
-        epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=True,
-                             preload=preload)
+        epochs = read_epochs(temp_fname, proj=False, preload=preload)
+        epochs.set_eeg_reference().apply_proj()
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
-        epochs = read_epochs(temp_fname, add_eeg_ref=True, proj=False,
-                             preload=preload)
+        epochs = read_epochs(temp_fname, proj=False, preload=preload)
+        epochs.set_eeg_reference()
         assert_raises(AssertionError, assert_allclose,
                       epochs.get_data().mean(axis=1), 0., atol=1e-15)
         epochs.add_eeg_average_proj()
@@ -818,17 +836,16 @@ def test_epochs_proj():
 
 
 def test_evoked_arithmetic():
-    """Test arithmetic of evoked data
-    """
+    """Test arithmetic of evoked data."""
     raw, events, picks = _get_data()
     epochs1 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                     baseline=(None, 0))
+                     baseline=(None, 0), add_eeg_ref=False)
     evoked1 = epochs1.average()
     epochs2 = Epochs(raw, events[4:8], event_id, tmin, tmax, picks=picks,
-                     baseline=(None, 0))
+                     baseline=(None, 0), add_eeg_ref=False)
     evoked2 = epochs2.average()
     epochs = Epochs(raw, events[:8], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
     evoked = epochs.average()
     evoked_sum = combine_evoked([evoked1, evoked2], weights='nave')
     assert_array_equal(evoked.data, evoked_sum.data)
@@ -839,15 +856,15 @@ def test_evoked_arithmetic():
 
 
 def test_evoked_io_from_epochs():
-    """Test IO of evoked data made from epochs
-    """
+    """Test IO of evoked data made from epochs."""
     tempdir = _TempDir()
     raw, events, picks = _get_data()
     # offset our tmin so we don't get exactly a zero value when decimating
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         epochs = Epochs(raw, events[:4], event_id, tmin + 0.011, tmax,
-                        picks=picks, baseline=(None, 0), decim=5)
+                        picks=picks, baseline=(None, 0), decim=5,
+                        add_eeg_ref=False)
     assert_true(len(w) == 1)
     evoked = epochs.average()
     evoked.info['proj_name'] = ''  # Test that empty string shortcuts to None.
@@ -862,7 +879,8 @@ def test_evoked_io_from_epochs():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         epochs = Epochs(raw, events[:4], event_id, 0.1, tmax,
-                        picks=picks, baseline=(0.1, 0.2), decim=5)
+                        picks=picks, baseline=(0.1, 0.2), decim=5,
+                        add_eeg_ref=False)
     evoked = epochs.average()
     evoked.save(op.join(tempdir, 'evoked-ave.fif'))
     evoked2 = read_evokeds(op.join(tempdir, 'evoked-ave.fif'))[0]
@@ -873,7 +891,8 @@ def test_evoked_io_from_epochs():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         epochs = Epochs(raw, events[:4], event_id, -0.2, tmax,
-                        picks=picks, baseline=(0.1, 0.2), decim=5)
+                        picks=picks, baseline=(0.1, 0.2), decim=5,
+                        add_eeg_ref=False)
     evoked = epochs.average()
     evoked.crop(0.099, None)
     assert_allclose(evoked.data, evoked2.data, rtol=1e-4, atol=1e-20)
@@ -881,12 +900,11 @@ def test_evoked_io_from_epochs():
 
 
 def test_evoked_standard_error():
-    """Test calculation and read/write of standard error
-    """
+    """Test calculation and read/write of standard error."""
     raw, events, picks = _get_data()
     tempdir = _TempDir()
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
     evoked = [epochs.average(), epochs.standard_error()]
     write_evokeds(op.join(tempdir, 'evoked-ave.fif'), evoked)
     evoked2 = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), [0, 1])
@@ -911,13 +929,11 @@ def test_evoked_standard_error():
 
 
 def test_reject_epochs():
-    """Test of epochs rejection
-    """
+    """Test of epochs rejection."""
     raw, events, picks = _get_data()
     events1 = events[events[:, 2] == event_id]
-    epochs = Epochs(raw, events1,
-                    event_id, tmin, tmax, baseline=(None, 0),
-                    reject=reject, flat=flat)
+    epochs = Epochs(raw, events1, event_id, tmin, tmax, baseline=(None, 0),
+                    reject=reject, flat=flat, add_eeg_ref=False)
     assert_raises(RuntimeError, len, epochs)
     n_events = len(epochs.events)
     data = epochs.get_data()
@@ -935,7 +951,7 @@ def test_reject_epochs():
     raw_2.info['bads'] = ['MEG 2443']
     reject_crazy = dict(grad=1000e-15, mag=4e-15, eeg=80e-9, eog=150e-9)
     epochs = Epochs(raw_2, events1, event_id, tmin, tmax, baseline=(None, 0),
-                    reject=reject_crazy, flat=flat)
+                    reject=reject_crazy, flat=flat, add_eeg_ref=False)
     epochs.drop_bad()
 
     assert_true(all('MEG 2442' in e for e in epochs.drop_log))
@@ -943,15 +959,15 @@ def test_reject_epochs():
 
     # Invalid reject_tmin/reject_tmax/detrend
     assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
-                  reject_tmin=1., reject_tmax=0)
+                  reject_tmin=1., reject_tmax=0, add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
-                  reject_tmin=tmin - 1, reject_tmax=1.)
+                  reject_tmin=tmin - 1, reject_tmax=1., add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
-                  reject_tmin=0., reject_tmax=tmax + 1)
+                  reject_tmin=0., reject_tmax=tmax + 1, add_eeg_ref=False)
 
     epochs = Epochs(raw, events1, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), reject=reject, flat=flat,
-                    reject_tmin=0., reject_tmax=.1)
+                    reject_tmin=0., reject_tmax=.1, add_eeg_ref=False)
     data = epochs.get_data()
     n_clean_epochs = len(data)
     assert_true(n_clean_epochs == 7)
@@ -960,7 +976,8 @@ def test_reject_epochs():
     assert_true(epochs.times[epochs._reject_time][-1] <= 0.1)
 
     # Invalid data for _is_good_epoch function
-    epochs = Epochs(raw, events1, event_id, tmin, tmax, reject=None, flat=None)
+    epochs = Epochs(raw, events1, event_id, tmin, tmax, reject=None, flat=None,
+                    add_eeg_ref=False)
     assert_equal(epochs._is_good_epoch(None), (False, ['NO_DATA']))
     assert_equal(epochs._is_good_epoch(np.zeros((1, 1))),
                  (False, ['TOO_SHORT']))
@@ -969,17 +986,16 @@ def test_reject_epochs():
 
 
 def test_preload_epochs():
-    """Test preload of epochs
-    """
+    """Test preload of epochs."""
     raw, events, picks = _get_data()
     epochs_preload = Epochs(raw, events[:16], event_id, tmin, tmax,
                             picks=picks, baseline=(None, 0), preload=True,
-                            reject=reject, flat=flat)
+                            reject=reject, flat=flat, add_eeg_ref=False)
     data_preload = epochs_preload.get_data()
 
     epochs = Epochs(raw, events[:16], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=False,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     data = epochs.get_data()
     assert_array_equal(data_preload, data)
     assert_array_almost_equal(epochs_preload.average().data,
@@ -987,12 +1003,11 @@ def test_preload_epochs():
 
 
 def test_indexing_slicing():
-    """Test of indexing and slicing operations
-    """
+    """Test of indexing and slicing operations."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:20], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=False,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
 
     data_normal = epochs.get_data()
 
@@ -1007,7 +1022,7 @@ def test_indexing_slicing():
     for preload in [True, False]:
         epochs2 = Epochs(raw, events[:20], event_id, tmin, tmax,
                          picks=picks, baseline=(None, 0), preload=preload,
-                         reject=reject, flat=flat)
+                         reject=reject, flat=flat, add_eeg_ref=False)
 
         if not preload:
             epochs2.drop_bad()
@@ -1045,14 +1060,14 @@ def test_indexing_slicing():
 
 
 def test_comparision_with_c():
-    """Test of average obtained vs C code
-    """
+    """Test of average obtained vs C code."""
     raw, events = _get_data()[:2]
     c_evoked = read_evokeds(evoked_nf_name, condition=0)
-    epochs = Epochs(raw, events, event_id, tmin, tmax,
-                    baseline=None, preload=True,
-                    reject=None, flat=None)
-    evoked = epochs.average()
+    epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=None,
+                    preload=True, reject=None, flat=None, add_eeg_ref=False,
+                    proj=False)
+    epochs.set_eeg_reference().apply_proj()
+    evoked = epochs.set_eeg_reference().average()
     sel = pick_channels(c_evoked.ch_names, evoked.ch_names)
     evoked_data = evoked.data
     c_evoked_data = c_evoked.data[sel]
@@ -1063,18 +1078,17 @@ def test_comparision_with_c():
 
 
 def test_crop():
-    """Test of crop of epochs
-    """
+    """Test of crop of epochs."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=False,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     assert_raises(RuntimeError, epochs.crop, None, 0.2)  # not preloaded
     data_normal = epochs.get_data()
 
     epochs2 = Epochs(raw, events[:5], event_id, tmin, tmax,
                      picks=picks, baseline=(None, 0), preload=True,
-                     reject=reject, flat=flat)
+                     reject=reject, flat=flat, add_eeg_ref=False)
     with warnings.catch_warnings(record=True) as w:
         epochs2.crop(-20, 200)
     assert_true(len(w) == 2)
@@ -1108,7 +1122,7 @@ def test_crop():
 
     epochs = Epochs(raw, events[:5], event_id, -1, 1,
                     picks=picks, baseline=(None, 0), preload=True,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     # We include nearest sample, so actually a bit beyound our bounds here
     assert_allclose(epochs.tmin, -1.0006410259015925, rtol=1e-12)
     assert_allclose(epochs.tmax, 1.0006410259015925, rtol=1e-12)
@@ -1126,12 +1140,12 @@ def test_resample():
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=False,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     assert_raises(RuntimeError, epochs.resample, 100)
 
     epochs_o = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
                       baseline=(None, 0), preload=True,
-                      reject=reject, flat=flat)
+                      reject=reject, flat=flat, add_eeg_ref=False)
     epochs = epochs_o.copy()
 
     data_normal = cp.deepcopy(epochs.get_data())
@@ -1199,15 +1213,14 @@ def test_resample():
 
 
 def test_detrend():
-    """Test detrending of epochs
-    """
+    """Test detrending of epochs."""
     raw, events, picks = _get_data()
 
     # test first-order
     epochs_1 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                      baseline=None, detrend=1)
+                      baseline=None, detrend=1, add_eeg_ref=False)
     epochs_2 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                      baseline=None, detrend=None)
+                      baseline=None, detrend=None, add_eeg_ref=False)
     data_picks = pick_types(epochs_1.info, meg=True, eeg=True,
                             exclude='bads')
     evoked_1 = epochs_1.average()
@@ -1220,9 +1233,11 @@ def test_detrend():
     # test zeroth-order case
     for preload in [True, False]:
         epochs_1 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                          baseline=(None, None), preload=preload)
+                          baseline=(None, None), preload=preload,
+                          add_eeg_ref=False)
         epochs_2 = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                          baseline=None, preload=preload, detrend=0)
+                          baseline=None, preload=preload, detrend=0,
+                          add_eeg_ref=False)
         a = epochs_1.get_data()
         b = epochs_2.get_data()
         # All data channels should be almost equal
@@ -1233,34 +1248,32 @@ def test_detrend():
 
     for value in ['foo', 2, False, True]:
         assert_raises(ValueError, Epochs, raw, events[:4], event_id,
-                      tmin, tmax, detrend=value)
+                      tmin, tmax, detrend=value, add_eeg_ref=False)
 
 
 def test_bootstrap():
-    """Test of bootstrapping of epochs
-    """
+    """Test of bootstrapping of epochs."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     epochs2 = bootstrap(epochs, random_state=0)
     assert_true(len(epochs2.events) == len(epochs.events))
     assert_true(epochs._data.shape == epochs2._data.shape)
 
 
 def test_epochs_copy():
-    """Test copy epochs
-    """
+    """Test copy epochs."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     copied = epochs.copy()
     assert_array_equal(epochs._data, copied._data)
 
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=False,
-                    reject=reject, flat=flat)
+                    reject=reject, flat=flat, add_eeg_ref=False)
     copied = epochs.copy()
     data = epochs.get_data()
     copied_data = copied.get_data()
@@ -1268,11 +1281,10 @@ def test_epochs_copy():
 
 
 def test_iter_evoked():
-    """Test the iterator for epochs -> evoked
-    """
+    """Test the iterator for epochs -> evoked."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
 
     for ii, ev in enumerate(epochs.iter_evoked()):
         x = ev.data
@@ -1281,11 +1293,10 @@ def test_iter_evoked():
 
 
 def test_subtract_evoked():
-    """Test subtraction of Evoked from Epochs
-    """
+    """Test subtraction of Evoked from Epochs."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
 
     # make sure subraction fails if data channels are missing
     assert_raises(ValueError, epochs.subtract_evoked,
@@ -1299,7 +1310,8 @@ def test_subtract_evoked():
 
     # use preloading and SSP from the start
     epochs2 = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
-                     baseline=(None, 0), preload=True, proj=True)
+                     baseline=(None, 0), preload=True, proj=True,
+                     add_eeg_ref=False)
 
     evoked = epochs2.average()
     epochs2.subtract_evoked(evoked)
@@ -1314,12 +1326,13 @@ def test_subtract_evoked():
 
 
 def test_epoch_eq():
-    """Test epoch count equalization and condition combining
-    """
+    """Test epoch count equalization and condition combining."""
     raw, events, picks = _get_data()
     # equalizing epochs objects
-    epochs_1 = Epochs(raw, events, event_id, tmin, tmax, picks=picks)
-    epochs_2 = Epochs(raw, events, event_id_2, tmin, tmax, picks=picks)
+    epochs_1 = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                      add_eeg_ref=False)
+    epochs_2 = Epochs(raw, events, event_id_2, tmin, tmax, picks=picks,
+                      add_eeg_ref=False)
     epochs_1.drop_bad()  # make sure drops are logged
     assert_true(len([l for l in epochs_1.drop_log if not l]) ==
                 len(epochs_1.events))
@@ -1332,15 +1345,17 @@ def test_epoch_eq():
     assert_true(epochs_1.events.shape[0] != epochs_2.events.shape[0])
     equalize_epoch_counts([epochs_1, epochs_2], method='mintime')
     assert_true(epochs_1.events.shape[0] == epochs_2.events.shape[0])
-    epochs_3 = Epochs(raw, events, event_id, tmin, tmax, picks=picks)
-    epochs_4 = Epochs(raw, events, event_id_2, tmin, tmax, picks=picks)
+    epochs_3 = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                      add_eeg_ref=False)
+    epochs_4 = Epochs(raw, events, event_id_2, tmin, tmax, picks=picks,
+                      add_eeg_ref=False)
     equalize_epoch_counts([epochs_3, epochs_4], method='truncate')
     assert_true(epochs_1.events.shape[0] == epochs_3.events.shape[0])
     assert_true(epochs_3.events.shape[0] == epochs_4.events.shape[0])
 
     # equalizing conditions
     epochs = Epochs(raw, events, {'a': 1, 'b': 2, 'c': 3, 'd': 4},
-                    tmin, tmax, picks=picks, reject=reject)
+                    tmin, tmax, picks=picks, reject=reject, add_eeg_ref=False)
     epochs.drop_bad()  # make sure drops are logged
     assert_true(len([l for l in epochs.drop_log if not l]) ==
                 len(epochs.events))
@@ -1393,7 +1408,7 @@ def test_epoch_eq():
 
     # equalizing with hierarchical tags
     epochs = Epochs(raw, events, {'a/x': 1, 'b/x': 2, 'a/y': 3, 'b/y': 4},
-                    tmin, tmax, picks=picks, reject=reject)
+                    tmin, tmax, picks=picks, reject=reject, add_eeg_ref=False)
     cond1, cond2 = ['a', ['b/x', 'b/y']], [['a/x', 'a/y'], 'b']
     es = [epochs.copy().equalize_event_counts(c, copy=False)[0]
           for c in (cond1, cond2)]
@@ -1413,44 +1428,47 @@ def test_epoch_eq():
 
 
 def test_access_by_name():
-    """Test accessing epochs by event name and on_missing for rare events
-    """
+    """Test accessing epochs by event name and on_missing for rare events."""
     tempdir = _TempDir()
     raw, events, picks = _get_data()
 
     # Test various invalid inputs
     assert_raises(ValueError, Epochs, raw, events, {1: 42, 2: 42}, tmin,
-                  tmax, picks=picks)
+                  tmax, picks=picks, add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
-                  tmin, tmax, picks=picks)
+                  tmin, tmax, picks=picks, add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
-                  tmin, tmax, picks=picks)
+                  tmin, tmax, picks=picks, add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events, 'foo', tmin, tmax,
-                  picks=picks)
+                  picks=picks, add_eeg_ref=False)
     assert_raises(ValueError, Epochs, raw, events, ['foo'], tmin, tmax,
-                  picks=picks)
+                  picks=picks, add_eeg_ref=False)
 
     # Test accessing non-existent events (assumes 12345678 does not exist)
     event_id_illegal = dict(aud_l=1, does_not_exist=12345678)
     assert_raises(ValueError, Epochs, raw, events, event_id_illegal,
-                  tmin, tmax)
+                  tmin, tmax, add_eeg_ref=False)
     # Test on_missing
     assert_raises(ValueError, Epochs, raw, events, 1, tmin, tmax,
-                  on_missing='foo')
+                  on_missing='foo', add_eeg_ref=False)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='warning')
+        Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='warning',
+               add_eeg_ref=False)
         nw = len(w)
         assert_true(1 <= nw <= 2)
-        Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='ignore')
+        Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='ignore',
+               add_eeg_ref=False)
         assert_equal(len(w), nw)
 
     # Test constructing epochs with a list of ints as events
-    epochs = Epochs(raw, events, [1, 2], tmin, tmax, picks=picks)
+    epochs = Epochs(raw, events, [1, 2], tmin, tmax, picks=picks,
+                    add_eeg_ref=False)
     for k, v in epochs.event_id.items():
         assert_equal(int(k), v)
 
-    epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
+    epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks,
+                    add_eeg_ref=False)
     assert_raises(KeyError, epochs.__getitem__, 'bar')
 
     data = epochs['a'].get_data()
@@ -1458,7 +1476,7 @@ def test_access_by_name():
     assert_true(len(data) == len(event_a))
 
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks,
-                    preload=True)
+                    preload=True, add_eeg_ref=False)
     assert_raises(KeyError, epochs.__getitem__, 'bar')
     temp_fname = op.join(tempdir, 'test-epo.fif')
     epochs.save(temp_fname)
@@ -1472,7 +1490,7 @@ def test_access_by_name():
     assert_array_equal(epochs2['a'].events, epochs['a'].events)
 
     epochs3 = Epochs(raw, events, {'a': 1, 'b': 2, 'c': 3, 'd': 4},
-                     tmin, tmax, picks=picks, preload=True)
+                     tmin, tmax, picks=picks, preload=True, add_eeg_ref=False)
     assert_equal(list(sorted(epochs3[('a', 'b')].event_id.values())),
                  [1, 2])
     epochs4 = epochs['a']
@@ -1493,9 +1511,10 @@ def test_access_by_name():
 
 @requires_pandas
 def test_to_data_frame():
-    """Test epochs Pandas exporter"""
+    """Test epochs Pandas exporter."""
     raw, events, picks = _get_data()
-    epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
+    epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks,
+                    add_eeg_ref=False)
     assert_raises(ValueError, epochs.to_data_frame, index=['foo', 'bar'])
     assert_raises(ValueError, epochs.to_data_frame, index='qux')
     assert_raises(ValueError, epochs.to_data_frame, np.arange(400))
@@ -1521,12 +1540,11 @@ def test_to_data_frame():
 
 
 def test_epochs_proj_mixin():
-    """Test SSP proj methods from ProjMixin class
-    """
+    """Test SSP proj methods from ProjMixin class."""
     raw, events, picks = _get_data()
     for proj in [True, False]:
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), proj=proj)
+                        baseline=(None, 0), proj=proj, add_eeg_ref=False)
 
         assert_true(all(p['active'] == proj for p in epochs.info['projs']))
 
@@ -1552,21 +1570,22 @@ def test_epochs_proj_mixin():
     # catch no-gos.
     # wrong proj argument
     assert_raises(ValueError, Epochs, raw, events[:4], event_id, tmin, tmax,
-                  picks=picks, baseline=(None, 0), proj='crazy')
+                  picks=picks, baseline=(None, 0), proj='crazy',
+                  add_eeg_ref=False)
 
     for preload in [True, False]:
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                         baseline=(None, 0), proj='delayed', preload=preload,
-                        add_eeg_ref=True, reject=reject)
+                        reject=reject, add_eeg_ref=False).set_eeg_reference()
         epochs_proj = Epochs(
             raw, events[:4], event_id, tmin, tmax, picks=picks,
-            baseline=(None, 0), proj=True, preload=preload, add_eeg_ref=True,
-            reject=reject)
+            baseline=(None, 0), proj=True, preload=preload, add_eeg_ref=False,
+            reject=reject).set_eeg_reference().apply_proj()
 
         epochs_noproj = Epochs(
             raw, events[:4], event_id, tmin, tmax, picks=picks,
-            baseline=(None, 0), proj=False, preload=preload, add_eeg_ref=True,
-            reject=reject)
+            baseline=(None, 0), proj=False, preload=preload, add_eeg_ref=False,
+            reject=reject).set_eeg_reference()
 
         assert_allclose(epochs.copy().apply_proj().get_data(),
                         epochs_proj.get_data(), rtol=1e-10, atol=1e-25)
@@ -1591,14 +1610,15 @@ def test_epochs_proj_mixin():
 
     # test mixin against manual application
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                    baseline=None, proj=False, add_eeg_ref=True)
+                    baseline=None, proj=False,
+                    add_eeg_ref=False).set_eeg_reference()
     data = epochs.get_data().copy()
     epochs.apply_proj()
     assert_allclose(np.dot(epochs._projector, data[0]), epochs._data[0])
 
 
 def test_delayed_epochs():
-    """Test delayed projection on Epochs"""
+    """Test delayed projection on Epochs."""
     raw, events, picks = _get_data()
     events = events[:10]
     picks = np.concatenate([pick_types(raw.info, meg=True, eeg=True)[::22],
@@ -1612,11 +1632,12 @@ def test_delayed_epochs():
     raw.info['lowpass'] = 40.  # fake the LP info so no warnings
     for decim in (1, 3):
         proj_data = Epochs(raw, events, event_id, tmin, tmax, proj=True,
-                           reject=reject, decim=decim)
+                           reject=reject, decim=decim, add_eeg_ref=False)
         use_tmin = proj_data.tmin
         proj_data = proj_data.get_data()
         noproj_data = Epochs(raw, events, event_id, tmin, tmax, proj=False,
-                             reject=reject, decim=decim).get_data()
+                             reject=reject, decim=decim,
+                             add_eeg_ref=False).get_data()
         assert_equal(proj_data.shape, noproj_data.shape)
         assert_equal(proj_data.shape[0], n_epochs)
         for preload in (True, False):
@@ -1627,7 +1648,8 @@ def test_delayed_epochs():
                     if ii in (0, 1):
                         epochs = Epochs(raw, events, event_id, tmin, tmax,
                                         proj=proj, reject=reject,
-                                        preload=preload, decim=decim)
+                                        preload=preload, decim=decim,
+                                        add_eeg_ref=False)
                     else:
                         fake_events = np.zeros((len(comp), 3), int)
                         fake_events[:, 0] = np.arange(len(comp))
@@ -1660,11 +1682,10 @@ def test_delayed_epochs():
 
 
 def test_drop_epochs():
-    """Test dropping of epochs.
-    """
+    """Test dropping of epochs."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
     events1 = events[events[:, 2] == event_id]
 
     # Bound checks
@@ -1692,15 +1713,15 @@ def test_drop_epochs():
 
 
 def test_drop_epochs_mult():
-    """Test that subselecting epochs or making less epochs is equivalent"""
+    """Test that subselecting epochs or making less epochs is equivalent."""
     raw, events, picks = _get_data()
     for preload in [True, False]:
         epochs1 = Epochs(raw, events, {'a': 1, 'b': 2},
                          tmin, tmax, picks=picks, reject=reject,
-                         preload=preload)['a']
+                         preload=preload, add_eeg_ref=False)['a']
         epochs2 = Epochs(raw, events, {'a': 1},
                          tmin, tmax, picks=picks, reject=reject,
-                         preload=preload)
+                         preload=preload, add_eeg_ref=False)
 
         if preload:
             # In the preload case you cannot know the bads if already ignored
@@ -1722,7 +1743,7 @@ def test_drop_epochs_mult():
 
 
 def test_contains():
-    """Test membership API"""
+    """Test membership API."""
     raw, events = _get_data(True)[:2]
     # Add seeg channel
     seeg = RawArray(np.zeros((1, len(raw.times))),
@@ -1741,7 +1762,7 @@ def test_contains():
         picks_contains = pick_types(raw.info, meg=meg, eeg=eeg, seeg=seeg)
         epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax,
                         picks=picks_contains, reject=None,
-                        preload=False)
+                        preload=False, add_eeg_ref=False)
         if eeg:
             test = 'eeg'
         elif seeg:
@@ -1756,12 +1777,11 @@ def test_contains():
 
 
 def test_drop_channels_mixin():
-    """Test channels-dropping functionality
-    """
+    """Test channels-dropping functionality."""
     raw, events = _get_data()[:2]
     # here without picks to get additional coverage
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=None,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     drop_ch = epochs.ch_names[:3]
     ch_names = epochs.ch_names[3:]
 
@@ -1777,11 +1797,10 @@ def test_drop_channels_mixin():
 
 
 def test_pick_channels_mixin():
-    """Test channel-picking functionality
-    """
+    """Test channel-picking functionality."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
     ch_names = epochs.ch_names[:3]
     epochs.preload = False
     assert_raises(RuntimeError, epochs.drop_channels, [ch_names[0]])
@@ -1798,15 +1817,15 @@ def test_pick_channels_mixin():
 
     # Invalid picks
     assert_raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
-                  picks=[])
+                  picks=[], add_eeg_ref=False)
 
 
 def test_equalize_channels():
-    """Test equalization of channels
-    """
+    """Test equalization of channels."""
     raw, events, picks = _get_data()
     epochs1 = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                     baseline=(None, 0), proj=False, preload=True)
+                     baseline=(None, 0), proj=False, preload=True,
+                     add_eeg_ref=False)
     epochs2 = epochs1.copy()
     ch_names = epochs1.ch_names[2:]
     epochs1.drop_channels(epochs1.ch_names[:1])
@@ -1818,12 +1837,13 @@ def test_equalize_channels():
 
 
 def test_illegal_event_id():
-    """Test handling of invalid events ids"""
+    """Test handling of invalid events ids."""
     raw, events, picks = _get_data()
     event_id_illegal = dict(aud_l=1, does_not_exist=12345678)
 
     assert_raises(ValueError, Epochs, raw, events, event_id_illegal, tmin,
-                  tmax, picks=picks, baseline=(None, 0), proj=False)
+                  tmax, picks=picks, baseline=(None, 0), proj=False,
+                  add_eeg_ref=False)
 
 
 def test_add_channels_epochs():
@@ -1832,7 +1852,8 @@ def test_add_channels_epochs():
 
     def make_epochs(picks, proj):
         return Epochs(raw, events, event_id, tmin, tmax, baseline=(None, 0),
-                      reject=None, preload=True, proj=proj, picks=picks)
+                      reject=None, preload=True, proj=proj, picks=picks,
+                      add_eeg_ref=False)
 
     picks = pick_types(raw.info, meg=True, eeg=True, exclude='bads')
     picks_meg = pick_types(raw.info, meg=True, eeg=False, exclude='bads')
@@ -1846,7 +1867,8 @@ def test_add_channels_epochs():
         epochs_meg.info._check_consistency()
         epochs_eeg.info._check_consistency()
 
-        epochs2 = add_channels_epochs([epochs_meg, epochs_eeg])
+        epochs2 = add_channels_epochs([epochs_meg, epochs_eeg],
+                                      add_eeg_ref=False)
 
         assert_equal(len(epochs.info['projs']), len(epochs2.info['projs']))
         assert_equal(len(epochs.info.keys()), len(epochs_meg.info.keys()))
@@ -1940,8 +1962,7 @@ def test_add_channels_epochs():
 
 
 def test_array_epochs():
-    """Test creating epochs from array
-    """
+    """Test creating epochs from array."""
     import matplotlib.pyplot as plt
     tempdir = _TempDir()
 
@@ -2024,11 +2045,10 @@ def test_array_epochs():
 
 
 def test_concatenate_epochs():
-    """Test concatenate epochs"""
+    """Test concatenate epochs."""
     raw, events, picks = _get_data()
-    epochs = Epochs(
-        raw=raw, events=events, event_id=event_id, tmin=tmin, tmax=tmax,
-        picks=picks)
+    epochs = Epochs(raw=raw, events=events, event_id=event_id, tmin=tmin,
+                    tmax=tmax, picks=picks, add_eeg_ref=False)
     epochs2 = epochs.copy()
     epochs_list = [epochs, epochs2]
     epochs_conc = concatenate_epochs(epochs_list)
@@ -2074,15 +2094,14 @@ def test_concatenate_epochs():
 
 
 def test_add_channels():
-    """Test epoch splitting / re-appending channel types
-    """
+    """Test epoch splitting / re-appending channel types."""
     raw, events, picks = _get_data()
     epoch_nopre = Epochs(
         raw=raw, events=events, event_id=event_id, tmin=tmin, tmax=tmax,
-        picks=picks)
+        picks=picks, add_eeg_ref=False)
     epoch = Epochs(
         raw=raw, events=events, event_id=event_id, tmin=tmin, tmax=tmax,
-        picks=picks, preload=True)
+        picks=picks, preload=True, add_eeg_ref=False)
     epoch_eeg = epoch.copy().pick_types(meg=False, eeg=True)
     epoch_meg = epoch.copy().pick_types(meg=True)
     epoch_stim = epoch.copy().pick_types(meg=False, stim=True)
@@ -2127,9 +2146,9 @@ def test_seeg_ecog():
 def test_default_values():
     """Test default event_id, tmax tmin values are working correctly"""
     raw, events = _get_data()[:2]
-    epoch_1 = Epochs(raw, events[:1], preload=True)
+    epoch_1 = Epochs(raw, events[:1], preload=True, add_eeg_ref=False)
     epoch_2 = Epochs(raw, events[:1], event_id=None, tmin=-0.2, tmax=0.5,
-                     preload=True)
+                     preload=True, add_eeg_ref=False)
     assert_equal(hash(epoch_1), hash(epoch_2))
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -560,7 +560,7 @@ def test_read_write_epochs():
 
     # Bad tmin/tmax parameters
     assert_raises(ValueError, Epochs, raw, events, event_id, tmax, tmin,
-                  baseline=None)
+                  baseline=None, add_eeg_ref=False)
 
     epochs_no_id = Epochs(raw, pick_events(events, include=event_id),
                           None, tmin, tmax, picks=picks,
@@ -617,7 +617,6 @@ def test_read_write_epochs():
         epochs = Epochs(raw, events, event_ids, tmin, tmax, picks=picks,
                         baseline=(None, 0), proj=proj, reject=reject,
                         add_eeg_ref=False)
-        epochs.set_eeg_reference()
         assert_equal(epochs.proj, proj if proj != 'delayed' else False)
         data1 = epochs.get_data()
         epochs2 = epochs.copy().apply_proj()
@@ -826,9 +825,6 @@ def test_epochs_proj():
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
         epochs = read_epochs(temp_fname, proj=False, preload=preload)
         epochs.set_eeg_reference()
-        assert_raises(AssertionError, assert_allclose,
-                      epochs.get_data().mean(axis=1), 0., atol=1e-15)
-        epochs.add_eeg_average_proj()
         assert_raises(AssertionError, assert_allclose,
                       epochs.get_data().mean(axis=1), 0., atol=1e-15)
         epochs.apply_proj()
@@ -1066,8 +1062,7 @@ def test_comparision_with_c():
     epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=None,
                     preload=True, reject=None, flat=None, add_eeg_ref=False,
                     proj=False)
-    epochs.set_eeg_reference().apply_proj()
-    evoked = epochs.set_eeg_reference().average()
+    evoked = epochs.set_eeg_reference().apply_proj().average()
     sel = pick_channels(c_evoked.ch_names, evoked.ch_names)
     evoked_data = evoked.data
     c_evoked_data = c_evoked.data[sel]
@@ -1885,80 +1880,81 @@ def test_add_channels_epochs():
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['meas_date'] += 10
-    add_channels_epochs([epochs_meg2, epochs_eeg])
+    add_channels_epochs([epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs2.info['filename'] = epochs2.info['filename'].upper()
-    epochs2 = add_channels_epochs([epochs_meg, epochs_eeg])
+    epochs2 = add_channels_epochs([epochs_meg, epochs_eeg],
+                                  add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.events[3, 2] -= 1
     assert_raises(ValueError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     assert_raises(ValueError, add_channels_epochs,
-                  [epochs_meg, epochs_eeg[:2]])
+                  [epochs_meg, epochs_eeg[:2]], add_eeg_ref=False)
 
     epochs_meg.info['chs'].pop(0)
     epochs_meg.info._update_redundant()
     assert_raises(RuntimeError, add_channels_epochs,
-                  [epochs_meg, epochs_eeg])
+                  [epochs_meg, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['sfreq'] = None
     assert_raises(RuntimeError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['sfreq'] += 10
     assert_raises(RuntimeError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['chs'][1]['ch_name'] = epochs_meg2.info['ch_names'][0]
     epochs_meg2.info._update_redundant()
     assert_raises(RuntimeError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['dev_head_t']['to'] += 1
     assert_raises(ValueError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['dev_head_t']['to'] += 1
     assert_raises(ValueError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['expimenter'] = 'foo'
     assert_raises(RuntimeError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.preload = False
     assert_raises(ValueError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.times += 0.4
     assert_raises(NotImplementedError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.times += 0.5
     assert_raises(NotImplementedError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.baseline = None
     assert_raises(NotImplementedError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.event_id['b'] = 2
     assert_raises(NotImplementedError, add_channels_epochs,
-                  [epochs_meg2, epochs_eeg])
+                  [epochs_meg2, epochs_eeg], add_eeg_ref=False)
 
 
 def test_array_epochs():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -16,9 +16,10 @@ from numpy.testing import (assert_array_almost_equal, assert_equal,
 from nose.tools import assert_true, assert_raises, assert_not_equal
 
 from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
-                 grand_average, combine_evoked, create_info, read_events, io,
+                 grand_average, combine_evoked, create_info, read_events,
                  Epochs, EpochsArray)
 from mne.evoked import _get_peak, Evoked, EvokedArray
+from mne.io import read_raw_fif
 from mne.tests.common import assert_naming
 from mne.utils import (_TempDir, requires_pandas, slow_test, requires_version,
                        run_tests_if_main)
@@ -34,7 +35,7 @@ event_name = op.join(base_dir, 'test-eve.fif')
 
 
 def test_decim():
-    """Test evoked decimation"""
+    """Test evoked decimation."""
     rng = np.random.RandomState(0)
     n_epochs, n_channels, n_times = 5, 10, 20
     dec_1, dec_2 = 2, 3
@@ -54,12 +55,13 @@ def test_decim():
     assert_array_equal(data_epochs, data_epochs_3)
 
     # Now let's do it with some real data
-    raw = io.read_raw_fif(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     events = read_events(event_name)
     sfreq_new = raw.info['sfreq'] / decim
     raw.info['lowpass'] = sfreq_new / 4.  # suppress aliasing warnings
     picks = pick_types(raw.info, meg=True, eeg=True, exclude=())
-    epochs = Epochs(raw, events, 1, -0.2, 0.5, picks=picks, preload=True)
+    epochs = Epochs(raw, events, 1, -0.2, 0.5, picks=picks, preload=True,
+                    add_eeg_ref=False)
     for offset in (0, 1):
         ev_ep_decim = epochs.copy().decimate(decim, offset).average()
         ev_decim = epochs.average().decimate(decim, offset)
@@ -75,7 +77,7 @@ def test_decim():
 
 @requires_version('scipy', '0.14')
 def test_savgol_filter():
-    """Test savgol filtering"""
+    """Test savgol filtering."""
     h_freq = 10.
     evoked = read_evokeds(fname, 0)
     freqs = fftpack.fftfreq(len(evoked.times), 1. / evoked.info['sfreq'])
@@ -97,7 +99,7 @@ def test_savgol_filter():
 
 
 def test_hash_evoked():
-    """Test evoked hashing"""
+    """Test evoked hashing."""
     ave = read_evokeds(fname, 0)
     ave_2 = read_evokeds(fname, 0)
     assert_equal(hash(ave), hash(ave_2))
@@ -110,7 +112,7 @@ def test_hash_evoked():
 
 @slow_test
 def test_io_evoked():
-    """Test IO for evoked data (fif + gz) with integer and str args"""
+    """Test IO for evoked data (fif + gz) with integer and str args."""
     tempdir = _TempDir()
     ave = read_evokeds(fname, 0)
 
@@ -169,7 +171,7 @@ def test_io_evoked():
 
 
 def test_shift_time_evoked():
-    """ Test for shifting of time scale"""
+    """ Test for shifting of time scale."""
     tempdir = _TempDir()
     # Shift backward
     ave = read_evokeds(fname, 0)
@@ -209,7 +211,7 @@ def test_shift_time_evoked():
 
 
 def test_evoked_resample():
-    """Test for resampling of evoked data"""
+    """Test for resampling of evoked data."""
     tempdir = _TempDir()
     # upsample, write it out, read it in
     ave = read_evokeds(fname, 0)
@@ -240,7 +242,7 @@ def test_evoked_resample():
 
 
 def test_evoked_detrend():
-    """Test for detrending evoked data"""
+    """Test for detrending evoked data."""
     ave = read_evokeds(fname, 0)
     ave_normal = read_evokeds(fname, 0)
     ave.detrend(0)
@@ -252,7 +254,7 @@ def test_evoked_detrend():
 
 @requires_pandas
 def test_to_data_frame():
-    """Test evoked Pandas exporter"""
+    """Test evoked Pandas exporter."""
     ave = read_evokeds(fname, 0)
     assert_raises(ValueError, ave.to_data_frame, picks=np.arange(400))
     df = ave.to_data_frame()
@@ -264,7 +266,7 @@ def test_to_data_frame():
 
 
 def test_evoked_proj():
-    """Test SSP proj operations"""
+    """Test SSP proj operations."""
     for proj in [True, False]:
         ave = read_evokeds(fname, condition=0, proj=proj)
         assert_true(all(p['active'] == proj for p in ave.info['projs']))
@@ -292,8 +294,7 @@ def test_evoked_proj():
 
 
 def test_get_peak():
-    """Test peak getter"""
-
+    """Test peak getter."""
     evoked = read_evokeds(fname, condition=0, proj=True)
     assert_raises(ValueError, evoked.get_peak, ch_type='mag', tmin=1)
     assert_raises(ValueError, evoked.get_peak, ch_type='mag', tmax=0.9)
@@ -334,7 +335,7 @@ def test_get_peak():
 
 
 def test_drop_channels_mixin():
-    """Test channels-dropping functionality"""
+    """Test channels-dropping functionality."""
     evoked = read_evokeds(fname, condition=0, proj=True)
     drop_ch = evoked.ch_names[:3]
     ch_names = evoked.ch_names[3:]
@@ -356,7 +357,7 @@ def test_drop_channels_mixin():
 
 
 def test_pick_channels_mixin():
-    """Test channel-picking functionality"""
+    """Test channel-picking functionality."""
     evoked = read_evokeds(fname, condition=0, proj=True)
     ch_names = evoked.ch_names[:3]
 
@@ -380,7 +381,7 @@ def test_pick_channels_mixin():
 
 
 def test_equalize_channels():
-    """Test equalization of channels"""
+    """Test equalization of channels."""
     evoked1 = read_evokeds(fname, condition=0, proj=True)
     evoked2 = evoked1.copy()
     ch_names = evoked1.ch_names[2:]
@@ -393,7 +394,7 @@ def test_equalize_channels():
 
 
 def test_arithmetic():
-    """Test evoked arithmetic"""
+    """Test evoked arithmetic."""
     ev = read_evokeds(fname, condition=0)
     ev1 = EvokedArray(np.ones_like(ev.data), ev.info, ev.times[0], nave=20)
     ev2 = EvokedArray(-np.ones_like(ev.data), ev.info, ev.times[0], nave=10)
@@ -463,7 +464,7 @@ def test_arithmetic():
 
 
 def test_array_epochs():
-    """Test creating evoked from array"""
+    """Test creating evoked from array."""
     tempdir = _TempDir()
 
     # creating
@@ -510,14 +511,14 @@ def test_array_epochs():
 
 
 def test_time_as_index():
-    """Test time as index"""
+    """Test time as index."""
     evoked = read_evokeds(fname, condition=0).crop(-.1, .1)
     assert_array_equal(evoked.time_as_index([-.1, .1], use_rounding=True),
                        [0, len(evoked.times) - 1])
 
 
 def test_add_channels():
-    """Test evoked splitting / re-appending channel types"""
+    """Test evoked splitting / re-appending channel types."""
     evoked = read_evokeds(fname, condition=0)
     evoked.info['buffer_size_sec'] = None
     hpi_coils = [{'event_bits': []},
@@ -550,7 +551,7 @@ def test_add_channels():
 
 
 def test_evoked_baseline():
-    """Test evoked baseline"""
+    """Test evoked baseline."""
     evoked = read_evokeds(fname, condition=0, baseline=None)
 
     # Here we create a data_set with constant data.

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -40,17 +40,17 @@ def test_mne_c_design():
            '--save', out_fname)
     run_subprocess(cmd)
     h = design_mne_c_filter(sfreq, None, 40)
-    h_c = read_raw_fif(out_fname)[0][0][0][time_sl]
+    h_c = read_raw_fif(out_fname, add_eeg_ref=False)[0][0][0][time_sl]
     assert_allclose(h, h_c, **tols)
 
     run_subprocess(cmd + ('--highpass', '5', '--highpassw', '2.5'))
     h = design_mne_c_filter(sfreq, 5, 40, 2.5)
-    h_c = read_raw_fif(out_fname)[0][0][0][time_sl]
+    h_c = read_raw_fif(out_fname, add_eeg_ref=False)[0][0][0][time_sl]
     assert_allclose(h, h_c, **tols)
 
     run_subprocess(cmd + ('--lowpass', '1000', '--highpass', '10'))
     h = design_mne_c_filter(sfreq, 10, None, verbose=True)
-    h_c = read_raw_fif(out_fname)[0][0][0][time_sl]
+    h_c = read_raw_fif(out_fname, add_eeg_ref=False)[0][0][0][time_sl]
     assert_allclose(h, h_c, **tols)
 
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -11,7 +11,7 @@ import copy as cp
 import mne
 from mne.datasets import testing
 from mne import pick_types
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne import compute_proj_epochs, compute_proj_evoked, compute_proj_raw
 from mne.io.proj import (make_projector, activate_proj,
                          _needs_eeg_average_ref_proj)
@@ -40,9 +40,8 @@ ecg_fname = op.join(sample_path, 'sample_audvis_ecg-proj.fif')
 
 
 def test_bad_proj():
-    """Test dealing with bad projection application
-    """
-    raw = Raw(raw_fname, preload=True)
+    """Test dealing with bad projection application."""
+    raw = read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
     events = read_events(event_fname)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
@@ -57,11 +56,12 @@ def test_bad_proj():
 
 
 def _check_warnings(raw, events, picks, count=3):
-    """Helper to count warnings"""
+    """Helper to count warnings."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         Epochs(raw, events, dict(aud_l=1, vis_l=3),
-               -0.2, 0.5, picks=picks, preload=True, proj=True)
+               -0.2, 0.5, picks=picks, preload=True, proj=True,
+               add_eeg_ref=False)
     assert_equal(len(w), count)
     for ww in w:
         assert_true('dangerous' in str(ww.message))
@@ -69,7 +69,7 @@ def _check_warnings(raw, events, picks, count=3):
 
 @testing.requires_testing_data
 def test_sensitivity_maps():
-    """Test sensitivity map computation"""
+    """Test sensitivity map computation."""
     fwd = mne.read_forward_solution(fwd_fname, surf_ori=True)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
@@ -118,17 +118,17 @@ def test_sensitivity_maps():
 
 
 def test_compute_proj_epochs():
-    """Test SSP computation on epochs"""
+    """Test SSP computation on epochs."""
     tempdir = _TempDir()
     event_id, tmin, tmax = 1, -0.2, 0.3
 
-    raw = Raw(raw_fname, preload=True)
+    raw = read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
     events = read_events(event_fname)
     bad_ch = 'MEG 2443'
     picks = pick_types(raw.info, meg=True, eeg=False, stim=False, eog=False,
                        exclude=[])
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=None, proj=False)
+                    baseline=None, proj=False, add_eeg_ref=False)
 
     evoked = epochs.average()
     projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0, n_jobs=1)
@@ -199,7 +199,7 @@ def test_compute_proj_raw():
     tempdir = _TempDir()
     # Test that the raw projectors work
     raw_time = 2.5  # Do shorter amount for speed
-    raw = Raw(raw_fname).crop(0, raw_time)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False).crop(0, raw_time)
     raw.load_data()
     for ii in (0.25, 0.5, 1, 2):
         with warnings.catch_warnings(record=True) as w:
@@ -262,8 +262,8 @@ def test_compute_proj_raw():
 
 
 def test_make_eeg_average_ref_proj():
-    """Test EEG average reference projection"""
-    raw = Raw(raw_fname, add_eeg_ref=False, preload=True)
+    """Test EEG average reference projection."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=True)
     eeg = mne.pick_types(raw.info, meg=False, eeg=True)
 
     # No average EEG reference
@@ -285,26 +285,27 @@ def test_has_eeg_average_ref_proj():
     """Test checking whether an EEG average reference exists"""
     assert_true(not _has_eeg_average_ref_proj([]))
 
-    raw = Raw(raw_fname, add_eeg_ref=True, preload=False)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=False)
+    raw.set_eeg_reference()
     assert_true(_has_eeg_average_ref_proj(raw.info['projs']))
 
 
 def test_needs_eeg_average_ref_proj():
     """Test checking whether a recording needs an EEG average reference"""
-    raw = Raw(raw_fname, add_eeg_ref=False, preload=False)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=False)
     assert_true(_needs_eeg_average_ref_proj(raw.info))
 
-    raw = Raw(raw_fname, add_eeg_ref=True, preload=False)
+    raw.set_eeg_reference()
     assert_true(not _needs_eeg_average_ref_proj(raw.info))
 
     # No EEG channels
-    raw = Raw(raw_fname, add_eeg_ref=False, preload=True)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=True)
     eeg = [raw.ch_names[c] for c in pick_types(raw.info, meg=False, eeg=True)]
     raw.drop_channels(eeg)
     assert_true(not _needs_eeg_average_ref_proj(raw.info))
 
     # Custom ref flag set
-    raw = Raw(raw_fname, add_eeg_ref=False, preload=False)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False, preload=False)
     raw.info['custom_ref_applied'] = True
     assert_true(not _needs_eeg_average_ref_proj(raw.info))
 

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -14,7 +14,7 @@ from nose.tools import assert_true, assert_equal, assert_raises
 from nose.plugins.skip import SkipTest
 
 from mne import Epochs, read_events, pick_types, read_evokeds
-from mne.io import Raw
+from mne.io import read_raw_fif
 from mne.datasets import testing
 from mne.report import Report
 from mne.utils import (_TempDir, requires_mayavi, requires_nibabel,
@@ -49,8 +49,7 @@ warnings.simplefilter('always')  # enable b/c these tests throw warnings
 @testing.requires_testing_data
 @requires_PIL
 def test_render_report():
-    """Test rendering -*.fif files for mne report.
-    """
+    """Test rendering -*.fif files for mne report."""
     tempdir = _TempDir()
     raw_fname_new = op.join(tempdir, 'temp_raw.fif')
     event_fname_new = op.join(tempdir, 'temp_raw-eve.fif')
@@ -67,9 +66,10 @@ def test_render_report():
     # create and add -epo.fif and -ave.fif files
     epochs_fname = op.join(tempdir, 'temp-epo.fif')
     evoked_fname = op.join(tempdir, 'temp-ave.fif')
-    raw = Raw(raw_fname_new)
+    raw = read_raw_fif(raw_fname_new, add_eeg_ref=False)
     picks = pick_types(raw.info, meg='mag', eeg=False)  # faster with one type
-    epochs = Epochs(raw, read_events(event_fname), 1, -0.2, 0.2, picks=picks)
+    epochs = Epochs(raw, read_events(event_fname), 1, -0.2, 0.2, picks=picks,
+                    add_eeg_ref=False)
     epochs.save(epochs_fname)
     epochs.average().save(evoked_fname)
 
@@ -130,8 +130,7 @@ def test_render_report():
 @requires_mayavi
 @requires_PIL
 def test_render_add_sections():
-    """Test adding figures/images to section.
-    """
+    """Test adding figures/images to section."""
     from PIL import Image
     tempdir = _TempDir()
     import matplotlib.pyplot as plt
@@ -183,8 +182,7 @@ def test_render_add_sections():
 @requires_mayavi
 @requires_nibabel()
 def test_render_mri():
-    """Test rendering MRI for mne report.
-    """
+    """Test rendering MRI for mne report."""
     tempdir = _TempDir()
     trans_fname_new = op.join(tempdir, 'temp-trans.fif')
     for a, b in [[trans_fname, trans_fname_new]]:
@@ -202,8 +200,7 @@ def test_render_mri():
 @testing.requires_testing_data
 @requires_nibabel()
 def test_render_mri_without_bem():
-    """Test rendering MRI without BEM for mne report.
-    """
+    """Test rendering MRI without BEM for mne report."""
     tempdir = _TempDir()
     os.mkdir(op.join(tempdir, 'sample'))
     os.mkdir(op.join(tempdir, 'sample', 'mri'))
@@ -220,8 +217,7 @@ def test_render_mri_without_bem():
 @testing.requires_testing_data
 @requires_nibabel()
 def test_add_htmls_to_section():
-    """Test adding html str to mne report.
-    """
+    """Test adding html str to mne report."""
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=subjects_dir)
     html = '<b>MNE-Python is AWESOME</b>'
@@ -234,8 +230,7 @@ def test_add_htmls_to_section():
 
 
 def test_add_slider_to_section():
-    """Test adding a slider with a series of images to mne report.
-    """
+    """Test adding a slider with a series of images to mne report."""
     tempdir = _TempDir()
     from matplotlib import pyplot as plt
     report = Report(info_fname=raw_fname,
@@ -258,6 +253,7 @@ def test_add_slider_to_section():
 
 
 def test_validate_input():
+    """Test Report input validation."""
     report = Report()
     items = ['a', 'b', 'c']
     captions = ['Letter A', 'Letter B', 'Letter C']

--- a/mne/tests/test_selection.py
+++ b/mne/tests/test_selection.py
@@ -20,7 +20,7 @@ def test_read_selection():
                  'Right-parietal', 'Left-occipital', 'Right-occipital',
                  'Left-frontal', 'Right-frontal']
 
-    raw = read_raw_fif(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     for i, name in enumerate(sel_names):
         sel = read_selection(name)
         assert_true(ch_names[i] in sel)
@@ -40,7 +40,7 @@ def test_read_selection():
     assert_true(len(set(frontal).intersection(set(occipital))) == 0)
 
     ch_names_new = [ch.replace(' ', '') for ch in ch_names]
-    raw_new = read_raw_fif(raw_new_fname)
+    raw_new = read_raw_fif(raw_new_fname, add_eeg_ref=False)
     for i, name in enumerate(sel_names):
         sel = read_selection(name, info=raw_new.info)
         assert_true(ch_names_new[i] in sel)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -140,14 +140,12 @@ def test_volume_stc():
         with warnings.catch_warnings(record=True):  # nib<->numpy
             img = nib.load(vol_fname)
         assert_true(img.shape == t1_img.shape + (len(stc.times),))
-        assert_array_almost_equal(img.get_affine(), t1_img.get_affine(),
-                                  decimal=5)
+        assert_array_almost_equal(img.affine, t1_img.affine, decimal=5)
 
         # export without saving
         img = stc.as_volume(src, dest='mri', mri_resolution=True)
         assert_true(img.shape == t1_img.shape + (len(stc.times),))
-        assert_array_almost_equal(img.get_affine(), t1_img.get_affine(),
-                                  decimal=5)
+        assert_array_almost_equal(img.affine, t1_img.affine, decimal=5)
 
     except ImportError:
         print('Save as nifti test skipped, needs NiBabel')

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -131,8 +131,9 @@ def test_io_surface():
             pts, tri, vol_info = read_surface(fname, read_metadata=True)
         assert_true(all('No volume info' in str(ww.message) for ww in w))
         write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info)
-        c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
-                                                read_metadata=True)
+        with warnings.catch_warnings(record=True) as w:  # No vol info
+            c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
+                                                    read_metadata=True)
         assert_array_equal(pts, c_pts)
         assert_array_equal(tri, c_tri)
         assert_true(_is_equal_dict([vol_info, c_vol_info]))

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -29,8 +29,7 @@ rng = np.random.RandomState(0)
 
 
 def test_helmet():
-    """Test loading helmet surfaces
-    """
+    """Test loading helmet surfaces."""
     base_dir = op.join(op.dirname(__file__), '..', 'io')
     fname_raw = op.join(base_dir, 'tests', 'data', 'test_raw.fif')
     fname_kit_raw = op.join(base_dir, 'kit', 'tests', 'data',
@@ -49,8 +48,7 @@ def test_helmet():
 
 @testing.requires_testing_data
 def test_head():
-    """Test loading the head surface
-    """
+    """Test loading the head surface."""
     surf_1 = get_head_surf('sample', subjects_dir=subjects_dir)
     surf_2 = get_head_surf('sample', 'head', subjects_dir=subjects_dir)
     assert_true(len(surf_1['rr']) < len(surf_2['rr']))  # BEM vs dense head
@@ -59,8 +57,7 @@ def test_head():
 
 
 def test_huge_cross():
-    """Test cross product with lots of elements
-    """
+    """Test cross product with lots of elements."""
     x = rng.rand(100000, 3)
     y = rng.rand(1, 3)
     z = np.cross(x, y)
@@ -69,7 +66,7 @@ def test_huge_cross():
 
 
 def test_compute_nearest():
-    """Test nearest neighbor searches"""
+    """Test nearest neighbor searches."""
     x = rng.randn(500, 3)
     x /= np.sqrt(np.sum(x ** 2, axis=1))[:, None]
     nn_true = rng.permutation(np.arange(500, dtype=np.int))[:20]
@@ -93,8 +90,7 @@ def test_compute_nearest():
 @slow_test
 @testing.requires_testing_data
 def test_make_morph_maps():
-    """Test reading and creating morph maps
-    """
+    """Test reading and creating morph maps."""
     # make a new fake subjects_dir
     tempdir = _TempDir()
     for subject in ('sample', 'sample_ds', 'fsaverage_ds'):
@@ -124,15 +120,16 @@ def test_make_morph_maps():
 
 @testing.requires_testing_data
 def test_io_surface():
-    """Test reading and writing of Freesurfer surface mesh files
-    """
+    """Test reading and writing of Freesurfer surface mesh files."""
     tempdir = _TempDir()
     fname_quad = op.join(data_path, 'subjects', 'bert', 'surf',
                          'lh.inflated.nofix')
     fname_tri = op.join(data_path, 'subjects', 'fsaverage', 'surf',
                         'lh.inflated')
     for fname in (fname_quad, fname_tri):
-        pts, tri, vol_info = read_surface(fname, read_metadata=True)
+        with warnings.catch_warnings(record=True) as w:
+            pts, tri, vol_info = read_surface(fname, read_metadata=True)
+        assert_true(all('No volume info' in str(ww.message) for ww in w))
         write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info)
         c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
                                                 read_metadata=True)
@@ -143,8 +140,7 @@ def test_io_surface():
 
 @testing.requires_testing_data
 def test_read_curv():
-    """Test reading curvature data
-    """
+    """Test reading curvature data."""
     fname_curv = op.join(data_path, 'subjects', 'fsaverage', 'surf', 'lh.curv')
     fname_surf = op.join(data_path, 'subjects', 'fsaverage', 'surf',
                          'lh.inflated')
@@ -157,8 +153,7 @@ def test_read_curv():
 @requires_tvtk
 @requires_mayavi
 def test_decimate_surface():
-    """Test triangular surface decimation
-    """
+    """Test triangular surface decimation."""
     points = np.array([[-0.00686118, -0.10369860, 0.02615170],
                        [-0.00713948, -0.10370162, 0.02614874],
                        [-0.00686208, -0.10368247, 0.02588313],

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -116,7 +116,7 @@ def test_get_inst_data():
     assert_equal(_get_inst_data(raw), raw._data)
     raw.pick_channels(raw.ch_names[:2])
 
-    epochs = _segment_raw(raw, 0.5, add_eeg_ref=False)
+    epochs = _segment_raw(raw, 0.5)
     assert_equal(_get_inst_data(epochs), epochs._data)
 
     evoked = epochs.average()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -109,12 +109,12 @@ def test_object_size():
 
 def test_get_inst_data():
     """Test _get_inst_data"""
-    raw = read_raw_fif(fname_raw)
+    raw = read_raw_fif(fname_raw, add_eeg_ref=False)
     raw.crop(tmax=1.)
     assert_equal(_get_inst_data(raw), raw._data)
     raw.pick_channels(raw.ch_names[:2])
 
-    epochs = _segment_raw(raw, 0.5)
+    epochs = _segment_raw(raw, 0.5, add_eeg_ref=False)
     assert_equal(_get_inst_data(epochs), epochs._data)
 
     evoked = epochs.average()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -54,7 +54,9 @@ def test_buggy_mkl():
     @buggy_mkl_svd
     def foo(a, b):
         raise np.linalg.LinAlgError('SVD did not converge')
-    assert_raises(SkipTest, foo, 1, 2)
+    with warnings.catch_warnings(record=True) as w:
+        assert_raises(SkipTest, foo, 1, 2)
+    assert_true(all('convergence error' in str(ww.message) for ww in w))
 
     @buggy_mkl_svd
     def bar(c, d, e):

--- a/mne/time_frequency/tests/test_ar.py
+++ b/mne/time_frequency/tests/test_ar.py
@@ -15,8 +15,7 @@ raw_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data',
 @requires_patsy
 @requires_statsmodels
 def test_yule_walker():
-    """Test Yule-Walker against statsmodels
-    """
+    """Test Yule-Walker against statsmodels."""
     from statsmodels.regression.linear_model import yule_walker as sm_yw
     d = np.random.randn(100)
     sm_rho, sm_sigma = sm_yw(d, order=2)
@@ -26,9 +25,8 @@ def test_yule_walker():
 
 
 def test_ar_raw():
-    """Test fitting AR model on raw data
-    """
-    raw = io.read_raw_fif(raw_fname)
+    """Test fitting AR model on raw data."""
+    raw = io.read_raw_fif(raw_fname, add_eeg_ref=False)
     # pick MEG gradiometers
     picks = pick_types(raw.info, meg='grad', exclude='bads')
     picks = picks[:2]

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -3,8 +3,8 @@ import os.path as op
 from numpy.testing import assert_array_almost_equal, assert_raises
 from nose.tools import assert_true
 
-from mne import io, pick_types, Epochs, read_events
-from mne.io import RawArray
+from mne import pick_types, Epochs, read_events
+from mne.io import RawArray, read_raw_fif
 from mne.utils import requires_version, slow_test
 from mne.time_frequency import psd_welch, psd_multitaper
 
@@ -15,9 +15,8 @@ event_fname = op.join(base_dir, 'test-eve.fif')
 
 @requires_version('scipy', '0.12')
 def test_psd():
-    """Tests the welch and multitaper PSD
-    """
-    raw = io.read_raw_fif(raw_fname)
+    """Tests the welch and multitaper PSD."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     picks_psd = [0, 1]
 
     # Populate raw with sinusoids
@@ -68,13 +67,13 @@ def test_psd():
     events[:, 0] -= first_samp
     tmin, tmax, event_id = -0.5, 0.5, 1
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks_psd,
-                    proj=False, preload=True, baseline=None)
+                    proj=False, preload=True, baseline=None, add_eeg_ref=False)
     evoked = epochs.average()
 
     tmin_full, tmax_full = -1, 1
     epochs_full = Epochs(raw, events[:10], event_id, tmin_full, tmax_full,
                          picks=picks_psd, proj=False, preload=True,
-                         baseline=None)
+                         baseline=None, add_eeg_ref=False)
     kws_psd = dict(tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax,
                    picks=picks_psd)  # Common to all
     funcs = [(psd_welch, kws_welch),
@@ -130,9 +129,8 @@ def test_psd():
 @slow_test
 @requires_version('scipy', '0.12')
 def test_compares_psd():
-    """Test PSD estimation on raw for plt.psd and scipy.signal.welch
-    """
-    raw = io.read_raw_fif(raw_fname)
+    """Test PSD estimation on raw for plt.psd and scipy.signal.welch."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
 
     exclude = raw.info['bads'] + ['MEG 2443', 'EEG 053']  # bads + 2 more
 

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -12,7 +12,8 @@ from numpy.testing import assert_array_almost_equal, assert_allclose
 
 from scipy import fftpack
 
-from mne import io, read_events, Epochs, pick_types
+from mne import read_events, Epochs
+from mne.io import read_raw_fif
 from mne.time_frequency._stockwell import (tfr_stockwell, _st,
                                            _precompute_st_windows)
 from mne.time_frequency.tfr import AverageTFR
@@ -20,21 +21,9 @@ from mne.time_frequency.tfr import AverageTFR
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 
-event_id, tmin, tmax = 1, -0.2, 0.5
-event_id_2 = 2
-raw = io.read_raw_fif(raw_fname, add_eeg_ref=False)
-event_name = op.join(base_dir, 'test-eve.fif')
-events = read_events(event_name)
-picks = pick_types(raw.info, meg=True, eeg=True, stim=True,
-                   ecg=True, eog=True, include=['STI 014'],
-                   exclude='bads')
-
-reject = dict(grad=1000e-12, mag=4e-12, eeg=80e-6, eog=150e-6)
-flat = dict(grad=1e-15, mag=1e-15)
-
 
 def test_stockwell_core():
-    """Test stockwell transform"""
+    """Test stockwell transform."""
     # adapted from
     # http://vcs.ynic.york.ac.uk/docs/naf/intro/concepts/timefreq.html
     sfreq = 1000.0  # make things easy to understand
@@ -75,9 +64,14 @@ def test_stockwell_core():
 
 
 def test_stockwell_api():
-    """Test stockwell functions"""
+    """Test stockwell functions."""
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
+    event_id, tmin, tmax = 1, -0.2, 0.5
+    event_name = op.join(base_dir, 'test-eve.fif')
+    events = read_events(event_name)
     epochs = Epochs(raw, events,  # XXX pick 2 has epochs of zeros.
-                    event_id, tmin, tmax, picks=[0, 1, 3], baseline=(None, 0))
+                    event_id, tmin, tmax, picks=[0, 1, 3], baseline=(None, 0),
+                    add_eeg_ref=False)
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:
         with warnings.catch_warnings(record=True):  # zero papdding
             power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -4,7 +4,8 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 import mne
-from mne import io, Epochs, read_events, pick_types, create_info, EpochsArray
+from mne import Epochs, read_events, pick_types, create_info, EpochsArray
+from mne.io import read_raw_fif
 from mne.utils import (_TempDir, run_tests_if_main, slow_test, requires_h5py,
                        grand_average)
 from mne.time_frequency import single_trial_power
@@ -24,7 +25,7 @@ event_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
 
 
 def test_morlet():
-    """Test morlet with and without zero mean"""
+    """Test morlet with and without zero mean."""
     Wz = morlet(1000, [10], 2., zero_mean=True)
     W = morlet(1000, [10], 2., zero_mean=False)
 
@@ -33,14 +34,14 @@ def test_morlet():
 
 
 def test_time_frequency():
-    """Test the to-be-deprecated time-frequency transform (PSD and ITC)"""
+    """Test the to-be-deprecated time-frequency transform (PSD and ITC)."""
     # Set parameters
     event_id = 1
     tmin = -0.2
     tmax = 0.498  # Allows exhaustive decimation testing
 
     # Setup for reading the raw data
-    raw = io.read_raw_fif(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     events = read_events(event_fname)
 
     include = []
@@ -52,13 +53,13 @@ def test_time_frequency():
 
     picks = picks[:2]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
     data = epochs.get_data()
     times = epochs.times
     nave = len(data)
 
     epochs_nopicks = Epochs(raw, events, event_id, tmin, tmax,
-                            baseline=(None, 0))
+                            baseline=(None, 0), add_eeg_ref=False)
 
     freqs = np.arange(6, 20, 5)  # define frequencies of interest
     n_cycles = freqs / 4.
@@ -220,7 +221,7 @@ def test_time_frequency():
 
 
 def test_dpsswavelet():
-    """Test DPSS tapers"""
+    """Test DPSS tapers."""
     freqs = np.arange(5, 25, 3)
     Ws = _make_dpss(1000, freqs=freqs, n_cycles=freqs / 2., time_bandwidth=4.0,
                     zero_mean=True)
@@ -235,7 +236,7 @@ def test_dpsswavelet():
 
 @slow_test
 def test_tfr_multitaper():
-    """Test tfr_multitaper"""
+    """Test tfr_multitaper."""
     sfreq = 200.0
     ch_names = ['SIM0001', 'SIM0002']
     ch_types = ['grad', 'grad']
@@ -319,7 +320,7 @@ def test_tfr_multitaper():
 
 
 def test_crop():
-    """Test TFR cropping"""
+    """Test TFR cropping."""
     data = np.zeros((3, 2, 3))
     times = np.array([.1, .2, .3])
     freqs = np.array([.10, .20])
@@ -334,7 +335,7 @@ def test_crop():
 
 @requires_h5py
 def test_io():
-    """Test TFR IO capacities"""
+    """Test TFR IO capacities."""
 
     tempdir = _TempDir()
     fname = op.join(tempdir, 'test-tfr.h5')
@@ -425,8 +426,7 @@ def test_plot():
 
 
 def test_add_channels():
-    """Test tfr splitting / re-appending channel types
-    """
+    """Test tfr splitting / re-appending channel types."""
     data = np.zeros((6, 2, 3))
     times = np.array([.1, .2, .3])
     freqs = np.array([.10, .20])
@@ -461,14 +461,14 @@ def test_add_channels():
 
 
 def test_compute_tfr():
-    """Test _compute_tfr function"""
+    """Test _compute_tfr function."""
     # Set parameters
     event_id = 1
     tmin = -0.2
     tmax = 0.498  # Allows exhaustive decimation testing
 
     # Setup for reading the raw data
-    raw = io.read_raw_fif(raw_fname)
+    raw = read_raw_fif(raw_fname, add_eeg_ref=False)
     events = read_events(event_fname)
 
     exclude = raw.info['bads'] + ['MEG 2443', 'EEG 053']  # bads + 2 more

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -479,7 +479,7 @@ def test_compute_tfr():
 
     picks = picks[:2]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0))
+                    baseline=(None, 0), add_eeg_ref=False)
     data = epochs.get_data()
     sfreq = epochs.info['sfreq']
     freqs = np.arange(10, 20, 3).astype(float)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -341,13 +341,11 @@ def warn(message, category=RuntimeWarning):
     """
     import mne
     root_dir = op.dirname(mne.__file__)
-    stacklevel = 1
     frame = None
     stack = inspect.stack()
     last_fname = ''
     for fi, frame in enumerate(stack):
-        fname = frame[1]
-        del frame
+        fname, lineno = frame[1:3]
         if fname == '<string>' and last_fname == 'utils.py':  # in verbose dec
             last_fname = fname
             continue
@@ -356,12 +354,14 @@ def warn(message, category=RuntimeWarning):
         if not (fname.startswith(root_dir) or
                 ('unittest' in fname and 'case' in fname)) or \
                 op.basename(op.dirname(fname)) == 'tests':
-            stacklevel = fi + 1
             break
         last_fname = op.basename(fname)
-    del stack
     if logger.level <= logging.WARN:
-        warnings.warn(message, category, stacklevel=stacklevel)
+        # We need to use this instead of warn(message, category, stacklevel)
+        # because we move out of the MNE stack, so warnings won't properly
+        # recognize the module name (and our warnings.simplefilter will fail)
+        warnings.warn_explicit(message, category, fname, lineno,
+                               'mne', globals().get('__warningregistry__', {}))
     logger.warning(message)
 
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -716,20 +716,22 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                           "using:\n\n    $ pip install -U pysurfer" %
                           surfer.__version__)
 
+    if time_unit is None:
+        if initial_time is not None:
+            warn("The time_unit parameter default will change from 'ms' to "
+                 "'s' in MNE 0.14 and be removed in 0.15. To avoid this "
+                 "warning specify the parameter explicitly.",
+                 DeprecationWarning)
+        time_unit = 'ms'
+    elif time_unit not in ('s', 'ms'):
+        raise ValueError("time_unit needs to be 's' or 'ms', got %r" %
+                         (time_unit,))
+
     if initial_time is not None and surfer_version > v06:
         kwargs = {'initial_time': initial_time}
         initial_time = None  # don't set it twice
     else:
         kwargs = {}
-
-    if time_unit is None:
-        warn("The time_unit parameter default will change from 'ms' to 's' "
-             "in MNE 0.14. To avoid this warning specify the parameter "
-             "explicitly.", DeprecationWarning)
-        time_unit = 'ms'
-    elif time_unit not in ('s', 'ms'):
-        raise ValueError("time_unit needs to be 's' or 'ms', got %r" %
-                         (time_unit,))
 
     if time_label == 'auto':
         if time_unit == 'ms':

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -223,7 +223,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         # break up continuous signal into segments
         from ..epochs import _segment_raw
         inst = _segment_raw(inst, segment_length=2., verbose=False,
-                            preload=True, add_eeg_ref=False)
+                            preload=True)
     if inst.times[0] < 0. and inst.times[-1] > 0.:
         plot_line_at_zero = True
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -223,7 +223,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         # break up continuous signal into segments
         from ..epochs import _segment_raw
         inst = _segment_raw(inst, segment_length=2., verbose=False,
-                            preload=True)
+                            preload=True, add_eeg_ref=False)
     if inst.times[0] < 0. and inst.times[-1] > 0.:
         plot_line_at_zero = True
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -281,7 +281,10 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
     # Load the T1 data
     nim = nib.load(mri_fname)
     data = nim.get_data()
-    affine = nim.get_affine()
+    try:
+        affine = nim.affine
+    except AttributeError:  # older nibabel
+        affine = nim.get_affine()
 
     n_sag, n_axi, n_cor = data.shape
     orientation_name2axis = dict(sagittal=0, axial=1, coronal=2)

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -12,7 +12,8 @@ import numpy as np
 
 from mne.epochs import equalize_epoch_counts, concatenate_epochs
 from mne.decoding import GeneralizationAcrossTime
-from mne import io, Epochs, read_events, pick_types
+from mne import Epochs, read_events, pick_types
+from mne.io import read_raw_fif
 from mne.utils import requires_sklearn, run_tests_if_main
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
@@ -30,7 +31,7 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
               event_id_gen=dict(aud_l=2, vis_l=4), test_times=None):
     """Aux function for testing GAT viz"""
     gat = GeneralizationAcrossTime()
-    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw = read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     raw.add_proj([], remove_existing=True)
     events = read_events(event_name)
     picks = pick_types(raw.info, meg='mag', stim=False, ecg=False,
@@ -40,7 +41,8 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     # Test on time generalization within one condition
     with warnings.catch_warnings(record=True):
         epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0), preload=True, decim=decim)
+                        baseline=(None, 0), preload=True, decim=decim,
+                        add_eeg_ref=False)
     epochs_list = [epochs[k] for k in event_id]
     equalize_epoch_counts(epochs_list)
     epochs = concatenate_epochs(epochs_list)

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -13,11 +13,10 @@ from nose.tools import assert_raises
 import numpy as np
 from numpy.testing import assert_equal
 
-from mne import io, read_events, Epochs
-from mne import pick_types
-from mne.utils import run_tests_if_main, requires_version
+from mne import read_events, Epochs, pick_types
 from mne.channels import read_layout
-
+from mne.io import read_raw_fif
+from mne.utils import run_tests_if_main, requires_version
 from mne.viz import plot_drop_log
 from mne.viz.utils import _fake_click
 
@@ -39,19 +38,23 @@ layout = read_layout('Vectorview-all')
 
 
 def _get_raw():
-    return io.read_raw_fif(raw_fname, preload=False)
+    """Get raw data."""
+    return read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
 
 
 def _get_events():
+    """Get events."""
     return read_events(event_name)
 
 
 def _get_picks(raw):
+    """Get picks."""
     return pick_types(raw.info, meg=True, eeg=False, stim=False,
                       ecg=False, eog=False, exclude='bads')
 
 
 def _get_epochs():
+    """Get epochs."""
     raw = _get_raw()
     events = _get_events()
     picks = _get_picks(raw)
@@ -59,18 +62,19 @@ def _get_epochs():
     picks = np.round(np.linspace(0, len(picks) + 1, n_chan)).astype(int)
     with warnings.catch_warnings(record=True):  # bad proj
         epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0))
+                        baseline=(None, 0), add_eeg_ref=False)
     return epochs
 
 
 def _get_epochs_delayed_ssp():
+    """Get epochs with delayed SSP."""
     raw = _get_raw()
     events = _get_events()
     picks = _get_picks(raw)
     reject = dict(mag=4e-12)
-    epochs_delayed_ssp = Epochs(raw, events[:10], event_id, tmin, tmax,
-                                picks=picks, baseline=(None, 0),
-                                proj='delayed', reject=reject)
+    epochs_delayed_ssp = Epochs(
+        raw, events[:10], event_id, tmin, tmax, picks=picks,
+        baseline=(None, 0), proj='delayed', reject=reject, add_eeg_ref=False)
     return epochs_delayed_ssp
 
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -15,8 +15,9 @@ import numpy as np
 from numpy.testing import assert_raises
 
 
-from mne import io, read_events, Epochs, pick_types, read_cov
+from mne import read_events, Epochs, pick_types, read_cov
 from mne.channels import read_layout
+from mne.io import read_raw_fif
 from mne.utils import slow_test, run_tests_if_main
 from mne.viz.evoked import _butterfly_onselect, plot_compare_evokeds
 from mne.viz.utils import _fake_click
@@ -39,19 +40,23 @@ layout = read_layout('Vectorview-all')
 
 
 def _get_raw():
-    return io.read_raw_fif(raw_fname, preload=False)
+    """Get raw data."""
+    return read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
 
 
 def _get_events():
+    """Get events."""
     return read_events(event_name)
 
 
 def _get_picks(raw):
+    """Get picks."""
     return pick_types(raw.info, meg=True, eeg=False, stim=False,
                       ecg=False, eog=False, exclude='bads')
 
 
 def _get_epochs():
+    """Get epochs."""
     raw = _get_raw()
     raw.add_proj([], remove_existing=True)
     events = _get_events()
@@ -59,28 +64,28 @@ def _get_epochs():
     # Use a subset of channels for plotting speed
     picks = picks[np.round(np.linspace(0, len(picks) - 1, n_chan)).astype(int)]
     picks[0] = 2  # make sure we have a magnetometer
-    with warnings.catch_warnings(record=True):  # proj
-        epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
-                        baseline=(None, 0))
+    epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
+                    baseline=(None, 0), add_eeg_ref=False)
     epochs.info['bads'] = [epochs.ch_names[-1]]
     return epochs
 
 
 def _get_epochs_delayed_ssp():
+    """Get epochs with delayed SSP."""
     raw = _get_raw()
     events = _get_events()
     picks = _get_picks(raw)
     reject = dict(mag=4e-12)
     epochs_delayed_ssp = Epochs(raw, events[:10], event_id, tmin, tmax,
                                 picks=picks, baseline=(None, 0),
-                                proj='delayed', reject=reject)
+                                proj='delayed', reject=reject,
+                                add_eeg_ref=False)
     return epochs_delayed_ssp
 
 
 @slow_test
 def test_plot_evoked():
-    """Test plotting of evoked
-    """
+    """Test plotting of evoked."""
     import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     with warnings.catch_warnings(record=True):

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -13,9 +13,10 @@ import warnings
 import numpy as np
 from numpy.testing import assert_raises
 
-from mne import (io, read_events, read_cov, read_source_spaces, read_evokeds,
+from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)
 from mne.datasets import testing
+from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
                      plot_snr_estimate)
@@ -42,16 +43,17 @@ event_fname = op.join(base_dir, 'test-eve.fif')
 
 
 def _get_raw():
-    return io.read_raw_fif(raw_fname, preload=True)
+    """Get raw data."""
+    return read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
 
 
 def _get_events():
+    """Get events."""
     return read_events(event_fname)
 
 
 def test_plot_cov():
-    """Test plotting of covariances
-    """
+    """Test plotting of covariances."""
     raw = _get_raw()
     cov = read_cov(cov_fname)
     with warnings.catch_warnings(record=True):  # bad proj
@@ -61,8 +63,7 @@ def test_plot_cov():
 @testing.requires_testing_data
 @requires_nibabel()
 def test_plot_bem():
-    """Test plotting of BEM contours
-    """
+    """Test plotting of BEM contours."""
     assert_raises(IOError, plot_bem, subject='bad-subject',
                   subjects_dir=subjects_dir)
     assert_raises(ValueError, plot_bem, subject='sample',
@@ -77,8 +78,7 @@ def test_plot_bem():
 
 
 def test_plot_events():
-    """Test plotting events
-    """
+    """Test plotting events."""
     event_labels = {'aud_l': 1, 'aud_r': 2, 'vis_l': 3, 'vis_r': 4}
     color = {1: 'green', 2: 'yellow', 3: 'red', 4: 'c'}
     raw = _get_raw()
@@ -103,8 +103,7 @@ def test_plot_events():
 
 @testing.requires_testing_data
 def test_plot_source_spectrogram():
-    """Test plotting of source spectrogram
-    """
+    """Test plotting of source spectrogram."""
     sample_src = read_source_spaces(op.join(subjects_dir, 'sample',
                                             'bem', 'sample-oct-6-src.fif'))
 
@@ -125,8 +124,7 @@ def test_plot_source_spectrogram():
 @slow_test
 @testing.requires_testing_data
 def test_plot_snr():
-    """Test plotting SNR estimate
-    """
+    """Test plotting SNR estimate."""
     inv = read_inverse_operator(inv_fname)
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     plot_snr_estimate(evoked, inv)
@@ -134,8 +132,7 @@ def test_plot_snr():
 
 @testing.requires_testing_data
 def test_plot_dipole_amplitudes():
-    """Test plotting dipole amplitudes
-    """
+    """Test plotting dipole amplitudes."""
     dipoles = read_dipole(dip_fname)
     dipoles.plot_amplitudes(show=False)
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -27,7 +27,7 @@ event_name = op.join(base_dir, 'test-eve.fif')
 
 def _get_raw():
     """Get raw data."""
-    raw = read_raw_fif(raw_fname, preload=True)
+    raw = read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
     # Throws a warning about a changed unit.
     with warnings.catch_warnings(record=True):
         raw.set_channel_types({raw.ch_names[0]: 'ias'})

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -8,7 +8,8 @@ import warnings
 
 from numpy.testing import assert_raises, assert_equal
 
-from mne import io, read_events, pick_types, Annotations
+from mne import read_events, pick_types, Annotations
+from mne.io import read_raw_fif
 from mne.utils import requires_version, run_tests_if_main
 from mne.viz.utils import _fake_click
 from mne.viz import plot_raw, plot_sensors
@@ -25,7 +26,8 @@ event_name = op.join(base_dir, 'test-eve.fif')
 
 
 def _get_raw():
-    raw = io.read_raw_fif(raw_fname, preload=True)
+    """Get raw data."""
+    raw = read_raw_fif(raw_fname, preload=True)
     # Throws a warning about a changed unit.
     with warnings.catch_warnings(record=True):
         raw.set_channel_types({raw.ch_names[0]: 'ias'})
@@ -35,6 +37,7 @@ def _get_raw():
 
 
 def _get_events():
+    """Get events."""
     return read_events(event_name)
 
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -12,9 +12,9 @@ from collections import namedtuple
 import numpy as np
 from numpy.testing import assert_raises
 
-from mne import io, read_events, Epochs
-from mne import pick_channels_evoked
+from mne import read_events, Epochs, pick_channels_evoked
 from mne.channels import read_layout
+from mne.io import read_raw_fif
 from mne.time_frequency.tfr import AverageTFR
 from mne.utils import run_tests_if_main
 
@@ -39,41 +39,46 @@ layout = read_layout('Vectorview-all')
 
 
 def _get_raw():
-    return io.read_raw_fif(raw_fname, preload=False)
+    """Get raw data."""
+    return read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
 
 
 def _get_events():
+    """Get events."""
     return read_events(event_name)
 
 
 def _get_picks(raw):
+    """Get picks."""
     return [0, 1, 2, 6, 7, 8, 306, 340, 341, 342]  # take a only few channels
 
 
 def _get_epochs():
+    """Get epochs."""
     raw = _get_raw()
+    raw.add_proj([], remove_existing=True)
     events = _get_events()
     picks = _get_picks(raw)
     # bad proj warning
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), verbose='error')
+                    baseline=(None, 0), add_eeg_ref=False)
     return epochs
 
 
 def _get_epochs_delayed_ssp():
+    """Get epochs with delayed SSP."""
     raw = _get_raw()
     events = _get_events()
     picks = _get_picks(raw)
     reject = dict(mag=4e-12)
-    epochs_delayed_ssp = Epochs(raw, events[:10], event_id, tmin, tmax,
-                                picks=picks, baseline=(None, 0),
-                                proj='delayed', reject=reject)
+    epochs_delayed_ssp = Epochs(
+        raw, events[:10], event_id, tmin, tmax, picks=picks,
+        baseline=(None, 0), proj='delayed', reject=reject, add_eeg_ref=False)
     return epochs_delayed_ssp
 
 
 def test_plot_topo():
-    """Test plotting of ERP topography
-    """
+    """Test plotting of ERP topography."""
     import matplotlib.pyplot as plt
     # Show topography
     evoked = _get_epochs().average()
@@ -129,8 +134,7 @@ def test_plot_topo():
 
 
 def test_plot_topo_image_epochs():
-    """Test plotting of epochs image topography
-    """
+    """Test plotting of epochs image topography."""
     import matplotlib.pyplot as plt
     title = 'ERF images - MNE sample data'
     epochs = _get_epochs()
@@ -142,8 +146,7 @@ def test_plot_topo_image_epochs():
 
 
 def test_plot_tfr_topo():
-    """Test plotting of TFR data
-    """
+    """Test plotting of TFR data."""
     epochs = _get_epochs()
     n_freqs = 3
     nave = 1

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -14,7 +14,8 @@ from numpy.testing import assert_raises, assert_array_equal
 from nose.tools import assert_true, assert_equal
 
 
-from mne import io, read_evokeds, read_proj
+from mne import read_evokeds, read_proj
+from mne.io import read_raw_fif
 from mne.io.constants import FIFF
 from mne.io.pick import pick_info, channel_indices_by_type
 from mne.channels import read_layout, make_eeg_layout
@@ -48,14 +49,14 @@ layout = read_layout('Vectorview-all')
 
 
 def _get_raw():
-    return io.read_raw_fif(raw_fname, preload=False)
+    """Get raw data."""
+    return read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
 
 
 @slow_test
 @testing.requires_testing_data
 def test_plot_topomap():
-    """Test topomap plotting
-    """
+    """Test topomap plotting."""
     import matplotlib.pyplot as plt
     from matplotlib.patches import Circle
     # evoked
@@ -272,8 +273,7 @@ def test_plot_topomap():
 
 
 def test_plot_tfr_topomap():
-    """Test plotting of TFR data
-    """
+    """Test plotting of TFR data."""
     import matplotlib as mpl
     import matplotlib.pyplot as plt
     raw = _get_raw()
@@ -312,6 +312,5 @@ def test_plot_tfr_topomap():
     bands = [(4, 8, 'Theta')]
     psd = np.random.rand(len(info['ch_names']), freqs.shape[0])
     plot_psds_topomap(psd, freqs, info, bands=bands, axes=[axes])
-
 
 run_tests_if_main()

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -96,7 +96,7 @@ def test_auto_scale():
     """Test auto-scaling of channels for quick plotting."""
     raw = read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     ev = read_events(ev_fname)
-    epochs = Epochs(raw, ev)
+    epochs = Epochs(raw, ev, add_eeg_ref=False)
     rand_data = np.random.randn(10, 100)
 
     for inst in [raw, epochs]:

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -29,8 +29,7 @@ ev_fname = op.join(base_dir, 'test_raw-eve.fif')
 
 
 def test_mne_analyze_colormap():
-    """Test mne_analyze_colormap
-    """
+    """Test mne_analyze_colormap."""
     assert_raises(ValueError, mne_analyze_colormap, [0])
     assert_raises(ValueError, mne_analyze_colormap, [-1, 1, 2])
     assert_raises(ValueError, mne_analyze_colormap, [0, 2, 1])
@@ -95,7 +94,7 @@ def test_add_background_image():
 
 def test_auto_scale():
     """Test auto-scaling of channels for quick plotting."""
-    raw = read_raw_fif(raw_fname, preload=False)
+    raw = read_raw_fif(raw_fname, preload=False, add_eeg_ref=False)
     ev = read_events(ev_fname)
     epochs = Epochs(raw, ev)
     rand_data = np.random.randn(10, 100)
@@ -122,6 +121,7 @@ def test_auto_scale():
 
 
 def test_validate_if_list_of_axes():
+    """Test validation of axes."""
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots(2, 2)
     assert_raises(ValueError, _validate_if_list_of_axes, ax)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -888,12 +888,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     if cmap == 'interactive':
         cmap = ('RdBu_r', True)
     elif not isinstance(cmap, tuple):
-        if len(picks) > 2:
-            warn('Disabling interactive colorbar for multiple axes. Turn '
-                 'interactivity on explicitly by passing cmap as a tuple.')
-            cmap = (cmap, False)
-        else:
-            cmap = (cmap, True)
+        cmap = (cmap, False if len(picks) > 2 else True)
     data = np.dot(ica.mixing_matrix_[:, picks].T,
                   ica.pca_components_[:ica.n_components_])
 
@@ -1400,12 +1395,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     if cmap == 'interactive':
         cmap = (None, True)
     elif not isinstance(cmap, tuple):
-        if len(times) > 2:
-            warn('Disabling interactive colorbar for multiple axes. Turn '
-                 'interactivity on explicitly by passing cmap as a tuple.')
-            cmap = (cmap, False)
-        else:
-            cmap = (cmap, True)
+        cmap = (cmap, False if len(times) > 2 else True)
     for idx, time in enumerate(times):
         tp, cn = plot_topomap(data[:, idx], pos, vmin=vmin, vmax=vmax,
                               sensors=sensors, res=res, names=names,

--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -31,7 +31,8 @@ tmin, tmax = 0, 20  # use the first 20s of data
 
 # Setup for reading the raw data (save memory by cropping the raw data
 # before loading it)
-raw = mne.io.read_raw_fif(raw_fname).crop(tmin, tmax).load_data()
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
+raw.crop(tmin, tmax).load_data()
 raw.info['bads'] = ['MEG 2443', 'EEG 053']  # bads + 2 more
 
 fmin, fmax = 2, 300  # look at frequencies between 2 and 300Hz

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -29,7 +29,7 @@ from mne.preprocessing import create_eog_epochs, create_ecg_epochs
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
 raw.filter(1, 40, n_jobs=2)  # 1Hz high pass is often helpful for fitting ICA
 
 picks_meg = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,

--- a/tutorials/plot_artifacts_correction_maxwell_filtering.py
+++ b/tutorials/plot_artifacts_correction_maxwell_filtering.py
@@ -24,7 +24,7 @@ fine_cal_fname = data_path + '/SSS/sss_cal_mgh.dat'
 
 ###############################################################################
 # Preprocess with Maxwell filtering
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
 raw.info['bads'] = ['MEG 2443', 'EEG 053', 'MEG 1032', 'MEG 2313']  # set bads
 # Here we don't use tSSS (set st_duration) because MGH data is very clean
 raw_sss = maxwell_filter(raw, cross_talk=ctc_fname, calibration=fine_cal_fname)

--- a/tutorials/plot_artifacts_correction_rejection.py
+++ b/tutorials/plot_artifacts_correction_rejection.py
@@ -12,7 +12,8 @@ from mne.datasets import sample
 
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
+raw.set_eeg_reference()
 
 ###############################################################################
 # .. _marking_bad_channels:
@@ -177,7 +178,7 @@ picks_meg = mne.pick_types(raw.info, meg=True, eeg=False, eog=True,
                            stim=False, exclude='bads')
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                     picks=picks_meg, baseline=baseline, reject=reject,
-                    reject_by_annotation=True)
+                    reject_by_annotation=True, add_eeg_ref=False)
 
 ###############################################################################
 # We then drop/reject the bad epochs

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -16,7 +16,8 @@ from mne.preprocessing import compute_proj_ecg, compute_proj_eog
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
+raw.set_eeg_reference()
 raw.pick_types(meg=True, ecg=True, eog=True, stim=True)
 
 ##############################################################################

--- a/tutorials/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/plot_brainstorm_phantom_elekta.py
@@ -38,7 +38,7 @@ print(__doc__)
 data_path = bst_phantom_elekta.data_path()
 
 raw_fname = op.join(data_path, 'kojak_all_200nAm_pp_no_chpi_no_ms_raw.fif')
-raw = read_raw_fif(raw_fname)
+raw = read_raw_fif(raw_fname, add_eeg_ref=False)
 
 ###############################################################################
 # Data channel array consisted of 204 MEG planor gradiometers,
@@ -79,7 +79,7 @@ raw.plot(events=events)
 tmin, tmax = -0.1, 0.1
 event_id = list(range(1, 33))
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, baseline=(None, -0.01),
-                    decim=5, preload=True)
+                    decim=5, preload=True, add_eeg_ref=False)
 epochs['1'].average().plot()
 
 ###############################################################################

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -17,9 +17,10 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_empty_room_fname = op.join(
     data_path, 'MEG', 'sample', 'ernoise_raw.fif')
-raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)
+raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname, add_eeg_ref=False)
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
+raw.set_eeg_reference()
 raw.info['bads'] += ['EEG 053']  # bads + 1 more
 
 ###############################################################################
@@ -135,4 +136,4 @@ evoked.plot_white(covs)
 #     vol. 108, 328-342, NeuroImage.
 #
 # .. [2] Taulu, S., Simola, J., Kajola, M., 2005. Applications of the signal
-#    space separation method. IEEE Trans. Signal Proc. 53, 3359–3372.
+#    space separation method. IEEE Trans. Signal Proc. 53, 3359-3372.

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -23,7 +23,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False, preload=True)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 
 ###############################################################################
 # Let's restrict the data to the EEG channels

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -22,7 +22,8 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
-raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=True, preload=True)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False, preload=True)
+raw.set_eeg_reference()
 
 ###############################################################################
 # Let's restrict the data to the EEG channels
@@ -98,7 +99,7 @@ reject = dict(eeg=180e-6, eog=150e-6)
 event_id, tmin, tmax = {'left/auditory': 1}, -0.2, 0.5
 events = mne.read_events(event_fname)
 epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
-                     reject=reject)
+                     reject=reject, add_eeg_ref=False)
 
 evoked_no_ref = mne.Epochs(raw_no_ref, **epochs_params).average()
 del raw_no_ref  # save memory

--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -18,7 +18,7 @@ import mne
 data_path = mne.datasets.sample.data_path()
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(fname, add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 
 ###############################################################################
 # To create time locked epochs, we first need a set of events that contain the

--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -17,7 +17,8 @@ import mne
 # First let's read in the raw sample data.
 data_path = mne.datasets.sample.data_path()
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
-raw = mne.io.read_raw_fif(fname)
+raw = mne.io.read_raw_fif(fname, add_eeg_ref=False)
+raw.set_eeg_reference()
 
 ###############################################################################
 # To create time locked epochs, we first need a set of events that contain the
@@ -109,7 +110,7 @@ picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=True)
 baseline = (None, 0.0)
 reject = {'mag': 4e-12, 'eog': 200e-6}
 epochs = mne.Epochs(raw, events=events, event_id=event_id, tmin=tmin,
-                    tmax=tmax, reject=reject, picks=picks)
+                    tmax=tmax, reject=reject, picks=picks, add_eeg_ref=False)
 
 ###############################################################################
 # Let's plot the epochs to see the results. The number at the top refers to the

--- a/tutorials/plot_epochs_to_data_frame.py
+++ b/tutorials/plot_epochs_to_data_frame.py
@@ -102,7 +102,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
 
 # For simplicity we will only consider the first 10 epochs
 events = mne.read_events(event_fname)[:10]
@@ -119,7 +119,8 @@ reject = dict(grad=4000e-13, eog=150e-6)
 event_id = dict(auditory_l=1, auditory_r=2, visual_l=3, visual_r=4)
 
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
-                    baseline=baseline, preload=True, reject=reject)
+                    baseline=baseline, preload=True, reject=reject,
+                    add_eeg_ref=False)
 
 ###############################################################################
 # Export DataFrame

--- a/tutorials/plot_epochs_to_data_frame.py
+++ b/tutorials/plot_epochs_to_data_frame.py
@@ -103,6 +103,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 
 raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
+raw.set_eeg_reference()  # set EEG average reference
 
 # For simplicity we will only consider the first 10 epochs
 events = mne.read_events(event_fname)[:10]

--- a/tutorials/plot_ica_from_raw.py
+++ b/tutorials/plot_ica_from_raw.py
@@ -26,7 +26,7 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
 raw.filter(1, 45, n_jobs=1, l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
            filter_length='10s', phase='zero-double')
 

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -134,7 +134,7 @@ print(raw_fname)
 #
 # Read data from file:
 
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
 print(raw)
 print(raw.info)
 
@@ -222,7 +222,8 @@ reject = dict(grad=4000e-13, mag=4e-12, eog=150e-6)
 # Read epochs:
 
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
-                    baseline=baseline, preload=False, reject=reject)
+                    baseline=baseline, preload=False, reject=reject,
+                    add_eeg_ref=False)
 print(epochs)
 
 ##############################################################################

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -22,7 +22,8 @@ from mne.minimum_norm import (make_inverse_operator, apply_inverse,
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
+raw.set_eeg_reference()
 events = mne.find_events(raw, stim_channel='STI 014')
 
 event_id = dict(aud_r=1)  # event trigger and conditions
@@ -34,8 +35,8 @@ picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=True,
 baseline = (None, 0)  # means from the first instant to t = 0
 reject = dict(grad=4000e-13, mag=4e-12, eog=150e-6)
 
-epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
-                    picks=picks, baseline=baseline, reject=reject)
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
+                    baseline=baseline, reject=reject, add_eeg_ref=False)
 
 ###############################################################################
 # Compute regularized noise covariance

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -23,7 +23,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 events = mne.find_events(raw, stim_channel='STI 014')
 
 event_id = dict(aud_r=1)  # event trigger and conditions

--- a/tutorials/plot_modifying_data_inplace.py
+++ b/tutorials/plot_modifying_data_inplace.py
@@ -21,7 +21,7 @@ from matplotlib import pyplot as plt
 # Load an example dataset, the preload flag loads the data into memory now
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG',
                     'sample', 'sample_audvis_raw.fif')
-raw = mne.io.read_raw_fif(data_path, preload=True, verbose=False)
+raw = mne.io.read_raw_fif(data_path, preload=True, add_eeg_ref=False)
 raw = raw.crop(0, 10)
 print(raw)
 

--- a/tutorials/plot_object_epochs.py
+++ b/tutorials/plot_object_epochs.py
@@ -28,8 +28,9 @@ from matplotlib import pyplot as plt
 
 data_path = mne.datasets.sample.data_path()
 # Load a dataset that contains events
-raw = mne.io.RawFIF(
-    op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif'))
+raw = mne.io.read_raw_fif(
+    op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif'),
+    add_eeg_ref=False)
 
 # If your raw object has a stim channel, you can construct an event array
 # easily
@@ -57,7 +58,7 @@ event_id = {'Auditory/Left': 1, 'Auditory/Right': 2}
 # Expose the raw data as epochs, cut from -0.1 s to 1.0 s relative to the event
 # onsets
 epochs = mne.Epochs(raw, events, event_id, tmin=-0.1, tmax=1,
-                    baseline=(None, 0), preload=True)
+                    baseline=(None, 0), preload=True, add_eeg_ref=False)
 print(epochs)
 
 ###############################################################################

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -31,7 +31,8 @@ from matplotlib import pyplot as plt
 # Load an example dataset, the preload flag loads the data into memory now
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG',
                     'sample', 'sample_audvis_raw.fif')
-raw = mne.io.read_raw_fif(data_path, preload=True, verbose=False)
+raw = mne.io.read_raw_fif(data_path, preload=True, add_eeg_ref=False)
+raw.set_eeg_reference()
 
 # Give the sample rate
 print('sample rate:', raw.info['sfreq'], 'Hz')

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -32,7 +32,7 @@ from matplotlib import pyplot as plt
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG',
                     'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(data_path, preload=True, add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 
 # Give the sample rate
 print('sample rate:', raw.info['sfreq'], 'Hz')

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -29,7 +29,8 @@ tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
 
 # Setup for reading the raw data
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
+raw.set_eeg_reference()
 raw.filter(2, None, method='iir')  # replace baselining with high-pass
 events = mne.read_events(event_fname)
 
@@ -41,7 +42,7 @@ picks = mne.pick_types(raw.info, meg='grad', eeg=False, stim=True, eog=True,
 # Read epochs
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                     picks=picks, baseline=None, preload=True,
-                    reject=dict(grad=4000e-13, eog=150e-6))
+                    reject=dict(grad=4000e-13, eog=150e-6), add_eeg_ref=False)
 
 epochs_list = [epochs[k] for k in event_id]
 mne.epochs.equalize_epoch_counts(epochs_list)

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -30,7 +30,7 @@ event_id = dict(aud_l=1, vis_l=3)
 
 # Setup for reading the raw data
 raw = mne.io.read_raw_fif(raw_fname, preload=True, add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 raw.filter(2, None, method='iir')  # replace baselining with high-pass
 events = mne.read_events(event_fname)
 

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -27,7 +27,7 @@ data_path = somato.data_path()
 raw_fname = data_path + '/MEG/somato/sef_raw_sss.fif'
 
 # Setup for reading the raw data
-raw = mne.io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname, add_eeg_ref=False)
 events = mne.find_events(raw, stim_channel='STI 014')
 
 # picks MEG gradiometers
@@ -38,7 +38,7 @@ event_id, tmin, tmax = 1, -1., 3.
 baseline = (None, 0)
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=baseline, reject=dict(grad=4000e-13, eog=350e-6),
-                    preload=True)
+                    preload=True, add_eeg_ref=False)
 
 epochs.resample(150., npad='auto')  # resample to reduce computation time
 

--- a/tutorials/plot_visualize_epochs.py
+++ b/tutorials/plot_visualize_epochs.py
@@ -10,10 +10,12 @@ import os.path as op
 import mne
 
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
-raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'))
+raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
+                          add_eeg_ref=False)
+raw.set_eeg_reference()
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))
 picks = mne.pick_types(raw.info, meg='grad')
-epochs = mne.Epochs(raw, events, [1, 2], picks=picks)
+epochs = mne.Epochs(raw, events, [1, 2], picks=picks, add_eeg_ref=False)
 
 ###############################################################################
 # This tutorial focuses on visualization of epoched data. All of the functions

--- a/tutorials/plot_visualize_epochs.py
+++ b/tutorials/plot_visualize_epochs.py
@@ -12,7 +12,7 @@ import mne
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
 raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
                           add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))
 picks = mne.pick_types(raw.info, meg='grad')
 epochs = mne.Epochs(raw, events, [1, 2], picks=picks, add_eeg_ref=False)

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -10,7 +10,9 @@ import os.path as op
 import mne
 
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
-raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'))
+raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
+                          add_eeg_ref=False)
+raw.set_eeg_reference()
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))
 
 ###############################################################################

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -12,7 +12,7 @@ import mne
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
 raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
                           add_eeg_ref=False)
-raw.set_eeg_reference()
+raw.set_eeg_reference()  # set EEG average reference
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))
 
 ###############################################################################


### PR DESCRIPTION
This PR basically acts as an API proposal for #3538 and #2727. @agramfort @dengemann and others feel free to have a look.

The one API thing that's missing is making `set_eeg_reference` a method of `Raw`, `Epochs`, and `Evoked`, which I think we should do. I'm okay with not doing the bipolar or `add_reference_channels` since they are used less often, and we can link to them in `See Also`. Is that okay with you @wmvanvliet?

I still need to update all examples along the lines of the one I did so far, as well as all tests that load raw data (ouch).

Closes #3538.
Closes #2727.
Closes #3584.