### PR TITLE
Closing file before attempting to delete

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,8 @@ BUG
     - Fix bug in :meth:`mne.Label.fill` where an empty label raised an error, by `Eric Larson`_
 
     - Fix :func:`mne.io.read_raw_ctf` to also include the samples in the last block by `Jaakko Leppakangas`_
+    
+    - Fix :meth:`mne.preprocessing.ICA.save` to close file before attempting to delete it when write fails by `jdue`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,7 +68,7 @@ BUG
 
     - Fix :func:`mne.viz.plot_topomap` to allow 0 contours by `Jaakko Leppakangas`_
 
-    - Fix :func:`mne.preprocessing.ica._pick_sources` increase threshold for rank estimation to 1e-14 by `jdue`_
+    - Fix :func:`mne.preprocessing.ica._pick_sources` increase threshold for rank estimation to 1e-14 by `Jesper Duemose Nielsen`_
 
     - Fix :meth:`raw.set_bipolar_reference` to support duplicates in anodes by `Jean-Baptiste Schiratti`_ and `Alex Gramfort`_
 
@@ -80,7 +80,7 @@ BUG
 
     - Fix :func:`mne.io.read_raw_ctf` to also include the samples in the last block by `Jaakko Leppakangas`_
     
-    - Fix :meth:`mne.preprocessing.ICA.save` to close file before attempting to delete it when write fails by `jdue`_
+    - Fix :meth:`mne.preprocessing.ICA.save` to close file before attempting to delete it when write fails by `Jesper Duemose Nielsen`_
 
 API
 ~~~
@@ -2149,4 +2149,4 @@ of commits):
 
 .. _Laura Gwilliams: http://lauragwilliams.github.io
 
-.. _jdue: https://github.com/jdue
+.. _Jesper Duemose Nielsen: https://github.com/jdue

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1363,10 +1363,11 @@ class ICA(ContainsMixin):
 
         try:
             _write_ica(fid, self)
+            end_file(fid)
         except Exception:
+            end_file(fid)
             os.remove(fname)
             raise
-        end_file(fid)
 
         return self
 


### PR DESCRIPTION
This PR concerns (the first half of) #4264.

I experienced a `PermissionError` when trying to save an ICA object to disk, however, this was not the error causing the write to fail but seemed to be the result of subsequently trying to delete the file (which was being written) before having closed it. Hence, this error was raised before the 'actual' error could be raised (and also prevented manual deletion of the file).

This PR implements a change to close the file before trying to delete it.