### PR TITLE
Fix to animate_topomap.

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -413,8 +413,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         blit : bool
             Whether to use blit to optimize drawing. In general, it is
             recommended to use blit in combination with ``show=True``. If you
-            intend to save the animation it is better to disable blit.
-            Defaults to True.
+            intend to save the animation it is better to disable blit. Blit is
+            always disabled for MacOSX backend and if matplotlib is in
+            interactive mode. Defaults to True.
         show : bool
             Whether to show the animation. Defaults to True.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -641,7 +641,9 @@ def _animate_evoked_topomap(evoked, ch_type='mag', times=None, frame_rate=None,
     blit : bool
         Whether to use blit to optimize drawing. In general, it is recommended
         to use blit in combination with ``show=True``. If you intend to save
-        the animation it is better to disable blit. Defaults to True.
+        the animation it is better to disable blit. Blit is always disabled for
+        MacOSX backend and if matplotlib is in interactive mode. Defaults to
+        True.
     show : bool
         Whether to show the animation. Defaults to True.
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2027,8 +2027,9 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
     blit : bool
         Whether to use blit to optimize drawing. In general, it is recommended
         to use blit in combination with ``show=True``. If you intend to save
-        the animation it is better to disable blit. For MacOSX blit is always
-        disabled. Defaults to True.
+        the animation it is better to disable blit. Blit is always disabled for
+        MacOSX backend and if matplotlib is in interactive mode. Defaults to
+        True.
     show : bool
         Whether to show the animation. Defaults to True.
 
@@ -2059,7 +2060,13 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
         raise ValueError('All times must be inside the evoked time series.')
     frames = [np.abs(evoked.times - time).argmin() for time in times]
 
-    blit = False if plt.get_backend() == 'MacOSX' else blit
+    if blit and plt.isinteractive():
+        logger.info('blit not supported with matplotlib in interactive mode. '
+                    'Disabling blit.')
+        blit = False
+    elif plt.get_backend() == 'MacOSX':
+        logger.info('blit not supported for MacOSX backend. Disabling blit.')
+        blit = False
     picks, pos, merge_grads, _, ch_type = _prepare_topo_plot(evoked,
                                                              ch_type=ch_type,
                                                              layout=None)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2060,13 +2060,15 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
         raise ValueError('All times must be inside the evoked time series.')
     frames = [np.abs(evoked.times - time).argmin() for time in times]
 
-    if blit and plt.isinteractive():
-        logger.info('blit not supported with matplotlib in interactive mode. '
-                    'Disabling blit.')
-        blit = False
-    elif plt.get_backend() == 'MacOSX':
-        logger.info('blit not supported for MacOSX backend. Disabling blit.')
-        blit = False
+    if blit:
+        if plt.isinteractive():
+            logger.info('blit not supported with matplotlib in interactive '
+                        'mode. Disabling blit.')
+            blit = False
+        elif plt.get_backend() == 'MacOSX':
+            logger.info('blit not supported for MacOSX backend. '
+                        'Disabling blit.')
+            blit = False
     picks, pos, merge_grads, _, ch_type = _prepare_topo_plot(evoked,
                                                              ch_type=ch_type,
                                                              layout=None)


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3515

Disables blit when mpl in interactive mode.
