### PR TITLE
MRG+1: Coreg-GUI: option to skip label

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -598,7 +598,7 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
 
     Returns
     -------
-    paths | dict
+    paths : dict
         Dictionary whose keys are relevant file type names (str), and whose
         values are lists of paths.
     """

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -986,7 +986,7 @@ def scale_labels(subject_to, pattern=None, overwrite=False, subject_from=None,
 
 
 def scale_mri(subject_from, subject_to, scale, overwrite=False,
-              subjects_dir=None, skip_fiducials=False):
+              subjects_dir=None, skip_fiducials=False, labels=True):
     """Create a scaled copy of an MRI subject.
 
     Parameters
@@ -1004,6 +1004,8 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
     skip_fiducials : bool
         Do not scale the MRI fiducials. If False (default), an IOError will be
         raised if no fiducials file can be found.
+    labels : bool
+        Also scale all labels (default True).
 
     See Also
     --------
@@ -1068,8 +1070,10 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
                            subjects_dir)
 
     # labels [in m]
-    scale_labels(subject_to, subject_from=subject_from, scale=scale,
-                 subjects_dir=subjects_dir)
+    os.mkdir(os.path.join(subjects_dir, subject_to, 'label'))
+    if labels:
+        scale_labels(subject_to, subject_from=subject_from, scale=scale,
+                     subjects_dir=subjects_dir)
 
 
 def scale_source_space(subject_to, src_name, subject_from=None, scale=None,

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1008,7 +1008,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
     labels : bool
         Also scale all labels (default True).
     annot : bool
-        Copy *.annot files to the new location (default False)
+        Copy *.annot files to the new location (default False).
 
     See Also
     --------

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -986,7 +986,8 @@ def scale_labels(subject_to, pattern=None, overwrite=False, subject_from=None,
 
 
 def scale_mri(subject_from, subject_to, scale, overwrite=False,
-              subjects_dir=None, skip_fiducials=False, labels=True):
+              subjects_dir=None, skip_fiducials=False, labels=True,
+              annot=False):
     """Create a scaled copy of an MRI subject.
 
     Parameters
@@ -1006,6 +1007,8 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
         raised if no fiducials file can be found.
     labels : bool
         Also scale all labels (default True).
+    annot : bool
+        Copy *.annot files to the new location (default False)
 
     See Also
     --------
@@ -1074,6 +1077,14 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
     if labels:
         scale_labels(subject_to, subject_from=subject_from, scale=scale,
                      subjects_dir=subjects_dir)
+
+    # copy *.annot files (they don't contain scale-dependent information)
+    if annot:
+        src_pattern = os.path.join(subjects_dir, subject_from, 'label',
+                                   '*.annot')
+        dst_dir = os.path.join(subjects_dir, subject_to, 'label')
+        for src_file in iglob(src_pattern):
+            shutil.copy(src_file, dst_dir)
 
 
 def scale_source_space(subject_to, src_name, subject_from=None, scale=None,

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -98,7 +98,6 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     <http://www.slideshare.net/mne-python/mnepython-scale-mri>`_.
     """
     config = get_config(home_dir=os.environ.get('_MNE_FAKE_HOME_DIR'))
-    prepare_bem = config.get('MNE_COREG_PREPARE_BEM', 'true') == 'true'
     if guess_mri_subject is None:
         guess_mri_subject = config.get(
             'MNE_COREG_GUESS_MRI_SUBJECT', 'true') == 'true'
@@ -124,7 +123,7 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     from ._coreg_gui import CoregFrame, _make_view
     view = _make_view(tabbed, split, scene_width, scene_height)
     frame = CoregFrame(inst, subject, subjects_dir, guess_mri_subject,
-                       head_opacity, head_high_res, prepare_bem, trans)
+                       head_opacity, head_high_res, trans, config)
     return _initialize_gui(frame, view)
 
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1264,7 +1264,7 @@ class ViewOptionsPanel(HasTraits):
 class CoregFrame(HasTraits):
     """GUI for head-MRI coregistration."""
 
-    model = Instance(CoregModel, ())
+    model = Instance(CoregModel)
 
     scene = Instance(MlabSceneModel, ())
     headview = Instance(HeadViewController)
@@ -1312,6 +1312,16 @@ class CoregFrame(HasTraits):
     queue = DelegatesTo('coreg_panel')
 
     view = _make_view()
+    
+    def _model_default(self):
+        return CoregModel(
+            scale_labels=self._config.get(
+                'MNE_COREG_SCALE_LABELS', 'true') == 'true',
+            copy_annot=self._config.get(
+                'MNE_COREG_COPY_ANNOT', 'true') == 'true',
+            prepare_bem_model=self._config.get(
+                'MNE_COREG_PREPARE_BEM', 'true') == 'true',
+        )
 
     def _subject_panel_default(self):
         return SubjectSelectorPanel(model=self.model.mri.subject_source)
@@ -1327,11 +1337,10 @@ class CoregFrame(HasTraits):
 
     def __init__(self, raw=None, subject=None, subjects_dir=None,
                  guess_mri_subject=True, head_opacity=1.,
-                 head_high_res=True, prepare_bem=True,
-                 trans=None):  # noqa: D102
+                 head_high_res=True, trans=None, config=None):  # noqa: D102
+        self._config = config or {}
         super(CoregFrame, self).__init__(guess_mri_subject=guess_mri_subject)
         self.subject_panel.model.use_high_res_head = head_high_res
-        self.model.prepare_bem_model = prepare_bem
         if not 0 <= head_opacity <= 1:
             raise ValueError(
                 "head_opacity needs to be a floating point number between 0 "
@@ -1521,6 +1530,12 @@ class CoregFrame(HasTraits):
                    home_dir, set_env=False)
         set_config('MNE_COREG_HEAD_OPACITY',
                    str(self.mri_obj.opacity),
+                   home_dir, set_env=False)
+        set_config('MNE_COREG_SCALE_LABELS',
+                   str(self.model.scale_labels).lower(),
+                   home_dir, set_env=False)
+        set_config('MNE_COREG_COPY_ANNOT',
+                   str(self.model.copy_annot).lower(),
                    home_dir, set_env=False)
         set_config('MNE_COREG_PREPARE_BEM',
                    str(self.model.prepare_bem_model).lower(),

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -816,8 +816,7 @@ class CoregPanel(HasPrivateTraits):
                                 enabled_when='can_prepare_bem_model'),
                            show_left=False,
                            label='Scaling options',
-                           show_border=True,
-                       ),
+                           show_border=True),
                        '_',
                        HGroup(Item('save', enabled_when='can_save',
                                    tooltip="Save the trans file and (if "
@@ -1320,8 +1319,7 @@ class CoregFrame(HasTraits):
             copy_annot=self._config.get(
                 'MNE_COREG_COPY_ANNOT', 'true') == 'true',
             prepare_bem_model=self._config.get(
-                'MNE_COREG_PREPARE_BEM', 'true') == 'true',
-        )
+                'MNE_COREG_PREPARE_BEM', 'true') == 'true')
 
     def _subject_panel_default(self):
         return SubjectSelectorPanel(model=self.model.mri.subject_source)

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -715,7 +715,8 @@ class CoregPanel(HasPrivateTraits):
                              Item('scale_z_inc',
                                   enabled_when='n_scale_params > 1',
                                   width=-50),
-                             show_labels=False, columns=4),
+                             show_labels=False, show_border=True,
+                             label='Scaling', columns=4),
                        HGroup(Item('fits_hsp_points',
                                    enabled_when='n_scale_params',
                                    tooltip="Rotate the digitizer head shape "

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1311,7 +1311,7 @@ class CoregFrame(HasTraits):
     queue = DelegatesTo('coreg_panel')
 
     view = _make_view()
-    
+
     def _model_default(self):
         return CoregModel(
             scale_labels=self._config.get(

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -71,7 +71,8 @@ from ._viewer import HeadViewController, PointObject, SurfaceObject
 
 defaults = DEFAULTS['coreg']
 
-laggy_float_editor = TextEditor(auto_set=False, enter_set=True, evaluate=float)
+laggy_float_editor = TextEditor(auto_set=False, enter_set=True, evaluate=float,
+                                format_func=lambda x: '%0.5f' % x)
 
 
 class CoregModel(HasPrivateTraits):

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -65,14 +65,14 @@ from ..coreg import (fit_matched_points, fit_point_cloud, scale_mri,
                      _find_fiducials_files, _point_cloud_error)
 from ..viz._3d import _toggle_mlab_render
 from ..utils import logger, set_config
-from ._fiducials_gui import MRIHeadWithFiducialsModel, FiducialsPanel
+from ._fiducials_gui import MRIHeadWithFiducialsModel, FiducialsPanel, _mm_fmt
 from ._file_traits import trans_wildcard, DigSource, SubjectSelectorPanel
 from ._viewer import HeadViewController, PointObject, SurfaceObject
 
 defaults = DEFAULTS['coreg']
 
 laggy_float_editor = TextEditor(auto_set=False, enter_set=True, evaluate=float,
-                                format_func=lambda x: '%0.5f' % x)
+                                format_func=_mm_fmt)
 
 
 class CoregModel(HasPrivateTraits):

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -31,6 +31,11 @@ from ._viewer import (HeadViewController, PointObject, SurfaceObject,
 defaults = DEFAULTS['coreg']
 
 
+def _mm_fmt(x):
+    """Format mm data."""
+    return '%0.5f' % x
+
+
 class MRIHeadWithFiducialsModel(HasPrivateTraits):
     """Represent an MRI head shape with fiducials.
 
@@ -226,8 +231,10 @@ class FiducialsPanel(HasPrivateTraits):
     # the layout of the dialog created
     view = View(VGroup(Item('fid_file', label='File'),
                        Item('fid_fname', show_label=False, style='readonly'),
-                       Item('set', style='custom', width=50),
-                       Item('current_pos', label='Pos', width=50),
+                       Item('set', style='custom', width=50,
+                            format_func=lambda x: x),
+                       Item('current_pos', label='Pos', width=50,
+                            format_func=_mm_fmt),
                        HGroup(Item('save', enabled_when='can_save',
                                    tooltip="If a filename is currently "
                                    "specified, save to that file, otherwise "

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -112,8 +112,12 @@ def test_coreg_model():
     assert_true(isinstance(model.points_eval_str, string_types))
 
     # scaling job
-    sdir, sfrom, sto, scale, skip_fiducials, bemsol = \
-        model.get_scaling_job('sample2', False, True)
+    assert_false(model.can_prepare_bem_model)
+    model.n_scale_params = 1
+    assert_true(model.can_prepare_bem_model)
+    model.prepare_bem_model = True
+    sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
+        model.get_scaling_job('sample2', False)
     assert_equal(sdir, subjects_dir)
     assert_equal(sfrom, 'sample')
     assert_equal(sto, 'sample2')
@@ -126,8 +130,9 @@ def test_coreg_model():
         if match:
             bems.add(match.group(1))
     assert_equal(set(bemsol), bems)
-    sdir, sfrom, sto, scale, skip_fiducials, bemsol = \
-        model.get_scaling_job('sample2', True, False)
+    model.prepare_bem_model = False
+    sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
+        model.get_scaling_job('sample2', True)
     assert_equal(bemsol, [])
     assert_true(skip_fiducials)
 
@@ -235,15 +240,16 @@ def test_coreg_model_with_fsaverage():
     assert_true(avg_point_distance_1param < avg_point_distance)
 
     # scaling job
-    sdir, sfrom, sto, scale, skip_fiducials, bemsol = \
-        model.get_scaling_job('scaled', False, True)
+    sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
+        model.get_scaling_job('scaled', False)
     assert_equal(sdir, tempdir)
     assert_equal(sfrom, 'fsaverage')
     assert_equal(sto, 'scaled')
     assert_equal(scale, model.scale)
     assert_equal(set(bemsol), set(('inner_skull-bem',)))
-    sdir, sfrom, sto, scale, skip_fiducials, bemsol = \
-        model.get_scaling_job('scaled', False, False)
+    model.prepare_bem_model = False
+    sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
+        model.get_scaling_job('scaled', False)
     assert_equal(bemsol, [])
 
     # scale with 3 parameters

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1468,10 +1468,12 @@ def set_memmap_min_size(memmap_min_size):
 known_config_types = (
     'MNE_BROWSE_RAW_SIZE',
     'MNE_CACHE_DIR',
+    'MNE_COREG_COPY_ANNOT',
     'MNE_COREG_GUESS_MRI_SUBJECT',
     'MNE_COREG_HEAD_HIGH_RES',
     'MNE_COREG_HEAD_OPACITY',
     'MNE_COREG_PREPARE_BEM',
+    'MNE_COREG_SCALE_LABELS',
     'MNE_COREG_SCENE_HEIGHT',
     'MNE_COREG_SCENE_WIDTH',
     'MNE_COREG_SUBJECTS_DIR',


### PR DESCRIPTION
This adds the option to skip labels and include *.annot files when scaling a brain. Also includes a small layout fix (marked on the screenshot). I wonder whether *.annot files could be linked rather than copied to be more efficient (but there are other files that we just copy during scaling so for now this is more consistent and might be safer)

CC @Eric89GXL 

<img width="1364" alt="screen shot 2017-02-20 at 11 25 05 am" src="https://cloud.githubusercontent.com/assets/145771/23133561/93268216-f75f-11e6-8bb3-2ea17530e400.png">