### PR TITLE
MRG: Buffer size 1 sec

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -83,7 +83,9 @@ BUG
 ~~~
 
     - Fixed Infomax/Extended Infomax when the user provides an initial weights matrix by `Jair Montoya Martinez`_
-    
+
+    - Fixed the default raw FIF writing buffer size to be 1 second instead of 10 seconds by `Eric Larson`_
+
     - Fixed channel selection order when MEG channels do not come first in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 
     - Fixed color ranges to correspond to the colorbar when plotting several time instances with :func:`mne.viz.plot_evoked_topomap` by `Jaakko Leppakangas`_
@@ -124,7 +126,7 @@ BUG
 
         - Fix comparisons of filter settings for determining "strictest"/"weakest" filter
 
-        - Weakest filter is now used for heterogeneous channel filter settings, leading to more consistent behavior with filtering methods applied to a subset of channels (e.g. ``Raw.filter`` with ``picks != None``).  
+        - Weakest filter is now used for heterogeneous channel filter settings, leading to more consistent behavior with filtering methods applied to a subset of channels (e.g. ``Raw.filter`` with ``picks != None``).
 
     - Fixed plotting and timing of :class:`Annotations` and restricted addition of annotations outside data range to prevent problems with cropping and concatenating data by `Jaakko Leppakangas`_
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1395,7 +1395,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return raw
 
     @verbose
-    def save(self, fname, picks=None, tmin=0, tmax=None, buffer_size_sec=10,
+    def save(self, fname, picks=None, tmin=0, tmax=None, buffer_size_sec=None,
              drop_small_buffer=False, proj=False, fmt='single',
              overwrite=False, split_size='2GB', verbose=None):
         """Save raw data to file
@@ -1861,10 +1861,7 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def _get_buffer_size(self, buffer_size_sec=None):
         """Helper to get the buffer size"""
         if buffer_size_sec is None:
-            if 'buffer_size_sec' in self.info:
-                buffer_size_sec = self.info['buffer_size_sec']
-            else:
-                buffer_size_sec = 10.0
+            buffer_size_sec = self.info.get('buffer_size_sec', 1.)
         return int(np.ceil(buffer_size_sec * self.info['sfreq']))
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1416,8 +1416,8 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Time in seconds of last sample to save. If None last sample
             is used.
         buffer_size_sec : float | None
-            Size of data chunks in seconds. If None, the buffer size of
-            the original file is used.
+            Size of data chunks in seconds. If None (default), the buffer
+            size of the original file is used.
         drop_small_buffer : bool
             Drop or not the last buffer. It is required by maxfilter (SSS)
             that only accepts raw files with buffers of the same size.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -458,7 +458,7 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, eog, misc, preload):
 
     # Some keys to be consistent with FIF measurement info
     info['description'] = None
-    info['buffer_size_sec'] = 10.
+    info['buffer_size_sec'] = 1.
     edf_info['nsamples'] = int(n_records * max_samp)
 
     # These are the conditions under which a stim channel will be interpolated

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -105,7 +105,7 @@ def _get_nicolet_info(fname, ch_type, eog, ecg, emg, misc):
     info = _empty_info(header_info['sample_freq'])
     info.update({'filename': fname,
                  'meas_date': calendar.timegm(date.utctimetuple()),
-                 'description': None, 'buffer_size_sec': 10.})
+                 'description': None, 'buffer_size_sec': 1.})
 
     if ch_type == 'eeg':
         ch_coil = FIFF.FIFFV_COIL_EEG


### PR DESCRIPTION
This fixes a long-standing bug where we defaulted to 10. sec instead of 1. sec for our raw FIF buffer size.

Ready for review/merge from my end.