### PR TITLE
[MRG] DOC coreg-GUI:  error message for invalid subject

### DIFF
--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1248,6 +1248,20 @@ class CoregFrame(HasTraits):
             self.model.mri.subjects_dir = subjects_dir
 
         if subject is not None:
+            if subject not in self.model.mri.subject_source.subjects:
+                msg = "%s is not a valid subject. " % subject
+                # no subjects -> ['']
+                if any(self.model.mri.subject_source.subjects):
+                    ss = ', '.join(self.model.mri.subject_source.subjects)
+                    msg += ("The following subjects have been found: %s "
+                            "(subjects_dir=%s). " %
+                            (ss, self.model.mri.subjects_dir))
+                else:
+                    msg += ("No subjects were found in subjects_dir=%s. " %
+                            self.model.mri.subjects_dir)
+                msg += ("Make sure all MRI subjects have head shape files "
+                        "(run $ mne make_scalp_surfaces).")
+                raise ValueError(msg)
             self.model.mri.subject = subject
 
         if guess_mri_subject is not None:

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -135,6 +135,7 @@ def test_coreg_model():
     model.load_trans(fname_trans)
 
     from mne.gui._coreg_gui import CoregFrame
+    assert_raises(ValueError, CoregFrame, raw_path, 'Elvis', tempdir)
     assert_raises(ValueError, CoregFrame, raw_path, 'Elvis', subjects_dir)
     x = CoregFrame(raw_path, 'sample', subjects_dir)
     os.environ['_MNE_GUI_TESTING_MODE'] = 'true'

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -135,6 +135,7 @@ def test_coreg_model():
     model.load_trans(fname_trans)
 
     from mne.gui._coreg_gui import CoregFrame
+    assert_raises(ValueError, CoregFrame, raw_path, 'Elvis', subjects_dir)
     x = CoregFrame(raw_path, 'sample', subjects_dir)
     os.environ['_MNE_GUI_TESTING_MODE'] = 'true'
     try:


### PR DESCRIPTION
This provides a better error message in cases like #3844

```
$ mne coreg -s Donald
Traceback (most recent call last):
  File "/Users/christian/Code/mne-python/mne/commands/mne_coreg.py", line 49, in <module>
    run()
  File "/Users/christian/Code/mne-python/mne/commands/mne_coreg.py", line 43, in run
    guess_mri_subject=options.guess_mri_subject)
  File "/Users/christian/Code/mne-python/mne/gui/__init__.py", line 70, in coregistration
    gui = CoregFrame(inst, subject, subjects_dir, guess_mri_subject)
  File "/Users/christian/Code/mne-python/mne/gui/_coreg_gui.py", line 1264, in __init__
    raise ValueError(msg)
ValueError: Donald is not a valid subject. No subjects were found in 
subjects_dir=/Applications/freesurfer/subjects. Make sure all MRI subjects have 
head shape files (run $ mne make_scalp_surfaces).

```