### PR TITLE
MRG: Compute patterns for multiple regressors

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -31,9 +31,9 @@ class LinearModel(BaseEstimator):
 
     Attributes
     ----------
-    ``filters_`` : ndarray, shape (n_features,) or (n_targets, n_features)
+    ``filters_`` : ndarray, shape ([n_targets], n_features)
         If fit, the filters used to decompose the data.
-    ``patterns_`` : ndarray, shape (n_features,) or (n_targets, n_features)
+    ``patterns_`` : ndarray, shape ([n_targets], n_features)
         If fit, the patterns used to restore M/EEG signals.
 
     Notes
@@ -71,7 +71,7 @@ class LinearModel(BaseEstimator):
         ----------
         X : array, shape (n_samples, n_features)
             The training input samples to estimate the linear coefficients.
-        y : array, shape (n_samples,) or (n_samples, n_targets)
+        y : array, shape (n_samples, [n_targets])
             The target values.
 
         Returns
@@ -105,7 +105,10 @@ class LinearModel(BaseEstimator):
     def filters_(self):
         if not hasattr(self.model, 'coef_'):
             raise ValueError('model does not have a `coef_` attribute.')
-        return np.squeeze(self.model.coef_)
+        filters = self.model.coef_
+        if filters.ndim == 2 and filters.shape[0] == 1:
+            filters = filters[0]
+        return filters
 
     def transform(self, X):
         """Transform the data using the linear model.

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -20,7 +20,8 @@ class LinearModel(BaseEstimator):
     The linear model coefficients (filters) are used to extract discriminant
     neural sources from the measured data. This class computes the
     corresponding patterns of these linear filters to make them more
-    interpretable [1]_.
+    interpretable [1]_. Note that X and Y need to be normalized for the
+    patterns to be interpretable.
 
     Parameters
     ----------
@@ -88,17 +89,11 @@ class LinearModel(BaseEstimator):
         self.model.fit(X, y)
 
         # computes the patterns
-        if (
-            not hasattr(self.model, 'coef_') or  # missing attribute
-            self.model.coef_.ndim > 2 or         # weird case
-            (self.model.coef_.size not in
-             self.model.coef_.shape)             # shape (n), (n, 1) or (1, n)
-        ):
-
+        if not hasattr(self.model, 'coef_'):
             raise ValueError('model needs a unidimensional coef_ attribute to '
                              'compute the patterns')
         self.filters_ = np.squeeze(self.model.coef_)
-        self.patterns_ = np.cov(X.T).dot(self.filters_)
+        self.patterns_ = np.dot(np.cov(X.T), np.dot(self.filters_.T, np.cov(y.T))).T
 
         return self
 

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -37,6 +37,7 @@ def _make_data(n_samples=1000, n_features=5, n_targets=3):
     """
 
     # Define Y latent factors
+    np.random.seed(0)
     cov_Y = np.eye(n_targets) * 10 + np.random.rand(n_targets, n_targets)
     mean_Y = np.random.rand(n_targets)
     Y = np.random.multivariate_normal(mean_Y, cov_Y, size=n_samples)
@@ -52,54 +53,6 @@ def _make_data(n_samples=1000, n_features=5, n_targets=3):
     X += np.random.rand(n_features)  # Put an offset
 
     return X, Y, A
-
-
-def __make_data(n_samples=1000, n_features=5, n_targets=3, noise_scale=2):
-    """Generate some testing data.
-
-    Parameters
-    ----------
-    noise_scale : float
-        The amount of noise (in standard deviations) to add to the data.
-
-    Returns
-    -------
-    X : ndarray, shape (n_samples, n_features)
-        The measured data.
-    Y : ndarray, shape (n_samples, n_targets)
-        The latent variables generating the data.
-    A : ndarray, shape (n_features, n_targets)
-        The forward model, mapping the latent variables (=Y) to the measured
-        data (=X).
-    """
-    N = 1000  # Number of samples
-    M = 5  # Number of features
-
-    # Y has 3 targets and the following covariance:
-    cov_Y = np.array([
-        [10, 1, 2],
-        [1, 5, 1],
-        [2, 1, 3],
-    ])
-    mean_Y = np.array([1, -3, 7])
-    Y = np.random.multivariate_normal(mean_Y, cov_Y, size=N)
-    Y += [1, 4, 2]  # Put an offset
-
-    # The pattern (=forward model)
-    A = np.array([
-        [1, 10, -3],
-        [4,  1,  8],
-        [3, -2,  4],
-        [1,  1,  1],
-        [7,  6,  0],
-    ]).astype(float)
-    # A = np.random.randn(5, 3)
-
-    X = Y.dot(A.T)
-    X += noise_scale * np.random.randn(N, M)
-    X += [5, 2, 6, 3, 9]  # Put an offset
-
-    return X, Y[:, :n_targets], A[:, :n_targets]
 
 
 @requires_sklearn_0_15
@@ -131,7 +84,6 @@ def test_get_coef():
         def inverse_transform(self, X):
             return X
 
-    np.random.RandomState(0)
     X, y, A = _make_data(n_samples=2000, n_features=3, n_targets=1)
 
     # I. Test inverse function

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -160,14 +160,25 @@ def test_get_coef():
 def test_linearmodel():
     """Test LinearModel class for computing filters and patterns.
     """
+    from sklearn.linear_model import LinearRegression
     np.random.seed(42)
     clf = LinearModel()
-    X = np.random.rand(20, 3)
-    y = np.arange(20) % 2
+    n, n_features = 20, 3
+    X = np.random.rand(n, n_features)
+    y = np.arange(n) % 2
     clf.fit(X, y)
-    assert_equal(clf.filters_.shape, (3,))
-    assert_equal(clf.patterns_.shape, (3,))
-    assert_raises(ValueError, clf.fit, np.random.rand(20, 3, 2), y)
+    assert_equal(clf.filters_.shape, (n_features,))
+    assert_equal(clf.patterns_.shape, (n_features,))
+    assert_raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
+
+    # check multi-target fit
+    n_targets = 5
+    clf = LinearModel(LinearRegression())
+    Y = np.random.rand(n, n_targets)
+    clf.fit(X, Y)
+    assert_equal(clf.filters_.shape, (n_targets, n_features))
+    assert_equal(clf.patterns_.shape, (n_targets, n_features))
+    assert_raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
 
 
 @requires_sklearn_0_15

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -148,12 +148,15 @@ def test_get_coef():
                            filters[:, t])
 
     # Check patterns with more than 1 regressor
-    X, Y, A = _make_data(n_samples=5000, n_features=5, n_targets=3)
-    lm = LinearModel(LinearRegression()).fit(X, Y)
-    assert_array_equal(lm.filters_.shape, lm.patterns_.shape, [2, 5])
-    assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
-    lm = LinearModel(Ridge(alpha=1)).fit(X, Y)
-    assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
+    for n_features in [1, 5]:
+        for n_targets in [1, 3]:
+            X, Y, A = _make_data(n_samples=5000, n_features=5, n_targets=3)
+            lm = LinearModel(LinearRegression()).fit(X, Y)
+            assert_array_equal(lm.filters_.shape, lm.patterns_.shape)
+            assert_array_equal(lm.filters_.shape, [3, 5])
+            assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
+            lm = LinearModel(Ridge(alpha=1)).fit(X, Y)
+            assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
 
 
 @requires_sklearn_0_15


### PR DESCRIPTION
This enhancement allows retrieving multiple co-linear patterns in case `Y` is multidimensional (e.g. left/right audio/visual).

While doing this, I encountered the following issue: FWIU, the Haufe's pattern trick only works when X and Y are z-scored. Consequently, I am not sure whether we should force `LinearModel` to apply such z-scoring inside (and break backward compatibility), or whether we should just warn the user (which creates possibilities of doing it wrong). I originally thought we would be fine with `StandardScaler` prior to the LinearModel, but this won't suffice for ensuring Y is centered over 0 with std of 1.

Overall, I would like to get second pair of eye o the validity of my equations.