### PR TITLE
MRG: Allow del_proj to delete all projs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,8 @@ Changelog
 
     - Add interactive annotation mode to :meth:`mne.io.Raw.plot` (accessed by pressing 'a') by `Jaakko Leppakangas`_
 
+    - Add support for deleting all projectors or a list of indices in :meth:`mne.io.Raw.del_proj` by `Eric Larson`_
+
 BUG
 ~~~
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -186,8 +186,8 @@ class ProjMixin(object):
         Parameters
         ----------
         idx : int | str
-            Index of the projector to remove. Can also be "all" to remove
-            all projectors.
+            Index of the projector to remove. Can also be "all" (default)
+            to remove all projectors.
 
         Returns
         -------

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -177,7 +177,7 @@ class ProjMixin(object):
         logger.info('SSP projectors applied...')
         return self
 
-    def del_proj(self, idx):
+    def del_proj(self, idx='all'):
         """Remove SSP projection vector.
 
         Note: The projection vector can only be removed if it is inactive
@@ -185,19 +185,22 @@ class ProjMixin(object):
 
         Parameters
         ----------
-        idx : int
-            Index of the projector to remove.
+        idx : int | str
+            Index of the projector to remove. Can also be "all" to remove
+            all projectors.
 
         Returns
         -------
         self : instance of Raw | Epochs | Evoked
         """
-        if self.info['projs'][idx]['active']:
+        if isinstance(idx, string_types) and idx == 'all':
+            idx = list(range(len(self.info['projs'])))
+        idx = np.atleast_1d(np.array(idx, int)).ravel()
+        if any(self.info['projs'][ii]['active'] for ii in idx):
             raise ValueError('Cannot remove projectors that have already '
                              'been applied')
-
-        self.info['projs'].pop(idx)
-
+        self.info['projs'] = [p for pi, p in enumerate(self.info['projs'])
+                              if pi not in idx]
         return self
 
     def plot_projs_topomap(self, ch_type=None, layout=None, axes=None):

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -185,7 +185,7 @@ class ProjMixin(object):
 
         Parameters
         ----------
-        idx : int | str
+        idx : int | list of int | str
             Index of the projector to remove. Can also be "all" (default)
             to remove all projectors.
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -60,6 +60,14 @@ def test_bad_proj():
     raw.info['bads'] = raw.ch_names[:10]
     _check_warnings(raw, events, count=0)
 
+    raw = read_raw_fif(raw_fname)
+    assert_raises(ValueError, raw.del_proj, 'foo')
+    n_proj = len(raw.info['projs'])
+    raw.del_proj(0)
+    assert_equal(len(raw.info['projs']), n_proj - 1)
+    raw.del_proj()
+    assert_equal(len(raw.info['projs']), 0)
+
 
 def _check_warnings(raw, events, picks=None, count=3):
     """Helper to count warnings."""


### PR DESCRIPTION
Up until now I've been doing `raw.add_proj([], remove_existing=True)`, which is silly. Now we can do `raw.del_proj()`.