### PR TITLE
[MRG] renaming section header and updating link

### DIFF
--- a/examples/decoding/README.txt
+++ b/examples/decoding/README.txt
@@ -1,5 +1,5 @@
 
-Decoding / Encoding
--------------------
+Machine Learning (Decoding, Encoding, and MVPA)
+-----------------------------------------------
 
 Decoding, encoding, and general machine learning examples.

--- a/examples/decoding/README.txt
+++ b/examples/decoding/README.txt
@@ -1,5 +1,5 @@
 
-Decoding / MVPA
----------------
+Decoding / Encoding
+-------------------
 
-Decoding, a.k.a. MVPA or machine learning examples.
+Decoding, encoding, and general machine learning examples.

--- a/examples/io/plot_read_epochs.py
+++ b/examples/io/plot_read_epochs.py
@@ -16,6 +16,7 @@ for both MEG and EEG data by averaging all the epochs.
 import mne
 from mne import io
 from mne.datasets import sample
+from matplotlib import pyplot as plt
 
 print(__doc__)
 
@@ -29,6 +30,7 @@ event_id, tmin, tmax = 1, -0.2, 0.5
 
 # Setup for reading the raw data
 raw = io.read_raw_fif(raw_fname)
+
 events = mne.read_events(event_fname)
 
 # Set up pick list: EEG + MEG - bad channels (modify to your needs)
@@ -45,4 +47,4 @@ evoked = epochs.average()  # average epochs to get the evoked response
 
 ###############################################################################
 # Show result
-evoked.plot()
+evoked.plot(joint=True)

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -234,7 +234,8 @@ mne.viz.tight_layout()
 # values for the "ridge" parameter. Here we will plot the model score as well
 # as the model coefficients for each value, in order to visualize how
 # coefficients change with different levels of regularization. These issues
-# as well as the STRF pipeline are described in detail in [1]_ and [2]_
+# as well as the STRF pipeline are described in detail in [1]_, [2]_, and
+# [4]_.
 
 # Plot model score for each ridge parameter
 fig = plt.figure(figsize=(20, 4))


### PR DESCRIPTION
This fixes a section header that I missed in the last PR. Also it looks like the docs didn't build the new tutorial HTML. I'm not sure why but it sounds like maybe it's because of the circle cache? Maybe @Eric89GXL has an idea for that one?