### PR TITLE
[MRG+1] spectrogram instead of welch

### DIFF
--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -481,13 +481,14 @@ def _get_sph_harm():
 
 
 
-def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
+def _spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):
     """
     Compute a spectrogram with consecutive Fourier transforms.
     Spectrograms can be used as a way of visualizing the change of a
     nonstationary signal's frequency content over time.
+
     Parameters
     ----------
     x : array_like
@@ -527,6 +528,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     mode : str, optional
         Defines what kind of return values are expected. Options are ['psd',
         'complex', 'magnitude', 'angle', 'phase'].
+
     Returns
     -------
     f : ndarray
@@ -536,12 +538,14 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     Sxx : ndarray
         Spectrogram of x. By default, the last axis of Sxx corresponds to the
         segment times.
+
     See Also
     --------
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
     welch: Power spectral density by Welch's method.
     csd: Cross spectral density by Welch's method.
+
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
@@ -550,31 +554,11 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     perhaps none at all) when computing a spectrogram, to maintain some
     statistical independence between individual segments.
     .. versionadded:: 0.16.0
+
     References
     ----------
     .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck "Discrete-Time
            Signal Processing", Prentice Hall, 1999.
-    Examples
-    --------
-    >>> from scipy import signal
-    >>> import matplotlib.pyplot as plt
-    Generate a test signal, a 2 Vrms sine wave whose frequency linearly changes
-    with time from 1kHz to 2kHz, corrupted by 0.001 V**2/Hz of white noise
-    sampled at 10 kHz.
-    >>> fs = 10e3
-    >>> N = 1e5
-    >>> amp = 2 * np.sqrt(2)
-    >>> noise_power = 0.001 * fs / 2
-    >>> time = np.arange(N) / fs
-    >>> freq = np.linspace(1e3, 2e3, N)
-    >>> x = amp * np.sin(2*np.pi*freq*time)
-    >>> x += np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
-    Compute and plot the spectrogram.
-    >>> f, t, Sxx = signal.spectrogram(x, fs)
-    >>> plt.pcolormesh(t, f, Sxx)
-    >>> plt.ylabel('Frequency [Hz]')
-    >>> plt.xlabel('Time [sec]')
-    >>> plt.show()
     """
     # Less overlap than welch, so samples are more statisically independent
     if noverlap is None:
@@ -597,6 +581,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     psd, csd, and spectrogram functions. It is not designed to be called
     externally. The windows are not averaged over; the result from each window
     is returned.
+
     Parameters
     ---------
     x : array_like
@@ -640,6 +625,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     mode : str, optional
         Defines what kind of return values are expected. Options are ['psd',
         'complex', 'magnitude', 'angle', 'phase'].
+
     Returns
     -------
     freqs : ndarray
@@ -648,12 +634,14 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         Array of times corresponding to each data segment
     result : ndarray
         Array of output data, contents dependant on *mode* kwarg.
+
     References
     ----------
     .. [1] Stack Overflow, "Rolling window for 1D arrays in Numpy?",
         http://stackoverflow.com/a/6811241
     .. [2] Stack Overflow, "Using strides for an efficient moving average
         filter", http://stackoverflow.com/a/4947453
+
     Notes
     -----
     Adapted from matplotlib.mlab
@@ -866,14 +854,17 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     axis is assumed to be the last axis of x. It is not designed to be called
     externally. The windows are not averaged over; the result from each window
     is returned.
+
     Returns
     -------
     result : ndarray
         Array of FFT data
+
     References
     ----------
     .. [1] Stack Overflow, "Repeat NumPy array without replicating data?",
         http://stackoverflow.com/a/5568169
+
     Notes
     -----
     Adapted from matplotlib.mlab
@@ -902,9 +893,12 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
 
 
 def get_spectrogram():
+    '''helper function to get relevant spectrogram'''
     from .utils import check_version
     if check_version('scipy', '0.16.0'):
         from scipy.signal import spectrogram
+    else:
+        spectrogram = _spectrogram
     return spectrogram
 
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -479,8 +479,6 @@ def _get_sph_harm():
 ###############################################################################
 # Scipy spectrogram (for mne.time_frequency.psd_welch) needed for scipy < 0.16
 
-
-
 def _spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -20,7 +20,9 @@ import re
 import warnings
 
 import numpy as np
-from scipy import linalg, __version__ as sp_version
+from scipy import linalg, fftpack, __version__ as sp_version
+from scipy.signal import signaltools
+from scipy.signal.windows import get_window
 
 
 ###############################################################################
@@ -472,6 +474,435 @@ def _get_sph_harm():
     else:
         from scipy.special import sph_harm
     return sph_harm
+
+
+###############################################################################
+# Scipy spectrogram (for mne.time_frequency.psd_welch) needed for scipy < 0.16
+def get_spectrogram():
+    from .utils import check_version
+    if check_version('scipy', '0.16.0'):
+        from scipy.signal import spectrogram
+    return spectrogram
+
+
+def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
+                nfft=None, detrend='constant', return_onesided=True,
+                scaling='density', axis=-1, mode='psd'):
+    """
+    Compute a spectrogram with consecutive Fourier transforms.
+    Spectrograms can be used as a way of visualizing the change of a
+    nonstationary signal's frequency content over time.
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to a Tukey window with shape parameter of 0.25.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap : int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg // 8``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    return_onesided : bool, optional
+        If True, return a one-sided spectrum for real data. If False return
+        a two-sided spectrum. Note that for complex data, a two-sided
+        spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the power spectral density ('density')
+        where `Pxx` has units of V**2/Hz and computing the power spectrum
+        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
+        and fs is measured in Hz.  Defaults to 'density'
+    axis : int, optional
+        Axis along which the spectrogram is computed; the default is over
+        the last axis (i.e. ``axis=-1``).
+    mode : str, optional
+        Defines what kind of return values are expected. Options are ['psd',
+        'complex', 'magnitude', 'angle', 'phase'].
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    t : ndarray
+        Array of segment times.
+    Sxx : ndarray
+        Spectrogram of x. By default, the last axis of Sxx corresponds to the
+        segment times.
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    welch: Power spectral density by Welch's method.
+    csd: Cross spectral density by Welch's method.
+    Notes
+    -----
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. In contrast to welch's method, where the entire
+    data stream is averaged over, one may wish to use a smaller overlap (or
+    perhaps none at all) when computing a spectrogram, to maintain some
+    statistical independence between individual segments.
+    .. versionadded:: 0.16.0
+    References
+    ----------
+    .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck "Discrete-Time
+           Signal Processing", Prentice Hall, 1999.
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+    Generate a test signal, a 2 Vrms sine wave whose frequency linearly changes
+    with time from 1kHz to 2kHz, corrupted by 0.001 V**2/Hz of white noise
+    sampled at 10 kHz.
+    >>> fs = 10e3
+    >>> N = 1e5
+    >>> amp = 2 * np.sqrt(2)
+    >>> noise_power = 0.001 * fs / 2
+    >>> time = np.arange(N) / fs
+    >>> freq = np.linspace(1e3, 2e3, N)
+    >>> x = amp * np.sin(2*np.pi*freq*time)
+    >>> x += np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+    Compute and plot the spectrogram.
+    >>> f, t, Sxx = signal.spectrogram(x, fs)
+    >>> plt.pcolormesh(t, f, Sxx)
+    >>> plt.ylabel('Frequency [Hz]')
+    >>> plt.xlabel('Time [sec]')
+    >>> plt.show()
+    """
+    # Less overlap than welch, so samples are more statisically independent
+    if noverlap is None:
+        noverlap = nperseg // 8
+
+    freqs, time, Pxy = _spectral_helper(x, x, fs, window, nperseg, noverlap,
+                                        nfft, detrend, return_onesided, scaling,
+                                        axis, mode=mode)
+
+    return freqs, time, Pxy
+
+
+def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
+                    noverlap=None, nfft=None, detrend='constant',
+                    return_onesided=True, scaling='spectrum', axis=-1,
+                    mode='psd'):
+    """
+    Calculate various forms of windowed FFTs for PSD, CSD, etc.
+    This is a helper function that implements the commonality between the
+    psd, csd, and spectrogram functions. It is not designed to be called
+    externally. The windows are not averaged over; the result from each window
+    is returned.
+    Parameters
+    ---------
+    x : array_like
+        Array or sequence containing the data to be analyzed.
+    y : array_like
+        Array or sequence containing the data to be analyzed. If this is
+        the same object in memoery as x (i.e. _spectral_helper(x, x, ...)),
+        the extra computations are spared.
+    fs : float, optional
+        Sampling frequency of the time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to 'hann'.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap : int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg // 2``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    return_onesided : bool, optional
+        If True, return a one-sided spectrum for real data. If False return
+        a two-sided spectrum. Note that for complex data, a two-sided
+        spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        measured in V and fs is measured in Hz.  Defaults to 'density'
+    axis : int, optional
+        Axis along which the periodogram is computed; the default is over
+        the last axis (i.e. ``axis=-1``).
+    mode : str, optional
+        Defines what kind of return values are expected. Options are ['psd',
+        'complex', 'magnitude', 'angle', 'phase'].
+    Returns
+    -------
+    freqs : ndarray
+        Array of sample frequencies.
+    t : ndarray
+        Array of times corresponding to each data segment
+    result : ndarray
+        Array of output data, contents dependant on *mode* kwarg.
+    References
+    ----------
+    .. [1] Stack Overflow, "Rolling window for 1D arrays in Numpy?",
+        http://stackoverflow.com/a/6811241
+    .. [2] Stack Overflow, "Using strides for an efficient moving average
+        filter", http://stackoverflow.com/a/4947453
+    Notes
+    -----
+    Adapted from matplotlib.mlab
+    .. versionadded:: 0.16.0
+    """
+    if mode not in ['psd', 'complex', 'magnitude', 'angle', 'phase']:
+        raise ValueError("Unknown value for mode %s, must be one of: "
+                         "'default', 'psd', 'complex', "
+                         "'magnitude', 'angle', 'phase'" % mode)
+
+    # If x and y are the same object we can save ourselves some computation.
+    same_data = y is x
+
+    if not same_data and mode != 'psd':
+        raise ValueError("x and y must be equal if mode is not 'psd'")
+
+    axis = int(axis)
+
+    # Ensure we have np.arrays, get outdtype
+    x = np.asarray(x)
+    if not same_data:
+        y = np.asarray(y)
+        outdtype = np.result_type(x,y,np.complex64)
+    else:
+        outdtype = np.result_type(x,np.complex64)
+
+    if not same_data:
+        # Check if we can broadcast the outer axes together
+        xouter = list(x.shape)
+        youter = list(y.shape)
+        xouter.pop(axis)
+        youter.pop(axis)
+        try:
+            outershape = np.broadcast(np.empty(xouter), np.empty(youter)).shape
+        except ValueError:
+            raise ValueError('x and y cannot be broadcast together.')
+
+    if same_data:
+        if x.size == 0:
+            return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
+    else:
+        if x.size == 0 or y.size == 0:
+            outshape = outershape + (min([x.shape[axis], y.shape[axis]]),)
+            emptyout = np.rollaxis(np.empty(outshape), -1, axis)
+            return emptyout, emptyout, emptyout
+
+    if x.ndim > 1:
+        if axis != -1:
+            x = np.rollaxis(x, axis, len(x.shape))
+            if not same_data and y.ndim > 1:
+                y = np.rollaxis(y, axis, len(y.shape))
+
+    # Check if x and y are the same length, zero-pad if neccesary
+    if not same_data:
+        if x.shape[-1] != y.shape[-1]:
+            if x.shape[-1] < y.shape[-1]:
+                pad_shape = list(x.shape)
+                pad_shape[-1] = y.shape[-1] - x.shape[-1]
+                x = np.concatenate((x, np.zeros(pad_shape)), -1)
+            else:
+                pad_shape = list(y.shape)
+                pad_shape[-1] = x.shape[-1] - y.shape[-1]
+                y = np.concatenate((y, np.zeros(pad_shape)), -1)
+
+    # X and Y are same length now, can test nperseg with either
+    if x.shape[-1] < nperseg:
+        warnings.warn('nperseg = {0:d}, is greater than input length = {1:d}, '
+                      'using nperseg = {1:d}'.format(nperseg, x.shape[-1]))
+        nperseg = x.shape[-1]
+
+    nperseg = int(nperseg)
+    if nperseg < 1:
+        raise ValueError('nperseg must be a positive integer')
+
+    if nfft is None:
+        nfft = nperseg
+    elif nfft < nperseg:
+        raise ValueError('nfft must be greater than or equal to nperseg.')
+    else:
+        nfft = int(nfft)
+
+    if noverlap is None:
+        noverlap = nperseg//2
+    elif noverlap >= nperseg:
+        raise ValueError('noverlap must be less than nperseg.')
+    else:
+        noverlap = int(noverlap)
+
+    # Handle detrending and window functions
+    if not detrend:
+        def detrend_func(d):
+            return d
+    elif not hasattr(detrend, '__call__'):
+        def detrend_func(d):
+            return signaltools.detrend(d, type=detrend, axis=-1)
+    elif axis != -1:
+        # Wrap this function so that it receives a shape that it could
+        # reasonably expect to receive.
+        def detrend_func(d):
+            d = np.rollaxis(d, -1, axis)
+            d = detrend(d)
+            return np.rollaxis(d, axis, len(d.shape))
+    else:
+        detrend_func = detrend
+
+    if isinstance(window, string_types) or type(window) is tuple:
+        win = get_window(window, nperseg)
+    else:
+        win = np.asarray(window)
+        if len(win.shape) != 1:
+            raise ValueError('window must be 1-D')
+        if win.shape[0] != nperseg:
+            raise ValueError('window must have length of nperseg')
+
+    if np.result_type(win,np.complex64) != outdtype:
+        win = win.astype(outdtype)
+
+    if mode == 'psd':
+        if scaling == 'density':
+            scale = 1.0 / (fs * (win*win).sum())
+        elif scaling == 'spectrum':
+            scale = 1.0 / win.sum()**2
+        else:
+            raise ValueError('Unknown scaling: %r' % scaling)
+    else:
+        scale = 1
+
+    if return_onesided is True:
+        if np.iscomplexobj(x):
+            sides = 'twosided'
+        else:
+            sides = 'onesided'
+            if not same_data:
+                if np.iscomplexobj(y):
+                    sides = 'twosided'
+    else:
+        sides = 'twosided'
+
+    if sides == 'twosided':
+        num_freqs = nfft
+    elif sides == 'onesided':
+        if nfft % 2:
+            num_freqs = (nfft + 1)//2
+        else:
+            num_freqs = nfft//2 + 1
+
+    # Perform the windowed FFTs
+    result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft)
+    result = result[..., :num_freqs]
+    freqs = fftpack.fftfreq(nfft, 1/fs)[:num_freqs]
+
+    if not same_data:
+        # All the same operations on the y data
+        result_y = _fft_helper(y, win, detrend_func, nperseg, noverlap, nfft)
+        result_y = result_y[..., :num_freqs]
+        result = np.conjugate(result) * result_y
+    elif mode == 'psd':
+        result = np.conjugate(result) * result
+    elif mode == 'magnitude':
+        result = np.absolute(result)
+    elif mode == 'angle' or mode == 'phase':
+        result = np.angle(result)
+    elif mode == 'complex':
+        pass
+
+    result *= scale
+    if sides == 'onesided':
+        if nfft % 2:
+            result[...,1:] *= 2
+        else:
+            # Last point is unpaired Nyquist freq point, don't double
+            result[...,1:-1] *= 2
+
+    t = np.arange(nperseg/2, x.shape[-1] - nperseg/2 + 1, nperseg - noverlap)/float(fs)
+
+    if sides != 'twosided' and not nfft % 2:
+        # get the last value correctly, it is negative otherwise
+        freqs[-1] *= -1
+
+    # we unwrap the phase here to handle the onesided vs. twosided case
+    if mode == 'phase':
+        result = np.unwrap(result, axis=-1)
+
+    result = result.astype(outdtype)
+
+    # All imaginary parts are zero anyways
+    if same_data and mode != 'complex':
+        result = result.real
+
+    # Output is going to have new last axis for window index
+    if axis != -1:
+        # Specify as positive axis index
+        if axis < 0:
+            axis = len(result.shape)-1-axis
+
+        # Roll frequency axis back to axis where the data came from
+        result = np.rollaxis(result, -1, axis)
+    else:
+        # Make sure window/time index is last axis
+        result = np.rollaxis(result, -1, -2)
+
+    return freqs, t, result
+
+
+def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
+    """
+    Calculate windowed FFT, for internal use by scipy.signal._spectral_helper
+    This is a helper function that does the main FFT calculation for
+    _spectral helper. All input valdiation is performed there, and the data
+    axis is assumed to be the last axis of x. It is not designed to be called
+    externally. The windows are not averaged over; the result from each window
+    is returned.
+    Returns
+    -------
+    result : ndarray
+        Array of FFT data
+    References
+    ----------
+    .. [1] Stack Overflow, "Repeat NumPy array without replicating data?",
+        http://stackoverflow.com/a/5568169
+    Notes
+    -----
+    Adapted from matplotlib.mlab
+    .. versionadded:: 0.16.0
+    """
+    # Created strided array of data segments
+    if nperseg == 1 and noverlap == 0:
+        result = x[..., np.newaxis]
+    else:
+        step = nperseg - noverlap
+        shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
+        strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])
+        result = np.lib.stride_tricks.as_strided(x, shape=shape,
+                                                 strides=strides)
+
+    # Detrend each data segment individually
+    result = detrend_func(result)
+
+    # Apply window by multiplication
+    result = win * result
+
+    # Perform the fft. Acts on last axis by default. Zero-pads automatically
+    result = fftpack.fft(result, n=nfft)
+
+    return result
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -478,11 +478,7 @@ def _get_sph_harm():
 
 ###############################################################################
 # Scipy spectrogram (for mne.time_frequency.psd_welch) needed for scipy < 0.16
-def get_spectrogram():
-    from .utils import check_version
-    if check_version('scipy', '0.16.0'):
-        from scipy.signal import spectrogram
-    return spectrogram
+
 
 
 def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
@@ -903,6 +899,13 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     result = fftpack.fft(result, n=nfft)
 
     return result
+
+
+def get_spectrogram():
+    from .utils import check_version
+    if check_version('scipy', '0.16.0'):
+        from scipy.signal import spectrogram
+    return spectrogram
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -20,9 +20,9 @@ import re
 import warnings
 
 import numpy as np
-from scipy import linalg, fftpack, __version__ as sp_version
-from scipy.signal import signaltools
-from scipy.signal.windows import get_window
+from scipy import linalg, __version__ as sp_version
+
+from .externals.six import string_types
 
 
 ###############################################################################
@@ -633,7 +633,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     t : ndarray
         Array of times corresponding to each data segment
     result : ndarray
-        Array of output data, contents dependant on *mode* kwarg.
+        Array of output data, contents dependent on *mode* kwarg.
 
     References
     ----------
@@ -647,6 +647,10 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     Adapted from matplotlib.mlab
     .. versionadded:: 0.16.0
     """
+    from scipy import fftpack
+    from scipy.signal import signaltools
+    from scipy.signal.windows import get_window
+
     if mode not in ['psd', 'complex', 'magnitude', 'angle', 'phase']:
         raise ValueError("Unknown value for mode %s, must be one of: "
                          "'default', 'psd', 'complex', "
@@ -694,7 +698,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
             if not same_data and y.ndim > 1:
                 y = np.rollaxis(y, axis, len(y.shape))
 
-    # Check if x and y are the same length, zero-pad if neccesary
+    # Check if x and y are the same length, zero-pad if necessary
     if not same_data:
         if x.shape[-1] != y.shape[-1]:
             if x.shape[-1] < y.shape[-1]:
@@ -870,6 +874,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     Adapted from matplotlib.mlab
     .. versionadded:: 0.16.0
     """
+    from scipy import fftpack
+
     # Created strided array of data segments
     if nperseg == 1 and noverlap == 0:
         result = x[..., np.newaxis]

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -7,6 +7,7 @@ import numpy as np
 from ..parallel import parallel_func
 from ..io.pick import _pick_data_channels
 from ..utils import logger, verbose, _time_mask
+from ..fixes import get_spectrogram
 from .multitaper import _psd_multitaper
 
 
@@ -82,7 +83,7 @@ def _psd_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
     """
-    from scipy.signal import spectrogram
+    spectrogram = get_spectrogram()
     dshape = x.shape[:-1]
     n_times = x.shape[-1]
     x = x.reshape(-1, n_times)

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -12,19 +12,8 @@ from .multitaper import _psd_multitaper
 
 def _pwelch(epoch, noverlap, nfft, fs, freq_mask, welch_fun):
     """Aux function."""
-    return welch_fun(epoch, nperseg=nfft, noverlap=noverlap,
-                     nfft=nfft, fs=fs)[1][..., freq_mask]
-
-
-def _compute_psd(data, fmin, fmax, Fs, n_fft, psd, n_overlap, pad_to):
-    """Compute the PSD."""
-    out = [psd(d, Fs=Fs, NFFT=n_fft, noverlap=n_overlap, pad_to=pad_to)
-           for d in data]
-    psd = np.array([o[0] for o in out])
-    freqs = out[0][1]
-    mask = (freqs >= fmin) & (freqs <= fmax)
-    freqs = freqs[mask]
-    return psd[:, mask], freqs
+    return welch_fun(epoch, fs=fs, nperseg=nfft, noverlap=noverlap,
+                     nfft=nfft, window='hann')[2][..., freq_mask, :]
 
 
 def _check_nfft(n, n_fft, n_overlap):
@@ -93,7 +82,7 @@ def _psd_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
     """
-    from scipy.signal import welch
+    from scipy.signal import spectrogram
     dshape = x.shape[:-1]
     n_times = x.shape[-1]
     x = x.reshape(-1, n_times)
@@ -111,11 +100,11 @@ def _psd_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     x_splits = np.array_split(x, n_jobs)
     f_psd = parallel(my_pwelch(d, noverlap=n_overlap, nfft=n_fft,
                      fs=sfreq, freq_mask=freq_mask,
-                     welch_fun=welch)
+                     welch_fun=spectrogram)
                      for d in x_splits)
 
-    # Combining/reshaping to original data shape
-    psds = np.concatenate(f_psd, axis=0)
+    # Combining, reducing windows and reshaping to original data shape
+    psds = np.concatenate(f_psd, axis=0).mean(axis=-1)
     psds = psds.reshape(np.hstack([dshape, -1]))
     return psds, freqs
 


### PR DESCRIPTION
Breaking up #3820 into smaller steps.  
a better way than #3822 -almost too simple ;)

This makes `psd_welch` use scipy's `spectral` instead of `welch`. `spectral` is used with the defaults used in welch here, but the windows are not averaged over - allowing for further steps outlined in #3820

I also removed `_compute_psd` because it was not used anywhere.