### PR TITLE
MRG: Fix example footer images

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -56,7 +56,7 @@ This documentation is for the <strong>development version {{ release }}</strong>
 
 {%- block footer %}
 <footer class="footer">
-  <div class="container"><img src="_static/institutions.png" alt="Institutions"></div>
+  <div class="container"><img src="{{ pathto('_static/institutions.png', 1) }}" alt="Institutions"></div>
   <div class="container">
     <ul class="list-inline">
       <li><a href="https://github.com/mne-tools/mne-python">GitHub</a></li>


### PR DESCRIPTION
This fixes our footer image in non-root pages, e.g.:

https://mne-tools.github.io/dev/auto_examples/connectivity/plot_cwt_sensor_connectivity.html#sphx-glr-auto-examples-connectivity-plot-cwt-sensor-connectivity-py