### PR TITLE
[MRG+1] Make time-freq functions on arrays public.

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -961,6 +961,8 @@ Functions that operate on ``np.ndarray`` objects:
    stft
    istft
    stftfreq
+   psd_array_multitaper
+   psd_array_welch
 
 
 :py:mod:`mne.time_frequency.tfr`:

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -946,7 +946,9 @@ Functions that operate on mne-python objects:
    tfr_morlet
    tfr_multitaper
    tfr_stockwell
-   tfr_array
+   tfr_array_morlet
+   tfr_array_multitaper
+   tfr_array_stockwell
    read_tfrs
    write_tfrs
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -946,6 +946,7 @@ Functions that operate on mne-python objects:
    tfr_morlet
    tfr_multitaper
    tfr_stockwell
+   tfr_array
    read_tfrs
    write_tfrs
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -177,9 +177,7 @@ API
 
     - The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use :class:`mne.EvokedArray` with :func:`mne.decoding.get_coef` instead, by `Jean-Remi King`_
 
-    - Made functions :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing psd on numpy arrays by `Jaakko Leppakangas`_
-
-    - Made functions :func:`mne.time_frequency.tfr_array_multitaper`, :func:`mne.time_frequency.tfr_array_morlet`, :func:`mne.time_frequency.tfr_array_stockwell`, :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing psd on numpy arrays by `Jaakko Leppakangas`_
+    - Made functions :func:`mne.time_frequency.tfr_array_multitaper`, :func:`mne.time_frequency.tfr_array_morlet`, :func:`mne.time_frequency.tfr_array_stockwell`, :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing TFRs and PSDs on numpy arrays by `Jaakko Leppakangas`_
 
 .. _changes_0_13:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -177,6 +177,8 @@ API
 
     - The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use :class:`mne.EvokedArray` with :func:`mne.decoding.get_coef` instead, by `Jean-Remi King`_
 
+    - Made functions :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing psd on numpy arrays by `Jaakko Leppakangas`_
+
 .. _changes_0_13:
 
 Version 0.13

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -179,6 +179,8 @@ API
 
     - Made functions :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing psd on numpy arrays by `Jaakko Leppakangas`_
 
+    - Made functions :func:`mne.time_frequency.tfr_array_multitaper`, :func:`mne.time_frequency.tfr_array_morlet`, :func:`mne.time_frequency.tfr_array_stockwell`, :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing psd on numpy arrays by `Jaakko Leppakangas`_
+
 .. _changes_0_13:
 
 Version 0.13

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -5,7 +5,7 @@
 import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator
-from ..time_frequency.tfr import tfr_array, _check_tfr_param
+from ..time_frequency.tfr import _compute_tfr, _check_tfr_param
 
 
 class TimeFrequency(TransformerMixin, BaseEstimator):
@@ -139,9 +139,10 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
             X = X[:, np.newaxis, :]
 
         # Compute time-frequency
-        Xt = tfr_array(X, self.frequencies, self.sfreq, self.method,
-                       self.n_cycles, True, self.time_bandwidth, self.use_fft,
-                       self.decim, self.output, self.n_jobs, self.verbose)
+        Xt = _compute_tfr(X, self.frequencies, self.sfreq, self.method,
+                          self.n_cycles, True, self.time_bandwidth,
+                          self.use_fft, self.decim, self.output, self.n_jobs,
+                          self.verbose)
 
         # Back to original shape
         if not shape:

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -5,7 +5,7 @@
 import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator
-from ..time_frequency.tfr import _compute_tfr, _check_tfr_param
+from ..time_frequency.tfr import tfr_array, _check_tfr_param
 
 
 class TimeFrequency(TransformerMixin, BaseEstimator):
@@ -139,10 +139,9 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
             X = X[:, np.newaxis, :]
 
         # Compute time-frequency
-        Xt = _compute_tfr(X, self.frequencies, self.sfreq, self.method,
-                          self.n_cycles, True, self.time_bandwidth,
-                          self.use_fft, self.decim, self.output, self.n_jobs,
-                          self.verbose)
+        Xt = tfr_array(X, self.frequencies, self.sfreq, self.method,
+                       self.n_cycles, True, self.time_bandwidth, self.use_fft,
+                       self.decim, self.output, self.n_jobs, self.verbose)
 
         # Back to original shape
         if not shape:

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -11,7 +11,7 @@ from .base import BaseEstimator
 
 from .. import pick_types
 from ..filter import filter_data, _triage_filter_params
-from ..time_frequency.psd import _psd_multitaper
+from ..time_frequency.psd import psd_array_multitaper
 from ..externals import six
 from ..utils import _check_type_picks
 
@@ -343,7 +343,7 @@ class PSDEstimator(TransformerMixin):
         if not isinstance(epochs_data, np.ndarray):
             raise ValueError("epochs_data should be of type ndarray (got %s)."
                              % type(epochs_data))
-        psd, _ = _psd_multitaper(
+        psd, _ = psd_array_multitaper(
             epochs_data, sfreq=self.sfreq, fmin=self.fmin, fmax=self.fmax,
             bandwidth=self.bandwidth, adaptive=self.adaptive,
             low_bias=self.low_bias, normalization=self.normalization,

--- a/mne/minimum_norm/tests/test_time_frequency.py
+++ b/mne/minimum_norm/tests/test_time_frequency.py
@@ -20,7 +20,7 @@ from mne.minimum_norm.time_frequency import (source_band_induced_power,
                                              compute_source_psd_epochs)
 
 
-from mne.time_frequency.multitaper import _psd_multitaper
+from mne.time_frequency.multitaper import psd_array_multitaper
 
 data_path = testing.data_path(download=False)
 fname_inv = op.join(data_path, 'MEG', 'sample',
@@ -175,8 +175,9 @@ def test_source_psd_epochs():
                                prepared=True)[0]
 
     sfreq = epochs.info['sfreq']
-    psd, freqs = _psd_multitaper(stc.data, sfreq=sfreq, bandwidth=bandwidth,
-                                 fmin=fmin, fmax=fmax)
+    psd, freqs = psd_array_multitaper(stc.data, sfreq=sfreq,
+                                      bandwidth=bandwidth, fmin=fmin,
+                                      fmax=fmax)
 
     assert_array_almost_equal(psd, stc_psd.data)
     assert_array_almost_equal(freqs, stc_psd.times)

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -1,10 +1,11 @@
 """Time frequency analysis tools."""
 
 from .tfr import (morlet, tfr_morlet, AverageTFR, tfr_multitaper,
-                  read_tfrs, write_tfrs, EpochsTFR, tfr_array)
+                  read_tfrs, write_tfrs, EpochsTFR, tfr_array_morlet)
 from .psd import psd_welch, psd_multitaper, psd_array_welch
 from .csd import CrossSpectralDensity, csd_epochs, csd_array
 from .ar import fit_iir_model_raw
-from .multitaper import dpss_windows, psd_array_multitaper
+from .multitaper import (dpss_windows, psd_array_multitaper,
+                         tfr_array_multitaper)
 from .stft import stft, istft, stftfreq
-from ._stockwell import tfr_stockwell
+from ._stockwell import tfr_stockwell, tfr_array_stockwell

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -1,7 +1,7 @@
 """Time frequency analysis tools."""
 
 from .tfr import (morlet, tfr_morlet, AverageTFR, tfr_multitaper,
-                  read_tfrs, write_tfrs, EpochsTFR)
+                  read_tfrs, write_tfrs, EpochsTFR, tfr_array)
 from .psd import psd_welch, psd_multitaper, psd_array_welch
 from .csd import CrossSpectralDensity, csd_epochs, csd_array
 from .ar import fit_iir_model_raw

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -2,7 +2,7 @@
 
 from .tfr import (morlet, tfr_morlet, AverageTFR, tfr_multitaper,
                   read_tfrs, write_tfrs, EpochsTFR)
-from .psd import psd_welch, psd_multitaper
+from .psd import psd_welch, psd_multitaper, psd_array_welch
 from .csd import CrossSpectralDensity, csd_epochs, csd_array
 from .ar import fit_iir_model_raw
 from .multitaper import dpss_windows, psd_array_multitaper

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -5,6 +5,6 @@ from .tfr import (morlet, tfr_morlet, AverageTFR, tfr_multitaper,
 from .psd import psd_welch, psd_multitaper
 from .csd import CrossSpectralDensity, csd_epochs, csd_array
 from .ar import fit_iir_model_raw
-from .multitaper import dpss_windows
+from .multitaper import dpss_windows, psd_array_multitaper
 from .stft import stft, istft, stftfreq
 from ._stockwell import tfr_stockwell

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -97,8 +97,8 @@ def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     return psd, itc
 
 
-def _induced_power_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
-                             decim=1, return_itc=False, n_jobs=1):
+def tfr_array_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
+                        decim=1, return_itc=False, n_jobs=1):
     """Compute power and intertrial coherence using Stockwell (S) transform.
 
     Parameters
@@ -241,14 +241,11 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     info = pick_info(inst.info, picks)
     data = data[:, picks, :]
     n_jobs = check_n_jobs(n_jobs)
-    power, itc, freqs = _induced_power_stockwell(data,
-                                                 sfreq=info['sfreq'],
-                                                 fmin=fmin, fmax=fmax,
-                                                 n_fft=n_fft,
-                                                 width=width,
-                                                 decim=decim,
-                                                 return_itc=return_itc,
-                                                 n_jobs=n_jobs)
+    power, itc, freqs = tfr_array_stockwell(data, sfreq=info['sfreq'],
+                                            fmin=fmin, fmax=fmax, n_fft=n_fft,
+                                            width=width, decim=decim,
+                                            return_itc=return_itc,
+                                            n_jobs=n_jobs)
     times = inst.times[::decim].copy()
     nave = len(data)
     out = AverageTFR(info, power, times, freqs, nave, method='stockwell-power')

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -97,8 +97,8 @@ def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     return psd, itc
 
 
-def tfr_array_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
-                        decim=1, return_itc=False, n_jobs=1):
+def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
+                        width=1.0, decim=1, return_itc=False, n_jobs=1):
     """Compute power and intertrial coherence using Stockwell (S) transform.
 
     Parameters
@@ -156,6 +156,14 @@ def tfr_array_stockwell(data, sfreq, fmin, fmax, n_fft=None, width=1.0,
         (2006). S-transform time-frequency analysis of P300 reveals deficits in
         individuals diagnosed with alcoholism.
         Clinical Neurophysiology 117 2128--2143
+
+    See Also
+    --------
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_array_morlet
     """
     n_epochs, n_channels = data.shape[:2]
     n_out = data.shape[2] // decim + bool(data.shape[2] % decim)
@@ -229,7 +237,11 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
 
     See Also
     --------
-    tfr_morlet, psd_multitaper
+    mne.time_frequency.tfr_array_stockwell
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_array_morlet
 
     Notes
     -----

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -560,3 +560,74 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     if ndim_in == 1:
         psd = psd[0]
     return psd, freqs
+
+
+@verbose
+def tfr_array_multitaper(epoch_data, frequencies, sfreq=1.0, n_cycles=7.0,
+                         zero_mean=True, time_bandwidth=None, use_fft=True,
+                         decim=1, output='complex', n_jobs=1, verbose=None):
+    """Compute time-frequency transforms.
+
+    Uses Morlet wavelets windowed with multiple DPSS multitapers.
+
+    Parameters
+    ----------
+    epoch_data : array of shape (n_epochs, n_channels, n_times)
+        The epochs.
+    frequencies : array-like of floats, shape (n_freqs)
+        The frequencies.
+    sfreq : float | int
+        Sampling frequency of the data. Defaults to 1.0.
+    n_cycles : float | array of float
+        Number of cycles  in the Morlet wavelet. Fixed number or one per
+        frequency. Defaults to 7.0.
+    zero_mean : bool
+        If True, make sure the wavelets have a mean of zero. Defaults to True.
+    time_bandwidth : float
+        If None, will be set to 4.0 (3 tapers). Time x (Full) Bandwidth
+        product. The number of good tapers (low-bias) is chosen automatically
+        based on this to equal floor(time_bandwidth - 1). Defaults to None
+    use_fft : bool
+        Use the FFT for convolutions or not. Defaults to True.
+    decim : int | slice
+        To reduce memory usage, decimation factor after time-frequency
+        decomposition. Defaults to 1.
+        If `int`, returns tfr[..., ::decim].
+        If `slice`, returns tfr[..., decim].
+
+        .. note::
+            Decimation may create aliasing artifacts, yet decimation
+            is done after the convolutions.
+
+    output : str, defaults to 'complex'
+
+        * 'complex' : single trial complex.
+        * 'power' : single trial power.
+        * 'phase' : single trial phase.
+        * 'avg_power' : average of single trial power.
+        * 'itc' : inter-trial coherence.
+        * 'avg_power_itc' : average of single trial power and inter-trial
+          coherence across trials.
+
+    n_jobs : int
+        The number of epochs to process at the same time. The parallelization
+        is implemented across channels. Defaults to 1.
+    verbose : bool, str, int, or None, defaults to None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    out : array
+        Time frequency transform of epoch_data. If output is in ['complex',
+        'phase', 'power'], then shape of out is (n_epochs, n_chans, n_freqs,
+        n_times), else it is (n_chans, n_freqs, n_times). If output is
+        'avg_power_itc', the real values code for 'avg_power' and the
+        imaginary values code for the 'itc': out = avg_power + i * itc
+    """
+    from .tfr import _compute_tfr
+    return _compute_tfr(epoch_data, frequencies, sfreq=sfreq,
+                        method='multitaper', n_cycles=n_cycles,
+                        zero_mean=zero_mean, time_bandwidth=time_bandwidth,
+                        use_fft=use_fft, decim=decim, output=output,
+                        n_jobs=n_jobs, verbose=verbose)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -495,7 +495,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
 
     See Also
     --------
-    mne.io.Raw.plot_psd, mne.Epochs.plot_psd, csd_epochs
+    mne.io.Raw.plot_psd, mne.Epochs.plot_psd, csd_epochs, psd_multitaper
 
     Notes
     -----
@@ -632,6 +632,10 @@ def tfr_array_multitaper(epoch_data, sfreq, frequencies, n_cycles=7.0,
     mne.time_frequency.tfr_array_morlet
     mne.time_frequency.tfr_stockwell
     mne.time_frequency.tfr_array_stockwell
+
+    Notes
+    -----
+    .. versionadded:: 0.14.0
     """
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, frequencies, sfreq=sfreq,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import fftpack, linalg
 
 from ..parallel import parallel_func
-from ..utils import sum_squared, warn
+from ..utils import sum_squared, warn, verbose
 
 
 def tridisolve(d, e, b, overwrite_b=True):
@@ -451,9 +451,10 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
     return x_mt, freqs
 
 
-def _psd_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
-                    adaptive=False, low_bias=True, normalization='length',
-                    n_jobs=1):
+@verbose
+def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
+                         adaptive=False, low_bias=True, normalization='length',
+                         n_jobs=1, verbose=None):
     """Compute power spectrum density (PSD) using a multi-taper method.
 
     Parameters
@@ -480,6 +481,9 @@ def _psd_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
         the signal (as in nitime).
     n_jobs : int
         Number of parallel jobs to use (only used if adaptive=True).
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -499,7 +499,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
 
     Notes
     -----
-    .. versionadded:: 0.12.0
+    .. versionadded:: 0.14.0
     """
     if normalization not in ('length', 'full'):
         raise ValueError('Normalization must be "length" or "full", not %s'

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -563,21 +563,21 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
 
 
 @verbose
-def tfr_array_multitaper(epoch_data, frequencies, sfreq=1.0, n_cycles=7.0,
+def tfr_array_multitaper(epoch_data, sfreq, frequencies, n_cycles=7.0,
                          zero_mean=True, time_bandwidth=None, use_fft=True,
                          decim=1, output='complex', n_jobs=1, verbose=None):
-    """Compute time-frequency transforms.
+    """Compute time-frequency transforms using wavelets and multitaper windows.
 
-    Uses Morlet wavelets windowed with multiple DPSS multitapers.
+    Uses Morlet wavelets windowed with multiple DPSS tapers.
 
     Parameters
     ----------
     epoch_data : array of shape (n_epochs, n_channels, n_times)
         The epochs.
+    sfreq : float | int
+        Sampling frequency of the data.
     frequencies : array-like of floats, shape (n_freqs)
         The frequencies.
-    sfreq : float | int
-        Sampling frequency of the data. Defaults to 1.0.
     n_cycles : float | array of float
         Number of cycles  in the Morlet wavelet. Fixed number or one per
         frequency. Defaults to 7.0.
@@ -624,6 +624,14 @@ def tfr_array_multitaper(epoch_data, frequencies, sfreq=1.0, n_cycles=7.0,
         n_times), else it is (n_chans, n_freqs, n_times). If output is
         'avg_power_itc', the real values code for 'avg_power' and the
         imaginary values code for the 'itc': out = avg_power + i * itc
+
+    See Also
+    --------
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_array_morlet
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_array_stockwell
     """
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, frequencies, sfreq=sfreq,

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -57,6 +57,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
                     n_jobs=1, verbose=None):
     """Compute power spectral density (PSD) using Welch's method.
 
+    Parameters
+    ----------
     x : array, shape=(..., n_times)
         The data to compute PSD from.
     sfreq : float

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -8,7 +8,7 @@ from ..parallel import parallel_func
 from ..io.pick import _pick_data_channels
 from ..utils import logger, verbose, _time_mask
 from ..fixes import get_spectrogram
-from .multitaper import _psd_multitaper
+from .multitaper import psd_array_multitaper
 
 
 def _psd_func(epoch, noverlap, nfft, fs, freq_mask, func):
@@ -52,8 +52,9 @@ def _check_psd_data(inst, tmin, tmax, picks, proj):
     return data, sfreq
 
 
-def _psd_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
-               n_jobs=1):
+@verbose
+def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
+                    n_jobs=1, verbose=None):
     """Compute power spectral density (PSD) using Welch's method.
 
     x : array, shape=(..., n_times)
@@ -161,7 +162,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     See Also
     --------
     mne.io.Raw.plot_psd, mne.Epochs.plot_psd, psd_multitaper,
-    csd_epochs
+    csd_epochs, psd_array_welch
 
     Notes
     -----
@@ -169,8 +170,8 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     """
     # Prep data
     data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj)
-    return _psd_welch(data, sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft,
-                      n_overlap=n_overlap, n_jobs=n_jobs)
+    return psd_array_welch(data, sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft,
+                           n_overlap=n_overlap, n_jobs=n_jobs, verbose=verbose)
 
 
 @verbose
@@ -241,7 +242,8 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
 
     See Also
     --------
-    mne.io.Raw.plot_psd, mne.Epochs.plot_psd, psd_welch, csd_epochs
+    mne.io.Raw.plot_psd, mne.Epochs.plot_psd, psd_welch, csd_epochs,
+    psd_array_multitaper
 
     Notes
     -----
@@ -249,7 +251,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     """
     # Prep data
     data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj)
-    return _psd_multitaper(data, sfreq, fmin=fmin, fmax=fmax,
-                           bandwidth=bandwidth, adaptive=adaptive,
-                           low_bias=low_bias,
-                           normalization=normalization, n_jobs=n_jobs)
+    return psd_array_multitaper(data, sfreq, fmin=fmin, fmax=fmax,
+                                bandwidth=bandwidth, adaptive=adaptive,
+                                low_bias=low_bias, normalization=normalization,
+                                n_jobs=n_jobs, verbose=verbose)

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -75,6 +75,9 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         to be <= n_fft. The default value is 0.
     n_jobs : int
         Number of CPUs to use in the computation.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------
@@ -83,6 +86,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         be the same as input.
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
+
+    Notes
+    -----
+    .. versionadded:: 0.14.0
     """
     spectrogram = get_spectrogram()
     dshape = x.shape[:-1]

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -143,9 +143,8 @@ def test_compares_psd():
     n_fft = 2048
 
     # Compute psds with the new implementation using Welch
-    psds_welch, freqs_welch = psd_welch(raw, tmin=tmin, tmax=tmax,
-                                        fmin=fmin, fmax=fmax,
-                                        proj=False, picks=picks,
+    psds_welch, freqs_welch = psd_welch(raw, tmin=tmin, tmax=tmax, fmin=fmin,
+                                        fmax=fmax, proj=False, picks=picks,
                                         n_fft=n_fft, n_jobs=1)
 
     # Compute psds with plt.psd

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -486,13 +486,13 @@ def test_compute_tfr():
          'avg_power_itc', 'avg_power', 'itc')):
         # Check exception
         if (func == tfr_array_multitaper) and (output == 'phase'):
-            assert_raises(NotImplementedError, func, data, freqs, sfreq=sfreq,
-                          output=output)
+            assert_raises(NotImplementedError, func, data, sfreq=sfreq,
+                          frequencies=freqs, output=output)
             continue
 
         # Check runs
-        out = func(data, freqs, sfreq, use_fft=use_fft, zero_mean=zero_mean,
-                   n_cycles=2., output=output)
+        out = func(data, sfreq=sfreq, frequencies=freqs, use_fft=use_fft,
+                   zero_mean=zero_mean, n_cycles=2., output=output)
         # Check shapes
         shape = np.r_[data.shape[:2], len(freqs), data.shape[2]]
         if ('avg' in output) or ('itc' in output):

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -10,7 +10,8 @@ from mne.utils import (_TempDir, run_tests_if_main, slow_test, requires_h5py,
                        grand_average)
 from mne.time_frequency.tfr import (morlet, tfr_morlet, _make_dpss,
                                     tfr_multitaper, AverageTFR, read_tfrs,
-                                    write_tfrs, combine_tfr, cwt, tfr_array)
+                                    write_tfrs, combine_tfr, cwt, _compute_tfr)
+from mne.time_frequency import tfr_array_multitaper, tfr_array_morlet
 from mne.viz.utils import _fake_click
 from itertools import product
 import matplotlib
@@ -455,8 +456,8 @@ def test_add_channels():
     assert_raises(AssertionError, tfr_meg.add_channels, tfr_badsf)
 
 
-def test_tfr_array():
-    """Test tfr_array function."""
+def test_compute_tfr():
+    """Test _compute_tfr function."""
     # Set parameters
     event_id = 1
     tmin = -0.2
@@ -479,19 +480,19 @@ def test_tfr_array():
     freqs = np.arange(10, 20, 3).astype(float)
 
     # Check all combination of options
-    for method, use_fft, zero_mean, output in product(
-        ('multitaper', 'morlet'), (False, True), (False, True),
+    for func, use_fft, zero_mean, output in product(
+        (tfr_array_multitaper, tfr_array_morlet), (False, True), (False, True),
         ('complex', 'power', 'phase',
          'avg_power_itc', 'avg_power', 'itc')):
         # Check exception
-        if (method == 'multitaper') and (output == 'phase'):
-            assert_raises(NotImplementedError, tfr_array, data, freqs,
-                          sfreq, method=method, output=output)
+        if (func == tfr_array_multitaper) and (output == 'phase'):
+            assert_raises(NotImplementedError, func, data, freqs, sfreq=sfreq,
+                          output=output)
             continue
 
         # Check runs
-        out = tfr_array(data, freqs, sfreq, method=method, use_fft=use_fft,
-                        zero_mean=zero_mean, n_cycles=2., output=output)
+        out = func(data, freqs, sfreq, use_fft=use_fft, zero_mean=zero_mean,
+                   n_cycles=2., output=output)
         # Check shapes
         shape = np.r_[data.shape[:2], len(freqs), data.shape[2]]
         if ('avg' in output) or ('itc' in output):
@@ -508,26 +509,26 @@ def test_tfr_array():
 
     # Check errors params
     for _data in (None, 'foo', data[0]):
-        assert_raises(ValueError, tfr_array, _data, freqs, sfreq)
+        assert_raises(ValueError, _compute_tfr, _data, freqs, sfreq)
     for _freqs in (None, 'foo', [[0]]):
-        assert_raises(ValueError, tfr_array, data, _freqs, sfreq)
+        assert_raises(ValueError, _compute_tfr, data, _freqs, sfreq)
     for _sfreq in (None, 'foo'):
-        assert_raises(ValueError, tfr_array, data, freqs, _sfreq)
+        assert_raises(ValueError, _compute_tfr, data, freqs, _sfreq)
     for key in ('output', 'method', 'use_fft', 'decim', 'n_jobs'):
         for value in (None, 'foo'):
             kwargs = {key: value}  # FIXME pep8
-            assert_raises(ValueError, tfr_array, data, freqs, sfreq,
+            assert_raises(ValueError, _compute_tfr, data, freqs, sfreq,
                           **kwargs)
 
     # No time_bandwidth param in morlet
-    assert_raises(ValueError, tfr_array, data, freqs, sfreq,
+    assert_raises(ValueError, _compute_tfr, data, freqs, sfreq,
                   method='morlet', time_bandwidth=1)
     # No phase in multitaper XXX Check ?
-    assert_raises(NotImplementedError, tfr_array, data, freqs, sfreq,
+    assert_raises(NotImplementedError, _compute_tfr, data, freqs, sfreq,
                   method='multitaper', output='phase')
 
     # Inter-trial coherence tests
-    out = tfr_array(data, freqs, sfreq, output='itc', n_cycles=2.)
+    out = _compute_tfr(data, freqs, sfreq, output='itc', n_cycles=2.)
     assert_true(np.sum(out >= 1) == 0)
     assert_true(np.sum(out <= 0) == 0)
 
@@ -542,12 +543,12 @@ def test_tfr_array():
         shape = np.r_[data.shape[:2], len(freqs), n_time]
         for method in ('multitaper', 'morlet'):
             # Single trials
-            out = tfr_array(data, freqs, sfreq, method=method, decim=decim,
-                            n_cycles=2.)
+            out = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
+                               n_cycles=2.)
             assert_array_equal(shape, out.shape)
             # Averages
-            out = tfr_array(data, freqs, sfreq, method=method, decim=decim,
-                            output='avg_power', n_cycles=2.)
+            out = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
+                               output='avg_power', n_cycles=2.)
             assert_array_equal(shape[1:], out.shape)
 
 run_tests_if_main()

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -678,7 +678,11 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 
     See Also
     --------
-    tfr_multitaper, tfr_stockwell
+    mne.time_frequency.tfr_array_morlet
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_array_stockwell
     """
     tfr_params = dict(n_cycles=n_cycles, n_jobs=n_jobs, use_fft=use_fft,
                       zero_mean=zero_mean)
@@ -687,23 +691,23 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 
 
 @verbose
-def tfr_array_morlet(epoch_data, frequencies, sfreq=1.0, n_cycles=7.0,
+def tfr_array_morlet(epoch_data, sfreq, frequencies, n_cycles=7.0,
                      zero_mean=False, use_fft=True, decim=1, output='complex',
                      n_jobs=1, verbose=None):
-    """Compute time-frequency transforms.
+    """Compute time-frequency transform using Morlet wavelets.
 
-    Convolves a Morlet wavelet.
+    Convolves epoch data with selected Morlet wavelets.
 
     Parameters
     ----------
     epoch_data : array of shape (n_epochs, n_channels, n_times)
         The epochs.
+    sfreq : float | int
+        Sampling frequency of the data.
     frequencies : array-like of floats, shape (n_freqs)
         The frequencies.
-    sfreq : float | int
-        Sampling frequency of the data. Defaults to 1.0.
     n_cycles : float | array of float, defaults to 7.0
-        Number of cycles  in the Morlet wavelet. Fixed number or one per
+        Number of cycles in the Morlet wavelet. Fixed number or one per
         frequency.
     zero_mean : bool | False
         If True, make sure the wavelets have a mean of zero. Defaults to False.
@@ -744,6 +748,14 @@ def tfr_array_morlet(epoch_data, frequencies, sfreq=1.0, n_cycles=7.0,
         n_times), else it is (n_chans, n_freqs, n_times). If output is
         'avg_power_itc', the real values code for 'avg_power' and the
         imaginary values code for the 'itc': out = avg_power + i * itc
+
+    See Also
+    --------
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_array_stockwell
     """
     return _compute_tfr(epoch_data=epoch_data, frequencies=frequencies,
                         sfreq=sfreq, method='morlet', n_cycles=n_cycles,
@@ -810,7 +822,11 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
 
     See Also
     --------
-    tfr_multitaper, tfr_stockwell
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_array_stockwell
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_array_morlet
 
     Notes
     -----

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -248,10 +248,9 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
 # Loop of convolution: single trial
 
 
-def _compute_tfr(epoch_data, frequencies, sfreq=1.0, method='morlet',
-                 n_cycles=7.0, zero_mean=None, time_bandwidth=None,
-                 use_fft=True, decim=1, output='complex', n_jobs=1,
-                 verbose=None):
+def tfr_array(epoch_data, frequencies, sfreq=1.0, method='morlet',
+              n_cycles=7.0, zero_mean=None, time_bandwidth=None, use_fft=True,
+              decim=1, output='complex', n_jobs=1, verbose=None):
     """Compute time-frequency transforms.
 
     Parameters
@@ -376,7 +375,7 @@ def _compute_tfr(epoch_data, frequencies, sfreq=1.0, method='morlet',
 
 def _check_tfr_param(frequencies, sfreq, method, zero_mean, n_cycles,
                      time_bandwidth, use_fft, decim, output):
-    """Aux. function to _compute_tfr to check the params validity."""
+    """Aux. function to tfr_array to check the params validity."""
     # Check frequencies
     if not isinstance(frequencies, (list, np.ndarray)):
         raise ValueError('frequencies must be an array-like, got %s '
@@ -450,7 +449,7 @@ def _check_tfr_param(frequencies, sfreq, method, zero_mean, n_cycles,
 
 
 def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
-    """Aux. function to _compute_tfr.
+    """Aux. function to tfr_array.
 
     Loops time-frequency transform across wavelets and epochs.
 
@@ -602,8 +601,8 @@ def _tfr_aux(method, inst, freqs, decim, return_itc, picks, average,
             raise ValueError('Inter-trial coherence is not supported'
                              ' with average=False')
 
-    out = _compute_tfr(data, freqs, info['sfreq'], method=method,
-                       output=output, decim=decim, **tfr_params)
+    out = tfr_array(data, freqs, info['sfreq'], method=method, output=output,
+                    decim=decim, **tfr_params)
     times = inst.times[decim].copy()
 
     if average:

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -756,6 +756,10 @@ def tfr_array_morlet(epoch_data, sfreq, frequencies, n_cycles=7.0,
     mne.time_frequency.tfr_array_multitaper
     mne.time_frequency.tfr_stockwell
     mne.time_frequency.tfr_array_stockwell
+
+    Notes
+    -----
+    .. versionadded:: 0.14.0
     """
     return _compute_tfr(epoch_data=epoch_data, frequencies=frequencies,
                         sfreq=sfreq, method='morlet', n_cycles=n_cycles,


### PR DESCRIPTION
Partial fix to https://github.com/mne-tools/mne-python/issues/3668

To avoid naming conflicts, I added `array` to the new public function names. So the new public functions are ``psd_array_multitaper`` and ``psd_array_welch``. LMK if there are others that need to be made public.

I'm not entirely sure where the overlap in ``tfr`` and ``multitapers`` is. Maybe there is some overlap in creating the tapers, but changing it seems dangerous. I'll let someone else take a stab at it.