### PR TITLE
WIP speed up topomap tests

### DIFF
--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -125,7 +125,7 @@ def test_plot_ica_properties():
     fig, ax = _create_properties_layout()
     assert_equal(len(ax), 5)
 
-    topoargs = dict(topomap_args={'res': res, 'contours':0, "sensors": False})
+    topoargs = dict(topomap_args={'res': res, 'contours': 0, "sensors": False})
     ica.plot_properties(raw, picks=0, **topoargs)
     ica.plot_properties(epochs, picks=1, dB=False, plot_std=1.5, **topoargs)
     ica.plot_properties(epochs, picks=1, image_args={'sigma': 1.5},

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -59,6 +59,7 @@ def _get_epochs():
 def test_plot_ica_components():
     """Test plotting of ICA solutions."""
     import matplotlib.pyplot as plt
+    res = 8
     raw = _get_raw()
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
               max_pca_components=3, n_pca_components=3)
@@ -68,12 +69,13 @@ def test_plot_ica_components():
     warnings.simplefilter('always', UserWarning)
     with warnings.catch_warnings(record=True):
         for components in [0, [0], [0, 1], [0, 1] * 2, None]:
-            ica.plot_components(components, image_interp='bilinear', res=16,
-                                colorbar=True)
+            ica.plot_components(components, image_interp='bilinear', res=res,
+                                colorbar=True, contours=0)
 
         # test interactive mode (passing 'inst' arg)
         plt.close('all')
-        ica.plot_components([0, 1], image_interp='bilinear', res=16, inst=raw)
+        ica.plot_components([0, 1], image_interp='bilinear', res=res, inst=raw,
+                            contours=0)
 
         fig = plt.gcf()
         ax = [a for a in fig.get_children() if isinstance(a, plt.Axes)]
@@ -122,7 +124,7 @@ def test_plot_ica_properties():
     fig, ax = _create_properties_layout()
     assert_equal(len(ax), 5)
 
-    topoargs = dict(topomap_args={'res': 10})
+    topoargs = dict(topomap_args={'res': res, 'contours':0, "sensors": False})
     ica.plot_properties(raw, picks=0, **topoargs)
     ica.plot_properties(epochs, picks=1, dB=False, plot_std=1.5, **topoargs)
     ica.plot_properties(epochs, picks=1, image_args={'sigma': 1.5},
@@ -141,7 +143,7 @@ def test_plot_ica_properties():
 
     fig, ax = plt.subplots(2, 3)
     ax = ax.ravel()[:-1]
-    ica.plot_properties(epochs, picks=1, axes=ax)
+    ica.plot_properties(epochs, picks=1, axes=ax, **topoargs)
     fig = ica.plot_properties(raw, picks=[0, 1], **topoargs)
     assert_equal(len(fig), 2)
     assert_raises(ValueError, plot_ica_properties, epochs, ica, picks=[0, 1],

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -60,6 +60,7 @@ def test_plot_ica_components():
     """Test plotting of ICA solutions."""
     import matplotlib.pyplot as plt
     res = 8
+    fast_test = {"res": res, "contours": 0, "sensors": False}
     raw = _get_raw()
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
               max_pca_components=3, n_pca_components=3)
@@ -69,13 +70,12 @@ def test_plot_ica_components():
     warnings.simplefilter('always', UserWarning)
     with warnings.catch_warnings(record=True):
         for components in [0, [0], [0, 1], [0, 1] * 2, None]:
-            ica.plot_components(components, image_interp='bilinear', res=res,
-                                colorbar=True, contours=0)
+            ica.plot_components(components, image_interp='bilinear',
+                                colorbar=True, **fast_test)
 
         # test interactive mode (passing 'inst' arg)
         plt.close('all')
-        ica.plot_components([0, 1], image_interp='bilinear', res=res, inst=raw,
-                            contours=0)
+        ica.plot_components([0, 1], image_interp='bilinear', inst=raw, res=16)
 
         fig = plt.gcf()
         ax = [a for a in fig.get_children() if isinstance(a, plt.Axes)]
@@ -104,6 +104,7 @@ def test_plot_ica_properties():
     """Test plotting of ICA properties."""
     import matplotlib.pyplot as plt
 
+    res = 8
     raw = _get_raw(preload=True)
     raw.add_proj([], remove_existing=True)
     events = _get_events()

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -84,7 +84,7 @@ def test_plot_topo():
 
     def return_inds(d):  # to test function kwarg to zorder arg of evoked.plot
         return list(range(d.shape[0]))
-    evoked.plot_joint(title='test', topomap_args=dict(contours=3),
+    evoked.plot_joint(title='test', topomap_args=dict(contours=0, res=8),
                       ts_args=dict(spatial_colors=True, zorder=return_inds))
     assert_raises(ValueError, evoked.plot_joint, ts_args=dict(axes=True))
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -291,9 +291,9 @@ def test_plot_tfr_topomap():
     n_freqs = 3
     nave = 1
     rng = np.random.RandomState(42)
-    keep_chans = [93, 94, 96, 97, 21, 22, 24, 25, 129, 130, 315, 316, 2, 5, 8, 11]
-    info = pick_info(raw.info, keep_chans)
-    data = rng.randn(len(keep_chans), n_freqs, len(times))
+    picks = [93, 94, 96, 97, 21, 22, 24, 25, 129, 130, 315, 316, 2, 5, 8, 11]
+    info = pick_info(raw.info, picks)
+    data = rng.randn(len(picks), n_freqs, len(times))
     tfr = AverageTFR(info, data, times, np.arange(n_freqs), nave)
     tfr.plot_topomap(ch_type='mag', tmin=0.05, tmax=0.150, fmin=0, fmax=10,
                      res=res, contours=0)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -742,7 +742,8 @@ def _inside_contour(pos, contour):
 def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', colorbar=False,
                       title=None, show=True, outlines='head', contours=6,
-                      image_interp='bilinear', head_pos=None, axes=None):
+                      image_interp='bilinear', head_pos=None, axes=None,
+                      sensors=True):
     """Plot single ica map to axes."""
     import matplotlib as mpl
     from ..channels import _get_ch_type
@@ -774,7 +775,8 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
     im = plot_topomap(data.ravel(), pos, vmin=vmin_, vmax=vmax_,
                       res=res, axes=axes, cmap=cmap, outlines=outlines,
                       image_mask=image_mask, contours=contours,
-                      image_interp=image_interp, show=show)[0]
+                      sensors=sensors, image_interp=image_interp,
+                      show=show)[0]
     if colorbar:
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -941,7 +943,8 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         im = plot_topomap(data_.flatten(), pos, vmin=vmin_, vmax=vmax_,
                           res=res, axes=ax, cmap=cmap[0], outlines=outlines,
                           image_mask=image_mask, contours=contours,
-                          image_interp=image_interp, show=False)[0]
+                          image_interp=image_interp, show=False,
+                          sensors=sensors)[0]
         im.axes.set_label('IC #%03d' % ii)
         if colorbar:
             divider = make_axes_locatable(ax)


### PR DESCRIPTION
Because topomap calls are a major aspect of our tests, this is essentially trying to pass `{"res": 8, "contours": 0, "sensors": False}` to as many topomap calls as possible.

The bad companion to #4224