### PR TITLE
[MRG] Disable interactive annotations when orig_time is not None.

### DIFF
--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -174,6 +174,12 @@ def test_plot_annotations():
     assert_equal(len(raw.annotations.onset), 0)
     assert_equal(len(raw.annotations.duration), 0)
     assert_equal(len(raw.annotations.description), 0)
+    plt.close('all')
+
+    raw.annotations = Annotations([1], [1], 'test', raw.info['meas_date'])
+    fig = raw.plot()
+    assert_raises(NotImplementedError, fig.canvas.key_press_event, 'a')
+    plt.close('all')
 
 
 @requires_version('scipy', '0.10')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -754,6 +754,10 @@ def _setup_annotation_fig(params):
     if params['fig_annotation'] is not None:
         params['fig_annotation'].canvas.close_event()
     annotations = params['raw'].annotations
+    if annotations is not None and annotations.orig_time is not None:
+        raise NotImplementedError('Interactive annotation mode is only '
+                                  'available for annotations with '
+                                  'orig_time=None.')
     labels = [] if annotations is None else list(set(annotations.description))
     labels = np.union1d(labels, params['added_label'])
     fig = figure_nobar(figsize=(4.5, 2.75 + len(labels) * 0.75))


### PR DESCRIPTION
Noticed that the drawn annotations don't align right when ``orig_time`` is not None. The fix gets quite involved, so I don't think I can get it working for 0.14.