### PR TITLE
ENH: verbose arg in set_eeg_reference

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -237,7 +237,8 @@ def _check_set(ch, projs, ch_type):
 class SetChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs."""
 
-    def set_eeg_reference(self, ref_channels=None):
+    @verbose
+    def set_eeg_reference(self, ref_channels=None, verbose=None):
         """Rereference EEG channels to new reference channel(s).
 
         If multiple reference channels are specified, they will be averaged. If
@@ -279,7 +280,8 @@ class SetChannelsMixin(object):
         mne.set_bipolar_reference
         """
         from ..io.reference import set_eeg_reference
-        return set_eeg_reference(self, ref_channels, copy=False)[0]
+        return set_eeg_reference(self, ref_channels, copy=False,
+                                 verbose=verbose)[0]
 
     def _get_channel_positions(self, picks=None):
         """Get channel locations from info.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -254,6 +254,10 @@ class SetChannelsMixin(object):
             is specified, the data is assumed to already have a proper
             reference and MNE will not attempt any re-referencing of the data.
             Defaults to an average reference (None).
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more).
 
         Returns
         -------
@@ -280,8 +284,7 @@ class SetChannelsMixin(object):
         mne.set_bipolar_reference
         """
         from ..io.reference import set_eeg_reference
-        return set_eeg_reference(self, ref_channels, copy=False,
-                                 verbose=verbose)[0]
+        return set_eeg_reference(self, ref_channels, copy=False)[0]
 
     def _get_channel_positions(self, picks=None):
         """Get channel locations from info.

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -12,7 +12,7 @@ from .pick import pick_types
 from .base import _BaseRaw
 from ..evoked import Evoked
 from ..epochs import _BaseEpochs
-from ..utils import logger, warn
+from ..utils import logger, warn, verbose
 
 
 def _apply_reference(inst, ref_from, ref_to=None):
@@ -231,7 +231,8 @@ def add_reference_channels(inst, ref_channels, copy=True):
     return inst
 
 
-def set_eeg_reference(inst, ref_channels=None, copy=True):
+@verbose
+def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
     """Rereference EEG channels to new reference channel(s).
 
     If multiple reference channels are specified, they will be averaged. If

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -252,6 +252,9 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
     copy : bool
         Specifies whether the data will be copied (True) or modified in place
         (False). Defaults to True.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------


### PR DESCRIPTION
I often use `progressbar.ProgressBar` to track progress in long-running analysis script. However, `set_eeg_reference` is verbose (without verbose argument) - which breaks the progressbar into separate lines ( 😞 ). I think there should be a verbose argument in these functions.

TODO:
- [x] add a test? (*not needed*)
- [x] maybe something is missing? (*seems not*)
- [x] argh, and I forgot about adding verbose to the docstring... will do