### PR TITLE
MRG AverageTFR.apply_baseline return self

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -98,9 +98,9 @@ def test_time_frequency():
     print(itc)  # test repr
     print(itc.ch_names)  # test property
     itc += power  # test add
-    itc -= power  # test add
+    itc -= power  # test sub
 
-    power.apply_baseline(baseline=(-0.1, 0), mode='logratio')
+    power = power.apply_baseline(baseline=(-0.1, 0), mode='logratio')
 
     assert_true('meg' in power)
     assert_true('grad' in power)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -971,9 +971,16 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
             If None no baseline correction is applied.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see mne.verbose).
+
+        Returns
+        -------
+        inst : instance of AverageTFR
+            The modified instance.        
+
         """  # noqa
         self.data = rescale(self.data, self.times, baseline, mode,
                             copy=False)
+        return self
 
 
 class AverageTFR(_BaseTFR):


### PR DESCRIPTION
Is there a reason for AverageTFR.apply_baseline not to return self, like all other instance methods that modify the instance? If not, this makes it return self.