### PR TITLE
ENH: Just use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@
 import os
 from os import path as op
 
-import setuptools  # noqa; we are using a setuptools namespace
-from numpy.distutils.core import setup
+from setuptools import setup
 
 # get the version (don't import mne here, so dependencies are not needed)
 version = None


### PR DESCRIPTION
@agramfort any reason why we use `numpy`'s `setup` instead of the one from `setuptools`? It removes a `conda` build requirement if we don't need to `import numpy`.