### PR TITLE
Fix Stockwell transform when n_fft is power of two

### DIFF
--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -15,11 +15,38 @@ from scipy import fftpack
 from mne import read_events, Epochs
 from mne.io import read_raw_fif
 from mne.time_frequency._stockwell import (tfr_stockwell, _st,
-                                           _precompute_st_windows)
+                                           _precompute_st_windows,
+                                           _check_input_st,
+                                           _st_power_itc)
+
 from mne.time_frequency.tfr import AverageTFR
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
+
+
+def test_stockwell_check_input():
+    """Test input checker for stockwell"""
+    # check for data size equal and unequal to a power of 2
+
+    for last_dim in (127, 128):
+        data = np.zeros((2, 10, last_dim))
+        x_in, n_fft, zero_pad = _check_input_st(data, None)
+
+        assert_equal(x_in.shape, (2, 10, 128))
+        assert_equal(n_fft, 128)
+        assert_equal(zero_pad, 128 - last_dim)
+
+
+def test_stockwell_st_no_zero_pad():
+    """Test stockwell power itc"""
+    data = np.zeros((20, 128))
+    start_f = 1
+    stop_f = 10
+    sfreq = 30
+    width = 2
+    W = _precompute_st_windows(data.shape[-1], start_f, stop_f, sfreq, width)
+    _st_power_itc(data, 10, True, 0, 1, W)
 
 
 def test_stockwell_core():


### PR DESCRIPTION
This is the continuation of PR #3605, which was closed due to commit chaos.

There were two related errors in `time_frequency/_stockwell.py`. Both were relevant only if the input data to the Stockwell transform has 2**N samples.

1) in `_check_input_st(x_in, n_fft)`: Return was indented wrongly and zero_pad was undefined iff `n_fft == 2**N`.
2) In _precompute_st_windows: The computation of TFR was wrong if `zero_pad == 0`.

This PR fixes these errors and adds two new tests in `time_frequency/tests/test_stockwell.py`
