### PR TITLE
MRG: Minor fixes to picking

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -83,6 +83,8 @@ BUG
 
     - Fix contour levels in :func:`mne.viz.plot_evoked_topomap` to be uniform across topomaps by `Jaakko Leppakangas`_
 
+    - Fix bug in :func:`mne.preprocessing.maxwell_filter` where fine calibration indices were mismatched leading to an ``AssertionError`` by `Eric Larson`_
+
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -85,6 +85,8 @@ BUG
 
     - Fix bug in :func:`mne.preprocessing.maxwell_filter` where fine calibration indices were mismatched leading to an ``AssertionError`` by `Eric Larson`_
 
+    - Fix bug in :func:`mne.preprocessing.fix_stim_artifact` where non-data channels were interpolated by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -26,7 +26,7 @@ from .io.tree import dir_tree_find
 from .io.open import fiff_open
 from .surface import (read_surface, write_surface, complete_surface_info,
                       _compute_nearest, _get_ico_surface, read_tri)
-from .utils import verbose, logger, run_subprocess, get_subjects_dir, warn
+from .utils import verbose, logger, run_subprocess, get_subjects_dir, warn, _pl
 from .externals.six import string_types
 
 
@@ -47,16 +47,16 @@ class ConductorModel(dict):
     def __repr__(self):  # noqa: D105
         if self['is_sphere']:
             center = ', '.join('%0.1f' % (x * 1000.) for x in self['r0'])
-            pl = '' if len(self['layers']) == 1 else 's'
             rad = self.radius
             if rad is None:  # no radius / MEG only
                 extra = 'Sphere (no layers): r0=[%s] mm' % center
             else:
                 extra = ('Sphere (%s layer%s): r0=[%s] R=%1.f mm'
-                         % (len(self['layers']) - 1, pl, center, rad * 1000.))
+                         % (len(self['layers']) - 1, _pl(self['layers']),
+                            center, rad * 1000.))
         else:
-            pl = '' if len(self['surfs']) == 1 else 's'
-            extra = ('BEM (%s layer%s)' % (len(self['surfs']), pl))
+            extra = ('BEM (%s layer%s)' % (len(self['surfs']),
+                                           _pl(self['surfs'])))
         return '<ConductorModel  |  %s>' % extra
 
     @property
@@ -931,7 +931,7 @@ def get_fitting_dig(info, dig_kinds='auto', verbose=None):
         kinds_str = ', '.join(['"%s"' % _dig_kind_rev[d]
                                for d in sorted(dig_kinds)])
         msg = ('Only %s head digitization points of the specified kind%s (%s,)'
-               % (len(hsp), 's' if len(dig_kinds) != 1 else '', kinds_str))
+               % (len(hsp), _pl(dig_kinds), kinds_str))
         if len(hsp) < 4:
             raise ValueError(msg + ', at least 4 required')
         else:

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1334,12 +1334,12 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
     channel type separately. Special care is taken to keep the
     rank of the data constant.
 
-    **Note:** This function is kept for reasons of backward-compatibility.
-    Please consider explicitly using the ``method`` parameter in
-    `compute_covariance` to directly combine estimation with regularization
-    in a data-driven fashion see the
-    `faq <http://martinos.org/mne/dev/faq.html#how-should-i-regularize-the-covariance-matrix>`_
-    for more information.
+    .. note:: This function is kept for reasons of backward-compatibility.
+              Please consider explicitly using the ``method`` parameter in
+              :func:`mne.compute_covariance` to directly combine estimation
+              with regularization in a data-driven fashion.
+              See the `faq <http://martinos.org/mne/dev/faq.html#how-should-i-regularize-the-covariance-matrix>`_
+              for more information.
 
     Parameters
     ----------
@@ -1390,6 +1390,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
     ch_names_eeg = [info_ch_names[i] for i in sel_eeg]
     ch_names_mag = [info_ch_names[i] for i in sel_mag]
     ch_names_grad = [info_ch_names[i] for i in sel_grad]
+    del sel_eeg, sel_mag, sel_grad
 
     # This actually removes bad channels from the cov, which is not backward
     # compatible, so let's leave all channels in
@@ -1441,9 +1442,6 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
         C[np.ix_(idx, idx)] = this_C
 
     # Put data back in correct locations
-    # XXX because this uses pick_channels it is not immune to reordering,
-    # but hopefully won't be a problem in practice so long as users don't
-    # reorder their data...
     idx = pick_channels(cov.ch_names, info_ch_names, exclude=exclude)
     cov['data'][np.ix_(idx, idx)] = C
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -32,7 +32,8 @@ from .bem import _bem_find_surface, _bem_explain_surface
 from .source_space import (_make_volume_source_space, SourceSpaces,
                            _points_outside_surface)
 from .parallel import parallel_func
-from .utils import logger, verbose, _time_mask, warn, _check_fname, check_fname
+from .utils import (logger, verbose, _time_mask, warn, _check_fname,
+                    check_fname, _pl)
 
 
 class Dipole(object):
@@ -1058,8 +1059,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     guess_data = dict(fwd=guess_fwd, fwd_svd=guess_fwd_svd,
                       fwd_orig=guess_fwd_orig, scales=guess_fwd_scales)
     del guess_fwd, guess_fwd_svd, guess_fwd_orig, guess_fwd_scales  # destroyed
-    pl = '' if guess_src['nuse'] == 1 else 's'
-    logger.info('[done %d source%s]' % (guess_src['nuse'], pl))
+    logger.info('[done %d source%s]' % (guess_src['nuse'],
+                                        _pl(guess_src['nuse'])))
 
     # Do actual fits
     data = data[picks]

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -42,7 +42,7 @@ from .fixes import _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
                   plot_epochs_image, plot_topo_image_epochs, plot_drop_log)
 from .utils import (check_fname, logger, verbose, _check_type_picks,
-                    _time_mask, check_random_state, warn,
+                    _time_mask, check_random_state, warn, _pl,
                     sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc)
 from .externals.six import iteritems, string_types
 from .externals.six.moves import zip
@@ -1048,7 +1048,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self._data = np.delete(self._data, indices, axis=0)
 
         count = len(indices)
-        logger.info('Dropped %d epoch%s' % (count, '' if count == 1 else 's'))
+        logger.info('Dropped %d epoch%s' % (count, _pl(count)))
         return self
 
     def _get_epoch_from_raw(self, idx, verbose=None):

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 from ..surface import fast_cross_3d, _project_onto_surface
 from ..io.constants import FIFF
 from ..transforms import apply_trans
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _pl
 from ..parallel import parallel_func
 from ..io.compensator import get_current_comp, make_compensator
 from ..io.pick import pick_types
@@ -791,8 +791,7 @@ def _compute_forwards_meeg(rr, fd, n_jobs, verbose=None):
         # Do the actual forward calculation for a list MEG/EEG sensors
         logger.info('Computing %s at %d source location%s '
                     '(free orientations)...'
-                    % (coil_type.upper(), len(rr),
-                       '' if len(rr) == 1 else 's'))
+                    % (coil_type.upper(), len(rr), _pl(rr)))
         # Calculate forward solution using spherical or BEM model
         B = fun(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs,
                 coil_type)

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -172,6 +172,7 @@ def _get_artemis123_info(fname):
         # a value of another ref channel to make writers/readers happy.
         if t['cal'] == 0:
             t['cal'] = 4.716e-10
+            info['bads'].append(t['ch_name'])
         t['loc'] = loc_dict.get(chan['name'], np.zeros(12))
 
         if (chan['name'].startswith('MEG')):
@@ -228,7 +229,7 @@ def _get_artemis123_info(fname):
 
         # append this channel to the info
         info['chs'].append(t)
-        if (chan['FLL_ResetLock'] == 'TRUE'):
+        if chan['FLL_ResetLock'] == 'TRUE':
             info['bads'].append(t['ch_name'])
 
     # reduce info['bads'] to unique set

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -168,6 +168,10 @@ def _get_artemis123_info(fname):
              'logno': i + 1, 'scanno': i + 1, 'range': 1.0,
              'unit_mul': FIFF.FIFF_UNITM_NONE,
              'coord_frame': FIFF.FIFFV_COORD_DEVICE}
+        # REF_018 has a zero cal which can cause problems. Let's set it to
+        # a value of another ref channel to make writers/readers happy.
+        if t['cal'] == 0:
+            t['cal'] = 4.716e-10
         t['loc'] = loc_dict.get(chan['name'], np.zeros(12))
 
         if (chan['name'].startswith('MEG')):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -339,6 +339,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         cals = np.empty(info['nchan'])
         for k in range(info['nchan']):
             cals[k] = info['chs'][k]['range'] * info['chs'][k]['cal']
+        bad = np.where(cals == 0)[0]
+        if len(bad) > 0:
+            raise ValueError('Bad cals for channels %s'
+                             % dict((ii, self.ch_names[ii]) for ii in bad))
         self.verbose = verbose
         self._cals = cals
         self._raw_extras = list(raw_extras)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -93,6 +93,10 @@ def pick_channels(ch_names, include, exclude=[]):
         List of channels.
     include : list of string
         List of channels to include (if empty include all available).
+
+        .. note:: This is to be treated as a set. The order of this list
+           is not used or maintained in ``sel``.
+
     exclude : list of string
         List of channels to exclude (if empty do not exclude any channel).
         Defaults to [].

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -25,8 +25,7 @@ fname_mc = op.join(data_path, 'SSS', 'test_move_anon_movecomp_raw_sss.fif')
 
 
 def test_pick_refs():
-    """Test picking of reference sensors
-    """
+    """Test picking of reference sensors."""
     infos = list()
     # KIT
     kit_dir = op.join(io_dir, 'kit', 'tests', 'data')
@@ -210,7 +209,7 @@ def test_pick_forward_seeg_ecog():
 
 
 def test_picks_by_channels():
-    """Test creating pick_lists"""
+    """Test creating pick_lists."""
     rng = np.random.RandomState(909)
 
     test_data = rng.random_sample((4, 2000))
@@ -237,6 +236,9 @@ def test_picks_by_channels():
     sfreq = 250.0
     info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
     raw = RawArray(test_data, info)
+    # This acts as a set, not an order
+    assert_array_equal(pick_channels(info['ch_names'], ['MEG 002', 'MEG 001']),
+                       [0, 1])
 
     # Make sure checks for list input work.
     assert_raises(ValueError, pick_channels, ch_names, 'MEG 001')
@@ -254,7 +256,7 @@ def test_picks_by_channels():
 
 
 def test_clean_info_bads():
-    """Test cleaning info['bads'] when bad_channels are excluded """
+    """Test cleaning info['bads'] when bad_channels are excluded."""
 
     raw_file = op.join(op.dirname(__file__), 'io', 'tests', 'data',
                        'test_raw.fif')

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -73,12 +73,15 @@ class InverseOperator(dict):
 
 
 def _pick_channels_inverse_operator(ch_names, inv):
-    """Data channel indices to be used knowing an inverse operator."""
-    sel = []
+    """Data channel indices to be used knowing an inverse operator.
+
+    Unlike ``pick_channels``, this respects the order of ch_names.
+    """
+    sel = list()
     for name in inv['noise_cov'].ch_names:
-        if name in ch_names:
+        try:
             sel.append(ch_names.index(name))
-        else:
+        except ValueError:
             raise ValueError('The inverse operator was computed with '
                              'channel %s which is not present in '
                              'the data. You should compute a new inverse '
@@ -785,10 +788,6 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9.,
     #
     #   Pick the correct channels from the data
     #
-    # XXX _pick_channels_inverse_operator does a set-like operation, so
-    # this (and all other calls with _pick_channels_inverse_operator)
-    # will fail if users have reordered their channels
-    # (or if e.g., one recording has a different order from another)
     sel = _pick_channels_inverse_operator(evoked.ch_names, inv)
     logger.info('Picked %d channels from the data' % len(sel))
     logger.info('Computing inverse...')

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -785,6 +785,10 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9.,
     #
     #   Pick the correct channels from the data
     #
+    # XXX _pick_channels_inverse_operator does a set-like operation, so
+    # this (and all other calls with _pick_channels_inverse_operator)
+    # will fail if users have reordered their channels
+    # (or if e.g., one recording has a different order from another)
     sel = _pick_channels_inverse_operator(evoked.ch_names, inv)
     logger.info('Picked %d channels from the data' % len(sel))
     logger.info('Computing inverse...')

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .peak_finder import peak_finder
 from .. import pick_types, pick_channels
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _pl
 from ..filter import filter_data
 from ..epochs import Epochs
 from ..externals.six import string_types
@@ -117,8 +117,7 @@ def _get_eog_channel_index(ch_name, inst):
             raise ValueError('%s not in channel list' % ch_name)
         else:
             logger.info('Using channel %s as EOG channel%s' % (
-                        " and ".join(ch_name),
-                        '' if len(eog_inds) < 2 else 's'))
+                        " and ".join(ch_name), _pl(eog_inds)))
     elif ch_name is None:
 
         eog_inds = pick_types(inst.info, meg=False, eeg=False, stim=False,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -46,7 +46,7 @@ from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state,
                      _get_fast_dot, compute_corr, _get_inst_data,
-                     copy_function_doc_to_method_doc)
+                     copy_function_doc_to_method_doc, _pl)
 from ..fixes import _get_args
 from ..filter import filter_data
 from .bads import find_outliers
@@ -1959,7 +1959,7 @@ def _detect_artifacts(ica, raw, start_find, stop_find, ecg_ch, ecg_score_func,
         else:
             found = list(np.atleast_1d(abs(scores).argsort()[node.criterion]))
 
-        case = (len(found), 's' if len(found) > 1 else '', node.name)
+        case = (len(found), _pl(found), node.name)
         logger.info('    found %s artifact%s by %s' % case)
         ica.exclude += found
 

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -8,7 +8,7 @@ from ..epochs import BaseEpochs
 from ..io import BaseRaw
 from ..event import find_events
 
-from ..io.pick import pick_channels
+from ..io.pick import _pick_data_channels
 
 
 def _get_window(start, end):
@@ -84,8 +84,7 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
     window = None
     if mode == 'window':
         window = _get_window(s_start, s_end)
-    ch_names = inst.info['ch_names']
-    picks = pick_channels(ch_names, ch_names)
+    picks = _pick_data_channels(inst.info)
 
     if isinstance(inst, BaseRaw):
         _check_preload(inst)

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -33,7 +33,7 @@ def _fix_artifact(data, window, picks, first_samp, last_samp, mode):
     from scipy.interpolate import interp1d
     if mode == 'linear':
         x = np.array([first_samp, last_samp])
-        f = interp1d(x, data[:, (first_samp, last_samp)])
+        f = interp1d(x, data[:, (first_samp, last_samp)][picks])
         xnew = np.arange(first_samp, last_samp)
         interp_data = f(xnew)
         data[picks, first_samp:last_samp] = interp_data

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -421,6 +421,14 @@ def test_basic():
     assert_raises(ValueError, maxwell_filter, raw, origin='foo')
     assert_raises(ValueError, maxwell_filter, raw, origin=[0] * 4)
     assert_raises(ValueError, maxwell_filter, raw, mag_scale='foo')
+    raw_missing = raw.copy().load_data()
+    raw_missing.info['bads'] = ['MEG0111']
+    raw_missing.pick_types(meg=True)  # will be missing the bad
+    maxwell_filter(raw_missing)
+    with warnings.catch_warnings(record=True) as w:
+        maxwell_filter(raw_missing, calibration=fine_cal_fname)
+    assert_equal(len(w), 1)
+    assert_true('not in data' in str(w[0].message))
 
 
 @testing.requires_testing_data

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -618,6 +618,20 @@ def test_fine_calibration():
     assert_allclose(py_cal['cal_chans'], mf_cal['cal_chans'])
     assert_allclose(py_cal['cal_corrs'], mf_cal['cal_corrs'],
                     rtol=1e-3, atol=1e-3)
+    # with missing channels
+    raw_missing = raw.copy().load_data()
+    raw_missing.info['bads'] = ['MEG0111', 'MEG0943']  # 1 mag, 1 grad
+    raw_missing.info._check_consistency()
+    raw_sss_bad = maxwell_filter(
+        raw_missing, calibration=fine_cal_fname, origin=mf_head_origin,
+        regularize=None, bad_condition='ignore')
+    raw_missing.pick_types()  # actually remove bads
+    raw_sss_bad.pick_channels(raw_missing.ch_names)  # remove them here, too
+    with warnings.catch_warnings(record=True):
+        raw_sss_missing = maxwell_filter(
+            raw_missing, calibration=fine_cal_fname, origin=mf_head_origin,
+            regularize=None, bad_condition='ignore')
+    assert_meg_snr(raw_sss_missing, raw_sss_bad, 1000., 10000.)
 
     # Test 3D SSS fine calibration (no equivalent func in MaxFilter yet!)
     # very low SNR as proc differs, eventually we should add a better test

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -25,7 +25,7 @@ from ..forward import (_magnetic_dipole_field_vec, _merge_meg_eeg_fwds,
 from ..transforms import _get_trans, transform_surface_to
 from ..source_space import _ensure_src, _points_outside_surface
 from ..source_estimate import _BaseSourceEstimate
-from ..utils import logger, verbose, check_random_state, warn
+from ..utils import logger, verbose, check_random_state, warn, _pl
 from ..parallel import check_n_jobs
 from ..externals.six import string_types
 
@@ -247,7 +247,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
     approx_events = int((len(times) / info['sfreq']) /
                         (stc.times[-1] - stc.times[0]))
     logger.info('Provided parameters will provide approximately %s event%s'
-                % (approx_events, '' if approx_events == 1 else 's'))
+                % (approx_events, _pl(approx_events)))
 
     # Extract necessary info
     meeg_picks = pick_types(info, meg=True, eeg=True, exclude=[])  # for sim
@@ -255,8 +255,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
     fwd_info = pick_info(info, meeg_picks)
     fwd_info['projs'] = []  # Ensure no 'projs' applied
     logger.info('Setting up raw simulation: %s position%s, "%s" interpolation'
-                % (len(dev_head_ts), 's' if len(dev_head_ts) != 1 else '',
-                   interp))
+                % (len(dev_head_ts), _pl(dev_head_ts), interp))
 
     verts = stc.vertices
     verts = [verts] if isinstance(stc, VolSourceEstimate) else verts
@@ -414,7 +413,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
 
         logger.info('  Simulating data for %0.3f-%0.3f sec with %s event%s'
                     % (tuple(offsets[fi - 1:fi + 1] / info['sfreq']) +
-                       (len(event_idxs), '' if len(event_idxs) == 1 else 's')))
+                       (len(event_idxs), _pl(event_idxs))))
 
         # Process data in large chunks to save on memory
         chunk_size = 10000

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -16,7 +16,7 @@ from scipy import sparse
 
 from .parametric import f_oneway
 from ..parallel import parallel_func, check_n_jobs
-from ..utils import split_list, logger, verbose, ProgressBar, warn
+from ..utils import split_list, logger, verbose, ProgressBar, warn, _pl
 from ..source_estimate import SourceEstimate
 
 
@@ -847,10 +847,10 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
             n_step_downs += 1
             if step_down_p > 0:
                 a_text = 'additional ' if n_step_downs > 1 else ''
-                pl = '' if n_removed == 1 else 's'
                 logger.info('Step-down-in-jumps iteration #%i found %i %s'
                             'cluster%s to exclude from subsequent iterations'
-                            % (n_step_downs, n_removed, a_text, pl))
+                            % (n_step_downs, n_removed, a_text,
+                               _pl(n_removed)))
         logger.info('Done.')
         # The clusters should have the same shape as the samples
         clusters = _reshape_clusters(clusters, sample_shape)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -7,7 +7,7 @@ import os.path as op
 
 from nose.tools import assert_true
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+                           assert_equal, assert_allclose)
 from nose.tools import assert_raises
 import numpy as np
 from scipy import linalg
@@ -16,7 +16,7 @@ import itertools as itt
 
 from mne.cov import (regularize, whiten_evoked, _estimate_rank_meeg_cov,
                      _auto_low_rank_model, _apply_scaling_cov,
-                     _undo_scaling_cov, prepare_noise_cov)
+                     _undo_scaling_cov, prepare_noise_cov, compute_whitener)
 
 from mne import (read_cov, write_cov, Epochs, merge_events,
                  find_events, compute_raw_covariance,
@@ -84,6 +84,42 @@ def test_cov_order():
     cov = read_cov(cov_fname)
     # no avg ref present warning
     prepare_noise_cov(cov, info, ch_names, verbose='error')
+    # big reordering
+    cov_reorder = cov.copy()
+    order = np.random.RandomState(0).permutation(np.arange(len(cov.ch_names)))
+    cov_reorder['names'] = [cov['names'][ii] for ii in order]
+    cov_reorder['data'] = cov['data'][order][:, order]
+    # Make sure we did this properly
+    _assert_reorder(cov_reorder, cov, order)
+    # Now check some functions that should get the same result for both
+    # regularize
+    cov_reg = regularize(cov, info)
+    cov_reg_reorder = regularize(cov_reorder, info)
+    _assert_reorder(cov_reg_reorder, cov_reg, order)
+    # prepare_noise_cov
+    cov_prep = prepare_noise_cov(cov, info, ch_names)
+    cov_prep_reorder = prepare_noise_cov(cov, info, ch_names)
+    _assert_reorder(cov_prep, cov_prep_reorder,
+                    order=np.arange(len(cov_prep['names'])))
+    # compute_whitener
+    whitener, w_ch_names = compute_whitener(cov, info)
+    whitener_2, w_ch_names_2 = compute_whitener(cov_reorder, info)
+    assert_array_equal(w_ch_names_2, w_ch_names)
+    assert_allclose(whitener_2, whitener)
+    # whiten_evoked
+    evoked = read_evokeds(ave_fname)[0]
+    evoked_white = whiten_evoked(evoked, cov)
+    evoked_white_2 = whiten_evoked(evoked, cov_reorder)
+    assert_allclose(evoked_white_2.data, evoked_white.data)
+
+
+def _assert_reorder(cov_new, cov_orig, order):
+    """Check that we get the same result under reordering."""
+    inv_order = np.argsort(order)
+    assert_array_equal([cov_new['names'][ii] for ii in inv_order],
+                       cov_orig['names'])
+    assert_allclose(cov_new['data'][inv_order][:, inv_order],
+                    cov_orig['data'], atol=1e-20)
 
 
 def test_ad_hoc_cov():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -33,7 +33,7 @@ import numpy as np
 from scipy import linalg, sparse
 
 from .externals.six.moves import urllib
-from .externals.six import string_types, StringIO, BytesIO
+from .externals.six import string_types, StringIO, BytesIO, integer_types
 from .externals.decorator import decorator
 
 from .fixes import _get_args
@@ -70,6 +70,12 @@ _doc_special_members = ('__contains__', '__getitem__', '__iter__', '__len__',
 
 ###############################################################################
 # RANDOM UTILITIES
+
+
+def _pl(x):
+    """Determine if plural should be used."""
+    len_x = x if isinstance(x, integer_types) else len(x)
+    return '' if len_x == 1 else 's'
 
 
 def _explain_exception(start=-1, stop=None, prefix='> '):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -74,7 +74,7 @@ _doc_special_members = ('__contains__', '__getitem__', '__iter__', '__len__',
 
 def _pl(x):
     """Determine if plural should be used."""
-    len_x = x if isinstance(x, integer_types) else len(x)
+    len_x = x if isinstance(x, (integer_types, np.generic)) else len(x)
     return '' if len_x == 1 else 's'
 
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -22,7 +22,7 @@ from ..defaults import _handle_default
 from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
                     plt_show, _process_times, DraggableColorbar, _setup_cmap,
                     _setup_vmin_vmax)
-from ..utils import logger, _clean_names, warn
+from ..utils import logger, _clean_names, warn, _pl
 from ..io.pick import pick_info
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
@@ -403,8 +403,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show,
                     ax.set_ylim(ylim[t])
                 elif plot_type == 'image':
                     im.set_clim(ylim[t])
-            ax.set_title(titles[t] + ' (%d channel%s)' % (
-                         len(D), 's' if len(D) > 1 else ''))
+            ax.set_title(titles[t] + ' (%d channel%s)' % (len(D), _pl(D)))
             ax.set_xlabel('time (ms)')
 
             if (plot_type == 'butterfly') and (hline is not None):


### PR DESCRIPTION
A few fixes in this one:

1. Fixed improper use of `pick_channels` in `maxwell_filter`. It doesn't respect the order of `include` so order must be determined separately.
2. Added a few notes where `pick_channels` behavior could (silently) cause us problems, but hopefully not.
3. Unified plurality in strings with new helper `_pl`.
4. Fixed improper `info['chs][n]['cal'] = 0.` in Artemis123.
5. Fixed `fix_stim_artifact` interpolating all channels instead of just the data channels.
