### PR TITLE
MRG: non partition cv in gat/decoding

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -102,6 +102,8 @@ Changelog
 BUG
 ~~~
 
+    - Raise error if the cv parameter of class:`mne.decoding.GeneralizationAcrossTime` and class:`mne.decoding.TimeDecoding` is not a partition and the predict_mode is "cross-validation" by `Jean-Remi King`_
+
     - Fixed a bug where selecting epochs using hierarchical event IDs (HIDs) was *and*-like instead of *or*-like. When doing e.g. ``epochs[('Auditory', 'Left')]``, previously all trials that contain ``'Auditory'`` *and* ``'Left'`` (like ``'Auditory/Left'``) would be selected, but now any conditions matching ``'Auditory'`` *or* ``'Left'`` will be selected (like ``'Auditory/Left'``, ``'Auditory/Right'``, and ``'Visual/Left'``). This is now consistent with how epoch selection was done without HID tags, e.g. ``epochs[['a', 'b']]`` would select all epochs of type ``'a'`` and type ``'b'``. By `Eric Larson`_
 
     - Fixed Infomax/Extended Infomax when the user provides an initial weights matrix by `Jair Montoya Martinez`_

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -323,9 +323,19 @@ def test_generalization_across_time():
     assert_true(0.0 <= np.min(scores) <= 1.0)
     assert_true(0.0 <= np.max(scores) <= 1.0)
 
+    # Test that error if cv is not partition
+    gat = GeneralizationAcrossTime(cv=cv_shuffle,
+                                   predict_mode='cross-validation')
+    gat.fit(epochs)
+    assert_raises(ValueError, gat.predict, epochs)
+    gat = GeneralizationAcrossTime(cv=cv_shuffle,
+                                   predict_mode='mean-prediction')
+    gat.fit(epochs)
+    gat.predict(epochs)
+
     # Test that gets error if train on one dataset, test on another, and don't
     # specify appropriate cv:
-    gat = GeneralizationAcrossTime(cv=cv_shuffle)
+    gat = GeneralizationAcrossTime()
     gat.fit(epochs)
     with warnings.catch_warnings(record=True):
         gat.fit(epochs)

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -212,6 +212,13 @@ class _GeneralizationAcrossTime(object):
                     'When predict_mode = "cross-validation", the training '
                     'and predicting cv schemes must be identical.')
 
+            # Check that cv is a partition: i.e. that each tested sample may
+            # have more than one prediction, such as with ShuffleSplit.
+            test_idx = [ii for _, test in self._cv_splits for ii in test]
+            if sum([sum(np.array(test_idx) == idx) > 1 for idx in test_idx]):
+                raise ValueError('cv must be a partition if predict_mode is '
+                                 '"cross-validation".')
+
         # Clean attributes
         for att in ['y_pred_', 'test_times_', 'scores_', 'scorer_', 'y_true_']:
             if hasattr(self, att):


### PR DESCRIPTION
I hadn't realized that some sklearn cv were not partitions, i.e. a given test sample may be predicted by different folds. 

IIUC, this is not supported by sklearn cross_val_predict. e.g. `cross_val_predict(clf, X, y, cv=ShuffleSplit()`

The previous behavior of mne.decoding.gat was to store the last prediction of each test (i.e. it just overwrite each prediction. Here we raise an explicit error if the user wants a cross-validation with a non partition cv.

Once again, we see the limit of internally handling the CV... 

@teonbrooks you're not going to be happy. 

closes https://github.com/mne-tools/mne-python/issues/3624
