### PR TITLE
MRG+1: nonuniform image option in tfr plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Changelog
 
     - Add ability to match channel names in a case insensitive manner when applying a :class:`mne.channels.Montage` by `Marijn van Vliet`_
 
+    - Add ``yscale`` keyword argument to :meth:`mne.time_frequency.AverageTFR.plot` that allows specifying whether to present the frequency axis in linear (``'linear'``) or log (``'log'``) scale. The default value is ``'auto'`` which detects whether frequencies are log-spaced and sets yscale to log. Added by `Mikołaj Magnuski`_
 
 BUG
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,8 @@ BUG
 
     - Fix :func:`mne.read_labels_from_annot` to set ``label.values[:]=1`` rather than 0 for consistency with the :class:`Label` class by `Jon Houck`_
 
+    - Fix plotting non-uniform freqs (for example log-spaced) in :meth:`mne.time_frequency.AverageTFR.plot` by `Mikołaj Magnuski`_
+
 API
 ~~~
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -887,8 +887,7 @@ class AverageTFR(_BaseTFR):
     def plot(self, picks, baseline=None, mode='mean', tmin=None,
              tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
              cmap='RdBu_r', dB=False, colorbar=True, show=True,
-             title=None, axes=None, layout=None, verbose=None,
-             imtype='normal'):
+             title=None, axes=None, layout=None, verbose=None):
         """Plot TFRs in a topography with images.
 
         Parameters
@@ -964,8 +963,6 @@ class AverageTFR(_BaseTFR):
             correct layout is inferred from the data.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see :func:`mne.verbose`).
-        imtype : str
-            Image type: 'normal' or 'nonuniform'. (...)
 
         Returns
         -------
@@ -1007,8 +1004,7 @@ class AverageTFR(_BaseTFR):
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
                         ylim=None, tfr=data[idx: idx + 1], freq=freqs,
                         x_label='Time (ms)', y_label='Frequency (Hz)',
-                        colorbar=colorbar, picker=False, cmap=cmap,
-                        imtype=imtype)
+                        colorbar=colorbar, picker=False, cmap=cmap)
             if title:
                 fig.suptitle(title)
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1002,9 +1002,9 @@ class AverageTFR(_BaseTFR):
             onselect_callback = partial(self._onselect, baseline=baseline,
                                         mode=mode, layout=layout)
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
-                        ylim=None, tfr=data[idx: idx + 1], freq=freqs,
+                        tfr=data[idx: idx + 1], freq=freqs,
                         x_label='Time (ms)', y_label='Frequency (Hz)',
-                        colorbar=colorbar, picker=False, cmap=cmap)
+                        colorbar=colorbar, cmap=cmap)
             if title:
                 fig.suptitle(title)
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -884,11 +884,11 @@ class AverageTFR(_BaseTFR):
         self.method = method
 
     @verbose
-    def plot(self, picks, baseline=None, mode='mean', tmin=None,
-             tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
-             cmap='RdBu_r', dB=False, colorbar=True, show=True,
-             title=None, axes=None, layout=None, verbose=None):
-        """Plot TFRs in a topography with images.
+    def plot(self, picks, baseline=None, mode='mean', tmin=None, tmax=None,
+             fmin=None, fmax=None, vmin=None, vmax=None, cmap='RdBu_r',
+             dB=False, colorbar=True, show=True, title=None, axes=None,
+             layout=None, yscale='auto', verbose=None):
+        """Plot TFRs as a two-dimensional image(s).
 
         Parameters
         ----------
@@ -961,6 +961,10 @@ class AverageTFR(_BaseTFR):
             Layout instance specifying sensor positions. Used for interactive
             plotting of topographies on rectangle selection. If possible, the
             correct layout is inferred from the data.
+        yscale : 'auto' (default) | 'linear' | 'log'
+            The scale of y (frequency) axis. 'linear' gives linear y axis,
+            'log' leads to log-spaced y axis and 'auto' detects if frequencies
+            are log-spaced and only then sets the y axis to 'log'.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see :func:`mne.verbose`).
 
@@ -1002,9 +1006,9 @@ class AverageTFR(_BaseTFR):
             onselect_callback = partial(self._onselect, baseline=baseline,
                                         mode=mode, layout=layout)
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
-                        tfr=data[idx: idx + 1], freq=freqs,
+                        ylim=None, tfr=data[idx: idx + 1], freq=freqs,
                         x_label='Time (ms)', y_label='Frequency (Hz)',
-                        colorbar=colorbar, cmap=cmap)
+                        colorbar=colorbar, cmap=cmap, yscale=yscale)
             if title:
                 fig.suptitle(title)
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1062,7 +1062,7 @@ class AverageTFR(_BaseTFR):
                   layout=None, cmap='RdBu_r', title=None, dB=False,
                   colorbar=True, layout_scale=0.945, show=True,
                   border='none', fig_facecolor='k', fig_background=None,
-                  font_color='w'):
+                  font_color='w', yscale='auto'):
         """Plot TFRs in a topography with images.
 
         Parameters
@@ -1131,6 +1131,10 @@ class AverageTFR(_BaseTFR):
             `matplotlib.pyplot.imshow`. Defaults to None.
         font_color: str | obj
             The color of tick labels in the colorbar. Defaults to white.
+        yscale : 'auto' (default) | 'linear' | 'log'
+            The scale of y (frequency) axis. 'linear' gives linear y axis,
+            'log' leads to log-spaced y axis and 'auto' detects if frequencies
+            are log-spaced and only then sets the y axis to 'log'.
 
         Returns
         -------
@@ -1157,7 +1161,7 @@ class AverageTFR(_BaseTFR):
         onselect_callback = partial(self._onselect, baseline=baseline,
                                     mode=mode, layout=layout)
 
-        click_fun = partial(_imshow_tfr, tfr=data, freq=freqs,
+        click_fun = partial(_imshow_tfr, tfr=data, freq=freqs, yscale=yscale,
                             cmap=(cmap, True), onselect=onselect_callback)
         imshow = partial(_imshow_tfr_unified, tfr=data, freq=freqs, cmap=cmap,
                          onselect=onselect_callback)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -887,7 +887,8 @@ class AverageTFR(_BaseTFR):
     def plot(self, picks, baseline=None, mode='mean', tmin=None,
              tmax=None, fmin=None, fmax=None, vmin=None, vmax=None,
              cmap='RdBu_r', dB=False, colorbar=True, show=True,
-             title=None, axes=None, layout=None, verbose=None):
+             title=None, axes=None, layout=None, verbose=None,
+             imtype='normal'):
         """Plot TFRs in a topography with images.
 
         Parameters
@@ -963,6 +964,8 @@ class AverageTFR(_BaseTFR):
             correct layout is inferred from the data.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see :func:`mne.verbose`).
+        imtype : str
+            Image type: 'normal' or 'nonuniform'. (...)
 
         Returns
         -------
@@ -1004,7 +1007,8 @@ class AverageTFR(_BaseTFR):
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
                         ylim=None, tfr=data[idx: idx + 1], freq=freqs,
                         x_label='Time (ms)', y_label='Frequency (Hz)',
-                        colorbar=colorbar, picker=False, cmap=cmap)
+                        colorbar=colorbar, picker=False, cmap=cmap,
+                        imtype=imtype)
             if title:
                 fig.suptitle(title)
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -159,4 +159,9 @@ def test_plot_tfr_topo():
     tfr = AverageTFR(epochs.info, data, epochs.times, freqs, nave)
     tfr.plot([4], baseline=(None, 0), mode='mean', vmax=14., show=False)
 
+    # one timesample
+    tfr = AverageTFR(epochs.info, data[:, :, [0]], epochs.times[[1]],
+                     freqs, nave)
+    tfr.plot([4], baseline=None, vmax=14., show=False)
+
 run_tests_if_main()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -153,7 +153,10 @@ def test_plot_tfr_topo():
     tfr.plot_topo(baseline=(None, 0), mode='ratio', title='Average power',
                   vmin=0., vmax=14., show=False)
     tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo')
-    tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo',
-             imtype='nonuniform')
+
+    # nonuniform freqs
+    freqs = np.logspace(*np.log10([3, 10]), num=3)
+    tfr = AverageTFR(epochs.info, data, epochs.times, freqs, nave)
+    tfr.plot([4], baseline=(None, 0), mode='mean', vmax=14., show=False)
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -176,17 +176,23 @@ def test_plot_tfr_topo():
                      freqs, nave)
     tfr.plot([4], baseline=None, vmax=14., show=False, yscale='linear')
 
-    # one freqency bin
-    tfr = AverageTFR(epochs.info, data[:, [0], :], epochs.times,
-                     freqs[[-1]], nave)
+    # one freqency bin, log scale required: as it doesn't make sense
+    # to plot log scale for one value, we test whether yscale is set to linear
     vmin, vmax = 0., 2.
     fig, ax = plt.subplots()
-    tmin, tmax = tfr.times[0], tfr.times[-1]
-    _imshow_tfr(ax, 3, tmin, tmax, vmin, vmax, None, tfr=tfr.data,
+    tmin, tmax = epochs.times[0], epochs.times[-1]
+    _imshow_tfr(ax, 3, tmin, tmax, vmin, vmax, None, tfr=data[:, [0], :],
                 freq=freqs[[-1]], x_label=None, y_label=None,
                 colorbar=False, cmap=('RdBu_r', True), yscale='log')
     fig = plt.gcf()
-    # doesn't make sense to plot log scale for one value:
     assert_equal(fig.axes[0].get_yaxis().get_scale(), 'linear')
+
+    # ValueError when freq[0] == 0 and yscale == 'log'
+    these_freqs = freqs[:3].copy()
+    these_freqs[0] = 0
+    assert_raises(ValueError, _imshow_tfr, ax, 3, tmin, tmax, vmin, vmax,
+                  None, tfr=data[:, :3, :], freq=these_freqs, x_label=None,
+                  y_label=None, colorbar=False, cmap=('RdBu_r', True),
+                  yscale='log')
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -153,5 +153,7 @@ def test_plot_tfr_topo():
     tfr.plot_topo(baseline=(None, 0), mode='ratio', title='Average power',
                   vmin=0., vmax=14., show=False)
     tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo')
+    tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo',
+             imtype='nonuniform')
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -153,8 +153,15 @@ def test_plot_tfr_topo():
     data = np.random.RandomState(0).randn(len(epochs.ch_names),
                                           n_freqs, len(epochs.times))
     tfr = AverageTFR(epochs.info, data, epochs.times, np.arange(n_freqs), nave)
-    tfr.plot_topo(baseline=(None, 0), mode='ratio', title='Average power',
-                  vmin=0., vmax=14., show=False)
+    fig = tfr.plot_topo(baseline=(None, 0), mode='ratio',
+                        title='Average power', vmin=0., vmax=14.)
+
+    # test opening tfr by clicking
+    num_figures_before = len(plt.get_fignums())
+    _fake_click(fig, fig.axes[-1], (0.08, 0.65))
+    assert_equal(num_figures_before + 1, len(plt.get_fignums()))
+    plt.close('all')
+
     tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo')
 
     # nonuniform freqs

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -163,18 +163,20 @@ def test_plot_tfr_topo():
     plt.close('all')
 
     tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo')
+    assert_raises(ValueError, tfr.plot, [4], yscale='lin', show=False)
 
     # nonuniform freqs
     freqs = np.logspace(*np.log10([3, 10]), num=3)
     tfr = AverageTFR(epochs.info, data, epochs.times, freqs, nave)
-    tfr.plot([4], baseline=(None, 0), mode='mean', vmax=14., show=False)
+    fig = tfr.plot([4], baseline=(None, 0), mode='mean', vmax=14., show=False)
+    assert_equal(fig.axes[0].get_yaxis().get_scale(), 'log')
 
     # one timesample
     tfr = AverageTFR(epochs.info, data[:, :, [0]], epochs.times[[1]],
                      freqs, nave)
-    tfr.plot([4], baseline=None, vmax=14., show=False)
+    tfr.plot([4], baseline=None, vmax=14., show=False, yscale='linear')
 
-    # one freq bin
+    # one freqency bin
     tfr = AverageTFR(epochs.info, data[:, [0], :], epochs.times,
                      freqs[[-1]], nave)
     vmin, vmax = 0., 2.
@@ -182,6 +184,9 @@ def test_plot_tfr_topo():
     tmin, tmax = tfr.times[0], tfr.times[-1]
     _imshow_tfr(ax, 3, tmin, tmax, vmin, vmax, None, tfr=tfr.data,
                 freq=freqs[[-1]], x_label=None, y_label=None,
-                colorbar=False, cmap=('RdBu_r', True))
+                colorbar=False, cmap=('RdBu_r', True), yscale='log')
+    fig = plt.gcf()
+    # doesn't make sense to plot log scale for one value:
+    assert_equal(fig.axes[0].get_yaxis().get_scale(), 'linear')
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -21,7 +21,8 @@ from mne.utils import run_tests_if_main
 from mne.viz import (plot_topo_image_epochs, _get_presser,
                      mne_analyze_colormap, plot_evoked_topo)
 from mne.viz.utils import _fake_click
-from mne.viz.topo import _plot_update_evoked_topo_proj, iter_topography
+from mne.viz.topo import (_plot_update_evoked_topo_proj, iter_topography,
+                          _imshow_tfr)
 
 # Set our plotters to test mode
 import matplotlib
@@ -144,6 +145,8 @@ def test_plot_topo_image_epochs():
 
 def test_plot_tfr_topo():
     """Test plotting of TFR data."""
+    import matplotlib.pyplot as plt
+
     epochs = _get_epochs()
     n_freqs = 3
     nave = 1
@@ -163,5 +166,15 @@ def test_plot_tfr_topo():
     tfr = AverageTFR(epochs.info, data[:, :, [0]], epochs.times[[1]],
                      freqs, nave)
     tfr.plot([4], baseline=None, vmax=14., show=False)
+
+    # one freq bin
+    tfr = AverageTFR(epochs.info, data[:, [0], :], epochs.times,
+                     freqs[[-1]], nave)
+    vmin, vmax = 0., 2.
+    fig, ax = plt.subplots()
+    tmin, tmax = tfr.times[0], tfr.times[-1]
+    _imshow_tfr(ax, 3, tmin, tmax, vmin, vmax, None, tfr=tfr.data,
+                freq=freqs[[-1]], x_label=None, y_label=None,
+                colorbar=False, cmap=('RdBu_r', True))
 
 run_tests_if_main()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -246,10 +246,9 @@ def _check_vlim(vlim):
     return not np.isscalar(vlim) and vlim is not None
 
 
-def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
-                tfr=None, freq=None, vline=None, x_label=None, y_label=None,
-                colorbar=False, picker=True, cmap=('RdBu_r', True), title=None,
-                hline=None):
+def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, tfr=None,
+                freq=None, x_label=None, y_label=None, colorbar=False,
+                cmap=('RdBu_r', True)):
     """Show time-freq map as 2d image."""
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RectangleSelector
@@ -267,21 +266,17 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                                freq_diff, [freq[-1] + freq_diff[-1]]])
     time_mesh, freq_mesh = np.meshgrid(time_lims, freq_lims)
 
-    img = ax.pcolormesh(time_mesh, freq_mesh, tfr[ch_idx], picker=picker,
-                        cmap=cmap, vmin=vmin, vmax=vmax)
+    img = ax.pcolormesh(time_mesh, freq_mesh, tfr[ch_idx], cmap=cmap,
+                        vmin=vmin, vmax=vmax)
     ax.set_xlim(extent[0], extent[1])
     ax.set_ylim(extent[2], extent[3])
 
-    if isinstance(ax, plt.Axes):
-        if x_label is not None:
-            ax.set_xlabel(x_label)
-        if y_label is not None:
-            ax.set_ylabel(y_label)
-    else:
-        if x_label is not None:
-            plt.xlabel(x_label)
-        if y_label is not None:
-            plt.ylabel(y_label)
+    if not isinstance(ax, plt.Axes):
+        ax = plt.gca()
+    if x_label is not None:
+        ax.set_xlabel(x_label)
+    if y_label is not None:
+        ax.set_ylabel(y_label)
     if colorbar:
         if isinstance(colorbar, DraggableColorbar):
             cbar = colorbar.cbar  # this happens with multiaxes case
@@ -289,10 +284,6 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
             cbar = plt.colorbar(mappable=img)
         if interactive_cmap:
             ax.CB = DraggableColorbar(cbar, img)
-    if title:
-        plt.title(title)
-    if not isinstance(ax, plt.Axes):
-        ax = plt.gca()
     ax.RS = RectangleSelector(ax, onselect=onselect)  # reference must be kept
 
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -246,9 +246,9 @@ def _check_vlim(vlim):
     return not np.isscalar(vlim) and vlim is not None
 
 
-def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, tfr=None,
-                freq=None, x_label=None, y_label=None, colorbar=False,
-                cmap=('RdBu_r', True)):
+def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
+                tfr=None, freq=None, x_label=None, y_label=None,
+                colorbar=False, cmap=('RdBu_r', True)):
     """Show time-freq map as 2d image."""
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RectangleSelector

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -249,7 +249,7 @@ def _check_vlim(vlim):
 def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                 tfr=None, freq=None, vline=None, x_label=None, y_label=None,
                 colorbar=False, picker=True, cmap=('RdBu_r', True), title=None,
-                hline=None, imtype='normal'):
+                hline=None):
     """Show time-freq map as 2d image."""
     import matplotlib.pyplot as plt
     from matplotlib.image import NonUniformImage
@@ -257,22 +257,14 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
 
     cmap, interactive_cmap = cmap
     extent = (tmin, tmax, freq[0], freq[-1])
+    times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
-    if imtype == 'normal':
-        img = ax.imshow(tfr[ch_idx], extent=extent, aspect="auto",
-                        origin="lower", vmin=vmin, vmax=vmax,
-                        picker=picker, cmap=cmap)
-    elif imtype == 'nonuniform':
-        # limitations of nonuniform image:
-        # * only two interpolation options ('none' and 'bilinear')
-        # * no aspect argument?
-        times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
-        img = NonUniformImage(ax, extent=extent, clim=(vmin, vmax),
-                              origin="lower", picker=picker, cmap=cmap)
-        img.set_data(times, freq, tfr[ch_idx])
-        ax.images.append(img)
-        ax.set_xlim(extent[0], extent[1])
-        ax.set_ylim(extent[2], extent[3])
+    img = NonUniformImage(ax, extent=extent, clim=(vmin, vmax),
+                          origin="lower", picker=picker, cmap=cmap)
+    img.set_data(times, freq, tfr[ch_idx])
+    ax.images.append(img)
+    ax.set_xlim(extent[0], extent[1])
+    ax.set_ylim(extent[2], extent[3])
 
     if isinstance(ax, plt.Axes):
         if x_label is not None:

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -259,10 +259,17 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
     extent = (tmin, tmax, freq[0], freq[-1])
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
-    img = NonUniformImage(ax, extent=extent, clim=(vmin, vmax),
-                          origin="lower", picker=picker, cmap=cmap)
-    img.set_data(times, freq, tfr[ch_idx])
-    ax.images.append(img)
+    # construct a grid of borders between time/frequency bins
+    time_diff = np.diff(times) / 2.
+    freq_diff = np.diff(freq) / 2.
+    time_lims = np.concatenate([[times[0] - time_diff[0]], times[:-1] +
+                               time_diff, [times[-1] + time_diff[-1]]])
+    freq_lims = np.concatenate([[freq[0] - freq_diff[0]], freq[:-1] +
+                               freq_diff, [freq[-1] + freq_diff[-1]]])
+    time_mesh, freq_mesh = np.meshgrid(time_lims, freq_lims)
+
+    img = ax.pcolormesh(time_mesh, freq_mesh, tfr[ch_idx], picker=picker,
+                        cmap=cmap, vmin=vmin, vmax=vmax)
     ax.set_xlim(extent[0], extent[1])
     ax.set_ylim(extent[2], extent[3])
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -259,8 +259,8 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
     # construct a grid of borders between time/frequency bins
-    time_diff = np.diff(times) / 2.
-    freq_diff = np.diff(freq) / 2.
+    time_diff = np.diff(times) / 2. if len(times) > 1 else [0.0005]
+    freq_diff = np.diff(freq) / 2. if len(freq) > 1 else [0.5]
     time_lims = np.concatenate([[times[0] - time_diff[0]], times[:-1] +
                                time_diff, [times[-1] + time_diff[-1]]])
     freq_lims = np.concatenate([[freq[0] - freq_diff[0]], freq[:-1] +

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -258,7 +258,6 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                          ", got {}".format(yscale))
 
     cmap, interactive_cmap = cmap
-    extent = (tmin, tmax, freq[0], freq[-1])
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
     # test yscale

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -265,7 +265,7 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
         raise ValueError('Using log scale for frequency axis requires all your'
                          ' frequencies to be positive (you cannot include'
                          ' the DC component (0 Hz) in the TFR).')
-    if len(freq) < 2:
+    if len(freq) < 2 or freq[0] == 0:
         yscale = 'linear'
     elif yscale != 'linear':
         ratio = freq[1:] / freq[:-1]

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -268,8 +268,12 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
 
     img = ax.pcolormesh(time_mesh, freq_mesh, tfr[ch_idx], cmap=cmap,
                         vmin=vmin, vmax=vmax)
-    ax.set_xlim(extent[0], extent[1])
-    ax.set_ylim(extent[2], extent[3])
+
+    # limits and yticks
+    ax.set_xlim(time_lims[0], time_lims[-1])
+    if ylim is None:
+        ylim = (freq_lims[0], freq_lims[-1])
+    ax.set_ylim(ylim)
 
     if not isinstance(ax, plt.Axes):
         ax = plt.gca()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -252,7 +252,6 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                 hline=None):
     """Show time-freq map as 2d image."""
     import matplotlib.pyplot as plt
-    from matplotlib.image import NonUniformImage
     from matplotlib.widgets import RectangleSelector
 
     cmap, interactive_cmap = cmap

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -249,16 +249,31 @@ def _check_vlim(vlim):
 def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                 tfr=None, freq=None, vline=None, x_label=None, y_label=None,
                 colorbar=False, picker=True, cmap=('RdBu_r', True), title=None,
-                hline=None):
-    """Show time-freq map on topo."""
+                hline=None, imtype='normal'):
+    """Show time-freq map as 2d image."""
     import matplotlib.pyplot as plt
+    from matplotlib.image import NonUniformImage
     from matplotlib.widgets import RectangleSelector
 
-    extent = (tmin, tmax, freq[0], freq[-1])
     cmap, interactive_cmap = cmap
+    extent = (tmin, tmax, freq[0], freq[-1])
 
-    img = ax.imshow(tfr[ch_idx], extent=extent, aspect="auto", origin="lower",
-                    vmin=vmin, vmax=vmax, picker=picker, cmap=cmap)
+    if imtype == 'normal':
+        img = ax.imshow(tfr[ch_idx], extent=extent, aspect="auto",
+                        origin="lower", vmin=vmin, vmax=vmax,
+                        picker=picker, cmap=cmap)
+    elif imtype == 'nonuniform':
+        # limitations of nonuniform image:
+        # * only two interpolation options ('none' and 'bilinear')
+        # * no aspect argument?
+        times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
+        img = NonUniformImage(ax, extent=extent, clim=(vmin, vmax),
+                              origin="lower", picker=picker, cmap=cmap)
+        img.set_data(times, freq, tfr[ch_idx])
+        ax.images.append(img)
+        ax.set_xlim(extent[0], extent[1])
+        ax.set_ylim(extent[2], extent[3])
+
     if isinstance(ax, plt.Axes):
         if x_label is not None:
             ax.set_xlabel(x_label)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -249,7 +249,7 @@ def _check_vlim(vlim):
 def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                 tfr=None, freq=None, x_label=None, y_label=None,
                 colorbar=False, cmap=('RdBu_r', True), yscale='auto'):
-    """Show time-freq map as 2d image."""
+    """Show time-frequency map as two-dimensional image."""
     from matplotlib import pyplot as plt, ticker
     from matplotlib.widgets import RectangleSelector
 
@@ -261,7 +261,11 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
     # test yscale
-    if len(freq) < 2 or np.any(freq <= 0):
+    if yscale == 'log' and not freq[0] > 0:
+        raise ValueError('Using log scale for frequency axis requires all your'
+                         ' frequencies to be positive (you cannot include'
+                         ' the DC component (0 Hz) in the TFR).')
+    if len(freq) < 2:
         yscale = 'linear'
     elif yscale != 'linear':
         ratio = freq[1:] / freq[:-1]

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -261,11 +261,11 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])
 
     # test yscale
-    if len(freq) < 2:
+    if len(freq) < 2 or np.any(freq <= 0):
         yscale = 'linear'
-    elif yscale is not 'linear':
+    elif yscale != 'linear':
         ratio = freq[1:] / freq[:-1]
-    if yscale is 'auto':
+    if yscale == 'auto':
         if freq[0] > 0 and np.allclose(ratio, ratio[0]):
             yscale = 'log'
         else:
@@ -277,15 +277,14 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
                                time_diff, [times[-1] + time_diff[-1]]])
 
     # the same for frequency - depending on whether yscale is log
-    if yscale is 'linear':
+    if yscale == 'linear':
         freq_diff = np.diff(freq) / 2. if len(freq) > 1 else [0.5]
         freq_lims = np.concatenate([[freq[0] - freq_diff[0]], freq[:-1] +
                                    freq_diff, [freq[-1] + freq_diff[-1]]])
     else:
-        from scipy.stats import gmean
         log_freqs = np.concatenate([[freq[0] / ratio[0]], freq,
                                    [freq[-1] * ratio[0]]])
-        freq_lims = gmean(np.vstack([log_freqs[:-1], log_freqs[1:]]), axis=0)
+        freq_lims = np.sqrt(log_freqs[:-1] * log_freqs[1:])
 
     # construct a time-frequency bounds grid
     time_mesh, freq_mesh = np.meshgrid(time_lims, freq_lims)
@@ -299,7 +298,7 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
         ylim = (freq_lims[0], freq_lims[-1])
     ax.set_ylim(ylim)
 
-    if yscale is 'log':
+    if yscale == 'log':
         ax.set_yscale('log')
         ax.get_yaxis().set_major_formatter(ticker.ScalarFormatter())
 

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -87,7 +87,7 @@ plt.show()
 # but you can also use :func:`mne.time_frequency.tfr_multitaper`
 # or :func:`mne.time_frequency.tfr_stockwell`.
 
-freqs = np.arange(6, 30, 3)  # define frequencies of interest
+freqs = np.logspace(*np.log10([6, 35]), num=8) # define frequencies of interest
 n_cycles = freqs / 2.  # different number of cycle per frequency
 power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles, use_fft=True,
                         return_itc=True, decim=3, n_jobs=1)

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -87,7 +87,8 @@ plt.show()
 # but you can also use :func:`mne.time_frequency.tfr_multitaper`
 # or :func:`mne.time_frequency.tfr_stockwell`.
 
-freqs = np.logspace(*np.log10([6, 35]), num=8) # define frequencies of interest
+# define frequencies of interest (log-spaced)
+freqs = np.logspace(*np.log10([6, 35]), num=8)
 n_cycles = freqs / 2.  # different number of cycle per frequency
 power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles, use_fft=True,
                         return_itc=True, decim=3, n_jobs=1)


### PR DESCRIPTION
fixes #3847
This is not finished API-wise. The way it works currently is that there is an `imtype` arg (temporary name - any ideas?) that allows `'normal'` or `'nonuniform'` and thus changes the plotting artist to be NonUniformImage.
I make it dependent on a kwarg because:
* NonUniformImage is a little less flexible - does have only two interpolation options for example ('none' and 'bilinear')
* I did not check it but it may be slower
* having a kwarg opens the door to adding `'logy'` option (next PR maybe - if you think that would be useful, see the last image)

A quick example:
* I used following `freqs`:
  <img width="431" alt="freqs used" src="https://cloud.githubusercontent.com/assets/8452354/21945486/ca96d53a-d9db-11e6-9222-1b6930038ad3.PNG">
* The first image is with `imtype='normal'` and therefore has incorrect y axis tick labels (alpha desync is in 10 Hz), the second one is with `imtype='nonuniform'` and has correct y axis tick labels etc.
  <img width="268" alt="nonuniform image" src="https://cloud.githubusercontent.com/assets/8452354/21945527/077d64b4-d9dc-11e6-9d5e-b21ebbae89f5.PNG">

For comparison, this is with log y (not a grat example but log y is frequently used in time-freq literature):
```python
fig = tfr_avg.plot([chan_ind], baseline=(-1.5, -0.5), mode='mean', show=False)
fig.axes[0].set_yscale('log')
extent = fig.axes[0].images[0].get_extent()
fig.axes[0].images[0].set_extent(extent[:2] + tuple(np.log10(extent[2:])))
```
<img width="282" alt="logscale" src="https://cloud.githubusercontent.com/assets/8452354/21945613/7e55bd70-d9dc-11e6-95c1-cfe81eb1591f.PNG">
