### PR TITLE
BUG/MINOR: remove transparent background for plot_compare_evoked

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1715,7 +1715,6 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     # finishing touches
     if invert_y:
         axes.invert_yaxis()
-    axes.patch.set_alpha(0)
     axes.spines['right'].set_color('none')
     axes.set_xlim(tmin, tmax)
 


### PR DESCRIPTION
plot_compare_evokeds somehow sets the background to transparent. I don't know why I originally did this, but I don't see a benefit right now and we got a complaint (because it doesn't play well with dark backgrounds). This removes the offending line.

@kambysese

closes #4091