### PR TITLE
FIX: anonymize info when missing fields

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,8 @@ BUG
 
     - Fix bug with finding layouts in :func:`mne.viz.plot_projs_topomap` by `Eric Larson`_
 
+    - Fix bug :func:`mne.io.anonymize_info` when Info does not contain 'file_id' or 'meas_id' fields by `Jean-Remi King`_
+
 API
 ~~~
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1577,10 +1577,11 @@ def anonymize_info(info):
         del info['subject_info']
     info['meas_date'] = [0, 0]
     for key_1 in ('file_id', 'meas_id'):
-        if (key_1 not in info.keys()) or (info[key_1] is None):
+        key = info.get(key_1)
+        if key is None:
             continue
         for key_2 in ('secs', 'msecs', 'usecs'):
-            if key_2 not in info[key_1].keys():
+            if key_2 not in key:
                 continue
             info[key_1][key_2] = 0
     return info

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1577,6 +1577,10 @@ def anonymize_info(info):
         del info['subject_info']
     info['meas_date'] = [0, 0]
     for key_1 in ('file_id', 'meas_id'):
+        if (key_1 not in info.keys()) or (info[key_1] is None):
+            continue
         for key_2 in ('secs', 'msecs', 'usecs'):
+            if key_2 not in info[key_1].keys():
+                continue
             info[key_1][key_2] = 0
     return info

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -370,5 +370,10 @@ def test_anonymize():
     assert_true(raw.info['file_id']['secs'] != orig_file_id)
     assert_true(raw.info['meas_id']['secs'] != orig_meas_id)
 
+    # Test no error for incomplete info
+    info = raw.info.copy()
+    info.pop('file_id')
+    anonymize_info(info)
+
 
 run_tests_if_main()


### PR DESCRIPTION
`anonymized()` throw me an error on some edf files whose file_id and meas_id fields where missing