### PR TITLE
[MRG+1] Small fixes to ICA tutorial.

### DIFF
--- a/examples/forward/plot_forward_sensitivity_maps.py
+++ b/examples/forward/plot_forward_sensitivity_maps.py
@@ -7,7 +7,7 @@ Sensitivity maps can be produced from forward operators that
 indicate how well different sensor types will be able to detect
 neural currents from different regions of the brain.
 
-To get started with forward modeling see ref:`tut_forward`.
+To get started with forward modeling see :ref:`tut_forward`.
 
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -69,7 +69,6 @@ print(ica)
 
 ###############################################################################
 # Plot ICA components
-
 ica.plot_components()  # can you spot some potential bad guys?
 
 
@@ -142,7 +141,7 @@ print(ica.labels_)
 # components.
 #
 # Now let's see how we would modify our signals if we removed this component
-# from the data
+# from the data.
 ica.plot_overlay(eog_average, exclude=eog_inds, show=False)
 # red -> before, black -> after. Yes! We remove quite a lot!
 
@@ -159,11 +158,20 @@ ica.exclude.extend(eog_inds)
 # ica = read_ica('my-ica.fif')
 
 ###############################################################################
+# Note that nothing is yet removed from the raw data. To remove the effects of
+# the rejected components,
+# :meth:`the apply method <mne.preprocessing.ICA.apply>` must be called.
+# Here we apply it on the copy of the first ten seconds, so that the rest of
+# this tutorial still works as intended.
+raw_copy = raw.copy().crop(0, 10)
+ica.apply(raw_copy)
+raw_copy.plot()  # check the result
+
+###############################################################################
 # Exercise: find and remove ECG artifacts using ICA!
 ecg_epochs = create_ecg_epochs(raw, tmin=-.5, tmax=.5)
 ecg_inds, scores = ica.find_bads_ecg(ecg_epochs, method='ctps')
 ica.plot_properties(ecg_epochs, picks=ecg_inds, psd_args={'fmax': 35.})
-
 
 ###############################################################################
 # What if we don't have an EOG channel?
@@ -257,6 +265,7 @@ fig_template, fig_detected = corrmap(icas, template=template, label="blinks",
 # :func:`mne.preprocessing.corrmap`.
 eog_component = reference_ica.get_components()[:, eog_inds[0]]
 
+###############################################################################
 # If you calculate a new ICA solution, you can provide this array instead of
 # specifying the template in reference to the list of ICA objects you want
 # to run CORRMAP on. (Of course, the retrieved component map arrays can


### PR DESCRIPTION
I noticed that the ``ica.apply`` is never called in our ICA tutorial. Also includes a couple of fixes to dead links.