### PR TITLE
MRG: roc_auc when y not in [0, 1]

### DIFF
--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -648,11 +648,13 @@ def _fix_auc(scoring, y):
     # This fixes sklearn's inability to compute roc_auc when y not in [0, 1]
     # scikit-learn/scikit-learn#6874
     if scoring is not None:
-        if hasattr(scoring, '_score_func'):
-            if hasattr(scoring._score_func, '__name__'):
-                if scoring._score_func.__name__ == 'roc_auc_score':
-                    if np.ndim(y) != 1 or len(set(y)) != 2:
-                        raise ValueError('roc_auc scoring can only be computed'
-                                         ' for two-class problems.')
-                    y = LabelEncoder().fit_transform(y)
+        if (
+            hasattr(scoring, '_score_func') and
+            hasattr(scoring._score_func, '__name__') and
+            scoring._score_func.__name__ == 'roc_auc_score'
+        ):
+            if np.ndim(y) != 1 or len(set(y)) != 2:
+                raise ValueError('roc_auc scoring can only be computed for '
+                                 'two-class problems.')
+            y = LabelEncoder().fit_transform(y)
     return y

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -66,6 +66,18 @@ def test_SearchLight():
         sl.fit(X, y)
         assert_raises(err, sl.score, X, y)
 
+    # Check sklearn's roc_auc fix: scikit-learn/scikit-learn#6874
+    # -- 3 class problem
+    sl = _SearchLight(LogisticRegression(), scoring='roc_auc')
+    y = np.arange(len(X)) % 3
+    sl.fit(X, y)
+    assert_raises(ValueError, sl.score, X, y)
+    # -- 2 class problem not in [0, 1]
+    y = np.arange(len(X)) % 2 + 1
+    sl.fit(X, y)
+    sl.score(X, y)
+    y = np.arange(len(X)) % 2
+
     for method, scoring in [
             ('predict_proba', 'roc_auc'), ('predict', roc_auc_score)]:
         sl1 = _SearchLight(LogisticRegression(), scoring=scoring)
@@ -164,6 +176,17 @@ def test_GeneralizationLight():
         gl = _GeneralizationLight(LogisticRegression(), scoring=scoring)
         gl.fit(X, y)
         assert_raises(err, gl.score, X, y)
+
+    # Check sklearn's roc_auc fix: scikit-learn/scikit-learn#6874
+    # -- 3 class problem
+    gl = _GeneralizationLight(LogisticRegression(), scoring='roc_auc')
+    y = np.arange(len(X)) % 3
+    gl.fit(X, y)
+    assert_raises(ValueError, gl.score, X, y)
+    # -- 2 class problem not in [0, 1]
+    y = np.arange(len(X)) % 2 + 1
+    gl.fit(X, y)
+    gl.score(X, y)
 
     # n_jobs
     gl = _GeneralizationLight(LogisticRegression(), n_jobs=2)

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -75,7 +75,9 @@ def test_SearchLight():
     # -- 2 class problem not in [0, 1]
     y = np.arange(len(X)) % 2 + 1
     sl.fit(X, y)
-    sl.score(X, y)
+    score = sl.score(X, y)
+    assert_array_equal(score, [roc_auc_score(y - 1, _y_pred - 1)
+                               for _y_pred in sl.decision_function(X).T])
     y = np.arange(len(X)) % 2
 
     for method, scoring in [
@@ -186,7 +188,10 @@ def test_GeneralizationLight():
     # -- 2 class problem not in [0, 1]
     y = np.arange(len(X)) % 2 + 1
     gl.fit(X, y)
-    gl.score(X, y)
+    score = gl.score(X, y)
+    manual_score = [[roc_auc_score(y - 1, _y_pred) for _y_pred in _y_preds]
+                    for _y_preds in gl.decision_function(X).transpose(1, 2, 0)]
+    assert_array_equal(score, manual_score)
 
     # n_jobs
     gl = _GeneralizationLight(LogisticRegression(), n_jobs=2)


### PR DESCRIPTION
Fixes error when scoring='roc_auc' and y is not in [0, 1]:

Should be ultimately solved in scikit-learn/scikit-learn#6874

Replaces #3717, Closes #3697
