### PR TITLE
WIP: Psd welch reborn

### DIFF
--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2323,6 +2323,29 @@ def _get_fast_dot():
     return fast_dot
 
 
+def get_reduction(reduction, axis=-1):
+    if isinstance(reduction, string_types):
+        if reduction == 'mean':
+            return lambda x: np.mean(x, axis=axis)
+        elif reduction == 'median':
+            return lambda x: np.median(x, axis=axis)
+        else:
+            raise ValueError('reduction, if string, must be "mean" or "median"'
+                             ', got {}'.format(reduction))
+    elif isinstance(reduction, (float, np.float64, np.float32)):
+        if reduction < 0 or reduction >= 0.5:
+            raise ValueError('reduction, if float, means proportion to trim in'
+                             ' trimmed mean, which has to be > 0 and < 0.5, '
+                             'got {}'.format(reduction))
+        from scipy.stats import trim_mean
+        return lambda x: trim_mean(x, reduction, axis=axis)
+    elif hasattr(reduction, '__call__'):
+        return reduction
+    else:
+        raise TypeError('unrecognized reduction type. Has to be string, '
+                        'float or callable, got {}'.format(reduction))
+
+
 def random_permutation(n_samples, random_state=None):
     """Emulate the randperm matlab function.
 


### PR DESCRIPTION
Currently there are 3 related issues concerning psd welch:

1. adding ability to reduce the windows with something else than mean (#3336)
2. making it sensitive to annotations - omitting data segments marked with bad annotations (#3731)
3. adding ability to define both segment length and padding (currently padding is not possible) (#3621)

**TL;DR**: This PR tries to adress all three in one go (see below for details).  
  

❗️ :construction: This is currently WIP, TODOs: :construction: ❗️ 
- [ ] add annotation-guided window removal
- [ ] clean up docs
- [ ] add tests
- [ ] there will surely be comments to address

This is also probably too early for a review, but I would like to hear your thoughts (all welcome: comments, suggestions, opinions, 🚲-shedding 😃 , etc.)

## window reduction (#3336)
`scipy.signal.spectral.welch` - that mne uses in `psd_welch` - already averages across windows so:
* one way is to directly use `_spectral_helper` from `scipy.signal.spectral` - it is the function used by (through `scipy.signal.spectral.csd`) `welch` to get the fft for windows (so it does not average windows)
* another way - so we don't rely on private scipy function - is to adapt it to our need. Our use of `_spectral_helper` would be more narrow:
  * `x` is the same as `y` so checks for `same_data` are not needed
  * `mode` is 'psd'
  * we operate on real-valued signal so only need one-sided fft
  This approach also requires copying `_fft_helper` from scipy but it is a short function.
* we could also implement this from scratch...

I have taken the second path and adapted `_spectral_helper` - I tested it against scipy's `_spectral_helper` to be sure it works ok (not sure if mne test relying on private scipy function is ok so I didn't include it so far - actually I didn't include any tests yet...).

My slight preferrence is to use `reduction` keyword argument for reduction across windows, where that can be either `'mean'`, `'median'`, callable or `None`:
* `'mean'` and `'median'` perform mean or median respectively
* callable is called on the windows (may additionally ensure that window dimension was reduced)
* `None` omit the reduction so `psd_welch` returns an array of shape `windows x channels x freqs` for raw and `windows x epochs x channels x freqs` for epochs.
* @kingjr proposed using float values < 0.5 for trimmed mean - I've implemented it here too (using `scipy.stats.trim_mean`)

I've added it as `get_reduction` to mne.utils. It can also be private if you prefer.
I was considering adding a little bit of magic by parsing strings like `trimmed-mean` or `10%trimmed-mean` etc. but passing a callable is more flexible. 


## padding (#3621)
Padding is the easiest issue - it requires only adding another kwarg that is passed downstram. My propositions for the kwarg are: `pad_to`, `pad`, `padding`, `zero_pad`, `zero_padding`. Currently I've picked `padding`, but I'm happy with other options too.
In this PR the `padding` is actually not passed to `scipy.signal.welch` because due to other two issues, I adapted `_spectral_helper` function and it is being used instead of `welch`.

`padding` is required to be `> n_fft` passing padding < n_fft results in error.


## omitting bad segments (#3731)
The approach I *(am planning to)* take here is somewhat suboptimal because bad segments are processed with fft and only rejected afterwards. But I guess it's better than nothing (and psd is fast anyway)... However, it might be possible to change the `_fft_helper` so that it optionally removes parts of the striaded array.

At the level of `psd_welch` this will be possible to control via `reject_by_annotation`, while at the level `_psd_welch` - maybe a `reject_windows` kwarg?
If `reject_windows` (or something like this) is not passed to `_psd_welch` then `psd_welch` would have to call `_psd_welch` with `reduction=None`, reject bad segments and then apply `reduction` itself.


**WDYT?**

Additional changes:
* I have removed `_compute_psd` as it was not used anywhere in mne
* I have also removed `welch_fun` argument from `_pwelch` - it was always the same function passed there, so I didn't see te point in keeping it


Some things I am considering and would be happy for input:
1. currently windows are last dimension of the psd array (scipy default) when being passed to reduction function but are moved to the first axis when reduction is `None` - this may be (a little) confusing.
2. If `reduction` is None and bad annotations are used what should be returned:
  * all windows except the bad ones
  * all windows with bad ones nanned out


## Example
I can update/create a relevant example, currently I am just pasting this one:
```python
from scipy.stats.mstats import gmean
from mne.time_frequency import _psd_welch
import seaborn as sns

# some mysterious data are loaded and epoched
# ...

sfreq = epochs.info['sfreq']
data = epochs.get_data()

reduction_names = ['mean', 'median', 'geometric mean', '10% trimmed mean']
reductions = ['mean', 'median', lambda x: gmean(x, axis=-1), 0.1]
psds = [list() for i in range(len(reductions))]

# calculate
for i, red in enumerate(reductions):
    psds[i], freq = _psd_welch(data, sfreq, n_fft=int(sfreq), 
                               n_overlap=int(sfreq / 4),
                               padding=int(sfreq * 2), fmax=45., reduction=red)

# plot
for i in range(len(reductions)):
    plt.plot(freq, psds[i][10, ch_ind, :], label=reduction_names[i])
plt.legend()
```
![psd_welch_example](https://cloud.githubusercontent.com/assets/8452354/20949106/01ff682a-bc18-11e6-8df5-39eb1592cf79.png)
