### PR TITLE
[MRG] Add support for event_type=3 when reading CNT data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ Changelog
 
     - Add :ref:`Representational Similarity Analysis (RSA) <sphx_glr_auto_examples_decoding_decoding_rsa.py>` example on :mod:`mne.datasets.visual_92_categories` dataset by `Jaakko Leppakangas`_, `Jean-Remi King`_ and `Alex Gramfort`_
 
+    - Add support for NeuroScan files with event type 3 in :func:`mne.io.read_raw_cnt` by `Marijn van Vliet`_
+
 BUG
 ~~~
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -233,7 +233,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
         event_size = np.fromfile(fid, dtype='<i4', count=1)[0]
         if event_type == 1:
             event_bytes = 8
-        elif event_type == 2:
+        elif event_type in (2, 3):
             event_bytes = 19
         else:
             raise IOError('Unexpected event size.')
@@ -245,8 +245,10 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
             event_id = np.fromfile(fid, dtype='u2', count=1)[0]
             fid.seek(event_offset + 9 + i * event_bytes + 4)
             offset = np.fromfile(fid, dtype='<i4', count=1)[0]
-            event_time = (offset - 900 - 75 * n_channels) // (n_channels *
-                                                              n_bytes)
+            if event_type == 3:
+                offset *= n_bytes * n_channels
+            event_time = offset - 900 - 75 * n_channels
+            event_time //= n_channels * n_bytes
             stim_channel[event_time - 1] = event_id
 
     info = _empty_info(sfreq)


### PR DESCRIPTION
.cnt files used by NeuroScan systems support different ways of encoding events (perhaps these reflect old and new versions of the file format). MNE currently only supports types 1 and 2. This PR adds supports for the newer type 3 events.

Closes #3882