### PR TITLE
BUG: fix elp montage rotation

### DIFF
--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -593,8 +593,8 @@ def _sph_to_cart(sph):
     out = np.empty((len(sph), 3))
     out[:, 2] = sph[:, 0] * np.cos(sph[:, 2])
     xy = sph[:, 0] * np.sin(sph[:, 2])
-    out[:, 0] = xy * np.cos(sph[:, 1])
-    out[:, 1] = xy * np.sin(sph[:, 1])
+    out[:, 1] = xy * np.cos(sph[:, 1])
+    out[:, 0] = xy * np.sin(sph[:, 1])
     return out
 
 


### PR DESCRIPTION
With .elp channel locations, without this patch:

![unknown-75](https://cloud.githubusercontent.com/assets/4321826/20154431/89ee194a-a6c7-11e6-9446-207cc6dcef06.png)

with this patch:

![unknown-8](https://cloud.githubusercontent.com/assets/4321826/20154414/7cba3538-a6c7-11e6-906d-80f73086e8af.png)

Possibly related to #3613 and/or #3690 ?

@Eric89GXL can you check? I'm really not sure.