### PR TITLE
default to STI101 instead of STI 014

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -387,7 +387,7 @@ def find_stim_steps(raw, pad_start=None, pad_stop=None, merge=0,
         affected by the trigger. If None, the config variables
         'MNE_STIM_CHANNEL', 'MNE_STIM_CHANNEL_1', 'MNE_STIM_CHANNEL_2',
         etc. are read. If these are not found, it will default to
-        'STI 014'.
+        'STI101' or 'STI 014', whichever is present.
 
     Returns
     -------
@@ -505,8 +505,8 @@ def find_events(raw, stim_channel=None, output='onset',
         affected by the trigger. If None, the config variables
         'MNE_STIM_CHANNEL', 'MNE_STIM_CHANNEL_1', 'MNE_STIM_CHANNEL_2',
         etc. are read. If these are not found, it will fall back to
-        'STI 014' if present, then fall back to the first channel of type
-        'stim', if present.
+        'STI101' or 'STI 014' if present, then fall back to the first channel
+        of type 'stim', if present.
     output : 'onset' | 'offset' | 'step'
         Whether to report when events start, when events end, or both.
     consecutive : bool | 'increasing'

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -500,7 +500,7 @@ FIFF.FIFF_MNE_EXTERNAL_LITTLE_ENDIAN = 3553     # Reference to an external binar
 # 3560... Miscellaneous
 #
 FIFF.FIFF_MNE_PROJ_ITEM_ACTIVE       = 3560     # Is this projection item active?
-FIFF.FIFF_MNE_EVENT_LIST             = 3561     # An event list (for STI 014)
+FIFF.FIFF_MNE_EVENT_LIST             = 3561     # An event list (for STI101 / STI 014)
 FIFF.FIFF_MNE_HEMI                   = 3562     # Hemisphere association for general purposes
 FIFF.FIFF_MNE_DATA_SKIP_NOP          = 3563     # A data skip turned off in the raw data
 FIFF.FIFF_MNE_ORIG_CH_INFO           = 3564     # Channel information before any changes

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1981,8 +1981,9 @@ def _get_stim_channel(stim_channel, info, raise_error=True):
     """Helper to determine the appropriate stim_channel
 
     First, 'MNE_STIM_CHANNEL', 'MNE_STIM_CHANNEL_1', 'MNE_STIM_CHANNEL_2', etc.
-    are read. If these are not found, it will fall back to 'STI 014' if
-    present, then fall back to the first channel of type 'stim', if present.
+    are read. If these are not found, it will fall back to 'STI101' or
+    'STI 014' if present, then fall back to the first channel of type
+    'stim', if present.
 
     Parameters
     ----------
@@ -2015,7 +2016,10 @@ def _get_stim_channel(stim_channel, info, raise_error=True):
     if ch_count > 0:
         return stim_channel
 
-    if 'STI 014' in info['ch_names']:
+    if 'STI101' in info['ch_names']:  # newer Elekta systems
+        return ['STI101']
+
+    if 'STI 014' in info['ch_names']:  # older Elekta systems
         return ['STI 014']
 
     from .io.pick import pick_types


### PR DESCRIPTION
Newer Elekta systems (at least TRIUX) use 'STI101' as the combination trigger channel, so it should be the default. If not found, fall back to 'STI 014'
Fixes #3554 