### PR TITLE
Fix names for train/test arrays in plot_gat_matrix

### DIFF
--- a/mne/viz/decoding.py
+++ b/mne/viz/decoding.py
@@ -64,9 +64,9 @@ def plot_gat_matrix(gat, title=None, vmin=None, vmax=None, tlim=None,
 
     # Define time limits
     if tlim is None:
-        tt_times = gat.train_times_['times']
-        tn_times = gat.test_times_['times']
-        tlim = [tn_times[0][0], tn_times[-1][-1], tt_times[0], tt_times[-1]]
+        tn_times = gat.train_times_['times']
+        tt_times = gat.test_times_['times']
+        tlim = [tt_times[0][0], tt_times[-1][-1], tn_times[0], tn_times[-1]]
 
     # Plot scores
     im = ax.imshow(gat.scores_, interpolation='nearest', origin='lower',


### PR DESCRIPTION
I was looking through the code for `plot_gat_matrix` and I saw this inconsistency in naming. Feel free to ignore this PR if you consider it too nitpicky ;)

