### PR TITLE
[MRG+2] keep relative position of events in concatenate_epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,8 @@ BUG
 
     - Fix ``picks`` default in :meth:`mne.io.Raw.filter` to include ``ref_meg`` channels by default by `Eric Larson`_
 
+    - :meth:`mne.concatenate_epochs` now maintains the relative position of events during concatenation by `Alexandre Barachant`_
+
 API
 ~~~
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2049,6 +2049,14 @@ def test_concatenate_epochs():
     epochs2.event_id = dict(a=2)
     assert_raises(ValueError, concatenate_epochs, [epochs1, epochs2])
 
+    # check events are shifted, but relative position are equal
+    epochs_list = [epochs.copy() for ii in range(3)]
+    epochs_cat = concatenate_epochs(epochs_list)
+    for ii in range(3):
+        evs = epochs_cat.events[ii * len(epochs):(ii + 1) * len(epochs)]
+        rel_pos = epochs_list[0].events[:, 0] - evs[:, 0]
+        assert_true(sum(rel_pos - rel_pos[0]) == 0)
+
 
 def test_add_channels():
     """Test epoch splitting / re-appending channel types."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2054,7 +2054,7 @@ def test_concatenate_epochs():
     epochs_cat = concatenate_epochs(epochs_list)
     for ii in range(3):
         evs = epochs_cat.events[ii * len(epochs):(ii + 1) * len(epochs)]
-        rel_pos = epochs_list[0].events[:, 0] - evs[:, 0]
+        rel_pos = epochs_list[ii].events[:, 0] - evs[:, 0]
         assert_true(sum(rel_pos - rel_pos[0]) == 0)
 
 


### PR DESCRIPTION
In concatenate_epochs, relative position of events are not conserved and replaced with arbitrary position (`events[:, 0] = np.arange(len(events)))`).

This will lead to problems when we apply operations relying on event position (e.g. Xdawn).

This PR fix this problem by maintaining relative position of events and adding an offset, arbitrarily set to to the position of the last event + tmax + 10s.

