### PR TITLE
MRG: Improve coreg visual space

### DIFF
--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -4,7 +4,7 @@
 #
 # License: BSD (3-clause)
 
-from ..utils import _check_mayavi_version, verbose
+from ..utils import _check_mayavi_version, verbose, get_config
 
 
 def combine_kit_markers():
@@ -24,9 +24,10 @@ def combine_kit_markers():
 
 
 @verbose
-def coregistration(tabbed=False, split=True, scene_width=500, inst=None,
+def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
                    subject=None, subjects_dir=None, guess_mri_subject=True,
-                   head_opacity=1., head_high_res=True, verbose=None):
+                   scene_height=None, head_opacity=1., head_high_res=True,
+                   verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -44,8 +45,10 @@ def coregistration(tabbed=False, split=True, scene_width=500, inst=None,
     split : bool
         Split the main panels with a movable splitter (good for QT4 but
         unnecessary for wx backend).
-    scene_width : int
+    scene_width : int | None
         Specify a minimum width for the 3d scene (in pixels).
+        Default is None, which uses ``MNE_COREG_SCENE_WIDTH`` config value
+        (which defaults to 500).
     inst : None | str
         Path to an instance file containing the digitizer data. Compatible for
         Raw, Epochs, and Evoked files.
@@ -57,6 +60,10 @@ def coregistration(tabbed=False, split=True, scene_width=500, inst=None,
     guess_mri_subject : bool
         When selecting a new head shape file, guess the subject's name based
         on the filename and change the MRI subject accordingly (default True).
+    scene_height : int | None
+        Specify a minimum height for the 3d scene (in pixels).
+        Default is None, which uses ``MNE_COREG_SCENE_WIDTH`` config value
+        (which defaults to 400).
     head_opacity : float
         The default opacity of the head surface in the range [0., 1.]
         (default: 1.).
@@ -74,11 +81,17 @@ def coregistration(tabbed=False, split=True, scene_width=500, inst=None,
     subjects for which no MRI is available
     <http://www.slideshare.net/mne-python/mnepython-scale-mri>`_.
     """
+    if scene_width is None:
+        scene_width = get_config('MNE_COREG_SCENE_WIDTH', 500)
+    if scene_height is None:
+        scene_height = get_config('MNE_COREG_SCENE_HEIGHT', 400)
+    scene_width = int(scene_width)
+    scene_height = int(scene_height)
     _check_mayavi_version()
     from ._backend import _check_backend
     _check_backend()
     from ._coreg_gui import CoregFrame, _make_view
-    view = _make_view(tabbed, split, scene_width)
+    view = _make_view(tabbed, split, scene_width, scene_height)
     gui = CoregFrame(inst, subject, subjects_dir, guess_mri_subject,
                      head_opacity, head_high_res)
     gui.configure_traits(view=view)

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1212,12 +1212,12 @@ class CoregFrame(HasTraits):
     guess_mri_subject = DelegatesTo('model')
 
     # Omit Points
-    distance = Float(5., desc="Maximal distance for head shape points from "
+    distance = Float(5., desc="maximal distance for head shape points from "
                      "MRI in mm")
-    omit_points = Button(label='Omit [mm]', desc="Omit head shape points "
+    omit_points = Button(label='Omit [mm]', desc="to omit head shape points "
                          "for the purpose of the automatic coregistration "
                          "procedure.")
-    reset_omit_points = Button(label='Reset', desc="Reset the "
+    reset_omit_points = Button(label='Reset', desc="to reset the "
                                "omission of head shape points to include all.")
     omitted_info = Property(Str, depends_on=['model.hsp.n_omitted'])
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Traits-based GUI for head-MRI coregistration."""
 
 # Authors: Christian Brodbeck <christianbrodbeck@nyu.edu>
@@ -22,7 +23,7 @@ from traits.api import (Bool, Button, cached_property, DelegatesTo, Directory,
                         Enum, Float, HasTraits, HasPrivateTraits, Instance,
                         Int, on_trait_change, Property, Str)
 from traitsui.api import (View, Item, Group, HGroup, VGroup, VGrid, EnumEditor,
-                          Handler, Label, TextEditor)
+                          Handler, Label, TextEditor, Spring)
 from traitsui.menu import Action, UndoButton, CancelButton, NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
@@ -75,15 +76,15 @@ class CoregModel(HasPrivateTraits):
     n_scale_params = Enum(0, 1, 3, desc="Scale the MRI to better fit the "
                           "subject's head shape (a new MRI subject will be "
                           "created with a name specified upon saving)")
-    scale_x = Float(1, label="Right (X)")
-    scale_y = Float(1, label="Anterior (Y)")
-    scale_z = Float(1, label="Superior (Z)")
-    rot_x = Float(0, label="Right (X)")
-    rot_y = Float(0, label="Anterior (Y)")
-    rot_z = Float(0, label="Superior (Z)")
-    trans_x = Float(0, label="Right (X)")
-    trans_y = Float(0, label="Anterior (Y)")
-    trans_z = Float(0, label="Superior (Z)")
+    scale_x = Float(1, label="R (X)")
+    scale_y = Float(1, label="A (Y)")
+    scale_z = Float(1, label="S (Z)")
+    rot_x = Float(0, label="R (X)")
+    rot_y = Float(0, label="A (Y)")
+    rot_z = Float(0, label="S (Z)")
+    trans_x = Float(0, label="R (X)")
+    trans_y = Float(0, label="A (Y)")
+    trans_z = Float(0, label="S (Z)")
 
     prepare_bem_model = Bool(True, desc="whether to run mne_prepare_bem_model "
                              "after scaling the MRI")
@@ -303,15 +304,16 @@ class CoregModel(HasPrivateTraits):
     def _get_fid_eval_str(self):
         d = (self.lpa_distance * 1000, self.nasion_distance * 1000,
              self.rpa_distance * 1000)
-        txt = ("Fiducials Error: LPA %.1f mm, NAS %.1f mm, RPA %.1f mm" % d)
+        txt = ("Error (mm): LPA %.1f, NAS %.1f, RPA %.1f" % d)
         return txt
 
     @cached_property
     def _get_points_eval_str(self):
         if self.point_distance is None:
             return ""
-        av_dist = np.mean(self.point_distance)
-        return "Average Points Error: %.1f mm" % (av_dist * 1000)
+        av_dist = 1000 * np.mean(self.point_distance)
+        std_dist = 1000 * np.std(self.point_distance)
+        return u"Points: μ=%.1f, σ = %.1f" % (av_dist, std_dist)
 
     def _get_raw_subject(self):
         # subject name guessed based on the inst file name
@@ -619,7 +621,7 @@ class CoregPanel(HasPrivateTraits):
     can_save = DelegatesTo('model')
     prepare_bem_model = DelegatesTo('model')
     save = Button(label="Save As...")
-    load_trans = Button
+    load_trans = Button(label='Load trans...')
     queue = Instance(queue.Queue, ())
     queue_feedback = Str('')
     queue_current = Str('')
@@ -636,32 +638,40 @@ class CoregPanel(HasPrivateTraits):
                        VGrid(Item('scale_x', editor=laggy_float_editor,
                                   show_label=True, tooltip="Scale along "
                                   "right-left axis",
-                                  enabled_when='n_scale_params > 0'),
+                                  enabled_when='n_scale_params > 0',
+                                  width=+50),
                              Item('scale_x_dec',
-                                  enabled_when='n_scale_params > 0'),
+                                  enabled_when='n_scale_params > 0',
+                                  width=-50),
                              Item('scale_x_inc',
-                                  enabled_when='n_scale_params > 0'),
+                                  enabled_when='n_scale_params > 0',
+                                  width=-50),
                              Item('scale_step', tooltip="Scaling step",
-                                  enabled_when='n_scale_params > 0'),
+                                  enabled_when='n_scale_params > 0',
+                                  width=+50),
                              Item('scale_y', editor=laggy_float_editor,
                                   show_label=True,
                                   enabled_when='n_scale_params > 1',
                                   tooltip="Scale along anterior-posterior "
-                                  "axis"),
+                                  "axis", width=+50),
                              Item('scale_y_dec',
-                                  enabled_when='n_scale_params > 1'),
+                                  enabled_when='n_scale_params > 1',
+                                  width=-50),
                              Item('scale_y_inc',
-                                  enabled_when='n_scale_params > 1'),
-                             Label('(Step)'),
+                                  enabled_when='n_scale_params > 1',
+                                  width=-50),
+                             Label('(Step)', width=+50),
                              Item('scale_z', editor=laggy_float_editor,
                                   show_label=True,
                                   enabled_when='n_scale_params > 1',
                                   tooltip="Scale along anterior-posterior "
-                                  "axis"),
+                                  "axis", width=+50),
                              Item('scale_z_dec',
-                                  enabled_when='n_scale_params > 1'),
+                                  enabled_when='n_scale_params > 1',
+                                  width=-50),
                              Item('scale_z_inc',
-                                  enabled_when='n_scale_params > 1'),
+                                  enabled_when='n_scale_params > 1',
+                                  width=-50),
                              show_labels=False, columns=4),
                        HGroup(Item('fits_hsp_points',
                                    enabled_when='n_scale_params',
@@ -682,55 +692,63 @@ class CoregPanel(HasPrivateTraits):
                                    "minimize the distance of the three "
                                    "fiducials."),
                               show_labels=False),
-                       '_',
-                       Label("Translation:"),
                        VGrid(Item('trans_x', editor=laggy_float_editor,
                                   show_label=True, tooltip="Move along "
-                                  "right-left axis"),
-                             'trans_x_dec', 'trans_x_inc',
-                             Item('trans_step', tooltip="Movement step"),
+                                  "right-left axis", width=+50),
+                             Item('trans_x_dec', width=-50),
+                             Item('trans_x_inc', width=-50),
+                             Item('trans_step', tooltip="Movement step",
+                                  width=+50),
                              Item('trans_y', editor=laggy_float_editor,
                                   show_label=True, tooltip="Move along "
-                                  "anterior-posterior axis"),
-                             'trans_y_dec', 'trans_y_inc',
-                             Label('(Step)'),
+                                  "anterior-posterior axis", width=+50),
+                             Item('trans_y_dec', width=-50),
+                             Item('trans_y_inc', width=-50),
+                             Label('(Step)', width=+50),
                              Item('trans_z', editor=laggy_float_editor,
                                   show_label=True, tooltip="Move along "
-                                  "anterior-posterior axis"),
-                             'trans_z_dec', 'trans_z_inc',
-                             show_labels=False, columns=4),
-                       Label("Rotation:"),
+                                  "anterior-posterior axis", width=+50),
+                             Item('trans_z_dec', width=-50),
+                             Item('trans_z_inc', width=-50),
+                             show_labels=False, show_border=True,
+                             label='Translation', columns=4),
                        VGrid(Item('rot_x', editor=laggy_float_editor,
                                   show_label=True, tooltip="Rotate along "
-                                  "right-left axis"),
-                             'rot_x_dec', 'rot_x_inc',
-                             Item('rot_step', tooltip="Rotation step"),
+                                  "right-left axis", width=+50),
+                             Item('rot_x_dec', width=-50),
+                             Item('rot_x_inc', width=-50),
+                             Item('rot_step', tooltip="Rotation step",
+                                  width=+50),
                              Item('rot_y', editor=laggy_float_editor,
                                   show_label=True, tooltip="Rotate along "
-                                  "anterior-posterior axis"),
-                             'rot_y_dec', 'rot_y_inc',
-                             Label('(Step)'),
+                                  "anterior-posterior axis", width=+50),
+                             Item('rot_y_dec', width=-50),
+                             Item('rot_y_inc', width=-50),
+                             Label('(Step)', width=+50),
                              Item('rot_z', editor=laggy_float_editor,
                                   show_label=True, tooltip="Rotate along "
-                                  "anterior-posterior axis"),
-                             'rot_z_dec', 'rot_z_inc',
-                             show_labels=False, columns=4),
+                                  "anterior-posterior axis", width=+50),
+                             Item('rot_z_dec', width=-50),
+                             Item('rot_z_inc', width=-50),
+                             show_labels=False, show_border=True,
+                             label='Rotation', columns=4),
                        # buttons
                        HGroup(Item('fit_hsp_points',
                                    enabled_when='has_pts_data',
                                    tooltip="Rotate the head shape (around the "
                                    "nasion) so as to minimize the distance "
                                    "from each head shape point to its closest "
-                                   "MRI point"),
+                                   "MRI point", width=10),
                               Item('fit_ap', enabled_when='has_fid_data',
                                    tooltip="Try to match the LPA and the RPA, "
-                                   "leaving the Nasion in place"),
+                                   "leaving the Nasion in place", width=10),
                               Item('fit_fid', enabled_when='has_fid_data',
                                    tooltip="Move and rotate the head shape so "
                                    "as to minimize the distance between the "
-                                   "MRI and head shape fiducials"),
-                              Item('load_trans', enabled_when='has_fid_data'),
+                                   "MRI and head shape fiducials", width=10),
                               show_labels=False),
+                       HGroup(Item('load_trans', enabled_when='has_fid_data',
+                              width=10), Spring(), show_labels=False),
                        '_',
                        Item('fid_eval_str', style='readonly'),
                        Item('points_eval_str', style='readonly'),
@@ -1045,7 +1063,6 @@ class NewMriDialog(HasPrivateTraits):
                 Item('overwrite', enabled_when='can_overwrite', tooltip="If a "
                      "subject with the chosen name exists, delete the old "
                      "subject"),
-                width=500,
                 buttons=[CancelButton,
                          Action(name='OK', enabled_when='can_save')])
 
@@ -1094,7 +1111,7 @@ class NewMriDialog(HasPrivateTraits):
             self.can_overwrite = False
 
 
-def _make_view(tabbed=False, split=False, scene_width=500):
+def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400):
     """Create a view for the CoregFrame.
 
     Parameters
@@ -1113,14 +1130,14 @@ def _make_view(tabbed=False, split=False, scene_width=500):
     view : traits View
         View object for the CoregFrame.
     """
-    view_options = VGroup(
-        Item('headview', style='custom'), 'view_options', show_border=True,
-        show_labels=False, label='View')
-
     scene = VGroup(
         Item('scene', show_label=False,
              editor=SceneEditor(scene_class=MayaviScene),
-             dock='vertical', width=scene_width), view_options)
+             dock='vertical', width=scene_width, height=scene_height),
+        VGroup(
+            Item('headview', style='custom'),
+            'view_options',
+            show_border=True, show_labels=False, label='View'))
 
     data_panel = VGroup(
         VGroup(Item('subject_panel', style='custom'), label="MRI Subject",
@@ -1138,20 +1155,19 @@ def _make_view(tabbed=False, split=False, scene_width=500):
                HGroup('guess_mri_subject',
                       Label('Guess MRI Subject from File Name'),
                       show_labels=False),
-               HGroup(Item('distance', show_label=True), 'omit_points',
-                      'reset_omit_points', show_labels=False),
+               HGroup(Item('distance', show_label=False, width=20),
+                      'omit_points', 'reset_omit_points', show_labels=False),
                Item('omitted_info', style='readonly', show_label=False),
                label='Head Shape Source (Raw/Epochs/Evoked)', show_border=True,
-               show_labels=False), show_labels=False, label="Data Source")
+               show_labels=False),
+        show_labels=False, label="Data Source")
 
     coreg_panel = VGroup(
-        Item('coreg_panel', style='custom'), label="Coregistration",
-        show_border=True, show_labels=False, enabled_when="fid_panel.locked")
+        Item('coreg_panel', style='custom', width=1),
+        label="Coregistration", show_border=True, show_labels=False,
+        enabled_when="fid_panel.locked")
 
-    if split:
-        main_layout = 'split'
-    else:
-        main_layout = 'normal'
+    main_layout = 'split' if split else 'normal'
 
     if tabbed:
         main = HGroup(scene,
@@ -1162,8 +1178,10 @@ def _make_view(tabbed=False, split=False, scene_width=500):
         main = HGroup(data_panel, scene, coreg_panel, show_labels=False,
                       layout=main_layout)
 
+    # Here we set the width and height to impossibly small numbers to force the
+    # window to be as tight as possible
     view = View(main, resizable=True, handler=CoregFrameHandler(),
-                buttons=NoButtons)
+                buttons=NoButtons, width=scene_width, height=scene_height)
     return view
 
 
@@ -1194,12 +1212,12 @@ class CoregFrame(HasTraits):
     guess_mri_subject = DelegatesTo('model')
 
     # Omit Points
-    distance = Float(5., label="Distance [mm]", desc="Maximal distance for "
-                     "head shape points from MRI in mm")
-    omit_points = Button(label='Omit Points', desc="Omit head shape points "
+    distance = Float(5., desc="Maximal distance for head shape points from "
+                     "MRI in mm")
+    omit_points = Button(label='Omit [mm]', desc="Omit head shape points "
                          "for the purpose of the automatic coregistration "
                          "procedure.")
-    reset_omit_points = Button(label='Reset Omission', desc="Reset the "
+    reset_omit_points = Button(label='Reset', desc="Reset the "
                                "omission of head shape points to include all.")
     omitted_info = Property(Str, depends_on=['model.hsp.n_omitted'])
 

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -14,7 +14,7 @@ from pyface.api import confirm, error, FileDialog, OK, YES
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
                         cached_property, DelegatesTo, Event, Instance,
                         Property, Array, Bool, Button, Enum)
-from traitsui.api import HGroup, Item, VGroup, View
+from traitsui.api import HGroup, Item, VGroup, View, ArrayEditor
 from traitsui.menu import NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
@@ -209,7 +209,7 @@ class FiducialsPanel(HasPrivateTraits):
     locked = DelegatesTo('model', 'lock_fiducials')
 
     set = Enum('LPA', 'Nasion', 'RPA')
-    current_pos = Array(float, (1, 3))  # for editing
+    current_pos = Array(float, (1, 3), editor=ArrayEditor(width=50))
 
     save_as = Button(label='Save As...')
     save = Button(label='Save')
@@ -221,16 +221,19 @@ class FiducialsPanel(HasPrivateTraits):
     picker = Instance(object)
 
     # the layout of the dialog created
-    view = View(VGroup(Item('fid_file', label='Fiducials File'),
+    view = View(VGroup(Item('fid_file', label='File'),
                        Item('fid_fname', show_label=False, style='readonly'),
-                       Item('set', style='custom'),
-                       Item('current_pos', label='Pos'),
+                       Item('set', style='custom', width=50),
+                       Item('current_pos', label='Pos', width=50),
                        HGroup(Item('save', enabled_when='can_save',
                                    tooltip="If a filename is currently "
                                    "specified, save to that file, otherwise "
-                                   "save to the default file name"),
-                              Item('save_as', enabled_when='can_save_as'),
-                              Item('reset_fid', enabled_when='can_reset'),
+                                   "save to the default file name",
+                                   width=10),
+                              Item('save_as', enabled_when='can_save_as',
+                                   width=10),
+                              Item('reset_fid', enabled_when='can_reset',
+                                   width=10),
                               show_labels=False),
                        enabled_when="locked==False"))
 

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -12,7 +12,7 @@ from traits.api import (Any, HasTraits, HasPrivateTraits, cached_property,
                         on_trait_change, Array, Bool, Button, DelegatesTo,
                         Directory, Enum, Event, File, Instance, Int, List,
                         Property, Str)
-from traitsui.api import View, Item, VGroup, HGroup
+from traitsui.api import View, Item, VGroup, HGroup, Label
 from pyface.api import DirectoryDialog, OK, ProgressDialog, error, information
 
 from ..bem import read_bem_surfaces
@@ -418,7 +418,7 @@ class MRISubjectSource(HasPrivateTraits):
         else:
             subjects = ['']
 
-        return subjects
+        return sorted(subjects)
 
     @cached_property
     def _get_subject_has_bem(self):
@@ -455,16 +455,20 @@ class SubjectSelectorPanel(HasPrivateTraits):
     subjects = DelegatesTo('model')
     use_high_res_head = DelegatesTo('model')
 
-    create_fsaverage = Button("Copy FsAverage to Subjects Folder",
+    create_fsaverage = Button("Copy 'fsaverage' to subjects directory",
                               desc="Copy the files for the fsaverage subject "
                               "to the subjects directory.")
 
-    view = View(VGroup(Item('subjects_dir', label='subjects_dir'),
-                       'subject',
+    view = View(VGroup(Label('Subjects directory and subject:',
+                             show_label=True),
+                       HGroup('subjects_dir', show_labels=False),
+                       HGroup('subject', show_labels=False),
                        HGroup(Item('use_high_res_head',
-                                   label='High Resolution Head')),
-                       Item('create_fsaverage', show_label=False,
-                            enabled_when='can_create_fsaverage')))
+                                   label='High Resolution Head',
+                                   show_label=True)),
+                       Item('create_fsaverage',
+                            enabled_when='can_create_fsaverage'),
+                       show_labels=False))
 
     def _create_fsaverage_fired(self):
         # progress dialog with indefinite progress bar

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1458,6 +1458,8 @@ def set_memmap_min_size(memmap_min_size):
 known_config_types = (
     'MNE_BROWSE_RAW_SIZE',
     'MNE_CACHE_DIR',
+    'MNE_COREG_SCENE_HEIGHT',
+    'MNE_COREG_SCENE_WIDTH',
     'MNE_CUDA_IGNORE_PRECISION',
     'MNE_DATA',
     'MNE_DATASETS_BRAINSTORM_PATH',


### PR DESCRIPTION
This PR aims to make coreg use space a little bit more efficiently. IMO for things like R/A/S if people don't know them, we can provide usable tooltips (but that might not even be necessary).

Builds on #3935, so WIP until that gets merged.

Doing:
```
mne coreg -s fsaverage -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif --verbose --head-opacity=0.5 --low-res-head
```
On `master` (but really #3935 to expose necessary command-line options):

![screenshot from 2017-01-26 16-27-36](https://cloud.githubusercontent.com/assets/2365790/22351147/9b9cd1d6-e3e4-11e6-8acf-a7e798ca2458.png)

This PR:

![screenshot from 2017-01-26 16-27-21](https://cloud.githubusercontent.com/assets/2365790/22351150/a0b632b6-e3e4-11e6-942b-0ba1a4f7398d.png)

@christianbrodbeck see if you like the changes.