### PR TITLE
[MRG+1]: Allow re-referencing to average reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -267,6 +267,8 @@ API
 
     - :func:`mne.preprocessing.create_ecg_epochs` now includes all the channels when ``picks=None`` by `Jaakko Leppakangas`_
 
+    - :func:`mne.io.set_eeg_reference` now allows moving from a custom to an average EEG reference by `Marijn van Vliet`_
+
 Authors
 ~~~~~~~
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -672,8 +672,8 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
     if info.get('custom_ref_applied', False):
         raise RuntimeError('A custom reference has been applied to the '
                            'data earlier. Please use the '
-                           'mne.io.set_eeg_reference function to move from one '
-                           'EEG reference to another.')
+                           'mne.io.set_eeg_reference function to move from '
+                           'one EEG reference to another.')
 
     logger.info("Adding average EEG reference projection.")
     eeg_sel = pick_types(info, meg=False, eeg=True, ref_meg=False,

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -670,9 +670,10 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
         The SSP/PCA projector.
     """
     if info.get('custom_ref_applied', False):
-        raise RuntimeError('Cannot add an average EEG reference projection '
-                           'since a custom reference has been applied to the '
-                           'data earlier.')
+        raise RuntimeError('A custom reference has been applied to the '
+                           'data earlier. Please use the '
+                           'mne.io.set_eeg_reference function to move from one '
+                           'EEG reference to another.')
 
     logger.info("Adding average EEG reference projection.")
     eeg_sel = pick_types(info, meg=False, eeg=True, ref_meg=False,

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -292,7 +292,8 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
             custom_ref_applied = inst.info['custom_ref_applied']
             try:
                 inst.info['custom_ref_applied'] = False
-                inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
+                inst.add_proj(make_eeg_average_ref_proj(inst.info,
+                              activate=False))
             except Exception as e:
                 inst.info['custom_ref_applied'] = custom_ref_applied
                 raise e

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -294,9 +294,9 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
                 inst.info['custom_ref_applied'] = False
                 inst.add_proj(make_eeg_average_ref_proj(inst.info,
                               activate=False))
-            except Exception as e:
+            except:
                 inst.info['custom_ref_applied'] = custom_ref_applied
-                raise e
+                raise
 
             return inst, None
     else:

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -287,7 +287,16 @@ def set_eeg_reference(inst, ref_channels=None, copy=True):
                  'has been left untouched.')
             return inst, None
         else:
-            inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
+            # Creating an average reference may fail. In this case, make sure
+            # that the custom_ref_applied flag is left untouched.
+            custom_ref_applied = inst.info['custom_ref_applied']
+            try:
+                inst.info['custom_ref_applied'] = False
+                inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
+            except Exception as e:
+                inst.info['custom_ref_applied'] = custom_ref_applied
+                raise e
+
             return inst, None
     else:
         logger.info('Applying a custom EEG reference.')

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -142,6 +142,12 @@ def test_set_eeg_reference():
                                         copy=False)
     assert_true(raw is reref)
 
+    # Test moving from custom to average reference
+    reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
+    reref, _ = set_eeg_reference(reref)
+    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    assert_equal(reref.info['custom_ref_applied'], False)
+
     # When creating an average reference fails, make sure the
     # custom_ref_applied flag remains untouched.
     reref = raw.copy()

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -142,6 +142,14 @@ def test_set_eeg_reference():
                                         copy=False)
     assert_true(raw is reref)
 
+    # When creating an average reference fails, make sure the
+    # custom_ref_applied flag remains untouched.
+    reref = raw.copy()
+    reref.info['custom_ref_applied'] = True
+    reref.pick_types(eeg=False)  # Cause making average ref fail
+    assert_raises(ValueError, set_eeg_reference, reref)
+    assert_true(reref.info['custom_ref_applied'])
+
 
 @testing.requires_testing_data
 def test_set_bipolar_reference():
@@ -308,8 +316,6 @@ def test_add_reference():
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True, proj='delayed')
     epochs_ref = add_reference_channels(epochs, 'Ref', copy=True)
-    # CAR after custom reference is an Error
-    assert_raises(RuntimeError, epochs_ref.set_eeg_reference)
 
     assert_equal(epochs_ref._data.shape[1], epochs._data.shape[1] + 1)
     _check_channel_names(epochs_ref, 'Ref')


### PR DESCRIPTION
There was a check in place that explicitly disallows moving from a custom reference to an average reference. Upon consideration, I cannot think of any reason why this should be disallowed. When cleaning EEG data (marking bad channels, etc.) it is quite common to first use a custom reference and when the data is clean, move to an average reference.

This PR removes the check and allows re-referencing to an average reference.