### PR TITLE
ENH/FIX: get rid of comp matrix warning

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -12,7 +12,7 @@ from itertools import count
 
 import numpy as np
 
-from ...utils import logger, verbose, sum_squared, warn
+from ...utils import logger, verbose, sum_squared,
 from ...transforms import (combine_transforms, invert_transform, apply_trans,
                            Transform)
 from ..constants import FIFF
@@ -1304,10 +1304,10 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
                        save_calibrated=0)]
     else:
         logger.info(
-             'Currently direct inclusion of 4D weight tables is not supported.'
-             ' For critical use cases please take into account the MNE command'
-             ' "mne_create_comp_data" to include weights as printed out by '
-             'the 4D "print_table" routine.')
+            'Currently direct inclusion of 4D weight tables is not supported.'
+            ' For critical use cases please take into account the MNE command'
+            ' "mne_create_comp_data" to include weights as printed out by '
+            'the 4D "print_table" routine.')
 
     # check that the info is complete
     info._update_redundant()

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1303,7 +1303,8 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
                        colcals=np.ones(mat.shape[1], dtype='>f4'),
                        save_calibrated=0)]
     else:
-        warn('Currently direct inclusion of 4D weight tables is not supported.'
+        logger.info(
+             'Currently direct inclusion of 4D weight tables is not supported.'
              ' For critical use cases please take into account the MNE command'
              ' "mne_create_comp_data" to include weights as printed out by '
              'the 4D "print_table" routine.')

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -12,7 +12,7 @@ from itertools import count
 
 import numpy as np
 
-from ...utils import logger, verbose, sum_squared,
+from ...utils import logger, verbose, sum_squared
 from ...transforms import (combine_transforms, invert_transform, apply_trans,
                            Transform)
 from ..constants import FIFF

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -53,11 +53,9 @@ def test_read_config():
 
 def test_crop_append():
     """Test crop and append raw."""
-    with warnings.catch_warnings(record=True):  # preload warning
-        warnings.simplefilter('always')
-        raw = _test_raw_reader(
-            read_raw_bti, pdf_fname=pdf_fnames[0],
-            config_fname=config_fnames[0], head_shape_fname=hs_fnames[0])
+    raw = _test_raw_reader(
+        read_raw_bti, pdf_fname=pdf_fnames[0],
+        config_fname=config_fnames[0], head_shape_fname=hs_fnames[0])
     y, t = raw[:]
     t0, t1 = 0.25 * t[-1], 0.75 * t[-1]
     mask = (t0 <= t) * (t <= t1)
@@ -72,8 +70,7 @@ def test_transforms():
     bti_trans = (0.0, 0.02, 0.11)
     bti_dev_t = Transform('ctf_meg', 'meg', _get_bti_dev_t(0.0, bti_trans))
     for pdf, config, hs, in zip(pdf_fnames, config_fnames, hs_fnames):
-        with warnings.catch_warnings(record=True):  # weight tables
-            raw = read_raw_bti(pdf, config, hs, preload=False)
+        raw = read_raw_bti(pdf, config, hs, preload=False)
         dev_ctf_t = raw.info['dev_ctf_t']
         dev_head_t_old = raw.info['dev_head_t']
         ctf_head_t = raw.info['ctf_head_t']
@@ -101,14 +98,12 @@ def test_raw():
         if op.exists(tmp_raw_fname):
             os.remove(tmp_raw_fname)
         ex = read_raw_fif(exported, preload=True, add_eeg_ref=False)
-        with warnings.catch_warnings(record=True):  # weight tables
-            ra = read_raw_bti(pdf, config, hs, preload=False)
+        ra = read_raw_bti(pdf, config, hs, preload=False)
         assert_true('RawBTi' in repr(ra))
         assert_equal(ex.ch_names[:NCH], ra.ch_names[:NCH])
         assert_array_almost_equal(ex.info['dev_head_t']['trans'],
                                   ra.info['dev_head_t']['trans'], 7)
-        with warnings.catch_warnings(record=True):  # headshape
-            assert_dig_allclose(ex.info, ra.info)
+        assert_dig_allclose(ex.info, ra.info)
         coil1, coil2 = [np.concatenate([d['loc'].flatten()
                         for d in r_.info['chs'][:NCH]])
                         for r_ in (ra, ex)]
@@ -151,17 +146,16 @@ def test_raw():
 def test_info_no_rename_no_reorder_no_pdf():
     """Test private renaming, reordering and partial construction option."""
     for pdf, config, hs in zip(pdf_fnames, config_fnames, hs_fnames):
-        with warnings.catch_warnings(record=True):  # weight tables
-            info, bti_info = _get_bti_info(
-                pdf_fname=pdf, config_fname=config, head_shape_fname=hs,
-                rotation_x=0.0, translation=(0.0, 0.02, 0.11), convert=False,
-                ecg_ch='E31', eog_ch=('E63', 'E64'),
-                rename_channels=False, sort_by_ch_name=False)
-            info2, bti_info = _get_bti_info(
-                pdf_fname=None, config_fname=config, head_shape_fname=hs,
-                rotation_x=0.0, translation=(0.0, 0.02, 0.11), convert=False,
-                ecg_ch='E31', eog_ch=('E63', 'E64'),
-                rename_channels=False, sort_by_ch_name=False)
+        info, bti_info = _get_bti_info(
+            pdf_fname=pdf, config_fname=config, head_shape_fname=hs,
+            rotation_x=0.0, translation=(0.0, 0.02, 0.11), convert=False,
+            ecg_ch='E31', eog_ch=('E63', 'E64'),
+            rename_channels=False, sort_by_ch_name=False)
+        info2, bti_info = _get_bti_info(
+            pdf_fname=None, config_fname=config, head_shape_fname=hs,
+            rotation_x=0.0, translation=(0.0, 0.02, 0.11), convert=False,
+            ecg_ch='E31', eog_ch=('E63', 'E64'),
+            rename_channels=False, sort_by_ch_name=False)
 
         assert_equal(info['ch_names'],
                      [ch['ch_name'] for ch in info['chs']])
@@ -195,15 +189,14 @@ def test_info_no_rename_no_reorder_no_pdf():
             np.array([ch['loc'] for ch in info2['chs']]))
 
     # just check reading data | corner case
-    with warnings.catch_warnings(record=True):  # weight tables
-        raw1 = read_raw_bti(
-            pdf_fname=pdf, config_fname=config, head_shape_fname=None,
-            sort_by_ch_name=False, preload=True)
-        # just check reading data | corner case
-        raw2 = read_raw_bti(
-            pdf_fname=pdf, config_fname=config, head_shape_fname=None,
-            rename_channels=False,
-            sort_by_ch_name=True, preload=True)
+    raw1 = read_raw_bti(
+        pdf_fname=pdf, config_fname=config, head_shape_fname=None,
+        sort_by_ch_name=False, preload=True)
+    # just check reading data | corner case
+    raw2 = read_raw_bti(
+        pdf_fname=pdf, config_fname=config, head_shape_fname=None,
+        rename_channels=False,
+        sort_by_ch_name=True, preload=True)
 
     sort_idx = [raw1.bti_ch_labels.index(ch) for ch in raw2.bti_ch_labels]
     raw1._data = raw1._data[sort_idx]
@@ -220,12 +213,10 @@ def test_no_conversion():
         rename_channels=False, sort_by_ch_name=False)
 
     for pdf, config, hs in zip(pdf_fnames, config_fnames, hs_fnames):
-        with warnings.catch_warnings(record=True):  # weight tables
-            raw_info, _ = get_info(pdf, config, hs, convert=False)
-        with warnings.catch_warnings(record=True):  # weight tables
-            raw_info_con = read_raw_bti(
-                pdf_fname=pdf, config_fname=config, head_shape_fname=hs,
-                convert=True, preload=False).info
+        raw_info, _ = get_info(pdf, config, hs, convert=False)
+        raw_info_con = read_raw_bti(
+            pdf_fname=pdf, config_fname=config, head_shape_fname=hs,
+            convert=True, preload=False).info
 
         pick_info(raw_info_con,
                   pick_types(raw_info_con, meg=True, ref_meg=True),
@@ -273,8 +264,7 @@ def test_no_conversion():
 def test_bytes_io():
     """Test bti bytes-io API."""
     for pdf, config, hs in zip(pdf_fnames, config_fnames, hs_fnames):
-        with warnings.catch_warnings(record=True):  # weight tables
-            raw = read_raw_bti(pdf, config, hs, convert=True, preload=False)
+        raw = read_raw_bti(pdf, config, hs, convert=True, preload=False)
 
         with open(pdf, 'rb') as fid:
             pdf = six.BytesIO(fid.read())

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -272,8 +272,8 @@ def test_bytes_io():
             config = six.BytesIO(fid.read())
         with open(hs, 'rb') as fid:
             hs = six.BytesIO(fid.read())
-        with warnings.catch_warnings(record=True):  # weight tables
-            raw2 = read_raw_bti(pdf, config, hs, convert=True, preload=False)
+
+        raw2 = read_raw_bti(pdf, config, hs, convert=True, preload=False)
         repr(raw2)
         assert_array_equal(raw[:][0], raw2[:][0])
 


### PR DESCRIPTION
After 4 years no one has cried about the compensation matrices. Currently these warnings are driving me nuts in mne-hcp. I'd suggest to degrade them to simple info messages. I updated the tests accordingly.

cc @Eric89GXL @jaeilepp 