### PR TITLE
Solving issue related with infomax when weights in not None

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -80,7 +80,7 @@ Changelog
 BUG
 ~~~
 
-    - Fixed Infomax/Extended Infomax when the user provides an initial weights matrix by `Jair Montoya Martínez`
+    - Fixed Infomax/Extended Infomax when the user provides an initial weights matrix by `Jair Montoya Martinez`_
     
     - Fixed channel selection order when MEG channels do not come first in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -80,6 +80,8 @@ Changelog
 BUG
 ~~~
 
+    - Fixed Infomax/Extended Infomax when the user provides an initial weights matrix by `Jair Montoya Martínez`
+    
     - Fixed channel selection order when MEG channels do not come first in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 
     - Fixed color ranges to correspond to the colorbar when plotting several time instances with :func:`mne.viz.plot_evoked_topomap` by `Jaakko Leppakangas`_

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -137,6 +137,8 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
     # initialize training
     if weights is None:
         weights = np.identity(n_features, dtype=np.float64)
+    else:
+        weights = weights.T
 
     BI = block * np.identity(n_features, dtype=np.float64)
     bias = np.zeros((n_features, 1), dtype=np.float64)

--- a/mne/preprocessing/tests/test_infomax.py
+++ b/mne/preprocessing/tests/test_infomax.py
@@ -123,6 +123,20 @@ def test_infomax_simple():
                 assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=1)
 
 
+def test_infomax_weights_ini():
+    """ Test the infomax algorithm when user provides an initial weights matrix.
+    """
+
+    X = np.random.random((3, 100))
+    weights = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float64)
+
+    w1 = infomax(X, max_iter=0, weights=weights, extended=True)
+    w2 = infomax(X, max_iter=0, weights=weights, extended=False)
+
+    assert_almost_equal(w1, weights)
+    assert_almost_equal(w2, weights)
+
+
 @requires_sklearn
 def test_non_square_infomax():
     """ Test non-square infomax


### PR DESCRIPTION
@Eric89GXL , @agramfort (this is the bug that I talked to you this week)

This pull request aims to solve an issue related with infomax when weights in not None.
The current infomax implementation does all its calculations using a transposed version of the weights matrix, and at the end it returns weights.T. But, if the user gives as input a weights matrix, infomax will take it as it is, that is, it will not transpose it, which results in a subtle error:
the algorithm will run, but the result will not be correct because it has not used the correct initial weights matrix.

Reproducibilitiy of this subtle error: 

If we run infomax using max_iter=0, the resulting weights matrix should be the same initial weights matrix provided by the user:

--------------------------------------------------------------------------------
import numpy as np
from mne.preprocessing.infomax_ import infomax

X = np.random.random((3, 100))
weights = np.array([[1,2,3],[4,5,6],[7,8,9]], dtype=np.float64)

w1 = infomax(X, max_iter=0, weights=weights, extended=True)
w2 = infomax(X, max_iter=0, weights=weights, extended=False)
--------------------------------------------------------------------------------

Here we can see that the resulting weights matrix is the transposed version of the weights matrix provided by the user, which is an error.

This pull request contains the solution to this issue, as well as the corresponding test.