### PR TITLE
FIX Coreg GUI scaling error

### DIFF
--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -985,11 +985,6 @@ class CoregPanel(HasPrivateTraits):
     def _scale_x_inc_fired(self):
         self.scale_x += self.scale_step
 
-    def _scale_x_changed(self, old, new):
-        if self.n_scale_params == 1:
-            self.scale_y = new
-            self.scale_z = new
-
     def _scale_y_dec_fired(self):
         step = 1. / self.scale_step
         self.scale_y *= step

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -168,7 +168,7 @@ class Object(HasPrivateTraits):
             pts = self.points
 
         self.src.data.points = pts
-        self.src.update()  # necessary for SurfaceObject since Mayavi 4.5.0
+        return True
 
 
 class PointObject(Object):
@@ -324,3 +324,8 @@ class SurfaceObject(Object):
 
         if not _testing_mode():
             self.scene.camera.parallel_scale = _scale
+
+    @on_trait_change('trans,points')
+    def _update_points(self):
+        if Object._update_points(self):
+            self.src.update()  # necessary for SurfaceObject since Mayavi 4.5.0

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -168,6 +168,7 @@ class Object(HasPrivateTraits):
             pts = self.points
 
         self.src.data.points = pts
+        self.src.update()  # necessary for SurfaceObject since Mayavi 4.5.0
 
 
 class PointObject(Object):


### PR DESCRIPTION
@Eric89GXL this fixes the MRI scaling problem with Mayavi 4.5 mentioned in https://github.com/mne-tools/mne-python/issues/3934 for me. I now get a long list of errors like the one below, but they don't seem to have a negative impact:

```
ERROR: In /Users/ilan/minonda/conda-bld/work/VTK-6.3.0/Common/ExecutionModel/vtkExecutive.cxx, line 784
vtkCompositeDataPipeline (0x7fb020cc48e0): Algorithm vtkAssignAttribute(0x7fb020cc2d60) returned failure for request: vtkInformation (0x7fb020cc2ee0)
  Debug: Off
  Modified Time: 1184422
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_DATA_OBJECT
  ALGORITHM_AFTER_FORWARD: 1
  FORWARD_DIRECTION: 0

```