### PR TITLE
MRG+1: Fix _plot_topo_onpick (#3871)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,6 +58,8 @@ Changelog
 BUG
 ~~~
 
+    - Fix callback function call in :func:`mne.viz.topo._plot_topo_onpick` by `Erkka Heinila`_
+
     - Fix reading multi-file CTF recordings in :class:`mne.io.ctf.RawCTF` by `Niklas Wilming`_
 
     - Fix computation of AR coefficients across channels in :func:`mne.time_frequency.fit_iir_model_raw` by `Eric Larson`_
@@ -1941,3 +1943,5 @@ of commits):
 .. _Annalisa Pascarella: http://www.iac.rm.cnr.it/~pasca/
 
 .. _Luke Bloy: https://scholar.google.com/citations?hl=en&user=Ad_slYcAAAAJ&view_op=list_works&sortby=pubdate
+
+.. _Erkka Heinila: https://github.com/Teekuningas

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -220,7 +220,7 @@ def _plot_topo_onpick(event, show_func):
         ax.set_axis_bgcolor(face_color)
 
         # allow custom function to override parameters
-        show_func(plt, ch_idx)
+        show_func(ax, ch_idx)
 
     except Exception as err:
         # matplotlib silently ignores exceptions in event handlers,

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -381,8 +381,8 @@ def _erfimage_imshow(ax, ch_idx, tmin, tmax, vmin, vmax, ylim=None, data=None,
     if sigma > 0.:
         this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma, axis=0)
 
-    img = ax.imshow(this_data, extent=[tmin, tmax, 0, len(data)], 
-                    aspect='auto', origin='lower', vmin=vmin, vmax=vmax, 
+    img = ax.imshow(this_data, extent=[tmin, tmax, 0, len(data)],
+                    aspect='auto', origin='lower', vmin=vmin, vmax=vmax,
                     picker=True, cmap=cmap, interpolation='nearest')
 
     ax = plt.gca()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -381,9 +381,9 @@ def _erfimage_imshow(ax, ch_idx, tmin, tmax, vmin, vmax, ylim=None, data=None,
     if sigma > 0.:
         this_data = ndimage.gaussian_filter1d(this_data, sigma=sigma, axis=0)
 
-    ax.imshow(this_data, extent=[tmin, tmax, 0, len(data)], aspect='auto',
-              origin='lower', vmin=vmin, vmax=vmax, picker=True, cmap=cmap,
-              interpolation='nearest')
+    img = ax.imshow(this_data, extent=[tmin, tmax, 0, len(data)], 
+                    aspect='auto', origin='lower', vmin=vmin, vmax=vmax, 
+                    picker=True, cmap=cmap, interpolation='nearest')
 
     ax = plt.gca()
     if x_label is not None:
@@ -391,7 +391,7 @@ def _erfimage_imshow(ax, ch_idx, tmin, tmax, vmin, vmax, ylim=None, data=None,
     if y_label is not None:
         ax.set_ylabel(y_label)
     if colorbar:
-        plt.colorbar()
+        plt.colorbar(mappable=img)
 
 
 def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,


### PR DESCRIPTION
Should fix #3871. I went through all mne-python's own related callback functions and seems they can all handle both axes object or pyplot coming. 