### PR TITLE
read_montage and read_dig_montage now use the same nose fiducial name…

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -120,6 +120,8 @@ API
 
     - The measurement info :class:`Info` no longer contains a potentially misleading ``info['filename']`` entry. Use class properties like :attr:`mne.io.Raw.filenames` or :attr:`mne.Epochs.filename` instead by `Eric Larson`_
 
+    - Default fiducial name change from 'nz' to 'nasion' in :func:`mne.channels.read_montage`, so that it is the same for both :class: `mne.channels.Montage` and :class: `mne.channels.DigMontage` by `Leonardo Barbosa`_
+
 .. _changes_0_13:
 
 Version 0.13
@@ -1943,3 +1945,5 @@ of commits):
 .. _Annalisa Pascarella: http://www.iac.rm.cnr.it/~pasca/
 
 .. _Luke Bloy: https://scholar.google.com/citations?hl=en&user=Ad_slYcAAAAJ&view_op=list_works&sortby=pubdate
+
+.. _Leonardo Barbosa: https://github.com/noreun

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -304,7 +304,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         if ext == '.hpts':
             fids = ('2', '1', '3')  # Alternate cardinal point names
         else:
-            fids = ('nz', 'lpa', 'rpa')
+            fids = ('nasion', 'lpa', 'rpa')
 
         missing = [name for name in fids
                    if name not in names_lower]

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -133,7 +133,8 @@ def test_montage():
     montage = read_montage('standard_1020', ch_names=ch_names)
     assert_array_equal(ch_names, montage.ch_names)
 
-    # test transform
+    # test transform with "other" [choose .sfp, could be any != from hpts]
+    # fiducials == ('nasion', 'lpa', 'rpa')
     input_str = """
     eeg Fp1 -95.0 -31.0 -3.0
     eeg AF7 -81 -59 -3
@@ -145,7 +146,24 @@ def test_montage():
     fname = op.join(tempdir, 'test_fid.hpts')
     with open(fname, 'w') as fid:
         fid.write(input_str)
-    montage = read_montage(op.join(tempdir, 'test_fid.hpts'), transform=True)
+    montage = read_montage(op.join(tempdir, kind), transform=True)
+
+    # test transform with "other" [choose .sfp, could be any != from hpts]
+    # fiducials == ('nasion', 'lpa', 'rpa')
+    input_str = """
+    Fp1 -95.0 -31.0 -3.0
+    AF7 -81 -59 -3
+    AF3 -87 -41 28
+    nasion -91 0 -42
+    lpa 0 -91 -42
+    rpa 0 91 -42
+    """
+    kind = 'test_fid.sfp'
+    fname = op.join(tempdir, kind)
+    with open(fname, 'w') as fid:
+        fid.write(input_str)
+    montage = read_montage(op.join(tempdir, kind), transform=True)
+
     # check coordinate transformation
     pos = np.array([-95.0, -31.0, -3.0])
     nasion = np.array([-91, 0, -42])
@@ -155,14 +173,14 @@ def test_montage():
     trans = get_ras_to_neuromag_trans(fids[0], fids[1], fids[2])
     pos = apply_trans(trans, pos)
     assert_array_equal(montage.pos[0], pos)
-    idx = montage.ch_names.index('2')
+    idx = montage.ch_names.index('nasion')
     assert_array_equal(montage.pos[idx, [0, 2]], [0, 0])
-    idx = montage.ch_names.index('1')
+    idx = montage.ch_names.index('lpa')
     assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
-    idx = montage.ch_names.index('3')
+    idx = montage.ch_names.index('rpa')
     assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
     pos = np.array([-95.0, -31.0, -3.0])
-    montage_fname = op.join(tempdir, 'test_fid.hpts')
+    montage_fname = op.join(tempdir, kind)
     montage = read_montage(montage_fname, unit='mm')
     assert_array_equal(montage.pos[0], pos * 1e-3)
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -133,7 +133,7 @@ def test_montage():
     montage = read_montage('standard_1020', ch_names=ch_names)
     assert_array_equal(ch_names, montage.ch_names)
 
-    # test transform 
+    # test transform
     input_strs = ["""
     eeg Fp1 -95.0 -31.0 -3.0
     eeg AF7 -81 -59 -3
@@ -181,7 +181,8 @@ def test_montage():
         assert_array_equal(montage.pos[0], pos * 1e-3)
 
         # test with last
-        info = create_info(montage.ch_names, 1e3, ['eeg'] * len(montage.ch_names))
+        info = create_info(montage.ch_names, 1e3,
+                           ['eeg'] * len(montage.ch_names))
         _set_montage(info, montage)
         pos2 = np.array([c['loc'][:3] for c in info['chs']])
         assert_array_equal(pos2, montage.pos)
@@ -197,7 +198,7 @@ def test_montage():
         assert_array_equal(pos3, montage.pos)
         assert_equal(montage.ch_names, evoked.info['ch_names'])
 
-        # Warning should be raised when some EEG are not specified in the montage
+        # Warning should be raised when some EEG are not specified in montage
         with warnings.catch_warnings(record=True) as w:
             info = create_info(montage.ch_names + ['foo', 'bar'], 1e3,
                                ['eeg'] * (len(montage.ch_names) + 2))

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -133,80 +133,76 @@ def test_montage():
     montage = read_montage('standard_1020', ch_names=ch_names)
     assert_array_equal(ch_names, montage.ch_names)
 
-    # test transform with "other" [choose .sfp, could be any != from hpts]
-    # fiducials == ('nasion', 'lpa', 'rpa')
-    input_str = """
+    # test transform 
+    input_strs = ["""
     eeg Fp1 -95.0 -31.0 -3.0
     eeg AF7 -81 -59 -3
     eeg AF3 -87 -41 28
     cardinal 2 -91 0 -42
     cardinal 1 0 -91 -42
     cardinal 3 0 91 -42
-    """
-    fname = op.join(tempdir, 'test_fid.hpts')
-    with open(fname, 'w') as fid:
-        fid.write(input_str)
-    montage = read_montage(op.join(tempdir, kind), transform=True)
-
-    # test transform with "other" [choose .sfp, could be any != from hpts]
-    # fiducials == ('nasion', 'lpa', 'rpa')
-    input_str = """
+    """, """
     Fp1 -95.0 -31.0 -3.0
     AF7 -81 -59 -3
     AF3 -87 -41 28
     nasion -91 0 -42
     lpa 0 -91 -42
     rpa 0 91 -42
-    """
-    kind = 'test_fid.sfp'
-    fname = op.join(tempdir, kind)
-    with open(fname, 'w') as fid:
-        fid.write(input_str)
-    montage = read_montage(op.join(tempdir, kind), transform=True)
+    """]
 
-    # check coordinate transformation
-    pos = np.array([-95.0, -31.0, -3.0])
-    nasion = np.array([-91, 0, -42])
-    lpa = np.array([0, -91, -42])
-    rpa = np.array([0, 91, -42])
-    fids = np.vstack((nasion, lpa, rpa))
-    trans = get_ras_to_neuromag_trans(fids[0], fids[1], fids[2])
-    pos = apply_trans(trans, pos)
-    assert_array_equal(montage.pos[0], pos)
-    idx = montage.ch_names.index('nasion')
-    assert_array_equal(montage.pos[idx, [0, 2]], [0, 0])
-    idx = montage.ch_names.index('lpa')
-    assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
-    idx = montage.ch_names.index('rpa')
-    assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
-    pos = np.array([-95.0, -31.0, -3.0])
-    montage_fname = op.join(tempdir, kind)
-    montage = read_montage(montage_fname, unit='mm')
-    assert_array_equal(montage.pos[0], pos * 1e-3)
+    all_fiducials = [['2', '1', '3'], ['nasion', 'lpa', 'rpa']]
 
-    # test with last
-    info = create_info(montage.ch_names, 1e3, ['eeg'] * len(montage.ch_names))
-    _set_montage(info, montage)
-    pos2 = np.array([c['loc'][:3] for c in info['chs']])
-    assert_array_equal(pos2, montage.pos)
-    assert_equal(montage.ch_names, info['ch_names'])
+    kinds = ['test_fid.hpts',  'test_fid.sfp']
 
-    info = create_info(
-        montage.ch_names, 1e3, ['eeg'] * len(montage.ch_names))
+    for kind, fiducials, input_str in zip(kinds, all_fiducials, input_strs):
+        fname = op.join(tempdir, kind)
+        with open(fname, 'w') as fid:
+            fid.write(input_str)
+        montage = read_montage(op.join(tempdir, kind), transform=True)
 
-    evoked = EvokedArray(
-        data=np.zeros((len(montage.ch_names), 1)), info=info, tmin=0)
-    evoked.set_montage(montage)
-    pos3 = np.array([c['loc'][:3] for c in evoked.info['chs']])
-    assert_array_equal(pos3, montage.pos)
-    assert_equal(montage.ch_names, evoked.info['ch_names'])
+        # check coordinate transformation
+        pos = np.array([-95.0, -31.0, -3.0])
+        nasion = np.array([-91, 0, -42])
+        lpa = np.array([0, -91, -42])
+        rpa = np.array([0, 91, -42])
+        fids = np.vstack((nasion, lpa, rpa))
+        trans = get_ras_to_neuromag_trans(fids[0], fids[1], fids[2])
+        pos = apply_trans(trans, pos)
+        assert_array_equal(montage.pos[0], pos)
+        idx = montage.ch_names.index(fiducials[0])
+        assert_array_equal(montage.pos[idx, [0, 2]], [0, 0])
+        idx = montage.ch_names.index(fiducials[1])
+        assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
+        idx = montage.ch_names.index(fiducials[2])
+        assert_array_equal(montage.pos[idx, [1, 2]], [0, 0])
+        pos = np.array([-95.0, -31.0, -3.0])
+        montage_fname = op.join(tempdir, kind)
+        montage = read_montage(montage_fname, unit='mm')
+        assert_array_equal(montage.pos[0], pos * 1e-3)
 
-    # Warning should be raised when some EEG are not specified in the montage
-    with warnings.catch_warnings(record=True) as w:
-        info = create_info(montage.ch_names + ['foo', 'bar'], 1e3,
-                           ['eeg'] * (len(montage.ch_names) + 2))
+        # test with last
+        info = create_info(montage.ch_names, 1e3, ['eeg'] * len(montage.ch_names))
         _set_montage(info, montage)
-        assert_true(len(w) == 1)
+        pos2 = np.array([c['loc'][:3] for c in info['chs']])
+        assert_array_equal(pos2, montage.pos)
+        assert_equal(montage.ch_names, info['ch_names'])
+
+        info = create_info(
+            montage.ch_names, 1e3, ['eeg'] * len(montage.ch_names))
+
+        evoked = EvokedArray(
+            data=np.zeros((len(montage.ch_names), 1)), info=info, tmin=0)
+        evoked.set_montage(montage)
+        pos3 = np.array([c['loc'][:3] for c in evoked.info['chs']])
+        assert_array_equal(pos3, montage.pos)
+        assert_equal(montage.ch_names, evoked.info['ch_names'])
+
+        # Warning should be raised when some EEG are not specified in the montage
+        with warnings.catch_warnings(record=True) as w:
+            info = create_info(montage.ch_names + ['foo', 'bar'], 1e3,
+                               ['eeg'] * (len(montage.ch_names) + 2))
+            _set_montage(info, montage)
+            assert_true(len(w) == 1)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Following [issue 3699](https://github.com/mne-tools/mne-python/issues/3699), the fiducials names should be standardized.