### PR TITLE
MINOR/FIX plot_comp_ev keys must be str

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1451,7 +1451,6 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
                        for ii, evoked in enumerate(evokeds))
     for cond in evokeds.keys():
         if not isinstance(cond, string_types):
-            t = type(cond)
             raise TypeError('Conditions must be str, not %s' % (type(cond),))
     conditions = sorted(list(evokeds.keys()))
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1450,9 +1450,9 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
         evokeds = dict((str(ii + 1), evoked)
                        for ii, evoked in enumerate(evokeds))
     for cond in evokeds.keys():
-        if not isinstance(cond, str):
+        if not isinstance(cond, string_types):
             t = type(cond)
-            raise TypeError("Conditions must be str, not {}.".format(t))
+            raise TypeError('Conditions must be str, not %s' % (type(cond),))
     conditions = sorted(list(evokeds.keys()))
 
     # get and set a few limits and variables (times, channels, units)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1366,6 +1366,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
         series and the parametric confidence interval is plotted as a shaded
         area. All instances must have the same shape - channel numbers, time
         points etc.
+        If dict, keys must be of type str.
     picks : int | list of int
         If int or list of int, the indices of the sensors to average and plot.
         Must all be of the same channel type.
@@ -1448,6 +1449,10 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     elif not isinstance(evokeds, dict):
         evokeds = dict((str(ii + 1), evoked)
                        for ii, evoked in enumerate(evokeds))
+    for cond in evokeds.keys():
+        if not isinstance(cond, str):
+            t = type(cond)
+            raise TypeError("Conditions must be str, not {}.".format(t))
     conditions = sorted(list(evokeds.keys()))
 
     # get and set a few limits and variables (times, channels, units)


### PR DESCRIPTION
plot_compare_evoked currently fails when the input keys are not str: 1. the keys' .split method is called, 2. they are sorted. I fear this is unavoidable and here it simply raises an error if the keys are not str.

(Keys are of a format similar to epochs event_id with "/" tags.)