### PR TITLE
[MRG+1] Remove copy from find_bads_exg.

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -993,13 +993,6 @@ class ICA(ContainsMixin):
         else:
             ecg = inst.ch_names[idx_ecg]
 
-        # some magic we need inevitably ...
-        if inst.ch_names != self.ch_names:
-            extra_picks = pick_types(inst.info, meg=False, ecg=True)
-            ch_names_to_pick = (self.ch_names +
-                                [inst.ch_names[k] for k in extra_picks])
-            inst = inst.copy().pick_channels(ch_names_to_pick)
-
         if method == 'ctps':
             if threshold is None:
                 threshold = 0.25
@@ -1092,9 +1085,6 @@ class ICA(ContainsMixin):
         # some magic we need inevitably ...
         # get targets befor equalizing
         targets = [self._check_target(k, inst, start, stop) for k in eog_chs]
-
-        if inst.ch_names != self.ch_names:
-            inst = inst.copy().pick_channels(self.ch_names)
 
         for ii, (eog_ch, target) in enumerate(zip(eog_chs, targets)):
             scores += [self.score_sources(inst, target=target,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -581,6 +581,10 @@ def test_ica_additional():
         ncomps_ = ica._check_n_pca_components(ncomps)
         assert_true(ncomps_ == expected)
 
+    raw.drop_channels(['MEG 2442'])
+    assert_raises(RuntimeError, ica.find_bads_eog, raw)
+    assert_raises(RuntimeError, ica.find_bads_ecg, raw)
+
 
 @requires_sklearn
 def test_run_ica():

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -581,7 +581,13 @@ def test_ica_additional():
         ncomps_ = ica._check_n_pca_components(ncomps)
         assert_true(ncomps_ == expected)
 
-    raw.drop_channels(['MEG 2442'])
+    ica = ICA()
+    ica.fit(raw, picks=picks[:5])
+    ica.find_bads_ecg(raw)
+    ica.find_bads_eog(epochs, ch_name='MEG 0121')
+    assert_array_equal(raw_data, raw[:][0])
+
+    raw.drop_channels(['MEG 0122'])
     assert_raises(RuntimeError, ica.find_bads_eog, raw)
     assert_raises(RuntimeError, ica.find_bads_ecg, raw)
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -481,6 +481,11 @@ def test_ica_additional():
         ica.detect_artifacts(raw, start_find=0, stop_find=50, ecg_ch=ch_name,
                              eog_ch=ch_name, skew_criterion=idx,
                              var_criterion=idx, kurt_criterion=idx)
+
+    evoked = epochs.average()
+    evoked_data = evoked.data.copy()
+    raw_data = raw[:][0].copy()
+    epochs_data = epochs.get_data().copy()
     with warnings.catch_warnings(record=True):
         idx, scores = ica.find_bads_ecg(raw, method='ctps')
         assert_equal(len(scores), ica.n_components_)
@@ -501,6 +506,16 @@ def test_ica_additional():
         idx, scores = ica.find_bads_eog(raw)
         assert_true(isinstance(scores, list))
         assert_equal(len(scores[0]), ica.n_components_)
+
+        idx, scores = ica.find_bads_eog(evoked, ch_name='MEG 1441')
+        assert_equal(len(scores), ica.n_components_)
+
+        idx, scores = ica.find_bads_ecg(evoked, method='correlation')
+        assert_equal(len(scores), ica.n_components_)
+
+    assert_array_equal(raw_data, raw[:][0])
+    assert_array_equal(epochs_data, epochs.get_data())
+    assert_array_equal(evoked_data, evoked.data)
 
     # check score funcs
     for name, func in get_score_funcs().items():


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/3883

I couldn't find a reason we make a copy of the instance and drop a part of the channels as it seems to be handled elsewhere. This required the data to be preloaded. There's also check for this [here](https://github.com/mne-tools/mne-python/blob/master/mne/preprocessing/ica.py#L611).

Hopefully the tests will catch it if something broke.