### PR TITLE
MRG: Generalize cov and pick functions

### DIFF
--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -628,7 +628,7 @@ def pick_channels_cov(orig, include=[], exclude='bads'):
     return res
 
 
-def _picks_by_type(info, meg_combined=False, ref_meg=False):
+def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     """Get data channel indices as separate list of tuples.
 
     Parameters
@@ -639,6 +639,9 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False):
         Whether to return combined picks for grad and mag.
     ref_meg : bool
         If True include CTF / 4D reference channels
+    exclude : list of string | str
+        List of channels to exclude. If 'bads' (default), exclude channels
+        in info['bads'].
 
     Returns
     -------
@@ -652,22 +655,22 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False):
     if has_mag and (meg_combined is not True or not has_grad):
         picks_list.append(
             ('mag', pick_types(info, meg='mag', eeg=False, stim=False,
-             ref_meg=ref_meg))
+             ref_meg=ref_meg, exclude=exclude))
         )
     if has_grad and (meg_combined is not True or not has_mag):
         picks_list.append(
             ('grad', pick_types(info, meg='grad', eeg=False, stim=False,
-             ref_meg=ref_meg))
+             ref_meg=ref_meg, exclude=exclude))
         )
     if has_mag and has_grad and meg_combined is True:
         picks_list.append(
             ('meg', pick_types(info, meg=True, eeg=False, stim=False,
-             ref_meg=ref_meg))
+             ref_meg=ref_meg, exclude=exclude))
         )
     if has_eeg:
         picks_list.append(
             ('eeg', pick_types(info, meg=False, eeg=True, stim=False,
-             ref_meg=ref_meg))
+             ref_meg=ref_meg, exclude=exclude))
         )
     return picks_list
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -16,7 +16,8 @@ import itertools as itt
 
 from mne.cov import (regularize, whiten_evoked, _estimate_rank_meeg_cov,
                      _auto_low_rank_model, _apply_scaling_cov,
-                     _undo_scaling_cov, prepare_noise_cov, compute_whitener)
+                     _undo_scaling_cov, prepare_noise_cov, compute_whitener,
+                     _apply_scaling_array, _undo_scaling_array)
 
 from mne import (read_cov, write_cov, Epochs, merge_events,
                  find_events, compute_raw_covariance,
@@ -492,6 +493,11 @@ def test_cov_scaling():
     _undo_scaling_cov(cov, picks_list, scalings=scalings)
     assert_array_equal(cov, cov2)
     assert_true(cov.max() < 1)
+
+    data = evoked.data.copy()
+    _apply_scaling_array(data, picks_list, scalings=scalings)
+    _undo_scaling_array(data, picks_list, scalings=scalings)
+    assert_allclose(data, evoked.data, atol=1e-20)
 
 
 @requires_sklearn_0_15


### PR DESCRIPTION
This is some private function refactoring that cleans up our code a bit in case we need to use `scalings` other places. For example it is necessary for https://github.com/mne-tools/mne-sandbox/pull/25.