### PR TITLE
Plot title of excluded components in gray

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -946,7 +946,10 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     if merge_grads:
         from ..channels.layout import _merge_grad_data
     for ii, data_, ax in zip(picks, data, axes):
-        ax.set_title('IC #%03d' % ii, fontsize=12)
+        if ii in ica.exclude:
+            ax.set_title('IC #%03d' % ii, fontsize=12, color='gray')
+        else:
+            ax.set_title('IC #%03d' % ii, fontsize=12)
         data_ = _merge_grad_data(data_) if merge_grads else data_
         vmin_, vmax_ = _setup_vmin_vmax(data_, vmin, vmax)
         im = plot_topomap(data_.flatten(), pos, vmin=vmin_, vmax=vmax_,


### PR DESCRIPTION
I think it would be helpful if excluded components (i.e. components that are in `ica.exclude`) were plotted differently in `ica.plot_components`. I've changed the component title to gray to distinguish them from normal ones.

IMO it would also be useful if the user could add components to the excluded list by clicking on their title. What do you think?