### PR TITLE
FIX: allows retrieving patterns from nested pipelines with SlidingEstimators

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -325,7 +325,6 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
        96-110. doi:10.1016/j.neuroimage.2013.10.067.
     """
-
     # Get the coefficients of the last estimator in case of nested pipeline
     est = estimator
     while hasattr(est, 'steps'):


### PR DESCRIPTION
This allows retrieving the patterns from nested pipelines: e.g.

```python
clf = make_pipeline(
    UnsupervisedSpatialFilter(PCA()),  # preprocessing on n_epochs x n_chans x n_times
    SlidingEstimator(make_pipeline(
       StandardScaler(),   # preprocessing on n_epochs x n_times
       Ridge()))
get_coef(clf)
```

(this @kingjr writing... @Eric89GXL  or @jona-sassenhagen, could you review it?)