### PR TITLE
FIX: 0-index ICA channel names in get_sources

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -786,7 +786,7 @@ class ICA(ContainsMixin):
         ch_names = []
         ch_info = info['chs'] = []
         for ii in range(self.n_components_):
-            this_source = 'ICA %03d' % (ii + 1)
+            this_source = 'ICA %03d' % (ii)
             ch_names.append(this_source)
             ch_info.append(dict(ch_name=this_source, cal=1,
                                 logno=ii + 1, coil_type=FIFF.FIFFV_COIL_NONE,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -786,7 +786,7 @@ class ICA(ContainsMixin):
         ch_names = []
         ch_info = info['chs'] = []
         for ii in range(self.n_components_):
-            this_source = 'ICA %03d' % (ii)
+            this_source = 'IC #%03d' % (ii)
             ch_names.append(this_source)
             ch_info.append(dict(ch_name=this_source, cal=1,
                                 logno=ii + 1, coil_type=FIFF.FIFFV_COIL_NONE,


### PR DESCRIPTION
Tiny fix to make ICA channel names 0-indexed in the output of ica.get_sources as they are in the ICA plot functions.

@dengemann 
