### PR TITLE
[MRG+1] FIX kit2fiff GIU for Ubuntu

### DIFF
--- a/mne/commands/mne_kit2fiff.py
+++ b/mne/commands/mne_kit2fiff.py
@@ -40,8 +40,14 @@ def run():
     parser.add_option('--output', dest='out_fname',
                       help='Name of the resulting fiff file',
                       metavar='filename')
+    parser.add_option('--debug', dest='debug', action='store_true',
+                      default=False,
+                      help='Set logging level for terminal output to debug')
 
     options, args = parser.parse_args()
+
+    if options.debug:
+        mne.set_log_level('debug')
 
     input_fname = options.input_fname
     if input_fname is None:

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -281,7 +281,9 @@ class Kit2FiffModel(HasPrivateTraits):
             data, times = self.raw[self.misc_chs]
         except Exception as err:
             if self.show_gui:
-                error(None, str(err), "Error Creating FsAverage")
+                error(None, "Error reading SQD data file: %s (Check the "
+                      "terminal output for details)" % str(err),
+                      "Error Reading SQD File")
             raise
         finally:
             if self.show_gui:
@@ -311,7 +313,7 @@ class Kit2FiffModel(HasPrivateTraits):
             if self.show_gui:
                 error(None, "Error reading SQD data file: %s (Check the "
                       "terminal output for details)" % str(err),
-                      "Error Reading SQD file")
+                      "Error Reading SQD File")
             raise
 
     @cached_property

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -668,7 +668,7 @@ class Kit2FiffFrame(HasTraits):
                 handler=Kit2FiffFrameHandler(),
                 height=700, resizable=True, buttons=NoButtons)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa: D102
         logger.debug(
             "Initializing Kit2fiff-GUI with %s backend", ETSConfig.toolkit)
         HasTraits.__init__(self, *args, **kwargs)

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -24,6 +24,7 @@ from pyface.api import (confirm, error, FileDialog, OK, YES, information,
 from traits.api import (HasTraits, HasPrivateTraits, cached_property, Instance,
                         Property, Bool, Button, Enum, File, Float, Int, List,
                         Str, Array, DelegatesTo)
+from traits.trait_base import ETSConfig
 from traitsui.api import (View, Item, HGroup, VGroup, spring, TextEditor,
                           CheckListEditor, EnumEditor, Handler)
 from traitsui.menu import NoButtons
@@ -666,6 +667,11 @@ class Kit2FiffFrame(HasTraits):
                        ),
                 handler=Kit2FiffFrameHandler(),
                 height=700, resizable=True, buttons=NoButtons)
+
+    def __init__(self, *args, **kwargs):
+        logger.debug(
+            "Initializing Kit2fiff-GUI with %s backend", ETSConfig.toolkit)
+        HasTraits.__init__(self, *args, **kwargs)
 
     # can't be static method due to Traits
     def _model_default(self):

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -6,6 +6,7 @@
 
 from collections import Counter
 import os
+import sys
 from warnings import warn
 
 import numpy as np
@@ -46,8 +47,8 @@ if backend_is_wx:
     hsp_wildcard = ['Head Shape Points (*.hsp;*.txt)|*.hsp;*.txt']
     elp_wildcard = ['Head Shape Fiducials (*.elp;*.txt)|*.elp;*.txt']
     kit_con_wildcard = ['Continuous KIT Files (*.sqd;*.con)|*.sqd;*.con']
-elif os.name == 'nt':
-    # on Windows, multiple wildcards does not seem to work
+elif sys.platform in ('win32',  'linux2'):
+    # on Windows and Ubuntu, multiple wildcards does not seem to work
     hsp_wildcard = ['*.hsp', '*.txt']
     elp_wildcard = ['*.elp', '*.txt']
     kit_con_wildcard = ['*.sqd', '*.con']

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -5,6 +5,7 @@
 # License: BSD (3-clause)
 
 import os
+import sys
 
 import numpy as np
 
@@ -34,8 +35,8 @@ if backend_is_wx:
                     'Pickled markers (*.pickled)|*.pickled']
     mrk_out_wildcard = ["Tab separated values file (*.txt)|*.txt"]
 else:
-    if os.name == 'nt':
-        # on Windows, multiple wildcards does not seem to work
+    if sys.platform in ('win32',  'linux2'):
+        # on Windows and Ubuntu, multiple wildcards does not seem to work
         mrk_wildcard = ["*.sqd", "*.mrk", "*.txt", "*.pickled"]
     else:
         mrk_wildcard = ["*.sqd;*.mrk;*.txt;*.pickled"]


### PR DESCRIPTION
Turns out Ubuntu has the same problem with wildcards as Windows (cf. https://github.com/mne-tools/mne-python/pull/4013)

CC @ellenlau 