### PR TITLE
[MRG] Optimize read_source_estimate function

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -38,35 +38,40 @@ def _read_stc(filename):
 
     stc = dict()
     offset = 0
+    num_bytes = 4
 
     # read tmin in ms
-    stc['tmin'] = float(np.frombuffer(buf, dtype=">f4", count=1, offset=offset))
+    stc['tmin'] = float(np.frombuffer(buf, dtype=">f4", count=1,
+                                      offset=offset))
     stc['tmin'] /= 1000.0
-    offset += np.dtype('>f4').itemsize
+    offset += num_bytes
 
     # read sampling rate in ms
-    stc['tstep'] = float(np.frombuffer(buf, dtype=">f4", count=1, offset=offset))
+    stc['tstep'] = float(np.frombuffer(buf, dtype=">f4", count=1,
+                                       offset=offset))
     stc['tstep'] /= 1000.0
-    offset += np.dtype('>f4').itemsize
+    offset += num_bytes
 
     # read number of vertices/sources
     vertices_n = int(np.frombuffer(buf, dtype=">u4", count=1, offset=offset))
-    offset += np.dtype('>u4').itemsize
+    offset += num_bytes
 
     # read the source vector
-    stc['vertices'] = np.frombuffer(buf, dtype=">u4", count=vertices_n, offset=offset)
-    offset += np.dtype('>u4').itemsize * vertices_n
+    stc['vertices'] = np.frombuffer(buf, dtype=">u4", count=vertices_n,
+                                    offset=offset)
+    offset += num_bytes * vertices_n
 
     # read the number of timepts
     data_n = int(np.frombuffer(buf, dtype=">u4", count=1, offset=offset))
-    offset += np.dtype('>u4').itemsize
+    offset += num_bytes
 
     if (vertices_n and  # vertices_n can be 0 (empty stc)
             ((len(buf) / 4 - 4 - vertices_n) % (data_n * vertices_n)) != 0):
         raise ValueError('incorrect stc file size')
 
     # read the data matrix
-    stc['data'] = np.frombuffer(buf, dtype=">f4", count=vertices_n * data_n, offset=offset)
+    stc['data'] = np.frombuffer(buf, dtype=">f4", count=vertices_n * data_n,
+                                offset=offset)
     stc['data'] = stc['data'].reshape([data_n, vertices_n]).T
 
     return stc

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -66,7 +66,7 @@ def _read_stc(filename):
     offset += num_bytes
 
     if (vertices_n and  # vertices_n can be 0 (empty stc)
-            ((len(buf) / 4 - 4 - vertices_n) % (data_n * vertices_n)) != 0):
+            ((len(buf) // 4 - 4 - vertices_n) % (data_n * vertices_n)) != 0):
         raise ValueError('incorrect stc file size')
 
     # read the data matrix


### PR DESCRIPTION
I'm having a weird use case for which I need to load in 2413 source estimate objects. While waiting for it to load, I looked at the source code and found a simple way to make the loading roughly twice as fast. Reading an stc is probably almost never a bottleneck, but hey, it's a small change *shrug*.

Seeking to the end of the file can be a costly operation on some file systems, especially when reading from a network mount. Since all bytes of the file are read during this function anyway, it makes more sense to
just read everything into a buffer instead of doing file seeks.

