### PR TITLE
FIX: Remove IPython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,8 @@ install:
         source ${MNE_ROOT}/bin/mne_setup_sh;
         conda install --yes --quiet $ENSURE_PACKAGES pandas$PANDAS scikit-learn$SKLEARN h5py pillow;
         pip install -q joblib nibabel;
-        if [ "${PYTHON}" == "3.5" ]; then
-          conda install --yes --quiet $ENSURE_PACKAGES ipython;
-        else
-          conda install --yes --quiet $ENSURE_PACKAGES ipython statsmodels pandas$PANDAS;
+        if [ "${PYTHON}" != "3.5" ]; then
+          conda install --yes --quiet $ENSURE_PACKAGES statsmodels pandas$PANDAS;
           pip install nitime faulthandler;
           if [ "${NUMPY}" != "=1.8" ]; then
             conda install --yes --quiet $ENSURE_PACKAGES mayavi$MAYAVI;


### PR DESCRIPTION
With the latest `PySurfer` release we shouldn't need to install IPython anymore. If this works I'll merge.