### PR TITLE
MRG: Only warn for non-eeg-avg proj

### DIFF
--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -512,7 +512,10 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
                 psize = sqrt(np.sum(this_vecs[:, v] * this_vecs[:, v]))
                 if psize > 0:
                     orig_n = p['data']['data'].shape[1]
-                    if len(vecsel) < 0.9 * orig_n and not inplace:
+                    # Average ref still works if channels are removed
+                    if len(vecsel) < 0.9 * orig_n and not inplace and \
+                            (p['kind'] != FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF or
+                             len(vecsel) == 1):
                         warn('Projection vector "%s" has magnitude %0.2f '
                              '(should be unity), applying projector with '
                              '%s/%s of the original channels available may '

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -49,13 +49,19 @@ def test_bad_proj():
     _check_warnings(raw, events, picks)
     # still bad
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
-    _check_warnings(raw, events, np.arange(len(raw.ch_names)))
+    _check_warnings(raw, events)
     # "fixed"
     raw.info.normalize_proj()  # avoid projection warnings
-    _check_warnings(raw, events, np.arange(len(raw.ch_names)), count=0)
+    _check_warnings(raw, events, count=0)
+    # eeg avg ref is okay
+    raw = read_raw_fif(raw_fname, preload=True).pick_types(meg=False, eeg=True)
+    raw.set_eeg_reference()
+    _check_warnings(raw, events, count=0)
+    raw.info['bads'] = raw.ch_names[:10]
+    _check_warnings(raw, events, count=0)
 
 
-def _check_warnings(raw, events, picks, count=3):
+def _check_warnings(raw, events, picks=None, count=3):
     """Helper to count warnings."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')


### PR DESCRIPTION
This makes it so that we don't get warnings about subselected channels from EEG average ref proj (they work fine) like:
```
Projection vector "Average EEG reference" has magnitude 0.12 (should be unity), applying projector with 53/60 of the original channels available may be dangerous, consider recomputing and adding projection vectors for channels that are eventually used. If this is intentional, consider using info.normalize_proj()
```