### PR TITLE
ENH: Update docstrings in epochs.average() to clarify function with ICA channels

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -703,13 +703,14 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         # if instance contains ICA channels they won't be included unless picks
         # is specified
-        check_ICA = [x.startswith('ICA') for x in self.ch_names]
-        if np.all(check_ICA) and picks is None:
-            raise TypeError('picks must be specified (i.e. not None) for ICA '
-                            'channel data')
-        elif np.any(check_ICA) and picks is None:
-            warn('ICA channels will not be included unless explicitly '
-                 'selected in picks')
+        if picks is None:
+            check_ICA = [x.startswith('ICA') for x in self.ch_names]
+            if np.all(check_ICA):
+                raise TypeError('picks must be specified (i.e. not None) for '
+                                'ICA channel data')
+            elif np.any(check_ICA):
+                warn('ICA channels will not be included unless explicitly '
+                     'selected in picks')
 
         n_channels = len(self.ch_names)
         n_times = len(self.times)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -676,8 +676,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         they correspond to different conditions. To average by condition,
         do ``epochs[condition].average()`` for each condition separately.
 
-        Will not include ICA channels when picks=None. If object contains only
-        ICA channels, an error will occur.
+        Will not include ICA channels, when picks=None. If picks = None and the
+        object contains only ICA channels, an error will occur.
         """
         return self._compute_mean_or_stderr(picks, 'ave')
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -676,8 +676,10 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         they correspond to different conditions. To average by condition,
         do ``epochs[condition].average()`` for each condition separately.
 
-        Will not include ICA channels, when picks=None. If picks = None and the
-        object contains only ICA channels, an error will occur.
+        When picks is None and epochs contain only ICA channels, no channels
+        are selected, resulting in an error. This is because ICA channels
+        are not considered data channels (they are of misc type) and only data
+        channels are selected when picks is None.
         """
         return self._compute_mean_or_stderr(picks, 'ave')
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -676,7 +676,8 @@ class _BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         they correspond to different conditions. To average by condition,
         do ``epochs[condition].average()`` for each condition separately.
 
-        Will not include ICA channels when picks=None.
+        Will not include ICA channels when picks=None. If object contains only
+        ICA channels, an error will occur.
         """
         return self._compute_mean_or_stderr(picks, 'ave')
 


### PR DESCRIPTION
Adds warnings and readable errors to clarify how to use epochs.average() in the case of epochs object generated from `ica.get_sources`

as discussed in issue #3647 

@jona-sassenhagen @agramfort 