### PR TITLE
adding 3d to 2d snapshot for ecog plotting

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 
     - Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` by `Eric Larson`_
 
+    - Add option to convert 3d electrode plots to a snapshot with 2d electrode positions with :func:`mne.viz.snapshot_brain_montage` by `Chris Holdgraf`_
+
 BUG
 ~~~
 

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -7,7 +7,8 @@ from .topo import plot_topo_image_epochs, iter_topography
 from .utils import (tight_layout, mne_analyze_colormap, compare_fiff,
                     ClickableImage, add_background_image, plot_sensors)
 from ._3d import (plot_sparse_source_estimates, plot_source_estimates,
-                  plot_trans, plot_evoked_field, plot_dipole_locations)
+                  plot_trans, plot_evoked_field, plot_dipole_locations,
+                  snapshot_brain_montage)
 from .misc import (plot_cov, plot_bem, plot_events, plot_source_spectrogram,
                    _get_presser, plot_dipole_amplitudes, plot_ideal_filter,
                    plot_filter, adjust_axes)

--- a/tutorials/plot_ecog.py
+++ b/tutorials/plot_ecog.py
@@ -7,15 +7,18 @@ MNE supports working with more than just MEG and EEG data. Here we show some
 of the functions that can be used to facilitate working with
 electrocorticography (ECoG) data.
 """
-# Author: Eric Larson <larson.eric.d@gmail.com>
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Chris Holdgraf <choldgraf@gmail.com>
 #
 # License: BSD (3-clause)
 
+import numpy as np
+import matplotlib.pyplot as plt
 from scipy.io import loadmat
 from mayavi import mlab
 
 import mne
-from mne.viz import plot_trans
+from mne.viz import plot_trans, snapshot_brain_montage
 
 print(__doc__)
 
@@ -45,3 +48,27 @@ info = mne.create_info(ch_names, 1000., 'ecog', montage=mon)
 subjects_dir = mne.datasets.sample.data_path() + '/subjects'
 fig = plot_trans(info, trans=None, subject='sample', subjects_dir=subjects_dir)
 mlab.view(200, 70)
+
+###############################################################################
+# Sometimes it is useful to make a scatterplot for the current figure view.
+# This is best accomplished with matplotlib. We can capture an image of the
+# current mayavi view, along with the xy position of each electrode, with the
+# `snapshot_brain_montage` function.
+
+# We'll once again plot the surface, then take a snapshot.
+fig = plot_trans(info, trans=None, subject='sample', subjects_dir=subjects_dir)
+mlab.view(200, 70)
+xy, im = snapshot_brain_montage(fig, mon)
+
+# Convert from a dictionary to array to plot
+xy_pts = np.vstack(xy[ch] for ch in info['ch_names'])
+
+# Define an arbitrary "activity" pattern for viz
+activity = np.linspace(100, 200, xy_pts.shape[0])
+
+# This allows us to use matplotlib to create arbitrary 2d scatterplots
+_, ax = plt.subplots(figsize=(10, 10))
+ax.imshow(im)
+ax.scatter(*xy_pts.T, c=activity, s=200, cmap='coolwarm')
+ax.set_axis_off()
+plt.show()


### PR DESCRIPTION
Hey all - this a quick extension of @Eric89GXL's recent ecog plotting tutorial. We had discussed including a few functions in the example to show how you could create a snapshot of the current view for ecog plotting. In this PR, I'm adding these functions to the `_viz3d` module and added a `snapshot_montage` function for doing this automatically (and extended the example to show it).

I can delete those functions and just put the code in the example if people would prefer, but wanted to give an idea of what the code would look like if we just added the functionality. LMK what folks think.