### PR TITLE
MRG: Refactor field mapping LUT to use interp1d

### DIFF
--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from copy import deepcopy
-from functools import partial
 
 import numpy as np
 from scipy import linalg
@@ -15,7 +14,6 @@ from ..io.proj import _has_eeg_average_ref_proj, make_projector
 from ..transforms import transform_surface_to, read_trans, _find_trans
 from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
-                         _get_legen_lut_fast, _get_legen_lut_accurate,
                          _do_cross_dots)
 from ..parallel import check_n_jobs
 from ..utils import logger, verbose
@@ -45,18 +43,12 @@ def _ad_hoc_noise(coils, ch_type='meg'):
 
 def _setup_dots(mode, coils, ch_type):
     """Setup dot products."""
+    from scipy.interpolate import interp1d
     int_rad = 0.06
     noise = _ad_hoc_noise(coils, ch_type)
-    if mode == 'fast':
-        # Use 50 coefficients with nearest-neighbor interpolation
-        n_coeff = 50
-        lut_fun = _get_legen_lut_fast
-    else:  # 'accurate'
-        # Use 100 coefficients with linear interpolation
-        n_coeff = 100
-        lut_fun = _get_legen_lut_accurate
+    n_coeff, interp = (50, 'nearest') if mode == 'fast' else (100, 'linear')
     lut, n_fact = _get_legen_table(ch_type, False, n_coeff, verbose=False)
-    lut_fun = partial(lut_fun, lut=lut)
+    lut_fun = interp1d(np.linspace(-1, 1, lut.shape[0]), lut, interp, axis=0)
     return int_rad, noise, lut_fun, n_fact
 
 

--- a/mne/forward/_lead_dots.py
+++ b/mne/forward/_lead_dots.py
@@ -69,9 +69,8 @@ def _get_legen_table(ch_type, volume_integral=False, n_coeff=100,
         extra_str = ''
         lut_shape = (n_interp + 1, n_coeff)
     if not op.isfile(fname) or force_calc:
-        n_out = (n_interp // 2)
         logger.info('Generating Legendre%s table...' % extra_str)
-        x_interp = np.arange(-n_out, n_out + 1, dtype=np.float64) / n_out
+        x_interp = np.linspace(-1, 1, n_interp + 1)
         lut = leg_fun(x_interp, n_coeff).astype(np.float32)
         if not force_calc:
             with open(fname, 'wb') as fid:
@@ -104,42 +103,6 @@ def _get_legen_table(ch_type, volume_integral=False, n_coeff=100,
         # skip the first set of coefficients because they are not used
         lut = lut[:, 1:].copy()
     return lut, n_fact
-
-
-def _get_legen_lut_fast(x, lut, block=None):
-    """Return Legendre coefficients for given x values in -1<=x<=1."""
-    # map into table vals (works for both vals and deriv tables)
-    n_interp = (lut.shape[0] - 1.0)
-    # equiv to "(x + 1.0) / 2.0) * n_interp" but faster
-    mm = x * (n_interp / 2.0)
-    mm += 0.5 * n_interp
-    # nearest-neighbor version (could be decent enough...)
-    idx = np.round(mm).astype(int)
-    if block is None:
-        vals = lut[idx]
-    else:  # read only one block at a time to minimize memory consumption
-        vals = lut[idx, :, block]
-    return vals
-
-
-def _get_legen_lut_accurate(x, lut, block=None):
-    """Return Legendre coefficients for given x values in -1<=x<=1."""
-    # map into table vals (works for both vals and deriv tables)
-    n_interp = (lut.shape[0] - 1.0)
-    # equiv to "(x + 1.0) / 2.0) * n_interp" but faster
-    mm = x * (n_interp / 2.0)
-    mm += 0.5 * n_interp
-    # slower, more accurate interpolation version
-    mm = np.minimum(mm, n_interp - 0.0000000001)
-    idx = np.floor(mm).astype(int)
-    w2 = mm - idx
-    if block is None:
-        w2.shape += tuple([1] * (lut.ndim - w2.ndim))  # expand to correct size
-        vals = (1 - w2) * lut[idx] + w2 * lut[idx + 1]
-    else:  # read only one block at a time to minimize memory consumption
-        w2.shape += tuple([1] * (lut[:, :, block].ndim - w2.ndim))
-        vals = (1 - w2) * lut[idx, :, block] + w2 * lut[idx + 1, :, block]
-    return vals
 
 
 def _comp_sum_eeg(beta, ctheta, lut_fun, n_fact):
@@ -266,6 +229,7 @@ def _fast_sphere_dot_r0(r, rr1_orig, rr2s, lr1, lr2s, cosmags1, cosmags2s,
 
     # outer product, sum over coords
     ct = np.einsum('ik,jk->ij', rr1_orig, rr2)
+    np.clip(ct, -1, 1, ct)
 
     # expand axes
     rr1 = rr1_orig[:, np.newaxis, :]  # (n_rr1, n_rr2, n_coord) e.g. 4x4x3

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -1,18 +1,15 @@
-from functools import partial
 from os import path as op
 
 import numpy as np
 from numpy.polynomial import legendre
 from numpy.testing import (assert_allclose, assert_array_equal, assert_equal,
                            assert_array_almost_equal)
+from scipy.interpolate import interp1d
 from nose.tools import assert_raises, assert_true
 
 from mne.forward import _make_surface_mapping, make_field_map
 from mne.forward._lead_dots import (_comp_sum_eeg, _comp_sums_meg,
-                                    _get_legen_table,
-                                    _get_legen_lut_fast,
-                                    _get_legen_lut_accurate,
-                                    _do_cross_dots)
+                                    _get_legen_table, _do_cross_dots)
 from mne.forward._make_forward import _create_meg_coils
 from mne.forward._field_interpolation import _setup_dots
 from mne.surface import get_meg_helmet_surf, get_head_surf
@@ -32,7 +29,7 @@ subjects_dir = op.join(data_path, 'subjects')
 
 
 def test_legendre_val():
-    """Test Legendre polynomial (derivative) equivalence"""
+    """Test Legendre polynomial (derivative) equivalence."""
     rng = np.random.RandomState(0)
     # check table equiv
     xs = np.linspace(-1., 1., 1000)
@@ -42,10 +39,11 @@ def test_legendre_val():
     vals_np = legendre.legvander(xs, n_terms - 1)
 
     # Table approximation
-    for fun, nc in zip([_get_legen_lut_fast, _get_legen_lut_accurate],
-                       [100, 50]):
+    for nc, interp in zip([100, 50], ['nearest', 'linear']):
         lut, n_fact = _get_legen_table('eeg', n_coeff=nc, force_calc=True)
-        vals_i = fun(xs, lut)
+        lut_fun = interp1d(np.linspace(-1, 1, lut.shape[0]), lut, interp,
+                           axis=0)
+        vals_i = lut_fun(xs)
         # Need a "1:" here because we omit the first coefficient in our table!
         assert_allclose(vals_np[:, 1:vals_i.shape[1] + 1], vals_i,
                         rtol=1e-2, atol=5e-3)
@@ -53,7 +51,6 @@ def test_legendre_val():
         # Now let's look at our sums
         ctheta = rng.rand(20, 30) * 2.0 - 1.0
         beta = rng.rand(20, 30) * 0.8
-        lut_fun = partial(fun, lut=lut)
         c1 = _comp_sum_eeg(beta.flatten(), ctheta.flatten(), lut_fun, n_fact)
         c1.shape = beta.shape
 
@@ -74,15 +71,15 @@ def test_legendre_val():
     ctheta = rng.rand(20 * 30) * 2.0 - 1.0
     beta = rng.rand(20 * 30) * 0.8
     lut, n_fact = _get_legen_table('meg', n_coeff=10, force_calc=True)
-    fun = partial(_get_legen_lut_fast, lut=lut)
+    fun = interp1d(np.linspace(-1, 1, lut.shape[0]), lut, 'nearest', axis=0)
     coeffs = _comp_sums_meg(beta, ctheta, fun, n_fact, False)
     lut, n_fact = _get_legen_table('meg', n_coeff=20, force_calc=True)
-    fun = partial(_get_legen_lut_accurate, lut=lut)
+    fun = interp1d(np.linspace(-1, 1, lut.shape[0]), lut, 'linear', axis=0)
     coeffs = _comp_sums_meg(beta, ctheta, fun, n_fact, False)
 
 
 def test_legendre_table():
-    """Test Legendre table calculation"""
+    """Test Legendre table calculation."""
     # double-check our table generation
     n = 10
     for ch_type in ['eeg', 'meg']:
@@ -96,7 +93,7 @@ def test_legendre_table():
 
 @testing.requires_testing_data
 def test_make_field_map_eeg():
-    """Test interpolation of EEG field onto head"""
+    """Test interpolation of EEG field onto head."""
     evoked = read_evokeds(evoked_fname, condition='Left Auditory')
     evoked.info['bads'] = ['MEG 2443', 'EEG 053']  # add some bads
     surf = get_head_surf('sample', subjects_dir=subjects_dir)
@@ -121,7 +118,7 @@ def test_make_field_map_eeg():
 @testing.requires_testing_data
 @slow_test
 def test_make_field_map_meg():
-    """Test interpolation of MEG field onto helmet | head"""
+    """Test interpolation of MEG field onto helmet | head."""
     evoked = read_evokeds(evoked_fname, condition='Left Auditory')
     info = evoked.info
     surf = get_meg_helmet_surf(info)
@@ -172,7 +169,7 @@ def test_make_field_map_meg():
 
 @testing.requires_testing_data
 def test_make_field_map_meeg():
-    """Test making a M/EEG field map onto helmet & head"""
+    """Test making a M/EEG field map onto helmet & head."""
     evoked = read_evokeds(evoked_fname, baseline=(-0.2, 0.0))[0]
     picks = pick_types(evoked.info, meg=True, eeg=True)
     picks = picks[::10]
@@ -196,7 +193,7 @@ def test_make_field_map_meeg():
 def _setup_args(info):
     """Helper to test_as_meg_type_evoked."""
     coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'])
-    int_rad, noise, lut_fun, n_fact = _setup_dots('fast', coils, 'meg')
+    int_rad, noise, lut_fun, n_fact = _setup_dots('accurate', coils, 'meg')
     my_origin = np.array([0., 0., 0.04])
     args_dict = dict(intrad=int_rad, volume=False, coils1=coils, r0=my_origin,
                      ch_type='meg', lut=lut_fun, n_fact=n_fact)
@@ -206,7 +203,6 @@ def _setup_args(info):
 @testing.requires_testing_data
 def test_as_meg_type_evoked():
     """Test interpolation of data on to virtual channels."""
-
     # validation tests
     evoked = read_evokeds(evoked_fname, condition='Left Auditory')
     assert_raises(ValueError, evoked.as_type, 'meg')

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -193,7 +193,7 @@ def test_make_field_map_meeg():
 def _setup_args(info):
     """Helper to test_as_meg_type_evoked."""
     coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'])
-    int_rad, noise, lut_fun, n_fact = _setup_dots('accurate', coils, 'meg')
+    int_rad, noise, lut_fun, n_fact = _setup_dots('fast', coils, 'meg')
     my_origin = np.array([0., 0., 0.04])
     args_dict = dict(intrad=int_rad, volume=False, coils1=coils, r0=my_origin,
                      ch_type='meg', lut=lut_fun, n_fact=n_fact)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -50,7 +50,7 @@ fname_bem_meg = op.join(subjects_dir, 'sample', 'bem',
 def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
                       meg_rtol=1e-4, meg_atol=1e-9,
                       eeg_rtol=1e-3, eeg_atol=1e-3):
-    """Helper to test forwards"""
+    """Test forwards."""
     # check source spaces
     assert_equal(len(fwd['src']), len(fwd_py['src']))
     _compare_source_spaces(fwd['src'], fwd_py['src'], mode='approx')
@@ -94,8 +94,7 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
 
 
 def test_magnetic_dipole():
-    """Test basic magnetic dipole forward calculation
-    """
+    """Test basic magnetic dipole forward calculation."""
     trans = Transform('mri', 'head')
     info = read_info(fname_raw)
     picks = pick_types(info, meg=True, eeg=False, exclude=[])
@@ -114,8 +113,7 @@ def test_magnetic_dipole():
 @testing.requires_testing_data
 @requires_mne
 def test_make_forward_solution_kit():
-    """Test making fwd using KIT, BTI, and CTF (compensated) files
-    """
+    """Test making fwd using KIT, BTI, and CTF (compensated) files."""
     kit_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'kit',
                       'tests', 'data')
     sqd_path = op.join(kit_dir, 'test.sqd')
@@ -206,8 +204,7 @@ def test_make_forward_solution_kit():
 @slow_test
 @testing.requires_testing_data
 def test_make_forward_solution():
-    """Test making M-EEG forward solution from python
-    """
+    """Test making M-EEG forward solution from python."""
     fwd_py = make_forward_solution(fname_raw, fname_trans, fname_src,
                                    fname_bem, mindist=5.0, eeg=True, meg=True)
     assert_true(isinstance(fwd_py, Forward))
@@ -219,7 +216,7 @@ def test_make_forward_solution():
 @testing.requires_testing_data
 @requires_mne
 def test_make_forward_solution_sphere():
-    """Test making a forward solution with a sphere model"""
+    """Test making a forward solution with a sphere model."""
     temp_dir = _TempDir()
     fname_src_small = op.join(temp_dir, 'sample-oct-2-src.fif')
     src = setup_source_space('sample', fname_src_small, 'oct2',
@@ -248,8 +245,7 @@ def test_make_forward_solution_sphere():
 @testing.requires_testing_data
 @requires_nibabel(False)
 def test_forward_mixed_source_space():
-    """Test making the forward solution for a mixed source space
-    """
+    """Test making the forward solution for a mixed source space."""
     temp_dir = _TempDir()
     # get the surface source space
     surf = read_source_spaces(fname_src)
@@ -299,7 +295,7 @@ def test_forward_mixed_source_space():
 @slow_test
 @testing.requires_testing_data
 def test_make_forward_dipole():
-    """Test forward-projecting dipoles"""
+    """Test forward-projecting dipoles."""
     rng = np.random.RandomState(0)
 
     evoked = read_evokeds(fname_evo)[0]


### PR DESCRIPTION
We had implemented nearest-neighbor and linear interpolation ourselves in the field interpolation code. This uses the more-standard `scipy.interpolate.interp1d` instead. In theory we could get some speedups, but testing shows it to be about the same. In any case, should help keep things more maintainable.