### PR TITLE
[MRG +1] Allow int eventtype in eeglab epoch reader.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,6 +63,8 @@ Changelog
 
     - Add option in :func:`mne.io.read_raw_edf` to allow channel exclusion by `Jaakko Leppakangas`_
 
+    - Allow integer event codes in :func:`mne.io.read_epochs_eeglab` by `Jaakko Leppakangas`_
+
 BUG
 ~~~
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -484,6 +484,8 @@ class EpochsEEGLAB(BaseEpochs):
             ev_idx = 0
             warn_multiple_events = False
             for ep in eeg.epoch:
+                if isinstance(ep.eventtype, int):
+                    ep.eventtype = str(ep.eventtype)
                 if not isinstance(ep.eventtype, string_types):
                     event_type = '/'.join(ep.eventtype.tolist())
                     event_name.append(event_type)


### PR DESCRIPTION
See https://github.com/mne-tools/mne-python/issues/2672#issuecomment-273058747

I've never really used the EEGLAB files so I'm not sure if the fix is the right one. I simply cast the int to a string. @jona-sassenhagen @jasmainak 