### PR TITLE
[MRG] FIX RawKIT:  stim=list with stim_code='channel'

### DIFF
--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -188,11 +188,13 @@ class RawKIT(_BaseRaw):
                 else:
                     raise ValueError("stim needs to be list of int, '>' or "
                                      "'<', not %r" % str(stim))
-            elif np.max(stim) >= self._raw_extras[0]['nchan']:
-                raise ValueError('Tried to set stim channel %i, but sqd file '
-                                 'only has %i channels'
-                                 % (np.max(stim),
-                                    self._raw_extras[0]['nchan']))
+            else:
+                stim = np.asarray(stim, int)
+                if stim.max() >= self._raw_extras[0]['nchan']:
+                    raise ValueError(
+                        'Got stim=%s, but sqd file only has %i channels' %
+                        (stim, self._raw_extras[0]['nchan']))
+
             # modify info
             nchan = self._raw_extras[0]['nchan'] + 1
             ch_name = 'STI 014'

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -130,6 +130,11 @@ def test_raw_events():
     assert_array_equal(find_events(raw, output='step', consecutive=True),
                        evts(0, 160, 0, 160, 0))
 
+    raw = read_raw_kit(sqd_path, stim=range(160, 162), slope='+',
+                       stim_code='channel')
+    assert_array_equal(find_events(raw, output='step', consecutive=True),
+                       evts(0, 160, 0, 160, 0))
+
 
 def test_ch_loc():
     """Test raw kit loc."""


### PR DESCRIPTION
Small fix for the KIT reader. If stim was not coerced to an array that lead to problems later on.