### PR TITLE
Fix for EGI RS data

### DIFF
--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -202,6 +202,7 @@ class RawEGI(BaseRaw):
 
         logger.info('    Assembling measurement info ...')
 
+        event_codes = []
         if egi_info['n_events'] > 0:
             event_codes = list(egi_info['event_codes'])
             if include is None:


### PR DESCRIPTION
It fixes the bug introduced by #4079 which prevents reading EGI data when no triggers are present.