### PR TITLE
MRG: Raw PSD respects annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,8 @@ API
 
     - :func:`mne.io.read_raw_edf` has now ``'auto'`` option for ``stim_channel`` (default in version 0.16) that automatically detects if EDF annotations or GDF events exist in the header and constructs the stim channel based on these events by `Jaakko Leppakangas`_
 
+    - :meth:`mne.io.Raw.plot_psd` now rejects data annotated bad by default. Turn off with ``reject_by_annotation=False``, by `Eric Larson`_
+
 .. _changes_0_14:
 
 Version 0.14

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1741,13 +1741,14 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  color='black', area_mode='std', area_alpha=0.33,
                  n_overlap=0, dB=True, average=None, show=True,
                  n_jobs=1, line_alpha=None, spatial_colors=None,
-                 xscale='linear', verbose=None):
+                 xscale='linear', reject_by_annotation=True, verbose=None):
         return plot_raw_psd(
             self, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax, proj=proj,
             n_fft=n_fft, picks=picks, ax=ax, color=color, area_mode=area_mode,
             area_alpha=area_alpha, n_overlap=n_overlap, dB=dB, average=average,
             show=show, n_jobs=n_jobs, line_alpha=line_alpha,
-            spatial_colors=spatial_colors, xscale=xscale)
+            spatial_colors=spatial_colors, xscale=xscale,
+            reject_by_annotation=reject_by_annotation)
 
     @copy_function_doc_to_method_doc(plot_raw_psd_topo)
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -209,7 +209,7 @@ def test_compute_proj_epochs():
     # XXX : test something
 
     # test parallelization
-    projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0, n_jobs=2,
+    projs = compute_proj_epochs(epochs, n_grad=1, n_mag=1, n_eeg=0, n_jobs=1,
                                 desc_prefix='foobar')
     assert_true(all('foobar' in x['desc'] for x in projs))
     projs = activate_proj(projs)

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -6,7 +6,7 @@ from nose.tools import assert_true, assert_equal
 
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
-from mne.utils import requires_version, slow_test, run_tests_if_main
+from mne.utils import slow_test, run_tests_if_main
 from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -581,7 +581,8 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
                  n_fft=None, picks=None, ax=None, color='black',
                  area_mode='std', area_alpha=0.33, n_overlap=0, dB=True,
                  average=None, show=True, n_jobs=1, line_alpha=None,
-                 spatial_colors=None, xscale='linear', verbose=None):
+                 spatial_colors=None, xscale='linear',
+                 reject_by_annotation=True, verbose=None):
     """Plot the power spectral density across channels.
 
     Parameters
@@ -639,6 +640,13 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         Whether to use spatial colors. Only used when ``average=False``.
     xscale : str
         Can be 'linear' (default) or 'log'.
+    reject_by_annotation : bool
+        Whether to omit bad segments from the data while computing the
+        PSD. If True, annotated segments with a description that starts
+        with 'bad' are omitted. Has no effect if ``inst`` is an Epochs or
+        Evoked object. Defaults to True.
+
+        .. versionadded:: 0.15.0
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -675,7 +683,8 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         ax = ax_list[ii]
         psds, freqs = psd_welch(raw, tmin=tmin, tmax=tmax, picks=picks,
                                 fmin=fmin, fmax=fmax, proj=proj, n_fft=n_fft,
-                                n_overlap=n_overlap, n_jobs=n_jobs)
+                                n_overlap=n_overlap, n_jobs=n_jobs,
+                                reject_by_annotation=reject_by_annotation)
 
         ylabel = _convert_psds(psds, dB, scalings_list[ii], units_list[ii],
                                [raw.ch_names[pi] for pi in picks])


### PR DESCRIPTION
This makes `raw.plot_psd()` respect / ignore annotations by default. Ready for review/merge from my end.

cc @wronk 

@mmagnuski you might be interested, too, since you have some PSD-related PR going IIRC.