### PR TITLE
fix sys channel in fieldtrip client

### DIFF
--- a/mne/externals/FieldTrip.py
+++ b/mne/externals/FieldTrip.py
@@ -309,7 +309,7 @@ class Client:
                 (chunk_type, chunk_len) = struct.unpack(
                     'II', payload[offset:offset + 8])
                 offset += 8
-                if offset + chunk_len < bufsize:
+                if offset + chunk_len > bufsize:
                     break
                 H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len

--- a/mne/externals/FieldTrip.py
+++ b/mne/externals/FieldTrip.py
@@ -309,7 +309,7 @@ class Client:
                 (chunk_type, chunk_len) = struct.unpack(
                     'II', payload[offset:offset + 8])
                 offset += 8
-                if offset + chunk_len > bufsize:
+                if offset + chunk_len < bufsize:
                     break
                 H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len

--- a/mne/externals/FieldTrip.py
+++ b/mne/externals/FieldTrip.py
@@ -309,7 +309,7 @@ class Client:
                 (chunk_type, chunk_len) = struct.unpack(
                     'II', payload[offset:offset + 8])
                 offset += 8
-                if offset + chunk_len >= bufsize:
+                if offset + chunk_len > bufsize:
                     break
                 H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len

--- a/mne/externals/FieldTrip.py
+++ b/mne/externals/FieldTrip.py
@@ -309,7 +309,7 @@ class Client:
                 (chunk_type, chunk_len) = struct.unpack(
                     'II', payload[offset:offset + 8])
                 offset += 8
-                if offset + chunk_len < bufsize:
+                if offset + chunk_len >= bufsize:
                     break
                 H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -171,6 +171,8 @@ class FieldTripClient(object):
                     this_info['kind'] = FIFF.FIFFV_ECG_CH
                 elif ch.startswith('MISC'):
                     this_info['kind'] = FIFF.FIFFV_MISC_CH
+                elif ch.startswith('SYS'):
+                    this_info['kind'] = FIFF.FIFFV_SYST_CH
 
                 # Fieldtrip already does calibration
                 this_info['range'] = 1.0


### PR DESCRIPTION
Tried to run `ftclient_rt_compute_psd` example on TRIUX system, and getting:

```
File "/home/jussi/projects/mne-python/mne/io/pick.py", line 301, in pick_types
    kind = info['chs'][k]['kind']

KeyError: 'kind'
```
Looking at the code, I discovered that 'kind' is not written for TRIUX sys channels which causes example to fail. Fixed here.
(Maybe the if..elif should also raise an exception for unknown channel types to make it safer).


