### PR TITLE
MRG: Fix BTi reading for Magnes2500

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -543,7 +543,9 @@ BUG
 
     - Fix bug when merging info that has a field with list of dicts by `Jaakko Leppakangas`_
 
-    - The BTI/4D reader now considers user defined channel labels instead of the hard-ware names, however only for channels other than MEG. By `Denis Engemann`_ and `Alex Gramfort`_.
+    - The BTi/4D reader now considers user defined channel labels instead of the hard-ware names, however only for channels other than MEG. By `Denis Engemann`_ and `Alex Gramfort`_.
+
+    - The BTi reader :func:`mne.io.read_raw_bti` can now read 2500 system data, by `Eric Larson`_
 
     - Fix bug in :func:`mne.compute_raw_covariance` where rejection by non-data channels (e.g. EOG) was not done properly by `Eric Larson`_.
 

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -225,7 +225,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.30', misc='0.3')
+    releases = dict(testing='0.31', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -275,7 +275,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='1d5da3a809fded1ef5734444ab5bf857',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='f61041e3f3f2ba0def8a2ca71592cc41',
-        testing='a8209367a0795f8e6d31bbc913227fae',
+        testing='037711ea367c610bd673c11b9b2325ca',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         visual_92_categories='46c7e590f4a48596441ce001595d5e58',
     )

--- a/mne/io/bti/__init__.py
+++ b/mne/io/bti/__init__.py
@@ -1,4 +1,4 @@
-"""Bti module for conversion to FIF."""
+"""BTi module for conversion to FIF."""
 
 # Author: Denis A. Engemann <denis.engemann@gmail.com>
 

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -22,7 +22,7 @@ from .constants import BTI
 from .read import (read_int32, read_int16, read_float, read_double,
                    read_transform, read_char, read_int64, read_uint16,
                    read_uint32, read_double_matrix, read_float_matrix,
-                   read_int16_matrix)
+                   read_int16_matrix, read_dev_header)
 from ...externals import six
 
 FIFF_INFO_CHS_FIELDS = ('loc',
@@ -300,15 +300,16 @@ def _read_config(fname):
         for block in range(cfg['hdr']['total_user_blocks']):
             ub = dict()
 
-            ub['hdr'] = {'nbytes': read_int32(fid),
+            ub['hdr'] = {'nbytes': read_uint32(fid),
                          'kind': read_str(fid, 20),
                          'checksum': read_int32(fid),
                          'username': read_str(fid, 32),
-                         'timestamp': read_int32(fid),
-                         'user_space_size': read_int32(fid),
+                         'timestamp': read_uint32(fid),
+                         'user_space_size': read_uint32(fid),
                          'reserved': read_char(fid, 32)}
 
             _correct_offset(fid)
+            start_bytes = fid.tell()
             kind = ub['hdr'].pop('kind')
             if not kind:  # make sure reading goes right. Should never be empty
                 raise RuntimeError('Could not read user block. Probably you '
@@ -464,20 +465,19 @@ def _read_config(fname):
                         cols = dta['hdr']['n_e_values']
                         dta['etable'] = read_float_matrix(fid, rows, cols)
 
-                        _correct_offset(fid)
-
                 elif any([kind == BTI.UB_B_WEIGHTS_USED,
                           kind[:4] == BTI.UB_B_WEIGHT_TABLE]):
-                    dta['hdr'] = {'version': read_int32(fid),
-                                  'entry_size': read_int32(fid),
-                                  'n_entries': read_int32(fid),
-                                  'name': read_str(fid, 32),
-                                  'description': read_str(fid, 80),
-                                  'n_anlg': read_int32(fid),
-                                  'n_dsp': read_int32(fid),
-                                  'reserved': read_str(fid, 72)}
-
+                    dta['hdr'] = dict(
+                        version=read_int32(fid),
+                        n_bytes=read_uint32(fid),
+                        n_entries=read_uint32(fid),
+                        name=read_str(fid, 32))
                     if dta['hdr']['version'] == 2:
+                        dta['hdr'].update(
+                            description=read_str(fid, 80),
+                            n_anlg=read_uint32(fid),
+                            n_dsp=read_uint32(fid),
+                            reserved=read_str(fid, 72))
                         dta['ch_names'] = [read_str(fid, 16) for ch in
                                            range(dta['hdr']['n_entries'])]
                         dta['anlg_ch_names'] = [read_str(fid, 16) for ch in
@@ -485,33 +485,38 @@ def _read_config(fname):
 
                         dta['dsp_ch_names'] = [read_str(fid, 16) for ch in
                                                range(dta['hdr']['n_dsp'])]
-
-                        rows = dta['hdr']['n_entries']
-                        cols = dta['hdr']['n_dsp']
-                        dta['dsp_wts'] = read_float_matrix(fid, rows, cols)
-                        cols = dta['hdr']['n_anlg']
-                        dta['anlg_wts'] = read_int16_matrix(fid, rows, cols)
-
+                        dta['dsp_wts'] = read_float_matrix(
+                            fid, dta['hdr']['n_entries'], dta['hdr']['n_dsp'])
+                        dta['anlg_wts'] = read_int16_matrix(
+                            fid, dta['hdr']['n_entries'], dta['hdr']['n_anlg'])
                     else:  # handle MAGNES2500 naming scheme
+                        fid.seek(start_bytes + ub['hdr']['user_space_size'] -
+                                 dta['hdr']['n_bytes'] *
+                                 dta['hdr']['n_entries'], 0)
+
+                        dta['hdr']['n_dsp'] = dta['hdr']['n_bytes'] // 4 - 2
+                        assert (dta['hdr']['n_dsp'] ==
+                                len(BTI_WH2500_REF_MAG) +
+                                len(BTI_WH2500_REF_GRAD))
                         dta['ch_names'] = ['WH2500'] * dta['hdr']['n_entries']
-                        dta['anlg_ch_names'] = BTI_WH2500_REF_MAG[:3]
-                        dta['hdr']['n_anlg'] = len(dta['anlg_ch_names'])
-                        dta['dsp_ch_names'] = BTI_WH2500_REF_GRAD
-                        dta['hdr.n_dsp'] = len(dta['dsp_ch_names'])
-                        dta['anlg_wts'] = np.zeros((dta['hdr']['n_entries'],
-                                                    dta['hdr']['n_anlg']),
-                                                   dtype='i2')
-                        dta['dsp_wts'] = np.zeros((dta['hdr']['n_entries'],
-                                                   dta['hdr']['n_dsp']),
-                                                  dtype='f4')
+                        dta['hdr']['n_anlg'] = 3
+                        # These orders could be wrong, so don't set them
+                        # for now
+                        # dta['anlg_ch_names'] = BTI_WH2500_REF_MAG[:3]
+                        # dta['dsp_ch_names'] = (BTI_WH2500_REF_GRAD +
+                        #                        BTI_WH2500_REF_MAG)
+                        dta['anlg_wts'] = np.zeros(
+                            (dta['hdr']['n_entries'], dta['hdr']['n_anlg']),
+                            dtype='i2')
+                        dta['dsp_wts'] = np.zeros(
+                            (dta['hdr']['n_entries'], dta['hdr']['n_dsp']),
+                            dtype='f4')
                         for n in range(dta['hdr']['n_entries']):
-                            dta['anlg_wts'][d] = read_int16_matrix(
+                            dta['anlg_wts'][n] = read_int16_matrix(
                                 fid, 1, dta['hdr']['n_anlg'])
                             read_int16(fid)
-                            dta['dsp_wts'][d] = read_float_matrix(
+                            dta['dsp_wts'][n] = read_float_matrix(
                                 fid, 1, dta['hdr']['n_dsp'])
-
-                        _correct_offset(fid)
 
                 elif kind == BTI.UB_B_TRIG_MASK:
                     dta['version'] = read_int32(fid)
@@ -531,17 +536,18 @@ def _read_config(fname):
                 dta['unknown'] = {'hdr': read_char(fid,
                                   ub['hdr']['user_space_size'])}
 
+            n_read = fid.tell() - start_bytes
+            if n_read != ub['hdr']['user_space_size']:
+                raise RuntimeError('Internal MNE reading error, read size %d '
+                                   '!= %d expected size for kind %s'
+                                   % (n_read, ub['hdr']['user_space_size'],
+                                      kind))
             ub.update(dta)  # finally update the userblock data
             _correct_offset(fid)  # after reading.
 
         cfg['chs'] = list()
 
         # prepare reading channels
-        def dev_header(x):
-            """Create a dev header."""
-            return dict(size=read_int32(x), checksum=read_int32(x),
-                        reserved=read_str(x, 32))
-
         for channel in range(cfg['hdr']['total_chans']):
             ch = {'name': read_str(fid, 16),
                   'chan_no': read_int16(fid),
@@ -561,10 +567,10 @@ def _read_config(fname):
             _correct_offset(fid)  # before and after
             dta = dict()
             if ch['ch_type'] in [BTI.CHTYPE_MEG, BTI.CHTYPE_REFERENCE]:
-                dev = {'device_info': dev_header(fid),
+                dev = {'device_info': read_dev_header(fid),
                        'inductance': read_float(fid),
                        'padding': read_str(fid, 4),
-                       'transform': _correct_trans(read_transform(fid)),
+                       'transform': _correct_trans(read_transform(fid), False),
                        'xform_flag': read_int16(fid),
                        'total_loops': read_int16(fid)}
 
@@ -583,30 +589,30 @@ def _read_config(fname):
                     dta['loops'] += [d]
 
             elif ch['ch_type'] == BTI.CHTYPE_EEG:
-                dta = {'device_info': dev_header(fid),
+                dta = {'device_info': read_dev_header(fid),
                        'impedance': read_float(fid),
                        'padding': read_str(fid, 4),
                        'transform': read_transform(fid),
                        'reserved': read_char(fid, 32)}
 
             elif ch['ch_type'] == BTI.CHTYPE_EXTERNAL:
-                dta = {'device_info': dev_header(fid),
+                dta = {'device_info': read_dev_header(fid),
                        'user_space_size': read_int32(fid),
                        'reserved': read_str(fid, 32)}
 
             elif ch['ch_type'] == BTI.CHTYPE_TRIGGER:
-                dta = {'device_info': dev_header(fid),
+                dta = {'device_info': read_dev_header(fid),
                        'user_space_size': read_int32(fid)}
                 fid.seek(2, 1)
                 dta['reserved'] = read_str(fid, 32)
 
             elif ch['ch_type'] in [BTI.CHTYPE_UTILITY, BTI.CHTYPE_DERIVED]:
-                dta = {'device_info': dev_header(fid),
+                dta = {'device_info': read_dev_header(fid),
                        'user_space_size': read_int32(fid),
                        'reserved': read_str(fid, 32)}
 
             elif ch['ch_type'] == BTI.CHTYPE_SHORTED:
-                dta = {'device_info': dev_header(fid),
+                dta = {'device_info': read_dev_header(fid),
                        'reserved': read_str(fid, 32)}
 
             ch.update(dta)  # add data collected
@@ -954,12 +960,15 @@ def _read_bti_header(pdf_fname, config_fname, sort_by_ch_name=True):
     return info
 
 
-def _correct_trans(t):
+def _correct_trans(t, check=True):
     """Convert to a transformation matrix."""
     t = np.array(t, np.float64)
     t[:3, :3] *= t[3, :3][:, np.newaxis]  # apply scalings
     t[3, :3] = 0.  # remove them
-    assert t[3, 3] == 1.
+    if check:
+        assert t[3, 3] == 1.
+    else:
+        t[3, 3] = 1.
     return t
 
 
@@ -1090,9 +1099,14 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
 
     if not isinstance(config_fname, six.BytesIO):
         if not op.isabs(config_fname):
-            config_fname = op.abspath(config_fname)
-
-        if not op.exists(config_fname):
+            config_tries = [op.abspath(config_fname),
+                            op.abspath(op.join(op.dirname(pdf_fname),
+                                               config_fname))]
+            for config_try in config_tries:
+                if op.isfile(config_try):
+                    config_fname = config_try
+                    break
+        if not op.isfile(config_fname):
             raise ValueError('Could not find the config file %s. Please check'
                              ' whether you are in the right directory '
                              'or pass the full name' % config_fname)
@@ -1107,7 +1121,8 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
         if not op.isfile(head_shape_fname):
             raise ValueError('Could not find the head_shape file "%s". '
                              'You should check whether you are in the '
-                             'right directory or pass the full file name.'
+                             'right directory, pass the full file name, '
+                             'or pass head_shape_fname=None.'
                              % orig_name)
 
     logger.info('Reading 4D PDF file %s...' % pdf_fname)

--- a/mne/io/bti/read.py
+++ b/mne/io/bti/read.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 
+from ..utils import read_str
+
 
 def _unpack_matrix(fid, rows, cols, dtype, out_dtype):
     """Unpack matrix."""
@@ -106,3 +108,9 @@ def read_double_matrix(fid, rows, cols):
 def read_transform(fid):
     """Read 64bit float matrix transform from bti file."""
     return read_double_matrix(fid, rows=4, cols=4)
+
+
+def read_dev_header(x):
+    """Create a dev header."""
+    return dict(size=read_int32(x), checksum=read_int32(x),
+                reserved=read_str(x, 32))

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -13,6 +13,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose)
 from nose.tools import assert_true, assert_raises, assert_equal
 
+from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_bti
 from mne.io.bti.bti import (_read_config, _process_bti_headshape,
                             _read_bti_header, _get_bti_dev_t,
@@ -38,8 +39,17 @@ exported_fnames = [op.join(base_dir, 'exported4D_%s_raw.fif' % a)
                    for a in archs]
 tmp_raw_fname = op.join(base_dir, 'tmp_raw.fif')
 
+fname_2500 = op.join(testing.data_path(download=False), 'BTi', 'erm_HFH',
+                     'c,rfDC')
+
 # the 4D exporter doesn't export all channels, so we confine our comparison
 NCH = 248
+
+
+@testing.requires_testing_data
+def test_read_2500():
+    """Test reading data from 2500 system."""
+    _test_raw_reader(read_raw_bti, pdf_fname=fname_2500, head_shape_fname=None)
 
 
 def test_read_config():


### PR DESCRIPTION
@dengemann this touches some of your code from 2013 (!) that apparently has a bug. I guess these lines weren't covered or ever used before this :(

I am trying to read some BTi data, I think from MAGNES2500. I hit this bug where `d` was used instead of `n`, but after fixing it I hit a bug when it tries to read the next "block", so I suspect there is something wrong with these 2500-specific lines.

Do you have some MAGNES2500 data that you were using to test/develop originally? What did you use to figure out these lines?

Closes #2170.