### PR TITLE
[MRG] Fix to gdf event reading.

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -77,6 +77,9 @@ class RawEDF(BaseRaw):
 
     It is also possible to retrieve system codes, but no particular effort has
     been made to decode these in MNE.
+    For GDF files, the stimulus channel is constructed from the events in the
+    header. You should use keyword ``stim_channel=-1`` to add it at the end of
+    the channel list.
 
     See Also
     --------
@@ -128,6 +131,7 @@ class RawEDF(BaseRaw):
         annot = self._raw_extras[fi]['annot']
         annotmap = self._raw_extras[fi]['annotmap']
         subtype = self._raw_extras[fi]['subtype']
+        events = self._raw_extras[fi].get('events', None)
 
         if np.size(dtype_byte) > 1:
             if len(np.unique(dtype_byte)) > 1:
@@ -202,6 +206,10 @@ class RawEDF(BaseRaw):
                             if annot and annotmap or tal_channels is not None:
                                 # don't resample, it gets overwritten later
                                 ch_data = np.zeros((len(ch_data, buf_len)))
+                            elif events is not None:  # GDF events
+                                ch_data = self._raw_extras[fi]['stim_data']
+                                ch_data = ch_data[start:stop].reshape((
+                                    stop - start, buf_len))
                             else:
                                 # Stim channel will be interpolated
                                 old = np.linspace(0, 1, n_samps[ci] + 1, True)
@@ -354,8 +362,10 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
              ', '.join(ch_names[i] for i in idx))
         cals[idx] = 1
 
+    if ext == 'gdf' and stim_channel == -1:
+        cals = np.append(cals, 1)
     # Check that stimulus channel exists in dataset
-    if stim_channel is not None:
+    if stim_channel is not None or stim_channel is not False:
         stim_channel = _check_stim_channel(stim_channel, ch_names, include)
 
     # Annotations
@@ -608,7 +618,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
     edf_info = dict()
     # edf_info['annot'] = annot
     # edf_info['annotmap'] = annotmap
-    edf_info['events'] = []
+    events = []
 
     with open(fname, 'rb') as fid:
 
@@ -730,7 +740,6 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 etmode = np.fromfile(fid, np.uint8, 1).tolist()
                 sr = np.fromfile(fid, np.uint8, 3)
                 event_sr = sr[0]
-                events = []
                 for i in range(1, len(sr)):
                     event_sr = event_sr + sr[i] * 256 ** i
                 n_events = np.fromfile(fid, np.uint32, 1)[0]
@@ -740,13 +749,10 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 if etmode == 3:
                     chn = np.fromfile(fid, np.uint16, n_events * 2)
                     dur = np.fromfile(fid, np.uint32, n_events * 4)
-                    events.append([n_events, pos, typ, chn, dur])
                 else:
-                    dur = np.zeros(n_events, dtype=np.uint32)
-                    events.append([n_events, pos, typ])
-
-                edf_info['events'] = events
-                # info['events'] = np.c_[pos, dur, typ]
+                    chn = np.zeros(n_events, dtype=np.int32)
+                    dur = np.ones(n_events, dtype=np.uint32)
+                events = [n_events, pos, typ, chn, dur]
 
         # GDF 2.x
         # ----------------------------------------------------------------------
@@ -949,7 +955,6 @@ def _read_gdf_header(fname, stim_channel, exclude):
             etp = edf_info['data_offset'] + edf_info['n_records'] * \
                 edf_info['bytes_tot']
             fid.seek(etp)  # skip data to go to event table
-            events = []
             etmode = fid.read(1).decode()
             if etmode != '':
                 etmode = np.fromstring(etmode, np.uint8).tolist()[0]
@@ -973,14 +978,31 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 if etmode == 3:
                     chn = np.fromfile(fid, np.uint16, n_events)
                     dur = np.fromfile(fid, np.uint32, n_events)
-                    events.append([n_events, pos, typ, chn, dur])
                 else:
-                    dur = np.zeros(n_events, dtype=np.uint32)
-                    events.append([n_events, pos, typ])
-
-                edf_info['events'] = events
+                    chn = np.zeros(n_events, dtype=np.uint32)
+                    dur = np.ones(n_events, dtype=np.uint32)
+                events = [n_events, pos, typ, chn, dur]
                 edf_info['event_sfreq'] = event_sr
 
+    if stim_channel == -1 and edf_info['nchan'] not in exclude:
+        if len(events) == 0:
+            warn('No events found. Cannot construct a stimulus channel.')
+            return edf_info
+        edf_info['include'].append(edf_info['nchan'])
+        edf_info['n_samps'] = np.append(edf_info['n_samps'], 0)
+        edf_info['units'] = np.append(edf_info['units'], 1)
+        edf_info['nchan'] += 1
+        edf_info['ch_names'] += [u'STI 014']
+        edf_info['physical_min'] = np.append(edf_info['physical_min'], 0)
+        edf_info['digital_min'] = np.append(edf_info['digital_min'], 0)
+        vmax = np.max(events[2])
+        edf_info['physical_max'] = np.append(edf_info['physical_max'], vmax)
+        edf_info['digital_max'] = np.append(edf_info['digital_max'], vmax)
+        data = np.zeros(np.max(n_samps * n_records))
+        for samp, id, dur in zip(events[1], events[2], events[4]):
+            data[samp:samp + dur] += id
+        edf_info['stim_data'] = data
+    edf_info['events'] = events
     return edf_info
 
 
@@ -1037,6 +1059,8 @@ def _check_stim_channel(stim_channel, ch_names, include):
                 err += ' Closest match is "{}".'.format(casematch[0])
             raise ValueError(err)
     else:
+        if stim_channel is True:
+            stim_channel = -1
         if stim_channel == -1:
             stim_channel = len(include) - 1
         elif stim_channel > len(ch_names):
@@ -1109,6 +1133,9 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
 
     It is also possible to retrieve system codes, but no particular effort has
     been made to decode these in MNE.
+    For GDF files, the stimulus channel is constructed from the events in the
+    header. You should use keyword ``stim_channel=-1`` to add it at the end of
+    the channel list.
 
     See Also
     --------

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -343,6 +343,8 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
         if annot is not None:
             warn('Annotations not yet supported for GDF files.')
         edf_info = _read_gdf_header(fname, stim_channel, exclude)
+        if 'stim_data' not in edf_info and stim_channel == -1:
+            stim_channel = None  # Cannot construct stim channel.
     else:
         raise NotImplementedError(
             'Only GDF, EDF, and BDF files are supported, got %s.' % ext)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -131,7 +131,7 @@ class RawEDF(BaseRaw):
         annot = self._raw_extras[fi]['annot']
         annotmap = self._raw_extras[fi]['annotmap']
         subtype = self._raw_extras[fi]['subtype']
-        events = self._raw_extras[fi].get('events', None)
+        stim_data = self._raw_extras[fi].get('stim_data', None)  # for GDF
 
         if np.size(dtype_byte) > 1:
             if len(np.unique(dtype_byte)) > 1:
@@ -206,7 +206,7 @@ class RawEDF(BaseRaw):
                             if annot and annotmap or tal_channels is not None:
                                 # don't resample, it gets overwritten later
                                 ch_data = np.zeros((len(ch_data, buf_len)))
-                            elif events is not None:  # GDF events
+                            elif stim_data is not None:  # GDF events
                                 ch_data = self._raw_extras[fi]['stim_data']
                                 ch_data = ch_data[start:stop].reshape((
                                     stop - start, buf_len))
@@ -365,7 +365,7 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     if ext == 'gdf' and stim_channel == -1:
         cals = np.append(cals, 1)
     # Check that stimulus channel exists in dataset
-    if stim_channel is not None or stim_channel is not False:
+    if stim_channel is not None:
         stim_channel = _check_stim_channel(stim_channel, ch_names, include)
 
     # Annotations

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -958,27 +958,28 @@ def _read_gdf_header(fname, stim_channel, exclude):
                     sr = np.fromfile(fid, np.uint8, 3)
                     event_sr = sr[0]
                     for i in range(1, len(sr)):
-                        event_sr = event_sr + sr[i] * 2**i
+                        event_sr = event_sr + sr[i] * 2**(i * 8)
                     n_events = np.fromfile(fid, np.uint32, 1)[0]
                 else:
                     ne = np.fromfile(fid, np.uint8, 3)
                     n_events = ne[0]
                     for i in range(1, len(ne)):
-                        n_events = n_events + ne[i] * 2**i
+                        n_events = n_events + ne[i] * 2**(i * 8)
                     event_sr = np.fromfile(fid, np.float32, 1)[0]
 
-                pos = np.fromfile(fid, np.uint32, n_events * 4)
-                typ = np.fromfile(fid, np.uint16, n_events * 2)
+                pos = np.fromfile(fid, np.uint32, n_events) - 1  # 1-based inds
+                typ = np.fromfile(fid, np.uint16, n_events)
 
                 if etmode == 3:
-                    chn = np.fromfile(fid, np.uint16, n_events * 2)
-                    dur = np.fromfile(fid, np.uint32, n_events * 4)
+                    chn = np.fromfile(fid, np.uint16, n_events)
+                    dur = np.fromfile(fid, np.uint32, n_events)
                     events.append([n_events, pos, typ, chn, dur])
                 else:
                     dur = np.zeros(n_events, dtype=np.uint32)
                     events.append([n_events, pos, typ])
 
                 edf_info['events'] = events
+                edf_info['event_sfreq'] = event_sr
 
     return edf_info
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -80,7 +80,9 @@ class RawEDF(BaseRaw):
 
     For GDF files, the stimulus channel is constructed from the events in the
     header. You should use keyword ``stim_channel=-1`` to add it at the end of
-    the channel list.
+    the channel list. The id numbers of overlapping events are simply combined
+    through addition. To get the original events from the header, use method
+    ``raw.get_gdf_events``.
 
     See Also
     --------
@@ -1164,7 +1166,9 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
 
     For GDF files, the stimulus channel is constructed from the events in the
     header. You should use keyword ``stim_channel=-1`` to add it at the end of
-    the channel list.
+    the channel list. The id numbers of overlapping events are simply combined
+    through addition. To get the original events from the header, use method
+    ``raw.get_gdf_events``.
 
     See Also
     --------

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -77,6 +77,7 @@ class RawEDF(BaseRaw):
 
     It is also possible to retrieve system codes, but no particular effort has
     been made to decode these in MNE.
+
     For GDF files, the stimulus channel is constructed from the events in the
     header. You should use keyword ``stim_channel=-1`` to add it at the end of
     the channel list.
@@ -1129,6 +1130,7 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
 
     It is also possible to retrieve system codes, but no particular effort has
     been made to decode these in MNE.
+
     For GDF files, the stimulus channel is constructed from the events in the
     header. You should use keyword ``stim_channel=-1`` to add it at the end of
     the channel list.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -749,6 +749,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 else:
                     chn = np.zeros(n_events, dtype=np.int32)
                     dur = np.ones(n_events, dtype=np.uint32)
+                np.clip(dur, 1, np.inf, out=dur)
                 events = [n_events, pos, typ, chn, dur]
 
         # GDF 2.x
@@ -978,6 +979,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 else:
                     chn = np.zeros(n_events, dtype=np.uint32)
                     dur = np.ones(n_events, dtype=np.uint32)
+                np.clip(dur, 1, np.inf, out=dur)
                 events = [n_events, pos, typ, chn, dur]
                 edf_info['event_sfreq'] = event_sr
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -735,20 +735,19 @@ def _read_gdf_header(fname, stim_channel, exclude):
             etp = header_nbytes + n_records * edf_info['bytes_tot']
             # skip data to go to event table
             fid.seek(etp)
-            etmode = fid.read(1).decode()
-            if etmode != '':
-                etmode = np.fromfile(fid, np.uint8, 1).tolist()
+            etmode = np.fromfile(fid, np.uint8, 1)[0]
+            if etmode in (1, 3):
                 sr = np.fromfile(fid, np.uint8, 3)
                 event_sr = sr[0]
                 for i in range(1, len(sr)):
-                    event_sr = event_sr + sr[i] * 256 ** i
+                    event_sr = event_sr + sr[i] * 2 ** (i * 8)
                 n_events = np.fromfile(fid, np.uint32, 1)[0]
-                pos = np.fromfile(fid, np.uint32, n_events * 4)
-                typ = np.fromfile(fid, np.uint16, n_events * 2)
+                pos = np.fromfile(fid, np.uint32, n_events)
+                typ = np.fromfile(fid, np.uint16, n_events)
 
                 if etmode == 3:
-                    chn = np.fromfile(fid, np.uint16, n_events * 2)
-                    dur = np.fromfile(fid, np.uint32, n_events * 4)
+                    chn = np.fromfile(fid, np.uint16, n_events)
+                    dur = np.fromfile(fid, np.uint32, n_events)
                 else:
                     chn = np.zeros(n_events, dtype=np.int32)
                     dur = np.ones(n_events, dtype=np.uint32)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -737,7 +737,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
                 for i in range(1, len(sr)):
                     event_sr = event_sr + sr[i] * 2 ** (i * 8)
                 n_events = np.fromfile(fid, np.uint32, 1)[0]
-                pos = np.fromfile(fid, np.uint32, n_events)
+                pos = np.fromfile(fid, np.uint32, n_events) - 1  # 1-based inds
                 typ = np.fromfile(fid, np.uint16, n_events)
 
                 if etmode == 3:

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -182,6 +182,8 @@ def test_stim_channel():
         raw[:]
     assert_equal(len(w), 0)
 
+    assert_raises(TypeError, raw_py.get_gdf_events)
+
 
 def test_parse_annotation():
     """Test parsing the tal channel."""

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -9,7 +9,9 @@ from __future__ import print_function
 import os.path as op
 import warnings
 
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from nose.tools import assert_true
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
 import numpy as np
 import scipy.io as sio
 
@@ -52,6 +54,8 @@ def test_gdf2_data():
     """Test reading raw GDF 2.x files."""
     raw = read_raw_edf(gdf2_path + '.gdf', eog=None, misc=None, preload=True,
                        stim_channel='STATUS')
+    nchan = raw.info['nchan']
+    ch_names = raw.ch_names  # Renamed STATUS -> STI 014.
     picks = pick_types(raw.info, meg=False, eeg=True, exclude='bads')
     data, _ = raw[picks]
 
@@ -66,8 +70,14 @@ def test_gdf2_data():
     # Find events
     events = find_events(raw, verbose=1)
     events[:, 2] >>= 8  # last 8 bits are system events in biosemi files
-    assert(events.shape[0] == 2)  # 2 events in file
+    assert_equal(events.shape[0], 2)  # 2 events in file
     assert_array_equal(events[:, 2], [20, 28])
 
+    with warnings.catch_warnings(record=True) as w:
+        raw = read_raw_edf(gdf2_path + '.gdf')  # header contains no events
+        assert_equal(len(w), 1)
+        assert_true(str(w[0].message).startswith('No events found.'))
+    assert_equal(nchan, raw.info['nchan'])  # stim channel not constructed
+    assert_array_equal(ch_names[1:], raw.ch_names[1:])
 
 run_tests_if_main()

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -29,7 +29,7 @@ gdf2_path = op.join(data_path, 'GDF', 'test_gdf_2.20')
 def test_gdf_data():
     """Test reading raw GDF 1.x files."""
     raw = read_raw_edf(gdf1_path + '.gdf', eog=None,
-                       misc=None, preload=True, stim_channel=None)
+                       misc=None, preload=True, stim_channel=-1)
     picks = pick_types(raw.info, meg=False, eeg=True, exclude='bads')
     data, _ = raw[picks]
 
@@ -40,6 +40,11 @@ def test_gdf_data():
 
     # Assert data are almost equal
     assert_array_almost_equal(data, data_biosig, 8)
+
+    # Test for stim channel
+    events = find_events(raw, shortest_event=1)
+    # The events are overlapping.
+    assert_array_equal(events[:, 0], raw._raw_extras[0]['events'][1][::2])
 
 
 @testing.requires_testing_data

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -48,12 +48,18 @@ def test_gdf_data():
     # The events are overlapping.
     assert_array_equal(events[:, 0], raw._raw_extras[0]['events'][1][::2])
 
+    # Test events are encoded to stim channel.
+    events = find_events(raw)
+    evs = raw.get_gdf_events()
+    assert_true(all([event in evs[1] for event in events[:, 0]]))
+
 
 @testing.requires_testing_data
 def test_gdf2_data():
     """Test reading raw GDF 2.x files."""
     raw = read_raw_edf(gdf2_path + '.gdf', eog=None, misc=None, preload=True,
                        stim_channel='STATUS')
+
     nchan = raw.info['nchan']
     ch_names = raw.ch_names  # Renamed STATUS -> STI 014.
     picks = pick_types(raw.info, meg=False, eeg=True, exclude='bads')
@@ -79,5 +85,6 @@ def test_gdf2_data():
         assert_true(str(w[0].message).startswith('No events found.'))
     assert_equal(nchan, raw.info['nchan'])  # stim channel not constructed
     assert_array_equal(ch_names[1:], raw.ch_names[1:])
+
 
 run_tests_if_main()


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/4252

The 24bit integer was not read correctly. It was also reading too much data. The documentation is available here https://arxiv.org/pdf/cs/0608052.pdf (page 9).

@robintibor can you check if this fixes your problem?

I'm not sure what the stim channel (STI 014) is recording, but it doesn't seem to be the events. I wonder if it would be best to synthesize the stim channel with the events extracted here.