### PR TITLE
[MRG] FIX kit2fiff-gui wildcards on Windows

### DIFF
--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -46,6 +46,11 @@ if backend_is_wx:
     hsp_wildcard = ['Head Shape Points (*.hsp;*.txt)|*.hsp;*.txt']
     elp_wildcard = ['Head Shape Fiducials (*.elp;*.txt)|*.elp;*.txt']
     kit_con_wildcard = ['Continuous KIT Files (*.sqd;*.con)|*.sqd;*.con']
+elif os.name == 'nt':
+    # on Windows, multiple wildcards does not seem to work
+    hsp_wildcard = ['*.hsp', '*.txt']
+    elp_wildcard = ['*.elp', '*.txt']
+    kit_con_wildcard = ['*.sqd', '*.con']
 else:
     hsp_wildcard = ['*.hsp;*.txt']
     elp_wildcard = ['*.elp;*.txt']

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -34,7 +34,11 @@ if backend_is_wx:
                     'Pickled markers (*.pickled)|*.pickled']
     mrk_out_wildcard = ["Tab separated values file (*.txt)|*.txt"]
 else:
-    mrk_wildcard = ["*.sqd;*.mrk;*.txt;*.pickled"]
+    if os.name == 'nt':
+        # on Windows, multiple wildcards does not seem to work
+        mrk_wildcard = ["*.sqd", "*.mrk", "*.txt", "*.pickled"]
+    else:
+        mrk_wildcard = ["*.sqd;*.mrk;*.txt;*.pickled"]
     mrk_out_wildcard = "*.txt"
 out_ext = '.txt'
 


### PR DESCRIPTION
When multiple wildcards are separated by `;` on Windows no files show at all. Making them separate lists items is not ideal but I don't know how multiple wildcards can be combined in one filter...