### PR TITLE
WIP: some love for our covariance code

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,6 +95,8 @@ BUG
 
     - Fix :func:`mne.transforms.transform_surface_to` to actually copy when ``copy=True`` by `Eric Larson`_
 
+    - Fix :func:`mne.compute_covariance` to support multiprocessing for shrinkage estimators by `Denis Engemann`_
+
 API
 ~~~
 
@@ -115,6 +117,8 @@ API
     - Make function `mne.io.eeglab.read_events_eeglab` public to allow loading overlapping events from EEGLAB files, by `Jona Sassenhagen`_.
 
     - :func:`mne.find_events` ``mask_type`` parameter will change from ``'not_and'`` to ``'and'`` in 0.16.
+
+    - :func:`mne.viz.evoked.plot_evoked_white` now exposes a rank parameter to allow manually specifying the spatial degrees of freedom. The function issues a warning when the apparent rank of the covariance differs from the expected rank of the data, as indicated by SSP and SSS processing histories. By `Denis Engemann`_
 
     - Instead of raising an error, duplicate channel names in the data file are now appended with a running number by `Jaakko Leppakangas`_
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -33,6 +33,7 @@ from .io.kit import read_epochs_kit
 from .io.eeglab import read_epochs_eeglab
 from .io.reference import (set_eeg_reference, set_bipolar_reference,
                            add_reference_channels)
+from .io.proc_history import get_rank_sss
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -33,7 +33,7 @@ from .io.kit import read_epochs_kit
 from .io.eeglab import read_epochs_eeglab
 from .io.reference import (set_eeg_reference, set_bipolar_reference,
                            add_reference_channels)
-from .io.proc_history import get_rank_sss
+from .io.proc_history import _get_rank_sss
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1114,8 +1114,8 @@ class _ShrunkCovariance(BaseEstimator):
                  shrinkage=0.1):
         from sklearn.covariance import EmpiricalCovariance
         self.estimator = EmpiricalCovariance(
-                store_precision=store_precision,
-                assume_centered=assume_centered)
+            store_precision=store_precision,
+            assume_centered=assume_centered)
 
         self.store_precision = store_precision
         self.assume_centered = assume_centered

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -38,6 +38,7 @@ from . import viz
 
 from .externals.six.moves import zip
 from .externals.six import string_types
+from .fixes import BaseEstimator
 
 
 def _check_covs_algebra(cov1, cov2):
@@ -878,7 +879,6 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     _apply_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
     estimator_cov_info = list()
     msg = 'Estimating covariance using %s'
-    _RegCovariance, _ShrunkCovariance = _get_covariance_classes()
     for this_method in method:
         data_ = data.copy()
         name = this_method.__name__ if callable(this_method) else this_method
@@ -1068,117 +1068,133 @@ def _auto_low_rank_model(data, mode, n_jobs, method_params, cv,
     return est, runtime_info
 
 
-def _get_covariance_classes():
-    """Prepare special cov estimators."""
-    from sklearn.covariance import (EmpiricalCovariance, shrunk_covariance,
-                                    ShrunkCovariance)
+class _RegCovariance(BaseEstimator):
+    """Aux class."""
 
-    class _RegCovariance(EmpiricalCovariance):
-        """Aux class."""
+    def __init__(self, info, grad=0.01, mag=0.01, eeg=0.0,
+                 store_precision=False, assume_centered=False):
+        from sklearn.covariance import EmpiricalCovariance
+        self.estimator = EmpiricalCovariance(
+            store_precision=store_precision,
+            assume_centered=assume_centered)
+        self.info = info
+        self.grad = grad
+        self.mag = mag
+        self.eeg = eeg
+        self.store_precision = store_precision
+        self.assume_centered = assume_centered
 
-        def __init__(self, info, grad=0.01, mag=0.01, eeg=0.0,
-                     store_precision=False, assume_centered=False):
-            self.info = info
-            self.grad = grad
-            self.mag = mag
-            self.eeg = eeg
-            self.store_precision = store_precision
-            self.assume_centered = assume_centered
+    def fit(self, X):
+        self.covariance_ = self.estimator.fit(X).covariance_
+        self.covariance_ = 0.5 * (self.covariance_ + self.covariance_.T)
+        cov_ = Covariance(
+            data=self.covariance_, names=self.info['ch_names'],
+            bads=self.info['bads'], projs=self.info['projs'],
+            nfree=len(self.covariance_))
+        cov_ = regularize(cov_, self.info, grad=self.grad, mag=self.mag,
+                          eeg=self.eeg, proj=False,
+                          exclude='bads')  # ~proj == important!!
+        self.estimator.covariance_ = self.covariance_ = cov_.data
 
-        def fit(self, X):
-            EmpiricalCovariance.fit(self, X)
-            self.covariance_ = 0.5 * (self.covariance_ + self.covariance_.T)
-            cov_ = Covariance(
-                data=self.covariance_, names=self.info['ch_names'],
-                bads=self.info['bads'], projs=self.info['projs'],
-                nfree=len(self.covariance_))
-            cov_ = regularize(cov_, self.info, grad=self.grad, mag=self.mag,
-                              eeg=self.eeg, proj=False,
-                              exclude='bads')  # ~proj == important!!
-            self.covariance_ = cov_.data
-            return self
+        return self
 
-    class _ShrunkCovariance(ShrunkCovariance):
-        """Aux class."""
+    def score(self, X_test, y=None):
+        """Delegation to modified EmpiricalCovariance instance"""
+        return self.estimator.score(X_test, y=y)
 
-        def __init__(self, store_precision, assume_centered,
-                     shrinkage=0.1):
-            self.store_precision = store_precision
-            self.assume_centered = assume_centered
-            self.shrinkage = shrinkage
+    def get_precision(self):
+        """Delegation to modified EmpiricalCovariance instance"""
+        return self.estimator.get_precision()
 
-        def fit(self, X):
-            EmpiricalCovariance.fit(self, X)
-            cov = self.covariance_
 
-            if not isinstance(self.shrinkage, (list, tuple)):
-                shrinkage = [('all', self.shrinkage, np.arange(len(cov)))]
-            else:
-                shrinkage = self.shrinkage
+class _ShrunkCovariance(BaseEstimator):
+    """Aux class."""
 
-            zero_cross_cov = np.zeros_like(cov, dtype=bool)
-            for a, b in itt.combinations(shrinkage, 2):
-                picks_i, picks_j = a[2], b[2]
-                ch_ = a[0], b[0]
-                if 'eeg' in ch_:
-                    zero_cross_cov[np.ix_(picks_i, picks_j)] = True
-                    zero_cross_cov[np.ix_(picks_j, picks_i)] = True
+    def __init__(self, store_precision, assume_centered,
+                 shrinkage=0.1):
+        from sklearn.covariance import EmpiricalCovariance
+        self.estimator = EmpiricalCovariance(
+                store_precision=store_precision,
+                assume_centered=assume_centered)
 
-            self.zero_cross_cov_ = zero_cross_cov
+        self.store_precision = store_precision
+        self.assume_centered = assume_centered
+        self.shrinkage = shrinkage
 
-            # Apply shrinkage to blocks
-            for ch_type, c, picks in shrinkage:
-                sub_cov = cov[np.ix_(picks, picks)]
-                cov[np.ix_(picks, picks)] = shrunk_covariance(sub_cov,
-                                                              shrinkage=c)
+    def fit(self, X):
+        from sklearn.covariance import shrunk_covariance
+        cov = self.estimator.fit(X).covariance_
 
-            # Apply shrinkage to cross-cov
-            for a, b in itt.combinations(shrinkage, 2):
-                shrinkage_i, shrinkage_j = a[1], b[1]
-                picks_i, picks_j = a[2], b[2]
-                c_ij = np.sqrt((1. - shrinkage_i) * (1. - shrinkage_j))
-                cov[np.ix_(picks_i, picks_j)] *= c_ij
-                cov[np.ix_(picks_j, picks_i)] *= c_ij
+        if not isinstance(self.shrinkage, (list, tuple)):
+            shrinkage = [('all', self.shrinkage, np.arange(len(cov)))]
+        else:
+            shrinkage = self.shrinkage
 
-            # Set to zero the necessary cross-cov
-            if np.any(zero_cross_cov):
-                cov[zero_cross_cov] = 0.0
+        zero_cross_cov = np.zeros_like(cov, dtype=bool)
+        for a, b in itt.combinations(shrinkage, 2):
+            picks_i, picks_j = a[2], b[2]
+            ch_ = a[0], b[0]
+            if 'eeg' in ch_:
+                zero_cross_cov[np.ix_(picks_i, picks_j)] = True
+                zero_cross_cov[np.ix_(picks_j, picks_i)] = True
 
-            self.covariance_ = cov
-            return self
+        self.zero_cross_cov_ = zero_cross_cov
 
-        def score(self, X_test, y=None):
-            """Compute the log-likelihood of a Gaussian data set.
+        # Apply shrinkage to blocks
+        for ch_type, c, picks in shrinkage:
+            sub_cov = cov[np.ix_(picks, picks)]
+            cov[np.ix_(picks, picks)] = shrunk_covariance(sub_cov,
+                                                          shrinkage=c)
 
-            This uses `self.covariance_` as an estimator of the data's
-            covariance matrix.
+        # Apply shrinkage to cross-cov
+        for a, b in itt.combinations(shrinkage, 2):
+            shrinkage_i, shrinkage_j = a[1], b[1]
+            picks_i, picks_j = a[2], b[2]
+            c_ij = np.sqrt((1. - shrinkage_i) * (1. - shrinkage_j))
+            cov[np.ix_(picks_i, picks_j)] *= c_ij
+            cov[np.ix_(picks_j, picks_i)] *= c_ij
 
-            Parameters
-            ----------
-            X_test : array-like, shape = [n_samples, n_features]
-                Test data of which we compute the likelihood, where n_samples
-                is the number of samples and n_features is the number of
-                features. X_test is assumed to be drawn from the same
-                distribution as the data used in fit (including centering).
+        # Set to zero the necessary cross-cov
+        if np.any(zero_cross_cov):
+            cov[zero_cross_cov] = 0.0
 
-            y : not used, present for API consistence purpose.
+        self.estimator.covariance_ = self.covariance_ = cov
+        return self
 
-            Returns
-            -------
-            res : float
-                The likelihood of the data set with `self.covariance_` as an
-                estimator of its covariance matrix.
-            """
-            from sklearn.covariance import empirical_covariance, log_likelihood
-            # compute empirical covariance of the test set
-            test_cov = empirical_covariance(X_test - self.location_,
-                                            assume_centered=True)
-            if np.any(self.zero_cross_cov_):
-                test_cov[self.zero_cross_cov_] = 0.
-            res = log_likelihood(test_cov, self.get_precision())
-            return res
+    def score(self, X_test, y=None):
+        """Compute the log-likelihood of a Gaussian data set.
 
-    return _RegCovariance, _ShrunkCovariance
+        This uses `self.covariance_` as an estimator of the data's
+        covariance matrix.
+
+        Parameters
+        ----------
+        X_test : array-like, shape = [n_samples, n_features]
+            Test data of which we compute the likelihood, where n_samples
+            is the number of samples and n_features is the number of
+            features. X_test is assumed to be drawn from the same
+            distribution as the data used in fit (including centering).
+
+        y : not used, present for API consistence purpose.
+
+        Returns
+        -------
+        res : float
+            The likelihood of the data set with `self.covariance_` as an
+            estimator of its covariance matrix.
+        """
+        from sklearn.covariance import empirical_covariance, log_likelihood
+        # compute empirical covariance of the test set
+        test_cov = empirical_covariance(X_test - self.estimator.location_,
+                                        assume_centered=True)
+        if np.any(self.zero_cross_cov_):
+            test_cov[self.zero_cross_cov_] = 0.
+        res = log_likelihood(test_cov, self.estimator.get_precision())
+        return res
+
+    def get_precision(self):
+        """Delegation to modified EmpiricalCovariance instance"""
+        return self.estimator.get_precision()
 
 
 ###############################################################################

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1099,11 +1099,11 @@ class _RegCovariance(BaseEstimator):
         return self
 
     def score(self, X_test, y=None):
-        """Delegation to modified EmpiricalCovariance instance"""
+        """Delegate call to modified EmpiricalCovariance instance."""
         return self.estimator.score(X_test, y=y)
 
     def get_precision(self):
-        """Delegation to modified EmpiricalCovariance instance"""
+        """Delegate call to modified EmpiricalCovariance instance."""
         return self.estimator.get_precision()
 
 
@@ -1162,27 +1162,7 @@ class _ShrunkCovariance(BaseEstimator):
         return self
 
     def score(self, X_test, y=None):
-        """Compute the log-likelihood of a Gaussian data set.
-
-        This uses `self.covariance_` as an estimator of the data's
-        covariance matrix.
-
-        Parameters
-        ----------
-        X_test : array-like, shape = [n_samples, n_features]
-            Test data of which we compute the likelihood, where n_samples
-            is the number of samples and n_features is the number of
-            features. X_test is assumed to be drawn from the same
-            distribution as the data used in fit (including centering).
-
-        y : not used, present for API consistence purpose.
-
-        Returns
-        -------
-        res : float
-            The likelihood of the data set with `self.covariance_` as an
-            estimator of its covariance matrix.
-        """
+        """Delegate to modified EmpiricalCovariance instance."""
         from sklearn.covariance import empirical_covariance, log_likelihood
         # compute empirical covariance of the test set
         test_cov = empirical_covariance(X_test - self.estimator.location_,
@@ -1193,7 +1173,7 @@ class _ShrunkCovariance(BaseEstimator):
         return res
 
     def get_precision(self):
-        """Delegation to modified EmpiricalCovariance instance"""
+        """Delegate to modified EmpiricalCovariance instance."""
         return self.estimator.get_precision()
 
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -359,7 +359,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return plot_evoked_field(self, surf_maps, time=time,
                                  time_label=time_label, n_jobs=n_jobs)
 
-    def plot_white(self, noise_cov, show=True):
+    def plot_white(self, noise_cov, rank=None, show=True):
         """Plot whitened evoked response.
 
         Plots the whitened evoked response and the whitened GFP as described in
@@ -378,6 +378,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         ----------
         noise_cov : list | instance of Covariance | str
             The noise covariance as computed by ``mne.cov.compute_covariance``.
+        rank : dict of int | None
+            Dict of ints where keys are 'eeg', 'mag' or 'grad'. If None,
+            the rank is detected automatically. Defaults to None. Note.
+            The rank estimation will be printed by the logger for each noise
+            covariance estimator that is passed.
         show : bool
             Whether to show the figure or not. Defaults to True.
 
@@ -397,7 +402,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         .. versionadded:: 0.9.0
         """
         return _plot_evoked_white(self, noise_cov=noise_cov, scalings=None,
-                                  rank=None, show=show)
+                                  rank=rank, show=show)
 
     @copy_function_doc_to_method_doc(plot_evoked_joint)
     def plot_joint(self, times="peaks", title='', picks=None,

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -24,10 +24,10 @@ from mne import (concatenate_events, find_events, equalize_channels,
 from mne.utils import (_TempDir, requires_pandas, slow_test, object_diff,
                        requires_mne, run_subprocess, run_tests_if_main)
 from mne.externals.six.moves import zip, cPickle as pickle
-from mne.io.proc_history import _get_sss_rank
 from mne.io.pick import _picks_by_type
 from mne.annotations import Annotations
 from mne.tests.common import assert_naming
+from mne import get_rank_sss
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -173,8 +173,7 @@ def test_rank_estimation():
         if len(raw.info['proc_history']) == 0:
             expected_rank = n_meg + n_eeg
         else:
-            mf = raw.info['proc_history'][0]['max_info']
-            expected_rank = _get_sss_rank(mf) + n_eeg
+            expected_rank = get_rank_sss(raw.info) + n_eeg
         assert_array_equal(raw.estimate_rank(scalings=scalings), expected_rank)
         assert_array_equal(raw.estimate_rank(picks=picks_eeg,
                                              scalings=scalings), n_eeg)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -27,7 +27,7 @@ from mne.externals.six.moves import zip, cPickle as pickle
 from mne.io.pick import _picks_by_type
 from mne.annotations import Annotations
 from mne.tests.common import assert_naming
-from mne import get_rank_sss
+from mne import _get_rank_sss
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -173,7 +173,7 @@ def test_rank_estimation():
         if len(raw.info['proc_history']) == 0:
             expected_rank = n_meg + n_eeg
         else:
-            expected_rank = get_rank_sss(raw.info) + n_eeg
+            expected_rank = _get_rank_sss(raw.info) + n_eeg
         assert_array_equal(raw.estimate_rank(scalings=scalings), expected_rank)
         assert_array_equal(raw.estimate_rank(picks=picks_eeg,
                                              scalings=scalings), n_eeg)

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -331,15 +331,18 @@ def _get_rank_sss(inst):
 
     max_infos = list()
     for proc_info in info.get('proc_history', list()):
-        max_info = proc_info.get('max_info', {})
-        if len(max_info['sss_info']) > 0:
-            max_infos.append(max_info)
-    if len(max_info) > 1:
-        logger.info('found multiple SSS records. Using the first.')
-    elif len(max_info) == 0:
-        raise ValueError(
-            'Did not find any SSS record. You should use data-based '
-            'rank estimate instead')
-
-    max_info = max_infos[0]
+        max_info = proc_info.get('max_info')
+        if max_info is not None:
+            if len(max_info) > 0:
+                max_infos.append(max_info)
+            elif len(max_info) > 1:
+                logger.info('found multiple SSS records. Using the first.')
+            elif len(max_info) == 0:
+                raise ValueError(
+                    'Did not find any SSS record. You should use data-based '
+                    'rank estimate instead')
+    if len(max_infos) > 0:
+        max_info = max_infos[0]
+    else:
+        raise ValueError('There is no `max_info` here. Sorry.')
     return _get_sss_rank(max_info)

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -318,6 +318,7 @@ def _get_rank_sss(inst):
     ----------
     inst : instance of Raw, Epochs or Evoked, or Info
         Any MNE object with an .info attribute
+
     Returns
     -------
     rank : int

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -335,7 +335,7 @@ def get_rank_sss(inst):
         if len(max_info['sss_info']) > 0:
             max_infos.append(max_info)
     if len(max_info) > 1:
-        logger.info('found multiple SSS records. Using then first')
+        logger.info('found multiple SSS records. Using the first.')
     elif len(max_info) == 0:
         raise ValueError(
             'Did not find any SSS record. You should use data-based '

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -16,8 +16,7 @@ from .write import (start_block, end_block, write_int, write_float,
 from .tag import find_tag
 from .constants import FIFF
 from ..externals.six import text_type, string_types
-from ..utils import warn
-
+from ..utils import warn, logger
 
 _proc_keys = ['parent_file_id', 'block_id', 'parent_block_id',
               'date', 'experimenter', 'creator']
@@ -307,3 +306,40 @@ def _get_sss_rank(sss):
     nfree -= (len(sss['sss_info']['components'][:nfree]) -
               sss['sss_info']['components'][:nfree].sum())
     return nfree
+
+
+def get_rank_sss(inst):
+    """Look up rank from SSS data.
+
+    .. note::
+        Throws an error if SSS has not been applied.
+
+    Parameters
+    ----------
+    inst : instance of Raw, Epochs or Evoked, or Info
+        Any MNE object with an .info attribute
+    Returns
+    -------
+    rank : int
+        The numerical rank as predicted by the number of SSS
+        components.
+    """
+    if not isinstance(inst, dict):
+        info = inst.info
+    else:
+        info = inst
+
+    max_infos = list()
+    for proc_info in info.get('proc_history', list()):
+        max_info = proc_info.get('max_info', {})
+        if len(max_info['sss_info']) > 0:
+            max_infos.append(max_info)
+    if len(max_info) > 1:
+        logger.info('found multiple SSS records. Using then first')
+    elif len(max_info) == 0:
+        raise ValueError(
+            'Did not find any SSS record. You should use data-based '
+            'rank estimate instead')
+
+    max_info = max_infos[0]
+    return _get_sss_rank(max_info)

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -308,7 +308,7 @@ def _get_sss_rank(sss):
     return nfree
 
 
-def get_rank_sss(inst):
+def _get_rank_sss(inst):
     """Look up rank from SSS data.
 
     .. note::

--- a/mne/io/tests/test_proc_history.py
+++ b/mne/io/tests/test_proc_history.py
@@ -4,9 +4,9 @@
 
 import numpy as np
 import os.path as op
-from mne.io import read_info
+from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
-from mne.io.proc_history import _get_sss_rank
+from mne import get_rank_sss
 from nose.tools import assert_true, assert_equal
 
 base_dir = op.join(op.dirname(__file__), 'data')
@@ -40,7 +40,10 @@ def test_maxfilter_io():
 
 def test_maxfilter_get_rank():
     """Test maxfilter rank lookup."""
-    mf = read_info(raw_fname)['proc_history'][0]['max_info']
+    raw = read_raw_fif(raw_fname)
+
+    mf = raw.info['proc_history'][0]['max_info']
     rank1 = mf['sss_info']['nfree']
-    rank2 = _get_sss_rank(mf)
+
+    rank2 = get_rank_sss(raw)
     assert_equal(rank1, rank2)

--- a/mne/io/tests/test_proc_history.py
+++ b/mne/io/tests/test_proc_history.py
@@ -6,7 +6,7 @@ import numpy as np
 import os.path as op
 from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
-from mne import get_rank_sss
+from mne import _get_rank_sss
 from nose.tools import assert_true, assert_equal
 
 base_dir = op.join(op.dirname(__file__), 'data')
@@ -45,5 +45,5 @@ def test_maxfilter_get_rank():
     mf = raw.info['proc_history'][0]['max_info']
     rank1 = mf['sss_info']['nfree']
 
-    rank2 = get_rank_sss(raw)
+    rank2 = _get_rank_sss(raw)
     assert_equal(rank1, rank2)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -576,7 +576,7 @@ def test_compute_covariance_auto_reg():
                               method_params=method_params,
                               return_estimators=True)
 
-    # make sure regularization changes something everywhere.
+    # make sure regularization produces strutured differencess
     diag_mask = np.eye(len(epochs.ch_names)).astype(bool)
     off_diag_mask = np.invert(diag_mask)
     for cov_a, cov_b in itt.combinations(covs, 2):

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -597,4 +597,5 @@ def test_compute_covariance_auto_reg():
     assert_raises(ValueError, compute_covariance, epochs, method='shrunk',
                   scalings=dict(misc=123))
 
+
 run_tests_if_main()

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -576,7 +576,7 @@ def test_compute_covariance_auto_reg():
                               method_params=method_params,
                               return_estimators=True)
 
-    # make sure regularization produces strutured differencess
+    # make sure regularization produces structured differencess
     diag_mask = np.eye(len(epochs.ch_names)).astype(bool)
     off_diag_mask = np.invert(diag_mask)
     for cov_a, cov_b in itt.combinations(covs, 2):

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -585,23 +585,23 @@ def test_compute_covariance_auto_reg():
                 cov_b['method'] == 'empirical'):
 
             assert_true(not np.any(
-                            cov_a['data'][diag_mask] ==
-                            cov_b['data'][diag_mask]))
+                        cov_a['data'][diag_mask] ==
+                        cov_b['data'][diag_mask]))
 
             # but the rest is the same
             assert_array_equal(
-                 cov_a['data'][off_diag_mask],
-                 cov_b['data'][off_diag_mask])
+                cov_a['data'][off_diag_mask],
+                cov_b['data'][off_diag_mask])
 
         else:
             # and here we have shrinkage everywhere.
             assert_true(not np.any(
-                            cov_a['data'][diag_mask] ==
-                            cov_b['data'][diag_mask]))
+                        cov_a['data'][diag_mask] ==
+                        cov_b['data'][diag_mask]))
 
             assert_true(not np.any(
-                            cov_a['data'][diag_mask] ==
-                            cov_b['data'][diag_mask]))
+                        cov_a['data'][diag_mask] ==
+                        cov_b['data'][diag_mask]))
 
     logliks = [c['loglik'] for c in covs]
     assert_true(np.diff(logliks).max() <= 0)  # descending order

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -32,7 +32,7 @@ from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
                       _draw_outlines, _prepare_topomap, _topomap_animation,
                       _set_contour_locator)
 from ..channels.layout import _pair_grad_sensors, _auto_topomap_coords
-from ..io.proc_history import get_rank_sss
+from ..io.proc_history import _get_rank_sss
 
 
 def _butterfly_onpick(event, params):
@@ -853,7 +853,7 @@ def _plot_update_evoked(params, bools):
     params['fig'].canvas.draw()
 
 
-def plot_evoked_white(evoked, noise_cov, show=True):
+def plot_evoked_white(evoked, noise_cov, rank=None, show=True):
     """Plot whitened evoked response.
 
     Plots the whitened evoked response and the whitened GFP as described in
@@ -875,6 +875,11 @@ def plot_evoked_white(evoked, noise_cov, show=True):
         The noise covariance as computed by ``mne.cov.compute_covariance``.
     show : bool
         Show figure if True.
+    rank : dict of int | None
+        Dict of ints where keys are 'eeg', 'mag' or 'grad'. If None,
+        the rank is detected automatically. Defaults to None. Note.
+        The rank estimation will be printed by the logger for each noise
+        covariance estimator that is passed.
 
     Returns
     -------
@@ -889,6 +894,13 @@ def plot_evoked_white(evoked, noise_cov, show=True):
     """
     return _plot_evoked_white(evoked=evoked, noise_cov=noise_cov,
                               scalings=None, rank=None, show=show)
+
+
+def _match_proj_type(proj, ch_names):
+    """see if proj should be counted"""
+    proj_ch_names = proj['data']['col_names']
+    select = any(kk in ch_names for kk in proj_ch_names)
+    return select
 
 
 def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
@@ -906,11 +918,6 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
         Note. Theses values were tested on different datests across various
         conditions. You should not need to update them.
 
-    rank : dict of int | None
-        Dict of ints where keys are 'eeg', 'mag' or 'grad'. If None,
-        the rank is detected automatically. Defaults to None. Note.
-        The rank estimation will be printed by the logger for each noise
-        covariance estimator that is passed.
     """
     from ..cov import whiten_evoked, read_cov  # recursive import
     from ..cov import _estimate_rank_meeg_cov
@@ -960,6 +967,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
     n_ch_used = len(ch_used)
 
     # make sure we use the same rank estimates for GFP and whitening
+
     rank_list = []
     for cov in noise_cov:
         rank_ = {}
@@ -972,17 +980,27 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
             for ch_type, this_picks in picks_list2:
                 this_info = pick_info(evoked.info, this_picks)
                 idx = np.ix_(this_picks, this_picks)
+                this_estimated_rank = _estimate_rank_meeg_cov(
+                    C[idx], this_info, scalings)
+                expected_rank = len(this_picks)
+                expected_rank_reduction = 0
                 if has_meg and has_sss and ch_type in ('meg', 'grad', 'mag'):
-                    logger.info('Reading SSS rank from proc info')
-                    this_rank = get_rank_sss(evoked)
-                    logger.info('Looking for SSP vectors')
-                    n_ssp = sum(pp['active'] for pp in cov['projs'])
-                    this_rank -= n_ssp
-                    logger.info('final rank (%s) = %i' % (ch_type, this_rank))
-                else:
-                    this_rank = _estimate_rank_meeg_cov(C[idx], this_info,
-                                                        scalings)
-                rank_[ch_type] = this_rank
+                    sss_rank = _get_rank_sss(evoked)
+                    expected_rank_reduction += (expected_rank - sss_rank)
+                n_ssp = sum(pp['active'] for pp in cov['projs'] if
+                            _match_proj_type(pp, this_info['ch_names']))
+                expected_rank_reduction += n_ssp
+                expected_rank -= expected_rank_reduction
+                if this_estimated_rank != expected_rank:
+                    msg = (
+                        'For (%s) the expected and estimated rank diverge '
+                        '(%i VS %i). \nThis may lead to surprising reults. '
+                        '\nPlease consider using the `rank` parameter to '
+                        'manually specify the spatial degrees of freedom.'
+                    )
+                    msg %= (ch_type, expected_rank, this_estimated_rank)
+                    logger.warning(msg)
+                rank_[ch_type] = this_estimated_rank
         if rank is not None:
             rank_.update(rank)
         rank_list.append(rank_)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -873,13 +873,13 @@ def plot_evoked_white(evoked, noise_cov, rank=None, show=True):
         The evoked response.
     noise_cov : list | instance of Covariance | str
         The noise covariance as computed by ``mne.cov.compute_covariance``.
-    show : bool
-        Show figure if True.
     rank : dict of int | None
         Dict of ints where keys are 'eeg', 'mag' or 'grad'. If None,
         the rank is detected automatically. Defaults to None. Note.
         The rank estimation will be printed by the logger for each noise
         covariance estimator that is passed.
+    show : bool
+        Show figure if True.
 
     Returns
     -------

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -961,8 +961,8 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
         # if SSSed, mags and grad are not longer independent
         # for correct display of the whitening we will drop the cross-terms
         # (the gradiometer * magnetometer covariance)
-        has_sss = (evoked.info['proc_history'][0].get('max_info') is not None
-                   and has_meg)
+        has_sss = (evoked.info['proc_history'][0].get('max_info') is not
+                   None and has_meg)
     if has_sss:
         logger.info('SSS has been applied to data. Showing mag and grad '
                     'whitening jointly.')

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -167,6 +167,8 @@ def test_plot_evoked():
         evoked_sss.info['proc_history'] = [dict(max_info=None)]
         evoked_sss.plot_white(cov)
         evoked_sss.plot_white(cov_fname)
+        evoked_sss.plot_white(cov_fname, rank=dict(mag=99))
+        evoked_sss.plot_white(cov_fname, rank=dict(grad=203))
 
         # plot with bad channels excluded, spatial_colors, zorder & pos. layout
         evoked.rename_channels({'MEG 0133': 'MEG 0000'})

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -161,7 +161,7 @@ evoked_meg.plot_white([noise_cov_meg, noise_cov])
 
 
 ##############################################################################
-# Based on the negative log-likelihood, the baseline covariance3
+# Based on the negative log-likelihood, the baseline covariance
 # seems more appropriate.
 
 ###############################################################################

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -37,8 +37,8 @@ raw.info['bads'] += ['EEG 053']  # bads + 1 more
 #
 # Keep in mind that you want to match your empty room dataset to your
 # actual MEG data, processing-wise. Ensure that filters
-# are all the same and if you use ICA, apply it ot both your nois and
-# your MEG recordign. In this case we did not filter the data and
+# are all the same and if you use ICA, apply it ot both your noise and
+# your MEG recording. In this case we did not filter the data and
 # we don't use ICA. However, we do have bad channels and projections in
 # the MEG data, and, hence, we want to make sure they get stored in the
 # covariance object.

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -4,6 +4,8 @@
 Computing covariance matrix
 ===========================
 """
+from copy import deepcopy
+
 import os.path as op
 
 import mne
@@ -15,13 +17,16 @@ from mne.datasets import sample
 # construct a noise covariance matrix that can be used when computing the
 # inverse solution. For more information, see :ref:`BABDEEEB`.
 data_path = sample.data_path()
+
 raw_empty_room_fname = op.join(
     data_path, 'MEG', 'sample', 'ernoise_raw.fif')
 raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)
+
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(raw_fname)
 raw.set_eeg_reference()
 raw.info['bads'] += ['EEG 053']  # bads + 1 more
+
 
 ###############################################################################
 # The definition of noise depends on the paradigm. In MEG it is quite common
@@ -33,12 +38,26 @@ raw.info['bads'] += ['EEG 053']  # bads + 1 more
 # useful if you use resting state as a noise baseline. Here we use the whole
 # empty room recording to compute the noise covariance (tmax=None is the same
 # as the end of the recording, see :func:`mne.compute_raw_covariance`).
+#
+# Keep in mind that you want to match your empty room dataset to your
+# actual MEG data, processing-wise. Ensure that filters
+# are all the same and if you use ICA, apply it ot both your nois and
+# your MEG recordign. In this case we did not filter the data and
+# we don't use ICA. However, we do have bad channels and projections in
+# the MEG data, and, hence, we want to make sure they get stored in the
+# covariance object.
+
+raw_empty_room.info['bads'] = [
+    bb for bb in raw.info['bads'] if 'EEG' not in bb]
+raw_empty_room.add_proj(
+    [deepcopy(pp) for pp in raw.info['projs'] if 'EEG' not in pp['desc']])
+
 noise_cov = mne.compute_raw_covariance(raw_empty_room, tmin=0, tmax=None)
 
 ###############################################################################
-# Now that you the covariance matrix in a python object you can save it to a
-# file with :func:`mne.write_cov`. Later you can read it back to a python
-# object using :func:`mne.read_cov`.
+# Now that you the covariance matrix in an MNE-Python object you can save it
+# to a file with :func:`mne.write_cov`. Later you can read it back
+# using :func:`mne.read_cov`.
 #
 # You can also use the pre-stimulus baseline to estimate the noise covariance.
 # First we have to construct the epochs. When computing the covariance, you
@@ -46,13 +65,13 @@ noise_cov = mne.compute_raw_covariance(raw_empty_room, tmin=0, tmax=None)
 # covariance matrix will be inaccurate. In MNE this is done by default, but
 # just to be sure, we define it here manually.
 events = mne.find_events(raw)
-epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.0,
-                    baseline=(-0.2, 0.0))
+epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.5,
+                    baseline=(-0.2, 0.0), decim=3)
 
 ###############################################################################
-# Note that this method also attenuates the resting state activity in your
-# source estimates.
-noise_cov_baseline = mne.compute_covariance(epochs)
+# Note that this method also attenuates any activity in your
+# source estimates that resemble the baseline, if you like it or not.
+noise_cov_baseline = mne.compute_covariance(epochs, tmax=0)
 
 ###############################################################################
 # Plot the covariance matrices
@@ -61,7 +80,8 @@ noise_cov_baseline = mne.compute_covariance(epochs)
 # Try setting proj to False to see the effect. Notice that the projectors in
 # epochs are already applied, so ``proj`` parameter has no effect.
 noise_cov.plot(raw_empty_room.info, proj=True)
-noise_cov_baseline.plot(epochs.info)
+noise_cov_baseline.plot(epochs.info, proj=True)
+
 
 ###############################################################################
 # How should I regularize the covariance matrix?
@@ -78,7 +98,9 @@ noise_cov_baseline.plot(epochs.info)
 # described in [1]_. For this the 'auto' option can be used. With this
 # option cross-validation will be used to learn the optimal regularization:
 
-cov = mne.compute_covariance(epochs, tmax=0., method='auto')
+nois_cov_reg = mne.compute_covariance(epochs, tmax=0.,
+                                      method='auto')
+
 
 ###############################################################################
 # This procedure evaluates the noise covariance quantitatively by how well it
@@ -95,7 +117,8 @@ cov = mne.compute_covariance(epochs, tmax=0., method='auto')
 # of freedom, e.g. ``ddof=3`` with 2 active SSP vectors):
 
 evoked = epochs.average()
-evoked.plot_white(cov)
+evoked.plot_white(noise_cov_reg)
+
 
 ###############################################################################
 # This plot displays both, the whitened evoked signals for each channels and
@@ -118,14 +141,32 @@ evoked.plot_white(cov)
 # For expert use cases or debugging the alternative estimators can also be
 # compared:
 
-covs = mne.compute_covariance(epochs, tmax=0., method=('empirical', 'shrunk'),
-                              return_estimators=True)
+noise_covs = mne.compute_covariance(
+    epochs, tmax=0., method=('empirical', 'shrunk'), return_estimators=True)
 evoked = epochs.average()
-evoked.plot_white(covs)
+evoked.plot_white(noise_covs)
+
 
 ##############################################################################
 # This will plot the whitened evoked for the optimal estimator and display the
 # GFPs for all estimators as separate lines in the related panel.
+
+
+##############################################################################
+# Finally, let's have a look at the difference between empty room and
+# event related covariance.
+
+evoked_meg = evoked.pick_types(meg=True, eeg=False)
+noise_cov_meg = mne.pick_channels_cov(noise_cov_baseline, evoked_meg.ch_names)
+noise_cov['method'] = 'empty_room'
+noise_cov_meg['method'] = 'basleline'
+
+evoked_meg.plot_white([noise_cov_meg, noise_cov])
+
+
+##############################################################################
+# Based on the negative log-likelihood, the baseline covariance3
+# seems more appropriate.
 
 ###############################################################################
 # References

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -21,7 +21,6 @@ data_path = sample.data_path()
 raw_empty_room_fname = op.join(
     data_path, 'MEG', 'sample', 'ernoise_raw.fif')
 raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)
-
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(raw_fname)
 raw.set_eeg_reference()
@@ -66,7 +65,7 @@ noise_cov = mne.compute_raw_covariance(raw_empty_room, tmin=0, tmax=None)
 # just to be sure, we define it here manually.
 events = mne.find_events(raw)
 epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.5,
-                    baseline=(-0.2, 0.0), decim=3)
+                    baseline=(-0.2, 0.0), decim=3)  # we'll decimate for speed
 
 ###############################################################################
 # Note that this method also attenuates any activity in your

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -37,8 +37,8 @@ raw.info['bads'] += ['EEG 053']  # bads + 1 more
 #
 # Keep in mind that you want to match your empty room dataset to your
 # actual MEG data, processing-wise. Ensure that filters
-# are all the same and if you use ICA, apply it ot both your noise and
-# your MEG recording. In this case we did not filter the data and
+# are all the same and if you use ICA, apply it to your empty-room and subject
+# data equivalently. In this case we did not filter the data and
 # we don't use ICA. However, we do have bad channels and projections in
 # the MEG data, and, hence, we want to make sure they get stored in the
 # covariance object.

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -4,8 +4,6 @@
 Computing covariance matrix
 ===========================
 """
-from copy import deepcopy
-
 import os.path as op
 
 import mne
@@ -17,7 +15,7 @@ from mne.datasets import sample
 # construct a noise covariance matrix that can be used when computing the
 # inverse solution. For more information, see :ref:`BABDEEEB`.
 data_path = sample.data_path()
-
+raw.info['projs'][0]['data']['col_names']
 raw_empty_room_fname = op.join(
     data_path, 'MEG', 'sample', 'ernoise_raw.fif')
 raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)
@@ -49,7 +47,7 @@ raw.info['bads'] += ['EEG 053']  # bads + 1 more
 raw_empty_room.info['bads'] = [
     bb for bb in raw.info['bads'] if 'EEG' not in bb]
 raw_empty_room.add_proj(
-    [deepcopy(pp) for pp in raw.info['projs'] if 'EEG' not in pp['desc']])
+    [pp.copy() for pp in raw.info['projs'] if 'EEG' not in pp['desc']])
 
 noise_cov = mne.compute_raw_covariance(raw_empty_room, tmin=0, tmax=None)
 
@@ -97,8 +95,8 @@ noise_cov_baseline.plot(epochs.info, proj=True)
 # described in [1]_. For this the 'auto' option can be used. With this
 # option cross-validation will be used to learn the optimal regularization:
 
-nois_cov_reg = mne.compute_covariance(epochs, tmax=0.,
-                                      method='auto')
+noise_cov_reg = mne.compute_covariance(epochs, tmax=0.,
+                                       method='auto')
 
 
 ###############################################################################

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -15,7 +15,6 @@ from mne.datasets import sample
 # construct a noise covariance matrix that can be used when computing the
 # inverse solution. For more information, see :ref:`BABDEEEB`.
 data_path = sample.data_path()
-raw.info['projs'][0]['data']['col_names']
 raw_empty_room_fname = op.join(
     data_path, 'MEG', 'sample', 'ernoise_raw.fif')
 raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)


### PR DESCRIPTION
Addresses #4140 #2497 #4251 and a series of issues reported over the last months when Neuromag is used with SSS.

1. I took care of the pickling issue
2. I implemented a public get_rank_sss function to conveniently look up the expected rank of the data
3. The evoked.plot_white now uses internally the calculation instead of estimation of the SSS rank, taking into account projs if existent.
4. I injected some care into the covariance tutorial which was not displaying the right kind of things, i.e., only showing the baseline.

More changes are planned. But it would be great to agree on what I propose here.
In a second PR I plan optimizations to the covariance computation itself by using a low rank computation whenever possible. This may, together with the changes here clear our way and help us address the last issue, namely optimal support for tSSS data.

cc @Eric89GXL @agramfort FYI @britta-wstnr 