### PR TITLE
[MRG] Compute channel connectivity using Delaunay.

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -313,7 +313,9 @@ Projections:
    find_layout
    make_eeg_layout
    make_grid_layout
+   find_ch_connectivity
    read_ch_connectivity
+   compute_ch_connectivity
    equalize_channels
    rename_channels
    generate_2d_layout

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -315,7 +315,6 @@ Projections:
    make_grid_layout
    find_ch_connectivity
    read_ch_connectivity
-   compute_ch_connectivity
    equalize_channels
    rename_channels
    generate_2d_layout

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,7 +59,7 @@ Changelog
 
     - Add :func:`mne.inverse_sparse.mxne_optim.dgap_l21l1` for computing the duality gap for TF-MxNE as the new stopping criterion by `Daniel Strohmeier`_
     
-    - Add :func:`mne.channels.find_ch_connectivity` that tries to infer the correct connectivity template using channel info. If no template is found, it computes the connectivity matrix using Delaunay triangulation of the 2d projected channel positions by `Jaakko Leppakangas`_
+    - Add :func:`mne.channels.find_ch_connectivity` that tries to infer the correct connectivity template using channel info. If no template is found, it computes the connectivity matrix using :class:`Delaunay <scipy.spatial.Delaunay>` triangulation of the 2d projected channel positions by `Jaakko Leppakangas`_
 
 BUG
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,8 @@ Changelog
 
     - Add :func:`mne.inverse_sparse.mxne_optim.dgap_l21l1` for computing the duality gap for TF-MxNE as the new stopping criterion by `Daniel Strohmeier`_
     
+    - Add :func:`mne.channels.find_ch_connectivity` that tries to infer the correct connectivity template using channel info. If no template is found, it computes the connectivity matrix using Delaunay triangulation of the 2d projected channel positions by `Jaakko Leppakangas`_
+
 BUG
 ~~~
 

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -9,4 +9,4 @@ from .montage import read_montage, read_dig_montage, Montage, DigMontage
 
 from .channels import (equalize_channels, rename_channels, fix_mag_coil_types,
                        read_ch_connectivity, _get_ch_type,
-                       find_ch_connectivity, compute_ch_connectivity)
+                       find_ch_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -8,4 +8,5 @@ from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
 from .montage import read_montage, read_dig_montage, Montage, DigMontage
 
 from .channels import (equalize_channels, rename_channels, fix_mag_coil_types,
-                       read_ch_connectivity, _get_ch_type)
+                       read_ch_connectivity, _get_ch_type,
+                       compute_connectivity)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -9,4 +9,4 @@ from .montage import read_montage, read_dig_montage, Montage, DigMontage
 
 from .channels import (equalize_channels, rename_channels, fix_mag_coil_types,
                        read_ch_connectivity, _get_ch_type,
-                       compute_connectivity)
+                       find_ch_connectivity, compute_ch_connectivity)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1054,9 +1054,9 @@ def find_ch_connectivity(info, ch_type):
     elif has_vv_grad and ch_type == 'grad':
         conn_name = 'neuromag306planar'
     elif ctf_other_types and ch_type == 'mag':
-        if info['cnhan'] < 100:
+        if info['nchan'] < 100:
             conn_name = 'ctf64'
-        elif info['cnhan'] > 200:
+        elif info['nchan'] > 200:
             conn_name = 'ctf275'
         else:
             conn_name = 'ctf151'

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -932,7 +932,7 @@ def read_ch_connectivity(fname, picks=None):
 
     Returns
     -------
-    ch_connectivity : scipy.sparse matrix
+    ch_connectivity : scipy.sparse matrix, shape (n_channels, n_channels)
         The connectivity matrix.
     ch_names : list
         The list of channel names present in connectivity matrix.
@@ -1032,7 +1032,7 @@ def find_ch_connectivity(info, ch_type):
 
     Returns
     -------
-    ch_connectivity : scipy.sparse matrix
+    ch_connectivity : scipy.sparse matrix, shape (n_channels, n_channels)
         The connectivity matrix.
     ch_names : list
         The list of channel names present in connectivity matrix.
@@ -1053,13 +1053,6 @@ def find_ch_connectivity(info, ch_type):
         conn_name = 'neuromag306mag'
     elif has_vv_grad and ch_type == 'grad':
         conn_name = 'neuromag306planar'
-    elif ctf_other_types and ch_type == 'mag':
-        if info['nchan'] < 100:
-            conn_name = 'ctf64'
-        elif info['nchan'] > 200:
-            conn_name = 'ctf275'
-        else:
-            conn_name = 'ctf151'
     elif has_4D_mag:
         if 'MEG 248' in info['ch_names']:
             idx = info['ch_names'].index('MEG 248')
@@ -1073,6 +1066,13 @@ def find_ch_connectivity(info, ch_type):
             idx = info['ch_names'].index('MEG 148')
             if info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_MAGNES_MAG:
                 conn_name = 'bti148'
+    elif has_CTF_grad and ch_type == 'mag':
+        if info['nchan'] < 100:
+            conn_name = 'ctf64'
+        elif info['nchan'] > 200:
+            conn_name = 'ctf275'
+        else:
+            conn_name = 'ctf151'
 
     if conn_name is not None:
         logger.info('Reading connectivity matrix for %s.' % conn_name)
@@ -1095,7 +1095,7 @@ def _compute_ch_connectivity(info, ch_type):
 
     Returns
     -------
-    ch_connectivity : scipy.sparse matrix
+    ch_connectivity : scipy.sparse matrix, shape (n_channels, n_channels)
         The connectivity matrix.
     ch_names : list
         The list of channel names present in connectivity matrix.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1085,7 +1085,7 @@ def find_ch_connectivity(info, ch_type):
 def _compute_ch_connectivity(info, ch_type):
     """Compute channel connectivity matrix using Delaunay triangulations.
 
-     Parameters
+    Parameters
     ----------
     info : instance of mne.measuerment_info.Info
         The measurement info.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1145,7 +1145,7 @@ def _compute_ch_connectivity(info, ch_type):
         ch_connectivity = sparse.csr_matrix(ch_connectivity)
     else:
         ch_connectivity = sparse.csr_matrix(neighbors)
-        ch_connectivity.setdiag(1)
+        ch_connectivity.setdiag(np.repeat(1, ch_connectivity.shape[0]))
 
     return ch_connectivity, ch_names
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -940,7 +940,6 @@ def read_ch_connectivity(fname, picks=None):
     See Also
     --------
     find_ch_connectivity
-    compute_ch_connectivity
     """
     from scipy.io import loadmat
     if not op.isabs(fname):
@@ -1041,7 +1040,6 @@ def find_ch_connectivity(info, ch_type):
     See Also
     --------
     read_ch_connectivity
-    compute_ch_connectivity
 
     Notes
     -----
@@ -1081,10 +1079,10 @@ def find_ch_connectivity(info, ch_type):
         return read_ch_connectivity(conn_name)
     logger.info('Could not find a connectivity matrix for the data. '
                 'Computing connectivity based on Delaunay triangulations.')
-    return compute_ch_connectivity(info, ch_type)
+    return _compute_ch_connectivity(info, ch_type)
 
 
-def compute_ch_connectivity(info, ch_type):
+def _compute_ch_connectivity(info, ch_type):
     """Compute channel connectivity matrix using Delaunay triangulations.
 
      Parameters
@@ -1101,15 +1099,6 @@ def compute_ch_connectivity(info, ch_type):
         The connectivity matrix.
     ch_names : list
         The list of channel names present in connectivity matrix.
-
-    See Also
-    --------
-    find_ch_connectivity
-    read_ch_connectivity
-
-    Notes
-    -----
-    .. versionadded:: 0.15
     """
     from ..channels.layout import (_auto_topomap_coords, _find_neighbors,
                                    _pair_grad_sensors)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -978,3 +978,18 @@ def generate_2d_layout(xy, w=.07, h=.05, pad=.02, ch_names=None,
 
     layout = Layout(box, loc_params, ch_names, ch_indices, name)
     return layout
+
+
+def _find_neighbors(xy):
+    """Find neighbors for each coordinate."""
+    from scipy.spatial import Delaunay
+    neighbors = list()
+    tri = Delaunay(xy)
+    for idx in range(len(xy)):
+        indices = np.where(tri.simplices == idx)[0]
+        this_n = list()
+        for ii in indices:
+            this_n.append(tri.simplices[ii])
+        this_n = np.unique(np.array(this_n).flatten())
+        neighbors.append(this_n[this_n != idx])
+    return neighbors

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -950,18 +950,3 @@ def generate_2d_layout(xy, w=.07, h=.05, pad=.02, ch_names=None,
 
     layout = Layout(box, loc_params, ch_names, ch_indices, name)
     return layout
-
-
-def _find_neighbors(xy):
-    """Find neighbors for each coordinate."""
-    from scipy.spatial import Delaunay
-    neighbors = list()
-    tri = Delaunay(xy)
-    for idx in range(len(xy)):
-        indices = np.where(tri.simplices == idx)[0]
-        this_n = list()
-        for ii in indices:
-            this_n.append(tri.simplices[ii])
-        this_n = np.unique(np.array(this_n).flatten())
-        neighbors.append(this_n[this_n != idx])
-    return neighbors

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -22,6 +22,7 @@ from ..io.constants import FIFF
 from ..io.meas_info import Info
 from ..utils import _clean_names, warn
 from ..externals.six.moves import map
+from .channels import _get_ch_info
 
 
 class Layout(object):
@@ -389,41 +390,12 @@ def find_layout(info, ch_type=None, exclude='bads'):
         raise ValueError('Invalid channel type (%s) requested '
                          '`ch_type` must be %s' % (ch_type, our_types))
 
-    chs = info['chs']
-    # Only take first 16 bits, as higher bits store CTF comp order
-    coil_types = set([ch['coil_type'] & 0xFFFF for ch in chs])
-    channel_types = set([ch['kind'] for ch in chs])
-
-    has_vv_mag = any(k in coil_types for k in
-                     [FIFF.FIFFV_COIL_VV_MAG_T1, FIFF.FIFFV_COIL_VV_MAG_T2,
-                      FIFF.FIFFV_COIL_VV_MAG_T3])
-    has_vv_grad = any(k in coil_types for k in [FIFF.FIFFV_COIL_VV_PLANAR_T1,
-                                                FIFF.FIFFV_COIL_VV_PLANAR_T2,
-                                                FIFF.FIFFV_COIL_VV_PLANAR_T3])
+    (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
+     has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
+     has_eeg_coils_and_meg, has_eeg_coils_only) = _get_ch_info(info)
     has_vv_meg = has_vv_mag and has_vv_grad
     has_vv_only_mag = has_vv_mag and not has_vv_grad
     has_vv_only_grad = has_vv_grad and not has_vv_mag
-    is_old_vv = ' ' in chs[0]['ch_name']
-
-    has_4D_mag = FIFF.FIFFV_COIL_MAGNES_MAG in coil_types
-    ctf_other_types = (FIFF.FIFFV_COIL_CTF_REF_MAG,
-                       FIFF.FIFFV_COIL_CTF_REF_GRAD,
-                       FIFF.FIFFV_COIL_CTF_OFFDIAG_REF_GRAD)
-    has_CTF_grad = (FIFF.FIFFV_COIL_CTF_GRAD in coil_types or
-                    (FIFF.FIFFV_MEG_CH in channel_types and
-                     any(k in ctf_other_types for k in coil_types)))
-    # hack due to MNE-C bug in IO of CTF
-    # only take first 16 bits, as higher bits store CTF comp order
-    n_kit_grads = sum(ch['coil_type'] & 0xFFFF == FIFF.FIFFV_COIL_KIT_GRAD
-                      for ch in chs)
-
-    has_any_meg = any([has_vv_mag, has_vv_grad, has_4D_mag, has_CTF_grad,
-                       n_kit_grads])
-    has_eeg_coils = (FIFF.FIFFV_COIL_EEG in coil_types and
-                     FIFF.FIFFV_EEG_CH in channel_types)
-    has_eeg_coils_and_meg = has_eeg_coils and has_any_meg
-    has_eeg_coils_only = has_eeg_coils and not has_any_meg
-
     if ch_type == "meg" and not has_any_meg:
         raise RuntimeError('No MEG channels present. Cannot find MEG layout.')
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -14,7 +14,8 @@ from scipy.io import savemat
 from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal, assert_false
 
-from mne.channels import rename_channels, read_ch_connectivity
+from mne.channels import (rename_channels, read_ch_connectivity,
+                          compute_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
@@ -214,5 +215,12 @@ def test_get_set_sensor_positions():
     raw1._set_channel_positions([[1, 2, 3]], [ch_name])
     assert_array_equal(raw1.info['chs'][13]['loc'],
                        raw2.info['chs'][13]['loc'])
+
+
+def test_compute_connectivity():
+    """Computing connectivity matrix."""
+    raw = read_raw_fif(raw_fname)
+    for ch_type in ['mag', 'eeg']:
+        conn, ch_names = compute_connectivity(raw.info, ch_type)
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -240,11 +240,13 @@ def test_find_ch_connectivity():
     bti_fname = op.join(data_path, 'BTi', 'erm_HFH', 'c,rfDC')
     bti_config_name = op.join(data_path, 'BTi', 'erm_HFH', 'config')
     raw = read_raw_bti(bti_fname, bti_config_name, None)
-    find_ch_connectivity(raw.info, 'mag')
+    _, ch_names = find_ch_connectivity(raw.info, 'mag')
+    assert_true('A1' in ch_names)
 
     ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf_short.ds')
     raw = read_raw_ctf(ctf_fname)
-    find_ch_connectivity(raw.info, 'mag')
+    _, ch_names = find_ch_connectivity(raw.info, 'mag')
+    assert_true('MLC11' in ch_names)
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -18,10 +18,11 @@ from mne.channels import (rename_channels, read_ch_connectivity,
                           find_ch_connectivity)
 from mne.channels.channels import (_ch_neighbor_connectivity,
                                    _compute_ch_connectivity)
-from mne.io import read_info, read_raw_fif
+from mne.io import read_info, read_raw_fif, read_raw_ctf, read_raw_bti
 from mne.io.constants import FIFF
 from mne.utils import _TempDir, run_tests_if_main
 from mne import pick_types, pick_channels
+from mne.datasets import testing
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -218,8 +219,11 @@ def test_get_set_sensor_positions():
                        raw2.info['chs'][13]['loc'])
 
 
+@testing.requires_testing_data
 def test_find_ch_connectivity():
     """Test computing the connectivity matrix."""
+    data_path = testing.data_path()
+
     raw = read_raw_fif(raw_fname)
     sizes = {'mag': 828, 'grad': 1700, 'eeg': 386}
     nchans = {'mag': 102, 'grad': 204, 'eeg': 60}
@@ -232,6 +236,15 @@ def test_find_ch_connectivity():
     # Test computing the conn matrix with gradiometers.
     conn, ch_names = _compute_ch_connectivity(raw.info, 'grad')
     assert_equal(conn.getnnz(), 2680)
+
+    bti_fname = op.join(data_path, 'BTi', 'erm_HFH', 'c,rfDC')
+    bti_config_name = op.join(data_path, 'BTi', 'erm_HFH', 'config')
+    raw = read_raw_bti(bti_fname, bti_config_name, None)
+    find_ch_connectivity(raw.info, 'mag')
+
+    ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf_short.ds')
+    raw = read_raw_ctf(ctf_fname)
+    find_ch_connectivity(raw.info, 'mag')
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -248,5 +248,7 @@ def test_find_ch_connectivity():
     _, ch_names = find_ch_connectivity(raw.info, 'mag')
     assert_true('MLC11' in ch_names)
 
+    assert_raises(ValueError, find_ch_connectivity, raw.info, 'eog')
+
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -16,7 +16,8 @@ from nose.tools import assert_raises, assert_true, assert_equal, assert_false
 
 from mne.channels import (rename_channels, read_ch_connectivity,
                           find_ch_connectivity)
-from mne.channels.channels import _ch_neighbor_connectivity
+from mne.channels.channels import (_ch_neighbor_connectivity,
+                                   _compute_ch_connectivity)
 from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
 from mne.utils import _TempDir, run_tests_if_main
@@ -220,7 +221,17 @@ def test_get_set_sensor_positions():
 def test_find_ch_connectivity():
     """Test computing the connectivity matrix."""
     raw = read_raw_fif(raw_fname)
+    sizes = {'mag': 828, 'grad': 1700, 'eeg': 386}
+    nchans = {'mag': 102, 'grad': 204, 'eeg': 60}
     for ch_type in ['mag', 'grad', 'eeg']:
         conn, ch_names = find_ch_connectivity(raw.info, ch_type)
+        # Silly test for checking the number of neighbors.
+        assert_equal(conn.getnnz(), sizes[ch_type])
+        assert_equal(len(ch_names), nchans[ch_type])
+
+    # Test computing the conn matrix with gradiometers.
+    conn, ch_names = _compute_ch_connectivity(raw.info, 'grad')
+    assert_equal(conn.getnnz(), 2680)
+
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal, assert_false
 
 from mne.channels import (rename_channels, read_ch_connectivity,
-                          compute_connectivity)
+                          find_ch_connectivity)
 from mne.channels.channels import _ch_neighbor_connectivity
 from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
@@ -217,10 +217,10 @@ def test_get_set_sensor_positions():
                        raw2.info['chs'][13]['loc'])
 
 
-def test_compute_connectivity():
-    """Computing connectivity matrix."""
+def test_find_ch_connectivity():
+    """Test computing the connectivity matrix."""
     raw = read_raw_fif(raw_fname)
     for ch_type in ['mag', 'grad', 'eeg']:
-        conn, ch_names = compute_connectivity(raw.info, ch_type)
+        conn, ch_names = find_ch_connectivity(raw.info, ch_type)
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -224,7 +224,7 @@ def test_find_ch_connectivity():
     """Test computing the connectivity matrix."""
     data_path = testing.data_path()
 
-    raw = read_raw_fif(raw_fname)
+    raw = read_raw_fif(raw_fname, preload=True)
     sizes = {'mag': 828, 'grad': 1700, 'eeg': 386}
     nchans = {'mag': 102, 'grad': 204, 'eeg': 60}
     for ch_type in ['mag', 'grad', 'eeg']:
@@ -232,10 +232,15 @@ def test_find_ch_connectivity():
         # Silly test for checking the number of neighbors.
         assert_equal(conn.getnnz(), sizes[ch_type])
         assert_equal(len(ch_names), nchans[ch_type])
+    assert_raises(ValueError, find_ch_connectivity, raw.info, None)
 
     # Test computing the conn matrix with gradiometers.
     conn, ch_names = _compute_ch_connectivity(raw.info, 'grad')
     assert_equal(conn.getnnz(), 2680)
+
+    # Test ch_type=None.
+    raw.pick_types(meg='mag')
+    find_ch_connectivity(raw.info, None)
 
     bti_fname = op.join(data_path, 'BTi', 'erm_HFH', 'c,rfDC')
     bti_config_name = op.join(data_path, 'BTi', 'erm_HFH', 'config')

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -220,7 +220,7 @@ def test_get_set_sensor_positions():
 def test_compute_connectivity():
     """Computing connectivity matrix."""
     raw = read_raw_fif(raw_fname)
-    for ch_type in ['mag', 'eeg']:
+    for ch_type in ['mag', 'grad', 'eeg']:
         conn, ch_names = compute_connectivity(raw.info, ch_type)
 
 run_tests_if_main()

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -24,7 +24,7 @@ from mne.viz import plot_topomap
 import mne
 from mne.stats import spatio_temporal_cluster_test
 from mne.datasets import sample
-from mne.channels import read_ch_connectivity
+from mne.channels import find_ch_connectivity
 
 print(__doc__)
 
@@ -62,9 +62,9 @@ X = [np.transpose(x, (0, 2, 1)) for x in X]  # transpose for clustering
 
 
 ###############################################################################
-# Load FieldTrip neighbor definition to setup sensor connectivity
-# ---------------------------------------------------------------
-connectivity, ch_names = read_ch_connectivity('neuromag306mag')
+# Find the FieldTrip neighbor definition to setup sensor connectivity
+# -------------------------------------------------------------------
+connectivity, ch_names = find_ch_connectivity(epochs.info, ch_type='mag')
 
 print(type(connectivity))  # it's a sparse matrix!
 


### PR DESCRIPTION
Related to https://github.com/mne-tools/mne-python/issues/4343

The computation for gradiometers is not working yet. I'm not sure what to do with the overlap. Maybe combine them so that for 204 channels it'll return conn matrix of 102X102?

The conn matrix seems to be a bit different to the connectivity [here](https://mne-tools.github.io/dev/auto_tutorials/plot_stats_spatio_temporal_cluster_sensors.html#sphx-glr-auto-tutorials-plot-stats-spatio-temporal-cluster-sensors-py), but the end result is quite identical.

![figure_1](https://user-images.githubusercontent.com/3456414/27582943-0c9a3a20-5b33-11e7-812e-58c3064129b4.png)