### PR TITLE
ENH: parallel jobs of tfr across wavelets

### DIFF
--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -65,7 +65,8 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
         """Init TimeFrequency transformer."""
         frequencies, sfreq, _, n_cycles, time_bandwidth, decim = \
             _check_tfr_param(frequencies, sfreq, method, True, n_cycles,
-                             time_bandwidth, use_fft, decim, output)
+                             time_bandwidth, use_fft, decim, output,
+                             parallel_across='channels')
         self.frequencies = frequencies
         self.sfreq = sfreq
         self.method = method

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -143,7 +143,7 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
         Xt = _compute_tfr(X, self.frequencies, self.sfreq, self.method,
                           self.n_cycles, True, self.time_bandwidth,
                           self.use_fft, self.decim, self.output, self.n_jobs,
-                          self.verbose)
+                          verbose=self.verbose, parallel_across='channels')
 
         # Back to original shape
         if not shape:

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -559,8 +559,8 @@ def test_compute_tfr():
         for pa in ('channels', 'frequencies'):
             out = _compute_tfr(data, freqs, sfreq, method='morlet',
                                decim=2, output=output, n_cycles=2.,
-                               n_jobs=2, parallel_across=pa)
-            assert_array_almost_equal(X, out)
+                               n_jobs=1, parallel_across=pa)
+            assert_array_equal(X, out)
     assert_raises(ValueError, _compute_tfr, data, freqs, parallel_across='foo')
     assert_raises(ValueError, _compute_tfr, data, freqs,
                   method='multitaper', parallel_across='frequencies')

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -552,4 +552,13 @@ def test_compute_tfr():
                                n_cycles=2.)
             assert_array_equal(shape[1:], out.shape)
 
+    # Test parallelization
+    X = _compute_tfr(data, freqs, sfreq, method='morlet',
+                     decim=2, output='avg_power', n_cycles=2.)
+    for pa in ('channels', 'frequencies'):
+        out = _compute_tfr(data, freqs, sfreq, method='morlet',
+                           decim=2, output='avg_power', n_cycles=2.,
+                           n_jobs=2, parallel_across=pa)
+        assert_array_almost_equal(X, out)
+
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -560,5 +560,8 @@ def test_compute_tfr():
                            decim=2, output='avg_power', n_cycles=2.,
                            n_jobs=2, parallel_across=pa)
         assert_array_almost_equal(X, out)
+    assert_raises(ValueError, _compute_tfr, data, freqs, parallel_across='foo')
+    assert_raises(ValueError, _compute_tfr, data, freqs,
+                  method='multitaper', parallel_across='frequencies')
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -553,13 +553,14 @@ def test_compute_tfr():
             assert_array_equal(shape[1:], out.shape)
 
     # Test parallelization
-    X = _compute_tfr(data, freqs, sfreq, method='morlet',
-                     decim=2, output='avg_power', n_cycles=2.)
-    for pa in ('channels', 'frequencies'):
-        out = _compute_tfr(data, freqs, sfreq, method='morlet',
-                           decim=2, output='avg_power', n_cycles=2.,
-                           n_jobs=2, parallel_across=pa)
-        assert_array_almost_equal(X, out)
+    for output in ('avg_power', 'power'):
+        X = _compute_tfr(data, freqs, sfreq, method='morlet',
+                         decim=2, output=output, n_cycles=2.)
+        for pa in ('channels', 'frequencies'):
+            out = _compute_tfr(data, freqs, sfreq, method='morlet',
+                               decim=2, output=output, n_cycles=2.,
+                               n_jobs=2, parallel_across=pa)
+            assert_array_almost_equal(X, out)
     assert_raises(ValueError, _compute_tfr, data, freqs, parallel_across='foo')
     assert_raises(ValueError, _compute_tfr, data, freqs,
                   method='multitaper', parallel_across='frequencies')

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -378,11 +378,13 @@ def _compute_tfr(epoch_data, frequencies, sfreq=1.0, method='morlet',
         # Parallelization is applied across frequencies.
         parallel, my_cwt, n_jobs = parallel_func(_tfr_loop_freqs, n_jobs)
         n_jobs = min(n_jobs, len(Ws[0]))
-        tfrs = parallel(my_cwt(epoch_data, w, output, use_fft, decim, dtype)
-                        for w in np.array_split(Ws[0], n_jobs))
-        tfrs = np.concatenate(tfrs, axis=0)
-        if not (('avg_' in output) or ('itc' in output)):
-            out = out.transpose(1, 0, 2, 3)  # from cfet to ecft
+        out = parallel(my_cwt(epoch_data, w, output, use_fft, decim, dtype)
+                       for w in np.array_split(Ws[0], n_jobs))
+        out = np.concatenate(out, axis=0)
+        if ('avg_' in output) or ('itc' in output):
+            out = out.transpose(1, 0, 2)  # from fct to cft
+        else:
+            out = out.transpose(2, 1, 0, 3)  # from cfet to ecft
     return out
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -373,7 +373,7 @@ def _compute_tfr(epoch_data, frequencies, sfreq=1.0, method='morlet',
 
         if ('avg_' not in output) and ('itc' not in output):
             # This is to enforce that the first dimension is for epochs
-            out = out.transpose(1, 0, 2, 3)  # from ceft to ecft
+            out = out.transpose(1, 0, 2, 3)  # from fcet to ecft
     else:
         # Parallelization is applied across frequencies.
         parallel, my_cwt, n_jobs = parallel_func(_tfr_loop_freqs, n_jobs)


### PR DESCRIPTION
This aims at optimizing the `_compute_tfr` function that I had cleaned up over the summer. It adds an option to parallelize across frequencies. It is computationally not quite as good when mkl is activated, but the memory load is much lower.

The usecase is intended towards audio decoding/STRF where we may need high time freq resolution of a few channels over long segments.

I know chris had his own implementation (couldn't find it anymore...), but I thought it'd be nice to have a single tfr function, rather than having too many redundancies.
