### PR TITLE
Pass first samples of individual files when reading multi-file CTF data.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,7 @@ Changelog
 
 BUG
 ~~~
+    - Fix reading multi-file CTF recordings in :class:`mne.io.ctf.RawCTF` by `Niklas Wilming`_
 
     - Fix computation of AR coefficients across channels in :func:`mne.time_frequency.fit_iir_model_raw` by `Eric Larson`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -338,6 +338,7 @@ The committer list for this release is the following (sorted by alphabetical ord
     * Michael Krause
     * Mikolaj Magnuski
     * Nick Foti
+    * Niklas Wilming
     * Phillip Alday
     * Simon-Shlomo Poil
     * Teon Brooks

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -338,7 +338,6 @@ The committer list for this release is the following (sorted by alphabetical ord
     * Michael Krause
     * Mikolaj Magnuski
     * Nick Foti
-    * Niklas Wilming
     * Phillip Alday
     * Simon-Shlomo Poil
     * Teon Brooks
@@ -1914,3 +1913,5 @@ of commits):
 .. _Keith Doelling: http://science.keithdoelling.com
 
 .. _Paul Pasler: https://github.com/ppasler
+
+.. _Niklas Wilming: https://github.com/nwilming

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -138,7 +138,7 @@ class RawCTF(BaseRaw):
             last_samps.append(sample_info['n_samp'] - 1)
             raw_extras.append(sample_info)
         super(RawCTF, self).__init__(
-            info, preload, last_samps=last_samps, filenames=fnames,
+            info, preload, first_samps=(0,)*len(last_samps), last_samps=last_samps, filenames=fnames,
             raw_extras=raw_extras, orig_format='int', verbose=verbose)
 
     @verbose

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -137,7 +137,7 @@ class RawCTF(BaseRaw):
             fnames.append(meg4_name)
             last_samps.append(sample_info['n_samp'] - 1)
             raw_extras.append(sample_info)
-            first_samps = [0, ] * len(last_samps)
+            first_samps = [0] * len(last_samps)
         super(RawCTF, self).__init__(
             info, preload, first_samps=first_samps,
             last_samps=last_samps, filenames=fnames,

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -138,7 +138,8 @@ class RawCTF(BaseRaw):
             last_samps.append(sample_info['n_samp'] - 1)
             raw_extras.append(sample_info)
         super(RawCTF, self).__init__(
-            info, preload, first_samps=(0,)*len(last_samps), last_samps=last_samps, filenames=fnames,
+            info, preload, first_samps=[0, ] * len(last_samps),
+            last_samps=last_samps, filenames=fnames,
             raw_extras=raw_extras, orig_format='int', verbose=verbose)
 
     @verbose

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -137,8 +137,9 @@ class RawCTF(BaseRaw):
             fnames.append(meg4_name)
             last_samps.append(sample_info['n_samp'] - 1)
             raw_extras.append(sample_info)
+            first_samps = [0, ] * len(last_samps)
         super(RawCTF, self).__init__(
-            info, preload, first_samps=[0, ] * len(last_samps),
+            info, preload, first_samps=first_samps,
             last_samps=last_samps, filenames=fnames,
             raw_extras=raw_extras, orig_format='int', verbose=verbose)
 


### PR DESCRIPTION
This should fix #3824 