### PR TITLE
[MRG+1] FIX coreg-gui:  find head shapes

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -39,6 +39,7 @@ head_bem_fname = pformat(bem_fname, name='head')
 fid_fname = pformat(bem_fname, name='fiducials')
 fid_fname_general = os.path.join(bem_dirname, "{head}-fiducials.fif")
 src_fname = os.path.join(bem_dirname, '{subject}-{spacing}-src.fif')
+_head_fnames = (head_bem_fname, pformat(bem_fname, name='head-medium'))
 _high_res_head_fnames = (os.path.join(bem_dirname, '{subject}-head-dense.fif'),
                          os.path.join(surf_dirname, 'lh.seghead'),
                          os.path.join(surf_dirname, 'lh.smseghead'))
@@ -57,8 +58,9 @@ def _make_writable_recursive(path):
             _make_writable(os.path.join(root, f))
 
 
-def _find_high_res_head(subject, subjects_dir):
-    for fname in _high_res_head_fnames:
+def _find_head_bem(subject, subjects_dir, high_res=False):
+    fnames = _high_res_head_fnames if high_res else _head_fnames
+    for fname in fnames:
         path = fname.format(subjects_dir=subjects_dir, subject=subject)
         if os.path.exists(path):
             return path
@@ -729,8 +731,8 @@ def _is_mri_subject(subject, subjects_dir=None):
         Whether ``subject`` is an mri subject.
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
-    fname = head_bem_fname.format(subjects_dir=subjects_dir, subject=subject)
-    return os.path.exists(fname)
+    return bool(_find_head_bem(subject, subjects_dir) or
+                _find_head_bem(subject, subjects_dir, high_res=True))
 
 
 def _is_scaled_mri_subject(subject, subjects_dir=None):

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -27,8 +27,7 @@ except Exception:
         Property = View = Item = HGroup = VGroup = SceneEditor = \
         NoButtons = error = trait_wraith
 
-from ..coreg import (fid_fname, head_bem_fname, _find_fiducials_files,
-                     _find_head_bem)
+from ..coreg import fid_fname, _find_fiducials_files, _find_head_bem
 from ..io import write_fiducials
 from ..io.constants import FIFF
 from ..utils import get_subjects_dir, logger
@@ -181,8 +180,8 @@ class MRIHeadWithFiducialsModel(HasPrivateTraits):
         else:
             path = _find_head_bem(subject, subjects_dir)
             if not path:
-                error(None, "No standard head model was found for subject {0}, "
-                      "using high resolution head model instead."
+                error(None, "No standard head model was found for subject "
+                      "{0}, using high resolution head model instead."
                       .format(subject), "No Standard Resolution Head")
                 path = _find_head_bem(subject, subjects_dir, high_res=True)
         self.bem.file = path

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -28,7 +28,7 @@ except Exception:
         NoButtons = error = trait_wraith
 
 from ..coreg import (fid_fname, head_bem_fname, _find_fiducials_files,
-                     _find_high_res_head)
+                     _find_head_bem)
 from ..io import write_fiducials
 from ..io.constants import FIFF
 from ..utils import get_subjects_dir, logger
@@ -168,20 +168,23 @@ class MRIHeadWithFiducialsModel(HasPrivateTraits):
         if not subjects_dir or not subject:
             return
 
-        path = None
+        # find head model
         if self.use_high_res_head:
-            path = _find_high_res_head(subjects_dir=subjects_dir,
-                                       subject=subject)
+            path = _find_head_bem(subject, subjects_dir, high_res=True)
             if not path:
                 error(None, "No high resolution head model was found for "
                       "subject {0}, using standard head instead. In order to "
                       "generate a high resolution head model, run:\n\n"
                       "    $ mne make_scalp_surfaces -s {0}"
                       "\n\n".format(subject), "No High Resolution Head")
-
-        if not path:
-            path = head_bem_fname.format(subjects_dir=subjects_dir,
-                                         subject=subject)
+                path = _find_head_bem(subject, subjects_dir)
+        else:
+            path = _find_head_bem(subject, subjects_dir)
+            if not path:
+                error(None, "No standard head model was found for subject {0}, "
+                      "using high resolution head model instead."
+                      .format(subject), "No Standard Resolution Head")
+                path = _find_head_bem(subject, subjects_dir, high_res=True)
         self.bem.file = path
 
         # find fiducials file


### PR DESCRIPTION
I noticed that after just running `$ mne make_scalp_surfaces` I did not have the standard head-bem.fif. Before this PR that was how subjects were discovered by the GUI. Now the heads from `$ mne make_scalp_surfaces` will also be discovered, and displaying the head shape will be consistent.