### PR TITLE
FIX: Fix ReceptiveField edge handling

### DIFF
--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -21,6 +21,7 @@ References
 """  # noqa: E501
 
 # Authors: Chris Holdgraf <choldgraf@gmail.com>
+#          Eric Larson <larson.eric.d@gmail.com>
 #
 # License: BSD (3-clause)
 # sphinx_gallery_thumbnail_number = 3

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -52,7 +52,7 @@ class ReceptiveField(BaseEstimator):
     ----------
     ``coef_`` : array, shape ([n_outputs, ]n_features, n_delays)
         The coefficients from the model fit, reshaped for easy visualization.
-        If ``y`` during :meth:`mne.decoding.ReceptiveField.fit` has one
+        During :meth:`mne.decoding.ReceptiveField.fit`, if ``y`` has one
         dimension (time), the ``n_outputs`` dimension here is omitted.
     ``delays_``: array, shape (n_delays,), dtype int
         The delays used to fit the model, in indices. To return the delays

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -268,7 +268,6 @@ class ReceptiveField(BaseEstimator):
         scorer_ = _SCORERS[self.scoring]
 
         # Generate predictions, then reshape so we can mask time
-        y_orig = y.copy()
         X, y = self._check_dimensions(X, y, predict=True)
         n_times, n_epochs, n_outputs = y.shape
         y_pred = self.predict(X)

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -60,8 +60,8 @@ class ReceptiveField(BaseEstimator):
     ``valid_samples_`` : slice
         The rows to keep during model fitting after removing rows with
         missing values due to time delaying. This can be used to get an
-        output equivalent to that of ``mode='valid'`` of
-        :func:`numpy.convolve` or :func:`numpy.correlate`.
+        output equivalent to using :func:`numpy.convolve` or
+        :func:`numpy.correlate` with ``mode='valid'``.
 
     See Also
     --------
@@ -224,8 +224,9 @@ class ReceptiveField(BaseEstimator):
         Returns
         -------
         y_pred : array, shape (n_times[, n_epochs], n_outputs)
-            The output predictions. Note that valid samples can be
-            obtained using ``y_pred[rf.valid_samples_]``.
+            The output predictions. "Note that valid samples (those
+            unaffected by edge artifacts during the time delaying step) can
+            be obtained using ``y_pred[rf.valid_samples_]``.
         """
         if not hasattr(self, 'delays_'):
             raise ValueError('Estimator has not been fit yet.')
@@ -333,6 +334,9 @@ def _pad_time_series(X, n_delays, fill_mean=True):
         The time series to pad.
     n_delays : int
         The number of delays.
+    fill_mean : bool
+        If True, the fill value will be the mean along the time dimension
+        of the feature. If False, the fill value will be zero.
 
     Returns
     -------
@@ -368,8 +372,8 @@ def _delay_time_series(X, tmin, tmax, sfreq, newaxis=0, axis=0,
         The axis in the output array that corresponds to time delays.
         Defaults to 0, for the first axis.
     fill_mean : bool
-        If True (usually when using fit_intercept=True), the fill value
-        will be the mean instead of zero.
+        If True, the fill value will be the mean along the time dimension
+        of the feature. If False, the fill value will be zero.
     axis : int
         The axis corresponding to the time dimension.
 

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -40,6 +40,7 @@ modeling with continuous inputs is described in:
        Frontiers in Human Neuroscience 10, 604. doi:10.3389/fnhum.2016.00604
 """
 # Authors: Chris Holdgraf <choldgraf@gmail.com>
+#          Eric Larson <larson.eric.d@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -207,8 +208,8 @@ times = rf.delays_ / float(rf.sfreq)
 # Choose the model that performed best on the held out data
 ix_best_alpha = np.argmax(scores)
 best_mod = models[ix_best_alpha]
-coefs = best_mod.coef_
-best_pred = best_mod.predict(X_test)[:, 0]
+coefs = best_mod.coef_[0]
+best_pred = best_mod.predict(X_test)[:, 0, 0]
 
 # Plot the original STRF, and the one that we recovered with modeling.
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5), sharey=True, sharex=True)
@@ -257,7 +258,7 @@ mne.viz.tight_layout()
 # Plot the STRF of each ridge parameter
 for ii, (rf, i_alpha) in enumerate(zip(models, alphas)):
     ax = plt.subplot2grid([2, 10], [0, ii], 1, 1)
-    ax.pcolormesh(times, rf.feature_names, rf.coef_, **kwargs)
+    ax.pcolormesh(times, rf.feature_names, rf.coef_[0], **kwargs)
     plt.xticks([], [])
     plt.yticks([], [])
     plt.autoscale(tight=True)
@@ -281,7 +282,8 @@ mne.viz.tight_layout()
 #           & & & -1 & 2 & -1 \\
 #           & & &    & -1 & 1\end{matrix}\right]
 #
-# This imposes a smoothness constraint of nearby time samples. Quoting [5]_:
+# This imposes a smoothness constraint of nearby time samples and/or features.
+# Quoting [5]_:
 #
 #    Tikhonov [identity] regularization (Equation 5) reduces overfitting by
 #    smoothing the TRF estimate in a way that is insensitive to
@@ -336,7 +338,7 @@ mne.viz.tight_layout()
 # Plot the STRF of each ridge parameter
 for ii, (rf, i_alpha) in enumerate(zip(models, alphas)):
     ax = plt.subplot2grid([2, 10], [0, ii], 1, 1)
-    ax.pcolormesh(times, rf.feature_names, rf.coef_, **kwargs)
+    ax.pcolormesh(times, rf.feature_names, rf.coef_[0], **kwargs)
     plt.xticks([], [])
     plt.yticks([], [])
     plt.autoscale(tight=True)

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -209,7 +209,7 @@ times = rf.delays_ / float(rf.sfreq)
 ix_best_alpha = np.argmax(scores)
 best_mod = models[ix_best_alpha]
 coefs = best_mod.coef_[0]
-best_pred = best_mod.predict(X_test)[:, 0, 0]
+best_pred = best_mod.predict(X_test)[:, 0]
 
 # Plot the original STRF, and the one that we recovered with modeling.
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5), sharey=True, sharex=True)


### PR DESCRIPTION
This fixes the edge handling when using Ridge, and it also changes the API a bit.

I also put in a little API change up for discussion. The output of `predict` is now `(n_times[, n_epochs], n_outputs)` instead of what's in `master` which is `(n_times * n_epochs[, n_outputs])`. This is really the result of two changes/ideas:

1. If you pass in something with `n_epochs` dimension, you now get something back with an `n_epochs` dimension.

2. You always have the `n_outputs` dimension, even if it's a singleton. In our definition of `fit` we have `y : array, shape (n_times[, n_epochs], n_outputs)`, i.e. the output dimension is always there, so it seems like we should always have it in `predict`, too.

Not sure if this violates some standard `sklearn` terms or not. Maybe we need to add the `vectorize=True` argument eventually to make the epochs stuff `sklearn`-compatible.

Closes #4253.