### PR TITLE
MRG+1: HPI support for Artemis123

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -431,7 +431,9 @@ def _fit_cHPI_amplitudes(raw, time_sl, hpi, fit_time, verbose=None):
         # loads good channels
         meg_chpi_data = raw[hpi['meg_picks'], time_sl][0]
 
-    mchpi_data = np.mean(meg_chpi_data, axis=1, keepdims=True)
+    mchpi_data = np.tile(np.mean(meg_chpi_data, axis=1, keepdims=True),
+                         (1, meg_chpi_data.shape[1]))
+    mchpi_data = mchpi_data.reshape(meg_chpi_data.shape)
     this_data = meg_chpi_data - mchpi_data
 
     # which HPI coils to use

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -311,7 +311,7 @@ def _fit_chpi_quat(coil_dev_rrs, coil_head_rrs, x0):
     return x, 1. - result / denom
 
 
-def _fit_dev_head_trans(dev_pnts, head_pnts):
+def _fit_coil_order_dev_head_trans(dev_pnts, head_pnts):
     """Compute Device to Head transform allowing for permutiatons of points."""
     id_quat = np.concatenate([rot_to_quat(np.eye(3)), [0.0, 0.0, 0.0]])
     best_order = None
@@ -342,7 +342,9 @@ def _setup_hpi_struct(info, model_n_window,
 
     Returns
     -------
-    hpi - Dict
+    hpi : dict
+        Dictionary of parameters representing the cHPI system and needed to
+        perform head localization.
     """
     from .preprocessing.maxwell import _prep_mf_coils
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -511,6 +511,9 @@ def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
     else:
         i_win = raw.time_as_index(t_win, use_rounding=True)
 
+    # clamp index windows
+    i_win = [max(i_win[0], 0), min(i_win[1], len(raw.times))]
+
     time_sl = slice(i_win[0], i_win[1])
 
     hpi = _setup_hpi_struct(raw.info, i_win[1] - i_win[0])

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -33,7 +33,7 @@ and (optionally) line frequencies from the data.
 from functools import partial
 
 import numpy as np
-from scipy import linalg, fftpack
+from scipy import linalg
 
 from .io.pick import pick_types, pick_channels
 from .io.constants import FIFF
@@ -41,9 +41,8 @@ from .forward import (_magnetic_dipole_field_vec, _create_meg_coils,
                       _concatenate_coils, _read_coil_defs)
 from .cov import make_ad_hoc_cov, _get_whitener_data
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
-                         quat_to_rot, rot_to_quat)
-from .utils import (verbose, logger, check_version, use_log_level,
-                    _check_fname, warn)
+                         quat_to_rot, rot_to_quat, Transform)
+from .utils import verbose, logger, use_log_level, _check_fname, warn
 
 # Eventually we should add:
 #   hpicons
@@ -146,16 +145,40 @@ def head_pos_to_trans_rot_t(quats):
     return translation, rotation, t
 
 
-# ############################################################################
-# Estimate positions from data
-
 @verbose
-def _get_hpi_info(info, adjust=False, verbose=None):
-    """Get HPI information from raw."""
+def _get_hpi_info(info, verbose=None):
+    """Helper to get HPI information from raw."""
     if len(info['hpi_meas']) == 0 or \
             ('coil_freq' not in info['hpi_meas'][0]['hpi_coils'][0]):
         raise RuntimeError('Appropriate cHPI information not found in'
                            'raw.info["hpi_meas"], cannot process cHPI')
+    hpi_coils = sorted(info['hpi_meas'][-1]['hpi_coils'],
+                       key=lambda x: x['number'])  # ascending (info) order
+
+    # how cHPI active is indicated in the FIF file
+    hpi_sub = info['hpi_subsystem']
+    if 'event_channel' in hpi_sub:
+        hpi_pick = pick_channels(info['ch_names'],
+                                 [hpi_sub['event_channel']])
+        hpi_pick = hpi_pick[0] if len(hpi_pick) > 0 else None
+    else:
+        hpi_pick = None  # there is no pick!
+    hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]
+    # not all HPI coils will actually be used
+    hpi_on = np.array([hpi_on[hc['number'] - 1] for hc in hpi_coils])
+    assert len(hpi_coils) == len(hpi_on)
+
+    # get frequencies
+    hpi_freqs = np.array([float(x['coil_freq']) for x in hpi_coils])
+    logger.info('Using %s HPI coils: %s Hz'
+                % (len(hpi_freqs), ' '.join(str(int(s)) for s in hpi_freqs)))
+
+    return hpi_freqs,  hpi_pick, hpi_on
+
+
+@verbose
+def _get_hpi_initial_fit(info, adjust=False, verbose=None):
+    """Helper to get HPI fit information from raw."""
     hpi_result = info['hpi_results'][-1]
     hpi_coils = sorted(info['hpi_meas'][-1]['hpi_coils'],
                        key=lambda x: x['number'])  # ascending (info) order
@@ -216,24 +239,7 @@ def _get_hpi_info(info, adjust=False, verbose=None):
     logger.debug('HP fitting limits: err = %.1f mm, gval = %.3f.'
                  % (1000 * hpi_result['dist_limit'], hpi_result['good_limit']))
 
-    # how cHPI active is indicated in the FIF file
-    hpi_sub = info['hpi_subsystem']
-    if 'event_channel' in hpi_sub:
-        hpi_pick = pick_channels(info['ch_names'],
-                                 [hpi_sub['event_channel']])
-        hpi_pick = hpi_pick[0] if len(hpi_pick) > 0 else None
-    else:
-        hpi_pick = None  # there is no pick!
-    hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]
-    # not all HPI coils will actually be used
-    hpi_on = np.array([hpi_on[hc['number'] - 1] for hc in hpi_coils])
-    assert len(hpi_coils) == len(hpi_on)
-
-    # get frequencies
-    hpi_freqs = np.array([float(x['coil_freq']) for x in hpi_coils])
-    logger.info('Using %s HPI coils: %s Hz'
-                % (len(hpi_freqs), ' '.join(str(int(s)) for s in hpi_freqs)))
-    return hpi_freqs, hpi_rrs, hpi_pick, hpi_on, pos_order
+    return hpi_rrs
 
 
 def _magnetic_dipole_objective(x, B, B2, coils, scale, method):
@@ -277,8 +283,8 @@ def _unit_quat_constraint(x):
     return 1 - (x * x).sum()
 
 
-def _fit_chpi_pos(coil_dev_rrs, coil_head_rrs, x0):
-    """Fit rotation and translation parameters for cHPI coils."""
+def _fit_chpi_quat(coil_dev_rrs, coil_head_rrs, x0):
+    """Fit rotation and translation (quaternion) parameters for cHPI coils."""
     from scipy.optimize import fmin_cobyla
     denom = np.sum((coil_head_rrs - np.mean(coil_head_rrs, axis=0)) ** 2)
     objective = partial(_chpi_objective, coil_dev_rrs=coil_dev_rrs,
@@ -292,16 +298,45 @@ def _fit_chpi_pos(coil_dev_rrs, coil_head_rrs, x0):
     return x, 1. - result / denom
 
 
+def _fit_dev_head_trans(dev_pnts, head_pnts):
+    """Compute Device to Head transform allowing for permutiatons of points."""
+    import itertools
+    id_quat = np.concatenate([rot_to_quat(np.eye(3)), [0.0, 0.0, 0.0]])
+    best_order = None
+    best_g = -999
+    best_quat = id_quat
+    for i in itertools.permutations(np.arange(len(head_pnts))):
+        head_pnts_tmp = head_pnts[np.array(i)]
+        this_quat, g = _fit_chpi_quat(dev_pnts, head_pnts_tmp, id_quat)
+        if g > best_g:
+            best_g = g
+            best_order = np.array(i)
+            best_quat = this_quat
+
+    # Convert Quaterion to transform
+    dev_head_t = np.concatenate(
+        (quat_to_rot(best_quat[:3]),
+         best_quat[3:][:, np.newaxis]), axis=1)
+    dev_head_t = np.concatenate((dev_head_t, [[0, 0, 0, 1.]]))
+    return dev_head_t, best_order
+
+
 @verbose
-def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
-                     exclude='bads', add_hpi_stim_pick=True,
-                     remove_aliased=False, verbose=None):
-    """Set up cHPI fits."""
-    from scipy.spatial.distance import cdist
+def _setup_hpi_struct(info, model_n_window,
+                      method='forward',
+                      exclude='bads',
+                      remove_aliased=False, verbose=None):
+    """Helper function to setup HPI structure for HPI localization.
+
+    Returns
+    -------
+    hpi - Dict
+    """
     from .preprocessing.maxwell import _prep_mf_coils
-    if not (check_version('numpy', '1.7') and check_version('scipy', '0.11')):
-        raise RuntimeError('numpy>=1.7 and scipy>=0.11 required')
-    hpi_freqs, coil_head_rrs, hpi_pick, hpi_ons = _get_hpi_info(info)[:4]
+
+    # grab basic info.
+    hpi_freqs, hpi_pick, hpi_ons = _get_hpi_info(info)
+    # worry about resampled/filtered data.
     # What to do e.g. if Raw has been resampled and some of our
     # HPI freqs would now be aliased
     highest = info.get('lowpass')
@@ -309,7 +344,6 @@ def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
     keepers = np.array([h <= highest for h in hpi_freqs], bool)
     if remove_aliased:
         hpi_freqs = hpi_freqs[keepers]
-        coil_head_rrs = coil_head_rrs[keepers]
         hpi_ons = hpi_ons[keepers]
     elif not keepers.all():
         raise RuntimeError('Found HPI frequencies %s above the lowpass '
@@ -322,16 +356,9 @@ def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
         line_freqs = np.zeros([0])
     logger.info('Line interference frequencies: %s Hz'
                 % ' '.join(['%d' % l for l in line_freqs]))
-    # initial transforms
-    dev_head_t = info['dev_head_t']['trans']
-    head_dev_t = invert_transform(info['dev_head_t'])['trans']
-    # determine timing
-    n_window = int(round(t_window * info['sfreq']))
-    logger.debug('Coordinate transformation:')
-    for d in (dev_head_t[0, :3], dev_head_t[1, :3], dev_head_t[2, :3],
-              dev_head_t[:3, 3] * 1000.):
-        logger.debug('{0:8.4f} {1:8.4f} {2:8.4f}'.format(*d))
-    slope = np.arange(n_window).astype(np.float64)[:, np.newaxis]
+
+    # build model to extract sinusoidal amplitudes.
+    slope = np.arange(model_n_window).astype(np.float64)[:, np.newaxis]
     slope -= np.mean(slope)
     rads = slope / info['sfreq']
     rads *= 2 * np.pi
@@ -342,16 +369,9 @@ def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
     model += [slope, np.ones(slope.shape)]
     model = np.concatenate(model, axis=1)
     inv_model = linalg.pinv(model)
-    # Set up highpass at half lowest cHPI freq
-    hp_n = 2 ** (int(np.ceil(np.log2(n_window))) + 1)
-    freqs = fftpack.rfftfreq(hp_n, 1. / info['sfreq'])
-    hp_ind = np.where(freqs >= hpi_freqs.min())[0][0] - 2
-    hp_window = np.concatenate(
-        [[0], np.repeat(np.hanning(hp_ind - 1)[:(hp_ind - 1) // 2],
-                        2)])[np.newaxis]
 
     # Set up magnetic dipole fits
-    picks_meg = pick_types(info, meg=True, eeg=False, exclude=exclude)
+    meg_picks = pick_types(info, meg=True, eeg=False, exclude=exclude)
     if len(exclude) > 0:
         if exclude == 'bads':
             msg = info['bads']
@@ -359,13 +379,8 @@ def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
             msg = exclude
         logger.debug('Static bad channels (%d): %s'
                      % (len(msg), u' '.join(msg)))
-    if add_hpi_stim_pick:
-        if hpi_pick is None:
-            raise RuntimeError('Could not find HPI status channel')
-        picks = np.concatenate([picks_meg, [hpi_pick]])
-    else:
-        picks = picks_meg
-    megchs = [ch for ci, ch in enumerate(info['chs']) if ci in picks_meg]
+
+    megchs = [ch for ci, ch in enumerate(info['chs']) if ci in meg_picks]
     templates = _read_coil_defs(elekta_defs=True, verbose=False)
     coils = _create_meg_coils(megchs, 'accurate', coilset=templates)
     if method == 'forward':
@@ -373,19 +388,16 @@ def _setup_chpi_fits(info, t_window, t_step_min, method='forward',
     else:  # == 'multipole'
         coils = _prep_mf_coils(info)
     scale = make_ad_hoc_cov(info, verbose=False)
-    scale = _get_whitener_data(info, scale, picks_meg, verbose=False)
-    orig_dev_head_quat = np.concatenate([rot_to_quat(dev_head_t[:3, :3]),
-                                         dev_head_t[:3, 3]])
-    dists = cdist(coil_head_rrs, coil_head_rrs)
-    hpi = dict(dists=dists, scale=scale, picks=picks, model=model,
-               inv_model=inv_model, coil_head_rrs=coil_head_rrs,
-               coils=coils, on=hpi_ons, n_window=n_window, method=method,
-               freqs=hpi_freqs, line_freqs=line_freqs,
-               hp_ind=hp_ind, hp_n=hp_n, hp_window=hp_window)
-    last = dict(quat=orig_dev_head_quat, coil_head_rrs=coil_head_rrs,
-                coil_dev_rrs=apply_trans(head_dev_t, coil_head_rrs),
-                sin_fit=None, fit_time=-t_step_min)
-    return hpi, last
+    scale = _get_whitener_data(info, scale, meg_picks, verbose=False)
+
+    hpi = dict(meg_picks=meg_picks, hpi_pick=hpi_pick,
+               model=model, inv_model=inv_model,
+               on=hpi_ons, n_window=model_n_window, method=method,
+               freqs=hpi_freqs, line_freqs=line_freqs, n_freqs=len(hpi_freqs),
+               scale=scale, coils=coils
+               )
+
+    return hpi
 
 
 def _time_prefix(fit_time):
@@ -394,9 +406,180 @@ def _time_prefix(fit_time):
 
 
 @verbose
+def _fit_cHPI_amplitudes(raw, time_sl, hpi, fit_time, verbose=None):
+    """Fit amplitudes for each channel from each of the N cHPI sinusoids.
+
+    Returns
+    -------
+    sin_fit : ndarray, shape (n_freqs, n_channels)) or None :
+        The sin amplitudes matching each cHPI frequency
+            or None if this time window should be skipped
+    """
+    with use_log_level(False):
+        # loads good channels
+        meg_chpi_data = raw[hpi['meg_picks'], time_sl][0]
+
+    mchpi_data = np.mean(meg_chpi_data, axis=1, keepdims=True)
+    this_data = meg_chpi_data - mchpi_data
+
+    # which HPI coils to use
+    # other then erroring I don't see this getting used elsewhere?
+    if hpi['hpi_pick'] is not None:
+        with use_log_level(False):
+            # loads hpi_stim channel
+            chpi_data = raw[hpi['hpi_pick'], time_sl][0]
+
+        ons = (np.round(chpi_data).astype(np.int) &
+               hpi['on'][:, np.newaxis]).astype(bool)
+        n_on = np.sum(ons, axis=0)
+        if not (n_on >= 3).all():
+            logger.info(_time_prefix(fit_time) + '%s < 3 HPI coils turned on, '
+                        'skipping fit' % (n_on.min(),))
+            return None
+        # #TODO REMOVE # ons = ons.all(axis=1)  # which HPI coils to use
+
+    n_freqs = hpi['n_freqs']
+    this_len = time_sl.stop - time_sl.start
+    if this_len == hpi['n_window']:
+        model, inv_model = hpi['model'], hpi['inv_model']
+    else:  # first or last window
+        model = hpi['model'][:this_len]
+        inv_model = linalg.pinv(model)
+    X = np.dot(inv_model, this_data.T)
+    X_sin, X_cos = X[:n_freqs], X[n_freqs:2 * n_freqs]
+
+    # use SVD across all sensors to estimate the sinusoid phase
+    sin_fit = np.zeros((n_freqs, X_sin.shape[1]))
+    for fi in range(n_freqs):
+        u, s, vt = np.linalg.svd(np.vstack((X_sin[fi, :], X_cos[fi, :])),
+                                 full_matrices=False)
+        # the first component holds the predominant phase direction
+        # (so ignore the second, effectively doing s[1] = 0):
+        X[[fi, fi + n_freqs], :] = np.outer(u[:, 0] * s[0], vt[0])
+        sin_fit[fi, :] = vt[0]
+
+    data_diff = np.dot(model, X).T - this_data
+
+    # compute amplitude correlation (For logging?)
+    g_sin = 1 - np.sqrt((data_diff**2).sum() / (this_data**2).sum())
+    g_chan = 1 - np.sqrt((data_diff**2).sum(axis=1) /
+                         (this_data**2).sum(axis=1))
+    logger.debug('    HPI amplitude correlation %0.3f: %0.3f '
+                 '(%s chnls > 0.90)' % (fit_time, g_sin,
+                                        (g_chan > 0.90).sum()))
+
+    return sin_fit
+
+
+@verbose
+def compute_head_localization(raw, initalLocs=None, time_win=[0, 1],
+                              verbose=None):
+    """Compute an updated the head localization Transform.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Raw data with cHPI information.
+    initalLocs : ndarray, shape(nCHPI, 3)
+        Initial localations of HPI coils. used to initalized solver.
+        if None (0, 0, 0) is choosen for each coil
+    time_win : list, shape (2)
+        Time window to fit. If None entire data run is used.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    dev_head_t,
+    hpi_dev,
+
+    """
+    # first localize the cHPIs
+    hpi_dev = _fit_device_hpi_positions(raw, t_win=time_win,
+                                        initial_dev_rrs=initalLocs)
+
+    # Digitized HPI points are needed.
+    if ('dig' in raw.info and raw.info['dig']):
+        hpi_head = np.array([d['r'] for d in raw.info['dig']
+                            if d['kind'] == FIFF.FIFFV_POINT_HPI])
+    else:
+        hpi_head = []
+
+    if (len(hpi_head) == 0):
+        warn('No digitized HPI points - not updating head_loc')
+        return raw.info['dev_head_t'], hpi_dev
+
+    if (len(hpi_head) != len(hpi_dev)):
+        raise RuntimeError("number of digitized (%d) and active (%d) " +
+                           "HPI coils not the same.")
+
+    t, order = _fit_dev_head_trans(hpi_dev, hpi_head)
+    dev_head_t = Transform(FIFF.FIFFV_COORD_DEVICE, FIFF.FIFFV_COORD_HEAD, t)
+
+    # TODO this should return an HPI_reulsts dict
+    # pos_order = order + 1
+    return dev_head_t, hpi_dev
+
+
+@verbose
+def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
+                              verbose=None):
+    """Calculate location of HPI coils in device coords for 1 tiem window.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Raw data with cHPI information.
+    t_win : list, shape (2)
+        Time window to fit. If None entire data run is used.
+    initial_dev_rrs : ???
+        Initial guess on HPI locations. If None (0,0,0) is used for each hpi.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    coil_dev_rrs : ndarray, shape (nCHPI, 3)
+        Fit locations of each cHPI coil in device coordinates
+    """
+    # 0. determine samples to fit.
+    if t_win is None:  # use the whole window
+        i_win = [0, len(raw.times)]
+    else:
+        i_win = raw.time_as_index(t_win, use_rounding=True)
+
+    time_sl = slice(i_win[0], i_win[1])
+
+    hpi = _setup_hpi_struct(raw.info, i_win[1] - i_win[0])
+
+    if initial_dev_rrs is None:
+        initial_dev_rrs = []
+        for i in range(hpi['n_freqs']):
+            initial_dev_rrs.append([0.0, 0.0, 0.0])
+
+    # 1. Fit amplitudes for each channel from each of the N cHPI sinusoids
+    sin_fit = _fit_cHPI_amplitudes(raw, time_sl, hpi, 0)
+
+    # skip this window if it bad.
+    # logging has already been done! Maybe turn this into an Exception
+    if sin_fit is None:
+        return None
+
+    # 2. fit each HPI coil
+    outs = [_fit_magnetic_dipole(f, pos, hpi['coils'], hpi['scale'],
+            hpi['method']) for f, pos in zip(sin_fit, initial_dev_rrs)]
+
+    coil_dev_rrs = np.array([o[0] for o in outs])
+
+    return coil_dev_rrs
+
+
+@verbose
 def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
                               t_window=0.2, dist_limit=0.005, gof_limit=0.98,
-                              verbose=None):
+                              enforce_geometry=True, verbose=None):
     """Calculate head positions using cHPI coils.
 
     Parameters
@@ -436,7 +619,25 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
     write_head_pos
     """
     from scipy.spatial.distance import cdist
-    hpi, last = _setup_chpi_fits(raw.info, t_window, t_step_min)
+    # extract initial geometry from info['hpi_results']
+    hpi_dig_head_rrs = _get_hpi_initial_fit(raw.info)
+
+    # extract hpi system information
+    hpi = _setup_hpi_struct(raw.info, int(round(t_window * raw.info['sfreq'])))
+
+    # move to device coords
+    dev_head_t = raw.info['dev_head_t']['trans']
+    head_dev_t = invert_transform(raw.info['dev_head_t'])['trans']
+    hpi_dig_dev_rrs = apply_trans(head_dev_t, hpi_dig_head_rrs)
+
+    # compute initial coil to coil distances
+    hpi_coil_dists = cdist(hpi_dig_head_rrs, hpi_dig_head_rrs)
+
+    # setup last iteration structure
+    last = dict(sin_fit=None, fit_time=t_step_min,
+                coil_dev_rrs=hpi_dig_dev_rrs,
+                quat=np.concatenate([rot_to_quat(dev_head_t[:3, :3]),
+                                     dev_head_t[:3, 3]]))
 
     t_begin = raw.times[0]
     t_end = raw.times[-1]
@@ -447,117 +648,95 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
     logger.info('Fitting up to %s time points (%0.1f sec duration)'
                 % (len(fit_idxs), t_end - t_begin))
     pos_0 = None
-    n_freqs = len(hpi['freqs'])
+
+    hpi['n_freqs'] = len(hpi['freqs'])
     for midpt in fit_idxs:
         #
-        # 1. Fit amplitudes for each channel from each of the N cHPI sinusoids
+        # 0. determine samples to fit.
         #
         fit_time = (midpt + raw.first_samp - hpi['n_window'] / 2.) /\
             raw.info['sfreq']
+
         time_sl = midpt - hpi['n_window'] // 2
         time_sl = slice(max(time_sl, 0),
                         min(time_sl + hpi['n_window'], len(raw.times)))
-        with use_log_level(False):
-            # loads good channels with hpi_stim
-            meg_chpi_data = raw[hpi['picks'], time_sl][0]
-        mchpi_data = np.mean(meg_chpi_data[:-1], axis=1, keepdims=True)
-        this_data = meg_chpi_data[:-1] - mchpi_data
-        chpi_data = meg_chpi_data[-1]  # copies hpi_stim
-        ons = (np.round(chpi_data).astype(np.int) &
-               hpi['on'][:, np.newaxis]).astype(bool)
-        n_on = np.sum(ons, axis=0)
-        if not (n_on >= 3).all():
-            logger.info(_time_prefix(fit_time) + '%s < 3 HPI coils turned on, '
-                        'skipping fit' % (n_on.min(),))
+
+        #
+        # 1. Fit amplitudes for each channel from each of the N cHPI sinusoids
+        #
+        sin_fit = _fit_cHPI_amplitudes(raw, time_sl, hpi, fit_time)
+
+        # skip this window if it bad.
+        # logging has already been done! Maybe turn this into an Exception
+        if sin_fit is None:
             continue
-        # ons = ons.all(axis=1)  # which HPI coils to use
-        this_len = time_sl.stop - time_sl.start
-        if this_len == hpi['n_window']:
-            model, inv_model = hpi['model'], hpi['inv_model']
-        else:  # first or last window
-            model = hpi['model'][:this_len]
-            inv_model = linalg.pinv(model)
-        X = np.dot(inv_model, this_data.T)
-        X_sin, X_cos = X[:n_freqs], X[n_freqs:2 * n_freqs]
 
-        # use SVD across all sensors to estimate the sinusoid phase
-        sin_fit = np.zeros((n_freqs, X_sin.shape[1]))
-        for fi in range(n_freqs):
-            u, s, vt = np.linalg.svd(np.vstack((X_sin[fi, :], X_cos[fi, :])),
-                                     full_matrices=False)
-            # the first component holds the predominant phase direction
-            # (so ignore the second, effectively doing s[1] = 0):
-            X[[fi, fi + n_freqs], :] = np.outer(u[:, 0] * s[0], vt[0])
-            sin_fit[fi, :] = vt[0]
-
-        data_diff = np.dot(model, X).T - this_data
-        del model, inv_model
-
-        g_sin = 1 - np.sqrt((data_diff**2).sum() / (this_data**2).sum())
-        g_chan = 1 - np.sqrt((data_diff**2).sum(axis=1) /
-                             (this_data**2).sum(axis=1))
-
+        # check if data has sufficiently changed
         if last['sin_fit'] is not None:  # first iteration
             corr = np.corrcoef(sin_fit.ravel(), last['sin_fit'].ravel())[0, 1]
             # check to see if we need to continue
             if fit_time - last['fit_time'] <= t_step_max - 1e-7 and \
                     corr * corr > 0.98:
-                continue  # don't need to re-fit data
-        last['sin_fit'] = sin_fit.copy()  # save *before* inplace sign mult
+                # don't need to refit data
+                continue
 
-        del X_sin, X_cos, X
+        # update 'last' sin_fit *before* inplace sign mult
+        last['sin_fit'] = sin_fit.copy()
 
         #
         # 2. Fit magnetic dipole for each coil to obtain coil positions
         #    in device coordinates
         #
-        logger.debug('    HPI amplitude correlation %0.3f: %0.3f '
-                     '(%s chnls > 0.90)' % (fit_time, g_sin,
-                                            (g_chan > 0.90).sum()))
         outs = [_fit_magnetic_dipole(f, pos, hpi['coils'], hpi['scale'],
                                      hpi['method'])
                 for f, pos in zip(sin_fit, last['coil_dev_rrs'])]
         this_coil_dev_rrs = np.array([o[0] for o in outs])
-        g_coils = [o[1] for o in outs]
-        these_dists = cdist(this_coil_dev_rrs, this_coil_dev_rrs)
-        these_dists = np.abs(hpi['dists'] - these_dists)
-        # there is probably a better algorithm for finding the bad ones...
-        good = False
-        use_mask = np.ones(n_freqs, bool)
-        while not good:
-            d = these_dists[use_mask][:, use_mask]
-            d_bad = (d > dist_limit)
-            good = not d_bad.any()
+
+        # filter coil fits based on the correspodnace to digitization geometry
+        use_mask = np.ones(hpi['n_freqs'], bool)
+        if enforce_geometry:
+            g_coils = [o[1] for o in outs]
+            these_dists = cdist(this_coil_dev_rrs, this_coil_dev_rrs)
+            these_dists = np.abs(hpi_coil_dists - these_dists)
+            # there is probably a better algorithm for finding the bad ones...
+            good = False
+            while not good:
+                d = these_dists[use_mask][:, use_mask]
+                d_bad = (d > dist_limit)
+                good = not d_bad.any()
+                if not good:
+                    if use_mask.sum() == 2:
+                        use_mask[:] = False
+                        break  # failure
+                    # exclude next worst point
+                    badness = (d * d_bad).sum(axis=0)
+                    exclude_coils = np.where(use_mask)[0][np.argmax(badness)]
+                    use_mask[exclude_coils] = False
+            good = use_mask.sum() >= 3
             if not good:
-                if use_mask.sum() == 2:
-                    use_mask[:] = False
-                    break  # failure
-                # exclude next worst point
-                badness = (d * d_bad).sum(axis=0)
-                exclude_coils = np.where(use_mask)[0][np.argmax(badness)]
-                use_mask[exclude_coils] = False
-        good = use_mask.sum() >= 3
-        if not good:
-            warn(_time_prefix(fit_time) + '%s/%s good HPI fits, '
-                 'cannot determine the transformation!'
-                 % (use_mask.sum(), n_freqs))
-            continue
+                warn(_time_prefix(fit_time) + '%s/%s good HPI fits, '
+                     'cannot determine the transformation!'
+                     % (use_mask.sum(), hpi['n_freqs']))
+                continue
 
         #
         # 3. Fit the head translation and rotation params (minimize error
         #    between coil positions and the head coil digitization positions)
         #
-        this_quat, g = _fit_chpi_pos(this_coil_dev_rrs[use_mask],
-                                     hpi['coil_head_rrs'][use_mask],
-                                     last['quat'])
+        this_quat, g = _fit_chpi_quat(this_coil_dev_rrs[use_mask],
+                                      hpi_dig_head_rrs[use_mask],
+                                      last['quat'])
         if g < gof_limit:
             logger.info(_time_prefix(fit_time) +
                         'Bad coil fit! (g=%7.3f)' % (g,))
             continue
+
+        # Convert Quaterion to transform
         this_dev_head_t = np.concatenate(
             (quat_to_rot(this_quat[:3]),
              this_quat[3:][:, np.newaxis]), axis=1)
         this_dev_head_t = np.concatenate((this_dev_head_t, [[0, 0, 0, 1.]]))
+
         # velocities, in device coords, of HPI coils
         # dt = fit_time - last['fit_time'] #
         dt = t_window
@@ -566,11 +745,12 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
                                           axis=1)) / dt)
         logger.info(_time_prefix(fit_time) +
                     ('%s/%s good HPI fits, movements [mm/s] = ' +
-                     ' / '.join(['% 6.1f'] * n_freqs))
-                    % ((use_mask.sum(), n_freqs) + vs))
+                     ' / '.join(['% 6.1f'] * hpi['n_freqs']))
+                    % ((use_mask.sum(), hpi['n_freqs']) + vs))
+
         # resulting errors in head coil positions
         est_coil_head_rrs = apply_trans(this_dev_head_t, this_coil_dev_rrs)
-        errs = 1000. * np.sqrt(((hpi['coil_head_rrs'] -
+        errs = 1000. * np.sqrt(((hpi_dig_head_rrs -
                                  est_coil_head_rrs) ** 2).sum(axis=-1))
         e = errs[use_mask].mean() / 1000.  # mm -> m
         d = 100 * np.sqrt(np.sum(last['quat'][3:] - this_quat[3:]) ** 2)  # cm
@@ -580,7 +760,7 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
             pos_0 = this_quat[3:].copy()
         d = 100 * np.sqrt(np.sum((this_quat[3:] - pos_0) ** 2))  # dis from 1st
         # MaxFilter averages over a 200 ms window for display, but we don't
-        for ii in range(n_freqs):
+        for ii in range(hpi['n_freqs']):
             if use_mask[ii]:
                 start, end = ' ', '/'
             else:
@@ -594,7 +774,7 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
                 log_str += '{8:6.3f} {9:6.3f} {10:6.3f}'
             elif ii == 3:
                 log_str += '{8:6.1f} {9:6.1f} {10:6.1f}'
-            vals = np.concatenate((1000 * hpi['coil_head_rrs'][ii],
+            vals = np.concatenate((1000 * hpi_dig_head_rrs[ii],
                                    1000 * est_coil_head_rrs[ii],
                                    [g_coils[ii], errs[ii]]))  # errs in mm
             if ii <= 2:
@@ -607,6 +787,7 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
                      % (fit_time, 100 * e, g, v, r, d))
         logger.debug('    #t = %0.3f, #q = %s '
                      % (fit_time, ' '.join(map('{:8.5f}'.format, this_quat))))
+
         quats.append(np.concatenate(([fit_time], this_quat, [g],
                                      [e * 100], [v])))  # e in centimeters
         last['fit_time'] = fit_time
@@ -654,9 +835,13 @@ def filter_chpi(raw, include_line=True, verbose=None):
     t_window = 0.2
     t_step = 0.01
     n_step = int(np.ceil(t_step * raw.info['sfreq']))
-    hpi = _setup_chpi_fits(raw.info, t_window, t_window, exclude='bads',
-                           add_hpi_stim_pick=False, remove_aliased=True,
-                           verbose=False)[0]
+    # hpi = _setup_chpi_fits(raw.info, t_window, t_window, exclude='bads',
+    #                        add_hpi_stim_pick=False, remove_aliased=True,
+    #                        verbose=False)[0]
+    hpi = _setup_hpi_struct(raw.info, int(round(t_window * raw.info['sfreq'])),
+                            exclude='bads', remove_aliased=True,
+                            verbose=False)
+
     fit_idxs = np.arange(0, len(raw.times) + hpi['n_window'] // 2, n_step)
     n_freqs = len(hpi['freqs'])
     n_remove = 2 * n_freqs

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -16,7 +16,7 @@ To fit head positions (continuously), the procedure using
     5. Use a linear model (DC + linear slope + sin + cos terms set up
        in ``_setup_hpi_struct``) to fit sinusoidal amplitudes to MEG
        channels. Use SVD to determine the phase/amplitude of the sinusoids.
-       This step is accomplished using using ``_fit_cHPI_amplitudes``
+       This step is accomplished using ``_fit_cHPI_amplitudes``
     6. If the amplitudes are 98% correlated with last position
        (and Δt < t_step_max), skip fitting.
     7. Fit magnetic dipoles using the amplitudes for each coil frequency
@@ -498,7 +498,7 @@ def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
         Raw data with cHPI information.
     t_win : list, shape (2)
         Time window to fit. If None entire data run is used.
-    initial_dev_rrs : ???
+    initial_dev_rrs : ndarry, shape (n_CHPI, 3) || None
         Initial guess on HPI locations. If None (0,0,0) is used for each hpi.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -329,7 +329,7 @@ def _setup_hpi_struct(info, model_n_window,
                       method='forward',
                       exclude='bads',
                       remove_aliased=False, verbose=None):
-    """Setup HPI structure for HPI localization.
+    """Generate HPI structure for HPI localization.
 
     Returns
     -------

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -482,7 +482,7 @@ def compute_head_localization(raw, initalLocs=None, time_win=[0, 1],
         Raw data with cHPI information.
     initalLocs : ndarray, shape(nCHPI, 3)
         Initial localations of HPI coils. used to initalized solver.
-        if None (0, 0, 0) is choosen for each coil
+        if None (0, 0, 0) is chosen for each coil
     time_win : list, shape (2)
         Time window to fit. If None entire data run is used.
     verbose : bool, str, int, or None

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -225,7 +225,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.31', misc='0.3')
+    releases = dict(testing='0.32', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -275,7 +275,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='1d5da3a809fded1ef5734444ab5bf857',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='f61041e3f3f2ba0def8a2ca71592cc41',
-        testing='037711ea367c610bd673c11b9b2325ca',
+        testing='bcda2bb49dfa8a9400aaeeb3c4b0a072',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         visual_92_categories='46c7e590f4a48596441ce001595d5e58',
     )

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -56,7 +56,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
 
 
 def _get_artemis123_info(fname, pos_fname=None):
-    """Extracting info from artemis123 header files."""
+    """Generate info struct from artemis123 header file."""
     fname = op.splitext(fname)[0]
     header = fname + '.txt'
 

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -13,7 +13,7 @@ from ..utils import _read_segments_file
 from ..base import BaseRaw
 from ..meas_info import _empty_info, _make_dig_points
 from ..constants import FIFF
-from ...chpi import compute_head_localization as comp_head_loc
+from ...chpi import _compute_head_localization as _comp_head_loc
 from ...transforms import get_ras_to_neuromag_trans, apply_trans, Transform
 
 
@@ -344,7 +344,7 @@ class RawArtemis123(BaseRaw):
                 warn('%d HPIs active. At least 3 needed to perform' % n_hpis +
                      'head localization')
             else:
-                trans, hpi_dev_rrs = comp_head_loc(self, time_win=[0, 1])
+                trans, hpi_dev_rrs = _comp_head_loc(self, time_win=[0, 1])
                 if pos_fname is None:
                     logger.info('Assuming Cardinal HPIs')
                     nas = hpi_dev_rrs[0]

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -367,7 +367,7 @@ class RawArtemis123(BaseRaw):
                         raise RuntimeError(mesg % (len(hpi_head),
                                                    len(hpi_dev)))
 
-                    # compute initial head to dev transfor and hpi ordering
+                    # compute initial head to dev transform and hpi ordering
                     head_to_dev_t, order = \
                         _fit_coil_order_dev_head_trans(hpi_dev, hpi_head)
 

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -345,7 +345,7 @@ class RawArtemis123(BaseRaw):
                     n_hpis += 1
             if n_hpis < 3:
                 warn('%d HPIs active. At least 3 needed to perform' % n_hpis +
-                     'head localization')
+                     'head localization\n *NO* head localization performed')
             else:
                 # Localized HPIs using the 1st seconds of data.
                 hpi_dev, hpi_g = _fit_device_hpi_positions(self,

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -133,7 +133,7 @@ def _get_artemis123_info(fname, pos_fname=None):
         warn('Non-Empty Filter histroy found, BUT is not supported' % k)
 
     # build mne info struct
-    info = _empty_info(float(header_info['Rate Out']))
+    info = _empty_info(float(header_info['DAQ Sample Rate']))
 
     # Attempt to get time/date from fname
     # Artemis123 files saved from the scanner observe the following
@@ -157,7 +157,6 @@ def _get_artemis123_info(fname, pos_fname=None):
         desc += '{} : {}\n'.format(k, header_info[k])
     desc += 'Comments : {}'.format(header_info['comments'])
 
-    info = _empty_info(float(header_info['Rate Out']))
     info.update({'meas_date': meas_date,
                  'description': desc, 'buffer_size_sec': 1.,
                  'subject_info': subject_info,

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -35,7 +35,12 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
         on the hard drive (slower, requires less memory).
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
-
+    pos_fname : str or None (defulat None)
+        If not None, load digitized head points from this file
+    head_loc : bool (default False)
+        If True attempt to perform head localization using HPI coils. If no
+        HPI coils are in info['dig'] hpic coils are assumed to be in canonical
+        order of fiducial points (nas, rpa, lpa).
     Returns
     -------
     raw : Instance of Raw
@@ -345,9 +350,10 @@ class RawArtemis123(BaseRaw):
                     lpa = hpi_dev_rrs[2]
                     rpa = hpi_dev_rrs[1]
                     t = get_ras_to_neuromag_trans(nas, lpa, rpa)
-                    self.info['dev_head_t'] = Transform(FIFF.FIFFV_COORD_DEVICE,
-                                                        FIFF.FIFFV_COORD_HEAD,
-                                                        t)
+                    self.info['dev_head_t'] = \
+                        Transform(FIFF.FIFFV_COORD_DEVICE,
+                                  FIFF.FIFFV_COORD_HEAD, t)
+
                     # transform fiducial points
                     nas = apply_trans(t, nas)
                     lpa = apply_trans(t, lpa)

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -6,7 +6,6 @@ import numpy as np
 import os.path as op
 import datetime
 import calendar
-from scipy.spatial.distance import cdist
 
 from .utils import _load_mne_locs, _read_pos
 from ...utils import logger, warn
@@ -316,6 +315,7 @@ class RawArtemis123(BaseRaw):
 
     def __init__(self, input_fname, preload=False, verbose=None,
                  pos_fname=None, head_loc=True):  # noqa: D102
+        from scipy.spatial.distance import cdist
 
         fname, ext = op.splitext(input_fname)
         if ext == '.txt':

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -18,7 +18,7 @@ from ...transforms import get_ras_to_neuromag_trans, apply_trans, Transform
 
 
 def read_raw_artemis123(input_fname, preload=False, verbose=None,
-                        pos_fname=None, head_loc=True):
+                        pos_fname=None, add_head_trans=True):
     """Read Artemis123 data as raw object.
 
     Parameters
@@ -37,9 +37,9 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
         If not None, override default verbose level (see mne.verbose).
     pos_fname : str or None (default None)
         If not None, load digitized head points from this file
-    head_loc : bool (default True)
-        If True attempt to perform initial head localization (compute initial
-        evice to head coordinate transform) using HPI coils. If no
+    add_head_trans : bool (default True)
+        If True attempt to perform initial head localization. Compute initial
+        device to head coordinate transform using HPI coils. If no
         HPI coils are in info['dig'] hpi coils are assumed to be in canonical
         order of fiducial points (nas, rpa, lpa).
 
@@ -53,7 +53,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
     mne.io.Raw : Documentation of attribute and methods.
     """
     return RawArtemis123(input_fname, preload=preload, verbose=verbose,
-                         pos_fname=pos_fname, head_loc=head_loc)
+                         pos_fname=pos_fname, add_head_trans=add_head_trans)
 
 
 def _get_artemis123_info(fname, pos_fname=None):
@@ -314,7 +314,7 @@ class RawArtemis123(BaseRaw):
     """
 
     def __init__(self, input_fname, preload=False, verbose=None,
-                 pos_fname=None, head_loc=True):  # noqa: D102
+                 pos_fname=None, add_head_trans=True):  # noqa: D102
         from scipy.spatial.distance import cdist
 
         fname, ext = op.splitext(input_fname)
@@ -338,7 +338,7 @@ class RawArtemis123(BaseRaw):
             verbose=verbose)
         self.info['hpi_results'] = []
 
-        if head_loc:
+        if add_head_trans:
             n_hpis = 0
             for d in info['hpi_subsystem']['hpi_coils']:
                 if d['event_bits'] == [256]:

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -56,7 +56,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
 
 
 def _get_artemis123_info(fname, pos_fname=None):
-    """Function for extracting info from artemis123 header files."""
+    """Extracting info from artemis123 header files."""
     fname = op.splitext(fname)[0]
     header = fname + '.txt'
 

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -41,6 +41,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
         If True attempt to perform head localization using HPI coils. If no
         HPI coils are in info['dig'] hpic coils are assumed to be in canonical
         order of fiducial points (nas, rpa, lpa).
+
     Returns
     -------
     raw : Instance of Raw

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -17,8 +17,7 @@ from mne import pick_types
 from mne.transforms import rot_to_quat, _angle_between_quats
 
 artemis123_dir = op.join(testing.data_path(download=False), 'ARTEMIS123')
-short_no_HPI_fname = op.join(artemis123_dir,
-                             'Artemis_Data_2016-11-03-15h-58m_test.bin')
+
 short_HPI_dip_fname = op.join(artemis123_dir,
                               'Artemis_Data_2017-04-04-15h-44m-' +
                               '22s_Motion_Translation-z.bin')
@@ -49,11 +48,12 @@ def test_data():
                      pos_fname=dig_fname)
 
     # test a random selected point
-    raw = read_raw_artemis123(short_no_HPI_fname, preload=True, head_loc=False)
+    raw = read_raw_artemis123(short_hpi_1kz_fname, preload=True,
+                              head_loc=False)
     meg_picks = pick_types(raw.info, meg=True, eeg=False)
 
     # checked against matlab reader.
-    assert_allclose(raw[meg_picks[12]][0][0][123], 3.072510659694672e-11)
+    assert_allclose(raw[meg_picks[12]][0][0][123], 1.08239606023e-11)
 
     dev_head_t_1 = np.array([[9.713e-01, 2.340e-01, -4.164e-02, 1.302e-04],
                              [-2.371e-01, 9.664e-01, -9.890e-02, 1.977e-03],

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -24,7 +24,7 @@ def test_data():
     _test_raw_reader(read_raw_artemis123, input_fname=short_no_HPI_fname)
 
     # test a random selected point
-    raw = read_raw_artemis123(short_no_HPI_fname, preload=True)
+    raw = read_raw_artemis123(short_no_HPI_fname, preload=True, head_loc=False)
     meg_picks = pick_types(raw.info, meg=True, eeg=False)
     # checked against matlab reader.
     assert_allclose(raw[meg_picks[12]][0][0][123], 3.072510659694672e-11)

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -4,7 +4,9 @@
 # License: BSD (3-clause)
 
 import os.path as op
+import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+from nose.tools import assert_true
 
 from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_artemis123
@@ -12,6 +14,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
 from mne.io.artemis123.utils import _generate_mne_locs_file, _load_mne_locs
 from mne import pick_types
+from mne.transforms import rot_to_quat, _angle_between_quats
 
 artemis123_dir = op.join(testing.data_path(download=False), 'ARTEMIS123')
 short_no_HPI_fname = op.join(artemis123_dir,
@@ -22,11 +25,28 @@ short_HPI_dip_fname = op.join(artemis123_dir,
 
 dig_fname = op.join(artemis123_dir, 'Phantom_040417_dig.pos')
 
+short_hpi_1kz_fname = op.join(artemis123_dir, 'Artemis_Data_2017-04-14-10h' +
+                              '-38m-59s_Phantom_1k_HPI_1s.bin')
+
+
+def _assert_trans(actual, desired, dist_tol=0.003, angle_tol=5.):
+    trans_est = actual[0:3, 3]
+    quat_est = rot_to_quat(actual[0:3, 0:3])
+    trans = desired[0:3, 3]
+    quat = rot_to_quat(desired[0:3, 0:3])
+
+    angle = 180 * _angle_between_quats(quat_est, quat) / np.pi
+    dist = np.sqrt(np.sum((trans - trans_est) ** 2))
+    assert_true(dist <= dist_tol, '%0.3f > %0.3f mm' % (1000 * dist,
+                                                        1000 * dist_tol))
+    assert_true(angle <= angle_tol, '%0.3f > %0.3f deg' % (angle, angle_tol))
+
 
 @testing.requires_testing_data
 def test_data():
     """Test reading raw Artemis123 files."""
-    _test_raw_reader(read_raw_artemis123, input_fname=short_no_HPI_fname)
+    _test_raw_reader(read_raw_artemis123, input_fname=short_hpi_1kz_fname,
+                     pos_fname=dig_fname)
 
     # test a random selected point
     raw = read_raw_artemis123(short_no_HPI_fname, preload=True, head_loc=False)
@@ -35,12 +55,30 @@ def test_data():
     # checked against matlab reader.
     assert_allclose(raw[meg_picks[12]][0][0][123], 3.072510659694672e-11)
 
+    dev_head_t_1 = np.array([[9.713e-01, 2.340e-01, -4.164e-02, 1.302e-04],
+                             [-2.371e-01, 9.664e-01, -9.890e-02, 1.977e-03],
+                             [1.710e-02,   1.059e-01, 9.942e-01, -8.159e-03],
+                             [0.0, 0.0, 0.0, 1.0]])
+
+    dev_head_t_2 = np.array([[9.890e-01, 1.475e-01, -8.090e-03, 4.997e-04],
+                             [-1.476e-01, 9.846e-01, -9.389e-02, 1.962e-03],
+                             [-5.888e-03, 9.406e-02, 9.955e-01, -1.610e-02],
+                             [0.0, 0.0, 0.0, 1.0]])
+
     # test with head loc no digitization
     raw = read_raw_artemis123(short_HPI_dip_fname, head_loc=True)
+    _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_1)
+    assert_equal(raw.info['sfreq'], 5000.0)
 
     # test with head loc and digitization
     raw = read_raw_artemis123(short_HPI_dip_fname,  head_loc=True,
                               pos_fname=dig_fname)
+    _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_1)
+
+    # test 1kz hpi head loc (different freq)
+    raw = read_raw_artemis123(short_hpi_1kz_fname, head_loc=True)
+    _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_2)
+    assert_equal(raw.info['sfreq'], 1000.0)
 
 
 def test_utils():

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -16,6 +16,11 @@ from mne import pick_types
 artemis123_dir = op.join(testing.data_path(download=False), 'ARTEMIS123')
 short_no_HPI_fname = op.join(artemis123_dir,
                              'Artemis_Data_2016-11-03-15h-58m_test.bin')
+short_HPI_dip_fname = op.join(artemis123_dir,
+                              'Artemis_Data_2017-04-04-15h-44m-' +
+                              '22s_Motion_Translation-z.bin')
+
+dig_fname = op.join(artemis123_dir, 'Phantom_040417.pos')
 
 
 @testing.requires_testing_data
@@ -26,8 +31,16 @@ def test_data():
     # test a random selected point
     raw = read_raw_artemis123(short_no_HPI_fname, preload=True, head_loc=False)
     meg_picks = pick_types(raw.info, meg=True, eeg=False)
+
     # checked against matlab reader.
     assert_allclose(raw[meg_picks[12]][0][0][123], 3.072510659694672e-11)
+
+    # test with digitization
+    raw = read_raw_artemis123(short_HPI_dip_fname, head_loc=True)
+
+    # test with digitization
+    raw = read_raw_artemis123(short_HPI_dip_fname,  head_loc=True,
+                              pos_fname=dig_fname)
 
 
 def test_utils():

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -49,7 +49,7 @@ def test_data():
 
     # test a random selected point
     raw = read_raw_artemis123(short_hpi_1kz_fname, preload=True,
-                              head_loc=False)
+                              add_head_trans=False)
     meg_picks = pick_types(raw.info, meg=True, eeg=False)
 
     # checked against matlab reader.
@@ -66,17 +66,17 @@ def test_data():
                              [0.0, 0.0, 0.0, 1.0]])
 
     # test with head loc no digitization
-    raw = read_raw_artemis123(short_HPI_dip_fname, head_loc=True)
+    raw = read_raw_artemis123(short_HPI_dip_fname, add_head_trans=True)
     _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_1)
     assert_equal(raw.info['sfreq'], 5000.0)
 
     # test with head loc and digitization
-    raw = read_raw_artemis123(short_HPI_dip_fname,  head_loc=True,
+    raw = read_raw_artemis123(short_HPI_dip_fname,  add_head_trans=True,
                               pos_fname=dig_fname)
     _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_1)
 
     # test 1kz hpi head loc (different freq)
-    raw = read_raw_artemis123(short_hpi_1kz_fname, head_loc=True)
+    raw = read_raw_artemis123(short_hpi_1kz_fname, add_head_trans=True)
     _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_2)
     assert_equal(raw.info['sfreq'], 1000.0)
 

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -20,7 +20,7 @@ short_HPI_dip_fname = op.join(artemis123_dir,
                               'Artemis_Data_2017-04-04-15h-44m-' +
                               '22s_Motion_Translation-z.bin')
 
-dig_fname = op.join(artemis123_dir, 'Phantom_040417.pos')
+dig_fname = op.join(artemis123_dir, 'Phantom_040417_dig.pos')
 
 
 @testing.requires_testing_data
@@ -35,10 +35,10 @@ def test_data():
     # checked against matlab reader.
     assert_allclose(raw[meg_picks[12]][0][0][123], 3.072510659694672e-11)
 
-    # test with digitization
+    # test with head loc no digitization
     raw = read_raw_artemis123(short_HPI_dip_fname, head_loc=True)
 
-    # test with digitization
+    # test with head loc and digitization
     raw = read_raw_artemis123(short_HPI_dip_fname,  head_loc=True,
                               pos_fname=dig_fname)
 

--- a/mne/io/artemis123/utils.py
+++ b/mne/io/artemis123/utils.py
@@ -1,7 +1,9 @@
 import numpy as np
 import os.path as op
 from ...utils import logger
-from ...transforms import rotation3d_align_z_axis
+from ...transforms import (rotation3d_align_z_axis, get_ras_to_neuromag_trans,
+                           apply_trans)
+from ..meas_info import _make_dig_points
 
 
 def _load_mne_locs(fname=None):
@@ -82,3 +84,55 @@ def _compute_mne_loc(coil_loc):
     R = rotation3d_align_z_axis(z_axis)
     loc[3:13] = R.T.reshape(9)
     return loc
+
+
+def _read_pos(fname):
+    """Read the .pos file and return positions as dig points."""
+    nas = None
+    lpa = None
+    rpa = None
+    hpi = None
+    extra = None
+    with open(fname, 'r') as fid:
+        for line in fid:
+            line = line.strip()
+            if len(line) > 0:
+                parts = line.split()
+                # The lines can have 4 or 5 parts. First part is for the id,
+                # which can be an int or a string. The last three are for xyz
+                # coordinates. The extra part is for additional info
+                # (e.g. 'Pz', 'Cz') which is ignored.
+                if len(parts) not in [4, 5]:
+                    continue
+
+                if parts[0].lower() == 'nasion':
+                    nas = np.array([float(p) for p in parts[-3:]]) / 100.
+                elif parts[0].lower() == 'left':
+                    lpa = np.array([float(p) for p in parts[-3:]]) / 100.
+                elif parts[0].lower() == 'right':
+                    rpa = np.array([float(p) for p in parts[-3:]]) / 100.
+                elif parts[0].lower().startswith('hpi'):
+                    if hpi is None:
+                        hpi = list()
+                    hpi.append(np.array([float(p) for p in parts[-3:]]) / 100.)
+                else:
+                    if extra is None:
+                        extra = list()
+                    extra.append(np.array([float(p)
+                                           for p in parts[-3:]]) / 100.)
+    # move into MNE head coords
+    if ((nas is not None) and (lpa is not None) and (rpa is not None)):
+        neuromag_trans = get_ras_to_neuromag_trans(nas, lpa, rpa)
+        nas = apply_trans(neuromag_trans, nas)
+        lpa = apply_trans(neuromag_trans, lpa)
+        rpa = apply_trans(neuromag_trans, rpa)
+
+        if hpi is not None:
+            hpi = apply_trans(neuromag_trans, hpi)
+
+        if extra is not None:
+            extra = apply_trans(neuromag_trans, extra)
+
+    digs = _make_dig_points(nasion=nas, lpa=lpa, rpa=rpa, hpi=hpi,
+                            extra_points=extra)
+    return digs

--- a/mne/io/artemis123/utils.py
+++ b/mne/io/artemis123/utils.py
@@ -111,7 +111,7 @@ def _read_pos(fname):
                     lpa = np.array([float(p) for p in parts[-3:]]) / 100.
                 elif parts[0].lower() == 'right':
                     rpa = np.array([float(p) for p in parts[-3:]]) / 100.
-                elif parts[0].lower().startswith('hpi'):
+                elif 'hpi' in parts[0].lower():
                     if hpi is None:
                         hpi = list()
                     hpi.append(np.array([float(p) for p in parts[-3:]]) / 100.)

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -17,7 +17,8 @@ from ..source_estimate import VolSourceEstimate
 from ..cov import make_ad_hoc_cov, read_cov
 from ..bem import fit_sphere_to_headshape, make_sphere_model, read_bem_solution
 from ..io import RawArray, BaseRaw
-from ..chpi import read_head_pos, head_pos_to_trans_rot_t, _get_hpi_info
+from ..chpi import (read_head_pos, head_pos_to_trans_rot_t, _get_hpi_info,
+                    _get_hpi_initial_fit)
 from ..io.constants import FIFF
 from ..forward import (_magnetic_dipole_field_vec, _merge_meg_eeg_fwds,
                        _stc_src_sel, convert_forward_solution,
@@ -265,7 +266,8 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
     ecg = ecg and len(meg_picks) > 0
     chpi = chpi and len(meg_picks) > 0
     if chpi:
-        hpi_freqs, hpi_rrs, hpi_pick, hpi_ons = _get_hpi_info(info)[:4]
+        hpi_freqs, hpi_pick, hpi_ons = _get_hpi_info(info)
+        hpi_rrs = _get_hpi_initial_fit(info)
         hpi_nns = hpi_rrs / np.sqrt(np.sum(hpi_rrs * hpi_rrs,
                                            axis=1))[:, np.newaxis]
         # turn on cHPI in file

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -244,7 +244,7 @@ def test_simulate_raw_chpi():
     raw_chpi = simulate_raw(raw, stc, None, src, sphere, cov=None, chpi=True,
                             head_pos=pos_fname, interp='zero')
     # test cHPI indication
-    hpi_freqs, _, hpi_pick, hpi_ons = _get_hpi_info(raw.info)[:4]
+    hpi_freqs, hpi_pick, hpi_ons = _get_hpi_info(raw.info)
     assert_allclose(raw_sim[hpi_pick][0], 0.)
     assert_allclose(raw_chpi[hpi_pick][0], hpi_ons.sum())
     # test that the cHPI signals make some reasonable values

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -15,7 +15,8 @@ from mne.io import read_raw_fif, read_info, RawArray
 from mne.io.constants import FIFF
 from mne.chpi import (_calculate_chpi_positions,
                       head_pos_to_trans_rot_t, read_head_pos,
-                      write_head_pos, filter_chpi, _get_hpi_info)
+                      write_head_pos, filter_chpi,
+                      _get_hpi_info, _get_hpi_initial_fit)
 from mne.fixes import assert_raises_regex
 from mne.transforms import rot_to_quat, _angle_between_quats
 from mne.simulation import simulate_raw
@@ -46,8 +47,8 @@ def test_chpi_adjust():
     """Test cHPI logging and adjustment."""
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
     with catch_logging() as log:
-        _get_hpi_info(raw.info, adjust=True, verbose='debug')
-
+        _get_hpi_initial_fit(raw.info, adjust=True, verbose='debug')
+        _get_hpi_info(raw.info, verbose='debug')
     # Ran MaxFilter (with -list, -v, -movecomp, etc.), and got:
     msg = ['HPIFIT: 5 coils digitized in order 5 1 4 3 2',
            'HPIFIT: 3 coils accepted: 1 2 4',
@@ -74,7 +75,8 @@ def test_chpi_adjust():
         'Note: HPI coil 3 isotrak is adjusted by 5.3 mm!',
         'Note: HPI coil 5 isotrak is adjusted by 3.2 mm!'] + msg[-2:]
     with catch_logging() as log:
-        _get_hpi_info(raw.info, adjust=True, verbose='debug')
+        _get_hpi_initial_fit(raw.info, adjust=True, verbose='debug')
+        _get_hpi_info(raw.info, verbose='debug')
     log = log.getvalue().splitlines()
     assert_true(set(log) == set(msg), '\n' + '\n'.join(set(msg) - set(log)))
 

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -345,23 +345,23 @@ def test_calculate_chpi_coil_locs():
     times, cHPI_digs = _calculate_chpi_coil_locs(raw_dec, verbose='debug')
 
     # spot check
-    assert_allclose(times[9], 9.9)
+    assert_allclose(times[9], 9.9, atol=1e-3)
     assert_allclose(cHPI_digs[9][2]['r'],
                     [-0.01937833, 0.00346804, 0.06331209], atol=1e-3)
-    assert_allclose(cHPI_digs[9][2]['gof'], 0.9957976)
+    assert_allclose(cHPI_digs[9][2]['gof'], 0.9957976, atol=1e-3)
 
     assert_allclose(cHPI_digs[9][4]['r'],
-                    [0.05442122, 0.00997692, 0.03721696],  atol=1e-3)
-    assert_allclose(cHPI_digs[9][4]['gof'], 0.075700080794629199)
+                    [0.05442122, 0.00997692, 0.03721696], atol=1e-3)
+    assert_allclose(cHPI_digs[9][4]['gof'], 0.075700080794629199, atol=1e-3)
 
     # test on 5k artemis data
     raw = read_raw_artemis123(art_fname, preload=True)
     times, cHPI_digs = _calculate_chpi_coil_locs(raw, verbose='debug')
 
-    assert_allclose(times[2], 2.9)
-    assert_allclose(cHPI_digs[2][0]['gof'], 0.9980471794552791)
+    assert_allclose(times[2], 2.9, atol=1e-3)
+    assert_allclose(cHPI_digs[2][0]['gof'], 0.9980471794552791, atol=1e-3)
     assert_allclose(cHPI_digs[2][0]['r'],
-                    [-0.0157762, 0.06655744, 0.00545172],  atol=1e-3)
+                    [-0.0157762, 0.06655744, 0.00545172], atol=1e-3)
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -11,7 +11,7 @@ import warnings
 
 from mne import (pick_types, Dipole, make_sphere_model, make_forward_dipole,
                  pick_info)
-from mne.io import read_raw_fif, read_info, RawArray
+from mne.io import read_raw_fif, read_raw_artemis123, read_info, RawArray
 from mne.io.constants import FIFF
 from mne.chpi import (_calculate_chpi_positions,
                       head_pos_to_trans_rot_t, read_head_pos,
@@ -38,6 +38,11 @@ sss_fif_fname = op.join(data_path, 'SSS', 'test_move_anon_raw_sss.fif')
 sss_hpisubt_fname = op.join(data_path, 'SSS', 'test_move_anon_hpisubt_raw.fif')
 chpi5_fif_fname = op.join(data_path, 'SSS', 'chpi5_raw.fif')
 chpi5_pos_fname = op.join(data_path, 'SSS', 'chpi5_raw_mc.pos')
+
+art_fname = op.join(data_path, 'ARTEMIS123', 'Artemis_Data_2017-04-04' +
+                    '-15h-44m-22s_Motion_Translation-z.bin')
+art_mc_fname = op.join(data_path, 'ARTEMIS123', 'Artemis_Data_2017-04-04' +
+                       '-15h-44m-22s_Motion_Translation-z_mc.pos')
 
 warnings.simplefilter('always')
 
@@ -209,6 +214,13 @@ def test_calculate_chpi_positions():
     raw.info['lowpass'] /= 2.
     assert_raises_regex(RuntimeError, 'above the',
                         _calculate_chpi_positions, raw)
+
+    # test on 5k artemis data
+    raw = read_raw_artemis123(art_fname, preload=True)
+    mf_quats = read_head_pos(art_mc_fname)
+    with catch_logging() as log:
+        py_quats = _calculate_chpi_positions(raw, verbose='debug')
+    _assert_quats(py_quats, mf_quats, dist_tol=0.004, angle_tol=2.5)
 
 
 @testing.requires_testing_data

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -51,7 +51,10 @@ def _fiducial_coords(points, coord_frame=None):
         points = (p for p in points if p['coord_frame'] == coord_frame)
     points_ = dict((p['ident'], p) for p in points if
                    p['kind'] == FIFF.FIFFV_POINT_CARDINAL)
-    return np.array([points_[i]['r'] for i in FIDUCIAL_ORDER])
+    if points_:
+        return np.array([points_[i]['r'] for i in FIDUCIAL_ORDER])
+    else:
+        return np.array([])
 
 
 def plot_head_positions(pos, mode='traces', cmap='viridis', direction='z',


### PR DESCRIPTION
This is an initial stage to get artemis data into a form that can be used with existing cHPI code. Essentially it provides some methods to do basic HPI fitting without digitization or initialization (coming from the scanner).

Next steps are to generate HPI_results structures to facilitate cHPI in a manner similar to what is being used for elekta data and provide better support for edge cases (multiple HPIs, no digitization, in non canonical ordering etc)