### PR TITLE
[MRG+1] Speed up epochs.plot.

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1005,13 +1005,16 @@ def _plot_update_epochs_proj(params, bools=None):
         params['info']['projs'] = [copy.deepcopy(params['projs'][ii])
                                    for ii in inds]
         params['proj_bools'] = bools
+    epochs = params['epochs']
+    n_epochs = params['n_epochs']
     params['projector'], _ = setup_proj(params['info'], add_eeg_ref=False,
                                         verbose=False)
-
-    start = int(params['t_start'] / len(params['epochs'].times))
-    n_epochs = params['n_epochs']
+    start = int(params['t_start'] / len(epochs.times))
     end = start + n_epochs
-    data = np.concatenate(params['epochs'][start:end].get_data(), axis=1)
+    if epochs._data is None:
+        data = np.concatenate(epochs[start:end].get_data(), axis=1)
+    else:  # preloaded data
+        data = np.concatenate(epochs._data[start:end], axis=1)
     if params['projector'] is not None:
         data = np.dot(params['projector'], data)
     types = params['types']

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1012,9 +1012,10 @@ def _plot_update_epochs_proj(params, bools=None):
     start = int(params['t_start'] / len(epochs.times))
     end = start + n_epochs
     if epochs._data is None:
+        # this is faster than epochs.get_data()[start:end] when not preloaded
         data = np.concatenate(epochs[start:end].get_data(), axis=1)
     else:  # preloaded data
-        data = np.concatenate(epochs._data[start:end], axis=1)
+        data = np.concatenate(epochs.get_data()[start:end], axis=1)
     if params['projector'] is not None:
         data = np.dot(params['projector'], data)
     types = params['types']

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1011,11 +1011,12 @@ def _plot_update_epochs_proj(params, bools=None):
                                         verbose=False)
     start = int(params['t_start'] / len(epochs.times))
     end = start + n_epochs
-    if epochs._data is None:
+    if epochs.preload:
+        data = np.concatenate(epochs.get_data()[start:end], axis=1)
+    else:
         # this is faster than epochs.get_data()[start:end] when not preloaded
         data = np.concatenate(epochs[start:end].get_data(), axis=1)
-    else:  # preloaded data
-        data = np.concatenate(epochs.get_data()[start:end], axis=1)
+
     if params['projector'] is not None:
         data = np.dot(params['projector'], data)
     types = params['types']


### PR DESCRIPTION
``__getitem__`` of epochs makes a copy slowing plotting down. This uses the preloaded data if available. The improvement isn't quite as dramatic as I hoped, but should make a difference with big datasets.