### PR TITLE
[MRG] Fix connectivity joblib hanging.

### DIFF
--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -469,7 +469,6 @@ def _get_n_epochs(epochs, n):
         if len(epochs_out) >= n:
             yield epochs_out
             epochs_out = list()
-    yield epochs_out
 
 
 def _check_method(method):


### PR DESCRIPTION
I noticed that joblib hangs if the amount of epochs is divisible with the number of jobs. This results in an empty list of data and makes an infinite while loop in joblib. The sklearn version has a fix for this. 

The fix here also removes silly logging messages like ``computing connectivity for epochs 9..8``.