### PR TITLE
MRG: Fix info equiv check

### DIFF
--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -18,11 +18,10 @@ from nose.tools import assert_true, assert_raises, assert_not_equal
 from mne.datasets import testing
 from mne.io.constants import FIFF
 from mne.io import RawArray, concatenate_raws, read_raw_fif
-from mne.io.meas_info import _is_equal_dict
 from mne.io.tests.test_raw import _test_concat, _test_raw_reader
 from mne import (concatenate_events, find_events, equalize_channels,
                  compute_proj_raw, pick_types, pick_channels, create_info)
-from mne.utils import (_TempDir, requires_pandas, slow_test,
+from mne.utils import (_TempDir, requires_pandas, slow_test, object_diff,
                        requires_mne, run_subprocess, run_tests_if_main)
 from mne.externals.six.moves import zip, cPickle as pickle
 from mne.io.proc_history import _get_sss_rank
@@ -1142,7 +1141,7 @@ def test_add_channels():
     assert_raises(ValueError, raw_meg.copy().add_channels, [raw_arr])
     raw_meg.copy().add_channels([raw_arr], force_update_info=True)
     # Make sure that values didn't get overwritten
-    assert_true(_is_equal_dict([raw_arr.info['dev_head_t'], orig_head_t]))
+    assert_equal(object_diff(raw_arr.info['dev_head_t'], orig_head_t), '')
 
     # Now test errors
     raw_badsf = raw_eeg.copy()

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -14,10 +14,9 @@ from mne.surface import (read_morph_map, _compute_nearest,
                          fast_cross_3d, get_head_surf, read_curvature,
                          get_meg_helmet_surf)
 from mne.utils import (_TempDir, requires_mayavi, requires_tvtk,
-                       run_tests_if_main, slow_test)
+                       run_tests_if_main, slow_test, object_diff)
 from mne.io import read_info
 from mne.transforms import _get_trans
-from mne.io.meas_info import _is_equal_dict
 
 data_path = testing.data_path(download=False)
 subjects_dir = op.join(data_path, 'subjects')
@@ -136,7 +135,7 @@ def test_io_surface():
                                                     read_metadata=True)
         assert_array_equal(pts, c_pts)
         assert_array_equal(tri, c_tri)
-        assert_true(_is_equal_dict([vol_info, c_vol_info]))
+        assert_equal(object_diff(vol_info, c_vol_info), '')
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Dicts have no guaranteed order, so the `_is_equal_dict` using a `zip` of `.items()` was unsafe. This uses `object_diff`, which uses a more careful algorithm.

FYI @jaeilepp the CI failure from #3685 was random (as in unpredictable), but it was also real (as in not safely ignored). It made a test fail in #3707, for example. This should fix it, though.