### PR TITLE
Fix to edf with reject.

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -375,7 +375,6 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
         n_samps = np.array([int(fid.read(8).decode()) for ch
                             in channels])
         edf_info['n_samps'] = n_samps
-        n_samps = n_samps[include]
 
         fid.read(32 * nchan).decode()  # reserved
         assert fid.tell() == header_nbytes
@@ -392,6 +391,7 @@ def _get_edf_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
                  ' Inferring from the file size.')
             edf_info['n_records'] = n_records = read_records
 
+    n_samps = n_samps[include]
     physical_ranges = physical_max - physical_min
     cals = digital_max - digital_min
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -133,7 +133,8 @@ def test_edf_data():
         fid_out.write(rbytes[:236])
         fid_out.write(bytes('-1      '.encode()))
         fid_out.write(rbytes[244:])
-    read_raw_edf(broken_fname, preload=True)
+    raw = read_raw_edf(broken_fname, preload=True)
+    read_raw_edf(broken_fname, exclude=raw.ch_names[:132], preload=True)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Took me a while to debug this. Rejecting channels with edf was failing if n_records is inferred from file size.