### PR TITLE
MRG+1: Fix re-raising of errors

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -480,7 +480,7 @@ def _find_events(data, first_samp, verbose=None, output='onset',
         events[:, 2] = event_id
         events[:, 0] -= 1
     else:
-        raise Exception("Invalid output parameter %r" % output)
+        raise ValueError("Invalid output parameter %r" % output)
 
     logger.info("%s events found" % len(events))
     logger.info("Events id: %s" % np.unique(events[:, 2]))

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -175,7 +175,7 @@ class Kit2FiffModel(HasPrivateTraits):
             if self.show_gui:
                 error(None, str(err), "Error Reading Fiducials")
             self.reset_traits(['fid_file'])
-            raise err
+            raise
         else:
             return pts
 
@@ -276,7 +276,7 @@ class Kit2FiffModel(HasPrivateTraits):
         except Exception as err:
             if self.show_gui:
                 error(None, str(err), "Error Creating FsAverage")
-            raise err
+            raise
         finally:
             if self.show_gui:
                 prog.close()
@@ -306,7 +306,7 @@ class Kit2FiffModel(HasPrivateTraits):
                 error(None, "Error reading SQD data file: %s (Check the "
                       "terminal output for details)" % str(err),
                       "Error Reading SQD file")
-            raise err
+            raise
 
     @cached_property
     def _get_sqd_fname(self):
@@ -619,7 +619,7 @@ class Kit2FiffPanel(HasPrivateTraits):
             error(None, "Error reading events from SQD data file: %s (Check "
                   "the terminal output for details)" % str(err),
                   "Error Reading events from SQD file")
-            raise err
+            raise
 
         if len(events) == 0:
             information(None, "No events were found with the current "

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -732,11 +732,11 @@ def test_preload_modify():
 
         try:
             raw[picks, :nsamp // 2] = data
-        except RuntimeError as err:
+        except RuntimeError:
             if not preload:
                 continue
             else:
-                raise err
+                raise
 
         tmp_fname = op.join(tempdir, 'raw.fif')
         raw.save(tmp_fname, overwrite=True)

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -112,9 +112,9 @@ def _compare(a, b):
             assert_array_almost_equal(a, b)
         else:
             assert_true(a == b)
-    except Exception as exptn:
+    except Exception:
         print(last_keys)
-        raise exptn
+        raise
 
 
 def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -525,8 +525,6 @@ def figure_nobar(*args, **kwargs):
         cbs = list(fig.canvas.callbacks.callbacks['key_press_event'].keys())
         for key in cbs:
             fig.canvas.callbacks.disconnect(key)
-    except Exception as ex:
-        raise ex
     finally:
         rcParams['toolbar'] = old_val
     return fig


### PR DESCRIPTION
FYI when using this pattern:
```
try:
    ...
except Exception as exp:
    ...
    raise exp
```
it gives a better traceback just to do at the end:
```
    raise
```
because then the proper/full traceback is given, instead of a traceback pointing only to the `raise exp` line (i.e., better than what we see in https://github.com/mne-tools/mne-python/issues/3945).

I already pushed https://github.com/mne-tools/mne-python/commit/f1fb89636a7086f2ecbe32e5da58b509cc770605 directly to master without realizing there were other occurrences in our code.