### PR TITLE
use weakest filter settings for heterogeneous channel filters

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -112,7 +112,9 @@ BUG
 
         - Use online software filter information when present
 
-        - Fix comparisons of filter settings for determining "strictest" filter
+        - Fix comparisons of filter settings for determining "strictest"/"weakest" filter
+
+        - Weakest filter is now used for heterogeneous channel filter settings, leading to more consistent behavior with filtering methods applied to a subset of channels (e.g. ``Raw.filter`` with ``picks != None``).  
 
     - Fixed plotting and timing of :class:`Annotations` and restricted addition of annotations outside data range to prevent problems with cropping and concatenating data by `Jaakko Leppakangas`_
 

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -84,7 +84,7 @@ def test_brainvision_data_highpass_filters():
 
     assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
-    assert_equal(raw.info['highpass'], 0.2)
+    assert_equal(raw.info['highpass'], 0.1)
     assert_equal(raw.info['lowpass'], 250.)
 
     # Homogeneous highpass in Hertz
@@ -114,7 +114,7 @@ def test_brainvision_data_highpass_filters():
 
     assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
-    assert_equal(raw.info['highpass'], 10.)
+    assert_equal(raw.info['highpass'], 5.)
     assert_equal(raw.info['lowpass'], 250.)
 
 
@@ -149,7 +149,7 @@ def test_brainvision_data_lowpass_filters():
     assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 0.1)
-    assert_equal(raw.info['lowpass'], 125.)
+    assert_equal(raw.info['lowpass'], 250.)
 
     # Homogeneous lowpass in seconds
     with warnings.catch_warnings(record=True) as w:  # event parsing
@@ -179,7 +179,7 @@ def test_brainvision_data_lowpass_filters():
     assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 0.1)
-    assert_equal(raw.info['lowpass'], 125.)
+    assert_equal(raw.info['lowpass'], 250.)
 
 
 def test_brainvision_data_partially_disabled_hw_filters():
@@ -203,8 +203,8 @@ def test_brainvision_data_partially_disabled_hw_filters():
 
     assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
-    assert_equal(raw.info['highpass'], 0.1)
-    assert_equal(raw.info['lowpass'], 250.)
+    assert_equal(raw.info['highpass'], 0.)
+    assert_equal(raw.info['lowpass'], 500.)
 
 
 def test_brainvision_data_software_filters_latin1_global_units():


### PR DESCRIPTION
Close #3577. Title really says it all --  makes the reader more consistent with the behavior of `Raw.filter` when `picks is not None`. 

Hopefully, the user is paying attention to his warnings and/or not doing online filtering, much less heterogeneous filtering. Should we include a note on this behavior somewhere in the documentation? Do any of the other file formats support heterogeneous channel filter settings?