### PR TITLE
[WIP] Welch PR 1 - add spectral helper

### DIFF
--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -17,17 +17,6 @@ def _pwelch(epoch, noverlap, nfft, fs, freq_mask):
                             )[2][..., freq_mask, :]
 
 
-def _compute_psd(data, fmin, fmax, Fs, n_fft, psd, n_overlap, pad_to):
-    """Compute the PSD."""
-    out = [psd(d, Fs=Fs, NFFT=n_fft, noverlap=n_overlap, pad_to=pad_to)
-           for d in data]
-    psd = np.array([o[0] for o in out])
-    freqs = out[0][1]
-    mask = (freqs >= fmin) & (freqs <= fmax)
-    freqs = freqs[mask]
-    return psd[:, mask], freqs
-
-
 def _check_nfft(n, n_fft, n_overlap):
     """Helper to make sure n_fft and n_overlap make sense."""
     n_fft = n if n_fft > n else n_fft

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -10,10 +10,10 @@ from ..utils import logger, verbose, _time_mask
 from .multitaper import _psd_multitaper
 
 
-def _pwelch(epoch, noverlap, nfft, fs, freq_mask, welch_fun):
+def _pwelch(epoch, noverlap, nfft, fs, freq_mask):
     """Aux function."""
-    return welch_fun(epoch, nperseg=nfft, noverlap=noverlap,
-                     nfft=nfft, fs=fs)[1][..., freq_mask]
+    return _spectral_helper(epoch, fs, nperseg=nfft, noverlap=noverlap
+                            )[2][..., freq_mask, :]
 
 
 def _compute_psd(data, fmin, fmax, Fs, n_fft, psd, n_overlap, pad_to):
@@ -110,12 +110,10 @@ def _psd_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     parallel, my_pwelch, n_jobs = parallel_func(_pwelch, n_jobs=n_jobs)
     x_splits = np.array_split(x, n_jobs)
     f_psd = parallel(my_pwelch(d, noverlap=n_overlap, nfft=n_fft,
-                     fs=sfreq, freq_mask=freq_mask,
-                     welch_fun=welch)
-                     for d in x_splits)
+                     fs=sfreq, freq_mask=freq_mask) for d in x_splits)
 
-    # Combining/reshaping to original data shape
-    psds = np.concatenate(f_psd, axis=0)
+    # Combining, reducing windows and reshaping to original data shape
+    psds = np.concatenate(f_psd, axis=0).mean(axis=-1)
     psds = psds.reshape(np.hstack([dshape, -1]))
     return psds, freqs
 
@@ -263,3 +261,233 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                            bandwidth=bandwidth, adaptive=adaptive,
                            low_bias=low_bias,
                            normalization=normalization,  n_jobs=n_jobs)
+
+
+def _spectral_helper(x, fs, window='hann', nperseg=256, noverlap=None,
+                     nfft=None, detrend='constant', scaling='density',
+                     axis=-1):
+    """
+    Calculate various forms of windowed FFTs for PSD.
+    This is a helper function that was adapted from scipy.
+    It is not designed to be called externally. The windows are not averaged
+    over; the result from each window is returned.
+
+    Parameters
+    ---------
+    x : array_like
+        Array or sequence containing the data to be analyzed.
+    fs : float
+        Sampling frequency of the time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to 'hann'.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap : int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg // 2``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        measured in V and fs is measured in Hz.  Defaults to 'density'
+    axis : int, optional
+        Axis along which the periodogram is computed; the default is over
+        the last axis (i.e. ``axis=-1``).
+
+    Returns
+    -------
+    freqs : ndarray
+        Array of sample frequencies.
+    t : ndarray
+        Array of times corresponding to each data segment
+    result : ndarray
+        Array of output data, contents dependant on *mode* kwarg.
+
+    References
+    ----------
+    .. [1] Stack Overflow, "Rolling window for 1D arrays in Numpy?",
+        http://stackoverflow.com/a/6811241
+    .. [2] Stack Overflow, "Using strides for an efficient moving average
+        filter", http://stackoverflow.com/a/4947453
+
+    Notes
+    -----
+    Adapted from scipy.signal.spectral which was in turn adapted from
+    matplotlib.mlab
+
+    Differences with respect to `scipy.signal.spectral._spectral_helper`:
+    * only one data argument - x instead of x and y, because csd is not
+      computed
+    * sampling frequency (`fs`) is no longer optional
+    * always returns one-sided spectrum thus `return_onesided` arg is gone
+    * use 'density' scaling by default (this is the default for
+      `scipy.signal.welch`)
+    * mode is always 'psd' so `mode` argument is removed
+    """
+
+    axis = int(axis)
+
+    # Ensure we have np.arrays
+    x = np.asarray(x)
+
+    if x.size == 0:
+        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
+
+    if x.ndim > 1:
+        if axis != -1:
+            x = np.rollaxis(x, axis, len(x.shape))
+
+    # test nperseg
+    if x.shape[-1] < nperseg:
+        warnings.warn('nperseg = {0:d}, is greater than input length = {1:d}, '
+                      'using nperseg = {1:d}'.format(nperseg, x.shape[-1]))
+        nperseg = x.shape[-1]
+
+    nperseg = int(nperseg)
+    if nperseg < 1:
+        raise ValueError('nperseg must be a positive integer')
+
+    if nfft is None:
+        nfft = nperseg
+    elif nfft < nperseg:
+        raise ValueError('nfft must be greater than or equal to nperseg.')
+    else:
+        nfft = int(nfft)
+
+    if noverlap is None:
+        noverlap = nperseg // 2
+    elif noverlap >= nperseg:
+        raise ValueError('noverlap must be less than nperseg.')
+    else:
+        noverlap = int(noverlap)
+
+    # Handle detrending and window functions
+    if not detrend:
+        def detrend_func(d):
+            return d
+    elif not hasattr(detrend, '__call__'):
+        def detrend_func(d):
+            return signaltools.detrend(d, type=detrend, axis=-1)
+    elif axis != -1:
+        # Wrap this function so that it receives a shape that it could
+        # reasonably expect to receive.
+        def detrend_func(d):
+            d = np.rollaxis(d, -1, axis)
+            d = detrend(d)
+            return np.rollaxis(d, axis, len(d.shape))
+    else:
+        detrend_func = detrend
+
+    if isinstance(window, string_types) or type(window) is tuple:
+        win = get_window(window, nperseg)
+    else:
+        win = np.asarray(window)
+        if len(win.shape) != 1:
+            raise ValueError('window must be 1-D')
+        if win.shape[0] != nperseg:
+            raise ValueError('window must have length of nperseg')
+
+    if scaling == 'density':
+        scale = 1.0 / (fs * (win*win).sum())
+    elif scaling == 'spectrum':
+        scale = 1.0 / win.sum()**2
+    else:
+        raise ValueError('Unknown scaling: %r' % scaling)
+
+    if nfft % 2:
+        num_freqs = (nfft + 1)//2
+    else:
+        num_freqs = nfft//2 + 1
+
+
+    # Perform the windowed FFTs
+    result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft)
+    result = result[..., :num_freqs]
+    freqs = fftpack.fftfreq(nfft, 1/fs)[:num_freqs]
+
+    result = (np.conjugate(result) * result).real
+    result *= scale
+
+    if nfft % 2:
+        result[...,1:] *= 2
+    else:
+        # Last point is unpaired Nyquist freq point, don't double
+        result[...,1:-1] *= 2
+
+    t = np.arange(nperseg / 2, x.shape[-1] - nperseg / 2 + 1,
+                  nperseg - noverlap) / float(fs)
+
+    if not nfft % 2:
+        # get the last value correctly, it is negative otherwise
+        freqs[-1] *= -1
+
+    # Output is going to have new last axis for window index
+    if axis != -1:
+        # Specify as positive axis index
+        if axis < 0:
+            axis = len(result.shape)-1-axis
+
+        # Roll frequency axis back to axis where the data came from
+        result = np.rollaxis(result, -1, axis)
+    else:
+        # Make sure window/time index is last axis
+        result = np.rollaxis(result, -1, -2)
+
+    return freqs, t, result
+
+
+def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
+    """
+    Calculate windowed FFT, for internal use by
+    `mne.time_frequency.psd._spectral_helper`.
+    This is a helper function that does the main FFT calculation for
+    _spectral helper. All input valdiation is performed there, and the data
+    axis is assumed to be the last axis of x. It is not designed to be called
+    externally. The windows are not averaged over; the result from each window
+    is returned.
+
+    Returns
+    -------
+    result : ndarray
+        Array of FFT data
+
+    References
+    ----------
+    .. [1] Stack Overflow, "Repeat NumPy array without replicating data?",
+        http://stackoverflow.com/a/5568169
+
+    Notes
+    -----
+    Copied from scipy.signal.spectral which was adapted from matplotlib.mlab
+    """
+    # Created strided array of data segments
+    if nperseg == 1 and noverlap == 0:
+        result = x[..., np.newaxis]
+    else:
+        step = nperseg - noverlap
+        shape = x.shape[:-1] + ((x.shape[-1] - noverlap) // step, nperseg)
+        strides = x.strides[:-1] + (step * x.strides[-1], x.strides[-1])
+        result = np.lib.stride_tricks.as_strided(x, shape=shape,
+                                                 strides=strides)
+
+    # Detrend each data segment individually
+    result = detrend_func(result)
+
+    # Apply window by multiplication
+    result = win * result
+
+    # Perform the fft. Acts on last axis by default. Zero-pads automatically
+    result = fftpack.fft(result, n=nfft)
+
+    return result

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 
+from ..externals.six import string_types
 from ..parallel import parallel_func
 from ..io.pick import _pick_data_channels
 from ..utils import logger, verbose, _time_mask
@@ -335,6 +336,9 @@ def _spectral_helper(x, fs, window='hann', nperseg=256, noverlap=None,
       `scipy.signal.welch`)
     * mode is always 'psd' so `mode` argument is removed
     """
+    from scipy import fftpack
+    from scipy.signal import signaltools
+    from scipy.signal.windows import get_window
 
     axis = int(axis)
 
@@ -471,6 +475,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     -----
     Copied from scipy.signal.spectral which was adapted from matplotlib.mlab
     """
+    from scipy import fftpack
+
     # Created strided array of data segments
     if nperseg == 1 and noverlap == 0:
         result = x[..., np.newaxis]

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -180,9 +180,8 @@ def test_compares_psd():
     assert_raises(ValueError, _spectral_helper, data, sfreq, nperseg=120,
                   nfft=60)
 
-
     # compare mne _spectral_helper with scipy's csd
-    from scipy.signal.spectral import csd
+    from scipy.signal.spectral import welch
 
     def win_avg(data):
         # Average over windows.
@@ -195,14 +194,14 @@ def test_compares_psd():
 
     kwargs = dict(window='blackman', nperseg=int(sfreq))
     freqs_mne, _, psds_mne = _spectral_helper(data, sfreq, **kwargs)
-    freqs_scipy, psds_scipy = csd(data, data, fs=sfreq, **kwargs)
+    freqs_scipy, psds_scipy = welch(data, fs=sfreq, **kwargs)
     assert_array_almost_equal(freqs_mne, freqs_scipy)
     assert_array_almost_equal(win_avg(psds_mne), psds_scipy)
 
     kwargs = dict(window=np.ones(120), nperseg=120, noverlap=80, nfft=240,
                   detrend=False, scaling='spectrum')
     freqs_mne, _, psds_mne = _spectral_helper(data, sfreq, **kwargs)
-    freqs_scipy, psds_scipy = csd(data, data, fs=sfreq, **kwargs)
+    freqs_scipy, psds_scipy = welch(data, fs=sfreq, **kwargs)
     assert_array_almost_equal(freqs_mne, freqs_scipy)
     assert_array_almost_equal(win_avg(psds_mne), psds_scipy)
 

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -7,6 +7,7 @@ from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
 from mne.utils import requires_version, slow_test, run_tests_if_main
 from mne.time_frequency import psd_welch, psd_multitaper
+from mne.time_frequency.psd import _spectral_helper
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -129,7 +130,8 @@ def test_psd():
 @slow_test
 @requires_version('scipy', '0.12')
 def test_compares_psd():
-    """Test PSD estimation on raw for plt.psd and scipy.signal.welch."""
+    """Test PSD estimation on raw for plt.psd and scipy.signal.welch
+    compare mne's _spectral_helper with scipy csd outputs"""
     raw = read_raw_fif(raw_fname)
 
     exclude = raw.info['bads'] + ['MEG 2443', 'EEG 053']  # bads + 2 more
@@ -151,8 +153,9 @@ def test_compares_psd():
     # Compute psds with plt.psd
     start, stop = raw.time_as_index([tmin, tmax])
     data, times = raw[picks, start:(stop + 1)]
+    sfreq = raw.info['sfreq']
     from matplotlib.pyplot import psd
-    out = [psd(d, Fs=raw.info['sfreq'], NFFT=n_fft) for d in data]
+    out = [psd(d, Fs=sfreq, NFFT=n_fft) for d in data]
     freqs_mpl = out[0][1]
     psds_mpl = np.array([o[0] for o in out])
 
@@ -171,5 +174,36 @@ def test_compares_psd():
 
     assert_true(np.sum(psds_welch < 0) == 0)
     assert_true(np.sum(psds_mpl < 0) == 0)
+
+    # test _spectral_helper errors and warnings
+    assert_raises(ValueError, _spectral_helper, data, sfreq, nperseg=0)
+    assert_raises(ValueError, _spectral_helper, data, sfreq, nperseg=120,
+                  nfft=60)
+
+
+    # compare mne _spectral_helper with scipy's csd
+    from scipy.signal.spectral import csd
+
+    def win_avg(data):
+        # Average over windows.
+        if len(data.shape) >= 2 and data.size > 0:
+            if data.shape[-1] > 1:
+                data = data.mean(axis=-1)
+            else:
+                data = np.reshape(data, data.shape[:-1])
+        return data
+
+    kwargs = dict(window='blackman', nperseg=int(sfreq))
+    freqs_mne, _, psds_mne = _spectral_helper(data, sfreq, **kwargs)
+    freqs_scipy, psds_scipy = csd(data, data, fs=sfreq, **kwargs)
+    assert_array_almost_equal(freqs_mne, freqs_scipy)
+    assert_array_almost_equal(win_avg(psds_mne), psds_scipy)
+
+    kwargs = dict(window=np.ones(120), nperseg=120, noverlap=80, nfft=240,
+                  detrend=False, scaling='spectrum')
+    freqs_mne, _, psds_mne = _spectral_helper(data, sfreq, **kwargs)
+    freqs_scipy, psds_scipy = csd(data, data, fs=sfreq, **kwargs)
+    assert_array_almost_equal(freqs_mne, freqs_scipy)
+    assert_array_almost_equal(win_avg(psds_mne), psds_scipy)
 
 run_tests_if_main()


### PR DESCRIPTION
Breaking up #3820 into smaller steps.  

This one adds `_spectral_helper` from `scipy.signal.spectral` which is needed for different window reductions (median, trimmed mean etc. - this will come in subsequent PR) - because all public `scipy` functions reduce windows with mean by default. This function has been somewhat adapted by throwing out unnecessary functionality. More on this in notes section of `_spectral_helper`, copied below:
> Differences with respect to `scipy.signal.spectral._spectral_helper`:
>* only one data argument - x instead of x and y, because csd is not
  computed
>* sampling frequency (`fs`) is no longer optional
>* always returns one-sided spectrum thus `return_onesided` arg is gone
>* use 'density' scaling by default (this is the default for
  `scipy.signal.welch`)
>* mode is always 'psd' so `mode` argument is removed

Todos:
- [ ] add tests against scipy's `csd` of relevant features of `_spectral_helper`

Things to discuss:
* is the way `_spectral_helper` is adapted ok for you?
* `_spectral_helper` returns psd, time and freq - but time is unused and freq is computed in `_psd_welch` - so these return args could be removed from `_spectral_helper`
* I removed `_compute_psd` because it was not used anywhere