### PR TITLE
[MRG+1] Fix writing of raws with empty annotations.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,6 +46,8 @@ BUG
 
     - :meth:`mne.concatenate_epochs` now maintains the relative position of events during concatenation by `Alexandre Barachant`_
 
+    - Fix writing of raw files with empty set of annotations by `Jaakko Leppakangas`_
+
 API
 ~~~
 

--- a/examples/io/plot_objects_from_arrays.py
+++ b/examples/io/plot_objects_from_arrays.py
@@ -151,6 +151,7 @@ for ai, asig in enumerate(seg.analogsignals):
     # We need the ravel() here because Neo < 0.5 gave 1D, Neo 0.5 gives
     # 2D (but still a single channel).
     data.append(asig.rescale('V').magnitude.ravel())
+
 data = np.array(data, float)
 
 sfreq = int(seg.analogsignals[0].sampling_rate.magnitude)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1585,10 +1585,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             annotations.onset -= tmin
             BaseRaw.annotations.fset(self, annotations, emit_warning=False)
 
-            # If all annotations are outside the data range, we set them to
-            # None. Otherwise this causes problems when saving and reading.
-            if len(self.annotations.onset) == 0:
-                self.annotations = None
         return self
 
     @verbose
@@ -2297,7 +2293,7 @@ def _start_writing_raw(name, info, sel=None, data_type=FIFF.FIFFT_FLOAT,
     #
     # Annotations
     #
-    if annotations is not None:
+    if annotations is not None and len(annotations.onset) > 0:
         start_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
         write_float(fid, FIFF.FIFF_MNE_BASELINE_MIN, annotations.onset)
         write_float(fid, FIFF.FIFF_MNE_BASELINE_MAX,

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -161,6 +161,8 @@ class Raw(BaseRaw):
                     tag = read_tag(fid, pos)
                     if kind == FIFF.FIFF_MNE_BASELINE_MIN:
                         onset = tag.data
+                        if onset is None:
+                            break  # bug in 0.14 wrote empty annotations
                     elif kind == FIFF.FIFF_MNE_BASELINE_MAX:
                         duration = tag.data - onset
                     elif kind == FIFF.FIFF_COMMENT:
@@ -169,8 +171,9 @@ class Raw(BaseRaw):
                                        description]
                     elif kind == FIFF.FIFF_MEAS_DATE:
                         orig_time = float(tag.data)
-                annotations = Annotations(onset, duration, description,
-                                          orig_time)
+                if onset is not None:
+                    annotations = Annotations(onset, duration, description,
+                                              orig_time)
 
             #   Locate the data of interest
             raw_node = dir_tree_find(meas, FIFF.FIFFB_RAW_DATA)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -63,6 +63,7 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
 
     # Test saving and reading
     out_fname = op.join(tempdir, 'test_raw.fif')
+    raw = concatenate_raws([raw])
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
     raw3 = read_raw_fif(out_fname)
     assert_equal(set(raw.info.keys()), set(raw3.info.keys()))


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/4164

Now the writer checks if the annotations are empty and doesn't try to write it in that case. It was previously trying to set empty annotations to None, but this is probably more appropriate.