### PR TITLE
[MRG] Change legend to use absolute positions.

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -166,8 +166,7 @@ def _plot_legend(pos, colors, axis, bads, outlines, loc):
         ax.scatter(pos_x[idx], pos_y[idx], s=5, marker='.', color='w',
                    zorder=1)
 
-    if isinstance(outlines, dict):
-        _draw_outlines(ax, outlines)
+    _draw_outlines(ax, outlines)
 
 
 def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
@@ -437,7 +436,8 @@ def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax):
     bads = [np.where(used_nm == bad)[0][0] for bad in info['bads'] if bad in
             used_nm]
     pos = _auto_topomap_coords(info, idx, ignore_overlap=True, to_sphere=True)
-    pos, outlines = _check_outlines(pos, 'skirt', None)
+    pos, outlines = _check_outlines(pos, np.array([1, 1]),
+                                    {'center': (0, 0), 'scale': (0.5, 0.5)})
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -30,7 +30,7 @@ from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
                       _draw_outlines, _prepare_topomap, _topomap_animation,
                       _set_contour_locator)
 from ..channels import find_layout
-from ..channels.layout import _pair_grad_sensors
+from ..channels.layout import _pair_grad_sensors, _auto_topomap_coords
 
 
 def _butterfly_onpick(event, params):
@@ -329,8 +329,10 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                          'colors.')
                     spatial_colors = selectable = False
                 if spatial_colors is True and len(idx) != 1:
-                    colors = _handle_spatial_colors(locs3d, info, idx,
-                                                    this_type, psd, ax)
+                    x, y, z = locs3d.T
+                    colors = _rgb(x, y, z)
+                    _handle_spatial_colors(colors, info, idx, this_type, psd,
+                                           ax)
                 else:
                     if isinstance(spatial_colors, (tuple, string_types)):
                         col = [spatial_colors]
@@ -429,12 +431,9 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                 useblit=blit, rectprops=dict(alpha=0.5, facecolor='red'))
 
 
-def _handle_spatial_colors(locs3d, info, idx, ch_type, psd, ax):
+def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax):
     """Set up spatial colors."""
-    x, y, z = locs3d.T
-    colors = _rgb(x, y, z)
     ch_type = None if ch_type not in ('meg', 'mag', 'grad', 'eeg') else ch_type
-
     layout = find_layout(info, ch_type=ch_type, exclude=[])
     if layout.kind == 'custom':
         head_pos = {'center': (0, 0), 'scale': (4.5, 4.5)}
@@ -444,16 +443,15 @@ def _handle_spatial_colors(locs3d, info, idx, ch_type, psd, ax):
         outlines = 'skirt'
     # drop channels that are not in the data
     used_nm = np.array(_clean_names(info['ch_names']))[idx]
-
     names = np.asarray([name for name in used_nm if name in layout.names])
 
     # find indices for bads
     bads = [np.where(names == bad)[0][0] for bad in info['bads'] if bad in
             names]
-    pos, outlines = _check_outlines(locs3d[:, :2], outlines, head_pos)
+    pos = _auto_topomap_coords(info, idx, to_sphere=True)
+    pos, outlines = _check_outlines(pos, outlines, head_pos)
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
-    return colors
 
 
 def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -29,7 +29,6 @@ from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
                       _draw_outlines, _prepare_topomap, _topomap_animation,
                       _set_contour_locator)
-from ..channels import find_layout
 from ..channels.layout import _pair_grad_sensors, _auto_topomap_coords
 
 
@@ -433,23 +432,12 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
 
 def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax):
     """Set up spatial colors."""
-    ch_type = None if ch_type not in ('meg', 'mag', 'grad', 'eeg') else ch_type
-    layout = find_layout(info, ch_type=ch_type, exclude=[])
-    if layout.kind == 'custom':
-        head_pos = {'center': (0, 0), 'scale': (4.5, 4.5)}
-        outlines = np.array([0.5, 0.5])
-    else:
-        head_pos = None
-        outlines = 'skirt'
-    # drop channels that are not in the data
     used_nm = np.array(_clean_names(info['ch_names']))[idx]
-    names = np.asarray([name for name in used_nm if name in layout.names])
-
     # find indices for bads
-    bads = [np.where(names == bad)[0][0] for bad in info['bads'] if bad in
-            names]
-    pos = _auto_topomap_coords(info, idx, to_sphere=True)
-    pos, outlines = _check_outlines(pos, outlines, head_pos)
+    bads = [np.where(used_nm == bad)[0][0] for bad in info['bads'] if bad in
+            used_nm]
+    pos = _auto_topomap_coords(info, idx, ignore_overlap=True, to_sphere=True)
+    pos, outlines = _check_outlines(pos, 'skirt', None)
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -446,13 +446,11 @@ def _handle_spatial_colors(locs3d, info, idx, ch_type, psd, ax):
     used_nm = np.array(_clean_names(info['ch_names']))[idx]
 
     names = np.asarray([name for name in used_nm if name in layout.names])
-    name_idx = [layout.names.index(name) for name in names]
 
     # find indices for bads
     bads = [np.where(names == bad)[0][0] for bad in info['bads'] if bad in
             names]
-    pos, outlines = _check_outlines(layout.pos[:, :2], outlines, head_pos)
-    pos = pos[name_idx]
+    pos, outlines = _check_outlines(locs3d[:, :2], outlines, head_pos)
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
     return colors


### PR DESCRIPTION
I noticed that the legend was not right when plotting ctf data:
![spatial_colors](https://cloud.githubusercontent.com/assets/3456414/25653973/94da3b2a-2fef-11e7-81cd-7d8f1b1b0325.png)

I suggest we change the legend to use absolute locations instead of the layout positions. 