### PR TITLE
Fixed ANSI codepage reading bug for .vhdr files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,8 @@ Changelog
 BUG
 ~~~
 
+    - Fix bug in :meth:`mne.io.read_raw_brainvision` read .vhdr files with ANSI codepage by `Okba Bekhelifi`_
+
     - Fix unit scaling when reading in EGI digitization files using :func:`mne.channels.read_dig_montage` by `Matt Boggess`_
 
     - Fix ``picks`` default in :meth:`mne.io.Raw.filter` to include ``ref_meg`` channels by default by `Eric Larson`_

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -6,6 +6,7 @@
 #          Eric Larson <larson.eric.d@gmail.com>
 #          Jona Sassenhagen <jona.sassenhagen@gmail.com>
 #          Phillip Alday <phillip.alday@unisa.edu.au>
+#          Okba Bekhelifi <okba.bekhelifi@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -215,6 +216,11 @@ def _read_vmrk_events(fname, event_id=None, response_trig_shift=0):
                                re.IGNORECASE & re.MULTILINE)
         if cp_setting:
             codepage = cp_setting.group(1).strip()
+        # BrainAmp Recorder also uses ANSI codepage
+        # an ANSI codepage raises a LookupError exception
+        # python recognize ANSI decoding as cp1252
+        if codepage == 'ANSI':
+            codepage = 'cp1252'
         txt = txt.decode(codepage)
     except UnicodeDecodeError:
         # if UTF-8 (new standard) or explicit codepage setting fails,
@@ -363,6 +369,11 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
                                    re.IGNORECASE & re.MULTILINE)
             if cp_setting:
                 codepage = cp_setting.group(1).strip()
+            # BrainAmp Recorder also uses ANSI codepage
+            # an ANSI codepage raises a LookupError exception
+            # python recognize ANSI decoding as cp1252
+            if codepage == 'ANSI':
+                codepage = 'cp1252'
             settings = settings.decode(codepage)
         except UnicodeDecodeError:
             # if UTF-8 (new standard) or explicit codepage setting fails,


### PR DESCRIPTION
BrainAmp recorder uses ANSI encoding also in the case of the OpenVibe BrainAmp file writer, it's the default encoding. reading raw .vhdr data files with ANSI codepage raises a LookupError in the "_read_vmrk_events" and "_get_vhdr_info" methods. 