### PR TITLE
MRG: search light n_jobs wrong split

### DIFF
--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -245,7 +245,7 @@ class _SearchLight(BaseEstimator, TransformerMixin):
         n_jobs = min(n_jobs, X.shape[-1])
         X_splits = np.array_split(X, n_jobs, axis=-1)
         est_splits = np.array_split(self.estimators_, n_jobs)
-        score = parallel(p_func(est, scoring, X, y)
+        score = parallel(p_func(est, scoring, x, y)
                          for (est, x) in zip(est_splits, X_splits))
 
         if n_jobs > 1:

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -68,7 +68,7 @@ def test_SearchLight():
 
     # Check sklearn's roc_auc fix: scikit-learn/scikit-learn#6874
     # -- 3 class problem
-    sl = _SearchLight(LogisticRegression(), scoring='roc_auc')
+    sl = _SearchLight(LogisticRegression(random_state=0), scoring='roc_auc')
     y = np.arange(len(X)) % 3
     sl.fit(X, y)
     assert_raises(ValueError, sl.score, X, y)
@@ -101,10 +101,12 @@ def test_SearchLight():
         assert_array_equal(score_manual, score_sl)
 
     # n_jobs
-    sl = _SearchLight(LogisticRegression(), n_jobs=2)
+    sl = _SearchLight(LogisticRegression(random_state=0), n_jobs=2,
+                      scoring='roc_auc')
     sl.fit(X, y)
     sl.predict(X)
-    sl.score(X, y)
+    score_njobs = sl.score(X, y)
+    assert_array_equal(score, score_njobs)
 
     # n_jobs > n_estimators
     sl.fit(X[..., [0]], y)

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -104,7 +104,7 @@ def test_SearchLight():
     sl = _SearchLight(LogisticRegression(random_state=0), n_jobs=1,
                       scoring='roc_auc')
     score_1job = sl.fit(X, y).score(X, y)
-    sl.n_jobs = -1
+    sl.n_jobs = 2
     score_njobs = sl.fit(X, y).score(X, y)
     assert_array_equal(score_1job, score_njobs)
     sl.predict(X)

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -101,12 +101,13 @@ def test_SearchLight():
         assert_array_equal(score_manual, score_sl)
 
     # n_jobs
-    sl = _SearchLight(LogisticRegression(random_state=0), n_jobs=2,
+    sl = _SearchLight(LogisticRegression(random_state=0), n_jobs=1,
                       scoring='roc_auc')
-    sl.fit(X, y)
+    score_1job = sl.fit(X, y).score(X, y)
+    sl.n_jobs = -1
+    score_njobs = sl.fit(X, y).score(X, y)
+    assert_array_equal(score_1job, score_njobs)
     sl.predict(X)
-    score_njobs = sl.score(X, y)
-    assert_array_equal(score, score_njobs)
 
     # n_jobs > n_estimators
     sl.fit(X[..., [0]], y)


### PR DESCRIPTION
Fix serious error introduced in #3502 when n_jobs > 1
 (otherwise the X is split in weird ways, and the scores get completely weird)

SearchLight is still private, and not used by TimeDecoding, so no consequence.