### PR TITLE
doc: fixing python 3 bug in decoding example

### DIFF
--- a/examples/decoding/plot_decoding_spatio_temporal_source.py
+++ b/examples/decoding/plot_decoding_spatio_temporal_source.py
@@ -76,7 +76,7 @@ inverse_operator = read_inverse_operator(fname_inv)
 X = np.zeros([n_epochs, n_vertices, n_times])
 
 # to save memory, we'll load and transform our epochs step by step.
-for condition_count, ep in zip([0, n_epochs / 2], epochs_list):
+for condition_count, ep in zip([0, int(n_epochs / 2)], epochs_list):
     stcs = apply_inverse_epochs(ep, inverse_operator, lambda2,
                                 method, pick_ori="normal",  # saves us memory
                                 return_generator=True)

--- a/examples/decoding/plot_decoding_spatio_temporal_source.py
+++ b/examples/decoding/plot_decoding_spatio_temporal_source.py
@@ -76,7 +76,7 @@ inverse_operator = read_inverse_operator(fname_inv)
 X = np.zeros([n_epochs, n_vertices, n_times])
 
 # to save memory, we'll load and transform our epochs step by step.
-for condition_count, ep in zip([0, int(n_epochs / 2)], epochs_list):
+for condition_count, ep in zip([0, n_epochs // 2], epochs_list):
     stcs = apply_inverse_epochs(ep, inverse_operator, lambda2,
                                 method, pick_ori="normal",  # saves us memory
                                 return_generator=True)

--- a/examples/time_frequency/plot_source_space_time_frequency.py
+++ b/examples/time_frequency/plot_source_space_time_frequency.py
@@ -54,7 +54,7 @@ bands = dict(alpha=[9, 11], beta=[18, 22])
 stcs = source_band_induced_power(epochs, inverse_operator, bands, n_cycles=2,
                                  use_fft=False, n_jobs=1)
 
-for b, stc in stcs.iteritems():
+for b, stc in stcs.items():
     stc.save('induced_power_%s' % b)
 
 ###############################################################################

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -783,7 +783,7 @@ def _decimate_surface(points, triangles, reduction):
     out = decimate.output
     tris = out.polys.to_array()
     # n-tuples + interleaved n-next -- reshape trick
-    return out.points.to_array(), tris.reshape(tris.size / 4, 4)[:, 1:]
+    return out.points.to_array(), tris.reshape(tris.size // 4, 4)[:, 1:]
 
 
 def decimate_surface(points, triangles, n_triangles):


### PR DESCRIPTION
Was getting a floating point indexing error. Hold off merging for a sec - it seems like there are a few other errors along these lines in the codebase. LMK if just wrapping stuff in `int(` is an OK solution. The problem is that since Python 3 returns a float if you do, e.g., `10 / 2`, then if you use this as an index it errors.