### PR TITLE
WIP: add public SSS rank getter

### DIFF
--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -33,6 +33,7 @@ from .io.kit import read_epochs_kit
 from .io.eeglab import read_epochs_eeglab
 from .io.reference import (set_eeg_reference, set_bipolar_reference,
                            add_reference_channels)
+from .io.proc_history import get_rank_sss
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -24,10 +24,10 @@ from mne import (concatenate_events, find_events, equalize_channels,
 from mne.utils import (_TempDir, requires_pandas, slow_test, object_diff,
                        requires_mne, run_subprocess, run_tests_if_main)
 from mne.externals.six.moves import zip, cPickle as pickle
-from mne.io.proc_history import _get_sss_rank
 from mne.io.pick import _picks_by_type
 from mne.annotations import Annotations
 from mne.tests.common import assert_naming
+from mne import get_rank_sss
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -174,8 +174,7 @@ def test_rank_estimation():
         if 'proc_history' not in raw.info:
             expected_rank = n_meg + n_eeg
         else:
-            mf = raw.info['proc_history'][0]['max_info']
-            expected_rank = _get_sss_rank(mf) + n_eeg
+            expected_rank = get_rank_sss(raw.info) + n_eeg
         assert_array_equal(raw.estimate_rank(scalings=scalings), expected_rank)
 
         assert_array_equal(raw.estimate_rank(picks=picks_eeg,

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -338,7 +338,7 @@ def get_rank_sss(inst):
         if len(max_info['sss_info']) > 0:
             max_infos.append(max_info)
     if len(max_info) > 1:
-        logger.info('found multiple SSS records. Using then first')
+        logger.info('found multiple SSS records. Using the first.')
     elif len(max_info) == 0:
         raise ValueError(
             'Did not find any SSS record. You should use data-based '

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -16,8 +16,7 @@ from .write import (start_block, end_block, write_int, write_float,
 from .tag import find_tag
 from .constants import FIFF
 from ..externals.six import text_type, string_types
-from ..utils import warn
-
+from ..utils import warn, logger
 
 _proc_keys = ['parent_file_id', 'block_id', 'parent_block_id',
               'date', 'experimenter', 'creator']
@@ -310,3 +309,40 @@ def _get_sss_rank(sss):
     nfree -= (len(sss['sss_info']['components'][:nfree]) -
               sss['sss_info']['components'][:nfree].sum())
     return nfree
+
+
+def get_rank_sss(inst):
+    """Look up rank from SSS data.
+
+    .. note::
+        Throws an error if SSS has not been applied.
+
+    Parameters
+    ----------
+    inst : instance of Raw, Epochs or Evoked, or Info
+        Any MNE object with an .info attribute
+    Returns
+    -------
+    rank : int
+        The numerical rank as predicted by the number of SSS
+        components.
+    """
+    if not isinstance(inst, dict):
+        info = inst.info
+    else:
+        info = inst
+
+    max_infos = list()
+    for proc_info in info.get('proc_history', list()):
+        max_info = proc_info.get('max_info', {})
+        if len(max_info['sss_info']) > 0:
+            max_infos.append(max_info)
+    if len(max_info) > 1:
+        logger.info('found multiple SSS records. Using then first')
+    elif len(max_info) == 0:
+        raise ValueError(
+            'Did not find any SSS record. You should use data-based '
+            'rank estimate instead')
+
+    max_info = max_infos[0]
+    return _get_sss_rank(max_info)

--- a/mne/io/tests/test_proc_history.py
+++ b/mne/io/tests/test_proc_history.py
@@ -4,9 +4,9 @@
 
 import numpy as np
 import os.path as op
-from mne.io import read_info
+from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
-from mne.io.proc_history import _get_sss_rank
+from mne import get_rank_sss
 from nose.tools import assert_true, assert_equal
 
 base_dir = op.join(op.dirname(__file__), 'data')
@@ -40,7 +40,10 @@ def test_maxfilter_io():
 
 def test_maxfilter_get_rank():
     """Test maxfilter rank lookup."""
-    mf = read_info(raw_fname)['proc_history'][0]['max_info']
+    raw = read_raw_fif(raw_fname)
+
+    mf = raw.info['proc_history'][0]['max_info']
     rank1 = mf['sss_info']['nfree']
-    rank2 = _get_sss_rank(mf)
+
+    rank2 = get_rank_sss(raw)
     assert_equal(rank1, rank2)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -23,12 +23,11 @@ from mne import (read_cov, write_cov, Epochs, merge_events,
                  find_events, compute_raw_covariance,
                  compute_covariance, read_evokeds, compute_proj_raw,
                  pick_channels_cov, pick_channels, pick_types, pick_info,
-                 make_ad_hoc_cov)
+                 make_ad_hoc_cov, get_rank_sss)
 from mne.io import read_raw_fif, RawArray, read_info
 from mne.tests.common import assert_naming, assert_snr
 from mne.utils import (_TempDir, slow_test, requires_sklearn_0_15,
                        run_tests_if_main)
-from mne.io.proc_history import _get_sss_rank
 from mne.io.pick import channel_type, _picks_by_type
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -457,8 +456,7 @@ def test_rank():
 
             # check sss
             if 'proc_history' in this_very_info:
-                mf = this_very_info['proc_history'][0]['max_info']
-                n_free = _get_sss_rank(mf)
+                n_free = get_rank_sss(this_very_info)
                 if 'mag' not in ch_types and 'grad' not in ch_types:
                     n_free = 0
                 # - n_projs XXX clarify


### PR DESCRIPTION
I think it would be a good moment to expose a public SSS rank lookup function.
@Eric89GXL @agramfort cc @jjnurminen so far I'm not 100% sure what it means when we find multiple SSS records in the processing history. It seems the definitive one is the first, at least according to our tests. If I take the last one we get crashes, but this is trivial, as our test just compares the maths to the n_free of the first entry. In our testing dataset the first entry suggests 112, the second 120 components. Which one is the right one?
cc @SherazKhan.