### PR TITLE
MRG+1: get patterns coefs with example

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1104,6 +1104,7 @@ Functions:
    :template: function.rst
 
    compute_ems
+   get_coef
 
 Realtime
 ========

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -175,7 +175,7 @@ API
 
     - An ``overwrite=False`` default parameter has been added to :func:`write_source_spaces` to protect against accidental overwrites, by `Eric Larson`_
 
-    - The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use mne.EvokedArray instead, by `Jean-Remi King`_
+    - The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use :class:`mne.EvokedArray` with :func:`mne.decoding.get_coef` instead, by `Jean-Remi King`_
 
 .. _changes_0_13:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,13 +73,11 @@ Changelog
 
     - Add interactive annotation mode to :meth:`mne.io.Raw.plot` (accessed by pressing 'a') by `Jaakko Leppakangas`_
 
-<<<<<<< 0c31b1e248bea43343bded9b7fa0e2d7aa664210
     - Add support for deleting all projectors or a list of indices in :meth:`mne.io.Raw.del_proj` by `Eric Larson`_
 
     - Add source space plotting with :meth:`mne.SourceSpaces.plot` using :func:`mne.viz.plot_trans` by `Eric Larson`_
-=======
-    - Add :func:`mne.decoding.get_coef` to retrieve and inverse the coefficients of a linear model, by `Jean-Remi King`_
->>>>>>> ENH: get patterns coefs with example
+
+    - Add :func:`mne.decoding.get_coef` to retrieve and inverse the coefficients of a linear model - typically a spatial filter or pattern, by `Jean-Remi King`_
 
     - Add support for reading in EGI MFF digitization coordinate files in :func:`mne.channels.read_dig_montage` by `Matt Boggess`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,9 +73,13 @@ Changelog
 
     - Add interactive annotation mode to :meth:`mne.io.Raw.plot` (accessed by pressing 'a') by `Jaakko Leppakangas`_
 
+<<<<<<< 0c31b1e248bea43343bded9b7fa0e2d7aa664210
     - Add support for deleting all projectors or a list of indices in :meth:`mne.io.Raw.del_proj` by `Eric Larson`_
 
     - Add source space plotting with :meth:`mne.SourceSpaces.plot` using :func:`mne.viz.plot_trans` by `Eric Larson`_
+=======
+    - Add :func:`mne.decoding.get_coef` to retrieve and inverse the coefficients of a linear model, by `Jean-Remi King`_
+>>>>>>> ENH: get patterns coefs with example
 
     - Add support for reading in EGI MFF digitization coordinate files in :func:`mne.channels.read_dig_montage` by `Matt Boggess`_
 
@@ -172,6 +176,8 @@ API
     - MNE's additional files for the ``fsaverage`` head/brain model are now included in MNE-Python, and the now superfluous ``mne_root`` parameter to  :func:`create_default_subject` has been deprecated by `Christian Brodbeck`_
 
     - An ``overwrite=False`` default parameter has been added to :func:`write_source_spaces` to protect against accidental overwrites, by `Eric Larson`_
+
+    - The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use mne.EvokedArray instead, by `Jean-Remi King`_
 
 .. _changes_0_13:
 

--- a/examples/decoding/decoding_rsa.py
+++ b/examples/decoding/decoding_rsa.py
@@ -27,7 +27,7 @@ References
        Frontiers in systems neuroscience 2 (2008): 4.
 .. [4] Cichy, R. M., Pantazis, D., & Oliva, A. "Resolving human object
        recognition in space and time." Nature neuroscience (2014): 17(3),
-       455-462
+       455-462.
 """
 
 # Authors: Jean-Remi King <jeanremi.king@gmail.com>

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -6,23 +6,22 @@ Motor imagery decoding from EEG data using the Common Spatial Pattern (CSP)
 Decoding of motor imagery applied to EEG data decomposed using CSP.
 Here the classifier is applied to features extracted on CSP filtered signals.
 
-See http://en.wikipedia.org/wiki/Common_spatial_pattern and [1]
+See http://en.wikipedia.org/wiki/Common_spatial_pattern and [1]_. The EEGBCI
+dataset is documented in [2]_. The data set is available at PhysioNet [3]_.
 
-The EEGBCI dataset is documented in [2]
-The data set is available at PhysioNet [3]
+References
+----------
 
-[1] Zoltan J. Koles. The quantitative extraction and topographic mapping
-    of the abnormal components in the clinical EEG. Electroencephalography
-    and Clinical Neurophysiology, 79(6):440--447, December 1991.
-
-[2] Schalk, G., McFarland, D.J., Hinterberger, T., Birbaumer, N.,
-    Wolpaw, J.R. (2004) BCI2000: A General-Purpose Brain-Computer Interface
-    (BCI) System. IEEE TBME 51(6):1034-1043
-
-[3] Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG,
-    Mietus JE, Moody GB, Peng C-K, Stanley HE. (2000) PhysioBank,
-    PhysioToolkit, and PhysioNet: Components of a New Research Resource for
-    Complex Physiologic Signals. Circulation 101(23):e215-e220
+.. [1] Zoltan J. Koles. The quantitative extraction and topographic mapping
+       of the abnormal components in the clinical EEG. Electroencephalography
+       and Clinical Neurophysiology, 79(6):440--447, December 1991.
+.. [2] Schalk, G., McFarland, D.J., Hinterberger, T., Birbaumer, N.,
+       Wolpaw, J.R. (2004) BCI2000: A General-Purpose Brain-Computer Interface
+       (BCI) System. IEEE TBME 51(6):1034-1043.
+.. [3] Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG,
+       Mietus JE, Moody GB, Peng C-K, Stanley HE. (2000) PhysioBank,
+       PhysioToolkit, and PhysioNet: Components of a New Research Resource for
+       Complex Physiologic Signals. Circulation 101(23):e215-e220.
 """
 # Authors: Martin Billinger <martin.billinger@tugraz.at>
 #

--- a/examples/decoding/plot_decoding_csp_space.py
+++ b/examples/decoding/plot_decoding_csp_space.py
@@ -6,12 +6,14 @@ Decoding in sensor space data using the Common Spatial Pattern (CSP)
 Decoding applied to MEG data in sensor space decomposed using CSP.
 Here the classifier is applied to features extracted on CSP filtered signals.
 
-See http://en.wikipedia.org/wiki/Common_spatial_pattern and [1]
+See http://en.wikipedia.org/wiki/Common_spatial_pattern and [1]_.
 
-[1] Zoltan J. Koles. The quantitative extraction and topographic mapping
-    of the abnormal components in the clinical EEG. Electroencephalography
-    and Clinical Neurophysiology, 79(6):440--447, December 1991.
+References
+----------
 
+.. [1] Zoltan J. Koles. The quantitative extraction and topographic mapping
+       of the abnormal components in the clinical EEG. Electroencephalography
+       and Clinical Neurophysiology, 79(6):440--447, December 1991.
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Romain Trachel <romain.trachel@inria.fr>

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -3,15 +3,17 @@
 Decoding sensor space data with generalization across time and conditions
 =========================================================================
 
-This example runs the analysis computed in:
+This example runs the analysis described in [1]_. It illustrates how one can
+fit a linear classifier to identify a discriminatory topography at a given time
+instant and subsquently assess whether this linear model can accurately predict
+all of the time samples of a second set of conditions.
 
-King & Dehaene (2014) 'Characterizing the dynamics of mental
-representations: the temporal generalization method', Trends In Cognitive
-Sciences, 18(4), 203-210.
-http://www.ncbi.nlm.nih.gov/pubmed/24593982
+References
+----------
 
-The idea is to learn at one time instant and assess if the decoder
-can predict accurately over time and on a second set of conditions.
+.. [1] King & Dehaene (2014) 'Characterizing the dynamics of mental
+       representations: the temporal generalization method', Trends In
+       Cognitive Sciences, 18(4), 203-210. doi: 10.1016/j.tics.2014.01.002.
 """
 # Authors: Jean-Remi King <jeanremi.king@gmail.com>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -5,8 +5,8 @@ Decoding sensor space data with generalization across time and conditions
 
 This example runs the analysis described in [1]_. It illustrates how one can
 fit a linear classifier to identify a discriminatory topography at a given time
-instant and subsquently assess whether this linear model can accurately predict
-all of the time samples of a second set of conditions.
+instant and subsequently assess whether this linear model can accurately
+predict all of the time samples of a second set of conditions.
 
 References
 ----------

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -9,14 +9,15 @@ to create features vectors that will be fed into a Logistic Regression.
 
 References
 ----------
-[1] Rivet, B., Souloumiac, A., Attina, V., & Gibert, G. (2009). xDAWN
-algorithm to enhance evoked potentials: application to brain-computer
-interface. Biomedical Engineering, IEEE Transactions on, 56(8), 2035-2043.
 
-[2] Rivet, B., Cecotti, H., Souloumiac, A., Maby, E., & Mattout, J. (2011,
-August). Theoretical analysis of xDAWN algorithm: application to an
-efficient sensor selection in a P300 BCI. In Signal Processing Conference,
-2011 19th European (pp. 1382-1386). IEEE.
+.. [1] Rivet, B., Souloumiac, A., Attina, V., & Gibert, G. (2009). xDAWN
+       algorithm to enhance evoked potentials: application to brain-computer
+       interface. Biomedical Engineering, IEEE Transactions on, 56(8),
+       2035-2043.
+.. [2] Rivet, B., Cecotti, H., Souloumiac, A., Maby, E., & Mattout, J. (2011,
+       August). Theoretical analysis of xDAWN algorithm: application to an
+       efficient sensor selection in a P300 BCI. In Signal Processing
+       Conference, 2011 19th European (pp. 1382-1386). IEEE.
 """
 # Authors: Alexandre Barachant <alexandre.barachant@gmail.com>
 #

--- a/examples/decoding/plot_ems_filtering.py
+++ b/examples/decoding/plot_ems_filtering.py
@@ -3,24 +3,25 @@
 Compute effect-matched-spatial filtering (EMS)
 ==============================================
 
-This example computes the EMS to reconstruct the time course of
-the experimental effect as described in:
+This example computes the EMS to reconstruct the time course of the
+experimental effect as described in [1]_.
 
-Aaron Schurger, Sebastien Marti, and Stanislas Dehaene, "Reducing multi-sensor
-data to a single time course that reveals experimental effects",
-BMC Neuroscience 2013, 14:122
-
-
-This technique is used to create spatial filters based on the
-difference between two conditions. By projecting the trial onto the
-corresponding spatial filters, surrogate single trials are created
-in which multi-sensor activity is reduced to one time series which
-exposes experimental effects, if present.
+This technique is used to create spatial filters based on the difference
+between two conditions. By projecting the trial onto the corresponding spatial
+filters, surrogate single trials are created in which multi-sensor activity is
+reduced to one time series which exposes experimental effects, if present.
 
 We will first plot a trials x times image of the single trials and order the
 trials by condition. A second plot shows the average time series for each
-condition. Finally a topographic plot is created which exhibits the
-temporal evolution of the spatial filters.
+condition. Finally a topographic plot is created which exhibits the temporal
+evolution of the spatial filters.
+
+References
+----------
+
+.. [1] Aaron Schurger, Sebastien Marti, and Stanislas Dehaene, "Reducing
+       multi-sensor data to a single time course that reveals experimental
+       effects", BMC Neuroscience 2013, 14:122.
 """
 # Author: Denis Engemann <denis.engemann@gmail.com>
 #         Jean-Remi King <jeanremi.king@gmail.com>

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -7,16 +7,19 @@ Linear classifier on sensor data with plot patterns and filters
 Decoding, a.k.a MVPA or supervised machine learning applied to MEG and EEG
 data in sensor space. Fit a linear classifier with the LinearModel object
 providing topographical patterns which are more neurophysiologically
-interpretable [1] than the classifier filters (weight vectors).
+interpretable [1]_ than the classifier filters (weight vectors).
 The patterns explain how the MEG and EEG data were generated from the
 discriminant neural sources which are extracted by the filters.
 Note patterns/filters in MEG data are more similar than EEG data
 because the noise is less spatially correlated in MEG than EEG.
 
-[1] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
-Blankertz, B., & Bießmann, F. (2014). On the interpretation of
-weight vectors of linear models in multivariate neuroimaging.
-NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
+References
+----------
+
+.. [1] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
+       Blankertz, B., & Bießmann, F. (2014). On the interpretation of
+       weight vectors of linear models in multivariate neuroimaging.
+       NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Romain Trachel <trachelr@gmail.com>
@@ -95,7 +98,7 @@ for name, coef in (('patterns', model.patterns_), ('filters', model.filters_)):
 X = epochs.pick_types(meg=False, eeg=True)
 y = epochs.events[:, 2]
 
-# Define a unique pipeline to sequentially
+# Define a unique pipeline to sequentially:
 clf = make_pipeline(
     Vectorizer(),                       # 1) vectorize across time and channels
     StandardScaler(),                   # 2) normalize features across trials

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -107,6 +107,8 @@ clf.fit(X, y)
 
 # Extract and plot patterns and filters
 for name in ('patterns_', 'filters_'):
+    # The `inverse_transform` parameter will call this method on any estimator
+    # contained in the pipeline, in reverse order.
     coef = get_coef(clf, name, inverse_transform=True)
     evoked = EvokedArray(coef, epochs.info, tmin=epochs.tmin)
     evoked.plot_topomap(title='EEG %s' % name[:-1])

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -80,7 +80,7 @@ model.fit(X, labels)
 
 # Extract and plot spatial filters and spatial patterns
 for name, coef in (('patterns', model.patterns_), ('filters', model.filters_)):
-    # We fitted the linear model onto a Z-scored data. To make the filters
+    # We fitted the linear model onto Z-scored data. To make the filters
     # interpretable, we must reverse this normalization step
     coef = scaler.inverse_transform([coef])[0]
 

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -4,7 +4,7 @@ from .transformer import Scaler, FilterEstimator
 from .transformer import (PSDEstimator, Vectorizer,
                           UnsupervisedSpatialFilter, TemporalFilter)
 from .mixin import TransformerMixin
-from .base import BaseEstimator, LinearModel
+from .base import BaseEstimator, LinearModel, get_coef
 from .csp import CSP
 from .ems import compute_ems, EMS
 from .time_gen import GeneralizationAcrossTime, TimeDecoding

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -742,6 +742,7 @@ def _make_scorer(scoring):
         If str, must be compatible with sklearn sklearn's get_scorer.
         If callable, function with signature ``score_func(y, y_pred,
         **kwargs)``.
+
     Returns
     -------
     scorer : callable | None
@@ -760,7 +761,7 @@ def _make_scorer(scoring):
 
 
 def _get_inverse_funcs(estimator, terminal=True):
-    """Retrieve the inverse functions of an pipeline or an estimator"""
+    """Retrieve the inverse functions of an pipeline or an estimator."""
     inverse_func = [False]
     if hasattr(estimator, 'steps'):
         # if pipeline, retrieve all steps by nesting
@@ -812,7 +813,7 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
     .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
        Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
-       96-110. doi:10.1016/j.neuroimage.2013.10.067
+       96-110. doi:10.1016/j.neuroimage.2013.10.067.
     """
     # If searchlight, loop across estimators
     if hasattr(estimator, 'estimators_'):

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -838,6 +838,8 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
                 raise ValueError('inverse_transform can only be applied onto '
                                  'pipeline estimators.')
 
+            # The inverse_transform parameter will call this method on any
+            # estimator contained in the pipeline, in reverse order.
             for inverse_func in _get_inverse_funcs(estimator)[::-1]:
                 coef = inverse_func([coef])[0]
         return coef

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -250,7 +250,8 @@ class LinearModel(BaseEstimator):
         """
         X = np.asarray(X)
         if X.ndim != 2:
-            raise ValueError('LinearModel only accepts 2-dimensional X')
+            raise ValueError('LinearModel only accepts 2-dimensional X, got '
+                             '%s instead.' % (X.shape,))
 
         # fit the Model
         self.model.fit(X, y)
@@ -259,9 +260,10 @@ class LinearModel(BaseEstimator):
         if (
             not hasattr(self.model, 'coef_') or  # missing attribute
             self.model.coef_.ndim > 2 or         # weird case
-            ((self.model.coef_.ndim == 2) and    # shape (n), (n, 1) or (1, n)
-             (1 not in self.model.coef_.shape))
+            (self.model.coef_.size not in
+             self.model.coef_.shape)             # shape (n), (n, 1) or (1, n)
         ):
+
             raise ValueError('model needs a unidimensional coef_ attribute to '
                              'compute the patterns')
         self.filters_ = np.squeeze(self.model.coef_)
@@ -785,6 +787,7 @@ def _get_inverse_funcs(estimator, terminal=True):
 
 def get_coef(estimator, attr='filters_', inverse_transform=False):
     """Retrieve the coefficients of an estimator ending with a Linear Model.
+
     This is typically useful to retrieve "spatial filters" or "spatial
     patterns" of decoding models [1]_.
 
@@ -794,7 +797,7 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
         An estimator from scikit-learn.
     attr : str
         The name of the coefficient attribute to retrieve. Typically 'filters_'
-        or 'pattern_'. Defaults to 'filters_'.
+        or 'patterns_'. Defaults to 'filters_'.
     inverse_transform : bool
         If True, returns the coefficients after inverse transforming them with
         the transformer steps of the estimator.

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -804,8 +804,8 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
     coef : array
         The coefficients.
 
-    Reference
-    ---------
+    References
+    ----------
     .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
        Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -806,10 +806,6 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
 
     Reference
     ---------
-    .. [1] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
-       Blankertz, B., & Bießmann, F. (2014). On the interpretation of
-       weight vectors of linear models in multivariate neuroimaging.
-       NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
 
     """
     # If searchlight, loop across estimators

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -807,9 +807,9 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
     Reference
     ---------
     .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
-       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weigh
+       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
-       96–110. doi:10.1016/j.neuroimage.2013.10.067
+       96-110. doi:10.1016/j.neuroimage.2013.10.067
     """
     # If searchlight, loop across estimators
     if hasattr(estimator, 'estimators_'):

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -806,7 +806,10 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
 
     Reference
     ---------
-
+    .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
+       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weigh
+       vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
+       96–110. doi:10.1016/j.neuroimage.2013.10.067
     """
     # If searchlight, loop across estimators
     if hasattr(estimator, 'estimators_'):

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -784,7 +784,9 @@ def _get_inverse_funcs(estimator, terminal=True):
 
 
 def get_coef(estimator, attr='filters_', inverse_transform=False):
-    """Retrieve the coefficients of an estimator.
+    """Retrieve the coefficients of an estimator ending with a Linear Model.
+    This is typically useful to retrieve "spatial filters" or "spatial
+    patterns" of decoding models [1]_.
 
     Parameters
     ----------
@@ -801,6 +803,14 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
     -------
     coef : array
         The coefficients.
+
+    Reference
+    ---------
+    .. [1] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
+       Blankertz, B., & Bießmann, F. (2014). On the interpretation of
+       weight vectors of linear models in multivariate neuroimaging.
+       NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
+
     """
     # If searchlight, loop across estimators
     if hasattr(estimator, 'estimators_'):

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -2,6 +2,7 @@
 # Authors: Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Romain Trachel <trachelr@gmail.com>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#          Jean-Remi King <jeanremi.king@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -10,7 +11,7 @@ import numpy as np
 
 from ..externals.six import iteritems
 from ..fixes import _get_args
-from ..utils import check_version
+from ..utils import check_version, deprecated
 
 
 class BaseEstimator(object):
@@ -183,14 +184,12 @@ def _pprint(params, offset=0, printer=repr):
 
 
 class LinearModel(BaseEstimator):
-    """Clone a Linear Model from sklearn and update attributes for each fit.
+    """Compute and store patterns from linear models.
 
-    The linear model coefficients
-    (filters) are used to extract discriminant neural sources from
-    the measured data. This class implements the computation of patterns
-    which provides neurophysiologically interpretable information [1]_,
-    in the sense that significant nonzero weights are only observed at channels
-    where activity is related to discriminant neural sources.
+    The linear model coefficients (filters) are used to extract discriminant
+    neural sources from the measured data. This class computes the
+    corresponding patterns of these linear filters to make them more
+    interpretable [1]_.
 
     Parameters
     ----------
@@ -202,9 +201,9 @@ class LinearModel(BaseEstimator):
     Attributes
     ----------
     ``filters_`` : ndarray
-        If fit, the filters used to decompose the data, else None.
+        If fit, the filters used to decompose the data.
     ``patterns_`` : ndarray
-        If fit, the patterns used to restore M/EEG signals, else None.
+        If fit, the patterns used to restore M/EEG signals.
 
     Notes
     -----
@@ -230,8 +229,6 @@ class LinearModel(BaseEstimator):
             model = LogisticRegression()
 
         self.model = model
-        self.patterns_ = None
-        self.filters_ = None
 
     def fit(self, X, y):
         """Estimate the coefficients of the linear model.
@@ -241,41 +238,49 @@ class LinearModel(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape (n_epochs, n_features)
-            The data to estimate the coeffiscient.
-        y : array, shape (n_epochs,)
-            The class for each epoch.
+        X : array, shape (n_samples, n_features)
+            The training input samples to estimate the linear coefficients.
+        y : array, shape (n_samples,)
+            The target values.
 
         Returns
         -------
         self : instance of LinearModel
             Returns the modified instance.
         """
+        X = np.asarray(X)
+        if X.ndim != 2:
+            raise ValueError('LinearModel only accepts 2-dimensional X')
+
         # fit the Model
         self.model.fit(X, y)
+
         # computes the patterns
-        assert hasattr(self.model, 'coef_'), \
-            "model needs a coef_ attribute to compute the patterns"
-        self.patterns_ = np.dot(X.T, np.dot(X, self.model.coef_.T))
-        self.filters_ = self.model.coef_
+        if (
+            not hasattr(self.model, 'coef_') or  # missing attribute
+            self.model.coef_.ndim > 2 or         # weird case
+            ((self.model.coef_.ndim == 2) and    # shape (n), (n, 1) or (1, n)
+             (1 not in self.model.coef_.shape))
+        ):
+            raise ValueError('model needs a unidimensional coef_ attribute to '
+                             'compute the patterns')
+        self.filters_ = np.squeeze(self.model.coef_)
+        self.patterns_ = np.cov(X.T).dot(self.filters_)
 
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X):
         """Transform the data using the linear model.
 
         Parameters
         ----------
-        X : array, shape (n_epochs, n_features)
+        X : array, shape (n_samples, n_features)
             The data to transform.
-        y : array, shape (n_epochs,)
-            The class for each epoch.
 
         Returns
         -------
-        y_pred : array, shape (n_epochs,)
-            Predicted class label per epoch.
-
+        y_pred : array, shape (n_samples,)
+            The predicted targets.
         """
         return self.model.transform(X)
 
@@ -284,15 +289,15 @@ class LinearModel(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape (n_epochs, n_features)
-            The data to transform.
-        y : array, shape (n_epochs,)
-            The class for each epoch.
+        X : array, shape (n_samples, n_features)
+            The training input samples to estimate the linear coefficients.
+        y : array, shape (n_samples,)
+            The target values.
 
         Returns
         -------
-        y_pred : array, shape (n_epochs,)
-            Predicted class label per epoch.
+        y_pred : array, shape (n_samples,)
+            The predicted targets.
 
         """
         return self.fit(X, y).transform(X)
@@ -302,12 +307,12 @@ class LinearModel(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape (n_epochs, n_features)
+        X : array, shape (n_samples, n_features)
             The data used to compute the predictions.
 
         Returns
         -------
-        y_pred : array, shape (n_epochs,)
+        y_pred : array, shape (n_samples,)
             The predictions.
         """
         return self.model.predict(X)
@@ -317,10 +322,10 @@ class LinearModel(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape (n_epochs, n_features)
+        X : array, shape (n_samples, n_features)
             The data to transform.
-        y : array, shape (n_epochs,)
-            The class for each epoch.
+        y : array, shape (n_samples,)
+            The target values.
 
         Returns
         -------
@@ -329,6 +334,8 @@ class LinearModel(BaseEstimator):
         """
         return self.model.score(X, y)
 
+    @deprecated('plot_filters is deprecated and will be removed in 0.15, '
+                'use EvokedArray instead.')
     def plot_patterns(self, info, times=None, ch_type=None, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                       colorbar=True, scale=None, scale_time=1e3, unit='a.u.',
@@ -489,6 +496,8 @@ class LinearModel(BaseEstimator):
                                      image_interp=image_interp, show=show,
                                      head_pos=head_pos, average=average)
 
+    @deprecated('plot_filters is deprecated and will be removed in 0.15, '
+                'use EvokedArray instead.')
     def plot_filters(self, info, times=None, ch_type=None, layout=None,
                      vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                      colorbar=True, scale=None, scale_time=1e3, unit='a.u.',
@@ -746,3 +755,76 @@ def _make_scorer(scoring):
         return get_scorer(scoring)
     else:
         return make_scorer(scoring)
+
+
+def _get_inverse_funcs(estimator, terminal=True):
+    """Retrieve the inverse functions of an pipeline or an estimator"""
+    inverse_func = [False]
+    if hasattr(estimator, 'steps'):
+        # if pipeline, retrieve all steps by nesting
+        inverse_func = list()
+        for _, est in estimator.steps:
+            inverse_func.extend(_get_inverse_funcs(est, terminal=False))
+    elif hasattr(estimator, 'inverse_transform'):
+        # if not pipeline attempt to retrieve inverse function
+        inverse_func = [estimator.inverse_transform]
+
+    # If terminal node, check that that the last estimator is a classifier,
+    # and remove it from the transformers.
+    if terminal:
+        last_is_estimator = inverse_func[-1] is False
+        all_invertible = not(False in inverse_func[:-1])
+        if last_is_estimator and all_invertible:
+            # keep all inverse transformation and remove last estimation
+            inverse_func = inverse_func[:-1]
+        else:
+            inverse_func = list()
+
+    return inverse_func
+
+
+def get_coef(estimator, attr='filters_', inverse_transform=False):
+    """Retrieve the coefficients of an estimator.
+
+    Parameters
+    ----------
+    estimator : object | None
+        An estimator from scikit-learn.
+    attr : str
+        The name of the coefficient attribute to retrieve. Typically 'filters_'
+        or 'pattern_'. Defaults to 'filters_'.
+    inverse_transform : bool
+        If True, returns the coefficients after inverse transforming them with
+        the transformer steps of the estimator.
+
+    Returns
+    -------
+    coef : array
+        The coefficients.
+    """
+    # If searchlight, loop across estimators
+    if hasattr(estimator, 'estimators_'):
+        coef = list()
+        for est in estimator.estimators_:
+            coef.append(get_coef(est, attr, inverse_transform))
+        return np.array(coef)
+
+    else:
+        # Get the coefficients of the last estimator in case of nested pipeline
+        est = estimator
+        while hasattr(est, 'steps'):
+            est = est.steps[-1][1]
+        if not hasattr(est, attr):
+            raise ValueError('This estimator does not have a %s '
+                             'attribute.' % attr)
+        coef = getattr(est, attr)
+
+        # inverse pattern e.g. to get back physical units
+        if inverse_transform:
+            if not hasattr(estimator, 'steps'):
+                raise ValueError('inverse_transform can only be applied onto '
+                                 'pipeline estimators.')
+
+            for inverse_func in _get_inverse_funcs(estimator)[::-1]:
+                coef = inverse_func([coef])[0]
+        return coef

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -5,12 +5,12 @@
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal, assert_raises
-from ...utils import requires_sklearn_0_15
+from ...utils import requires_sklearn
 from ..base import _get_inverse_funcs, LinearModel, get_coef
 from ..search_light import _SearchLight
 
 
-@requires_sklearn_0_15
+@requires_sklearn
 def test_get_coef():
     from sklearn.base import TransformerMixin, BaseEstimator
     from sklearn.pipeline import make_pipeline
@@ -113,6 +113,7 @@ def test_get_coef():
                            filters[t])
 
 
+@requires_sklearn
 def test_linearmodel():
     clf = LinearModel()
     X = np.random.rand(20, 3)

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -118,6 +118,8 @@ def test_get_coef():
 
 @requires_sklearn
 def test_linearmodel():
+    """Test LinearModel class for computing filters and patterns.
+    """
     clf = LinearModel()
     X = np.random.rand(20, 3)
     y = np.arange(20) % 2

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -1,0 +1,125 @@
+# Author: Jean-Remi King, <jeanremi.king@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+from nose.tools import assert_true, assert_equal, assert_raises
+from ...utils import requires_sklearn_0_15
+from ..base import _get_inverse_funcs, LinearModel, get_coef
+from ..search_light import _SearchLight
+
+
+@requires_sklearn_0_15
+def test_get_coef():
+    from sklearn.base import TransformerMixin, BaseEstimator
+    from sklearn.pipeline import make_pipeline
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.linear_model import LinearRegression
+
+    # Define a classifier, an invertible transformer and an non-invertible one.
+
+    class Clf(BaseEstimator):
+        def fit(self, X, y):
+            return self
+
+    class NoInv(TransformerMixin):
+        def fit(self, X, y):
+            return self
+
+        def transform(self, X):
+            return X
+
+    class Inv(NoInv):
+        def inverse_transform(self, X):
+            return X
+
+    np.random.seed(0)
+    n_samples, n_features = 20, 3
+    y = (np.arange(n_samples) % 2) * 2 - 1
+    w = np.random.randn(n_features, 1)
+    X = w.dot(y[np.newaxis, :]).T + np.random.randn(n_samples, n_features)
+
+    # I. Test inverse function
+
+    # Check that we retrieve the right number of inverse functions even if
+    # there are nested pipelines
+    good_estimators = [
+        (1, make_pipeline(Inv(), Clf())),
+        (2, make_pipeline(Inv(), Inv(), Clf())),
+        (3, make_pipeline(Inv(), make_pipeline(Inv(), Inv()), Clf())),
+    ]
+
+    for expected_n, est in good_estimators:
+        est.fit(X, y)
+        assert_true(expected_n == len(_get_inverse_funcs(est)))
+
+    bad_estimators = [
+        Clf(),  # no preprocessing
+        Inv(),  # final estimator isn't classifier
+        make_pipeline(NoInv(), Clf()),  # first step isn't invertible
+        make_pipeline(Inv(), make_pipeline(
+            Inv(), NoInv()), Clf()),  # nested step isn't invertible
+    ]
+    for est in bad_estimators:
+        est.fit(X, y)
+        invs = _get_inverse_funcs(est)
+        assert_equal(invs, list())
+
+    # II. Test get coef for simple estimator and pipelines
+    for clf in (LinearModel(), make_pipeline(StandardScaler(), LinearModel())):
+        clf.fit(X, y)
+        # Retrieve final linear model
+        filters = get_coef(clf, 'filters_', False)
+        if hasattr(clf, 'steps'):
+            coefs = clf.steps[-1][-1].model.coef_
+        else:
+            coefs = clf.model.coef_
+        assert_array_equal(filters, coefs[0])
+        patterns = get_coef(clf, 'patterns_', False)
+        assert_true(filters[0] != patterns[0])
+        n_chans = X.shape[1]
+        assert_array_equal(filters.shape, patterns.shape, [n_chans, n_chans])
+
+    # Inverse transform linear model
+    filters_inv = get_coef(clf, 'filters_', True)
+    assert_true(filters[0] != filters_inv[0])
+    patterns_inv = get_coef(clf, 'patterns_', True)
+    assert_true(patterns[0] != patterns_inv[0])
+
+    # Check patterns values
+    clf = make_pipeline(StandardScaler(), LinearModel(LinearRegression()))
+    clf.fit(X, y)
+    patterns = get_coef(clf, 'patterns_', True)
+    mean, std = X.mean(0), X.std(0)
+    X = (X - mean) / std
+    coef = np.linalg.pinv(X.T.dot(X)).dot(X.T.dot(y))
+    patterns_manual = np.cov(X.T).dot(coef)
+    assert_array_almost_equal(patterns, patterns_manual * std + mean)
+
+    # Check with search_light:
+    n_samples, n_features, n_times = 20, 3, 5
+    y = np.arange(n_samples) % 2
+    X = np.random.rand(n_samples, n_features, n_times)
+    clf = _SearchLight(make_pipeline(StandardScaler(), LinearModel()))
+    clf.fit(X, y)
+    for inverse in (True, False):
+        patterns = get_coef(clf, 'patterns_', inverse)
+        filters = get_coef(clf, 'filters_', inverse)
+        assert_array_equal(filters.shape, patterns.shape,
+                           [n_features, n_times])
+    for t in [0, 1]:
+        assert_array_equal(get_coef(clf.estimators_[t], 'filters_', False),
+                           filters[t])
+
+
+def test_linearmodel():
+    clf = LinearModel()
+    X = np.random.rand(20, 3)
+    y = np.arange(20) % 2
+    clf.fit(X, y)
+    assert_equal(clf.filters_.shape[0], 3)
+    assert_equal(clf.filters_.ndim, 1)
+    assert_equal(clf.patterns_.shape[0], 3)
+    assert_equal(clf.patterns_.ndim, 1)
+    assert_raises(ValueError, clf.fit, np.random.rand(20, 3, 2), y)

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -12,6 +12,9 @@ from ..search_light import _SearchLight
 
 @requires_sklearn
 def test_get_coef():
+    """Test the retrieval of linear coefficients (filters and patterns) from
+    simple and pipeline estimators.
+    """
     from sklearn.base import TransformerMixin, BaseEstimator
     from sklearn.pipeline import make_pipeline
     from sklearn.preprocessing import StandardScaler
@@ -34,7 +37,7 @@ def test_get_coef():
         def inverse_transform(self, X):
             return X
 
-    np.random.seed(0)
+    np.random.RandomState(0)
     n_samples, n_features = 20, 3
     y = (np.arange(n_samples) % 2) * 2 - 1
     w = np.random.randn(n_features, 1)
@@ -119,8 +122,6 @@ def test_linearmodel():
     X = np.random.rand(20, 3)
     y = np.arange(20) % 2
     clf.fit(X, y)
-    assert_equal(clf.filters_.shape[0], 3)
-    assert_equal(clf.filters_.ndim, 1)
-    assert_equal(clf.patterns_.shape[0], 3)
-    assert_equal(clf.patterns_.ndim, 1)
+    assert_equal(clf.filters_.shape, (3,))
+    assert_equal(clf.patterns_.shape, (3,))
     assert_raises(ValueError, clf.fit, np.random.rand(20, 3, 2), y)

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -5,12 +5,12 @@
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal, assert_raises
-from ...utils import requires_sklearn
+from ...utils import requires_sklearn_0_15
 from ..base import _get_inverse_funcs, LinearModel, get_coef
 from ..search_light import _SearchLight
 
 
-@requires_sklearn
+@requires_sklearn_0_15
 def test_get_coef():
     """Test the retrieval of linear coefficients (filters and patterns) from
     simple and pipeline estimators.
@@ -116,7 +116,7 @@ def test_get_coef():
                            filters[t])
 
 
-@requires_sklearn
+@requires_sklearn_0_15
 def test_linearmodel():
     """Test LinearModel class for computing filters and patterns.
     """


### PR DESCRIPTION
After a couple of iterations, I believe the best way to deal with the extraction and plotting of spatial filters and spatial patterns is to i) ensure that we use the LinearModel class at the end of our pipeline and ii) use a function that can extract and inverse transform these coefficients.

This API allows a full sklearn compatibility, and avoid adding additional complex attributes to `SearchLight` and `GeneralizationLight` (filters_, inverse_filters, inverse_patterns etc)

```python
clf = make_pipeline(Vectorizer(), StandardScaler(), LinearModel(LogisticRegression()))
clf.fit(X, y)
coef = get_coef(clf, 'filters_', inverse_transform=True)
evoked = EvokedArray(coef, epochs.info, tmin=epochs.tmin)
```

Features:
- [x] extract linear coefficients (filters and patterns) for pipeline and search lights (GAT etc)
- [x] add option to inverse_transform the coefficients
- [x] add get_coef to extract and invert_transform linear coefficient of (nested) pipelines.
- [x] add unit test to linear model
- [x] make get_coef compatible with `_SearchLight` and `_GeneralizationLight`
- [x] update example

@trachelr @agramfort @teonbrooks @jona-sassenhagen @choldgraf 

- closes #3424
- partially closes #3681 (partially because I think we should not recommend using Haufe's trick on a vectorized model, because we're spreading information across time in a non trivial way)
- partially closes #3550 (partially, because it will be solved once we replace GAT by _GeneralizationLight)
