### PR TITLE
MRG +1: Add EEG electrodes to coreg

### DIFF
--- a/examples/visualization/plot_meg_sensors.py
+++ b/examples/visualization/plot_meg_sensors.py
@@ -42,4 +42,11 @@ for system, raw in raws.items():
     ref_meg = False if system == 'KIT' else True
     fig = plot_trans(raw.info, trans=None, dig=False, eeg_sensors=False,
                      meg_sensors=True, coord_frame='meg', ref_meg=ref_meg)
-    mlab.title(system)
+    text = mlab.title(system)
+    text.x_position = 0.5
+    text.y_position = 0.95
+    text.property.vertical_justification = 'top'
+    text.property.justification = 'center'
+    text.actor.text_scale_mode = 'none'
+    text.property.bold = True
+    mlab.draw(fig)

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -43,6 +43,8 @@ def run():
     parser.add_option("--low-res-head",
                       action='store_true', default=False, dest="low_res_head",
                       help="Use a low-resolution head surface.")
+    parser.add_option('--trans', dest='trans', default=None,
+                      help='Head<->MRI transform FIF file ("-trans.fif")')
     parser.add_option('--verbose', action='store_true', dest='verbose',
                       help='Turn on verbose mode.')
 
@@ -65,6 +67,7 @@ def run():
                                guess_mri_subject=options.guess_mri_subject,
                                head_opacity=options.head_opacity,
                                head_high_res=head_high_res,
+                               trans=options.trans,
                                verbose=options.verbose)
     if is_main:
         sys.exit(0)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -61,6 +61,7 @@ def _make_writable_recursive(path):
 
 def _find_head_bem(subject, subjects_dir, high_res=False):
     """Find a high resolution head."""
+    # XXX this should be refactored with mne.surface.get_head_surf ...
     fnames = _high_res_head_fnames if high_res else _head_fnames
     for fname in fnames:
         path = fname.format(subjects_dir=subjects_dir, subject=subject)

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -37,6 +37,24 @@ DEFAULTS = dict(
                      linewidth=0,
                      markeredgewidth=1,
                      markersize=4),
+    coreg=dict(
+        dig_fid_opacity=0.3,
+
+        mri_fid_scale=1e-2,
+        dig_fid_scale=3e-2,
+        extra_scale=4e-3,
+        eeg_scale=4e-3, eegp_scale=20e-3, eegp_height=0.1,
+        ecog_scale=5e-3,
+        hpi_scale=15e-3,
+
+        head_color=(0.988, 0.89, 0.74),
+        extra_color=(1., 1., 1.),
+        eeg_color=(1., 0.596, 0.588), eegp_color=(0.839, 0.15, 0.16),
+        ecog_color=(1., 1., 1.),
+        lpa_color=(1., 0., 0.),
+        nasion_color=(0., 1., 0.),
+        rpa_color=(0., 0., 1.),
+    ),
 )
 
 

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -38,7 +38,7 @@ def combine_kit_markers():
 def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
                    subject=None, subjects_dir=None, guess_mri_subject=None,
                    scene_height=None, head_opacity=None, head_high_res=None,
-                   verbose=None):
+                   trans=None, verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -83,6 +83,8 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
         Use a high resolution head surface.
         Default is None, which uses ``MNE_COREG_HEAD_HIGH_RES`` config value
         (which defaults to True).
+    trans : str | None
+        The transform file to use.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -122,7 +124,7 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     from ._coreg_gui import CoregFrame, _make_view
     view = _make_view(tabbed, split, scene_width, scene_height)
     frame = CoregFrame(inst, subject, subjects_dir, guess_mri_subject,
-                       head_opacity, head_high_res, prepare_bem)
+                       head_opacity, head_high_res, prepare_bem, trans)
     return _initialize_gui(frame, view)
 
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -4,7 +4,7 @@
 Hierarchy
 ---------
 This is the hierarchy of classes for control. Brackets like [1] denote
-properties that ar equivalent.
+properties that are set to be equivalent.
 
 ::
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -970,7 +970,7 @@ class CoregPanel(HasPrivateTraits):
             self.model.load_trans(trans_file)
         except Exception as e:
             error(None, "Error loading trans file %s: %s (See terminal "
-                  "for details)" % str(e), "Error Saving Trans File")
+                  "for details)" % (trans_file, e), "Error Loading Trans File")
             raise
 
     def _save_fired(self):
@@ -1034,7 +1034,7 @@ class CoregPanel(HasPrivateTraits):
             self.model.save_trans(trans_file)
         except Exception as e:
             error(None, "Error saving -trans.fif file: %s (See terminal for "
-                  "details)" % str(e), "Error Saving Trans File")
+                  "details)" % (e,), "Error Saving Trans File")
             raise
 
         # save the scaled MRI
@@ -1347,8 +1347,7 @@ class CoregFrame(HasTraits):
                 self.model.load_trans(trans)
             except Exception as e:
                 error(None, "Error loading trans file %s: %s (See terminal "
-                      "for details)" % (trans, str(e)),
-                      "Error Saving Trans File")
+                      "for details)" % (trans, e), "Error Loading Trans File")
 
     @on_trait_change('subject_panel.subject')
     def _set_title(self):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1225,12 +1225,12 @@ class ViewOptionsPanel(HasTraits):
     mri_obj = Instance(SurfaceObject)
     hsp_obj = Instance(PointObject)
     eeg_obj = Instance(PointObject)
-    view = View(VGroup(Item('mri_obj', style='custom',  # show_border=True,
-                            label="MRI Head Surface"),
-                       Item('hsp_obj', style='custom',  # show_border=True,
-                            label="Head Shape Points"),
+    view = View(VGroup(Item('mri_obj', style='custom',
+                            label="MRI head"),
+                       Item('hsp_obj', style='custom',
+                            label="Head shape"),
                        Item('eeg_obj', style='custom',
-                            label='EEG Points')),
+                            label='EEG')),
                 title="View Options")
 
 
@@ -1434,7 +1434,8 @@ class CoregFrame(HasTraits):
         self.scene.render()
         self.scene.camera.focal_point = (0., 0., 0.)
         self.view_options_panel = ViewOptionsPanel(mri_obj=self.mri_obj,
-                                                   hsp_obj=self.hsp_obj)
+                                                   hsp_obj=self.hsp_obj,
+                                                   eeg_obj=self.eeg_obj)
 
     @cached_property
     def _get_hsp_visible(self):

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -19,13 +19,16 @@ from traitsui.menu import NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
 from ..coreg import fid_fname, _find_fiducials_files, _find_head_bem
+from ..defaults import DEFAULTS
 from ..io import write_fiducials
 from ..io.constants import FIFF
 from ..utils import get_subjects_dir, logger
+from ..viz._3d import _toggle_mlab_render
 from ._file_traits import (SurfaceSource, fid_wildcard, FiducialsSource,
                            MRISubjectSource, SubjectSelectorPanel)
-from ._viewer import (defaults, HeadViewController, PointObject, SurfaceObject,
+from ._viewer import (HeadViewController, PointObject, SurfaceObject,
                       headview_borders)
+defaults = DEFAULTS['coreg']
 
 
 class MRIHeadWithFiducialsModel(HasPrivateTraits):
@@ -412,7 +415,7 @@ class FiducialsFrame(HasTraits):
 
     @on_trait_change('scene.activated')
     def _init_plot(self):
-        self.scene.disable_render = True
+        _toggle_mlab_render(self, False)
 
         lpa_color = defaults['lpa_color']
         nasion_color = defaults['nasion_color']
@@ -443,7 +446,7 @@ class FiducialsFrame(HasTraits):
         self.sync_trait('point_scale', self.rpa_obj, mutual=False)
 
         self.headview.left = True
-        self.scene.disable_render = False
+        _toggle_mlab_render(self, True)
 
         # picker
         self.scene.mayavi_scene.on_mouse_pick(self.panel._on_pick, type='cell')

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -375,7 +375,7 @@ class DigSource(HasPrivateTraits):
     def _get_eeg_points(self):
         if not self.inst or not self.eeg_dig:
             return np.empty((0, 3))
-        dig = np.array([d['r'][:3] for d in self.eeg_dig])
+        dig = np.array([d['r'] for d in self.eeg_dig])
         dig.shape = (-1, 3)
         return dig
 

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -376,7 +376,6 @@ class DigSource(HasPrivateTraits):
         if not self.inst or not self.eeg_dig:
             return np.empty((0, 3))
         dig = np.array([d['r'] for d in self.eeg_dig])
-        dig.shape = (-1, 3)
         return dig
 
     def _file_changed(self):

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -339,7 +339,7 @@ class DigSource(HasPrivateTraits):
     def _get_eeg_dig(self):
         """Get EEG from info['dig']."""
         if not self.inst:
-            return np.empty((0, 3))
+            return []
         dig = [d for d in self.inst['dig']
                if d['kind'] == FIFF.FIFFV_POINT_EEG]
         return dig
@@ -463,6 +463,12 @@ class MRISubjectSource(HasPrivateTraits):
         self.use_high_res_head = False
         self.subject = 'fsaverage'
 
+    @on_trait_change('subjects_dir')
+    def _emit_subject(self):
+        # This silliness is the only way I could figure out to get the
+        # on_trait_change('subject_panel.subject') in CoregFrame to work!
+        self.subject = self.subject
+
 
 class SubjectSelectorPanel(HasPrivateTraits):
     """Subject selector panel."""
@@ -491,12 +497,6 @@ class SubjectSelectorPanel(HasPrivateTraits):
                        Item('create_fsaverage',
                             enabled_when='can_create_fsaverage'),
                        show_labels=False))
-
-    @on_trait_change('subjects_dir')
-    def _emit_subject(self):
-        # This silliness is the only way I could figure out to get the
-        # on_trait_change('subject_panel.subject') in CoregFrame to work!
-        self.subject = self.subject
 
     def _create_fsaverage_fired(self):
         # progress dialog with indefinite progress bar

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -552,14 +552,15 @@ class Kit2FiffPanel(HasPrivateTraits):
         t.start()
 
         # setup mayavi visualization
-        self.fid_obj = PointObject(scene=self.scene, color=(25, 225, 25),
+        self.fid_obj = PointObject(scene=self.scene, color=(0.1, 1., 0.1),
                                    point_scale=5e-3, name='Fiducials')
-        self.elp_obj = PointObject(scene=self.scene, color=(50, 50, 220),
+        self.elp_obj = PointObject(scene=self.scene,
+                                   color=(0.196, 0.196, 0.863),
                                    point_scale=1e-2, opacity=.2, name='ELP')
-        self.hsp_obj = PointObject(scene=self.scene, color=(200, 200, 200),
+        self.hsp_obj = PointObject(scene=self.scene, color=(0.784,) * 3,
                                    point_scale=2e-3, name='HSP')
-        for name, obj in zip(['fid', 'elp', 'hsp'],
-                             [self.fid_obj, self.elp_obj, self.hsp_obj]):
+        for name in ('fid', 'elp', 'hsp'):
+            obj = getattr(self, name + '_obj')
             self.model.sync_trait(name, obj, 'points', mutual=False)
             self.model.sync_trait('head_dev_trans', obj, 'trans', mutual=False)
         self.scene.camera.parallel_scale = 0.15

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -377,21 +377,24 @@ class CombineMarkersPanel(HasTraits):  # noqa: D401
         m = self.model
         m.sync_trait('distance', self, 'distance', mutual=False)
 
-        self.mrk1_obj = PointObject(scene=self.scene, color=(155, 55, 55),
+        self.mrk1_obj = PointObject(scene=self.scene,
+                                    color=(0.608, 0.216, 0.216),
                                     point_scale=self.scale)
         self.sync_trait('trans', self.mrk1_obj, mutual=False)
         m.mrk1.sync_trait('points', self.mrk1_obj, 'points', mutual=False)
         m.mrk1.sync_trait('enabled', self.mrk1_obj, 'visible',
                           mutual=False)
 
-        self.mrk2_obj = PointObject(scene=self.scene, color=(55, 155, 55),
+        self.mrk2_obj = PointObject(scene=self.scene,
+                                    color=(0.216, 0.608, 0.216),
                                     point_scale=self.scale)
         self.sync_trait('trans', self.mrk2_obj, mutual=False)
         m.mrk2.sync_trait('points', self.mrk2_obj, 'points', mutual=False)
         m.mrk2.sync_trait('enabled', self.mrk2_obj, 'visible',
                           mutual=False)
 
-        self.mrk3_obj = PointObject(scene=self.scene, color=(150, 200, 255),
+        self.mrk3_obj = PointObject(scene=self.scene,
+                                    color=(0.588, 0.784, 1.),
                                     point_scale=self.scale)
         self.sync_trait('trans', self.mrk3_obj, mutual=False)
         m.mrk3.sync_trait('points', self.mrk3_obj, 'points', mutual=False)

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -14,7 +14,7 @@ from mayavi.tools.mlab_scene_model import MlabSceneModel
 from pyface.api import error
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
                         Instance, Array, Bool, Button, Enum, Float, Int, List,
-                        Range, Str, Tuple)
+                        Range, Str, RGBColor)
 from traitsui.api import View, Item, HGroup, VGrid, VGroup
 from tvtk.api import tvtk
 
@@ -126,7 +126,8 @@ class Object(HasPrivateTraits):
     scene = Instance(MlabSceneModel, ())
     src = Instance(VTKDataSource)
 
-    color = Tuple()
+    # This should be Tuple, but it is broken on Anaconda as of 2016/12/16
+    color = RGBColor()
     point_scale = Float(10, label='Point Scale')
     opacity = Range(low=0., high=1., value=1.)
     visible = Bool(True)
@@ -166,6 +167,10 @@ class PointObject(Object):
 
     glyph = Instance(Glyph)
     resolution = Int(8)
+
+    view = View(HGroup(Item('visible', show_label=False),
+                       Item('color', show_label=False),
+                       Item('opacity')))
 
     def __init__(self, view='points', *args, **kwargs):
         """Init.
@@ -267,7 +272,8 @@ class SurfaceObject(Object):
     surf = Instance(Surface)
 
     view = View(HGroup(Item('visible', show_label=False),
-                       Item('color', show_label=False), Item('opacity')))
+                       Item('color', show_label=False),
+                       Item('opacity')))
 
     def clear(self):  # noqa: D102
         if hasattr(self.src, 'remove'):

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -13,25 +13,23 @@ from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from pyface.api import error
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
-                        cached_property, Instance, Property, Array, Bool,
-                        Button, Color, Enum, Float, Int, List, Range, Str)
+                        Instance, Array, Bool, Button, Enum, Float, Int, List,
+                        Range, Str, Tuple)
 from traitsui.api import View, Item, HGroup, VGrid, VGroup
+from tvtk.api import tvtk
 
 from ..surface import complete_surface_info
 from ..transforms import apply_trans
+from ..utils import SilenceStdout
+from ..viz._3d import _create_mesh_surf, _toggle_mlab_render
 
 
 headview_borders = VGroup(Item('headview', style='custom', show_label=False),
                           show_border=True, label='View')
-defaults = {'mri_fid_scale': 1e-2, 'hsp_fid_scale': 3e-2,
-            'hsp_fid_opacity': 0.3, 'hsp_points_scale': 4e-3,
-            'mri_color': (252, 227, 191), 'hsp_point_color': (255, 255, 255),
-            'lpa_color': (255, 0, 0), 'nasion_color': (0, 255, 0),
-            'rpa_color': (0, 0, 255)}
 
 
 class HeadViewController(HasTraits):
-    """Set head views for Anterior-Left-Superior coordinate system.
+    """Set head views for the given coordinate system.
 
     Parameters
     ----------
@@ -48,6 +46,7 @@ class HeadViewController(HasTraits):
     front = Button()
     left = Button()
     top = Button()
+    interaction = Enum('Trackball', 'Terrain')
 
     scale = Float(0.16)
 
@@ -55,11 +54,13 @@ class HeadViewController(HasTraits):
 
     view = View(VGrid('0', 'top', '0', Item('scale', label='Scale',
                                             show_label=True),
-                      'right', 'front', 'left', show_labels=False, columns=4))
+                      'right', 'front', 'left', 'interaction',
+                      show_labels=False, columns=4))
 
     @on_trait_change('scene.activated')
     def _init_view(self):
         self.scene.parallel_projection = True
+        self._trackball_interactor = None
 
         # apparently scene,activated happens several times
         if self.scene.renderer:
@@ -67,49 +68,52 @@ class HeadViewController(HasTraits):
             # and apparently this does not happen by default:
             self.on_trait_change(self.scene.render, 'scale')
 
+    @on_trait_change('interaction')
+    def on_set_interaction(self, _, interaction):
+        if self.scene is None:
+            return
+        if interaction == 'Terrain':
+            # Ensure we're in the correct orientatino for the
+            # InteractorStyleTerrain to have the correct "up"
+            if self._trackball_interactor is None:
+                self._trackball_interactor = \
+                    self.scene.interactor.interactor_style
+            self.on_set_view('front', '')
+            self.scene.mlab.draw()
+            self.scene.interactor.interactor_style = \
+                tvtk.InteractorStyleTerrain()
+            self.on_set_view('front', '')
+            self.scene.mlab.draw()
+        else:  # interaction == 'trackball'
+            self.scene.interactor.interactor_style = self._trackball_interactor
+
     @on_trait_change('top,left,right,front')
     def on_set_view(self, view, _):
         if self.scene is None:
             return
 
         system = self.system
-        kwargs = None
-
-        if system == 'ALS':
-            if view == 'front':
-                kwargs = dict(azimuth=0, elevation=90, roll=-90)
-            elif view == 'left':
-                kwargs = dict(azimuth=90, elevation=90, roll=180)
-            elif view == 'right':
-                kwargs = dict(azimuth=-90, elevation=90, roll=0)
-            elif view == 'top':
-                kwargs = dict(azimuth=0, elevation=0, roll=-90)
-        elif system == 'RAS':
-            if view == 'front':
-                kwargs = dict(azimuth=90, elevation=90, roll=180)
-            elif view == 'left':
-                kwargs = dict(azimuth=180, elevation=90, roll=90)
-            elif view == 'right':
-                kwargs = dict(azimuth=0, elevation=90, roll=270)
-            elif view == 'top':
-                kwargs = dict(azimuth=90, elevation=0, roll=180)
-        elif system == 'ARI':
-            if view == 'front':
-                kwargs = dict(azimuth=0, elevation=90, roll=90)
-            elif view == 'left':
-                kwargs = dict(azimuth=-90, elevation=90, roll=180)
-            elif view == 'right':
-                kwargs = dict(azimuth=90, elevation=90, roll=0)
-            elif view == 'top':
-                kwargs = dict(azimuth=0, elevation=180, roll=90)
-        else:
+        kwargs = dict(ALS=dict(front=(0, 90, -90),
+                               left=(90, 90, 180),
+                               right=(-90, 90, 0),
+                               top=(0, 0, -90)),
+                      RAS=dict(front=(90., 90., 180),
+                               left=(180, 90, 90),
+                               right=(0., 90, 270),
+                               top=(90, 0, 180)),
+                      ARI=dict(front=(0, 90, 90),
+                               left=(-90, 90, 180),
+                               right=(90, 90, 0),
+                               top=(0, 180, 90)))
+        if system not in kwargs:
             raise ValueError("Invalid system: %r" % system)
-
-        if kwargs is None:
+        if view not in kwargs[system]:
             raise ValueError("Invalid view: %r" % view)
-
-        self.scene.mlab.view(distance=None, reset_roll=True,
-                             figure=self.scene.mayavi_scene, **kwargs)
+        kwargs = dict(zip(('azimuth', 'elevation', 'roll'),
+                          kwargs[system][view]))
+        with SilenceStdout():
+            self.scene.mlab.view(distance=None, reset_roll=True,
+                                 figure=self.scene.mayavi_scene, **kwargs)
 
 
 class Object(HasPrivateTraits):
@@ -122,19 +126,10 @@ class Object(HasPrivateTraits):
     scene = Instance(MlabSceneModel, ())
     src = Instance(VTKDataSource)
 
-    color = Color()
-    rgbcolor = Property(depends_on='color')
+    color = Tuple()
     point_scale = Float(10, label='Point Scale')
     opacity = Range(low=0., high=1., value=1.)
     visible = Bool(True)
-
-    @cached_property
-    def _get_rgbcolor(self):
-        if hasattr(self.color, 'Get'):  # wx
-            color = tuple(v / 255. for v in self.color.Get())
-        else:
-            color = self.color.getRgbF()[:3]
-        return color
 
     @on_trait_change('trans,points')
     def _update_points(self):
@@ -199,7 +194,7 @@ class PointObject(Object):
 
     @on_trait_change('label')
     def _show_labels(self, show):
-        self.scene.disable_render = True
+        _toggle_mlab_render(self, False)
         while self.text3d:
             text = self.text3d.pop()
             text.remove()
@@ -211,8 +206,7 @@ class PointObject(Object):
                 t = text3d(x, y, z, ' %i' % i, scale=.01, color=self.rgbcolor,
                            figure=fig)
                 self.text3d.append(t)
-
-        self.scene.disable_render = False
+        _toggle_mlab_render(self, True)
 
     @on_trait_change('visible')
     def _on_hide(self):
@@ -222,28 +216,30 @@ class PointObject(Object):
     @on_trait_change('scene.activated')
     def _plot_points(self):
         """Add the points to the mayavi pipeline"""
-#         _scale = self.scene.camera.parallel_scale
+        from . import _testing_mode
 
         if hasattr(self.glyph, 'remove'):
             self.glyph.remove()
         if hasattr(self.src, 'remove'):
             self.src.remove()
 
+        _toggle_mlab_render(self, False)
         x, y, z = self.points.T
         scatter = pipeline.scalar_scatter(x, y, z)
-        glyph = pipeline.glyph(scatter, color=self.rgbcolor,
-                               figure=self.scene.mayavi_scene,
+        fig = self.scene.mayavi_scene if not _testing_mode() else None
+        glyph = pipeline.glyph(scatter, color=self.color,
+                               figure=fig,
                                scale_factor=self.point_scale, opacity=1.,
                                resolution=self.resolution)
         self.src = scatter
         self.glyph = glyph
 
         self.sync_trait('point_scale', self.glyph.glyph.glyph, 'scale_factor')
-        self.sync_trait('rgbcolor', self.glyph.actor.property, 'color',
-                        mutual=False)
+        self.sync_trait('color', self.glyph.actor.property, mutual=False)
         self.sync_trait('visible', self.glyph)
         self.sync_trait('opacity', self.glyph.actor.property)
         self.on_trait_change(self._update_points, 'points')
+        _toggle_mlab_render(self, True)
 
 #         self.scene.camera.parallel_scale = _scale
 
@@ -290,19 +286,11 @@ class SurfaceObject(Object):
             return
 
         fig = self.scene.mayavi_scene
-
-        x, y, z = self.points.T
-        nn = complete_surface_info(dict(rr=self.points, tris=self.tri),
-                                   verbose='error')['nn']
-        if self.rep == 'Wireframe':
-            rep = 'wireframe'
-        else:
-            rep = 'surface'
-
-        src = pipeline.triangular_mesh_source(x, y, z, self.tri, figure=fig)
-        src.data.point_data.normals = nn
-        src.data.cell_data.normals = None
-        surf = pipeline.surface(src, figure=fig, color=self.rgbcolor,
+        surf = complete_surface_info(dict(rr=self.points, tris=self.tri),
+                                     verbose='error')
+        src = _create_mesh_surf(surf, fig=fig)
+        rep = 'wireframe' if self.rep == 'Wireframe' else 'surface'
+        surf = pipeline.surface(src, figure=fig, color=self.color,
                                 representation=rep, line_width=1)
         surf.actor.property.backface_culling = True
 
@@ -310,9 +298,8 @@ class SurfaceObject(Object):
         self.surf = surf
 
         self.sync_trait('visible', self.surf, 'visible')
-        self.sync_trait('rgbcolor', self.surf.actor.property, 'color',
-                        mutual=False)
-        self.sync_trait('opacity', self.surf.actor.property, 'opacity')
+        self.sync_trait('color', self.surf.actor.property, mutual=False)
+        self.sync_trait('opacity', self.surf.actor.property)
 
         self.scene.camera.parallel_scale = _scale
 

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -236,6 +236,7 @@ class PointObject(Object):
                                figure=fig,
                                scale_factor=self.point_scale, opacity=1.,
                                resolution=self.resolution)
+        glyph.actor.property.backface_culling = True
         self.src = scatter
         self.glyph = glyph
 

--- a/mne/gui/tests/test_file_traits.py
+++ b/mne/gui/tests/test_file_traits.py
@@ -57,10 +57,10 @@ def test_fiducials_source():
 @testing.requires_testing_data
 @requires_mayavi
 def test_inst_source():
-    """Test InstSource"""
-    from mne.gui._file_traits import InstSource
+    """Test DigSource"""
+    from mne.gui._file_traits import DigSource
 
-    inst = InstSource()
+    inst = DigSource()
     assert_equal(inst.inst_fname, '-')
 
     inst.file = inst_path

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -254,7 +254,7 @@ def _triangle_coords(r, geom, best):
     return x, y, z
 
 
-def _project_onto_surface(rrs, surf, project_rrs=False):
+def _project_onto_surface(rrs, surf, project_rrs=False, return_nn=False):
     """Project points onto (scalp) surface."""
     surf_geom = _get_tri_supp_geom(surf)
     coords = np.empty((len(rrs), 3))
@@ -271,6 +271,8 @@ def _project_onto_surface(rrs, surf, project_rrs=False):
     if project_rrs:  #
         out += (np.einsum('ij,jik->jk', weights,
                           surf['rr'][surf['tris'][tri_idx]]),)
+    if return_nn:
+        out += (surf_geom['nn'][tri_idx],)
     return out
 
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2265,6 +2265,18 @@ class ArgvSetter(object):
         sys.stderr = self.orig_stderr
 
 
+class SilenceStdout(object):
+    """Silence stdout."""
+
+    def __enter__(self):  # noqa: D105
+        self.stdout = sys.stdout
+        sys.stdout = StringIO()
+        return self
+
+    def __exit__(self, *args):  # noqa: D105
+        sys.stdout = self.stdout
+
+
 def md5sum(fname, block_size=1048576):  # 2 ** 20
     """Calculate the md5sum for a file.
 

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -165,7 +165,6 @@ mne.viz.plot_evoked_topo(evoked, color=colors,
 ###############################################################################
 # Visualizing field lines in 3D
 # -----------------------------
-#
 # We now compute the field maps to project MEG and EEG data to MEG helmet
 # and scalp surface.
 #


### PR DESCRIPTION
This PR:

1. Moves toward unified treatment of colors and sizes between `coreg` and `mne.viz.plot_trans` by using our standard `mne.defaults.DEFAULTS`.
2. Enables plotting of EEG electrodes in `mne coreg` (first step toward #3700)
3. Refactors not to use Traits `Color` since it's actually not as easy as just using `Tuple` to store a color.
4. Modifies `plot_trans` to use cylinders for EEG sensors and source space dipoles, since both have an orientation.
5. Adds "Terrain"-style interactivity. I'm not sure how / if we can add this as a command-line option.
6. Enables `Load Trans` even when MRI fiducials are not present. For some reason this does not actually transform the points, though (?). We'll want to fix that -- you shouldn't be required to have MRI fiducials to use a trans, or even to fit head shape really.
7. Sets the window title to `subject - MNE Coreg`
8. Allows for `--trans` argument

Examples:

![screenshot from 2017-02-14 15-37-58](https://cloud.githubusercontent.com/assets/2365790/22948853/08d31f38-f2ce-11e6-9aa8-d06996a19704.png)
![screenshot from 2017-02-14 15-38-26](https://cloud.githubusercontent.com/assets/2365790/22948856/0a7f7aca-f2ce-11e6-86a7-a9f372c34693.png)
![screenshot from 2017-02-14 15-49-21](https://cloud.githubusercontent.com/assets/2365790/22948857/0bf87708-f2ce-11e6-878f-43d95ba17a61.png)