### PR TITLE
MRG: Fix projector check

### DIFF
--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -527,7 +527,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
             for v in range(p['data']['nrow']):
                 psize = sqrt(np.sum(this_vecs[:, v] * this_vecs[:, v]))
                 if psize > 0:
-                    orig_n = p['data']['data'].shape[1]
+                    orig_n = p['data']['data'].any(axis=0).sum()
                     # Average ref still works if channels are removed
                     if len(vecsel) < 0.9 * orig_n and not inplace and \
                             (p['kind'] != FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF or


### PR DESCRIPTION
Newer style Neuromag projectors can have all 306 channels even if only grad or mag are used in the vector. This fixes the logic for checking if the projector has been depleted by bads or picking.