### PR TITLE
MRG: Dont warn about EEG avg proj during filter_chpi

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1332,10 +1332,11 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
             rank_eeg = _estimate_rank_meeg_cov(C_eeg, this_info, scalings)
         eig[out_eeg_idx], eigvec[np.ix_(out_eeg_idx, out_eeg_idx)], = \
             _get_ch_whitener(C_eeg, False, 'EEG', rank_eeg)
-    if _needs_eeg_average_ref_proj(info):
-        warn('No average EEG reference present in info["projs"], covariance '
-             'may be adversely affected. Consider recomputing covariance using'
-             ' a raw file with an average eeg reference projector added.')
+        if _needs_eeg_average_ref_proj(info):
+            warn('No average EEG reference present in info["projs"], '
+                 'covariance may be adversely affected. Consider recomputing '
+                 'covariance using with an average eeg reference projector '
+                 'added.')
     noise_cov = noise_cov.copy()
     noise_cov.update(data=C, eig=eig, eigvec=eigvec, dim=len(ch_names),
                      diag=False, names=ch_names)

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -325,8 +325,10 @@ def test_chpi_subtraction():
     """Test subtraction of cHPI signals."""
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True)
     raw.info['bads'] = ['MEG0111']
+    raw.del_proj()
     with catch_logging() as log:
         filter_chpi(raw, include_line=False, verbose=True)
+    assert_true('No average EEG' not in log.getvalue())
     assert_true('5 cHPI' in log.getvalue())
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
     raw.crop(0, 16)


### PR DESCRIPTION
I was getting warnings about an avg eeg ref proj during `mne.chpi.filter_chpi`, which only operates on MEG channels. This fixes our `cov` code so that it only warns about EEG ref when EEG channels are picked.