### PR TITLE
MRG: Fixes for docstyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ codespell-error:  # running on travis
 
 pydocstyle:
 	@pydocstyle
+	@pydocstyle --convention=numpy
 
 manpages:
 	@echo "I: generating manpages"

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ codespell-error:  # running on travis
 
 pydocstyle:
 	@pydocstyle
-	@pydocstyle --convention=numpy
 
 manpages:
 	@echo "I: generating manpages"

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1709,7 +1709,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
     """Create 3-Layer BEM model from prepared flash MRI images.
 
     Parameters
-    -----------
+    ----------
     subject : str
         Subject name.
     overwrite : bool

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -57,7 +57,7 @@ def _contains_ch_type(info, ch_type):
     """Check whether a certain channel type is in an info object.
 
     Parameters
-    ---------
+    ----------
     info : instance of Info
         The measurement information.
     ch_type : str

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -56,7 +56,7 @@ class _EpochMeanConEstBase(_AbstractConEstBase):
         self.con_scores = None
 
     def start_epoch(self):  # noqa: D401
-        """This method is called at the start of each epoch."""
+        """Called at the start of each epoch."""
         pass  # for this type of con. method we don't do anything
 
     def combine(self, other):

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -600,32 +600,8 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
             WPLI = ------------------
                       E[|Im(Sxy)|]
 
-        'wpli2_debiased' : Debiased estimator of squared WPLI [5].
+        'wpli2_debiased' : Debiased estimator of squared WPLI [5]_.
 
-
-    References
-    ----------
-
-    .. [1] Nolte et al. "Identifying true brain interaction from EEG data using
-           the imaginary part of coherency" Clinical neurophysiology, vol. 115,
-           no. 10, pp. 2292-2307, Oct. 2004.
-
-    .. [2] Lachaux et al. "Measuring phase synchrony in brain signals" Human
-           brain mapping, vol. 8, no. 4, pp. 194-208, Jan. 1999.
-
-    .. [3] Vinck et al. "The pairwise phase consistency: a bias-free measure of
-           rhythmic neuronal synchronization" NeuroImage, vol. 51, no. 1,
-           pp. 112-122, May 2010.
-
-    .. [4] Stam et al. "Phase lag index: assessment of functional connectivity
-           from multi channel EEG and MEG with diminished bias from common
-           sources" Human brain mapping, vol. 28, no. 11, pp. 1178-1193,
-           Nov. 2007.
-
-    .. [5] Vinck et al. "An improved index of phase-synchronization for
-           electro-physiological data in the presence of volume-conduction,
-           noise and sample-size bias" NeuroImage, vol. 55, no. 4,
-           pp. 1548-1565, Apr. 2011.
 
     Parameters
     ----------
@@ -714,6 +690,29 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
     n_tapers : int
         The number of DPSS tapers used. Only defined in 'multitaper' mode.
         Otherwise None is returned.
+
+    References
+    ----------
+    .. [1] Nolte et al. "Identifying true brain interaction from EEG data using
+           the imaginary part of coherency" Clinical neurophysiology, vol. 115,
+           no. 10, pp. 2292-2307, Oct. 2004.
+
+    .. [2] Lachaux et al. "Measuring phase synchrony in brain signals" Human
+           brain mapping, vol. 8, no. 4, pp. 194-208, Jan. 1999.
+
+    .. [3] Vinck et al. "The pairwise phase consistency: a bias-free measure of
+           rhythmic neuronal synchronization" NeuroImage, vol. 51, no. 1,
+           pp. 112-122, May 2010.
+
+    .. [4] Stam et al. "Phase lag index: assessment of functional connectivity
+           from multi channel EEG and MEG with diminished bias from common
+           sources" Human brain mapping, vol. 28, no. 11, pp. 1178-1193,
+           Nov. 2007.
+
+    .. [5] Vinck et al. "An improved index of phase-synchronization for
+           electro-physiological data in the presence of volume-conduction,
+           noise and sample-size bias" NeuroImage, vol. 55, no. 4,
+           pp. 1548-1565, Apr. 2011.
     """
     if n_jobs != 1:
         parallel, my_epoch_spectral_connectivity, _ = \

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -598,7 +598,7 @@ def _find_label_paths(subject='fsaverage', pattern=None, subjects_dir=None):
         (sys.environ['SUBJECTS_DIR'])
 
     Returns
-    ------
+    -------
     paths : list
         List of paths relative to the subject's label directory
     """

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -159,6 +159,7 @@ def _inv_block_diag(A, n):
         The matrix.
     n : int
         The block size.
+
     Returns
     -------
     bd : sparse matrix

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1185,7 +1185,7 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400):
     scene_width : int
         Specify a minimum width for the 3d scene (in pixels).
 
-    returns
+    Returns
     -------
     view : traits View
         View object for the CoregFrame.

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -376,23 +376,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     """Time-Frequency Mixed-norm estimate (TF-MxNE).
 
     Compute L1/L2 + L1 mixed-norm solution on time-frequency
-    dictionary. Works with evoked data.
-
-    References:
-
-    A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
-    Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
-    non-stationary source activations
-    Neuroimage, Volume 70, 15 April 2013, Pages 410-422, ISSN 1053-8119,
-    DOI: 10.1016/j.neuroimage.2012.12.051.
-
-    A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
-    Functional Brain Imaging with M/EEG Using Structured Sparsity in
-    Time-Frequency Dictionaries
-    Proceedings Information Processing in Medical Imaging
-    Lecture Notes in Computer Science, 2011, Volume 6801/2011,
-    600-611, DOI: 10.1007/978-3-642-22092-0_49
-    http://dx.doi.org/10.1007/978-3-642-22092-0_49
+    dictionary. Works with evoked data [1]_ [2]_.
 
     Parameters
     ----------
@@ -457,6 +441,22 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     See Also
     --------
     mixed_norm
+
+    References
+    ----------
+    .. [1] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
+       Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
+       non-stationary source activations
+       Neuroimage, Volume 70, 15 April 2013, Pages 410-422, ISSN 1053-8119,
+       DOI: 10.1016/j.neuroimage.2012.12.051.
+
+    .. [2] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
+       Functional Brain Imaging with M/EEG Using Structured Sparsity in
+       Time-Frequency Dictionaries
+       Proceedings Information Processing in Medical Imaging
+       Lecture Notes in Computer Science, 2011, Volume 6801/2011,
+       600-611, DOI: 10.1007/978-3-642-22092-0_49
+       http://dx.doi.org/10.1007/978-3-642-22092-0_49
     """
     _check_reference(evoked)
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -933,8 +933,8 @@ class ICA(ContainsMixin):
                       method='ctps', verbose=None):
         """Detect ECG related components using correlation.
 
-        Note. If no ECG channel is available, routine attempts to create
-        an artificial ECG based on cross-channel averaging.
+        .. note:: If no ECG channel is available, routine attempts to create
+                  an artificial ECG based on cross-channel averaging.
 
         Parameters
         ----------
@@ -980,7 +980,7 @@ class ICA(ContainsMixin):
         scores : np.ndarray of float, shape (``n_components_``)
             The correlation scores.
 
-        See also
+        See Also
         --------
         find_bads_eog
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1747,17 +1747,15 @@ def _compute_sphere_activation_in(degrees):
     Returns
     -------
     a_power : ndarray
-        The a_lm associated for the associated degrees.
+        The a_lm associated for the associated degrees (see [1]_).
     rho_i : float
         The current density.
 
-    Notes
-    -----
-    See also:
-
-        A 122-channel whole-cortex SQUID system for measuring the brain’s
-        magnetic fields. Knuutila et al. IEEE Transactions on Magnetics,
-        Vol 29 No 6, Nov 1993.
+    References
+    ----------
+    .. [1] A 122-channel whole-cortex SQUID system for measuring the brain’s
+       magnetic fields. Knuutila et al. IEEE Transactions on Magnetics,
+       Vol 29 No 6, Nov 1993.
     """
     r_in = 0.080  # radius of the randomly-activated sphere
 

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -19,8 +19,8 @@ def bin_perm_rep(ndim, a=0, b=1):
     (0,1) in ndim dimensions.  The array is shaped as (2**ndim,ndim), and is
     ordered with the last index changing fastest.  For examble, for ndim=3:
 
-    Examples:
-
+    Examples
+    --------
     >>> bin_perm_rep(3)
     array([[0, 0, 0],
            [0, 0, 1],

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -99,7 +99,7 @@ def check_parameters_match(func, doc=None):
 
 @requires_numpydoc
 def test_docstring_parameters():
-    """Test module docstring formatting"""
+    """Test module docstring formatting."""
     from numpydoc import docscrape
 
     # skip modules that require mayavi if mayavi is not installed
@@ -112,7 +112,8 @@ def test_docstring_parameters():
 
     incorrect = []
     for name in public_modules_:
-        module = __import__(name, globals())
+        with warnings.catch_warnings(record=True):  # traits warnings
+            module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)
         classes = inspect.getmembers(module, inspect.isclass)
@@ -157,11 +158,15 @@ def test_tabs():
         if not ispkg and modname not in ignore:
             # mod = importlib.import_module(modname)  # not py26 compatible!
             try:
-                __import__(modname)
+                with warnings.catch_warnings(record=True):  # traits
+                    __import__(modname)
             except Exception:  # can't import properly
                 continue
             mod = sys.modules[modname]
-            source = getsource(mod)
+            try:
+                source = getsource(mod)
+            except IOError:  # user probably should have run "make clean"
+                continue
             assert_true('\t' not in source,
                         '"%s" has tabs, please remove them or add it to the'
                         'ignore list' % modname)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -11,13 +11,12 @@ from ..utils import sum_squared, warn, verbose
 
 
 def tridisolve(d, e, b, overwrite_b=True):
-    """Symmetric tridiagonal system solver, from Golub and Van Loan pg 157.
+    """Symmetric tridiagonal system solver, from Golub and Van Loan p157.
 
-    Note: Copied from NiTime
+    .. note:: Copied from NiTime.
 
     Parameters
     ----------
-
     d : ndarray
       main diagonal stored in d[:]
     e : ndarray
@@ -27,7 +26,6 @@ def tridisolve(d, e, b, overwrite_b=True):
 
     Returns
     -------
-
     x : ndarray
       Solution to Ax = b (if overwrite_b is False). Otherwise solution is
       stored in previous RHS vector b
@@ -63,11 +61,10 @@ def tridi_inverse_iteration(d, e, w, x0=None, rtol=1e-8):
     This will find the eigenvector corresponding to the given eigenvalue
     in a symmetric tridiagonal system.
 
-    Note: Copied from NiTime
+    ..note:: Copied from NiTime.
 
     Parameters
     ----------
-
     d : ndarray
       main diagonal of the tridiagonal system
     e : ndarray
@@ -83,7 +80,6 @@ def tridi_inverse_iteration(d, e, w, x0=None, rtol=1e-8):
     -------
     e: ndarray
       The converged eigenvector
-
     """
     eig_diag = d - w
     if x0 is None:
@@ -108,7 +104,7 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
     Will give of orders [0,Kmax-1] for a given frequency-spacing multiple
     NW and sequence length N.
 
-    Note: Copied from NiTime
+    .. note:: Copied from NiTime.
 
     Parameters
     ----------
@@ -254,11 +250,10 @@ def _psd_from_mt_adaptive(x_mt, eigvals, freq_mask, max_iter=150,
                           return_weights=False):
     r"""Use iterative procedure to compute the PSD from tapered spectra.
 
-    Note: Modified from NiTime
+    .. note:: Modified from NiTime.
 
     Parameters
     ----------
-
     x_mt : array, shape=(n_signals, n_tapers, n_freqs)
        The DFTs of the tapered sequences (only positive frequencies)
     eigvals : array, length n_tapers

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1128,7 +1128,7 @@ def _check_pyface_backend():
 
     Notes
     -----
-    See also: http://docs.enthought.com/pyface/
+    See also http://docs.enthought.com/pyface/.
     """
     try:
         from traits.trait_base import ETSConfig

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -392,7 +392,6 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
 
     Parameters
     ----------
-
     epochs : instance of Epochs
         The epochs object
     picks : array-like of int | None

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1620,28 +1620,27 @@ class DraggableColorbar(object):
 
 
 class SelectFromCollection(object):
-    """Select channels from a matplotlib collection using `LassoSelector`.
+    """Select channels from a matplotlib collection using ``LassoSelector``.
 
     Selected channels are saved in the ``selection`` attribute. This tool
     highlights selected points by fading other points out (i.e., reducing their
     alpha values).
 
-    Notes:
-    This tool selects collection objects based on their *origins*
-    (i.e., `offsets`). Emits mpl event 'lasso_event' when selection is ready.
-
     Parameters
     ----------
     ax : Instance of Axes
         Axes to interact with.
-
     collection : Instance of matplotlib collection
         Collection you want to select from.
-
     alpha_other : 0 <= float <= 1
         To highlight a selection, this tool sets all selected points to an
         alpha value of 1 and non-selected points to `alpha_other`.
         Defaults to 0.3.
+
+    Notes
+    -----
+    This tool selects collection objects based on their *origins*
+    (i.e., `offsets`). Emits mpl event 'lasso_event' when selection is ready.
     """
 
     def __init__(self, ax, collection, ch_names,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,5 +36,6 @@ ignore = E241,E305
 convention = pep257
 match_dir = ^(?!\.|externals|doc|tutorials|examples|logo|tests).*$
 match = (?!test_|fixes).*\.py
-add-ignore = D100,D413
+add-ignore = D100,D413,D100
+add-select = D214,D215,D404,D405,D406,D407,D408,D409,D410,D411
 ignore-decorators = ^(copy_.*_doc_to_|on_trait_change|cached_property|deprecated).*

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,5 +36,5 @@ ignore = E241,E305
 convention = pep257
 match_dir = ^(?!\.|externals|doc|tutorials|examples|logo|tests).*$
 match = (?!test_|fixes).*\.py
-add-ignore = D100
+add-ignore = D100,D413
 ignore-decorators = ^(copy_.*_doc_to_|on_trait_change|cached_property|deprecated).*


### PR DESCRIPTION
We have some failures on `master` because `pydocstyle` became more stringent. This fixes them.

WIP because `pydocstyle` also now supports the `numpy` standard, so I want to see how difficult it will be to implement those fixes.