### PR TITLE
MRG: use  dipole output for sparse inverse methods

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,7 +59,7 @@ Changelog
 
     - Add :func:`mne.inverse_sparse.mxne_optim.dgap_l21l1` for computing the duality gap for TF-MxNE as the new stopping criterion by `Daniel Strohmeier`_
 
-    - Add option to return dipole objects in sparse source imaging methods by `Daniel Strohmeier`_
+    - Add option to return a list of :class:`Dipole` objects in sparse source imaging methods by `Daniel Strohmeier`_
 
     - Add :func:`mne.inverse_sparse.mxne_inverse.make_sparse_stc_from_dipoles` to generate stc objects from lists of dipoles by `Daniel Strohmeier`_
     

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,6 +58,10 @@ Changelog
     - Speed up :meth:`mne.io.Raw.plot` and :meth:`mne.Epochs.plot` using (automatic) decimation based on low-passing with ``decim='auto'`` parameter by `Eric Larson`_ and `Jaakko Leppakangas`_
 
     - Add :func:`mne.inverse_sparse.mxne_optim.dgap_l21l1` for computing the duality gap for TF-MxNE as the new stopping criterion by `Daniel Strohmeier`_
+
+    - Add option to return dipole objects in sparse source imaging methods by `Daniel Strohmeier`_
+
+    - Add :func:`mne.inverse_sparse.mxne_inverse.make_sparse_stc_from_dipoles` to generate stc objects from lists of dipoles by `Daniel Strohmeier`_
     
     - Add :func:`mne.channels.find_ch_connectivity` that tries to infer the correct connectivity template using channel info. If no template is found, it computes the connectivity matrix using :class:`Delaunay <scipy.spatial.Delaunay>` triangulation of the 2d projected channel positions by `Jaakko Leppakangas`_
 

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -56,7 +56,7 @@ dipoles, residual = gamma_map(
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
+idx = np.argmax([np.max(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -15,7 +15,8 @@ import numpy as np
 import mne
 from mne.datasets import sample
 from mne.inverse_sparse import gamma_map
-from mne.viz import plot_sparse_source_estimates
+from mne.viz import (plot_sparse_source_estimates,
+                     plot_dipole_locations, plot_dipole_amplitudes)
 
 print(__doc__)
 
@@ -73,7 +74,6 @@ dipoles = gamma_map(evoked, forward, cov, alpha, xyz_same_gamma=True,
 
 ###############################################################################
 # View dipoles and MRI
-from mne.viz import plot_dipole_locations, plot_dipole_amplitudes
 plot_dipole_amplitudes(dipoles)
 
 trans = forward['mri_head_t']

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -3,10 +3,15 @@
 Compute a sparse inverse solution using the Gamma-Map empirical Bayesian method
 ===============================================================================
 
-See Wipf et al. "A unified Bayesian framework for MEG/EEG source imaging."
-NeuroImage, vol. 44, no. 3, pp. 947?66, Mar. 2009.
+References:
+----------
+.. [1] D. Wipf, S. Nagarajan
+   "A unified Bayesian framework for MEG/EEG source imaging",
+   Neuroimage, Volume 44, Number 3, pp. 947-966, Feb. 2009.
+   DOI: 10.1016/j.neuroimage.2008.02.059
 """
 # Author: Martin Luessi <mluessi@nmr.mgh.harvard.edu>
+#         Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>
 #
 # License: BSD (3-clause)
 

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -51,7 +51,7 @@ dipoles, residual = gamma_map(
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax(np.array([np.amax(np.abs(dip.amplitude)) for dip in dipoles]))
+idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -19,7 +19,7 @@ import numpy as np
 
 import mne
 from mne.datasets import sample
-from mne.inverse_sparse import gamma_map, make_sparse_stc_from_dipoles
+from mne.inverse_sparse import gamma_map, make_stc_from_dipoles
 from mne.viz import (plot_sparse_source_estimates,
                      plot_dipole_locations, plot_dipole_amplitudes)
 
@@ -80,7 +80,7 @@ residual.plot(titles=dict(grad='Residuals Gradiometers'), ylim=ylim,
 
 ###############################################################################
 # Generate stc from dipoles
-stc = make_sparse_stc_from_dipoles(dipoles, forward)
+stc = make_stc_from_dipoles(dipoles, forward['src'])
 
 ###############################################################################
 # View in 2D and 3D ("glass" brain like 3D plot)

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -46,7 +46,6 @@ stc, residual = gamma_map(evoked, forward, cov, alpha, xyz_same_gamma=True,
                           return_residual=True)
 
 # View in 2D and 3D ("glass" brain like 3D plot)
-
 # Show the sources as spheres scaled by their strength
 scale_factors = np.max(np.abs(stc.data), axis=1)
 scale_factors = 0.5 * (1 + scale_factors / np.max(scale_factors))
@@ -56,6 +55,21 @@ plot_sparse_source_estimates(
     modes=['sphere'], opacity=0.1, scale_factors=(scale_factors, None),
     fig_name="Gamma-MAP")
 
+###############################################################################
+# Run solver returning dipoles
+# Compute (ir)MxNE inverse solution
+dipoles = gamma_map(evoked, forward, cov, alpha, xyz_same_gamma=True,
+                    return_as_dipoles=True, return_residual=False)
+
+# View dipoles and MRI
+plot_dipole_amplitudes(dipoles)
+
+trans = forward['mri_head_t']
+for dip in dipoles:
+    plot_dipole_locations(dip, trans, 'sample', subjects_dir=subjects_dir,
+                          mode='orthoview', idx='amplitude')
+
+###############################################################################
 # Show the evoked response and the residual for gradiometers
 ylim = dict(grad=[-120, 120])
 evoked.pick_types(meg='grad', exclude='bads')
@@ -65,18 +79,3 @@ evoked.plot(titles=dict(grad='Evoked Response Gradiometers'), ylim=ylim,
 residual.pick_types(meg='grad', exclude='bads')
 residual.plot(titles=dict(grad='Residuals Gradiometers'), ylim=ylim,
               proj=True)
-
-###############################################################################
-# Run solver returning dipoles
-# Compute (ir)MxNE inverse solution
-dipoles = gamma_map(evoked, forward, cov, alpha, xyz_same_gamma=True,
-                    return_residual=False, return_as_dipoles=True)
-
-###############################################################################
-# View dipoles and MRI
-plot_dipole_amplitudes(dipoles)
-
-trans = forward['mri_head_t']
-for dip in dipoles:
-    plot_dipole_locations(dip, trans, 'sample', subjects_dir=subjects_dir,
-                          mode='orthoview', idx='amplitude')

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -64,3 +64,19 @@ evoked.plot(titles=dict(grad='Evoked Response Gradiometers'), ylim=ylim,
 residual.pick_types(meg='grad', exclude='bads')
 residual.plot(titles=dict(grad='Residuals Gradiometers'), ylim=ylim,
               proj=True)
+
+###############################################################################
+# Run solver returning dipoles
+# Compute (ir)MxNE inverse solution
+dipoles = gamma_map(evoked, forward, cov, alpha, xyz_same_gamma=True,
+                    return_residual=False, return_as_dipoles=True)
+
+###############################################################################
+# View dipoles and MRI
+from mne.viz import plot_dipole_locations, plot_dipole_amplitudes
+plot_dipole_amplitudes(dipoles)
+
+trans = forward['mri_head_t']
+for dip in dipoles:
+    plot_dipole_locations(dip, trans, 'sample', subjects_dir=subjects_dir,
+                          mode='orthoview', idx='amplitude')

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -76,7 +76,7 @@ dipoles, residual = mixed_norm(
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
+idx = np.argmax([np.max(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -88,7 +88,6 @@ plot_sparse_source_estimates(src_fsaverage, stc_fsaverage, bgcolor=(1, 1, 1),
                              fig_name="Morphed MxNE (cond %s)" % condition,
                              opacity=0.1)
 
-
 ###############################################################################
 # Run solver returning dipoles
 # Compute (ir)MxNE inverse solution

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -28,7 +28,8 @@ import mne
 from mne.datasets import sample
 from mne.inverse_sparse import mixed_norm
 from mne.minimum_norm import make_inverse_operator, apply_inverse
-from mne.viz import plot_sparse_source_estimates
+from mne.viz import (plot_sparse_source_estimates,
+                     plot_dipole_locations, plot_dipole_amplitudes)
 
 print(__doc__)
 
@@ -99,7 +100,6 @@ dipoles = mixed_norm(
 
 ###############################################################################
 # View dipoles and MRI
-from mne.viz import plot_dipole_locations, plot_dipole_amplitudes
 plot_dipole_amplitudes(dipoles)
 
 trans = forward['mri_head_t']

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -21,6 +21,7 @@ References
    Tuebingen, 2014. 10.1109/PRNI.2014.6858545
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#         Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>
 #
 # License: BSD (3-clause)
 

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -29,7 +29,7 @@ import numpy as np
 
 import mne
 from mne.datasets import sample
-from mne.inverse_sparse import mixed_norm, make_sparse_stc_from_dipoles
+from mne.inverse_sparse import mixed_norm, make_stc_from_dipoles
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.viz import (plot_sparse_source_estimates,
                      plot_dipole_locations, plot_dipole_amplitudes)
@@ -97,7 +97,7 @@ residual.plot(ylim=ylim, proj=True)
 
 ###############################################################################
 # Generate stc from dipoles
-stc = make_sparse_stc_from_dipoles(dipoles, forward)
+stc = make_stc_from_dipoles(dipoles, forward['src'])
 
 ###############################################################################
 # View in 2D and 3D ("glass" brain like 3D plot)

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -86,3 +86,23 @@ src_fsaverage = mne.read_source_spaces(src_fsaverage_fname)
 plot_sparse_source_estimates(src_fsaverage, stc_fsaverage, bgcolor=(1, 1, 1),
                              fig_name="Morphed MxNE (cond %s)" % condition,
                              opacity=0.1)
+
+
+###############################################################################
+# Run solver returning dipoles
+# Compute (ir)MxNE inverse solution
+dipoles = mixed_norm(
+    evoked, forward, cov, alpha, loose=loose, depth=depth, maxit=3000,
+    tol=1e-4, active_set_size=10, debias=True, weights=stc_dspm,
+    weights_min=8., n_mxne_iter=n_mxne_iter, return_residual=False,
+    return_as_dipoles=True)
+
+###############################################################################
+# View dipoles and MRI
+from mne.viz import plot_dipole_locations, plot_dipole_amplitudes
+plot_dipole_amplitudes(dipoles)
+
+trans = forward['mri_head_t']
+for dip in dipoles:
+    plot_dipole_locations(dip, trans, 'sample', subjects_dir=subjects_dir,
+                          mode='orthoview', idx='amplitude')

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -75,7 +75,7 @@ dipoles, residual = mixed_norm(
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax(np.array([np.amax(np.abs(dip.amplitude)) for dip in dipoles]))
+idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -112,7 +112,7 @@ dipoles = tf_mixed_norm(evoked, forward, cov, alpha_space, alpha_time,
                         loose=loose, depth=depth, maxit=200, tol=1e-4,
                         weights=stc_dspm, weights_min=8., debias=True,
                         wsize=16, tstep=4, window=0.05,
-                        return_as_dipoles=True, return_residual=True)
+                        return_as_dipoles=True, return_residual=False)
 
 # Crop to remove edges
 for dip in dipoles:

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -41,7 +41,7 @@ import numpy as np
 import mne
 from mne.datasets import sample
 from mne.minimum_norm import make_inverse_operator, apply_inverse
-from mne.inverse_sparse import tf_mixed_norm, make_sparse_stc_from_dipoles
+from mne.inverse_sparse import tf_mixed_norm, make_stc_from_dipoles
 from mne.viz import (plot_sparse_source_estimates,
                      plot_dipole_locations, plot_dipole_amplitudes)
 
@@ -127,7 +127,7 @@ residual.plot(titles=dict(grad='Residuals: Gradiometers'), ylim=ylim,
 
 ###############################################################################
 # Generate stc from dipoles
-stc = make_sparse_stc_from_dipoles(dipoles, forward)
+stc = make_stc_from_dipoles(dipoles, forward['src'])
 
 ###############################################################################
 # View in 2D and 3D ("glass" brain like 3D plot)

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -103,7 +103,7 @@ residual.crop(tmin=-0.05, tmax=0.3)
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
+idx = np.argmax([np.max(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -17,22 +17,22 @@ The benefit of this approach is that:
     trapped in local minima.
 
 References:
+----------
+.. [1] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
+   "Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
+   non-stationary source activations",
+   Neuroimage, Volume 70, pp. 410-422, 15 April 2013.
+   DOI: 10.1016/j.neuroimage.2012.12.051
 
-A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
-Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
-non-stationary source activations
-Neuroimage, Volume 70, 15 April 2013, Pages 410-422, ISSN 1053-8119,
-DOI: 10.1016/j.neuroimage.2012.12.051.
-
-A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
-Functional Brain Imaging with M/EEG Using Structured Sparsity in
-Time-Frequency Dictionaries
-Proceedings Information Processing in Medical Imaging
-Lecture Notes in Computer Science, 2011, Volume 6801/2011,
-600-611, DOI: 10.1007/978-3-642-22092-0_49
-http://dx.doi.org/10.1007/978-3-642-22092-0_49
+.. [2] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
+   "Functional Brain Imaging with M/EEG Using Structured Sparsity in
+   Time-Frequency Dictionaries",
+   Proceedings Information Processing in Medical Imaging
+   Lecture Notes in Computer Science, Volume 6801/2011, pp. 600-611, 2011.
+   DOI: 10.1007/978-3-642-22092-0_49
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#         Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>
 #
 # License: BSD (3-clause)
 

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -103,7 +103,7 @@ residual.crop(tmin=-0.05, tmax=0.3)
 plot_dipole_amplitudes(dipoles)
 
 # Plot dipole location of the strongest dipole with MRI slices
-idx = np.argmax(np.array([np.amax(np.abs(dip.amplitude)) for dip in dipoles]))
+idx = np.argmax([np.amax(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',
                       idx='amplitude')

--- a/mne/inverse_sparse/__init__.py
+++ b/mne/inverse_sparse/__init__.py
@@ -4,5 +4,6 @@
 #
 # License: Simplified BSD
 
-from .mxne_inverse import mixed_norm, tf_mixed_norm
+from .mxne_inverse import (mixed_norm, tf_mixed_norm,
+                           make_sparse_stc_from_dipoles)
 from ._gamma_map import gamma_map

--- a/mne/inverse_sparse/__init__.py
+++ b/mne/inverse_sparse/__init__.py
@@ -5,5 +5,5 @@
 # License: Simplified BSD
 
 from .mxne_inverse import (mixed_norm, tf_mixed_norm,
-                           make_sparse_stc_from_dipoles)
+                           make_stc_from_dipoles)
 from ._gamma_map import gamma_map

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -299,9 +299,10 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     if return_as_dipoles:
         out = _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M,
-                                   M_estimated)
+                                   M_estimated, active_is_idx=True)
     else:
-        out = _make_sparse_stc(X, active_set, forward, tmin, tstep)
+        out = _make_sparse_stc(X, active_set, forward, tmin, tstep,
+                               active_is_idx=True, verbose=verbose)
 
     logger.info('[done]')
 

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -233,8 +233,10 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
            Neuroelectromagnetic Source Localization, Advances in Neural
            Information Process. Systems (2007)
 
-    .. [2] Wipf et al. A unified Bayesian framework for MEG/EEG source
-           imaging, NeuroImage, vol. 44, no. 3, pp. 947-66, Mar. 2009.
+    .. [2] D. Wipf, S. Nagarajan
+           "A unified Bayesian framework for MEG/EEG source imaging",
+           Neuroimage, Volume 44, Number 3, pp. 947-966, Feb. 2009.
+           DOI: 10.1016/j.neuroimage.2008.02.059
     """
     _check_reference(evoked)
 

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -299,7 +299,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     if return_as_dipoles:
         out = _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M,
-                            M_estimated)
+                                   M_estimated)
     else:
         out = _make_sparse_stc(X, active_set, forward, tmin, tstep)
 

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -13,7 +13,7 @@ from ..utils import logger, verbose, warn
 from ..externals.six.moves import xrange as range
 from .mxne_inverse import (_make_sparse_stc, _prepare_gain,
                            _reapply_source_weighting, _compute_residual,
-                           _make_dipoles)
+                           _make_dipoles_sparse)
 
 
 @verbose
@@ -298,7 +298,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
     tstep = 1.0 / evoked.info['sfreq']
 
     if return_as_dipoles:
-        out = _make_dipoles(X, active_set, forward, tmin, tstep, M,
+        out = _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M,
                             M_estimated)
     else:
         out = _make_sparse_stc(X, active_set, forward, tmin, tstep)

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -183,12 +183,13 @@ def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_est,
 
     dipoles = []
     for k, i_dip in enumerate(active_idx):
-        i_pos = forward['source_rr'][i_dip][np.newaxis, :].repeat(len(times),
-                                                                  axis=0)
+        i_pos = forward['source_rr'][i_dip][np.newaxis, :]
+        i_pos = i_pos.repeat(len(times), axis=0)
         X_ = X[k * n_dip_per_pos: (k + 1) * n_dip_per_pos]
         if n_dip_per_pos == 1:
             amplitude = X_[0]
-            i_ori = forward['source_nn'][i_dip]
+            i_ori = forward['source_nn'][i_dip][np.newaxis, :]
+            i_ori = i_ori.repeat(len(times), axis=0)
         else:
             if forward['surf_ori']:
                 X_ = np.dot(forward['source_nn'][i_dip *

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -163,7 +163,7 @@ def _make_sparse_stc(X, active_set, forward, tmin, tstep,
 
 @verbose
 def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_estimated,
-                  verbose=None):
+                         verbose=None):
 
     times = tmin + tstep * np.arange(X.shape[1])
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -163,11 +163,15 @@ def _make_sparse_stc(X, active_set, forward, tmin, tstep,
 
 @verbose
 def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_estimated,
-                         verbose=None):
+                         active_is_idx=False, verbose=None):
 
     times = tmin + tstep * np.arange(X.shape[1])
 
-    active_idx = np.where(active_set)[0]
+    if not active_is_idx:
+        active_idx = np.where(active_set)[0]
+    else:
+        active_idx = active_set
+
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
     if n_dip_per_pos > 1:
         active_idx = np.unique(active_idx // n_dip_per_pos)

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -162,10 +162,10 @@ def _make_sparse_stc(X, active_set, forward, tmin, tstep,
 
 
 @verbose
-def _make_dipoles(X, active_set, forward, tmin, tstep, M, M_estimated,
+def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_estimated,
                   verbose=None):
 
-    times = np.arange(tmin, tmin + X.shape[1] * tstep, tstep)
+    times = tmin + tstep * np.arange(X.shape[1])
 
     active_idx = np.where(active_set)[0]
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
@@ -367,7 +367,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
         tstep = 1.0 / e.info['sfreq']
         Xe = X[:, cnt:(cnt + len(e.times))]
         if return_as_dipoles:
-            out = _make_dipoles(
+            out = _make_dipoles_sparse(
                 Xe, active_set, forward, tmin, tstep,
                 M[:, cnt:(cnt + len(e.times))],
                 M_estimated[:, cnt:(cnt + len(e.times))], verbose=None)
@@ -572,7 +572,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
             forward, evoked, X, active_set, gain_info)
 
     if return_as_dipoles:
-        out = _make_dipoles(
+        out = _make_dipoles_sparse(
             X, active_set, forward, evoked.times[0], 1.0 / info['sfreq'],
             M, M_estimated, verbose=None)
     else:

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -204,6 +204,30 @@ def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_est,
 
 @verbose
 def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
+    """Convert a list of spatio-temporal dipoles into a SourceEstimate.
+
+    Parameters
+    ----------
+    dipoles : Dipole | list of instances of Dipole
+        Dipoles to convert.
+    forward : dict
+        Forward operator.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    stc : SourceEstimate
+        The source estimate.
+    """
+    logger.info('Converting dipoles into a SourceEstimate.')
+    if isinstance(dipoles, Dipole):
+        dipoles = [dipoles]
+    if not isinstance(dipoles, list):
+        raise ValueError('Dipoles must be an instance of Dipole or '
+                         'a list of instances of Dipole. '
+                         'Got %s!' % type(dipoles))
     tmin = dipoles[0].times[0]
     tstep = dipoles[0].times[1] - tmin
     X = np.zeros((len(dipoles), len(dipoles[0].times)))
@@ -224,6 +248,7 @@ def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
             rh_vertno.append(src[1]['vertno'][idx - n_lh_points])
     vertices = [np.array(lh_vertno), np.array(rh_vertno)]
     stc = SourceEstimate(X, vertices=vertices, tmin=tmin, tstep=tstep)
+    logger.info('[done]')
     return stc
 
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -176,7 +176,10 @@ def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_estimated,
     if n_dip_per_pos > 1:
         active_idx = np.unique(active_idx // n_dip_per_pos)
 
-    gof = linalg.norm(M_estimated, axis=0) / linalg.norm(M, axis=0) * 100.
+    gof = np.zeros(M_estimated.shape[1])
+    M_norm = linalg.norm(M, axis=0)
+    gof[M_norm > 0.0] = (linalg.norm(M_estimated, axis=0)[M_norm > 0.0] /
+                         M_norm[M_norm > 0.0] * 100.)
 
     dipoles = []
     for k, i_dip in enumerate(active_idx):

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -556,7 +556,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
        "Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
        non-stationary source activations",
        Neuroimage, Volume 70, pp. 410-422, 15 April 2013.
-       DOI: 10.1016/j.neuroimage.2012.12.051.
+       DOI: 10.1016/j.neuroimage.2012.12.051
 
     .. [2] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
        "Functional Brain Imaging with M/EEG Using Structured Sparsity in

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -205,15 +205,15 @@ def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_est,
 
 
 @verbose
-def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
+def make_stc_from_dipoles(dipoles, src, verbose=None):
     """Convert a list of spatio-temporal dipoles into a SourceEstimate.
 
     Parameters
     ----------
     dipoles : Dipole | list of instances of Dipole
-        Dipoles to convert.
-    forward : dict
-        Forward operator.
+        The dipoles to convert.
+    src : instance of SourceSpaces
+        The source space used to generate the forward operator.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -233,7 +233,8 @@ def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
     tmin = dipoles[0].times[0]
     tstep = dipoles[0].times[1] - tmin
     X = np.zeros((len(dipoles), len(dipoles[0].times)))
-    src = forward['src']
+    source_rr = np.concatenate([_src['rr'][_src['vertno'], :] for _src in src],
+                               axis=0)
     n_lh_points = len(src[0]['vertno'])
     lh_vertno = list()
     rh_vertno = list()
@@ -242,7 +243,7 @@ def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
             raise ValueError('Only dipoles with fixed position over time '
                              'are supported!')
         X[i] = dipoles[i].amplitude
-        idx = np.all(forward['source_rr'] == dipoles[i].pos[0], axis=1)
+        idx = np.all(source_rr == dipoles[i].pos[0], axis=1)
         idx = np.where(idx)[0][0]
         if idx < n_lh_points:
             lh_vertno.append(src[0]['vertno'][idx])

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -177,14 +177,14 @@ def _make_dipoles(X, active_set, forward, tmin, tstep, M, M_estimated,
     dipoles = []
     for k, i_dip in enumerate(active_idx):
         i_pos = forward['source_rr'][i_dip][np.newaxis, :].repeat(len(times),
-            axis=0)
+                                                                  axis=0)
         X_ = X[k * n_dip_per_pos: (k + 1) * n_dip_per_pos]
         if n_dip_per_pos == 1:
             amplitude = X_
             i_ori = forward['source_nn'][i_dip]
         elif forward['surf_ori']:
-            X_ = np.dot(forward['source_nn'][i_dip *\
-                n_dip_per_pos:(i_dip + 1) * n_dip_per_pos].T, X_)
+            X_ = np.dot(forward['source_nn'][i_dip *
+                        n_dip_per_pos:(i_dip + 1) * n_dip_per_pos].T, X_)
             amplitude = linalg.norm(X_, ord=None, axis=0)
             i_ori = (X_ / amplitude).T
         else:
@@ -372,7 +372,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
                 M[:, cnt:(cnt + len(e.times))],
                 M_estimated[:, cnt:(cnt + len(e.times))], verbose=None)
         else:
-             out = _make_sparse_stc(Xe, active_set, forward, tmin, tstep)
+            out = _make_sparse_stc(Xe, active_set, forward, tmin, tstep)
         outs.append(out)
         cnt += len(e.times)
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -247,7 +247,8 @@ def make_sparse_stc_from_dipoles(dipoles, forward, verbose=None):
             lh_vertno.append(src[0]['vertno'][idx])
         else:
             rh_vertno.append(src[1]['vertno'][idx - n_lh_points])
-    vertices = [np.array(lh_vertno), np.array(rh_vertno)]
+    vertices = [np.array(lh_vertno).astype(int),
+                np.array(rh_vertno).astype(int)]
     stc = SourceEstimate(X, vertices=vertices, tmin=tmin, tstep=tstep)
     logger.info('[done]')
     return stc

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -177,9 +177,10 @@ def _make_dipoles_sparse(X, active_set, forward, tmin, tstep, M, M_est,
         active_idx = np.unique(active_idx // n_dip_per_pos)
 
     gof = np.zeros(M_est.shape[1])
-    M_norm = np.sqrt(np.sum(M ** 2, axis=0))
-    gof[M_norm > 0.0] = (np.sqrt(np.sum(M_est ** 2., axis=0))[M_norm > 0.0] /
-                         M_norm[M_norm > 0.0] * 100.)
+    M_norm2 = np.sum(M ** 2, axis=0)
+    R_norm2 = np.sum((M - M_est) ** 2, axis=0)
+    gof[M_norm2 > 0.0] = 1. - R_norm2[M_norm2 > 0.0] / M_norm2[M_norm2 > 0.0]
+    gof *= 100.
 
     dipoles = []
     for k, i_dip in enumerate(active_idx):

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -138,8 +138,8 @@ def prox_l1(Y, alpha, n_orient):
     .. [1] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
        "Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
        non-stationary source activations",
-       Neuroimage, Volume 70, pp. 410-422, 15 April 2013. ISSN 1053-8119,
-       DOI: 10.1016/j.neuroimage.2012.12.051.
+       Neuroimage, Volume 70, pp. 410-422, 15 April 2013.
+       DOI: 10.1016/j.neuroimage.2012.12.051
 
     Example
     -------
@@ -1099,8 +1099,8 @@ def tf_mixed_norm_solver(M, G, alpha_space, alpha_time, wsize=64, tstep=4,
     .. [1] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
        "Time-Frequency Mixed-Norm Estimates: Sparse M/EEG imaging with
        non-stationary source activations",
-       Neuroimage, Volume 70, pp. 410-422, 15 April 2013. ISSN 1053-8119,
-       DOI: 10.1016/j.neuroimage.2012.12.051.
+       Neuroimage, Volume 70, pp. 410-422, 15 April 2013.
+       DOI: 10.1016/j.neuroimage.2012.12.051
 
     .. [2] A. Gramfort, D. Strohmeier, J. Haueisen, M. Hamalainen, M. Kowalski
        "Functional Brain Imaging with M/EEG Using Structured Sparsity in

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -6,8 +6,7 @@ import os.path as op
 
 from nose.tools import assert_true
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_array_equal, assert_allclose)
+from numpy.testing import assert_array_almost_equal, assert_equal
 
 from mne.datasets import testing
 from mne import read_cov, read_forward_solution, read_evokeds

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -13,7 +13,7 @@ from mne.datasets import testing
 from mne import read_cov, read_forward_solution, read_evokeds
 from mne.cov import regularize
 from mne.inverse_sparse import gamma_map
-from mne.inverse_sparse.mxne_inverse import make_sparse_stc_from_dipoles
+from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne import pick_types_forward
 from mne.utils import run_tests_if_main, slow_test
 from mne.dipole import Dipole
@@ -76,7 +76,7 @@ def test_gamma_map():
                      xyz_same_gamma=False, update_mode=1,
                      return_as_dipoles=True)
     assert_true(isinstance(dips[0], Dipole))
-    stc_dip = make_sparse_stc_from_dipoles(dips, forward)
+    stc_dip = make_stc_from_dipoles(dips, forward['src'])
     _check_stcs(stc, stc_dip)
 
     # force fixed orientation

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -6,7 +6,8 @@ import os.path as op
 
 from nose.tools import assert_true
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_equal
+from numpy.testing import (assert_array_almost_equal, assert_equal,
+                           assert_array_equal)
 
 from mne.datasets import testing
 from mne import read_cov, read_forward_solution, read_evokeds
@@ -65,5 +66,12 @@ def test_gamma_map():
                     loose=None, return_residual=False)
     _check_stc(stc, evoked, 85739, 20)
 
+    dips = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
+                     xyz_same_gamma=False, update_mode=2,
+                     loose=None, return_residual=False,
+                     return_as_dipoles=True)
+    assert_array_almost_equal(dips[0].times, evoked.times, 5)
+    assert_array_equal(dips[0].pos[0],
+                       forward['src'][0]['rr'][stc.vertices[0][0]])
 
 run_tests_if_main()

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -29,16 +29,6 @@ label = 'Aud-rh'
 fname_label = op.join(data_path, 'MEG', 'sample', 'labels', '%s.label' % label)
 
 
-def _check_stcs(stc1, stc2):
-    """Helper to check correctness"""
-    assert_allclose(stc1.times, stc2.times)
-    assert_allclose(stc1.data, stc2.data)
-    assert_allclose(stc1.vertices[0], stc2.vertices[0])
-    assert_allclose(stc1.vertices[1], stc2.vertices[1])
-    assert_allclose(stc1.tmin, stc2.tmin)
-    assert_allclose(stc1.tstep, stc2.tstep)
-
-
 @slow_test
 @testing.requires_testing_data
 def test_mxne_inverse():

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -5,8 +5,7 @@
 
 import os.path as op
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, assert_allclose,
-                           assert_array_equal)
+from numpy.testing import assert_array_almost_equal, assert_allclose
 from nose.tools import assert_true, assert_equal
 
 from mne.datasets import testing

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -12,7 +12,7 @@ from mne.datasets import testing
 from mne.label import read_label
 from mne import read_cov, read_forward_solution, read_evokeds
 from mne.inverse_sparse import mixed_norm, tf_mixed_norm
-from mne.inverse_sparse.mxne_inverse import make_sparse_stc_from_dipoles
+from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne.minimum_norm import apply_inverse, make_inverse_operator
 from mne.utils import run_tests_if_main, slow_test
 from mne.dipole import Dipole
@@ -98,7 +98,7 @@ def test_mxne_inverse():
                       depth=depth, maxit=300, tol=1e-8, active_set_size=10,
                       weights=stc_dspm, weights_min=weights_min,
                       solver='cd', return_as_dipoles=True)
-    stc_dip = make_sparse_stc_from_dipoles(dips, forward)
+    stc_dip = make_stc_from_dipoles(dips, forward['src'])
     assert_true(isinstance(dips[0], Dipole))
     _check_stcs(stc_cd, stc_dip)
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -575,7 +575,7 @@ def _get_presser(fig):
     return func
 
 
-def plot_dipole_amplitudes(dipoles, colors=None, show=True):
+def plot_dipole_amplitudes(dipoles, colors=None, show=True, linewidth=2):
     """Plot the amplitude traces of a set of dipoles.
 
     Parameters
@@ -586,6 +586,8 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
         Color to plot with each dipole. If None default colors are used.
     show : bool
         Show figure if True.
+    linewidth : int
+        Line width in 2D plot.
 
     Returns
     -------
@@ -602,7 +604,8 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
     fig, ax = plt.subplots(1, 1)
     xlim = [np.inf, -np.inf]
     for dip, color in zip(dipoles, colors):
-        ax.plot(dip.times, dip.amplitude * 1e9, color=color, linewidth=1.5)
+        ax.plot(dip.times, dip.amplitude * 1e9, color=color,
+                linewidth=linewidth)
         xlim[0] = min(xlim[0], dip.times[0])
         xlim[1] = max(xlim[1], dip.times[-1])
     ax.set_xlim(xlim)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -575,7 +575,7 @@ def _get_presser(fig):
     return func
 
 
-def plot_dipole_amplitudes(dipoles, colors=None, show=True, linewidth=2):
+def plot_dipole_amplitudes(dipoles, colors=None, show=True):
     """Plot the amplitude traces of a set of dipoles.
 
     Parameters
@@ -586,8 +586,6 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True, linewidth=2):
         Color to plot with each dipole. If None default colors are used.
     show : bool
         Show figure if True.
-    linewidth : int
-        Line width in 2D plot.
 
     Returns
     -------
@@ -604,8 +602,7 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True, linewidth=2):
     fig, ax = plt.subplots(1, 1)
     xlim = [np.inf, -np.inf]
     for dip, color in zip(dipoles, colors):
-        ax.plot(dip.times, dip.amplitude * 1e9, color=color,
-                linewidth=linewidth)
+        ax.plot(dip.times, dip.amplitude * 1e9, color=color, linewidth=1.5)
         xlim[0] = min(xlim[0], dip.times[0])
         xlim[1] = max(xlim[1], dip.times[-1])
     ax.set_xlim(xlim)


### PR DESCRIPTION
This PR adds dipole output to our sparse solvers.

Visualization is currently done with `plot_dipole_locations` looping over dipoles or by giving the list of dipoles to `plot_dipole_locations`