### PR TITLE
MRG: Fix ELP reading

### DIFF
--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -245,6 +245,21 @@ def test_read_dig_montage():
     assert_array_equal(montage_cm.hpi, montage.hpi)
     assert_raises(ValueError, read_dig_montage, hsp, hpi, elp, names,
                   unit='km')
+    # extra columns
+    extra_hsp = op.join(tempdir, 'test.txt')
+    with open(hsp, 'rb') as fin:
+        with open(extra_hsp, 'wb') as fout:
+            for line in fin:
+                if line.startswith(b'%'):
+                    fout.write(line)
+                else:
+                    # extra column
+                    fout.write(line.rstrip() + b' 0.0 0.0 0.0\n')
+    with warnings.catch_warnings(record=True) as w:
+        montage_extra = read_dig_montage(extra_hsp, hpi, elp, names)
+    assert_true(len(w) == 1 and all('columns' in str(ww.message) for ww in w))
+    assert_allclose(montage_extra.hsp, montage.hsp)
+    assert_allclose(montage_extra.elp, montage.elp)
 
 
 def test_set_dig_montage():

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -423,6 +423,10 @@ def _read_dig_points(fname, comments='%', unit='auto'):
         dig_points = np.loadtxt(fname, comments=comments, ndmin=2)
         if unit == 'auto':
             unit = 'mm'
+        if dig_points.shape[1] > 3:
+            warn('Found %d columns instead of 3, using first 3 for XYZ '
+                 'coordinates' % (dig_points.shape[1],))
+            dig_points = dig_points[:, :3]
 
     if dig_points.shape[-1] != 3:
         err = 'Data must be (n, 3) instead of %s' % (dig_points.shape,)


### PR DESCRIPTION
Sometimes the files can be written out with more columns than just X,Y,Z, this makes it possible to read them (with a warning).