### PR TITLE
MRG: Unify some norms and math

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -25,7 +25,8 @@ from .io.tag import find_tag
 from .io.tree import dir_tree_find
 from .io.open import fiff_open
 from .surface import (read_surface, write_surface, complete_surface_info,
-                      _compute_nearest, _get_ico_surface, read_tri)
+                      _compute_nearest, _get_ico_surface, read_tri,
+                      _fast_cross_nd_sum, _get_solids)
 from .utils import verbose, logger, run_subprocess, get_subjects_dir, warn, _pl
 from .externals.six import string_types
 
@@ -80,7 +81,6 @@ def _calc_beta(rk, rk_norm, rk1, rk1_norm):
 
 def _lin_pot_coeff(fros, tri_rr, tri_nn, tri_area):
     """Compute the linear potential matrix element computations."""
-    from .source_space import _fast_cross_nd_sum
     omega = np.zeros((len(fros), 3))
 
     # we replicate a little bit of the _get_solids code here for speed
@@ -392,7 +392,6 @@ def _order_surfaces(surfs):
 def _assert_complete_surface(surf):
     """Check the sum of solid angles as seen from inside."""
     # from surface_checks.c
-    from .source_space import _get_solids
     tot_angle = 0.
     # Center of mass....
     cm = surf['rr'].mean(axis=0)
@@ -417,7 +416,6 @@ _surf_name = {
 def _assert_inside(fro, to):
     """Helper to check one set of points is inside a surface."""
     # this is "is_inside" in surface_checks.c
-    from .source_space import _get_solids
     tot_angle = _get_solids(to['rr'][to['tris']], fro['rr'])
     if (np.abs(tot_angle / (2 * np.pi) - 1.0) > 1e-5).any():
         raise RuntimeError('Surface %s is not completely inside surface %s'

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -70,7 +70,7 @@ class ConductorModel(dict):
 def _calc_beta(rk, rk_norm, rk1, rk1_norm):
     """These coefficients are used to calculate the magic vector omega."""
     rkk1 = rk1[0] - rk[0]
-    size = np.sqrt(np.dot(rkk1, rkk1))
+    size = np.linalg.norm(rkk1)
     rkk1 /= size
     num = rk_norm + np.dot(rk, rkk1)
     den = rk1_norm + np.dot(rk1, rkk1)
@@ -84,17 +84,18 @@ def _lin_pot_coeff(fros, tri_rr, tri_nn, tri_area):
     omega = np.zeros((len(fros), 3))
 
     # we replicate a little bit of the _get_solids code here for speed
+    # (we need some of the intermediate values later)
     v1 = tri_rr[np.newaxis, 0, :] - fros
     v2 = tri_rr[np.newaxis, 1, :] - fros
     v3 = tri_rr[np.newaxis, 2, :] - fros
     triples = _fast_cross_nd_sum(v1, v2, v3)
-    l1 = np.sqrt(np.sum(v1 * v1, axis=1))
-    l2 = np.sqrt(np.sum(v2 * v2, axis=1))
-    l3 = np.sqrt(np.sum(v3 * v3, axis=1))
-    ss = (l1 * l2 * l3 +
-          np.sum(v1 * v2, axis=1) * l3 +
-          np.sum(v1 * v3, axis=1) * l2 +
-          np.sum(v2 * v3, axis=1) * l1)
+    l1 = np.linalg.norm(v1, axis=1)
+    l2 = np.linalg.norm(v2, axis=1)
+    l3 = np.linalg.norm(v3, axis=1)
+    ss = l1 * l2 * l3
+    ss += np.einsum('ij,ij,i->i', v1, v2, l3)
+    ss += np.einsum('ij,ij,i->i', v1, v3, l2)
+    ss += np.einsum('ij,ij,i->i', v2, v3, l1)
     solids = np.arctan2(triples, ss)
 
     # We *could* subselect the good points from v1, v2, v3, triples, solids,
@@ -956,7 +957,7 @@ def _fit_sphere_to_headshape(info, dig_kinds, verbose=None):
         warn('Estimated head size (%0.1f mm) exceeded 99th '
              'percentile for adult head size' % (1e3 * radius,))
     # > 2 cm away from head center in X or Y is strange
-    if np.sqrt(np.sum(origin_head[:2] ** 2)) > 0.02:
+    if np.linalg.norm(origin_head[:2]) > 0.02:
         warn('(X, Y) fit (%0.1f, %0.1f) more than 20 mm from '
              'head frame origin' % tuple(1e3 * origin_head[:2]))
     logger.info('Origin head coordinates:'.ljust(30) +
@@ -980,9 +981,9 @@ def _fit_sphere(points, disp='auto'):
     x0 = np.concatenate([center_init, [radius_init]])
 
     def cost_fun(center_rad):
-        d = points - center_rad[:3]
-        d = (np.sqrt(np.sum(d * d, axis=1)) - center_rad[3])
-        return np.sum(d * d)
+        d = np.linalg.norm(points - center_rad[:3], axis=1) - center_rad[3]
+        d *= d
+        return d.sum()
 
     def constraint(center_rad):
         return center_rad[3]  # radius must be >= 0

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -22,7 +22,7 @@ from .io import read_fiducials, write_fiducials
 from .label import read_label, Label
 from .source_space import (add_source_space_distances, read_source_spaces,
                            write_source_spaces)
-from .surface import read_surface, write_surface
+from .surface import read_surface, write_surface, _normalize_vectors
 from .bem import read_bem_surfaces, write_bem_surfaces
 from .transforms import rotation, rotation3d, scaling, translation
 from .utils import get_config, get_subjects_dir, logger, pformat
@@ -921,7 +921,7 @@ def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
         surf['rr'] *= scale
         if nn_scale is not None:
             surf['nn'] *= nn_scale
-            surf['nn'] /= np.sqrt(np.sum(surf['nn'] ** 2, 1))[:, np.newaxis]
+            _normalize_vectors(surf['nn'])
     write_bem_surfaces(dst, surfs)
 
 
@@ -1153,7 +1153,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
                 ss['dist_limit'] *= scale
         else:  # non-uniform scaling
             ss['nn'] *= nn_scale
-            ss['nn'] /= np.sqrt(np.sum(ss['nn'] ** 2, 1))[:, np.newaxis]
+            _normalize_vectors(ss['nn'])
             if ss['dist'] is not None:
                 add_dist = True
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -24,10 +24,9 @@ from .io.write import (start_block, end_block, write_int,
 from .bem import read_bem_surfaces
 from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _tessellate_sphere_surf, _get_surf_neighbors,
-                      _normalize_vectors,
-                      complete_surface_info, _compute_nearest,
-                      fast_cross_3d, _fast_cross_nd_sum, mesh_dist,
-                      _triangle_neighbors)
+                      _normalize_vectors, _get_solids, _triangle_neighbors,
+                      complete_surface_info, _compute_nearest, fast_cross_3d,
+                      mesh_dist)
 from .utils import (get_subjects_dir, run_subprocess, has_freesurfer,
                     has_nibabel, check_fname, logger, verbose,
                     check_version, _get_call_line, warn, _check_fname)
@@ -819,9 +818,7 @@ def _complete_source_space_info(this, verbose=None):
     r3 = this['rr'][this['tris'][:, 2], :]
     this['tri_cent'] = (r1 + r2 + r3) / 3.0
     this['tri_nn'] = fast_cross_3d((r2 - r1), (r3 - r1))
-    size = np.sqrt(np.sum(this['tri_nn'] ** 2, axis=1))
-    this['tri_area'] = size / 2.0
-    this['tri_nn'] /= size[:, None]
+    this['tri_area'] = _normalize_vectors(this['tri_nn']) / 2.0
     logger.info('[done]')
 
     #   Selected triangles
@@ -832,8 +829,7 @@ def _complete_source_space_info(this, verbose=None):
         r3 = this['rr'][this['use_tris'][:, 2], :]
         this['use_tri_cent'] = (r1 + r2 + r3) / 3.0
         this['use_tri_nn'] = fast_cross_3d((r2 - r1), (r3 - r1))
-        this['use_tri_area'] = np.sqrt(np.sum(this['use_tri_nn'] ** 2, axis=1)
-                                       ) / 2.0
+        this['use_tri_area'] = np.linalg.norm(this['use_tri_nn'], axis=1) / 2.
     logger.info('[done]')
 
 
@@ -1722,7 +1718,7 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
     cm = np.mean(surf['rr'], axis=0)  # center of mass
 
     # Define the sphere which fits the surface
-    maxdist = np.sqrt(np.max(np.sum((surf['rr'] - cm) ** 2, axis=1)))
+    maxdist = np.linalg.norm(surf['rr'] - cm, axis=1).max()
 
     logger.info('Surface CM = (%6.1f %6.1f %6.1f) mm'
                 % (1000 * cm[0], 1000 * cm[1], 1000 * cm[2]))
@@ -1761,7 +1757,7 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
     logger.info('%d sources before omitting any.', sp['nuse'])
 
     # Exclude infeasible points
-    dists = np.sqrt(np.sum((sp['rr'] - cm) ** 2, axis=1))
+    dists = np.linalg.norm(sp['rr'] - cm, axis=1)
     bads = np.where(np.logical_or(dists < exclude, dists > maxdist))[0]
     sp['inuse'][bads] = False
     sp['nuse'] -= len(bads)
@@ -1882,7 +1878,7 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
         # Filter out points too far from volume region voxels
         dists = _compute_nearest(rr_voi, sp['rr'], return_dists=True)[1]
         # Maximum distance from center of mass of a voxel to any of its corners
-        maxdist = np.sqrt(((trans[:3, :3].sum(0) / 2.) ** 2).sum())
+        maxdist = np.linalg.norm(trans[:3, :3].sum(0) / 2.)
         bads = np.where(dists > maxdist)[0]
 
         # Update source info
@@ -2192,43 +2188,6 @@ def _points_outside_surface(rr, surf, n_jobs=1, verbose=None):
     tot_angles = parallel(p_fun(surf['rr'][tris], rr)
                           for tris in np.array_split(surf['tris'], n_jobs))
     return np.abs(np.sum(tot_angles, axis=0) / (2 * np.pi) - 1.0) > 1e-5
-
-
-def _get_solids(tri_rrs, fros):
-    """Compute _sum_solids_div total angle in chunks."""
-    # NOTE: This incorporates the division by 4PI that used to be separate
-    # for tri_rr in tri_rrs:
-    #     v1 = fros - tri_rr[0]
-    #     v2 = fros - tri_rr[1]
-    #     v3 = fros - tri_rr[2]
-    #     triple = np.sum(fast_cross_3d(v1, v2) * v3, axis=1)
-    #     l1 = np.sqrt(np.sum(v1 * v1, axis=1))
-    #     l2 = np.sqrt(np.sum(v2 * v2, axis=1))
-    #     l3 = np.sqrt(np.sum(v3 * v3, axis=1))
-    #     s = (l1 * l2 * l3 +
-    #          np.sum(v1 * v2, axis=1) * l3 +
-    #          np.sum(v1 * v3, axis=1) * l2 +
-    #          np.sum(v2 * v3, axis=1) * l1)
-    #     tot_angle -= np.arctan2(triple, s)
-
-    # This is the vectorized version, but with a slicing heuristic to
-    # prevent memory explosion
-    tot_angle = np.zeros((len(fros)))
-    slices = np.r_[np.arange(0, len(fros), 100), [len(fros)]]
-    for i1, i2 in zip(slices[:-1], slices[1:]):
-        v1 = fros[i1:i2] - tri_rrs[:, 0, :][:, np.newaxis]
-        v2 = fros[i1:i2] - tri_rrs[:, 1, :][:, np.newaxis]
-        v3 = fros[i1:i2] - tri_rrs[:, 2, :][:, np.newaxis]
-        triples = _fast_cross_nd_sum(v1, v2, v3)
-        l1 = np.sqrt(np.sum(v1 * v1, axis=2))
-        l2 = np.sqrt(np.sum(v2 * v2, axis=2))
-        l3 = np.sqrt(np.sum(v3 * v3, axis=2))
-        ss = (l1 * l2 * l3 +
-              np.sum(v1 * v2, axis=2) * l3 +
-              np.sum(v1 * v3, axis=2) * l2 +
-              np.sum(v2 * v3, axis=2) * l1)
-        tot_angle[i1:i2] = -np.sum(np.arctan2(triples, ss), axis=0)
-    return tot_angle
 
 
 @verbose


### PR DESCRIPTION
The original purpose was to fix a `surf['nn']` normalization in `mne/coreg.py`, but then I added some unification of norm calculations. Some of the `linalg.norm` calls (which is the same speed as `np.sqrt(np.sum(...))` for large-ish arrays) should save memory allocations, as should the `np.einsum` calls.