### PR TITLE
FIX: maxfilter channel names extra space bug

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -323,7 +323,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         meg_ch_names = [info['ch_names'][p] for p in meg_picks]
         # checking for extra space ambiguity in channel names
         # between old and new fif files
-        if meg_ch_names[0][3] != ctc_chs[0][3]:
+        if meg_ch_names[0] not in ctc_chs:
             ctc_chs = _clean_names(ctc_chs, remove_whitespace=True)
         missing = sorted(list(set(meg_ch_names) - set(ctc_chs)))
         if len(missing) != 0:

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -321,6 +321,10 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         sss_ctc = _read_ctc(cross_talk)
         ctc_chs = sss_ctc['proj_items_chs']
         meg_ch_names = [info['ch_names'][p] for p in meg_picks]
+        # checking for extra space ambiguity in channel names
+        # between old and new fif files
+        if meg_ch_names[0][3] != ctc_chs[0][3]:
+            ctc_chs = _clean_names(ctc_chs, remove_whitespace=True)
         missing = sorted(list(set(meg_ch_names) - set(ctc_chs)))
         if len(missing) != 0:
             raise RuntimeError('Missing MEG channels in cross-talk matrix:\n%s'

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -970,9 +970,9 @@ def test_triux():
                             st_duration=4., verbose=True)
     assert_meg_snr(sss_py, read_crop(tri_sss_st4_fname), 700., 1600)
 
+
 @testing.requires_testing_data
 def test_MGH_cross_talk():
-    """Test Maxwell filter with MGH cross-talk cancellation."""
     raw = read_crop(raw_fname, (0., 1.))
     print(raw_fname)
     raw_sss = maxwell_filter(raw, cross_talk=ctc_mgh_fname)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -970,4 +970,13 @@ def test_triux():
                             st_duration=4., verbose=True)
     assert_meg_snr(sss_py, read_crop(tri_sss_st4_fname), 700., 1600)
 
+@testing.requires_testing_data
+def test_MGH_cross_talk():
+    """Test Maxwell filter with MGH cross-talk cancellation."""
+    raw = read_crop(raw_fname, (0., 1.))
+    print(raw_fname)
+    raw_sss = maxwell_filter(raw, cross_talk=ctc_mgh_fname)
+    py_ctc = raw_sss.info['proc_history'][0]['max_info']['sss_ctc']
+    assert_true(len(py_ctc) > 0)
+
 run_tests_if_main()


### PR DESCRIPTION
Hi Eric,
Please review my changes to address extra space bug between old and new fif files.
Two files are changed, maxwell.py and test_maxwell.py as you suggested.