### PR TITLE
WIP: Dont reapply projection for epochs with proj=False

### DIFF
--- a/doc/manual/preprocessing/ssp.rst
+++ b/doc/manual/preprocessing/ssp.rst
@@ -10,7 +10,7 @@ Projections
 The Signal-Space Projection (SSP) method
 ========================================
 
-The Signal-Space Projection (SSP) is one approach to rejection 
+The Signal-Space Projection (SSP) is one approach to rejection
 of external disturbances in software. Unlike many other noise-cancellation
 approaches, SSP does not require additional reference sensors to record the disturbance
 fields. Instead, SSP relies on the fact that the magnetic field
@@ -141,7 +141,7 @@ Once a projector is applied on the data, it is said to be `active`.
 The proj attribute
 ------------------
 
-It is available in all the basic data containers: ``Raw``, ``Epochs`` and ``Evoked``. It is ``True`` if at least one projector is present and all of them are `active`. 
+It is available in all the basic data containers: ``Raw``, ``Epochs`` and ``Evoked``. It is ``True`` if at least one projector is present and all of them are `active`.
 
 Computing projectors
 --------------------
@@ -153,7 +153,7 @@ The general assumption these functions make is that the data passed contains
 raw, epochs or averages of the artifact. Typically this involves continues raw
 data of empty room recordings or averaged ECG or EOG artifacts.
 
-A second set of highlevel convenience functions is provided to compute projection vector for typical usecases. This includes :func:`mne.preprocessing.compute_proj_ecg` and :func:`mne.preprocessing.compute_proj_eog` for computing the ECG and EOG related artifact components, respectively. For computing the eeg reference signal, the function :func:`mne.preprocessing.ssp.make_eeg_average_ref_proj` can be used. The underlying implementation can be found in :mod:`mne.preprocessing.ssp`.
+A second set of highlevel convenience functions is provided to compute projection vector for typical usecases. This includes :func:`mne.preprocessing.compute_proj_ecg` and :func:`mne.preprocessing.compute_proj_eog` for computing the ECG and EOG related artifact components, respectively. For computing the eeg reference signal, the function :func:`mne.set_eeg_reference` can be used. The underlying implementation can be found in :mod:`mne.preprocessing.ssp`.
 
 .. warning:: It is best to compute projectors only on channels that will be
              used (e.g., excluding bad channels). This ensures that
@@ -191,7 +191,7 @@ The projectors might not be applied if data are not :ref:`preloaded <memory>`. I
 Delayed projectors
 ------------------
 
-The suggested pipeline is ``proj=True`` in epochs (it's computationally cheaper than for raw). When you use delayed SSP in ``Epochs``, projectors are applied when you call :func:`mne.Epochs.get_data` method. They are not applied to the ``evoked`` data unless you call ``apply_proj()``. The reason is that you want to reject epochs with projectors although it's not stored in the projector mode. 
+The suggested pipeline is ``proj=True`` in epochs (it's computationally cheaper than for raw). When you use delayed SSP in ``Epochs``, projectors are applied when you call :func:`mne.Epochs.get_data` method. They are not applied to the ``evoked`` data unless you call ``apply_proj()``. The reason is that you want to reject epochs with projectors although it's not stored in the projector mode.
 
 .. topic:: Examples:
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -374,16 +374,9 @@ Projections:
    compute_proj_epochs
    compute_proj_evoked
    compute_proj_raw
+   set_eeg_reference
    read_proj
    write_proj
-
-.. currentmodule:: mne.preprocessing.ssp
-
-.. autosummary::
-   :toctree: generated/
-   :template: function.rst
-
-   make_eeg_average_ref_proj
 
 Manipulate channels and set sensors locations for processing and plotting:
 

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -341,7 +341,7 @@ def test_make_forward_dipole():
     for s in stc:
         evo_test = simulate_evoked(fwd, s, info, cov,
                                    snr=snr, random_state=rng)
-        # evo_test.add_proj(make_eeg_average_ref_proj(evo_test.info))
+        # evo_test.set_eeg_reference()
         dfit, resid = fit_dipole(evo_test, cov, sphere, None)
         times += dfit.times.tolist()
         pos += dfit.pos.tolist()

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -17,7 +17,7 @@ from ..open import fiff_open, _fiff_get_fid, _get_next_fname
 from ..meas_info import read_meas_info
 from ..tree import dir_tree_find
 from ..tag import read_tag, read_tag_info
-from ..proj import make_eeg_average_ref_proj, _needs_eeg_average_ref_proj
+from ..proj import _make_eeg_average_ref_proj, _needs_eeg_average_ref_proj
 from ..base import (_BaseRaw, _RawShell, _check_raw_compatibility,
                     _check_maxshield)
 from ..utils import _mult_cal_one
@@ -137,8 +137,7 @@ class Raw(_BaseRaw):
 
         # combine information from each raw file to construct self
         if add_eeg_ref and _needs_eeg_average_ref_proj(self.info):
-            eeg_ref = make_eeg_average_ref_proj(self.info, activate=False)
-            self.add_proj(eeg_ref)
+            self.add_proj(_make_eeg_average_ref_proj(self.info))
 
         # combine annotations
         self.annotations = raws[0].annotations

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 from .constants import FIFF
-from .proj import _has_eeg_average_ref_proj, make_eeg_average_ref_proj
+from .proj import _has_eeg_average_ref_proj, _make_eeg_average_ref_proj
 from .pick import pick_types
 from .base import _BaseRaw
 from ..evoked import Evoked
@@ -287,7 +287,7 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
                  'has been left untouched.')
             return inst, None
         else:
-            inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
+            inst.add_proj(_make_eeg_average_ref_proj(inst.info))
             return inst, None
     else:
         logger.info('Applying a custom EEG reference.')

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -11,7 +11,7 @@ import numpy as np
 from .. import Epochs, compute_proj_evoked, compute_proj_epochs
 from ..utils import logger, verbose, warn
 from .. import pick_types
-from ..io import make_eeg_average_ref_proj
+from ..io.proj import _make_eeg_average_ref_proj
 from .ecg import find_ecg_events
 from .eog import find_eog_events
 
@@ -108,6 +108,9 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
     if not raw.preload:
         raise ValueError('raw needs to be preloaded, '
                          'use preload=True in constructor')
+    if avg_ref:
+        warn('avg_ref is deprecated and will be removed in 0.14',
+             DeprecationWarning)
 
     if no_proj:
         projs = []
@@ -117,8 +120,7 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
                     % len(projs))
 
     if avg_ref:
-        eeg_proj = make_eeg_average_ref_proj(raw.info)
-        projs.append(eeg_proj)
+        projs.append(_make_eeg_average_ref_proj(raw.info))
 
     if raw_event is None:
         raw_event = raw
@@ -260,6 +262,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
     bads : list
         List with (additional) bad channels.
     avg_ref : bool
+        Deprecated, use raw.set_eeg_reference().
         Add EEG average reference proj.
     no_proj : bool
         Exclude the SSP projectors currently in the fiff file.
@@ -353,6 +356,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
     bads : list
         List with (additional) bad channels.
     avg_ref : bool
+        Deprecated, use raw.set_eeg_reference().
         Add EEG average reference proj.
     no_proj : bool
         Exclude the SSP projectors currently in the fiff file.

--- a/mne/tests/common.py
+++ b/mne/tests/common.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import warnings
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 
@@ -97,9 +99,11 @@ def assert_dig_allclose(info_py, info_bin):
                         err_msg='Failure on %s:\n%s\n%s'
                         % (ii, d_py['r'], d_bin['r']))
     if any(d['kind'] == FIFF.FIFFV_POINT_EXTRA for d in dig_py):
-        r_bin, o_head_bin, o_dev_bin = fit_sphere_to_headshape(info_bin,
-                                                               units='m')
-        r_py, o_head_py, o_dev_py = fit_sphere_to_headshape(info_py, units='m')
+        with warnings.catch_warnings(record=True):  # bad distances
+            r_bin, o_head_bin, o_dev_bin = fit_sphere_to_headshape(info_bin,
+                                                                   units='m')
+            r_py, o_head_py, o_dev_py = fit_sphere_to_headshape(info_py,
+                                                                units='m')
         assert_allclose(r_py, r_bin, atol=1e-6)
         assert_allclose(o_dev_py, o_dev_bin, rtol=1e-5, atol=1e-6)
         assert_allclose(o_head_py, o_head_bin, rtol=1e-5, atol=1e-6)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -18,7 +18,6 @@ from mne.simulation import simulate_evoked
 from mne.datasets import testing
 from mne.utils import (run_tests_if_main, _TempDir, slow_test, requires_mne,
                        run_subprocess)
-from mne.proj import make_eeg_average_ref_proj
 
 from mne.io import read_raw_fif, read_raw_ctf
 
@@ -120,7 +119,7 @@ def test_dipole_fitting():
         pick_types(evoked.info, meg=True, eeg=False)[::2],
         pick_types(evoked.info, meg=False, eeg=True)[::2]]))
     evoked.pick_channels([evoked.ch_names[p] for p in picks])
-    evoked.add_proj(make_eeg_average_ref_proj(evoked.info))
+    evoked.set_eeg_reference()
     write_evokeds(fname_sim, evoked)
 
     # Run MNE-C version


### PR DESCRIPTION
Closes #2310.

Implements a few changes:
1. Once a projection is applied, remove from proj the channels ignored when it was applied.
2. Throw a warning if reapplying a projection if the channels have changed.
3. Don't set proj = True in Epochs constructor based on raw.proj anymore. This requires a bit of a hacky solution. Our `Epochs` code relies on `epochs.proj` to decide whether or not to project, which is a property 
   in the `ProjMixin` that just looks at the `active` state of all projs, which will be `True` if `raw.apply_proj()` is done. So to work around this I've added a private `._proj_bypass` attribute based on the `Epochs(..., proj=?)` parameter that gets passed.
4. ~~Deprecation cycle to change default `buffer_size_sec=10.` to a saner `buffer_size_sec=None` (i.e. use buffer size of input), which can be important for things like MaxFilter.~~

I'll have to look at how Travis reacts to these changes...
