### PR TITLE
[MRG+2] Make EEG (re-)referencing more intuitive

### DIFF
--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -41,21 +41,21 @@ fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
 # No reference. This assumes that the EEG has already been referenced properly.
 # This explicitly prevents MNE from adding a default EEG reference.
-raw, _ = mne.io.set_eeg_reference(raw, [])
+raw.set_eeg_reference([])
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
 evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'))
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
-raw, _ = mne.io.set_eeg_reference(raw)
+raw.set_eeg_reference()
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
 evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'))
 
 # Re-reference from an average reference to the mean of channels EEG 001 and
 # EEG 002.
-raw, _ = mne.io.set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
+raw.set_eeg_reference(['EEG 001', 'EEG 002'])
 evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
 evoked_custom.plot(axes=ax3, titles=dict(eeg='EEG Custom reference'))

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -31,7 +31,7 @@ events = mne.read_events(event_fname)
 picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True, exclude='bads')
 
 ###############################################################################
-# Apply different EEG referencing schemes and plot the resulting evokeds
+# Apply different EEG referencing schemes and plot the resulting evokeds.
 
 reject = dict(eeg=180e-6, eog=150e-6)
 epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
@@ -41,25 +41,21 @@ fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
 # No reference. This assumes that the EEG has already been referenced properly.
 # This explicitly prevents MNE from adding a default EEG reference.
-raw_no_ref, _ = mne.io.set_eeg_reference(raw, [])
-evoked_no_ref = mne.Epochs(raw_no_ref, **epochs_params).average()
-del raw_no_ref  # Free memory
+raw, _ = mne.io.set_eeg_reference(raw, [])
+evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
 evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'))
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
-raw_car, _ = mne.io.set_eeg_reference(raw)
-evoked_car = mne.Epochs(raw_car, **epochs_params).average()
-del raw_car
+raw, _ = mne.io.set_eeg_reference(raw)
+evoked_car = mne.Epochs(raw, **epochs_params).average()
 
 evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'))
 
-# Use the mean of channels EEG 001 and EEG 002 as a reference
-raw_custom, _ = mne.io.set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
-evoked_custom = mne.Epochs(raw_custom, **epochs_params).average()
-del raw_custom
+# Re-reference from an average reference to the mean of channels EEG 001 and
+# EEG 002.
+raw, _ = mne.io.set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
+evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
 evoked_custom.plot(axes=ax3, titles=dict(eeg='EEG Custom reference'))
-
-mne.viz.tight_layout()

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -284,6 +284,10 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
     set_bipolar_reference : Convenience function for creating bipolar
                             references.
     """
+    if not isinstance(inst, (BaseRaw, BaseEpochs, Evoked)):
+        raise ValueError('Setting a reference is only supported for instances '
+                         'of Raw, Epochs or Evoked.')
+
     if ref_channels is None:
         # CAR requested
         if _has_eeg_average_ref_proj(inst.info['projs']):
@@ -298,8 +302,9 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
                 inst.info['custom_ref_applied'] = False
                 inst.add_proj(make_eeg_average_ref_proj(inst.info,
                               activate=False))
-                # Apply the reference if data has been preloaded
-                if hasattr(inst, '_data') or hasattr(inst, 'data'):
+                # If the data has been preloaded, projections will no longer be
+                # automatically applied.
+                if isinstance(inst, Evoked) or inst.preload:
                     logger.info('Average reference projection was added, but '
                                 "hasn't been applied yet. Use the "
                                 '.apply_proj() method function to apply '

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -233,22 +233,51 @@ def add_reference_channels(inst, ref_channels, copy=True):
 
 @verbose
 def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
-    """Rereference EEG channels to new reference channel(s).
+    """Specify which reference to use for EEG data.
 
-    If multiple reference channels are specified, they will be averaged. If
-    no reference channels are specified, an average reference will be applied.
+    By default, MNE-Python will automatically re-reference the EEG signal to use an
+    average reference (see below). Use this function to explicitly specify the
+    desired reference for EEG. This can be either an existing electrode or a
+    new virtual channel. This function will re-reference the data according to
+    the desired reference and prevent MNE-Python from automatically adding an
+    average reference.
+
+    Some common referencing schemes and the corresponding value for the
+    ``ref_channels`` parameter:
+
+    No re-referencing:
+        If the EEG data is already using the proper reference, set
+        ``ref_channels=[]``. This will prevent MNE-Python from automatically
+        re-referencing the data to an average reference.
+
+    Average reference:
+        A new virtual reference electrode is created by averaging the current
+        EEG signal. Make sure that all bad EEG channels are properly marked
+        and set ``ref_channels=None``.
+
+    A single electrode:
+        Set ``ref_channels`` to the name of the channel that will act as the
+        new reference.
+
+    The mean of multiple electrodes:
+        A new virtual reference electrode is created by computing the average
+        of the current EEG signal recorded from two or more selected channels.
+        Set ``ref_channels`` to a list of channel names, indicating which
+        channels to use. For example, to apply an average mastoid reference,
+        when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
+
 
     Parameters
     ----------
     inst : instance of Raw | Epochs | Evoked
         Instance of Raw or Epochs with EEG channels and reference channel(s).
     ref_channels : list of str | None
-        The names of the channels to use to construct the reference. If
-        None (default), an average reference will be added as an SSP
-        projector but not immediately applied to the data. If an empty list
-        is specified, the data is assumed to already have a proper reference
-        and MNE will not attempt any re-referencing of the data. Defaults
-        to an average reference (None).
+        The names of the channels to use to construct the reference. To apply
+        an average reference, specify ``None`` here (default). It will be added
+        as an SSP projector, so it is not immediately applied to the data. If
+        an empty list is specified, the data is assumed to already have a
+        proper reference and MNE will not attempt any re-referencing of the
+        data. Defaults to an average reference (None).
     copy : bool
         Specifies whether the data will be copied (True) or modified in place
         (False). Defaults to True.
@@ -276,6 +305,11 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
 
     3. In order to apply a reference other than an average reference, the data
        must be preloaded.
+
+    4. Re-referencing to an average reference is done with an SSP projector.
+       This allows applying this reference without preloading the data. Be
+       aware that on preloaded data, SSP projectors are not automatically
+       applied. Use the ``apply_proj()`` method to apply them.
 
     .. versionadded:: 0.9.0
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -356,7 +356,7 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
             return inst, None
 
     if ref_channels == []:
-        logger.info('EEG data marked as having the desired reference. '
+        logger.info('EEG data marked as already having the desired reference. '
                     'Preventing automatic future re-referencing to an average '
                     'reference.')
     else:

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -300,8 +300,10 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
                               activate=False))
                 # Apply the reference if data has been preloaded
                 if hasattr(inst, '_data') or hasattr(inst, 'data'):
-                    inst.apply_proj()
-
+                    logger.info('Average reference projection was added, but '
+                                "hasn't been applied yet. Use the "
+                                '.apply_proj() method function to apply '
+                                'projections.')
             except:
                 inst.info['custom_ref_applied'] = custom_ref_applied
                 raise

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -235,12 +235,12 @@ def add_reference_channels(inst, ref_channels, copy=True):
 def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
     """Specify which reference to use for EEG data.
 
-    By default, MNE-Python will automatically re-reference the EEG signal to use an
-    average reference (see below). Use this function to explicitly specify the
-    desired reference for EEG. This can be either an existing electrode or a
-    new virtual channel. This function will re-reference the data according to
-    the desired reference and prevent MNE-Python from automatically adding an
-    average reference.
+    By default, MNE-Python will automatically re-reference the EEG signal to
+    use an average reference (see below). Use this function to explicitly
+    specify the desired reference for EEG. This can be either an existing
+    electrode or a new virtual channel. This function will re-reference the
+    data according to the desired reference and prevent MNE-Python from
+    automatically adding an average reference.
 
     Some common referencing schemes and the corresponding value for the
     ``ref_channels`` parameter:
@@ -348,10 +348,16 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
                 raise
 
             return inst, None
+
+    if ref_channels == []:
+        logger.info('EEG data marked as having the desired reference. '
+                    'Preventing automatic future re-referencing to an average '
+                    'reference.')
     else:
         logger.info('Applying a custom EEG reference.')
-        inst = inst.copy() if copy else inst
-        return _apply_reference(inst, ref_channels)
+
+    inst = inst.copy() if copy else inst
+    return _apply_reference(inst, ref_channels)
 
 
 def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -84,8 +84,8 @@ def _apply_reference(inst, ref_from, ref_to=None):
 
         # Apply any other type of projection
         elif (not proj['active'] and
-            len([ch for ch in (ref_from + ref_to)
-                 if ch in proj['data']['col_names']]) > 0):
+              len([ch for ch in (ref_from + ref_to)
+                   if ch in proj['data']['col_names']]) > 0):
 
             logger.info(
                 'Inactive signal space projection (SSP) operators are '

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -127,7 +127,9 @@ def test_set_eeg_reference():
     assert_true(not _has_eeg_average_ref_proj(raw.info['projs']))
     reref, ref_data = set_eeg_reference(raw)
     assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    assert_true(not reref.info['projs'][0]['active'])
     assert_true(ref_data is None)
+    reref.apply_proj()
     eeg_chans = [raw.ch_names[ch]
                  for ch in pick_types(raw.info, meg=False, eeg=True)]
     _test_reference(raw, reref, ref_data,

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -49,7 +49,8 @@ def _test_reference(raw, reref, ref_data, ref_from):
         _reref = reref._data
 
     # Check that the ref has been properly computed
-    assert_array_equal(ref_data, _data[..., picks_ref, :].mean(-2))
+    if ref_data is not None:
+        assert_array_equal(ref_data, _data[..., picks_ref, :].mean(-2))
 
     # Get the raw EEG data and other channel data
     raw_eeg_data = _data[..., picks_eeg, :]
@@ -59,15 +60,16 @@ def _test_reference(raw, reref, ref_data, ref_from):
     reref_eeg_data = _reref[..., picks_eeg, :]
     reref_other_data = _reref[..., picks_other, :]
 
-    # Undo rereferencing of EEG channels
-    if isinstance(raw, BaseEpochs):
-        unref_eeg_data = reref_eeg_data + ref_data[:, np.newaxis, :]
-    else:
-        unref_eeg_data = reref_eeg_data + ref_data
-
-    # Check that both EEG data and other data is the same
-    assert_allclose(raw_eeg_data, unref_eeg_data, 1e-6, atol=1e-15)
+    # Check that non-EEG channels are untouched
     assert_allclose(raw_other_data, reref_other_data, 1e-6, atol=1e-15)
+
+    # Undo rereferencing of EEG channels if possible
+    if ref_data is not None:
+        if isinstance(raw, BaseEpochs):
+            unref_eeg_data = reref_eeg_data + ref_data[:, np.newaxis, :]
+        else:
+            unref_eeg_data = reref_eeg_data + ref_data
+        assert_allclose(raw_eeg_data, unref_eeg_data, 1e-6, atol=1e-15)
 
 
 @testing.requires_testing_data
@@ -126,11 +128,22 @@ def test_set_eeg_reference():
     reref, ref_data = set_eeg_reference(raw)
     assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
     assert_true(ref_data is None)
+    eeg_chans = [raw.ch_names[ch]
+                 for ch in pick_types(raw.info, meg=False, eeg=True)]
+    _test_reference(raw, reref, ref_data,
+                    [ch for ch in eeg_chans if ch not in raw.info['bads']])
 
     # Test setting an average reference when one was already present
-    with warnings.catch_warnings(record=True):  # weight tables
+    with warnings.catch_warnings(record=True):
         reref, ref_data = set_eeg_reference(raw, copy=False)
     assert_true(ref_data is None)
+
+    # Test setting an average reference on non-preloaded data
+    raw_nopreload = read_raw_fif(fif_fname, preload=False)
+    raw_nopreload.info['projs'] = []
+    reref, ref_data = set_eeg_reference(raw_nopreload)
+    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    assert_true(not reref.info['projs'][0]['active'])
 
     # Rereference raw data by creating a copy of original data
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'], copy=True)
@@ -155,6 +168,12 @@ def test_set_eeg_reference():
     reref.pick_types(eeg=False)  # Cause making average ref fail
     assert_raises(ValueError, set_eeg_reference, reref)
     assert_true(reref.info['custom_ref_applied'])
+
+    # Test moving from average to custom reference
+    reref, ref_data = set_eeg_reference(raw)
+    reref, _ = set_eeg_reference(reref, ['EEG 001', 'EEG 002'])
+    assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
+    assert_equal(reref.info['custom_ref_applied'], True)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
To make (re-)referencing of the EEG a bit more intuitive, this PR changes the following:

 - Moving from an average to a custom reference completely removes the average reference projection from the `info['projs']` list. A message is printed when this happens.
 - When setting an average reference on data that has been preloaded, the projection is automatically applied.
 - The referencing example has been updated to re-reference the same data, instead of making copies of the original un-referenced data. This emphasizes that it is possible to freely move from one referencing  scheme to another.

Fixes #3998 #3981 