### PR TITLE
WIP: add reduction keyword to pwelch

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,8 @@ Changelog
 
     - Speed up :meth:`mne.io.Raw.plot` and :meth:`mne.Epochs.plot` using (automatic) decimation based on low-passing with ``decim='auto'`` parameter by `Eric Larson`_ and `Jaakko Leppakangas`_
 
+   - Add ``combine`` keyword argument to :func:`mne.time_frequency.psd_welch` and :func:`mne.time_frequency.psd_array_welch` that allows specifying the reduction to apply to welch windows. This allows for example to get median of welch windows or do not reduce the windows at all (``combine=None``). The default value is ``'mean'`` which corresponds to nan-safe mean. Added by `Mikołaj Magnuski`_
+
 BUG
 ~~~
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -726,7 +726,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         nfft = int(nfft)
 
     if noverlap is None:
-        noverlap = nperseg // 2
+        noverlap = nperseg//2
     elif noverlap >= nperseg:
         raise ValueError('noverlap must be less than nperseg.')
     else:
@@ -763,9 +763,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
 
     if mode == 'psd':
         if scaling == 'density':
-            scale = 1.0 / (fs * (win * win).sum())
+            scale = 1.0 / (fs * (win*win).sum())
         elif scaling == 'spectrum':
-            scale = 1.0 / win.sum() ** 2
+            scale = 1.0 / win.sum()**2
         else:
             raise ValueError('Unknown scaling: %r' % scaling)
     else:
@@ -786,14 +786,14 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         num_freqs = nfft
     elif sides == 'onesided':
         if nfft % 2:
-            num_freqs = (nfft + 1) // 2
+            num_freqs = (nfft + 1)//2
         else:
-            num_freqs = nfft // 2 + 1
+            num_freqs = nfft//2 + 1
 
     # Perform the windowed FFTs
     result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft)
     result = result[..., :num_freqs]
-    freqs = fftpack.fftfreq(nfft, 1 / fs)[:num_freqs]
+    freqs = fftpack.fftfreq(nfft, 1/fs)[:num_freqs]
 
     if not same_data:
         # All the same operations on the y data
@@ -812,13 +812,12 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     result *= scale
     if sides == 'onesided':
         if nfft % 2:
-            result[..., 1:] *= 2
+            result[...,1:] *= 2
         else:
             # Last point is unpaired Nyquist freq point, don't double
-            result[..., 1:-1] *= 2
+            result[...,1:-1] *= 2
 
-    t = np.arange(nperseg / 2, x.shape[-1] - nperseg / 2 + 1,
-                  nperseg - noverlap) / float(fs)
+    t = np.arange(nperseg/2, x.shape[-1] - nperseg/2 + 1, nperseg - noverlap)/float(fs)
 
     if sides != 'twosided' and not nfft % 2:
         # get the last value correctly, it is negative otherwise
@@ -838,7 +837,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     if axis != -1:
         # Specify as positive axis index
         if axis < 0:
-            axis = len(result.shape) - 1 - axis
+            axis = len(result.shape)-1-axis
 
         # Roll frequency axis back to axis where the data came from
         result = np.rollaxis(result, -1, axis)
@@ -880,8 +879,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
         result = x[..., np.newaxis]
     else:
         step = nperseg - noverlap
-        shape = x.shape[:-1] + ((x.shape[-1] - noverlap) // step, nperseg)
-        strides = x.strides[:-1] + (step * x.strides[-1], x.strides[-1])
+        shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
+        strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])
         result = np.lib.stride_tricks.as_strided(x, shape=shape,
                                                  strides=strides)
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -907,54 +907,6 @@ def get_spectrogram():
 
 
 ###############################################################################
-# Scipy trim_mean (for mne.time_frequency.psd_welch) needed for scipy < 0.12
-
-def _trim_mean(a, proportiontocut, axis=0):
-    """
-    Return mean of array after trimming distribution from both tails.
-    If `proportiontocut` = 0.1, slices off 'leftmost' and 'rightmost' 10% of
-    scores. The input is sorted before slicing. Slices off less if proportion
-    results in a non-integer slice index (i.e., conservatively slices off
-    `proportiontocut` ).
-
-    Parameters
-    ----------
-    a : array_like
-        Input array
-    proportiontocut : float
-        Fraction to cut off of both tails of the distribution
-    axis : int or None, optional
-        Axis along which the trimmed means are computed. Default is 0.
-        If None, compute over the whole array `a`.
-
-    Returns
-    -------
-    trim_mean : ndarray
-        Mean of trimmed array.
-    """
-    a = np.asarray(a)
-
-    if a.size == 0:
-        return np.nan
-
-    if axis is None:
-        a = a.ravel()
-        axis = 0
-
-    nobs = a.shape[axis]
-    lowercut = int(proportiontocut * nobs)
-    uppercut = nobs - lowercut
-    if (lowercut > uppercut):
-        raise ValueError("Proportion too big.")
-
-    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
-
-    sl = [slice(None)] * atmp.ndim
-    sl[axis] = slice(lowercut, uppercut)
-    return np.nanmean(atmp[sl], axis=axis)
-
-
-###############################################################################
 # Misc utilities
 
 def assert_true(expr, msg='False is not True'):

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -951,17 +951,7 @@ def _trim_mean(a, proportiontocut, axis=0):
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
-    return np.mean(atmp[sl], axis=axis)
-
-
-def get_trim_mean():
-    '''helper function to get relevant trim_mean'''
-    from .utils import check_version
-    if check_version('scipy', '0.13.0'):
-        from scipy.stats import trim_mean
-    else:
-        trim_mean = _trim_mean
-    return trim_mean
+    return np.nanmean(atmp[sl], axis=axis)
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -726,7 +726,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         nfft = int(nfft)
 
     if noverlap is None:
-        noverlap = nperseg//2
+        noverlap = nperseg // 2
     elif noverlap >= nperseg:
         raise ValueError('noverlap must be less than nperseg.')
     else:
@@ -763,9 +763,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
 
     if mode == 'psd':
         if scaling == 'density':
-            scale = 1.0 / (fs * (win*win).sum())
+            scale = 1.0 / (fs * (win * win).sum())
         elif scaling == 'spectrum':
-            scale = 1.0 / win.sum()**2
+            scale = 1.0 / win.sum() ** 2
         else:
             raise ValueError('Unknown scaling: %r' % scaling)
     else:
@@ -786,14 +786,14 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         num_freqs = nfft
     elif sides == 'onesided':
         if nfft % 2:
-            num_freqs = (nfft + 1)//2
+            num_freqs = (nfft + 1) // 2
         else:
-            num_freqs = nfft//2 + 1
+            num_freqs = nfft // 2 + 1
 
     # Perform the windowed FFTs
     result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft)
     result = result[..., :num_freqs]
-    freqs = fftpack.fftfreq(nfft, 1/fs)[:num_freqs]
+    freqs = fftpack.fftfreq(nfft, 1 / fs)[:num_freqs]
 
     if not same_data:
         # All the same operations on the y data
@@ -812,12 +812,13 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     result *= scale
     if sides == 'onesided':
         if nfft % 2:
-            result[...,1:] *= 2
+            result[..., 1:] *= 2
         else:
             # Last point is unpaired Nyquist freq point, don't double
-            result[...,1:-1] *= 2
+            result[..., 1:-1] *= 2
 
-    t = np.arange(nperseg/2, x.shape[-1] - nperseg/2 + 1, nperseg - noverlap)/float(fs)
+    t = np.arange(nperseg / 2, x.shape[-1] - nperseg / 2 + 1,
+                  nperseg - noverlap) / float(fs)
 
     if sides != 'twosided' and not nfft % 2:
         # get the last value correctly, it is negative otherwise
@@ -837,7 +838,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     if axis != -1:
         # Specify as positive axis index
         if axis < 0:
-            axis = len(result.shape)-1-axis
+            axis = len(result.shape) - 1 - axis
 
         # Roll frequency axis back to axis where the data came from
         result = np.rollaxis(result, -1, axis)
@@ -879,8 +880,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
         result = x[..., np.newaxis]
     else:
         step = nperseg - noverlap
-        shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
-        strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])
+        shape = x.shape[:-1] + ((x.shape[-1] - noverlap) // step, nperseg)
+        strides = x.strides[:-1] + (step * x.strides[-1], x.strides[-1])
         result = np.lib.stride_tricks.as_strided(x, shape=shape,
                                                  strides=strides)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1741,14 +1741,15 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  color='black', area_mode='std', area_alpha=0.33,
                  n_overlap=0, dB=True, average=None, show=True,
                  n_jobs=1, line_alpha=None, spatial_colors=None,
-                 xscale='linear', reject_by_annotation=True, verbose=None):
+                 xscale='linear', reject_by_annotation=True, combine='mean',
+                 verbose=None):
         return plot_raw_psd(
             self, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax, proj=proj,
             n_fft=n_fft, picks=picks, ax=ax, color=color, area_mode=area_mode,
             area_alpha=area_alpha, n_overlap=n_overlap, dB=dB, average=average,
             show=show, n_jobs=n_jobs, line_alpha=line_alpha,
             spatial_colors=spatial_colors, xscale=xscale,
-            reject_by_annotation=reject_by_annotation)
+            reject_by_annotation=reject_by_annotation, combine=combine)
 
     @copy_function_doc_to_method_doc(plot_raw_psd_topo)
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -1,5 +1,6 @@
 # Authors : Alexandre Gramfort, alexandre.gramfort@telecom-paristech.fr (2011)
 #           Denis A. Engemann <denis.engemann@gmail.com>
+#           Mikolaj Magnuski <mmagnuski@swps.edu.pl>
 # License : BSD 3-clause
 
 import numpy as np

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -97,8 +97,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         values to trim before performing mean (has to be > 0 and < 0.5) ie.
         trimmed-mean. If function it has to perform the reduction along last
         dimension. If None, no reduction is performed and psd's for individual
-        windows are returned. In such case the output psds have one more
-        dimension than the input array with windows at -3 dimension.
+        windows are returned. In such case the output PSDs have one more
+        dimension than the input array with windows as the last dimension.
 
         .. versionadded:: 0.15.0
     n_jobs : int
@@ -207,7 +207,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         values to trim before performing mean (has to be > 0 and < 0.5) ie.
         trimmed-mean. If function it has to perform the reduction along last
         dimension. If None, no reduction is performed and psd's for individual
-        windows are returned. In such case the output psds have one more
+        windows are returned. In such case the output PSDs have one more
         dimension than the input array with windows at -3 dimension.
 
         .. versionadded:: 0.15.0

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -46,9 +46,9 @@ def _check_psd_data(inst, tmin, tmax, picks, proj, reject_by_annotation=False):
     time_mask = _time_mask(inst.times, tmin, tmax, sfreq=inst.info['sfreq'])
     if picks is None:
         picks = _pick_data_channels(inst.info, with_ref_meg=False)
-    if isinstance(picks, int):
-        # Just to be on the safe side if picks is int: in that case
-        # epochs.get_data()[:, picks] would drop channels dimension
+    if isinstance(picks, numbers.Integral):
+        # Fix for IndexError when picks is int: in that case inst.data[picks]
+        # or epochs.get_data()[:, picks] would drop channels dimension
         picks = [picks]
     if proj:
         # Copy first so it's not modified

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -148,6 +148,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         psds = np.concatenate([combine(f_s) for f_s in f_spectrogram],
                               axis=0).reshape(dshape + (-1,))
     else:
+        psds = np.concatenate(f_spectrogram, axis=0)
         n_windows = psds.shape[-1]
         psds = psds.reshape(dshape + (-1, n_windows))
         # windows are put at -3 position so that the output is of shape

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -113,21 +113,12 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     psds : ndarray, shape (..., n_freqs)
         The power spectral densities. All dimensions up to the last will
         be the same as input unless combine is None. When combine is None
-        the PSDs are of shape (..., n_freqs, n_windows)
+        the PSDs are of shape (..., n_freqs, n_windows).
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
 
     Notes
     -----
-    Please note that if using ``combine=None`` the ``psds`` output shape will
-    be different from the shape of :func:`mne.time_frequency.psd_welch`
-    ``psds`` output. This function returns windows as the last dimension of
-    ``psds`` while :func:`mne.time_frequency.psd_welch` returns windows at -3
-    dimesion. This difference is caused by the fact that possible shapes of
-    input to this function are much more variable than inputs to
-    :func:`mne.time_frequency.psd_welch` - and placing windows at -3 dimension
-    would lead to inconsistencies anyway. Enjoy!
-
     .. versionadded:: 0.14.0
     """
     spectrogram = get_spectrogram()
@@ -218,7 +209,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         trimmed-mean. If function it has to perform the reduction along last
         dimension. If None, no reduction is performed and PSDs for individual
         windows are returned. In such case the output PSDs have one more
-        dimension than the input array with windows at -3 dimension.
+        dimension than the input array with windows as the last dimension.
 
         .. versionadded:: 0.15.0
     verbose : bool, str, int, or None
@@ -227,13 +218,12 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
 
     Returns
     -------
-    psds : ndarray, shape (..., n_freqs)
-        The power spectral densities. If input is of type Raw, returned PSDs
-        are shaped (n_channels, n_freqs), if input is type Epochs returned PSDs
-        are shaped (n_epochs, n_channels, n_freqs). However if combine is None
-        then if input is of type Raw, returned PSDs will be shaped (n_windows,
-        n_channels, n_freqs), if input is type Epochs then PSDs will be shaped
-        (n_epochs, n_windows, n_channels, n_freqs).
+    psds : ndarray, shape (..., n_freqs) or (..., n_freqs, n_windows)
+        The power spectral densities. If combine is not None and input is of
+        type Raw, returned PSDs are shaped (n_channels, n_freqs), if input is
+        of type Epochs returned PSDs are shaped (n_epochs, n_channels,
+        n_freqs). When combine is None the PSDs are of shape (..., n_freqs,
+        n_windows).
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
 
@@ -254,11 +244,6 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
                                  n_per_seg=n_per_seg, combine=combine,
                                  n_jobs=n_jobs, verbose=verbose)
     # reshape if combine is None:
-    if combine is None:
-        # windows are put at -3 position so that the output is of shape
-        # windows x channels x frequencies for raw data and
-        # epochs x windows x channels x frequencies for epochs
-        psds = np.rollaxis(psds, -1, -3)
     return psds, freq
 
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -93,9 +93,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         performing mean (has to be > 0 and < 0.5) ie. trimmed-mean. If function
         it has to perform the reduction along last dimension. If None - no
         reduction is performed and psd's for individual windows are returned
-        (so that the output psds are of shape (windows, channels, frequencies)
-        for 2d input data and (windows, epochs, channels, frequencies) for 3d
-        input data)
+        In such case the output psds have one more dimension than the input
+        array with windows at -3 dimension.
     n_jobs : int
         Number of CPUs to use in the computation.
     verbose : bool, str, int, or None
@@ -104,7 +103,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
 
     Returns
     -------
-    psds : ndarray, shape (..., n_freqs) or
+    psds : ndarray, shape (..., n_freqs) or (..., n_windows, ..., n_freqs)
         The power spectral densities. All dimensions up to the last will
         be the same as input.
     freqs : ndarray, shape (n_freqs,)
@@ -142,10 +141,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     psds = np.concatenate(f_spectrogram, axis=0)
     if reduction is not None:
         reduction = _get_reduction(reduction)
-        psds = reduction(psds).reshape(np.hstack([dshape, -1]))
+        psds = reduction(psds).reshape(dshape + (-1,))
     else:
         n_windows = psds.shape[-1]
-        psds = psds.reshape(np.hstack([dshape, -1, n_windows]))
+        psds = psds.reshape(dshape + (-1, n_windows))
         # windows are put at -3 position so that the output is of shape
         # windows x channels x frequencies for raw data and
         # epochs x windows x channels x frequencies for epochs
@@ -206,9 +205,9 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         performing mean (has to be > 0 and < 0.5) ie. trimmed-mean. If function
         it has to perform the reduction along last dimension. If None - no
         reduction is performed and psd's for individual windows are returned
-        (so that the output psds are of shape (windows, channels, frequencies)
-        for 2d input data and (windows, epochs, channels, frequencies) for 3d
-        input data)
+        In such case the output psds are of shape (windows, channels,
+        frequencies) for raw data and (epochs, windows, channels, frequencies)
+        for epochs.
 
         .. versionadded:: 0.15.0
     verbose : bool, str, int, or None
@@ -217,7 +216,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
 
     Returns
     -------
-    psds : ndarray, shape (..., n_freqs)
+    psds : ndarray, shape (..., n_freqs) or (..., n_windows, ..., n_freqs)
         The power spectral densities. If input is of type Raw,
         then psds will be shape (n_channels, n_freqs), if input is type Epochs
         then psds will be shape (n_epochs, n_channels, n_freqs).

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -27,9 +27,9 @@ def _check_nfft(n, n_fft, n_per_seg, n_overlap):
     n_per_seg = n_fft if n_per_seg is None or n_per_seg > n_fft else n_per_seg
     n_per_seg = n if n_per_seg > n else n_per_seg
     if n_overlap >= n_per_seg:
-        raise ValueError(('n_overlap cannot be greater than n_per_seg (or '
-                          'n_fft). Got n_overlap of %d while n_per_seg is '
-                          '%d.') % (n_overlap, n_per_seg))
+        raise ValueError(('n_overlap cannot be greater than or equal to '
+                          'n_per_seg (or n_fft). Got n_overlap of %d while '
+                          'n_per_seg is %d.') % (n_overlap, n_per_seg))
     return n_fft, n_per_seg, n_overlap
 
 
@@ -81,8 +81,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         The length of FFT used, must be ``>= n_per_seg`` (default: 256).
         The segments will be zero-padded if ``n_fft > n_per_seg``.
     n_overlap : int
-        The number of points of overlap between segments. Will be adjusted
-        to be <= n_per_seg. The default value is 0.
+        The number of points of overlap between segments. Must be < n_per_seg.
+        The default value is 0.
     n_per_seg : int | None
         Length of each Welch segment. The smaller it is with respect to the
         signal length the smoother are the PSDs. Defaults to None, which sets
@@ -180,8 +180,8 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         If n_per_seg is None, n_fft must be >= number of time points
         in the data.
     n_overlap : int
-        The number of points of overlap between segments. Will be adjusted
-        to be <= n_per_seg. The default value is 0.
+        The number of points of overlap between segments. Must be < n_per_seg.
+        The default value is 0.
     n_per_seg : int | None
         Length of each Welch segment. The smaller it is with respect to the
         signal length the smoother are the PSDs. Defaults to None, which sets

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -146,7 +146,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     else:
         n_windows = psds.shape[-1]
         psds = psds.reshape(np.hstack([dshape, -1, n_windows]))
-        psds = np.moveaxis(psds, -1, 0) # windows as first dimension
+        # windows are put at -3 position so that the output is of shape
+        # windows x channels x frequencies for raw data and
+        # epochs x windows x channels x frequencies for epochs
+        psds = np.rollaxis(psds, -1, -3)
     return psds, freqs
 
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..parallel import parallel_func
 from ..io.pick import _pick_data_channels
-from ..utils import logger, verbose, _time_mask, get_reduction
+from ..utils import logger, verbose, _time_mask, _get_reduction
 from ..fixes import get_spectrogram
 from .multitaper import psd_array_multitaper
 
@@ -141,8 +141,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     #       (this would require pushing reduction into fixes._spectrogram)
     psds = np.concatenate(f_spectrogram, axis=0)
     if reduction is not None:
-        red_fun = get_reduction(reduction)
-        psds = red_fun(psds).reshape(np.hstack([dshape, -1]))
+        reduction = _get_reduction(reduction)
+        psds = reduction(psds).reshape(np.hstack([dshape, -1]))
     else:
         n_windows = psds.shape[-1]
         psds = psds.reshape(np.hstack([dshape, -1, n_windows]))

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -47,8 +47,8 @@ def _check_psd_data(inst, tmin, tmax, picks, proj, reject_by_annotation=False):
     if picks is None:
         picks = _pick_data_channels(inst.info, with_ref_meg=False)
     if isinstance(picks, int):
-        # Raw get_data() method doesn't guarantee 2d data if picks is int
-        # the same for epochs.get_data()[:, picks]
+        # Just to be on the safe side if picks is int: in that case
+        # epochs.get_data()[:, picks] would drop channels dimension
         picks = [picks]
     if proj:
         # Copy first so it's not modified
@@ -97,7 +97,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         'mean' or 'median'. If float it is understood as the proportion of
         values to trim before performing mean (has to be > 0 and < 0.5) ie.
         trimmed-mean. If function it has to perform the reduction along last
-        dimension. If None, no reduction is performed and psd's for individual
+        dimension. If None, no reduction is performed and PSDs for individual
         windows are returned. In such case the output PSDs have one more
         dimension than the input array with windows as the last dimension.
 
@@ -113,12 +113,21 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     psds : ndarray, shape (..., n_freqs)
         The power spectral densities. All dimensions up to the last will
         be the same as input unless combine is None. When combine is None
-        the psds are of shape (..., n_freqs, n_windows)
+        the PSDs are of shape (..., n_freqs, n_windows)
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
 
     Notes
     -----
+    Please note that if using ``combine=None`` the ``psds`` output shape will
+    be different from the shape of :func:`mne.time_frequency.psd_welch`
+    ``psds`` output. This function returns windows as the last dimension of
+    ``psds`` while :func:`mne.time_frequency.psd_welch` returns windows at -3
+    dimesion. This difference is caused by the fact that possible shapes of
+    input to this function are much more variable than inputs to
+    :func:`mne.time_frequency.psd_welch` - and placing windows at -3 dimension
+    would lead to inconsistencies anyway. Enjoy!
+
     .. versionadded:: 0.14.0
     """
     spectrogram = get_spectrogram()
@@ -207,7 +216,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         'mean' or 'median'. If float it is understood as the proportion of
         values to trim before performing mean (has to be > 0 and < 0.5) ie.
         trimmed-mean. If function it has to perform the reduction along last
-        dimension. If None, no reduction is performed and psd's for individual
+        dimension. If None, no reduction is performed and PSDs for individual
         windows are returned. In such case the output PSDs have one more
         dimension than the input array with windows at -3 dimension.
 
@@ -219,11 +228,11 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     Returns
     -------
     psds : ndarray, shape (..., n_freqs)
-        The power spectral densities. If input is of type Raw, returned psds
-        are shaped (n_channels, n_freqs), if input is type Epochs returned psds
+        The power spectral densities. If input is of type Raw, returned PSDs
+        are shaped (n_channels, n_freqs), if input is type Epochs returned PSDs
         are shaped (n_epochs, n_channels, n_freqs). However if combine is None
-        then if input is of type Raw, returned psds will be shaped (n_windows,
-        n_channels, n_freqs), if input is type Epochs then psds will be shaped
+        then if input is of type Raw, returned PSDs will be shaped (n_windows,
+        n_channels, n_freqs), if input is type Epochs then PSDs will be shaped
         (n_epochs, n_windows, n_channels, n_freqs).
     freqs : ndarray, shape (n_freqs,)
         The frequencies.

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -239,10 +239,10 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     # Prep data
     data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj,
                                   reject_by_annotation=reject_by_annotation)
-    psds, freq = psd_array_welch(data, sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft,
-                                 n_overlap=n_overlap, n_per_seg=n_per_seg,
-                                 combine=combine, n_jobs=n_jobs,
-                                 verbose=verbose)
+    psds, freq = psd_array_welch(data, sfreq, fmin=fmin, fmax=fmax,
+                                 n_fft=n_fft, n_overlap=n_overlap,
+                                 n_per_seg=n_per_seg, combine=combine,
+                                 n_jobs=n_jobs, verbose=verbose)
     # reshape if combine is None:
     if combine is None:
         # windows are put at -3 position so that the output is of shape

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -3,6 +3,7 @@
 #           Mikolaj Magnuski <mmagnuski@swps.edu.pl>
 # License : BSD 3-clause
 
+import numbers
 import numpy as np
 
 from ..parallel import parallel_func

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -6,8 +6,7 @@ from nose.tools import assert_true, assert_equal
 
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
-from mne.fixes import _trim_mean
-from mne.utils import slow_test, run_tests_if_main
+from mne.utils import slow_test, run_tests_if_main, _trim_mean
 from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -6,7 +6,7 @@ from nose.tools import assert_true, assert_equal
 
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
-from mne.fixes import get_trim_mean
+from mne.fixes import _trim_mean
 from mne.utils import slow_test, run_tests_if_main
 from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
 
@@ -97,9 +97,8 @@ def test_psd():
     windows, freqs = psd_welch(raw, proj=False, combine=None, **kws_psd)
     windows_mean, _ = psd_welch(raw, proj=False, combine='mean', **kws_psd)
     assert_array_almost_equal(windows.mean(axis=-3), windows_mean)
-    trim_mean = get_trim_mean()
     windows_trim, _ = psd_welch(raw, proj=False, combine=0.2, **kws_psd)
-    assert_array_almost_equal(trim_mean(windows, 0.2, axis=-3), windows_trim)
+    assert_array_almost_equal(_trim_mean(windows, 0.2, axis=-3), windows_trim)
 
     # test combine with function
     windows_max, freqs = psd_welch(

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -100,8 +100,8 @@ def test_psd():
     assert_array_almost_equal(trim_mean(windows, 0.2, axis=-3), windows_trim)
 
     # test reduction with function
-    func = lambda x: x.max(axis=-1)
-    windows_max, freqs = psd_welch(raw, proj=False, reduction=func, **kws_psd)
+    windows_max, freqs = psd_welch(
+        raw, proj=False, reduction=lambda x: x.max(axis=-1), **kws_psd)
     assert_array_almost_equal(np.max(windows, axis=-3), windows_max)
 
     # -- Epochs/Evoked --

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -3,12 +3,11 @@ import os.path as op
 from numpy.testing import (assert_array_almost_equal, assert_raises,
                            assert_allclose)
 from nose.tools import assert_true, assert_equal
-from scipy.stats import trim_mean
 
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
 from mne.fixes import get_trim_mean
-from mne.utils import requires_version, slow_test, run_tests_if_main
+from mne.utils import slow_test, run_tests_if_main
 from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -94,17 +94,17 @@ def test_psd():
     kws_psd_temp.update(dict(n_fft=128, n_per_seg=64, n_overlap=90))
     assert_raises(ValueError, psd_welch, raw, proj=False, **kws_psd_temp)
 
-    # test reduction
-    windows, freqs = psd_welch(raw, proj=False, reduction=None, **kws_psd)
-    windows_mean, _ = psd_welch(raw, proj=False, reduction='mean', **kws_psd)
+    # test combine
+    windows, freqs = psd_welch(raw, proj=False, combine=None, **kws_psd)
+    windows_mean, _ = psd_welch(raw, proj=False, combine='mean', **kws_psd)
     assert_array_almost_equal(windows.mean(axis=-3), windows_mean)
     trim_mean = get_trim_mean()
-    windows_trim, _ = psd_welch(raw, proj=False, reduction=0.2, **kws_psd)
+    windows_trim, _ = psd_welch(raw, proj=False, combine=0.2, **kws_psd)
     assert_array_almost_equal(trim_mean(windows, 0.2, axis=-3), windows_trim)
 
-    # test reduction with function
+    # test combine with function
     windows_max, freqs = psd_welch(
-        raw, proj=False, reduction=lambda x: x.max(axis=-1), **kws_psd)
+        raw, proj=False, combine=lambda x: x.max(axis=-1), **kws_psd)
     assert_array_almost_equal(np.max(windows, axis=-3), windows_max)
 
     # -- Epochs/Evoked --

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -95,14 +95,14 @@ def test_psd():
     # test reduction
     windows, freqs = psd_welch(raw, proj=False, reduction=None, **kws_psd)
     windows_mean, _ = psd_welch(raw, proj=False, reduction='mean', **kws_psd)
-    assert_array_almost_equal(windows.mean(axis=0), windows_mean)
+    assert_array_almost_equal(windows.mean(axis=-3), windows_mean)
     windows_trim, _ = psd_welch(raw, proj=False, reduction=0.2, **kws_psd)
-    assert_array_almost_equal(trim_mean(windows, 0.2, axis=0), windows_trim)
+    assert_array_almost_equal(trim_mean(windows, 0.2, axis=-3), windows_trim)
 
     # test reduction with function
     func = lambda x: x.max(axis=-1)
     windows_max, freqs = psd_welch(raw, proj=False, reduction=func, **kws_psd)
-    assert_array_almost_equal(np.max(windows, axis=0), windows_max)
+    assert_array_almost_equal(np.max(windows, axis=-3), windows_max)
 
     # -- Epochs/Evoked --
     events = read_events(event_fname)

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -75,7 +75,7 @@ def test_psd():
         # Array input shouldn't work
         assert_raises(ValueError, func, raw[:3, :20][0])
 
-    # test n_per_seg in psd_welch (and padding)
+    # test n_per_seg_ psd_welch (and padding)
     psds1, freqs1 = psd_welch(raw, proj=False, n_fft=128, n_per_seg=128,
                               **kws_psd)
     psds2, freqs2 = psd_welch(raw, proj=False, n_fft=256, n_per_seg=128,
@@ -95,14 +95,14 @@ def test_psd():
     # test combine
     windows, freqs = psd_welch(raw, proj=False, combine=None, **kws_psd)
     windows_mean, _ = psd_welch(raw, proj=False, combine='mean', **kws_psd)
-    assert_array_almost_equal(windows.mean(axis=-3), windows_mean)
+    assert_array_almost_equal(windows.mean(axis=-1), windows_mean)
     windows_trim, _ = psd_welch(raw, proj=False, combine=0.2, **kws_psd)
-    assert_array_almost_equal(_trim_mean(windows, 0.2, axis=-3), windows_trim)
+    assert_array_almost_equal(_trim_mean(windows, 0.2, axis=-1), windows_trim)
 
     # test combine with function
-    windows_max, freqs = psd_welch(
+    windows_max, _ = psd_welch(
         raw, proj=False, combine=lambda x: x.max(axis=-1), **kws_psd)
-    assert_array_almost_equal(np.max(windows, axis=-3), windows_max)
+    assert_array_almost_equal(np.max(windows, axis=-1), windows_max)
 
     # -- Epochs/Evoked --
     events = read_events(event_fname)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2420,6 +2420,7 @@ def _get_fast_dot():
 def _trim_mean(a, proportiontocut, axis=0):
     """
     Return mean of array after trimming distribution from both tails.
+
     If `proportiontocut` = 0.1, slices off 'leftmost' and 'rightmost' 10% of
     scores. The input is sorted before slicing. Slices off less if proportion
     results in a non-integer slice index (i.e., conservatively slices off

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -40,7 +40,7 @@ from .externals.six.moves import urllib
 from .externals.six import string_types, StringIO, BytesIO, integer_types
 from .externals.decorator import decorator
 
-from .fixes import _get_args, get_trim_mean
+from .fixes import _get_args, _trim_mean
 
 logger = logging.getLogger('mne')  # one selection here used across mne-python
 logger.propagate = False  # don't propagate (in case of multiple imports)
@@ -2430,8 +2430,7 @@ def _get_reduction(reduction, axis=-1):
             raise ValueError('reduction, if float, means proportion to trim in'
                              ' trimmed mean, which has to be > 0 and < 0.5, '
                              'got {}'.format(reduction))
-        trim_mean = get_trim_mean()
-        return lambda x: trim_mean(x, reduction, axis=axis)
+        return lambda x: _trim_mean(x, reduction, axis=axis)
     elif hasattr(reduction, '__call__'):
         return reduction
     else:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2415,7 +2415,7 @@ def _get_fast_dot():
     return fast_dot
 
 
-def get_reduction(reduction, axis=-1):
+def _get_reduction(reduction, axis=-1):
     if isinstance(reduction, string_types):
         if reduction == 'mean':
             return lambda x: np.mean(x, axis=axis)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2429,7 +2429,8 @@ def _get_reduction(reduction, axis=-1):
             raise ValueError('reduction, if float, means proportion to trim in'
                              ' trimmed mean, which has to be > 0 and < 0.5, '
                              'got {}'.format(reduction))
-        from scipy.stats import trim_mean
+        from .fixes import get_trim_mean
+        trim_mean = get_trim_mean()
         return lambda x: trim_mean(x, reduction, axis=axis)
     elif hasattr(reduction, '__call__'):
         return reduction

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -17,6 +17,7 @@ import json
 import logging
 from math import log, ceil
 import multiprocessing
+import numbers
 import operator
 import os
 import os.path as op
@@ -2424,7 +2425,7 @@ def _get_reduction(reduction, axis=-1):
         else:
             raise ValueError('reduction, if string, must be "mean" or "median"'
                              ', got {}'.format(reduction))
-    elif isinstance(reduction, (float, np.float64, np.float32)):
+    elif isinstance(reduction, numbers.Real):
         if reduction < 0 or reduction >= 0.5:
             raise ValueError('reduction, if float, means proportion to trim in'
                              ' trimmed mean, which has to be > 0 and < 0.5, '

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -39,7 +39,7 @@ from .externals.six.moves import urllib
 from .externals.six import string_types, StringIO, BytesIO, integer_types
 from .externals.decorator import decorator
 
-from .fixes import _get_args
+from .fixes import _get_args, get_trim_mean
 
 logger = logging.getLogger('mne')  # one selection here used across mne-python
 logger.propagate = False  # don't propagate (in case of multiple imports)
@@ -2429,7 +2429,6 @@ def _get_reduction(reduction, axis=-1):
             raise ValueError('reduction, if float, means proportion to trim in'
                              ' trimmed mean, which has to be > 0 and < 0.5, '
                              'got {}'.format(reduction))
-        from .fixes import get_trim_mean
         trim_mean = get_trim_mean()
         return lambda x: trim_mean(x, reduction, axis=axis)
     elif hasattr(reduction, '__call__'):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2415,6 +2415,29 @@ def _get_fast_dot():
     return fast_dot
 
 
+def get_reduction(reduction, axis=-1):
+    if isinstance(reduction, string_types):
+        if reduction == 'mean':
+            return lambda x: np.mean(x, axis=axis)
+        elif reduction == 'median':
+            return lambda x: np.median(x, axis=axis)
+        else:
+            raise ValueError('reduction, if string, must be "mean" or "median"'
+                             ', got {}'.format(reduction))
+    elif isinstance(reduction, (float, np.float64, np.float32)):
+        if reduction < 0 or reduction >= 0.5:
+            raise ValueError('reduction, if float, means proportion to trim in'
+                             ' trimmed mean, which has to be > 0 and < 0.5, '
+                             'got {}'.format(reduction))
+        from scipy.stats import trim_mean
+        return lambda x: trim_mean(x, reduction, axis=axis)
+    elif hasattr(reduction, '__call__'):
+        return reduction
+    else:
+        raise TypeError('unrecognized reduction type. Has to be string, '
+                        'float or callable, got {}'.format(reduction))
+
+
 def random_permutation(n_samples, random_state=None):
     """Emulate the randperm matlab function.
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2418,9 +2418,9 @@ def _get_fast_dot():
 def _get_reduction(reduction, axis=-1):
     if isinstance(reduction, string_types):
         if reduction == 'mean':
-            return lambda x: np.mean(x, axis=axis)
+            return lambda x: np.nanmean(x, axis=axis)
         elif reduction == 'median':
-            return lambda x: np.median(x, axis=axis)
+            return lambda x: np.nanmedian(x, axis=axis)
         else:
             raise ValueError('reduction, if string, must be "mean" or "median"'
                              ', got {}'.format(reduction))

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -591,7 +591,7 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
                  area_mode='std', area_alpha=0.33, n_overlap=0, dB=True,
                  average=None, show=True, n_jobs=1, line_alpha=None,
                  spatial_colors=None, xscale='linear',
-                 reject_by_annotation=True, verbose=None):
+                 reject_by_annotation=True, combine='mean', verbose=None):
     """Plot the power spectral density across channels.
 
     Parameters
@@ -656,6 +656,14 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         Evoked object. Defaults to True.
 
         .. versionadded:: 0.15.0
+    combine : str | float | callable
+        The type of reduction to perform on welch windows. If string it can be
+        'mean' or 'median'. If float it is understood as the proportion of
+        values to trim before performing mean (has to be > 0 and < 0.5) ie.
+        trimmed-mean. If function it has to perform the reduction along last
+        dimension.
+
+        .. versionadded:: 0.15.0
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -674,6 +682,10 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
     if average and spatial_colors:
         raise ValueError('Average and spatial_colors cannot be enabled '
                          'simultaneously.')
+    if combine is None:
+        raise ValueError('`combine` cannot be None plot_raw_psd - you have to'
+                         ' specify a way to combine welch windows (for'
+                         ' example `"mean"`).')
     if spatial_colors is None:
         spatial_colors = False if average else True
 
@@ -693,7 +705,8 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         psds, freqs = psd_welch(raw, tmin=tmin, tmax=tmax, picks=picks,
                                 fmin=fmin, fmax=fmax, proj=proj, n_fft=n_fft,
                                 n_overlap=n_overlap, n_jobs=n_jobs,
-                                reject_by_annotation=reject_by_annotation)
+                                reject_by_annotation=reject_by_annotation,
+                                combine=combine)
 
         ylabel = _convert_psds(psds, dB, scalings_list[ii], units_list[ii],
                                [raw.ch_names[pi] for pi in picks])

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -156,17 +156,16 @@ plt.show()
 # use ``combine=None`` to get all the welch windows without averaging. Notice
 # the dimensions of the output.
 psds_windows, freqs = psd_welch(epochs, combine=None, **welch_args)
-n_epochs, n_windows, n_channels, n_freqs = psds_windows.shape
-print('dimensions of returned PSDs: n_epochs, n_windows, n_channels, n_freqs')
+n_epochs, n_channels, n_freqs, n_windows = psds_windows.shape
+print('dimensions of returned PSDs: n_epochs, n_channels, n_freqs, n_windows')
 print('PSDs shape in each dimension: ', end='')
-print(n_epochs, n_windows, n_channels, n_freqs, sep=', ')
+print(n_epochs, n_channels, n_freqs, n_windows, sep=', ')
 
 ###############################################################################
 # Now we'll pick power only at 10 Hz and unroll epochs and welch windows into
 # one vector whose histogram we plot.
 alpha = np.where(freqs == 10)[0][0]
-counts, bins, patches = plt.hist(
-    psds_windows[..., alpha].reshape(n_epochs * n_windows), bins=50)
+counts, bins, patches = plt.hist(psds_windows[:, 0, alpha, :].ravel(), bins=50)
 plt.show()
 
 ###############################################################################

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -78,8 +78,8 @@ ax.set(title='Multitaper PSD (gradiometers)', xlabel='Frequency',
 plt.show()
 
 ###############################################################################
-# To see the difference between `psd_multitaper` and `psd_welch` - we are
-# going to compare PSDs obtained with each function.
+# To see the difference between :func:`psd_multitaper` and :func:`psd_welch`
+# - we are going to compare PSDs obtained with each function.
 ch_index = epochs.ch_names.index('MEG 2333')
 
 psds_m, freqs_m = psd_multitaper(epochs, picks=[ch_index],
@@ -106,7 +106,7 @@ plt.show()
 
 ###############################################################################
 # We can observe that multitaper estimation yields smoother spectrum - the
-# amount of smoothing can be controlled with `bandwidth` argument:
+# amount of smoothing can be controlled with ``bandwidth`` argument:
 bandwidths = np.arange(1, 7)
 colors = plt.cm.viridis(bandwidths / 7)
 
@@ -127,7 +127,7 @@ plt.show()
 # While in multitaper the averaging is done across independent realizations of
 # the signal (using slepian tapers), welch method averages across time
 # segments of the signal (often overlapping). Instead of averaging the windows
-# you can choose a different reduction by specifying `combine`:
+# you can choose a different reduction by specifying ``combine``:
 welch_args = dict(picks=[ch_index], n_fft=epochs.info['sfreq'],
                   n_overlap=int(epochs.info['sfreq'] / 2), fmin=2, fmax=25)
 psds_w, freqs = psd_welch(epochs, combine='mean', **welch_args)
@@ -153,7 +153,7 @@ plt.show()
 # The reduction in power that can be seen in the figure above is due to the
 # fact that values for power spectral density follow a positive skewed
 # gamma-like distribution. Lets take a look at this distribution. First we will
-# use `combine=None` to get all the welch windows without averaging. Notice
+# use ``combine=None`` to get all the welch windows without averaging. Notice
 # the dimensions of the output.
 psds_windows, freqs = psd_welch(epochs, combine=None, **welch_args)
 n_epochs, n_windows, n_channels, n_freqs = psds_windows.shape

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -128,12 +128,12 @@ plt.show()
 # While in multitaper the averaging is done across independent realizations of
 # the signal (using slepian tapers), welch method averages across time
 # segments of the signal (often overlapping). Instead of averaging the windows
-# you can choose a different reduction by specifying `reduction`:
+# you can choose a different reduction by specifying `combine`:
 welch_args = dict(picks=[ch_index], n_fft=epochs.info['sfreq'],
                   n_overlap=int(epochs.info['sfreq'] / 2), fmin=2, fmax=25)
-psds_w, freqs = psd_welch(epochs, reduction='mean', **welch_args)
-psds_w_trimmed, _ = psd_welch(epochs, reduction=0.15, **welch_args)
-psds_w_median, _ = psd_welch(epochs, reduction='median', **welch_args)
+psds_w, freqs = psd_welch(epochs, combine='mean', **welch_args)
+psds_w_trimmed, _ = psd_welch(epochs, combine=0.15, **welch_args)
+psds_w_median, _ = psd_welch(epochs, combine='median', **welch_args)
 
 psd_w = psds_w[:, 0].mean(axis=0)
 psd_w_trim = psds_w_trimmed[:, 0].mean(axis=0)
@@ -145,17 +145,18 @@ ax.plot(freqs, psd_w, color='cornflowerblue', label='welch, mean')
 ax.plot(freqs, psd_w_trim, color='seagreen', label='welch, trimmed mean')
 ax.plot(freqs, psd_w_med, color='crimson', label='welch, median')
 
-ax.set(title='Welch with mean and median reductions', xlabel='Frequency',
+ax.set(title='Welch with mean and median combine', xlabel='Frequency',
        ylabel='Power Spectral Density')
 ax.legend()
 plt.show()
 
 ###############################################################################
-# The reduction is due to the fact that values for power spectral density
-# follow a positive skewed gamma-like distribution. Lets take a look at this
-# distribution. First we will use `reduction=None` to get all the welch windows
-# without averaging. Notice the dimensions of the output.
-psds_windows, freqs = psd_welch(epochs, reduction=None, **welch_args)
+# The reduction in power that can be seen in the figure above is due to the
+# fact that values for power spectral density follow a positive skewed
+# gamma-like distribution. Lets take a look at this distribution. First we will
+# use `combine=None` to get all the welch windows without averaging. Notice
+# the dimensions of the output.
+psds_windows, freqs = psd_welch(epochs, combine=None, **welch_args)
 n_epochs, n_windows, n_channels, n_freqs = psds_windows.shape
 print('dimensions of returned PSDs: n_epochs, n_windows, n_channels, n_freqs')
 print('PSDs shape in each dimension: ', end='')

--- a/tutorials/plot_sensors_time_frequency.py
+++ b/tutorials/plot_sensors_time_frequency.py
@@ -18,7 +18,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import mne
-from mne.time_frequency import tfr_morlet, psd_multitaper
+from mne.time_frequency import tfr_morlet, psd_multitaper, psd_welch
 from mne.datasets import somato
 
 ###############################################################################
@@ -80,7 +80,6 @@ plt.show()
 ###############################################################################
 # To see the difference between `psd_multitaper` and `psd_welch` - we are
 # going to compare PSDs obtained with each function.
-from mne.time_frequency import psd_welch
 ch_index = epochs.ch_names.index('MEG 2333')
 
 psds_m, freqs_m = psd_multitaper(epochs, picks=[ch_index],


### PR DESCRIPTION
This PR adds ability to specify reduction to apply to welch windows (#3336)
It's actually part of #3820 with some tests added.
@Eric89GXL I was looking for a branch/stash fixing #3621 and found this instead. But I'll push PR adressing n_fft issue today.

This adds `reduction` keyword argument for reduction across windows, where that can be either `'mean'`, `'median'`, callable or `None`:
* `'mean'` and `'median'` perform mean or median respectively
* callable is called on the windows (may additionally ensure that window dimension was reduced)
* `None` omit the reduction so `psd_welch` returns an array of shape `windows x channels x freqs` for raw and `windows x epochs x channels x freqs` for epochs.
* @kingjr proposed using float values < 0.5 for trimmed mean - I've implemented it here too (using `scipy.stats.trim_mean`)

I've added it as `get_reduction` to mne.utils. It can also be private if you prefer.
I've also added a few tests to `test_psd` - they pass locally, but I'll see what CIs have to say. 
❗️ the windows are the last dimension if a reduction is applied (so if custom function is used it has to reduce across axis=-1), but when reduction is `None` they are moved to the -3 dimension. This means that raw output is of diemnsions `windows x channels x freqs` and epochs are of `epochs x windows x channels x freqs` ❗️ 

TODOs:
- [x] I'll modify existing tutorial/example that shows how to use reduction
- [x] I'll add a whats new entry once all is cool (CIs green, comments adressed etc.)

Closes #3336