### PR TITLE
MRG: Fix topomap masking

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,10 +65,12 @@ BUG
     - Fix :func:`mne.viz.plot_sensors` to maintain proper aspect ratio by `Eric Larson`_
 
     - Fix :func:`mne.viz.plot_topomap` to allow 0 contours by `Jaakko Leppakangas`_
-    
+
     - Fix :func:`mne.preprocessing.ica._pick_sources` increase threshold for rank estimation to 1e-14 by `jdue`_
 
     - Fix :meth:`raw.set_bipolar_reference` to support duplicates in anodes by `Jean-Baptiste Schiratti`_ and `Alex Gramfort`_
+
+    - Fix :meth:`mne.Evoked.plot_topomap` when using the ``mask`` argument with paired gradiometers by `Eric Larson`_
 
 API
 ~~~

--- a/examples/stats/plot_sensor_permutation_test.py
+++ b/examples/stats/plot_sensor_permutation_test.py
@@ -34,13 +34,9 @@ tmax = 0.5
 raw = io.read_raw_fif(raw_fname)
 events = mne.read_events(event_fname)
 
-#   Set up pick list: MEG + STI 014 - bad channels (modify to your needs)
-include = []  # or stim channel ['STI 014']
-raw.info['bads'] += ['MEG 2443', 'EEG 053']  # bads + 2 more
-
 # pick MEG Gradiometers
 picks = mne.pick_types(raw.info, meg='grad', eeg=False, stim=False, eog=True,
-                       include=include, exclude='bads')
+                       exclude='bads')
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), reject=dict(grad=4000e-13, eog=150e-6))
 data = epochs.get_data()

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -89,6 +89,18 @@ def test_plot_topomap():
     plt.close('all')
     plt_topomap(times=[-0.1, 0.2])
     plt.close('all')
+    evoked_grad = evoked.copy().crop(0, 0).pick_types(meg='grad')
+    mask = np.zeros((204, 1), bool)
+    mask[[0, 3, 5, 6]] = True
+    names = []
+
+    def proc_names(x):
+        names.append(x)
+        return x[4:]
+
+    evoked_grad.plot_topomap(ch_type='grad', times=[0], mask=mask,
+                             show_names=proc_names, **fast_test)
+    assert_equal(names, [u'MEG 012x', u'MEG 013x', u'MEG 014x', u'MEG 011x'])
     mask = np.zeros_like(evoked.data, dtype=bool)
     mask[[1, 5], :] = True
     plt_topomap(ch_type='mag', outlines=None)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1434,8 +1434,12 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     images, contours_ = [], []
 
     if mask is not None:
-        _picks = picks[::2 if ch_type not in ['mag', 'eeg'] else 1]
-        mask_ = mask[np.ix_(_picks, time_idx)]
+        if ch_type not in ['mag', 'eeg']:
+            mask_ = (mask[np.ix_(picks[::2], time_idx)] |
+                     mask[np.ix_(picks[1::2], time_idx)])
+        else:
+            _picks = picks
+            mask_ = mask[np.ix_(_picks, time_idx)]
 
     pos, outlines = _check_outlines(pos, outlines, head_pos)
     if outlines is not None:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1438,8 +1438,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
             mask_ = (mask[np.ix_(picks[::2], time_idx)] |
                      mask[np.ix_(picks[1::2], time_idx)])
         else:
-            _picks = picks
-            mask_ = mask[np.ix_(_picks, time_idx)]
+            mask_ = mask[np.ix_(picks, time_idx)]
 
     pos, outlines = _check_outlines(pos, outlines, head_pos)
     if outlines is not None:


### PR DESCRIPTION
This fixes two problems.

First, the `mask` wasn't working properly for paired gradiometers.

Second, we were doing `raw.info['bads'] += ` when those bads were already present in the evoked file. We have that elsewhere in tutorials so it seems overkill here anyway.