### PR TITLE
ENH: Deal with acquisition skips

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -14,12 +14,12 @@ class Annotations(object):
     """Annotation object for annotating segments of raw data.
 
     Annotations are added to instance of :class:`mne.io.Raw` as an attribute
-    named ``annotations``. See the example below. To reject bad epochs using
-    annotations, use annotation description starting with 'bad' keyword. The
-    epochs with overlapping bad segments are then rejected automatically by
-    default.
+    named ``annotations``. To reject bad epochs using annotations, use
+    annotation description starting with 'bad' keyword. The epochs with
+    overlapping bad segments are then rejected automatically by default.
 
     To remove epochs with blinks you can do::
+
         >>> eog_events = mne.preprocessing.find_eog_events(raw)  # doctest: +SKIP
         >>> n_blinks = len(eog_events)  # doctest: +SKIP
         >>> onset = eog_events[:, 0] / raw.info['sfreq'] - 0.25  # doctest: +SKIP
@@ -83,6 +83,10 @@ class Annotations(object):
         self.onset = onset
         self.duration = duration
         self.description = np.array(description, dtype=str)
+
+    def __len__(self):
+        """The number of annotations."""
+        return len(self.duration)
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -225,7 +225,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.30', misc='0.3')
+    releases = dict(testing='0.31', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -275,7 +275,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='1d5da3a809fded1ef5734444ab5bf857',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='f61041e3f3f2ba0def8a2ca71592cc41',
-        testing='a8209367a0795f8e6d31bbc913227fae',
+        testing='037711ea367c610bd673c11b9b2325ca',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         visual_92_categories='46c7e590f4a48596441ce001595d5e58',
     )

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -22,7 +22,8 @@ from ..base import (BaseRaw, _RawShell, _check_raw_compatibility,
                     _check_maxshield)
 from ..utils import _mult_cal_one
 
-from ...annotations import Annotations, _combine_annotations
+from ...annotations import Annotations, _combine_annotations, _onset_to_seconds
+
 from ...event import AcqParserFIF
 from ...utils import check_fname, logger, verbose, warn
 
@@ -132,10 +133,9 @@ class Raw(BaseRaw):
                         self.annotations = Annotations((), (), ())
                     start = skip['first'] - first_samp + offset
                     stop = skip['last'] - first_samp - 1 + offset
-                    self.annotations.append(start / self.info['sfreq'],
-                                            (stop - start) /
-                                            self.info['sfreq'],
-                                            'BAD_ACQ_SKIP')
+                    self.annotations.append(
+                        _onset_to_seconds(self, start / self.info['sfreq']),
+                        (stop - start) / self.info['sfreq'], 'BAD_ACQ_SKIP')
         if preload:
             self._preload_data(preload)
         else:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -35,6 +35,7 @@ testing_path = testing.data_path(download=False)
 data_dir = op.join(testing_path, 'MEG', 'sample')
 fif_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 ms_fname = op.join(testing_path, 'SSS', 'test_move_anon_raw.fif')
+skip_fname = op.join(testing_path, 'misc', 'intervalrecording_raw.fif')
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'tests', 'data')
 test_fif_fname = op.join(base_dir, 'test_raw.fif')
@@ -46,6 +47,14 @@ bad_file_works = op.join(base_dir, 'test_bads.txt')
 bad_file_wrong = op.join(base_dir, 'test_wrong_bads.txt')
 hp_fname = op.join(base_dir, 'test_chpi_raw_hp.txt')
 hp_fif_fname = op.join(base_dir, 'test_chpi_raw_sss.fif')
+
+
+@testing.requires_testing_data
+def test_acq_skip():
+    """Test treatment of acquisition skips."""
+    raw = read_raw_fif(skip_fname)
+    assert_equal(len(raw.times), 17000)
+    assert_equal(len(raw.annotations), 3)  # there are 3 skips
 
 
 def test_fix_types():


### PR DESCRIPTION
@bmaess pointed out that Neuromag allows starting and stopping recordings within a single file, e.g.:

![screenshot from 2017-02-20 15-17-07](https://cloud.githubusercontent.com/assets/2365790/23140455/b9555aaa-f77f-11e6-9551-8002c128b64a.png)

It's nice that we already have these skips in place. Ideally we could do things like `raw.filter(...)` and have it know to treat these separately, but for now let's leave that for a future enhancement.

@agramfort mentioned as a first-order fix we could add these sections to `raw.annotations`. I've implemented that, with `BAD` in the name. This way, if we make further enhancements like `raw.filter` or other functions being annotation-aware, we get these enhancements for free. In the meantime then @bmaess can begrudgingly iterate over the good sections as necessary to get sections filtered :)

It looks like this:

![screenshot from 2017-02-20 15-52-34](https://cloud.githubusercontent.com/assets/2365790/23141388/99e17424-f784-11e6-80c7-09766b38dc51.png)

Sound reasonable? If so @jaeilepp can you have a look? I'm probably not doing `Annotations` quite right/safely.