### PR TITLE
Adjust sensor size and sensor name positions

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1507,6 +1507,7 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
                          ch_names=ch_names, show_names=show_names)
         fig.canvas.mpl_connect('pick_event', picker)
 
+    ax.axis("off")  # remove border around figure
     fig.suptitle(title)
     closed = partial(_close_event, fig=fig)
     fig.canvas.mpl_connect('close_event', closed)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1483,7 +1483,7 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
                                              'scale': (4.5, 4.5)})
         _draw_outlines(ax, outlines)
 
-        pts = ax.scatter(pos[:, 0], pos[:, 1], picker=True, c=colors, s=75,
+        pts = ax.scatter(pos[:, 0], pos[:, 1], picker=True, c=colors, s=25,
                          edgecolor=edgecolors, linewidth=2, clip_on=False)
 
         if select:
@@ -1500,7 +1500,7 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
             if pos.shape[1] == 3:
                 ax.text(this_pos[0], this_pos[1], this_pos[2], ch_names[idx])
             else:
-                ax.text(this_pos[0], this_pos[1], ch_names[idx])
+                ax.text(this_pos[0] + 0.015, this_pos[1], ch_names[idx])
         connect_picker = select
     if connect_picker:
         picker = partial(_onpick_sensor, fig=fig, ax=ax, pos=pos,

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1469,6 +1469,9 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
 
         ax.azim = 90
         ax.elev = 0
+        ax.xaxis.set_label_text('x')
+        ax.yaxis.set_label_text('y')
+        ax.zaxis.set_label_text('z')
     else:
         ax.text(0, 0, '', zorder=1)
         # Equal aspect for 3D looks bad, so only use for 2D
@@ -1489,6 +1492,8 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
         if select:
             fig.lasso = SelectFromCollection(ax, pts, ch_names)
 
+        ax.axis("off")  # remove border around figure
+
     connect_picker = True
     if show_names:
         if isinstance(show_names, (list, np.ndarray)):  # only given channels
@@ -1507,7 +1512,6 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
                          ch_names=ch_names, show_names=show_names)
         fig.canvas.mpl_connect('pick_event', picker)
 
-    ax.axis("off")  # remove border around figure
     fig.suptitle(title)
     closed = partial(_close_event, fig=fig)
     fig.canvas.mpl_connect('close_event', closed)


### PR DESCRIPTION
The sensor symbols were too large and were plotted partly over the sensor names, so I decreased the symbol size and shifted the names slightly to the right (see images for before/after). It would be good if someone else tested this on a different platform.

Before:
![plot_sensors_orig](https://cloud.githubusercontent.com/assets/4377312/26156338/4e0a25ca-3b16-11e7-87f2-8f7cbbf7e490.png)

After:
![plot_sensors_modified](https://cloud.githubusercontent.com/assets/4377312/26156351/53bc9c46-3b16-11e7-8616-3cbf32baf18f.png)
