### PR TITLE
MRG bug with picks in interpolation code

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -116,6 +116,8 @@ BUG
 
     - Fixed ICA plotting functions to refer to IC index instead of component number by `Andreas Hojlund`_ and `Jaakko Leppakangas`_
 
+    - Fixed bug with ``picks`` when interpolating MEG channels by `Mainak Jas`_.
+
 API
 ~~~
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -172,14 +172,15 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
         If not None, override default verbose level (see mne.verbose).
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False, exclude=[])
-    ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     picks_good = pick_types(inst.info, meg=True, eeg=False, exclude='bads')
+    meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
+    bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 
     # select the bad meg channel to be interpolated
-    if len(inst.info['bads']) == 0:
+    if len(bads_meg) == 0:
         picks_bad = []
     else:
-        picks_bad = pick_channels(ch_names, inst.info['bads'],
+        picks_bad = pick_channels(inst.info['ch_names'], bads_meg,
                                   exclude=[])
 
     # return without doing anything if there are no meg channels

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -92,6 +92,15 @@ def test_interpolation():
         inst.info['bads'] = [inst.ch_names[1]]
         assert_raises(ValueError, inst.interpolate_bads)
 
+    # check that interpolation works when non M/EEG channels are present
+    # before MEG channels
+    with warnings.catch_warnings(record=True):  # change of units
+        raw.rename_channels({'MEG 0113': 'TRIGGER'})
+        raw.set_channel_types({'TRIGGER': 'stim'})
+        raw.info['bads'] = [raw.info['ch_names'][1]]
+        raw.load_data()
+        raw.interpolate_bads()
+
     # check that interpolation works for MEG
     epochs_meg.info['bads'] = ['MEG 0141']
     evoked = epochs_meg.average()


### PR DESCRIPTION
I added a test, which basically reproduces the problem that was there. If the trigger channel was before the MEG channels, then trying to interpolate the first MEG channel would produce an error. This PR fixes that