### PR TITLE
adding numpy integer check

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1406,7 +1406,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
             raise ValueError("A GFP with less than 2 channels doesn't work, "
                              "please pick more channels.")
     else:
-        if not isinstance(picks[0], int):
+        if not isinstance(picks[0], (int, np.integer)):
             msg = "'picks' must be int or a list of int, not {0}."
             raise ValueError(msg.format(type(picks)))
         ch_names = [example.ch_names[pick] for pick in picks]


### PR DESCRIPTION
I noticed that in python 3 sometimes pick_channels will cause code to break, because it seems like numpy numeric types behave slightly differently. If you do `isinstance(np.int64(3), int)` it'll return False in python3, which caused some functions to error. This is just one example that I was currently trying to run, but it seems like we might need to find other places in the code where similar things are happening, and add a `np.integer` check as well?