### PR TITLE
Avoid printing a leading ' when printing info dict

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -412,7 +412,7 @@ class Info(dict):
                 entr += " (%s)" % ', '.join("%s: %d" % (ch_type.upper(), count)
                                             for ch_type, count
                                             in ch_counts.items())
-            strs.append('%s : %s%s' % (k, str(type(v))[7:-2], entr))
+            strs.append('%s : %s%s' % (k, str(type(v))[8:-2], entr))
             if k in ['sfreq', 'lowpass', 'highpass']:
                 strs[-1] += ' Hz'
         strs_non_empty = sorted(s for s in strs if '|' in s)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -412,7 +412,7 @@ class Info(dict):
                 entr += " (%s)" % ', '.join("%s: %d" % (ch_type.upper(), count)
                                             for ch_type, count
                                             in ch_counts.items())
-            strs.append('%s : %s%s' % (k, str(type(v))[8:-2], entr))
+            strs.append('%s : %s%s' % (k, type(v).__name__, entr))
             if k in ['sfreq', 'lowpass', 'highpass']:
                 strs[-1] += ' Hz'
         strs_non_empty = sorted(s for s in strs if '|' in s)


### PR DESCRIPTION
I think this was not intentional, when printing the info dict the values always start with a single quote, e.g.

    <Info | 16 non-empty fields
        bads : 'list | 0 items
        buffer_size_sec : 'float | 1.0
        ch_names : 'list | Fp1, AF7, AF3, F1, F3, F5, F7, FT7, FC5, ...
        chs : 'list | 64 items (EEG: 64)

This PR removes these leading quotes.