### PR TITLE
Fix for `set_bipolar_reference`

### DIFF
--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -397,7 +397,7 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
 
 
 def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
-                          copy=True):
+                          copy=True, verbose=None):
     """Rereference selected channels using a bipolar referencing scheme.
 
     A bipolar reference takes the difference between two channels (the anode
@@ -432,6 +432,9 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     copy : bool
         Whether to operate on a copy of the data (True) or modify it in-place
         (False). Defaults to True.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------
@@ -504,7 +507,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     if copy:
         inst = inst.copy()
 
-    rem_ca = cathode[:]
+    rem_ca = list(cathode)
     for i, (an, ca, name, chs) in enumerate(
             zip(anode, cathode, ch_name, new_chs)):
         if an in anode[i + 1:]:

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -504,6 +504,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     if copy:
         inst = inst.copy()
 
+    rem_ca = cathode[:]
     for i, (an, ca, name, chs) in enumerate(
             zip(anode, cathode, ch_name, new_chs)):
         if an in anode[i + 1:]:
@@ -517,8 +518,11 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info['chs'][an_idx]['ch_name'] = name
         logger.info('Bipolar channel added as "%s".' % name)
         inst.info._update_redundant()
+        if an in rem_ca:
+            idx = rem_ca.index(an)
+            del rem_ca[idx]
 
-    # Drop anode and cathode channels
-    inst.drop_channels(cathode)
+    # Drop remaining cathode channels
+    inst.drop_channels(rem_ca)
 
     return inst

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -396,6 +396,7 @@ def set_eeg_reference(inst, ref_channels=None, copy=True, verbose=None):
     return _apply_reference(inst, ref_channels)
 
 
+@verbose
 def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
                           copy=True, verbose=None):
     """Rereference selected channels using a bipolar referencing scheme.

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -239,8 +239,8 @@ def test_set_bipolar_reference():
 
     # Minimalist call with twice the same anode
     reref = set_bipolar_reference(raw,
-                                  ['EEG 001', 'EEG 001'],
-                                  ['EEG 002', 'EEG 003'])
+                                  ['EEG 001', 'EEG 001', 'EEG 002'],
+                                  ['EEG 002', 'EEG 003', 'EEG 003'])
     assert_true('EEG 001-EEG 002' in reref.ch_names)
     assert_true('EEG 001-EEG 003' in reref.ch_names)
 


### PR DESCRIPTION
This PR fixes a small bug in #4218 and proposes to add a `verbose` parameter to `set_bipolar_reference`. Indeed, in `set_bipolar_reference`, `inst.drop_channels(cathode)` raises an error if there is a non-empty intersection between the lists `anode` and `cathode` (we try to drop channels which no longer exist). 