### PR TITLE
MRG: Fixes for montage

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 
     - Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` by `Eric Larson`_
 
+    - Add support for FastTrack Polhemus ``.mat`` file outputs in ``hpts`` argument of :func:`mne.channels.read_dig_montage` by `Eric Larson`_
+
     - Add option to convert 3d electrode plots to a snapshot with 2d electrode positions with :func:`mne.viz.snapshot_brain_montage` by `Chris Holdgraf`_
 
     - Add skull surface plotting option to :func:`mne.viz.plot_trans` by `Jaakko Leppakangas`_
@@ -55,6 +57,8 @@ BUG
     - Fix colormap selection in :func:`mne.viz.plot_evoked_topomap` when using positive vmin with negative data by `Jaakko Leppakangas`_
 
     - Fix channel name comparison in :func:`mne.read_montage` so that if ``ch_names`` is provided, the returned montage will have channel names in the same letter case by `Jaakko Leppakangas`_
+
+    - Fix :meth:`inst.set_montage(montage) <mne.io.Raw.set_montage>` to only set ``inst.info['dev_head_t']`` if ``dev_head_t=True`` in :func:`mne.channels.read_dig_montage` by `Eric Larson`_
 
     - Fix handling of events in :class:`mne.realtime.RtEpochs` when the triggers were split between two buffers resulting in missing and/or duplicate epochs by `Mainak Jas`_ and `Antti Rantala`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Changelog
 
     - Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` by `Eric Larson`_
 
-    - Add support for FastTrack Polhemus ``.mat`` file outputs in ``hpts`` argument of :func:`mne.channels.read_dig_montage` by `Eric Larson`_
+    - Add support for FastTrack Polhemus ``.mat`` file outputs in ``hsp`` argument of :func:`mne.channels.read_dig_montage` by `Eric Larson`_
 
     - Add option to convert 3d electrode plots to a snapshot with 2d electrode positions with :func:`mne.viz.snapshot_brain_montage` by `Chris Holdgraf`_
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -418,7 +418,7 @@ class SetChannelsMixin(object):
 
     @verbose
     def set_montage(self, montage, verbose=None):
-        """Set EEG sensor configuration.
+        """Set EEG sensor configuration and head digitization.
 
         Parameters
         ----------

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -479,7 +479,7 @@ class DigMontage(object):
             dig_points=self.hsp, dig_ch_pos=self.dig_ch_pos)
 
     def save(self, fname):
-        """Save digitization points to FIF
+        """Save digitization points to FIF.
 
         Parameters
         ----------

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -480,7 +480,7 @@ class DigMontage(object):
     def _get_dig(self):
         """Get the digitization list."""
         return _make_dig_points(
-            nasion=self.nasion, lpa=self.lpa, rpa=self.rpa, hpi=self.hpi,
+            nasion=self.nasion, lpa=self.lpa, rpa=self.rpa, hpi=self.elp,
             extra_points=self.hsp, dig_ch_pos=self.dig_ch_pos)
 
     def save(self, fname):
@@ -526,7 +526,9 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
     hpi : None | str | array, shape (n_hpi, 3)
         If str, this corresponds to the filename of Head Position Indicator
         (HPI) points. If numpy.array, this corresponds to an array
-        of HPI points. These points are in device space.
+        of HPI points. These points are in device space, and are only
+        necessary if computation of a ``dev_head_t`` by the
+        :class:`DigMontage` is required.
     elp : None | str | array, shape (n_fids + n_hpi, 3)
         If str, this corresponds to the filename of electrode position
         points. This is typically used with the Polhemus FastSCAN system.

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -416,7 +416,8 @@ class DigMontage(object):
         """String representation."""
         s = ('<DigMontage | %d extras (headshape), %d HPIs, %d fiducials, %d '
              'channels>' %
-             (len(self.hsp), len(self.point_names),
+             (len(self.hsp) if self.hsp is not None else 0,
+              len(self.point_names) if self.point_names is not None else 0,
               sum(x is not None for x in (self.lpa, self.rpa, self.nasion)),
               len(self.dig_ch_pos) if self.dig_ch_pos is not None else 0,))
         return s
@@ -620,8 +621,8 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
                 _check_frame(d, 'head')
                 dig_ch_pos['EEG%03d' % d['ident']] = d['r']
         fids = [fids.get(key) for key in ('nasion', 'lpa', 'rpa')]
-        hsp = np.array(hsp)
-        elp = np.array(elp)
+        hsp = np.array(hsp) if len(hsp) else None
+        elp = np.array(elp) if len(elp) else None
         coord_frame = 'head'
     else:
         fids = [None] * 3

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -469,6 +469,9 @@ class DigMontage(object):
     def compute_dev_head_t(self):
         """Compute the Neuromag dev_head_t from matched points."""
         from ..coreg import fit_matched_points
+        if self.elp is None or self.hpi is None:
+            raise RuntimeError('must have both elp and hpi to compute the '
+                               'device to head transform')
         self.dev_head_t = fit_matched_points(tgt_pts=self.elp,
                                              src_pts=self.hpi, out='trans')
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -263,13 +263,15 @@ def test_set_dig_montage():
         rpa_dig = np.array([p['r'] for p in info['dig']
                             if all([p['ident'] == FIFF.FIFFV_POINT_RPA,
                                     p['kind'] == FIFF.FIFFV_POINT_CARDINAL])])
-        hpi_dig = np.array([p['r'] for p in info['dig']
-                            if p['kind'] == FIFF.FIFFV_POINT_HPI])
+        # hpi_dig = np.array([p['r'] for p in info['dig']
+        #                     if p['kind'] == FIFF.FIFFV_POINT_HPI])
         assert_allclose(hs, hsp_points, atol=1e-7)
         assert_allclose(nasion_dig.ravel(), nasion_point, atol=1e-7)
         assert_allclose(lpa_dig.ravel(), lpa_point, atol=1e-7)
         assert_allclose(rpa_dig.ravel(), rpa_point, atol=1e-7)
-        assert_allclose(hpi_dig, hpi_points, atol=1e-7)
+        # This does not actually match because the HPI points after
+        # conversion are in head coordinates!
+        # assert_allclose(hpi_dig, hpi_points, atol=1e-7)
 
 
 @testing.requires_testing_data

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -268,8 +268,6 @@ def test_set_dig_montage():
         assert_allclose(lpa_dig.ravel(), lpa_point, atol=1e-7)
         assert_allclose(rpa_dig.ravel(), rpa_point, atol=1e-7)
         assert_allclose(hpi_dig, hpi_points, atol=1e-7)
-        assert_allclose(use_mon.dev_head_t, info['dev_head_t']['trans'],
-                        atol=1e-7)
 
 
 @testing.requires_testing_data

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -233,11 +233,10 @@ def test_set_dig_montage():
     names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']
     hsp_points = _read_dig_points(hsp)
     elp_points = _read_dig_points(elp)
-    hpi_points = read_mrk(hpi)
-    p0, p1, p2 = elp_points[:3]
-    nm_trans = get_ras_to_neuromag_trans(p0, p1, p2)
+    nasion, lpa, rpa = elp_points[:3]
+    nm_trans = get_ras_to_neuromag_trans(nasion, lpa, rpa)
     elp_points = apply_trans(nm_trans, elp_points)
-    nasion_point, lpa_point, rpa_point = elp_points[:3]
+    nasion, lpa, rpa = elp_points[:3]
     hsp_points = apply_trans(nm_trans, hsp_points)
 
     montage = read_dig_montage(hsp, hpi, elp, names, transform=True,
@@ -263,15 +262,13 @@ def test_set_dig_montage():
         rpa_dig = np.array([p['r'] for p in info['dig']
                             if all([p['ident'] == FIFF.FIFFV_POINT_RPA,
                                     p['kind'] == FIFF.FIFFV_POINT_CARDINAL])])
-        # hpi_dig = np.array([p['r'] for p in info['dig']
-        #                     if p['kind'] == FIFF.FIFFV_POINT_HPI])
+        hpi_dig = np.array([p['r'] for p in info['dig']
+                            if p['kind'] == FIFF.FIFFV_POINT_HPI])
         assert_allclose(hs, hsp_points, atol=1e-7)
-        assert_allclose(nasion_dig.ravel(), nasion_point, atol=1e-7)
-        assert_allclose(lpa_dig.ravel(), lpa_point, atol=1e-7)
-        assert_allclose(rpa_dig.ravel(), rpa_point, atol=1e-7)
-        # This does not actually match because the HPI points after
-        # conversion are in head coordinates!
-        # assert_allclose(hpi_dig, hpi_points, atol=1e-7)
+        assert_allclose(nasion_dig.ravel(), nasion, atol=1e-7)
+        assert_allclose(lpa_dig.ravel(), lpa, atol=1e-7)
+        assert_allclose(rpa_dig.ravel(), rpa, atol=1e-7)
+        assert_allclose(hpi_dig, elp_points[3:], atol=1e-7)
 
 
 @testing.requires_testing_data

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -470,7 +470,7 @@ def _write_dig_points(fname, dig_points):
 
 
 def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
-                     dig_points=None, dig_ch_pos=None):
+                     extra_points=None, dig_ch_pos=None):
     """Construct digitizer info for the info.
 
     Parameters
@@ -483,7 +483,7 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
         Point designated as the right auricular point.
     hpi : array-like | numpy.ndarray, shape (n_points, 3) | None
         Points designated as head position indicator points.
-    dig_points : array-like | numpy.ndarray, shape (n_points, 3)
+    extra_points : array-like | numpy.ndarray, shape (n_points, 3)
         Points designed as the headshape points.
     dig_ch_pos : dict
         Dict of EEG channel positions.
@@ -496,56 +496,46 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
     dig = []
     if lpa is not None:
         lpa = np.asarray(lpa)
-        if lpa.shape == (3,):
-            dig.append({'r': lpa, 'ident': FIFF.FIFFV_POINT_LPA,
-                        'kind': FIFF.FIFFV_POINT_CARDINAL,
-                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('LPA should have the shape (3,) instead of %s'
-                   % (lpa.shape,))
-            raise ValueError(msg)
+        if lpa.shape != (3,):
+            raise ValueError('LPA should have the shape (3,) instead of %s'
+                             % (lpa.shape,))
+        dig.append({'r': lpa, 'ident': FIFF.FIFFV_POINT_LPA,
+                    'kind': FIFF.FIFFV_POINT_CARDINAL,
+                    'coord_frame': FIFF.FIFFV_COORD_HEAD})
     if nasion is not None:
         nasion = np.asarray(nasion)
-        if nasion.shape == (3,):
-            dig.append({'r': nasion, 'ident': FIFF.FIFFV_POINT_NASION,
-                        'kind': FIFF.FIFFV_POINT_CARDINAL,
-                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('Nasion should have the shape (3,) instead of %s'
-                   % (nasion.shape,))
-            raise ValueError(msg)
+        if nasion.shape != (3,):
+            raise ValueError('Nasion should have the shape (3,) instead of %s'
+                             % (nasion.shape,))
+        dig.append({'r': nasion, 'ident': FIFF.FIFFV_POINT_NASION,
+                    'kind': FIFF.FIFFV_POINT_CARDINAL,
+                    'coord_frame': FIFF.FIFFV_COORD_HEAD})
     if rpa is not None:
         rpa = np.asarray(rpa)
-        if rpa.shape == (3,):
-            dig.append({'r': rpa, 'ident': FIFF.FIFFV_POINT_RPA,
-                        'kind': FIFF.FIFFV_POINT_CARDINAL,
-                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('RPA should have the shape (3,) instead of %s'
-                   % (rpa.shape,))
-            raise ValueError(msg)
+        if rpa.shape != (3,):
+            raise ValueError('RPA should have the shape (3,) instead of %s'
+                             % (rpa.shape,))
+        dig.append({'r': rpa, 'ident': FIFF.FIFFV_POINT_RPA,
+                    'kind': FIFF.FIFFV_POINT_CARDINAL,
+                    'coord_frame': FIFF.FIFFV_COORD_HEAD})
     if hpi is not None:
         hpi = np.asarray(hpi)
-        if hpi.shape[1] == 3:
-            for idx, point in enumerate(hpi):
-                dig.append({'r': point, 'ident': idx + 1,
-                            'kind': FIFF.FIFFV_POINT_HPI,
-                            'coord_frame': FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('HPI should have the shape (n_points, 3) instead of '
-                   '%s' % (hpi.shape,))
-            raise ValueError(msg)
-    if dig_points is not None:
-        dig_points = np.asarray(dig_points)
-        if dig_points.shape[1] == 3:
-            for idx, point in enumerate(dig_points):
-                dig.append({'r': point, 'ident': idx + 1,
-                            'kind': FIFF.FIFFV_POINT_EXTRA,
-                            'coord_frame': FIFF.FIFFV_COORD_HEAD})
-        else:
-            msg = ('Points should have the shape (n_points, 3) instead of '
-                   '%s' % (dig_points.shape,))
-            raise ValueError(msg)
+        if hpi.ndim != 2 or hpi.shape[1] != 3:
+            raise ValueError('HPI should have the shape (n_points, 3) instead '
+                             'of %s' % (hpi.shape,))
+        for idx, point in enumerate(hpi):
+            dig.append({'r': point, 'ident': idx + 1,
+                        'kind': FIFF.FIFFV_POINT_HPI,
+                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
+    if extra_points is not None:
+        extra_points = np.asarray(extra_points)
+        if extra_points.shape[1] != 3:
+            raise ValueError('Points should have the shape (n_points, 3) '
+                             'instead of %s' % (extra_points.shape,))
+        for idx, point in enumerate(extra_points):
+            dig.append({'r': point, 'ident': idx + 1,
+                        'kind': FIFF.FIFFV_POINT_EXTRA,
+                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
     if dig_ch_pos is not None:
         keys = sorted(dig_ch_pos.keys())
         try:  # use the last 3 as int if possible (e.g., EEG001->1)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -370,7 +370,8 @@ def _read_dig_points(fname, comments='%', unit='auto'):
     Parameters
     ----------
     fname : str
-        The filepath of space delimited file with points.
+        The filepath of space delimited file with points, or a .mat file
+        (Polhemus FastTrak format).
     comments : str
         The character used to indicate the start of a comment;
         Default: '%'.
@@ -399,6 +400,9 @@ def _read_dig_points(fname, comments='%', unit='auto'):
         points_str = [m.groups() for m in re.finditer(coord_pattern, file_str,
                                                       re.MULTILINE)]
         dig_points = np.array(points_str, dtype=float)
+    elif ext == '.mat':  # like FastScan II
+        from scipy.io import loadmat
+        dig_points = loadmat(fname)['Points'].T
     else:
         dig_points = np.loadtxt(fname, comments=comments, ndmin=2)
         if unit == 'auto':

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -209,20 +209,20 @@ def test_io_dig_points():
 
 def test_make_dig_points():
     """Test application of Polhemus HSP to info."""
-    dig_points = _read_dig_points(hsp_fname)
+    extra_points = _read_dig_points(hsp_fname)
     info = create_info(ch_names=['Test Ch'], sfreq=1000., ch_types=None)
     assert_false(info['dig'])
 
-    info['dig'] = _make_dig_points(dig_points=dig_points)
+    info['dig'] = _make_dig_points(extra_points=extra_points)
     assert_true(info['dig'])
     assert_allclose(info['dig'][0]['r'], [-.10693, .09980, .06881])
 
-    dig_points = _read_dig_points(elp_fname)
-    nasion, lpa, rpa = dig_points[:3]
+    elp_points = _read_dig_points(elp_fname)
+    nasion, lpa, rpa = elp_points[:3]
     info = create_info(ch_names=['Test Ch'], sfreq=1000., ch_types=None)
     assert_false(info['dig'])
 
-    info['dig'] = _make_dig_points(nasion, lpa, rpa, dig_points[3:], None)
+    info['dig'] = _make_dig_points(nasion, lpa, rpa, elp_points[3:], None)
     assert_true(info['dig'])
     idx = [d['ident'] for d in info['dig']].index(FIFF.FIFFV_POINT_NASION)
     assert_array_equal(info['dig'][idx]['r'],
@@ -231,9 +231,9 @@ def test_make_dig_points():
     assert_raises(ValueError, _make_dig_points, None, lpa[:2])
     assert_raises(ValueError, _make_dig_points, None, None, rpa[:2])
     assert_raises(ValueError, _make_dig_points, None, None, None,
-                  dig_points[:, :2])
+                  elp_points[:, :2])
     assert_raises(ValueError, _make_dig_points, None, None, None, None,
-                  dig_points[:, :2])
+                  elp_points[:, :2])
 
 
 def test_redundant():
@@ -332,7 +332,7 @@ def test_check_consistency():
 
 
 def test_anonymize():
-    """Checks that sensitive information can be anonymized."""
+    """Test that sensitive information can be anonymized."""
     assert_raises(ValueError, anonymize_info, 'foo')
 
     # Fake some subject data

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -341,19 +341,25 @@ def write_ch_info(fid, ch):
         fid.write(b('\0') * (16 - len(ch_name)))
 
 
-def write_dig_point(fid, dig):
-    """Write a digitizer data point into a fif file."""
-    data_size = 5 * 4
-
-    fid.write(np.array(FIFF.FIFF_DIG_POINT, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_DIG_POINT_STRUCT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-
-    #   Start writing fiffDigPointRec
-    fid.write(np.array(dig['kind'], dtype='>i4').tostring())
-    fid.write(np.array(dig['ident'], dtype='>i4').tostring())
-    fid.write(np.array(dig['r'][:3], dtype='>f4').tostring())
+def write_dig_points(fid, dig, block=False, coord_frame=None):
+    """Write a set of digitizer data points into a fif file."""
+    if dig is not None:
+        data_size = 5 * 4
+        if block:
+            start_block(fid, FIFF.FIFFB_ISOTRAK)
+        if coord_frame is not None:
+            write_int(fid, FIFF.FIFF_MNE_COORD_FRAME, coord_frame)
+        for d in dig:
+            fid.write(np.array(FIFF.FIFF_DIG_POINT, '>i4').tostring())
+            fid.write(np.array(FIFF.FIFFT_DIG_POINT_STRUCT, '>i4').tostring())
+            fid.write(np.array(data_size, dtype='>i4').tostring())
+            fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, '>i4').tostring())
+            #   Start writing fiffDigPointRec
+            fid.write(np.array(d['kind'], '>i4').tostring())
+            fid.write(np.array(d['ident'], '>i4').tostring())
+            fid.write(np.array(d['r'][:3], '>f4').tostring())
+        if block:
+            end_block(fid, FIFF.FIFFB_ISOTRAK)
 
 
 def write_float_sparse_rcs(fid, kind, mat):

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -35,7 +35,8 @@ _str_to_frame = dict(meg=FIFF.FIFFV_COORD_DEVICE,
                      ras=FIFF.FIFFV_MNE_COORD_RAS,
                      fs_tal=FIFF.FIFFV_MNE_COORD_FS_TAL,
                      ctf_head=FIFF.FIFFV_MNE_COORD_CTF_HEAD,
-                     ctf_meg=FIFF.FIFFV_MNE_COORD_CTF_DEVICE)
+                     ctf_meg=FIFF.FIFFV_MNE_COORD_CTF_DEVICE,
+                     unknown=FIFF.FIFFV_COORD_UNKNOWN)
 _frame_to_str = dict((val, key) for key, val in _str_to_frame.items())
 
 _verbose_frames = {FIFF.FIFFV_COORD_UNKNOWN: 'unknown',
@@ -62,9 +63,9 @@ def _to_const(cf):
         if cf not in _str_to_frame:
             raise ValueError('Unknown cf %s' % cf)
         cf = _str_to_frame[cf]
-    elif not isinstance(cf, int):
+    elif not isinstance(cf, (int, np.integer)):
         raise TypeError('cf must be str or int, not %s' % type(cf))
-    return cf
+    return int(cf)
 
 
 class Transform(dict):

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -4,7 +4,7 @@ import numpy as np
 from .utils import plt_show
 
 
-def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
+def plot_montage(montage, scale_factor=20, show_names=False, show=True):
     """Plot a montage.
 
     Parameters
@@ -12,7 +12,7 @@ def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
     montage : instance of Montage
         The montage to visualize.
     scale_factor : float
-        Determines the size of the points. Defaults to 1.5.
+        Determines the size of the points. Defaults to 20.
     show_names : bool
         Whether to show the channel names. Defaults to False.
     show : bool
@@ -32,7 +32,7 @@ def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
 
     if isinstance(montage, Montage):
         pos = montage.pos
-        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2])
+        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2], s=scale_factor)
         if show_names:
             ch_names = montage.ch_names
             for ch_name, x, y, z in zip(ch_names, pos[:, 0],
@@ -40,7 +40,7 @@ def plot_montage(montage, scale_factor=1.5, show_names=False, show=True):
                 ax.text(x, y, z, ch_name)
     elif isinstance(montage, DigMontage):
         pos = np.vstack((montage.hsp, montage.elp))
-        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2])
+        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2], s=scale_factor)
         if show_names:
             if montage.point_names:
                 hpi_names = montage.point_names


### PR DESCRIPTION
Some minor fixes and refactoring of `Montage`/`DigMontage`, their associated reading functions, and docs.

Functionally a change is to allow reading of `.mat` output files from Polhemus FastTrak systems. Bugfix is that if `dev_head_t=False` in `read_dig_montage`, then `inst.set_montage(montage)` will *not* set the `inst.info['dev_head_t']`. In `master` it sets it to identity, which is probably not what we want.

Sound okay @teonbrooks?