### PR TITLE
WIP: Make EpochsTFR more like Epochs

### DIFF
--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1530,8 +1530,8 @@ class EpochsTFR(_BaseTFR):
     .. versionadded:: 0.13.0
     """
     @verbose
-    def __init__(self, info, data, times, freqs, comment=None,
-                 method=None, verbose=None):
+    def __init__(self, info, data, times, freqs, events=None, event_id=None,
+                 comment=None, method=None, verbose=None):
         self.info = info
         if data.ndim != 4:
             raise ValueError('data should be 4d. Got %d.' % data.ndim)


### PR DESCRIPTION
Extending the @agramfort's efforts in #3476 : would it make sense to extend to slightly modify `EpochsTFR` to be more similar to `Epochs`?
1. include the `events` infrastructure
   - include an `events` field
   - include the by-condition / `events_id` indexing mechanism
2. add a `get_data()` method and ditch the `data` field?

For (2): This would make `EpochsTFR` differ from `AverageTFR`, but `Epochs` differs from `Evoked` in exactly the same way, so I'm not sure if that's really a problem.
