### PR TITLE
do not index empty list in _get_hpi_info

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -192,7 +192,9 @@ def _get_hpi_info(info, adjust=False, verbose=None):
     hpi_sub = info['hpi_subsystem']
     if 'event_channel' in hpi_sub:
         hpi_pick = pick_channels(info['ch_names'],
-                                 [hpi_sub['event_channel']])[0]
+                                 [hpi_sub['event_channel']])
+        if len(hpi_pick) > 0:
+            hpi_pick = hpi_pick[0]
     else:
         hpi_pick = None  # there is no pick!
     hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -193,8 +193,7 @@ def _get_hpi_info(info, adjust=False, verbose=None):
     if 'event_channel' in hpi_sub:
         hpi_pick = pick_channels(info['ch_names'],
                                  [hpi_sub['event_channel']])
-        if len(hpi_pick) > 0:
-            hpi_pick = hpi_pick[0]
+        hpi_pick = hpi_pick[0] if len(hpi_pick) > 0 else None
     else:
         hpi_pick = None  # there is no pick!
     hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]


### PR DESCRIPTION
I wanted to get HPI freqs from an Evoked where only MEG* channels were present using `_get_hpi_info`.
It failed, since in this case `pick_channels` returns an empty list trying to pick SYS201 and then the code tries to index it.
I added a check for nonempty list.