### PR TITLE
MRG: Fix epoch check

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -248,8 +248,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 raise ValueError('events must be an array of type int')
             if events.ndim != 2 or events.shape[1] != 3:
                 raise ValueError('events must be 2D with 3 columns')
-            if len(np.unique(events[:, 0])) != len(events):
-                raise RuntimeError('Event time samples were not unique')
             for key, val in self.event_id.items():
                 if val not in events[:, 2]:
                     msg = ('No matching events found for %s '
@@ -273,6 +271,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             else:
                 self.drop_log = drop_log
             events = events[selected]
+            if len(np.unique(events[:, 0])) != len(events):
+                raise RuntimeError('Event time samples were not unique')
             n_events = len(events)
             if n_events > 1:
                 if np.diff(events.astype(np.int64)[:, 0]).min() <= 0:

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -453,7 +453,7 @@ def test_epochs_hash():
 
 
 def test_event_ordering():
-    """Test event order"""
+    """Test event order."""
     raw, events = _get_data()[:2]
     events2 = events.copy()
     rng.shuffle(events2)
@@ -465,6 +465,13 @@ def test_event_ordering():
             assert_equal(len(w), ii)
             if ii > 0:
                 assert_true('chronologically' in '%s' % w[-1].message)
+    # Duplicate events should be an error...
+    events2 = events[[0, 0]]
+    events2[:, 2] = [1, 2]
+    assert_raises(RuntimeError, Epochs, raw, events2, event_id=None)
+    # But only if duplicates are actually used by event_id
+    assert_equal(len(Epochs(raw, events2, event_id=dict(a=1), preload=True)),
+                 1)
 
 
 def test_epochs_bad_baseline():


### PR DESCRIPTION
Fix the check for overlapping events. They are only a problem if offending events are actually selected by `event_id`.