### PR TITLE
FIX: concatenate_epochs now checks for event_id correspondence

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -142,6 +142,8 @@ BUG
 
     - Fix bug with :func:`mne.simulation.simulate_raw` when ``interp != 'zero'`` by `Eric Larson`_
 
+    - Raise error in :func:`mne.epochs.concatenate_epochs` when concatenated epochs have conflicting event_id by `Mikołaj Magnuski`_
+
 
 API
 ~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2701,10 +2701,9 @@ def _concatenate_epochs(epochs_list, with_data=True):
             raise ValueError('Baseline must be same for all epochs')
 
         # compare event_id
-        common_keys = list(set(event_id.keys()).intersection(
-            set(epochs.event_id)))
-        for k in common_keys:
-            if not event_id[k] == epochs.event_id[k]:
+        common_keys = list(set(event_id).intersection(set(epochs.event_id)))
+        for key in common_keys:
+            if not event_id[key] == epochs.event_id[key]:
                 raise ValueError('event_id values must be the same for '
                                  'identical keys for all concatenated epochs.')
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2700,6 +2700,14 @@ def _concatenate_epochs(epochs_list, with_data=True):
         if epochs.baseline != baseline:
             raise ValueError('Baseline must be same for all epochs')
 
+        # compare event_id
+        common_keys = list(set(event_id.keys()).intersection(
+            set(epochs.event_id)))
+        for k in common_keys:
+            if not event_id[k] == epochs.event_id[k]:
+                raise ValueError('event_id values must be the same for '
+                                 'identical keys for all concatenated epochs.')
+
         if with_data:
             data.append(epochs.get_data())
         events.append(epochs.events)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2704,8 +2704,11 @@ def _concatenate_epochs(epochs_list, with_data=True):
         common_keys = list(set(event_id).intersection(set(epochs.event_id)))
         for key in common_keys:
             if not event_id[key] == epochs.event_id[key]:
-                raise ValueError('event_id values must be the same for '
-                                 'identical keys for all concatenated epochs.')
+                msg = ('event_id values must be the same for identical keys '
+                       'for all concatenated epochs. Key "{}" maps to {} in '
+                       'some epochs and to {} in others.')
+                raise ValueError(msg.format(key, event_id[key],
+                                            epochs.event_id[key]))
 
         if with_data:
             data.append(epochs.get_data())

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2041,6 +2041,13 @@ def test_concatenate_epochs():
     epochs.info['dev_head_t'] = None
     concatenate_epochs([epochs, epochs2])  # should work
 
+    # check that different event_id does not work:
+    epochs1 = epochs.copy()
+    epochs2 = epochs.copy()
+    epochs1.event_id = dict(a=1)
+    epochs2.event_id = dict(a=2)
+    assert_raises(ValueError, concatenate_epochs, [epochs1, epochs2])
+
 
 def test_add_channels():
     """Test epoch splitting / re-appending channel types."""


### PR DESCRIPTION
Fixes #3992

I'll add a note to whats new once CI's are green.