### PR TITLE
Proposal: function to quickly generate `y` for decoding schemes

### DIFF
--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -4,7 +4,7 @@ from .transformer import Scaler, FilterEstimator
 from .transformer import (PSDEstimator, Vectorizer,
                           UnsupervisedSpatialFilter, TemporalFilter)
 from .mixin import TransformerMixin
-from .base import BaseEstimator, LinearModel
+from .base import BaseEstimator, LinearModel, dummy_encoding
 from .csp import CSP
 from .ems import compute_ems, EMS
 from .time_gen import GeneralizationAcrossTime, TimeDecoding

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -819,6 +819,9 @@ def dummy_encoding(epochs, use_events=None):
     """
     if use_events is None:
         use_events = sorted(epochs.event_id.keys())
+        order = np.argsort([epochs.event_id[event] for event in use_events],
+                           kind='mergesort')  # use a stable sort
+        use_events = [use_events[x] for x in order]
 
     if len(use_events) < 2:
         raise ValueError('You need to specify at least two event types.')

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -761,10 +761,10 @@ def dummy_encoding(epochs, use_events=None):
 
     If more than two classes are present, or epochs are present that belong to
     no class or to multiple classes, a matrix will be generated where each
-    column corresponds to a class and each row encodes to which class(es) the
-    epoch belongs. By default the columns of the matrix will correspond to the
-    events in order of their respective event-ids (further ordered by their
-    event name if multiple classes share the same event-id).  Use the
+    column corresponds to a class and each row encodes which class(es) the
+    epoch belongs to. By default, the columns of the matrix will correspond to
+    the events in order of their respective event-ids (further ordered by their
+    event name if multiple classes share the same event-id). Use the
     `use_events` parameter to specify a different order.
 
     Parameters

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -6,6 +6,7 @@ from mne.decoding import dummy_encoding
 
 
 def test_dummy_encoding():
+    """Test generating a target variable from epochs."""
     events = np.array([[0, 0, 1],
                        [1, 0, 2],
                        [2, 0, 1],

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -1,0 +1,80 @@
+import numpy as np
+from numpy.testing import assert_array_equal, assert_raises, assert_equal
+
+import mne
+from mne.decoding import dummy_encoding
+
+
+def test_dummy_encoding():
+    events = np.array([[0, 0, 1],
+                       [1, 0, 2],
+                       [2, 0, 1],
+                       [3, 0, 1],
+                       [4, 0, 2]])
+    event_id = dict(a=1, b=2)
+    epochs = mne.EpochsArray(np.random.randn(5, 2, 10),
+                             mne.create_info(2, 1000.),
+                             events, event_id=event_id)
+
+    # Basic case of two classes
+    assert_array_equal(dummy_encoding(epochs),
+                       [0, 1, 0, 0, 1])
+    assert_array_equal(dummy_encoding(epochs, ['a', 'b']),
+                       [0, 1, 0, 0, 1])
+    assert_array_equal(dummy_encoding(epochs, ['b', 'a']),
+                       [1, 0, 1, 1, 0])
+    assert_equal(dummy_encoding(epochs, ['b', 'a']).dtype, np.int)
+
+    # Multiple classes
+    events = np.array([[0, 0, 1],
+                       [1, 0, 2],
+                       [2, 0, 1],
+                       [3, 0, 3],
+                       [4, 0, 2]])
+    event_id = dict(a=1, b=2, c=3, d=3)
+    epochs = mne.EpochsArray(np.random.randn(5, 2, 10),
+                             mne.create_info(2, 1000.),
+                             events, event_id=event_id)
+    assert_array_equal(dummy_encoding(epochs),
+                       [[1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [1, 0, 0, 0],
+                        [0, 0, 1, 1],
+                        [0, 1, 0, 0]])
+    assert_array_equal(dummy_encoding(epochs, ['b', 'a', 'd', 'c']),
+                       [[0, 1, 0, 0],
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 1],
+                        [1, 0, 0, 0]])
+
+    # Case where some epochs don't belong to any class. Should generate a
+    # matrix, not a list.
+    assert_array_equal(dummy_encoding(epochs, ['a', 'b']),
+                       [[1, 0],
+                        [0, 1],
+                        [1, 0],
+                        [0, 0],
+                        [0, 1]])
+
+    # Case where some epochs belong to multiple classes. Should generate a
+    # matrix, not a list.
+    assert_array_equal(dummy_encoding(epochs, ['c', 'd']),
+                       [[0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [1, 1],
+                        [0, 0]])
+
+    # Don't know why you would want to do this, but these should work
+    assert_array_equal(dummy_encoding(epochs, ['a', 'a']),
+                       [[1, 1],
+                        [0, 0],
+                        [1, 1],
+                        [0, 0],
+                        [0, 0]])
+
+    # Invalid inputs
+    assert_raises(ValueError, dummy_encoding, epochs, ['a', 'b', 'foo'])
+    assert_raises(ValueError, dummy_encoding, epochs, ['a'])
+    assert_raises(ValueError, dummy_encoding, epochs, [])


### PR DESCRIPTION
Per request from Lauri Parkkonen, a proposal for a new function.

For decoding tasks, we need a function to conveniently construct the `y` variable for scikit-learn models. This PR adds a function `dummy_encoding` that tries to do the right thing when given an `Epochs` object, so you can do this:

    epochs = epochs[['left', 'right']]
    X = epochs.get_data()
    y = mne.decoding.dummy_encoding(epochs)

See the docstring of the function for details.