### PR TITLE
[MRG+1] Match channels in case insensitive manner when applying montage

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,6 +63,8 @@ Changelog
 
     - Add option in :func:`mne.io.read_raw_edf` to allow channel exclusion by `Jaakko Leppakangas`_
 
+    - Add ability to match channel names in a case insensitive manner when applying a :class:`mne.channels.Montage` by `Marijn van Vliet`_
+
 BUG
 ~~~
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -205,6 +205,23 @@ def test_montage():
             _set_montage(info, montage)
             assert_true(len(w) == 1)
 
+    # Channel names can be treated case insensitive
+    with warnings.catch_warnings(record=True) as w:
+        info = create_info(['FP1', 'af7', 'AF3'], 1e3, ['eeg'] * 3)
+        _set_montage(info, montage)
+        assert_true(len(w) == 0)
+
+    # Unless there is a collision in names
+    with warnings.catch_warnings(record=True) as w:
+        info = create_info(['FP1', 'Fp1', 'AF3'], 1e3, ['eeg'] * 3)
+        _set_montage(info, montage)
+        assert_true(len(w) == 1)
+    with warnings.catch_warnings(record=True) as w:
+        montage.ch_names = ['FP1', 'Fp1', 'AF3']
+        info = create_info(['fp1', 'AF3'], 1e3, ['eeg', 'eeg'])
+        _set_montage(info, montage)
+        assert_true(len(w) == 1)
+
 
 @testing.requires_testing_data
 def test_read_locs():


### PR DESCRIPTION
When a montage defines a position for electrode FP1 and the channel name in the data is Fp1, that should be good enough. This crops up from time to time when defaulting back on the `standard_1005` montage.