### PR TITLE
ENH: add inverse_transform method to UnsupervisedSpatialFilter

### DIFF
--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -206,8 +206,8 @@ def test_unsupervised_spatial_filter():
     assert_equal(usf.transform(X).ndim, 3)
     # test fit_transform
     assert_array_almost_equal(usf.transform(X), usf1.fit_transform(X))
-    # assert shape
     assert_equal(usf.transform(X).shape[1], n_components)
+    assert_array_almost_equal(usf.inverse_transform(usf.transform(X)), X)
 
     # Test with average param
     usf = UnsupervisedSpatialFilter(PCA(4), average=True)

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -630,7 +630,7 @@ class UnsupervisedSpatialFilter(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        X : array, shape (n_trials, n_channels, n_times)
+        X : array, shape (n_epochs, n_channels, n_times)
             The transformed data.
         """
         return self.fit(X).transform(X)
@@ -645,16 +645,50 @@ class UnsupervisedSpatialFilter(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        X : array, shape (n_trials, n_channels, n_times)
+        X : array, shape (n_epochs, n_channels, n_times)
+            The transformed data.
+        """
+        return self._apply_method(X, 'transform')
+
+    def inverse_transform(self, X):
+        """Inverse transform the data to its original space.
+
+        Parameters
+        ----------
+        X : array, shape (n_epochs, n_components, n_times)
+            The data to be inverted.
+
+        Returns
+        -------
+        X : array, shape (n_epochs, n_channels, n_times)
+            The transformed data.
+        """
+        return self._apply_method(X, 'inverse_transform')
+
+    def _apply_method(self, X, method):
+        """Vectorize time samples as trials, apply method and reshape back.
+
+        Parameters
+        ----------
+        X : array, shape (n_epochs, n_dims, n_times)
+            The data to be inverted.
+
+        Returns
+        -------
+        X : array, shape (n_epochs, n_dims, n_times)
             The transformed data.
         """
         n_epochs, n_channels, n_times = X.shape
         # trial as time samples
-        X = np.transpose(X, [1, 0, 2]).reshape([n_channels, n_epochs *
-                                                n_times]).T
-        X = self.estimator.transform(X)
+        X = np.transpose(X, [1, 0, 2])
+        X = np.reshape(X, [n_channels, n_epochs * n_times]).T
+        # apply method
+        method = getattr(self.estimator, method)
+        X = method(X)
+        # put it back to n_epochs, n_dimensions
         X = np.reshape(X.T, [-1, n_epochs, n_times]).transpose([1, 0, 2])
         return X
+
 
 
 class TemporalFilter(TransformerMixin):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -690,7 +690,6 @@ class UnsupervisedSpatialFilter(TransformerMixin, BaseEstimator):
         return X
 
 
-
 class TemporalFilter(TransformerMixin):
     """Estimator to filter data array along the last dimension.
 


### PR DESCRIPTION
This is a missing feature when we attempt to interpret the model of the following type of pipeline.

 ```python
clf = make_pipeline(UnsupervisedSpatialFilter(PCA()), Vectorizer(), LinearModel())
clf.fit(X=epochs.get_data(), y=epochs.events[:, 2])
patterns = get_coef(clf, 'patterns_', inverse_transform=True)
mne.EvokedArray(patterns, epochs.info).plot()
```