### PR TITLE
FIX: set _bad_dropped to True after constructing epochs data from eeglab file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,6 +62,8 @@ BUG
 
     - Fix sanity check for incompatible ``threshold`` and ``tail`` values in clustering functions like :func:`mne.stats.spatio_temporal_cluster_1samp_test` by `Eric Larson`_
 
+    - Fix ``_bad_dropped`` not being set when loading eeglab epoched files via :func:`mne.io.eeglab.read_epochs_eeglab` which resulted in ``len()`` not working for :class:`mne.io.eeglab.EpochsEEGLAB`; by `Mikołaj Magnuski`_
+
 API
 ~~~
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -555,6 +555,9 @@ class EpochsEEGLAB(_BaseEpochs):
             info, data, events, event_id, tmin, tmax, baseline,
             reject=reject, flat=flat, reject_tmin=reject_tmin,
             reject_tmax=reject_tmax, verbose=verbose)
+
+        # data are preloaded but _bad_dropped is not set so we do it here:
+        self._bad_dropped = True
         logger.info('Ready.')
 
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -6,7 +6,7 @@ import os.path as op
 import shutil
 
 import warnings
-from nose.tools import assert_raises, assert_equal
+from nose.tools import assert_raises, assert_equal, assert_true
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -65,7 +65,7 @@ def test_io_set():
         raw0.filter(1, None, l_trans_bandwidth='auto', filter_length='auto',
                     phase='zero')  # test that preloading works
 
-    # test that using uin16_codec does not break stuff
+    # test that using uint16_codec does not break stuff
     raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
                            event_id=event_id, preload=False,
                            uint16_codec='ascii')
@@ -96,6 +96,8 @@ def test_io_set():
 
     epochs = read_epochs_eeglab(epochs_fname, epochs.events, event_id)
     assert_equal(len(epochs.events), 4)
+    assert_true(epochs.preload)
+    assert_true(epochs._bad_dropped)
     epochs = read_epochs_eeglab(epochs_fname, out_fname, event_id)
     assert_raises(ValueError, read_epochs_eeglab, epochs_fname,
                   None, event_id)


### PR DESCRIPTION
fixes #3786
currently I'm setting this manually - this may be not be the best way to do this, but passing `preload_at_end` to _BaseEpochs constructor does not work in this case - the data are already preloaded and passed to the constructor while `preload_at_end` asserts that `_data` is None.
Let me know if there is better way to do this - but it seems to work well currently.