### PR TITLE
[MRG] Increase bottom border in order to show the x label completely

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -441,7 +441,7 @@ def _layout_figure(params):
     l_border = 100
     r_border = 10
     t_border = 35
-    b_border = 40
+    b_border = 45
 
     # only bother trying to reset layout if it's reasonable to do so
     if size[0] < 2 * scroll_width or size[1] < 2 * scroll_width + hscroll_dist:


### PR DESCRIPTION
The x label (where it says "Time (s)") in the raw plot figure was not shown completely. I increased the bottom border to fix this.

Before:
![before](https://user-images.githubusercontent.com/4377312/27731393-12a624cc-5d8d-11e7-9b08-b962258c3c3b.png)

After:
![after](https://user-images.githubusercontent.com/4377312/27731397-15ced27a-5d8d-11e7-91f7-de987fcd11c8.png)
