### PR TITLE
MRG+1: MAINT: Unify treatement of _data

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -124,8 +124,8 @@ def equalize_channels(candidates, verbose=None):
 
     if not all(isinstance(c, (BaseRaw, BaseEpochs, Evoked, AverageTFR))
                for c in candidates):
-        valid = ['Raw', 'Epochs', 'Evoked', 'AverageTFR']
-        raise ValueError('candidates must be ' + ' or '.join(valid))
+        raise ValueError('candidates must be Raw, Epochs, Evoked, or '
+                         'AverageTFR')
 
     chan_max_idx = np.argmax([c.info['nchan'] for c in candidates])
     chan_template = candidates[chan_max_idx].ch_names
@@ -674,38 +674,26 @@ class UpdateChannelsMixin(object):
 
     def _pick_drop_channels(self, idx):
         # avoid circular imports
-        from ..io.base import BaseRaw
-        from ..epochs import BaseEpochs
-        from ..evoked import Evoked
+        from ..io.base import _check_preload
         from ..time_frequency import AverageTFR
 
-        if isinstance(self, (BaseRaw, BaseEpochs)):
-            if not self.preload:
-                raise RuntimeError('If Raw or Epochs, data must be preloaded '
-                                   'to drop or pick channels')
+        _check_preload(self, 'adding or dropping channels')
 
-        def inst_has(attr):
-            return getattr(self, attr, None) is not None
-
-        if inst_has('picks'):
+        if getattr(self, 'picks', None) is not None:
             self.picks = self.picks[idx]
 
-        if inst_has('_cals'):
+        if hasattr(self, '_cals'):
             self._cals = self._cals[idx]
 
         pick_info(self.info, idx, copy=False)
 
-        if inst_has('_projector'):
+        if getattr(self, '_projector', None) is not None:
             self._projector = self._projector[idx][:, idx]
 
-        if isinstance(self, BaseRaw) and inst_has('_data'):
-            self._data = self._data.take(idx, axis=0)
-        elif isinstance(self, BaseEpochs) and inst_has('_data'):
-            self._data = self._data.take(idx, axis=1)
-        elif isinstance(self, AverageTFR) and inst_has('data'):
-            self.data = self.data.take(idx, axis=0)
-        elif isinstance(self, Evoked):
-            self.data = self.data.take(idx, axis=0)
+        if self.preload:
+            # All others (Evoked, Epochs, Raw) have chs axis=-2
+            axis = -3 if isinstance(self, AverageTFR) else -2
+            self._data = self._data.take(idx, axis=axis)
 
     def add_channels(self, add_list, force_update_info=False):
         """Append new channels to the instance.
@@ -735,23 +723,20 @@ class UpdateChannelsMixin(object):
             raise AssertionError('Input must be a list or tuple of objs')
 
         # Object-specific checks
-        if isinstance(self, (BaseRaw, BaseEpochs)):
-            if not all([inst.preload for inst in add_list] + [self.preload]):
-                raise AssertionError('All data must be preloaded')
-            data_name = '_data'
-            if isinstance(self, BaseRaw):
-                con_axis = 0
-                comp_class = BaseRaw
-            elif isinstance(self, BaseEpochs):
-                con_axis = 1
-                comp_class = BaseEpochs
+        if not all([inst.preload for inst in add_list] + [self.preload]):
+            raise AssertionError('All data must be preloaded')
+        if isinstance(self, BaseRaw):
+            con_axis = 0
+            comp_class = BaseRaw
+        elif isinstance(self, BaseEpochs):
+            con_axis = 1
+            comp_class = BaseEpochs
         else:
-            data_name = 'data'
             con_axis = 0
             comp_class = type(self)
         if not all(isinstance(inst, comp_class) for inst in add_list):
             raise AssertionError('All input data must be of same type')
-        data = [getattr(inst, data_name) for inst in [self] + add_list]
+        data = [inst._data for inst in [self] + add_list]
 
         # Make sure that all dimensions other than channel axis are the same
         compare_axes = [i for i in range(data[0].ndim) if i != con_axis]
@@ -765,7 +750,7 @@ class UpdateChannelsMixin(object):
         new_info = _merge_info(infos, force_update_to_first=force_update_info)
 
         # Now update the attributes
-        setattr(self, data_name, data)
+        self._data = data
         self.info = new_info
         if isinstance(self, BaseRaw):
             self._cals = np.concatenate([getattr(inst, '_cals')

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -94,13 +94,11 @@ def _do_interp_dots(inst, interpolation, goods_idx, bads_idx):
     from ..epochs import BaseEpochs
     from ..evoked import Evoked
 
-    if isinstance(inst, BaseRaw):
+    if isinstance(inst, (BaseRaw, Evoked)):
         inst._data[bads_idx] = interpolation.dot(inst._data[goods_idx])
     elif isinstance(inst, BaseEpochs):
         inst._data[:, bads_idx, :] = np.einsum('ij,xjy->xiy', interpolation,
                                                inst._data[:, goods_idx, :])
-    elif isinstance(inst, Evoked):
-        inst.data[bads_idx] = interpolation.dot(inst.data[goods_idx])
     else:
         raise ValueError('Inputs of type {0} are not supported'
                          .format(type(inst)))

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -110,9 +110,18 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 fname, condition, kind, allow_maxshield)
         self.kind = _aspect_rev.get(str(self._aspect_kind), 'Unknown')
         self.verbose = verbose
+        self.preload = True
         # project and baseline correct
         if proj:
             self.apply_proj()
+
+    @property
+    def _data(self):
+        return self.data
+
+    @_data.setter
+    def _data(self, data):
+        self.data = data
 
     @verbose
     def apply_baseline(self, baseline=(None, 0), verbose=None):
@@ -721,6 +730,7 @@ class EvokedArray(Evoked):
         self.comment = comment
         self.picks = None
         self.verbose = verbose
+        self.preload = True
         self._projector = None
         if not isinstance(self.kind, string_types):
             raise TypeError('kind must be a string, not "%s"' % (type(kind),))

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -117,10 +117,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @property
     def data(self):
+        """The data matrix."""
         return self._data
 
     @data.setter
     def data(self, data):
+        """Set the data matrix."""
         self._data = data
 
     @verbose

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -116,12 +116,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self.apply_proj()
 
     @property
-    def _data(self):
-        return self.data
+    def data(self):
+        return self._data
 
-    @_data.setter
-    def _data(self, data):
-        self.data = data
+    @data.setter
+    def data(self, data):
+        self._data = data
 
     @verbose
     def apply_baseline(self, baseline=(None, 0), verbose=None):

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2255,17 +2255,10 @@ class FilterMixin(object):
                Differentiation of Data by Simplified Least Squares
                Procedures". Analytical Chemistry 36 (8): 1627-39.
         """  # noqa: E501
-        from .evoked import Evoked
-        from .epochs import BaseEpochs
         inst = self.copy() if copy else self
-        if isinstance(inst, Evoked):
-            data = inst.data
-            axis = 1
-        elif isinstance(inst, BaseEpochs):
-            if not inst.preload:
-                raise RuntimeError('data must be preloaded to filter')
-            data = inst._data
-            axis = 2
+        if not inst.preload:
+            raise RuntimeError('data must be preloaded to filter')
+        data = inst._data
 
         h_freq = float(h_freq)
         if h_freq >= inst.info['sfreq'] / 2.:
@@ -2277,7 +2270,7 @@ class FilterMixin(object):
         from scipy.signal import savgol_filter
         window_length = (int(np.round(inst.info['sfreq'] /
                                       h_freq)) // 2) * 2 + 1
-        data[...] = savgol_filter(data, axis=axis, polyorder=5,
+        data[...] = savgol_filter(data, axis=-1, polyorder=5,
                                   window_length=window_length)
         return inst
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -139,6 +139,7 @@ class ProjMixin(object):
             The instance.
         """
         from ..epochs import BaseEpochs
+        from ..evoked import Evoked
         from .base import BaseRaw
         if self.info['projs'] is None or len(self.info['projs']) == 0:
             logger.info('No projector specified for this dataset. '
@@ -163,17 +164,15 @@ class ProjMixin(object):
                         ' Doing nothing.')
             return self
         self._projector, self.info = _projector, info
-        if isinstance(self, BaseRaw):
+        if isinstance(self, (BaseRaw, Evoked)):
             if self.preload:
                 self._data = np.dot(self._projector, self._data)
-        elif isinstance(self, BaseEpochs):
+        else:  # BaseEpochs
             if self.preload:
                 for ii, e in enumerate(self._data):
                     self._data[ii] = self._project_epoch(e)
             else:
                 self.load_data()  # will automatically apply
-        else:  # Evoked
-            self.data = np.dot(self._projector, self.data)
         logger.info('SSP projectors applied...')
         return self
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -11,7 +11,7 @@ import numpy as np
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_array_equal, assert_allclose
 
-from mne import (pick_channels, pick_types, Evoked, Epochs, read_events,
+from mne import (pick_channels, pick_types, Epochs, read_events,
                  set_eeg_reference, set_bipolar_reference,
                  add_reference_channels)
 from mne.epochs import BaseEpochs
@@ -41,12 +41,8 @@ def _test_reference(raw, reref, ref_data, ref_from):
     picks_ref = [raw.ch_names.index(ch) for ch in ref_from]
 
     # Get data
-    if isinstance(raw, Evoked):
-        _data = raw.data
-        _reref = reref.data
-    else:
-        _data = raw._data
-        _reref = reref._data
+    _data = raw._data
+    _reref = reref._data
 
     # Check that the ref has been properly computed
     if ref_data is not None:

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -9,6 +9,7 @@ from ..io import BaseRaw
 from ..event import find_events
 
 from ..io.pick import _pick_data_channels
+from ..io.base import _check_preload
 
 
 def _get_window(start, end):
@@ -18,14 +19,6 @@ def _get_window(start, end):
                        np.ones(np.abs(end - start) - 4),
                        hann(4)[-2:]].T
     return window
-
-
-def _check_preload(inst):
-    """Check if inst.preload is False. If it is False, raising error."""
-    if inst.preload is False:
-        raise RuntimeError('Modifying data of Instance is only supported '
-                           'when preloading is used. Use preload=True '
-                           '(or string) in the constructor.')
 
 
 def _fix_artifact(data, window, picks, first_samp, last_samp, mode):
@@ -86,8 +79,8 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
         window = _get_window(s_start, s_end)
     picks = _pick_data_channels(inst.info)
 
+    _check_preload(inst, 'fix_stim_artifact')
     if isinstance(inst, BaseRaw):
-        _check_preload(inst)
         if events is None:
             events = find_events(inst, stim_channel=stim_channel)
         if len(events) == 0:
@@ -104,7 +97,6 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
             _fix_artifact(data, window, picks, first_samp, last_samp, mode)
 
     elif isinstance(inst, BaseEpochs):
-        _check_preload(inst)
         if inst.reject is not None:
             raise RuntimeError('Reject is already applied. Use reject=None '
                                'in the constructor.')

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -90,12 +90,9 @@ def linear_regression(inst, design_matrix, names=None):
         parameters = [p[name] for p in lm_params]
         for ii, value in enumerate(parameters):
             out_ = out.copy()
-            if isinstance(out_, SourceEstimate):
-                out_._data[:] = value
-            elif isinstance(out_, Evoked):
-                out_.data[:] = value
-            else:
+            if not isinstance(out_, (SourceEstimate, Evoked)):
                 raise RuntimeError('Invalid container.')
+            out_._data[:] = value
             parameters[ii] = out_
         lm_fits[name] = lm(*parameters)
     logger.info('Done')

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -46,7 +46,7 @@ def _check_psd_data(inst, tmin, tmax, picks, proj):
         data, times = inst[picks, start:(stop + 1)]
     elif isinstance(inst, BaseEpochs):
         data = inst.get_data()[:, picks][:, :, time_mask]
-    elif isinstance(inst, Evoked):
+    else:  # Evoked
         data = inst.data[picks][:, time_mask]
 
     return data, sfreq

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -762,12 +762,12 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
     """Base TFR class."""
 
     @property
-    def _data(self):
-        return self.data
+    def data(self):
+        return self._data
 
-    @_data.setter
-    def _data(self, data):
-        self.data = data
+    @data.setter
+    def data(self, data):
+        self._data = data
 
     @property
     def ch_names(self):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -762,6 +762,14 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
     """Base TFR class."""
 
     @property
+    def _data(self):
+        return self.data
+
+    @_data.setter
+    def _data(self, data):
+        self.data = data
+
+    @property
     def ch_names(self):
         """Channel names."""
         return self.info['ch_names']
@@ -882,6 +890,7 @@ class AverageTFR(_BaseTFR):
         self.nave = nave
         self.comment = comment
         self.method = method
+        self.preload = True
 
     @verbose
     def plot(self, picks, baseline=None, mode='mean', tmin=None, tmax=None,
@@ -1411,6 +1420,7 @@ class EpochsTFR(_BaseTFR):
         self.freqs = np.array(freqs, dtype=float)
         self.comment = comment
         self.method = method
+        self.preload = True
 
     def __repr__(self):  # noqa: D105
         s = "time : [%f, %f]" % (self.times[0], self.times[-1])
@@ -1510,7 +1520,7 @@ def _get_data(inst, return_itc):
     else:
         if return_itc:
             raise ValueError('return_itc must be False for evoked data')
-        data = inst.data[np.newaxis, ...].copy()
+        data = inst.data[np.newaxis].copy()
     return data
 
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -524,12 +524,10 @@ def _get_inst_data(inst):
     from . import Evoked
     from .time_frequency.tfr import _BaseTFR
 
-    if isinstance(inst, (BaseRaw, BaseEpochs)):
+    if isinstance(inst, (BaseRaw, BaseEpochs, Evoked, _BaseTFR)):
         if not inst.preload:
             inst.load_data()
         return inst._data
-    elif isinstance(inst, (Evoked, _BaseTFR)):
-        return inst.data
     else:
         raise TypeError('The argument must be an instance of Raw, Epochs, '
                         'Evoked, EpochsTFR or AverageTFR, got {0}.'.format(


### PR DESCRIPTION
Some simplifications from adding `evoked.preload = True` and wrapping `evoked._data` to `evoked.data`, same for `AverageTFR` and `EpochsTFR`.

There are probably other examples in the code, but this at least gets the ball rolling.