### PR TITLE
Explicit cutoff for rank estimation when inverting ica._pre_whitener

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,6 +63,8 @@ BUG
     - Fix :func:`mne.viz.plot_sensors` to maintain proper aspect ratio by `Eric Larson`_
 
     - Fix :func:`mne.viz.plot_topomap` to allow 0 contours by `Jaakko Leppakangas`_
+    
+    - Fix :func:`mne.preprocessing.ica._pick_sources` increase threshold for rank estimation to 1e-14 by `jdue`
 
 API
 ~~~

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1339,7 +1339,7 @@ class ICA(ContainsMixin):
         if self.noise_cov is None:  # revert standardization
             data *= self._pre_whitener
         else:
-            data = fast_dot(linalg.pinv(self._pre_whitener, cond=1e-9), data)
+            data = fast_dot(linalg.pinv(self._pre_whitener, cond=1e-14), data)
 
         return data
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1339,7 +1339,7 @@ class ICA(ContainsMixin):
         if self.noise_cov is None:  # revert standardization
             data *= self._pre_whitener
         else:
-            data = fast_dot(linalg.pinv(self._pre_whitener), data)
+            data = fast_dot(linalg.pinv(self._pre_whitener, cond=1e-9), data)
 
         return data
 


### PR DESCRIPTION
This pull request concerns #4215.

I experienced problems using the ica.apply() method for average referenced EEG data when supplying a noise covariance matrix. The issue seemed to occur in `ica._pick_sources`, specifically the line where the pre-whitening matrix is inverted, i.e., `data = fast_dot(linalg.pinv(self._pre_whitener), data)`. Due to the applied average referencing, the data was rank deficient, however, this was not recognized by (scipy.)linalg.pinv. A suggestion in #4215 was to use a higher cutoff value for singular values when determining effective rank, i.e., explicitly setting the `cond` argument.

On my system, Windows 10 64-bit running python 3.6, the default cutoff is about 2.22e-16. I tested two cases. For my own data, the singular values (as estimated by scipy.linalg.lstsq called by scipy.linalg.pinv), relative to the largest one, were
```
array([  1.00000000e+00,   9.31047876e-01,   8.04210303e-01, ...,
         3.91676380e-02,   3.22353441e-02,   5.37981650e-16])
```
whereas when testing [this](http://martinos.org/mne/stable/auto_tutorials/plot_artifacts_correction_ica.html) MNE example (slightly modified), the results were
```
array([  1.00000000e+00,   9.76304156e-01,   9.55330802e-01, ...,
         2.81062987e-02,   1.29452602e-02,   3.04498081e-15])
```
A suggestion was made to explicitly set the `cond` argument to for example 1e-9 which would resolve both cases. If these can be considered representative this should provide a stable estimate of the rank seeing as 1e-9 is about half way between the last and the second to last singular values. Perhaps it might even be lowered a bit.