### PR TITLE
MRG+1: Change label COM for issue #3906

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -114,6 +114,8 @@ BUG
 
     - Fix bug in :func:`mne.io.read_raw_edf` when ``preload=False`` and channels have different sampling rates by `Jaakko Leppakangas`_
 
+    - Fix :func:`mne.labels.read_labels_from_annot` to set label.values=1 rather than 0 for consistency with the label class by `Jon Houck`_
+
 API
 ~~~
 
@@ -1921,7 +1923,7 @@ of commits):
 
 .. _Natalie Klein: http://www.stat.cmu.edu/people/students/neklein
 
-.. _Jon Houck: http://www.unm.edu/~jhouck/
+.. _Jon Houck: https://scholar.google.com/citations?user=DNoS05IAAAAJ&hl=en
 
 .. _Pablo-Arias: https://github.com/Pablo-Arias
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -114,7 +114,7 @@ BUG
 
     - Fix bug in :func:`mne.io.read_raw_edf` when ``preload=False`` and channels have different sampling rates by `Jaakko Leppakangas`_
 
-    - Fix :func:`mne.labels.read_labels_from_annot` to set label.values=1 rather than 0 for consistency with the label class by `Jon Houck`_
+    - Fix :func:`mne.read_labels_from_annot` to set ``label.values[:]=1`` rather than 0 for consistency with the :class:`Label` class by `Jon Houck`_
 
 API
 ~~~

--- a/mne/label.py
+++ b/mne/label.py
@@ -749,8 +749,8 @@ class Label(object):
             raise ValueError('Cannot compute COM with negative values')
         if np.all(self.values == 0):
             raise ValueError('Cannot compute COM with all values == 0. For '
-                            'structural labels, consider setting to ones via '
-                            'label.values[:] = 1.')
+                             'structural labels, consider setting to ones via '
+                             'label.values[:] = 1.')
         vertex = _center_of_mass(self.vertices, self.values, self.hemi, surf,
                                  subject, subjects_dir, restrict_vertices)
         return vertex

--- a/mne/label.py
+++ b/mne/label.py
@@ -747,6 +747,9 @@ class Label(object):
         subject = _check_subject(self.subject, subject)
         if np.any(self.values < 0):
             raise ValueError('Cannot compute COM with negative values')
+        if np.all(self.values == 0):
+            raise RuntimeWarning('Label values are all 0, treating as a structural label\n')
+            self.values = np.ones(self.values.shape)
         vertex = _center_of_mass(self.vertices, self.values, self.hemi, surf,
                                  subject, subjects_dir, restrict_vertices)
         return vertex

--- a/mne/label.py
+++ b/mne/label.py
@@ -747,9 +747,10 @@ class Label(object):
         subject = _check_subject(self.subject, subject)
         if np.any(self.values < 0):
             raise ValueError('Cannot compute COM with negative values')
-        if np.all(self.values == 0):
-            raise RuntimeWarning('Label values are all 0, treating as a structural label\n')
-            self.values = np.ones(self.values.shape)
+        if np.any(self.values == 0):
+            raise ValueError('Cannot compute COM with all values == 0. For '
+                            'structural labels, consider setting to ones via '
+                            'label.values[:] = 1.')
         vertex = _center_of_mass(self.vertices, self.values, self.hemi, surf,
                                  subject, subjects_dir, restrict_vertices)
         return vertex
@@ -1824,7 +1825,7 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
             if (regexp is not None) and not r_.match(name):
                 continue
             pos = vert_pos[vertices, :]
-            values = np.zeros(len(vertices))
+            values = np.ones(len(vertices))
             label_rgba = tuple(label_rgba / 255.)
             label = Label(vertices, pos, values, hemi, name=name,
                           subject=subject, color=label_rgba)

--- a/mne/label.py
+++ b/mne/label.py
@@ -747,7 +747,7 @@ class Label(object):
         subject = _check_subject(self.subject, subject)
         if np.any(self.values < 0):
             raise ValueError('Cannot compute COM with negative values')
-        if np.any(self.values == 0):
+        if np.all(self.values == 0):
             raise ValueError('Cannot compute COM with all values == 0. For '
                             'structural labels, consider setting to ones via '
                             'label.values[:] = 1.')

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -809,6 +809,9 @@ def test_label_center_of_mass():
         label.values[:] = -1
         assert_raises(ValueError, label.center_of_mass,
                       subjects_dir=subjects_dir)
+        label.values[:] = 0
+        assert_raises(ValueError, label.center_of_mass, 
+                      subjects_dir=subjects_dir)          
         label.values[:] = 1
         assert_equal(label.center_of_mass(subjects_dir=subjects_dir), expected)
         assert_equal(label.center_of_mass(subjects_dir=subjects_dir,
@@ -837,5 +840,6 @@ def test_label_center_of_mass():
                   surf=1)
     assert_raises(IOError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf='foo')
-
+    assert_raises(ValueError, label.center_of_mass, subjects_dir=subjects_dir,
+                  ### SOMETHING GOES HERE)
 run_tests_if_main()

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -840,6 +840,4 @@ def test_label_center_of_mass():
                   surf=1)
     assert_raises(IOError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf='foo')
-    assert_raises(ValueError, label.center_of_mass, subjects_dir=subjects_dir,
-                  ### SOMETHING GOES HERE)
 run_tests_if_main()

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -810,8 +810,8 @@ def test_label_center_of_mass():
         assert_raises(ValueError, label.center_of_mass,
                       subjects_dir=subjects_dir)
         label.values[:] = 0
-        assert_raises(ValueError, label.center_of_mass, 
-                      subjects_dir=subjects_dir)          
+        assert_raises(ValueError, label.center_of_mass,
+                      subjects_dir=subjects_dir)
         label.values[:] = 1
         assert_equal(label.center_of_mass(subjects_dir=subjects_dir), expected)
         assert_equal(label.center_of_mass(subjects_dir=subjects_dir,


### PR DESCRIPTION
Change to test whether all values in a label are non-zero.  If they are, set them instead to ones.  This should allow label.center-of-mass to return the centroid for structural labels like those read from read_labels_from_annot.  Should also allow simulate_sparse_stc to work as expected with these labels when location='center' (rather than the default 'random').