### PR TITLE
fixing epochs image bug

### DIFF
--- a/examples/visualization/plot_channel_epochs_image.py
+++ b/examples/visualization/plot_channel_epochs_image.py
@@ -70,6 +70,10 @@ def order_func(times, data):
 good_pick = 97  # channel with a clear evoked response
 bad_pick = 98  # channel with no evoked response
 
+# We'll also plot a sample time onset for each trial
+plt_times = np.linspace(0, .2, len(epochs))
+
 plt.close('all')
 mne.viz.plot_epochs_image(epochs, [good_pick, bad_pick], sigma=0.5, vmin=-100,
-                          vmax=250, colorbar=True, order=order_func, show=True)
+                          vmax=250, colorbar=True, order=order_func,
+                          overlay_times=plt_times, show=True)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -197,7 +197,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                         aspect='auto', origin='lower', interpolation='nearest',
                         vmin=this_vmin, vmax=this_vmax, cmap=cmap[0])
         if this_overlay_times is not None:
-            plt.plot(1e3 * this_overlay_times, 0.5 + np.arange(len(this_data)),
+            ax1.plot(1e3 * this_overlay_times, 0.5 + np.arange(len(this_data)),
                      'k', linewidth=2)
         ax1.set_title(epochs.ch_names[idx])
         ax1.set_ylabel('Epochs')


### PR DESCRIPTION
A labmate of mine was trying to use the epochs image plotting and found this bug when trying to overlay times on an image plot:

![image](https://cloud.githubusercontent.com/assets/1839645/20414060/6fe82d50-ace5-11e6-8e92-15ccbe86a0d7.png)

I looked into the code and I'm pretty sure it's because there is some non-OOP matplotlib code in the `plot_epochs_image` function that is causing the line plot to show on the wrong axis. This just tries to make that fix and on my computer it fixes the problem.

I also added one line to the example so that this functionality is shown, in the hope that if something breaks in the future it will be easier to catch (since it seems that testing for matplotlib plots is tricky). LMK if people want it done differently. Here's the new output plot:

![image](https://cloud.githubusercontent.com/assets/1839645/20414122/c0ff09ac-ace5-11e6-9b20-01e9d9d3694f.png)

Note: I could do something like `epochs.times[np.argmax(data, axis=1)` to choose times according to the maximal amplitude of each trial, but this causes some timepoints that are way off and most likely noise to be picked for a few trials.
