### PR TITLE
FIX: replace broken logic with Counter

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -15,6 +15,7 @@ import json
 import os.path as op
 from distutils.version import LooseVersion
 from numbers import Integral
+from collections import Counter
 
 import numpy as np
 import scipy
@@ -827,7 +828,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if len(self.event_id) == 1:
             comment = next(iter(self.event_id.keys()))
         else:
-            count = np.bincount(self.events[:, 2])
+            count = Counter(self.events[:, 2])
             comments = list()
             for key, value in self.event_id.items():
                 comments.append('%.2f * %s' % (


### PR DESCRIPTION
This addresses some dormant bugs with our _name property. In some cases the value can be higher than the length of the array returned by np.bincount. To me the way to do things is `collections.Counter`. I stumbled over this while trying to fix builds in autoreject with @jasmainak.