### PR TITLE
MRG: plot_filter

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -466,12 +466,10 @@ EEG referencing:
    :toctree: generated/
    :template: function.rst
 
-   band_pass_filter
    construct_iir_filter
+   create_filter
    estimate_ringing_samples
    filter_data
-   high_pass_filter
-   low_pass_filter
    notch_filter
 
 Head position estimation:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - ...
+    - Add filter plotting function :func:`mne.viz.plot_filter` and creation function :func:`mne.filter.create_filter` by `Eric Larson`_
 
 BUG
 ~~~
@@ -25,7 +25,7 @@ BUG
 API
 ~~~
 
-    - ...
+    - The filtering functions ``band_pass_filter``, ``band_stop_filter``, ``low_pass_filter``, and ``high_pass_filter`` have been deprecated in favor of :func:`mne.filter.filter_data` by `Eric Larson`_
 
 .. _changes_0_13:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-    - Add filter plotting function :func:`mne.viz.plot_filter` and creation function :func:`mne.filter.create_filter` by `Eric Larson`_
+    - Add filter plotting functions :func:`mne.viz.plot_filter` and :func:`mne.viz.plot_ideal_filter` as well as filter creation function :func:`mne.filter.create_filter` by `Eric Larson`_
 
 BUG
 ~~~

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -9,7 +9,7 @@ from mne.connectivity.spectral import _CohEst
 
 from mne import SourceEstimate
 from mne.utils import run_tests_if_main, slow_test
-from mne.filter import band_pass_filter
+from mne.filter import filter_data
 
 trans_bandwidth = 2.5
 filt_kwargs = dict(filter_length='auto', fir_window='hamming', phase='zero',
@@ -53,9 +53,8 @@ def test_spectral_connectivity():
     # simulate connectivity from 5Hz..15Hz
     fstart, fend = 5.0, 15.0
     for i in range(n_epochs):
-        data[i, 1, :] = band_pass_filter(data[i, 0, :],
-                                         sfreq, fstart, fend,
-                                         **filt_kwargs)
+        data[i, 1, :] = filter_data(data[i, 0, :], sfreq, fstart, fend,
+                                    **filt_kwargs)
         # add some noise, so the spectrum is not exactly zero
         data[i, 1, :] += 1e-2 * np.random.randn(n_times)
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -977,8 +977,8 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
                 data, sfreq, None, None, None, None,
                 filter_length, method, phase, fir_window)
         if method == 'iir':
-            filt = dict() if iir_params is None else deepcopy(iir_params)
-            filt.update(b=np.array([1.]), a=np.array([1.]))
+            out = dict() if iir_params is None else deepcopy(iir_params)
+            out.update(b=np.array([1.]), a=np.array([1.]))
         else:
             freq = [0, sfreq / 2.]
             gain = [1., 1.]
@@ -1033,6 +1033,8 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
                     freq = [0] + freq
                     gain = [0] + gain
         else:
+            # This could possibly be removed after 0.14 release, but might
+            # as well leave it in to sanity check notch_filter
             if len(l_freq) != len(h_freq):
                 raise ValueError('l_freq and h_freq must be the same length')
             msg = 'Setting up band-stop filter'

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -642,9 +642,9 @@ def construct_iir_filter(iir_params, f_pass=None, f_stop=None, sfreq=None,
     return iir_params
 
 
-def _check_method(method, iir_params, extra_types):
+def _check_method(method, iir_params, extra_types=()):
     """Helper to parse method arguments"""
-    allowed_types = ['iir', 'fir', 'fft'] + extra_types
+    allowed_types = ['iir', 'fir', 'fft'] + list(extra_types)
     if not isinstance(method, string_types):
         raise TypeError('method must be a string')
     if method not in allowed_types:
@@ -783,6 +783,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
     """
     if not isinstance(data, np.ndarray):
         raise ValueError('data must be an array')
+    iir_params, method = _check_method(method, iir_params)
     filt = create_filter(
         data, sfreq, l_freq, h_freq, filter_length, l_trans_bandwidth,
         h_trans_bandwidth, method, iir_params, phase, fir_window)
@@ -969,7 +970,7 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
         l_freq = np.array(l_freq, float).ravel()
         if (l_freq == 0).all():
             l_freq = None
-    iir_params, method = _check_method(method, iir_params, [])
+    iir_params, method = _check_method(method, iir_params)
     if l_freq is None and h_freq is None:
         data, sfreq, _, _, _, _, filter_length, phase, fir_window = \
             _triage_filter_params(

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -787,7 +787,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
     filt = create_filter(
         data, sfreq, l_freq, h_freq, filter_length, l_trans_bandwidth,
         h_trans_bandwidth, method, iir_params, phase, fir_window)
-    if method == 'fir':
+    if method in ('fir', 'fft'):
         data = _overlap_add_filter(data, filt, None, phase, picks, n_jobs,
                                    copy)
     else:
@@ -1074,7 +1074,7 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
     return out
 
 
-@deprecated('band_stop_filter is deprecated and will be removed in 0.15, '
+@deprecated('band_pass_filter is deprecated and will be removed in 0.15, '
             'use filter_data instead.')
 @verbose
 def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='auto',
@@ -1168,9 +1168,6 @@ def band_pass_filter(x, Fs, Fp1, Fp2, filter_length='auto',
     See Also
     --------
     filter_data
-    band_stop_filter
-    high_pass_filter
-    low_pass_filter
     notch_filter
     resample
 
@@ -1292,9 +1289,6 @@ def band_stop_filter(x, Fs, Fp1, Fp2, filter_length='auto',
     See Also
     --------
     filter_data
-    band_pass_filter
-    high_pass_filter
-    low_pass_filter
     notch_filter
     resample
 
@@ -1404,9 +1398,6 @@ def low_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth='auto',
     See Also
     --------
     filter_data
-    band_pass_filter
-    band_stop_filter
-    high_pass_filter
     notch_filter
     resample
 
@@ -1513,9 +1504,6 @@ def high_pass_filter(x, Fs, Fp, filter_length='auto', trans_bandwidth='auto',
     See Also
     --------
     filter_data
-    band_pass_filter
-    band_stop_filter
-    low_pass_filter
     notch_filter
     resample
 
@@ -1633,10 +1621,6 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
     See Also
     --------
     filter_data
-    band_pass_filter
-    band_stop_filter
-    high_pass_filter
-    low_pass_filter
     resample
 
     Notes
@@ -1684,7 +1668,7 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
                 raise ValueError('notch_widths must be None, scalar, or the '
                                  'same length as freqs')
 
-    if method in ['fir', 'iir']:
+    if method in ('fir', 'iir'):
         # Speed this up by computing the fourier coefficients once
         tb_2 = trans_bandwidth / 2.0
         lows = [freq - nw / 2.0 - tb_2

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -812,7 +812,7 @@ def test_filter():
         data_bs, _ = raw_bs[picks, :]
         raw_notch = raw.copy().notch_filter(
             60.0, picks=picks, n_jobs=2, method='fir', filter_length='auto',
-            trans_bandwidth=2 * trans)
+            trans_bandwidth=2 * trans, phase='zero', fir_window='hamming')
     data_notch, _ = raw_notch[picks, :]
     assert_array_almost_equal(data_bs, data_notch, sig_dec_notch)
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -760,8 +760,7 @@ def test_filter():
 
     trans = 2.0
     filter_params = dict(picks=picks, filter_length='auto',
-                         h_trans_bandwidth=trans, l_trans_bandwidth=trans,
-                         phase='zero', fir_window='hamming')
+                         h_trans_bandwidth=trans, l_trans_bandwidth=trans)
     raw_lp = raw.copy().filter(None, 8.0, **filter_params)
     raw_hp = raw.copy().filter(16.0, None, **filter_params)
     raw_bp = raw.copy().filter(8.0 + trans, 16.0 - trans, **filter_params)
@@ -811,8 +810,8 @@ def test_filter():
         raw_bs = raw.copy().filter(60.0 + trans, 60.0 - trans, **filter_params)
         data_bs, _ = raw_bs[picks, :]
         raw_notch = raw.copy().notch_filter(
-            60.0, picks=picks, n_jobs=2, method='fir', filter_length='auto',
-            trans_bandwidth=2 * trans, phase='zero', fir_window='hamming')
+            60.0, picks=picks, n_jobs=2, method='fir',
+	    trans_bandwidth=2 * trans)
     data_notch, _ = raw_notch[picks, :]
     assert_array_almost_equal(data_bs, data_notch, sig_dec_notch)
 
@@ -872,9 +871,7 @@ def test_filter_picks():
         picks['meg'] = ch_type if ch_type in ('mag', 'grad') else False
         picks['fnirs'] = ch_type if ch_type in ('hbo', 'hbr') else False
         raw_ = raw.copy().pick_types(**picks)
-        raw_.filter(10, 30, l_trans_bandwidth='auto',
-                    h_trans_bandwidth='auto', filter_length='auto',
-                    phase='zero', fir_window='hamming')
+        raw_.filter(10, 30)
 
     # -- Error if no data channel
     for ch_type in ('misc', 'stim'):

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -811,7 +811,7 @@ def test_filter():
         data_bs, _ = raw_bs[picks, :]
         raw_notch = raw.copy().notch_filter(
             60.0, picks=picks, n_jobs=2, method='fir',
-	    trans_bandwidth=2 * trans)
+            trans_bandwidth=2 * trans)
     data_notch, _ = raw_notch[picks, :]
     assert_array_almost_equal(data_bs, data_notch, sig_dec_notch)
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -9,7 +9,7 @@ import numpy as np
 from .. import pick_types, pick_channels
 from ..externals.six import string_types
 from ..utils import logger, verbose, sum_squared, warn
-from ..filter import band_pass_filter
+from ..filter import filter_data
 from ..epochs import Epochs, _BaseEpochs
 from ..io.base import _BaseRaw
 from ..evoked import Evoked
@@ -52,10 +52,8 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
     """
     win_size = int(round((60.0 * sfreq) / 120.0))
 
-    filtecg = band_pass_filter(ecg, sfreq, l_freq, h_freq,
-                               filter_length=filter_length,
-                               l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
-                               phase='zero-double', fir_window='hann')
+    filtecg = filter_data(ecg, sfreq, l_freq, h_freq, None, filter_length,
+                          0.5, 0.5, phase='zero-double', fir_window='hann')
 
     ecg_abs = np.abs(filtecg)
     init = int(sfreq)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -9,7 +9,7 @@ import numpy as np
 from .peak_finder import peak_finder
 from .. import pick_types, pick_channels
 from ..utils import logger, verbose
-from ..filter import band_pass_filter
+from ..filter import filter_data
 from ..epochs import Epochs
 from ..externals.six import string_types
 
@@ -70,19 +70,17 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
 
     # filtering to remove dc offset so that we know which is blink and saccades
     fmax = np.minimum(45, sampling_rate / 2.0 - 0.75)  # protect Nyquist
-    filteog = np.array([band_pass_filter(
-        x, sampling_rate, 2, fmax, filter_length=filter_length,
-        l_trans_bandwidth=0.5, h_trans_bandwidth=0.5, phase='zero-double',
-        fir_window='hann') for x in eog])
+    filteog = np.array([filter_data(
+        x, sampling_rate, 2, fmax, None, filter_length, 0.5, 0.5,
+        phase='zero-double', fir_window='hann') for x in eog])
     temp = np.sqrt(np.sum(filteog ** 2, axis=1))
 
     indexmax = np.argmax(temp)
 
     # easier to detect peaks with filtering.
-    filteog = band_pass_filter(
-        eog[indexmax], sampling_rate, l_freq, h_freq,
-        filter_length=filter_length, l_trans_bandwidth=0.5,
-        h_trans_bandwidth=0.5, phase='zero-double', fir_window='hann')
+    filteog = filter_data(
+        eog[indexmax], sampling_rate, l_freq, h_freq, None,
+        filter_length, 0.5, 0.5, phase='zero-double', fir_window='hann')
 
     # detecting eog blinks and generating event file
 

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -297,8 +297,8 @@ def test_filters():
     # > Nyq/2
     assert_raises(ValueError, filter_data, a, sfreq, 4, sfreq / 2., None,
                   100, 1.0, 1.0)
-    assert_raises(ValueError, low_pass_filter, a, sfreq, sfreq / 2.,
-                  100, 1.0)
+    assert_raises(ValueError, filter_data, a, sfreq, -1, None, None,
+                  100, 1.0, 1.0)
     # check our short-filter warning:
     with warnings.catch_warnings(record=True) as w:
         # Warning for low attenuation

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -12,7 +12,7 @@ from mne.io import RawArray, read_raw_fif
 from mne.filter import (filter_data, resample, _resample_stim_channels,
                         construct_iir_filter, notch_filter, detrend,
                         _overlap_add_filter, _smart_pad, design_mne_c_filter,
-                        estimate_ringing_samples)
+                        estimate_ringing_samples, create_filter)
 
 from mne.utils import (sum_squared, run_tests_if_main, slow_test,
                        catch_logging, requires_version, _TempDir,
@@ -299,6 +299,10 @@ def test_filters():
                   100, 1.0, 1.0)
     assert_raises(ValueError, filter_data, a, sfreq, -1, None, None,
                   100, 1.0, 1.0)
+    # these should work
+    create_filter(a, sfreq, None, None)
+    create_filter(a, sfreq, None, None, method='iir')
+
     # check our short-filter warning:
     with warnings.catch_warnings(record=True) as w:
         # Warning for low attenuation

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -9,11 +9,10 @@ from scipy.signal import resample as sp_resample, butter
 
 from mne import create_info
 from mne.io import RawArray, read_raw_fif
-from mne.filter import (band_pass_filter, high_pass_filter, low_pass_filter,
-                        band_stop_filter, resample, _resample_stim_channels,
+from mne.filter import (filter_data, resample, _resample_stim_channels,
                         construct_iir_filter, notch_filter, detrend,
                         _overlap_add_filter, _smart_pad, design_mne_c_filter,
-                        estimate_ringing_samples, filter_data)
+                        estimate_ringing_samples)
 
 from mne.utils import (sum_squared, run_tests_if_main, slow_test,
                        catch_logging, requires_version, _TempDir,
@@ -144,53 +143,52 @@ def test_iir_stability():
     sig = np.empty(1000)
     sfreq = 1000
     # This will make an unstable filter, should throw RuntimeError
-    assert_raises(RuntimeError, high_pass_filter, sig, sfreq, 0.6,
+    assert_raises(RuntimeError, filter_data, sig, sfreq, 0.6, None,
                   method='iir', iir_params=dict(ftype='butter', order=8,
                                                 output='ba'))
     # This one should work just fine
-    high_pass_filter(sig, sfreq, 0.6, method='iir',
-                     iir_params=dict(ftype='butter', order=8, output='sos'))
+    filter_data(sig, sfreq, 0.6, None, method='iir',
+                iir_params=dict(ftype='butter', order=8, output='sos'))
     # bad system type
-    assert_raises(ValueError, high_pass_filter, sig, sfreq, 0.6, method='iir',
+    assert_raises(ValueError, filter_data, sig, sfreq, 0.6, None, method='iir',
                   iir_params=dict(ftype='butter', order=8, output='foo'))
     # missing ftype
-    assert_raises(RuntimeError, high_pass_filter, sig, sfreq, 0.6,
+    assert_raises(RuntimeError, filter_data, sig, sfreq, 0.6, None,
                   method='iir', iir_params=dict(order=8, output='sos'))
     # bad ftype
-    assert_raises(RuntimeError, high_pass_filter, sig, sfreq, 0.6,
+    assert_raises(RuntimeError, filter_data, sig, sfreq, 0.6, None,
                   method='iir',
                   iir_params=dict(order=8, ftype='foo', output='sos'))
     # missing gstop
-    assert_raises(RuntimeError, high_pass_filter, sig, sfreq, 0.6,
+    assert_raises(RuntimeError, filter_data, sig, sfreq, 0.6, None,
                   method='iir', iir_params=dict(gpass=0.5, output='sos'))
     # can't pass iir_params if method='fft'
-    assert_raises(ValueError, high_pass_filter, sig, sfreq, 0.1,
+    assert_raises(ValueError, filter_data, sig, sfreq, 0.1, None,
                   method='fft', iir_params=dict(ftype='butter', order=2,
                                                 output='sos'))
     # method must be string
-    assert_raises(TypeError, high_pass_filter, sig, sfreq, 0.1,
+    assert_raises(TypeError, filter_data, sig, sfreq, 0.1, None,
                   method=1)
     # unknown method
-    assert_raises(ValueError, high_pass_filter, sig, sfreq, 0.1,
+    assert_raises(ValueError, filter_data, sig, sfreq, 0.1, None,
                   method='blah')
     # bad iir_params
-    assert_raises(TypeError, high_pass_filter, sig, sfreq, 0.1,
+    assert_raises(TypeError, filter_data, sig, sfreq, 0.1, None,
                   method='iir', iir_params='blah')
-    assert_raises(ValueError, high_pass_filter, sig, sfreq, 0.1,
+    assert_raises(ValueError, filter_data, sig, sfreq, 0.1, None,
                   method='fft', iir_params=dict())
 
     # should pass because dafault trans_bandwidth is not relevant
     iir_params = dict(ftype='butter', order=2, output='sos')
-    x_sos = high_pass_filter(sig, 250, 0.5, method='iir',
-                             iir_params=iir_params)
+    x_sos = filter_data(sig, 250, 0.5, None, method='iir',
+                        iir_params=iir_params)
     iir_params_sos = construct_iir_filter(iir_params, f_pass=0.5, sfreq=250,
                                           btype='highpass')
-    x_sos_2 = high_pass_filter(sig, 250, 0.5, method='iir',
-                               iir_params=iir_params_sos)
+    x_sos_2 = filter_data(sig, 250, 0.5, None, method='iir',
+                          iir_params=iir_params_sos)
     assert_allclose(x_sos[100:-100], x_sos_2[100:-100])
-    x_ba = high_pass_filter(sig, 250, 0.5, method='iir',
-                            iir_params=dict(ftype='butter', order=2,
-                                            output='ba'))
+    x_ba = filter_data(sig, 250, 0.5, None, method='iir',
+                       iir_params=dict(ftype='butter', order=2, output='ba'))
     # Note that this will fail for higher orders (e.g., 6) showing the
     # hopefully decreased numerical error of SOS
     assert_allclose(x_sos[100:-100], x_ba[100:-100])
@@ -289,33 +287,37 @@ def test_filters():
 
     # let's test our catchers
     for fl in ['blah', [0, 1], 1000.5, '10ss', '10']:
-        assert_raises(ValueError, band_pass_filter, a, sfreq, 4, 8, fl, 1., 1.)
+        assert_raises(ValueError, filter_data, a, sfreq, 4, 8, None, fl,
+                      1.0, 1.0)
     for nj in ['blah', 0.5]:
-        assert_raises(ValueError, band_pass_filter, a, sfreq, 4, 8, 100,
-                      1., 1., n_jobs=nj)
-    assert_raises(ValueError, band_pass_filter, a, sfreq, 4, 8, 100,
+        assert_raises(ValueError, filter_data, a, sfreq, 4, 8, None, 1000,
+                      1.0, 1.0, n_jobs=nj, phase='zero', fir_window='hann')
+    assert_raises(ValueError, filter_data, a, sfreq, 4, 8, None, 100,
                   1., 1., fir_window='foo')
     # > Nyq/2
-    assert_raises(ValueError, band_pass_filter, a, sfreq, 4, sfreq / 2.,
+    assert_raises(ValueError, filter_data, a, sfreq, 4, sfreq / 2., None,
                   100, 1.0, 1.0)
     assert_raises(ValueError, low_pass_filter, a, sfreq, sfreq / 2.,
                   100, 1.0)
     # check our short-filter warning:
     with warnings.catch_warnings(record=True) as w:
         # Warning for low attenuation
-        band_pass_filter(a, sfreq, 1, 8, filter_length=256)
+        filter_data(a, sfreq, 1, 8, filter_length=256)
     assert_true(any('attenuation' in str(ww.message) for ww in w))
     with warnings.catch_warnings(record=True) as w:
         # Warning for too short a filter
-        band_pass_filter(a, sfreq, 1, 8, filter_length='0.5s')
+        filter_data(a, sfreq, 1, 8, filter_length='0.5s')
     assert_true(any('Increase filter_length' in str(ww.message) for ww in w))
 
     # try new default and old default
     for fl in ['auto', '10s', '5000ms', 1024]:
-        bp = band_pass_filter(a, sfreq, 4, 8, fl, 1.0, 1.0)
-        bs = band_stop_filter(a, sfreq, 4 - 1.0, 8 + 1.0, fl, 1.0, 1.0)
-        lp = low_pass_filter(a, sfreq, 8, fl, 1.0, n_jobs=2)
-        hp = high_pass_filter(lp, sfreq, 4, fl, 1.0)
+        bp = filter_data(a, sfreq, 4, 8, None, fl, 1.0, 1.0)
+        bs = filter_data(a, sfreq, 8 + 1.0, 4 - 1.0, None, fl, 1.0, 1.0,
+                         phase='zero', fir_window='hamming')
+        lp = filter_data(a, sfreq, None, 8, None, fl, 10, 1.0, n_jobs=2,
+                         phase='zero', fir_window='hamming')
+        hp = filter_data(lp, sfreq, 4, None, None, fl, 1.0, 10, phase='zero',
+                         fir_window='hamming')
         assert_array_almost_equal(hp, bp, 4)
         assert_array_almost_equal(bp + bs, a, 4)
 
@@ -366,16 +368,16 @@ def test_filters():
     a = rng.randn(5 * sfreq, 5 * sfreq)
     b = a[:, None, :]
 
-    a_filt = band_pass_filter(a, sfreq, 4, 8, 400, 2.0, 2.0)
-    b_filt = band_pass_filter(b, sfreq, 4, 8, 400, 2.0, 2.0, picks=[0])
+    a_filt = filter_data(a, sfreq, 4, 8, None, 400, 2.0, 2.0)
+    b_filt = filter_data(b, sfreq, 4, 8, [0], 400, 2.0, 2.0)
 
     assert_array_equal(a_filt[:, None, :], b_filt)
 
     # check for n-dimensional case
     a = rng.randn(2, 2, 2, 2)
     with warnings.catch_warnings(record=True):  # filter too long
-        assert_raises(ValueError, band_pass_filter, a, sfreq, 4, 8, 100,
-                      1.0, 1.0, picks=np.array([0, 1]))
+        assert_raises(ValueError, filter_data, a, sfreq, 4, 8,
+                      np.array([0, 1]), 100, 1.0, 1.0)
 
 
 def test_filter_auto():
@@ -390,11 +392,11 @@ def test_filter_auto():
     t = np.arange(N) / sfreq
     x += np.sin(2 * np.pi * sine_freq * t)
     x_orig = x.copy()
-    x_filt = low_pass_filter(x, sfreq, lp)
+    x_filt = filter_data(x, sfreq, None, lp)
     assert_array_equal(x, x_orig)
     # the firwin2 function gets us this close
     assert_allclose(x, x_filt, rtol=1e-4, atol=1e-4)
-    assert_array_equal(x_filt, low_pass_filter(x, sfreq, lp))
+    assert_array_equal(x_filt, filter_data(x, sfreq, None, lp, None))
     assert_array_equal(x, x_orig)
     assert_array_equal(x_filt, filter_data(x, sfreq, None, lp))
     assert_array_equal(x, x_orig)
@@ -420,31 +422,24 @@ def test_cuda():
 
     with catch_logging() as log_file:
         for fl in ['auto', '10s', 2048]:
-            bp = band_pass_filter(a, sfreq, 4, 8, fl, 1.0, 1.0, n_jobs=1,
-                                  fir_window='hann')
-            bs = band_stop_filter(a, sfreq, 4 - 1.0, 8 + 1.0, fl, 1.0, 1.0,
-                                  n_jobs=1, fir_window='hann')
-            lp = low_pass_filter(a, sfreq, 8, fl, 1.0, n_jobs=1,
-                                 fir_window='hann')
-            hp = high_pass_filter(lp, sfreq, 4, fl, 1.0, n_jobs=1,
-                                  fir_window='hann')
-
-            bp_c = band_pass_filter(a, sfreq, 4, 8, fl, 1.0, 1.0,
-                                    n_jobs='cuda', verbose='INFO',
-                                    fir_window='hann')
-            bs_c = band_stop_filter(a, sfreq, 4 - 1.0, 8 + 1.0, fl, 1.0, 1.0,
-                                    n_jobs='cuda', verbose='INFO',
-                                    fir_window='hann')
-            lp_c = low_pass_filter(a, sfreq, 8, fl, 1.0,
-                                   n_jobs='cuda', verbose='INFO',
-                                   fir_window='hann')
-            hp_c = high_pass_filter(lp, sfreq, 4, fl, 1.0,
-                                    n_jobs='cuda', verbose='INFO',
-                                    fir_window='hann')
-
+            args = [a, sfreq, 4, 8, None, fl, 1.0, 1.0]
+            bp = filter_data(*args)
+            bp_c = filter_data(*args, n_jobs='cuda', verbose='info')
             assert_array_almost_equal(bp, bp_c, 12)
+
+            args = [a, sfreq, 8 + 1.0, 4 - 1.0, None, fl, 1.0, 1.0]
+            bs = filter_data(*args)
+            bs_c = filter_data(*args, n_jobs='cuda', verbose='info')
             assert_array_almost_equal(bs, bs_c, 12)
+
+            args = [a, sfreq, None, 8, None, fl, 1.0]
+            lp = filter_data(*args)
+            lp_c = filter_data(*args, n_jobs='cuda', verbose='info')
             assert_array_almost_equal(lp, lp_c, 12)
+
+            args = [lp, sfreq, 4, None, None, fl, 1.0]
+            hp = filter_data(*args)
+            hp_c = filter_data(*args, n_jobs='cuda', verbose='info')
             assert_array_almost_equal(hp, hp_c, 12)
 
     # check to make sure we actually used CUDA

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -10,7 +10,8 @@ from .utils import (tight_layout, mne_analyze_colormap, compare_fiff,
 from ._3d import (plot_sparse_source_estimates, plot_source_estimates,
                   plot_trans, plot_evoked_field, plot_dipole_locations)
 from .misc import (plot_cov, plot_bem, plot_events, plot_source_spectrogram,
-                   _get_presser, plot_dipole_amplitudes)
+                   _get_presser, plot_dipole_amplitudes, plot_ideal_filter,
+                   plot_filter, adjust_axes)
 from .evoked import (plot_evoked, plot_evoked_image, plot_evoked_white,
                      plot_snr_estimate, plot_evoked_topo,
                      plot_evoked_joint, plot_compare_evokeds)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -670,6 +670,8 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     h : tuple or ndarray
         Can be a (b, a) tuple, 1D ndarray (for FIR filter) or 2D ndarray
         for SOS filter.
+    sfreq : float
+        Sample rate of the data (Hz).
     freq : array-like or None
         The ideal response frequencies to plot.
         If None, do not plot the ideal response.
@@ -746,7 +748,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     return fig
 
 
-def plot_ideal_filter(freq, gain, ax, title='', flim=None, alim=(-60, 10),
+def plot_ideal_filter(freq, gain, axes, title='', flim=None, alim=(-60, 10),
                       color='r', alpha=0.5, linestyle='--', show=True):
     """Plot an ideal filter response.
 
@@ -804,14 +806,14 @@ def plot_ideal_filter(freq, gain, ax, title='', flim=None, alim=(-60, 10),
             my_freq.append(freq[ii])
             my_gain.append(gain[ii])
     my_gain = 10 * np.log10(np.maximum(my_gain, 10 ** (alim[0] / 10.)))
-    ax.fill_between(xs, alim[0], ys, color=color, alpha=0.1)
-    ax.semilogx(my_freq, my_gain, color=color, linestyle=linestyle,
-                alpha=0.5, linewidth=4, zorder=3)
-    xticks = _log_ticks(flim if flim is not None else ax.get_ylim())
-    ax.set(xlim=flim, ylim=alim, xticks=xticks, xlabel='Frequency (Hz)',
-           ylabel='Amplitude (dB)')
-    ax.set(xticklabels=xticks)
-    adjust_axes(ax)
+    axes.fill_between(xs, alim[0], ys, color=color, alpha=0.1)
+    axes.semilogx(my_freq, my_gain, color=color, linestyle=linestyle,
+                  alpha=0.5, linewidth=4, zorder=3)
+    xticks = _log_ticks(flim if flim is not None else axes.get_ylim())
+    axes.set(xlim=flim, ylim=alim, xticks=xticks, xlabel='Frequency (Hz)',
+             ylabel='Amplitude (dB)')
+    axes.set(xticklabels=xticks)
+    adjust_axes(axes)
     tight_layout()
     plt_show(show)
-    return ax.figure
+    return axes.figure

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -744,7 +744,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
             h = lfilter(h['b'], h['a'], delta)
         title = 'SOS (IIR) filter' if title is None else title
     else:
-        H = freqz(h, [1.], omega)[1]
+        H = freqz(h, worN=omega)[1]
         with warnings.catch_warnings(record=True):  # singular GD
             gd = group_delay((h, [1.]), omega)[1]
         title = 'FIR filter' if title is None else title
@@ -766,7 +766,6 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     for ax in axes[1:]:
         ax.set(xticks=xticks)
         ax.set(xticklabels=xticklabels, xlim=flim)
-    print(xticks, xticklabels)
     axes[1].set(ylim=alim,  ylabel='Amplitude (dB)')
     dlim = [0, 1.05 * gd[1:].max()]
     axes[2].set(ylim=dlim, ylabel='Delay (sec)', xlabel='Frequency (Hz)')

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -11,7 +11,7 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_raises, assert_allclose
+from numpy.testing import assert_raises
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -11,7 +11,7 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_raises
+from numpy.testing import assert_raises, assert_allclose
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)
@@ -62,20 +62,21 @@ def test_plot_filter():
     data = np.zeros(5000)
     freq = [0, 2, 40, 50, 500]
     gain = [0, 1, 1, 0, 0]
-    plot_filter(create_filter(data, sfreq, l_freq, h_freq), sfreq)
+    h = create_filter(data, sfreq, l_freq, h_freq)
+    plot_filter(h, sfreq)
     plt.close('all')
-    plot_filter(create_filter(data, sfreq, l_freq, h_freq), sfreq,
-                freq, gain)
+    plot_filter(h, sfreq, freq, gain)
     plt.close('all')
-    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir'),
-                sfreq)
+    iir = create_filter(data, sfreq, l_freq, h_freq, method='iir')
+    plot_filter(iir, sfreq)
     plt.close('all')
-    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir'),
-                sfreq,  freq, gain)
+    plot_filter(iir, sfreq,  freq, gain)
     plt.close('all')
-    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir',
-                              iir_params=dict(output='ba')),
-                sfreq,  freq, gain)
+    iir_ba = create_filter(data, sfreq, l_freq, h_freq, method='iir',
+                           iir_params=dict(output='ba'))
+    plot_filter(iir_ba, sfreq,  freq, gain)
+    plt.close('all')
+    plot_filter(h, sfreq, freq, gain, fscale='linear')
     plt.close('all')
 
 

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -16,11 +16,13 @@ from numpy.testing import assert_raises
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)
 from mne.datasets import testing
+from mne.filter import create_filter
 from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
-                     plot_snr_estimate)
-from mne.utils import requires_nibabel, run_tests_if_main, slow_test
+                     plot_snr_estimate, plot_filter)
+from mne.utils import (requires_nibabel, run_tests_if_main, slow_test,
+                       requires_version)
 
 # Set our plotters to test mode
 import matplotlib
@@ -50,6 +52,31 @@ def _get_raw():
 def _get_events():
     """Get events."""
     return read_events(event_fname)
+
+
+@requires_version('scipy', '0.16')
+def test_plot_filter():
+    """Test filter plotting."""
+    import matplotlib.pyplot as plt
+    l_freq, h_freq, sfreq = 2., 40., 1000.
+    data = np.zeros(5000)
+    freq = [0, 2, 40, 50, 500]
+    gain = [0, 1, 1, 0, 0]
+    plot_filter(create_filter(data, sfreq, l_freq, h_freq), sfreq)
+    plt.close('all')
+    plot_filter(create_filter(data, sfreq, l_freq, h_freq), sfreq,
+                freq, gain)
+    plt.close('all')
+    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir'),
+                sfreq)
+    plt.close('all')
+    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir'),
+                sfreq,  freq, gain)
+    plt.close('all')
+    plot_filter(create_filter(data, sfreq, l_freq, h_freq, method='iir',
+                              iir_params=dict(output='ba')),
+                sfreq,  freq, gain)
+    plt.close('all')
 
 
 def test_plot_cov():

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -436,7 +436,7 @@ plt.show()
 #           these phase issues can theoretically be mitigated.
 
 sos = signal.iirfilter(2, f_p / nyq, btype='low', ftype='butter', output='sos')
-plot_filter(sos, sfreq, freq, gain, 'Butterworth order=2', flim=flim)
+plot_filter(dict(sos=sos), sfreq, freq, gain, 'Butterworth order=2', flim=flim)
 
 # Eventually this will just be from scipy signal.sosfiltfilt, but 0.18 is
 # not widely adopted yet (as of June 2016), so we use our wrapper...
@@ -463,7 +463,7 @@ x_shallow = sosfiltfilt(sos, x)
 # with a longer impulse response:
 
 sos = signal.iirfilter(8, f_p / nyq, btype='low', ftype='butter', output='sos')
-plot_filter(sos, sfreq, freq, gain, 'Butterworth order=8', flim=flim)
+plot_filter(dict(sos=sos), sfreq, freq, gain, 'Butterworth order=8', flim=flim)
 x_steep = sosfiltfilt(sos, x)
 
 ###############################################################################
@@ -474,8 +474,8 @@ x_steep = sosfiltfilt(sos, x)
 
 sos = signal.iirfilter(8, f_p / nyq, btype='low', ftype='cheby1', output='sos',
                        rp=1)  # dB of acceptable pass-band ripple
-plot_filter(sos, sfreq, freq, gain, 'Chebychev-1 order=8, ripple=1 dB',
-            flim=flim)
+plot_filter(dict(sos=sos), sfreq, freq, gain,
+            'Chebychev-1 order=8, ripple=1 dB', flim=flim)
 
 ###############################################################################
 # And if we can live with even more ripple, we can get it slightly steeper,
@@ -484,8 +484,8 @@ plot_filter(sos, sfreq, freq, gain, 'Chebychev-1 order=8, ripple=1 dB',
 
 sos = signal.iirfilter(8, f_p / nyq, btype='low', ftype='cheby1', output='sos',
                        rp=6)
-plot_filter(sos, sfreq, freq, gain, 'Chebychev-1 order=8, ripple=6 dB',
-            flim=flim)
+plot_filter(dict(sos=sos), sfreq, freq, gain,
+            'Chebychev-1 order=8, ripple=6 dB', flim=flim)
 
 ###############################################################################
 # Applying IIR filters

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -322,7 +322,7 @@ freq = [0., f_p, f_s, sfreq / 2.]
 gain = [1., 1., 0., 0.]
 # This would be equivalent:
 # h = signal.firwin2(n, freq, gain, nyq=sfreq / 2.)
-h = mne.filter.create_filter(None, f_p, sfreq)
+h = mne.filter.create_filter(x, sfreq, l_freq=None, h_freq=f_p)
 x_shallow = np.convolve(h, x)[len(h) // 2:]
 
 plot_filter(h, sfreq, freq, gain, 'MNE-Python 0.14 default', flim=flim)
@@ -342,7 +342,7 @@ freq = [0., f_p, f_s, sfreq / 2.]
 gain = [1., 1., 0., 0.]
 # This would be equivalent
 # h = signal.firwin2(n, freq, gain, nyq=sfreq / 2.)
-h = mne.filter.create_filter(None, f_p, sfreq,
+h = mne.filter.create_filter(x, sfreq, l_freq=None, h_freq=f_p,
                              h_trans_bandwidth=transition_band,
                              filter_length='%ss' % filter_dur)
 x_steep = np.convolve(np.convolve(h, x)[::-1], h)[::-1][len(h) - 1:-len(h) - 1]

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -41,7 +41,7 @@ from mne import combine_evoked
 from mne.minimum_norm import apply_inverse
 from mne.datasets.brainstorm import bst_auditory
 from mne.io import read_raw_ctf
-from mne.filter import notch_filter, low_pass_filter
+from mne.filter import notch_filter, filter_data
 
 print(__doc__)
 
@@ -254,17 +254,10 @@ del epochs_standard, epochs_deviant
 # of this tutorial, we do it at evoked stage.
 if use_precomputed:
     sfreq = evoked_std.info['sfreq']
-    nchan = evoked_std.info['nchan']
     notches = [60, 120, 180]
-    for ch_idx in range(nchan):
-        evoked_std.data[ch_idx] = notch_filter(evoked_std.data[ch_idx], sfreq,
-                                               notches, verbose='ERROR')
-        evoked_dev.data[ch_idx] = notch_filter(evoked_dev.data[ch_idx], sfreq,
-                                               notches, verbose='ERROR')
-        evoked_std.data[ch_idx] = low_pass_filter(evoked_std.data[ch_idx],
-                                                  sfreq, 100, verbose='ERROR')
-        evoked_dev.data[ch_idx] = low_pass_filter(evoked_dev.data[ch_idx],
-                                                  sfreq, 100, verbose='ERROR')
+    for evoked in (evoked_std, evoked_dev):
+        evoked.data[:] = notch_filter(evoked.data, sfreq, notches)
+        evoked.data[:] = filter_data(evoked_std.data, sfreq, None, 100)
 
 ###############################################################################
 # Here we plot the ERF of standard and deviant conditions. In both conditions


### PR DESCRIPTION
Can't merge until #3622 is in.

This deprecates `band_stop_filter`, `band_pass_filter`, `low_pass_filter`, and `high_pass_filter` in favor of `filter_data` (one way to do things) but it's easy to undo the deprecation if that's preferred.

Still need to do some docstrings and eliminate some uses of newly deprecated functions, but the basic plotting functions are getting there.

Closes #3625.