### PR TITLE
MRG: Better filtering

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,6 @@ Current
 Changelog
 ~~~~~~~~~
 
-
     - :meth:`mne.channels.Layout.plot` and :func:`mne.viz.plot_layout` now allows plotting a subset of channels with ``picks`` argument by `Jaakko Leppakangas`_
 
     - Add .bvef extension (BrainVision Electrodes File) to :func:`mne.channels.read_montage` by `Jean-Baptiste Schiratti`_
@@ -33,8 +32,12 @@ BUG
 
     - Fix unit scaling when reading in EGI digitization files using :func:`mne.channels.read_dig_montage` by `Matt Boggess`_
 
+    - Fix ``picks`` default in :meth:`mne.io.Raw.filter` to include ``ref_meg`` channels by default by `Eric Larson`_
+
 API
 ~~~
+
+    - Add new filtering mode ``fir_design='firwin'`` (default in the next 0.16 release) that gets improved attenuation using fewer samples compared to ``fir_design='firwin2'`` (default in the current 0.15 release) by `Eric Larson`_
 
     - Make the goodness of fit (GOF) of the dipoles returned by :func:`mne.beamformer.rap_music` consistent with the GOF of dipoles returned by :func:`mne.fit_dipole` by `Alex Gramfort`_.
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -725,9 +725,11 @@ class TemporalFilter(TransformerMixin):
         The window to use in FIR design, can be "hamming", "hann",
         or "blackman".
     fir_design : str
-        Can be "firwin" (default in 0.16) to use :func:`scipy.signal.firwin`,
-        or "firwin2" (default in 0.15 and before) to use
-        :func:`scipy.signal.firwin2`.
+        Can be "firwin" (default in 0.16) to use
+        :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+        before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+        time-domain design technique that generally gives improved
+        attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -806,7 +806,8 @@ class TemporalFilter(TransformerMixin):
         shape = X.shape
         X = X.reshape(-1, shape[-1])
         (X, self.sfreq, self.l_freq, self.h_freq, self.l_trans_bandwidth,
-         self.h_trans_bandwidth, self.filter_length, _, self.fir_window) = \
+         self.h_trans_bandwidth, self.filter_length, _, self.fir_window,
+         self.fir_design) = \
             _triage_filter_params(X, self.sfreq, self.l_freq, self.h_freq,
                                   self.l_trans_bandwidth,
                                   self.h_trans_bandwidth, self.filter_length,
@@ -819,6 +820,6 @@ class TemporalFilter(TransformerMixin):
                         h_trans_bandwidth=self.h_trans_bandwidth,
                         n_jobs=self.n_jobs, method=self.method,
                         iir_params=self.iir_params, copy=False,
-                        fir_window=self.fir_window,
+                        fir_window=self.fir_window, fir_design=self.fir_design,
                         verbose=self.verbose)
         return X.reshape(shape)

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -724,6 +724,13 @@ class TemporalFilter(TransformerMixin):
     fir_window : str, defaults to 'hamming'
         The window to use in FIR design, can be "hamming", "hann",
         or "blackman".
+    fir_design : str
+        Can be "firwin" (default in 0.16) to use :func:`scipy.signal.firwin`,
+        or "firwin2" (default in 0.15 and before) to use
+        :func:`scipy.signal.firwin2`.
+
+        ..versionadded:: 0.15
+
     verbose : bool, str, int, or None, defaults to None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more). Defaults to
@@ -739,7 +746,7 @@ class TemporalFilter(TransformerMixin):
     def __init__(self, l_freq=None, h_freq=None, sfreq=1.0,
                  filter_length='auto', l_trans_bandwidth='auto',
                  h_trans_bandwidth='auto', n_jobs=1, method='fir',
-                 iir_params=None, fir_window='hamming',
+                 iir_params=None, fir_window='hamming', fir_design=None,
                  verbose=None):  # noqa: D102
         self.l_freq = l_freq
         self.h_freq = h_freq
@@ -751,6 +758,7 @@ class TemporalFilter(TransformerMixin):
         self.method = method
         self.iir_params = iir_params
         self.fir_window = fir_window
+        self.fir_design = fir_design
         self.verbose = verbose
 
         if not isinstance(self.n_jobs, int) and self.n_jobs == 'cuda':
@@ -803,7 +811,8 @@ class TemporalFilter(TransformerMixin):
                                   self.l_trans_bandwidth,
                                   self.h_trans_bandwidth, self.filter_length,
                                   self.method, phase='zero',
-                                  fir_window=self.fir_window)
+                                  fir_window=self.fir_window,
+                                  fir_design=self.fir_design)
         X = filter_data(X, self.sfreq, self.l_freq, self.h_freq,
                         filter_length=self.filter_length,
                         l_trans_bandwidth=self.l_trans_bandwidth,

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -14,8 +14,8 @@ from .parallel import parallel_func, check_n_jobs
 from .time_frequency.multitaper import dpss_windows, _mt_spectra
 from .utils import logger, verbose, sum_squared, check_version, warn
 
-# These values are *double* what is given in Ifeachor and Jervis.
-_length_factors = dict(hann=6.2, hamming=6.6, blackman=11.0)
+# These values from Ifeachor and Jervis.
+_length_factors = dict(hann=3.1, hamming=3.3, blackman=5.0)
 
 
 def is_power2(num):
@@ -310,7 +310,7 @@ def _firwin_design(N, freq, gain, window, sfreq):
         assert this_gain in (0, 1)
         if this_gain != prev_gain:
             # Get the correct N to satistify the requested transition bandwidth
-            transition = prev_freq - this_freq
+            transition = (prev_freq - this_freq) / 2.
             this_N = int(round(_length_factors[window] / transition))
             this_N += (1 - this_N % 2)  # make it odd
             if this_N > N:
@@ -1778,9 +1778,9 @@ def _triage_filter_params(x, sfreq, l_freq, h_freq,
             if filter_length == 'auto':
                 h_check = h_trans_bandwidth if h_freq is not None else np.inf
                 l_check = l_trans_bandwidth if l_freq is not None else np.inf
-                div_fact = 2. if fir_design == 'firwin' else 1.
+                mult_fact = 2. if fir_design == 'firwin2' else 1.
                 filter_length = max(int(round(
-                    _length_factors[fir_window] * (sfreq / div_fact) /
+                    _length_factors[fir_window] * sfreq * mult_fact /
                     float(min(h_check, l_check)))), 1)
                 logger.info('Filter length of %s samples (%0.3f sec) selected'
                             % (filter_length, filter_length / sfreq))

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -813,9 +813,11 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
         .. versionadded:: 0.13
     fir_design : str
-        Can be "firwin" (default in 0.16) to use :func:`scipy.signal.firwin`,
-        or "firwin2" (default in 0.15 and before) to use
-        :func:`scipy.signal.firwin2`.
+        Can be "firwin" (default in 0.16) to use
+        :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+        before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+        time-domain design technique that generally gives improved
+        attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
     verbose : bool, str, int, or None
@@ -935,9 +937,11 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
 
         .. versionadded:: 0.13
     fir_design : str
-        Can be "firwin" (default in 0.16) to use :func:`scipy.signal.firwin`,
-        or "firwin2" (default in 0.15 and before) to use
-        :func:`scipy.signal.firwin2`.
+        Can be "firwin" (default in 0.16) to use
+        :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+        before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+        time-domain design technique that generally gives improved
+        attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
     verbose : bool, str, int, or None
@@ -1233,9 +1237,11 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
         .. versionadded:: 0.13
 
     fir_design : str
-        Can be "firwin" (default in 0.16) to use :func:`scipy.signal.firwin`,
-        or "firwin2" (default in 0.15 and before) to use
-        :func:`scipy.signal.firwin2`.
+        Can be "firwin" (default in 0.16) to use
+        :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+        before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+        time-domain design technique that generally gives improved
+        attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
 

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -66,21 +66,16 @@ def test_array_raw():
     picks = pick_types(raw2.info, misc=True, exclude='bads')[:4]
     assert_equal(len(picks), 4)
     raw_lp = raw2.copy()
-    raw_lp.filter(None, 4.0, h_trans_bandwidth=4.,
-                  filter_length='auto', picks=picks, n_jobs=2, phase='zero',
-                  fir_window='hamming')
+    kwargs = dict(fir_design='firwin', picks=picks)
+    raw_lp.filter(None, 4.0, h_trans_bandwidth=4., n_jobs=2, **kwargs)
     raw_hp = raw2.copy()
-    raw_hp.filter(16.0, None, l_trans_bandwidth=4.,
-                  filter_length='auto', picks=picks, n_jobs=2, phase='zero',
-                  fir_window='hamming')
+    raw_hp.filter(16.0, None, l_trans_bandwidth=4., n_jobs=2, **kwargs)
     raw_bp = raw2.copy()
-    raw_bp.filter(8.0, 12.0, l_trans_bandwidth=4.,
-                  h_trans_bandwidth=4., filter_length='auto', picks=picks,
-                  phase='zero', fir_window='hamming')
+    raw_bp.filter(8.0, 12.0, l_trans_bandwidth=4., h_trans_bandwidth=4.,
+                  **kwargs)
     raw_bs = raw2.copy()
     raw_bs.filter(16.0, 4.0, l_trans_bandwidth=4., h_trans_bandwidth=4.,
-                  filter_length='auto', picks=picks, n_jobs=2, phase='zero',
-                  fir_window='hamming')
+                  n_jobs=2, **kwargs)
     data, _ = raw2[picks, :]
     lp_data, _ = raw_lp[picks, :]
     hp_data, _ = raw_hp[picks, :]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1096,7 +1096,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def filter(self, l_freq, h_freq, picks=None, filter_length='auto',
                l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
                method='fir', iir_params=None, phase='zero',
-               fir_window='hamming', verbose=None):
+               fir_window='hamming', fir_design=None, verbose=None):
         """Filter a subset of channels.
 
         Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
@@ -1180,13 +1180,17 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             then a minimum-phase, causal filter will be used.
 
             .. versionadded:: 0.13
-
         fir_window : str
             The window to use in FIR design, can be "hamming" (default),
             "hann" (default in 0.13), or "blackman".
 
             .. versionadded:: 0.13
+        fir_design : str
+            Can be "firwin" (default in 0.16) to use
+            :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+            before) to use :func:`scipy.signal.firwin2`.
 
+            ..versionadded:: 0.15
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -1231,7 +1235,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         filter_data(self._data, self.info['sfreq'], l_freq, h_freq, picks,
                     filter_length, l_trans_bandwidth, h_trans_bandwidth,
                     n_jobs, method, iir_params, copy=False, phase=phase,
-                    fir_window=fir_window)
+                    fir_window=fir_window, fir_design=fir_design)
         # update info if filter is applied to all data channels,
         # and it's not a band-stop filter
         if update_info:
@@ -1250,7 +1254,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                      notch_widths=None, trans_bandwidth=1.0, n_jobs=1,
                      method='fft', iir_params=None, mt_bandwidth=None,
                      p_value=0.05, phase='zero', fir_window='hamming',
-                     verbose=None):
+                     fir_design=None, verbose=None):
         """Notch filter a subset of channels.
 
         Applies a zero-phase notch filter to the channels selected by
@@ -1321,13 +1325,17 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             then a minimum-phase, causal filter will be used.
 
             .. versionadded:: 0.13
-
         fir_window : str
             The window to use in FIR design, can be "hamming" (default),
             "hann", or "blackman".
 
             .. versionadded:: 0.13
+        fir_design : str
+            Can be "firwin" (default in 0.16) to use
+            :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+            before) to use :func:`scipy.signal.firwin2`.
 
+            ..versionadded:: 0.15
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -1360,7 +1368,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             notch_widths=notch_widths, trans_bandwidth=trans_bandwidth,
             method=method, iir_params=iir_params, mt_bandwidth=mt_bandwidth,
             p_value=p_value, picks=picks, n_jobs=n_jobs, copy=False,
-            phase=phase, fir_window=fir_window)
+            phase=phase, fir_window=fir_window, fir_design=fir_design)
         return self
 
     @verbose

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1189,7 +1189,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fir_design : str
             Can be "firwin" (default in 0.16) to use
             :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
-            before) to use :func:`scipy.signal.firwin2`.
+            before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+            time-domain design technique that generally gives improved
+            attenuation using fewer samples than "firwin2".
 
             ..versionadded:: 0.15
         verbose : bool, str, int, or None
@@ -1334,7 +1336,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fir_design : str
             Can be "firwin" (default in 0.16) to use
             :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
-            before) to use :func:`scipy.signal.firwin2`.
+            before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+            time-domain design technique that generally gives improved
+            attenuation using fewer samples than "firwin2".
 
             ..versionadded:: 0.15
         verbose : bool, str, int, or None

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1134,16 +1134,17 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         filter_length : str | int
             Length of the FIR filter to use (if applicable):
 
-                * int: specified length in samples.
-                * 'auto' (default): the filter length is chosen based
-                  on the size of the transition regions (6.6 times the
-                  reciprocal of the shortest transition band for
-                  fir_window='hamming').
-                * str: a human-readable time in
-                  units of "s" or "ms" (e.g., "10s" or "5500ms") will be
-                  converted to that number of samples if ``phase="zero"``, or
-                  the shortest power-of-two length at least that duration for
-                  ``phase="zero-double"``.
+            * 'auto' (default): the filter length is chosen based
+              on the size of the transition regions (6.6 times the reciprocal
+              of the shortest transition band for fir_window='hamming'
+              and fir_design="firwin2", and half that for "firwin").
+            * str: a human-readable time in
+              units of "s" or "ms" (e.g., "10s" or "5500ms") will be
+              converted to that number of samples if ``phase="zero"``, or
+              the shortest power-of-two length at least that duration for
+              ``phase="zero-double"``.
+            * int: specified length in samples. For fir_design="firwin",
+              this should not be used.
 
         l_trans_bandwidth : float | str
             Width of the transition band at the low cut-off frequency in Hz

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -774,7 +774,8 @@ def test_filter():
 
     trans = 2.0
     filter_params = dict(picks=picks, filter_length='auto',
-                         h_trans_bandwidth=trans, l_trans_bandwidth=trans)
+                         h_trans_bandwidth=trans, l_trans_bandwidth=trans,
+                         fir_design='firwin')
     raw_lp = raw.copy().filter(None, 8.0, **filter_params)
     raw_hp = raw.copy().filter(16.0, None, **filter_params)
     raw_bp = raw.copy().filter(8.0 + trans, 16.0 - trans, **filter_params)
@@ -852,7 +853,7 @@ def test_filter():
         assert_true(raw.info['lowpass'] is None)
         assert_true(raw.info['highpass'] is None)
         kwargs = dict(l_trans_bandwidth=20, h_trans_bandwidth=20,
-                      filter_length='auto', phase='zero', fir_window='hann')
+                      filter_length='auto', phase='zero', fir_design='firwin')
         raw_filt = raw.copy().filter(l_freq, h_freq, picks=np.arange(1),
                                      **kwargs)
         assert_true(raw.info['lowpass'] is None)
@@ -885,7 +886,7 @@ def test_filter_picks():
         picks['meg'] = ch_type if ch_type in ('mag', 'grad') else False
         picks['fnirs'] = ch_type if ch_type in ('hbo', 'hbr') else False
         raw_ = raw.copy().pick_types(**picks)
-        raw_.filter(10, 30)
+        raw_.filter(10, 30, fir_design='firwin')
 
     # -- Error if no data channel
     for ch_type in ('misc', 'stim'):
@@ -1069,7 +1070,7 @@ def test_hilbert():
     raw_filt = raw.copy()
     raw_filt.filter(10, 20, picks=picks, l_trans_bandwidth='auto',
                     h_trans_bandwidth='auto', filter_length='auto',
-                    phase='zero', fir_window='blackman')
+                    phase='zero', fir_window='blackman', fir_design='firwin')
     raw_filt_2 = raw_filt.copy()
 
     raw2 = raw.copy()

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -741,6 +741,5 @@ def _pick_data_or_ica(info):
     if 'ICA ' in ','.join(ch_names):
         picks = pick_types(info, exclude=[], misc=True)
     else:
-        picks = _pick_data_channels(info, exclude=[],
-                                    with_ref_meg=False)
+        picks = _pick_data_channels(info, exclude=[], with_ref_meg=True)
     return picks

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -53,7 +53,8 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
     win_size = int(round((60.0 * sfreq) / 120.0))
 
     filtecg = filter_data(ecg, sfreq, l_freq, h_freq, None, filter_length,
-                          0.5, 0.5, phase='zero-double', fir_window='hann')
+                          0.5, 0.5, phase='zero-double', fir_window='hann',
+                          fir_design='firwin2')
 
     ecg_abs = np.abs(filtecg)
     init = int(sfreq)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -71,7 +71,8 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     fmax = np.minimum(45, sampling_rate / 2.0 - 0.75)  # protect Nyquist
     filteog = np.array([filter_data(
         x, sampling_rate, 2, fmax, None, filter_length, 0.5, 0.5,
-        phase='zero-double', fir_window='hann') for x in eog])
+        phase='zero-double', fir_window='hann', fir_design='firwin2')
+        for x in eog])
     temp = np.sqrt(np.sum(filteog ** 2, axis=1))
 
     indexmax = np.argmax(temp)
@@ -79,7 +80,8 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     # easier to detect peaks with filtering.
     filteog = filter_data(
         eog[indexmax], sampling_rate, l_freq, h_freq, None,
-        filter_length, 0.5, 0.5, phase='zero-double', fir_window='hann')
+        filter_length, 0.5, 0.5, phase='zero-double', fir_window='hann',
+        fir_design='firwin2')
 
     # detecting eog blinks and generating event file
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2174,7 +2174,8 @@ def _band_pass_filter(ica, sources, target, l_freq, h_freq, verbose=None):
         logger.info('... filtering ICA sources')
         # use FIR here, steeper is better
         kw = dict(phase='zero-double', filter_length='10s', fir_window='hann',
-                  l_trans_bandwidth=0.5, h_trans_bandwidth=0.5)
+                  l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
+                  fir_design='firwin2')
         sources = filter_data(sources, ica.info['sfreq'], l_freq, h_freq, **kw)
         logger.info('... filtering target')
         target = filter_data(target, ica.info['sfreq'], l_freq, h_freq, **kw)

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -183,7 +183,7 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
     raw.filter(l_freq, h_freq, picks=picks, filter_length=filter_length,
                n_jobs=n_jobs, method=filter_method, iir_params=iir_params,
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
-               phase='zero-double')
+               phase='zero-double', fir_design='firwin2')
 
     epochs = Epochs(raw, events, None, tmin, tmax, baseline=None, preload=True,
                     picks=picks, reject=reject, flat=flat, proj=True)

--- a/mne/preprocessing/tests/test_eeglab_infomax.py
+++ b/mne/preprocessing/tests/test_eeglab_infomax.py
@@ -36,7 +36,8 @@ def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
 
     raw.filter(1, 45, picks=picks, filter_length='10s',
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
-               phase='zero-double', fir_window='hann')  # use the old way
+               phase='zero-double', fir_window='hann',
+               fir_design='firwin2')  # use the old way
     X = raw[picks, :][0][:, ::20]
 
     # Subtract the mean

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -408,15 +408,12 @@ def test_ica_additional():
 
         # test filtering
         d1 = ica_raw._data[0].copy()
-        ica_raw.filter(4, 20, l_trans_bandwidth='auto',
-                       h_trans_bandwidth='auto', filter_length='auto',
-                       phase='zero', fir_window='hamming')
+        ica_raw.filter(4, 20, fir_design='firwin2')
         assert_equal(ica_raw.info['lowpass'], 20.)
         assert_equal(ica_raw.info['highpass'], 4.)
         assert_true((d1 != ica_raw._data[0]).any())
         d1 = ica_raw._data[0].copy()
-        ica_raw.notch_filter([10], filter_length='auto', trans_bandwidth=10,
-                             phase='zero', fir_window='hamming')
+        ica_raw.notch_filter([10], trans_bandwidth=10, fir_design='firwin')
         assert_true((d1 != ica_raw._data[0]).any())
 
         ica.n_pca_components = 2

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -24,13 +24,11 @@ def test_compute_proj_ecg():
     raw.load_data()
     for average in [False, True]:
         # For speed, let's not filter here (must also not reject then)
-        projs, events = compute_proj_ecg(raw, n_mag=2, n_grad=2, n_eeg=2,
-                                         ch_name='MEG 1531', bads=['MEG 2443'],
-                                         average=average, avg_ref=True,
-                                         no_proj=True, l_freq=None,
-                                         h_freq=None, reject=None,
-                                         tmax=dur_use, qrs_threshold=0.5,
-                                         filter_length=6000)
+        projs, events = compute_proj_ecg(
+            raw, n_mag=2, n_grad=2, n_eeg=2, ch_name='MEG 1531',
+            bads=['MEG 2443'], average=average, avg_ref=True, no_proj=True,
+            l_freq=None, h_freq=None, reject=None, tmax=dur_use,
+            qrs_threshold=0.5, filter_length=6000)
         assert_true(len(projs) == 7)
         # heart rate at least 0.5 Hz, but less than 3 Hz
         assert_true(events.shape[0] > 0.5 * dur_use and
@@ -51,11 +49,10 @@ def test_compute_proj_ecg():
         # without setting a bad channel, this should throw a warning
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            projs, events = compute_proj_ecg(raw, n_mag=2, n_grad=2, n_eeg=2,
-                                             ch_name='MEG 1531', bads=[],
-                                             average=average, avg_ref=True,
-                                             no_proj=True, l_freq=None,
-                                             h_freq=None, tmax=dur_use)
+            projs, events = compute_proj_ecg(
+                raw, n_mag=2, n_grad=2, n_eeg=2, ch_name='MEG 1531', bads=[],
+                average=average, avg_ref=True, no_proj=True, l_freq=None,
+                h_freq=None, tmax=dur_use)
         assert_true(len(w) >= 1)
         assert_equal(projs, None)
 

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -343,12 +343,11 @@ x += np.sin(2. * np.pi * 60. * np.arange(len(x)) / sfreq) / 2000.
 
 transition_band = 0.25 * f_p
 f_s = f_p + transition_band
-filter_dur = 6.6 / transition_band  # sec
+filter_dur = 6.6 / transition_band / 2.  # sec
 n = int(sfreq * filter_dur)
 freq = [0., f_p, f_s, sfreq / 2.]
 gain = [1., 1., 0., 0.]
 # This would be equivalent:
-# h = signal.firwin2(n, freq, gain, nyq=sfreq / 2.)
 h = mne.filter.create_filter(x, sfreq, l_freq=None, h_freq=f_p,
                              fir_design='firwin')
 x_v16 = np.convolve(h, x)[len(h) // 2:]
@@ -356,8 +355,10 @@ x_v16 = np.convolve(h, x)[len(h) // 2:]
 plot_filter(h, sfreq, freq, gain, 'MNE-Python 0.16 default', flim=flim)
 
 ###############################################################################
-# Filter it with a different design mode (firwin2), and also
-# compensate for the constant filter delay):
+# Filter it with a different design mode ``fir_design="firwin2"``, and also
+# compensate for the constant filter delay. This method does not produce
+# quite as sharp a transition compared to ``fir_design="firwin"``, despite
+# being twice as long:
 
 transition_band = 0.25 * f_p
 f_s = f_p + transition_band
@@ -413,7 +414,7 @@ plot_filter(h, sfreq, freq, gain, 'MNE-C default', flim=flim)
 # And now an example of a minimum-phase filter:
 
 h = mne.filter.create_filter(x, sfreq, l_freq=None, h_freq=f_p,
-                             phase='minimum', fir_design='firwin2')
+                             phase='minimum', fir_design='firwin')
 x_min = np.convolve(h, x)
 transition_band = 0.25 * f_p
 f_s = f_p + transition_band

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -209,7 +209,8 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 sec)', flim=flim)
 # based on desired response characteristics. These include:
 #
 #     1. The Remez_ algorithm (:func:`scipy.signal.remez`, `MATLAB firpm`_)
-#     2. Windowed FIR design (:func:`scipy.signal.firwin2`, `MATLAB fir2`_)
+#     2. Windowed FIR design (:func:`scipy.signal.firwin2`, `MATLAB fir2`_
+#        and :func:`scipy.signal.firwin`)
 #     3. Least squares designs (:func:`scipy.signal.firls`, `MATLAB firls`_)
 #     4. Frequency-domain design (construct filter in Fourier
 #        domain and use an :func:`IFFT <scipy.fftpack.ifft>` to invert it)
@@ -781,7 +782,7 @@ baseline_plot(x)
 # and thus :func:`mne.io.Raw.filter` is used. This function under the hood
 # (among other things) calls :func:`mne.filter.filter_data` to actually
 # filter the data, which by default applies a zero-phase FIR filter designed
-# using :func:`scipy.signal.firwin2`. In Widmann *et al.* 2015 [7]_, they
+# using :func:`scipy.signal.firwin`. In Widmann *et al.* 2015 [7]_, they
 # suggest a specific set of parameters to use for high-pass filtering,
 # including:
 #
@@ -827,27 +828,28 @@ baseline_plot(x)
 # To choose the filter length automatically with ``filter_length='auto'``,
 # the reciprocal of the shortest transition bandwidth is used to ensure
 # decent attenuation at the stop frequency. Specifically, the reciprocal
-# (in samples) is multiplied by 6.2, 6.6, or 11.0 for the Hann, Hamming,
+# (in samples) is multiplied by 3.1, 3.3, or 5.0 for the Hann, Hamming,
 # or Blackman windows, respectively as selected by the ``fir_window``
-# argument.
+# argument for ``fir_design='firwin'``, and double these for
+# ``fir_design='firwin2'`` mode.
 #
-# .. note:: These multiplicative factors are double what is given in
-#           Ifeachor and Jervis [2]_ (p. 357). The window functions have a
-#           smearing effect on the frequency response; I&J thus take the
-#           approach of setting the stop frequency as
-#           :math:`f_s = f_p + f_{trans} / 2.`, but our stated definitions of
-#           :math:`f_s` and :math:`f_{trans}` do not
-#           allow us to do this in a nice way. Instead, we increase our filter
-#           length to achieve acceptable (20+ dB) attenuation by
-#           :math:`f_s = f_p + f_{trans}`, and excellent (50+ dB)
-#           attenuation by :math:`f_s + f_{trans}` (and usually earlier).
+# .. note:: For ``fir_design='firwin2'``, the multiplicative factors are
+#           doubled compared to what is given in Ifeachor and Jervis [2]_
+#           (p. 357), as :func:`scipy.signal.firwin2` has a smearing effect
+#           on the frequency response, which we compensate for by
+#           increasing the filter length. This is why
+#           ``fir_desgin='firwin'`` is preferred to ``fir_design='firwin2'``.
 #
 # In 0.14, we default to using a Hamming window in filter design, as it
 # provides up to 53 dB of stop-band attenuation with small pass-band ripple.
 #
 # .. note:: In band-pass applications, often a low-pass filter can operate
 #           effectively with fewer samples than the high-pass filter, so
-#           it is advisable to apply the high-pass and low-pass separately.
+#           it is advisable to apply the high-pass and low-pass separately
+#           when using ``fir_design='firwin2'``. For design mode
+#           ``fir_design='firwin'``, there is no need to separate the
+#           operations, as the lowpass and highpass elements are constructed
+#           separately to meet the transition band requirements.
 #
 # For more information on how to use the
 # MNE-Python filtering functions with real data, consult the preprocessing

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -178,7 +178,7 @@ if not use_precomputed:
 # We also lowpass filter the data at 100 Hz to remove the hf components.
 if not use_precomputed:
     raw.filter(None, 100., h_trans_bandwidth=0.5, filter_length='10s',
-               phase='zero-double')
+               phase='zero-double', fir_design='firwin2')
 
 ###############################################################################
 # Epoching and averaging.

--- a/tutorials/plot_ica_from_raw.py
+++ b/tutorials/plot_ica_from_raw.py
@@ -28,7 +28,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 raw.filter(1, 45, n_jobs=1, l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
-           filter_length='10s', phase='zero-double')
+           filter_length='10s', phase='zero-double', fir_design='firwin2')
 raw.annotations = mne.Annotations([1], [10], 'BAD')
 raw.plot(block=True)
 


### PR DESCRIPTION
Closes #4045.

~~WIP because it needs to:~~

- [x] respect different trans_bandwidths, e.g. for band-pass, band-stop, and notch filters (by changing length in the building function).
- [x] add a bit more narrative (preferably with refs?) to the tutorial
- [x] actually test band-stop, band-pass, and notch behaviors
- [x] force `length='auto'` in `firwin` mode (otherwise the transitions won't work properly)
- [x] update lots of tests to not throw warnings
- [x] update `whats_new.rst`

This also fixes a bug where `ref_meg` channels were not being filtered by default in `raw.filter`.