### PR TITLE
[MRG+1]: skip updating meas info on unknown channel type

### DIFF
--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -177,6 +177,7 @@ class FieldTripClient(object):
                 elif ch.startswith('SYS'):
                     this_info['kind'] = FIFF.FIFFV_SYST_CH
                 else:
+                    # cannot guess channel type, mark as MISC and warn later
                     this_info['kind'] = FIFF.FIFFV_MISC_CH
                     chs_unknown.append(ch)
 

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -175,6 +175,7 @@ class FieldTripClient(object):
                     this_info['kind'] = FIFF.FIFFV_SYST_CH
                 else:
                     # unknown channel type, do not include
+                    warn('Unknown channel type in FieldTrip header: %s' % ch)
                     continue
 
                 # Fieldtrip already does calibration

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -173,6 +173,9 @@ class FieldTripClient(object):
                     this_info['kind'] = FIFF.FIFFV_MISC_CH
                 elif ch.startswith('SYS'):
                     this_info['kind'] = FIFF.FIFFV_SYST_CH
+                else:
+                    # unknown channel type, do not include
+                    continue
 
                 # Fieldtrip already does calibration
                 this_info['range'] = 1.0

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -146,6 +146,9 @@ class FieldTripClient(object):
 
             # channel dictionary list
             info['chs'] = []
+            
+            # unrecognized channels
+            chs_unknown = []
 
             for idx, ch in enumerate(self.ft_header.labels):
                 this_info = dict()
@@ -174,9 +177,8 @@ class FieldTripClient(object):
                 elif ch.startswith('SYS'):
                     this_info['kind'] = FIFF.FIFFV_SYST_CH
                 else:
-                    # unknown channel type, do not include
-                    warn('Unknown channel type in FieldTrip header: %s' % ch)
-                    continue
+                    this_info['kind'] = FIFF.FIFFV_MISC_CH
+                    chs_unknown.append(ch)
 
                 # Fieldtrip already does calibration
                 this_info['range'] = 1.0
@@ -205,6 +207,13 @@ class FieldTripClient(object):
                 info['chs'].append(this_info)
                 info._update_redundant()
                 info._check_consistency()
+
+            if chs_unknown:
+                w = ('Following channels in the FieldTrip header were '
+                     'unrecognized and marked as MISC: ')
+                for ch_ in chs_unknown:
+                    w += ch_ + ' '
+                warn(w)
 
         else:
 

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -210,11 +210,9 @@ class FieldTripClient(object):
                 info._check_consistency()
 
             if chs_unknown:
-                w = ('Following channels in the FieldTrip header were '
-                     'unrecognized and marked as MISC: ')
-                for ch_ in chs_unknown:
-                    w += ch_ + ' '
-                warn(w)
+                msg = ('Following channels in the FieldTrip header were '
+                       'unrecognized and marked as MISC: ')
+                warn(msg + ', '.join(chs_unknown))
 
         else:
 

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -146,7 +146,7 @@ class FieldTripClient(object):
 
             # channel dictionary list
             info['chs'] = []
-            
+
             # unrecognized channels
             chs_unknown = []
 


### PR DESCRIPTION
I was testing the realtime client and got an error from `_guess_measurement_info` when it could not parse CHPI* channels that were sent (from a file) to the FieldTrip buffer. (The code does not write the 'kind' field for unknown channel types). I already had the same problem with TRIUX sys channels.

I propose this small fix that would simply skip updating `info['chs']` if it cannot comprehend the channel type. That should make it more future proof.


