### PR TITLE
MRG+1: Use frequency domain for xc/ac

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1116,6 +1116,7 @@ Classes:
    UnsupervisedSpatialFilter
    Vectorizer
    ReceptiveField
+   TimeDelayingRidge
    SlidingEstimator
    GeneralizingEstimator
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,8 @@ Changelog
 
     - Add :class:`mne.decoding.ReceptiveField` module for modeling electrode response to input features by `Chris Holdgraf`_
 
+    - Add :class:`mne.decoding.TimeDelayingRidge` class, used by default by :class:`mne.decoding.ReceptiveField`, to speed up auto- and cross-correlation computations and enable Laplacian regularization by `Ross Maddox`_ and `Eric Larson`_
+
     - Add new :mod:`mne.datasets.mtrf` dataset by `Chris Holdgraf`_
 
     - Add example of time-frequency decoding with CSP by `Laura Gwilliams`_
@@ -2053,7 +2055,7 @@ of commits):
 
 .. _Chris Bailey: https://github.com/cjayb
 
-.. _Ross Maddox: http://faculty.washington.edu/rkmaddox/
+.. _Ross Maddox: https://www.urmc.rochester.edu/labs/maddox-lab.aspx
 
 .. _Alexandre Barachant: http://alexandre.barachant.org
 

--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -32,7 +32,6 @@ from os.path import join
 
 import mne
 from mne.decoding import ReceptiveField
-from sklearn.linear_model import Ridge
 from sklearn.model_selection import KFold
 from sklearn.preprocessing import scale
 
@@ -86,7 +85,7 @@ tmin, tmax = -.4, .2
 
 # Initialize the model
 rf = ReceptiveField(tmin, tmax, sfreq, feature_names=['envelope'],
-                    estimator=Ridge(alpha=1.), scoring='corrcoef')
+                    estimator=1., scoring='corrcoef')
 # We'll have (tmax - tmin) * sfreq delays
 # and an extra 2 delays since we are inclusive on the beginning / end index
 n_delays = int((tmax - tmin) * sfreq) + 2
@@ -148,7 +147,7 @@ ix_plot = np.argmin(np.abs(time_plot - times))
 fig, ax = plt.subplots()
 mne.viz.plot_topomap(mean_coefs[:, ix_plot], pos=info, axes=ax, show=False,
                      vmin=-max_coef, vmax=max_coef)
-ax.set(title="Topomap of model coefficicients\nfor delay %s" % time_plot)
+ax.set(title="Topomap of model coefficients\nfor delay %s" % time_plot)
 mne.viz.tight_layout()
 
 plt.show()

--- a/mne/decoding/__init__.py
+++ b/mne/decoding/__init__.py
@@ -10,4 +10,5 @@ from .ems import compute_ems, EMS
 from .time_gen import GeneralizationAcrossTime, TimeDecoding
 from .time_frequency import TimeFrequency
 from .receptive_field import ReceptiveField
+from .time_delaying_ridge import TimeDelayingRidge
 from .search_light import SlidingEstimator, GeneralizingEstimator

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -164,12 +164,12 @@ class ReceptiveField(BaseEstimator):
             # X is now shape (n_times, n_epochs, n_feats, n_delays)
             X_del = _delay_time_series(X, self.tmin, self.tmax, self.sfreq,
                                        newaxis=X.ndim)
+            # Remove timepoints that don't have lag data after delaying
+            X_del = X_del[self.keep_samples_]
+            y = y[self.keep_samples_]
         else:
             X_del = X[..., np.newaxis]
 
-        # Remove timepoints that don't have lag data after delaying
-        X_del = X_del[self.keep_samples_]
-        y = y[self.keep_samples_]
         X_del = _reshape_for_est(X_del)
 
         # Concat times + epochs

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -1,6 +1,16 @@
-import numpy as np
+# -*- coding: utf-8 -*-
+# Authors: Chris Holdgraf <choldgraf@gmail.com>
+#          Eric Larson <larson.eric.d@gmail.com>
+
+# License: BSD (3-clause)
+
 import numbers
+
+import numpy as np
+
 from .base import get_coef, BaseEstimator, _check_estimator
+from .time_delaying_ridge import TimeDelayingRidge
+from ..externals.six import string_types
 
 
 class ReceptiveField(BaseEstimator):
@@ -137,6 +147,7 @@ class ReceptiveField(BaseEstimator):
         self.estimator_ = estimator
         _check_estimator(self.estimator_)
 
+        # Create input features
         n_times, n_epochs, n_feats = X.shape
         n_outputs = y.shape[2]
 
@@ -300,6 +311,18 @@ def _delay_time_series(X, tmin, tmax, sfreq, newaxis=0, axis=0):
     delayed: array, shape(..., n_delays, ...)
         The delayed data. It has the same shape as X, with an extra dimension
         created at ``newaxis`` that corresponds to each delay.
+
+    Examples
+    --------
+    >>> tmin, tmax = -0.2, 0.1
+    >>> sfreq = 10.
+    >>> x = np.arange(1, 6)
+    >>> x_del = _delay_time_series(x, tmin, tmax, sfreq)
+    >>> print(x_del)
+    [[ 0.  0.  1.  2.  3.]
+     [ 0.  1.  2.  3.  4.]
+     [ 1.  2.  3.  4.  5.]
+     [ 2.  3.  4.  5.  0.]]
     """
     _check_delayer_params(tmin, tmax, sfreq)
     delays = _times_to_delays(tmin, tmax, sfreq)

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -39,13 +39,13 @@ class ReceptiveField(BaseEstimator):
         float is passed, it will be interpreted as the `alpha` parameter
         to be passed to a Ridge regression model. If `None`, then a Ridge
         regression model with an alpha of 0 will be used.
+    fit_intercept : bool
+        If True (default), the sample mean is removed before fitting.
+        Ignored if ``estimator`` is a :class:`sklearn.base.BaseEstimator`.
     scoring : ['r2', 'corrcoef']
         Defines how predictions will be scored. Currently must be one of
         'r2' (coefficient of determination) or 'corrcoef' (the correlation
         coefficient).
-    fit_intercept : bool
-        If True (default), the sample mean is removed before fitting.
-        Ignored if ``estimator`` is a :class:`sklearn.base.BaseEstimator`.
 
     Attributes
     ----------

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -167,7 +167,8 @@ def test_receptive_field_fast():
             y[:-delay] = x[delay:]
             slims += [(1, 2)]
         for slim in slims:
-            for estimator in (Ridge(alpha=0.), 0.):
+            tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'quadratic')
+            for estimator in (Ridge(alpha=0.), 0., 0.1, tdr):
                 model = ReceptiveField(slim[0], slim[1], 1.,
                                        estimator=estimator)
                 model.fit(x[:, np.newaxis], y)
@@ -194,12 +195,19 @@ def test_receptive_field_fast():
          [0, 0, 0, 0, -1, 0],
          [0, 0, 0, 0, 0, 0]],
     ]
-    for estimator in (Ridge(alpha=0.), 0.):
+    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'quadratic')
+    for estimator in (Ridge(alpha=0.), 0., 0.01, tdr):
         model = ReceptiveField(slim[0], slim[1], 1.,
                                estimator=estimator)
         model.fit(x, y)
         assert_array_equal(model.delays_,
                            np.arange(slim[0], slim[1] + 1))
         assert_allclose(model.coef_, expected, atol=1e-1)
+    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.01, reg_type='foo')
+    model = ReceptiveField(slim[0], slim[1], 1., estimator=tdr)
+    assert_raises(ValueError, model.fit, x, y)
+    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.01, reg_type=['quadratic'])
+    model = ReceptiveField(slim[0], slim[1], 1., estimator=tdr)
+    assert_raises(ValueError, model.fit, x, y)
 
 run_tests_if_main()

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -168,7 +168,7 @@ def test_receptive_field_fast():
             y[:-delay] = x[delay:]
             slims += [(1, 2)]
         for slim in slims:
-            tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'quadratic',
+            tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'laplacian',
                                     fit_intercept=False)
             for estimator in (Ridge(alpha=0.), 0., 0.1, tdr):
                 model = ReceptiveField(slim[0], slim[1], 1.,
@@ -197,7 +197,7 @@ def test_receptive_field_fast():
          [0, 0, 0, 0, -1, 0],
          [0, 0, 0, 0, 0, 0]],
     ]
-    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'quadratic')
+    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.1, 'laplacian')
     for estimator in (Ridge(alpha=0.), 0., 0.01, tdr):
         model = ReceptiveField(slim[0], slim[1], 1.,
                                estimator=estimator)
@@ -208,7 +208,7 @@ def test_receptive_field_fast():
     tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.01, reg_type='foo')
     model = ReceptiveField(slim[0], slim[1], 1., estimator=tdr)
     assert_raises(ValueError, model.fit, x, y)
-    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.01, reg_type=['quadratic'])
+    tdr = TimeDelayingRidge(slim[0], slim[1], 1., 0.01, reg_type=['laplacian'])
     model = ReceptiveField(slim[0], slim[1], 1., estimator=tdr)
     assert_raises(ValueError, model.fit, x, y)
     # Now check the intercept_

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -177,5 +177,26 @@ def test_receptive_field_fast():
                 assert_allclose(model.coef_[0], expected, atol=1e-2)
                 p = model.predict(x[:, np.newaxis])[:, 0]
                 assert_allclose(y, p, atol=5e-2)
+    # multidimensional
+    x = rng.randn(1000, 3)
+    y = np.zeros((1000, 2))
+    slim = [-5, 0]
+    for ii in range(1, 5):
+        y[ii:, ii % 2] += (-1) ** ii * ii * x[:-ii, ii % 3]
+    expected = [
+        [[0, 0, 0, 0, 0, 0],
+         [0, 4, 0, 0, 0, 0],
+         [0, 0, 0, 2, 0, 0]],
+        [[0, 0, -3, 0, 0, 0],
+         [0, 0, 0, 0, -1, 0],
+         [0, 0, 0, 0, 0, 0]],
+    ]
+    for estimator in (Ridge(alpha=0.), 0.):
+        model = ReceptiveField(slim[0], slim[1], 1.,
+                               estimator=estimator)
+        model.fit(x, y)
+        assert_array_equal(model.delays_,
+                           np.arange(slim[0], slim[1] + 1))
+        assert_allclose(model.coef_, expected, atol=1e-1)
 
 run_tests_if_main()

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -181,6 +181,9 @@ def test_receptive_field_fast():
     x = rng.randn(1000, 3)
     y = np.zeros((1000, 2))
     slim = [-5, 0]
+    # This is a weird assignment, but it's just a way to distribute some
+    # unique values at various delays, and "expected" explains how they
+    # should appear in the resulting RF
     for ii in range(1, 5):
         y[ii:, ii % 2] += (-1) ** ii * ii * x[:-ii, ii % 3]
     expected = [

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from mne import io, pick_types
 from mne.utils import requires_sklearn_0_15, run_tests_if_main
-from mne.decoding import ReceptiveField
+from mne.decoding import ReceptiveField, TimeDelayingRidge
 from mne.decoding.receptive_field import (_delay_time_series, _SCORERS,
                                           _times_to_delays, _delays_to_slice)
 
@@ -120,7 +120,7 @@ def test_receptive_field():
                         estimator=0)
     str(rf)  # repr works before fit
     rf.fit(X, y)
-    assert_true(isinstance(rf.estimator_, Ridge))
+    assert_true(isinstance(rf.estimator_, TimeDelayingRidge))
     str(rf)  # repr works after fit
     rf = ReceptiveField(tmin, tmax, 1, ['one'], estimator=0)
     rf.fit(X[:, [0]], y)

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -58,7 +58,7 @@ def _compute_corrs(X, y, smin, smax):
 def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
     """Fit the model using correlation matrices."""
     from scipy import linalg
-    known_types = ('ridge', 'quadratic')
+    known_types = ('ridge', 'laplacian')
     if isinstance(reg_type, string_types):
         reg_type = (reg_type,) * 2
     if len(reg_type) != 2:
@@ -76,7 +76,7 @@ def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
 
     # regularize time
     reg = np.eye(n_trf)
-    if reg_type[0] == 'quadratic':
+    if reg_type[0] == 'laplacian':
         reg.flat[1::reg.shape[0] + 1] += -1
         reg.flat[reg.shape[0] + 1:-reg.shape[0] - 1:reg.shape[0] + 1] += 1
         reg.flat[reg.shape[0]::reg.shape[0] + 1] += -1
@@ -84,7 +84,7 @@ def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
     reg = linalg.block_diag(*args)
 
     # regularize features
-    if reg_type[1] == 'quadratic':
+    if reg_type[1] == 'laplacian':
         row_offset = n_trf * n_trf * n_ch_x
         reg.flat[n_trf::n_trf * n_ch_x + 1] += -1
         reg.flat[row_offset + n_trf:-row_offset:n_trf * n_ch_x + 1] += 1
@@ -137,9 +137,9 @@ class TimeDelayingRidge(BaseEstimator):
     sfreq : float
         The sampling frequency used to convert times into samples.
     alpha : float
-        The ridge (or quadratic) regularization factor.
+        The ridge (or laplacian) regularization factor.
     reg_type : str | list
-        Can be "ridge" (default) or "quadratic".
+        Can be "ridge" (default) or "laplacian".
         Can also be a 2-element list specifying how to regularize in time
         and across adjacent features.
     fit_intercept : bool

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""TimeDelayingRidge class."""
+# Authors: Gael Varoquaux <gael.varoquaux@normalesup.org>
+#          Romain Trachel <trachelr@gmail.com>
+#          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#          Jean-Remi King <jeanremi.king@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base import BaseEstimator
+from ..filter import next_fast_len
+
+
+def _compute_corrs(X, y, smin, smax):
+    """Compute the auto- and cross-correlations."""
+    len_trf = smax - smin
+    len_x, n_ch_x = X.shape
+    len_y, n_ch_y = y.shape
+
+    n_fft = next_fast_len(max(X.shape[0], y.shape[0]) + len_trf - 1)
+    X_in = np.fft.rfft(X.T, n_fft)
+    X_out = np.fft.rfft(y.T, n_fft)
+    del X, y
+
+    # compute the autocorrelations
+    ac = np.zeros((n_ch_x, n_ch_x, len_trf * 2 - 1))
+    for ch0 in range(n_ch_x):
+        for ch1 in range(ch0, n_ch_x):
+            ac_temp = np.fft.irfft(X_in[ch0] * np.conj(X_in[ch1]), n_fft)
+            ac[ch0, ch1] = np.concatenate((ac_temp[-len_trf + 1:],
+                                           ac_temp[:len_trf]))
+            if ch0 != ch1:
+                ac[ch1, ch0] = ac[ch0, ch1][::-1]
+
+    # compute the crosscorrelations
+    x_y = np.zeros((n_ch_y, n_ch_x, len_trf))
+    for ch_in in range(n_ch_x):
+        for ch_out in range(n_ch_y):
+            cc_temp = np.fft.irfft(X_out[ch_out] * X_in[ch_in].conj(),
+                                   n_fft)
+            # XXX Need to ensure smax > 0
+            if smin < 0:
+                x_y[ch_out, ch_in] = np.append(cc_temp[smin:], cc_temp[:smax])
+            else:
+                x_y[ch_out, ch_in] = cc_temp[smin:smax]
+
+    # make xxt and xy
+    x_xt = _make_x_xt(ac)
+    x_xt /= len_x
+    x_y.shape = (n_ch_y, n_ch_x * len_trf)
+    x_y /= len_x
+    return x_xt, x_y, n_ch_x
+
+
+def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
+    """Fit the model using correlation matrices."""
+    from scipy import linalg
+    known_types = ('ridge', 'laplacian')
+    if reg_type not in known_types:
+        raise ValueError('reg_type must be one of %s, got %s'
+                         % (known_types, reg_type))
+
+    # do the regularized solving
+    n_ch_out = x_y.shape[0]
+    assert x_y.shape[1] % n_ch_x == 0
+    n_trf = x_y.shape[1] // n_ch_x
+    if reg_type == 'ridge':
+        reg = np.eye(x_xt.shape[0])
+    else:  # if reg_type == 'laplacian':
+        reg = np.eye(n_trf)
+        reg.flat[reg.shape[0] + 1:-reg.shape[0] - 1:reg.shape[0] + 1] = 2
+        reg.flat[1::reg.shape[0] + 1] = -1
+        reg.flat[reg.shape[0]::reg.shape[0] + 1] = -1
+        args = [reg] * n_ch_x
+        reg = linalg.block_diag(*args)
+    mat = x_xt + alpha * reg
+    w = linalg.lstsq(mat, x_y.T)[0].T
+    w = w.reshape([n_ch_out, n_ch_in, n_trf])
+    return w
+
+
+def _make_x_xt(ac):
+    len_trf = (ac.shape[2] + 1) // 2
+    n_ch = ac.shape[0]
+    xxt = np.zeros([n_ch * len_trf] * 2)
+    for ch0 in range(n_ch):
+        for ch1 in range(n_ch):
+            xxt_temp = np.zeros((len_trf, len_trf))
+            xxt_temp[0, :] = ac[ch0, ch1, len_trf - 1:]
+            xxt_temp[:, 0] = ac[ch0, ch1, len_trf - 1::-1]
+            for ii in range(1, len_trf):
+                xxt_temp[ii, ii:] = ac[ch0, ch1, len_trf - 1:-ii]
+                xxt_temp[ii:, ii] = ac[ch0, ch1, len_trf - 1:ii - 1:-1]
+            xxt[ch0 * len_trf:(ch0 + 1) * len_trf,
+                ch1 * len_trf:(ch1 + 1) * len_trf] = xxt_temp
+    return xxt
+
+
+class TimeDelayingRidge(BaseEstimator):
+    """Ridge regression of data with time delays.
+
+    Parameters
+    ----------
+    smin : int
+        Minimum sample number (must be < 0).
+    smax : float
+        Maximum time used to predict the data.
+    alpha : float
+        The ridge (or laplacian) regularization.
+    reg_type : str
+        Can be "ridge" (default) or "laplacian".
+    """
+    def __init__(self, smin, smax, alpha=0., reg_type='ridge'):
+        assert smin < 0
+        assert smax >= 0
+        self._smin = -smax
+        self._smax = -smin + 1
+        self._alpha = float(alpha)
+        self._reg_type = reg_type
+
+    def fit(self, X, y):
+        """Estimate the coefficients of the linear model.
+
+        Parameters
+        ----------
+        X : array, shape (n_samples, n_features)
+            The training input samples to estimate the linear coefficients.
+        y : array, shape (n_samples, n_outputs)
+            The target values.
+
+        Returns
+        -------
+        self : instance of LinearModel
+            Returns the modified instance.
+        """
+        # These are split into two functions because it's possible that we
+        # might want to allow people to do them separately (e.g., to test
+        # different regularization parameters).
+        x_xt, x_y, n_ch_x = _compute_corrs(X, y, self._smin, self._smax)
+        self.coef_ = _fit_corrs(x_xt, x_y, n_ch_x,
+                                self._reg_type, self._alpha, n_ch_x)
+        self.coef_ = self.coef_[..., ::-1]
+        return self
+
+    def predict(self, X):
+        """Predict the output.
+
+        Parameters
+        ----------
+        X : array, shape (n_samples, n_features)
+            The data.
+
+        Returns
+        -------
+        X : ndarray
+            The predicted response.
+        """
+        out = np.zeros((X.shape[0], self.coef_.shape[0]))
+        for oi in range(self.coef_.shape[0]):
+            for fi in range(self.coef_.shape[1]):
+                # XXX This truncation is not correct... need to shift based
+                # on tmin/tmax locations
+                temp = np.convolve(X[:, fi], self.coef_[oi, fi])
+                out[:, oi] += temp[-self._smin:-self._smax + 1]
+        return out

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -101,7 +101,7 @@ def next_fast_len(target):
             # (quotient = ceil(target / p35))
             quotient = -(-target // p35)
 
-            p2 = 2 ** (quotient - 1).bit_length()
+            p2 = 2 ** int(quotient - 1).bit_length()
 
             N = p2 * p35
             if N == target:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2231,7 +2231,7 @@ def run_tests_if_main(measure_mem=False):
                 elapsed = int(round(time.time() - t1))
                 if elapsed >= max_elapsed:
                     max_elapsed, elapsed_name = elapsed, name
-                sys.stdout.write('time: %s sec%s\n' % (elapsed, mem))
+                sys.stdout.write('time: %0.3f sec%s\n' % (elapsed, mem))
                 sys.stdout.flush()
             except Exception as err:
                 if 'skiptest' in err.__class__.__name__.lower():
@@ -2240,9 +2240,10 @@ def run_tests_if_main(measure_mem=False):
                 else:
                     raise
     elapsed = int(round(time.time() - t0))
-    sys.stdout.write('Total: %s tests\n• %s sec (%s sec for %s)\n• Peak memory'
-                     ' %s MB (%s)\n' % (count, elapsed, max_elapsed,
-                                        elapsed_name, peak_mem, peak_name))
+    sys.stdout.write('Total: %s tests\n• %0.3f sec (%0.3f sec for %s)\n• '
+                     'Peak memory %s MB (%s)\n'
+                     % (count, elapsed, max_elapsed, elapsed_name, peak_mem,
+                        peak_name))
 
 
 class ArgvSetter(object):

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -268,8 +268,9 @@ mne.viz.tight_layout()
 # Using different regularization types
 # ------------------------------------
 # In addition to the standard ridge regularization, the
-# :class:`mne.decoding.TimeDelayingRidge` class also exposes quadratic
-# regularization term as:
+# :class:`mne.decoding.TimeDelayingRidge` class also exposes
+# `Laplacian <https://en.wikipedia.org/wiki/Laplacian_matrix>`_ regularization
+# term as:
 #
 # .. math::
 #    \left[\begin{matrix}
@@ -284,7 +285,7 @@ mne.viz.tight_layout()
 #
 #    Tikhonov [identity] regularization (Equation 5) reduces overfitting by
 #    smoothing the TRF estimate in a way that is insensitive to
-#    the amplitude of the signal of interest. However, the quadratic
+#    the amplitude of the signal of interest. However, the Laplacian
 #    approach (Equation 6) reduces off-sample error whilst preserving
 #    signal amplitude (Lalor et al., 2006). As a result, this approach
 #    usually leads to an improved estimate of the system’s response (as
@@ -296,7 +297,7 @@ old_scores = scores
 scores = np.zeros_like(alphas)
 models = []
 for ii, alpha in enumerate(alphas):
-    estimator = TimeDelayingRidge(tmin, tmax, sfreq, reg_type='quadratic',
+    estimator = TimeDelayingRidge(tmin, tmax, sfreq, reg_type='laplacian',
                                   alpha=alpha)
     rf = ReceptiveField(tmin, tmax, sfreq, freqs, estimator=estimator)
     rf.fit(X_train, y_train)
@@ -311,8 +312,8 @@ ix_best_alpha = np.argmax(scores)
 # Compare model performance
 # -------------------------
 # Below we visualize the model performance of each regularization method
-# (ridge vs. quadratic) for different levels of alpha. As you can see, the
-# quadratic method performs better in general, because it imposes a smoothness
+# (ridge vs. Laplacian) for different levels of alpha. As you can see, the
+# Laplacian method performs better in general, because it imposes a smoothness
 # constraint along the time and feature dimensions of the coefficients.
 # This matches the "true" receptive field structure and results in a better
 # model fit.
@@ -328,7 +329,7 @@ ax.annotate('Ridge regularization', (ix_best_alpha, old_scores[ix_best_alpha]),
             (ix_best_alpha - 0.5, old_scores[ix_best_alpha] - .02),
             arrowprops={'arrowstyle': '->'})
 plt.xticks(np.arange(len(alphas)), ["%.0e" % ii for ii in alphas])
-ax.set(xlabel="Quadratic regularization value", ylabel="Score ($R^2$)",
+ax.set(xlabel="Laplacian regularization value", ylabel="Score ($R^2$)",
        xlim=[-.4, len(alphas) - .6])
 mne.viz.tight_layout()
 
@@ -339,7 +340,7 @@ for ii, (rf, i_alpha) in enumerate(zip(models, alphas)):
     plt.xticks([], [])
     plt.yticks([], [])
     plt.autoscale(tight=True)
-fig.suptitle('Model coefficients / scores for quadtratic regularization', y=1)
+fig.suptitle('Model coefficients / scores for laplacian regularization', y=1)
 mne.viz.tight_layout()
 
 plt.show()

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -313,8 +313,9 @@ ix_best_alpha = np.argmax(scores)
 # Below we visualize the model performance of each regularization method
 # (ridge vs. quadratic) for different levels of alpha. As you can see, the
 # quadratic method performs better in general, because it imposes a smoothness
-# constraint along the time dimension of the coefficients. This matches
-# the "true" receptive field structure and results in a better model fit.
+# constraint along the time and feature dimensions of the coefficients.
+# This matches the "true" receptive field structure and results in a better
+# model fit.
 
 fig = plt.figure(figsize=(20, 4))
 ax = plt.subplot2grid([2, 10], [1, 0], 1, 10)

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -307,6 +307,15 @@ for ii, alpha in enumerate(alphas):
 
 ix_best_alpha = np.argmax(scores)
 
+###############################################################################
+# Compare model performance
+# -------------------------
+# Below we visualize the model performance of each regularization method
+# (ridge vs. quadratic) for different levels of alpha. As you can see, the
+# quadratic method performs better in general, because it imposes a smoothness
+# constraint along the time dimension of the coefficients. This matches
+# the "true" receptive field structure and results in a better model fit.
+
 fig = plt.figure(figsize=(20, 4))
 ax = plt.subplot2grid([2, 10], [1, 0], 1, 10)
 ax.plot(np.arange(len(alphas)), scores, marker='o', color='r')

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -292,6 +292,7 @@ mne.viz.tight_layout()
 #
 
 alphas = np.logspace(-4, 0, 10)
+old_scores = scores
 scores = np.zeros_like(alphas)
 models = []
 for ii, alpha in enumerate(alphas):
@@ -309,8 +310,12 @@ ix_best_alpha = np.argmax(scores)
 fig = plt.figure(figsize=(20, 4))
 ax = plt.subplot2grid([2, 10], [1, 0], 1, 10)
 ax.plot(np.arange(len(alphas)), scores, marker='o', color='r')
+ax.plot(np.arange(len(alphas)), old_scores, marker='o', color='0.5', ls=':')
 ax.annotate('Best parameter', (ix_best_alpha, scores[ix_best_alpha]),
-            (ix_best_alpha - 1, scores[ix_best_alpha] - .01),
+            (ix_best_alpha - 0.8, scores[ix_best_alpha] - .01),
+            arrowprops={'arrowstyle': '->'})
+ax.annotate('Ridge regularization', (ix_best_alpha, old_scores[ix_best_alpha]),
+            (ix_best_alpha - 0.5, old_scores[ix_best_alpha] - .02),
             arrowprops={'arrowstyle': '->'})
 plt.xticks(np.arange(len(alphas)), ["%.0e" % ii for ii in alphas])
 ax.set(xlabel="Quadratic regularization value", ylabel="Score ($R^2$)",

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -46,7 +46,6 @@ from mne.decoding import ReceptiveField
 from scipy.stats import multivariate_normal
 from scipy.io import loadmat
 from sklearn.preprocessing import scale
-from sklearn.linear_model import Ridge
 rng = np.random.RandomState(1337)  # To make this example reproducible
 
 ###############################################################################
@@ -190,7 +189,7 @@ alphas = np.logspace(-4, 0, 10)
 scores = np.zeros_like(alphas)
 models = []
 for ii, alpha in enumerate(alphas):
-    rf = ReceptiveField(tmin, tmax, sfreq, freqs, estimator=Ridge(alpha))
+    rf = ReceptiveField(tmin, tmax, sfreq, freqs, estimator=alpha)
     rf.fit(X_train, y_train)
 
     # Now make predictions about the model output, given input stimuli.
@@ -231,11 +230,11 @@ mne.viz.tight_layout()
 # ---------------------------------------
 #
 # Above we fit a :class:`mne.decoding.ReceptiveField` model for one of many
-# values for the "ridge" parameter. Here we will plot the model score as well
-# as the model coefficients for each value, in order to visualize how
-# coefficients change with different levels of regularization. These issues
-# as well as the STRF pipeline are described in detail in [1]_, [2]_, and
-# [4]_.
+# values for the ridge regularization parameter. Here we will plot the model
+# score as well as the model coefficients for each value, in order to
+# visualize how coefficients change with different levels of regularization.
+# These issues as well as the STRF pipeline are described in detail
+# in [1]_, [2]_, and [4]_.
 
 # Plot model score for each ridge parameter
 fig = plt.figure(figsize=(20, 4))


### PR DESCRIPTION
Here you go @agramfort.

In addition to `tutorials/plot_receptive_field.py` and `examples/plot_receptive_field.py`, I've also been using [this gist](https://gist.github.com/Eric89GXL/12724580917210db37ed2ef125156b93).