### PR TITLE
[MRG] Use mne.viz.utils.plot_sensors in mne.channels.montage.Montage.plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -49,7 +49,7 @@ Changelog
 
     - Add options to change time windowing in :func:`mne.filter.filter_chpi` by `Eric Larson`_
 
-    - :meth:`mne.channels.Montage.plot`, :meth:`mne.channels.Montage.plot`, and :func:`mne.viz.montage.plot_montage` now allow plotting channel locations as a topomap by `Clemens Brunner`_
+    - :meth:`mne.channels.Montage.plot`, :meth:`mne.channels.DigMontage.plot`, and :func:`mne.viz.montage.plot_montage` now allow plotting channel locations as a topomap by `Clemens Brunner`_
 
 BUG
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -49,6 +49,8 @@ Changelog
 
     - Add options to change time windowing in :func:`mne.filter.filter_chpi` by `Eric Larson`_
 
+    - :meth:`mne.channels.Montage.plot`, :meth:`mne.channels.Montage.plot`, and :func:`mne.viz.montage.plot_montage` now allow plotting channel locations as a topomap by `Clemens Brunner`_
+
 BUG
 ~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -433,9 +433,9 @@ class DigMontage(object):
         return s
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, show=True):
-        return plot_montage(self, scale_factor=scale_factor,
-                            show_names=show_names)
+    def plot(self, kind='3d', scale_factor=20, show_names=False, show=True):
+        return plot_montage(self, kind=kind, scale_factor=scale_factor,
+                            show_names=show_names, show=show)
 
     def transform_to_head(self):
         """Transform digitizer points to Neuromag head coordinates."""

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -73,9 +73,9 @@ class Montage(object):
         return s
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, kind='3d', scale_factor=20, show_names=False, show=True):
-        return plot_montage(self, kind=kind, scale_factor=scale_factor,
-                            show_names=show_names, show=show)
+    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True):
+        return plot_montage(self, scale_factor=scale_factor,
+                            show_names=show_names, kind=kind, show=show)
 
 
 def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
@@ -433,9 +433,9 @@ class DigMontage(object):
         return s
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, kind='3d', scale_factor=20, show_names=False, show=True):
-        return plot_montage(self, kind=kind, scale_factor=scale_factor,
-                            show_names=show_names, show=show)
+    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True):
+        return plot_montage(self, scale_factor=scale_factor,
+                            show_names=show_names, kind=kind, show=show)
 
     def transform_to_head(self):
         """Transform digitizer points to Neuromag head coordinates."""

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -73,9 +73,9 @@ class Montage(object):
         return s
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, show=True):
-        return plot_montage(self, scale_factor=scale_factor,
-                            show_names=show_names, show=True)
+    def plot(self, kind='3d', scale_factor=20, show_names=False, show=True):
+        return plot_montage(self, kind=kind, scale_factor=scale_factor,
+                            show_names=show_names, show=show)
 
 
 def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -27,8 +27,10 @@ def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
     """
     if isinstance(montage, mne.channels.montage.Montage):
         ch_names = montage.ch_names
+        title = montage.kind
     elif isinstance(montage, mne.channels.montage.DigMontage):
         ch_names = montage.point_names
+        title = None
     else:
         raise TypeError("montage must be an instance of "
                         "mne.channels.montage.Montage or"
@@ -38,7 +40,7 @@ def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
     info = mne.create_info(ch_names, sfreq=256, ch_types="eeg",
                            montage=montage)
     fig = plot_sensors(info, kind=kind, show_names=show_names, show=show,
-                       title=montage.kind)
+                       title=title)
     collection = fig.axes[0].collections[0]
     collection.set_sizes([scale_factor])
     return fig

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -11,12 +11,12 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     ----------
     montage : instance of Montage or DigMontage
         The montage to visualize.
-    kind : str
-        Whether to plot the montage as '3d' or 'topomap' (default).
     scale_factor : float
         Determines the size of the points.
     show_names : bool
         Whether to show the channel names.
+    kind : str
+        Whether to plot the montage as '3d' or 'topomap' (default).
     show : bool
         Show figure if True.
 

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -3,7 +3,7 @@ from ..utils import check_version
 from . import plot_sensors
 
 
-def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
+def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
                  show=True):
     """Plot a montage.
 

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -37,7 +37,8 @@ def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
         raise ValueError("kind must be 'topomap' or '3d'")
     info = mne.create_info(ch_names, sfreq=256, ch_types="eeg",
                            montage=montage)
-    fig = plot_sensors(info, kind=kind, show_names=show_names, show=show)
+    fig = plot_sensors(info, kind=kind, show_names=show_names, show=show,
+                       title=montage.kind)
     collection = fig.axes[0].collections[0]
     collection.set_sizes([scale_factor])
     return fig

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -3,20 +3,20 @@ import mne
 from .utils import plot_sensors
 
 
-def plot_montage(montage, kind='3d', scale_factor=20, show_names=False,
+def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
                  show=True):
     """Plot a montage.
 
     Parameters
     ----------
-    montage : instance of Montage
+    montage : instance of Montage or DigMontage
         The montage to visualize.
     kind : str
-        Whether to plot the montage as '3d' or 'topomap'.
+        Whether to plot the montage as '3d' or 'topomap' (default).
     scale_factor : float
-        Determines the size of the points. Defaults to 20.
+        Determines the size of the points.
     show_names : bool
-        Whether to show the channel names. Defaults to False.
+        Whether to show the channel names.
     show : bool
         Show figure if True.
 
@@ -29,6 +29,15 @@ def plot_montage(montage, kind='3d', scale_factor=20, show_names=False,
         ch_names = montage.ch_names
     elif isinstance(montage, mne.channels.montage.DigMontage):
         ch_names = montage.point_names
+    else:
+        raise TypeError("montage must be an instance of "
+                        "mne.channels.montage.Montage or"
+                        "mne.channels.montage.DigMontage")
+    if kind not in ['topomap', '3d']:
+        raise ValueError("kind must be 'topomap' or '3d'")
     info = mne.create_info(ch_names, sfreq=256, ch_types="eeg",
                            montage=montage)
-    return plot_sensors(info, kind=kind, show_names=show_names, show=show)
+    fig = plot_sensors(info, kind=kind, show_names=show_names, show=show)
+    collection = fig.axes[0].collections[0]
+    collection.set_sizes([scale_factor])
+    return fig

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -25,6 +25,10 @@ def plot_montage(montage, kind='3d', scale_factor=20, show_names=False,
     fig : Instance of matplotlib.figure.Figure
         The figure object.
     """
-    info = mne.create_info(montage.ch_names, sfreq=256, ch_types="eeg",
+    if isinstance(montage, mne.channels.montage.Montage):
+        ch_names = montage.ch_names
+    elif isinstance(montage, mne.channels.montage.DigMontage):
+        ch_names = montage.point_names
+    info = mne.create_info(ch_names, sfreq=256, ch_types="eeg",
                            montage=montage)
     return plot_sensors(info, kind=kind, show_names=show_names, show=show)

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -1,6 +1,6 @@
 """Functions to plot EEG sensor montages or digitizer montages."""
-import mne
-from .utils import plot_sensors
+from ..utils import check_version
+from . import plot_sensors
 
 
 def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
@@ -25,10 +25,12 @@ def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
     fig : Instance of matplotlib.figure.Figure
         The figure object.
     """
-    if isinstance(montage, mne.channels.montage.Montage):
+    from ..channels import Montage, DigMontage
+    from .. import create_info
+    if isinstance(montage, Montage):
         ch_names = montage.ch_names
         title = montage.kind
-    elif isinstance(montage, mne.channels.montage.DigMontage):
+    elif isinstance(montage, DigMontage):
         ch_names = montage.point_names
         title = None
     else:
@@ -37,10 +39,12 @@ def plot_montage(montage, kind='topomap', scale_factor=20, show_names=True,
                         "mne.channels.montage.DigMontage")
     if kind not in ['topomap', '3d']:
         raise ValueError("kind must be 'topomap' or '3d'")
-    info = mne.create_info(ch_names, sfreq=256, ch_types="eeg",
-                           montage=montage)
+    info = create_info(ch_names, sfreq=256, ch_types="eeg", montage=montage)
     fig = plot_sensors(info, kind=kind, show_names=show_names, show=show,
                        title=title)
     collection = fig.axes[0].collections[0]
-    collection.set_sizes([scale_factor])
+    if check_version("matplotlib", "1.4"):
+        collection.set_sizes([scale_factor])
+    else:
+        collection._sizes = [scale_factor]
     return fig

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -1,16 +1,18 @@
 """Functions to plot EEG sensor montages or digitizer montages."""
-import numpy as np
+import mne
+from .utils import plot_sensors
 
-from .utils import plt_show
 
-
-def plot_montage(montage, scale_factor=20, show_names=False, show=True):
+def plot_montage(montage, kind='3d', scale_factor=20, show_names=False,
+                 show=True):
     """Plot a montage.
 
     Parameters
     ----------
     montage : instance of Montage
         The montage to visualize.
+    kind : str
+        Whether to plot the montage as '3d' or 'topomap'.
     scale_factor : float
         Determines the size of the points. Defaults to 20.
     show_names : bool
@@ -23,35 +25,6 @@ def plot_montage(montage, scale_factor=20, show_names=False, show=True):
     fig : Instance of matplotlib.figure.Figure
         The figure object.
     """
-    from ..channels.montage import Montage, DigMontage
-
-    import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-    fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
-
-    if isinstance(montage, Montage):
-        pos = montage.pos
-        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2], s=scale_factor)
-        if show_names:
-            ch_names = montage.ch_names
-            for ch_name, x, y, z in zip(ch_names, pos[:, 0],
-                                        pos[:, 1], pos[:, 2]):
-                ax.text(x, y, z, ch_name)
-    elif isinstance(montage, DigMontage):
-        pos = np.vstack((montage.hsp, montage.elp))
-        ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2], s=scale_factor)
-        if show_names:
-            if montage.point_names:
-                hpi_names = montage.point_names
-                for hpi_name, x, y, z in zip(hpi_names, montage.elp[:, 0],
-                                             montage.elp[:, 1],
-                                             montage.elp[:, 2]):
-                    ax.text(x, y, z, hpi_name)
-
-    ax.set_xlabel('x')
-    ax.set_ylabel('y')
-    ax.set_zlabel('z')
-
-    plt_show(show)
-    return fig
+    info = mne.create_info(montage.ch_names, sfreq=256, ch_types="eeg",
+                           montage=montage)
+    return plot_sensors(info, kind=kind, show_names=show_names, show=show)

--- a/mne/viz/tests/test_montage.py
+++ b/mne/viz/tests/test_montage.py
@@ -26,7 +26,11 @@ def test_plot_montage():
     """
     m = read_montage('easycap-M1')
     m.plot()
-    m.plot(show_names=True)
+    m.plot(kind='3d')
+    m.plot(kind='3d', show_names=True)
+    m.plot(kind='topomap')
+    m.plot(kind='topomap', show_names=True)
     d = read_dig_montage(hsp, hpi, elp, point_names)
     d.plot()
-    d.plot(show_names=True)
+    d.plot(kind='3d')
+    d.plot(kind='3d', show_names=True)


### PR DESCRIPTION
Fixes #4275. Refactor `mne.channels.montage.Montage.plot` to use `mne.viz.utils.plot_sensors`. This means that the argument `scale_factor` is currently unused since this is not implemented in that method.