### PR TITLE
WIP: psf ctf update

### DIFF
--- a/examples/plot_deflect_spatial_filter.py
+++ b/examples/plot_deflect_spatial_filter.py
@@ -1,0 +1,253 @@
+"""
+=======================================
+Compute spatial filter based on DeFleCT
+=======================================
+
+Compute spatial filters obeying a combination of several constraints in the
+DeFleCT framework. Apply spatial filters to evoked data and plot SNR curves.
+Apply spatial filters to epoched data and compute between-labels spectral
+connectivity.
+
+The constraints that can be implemented are:
+- Suppress cross-talk within a small set of labels
+- Minimize cross-talk from other locations anywhere in the brain
+- Minimize the effect of noise (represented by noise covariance matrix).
+
+Different sensor types are combined by whitening with noise covariance matrix.
+First label is the target. Cross-talk with other labels should be zero. 
+Cross-talk to other sources will be minimized.
+OH July 15
+For reference, see http://www.ncbi.nlm.nih.gov/pubmed/23616402 and
+http://imaging.mrc-cbu.cam.ac.uk/meg/AnalyzingData/DeFleCT_SpatialFiltering_Tools.
+"""
+
+# Author: Olaf Hauk <olaf.hauk@mrc-cbu.cam.ac.uk>
+#
+# License: BSD (3-clause)
+
+print(__doc__)
+
+import matplotlib.pyplot as plt
+
+import mne
+from mne.datasets import sample
+from mne.minimum_norm import DeFleCT, read_inverse_operator
+from mne.source_estimate import SourceEstimate
+import numpy as np
+import scipy as sp
+
+
+### SPECIFY PATHS AND FILES
+
+# path to sample data set
+data_path = sample.data_path()
+# forward solution
+fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
+# noise covariance matrix
+fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
+
+# evoked data for SNR computation
+fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
+
+# raw data for functional connectivity
+fname_raw = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+fname_event = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+
+# 4 MNE-sample labels, for which to construct spatial filters
+fname_label = [data_path + '/MEG/sample/labels/Aud-rh.label',
+               data_path + '/MEG/sample/labels/Aud-lh.label',
+               data_path + '/MEG/sample/labels/Vis-rh.label',
+               data_path + '/MEG/sample/labels/Vis-lh.label',
+               ]
+nr_lbls = len( fname_label )
+
+
+#### SPECIFY ANALYSIS PARAMETERS
+
+# channel types
+pick_meg = True # or True/False/'grad'/'mag'
+pick_eeg = False
+
+# filename for cross-talk-function (CTF) output as STC file
+# CTFs for separate estimators as different time samples
+if pick_meg and pick_eeg:
+    stc_fname_out = 'deflect_eegmeg_4lbls'
+if pick_meg and not(pick_eeg):
+    stc_fname_out = 'deflect_meg_4lbls'
+if not(pick_meg) and pick_eeg:
+    stc_fname_out = 'deflect_eeg_4lbls'
+
+# for epoching raw data before connectivity analysis
+event_id, tmin, tmax = 1, -0.2, 0.5
+if (pick_eeg and pick_meg):
+    reject = dict(mag=4e-12, grad=4000e-13, eeg=120e-6, eog=150e-6)
+if pick_eeg and ~pick_meg:
+    reject = dict(eeg=120e-6, eog=150e-6)
+if ~pick_eeg and pick_meg:
+    reject = dict(mag=4e-12, grad=4000e-13, eog=150e-6)
+
+# parameters for summarising sub-leadfields
+
+# how to summarise sub-leadfields for labels ('svd', 'sum', 'mean')
+mode = 'svd'
+# how many SVD components per label/sub-leadfield (list)
+# 1 for first recommended, others may depend on size of label
+n_svd_comp = [1,2,2,2]
+
+SNR = 3
+lambda2_S = 1. / SNR**2.      # reg param for Gram matrix S in DeFleCT
+# reg params for covariance matrix
+lambda2_cov = {'mag': 1./10., 'gra': 1./10., 'eeg': 1./10.}
+
+#### READ FORWARD SOLUTION, NOISE COVMAT AND LABELS
+
+# read forward solution (sources in surface-based coordinates)
+forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forw_ch_names = forward['info']['ch_names']
+
+# read noise covariance matrix
+noise_cov = mne.read_cov(fname_cov)
+
+# read label(s)
+labels = [mne.read_label(ss) for ss in fname_label]
+
+
+#### COMPUTE DeFleCT ESTIMATORS
+spatial_filters = list()
+names = [ll.name for ll in labels]    # for later labelling of plots etc.
+
+# 1st estimator
+# original sequence, Aud-rh first
+labels_use = [ labels[perm] for perm in [0,1,2,3] ]
+w, ch_names, F, P, noise_cov_reg, _ = DeFleCT.DeFleCT_make_estimator(forward,
+                           noise_cov, labels_use, lambda2_cov, lambda2_S,
+                           pick_meg, pick_eeg, mode='svd',
+                           n_svd_comp=n_svd_comp, verbose=None)
+spatial_filters.append(w)
+
+# 2nd estimator
+labels_use = [ labels[perm] for perm in [1,0,2,3] ] # Aud-lh first
+w, ch_names, F, P, _, _ = DeFleCT.DeFleCT_make_estimator(forward,
+                           noise_cov, labels_use, lambda2_cov, lambda2_S,
+                           pick_meg, pick_eeg, mode='svd',
+                           n_svd_comp=n_svd_comp, verbose=None)
+spatial_filters.append(w)
+
+# 3rd estimator
+labels_use = [ labels[perm] for perm in [2,0,1,3] ] # Vis-rh first
+w, ch_names, F, P, _, _ = DeFleCT.DeFleCT_make_estimator(forward,
+                           noise_cov, labels_use, lambda2_cov, lambda2_S,
+                           pick_meg, pick_eeg, mode='svd',
+                           n_svd_comp=n_svd_comp, verbose=None)
+spatial_filters.append(w)
+
+# 4th estimator
+labels_use = [ labels[perm] for perm in [3,0,1,2] ] # Vis-lh first
+w, ch_names, F, P, _, _ = DeFleCT.DeFleCT_make_estimator(forward,
+                           noise_cov, labels_use, lambda2_cov, lambda2_S,
+                           pick_meg, pick_eeg, mode='svd',
+                           n_svd_comp=n_svd_comp, verbose=None)
+spatial_filters.append(w)
+
+n_filter = len(spatial_filters)
+
+noise_cov_mat = noise_cov_reg['data']
+
+#### COMPUTE CTFs (to check if DeFleCT produced desired spatial filters)
+ctfs = [w.dot(F) for w in spatial_filters]
+# normalize to maximum for easier display
+ctfs = [ctf/np.abs(ctf).max() for ctf in ctfs]
+
+# create source estimate object
+vertno = [ss['vertno'] for ss in forward['src']]
+stc_ctf = SourceEstimate(np.squeeze(ctfs).T, vertno, tmin=0., tstep=0.001)
+
+# save CTF as STC file for mne_analyze
+print "STC filename for CTFs: %s " % stc_fname_out
+stc_ctf.save(stc_fname_out)
+
+
+#### APPLY TO EVOKED DATA AND COMPUTE SNRs
+# (e.g. to check whether regularization is reasonable)
+# (assumes as many conditions in evoked as spatial filters in spatial_filters)
+
+# read and prepare evoked data
+evoked = [mne.read_evokeds(fname_evoked, condition=cc, baseline=(None, 0),
+                            proj=True) for cc in range(n_filter)]
+evoked = [mne.pick_channels_evoked(ee, ch_names) for ee in evoked]
+evoked_mat = [ee.data for ee in evoked]
+
+# Apply estimator to data
+evoked_tc = [spatial_filters[ff].dot(evoked_mat[ff]) for ff in range(n_filter)]
+
+# Compute SNR as ration with standard deviation of baseline (to 0ms)
+base_idx = [np.abs(ee.times).argmin() for ee in evoked]
+evoked_tc_snr = [evoked_tc[ff] / np.std(evoked_tc[:base_idx[ff]]) for ff
+                                                            in range(n_filter)]
+
+print "\n Evoked data:"
+for ff in np.arange(len(spatial_filters)):
+    print "Max SNR (std to baseline) %f: " % np.abs(evoked_tc_snr[ff]).max()
+print "\n"
+
+# Plot label time courses
+
+for ff in np.arange(n_filter):
+    plt.plot(evoked_tc_snr[ff].T)
+
+plt.title('Evoked DeFleCTed SNR timecourses')
+plt.legend(names, loc='upper right')
+plt.xlabel('Time (ms)')
+plt.ylabel('SNR (std)')
+
+
+### apply to EPOCHED DATA, COMPUTE CONNECTIVITY BETWEEN LABELS
+
+# Load raw data
+raw = mne.io.Raw(fname_raw, preload=True)
+events = mne.read_events(fname_event)
+picks = mne.pick_types(raw.info, meg=pick_meg, eeg=pick_eeg, eog=True,
+                                                    stim=False, exclude='bads')
+# Define epochs for left-auditory condition
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks, proj=True,
+                    baseline=(None, 0), reject=reject, preload=True)
+
+# apply spatial filters to epochs
+label_tc = DeFleCT.apply_spatial_filters_epochs(spatial_filters, epochs)
+
+fmin, fmax = 5., 40.       # min/max frequencies for coherence 
+sfreq = raw.info['sfreq']  # the sampling frequency of data
+
+# spectral connectivity
+con, freqs, times, n_epochs, n_tapers = mne.connectivity.spectral_connectivity(
+              label_tc, method='wpli2_debiased', mode='multitaper', sfreq=sfreq,
+                               fmin=fmin, fmax=fmax, mt_adaptive=True, n_jobs=1)
+
+n_rows, n_cols = con.shape[:2]
+fig, axes = plt.subplots(n_rows, n_cols, sharex=True, sharey=True)
+axes[0, 0].set_ylim([-.1, 0.8])
+plt.suptitle('Between labels connectivity')
+for i in range(n_rows):
+    for j in range(i + 1):
+        if i == j:
+            axes[i, j].set_axis_off()
+            continue
+
+        axes[i, j].plot(freqs, con[i, j, :])
+        axes[j, i].plot(freqs, con[i, j, :])
+
+        if j == 0:
+            axes[i, j].set_ylabel(names[i])
+            axes[0, i].set_title(names[i])
+        if i == (n_rows - 1):
+            axes[i, j].set_xlabel(names[j])
+        axes[i, j].set_xlim([fmin, fmax])
+        axes[j, i].set_xlim([fmin, fmax])
+
+        # Show band limits
+        for f in [8, 12, 18, 35]:
+            axes[i, j].axvline(f, color='k')
+            axes[j, i].axvline(f, color='k')
+plt.show()
+
+# Done

--- a/mne/minimum_norm/DeFleCT.py
+++ b/mne/minimum_norm/DeFleCT.py
@@ -1,0 +1,463 @@
+# Authors: Olaf Hauk <olaf.hauk@mrc-cbu.cam.ac.uk>
+#
+# License: BSD (3-clause)
+
+from copy import deepcopy
+import numpy as np
+import scipy
+from mne.utils import logger, verbose
+from mne import pick_types, pick_channels_forward, pick_channels_cov, SourceEstimate
+from mne.cov import prepare_noise_cov 
+from mne.cov import regularize as cov_regularize
+from mne.proj import make_eeg_average_ref_proj 
+from mne.minimum_norm.inverse import _prepare_forward
+
+
+def DeFleCT_matrix(F, P, i, t, lambda2_S=1/9.):
+    """ Computes the linear DeFleCT estimator given its component matrices
+
+    Parameters:
+    -----------
+    F: leadfield/forward solution matrix (n_chan x n_vert)
+    P: projection matrix (n_chan x n_comp)
+    i: desired sensitivity to columns in P
+    t: desired CTF associated with w
+    lambda2_S: regularization parameter for Gram matrix (S)
+    (notation taken from Hauk&Stenroos HBM 2014 paper)
+
+    Returns:
+    --------
+    w: np-array, Spatial filter/linear estimator for first column of P
+
+    OH July 2015
+    """
+
+    # variable names reflect the chain of matrix operations
+    # small t: transpose; small i: (pseudo)inverse
+    # brackets and +-* operations are not reflected in variable names
+
+    # w = (tF^t + (i - tF^t S-1 P) (P^t S-1 P)-1 P^t) S-1  
+    # S = F F^t + lambda2 C
+
+    # for whitened data, covariance matrix is identity
+
+    [n_chan, n_comp] = P.shape
+    [n_chan2, n_vert] = F.shape
+    if n_chan != n_chan2:
+        raise ValueError("\nNumber of channels doesn't match between P and F: \
+                            %d vs %d" % (n_chan, n_chan2))
+
+    n_comp2 = i.shape[0]
+    if n_comp != n_comp2:
+        raise ValueError("\nNumber of components doesn't match between P and i: \
+                            %d vs %d" % (n_comp, n_comp2))
+
+    n_vert2 = t.shape[1]
+    if n_vert != n_vert2:
+        raise ValueError("\nNumber of vertices doesn't match between F and t: \
+                            %d vs %d" % (n_vert, n_vert2))
+
+    reg_mat = np.eye( n_chan )   # for regulatisation 
+
+    # compute regularized inverse of Gram matrix S
+    S = np.dot(F,F.T)
+    S_trace = np.trace(S)
+    reg_trace = np.trace(reg_mat)
+    S = S + lambda2_S*(S_trace/reg_trace)*reg_mat
+
+    Si = scipy.linalg.pinv(S)
+
+    Si_P = Si.dot(P)
+
+    Pt_Si_P = P.T.dot(Si_P)
+
+    Pt_Si_P_cond = np.linalg.cond( Pt_Si_P )
+    logger.info("\nCondition number of Pt_Si_P: %f\n" % Pt_Si_P_cond)
+
+    PtSiPi = scipy.linalg.pinv(Pt_Si_P)
+
+    PtSiPi_Pt = PtSiPi.dot(P.T)
+
+    Ft_Si_P = F.T.dot(Si_P)
+
+    t_Ft = np.dot(t, F.T)
+    t_Ft_Si_P = np.dot(t, Ft_Si_P)
+
+    #i_t_F_S_P_P_S_P = np.dot((i - t_F_S_P), PSPi_Pt)
+    i_t_Ft_Si_P_PtSiPi_Pt = (i - t_Ft_Si_P).dot(PtSiPi_Pt)
+
+    w = (t_Ft + i_t_Ft_Si_P_PtSiPi_Pt).dot(Si)
+
+    return w
+
+
+def get_svd_comps(sub_leadfield, n_svd_comp):
+    """ Compute SVD components of sub-leadfield for selected channels 
+    (all channels in one SVD)
+    Parameters:
+    -----------
+    sub_leadfield: numpy array (n_sens x n_vert) with part of the leadfield matrix
+    n_svd_comp: scalar, number of SVD components required
+
+    Returns:
+    --------
+    u_svd: numpy array, n_svd_comp scaled SVD components of subleadfield for 
+           selected channels
+    s_svd: corresponding singular values
+    """
+
+    u_svd, s_svd, _ = np.linalg.svd(sub_leadfield,
+                                 full_matrices=False,
+                                 compute_uv=True)        
+
+    # get desired first vectors of u_svd
+    u_svd = u_svd[:, :n_svd_comp]
+   
+    # project SVD components on sub-leadfield, take sum over vertices
+    u_svd_proj = u_svd.T.dot(sub_leadfield).sum(axis=1)
+    # make sure overall projection has positive sign
+    u_svd = u_svd.dot(np.sign(np.diag(u_svd_proj)))
+
+    u_svd = u_svd * s_svd[:n_svd_comp][np.newaxis, :]
+
+    logger.info("\nFirst 5 singular values (n=%d): %s" % (u_svd.shape[0], \
+                                                         s_svd[0:5]))
+    
+    # explained variance by chosen components within sub-leadfield
+    my_comps = s_svd[0:n_svd_comp]
+
+    comp_var = (100. * np.sum(my_comps * my_comps) /
+                np.sum(s_svd * s_svd))
+    logger.info("Your %d component(s) explain(s) %.1f%% "
+                "variance." % (n_svd_comp, comp_var)) 
+
+    return u_svd
+
+
+
+def label_svd(sub_leadfield, n_svd_comp, ch_names):
+    """ Computes SVD of subleadfield for sensor types separately
+
+    Parameters:
+    -----------
+    sub_leadfield: numpy array (n_sens x n_vert) with part of the 
+                   leadfield matrix
+    n_svd_comp: scalar, number of SVD components required
+    ch_names: list of channel names
+
+    Returns:
+    --------
+    this_label_lfd_summary: numpy array, n_svd_comp scaled SVD components
+                            of subleadfield
+
+    OH Aug 2015
+    """
+
+    logger.info("\nComputing SVD within labels, using %d component(s)"
+                        % n_svd_comp)
+    
+
+    EEG_idx = [cc for cc in range(len(ch_names)) if ch_names[cc][:3]=='EEG']
+    MAG_idx = [cc for cc in range(len(ch_names)) if (ch_names[cc][:3]=='MEG'
+                                                and ch_names[cc][-1:]=='1')]
+    GRA_idx = [cc for cc in range(len(ch_names)) if (ch_names[cc][:3]=='MEG'
+                    and (ch_names[cc][-1:]=='2' or ch_names[cc][-1:]=='3'))]
+
+    list_idx = []
+    u_idx = -1 # keep track of which element of u_svd belongs t which sensor type
+    if MAG_idx:
+        list_idx.append(MAG_idx)
+        u_idx += 1
+        u_mag = u_idx
+    if GRA_idx:
+        list_idx.append(GRA_idx)
+        u_idx += 1
+        u_gra = u_idx
+    if EEG_idx:
+        list_idx.append(EEG_idx)
+        u_idx += 1
+        u_eeg = u_idx
+    
+    # # compute SVD of sub-leadfield for individual sensor types
+    u_svd = [get_svd_comps(sub_leadfield[ch_idx,:], n_svd_comp) for ch_idx
+                                                                  in list_idx]
+
+    # put sensor types back together
+    this_label_lfd_summary = np.zeros([len(ch_names),u_svd[0].shape[1]])
+    if MAG_idx:
+        this_label_lfd_summary[MAG_idx] = u_svd[u_mag]
+    if GRA_idx:
+        this_label_lfd_summary[GRA_idx] = u_svd[u_gra]
+    if EEG_idx:
+        this_label_lfd_summary[EEG_idx] = u_svd[u_eeg]    
+
+    return this_label_lfd_summary
+
+
+def DeFleCT_make_subleadfields(labels, forward, leadfield, mode='svd', 
+                                                   n_svd_comp=1, verbose=None):
+    """ Compute summaries of subleadfields for specific labels for creation of 
+        DeFleCT estimator
+
+    Parameters:
+    -----------
+    labels: list of labels, first label is the target for DeFleCT, remaining
+            ones to be suppressed
+    forward: forward solution 
+    leadfield: Leadfield matrix from forward solution
+    ch_names: list of channel names to be considered
+    mode : 'mean' | 'sum' | 'svd' |
+        PSFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-leadfields for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-leadfields for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable.
+        "sub-leadfields" are the parts of the forward solutions that belong to
+        vertices within invidual labels.
+    n_svd_comp : list of integer
+        Number of SVD components for which PSFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-leadfields are shown in screen output.
+        Either list with one value per label, or one value for all (in which
+        case only one component will be extracted for the first label as
+        target component)
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns:
+    --------
+    label_lfd_summary: numpy array (n_chan x ((n_labels-1)*n_svd_comp)+1)
+    First columns: target component for DeFleCT for first label
+    Following columns: Components for remaining labels, depending on 'mode'
+    if mode != 'svd': one components per label (i.e. n_svd_comp=1 above)
+    OH July 2015
+    """
+
+    # check if number of labels and number of SVD components are compatible
+    len_labels = len(labels)
+    len_svd = len(n_svd_comp)    
+    if len_svd > 1:    # if numbers supposed to exist for every label
+        if len_svd != len_labels:
+            raise ValueError("\nNumber of labels and SVD components do not \
+                                match: %d vs %d" % (len_labels, len_svd))
+    else:    # if only one number to be applied to all labels, except first
+        if len_labels > 1: # if only one label: keep n_svd_comp as is
+            # as specified for non-target labels
+            n_svd_comp = np.tile(n_svd_comp[0], len_labels).tolist()
+            n_svd_comp[0] = 1     # one component for first label
+
+    label_lfd_summary = np.array([])  # sub-leadfield summaries
+    fwd_idx_all = []  #  source space indices in labels
+
+    for [lli,ll] in enumerate(labels):
+        logger.info(ll)
+        if ll.hemi == 'rh':
+            # for RH labels, add number of LH vertices
+            offset = forward['src'][0]['vertno'].shape[0]
+            # remember whether we are in the LH or RH
+            this_hemi = 1
+        elif ll.hemi == 'lh':
+            offset = 0
+            this_hemi = 0
+
+        # get vertices on cortical surface inside label
+        idx = np.intersect1d(ll.vertices, forward['src'][this_hemi]['vertno'])
+
+        # get vertices in source space inside label
+        fwd_idx = np.searchsorted(forward['src'][this_hemi]['vertno'], idx)
+        fwd_idx_all.append(fwd_idx)
+
+        # get sub-leadfield matrix for label vertices
+        sub_leadfield = leadfield[:, fwd_idx + offset]
+
+        # compute summary data for labels
+        if mode == 'sum':  # sum across forward solutions in label
+            logger.info("Computing sums within labels")
+            this_label_lfd_summary = np.array(sub_leadfield.sum(axis=1))        
+        elif mode == 'mean':
+            logger.info("Computing means within labels")
+            this_label_lfd_summary = np.array(sub_leadfield.mean(axis=1))        
+        elif mode == 'svd':  # takes svd of forward solutions in label
+            ch_names = forward['info']['ch_names']
+
+            this_label_lfd_summary = label_svd(sub_leadfield, n_svd_comp[lli],
+                                                                      ch_names)
+
+        # initialise or append to existing list
+        if lli == 0:
+            label_lfd_summary = this_label_lfd_summary
+        else:            
+            label_lfd_summary = np.append(label_lfd_summary,
+                                           this_label_lfd_summary, 1)
+
+    return label_lfd_summary
+
+# Done
+
+
+def DeFleCT_make_estimator(forward, noise_cov, labels, lambda2_cov=3/10.,
+                           lambda2_S=1/9., pick_meg=True, pick_eeg=False,
+                           mode='svd', n_svd_comp=1, verbose=None):
+    """
+    Create the DeFleCT estimator for a set of labels
+
+    Parameters:
+    -----------
+    forward: forward solution (assumes surf_ori=True)
+    noise_cov: noise covariance matrix
+    lambda2_cov: regularisation paramter for noise covariance matrix (whitening)
+    pick_meg: Which MEG channels to pick (True/False/'grad'/'mag')
+    pick_eeg: Which EEG channels to pick (True/False)
+    labels: list of labels, first one is the target for DeFleCT
+    mode : 'mean' | 'sum' | 'svd' |
+        PSFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-leadfields for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-leadfields for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable.
+        "sub-leadfields" are the parts of the forward solutions that belong to
+        vertices within invidual labels.
+    n_svd_comp : integer
+        Number of SVD components for which PSFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-leadfields are shown in screen output.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns:
+    --------
+    w: np-array (1xn_chan), spatial filter for first column of P
+    F: np-array, whitened leadfield matrix (n_chan x n_vert)
+    P: np-array, whitened projection matrix (n_chan x n_comp)
+    noise_cov_mat: noise covariance matrix as used in DeFleCT
+    whitener: whitening matrix as used in DeFleCT
+    """
+    
+    # get wanted channels
+    picks = pick_types(forward['info'], meg=pick_meg, eeg=pick_eeg, eog=False,
+                        stim=False, exclude='bads')     
+    
+    fwd_ch_names_all = [c['ch_name'] for c in forward['info']['chs']]
+    fwd_ch_names = [fwd_ch_names_all[pp] for pp in picks]
+    ch_names = [c for c in fwd_ch_names
+                if ((c not in noise_cov['bads']) and
+                    (c not in forward['info']['bads'])) and
+                    (c in noise_cov.ch_names)]         
+
+    if not len(forward['info']['bads']) == len(noise_cov['bads']) or \
+            not all([b in noise_cov['bads'] for b in forward['info']['bads']]):
+        logger.info('\nforward["info"]["bads"] and noise_cov["bads"] do not '
+            'match excluding bad channels from both')
+
+    # reduce forward to desired channels
+    forward = pick_channels_forward(forward, ch_names) 
+    noise_cov = pick_channels_cov(noise_cov, ch_names)
+    
+    logger.info("\nNoise covariance matrix has %d channels." % 
+                                                    noise_cov.data.shape[0] )
+
+    info_fwd = deepcopy(forward['info'])
+    info_fwd['sfreq'] = 1000.
+    if pick_eeg:        
+        avgproj = make_eeg_average_ref_proj(info_fwd, activate=True)
+        info_fwd['projs'] = []
+        info_fwd['projs'].append(avgproj)        
+    else:
+        info_fwd['projs'] = noise_cov['projs']
+    
+    if lambda2_cov:  # regularize covariance matrix "old style"
+        lbd = lambda2_cov
+        noise_cov_reg = cov_regularize(noise_cov, info_fwd, mag=lbd['mag'],
+                                    grad=lbd['gra'], eeg=lbd['eeg'], proj=True)
+    else:  # use cov_mat as is
+        noise_cov_reg = noise_cov
+
+    fwd_info, leadfield, noise_cov_fwd, whitener, n_nzero = _prepare_forward(
+                             forward, info_fwd, noise_cov_reg,
+                             pca=False, rank=None, verbose=None)
+    leadfield = leadfield[:,2::3]  # assumes surf_ori=True, (normal component)
+    n_chan, n_vert = leadfield.shape
+    logger.info("\nLeadfield has dimensions %d by %d\n" % (n_chan, n_vert))    
+
+    # if EEG present: remove mean of columns for EEG (average-reference)
+    if pick_eeg:
+        print "\nReferening EEG \n"
+        EEG_idx = [cc for cc in range(len(ch_names)) if ch_names[cc][:3]=='EEG']
+        nr_eeg = len(EEG_idx)
+        lfdmean = leadfield[EEG_idx,:].mean(axis=0)
+        leadfield[EEG_idx,:] = leadfield[EEG_idx,:] - lfdmean[np.newaxis,:]
+
+    #### CREATE SUBLEADFIELDs FOR LABELS
+    # extract SUBLEADFIELDS for labels
+    label_lfd_summary = DeFleCT_make_subleadfields(labels, forward, leadfield,
+                            mode='svd', n_svd_comp=n_svd_comp, verbose=None)
+
+    #### COMPUTE DEFLECT ESTIMATOR
+    # rename variables to match paper
+    F = np.dot( whitener, leadfield )
+    P = np.dot( whitener, label_lfd_summary )
+    nr_comp = P.shape[1]
+
+    i = np.eye( nr_comp )[0,:].T          # desired sensitivity to columns in P
+    t = np.zeros(n_vert).T[np.newaxis,:]  # desired CTF associated with w
+
+    # Compute DeFleCT ESTIMATOR
+    w = DeFleCT_matrix(F, P, i, t, lambda2_S)
+
+    # add whitener on the right (i.e. input should be unwhitened)
+    w = w.dot(whitener)
+
+    return w, ch_names, leadfield, label_lfd_summary, noise_cov_fwd, whitener
+
+# Done
+
+
+def apply_spatial_filters_epochs(spatial_filters, epochs):
+    """
+    Apply spatial filter(s) (e.g. DeFleCT) to epochs
+
+    Parameters:
+    -----------
+    spatial_filters: list of numpy arrays, each array a spatial filter
+                     (e.g. from DeFleCT)
+    epochs: epoch object from mne.Epochs
+    Number of channels in spatial filter(s) and epochs must match
+
+    Returns:
+    --------
+    label_tc: list of label time courses as source estimate objects
+    """
+
+    # check for EOG channel(s)
+    eog_idx = pick_types(epochs.info, meg=False, eeg=False, eog=True)
+
+    # remove EOG channel(s) if necessary
+    if eog_idx:
+        epochs_use = epochs.drop_channels( [epochs.info['ch_names'][eog_idx]],
+                                           copy=True )
+    else:
+        epochs_use = epochs
+
+    epoch_data = epochs_use.get_data()
+    n_epochs = epoch_data.shape[0]
+
+    label_tc_list = [this_filter.dot(epoch_data[:,:,:]) for this_filter in
+                                                              spatial_filters ]
+    label_tc_np = np.squeeze(label_tc_list)
+
+    n_filters = len(spatial_filters)
+    #vertno = [ [np.array([ii+1]) for ii in np.arange(len(spatial_filters))]
+    vertno = [np.arange(n_filters), np.array([])]
+
+    label_tc = [SourceEstimate(label_tc_np[:,ee,:], vertno, tmin=epochs.tmin, 
+                    tstep=1./epochs.info['sfreq']) for ee in
+                                                       np.arange(n_epochs)]
+
+    return label_tc
+
+
+# Done

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -1,0 +1,928 @@
+# Authors: Olaf Hauk <olaf.hauk@mrc-cbu.cam.ac.uk>
+#          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#
+# License: BSD (3-clause)
+
+from copy import deepcopy
+
+import numpy as np
+from scipy import linalg
+
+<<<<<<< HEAD
+from mne import pick_types, pick_info
+from .. import pick_channels_forward
+from ..io.pick import pick_channels, pick_types
+from ..io.constants import FIFF
+=======
+from .. import pick_channels_forward
+from ..io.pick import pick_channels
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+from ..utils import logger, verbose
+from ..forward import convert_forward_solution
+from ..evoked import EvokedArray
+from ..source_estimate import SourceEstimate
+from .inverse import _subject_from_inverse
+from . import apply_inverse
+
+
+def _prepare_info(inverse_operator):
+    """Helper to get a usable dict"""
+    # in order to convert sub-leadfield matrix to evoked data type (pretending
+    # it's an epoch, see in loop below), uses 'info' from inverse solution
+    # because this has all the correct projector information
+    info = deepcopy(inverse_operator['info'])
+    info['sfreq'] = 1000.  # necessary
+    info['projs'] = inverse_operator['projs']
+    return info
+
+
+def _pick_leadfield(leadfield, forward, ch_names):
+    """Helper to pick out correct lead field components"""
+    picks_fwd = pick_channels(forward['info']['ch_names'], ch_names)
+    return leadfield[picks_fwd]
+
+
+@verbose
+def point_spread_function(inverse_operator, forward, labels, method='dSPM',
+                          lambda2=1 / 9., pick_ori=None, mode='mean',
+                          n_svd_comp=1, verbose=None):
+    """Compute point-spread functions (PSFs) for linear estimators
+
+    Compute point-spread functions (PSF) in labels for a combination of inverse
+    operator and forward solution. PSFs are computed for test sources that are
+    perpendicular to cortical surface.
+
+    Parameters
+    ----------
+    inverse_operator : instance of InverseOperator
+        Inverse operator.
+    forward : dict
+        Forward solution. Note: (Bad) channels not included in forward
+        solution will not be used in PSF computation.
+    labels : list of Label
+        Labels for which PSFs shall be computed.
+    method : 'MNE' | 'dSPM' | 'sLORETA'
+        Inverse method for which PSFs shall be computed (for apply_inverse).
+    lambda2 : float
+        The regularization parameter (for apply_inverse).
+    pick_ori : None | "normal"
+        If "normal", rather than pooling the orientations by taking the norm,
+        only the radial component is kept. This is only implemented
+        when working with loose orientations (for apply_inverse).
+    mode : 'mean' | 'sum' | 'svd' |
+        PSFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-leadfields for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-leadfields for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable.
+        "sub-leadfields" are the parts of the forward solutions that belong to
+        vertices within invidual labels.
+    n_svd_comp : integer
+        Number of SVD components for which PSFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-leadfields are shown in screen output.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns
+    -------
+    stc_psf : SourceEstimate
+        The PSFs for the specified labels
+        If mode='svd': n_svd_comp components per label are created
+        (i.e. n_svd_comp successive time points in mne_analyze)
+        The last sample is the summed PSF across all labels
+        Scaling of PSFs is arbitrary, and may differ greatly among methods
+        (especially for MNE compared to noise-normalized estimates).
+    label_singvals : list of dict
+        Singular values of SVD for sub-matrices of leadfield
+        (only if mode='svd').
+        Diffent list entries per label. Since SVD is applied separately for
+        channel types, dictionaries may contain keys 'mag', 'grad' or 'eeg'.
+    evoked_fwd : Evoked
+        Forward solutions corresponding to PSFs in stc_psf
+        If mode='svd': n_svd_comp components per label are created
+        (i.e. n_svd_comp successive time points in mne_analyze)
+        The last sample is the summed forward solution across all labels
+        (sum is taken across summary measures).
+    """
+
+<<<<<<< HEAD
+    print "Point Spread Function!"
+
+=======
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    mode = mode.lower()
+    if mode not in ['mean', 'sum', 'svd']:
+        raise ValueError("mode must be 'svd', 'mean' or 'sum'. Got %s."
+                         % mode)
+
+    logger.info("About to process %d labels" % len(labels))
+
+    # CHANGED (PSF and CTF differ with respect to source orientations?)
+    # for forward computations, orientations will be fixed
+    forward = convert_forward_solution(forward, force_fixed=True,
+                                       surf_ori=True)
+
+    info_inv = _prepare_info(inverse_operator)
+
+    fwd_ch_names = forward['info']['ch_names']
+    inv_ch_names = info_inv['ch_names']
+<<<<<<< HEAD
+    ch_names = [c for c in inv_ch_names if (c not in info_inv['bads'])]
+=======
+    ch_names = [c for c in inv_ch_names if (c not in info_inv['bads']) ]
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+    # select those bad channels that are actually used in current operator
+    # (otherwise could cause trouble later)
+    ch_bads = [c for c in info_inv['bads'] if (c in inv_ch_names)]
+    forward['info']['bads'] = ch_bads
+    inverse_operator['info']['bads'] = ch_bads
+
+<<<<<<< HEAD
+    # CHANGED
+    source_ori = {FIFF.FIFFV_MNE_UNKNOWN_ORI: 'Unknown',
+                  FIFF.FIFFV_MNE_FIXED_ORI: 'Fixed',
+                  FIFF.FIFFV_MNE_FREE_ORI: 'Free'}
+
+    # if not inv['source_ori'] == FIFF.FIFFV_MNE_FREE_ORI:
+
+    # reduce forward to channels in invop
+    forward = pick_channels_forward(forward, ch_names)
+
+    # CHANGED (see above)
+    # leadfield = _pick_leadfield(forward['sol']['data'][:, 2::3], forward,
+    #                            ch_names)
+    leadfield = _pick_leadfield(forward['sol']['data'], forward,
+                                ch_names)
+
+    label_psf_summary, label_singvals = _deflect_make_subleadfields(
+        labels, forward, leadfield, mode=mode, n_svd_comp=[n_svd_comp],
+        verbose=None)
+
+=======
+    # reduce forward to channels in invop
+    forward = pick_channels_forward(forward, ch_names)
+
+    leadfield = _pick_leadfield(forward['sol']['data'][:, 2::3], forward,
+                                                                   ch_names)
+
+    # average-referencing leadfield for EEG before SVD    
+    EEG_idx = [cc for cc in range(len(ch_names)) if ch_names[cc][:3]=='EEG']
+    nr_eeg = len(EEG_idx)
+    if nr_eeg: # if EEG present
+        lfdmean = leadfield[EEG_idx,:].mean(axis=0)
+        leadfield[EEG_idx,:] = leadfield[EEG_idx,:] - lfdmean[np.newaxis,:]
+
+    label_psf_summary = _deflect_make_subleadfields(labels, forward, leadfield,
+                            mode=mode, n_svd_comp=[n_svd_comp], verbose=None)
+
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    # compute sum across forward solutions for labels, append to end
+    label_psf_summary = np.c_[label_psf_summary,
+                              label_psf_summary.sum(axis=1)]
+
+    # convert sub-leadfield matrix to evoked data type (a bit of a hack)
+    info_fwd = forward['info']
+    info_fwd['sfreq'] = info_inv['sfreq']
+    info_fwd['projs'] = info_inv['projs']
+    evoked_fwd = EvokedArray(label_psf_summary, info=forward['info'], tmin=0.)
+
+    # compute PSFs by applying inverse operator to sub-leadfields
+    logger.info("About to apply inverse operator for method='%s' and "
+                "lambda2=%s" % (method, lambda2))
+
+    stc_psf = apply_inverse(evoked_fwd, inverse_operator, lambda2,
+                            method=method, pick_ori=pick_ori)
+
+    return stc_psf, label_singvals
+
+
+def _get_matrix_from_inverse_operator(inverse_operator, forward, labels=None,
+                                      method='dSPM', lambda2=1. / 9.,
+                                      pick_ori=None, mode='mean', n_svd_comp=1):
+    """Get inverse matrix from an inverse operator
+
+    Currently works only for fixed/loose orientation constraints
+    For loose orientation constraint, the CTFs are computed for the radial
+    component (pick_ori='normal').
+
+    Parameters
+    ----------
+    inverse_operator : instance of InverseOperator
+        The inverse operator.
+    forward : dict
+        The forward operator.
+    method : 'MNE' | 'dSPM' | 'sLORETA'
+        Inverse methods (for apply_inverse).
+    labels : list of Label | None
+        Labels for which CTFs shall be computed. If None, inverse matrix for
+        all vertices will be returned.
+    lambda2 : float
+        The regularization parameter (for apply_inverse).
+    pick_ori : None | "normal"
+        pick_ori : None | "normal"
+        If "normal", rather than pooling the orientations by taking the norm,
+        only the radial component is kept. This is only implemented
+        when working with loose orientations (for apply_inverse).
+        Determines whether whole inverse matrix G will have one or three rows
+        per vertex. This will also affect summary measures for labels.
+    mode : 'mean' | 'sum' | 'svd'
+        CTFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-inverse for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-inverse for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable.
+        "sub-inverse" is the part of the inverse matrix that belongs to
+        vertices within invidual labels.
+    n_svd_comp : int
+        Number of SVD components for which CTFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-inverses are shown in screen output.
+
+    Returns
+    -------
+    invmat : ndarray
+        Inverse matrix associated with inverse operator and specified
+        parameters.
+    label_singvals : list of dict
+        Singular values of SVD for sub-matrices of inverse operator
+        (only if mode='svd').
+        Diffent list entries per label. Since SVD is applied separately for
+        channel types, dictionaries may contain keys 'mag', 'grad' or 'eeg'.
+    """
+    mode = mode.lower()
+
+    # apply_inverse cannot produce 3 separate orientations
+    # therefore 'force_fixed=True' is required
+    if not forward['surf_ori']:
+        raise RuntimeError('Forward has to be surface oriented and '
+                           'force_fixed=True.')
+    if not (forward['source_ori'] == 1):
+        raise RuntimeError('Forward has to be surface oriented and '
+                           'force_fixed=True.')
+
+    if labels:
+        logger.info("About to process %d labels" % len(labels))
+    else:
+        logger.info("Computing whole inverse operator.")
+<<<<<<< HEAD
+
+    info_inv = _prepare_info(inverse_operator)
+
+    info_fwd = forward['info']
+
+    # only use channels that are good for inverse operator and forward sol
+    ch_names_inv = info_inv['ch_names']
+    n_chs_inv = len(ch_names_inv)
+    bads_inv = inverse_operator['info']['bads']
+
+    # good channels
+    ch_names = [c for c in ch_names_inv if (c not in bads_inv)]
+
+    n_chs = len(ch_names)  # number of good channels in inv_op
+
+    # indices of bad channels
+    ch_idx_bads = np.array([ch_names_inv.index(ch) for ch in bads_inv])
+
+    # create identity matrix as input for inverse operator
+    # set elements to zero for non-selected channels
+    id_mat = np.eye(n_chs_inv)
+
+    # convert identity matrix to evoked data type (pretending it's an epoch)
+    ev_id = EvokedArray(id_mat, info=info_inv, tmin=0.)
+=======
+    
+    info_inv = _prepare_info(inverse_operator)
+    inv_ch_names = info_inv['ch_names']
+    ch_names = [c for c in inv_ch_names if (c not in info_inv['bads']) ]
+    bad_idx = [inv_ch_names.index(cc) for cc in info_inv['bads']]
+
+    # create identity matrix as input for inverse operator
+    id_mat = np.eye(len(inv_ch_names))
+
+    # convert identity matrix to evoked data type (pretending it's an epoch)
+    ev_id = EvokedArray(id_mat, info=info_inv, tmin=0.)
+
+    snr = 3.0
+    lambda2 = 1.0 / snr ** 2
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+    # apply inverse operator to identity matrix in order to get inverse matrix
+    # free orientation constraint not possible because apply_inverse would
+    # combine components
+<<<<<<< HEAD
+
+    # pick_ori='normal' required because apply_inverse won't give separate
+    # orientations
+    if ~inverse_operator['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI:
+        pick_ori = 'normal'
+    else:
+        pick_ori = None
+=======
+    invmat_mat_op = apply_inverse(ev_id, inverse_operator, lambda2=lambda2,
+                                  method=method, pick_ori='normal')
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+    # columns for bad channels will be zero
+    invmat_mat_op = apply_inverse(ev_id, inverse_operator, lambda2=lambda2,
+                                  method=method, pick_ori=pick_ori)
+
+    # turn source estimate into numpty array
+    invmat_mat = invmat_mat_op.data
+<<<<<<< HEAD
+
+    # remove columns for bad channels (better for SVD)
+    invmat_mat = np.delete(invmat_mat, ch_idx_bads, axis=1)
+
+    logger.info("Dimension of inverse matrix: %s" % str(invmat_mat.shape))
+=======
+    # remove columns for bad channels (better for SVD)
+    invmat_mat = np.delete(invmat_mat, bad_idx, 1)
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+    invmat_summary = []
+
+    # if mode='svd', label_singvals will collect all SVD singular values for
+    # labels
+    label_singvals = []
+
+<<<<<<< HEAD
+    if labels:  # if labels specified, get summary of inverse matrix for labels
+=======
+    if labels: # if labels specified, get summary of inverse matrix for labels
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+        for ll in labels:
+            if ll.hemi == 'rh':
+                # for RH labels, add number of LH vertices
+                offset = forward['src'][0]['vertno'].shape[0]
+                # remember whether we are in the LH or RH
+                this_hemi = 1
+            elif ll.hemi == 'lh':
+                offset = 0
+                this_hemi = 0
+            else:
+                raise RuntimeError("Cannot determine hemisphere of label.")
+
+            # get vertices on cortical surface inside label
+            idx = np.intersect1d(ll.vertices,
+                                 forward['src'][this_hemi]['vertno'])
+
+             # get vertices in source space inside label
+            fwd_idx = np.searchsorted(forward['src'][this_hemi]['vertno'], idx)
+
+            # get sub-inverse for label vertices, one row per vertex
+            # TO BE CHANGED: assumes that both fwd and inv have fixed
+            # orientations
+            # i.e. one source per vertex
+            invmat_lbl = invmat_mat[fwd_idx + offset, :]
+
+            # compute summary data for labels
+            if mode == 'sum':  # takes sum across estimators in label
+                logger.info("Computing sums within labels")
+                this_invmat_summary = invmat_lbl.sum(axis=0)
+                this_invmat_summary = np.vstack(this_invmat_summary).T
+            elif mode == 'mean':
+                logger.info("Computing means within labels")
+                this_invmat_summary = invmat_lbl.mean(axis=0)
+                this_invmat_summary = np.vstack(this_invmat_summary).T
+            elif mode == 'svd':  # takes svd of sub-inverse in label
+                logger.info("Computing SVD within labels, using %d "
+                            "component(s)" % n_svd_comp)
+
+<<<<<<< HEAD
+                this_invmat_summary, s_svd_types = _label_svd(
+                    invmat_lbl.T, n_svd_comp, info_inv)
+
+                this_invmat_summary = this_invmat_summary.T
+                label_singvals.append(s_svd_types)
+=======
+                this_invmat_summary = _label_svd(invmat_lbl.T, n_svd_comp,
+                                                                      ch_names)
+                this_invmat_summary = this_invmat_summary.T
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+            invmat_summary.append(this_invmat_summary)
+
+        invmat = np.concatenate(invmat_summary, axis=0)
+
+<<<<<<< HEAD
+=======
+        
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    else:   # no labels provided: return whole matrix
+        invmat = invmat_mat
+
+    return invmat
+
+
+@verbose
+def cross_talk_function(inverse_operator, forward, labels,
+                        method='dSPM', lambda2=1 / 9., signed=False,
+                        mode='mean', n_svd_comp=1, verbose=None):
+    """Compute cross-talk functions (CTFs) for linear estimators
+
+    Compute cross-talk functions (CTF) in labels for a combination of inverse
+    operator and forward solution. CTFs are computed for test sources that are
+    perpendicular to cortical surface.
+
+    Parameters
+    ----------
+    inverse_operator : instance of InverseOperator
+        Inverse operator.
+    forward : dict
+        Forward solution. Note: (Bad) channels not included in forward
+        solution will not be used in CTF computation.
+    labels : list of Label
+        Labels for which CTFs shall be computed.
+    method : 'MNE' | 'dSPM' | 'sLORETA'
+        Inverse method for which CTFs shall be computed.
+    lambda2 : float
+        The regularization parameter.
+    signed : bool
+        If True, CTFs will be written as signed source estimates. If False,
+        absolute (unsigned) values will be written
+    mode : 'mean' | 'sum' | 'svd'
+        CTFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-inverses for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-inverses for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable. "sub-inverse" is the part of the inverse
+        matrix that belongs to vertices within invidual labels.
+    n_svd_comp : int
+        Number of SVD components for which CTFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-inverses are shown in screen output.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns
+    -------
+    stc_ctf : SourceEstimate
+        The CTFs for the specified labels.
+        If mode='svd': n_svd_comp components per label are created
+        (i.e. n_svd_comp successive time points in mne_analyze)
+        The last sample is the summed CTF across all labels.
+    label_singvals : list of dict
+        Singular values of SVD for sub-matrices of inverse operator
+        (only if mode='svd').
+        Diffent list entries per label. Since SVD is applied separately for
+        channel types, dictionaries may contain keys 'mag', 'grad' or 'eeg'.
+    """
+
+<<<<<<< HEAD
+    print "Cross-Talk Function!"
+
+=======
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    forward = convert_forward_solution(forward, force_fixed=True,
+                                       surf_ori=True)    
+
+    info_inv = _prepare_info(inverse_operator)
+    inv_ch_names = info_inv['ch_names']
+    ch_names = [c for c in inv_ch_names if (c not in info_inv['bads'])]
+
+    # reduce forward to channels in invop
+    forward = pick_channels_forward(forward, ch_names)
+
+<<<<<<< HEAD
+    # make sure forward and invop contain same (bad) channels
+    bads_fwd = forward['info']['bads']
+    bads_inv = inverse_operator['info']['bads']
+    bads = list(set(bads_fwd + bads_inv))  # unique bad channels
+
+    # possibly bad channels from forward
+    inverse_operator['info']['bads'] = bads
+    info_inv = _prepare_info(inverse_operator)  # add proj
+
+    inv_ch_names = info_inv['ch_names']
+
+    ch_names = [c for c in inv_ch_names if (c not in bads)]
+
+    # reduce forward to channels in invop
+    forward = pick_channels_forward(forward, exclude=bads)
+
+    # get the inverse matrix corresponding to inverse operator
+    # get summary components for labels if specified
+    invmat, label_singvals = _get_matrix_from_inverse_operator(
+        inverse_operator, forward, labels=labels, method=method,
+        lambda2=lambda2,  pick_ori=None, mode=mode, n_svd_comp=n_svd_comp)
+
+    # get the leadfield matrix from forward solution
+    leadfield = _pick_leadfield(forward['sol']['data'], forward, ch_names)
+=======
+    # select those bad channels that are actually used in current operator
+    # (otherwise could cause trouble later)
+    ch_bads = [c for c in info_inv['bads'] if (c in inv_ch_names)]
+    forward['info']['bads'] = ch_bads
+    inverse_operator['info']['bads'] = ch_bads
+    
+    # get the inverse matrix corresponding to inverse operator
+    # get summary components for labels if specified
+    invmat = _get_matrix_from_inverse_operator(inverse_operator, forward,
+                                            labels=labels, method=method,
+                                            lambda2=lambda2, mode=mode,
+                                            n_svd_comp=n_svd_comp)
+
+    # get the leadfield matrix from forward solution
+    leadfield = _pick_leadfield(forward['sol']['data'], forward, ch_names)
+
+    # average-referencing leadfield for EEG before SVD    
+    EEG_idx = [cc for cc in range(len(ch_names)) if ch_names[cc][:3]=='EEG']
+    nr_eeg = len(EEG_idx)
+    if nr_eeg: # if EEG present
+        lfdmean = leadfield[EEG_idx,:].mean(axis=0)
+        leadfield[EEG_idx,:] = leadfield[EEG_idx,:] - lfdmean[np.newaxis,:]
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+    # compute cross-talk functions (CTFs)
+    ctfs = np.dot(invmat, leadfield)
+
+    # compute sum across forward solutions for labels, append to end
+    ctfs = np.vstack((ctfs, ctfs.sum(axis=0)))
+
+    # if unsigned output requested, take absolute values
+    if not signed:
+        ctfs = np.abs(ctfs, out=ctfs)
+
+    # create source estimate object
+    vertno = [ss['vertno'] for ss in inverse_operator['src']]
+    stc_ctf = SourceEstimate(ctfs.T, vertno, tmin=0., tstep=1.)
+
+    stc_ctf.subject = _subject_from_inverse(inverse_operator)
+
+<<<<<<< HEAD
+    return stc_ctf, label_singvals
+
+=======
+    return stc_ctf
+# Done
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+# the next three functions are from DeFleCT module,
+# which is not available yet)
+
+def _deflect_make_subleadfields(labels, forward, leadfield, mode='svd',
+<<<<<<< HEAD
+                                n_svd_comp=[1], verbose=None):
+=======
+                                                   n_svd_comp=[1], verbose=None):
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    """ Compute summaries of subleadfields for specific labels for creation of
+        DeFleCT estimator
+
+    Parameters:
+    -----------
+    labels : list of labels
+        first label is the target for DeFleCT, remaining ones to be suppressed
+    forward : forward solution object
+    leadfield : 2D numpy array (n_chan x n_vert)
+        Leadfield matrix from forward solution
+<<<<<<< HEAD
+        Rows of leadfield must correspond to good channels in forward solution
+=======
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    ch_names: list of strings
+        channel names to be processed
+    mode : 'mean' | 'sum' | 'svd'
+        PSFs can be computed for different summary measures with labels:
+        'sum' or 'mean': sum or means of sub-leadfields for labels
+        This corresponds to situations where labels can be assumed to be
+        homogeneously activated.
+        'svd': SVD components of sub-leadfields for labels
+        This is better suited for situations where activation patterns are
+        assumed to be more variable.
+        "sub-leadfields" are the parts of the forward solutions that belong to
+        vertices within invidual labels.
+    n_svd_comp : list of integers
+        Number of SVD components for which PSFs will be computed and output
+        (irrelevant for 'sum' and 'mean'). Explained variances within
+        sub-leadfields are shown in screen output.
+        Either list with one value per label, or one value for all (in which
+        case only one component will be extracted for the first label as
+        target component)
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns:
+    --------
+    label_lfd_summary : numpy array (n_chan x ((n_labels-1)*n_svd_comp)+1)
+        First columns: target component for DeFleCT for first label
+        Following columns: Components for remaining labels, depending on 'mode'
+        if mode != 'svd': one components per label (i.e. n_svd_comp=1 above)
+<<<<<<< HEAD
+    label_singvals : list of dict
+        Singular values of SVD for sub-matrices of leadfield
+        (only if mode='svd').
+        Diffent list entries per label. Since SVD is applied separately for
+        channel types, dictionaries may contain keys 'mag', 'grad' or 'eeg'.
+=======
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    """
+
+    # check if number of labels and number of SVD components are compatible
+    len_labels = len(labels)
+    len_svd = len(n_svd_comp)
+    if len_svd > 1:    # if numbers supposed to exist for every label
+        if len_svd != len_labels:
+            raise ValueError("Number of labels and SVD components do not "
+<<<<<<< HEAD
+                             "match: %d vs %d" % (len_labels, len_svd))
+    else:    # if only one number to be applied to all labels, except first
+        if len_labels > 1:  # if only one label: keep n_svd_comp as is
+=======
+                                "match: %d vs %d" % (len_labels, len_svd))
+    else:    # if only one number to be applied to all labels, except first
+        if len_labels > 1: # if only one label: keep n_svd_comp as is
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+            # as specified for non-target labels
+            n_svd_comp = np.tile(n_svd_comp[0], len_labels).tolist()
+            n_svd_comp[0] = 1     # one component for first label
+
+    label_lfd_summary = np.array([])  # sub-leadfield summaries
+<<<<<<< HEAD
+    fwd_idx_all = []  # source space indices in labels
+
+    # if mode='svd', label_singvals will collect all SVD singular values for
+    # labels
+    label_singvals = []
+
+    for [lli, ll] in enumerate(labels):
+=======
+    fwd_idx_all = []  #  source space indices in labels
+
+    for [lli,ll] in enumerate(labels):
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+        logger.info(ll)
+        if ll.hemi == 'rh':
+            # for RH labels, add number of LH vertices
+            offset = forward['src'][0]['vertno'].shape[0]
+            # remember whether we are in the LH or RH
+            this_hemi = 1
+        elif ll.hemi == 'lh':
+            offset = 0
+            this_hemi = 0
+<<<<<<< HEAD
+        else:
+            raise RuntimeError("Cannot determine hemisphere of label.")
+=======
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+        # get vertices on cortical surface inside label
+        idx = np.intersect1d(ll.vertices, forward['src'][this_hemi]['vertno'])
+
+        # get vertices in source space inside label
+        fwd_idx = np.searchsorted(forward['src'][this_hemi]['vertno'], idx)
+        fwd_idx_all.append(fwd_idx)
+
+        # get sub-leadfield matrix for label vertices
+        sub_leadfield = leadfield[:, fwd_idx + offset]
+
+        # compute summary data for labels
+        if mode == 'sum':  # sum across forward solutions in label
+            logger.info("Computing sums within labels")
+            this_label_lfd_summary = np.array(sub_leadfield.sum(axis=1))
+            # for later concatenation:
+<<<<<<< HEAD
+            this_label_lfd_summary = this_label_lfd_summary[:, np.newaxis]
+        elif mode == 'mean':
+            logger.info("Computing means within labels")
+            this_label_lfd_summary = np.array(sub_leadfield.mean(axis=1))
+            this_label_lfd_summary = this_label_lfd_summary[:, np.newaxis]
+=======
+            this_label_lfd_summary = this_label_lfd_summary[:,np.newaxis]
+        elif mode == 'mean':
+            logger.info("Computing means within labels")
+            this_label_lfd_summary = np.array(sub_leadfield.mean(axis=1))
+            this_label_lfd_summary = this_label_lfd_summary[:,np.newaxis]
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+        elif mode == 'svd':  # takes svd of forward solutions in label
+            info_fwd = forward['info']
+            fwd_ch_names = info_fwd['ch_names']
+            ch_names = [c for c in fwd_ch_names if (c not in info_fwd['bads'])]
+<<<<<<< HEAD
+            this_label_lfd_summary, s_svd_types = _label_svd(
+                sub_leadfield, n_svd_comp[lli], info_fwd)
+
+            label_singvals.append(s_svd_types)
+=======
+            this_label_lfd_summary = _label_svd(sub_leadfield, n_svd_comp[lli],
+                                                                      ch_names)
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+        # initialise or append to existing list
+        if lli == 0:
+            label_lfd_summary = this_label_lfd_summary
+        else:
+            label_lfd_summary = np.append(label_lfd_summary,
+<<<<<<< HEAD
+                                          this_label_lfd_summary, 1)
+
+    return label_lfd_summary, label_singvals
+=======
+                                           this_label_lfd_summary, 1)
+
+    return label_lfd_summary
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+
+# Done
+
+
+def _get_svd_comps(sub_leadfield, n_svd_comp):
+    """ Compute SVD components of sub-leadfield for selected channels
+    (all channels in one SVD)
+    Parameters:
+    -----------
+    sub_leadfield : 2D numpy array (n_sens x n_vert)
+        sub-leadfield (for n_vert vertices in labels) for which SVD is required
+    n_svd_comp : scalar
+        number of SVD components required per sub-leadfield
+
+    Returns:
+    --------
+    u_svd : 2D numpy array (n_chan x n_svd_comp )
+        scaled SVD components of subleadfield for
+           selected channels
+    s_svd : numpy vector (n_chan)
+        corresponding singular values
+    """
+
+    u_svd, s_svd, _ = np.linalg.svd(sub_leadfield,
+<<<<<<< HEAD
+                                    full_matrices=False,
+                                    compute_uv=True)
+
+    # get desired first vectors of u_svd
+    u_svd = u_svd[:, :n_svd_comp]
+
+=======
+                                 full_matrices=False,
+                                 compute_uv=True)
+
+    # get desired first vectors of u_svd
+    u_svd = u_svd[:, :n_svd_comp]
+   
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    # project SVD components on sub-leadfield, take sum over vertices
+    u_svd_proj = u_svd.T.dot(sub_leadfield).sum(axis=1)
+    # make sure overall projection has positive sign
+    u_svd = u_svd.dot(np.sign(np.diag(u_svd_proj)))
+
+    u_svd = u_svd * s_svd[:n_svd_comp][np.newaxis, :]
+
+    logger.info("First 5 singular values (n=%d): %s" % (u_svd.shape[0],
+<<<<<<< HEAD
+                                                        s_svd[0:5]))
+
+=======
+                                                              s_svd[0:5]))
+    
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    # explained variance by chosen components within sub-leadfield
+    my_comps = s_svd[0:n_svd_comp]
+
+    comp_var = (100. * np.sum(my_comps * my_comps) / np.sum(s_svd * s_svd))
+    logger.info("Your %d component(s) explain(s) %.1f%% "
+                "variance." % (n_svd_comp, comp_var))
+
+<<<<<<< HEAD
+    return u_svd, s_svd
+
+
+def _label_svd(sub_leadfield, n_svd_comp, info):
+=======
+    return u_svd
+# Done
+
+
+def _label_svd(sub_leadfield, n_svd_comp, ch_names):
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+    """ Computes SVD of subleadfield for sensor types separately
+
+    Parameters:
+    -----------
+    sub_leadfield : 2D numpy array (n_sens x n_vert)
+        sub-leadfield (for n_vert vertices in labels) for which SVD is required
+<<<<<<< HEAD
+        rows of sub_leadfield must correspond to good channels in info
+    n_svd_comp : scalar
+        number of SVD components required for sub-leadfield
+    ch_names : list of strings 
+    CHANGED to info
+=======
+    n_svd_comp : scalar
+        number of SVD components required for sub-leadfield
+    ch_names : list of strings
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256
+        list of channel names
+
+    Returns:
+    --------
+    this_label_lfd_summary : numpy array (n_chan x n_comp)
+        n_svd_comp scaled SVD components of sub-leadfield
+<<<<<<< HEAD
+    s_svd: 1D numpy array (n_chan)
+        The singular values for all SVD components.
+    """
+
+    logger.info("\nComputing SVD within labels, using %d component(s)"
+                % n_svd_comp)
+
+    n_chs = len(info['ch_names'])  # overall number of channels
+
+    # indices of bad_channels
+    bads = info['bads']
+    bads_idx = [info['ch_names'].index(cc) for cc in info['bads']]
+    bads_idx = np.sort(bads_idx)
+    bads_idx = bads_idx[::-1]  # sorted indices in reverse order
+
+    types_idx = {}
+    # get indices to all (good+bad) channels per sensor type
+    types_idx['mag'] = pick_types(info, meg='mag', eeg=False, eog=False,
+                                   ecg=False,  exclude=[])
+    types_idx['grad'] = pick_types(info, meg='grad', eeg=False, eog=False,
+                                   ecg=False, exclude=[])
+    types_idx['eeg'] = pick_types(info, meg=False, eeg=True, eog=False,
+                                   ecg=False, exclude=[])
+
+    # sub-leadfield doesn't contain bad channels, but info (pick_channels) may,
+    # thus, correct indices from info for sub-leadfield accordingly
+    for bb in bads_idx:  # from highest to lowest
+        if (bb in types_idx['mag']) or (bb in types_idx['grad']) \
+                or (bb in types_idx['eeg']):
+            for cht in types_idx:
+                idx = types_idx[cht]
+                wh = np.where(idx == bb)
+                if not wh[0].shape == (0,):
+                    # remove element with index of bad channel
+                    idx = np.delete(idx, wh)
+                    n_chs -= 1  # reduce number of channels
+
+                idx[idx > bb] -= 1  # lower indices of all following channels
+                types_idx[cht] = idx
+
+    # initialise result matrix
+    this_label_lfd_summary = np.zeros([n_chs, n_svd_comp])
+
+    s_svd_types = {}  # for singular values per channel type
+    for cht in types_idx:  # check possible channel types
+
+        idx = types_idx[cht]
+        if not idx.shape == (0,):  # if channel type present
+
+            # compute SVD of sub-leadfield for individual sensor types
+            u_svd, s_svd = _get_svd_comps(sub_leadfield[idx, :], n_svd_comp)
+            s_svd_types[cht] = s_svd
+            this_label_lfd_summary[idx, :] = u_svd
+
+    return this_label_lfd_summary, s_svd_types
+=======
+    """
+
+    logger.info("\nComputing SVD within labels, using %d component(s)"
+                        % n_svd_comp)
+    
+
+    EEG_idx = [cc for cc in range(len(ch_names)) if ch_names[cc][:3]=='EEG']
+    MAG_idx = [cc for cc in range(len(ch_names)) if (ch_names[cc][:3]=='MEG'
+                                                and ch_names[cc][-1:]=='1')]
+    GRA_idx = [cc for cc in range(len(ch_names)) if (ch_names[cc][:3]=='MEG'
+                    and (ch_names[cc][-1:]=='2' or ch_names[cc][-1:]=='3'))]
+
+    list_idx = []
+    u_idx = -1 # keep track which element of u_svd belongs to which sensor type
+    if MAG_idx:
+        list_idx.append(MAG_idx)
+        u_idx += 1
+        u_mag = u_idx
+    if GRA_idx:
+        list_idx.append(GRA_idx)
+        u_idx += 1
+        u_gra = u_idx
+    if EEG_idx:
+        list_idx.append(EEG_idx)
+        u_idx += 1
+        u_eeg = u_idx
+    
+    # # compute SVD of sub-leadfield for individual sensor types
+    u_svd = [_get_svd_comps(sub_leadfield[ch_idx,:], n_svd_comp) for ch_idx
+                                                                  in list_idx]
+
+    # put sensor types back together
+    this_label_lfd_summary = np.zeros([len(ch_names),u_svd[0].shape[1]])
+    if MAG_idx:
+        this_label_lfd_summary[MAG_idx,:] = u_svd[u_mag]
+    if GRA_idx:
+        this_label_lfd_summary[GRA_idx,:] = u_svd[u_gra]
+    if EEG_idx:
+        this_label_lfd_summary[EEG_idx,:] = u_svd[u_eeg]
+
+    return this_label_lfd_summary
+# Done
+>>>>>>> 909407689498cb58d8026f18798a8dd210d4f256

--- a/mne/tests/test_psf_ctf.py
+++ b/mne/tests/test_psf_ctf.py
@@ -1,0 +1,200 @@
+"""
+===================================================================
+R must be symmetric for L2-MNE
+===================================================================
+"""
+
+# Authors: Olaf Hauk <olaf.hauk@mrc-cbu.cam.ac.uk>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+from copy import deepcopy
+import warnings
+
+import numpy as np
+from numpy.testing import (assert_array_almost_equal, assert_equal,
+                           assert_array_equal, assert_allclose)
+from nose.tools import assert_true, assert_raises, assert_not_equal
+import mne
+from mne.tests.common import assert_naming
+from mne.utils import (_TempDir, requires_pandas, slow_test, requires_version,
+                       run_tests_if_main)
+
+from mne.datasets import sample
+from mne.minimum_norm import read_inverse_operator
+from mne.minimum_norm.psf_ctf import cross_talk_function, \
+    point_spread_function, _get_matrix_from_inverse_operator, _label_svd, \
+    _prepare_info
+
+
+warnings.simplefilter('always')
+
+data_path = sample.data_path(download=False)
+subjects_dir = op.join(data_path, 'subjects')
+
+fname_fwd = op.join(data_path, 'MEG', 'sample',
+                    'sample_audvis-meg-eeg-oct-6-fwd.fif')
+
+# covariance matrix for inverse operator
+fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis-cov.fif')
+
+# evoked data
+fname_evoked = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
+
+fname_label = [op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-rh.label')]
+
+pick_meg = True
+pick_eeg = True
+
+
+def test_invmat():
+    """Test inverse operator matrix
+    """
+
+    # tests some sub-functions of PSF/CTF, e.g. if resolution matrix symmetric
+    # and SVD works
+
+    # read forward solution
+    forward = mne.read_forward_solution(
+        fname_fwd, force_fixed=True, surf_ori=True)
+
+    forward = mne.pick_channels_forward(forward, exclude='bads')
+
+    # read covariance matrix
+    noise_cov = mne.read_cov(fname_cov)
+
+    # read evoked data
+    evoked = mne.read_evokeds(fname_evoked, condition=0)
+
+    evoked.pick_types(meg=pick_meg, eeg=pick_eeg)
+    info = evoked.info
+
+    # regularisation parameter
+    snr = 3.
+    lambda2 = 1.0 / snr ** 2
+
+    inverse_operator = mne.minimum_norm.make_inverse_operator(info, forward,
+                                                              noise_cov=noise_cov, fixed=True, depth=None, loose=None)
+
+    leadfield = mne.minimum_norm.psf_ctf._pick_leadfield(
+        forward['sol']['data'], forward, evoked.ch_names)
+
+    # test SVD of sub-leadfield
+    # arbitrary vertex index
+    vert_idx = 1000
+    # dummy sub_leadfield for SVD
+    n_rep = 5
+    sub_leadfield = np.tile(leadfield[:, vert_idx], (n_rep, 1)).T
+
+    n_svd_comp = 1
+    this_label_lfd_summary, s_svd = _label_svd(sub_leadfield, n_svd_comp, info)
+
+    # arrays should be the same before and after SVD
+    assert_array_almost_equal(sub_leadfield[:, 0], this_label_lfd_summary[
+                              :, 0] / np.sqrt(n_rep), decimal=5)
+
+    # correlation should be exactly 1
+    corr_lfd = np.corrcoef(sub_leadfield[:, 0], this_label_lfd_summary[:, 0])
+
+    assert_true(corr_lfd[0, 1] > 0.9999)
+
+    method = 'MNE'
+    invmat, singvals = _get_matrix_from_inverse_operator(inverse_operator, forward, labels=None, method=method, lambda2=lambda2, mode='mean',
+                                                pick_ori=None, n_svd_comp=None)
+
+    info_inv = _prepare_info(inverse_operator)
+    sub_invmat = np.tile(invmat[vert_idx, :], (n_rep, 1)).T
+
+    this_label_inv_summary, s_svd = _label_svd(sub_invmat, n_svd_comp,
+                                               info_inv)
+
+    assert_array_almost_equal(sub_invmat[:, 0],
+                              this_label_inv_summary[:, 0] / np.sqrt(n_rep), decimal=5)
+
+    R = invmat.dot(leadfield)
+
+    # resolution matrix should be symmetric
+    assert_array_almost_equal(R, R.T)
+
+
+def test_psfctf():
+    """ Test cross-talk and point-spread functions
+    """
+
+    # read forward solution
+    forward = mne.read_forward_solution(
+        fname_fwd, force_fixed=True, surf_ori=True)
+
+    # read covariance matrix
+    noise_cov = mne.read_cov(fname_cov)
+
+    # read evoked data
+    evoked = mne.read_evokeds(fname_evoked, condition=0)
+
+    evoked.pick_types(meg=pick_meg, eeg=pick_eeg)
+
+    # get info for inverse operator
+    info = evoked.info
+
+    # read label(s)
+    labels = [mne.read_label(ss) for ss in fname_label]
+
+    # get label with one vertex
+    # label = [labels[0].split(parts=16, subjects_dir=subjects_dir, subject='sample')[0]]
+    label = [labels[0]]
+
+    # make inverse operator based on specified forward solution
+    inverse_operator = mne.minimum_norm.make_inverse_operator(
+        info, forward, noise_cov=noise_cov, fixed=True, depth=None)
+
+    # regularisation parameter
+    snr = 3.
+    lambda2 = 1.0 / snr ** 2
+
+    # how to reduce leadfield and inverse operator in labels
+    mode = 'svd'
+    n_svd_comp = 1
+
+    # PSF/CTF for MNE
+    method = 'MNE'  # can be 'MNE', 'dSPM', or 'sLORETA'
+
+    stc_ctf_mne, ctf_s_mne = cross_talk_function(
+        inverse_operator, forward, label, method=method, lambda2=lambda2,
+        signed=True, mode=mode, n_svd_comp=n_svd_comp)
+
+    stc_psf_mne, psf_s_mne = point_spread_function(
+        inverse_operator, forward, method=method, labels=label,
+        lambda2=lambda2, pick_ori=None, mode=mode, n_svd_comp=n_svd_comp)
+
+    # PSF/CTF for sLORETA
+    method = 'sLORETA'  # can be 'MNE', 'dSPM', or 'sLORETA'
+
+    stc_ctf_lor, ctf_s_lor = cross_talk_function(
+        inverse_operator, forward, label, method=method, lambda2=lambda2,
+        signed=True, mode=mode, n_svd_comp=n_svd_comp)
+
+    stc_psf_lor, psf_s_lor = point_spread_function(
+        inverse_operator, forward, method=method, labels=label,
+        lambda2=lambda2, pick_ori=None, mode=mode, n_svd_comp=n_svd_comp)
+
+    # check if matrix dimensions correct
+    assert_true(stc_ctf_mne.data.shape == stc_ctf_lor.data.shape)
+    assert_true(stc_psf_mne.data.shape == stc_psf_lor.data.shape)
+    assert_true(stc_psf_mne.data.shape == stc_ctf_lor.data.shape)
+
+    # check of correlations between some PSFs/CTFs reasonable
+    stc_corr = np.diag(np.corrcoef(
+        stc_ctf_mne.data[:, 0:4].T, stc_psf_mne.data[:, 0:4].T))
+    # liberal test, because SVD within labels may cause differences between STCs
+    assert_true(all(stc_corr > 0.6))
+
+    stc_corr = np.diag(np.corrcoef(
+        stc_ctf_mne.data[:, 0:4].T, stc_ctf_lor.data[:, 0:4].T))
+    # liberal test, because SVD within labels may cause differences between STCs
+    assert_true(all(stc_corr > 0.6))
+
+    # check if singular values for leadfield SVD the same
+    assert_array_almost_equal(psf_s_mne[0]['eeg'], psf_s_lor[0]['eeg'])
+    assert_array_almost_equal(psf_s_mne[0]['mag'], psf_s_lor[0]['mag'])
+    assert_array_almost_equal(psf_s_mne[0]['grad'], psf_s_lor[0]['grad'])


### PR DESCRIPTION
The psf_ctf module has been substantially revised, mostly with respect to combining sensory types, including new sub-functions. The main new items are _label_svd() and _get_svd_comps(), which perform SVDs for those parts of the leadfield or inverse operator matrix that belong to a particular label. The SVD is computed for sensor types (eeg/mag/grad) separately, and needs to take into account bad channels.
The corresponding test function is test_psf_ctf.py.