### PR TITLE
[MRG] Remove annotated segments in find_eog_events.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
     - Add Fieldtrip's electromyogram dataset, by `Alexandre Barachant`_
 
+    - Add ``reject_by_annotation`` option to :func:`mne.preprocessing.find_eog_events` (which is also utilised by :func:`mne.preprocessing.create_eog_epochs`) to omit data that is annotated as bad by `Jaakko Leppakangas`_
+
 BUG
 ~~~
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -49,7 +49,10 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
     eog_inds = _get_eog_channel_index(ch_name, raw)
     logger.info('EOG channel index for this subject is: %s' % eog_inds)
 
-    eog, _ = raw[eog_inds, :]
+    # Reject bad segments.
+    eog, times = raw.get_data(picks=eog_inds, reject_by_annotation='omit',
+                              return_times=True)
+    times = times * raw.info['sfreq'] + raw.first_samp
 
     eog_events = _find_eog_events(eog, event_id=event_id, l_freq=l_freq,
                                   h_freq=h_freq,
@@ -57,7 +60,8 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                                   first_samp=raw.first_samp,
                                   filter_length=filter_length,
                                   tstart=tstart)
-
+    # Map times to corresponding samples.
+    eog_events[:, 0] = times[eog_events[:, 0] - raw.first_samp]
     return eog_events
 
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -37,7 +37,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
     tstart : float
         Start detection after tstart seconds.
     reject_by_annotation : bool
-        Whether to omit data in that is annotated as bad.
+        Whether to omit data that is annotated as bad.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -52,7 +52,9 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
     logger.info('EOG channel index for this subject is: %s' % eog_inds)
 
     # Reject bad segments.
-    eog, times = raw.get_data(picks=eog_inds, reject_by_annotation='omit',
+    reject_by_annotation = 'omit' if reject_by_annotation else None
+    eog, times = raw.get_data(picks=eog_inds,
+                              reject_by_annotation=reject_by_annotation,
                               return_times=True)
     times = times * raw.info['sfreq'] + raw.first_samp
 
@@ -63,7 +65,8 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                                   filter_length=filter_length,
                                   tstart=tstart)
     # Map times to corresponding samples.
-    eog_events[:, 0] = np.round(times[eog_events[:, 0] - raw.first_samp])
+    eog_events[:, 0] = np.round(times[eog_events[:, 0] -
+                                      raw.first_samp]).astype(int)
     return eog_events
 
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -17,7 +17,7 @@ from ..externals.six import string_types
 @verbose
 def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                     filter_length='10s', ch_name=None, tstart=0,
-                    verbose=None):
+                    reject_by_annotation=False, verbose=None):
     """Locate EOG artifacts.
 
     Parameters
@@ -36,6 +36,8 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
         If not None, use specified channel(s) for EOG
     tstart : float
         Start detection after tstart seconds.
+    reject_by_annotation : bool
+        Whether to omit data in that is annotated as bad.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -61,7 +63,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                                   filter_length=filter_length,
                                   tstart=tstart)
     # Map times to corresponding samples.
-    eog_events[:, 0] = times[eog_events[:, 0] - raw.first_samp]
+    eog_events[:, 0] = np.round(times[eog_events[:, 0] - raw.first_samp])
     return eog_events
 
 
@@ -197,9 +199,10 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
     preload : bool
         Preload epochs or not.
     reject_by_annotation : bool
-        Whether to reject based on annotations. If True (default), epochs
-        overlapping with segments whose description begins with ``'bad'`` are
-        rejected. If False, no rejection based on annotations is performed.
+        Whether to reject based on annotations. If True (default), segments
+        whose description begins with ``'bad'`` are not used for finding
+        artifacts and epochs overlapping with them are rejected. If False, no
+        rejection based on annotations is performed.
 
         .. versionadded:: 0.14.0
 
@@ -213,7 +216,8 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
         Data epoched around EOG events.
     """
     events = find_eog_events(raw, ch_name=ch_name, event_id=event_id,
-                             l_freq=l_freq, h_freq=h_freq)
+                             l_freq=l_freq, h_freq=h_freq,
+                             reject_by_annotation=reject_by_annotation)
 
     # create epochs around EOG events
     eog_epochs = Epochs(raw, events=events, event_id=event_id, tmin=tmin,

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -1,6 +1,7 @@
 import os.path as op
 from nose.tools import assert_true
 
+from mne import Annotations
 from mne.io import read_raw_fif
 from mne.preprocessing.eog import find_eog_events
 
@@ -13,6 +14,10 @@ proj_fname = op.join(data_path, 'test-proj.fif')
 def test_find_eog():
     """Test find EOG peaks."""
     raw = read_raw_fif(raw_fname)
+    raw.annotations = Annotations([14, 21], [1, 1], 'BAD_blink')
     events = find_eog_events(raw)
-    n_events = len(events)
-    assert_true(n_events == 4)
+    assert_true(len(events) == 4)
+    assert_true(not all(events[:, 0] < 29000))
+
+    events = find_eog_events(raw, reject_by_annotation=True)
+    assert_true(all(events[:, 0] < 29000))


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/4165

I first tried setting the bad segments to zeros, but the edges along with the filtering caused false positives to every edge of an annotation.

This simply concatenates the good data, finds the blinks from that and maps the sample numbers to the original. See if this is not too hacky for you.

It only finds one false positive with the gist in https://github.com/mne-tools/mne-python/issues/4165. That's because the drift isn't entirely covered with an annotation. Should I add a param for using this or should it be always on?