### PR TITLE
MRG: Fix sensor aspect

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1765,12 +1765,11 @@ def plot_layout(layout, picks=None, show=True):
     .. versionadded:: 0.12.0
     """
     import matplotlib.pyplot as plt
-    fig = plt.figure()
+    fig = plt.figure(figsize=(max(plt.rcParams['figure.figsize']),) * 2)
     ax = fig.add_subplot(111)
     fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
                         hspace=None)
-    ax.set_xticks([])
-    ax.set_yticks([])
+    ax.set(xticks=[], yticks=[], aspect='equal')
     pos = [(p[0] + p[2] / 2., p[1] + p[3] / 2.) for p in layout.pos]
     pos, outlines = _check_outlines(pos, 'head')
     _draw_outlines(ax, outlines)
@@ -1782,6 +1781,7 @@ def plot_layout(layout, picks=None, show=True):
     for ii, (this_pos, ch_id) in enumerate(zip(pos, names)):
         ax.annotate(ch_id, xy=this_pos[:2], horizontalalignment='center',
                     verticalalignment='center', size='x-small')
+    tight_layout(fig=fig, pad=0, w_pad=0, h_pad=0)
     plt_show(show)
     return fig
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1404,7 +1404,7 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
     edgecolors = np.repeat('black', len(colors))
     edgecolors[bads] = 'red'
     if ax is None:
-        fig = plt.figure()
+        fig = plt.figure(figsize=(max(plt.rcParams['figure.figsize']),) * 2)
         if pos.shape[1] == 3:
             Axes3D(fig)
             ax = fig.gca(projection='3d')
@@ -1422,8 +1422,8 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
         ax.elev = 0
     else:
         ax.text(0, 0, '', zorder=1)
-        ax.set_xticks([])
-        ax.set_yticks([])
+        # Equal aspect for 3D looks bad, so only use for 2D
+        ax.set(xticks=[], yticks=[], aspect='equal')
         fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
                             hspace=None)
         if to_sphere:

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -59,7 +59,7 @@ print(raw.info['chs'][0]['loc'])
 
 ###############################################################################
 # And it's actually possible to plot the channel locations using
-# the :func:`mne.io.Raw.plot_sensors` method
+# :func:`mne.io.Raw.plot_sensors`.
 
 raw.plot_sensors()
 raw.plot_sensors('3d')  # in 3D
@@ -69,7 +69,7 @@ raw.plot_sensors('3d')  # in 3D
 # -------------------
 #
 # In the case where your data don't have locations you can set them
-# using a :func:`mne.channels.Montage`. MNE comes with a set of default
+# using a :class:`mne.channels.Montage`. MNE comes with a set of default
 # montages. To read one of them do:
 
 montage = mne.channels.read_montage('standard_1020')

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -105,7 +105,7 @@ raw.plot_projs_topomap()
 raw.plot()
 
 ###############################################################################
-# Now click the `proj` button at the lower right corner of the browser
+# Now click the ``proj`` button at the lower right corner of the browser
 # window. A selection dialog should appear, where you can toggle the projectors
 # on and off. Notice that the first four are already applied to the data and
 # toggling them does not change the data. However the newly added projectors
@@ -115,9 +115,9 @@ raw.plot()
 # projectors.
 #
 # Raw container also lets us easily plot the power spectra over the raw data.
-# Here we plot the data using `spatial_colors` to map the line colors to
+# Here we plot the data using ``spatial_colors`` to map the line colors to
 # channel locations (default in versions >= 0.15.0). Other option is to use the
-# `average` (default in < 0.15.0). See the API documentation for more info.
+# ``average`` (default in < 0.15.0). See the API documentation for more info.
 raw.plot_psd(tmax=np.inf, average=False)
 
 ###############################################################################


### PR DESCRIPTION
Makes our `plot_sensors` (2D) and `plot_layout` plot with the correct aspect ratio so the head is a circle instead of an ellipse.