### PR TITLE
MRG+1: Fix scaling for EGI digitization coordinates

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,7 +25,7 @@ Changelog
 BUG
 ~~~
 
-    - ...
+    - Fix unit scaling when reading in EGI digitization files using :func:`mne.channels.read_dig_montage` by `Matt Boggess`_
 
 API
 ~~~

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -683,15 +683,15 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
     else:
         fids = [None] * 3
         dig_ch_pos = None
-        scale = {'mm': 1e-3, 'cm': 1e-2, 'auto': 1e-3, 'm': None}
+        scale = dict(mm=1e-3, cm=1e-2, auto=1e-3, m=1)
         if unit not in scale:
             raise ValueError("Unit needs to be one of %s, not %r" %
-                             (tuple(map(repr, scale)), unit))
+                             (sorted(scale.keys()), unit))
 
         # HSP
         if isinstance(hsp, string_types):
             hsp = _read_dig_points(hsp, unit=unit)
-        elif hsp is not None and scale[unit]:
+        elif hsp is not None:
             hsp *= scale[unit]
 
         # HPI

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -649,18 +649,17 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
                         'Right periauricular point': 'rpa',
                         'Left periauricular point': 'lpa'}
 
-        scale = dict(mm=1e-3, cm=1e-2, auto=1e-2, m=None)
+        scale = dict(mm=1e-3, cm=1e-2, auto=1e-2, m=1)
         if unit not in scale:
             raise ValueError("Unit needs to be one of %s, not %r" %
-                             (tuple(map(repr, scale)), unit))
+                             (sorted(scale.keys()), unit))
 
         for s in sensors:
             name, number, kind = s[0].text, int(s[1].text), int(s[2].text)
             coordinates = np.array([float(s[3].text), float(s[4].text),
                                     float(s[5].text)])
 
-            if scale[unit] is not None:
-                coordinates *= scale[unit]
+            coordinates *= scale[unit]
 
             # EEG Channels
             if kind == 0:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -649,10 +649,19 @@ def read_dig_montage(hsp=None, hpi=None, elp=None, point_names=None,
                         'Right periauricular point': 'rpa',
                         'Left periauricular point': 'lpa'}
 
+        scale = dict(mm=1e-3, cm=1e-2, auto=1e-2, m=None)
+        if unit not in scale:
+            raise ValueError("Unit needs to be one of %s, not %r" %
+                             (tuple(map(repr, scale)), unit))
+
         for s in sensors:
             name, number, kind = s[0].text, int(s[1].text), int(s[2].text)
             coordinates = np.array([float(s[3].text), float(s[4].text),
                                     float(s[5].text)])
+
+            if scale[unit] is not None:
+                coordinates *= scale[unit]
+
             # EEG Channels
             if kind == 0:
                 dig_ch_pos['EEG %03d' % number] = coordinates

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -401,7 +401,7 @@ def test_fif_dig_montage():
 @testing.requires_testing_data
 def test_egi_dig_montage():
     """Test EGI MFF XML dig montage support."""
-    dig_montage = read_dig_montage(egi=egi_dig_montage_fname)
+    dig_montage = read_dig_montage(egi=egi_dig_montage_fname, unit='im')
 
     # # test round-trip IO
     temp_dir = _TempDir()

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -401,7 +401,7 @@ def test_fif_dig_montage():
 @testing.requires_testing_data
 def test_egi_dig_montage():
     """Test EGI MFF XML dig montage support."""
-    dig_montage = read_dig_montage(egi=egi_dig_montage_fname, unit='im')
+    dig_montage = read_dig_montage(egi=egi_dig_montage_fname, unit='m')
 
     # # test round-trip IO
     temp_dir = _TempDir()


### PR DESCRIPTION
I realized that a recent pull request I made to add in functionality for reading in EGI digitization files did not appropriately scale the digitization coordinate units. This merge would fix that scaling issue. I am really sorry for the oversight on my part and that this wasn't fixed before the 0.14 release.

