### PR TITLE
WIP: modified convert_forward_solution

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,7 +107,6 @@ Changelog
 
     - Add filtering functions :meth:`mne.Epochs.filter` and :meth:`mne.Evoked.filter`, as well as ``pad`` argument to :meth:`mne.io.Raw.filter`` by `Eric Larson`_
 
-
 BUG
 ~~~
 
@@ -238,6 +237,8 @@ API
     - Deprecate force_fixed and surf_ori in :func:`mne.forward.read_forward_solution` by `Daniel Strohmeier`_
 
     - :func:`mne.forward.convert_forward_solution` has a new argument ``use_cps``, which controls wether information on cortical patch statistics is applied while generating surface-oriented forward solutions with free and fixed orientation by `Daniel Strohmeier`_
+
+    - :func:`mne.forward.write_forward_solution` writes a forward solution as a forward solution with free orientation in X/Y/Z RAS coordinates if it is derived from a forward solution with free orientation and as a forward solution with fixed orientation in surface-based local coordinates otherwise by `Daniel Strohmeier`_
 
 
 .. _changes_0_14:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,6 +107,7 @@ Changelog
 
     - Add filtering functions :meth:`mne.Epochs.filter` and :meth:`mne.Evoked.filter`, as well as ``pad`` argument to :meth:`mne.io.Raw.filter`` by `Eric Larson`_
 
+
 BUG
 ~~~
 
@@ -233,6 +234,11 @@ API
     - The keyword argument ``frequencies`` has been deprecated in favor of ``freqs`` in various time-frequency functions, e.g. :func:`mne.time_frequency.tfr.tfr_array_morlet`, by `Eric Larson`_
 
     - Add ``patterns=False`` parameter in :class:`mne.decoding.ReceptiveField`. Turn on to compute inverse model coefficients, by `Nicolas Barascud`_
+
+    - Deprecate force_fixed and surf_ori in :func:`mne.forward.read_forward_solution` by `Daniel Strohmeier`_
+
+    - :func:`mne.forward.convert_forward_solution` has a new argument ``use_cps``, which controls wether information on cortical patch statistics is applied while generating surface-oriented forward solutions with free and fixed orientation by `Daniel Strohmeier`_
+
 
 .. _changes_0_14:
 

--- a/examples/forward/plot_forward_sensitivity_maps.py
+++ b/examples/forward/plot_forward_sensitivity_maps.py
@@ -28,7 +28,8 @@ fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
 subjects_dir = data_path + '/subjects'
 
 # Read the forward solutions with surface orientation
-fwd = mne.read_forward_solution(fwd_fname, surf_ori=True)
+fwd = mne.read_forward_solution(fwd_fname)
+fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
 leadfield = fwd['sol']['data']
 print("Leadfield size : %d x %d" % leadfield.shape)
 

--- a/examples/forward/plot_forward_sensitivity_maps.py
+++ b/examples/forward/plot_forward_sensitivity_maps.py
@@ -29,7 +29,7 @@ subjects_dir = data_path + '/subjects'
 
 # Read the forward solutions with surface orientation
 fwd = mne.read_forward_solution(fwd_fname)
-fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+fwd = mne.convert_forward_solution(fwd, surf_ori=True)
 leadfield = fwd['sol']['data']
 print("Leadfield size : %d x %d" % leadfield.shape)
 

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -40,8 +40,8 @@ evoked.crop(tmin=0.04, tmax=0.18)
 
 evoked = evoked.pick_types(eeg=False, meg=True)
 # Handling forward solution
-forward = mne.read_forward_solution(fwd_fname, surf_ori=True)
-
+forward = mne.read_forward_solution(fwd_fname)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 ###############################################################################
 # Auxiliary function to run the solver

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -87,14 +87,14 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     """
     # Import the necessary private functions
     from mne.inverse_sparse.mxne_inverse import \
-        (_prepare_gain, _to_fixed_ori, is_fixed_orient,
+        (_prepare_gain, is_fixed_orient,
          _reapply_source_weighting, _make_sparse_stc)
 
     all_ch_names = evoked.ch_names
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
-        forward = forward.copy()
-        _to_fixed_ori(forward)
+        forward = mne.convert_forward_solution(
+            forward, surf_ori=True, force_fixed=True, copy=True)
 
     # Handle depth weighting and whitening (here is no weights)
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -41,7 +41,7 @@ evoked.crop(tmin=0.04, tmax=0.18)
 evoked = evoked.pick_types(eeg=False, meg=True)
 # Handling forward solution
 forward = mne.read_forward_solution(fwd_fname)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 ###############################################################################
 # Auxiliary function to run the solver
@@ -94,7 +94,7 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
         forward = mne.convert_forward_solution(
-            forward, surf_ori=True, force_fixed=True, copy=True)
+            forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
 
     # Handle depth weighting and whitening (here is no weights)
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -43,9 +43,9 @@ evoked = evoked.pick_types(eeg=False, meg=True)
 forward = mne.read_forward_solution(fwd_fname)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
+
 ###############################################################################
 # Auxiliary function to run the solver
-
 def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     """Function to call a custom solver on evoked data
 

--- a/examples/inverse/plot_dics_beamformer.py
+++ b/examples/inverse/plot_dics_beamformer.py
@@ -53,7 +53,8 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 evoked = epochs.average()
 
 # Read forward operator
-forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Computing the data and noise cross-spectral density matrices
 # The time-frequency window was chosen on the basis of spectrograms from

--- a/examples/inverse/plot_dics_beamformer.py
+++ b/examples/inverse/plot_dics_beamformer.py
@@ -54,7 +54,7 @@ evoked = epochs.average()
 
 # Read forward operator
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Computing the data and noise cross-spectral density matrices
 # The time-frequency window was chosen on the basis of spectrograms from

--- a/examples/inverse/plot_dics_source_power.py
+++ b/examples/inverse/plot_dics_source_power.py
@@ -49,7 +49,7 @@ evoked = epochs.average()
 
 # Read forward operator
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Computing the data and noise cross-spectral density matrices
 # The time-frequency window was chosen on the basis of spectrograms from

--- a/examples/inverse/plot_dics_source_power.py
+++ b/examples/inverse/plot_dics_source_power.py
@@ -48,7 +48,8 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 evoked = epochs.average()
 
 # Read forward operator
-forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Computing the data and noise cross-spectral density matrices
 # The time-frequency window was chosen on the basis of spectrograms from

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -40,8 +40,8 @@ evoked = mne.read_evokeds(evoked_fname, condition=condition,
 evoked.crop(tmin=-50e-3, tmax=300e-3)
 
 # Read the forward solution
-forward = mne.read_forward_solution(fwd_fname, surf_ori=True,
-                                    force_fixed=False)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Read noise noise covariance matrix and regularize it
 cov = mne.read_cov(cov_fname)

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -40,7 +40,7 @@ evoked = mne.read_evokeds(evoked_fname, condition=condition,
 evoked.crop(tmin=-50e-3, tmax=300e-3)
 
 # Read the forward solution
-forward = mne.read_forward_solution(fname_fwd)
+forward = mne.read_forward_solution(fwd_fname)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read noise noise covariance matrix and regularize it

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -41,7 +41,7 @@ evoked.crop(tmin=-50e-3, tmax=300e-3)
 
 # Read the forward solution
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read noise noise covariance matrix and regularize it
 cov = mne.read_cov(cov_fname)

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -53,7 +53,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
 evoked = epochs.average()
 
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Compute regularized noise and data covariances
 noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk')

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -52,7 +52,8 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                     reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
 evoked = epochs.average()
 
-forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Compute regularized noise and data covariances
 noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk')

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -49,7 +49,7 @@ condition = 'Left Auditory'
 evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
 evoked.crop(tmin=0, tmax=0.3)
 # Handling forward solution
-forward = mne.read_forward_solution(fname_fwd)
+forward = mne.read_forward_solution(fwd_fname)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 ###############################################################################

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -50,7 +50,7 @@ evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
 evoked.crop(tmin=0, tmax=0.3)
 # Handling forward solution
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 ###############################################################################
 # Run solver

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -49,7 +49,8 @@ condition = 'Left Auditory'
 evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
 evoked.crop(tmin=0, tmax=0.3)
 # Handling forward solution
-forward = mne.read_forward_solution(fwd_fname, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 ###############################################################################
 # Run solver

--- a/examples/inverse/plot_mne_point_spread_function.py
+++ b/examples/inverse/plot_mne_point_spread_function.py
@@ -34,8 +34,8 @@ fname_label = [data_path + '/MEG/sample/labels/Aud-rh.label',
 
 
 # read forward solution
-forward = mne.read_forward_solution(fname_fwd, force_fixed=False,
-                                    surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # read inverse operators
 inverse_operator_eegmeg = read_inverse_operator(fname_inv_eegmeg)

--- a/examples/inverse/plot_mne_point_spread_function.py
+++ b/examples/inverse/plot_mne_point_spread_function.py
@@ -35,7 +35,7 @@ fname_label = [data_path + '/MEG/sample/labels/Aud-rh.label',
 
 # read forward solution
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # read inverse operators
 inverse_operator_eegmeg = read_inverse_operator(fname_inv_eegmeg)

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -40,7 +40,7 @@ evoked.crop(tmin=0.05, tmax=0.15)  # select N100
 evoked.pick_types(meg=True, eeg=False)
 
 # Read the forward solution
-forward = mne.read_forward_solution(fname_fwd)
+forward = mne.read_forward_solution(fwd_fname)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read noise covariance matrix

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -40,8 +40,8 @@ evoked.crop(tmin=0.05, tmax=0.15)  # select N100
 evoked.pick_types(meg=True, eeg=False)
 
 # Read the forward solution
-forward = mne.read_forward_solution(fwd_fname, surf_ori=True,
-                                    force_fixed=False)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Read noise covariance matrix
 noise_cov = mne.read_cov(cov_fname)

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -41,7 +41,7 @@ evoked.pick_types(meg=True, eeg=False)
 
 # Read the forward solution
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read noise covariance matrix
 noise_cov = mne.read_cov(cov_fname)

--- a/examples/inverse/plot_tf_dics.py
+++ b/examples/inverse/plot_tf_dics.py
@@ -84,7 +84,7 @@ epochs_noise = epochs_noise[:len(epochs.events)]
 
 # Read forward operator
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read label
 label = mne.read_label(fname_label)

--- a/examples/inverse/plot_tf_dics.py
+++ b/examples/inverse/plot_tf_dics.py
@@ -83,7 +83,8 @@ epochs_noise.apply_proj()
 epochs_noise = epochs_noise[:len(epochs.events)]
 
 # Read forward operator
-forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Read label
 label = mne.read_label(fname_label)

--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -93,7 +93,7 @@ epochs_noise = epochs_noise[:len(epochs.events)]
 
 # Read forward operator
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Read label
 label = mne.read_label(fname_label)

--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -92,7 +92,8 @@ epochs_noise = mne.Epochs(raw_noise, events_noise, event_id, tmin, tmax,
 epochs_noise = epochs_noise[:len(epochs.events)]
 
 # Read forward operator
-forward = mne.read_forward_solution(fname_fwd, surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 # Read label
 label = mne.read_label(fname_label)

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -66,7 +66,7 @@ evoked.crop(tmin=-0.1, tmax=0.4)
 
 # Handling forward solution
 forward = mne.read_forward_solution(fname_fwd)
-forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
+forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 ###############################################################################
 # Run solver

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -65,7 +65,7 @@ evoked = mne.pick_channels_evoked(evoked)
 evoked.crop(tmin=-0.1, tmax=0.4)
 
 # Handling forward solution
-forward = mne.read_forward_solution(fname_fwd)
+forward = mne.read_forward_solution(fwd_fname)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 ###############################################################################

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -65,8 +65,8 @@ evoked = mne.pick_channels_evoked(evoked)
 evoked.crop(tmin=-0.1, tmax=0.4)
 
 # Handling forward solution
-forward = mne.read_forward_solution(fwd_fname, force_fixed=False,
-                                    surf_ori=True)
+forward = mne.read_forward_solution(fname_fwd)
+forward = mne.convert_forward_solution(forward, surf_ori=True, use_cps=True)
 
 ###############################################################################
 # Run solver

--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -34,8 +34,7 @@ ave_fname = data_path + '/MEG/sample/sample_audvis-no-filter-ave.fif'
 cov_fname = data_path + '/MEG/sample/sample_audvis-cov.fif'
 
 fwd = mne.read_forward_solution(fwd_fname)
-fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
-								   use_cps=True)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
 cov = mne.read_cov(cov_fname)
 info = mne.io.read_info(ave_fname)

--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -35,7 +35,7 @@ cov_fname = data_path + '/MEG/sample/sample_audvis-cov.fif'
 
 fwd = mne.read_forward_solution(fwd_fname)
 fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
-								   use_cps=False)
+                                   use_cps=False)
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
 cov = mne.read_cov(cov_fname)
 info = mne.io.read_info(ave_fname)

--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -33,7 +33,9 @@ fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
 ave_fname = data_path + '/MEG/sample/sample_audvis-no-filter-ave.fif'
 cov_fname = data_path + '/MEG/sample/sample_audvis-cov.fif'
 
-fwd = mne.read_forward_solution(fwd_fname, force_fixed=True, surf_ori=True)
+fwd = mne.read_forward_solution(fwd_fname)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
+								   use_cps=True)
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
 cov = mne.read_cov(cov_fname)
 info = mne.io.read_info(ave_fname)

--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -34,7 +34,8 @@ ave_fname = data_path + '/MEG/sample/sample_audvis-no-filter-ave.fif'
 cov_fname = data_path + '/MEG/sample/sample_audvis-cov.fif'
 
 fwd = mne.read_forward_solution(fwd_fname)
-fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
+								   use_cps=False)
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
 cov = mne.read_cov(cov_fname)
 info = mne.io.read_info(ave_fname)

--- a/examples/visualization/plot_ssp_projs_sensitivity_map.py
+++ b/examples/visualization/plot_ssp_projs_sensitivity_map.py
@@ -25,7 +25,7 @@ fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
 ecg_fname = data_path + '/MEG/sample/sample_audvis_ecg-proj.fif'
 
 fwd = read_forward_solution(fname)
-fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+fwd = convert_forward_solution(fwd, surf_ori=True)
 
 projs = read_proj(ecg_fname)
 # take only one projection per channel type

--- a/examples/visualization/plot_ssp_projs_sensitivity_map.py
+++ b/examples/visualization/plot_ssp_projs_sensitivity_map.py
@@ -13,7 +13,7 @@ similar to the first SSP vector correcting for ECG.
 import matplotlib.pyplot as plt
 
 from mne import (read_forward_solution, read_proj, sensitivity_map,
-				 convert_forward_solution)
+                 convert_forward_solution)
 from mne.datasets import sample
 
 print(__doc__)

--- a/examples/visualization/plot_ssp_projs_sensitivity_map.py
+++ b/examples/visualization/plot_ssp_projs_sensitivity_map.py
@@ -12,7 +12,8 @@ similar to the first SSP vector correcting for ECG.
 
 import matplotlib.pyplot as plt
 
-from mne import read_forward_solution, read_proj, sensitivity_map
+from mne import (read_forward_solution, read_proj, sensitivity_map,
+				 convert_forward_solution)
 from mne.datasets import sample
 
 print(__doc__)
@@ -23,7 +24,9 @@ subjects_dir = data_path + '/subjects'
 fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
 ecg_fname = data_path + '/MEG/sample/sample_audvis_ecg-proj.fif'
 
-fwd = read_forward_solution(fname, surf_ori=True)
+fwd = read_forward_solution(fname)
+fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+
 projs = read_proj(ecg_fname)
 # take only one projection per channel type
 projs = projs[::2]

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -46,7 +46,7 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
         forward_surf_ori = _read_forward_solution_meg(
             fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(
-            fname_fwd, force_fixed=True)
+            fname_fwd, force_fixed=True, use_cps=False)
         forward_vol = mne.read_forward_solution(fname_fwd_vol)
         forward_vol = mne.convert_forward_solution(forward_vol, surf_ori=True)
     else:

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -44,7 +44,7 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
     if read_all_forward:
         forward_surf_ori = _read_forward_solution_meg(fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(fname_fwd, force_fixed=True,
-                                                   surf_ori=True)
+                                                   use_cps=False)
         forward_vol = mne.read_forward_solution(fname_fwd_vol, surf_ori=True)
     else:
         forward_surf_ori = None

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -30,7 +30,8 @@ fname_label = op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-lh.label')
 
 
 def _read_forward_solution_meg(*args, **kwargs):
-    fwd = mne.forward.forward._read_forward_solution(*args, **kwargs)
+    fwd = mne.read_forward_solution(*args)
+    fwd = mne.convert_forward_solution(fwd, **kwargs)
     return mne.pick_types_forward(fwd, meg=True, eeg=False)
 
 
@@ -42,10 +43,13 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
     raw.add_proj([], remove_existing=True)  # we'll subselect so remove proj
     forward = mne.read_forward_solution(fname_fwd)
     if read_all_forward:
-        forward_surf_ori = _read_forward_solution_meg(fname_fwd, surf_ori=True)
-        forward_fixed = _read_forward_solution_meg(fname_fwd, force_fixed=True,
+        forward_surf_ori = _read_forward_solution_meg(
+            fname_fwd, surf_ori=True, use_cps=True)
+        forward_fixed = _read_forward_solution_meg(
+            fname_fwd, force_fixed=True, use_cps=False)
+        forward_vol = mne.read_forward_solution(fname_fwd_vol)
+        forward_vol = mne.convert_forward_solution(forward_vol, surf_ori=True,
                                                    use_cps=False)
-        forward_vol = mne.read_forward_solution(fname_fwd_vol, surf_ori=True)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -30,7 +30,7 @@ fname_label = op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-lh.label')
 
 
 def _read_forward_solution_meg(*args, **kwargs):
-    fwd = mne.read_forward_solution(*args, **kwargs)
+    fwd = mne.forward.forward._read_forward_solution(*args, **kwargs)
     return mne.pick_types_forward(fwd, meg=True, eeg=False)
 
 

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -44,12 +44,11 @@ def _get_data(tmin=-0.11, tmax=0.15, read_all_forward=True, compute_csds=True):
     forward = mne.read_forward_solution(fname_fwd)
     if read_all_forward:
         forward_surf_ori = _read_forward_solution_meg(
-            fname_fwd, surf_ori=True, use_cps=True)
+            fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(
-            fname_fwd, force_fixed=True, use_cps=False)
+            fname_fwd, force_fixed=True)
         forward_vol = mne.read_forward_solution(fname_fwd_vol)
-        forward_vol = mne.convert_forward_solution(forward_vol, surf_ori=True,
-                                                   use_cps=False)
+        forward_vol = mne.convert_forward_solution(forward_vol, surf_ori=True)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -47,11 +47,11 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     forward = mne.read_forward_solution(fname_fwd)
     if all_forward:
         forward_surf_ori = _read_forward_solution_meg(
-            fname_fwd, surf_ori=True, use_cps=True)
+            fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(
-            fname_fwd, force_fixed=True, surf_ori=True, use_cps=True)
+            fname_fwd, force_fixed=True, surf_ori=True)
         forward_vol = _read_forward_solution_meg(
-            fname_fwd_vol, surf_ori=True, use_cps=False)
+            fname_fwd_vol, surf_ori=True)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -33,7 +33,8 @@ warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
 def _read_forward_solution_meg(*args, **kwargs):
-    fwd = mne.read_forward_solution(*args, **kwargs)
+    fwd = mne.read_forward_solution(*args)
+    fwd = mne.convert_forward_solution(fwd, **kwargs)
     return mne.pick_types_forward(fwd, meg=True, eeg=False)
 
 
@@ -45,10 +46,12 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     raw = mne.io.read_raw_fif(fname_raw, preload=True)
     forward = mne.read_forward_solution(fname_fwd)
     if all_forward:
-        forward_surf_ori = _read_forward_solution_meg(fname_fwd, surf_ori=True)
-        forward_fixed = _read_forward_solution_meg(fname_fwd, force_fixed=True,
-                                                   surf_ori=True)
-        forward_vol = _read_forward_solution_meg(fname_fwd_vol, surf_ori=True)
+        forward_surf_ori = _read_forward_solution_meg(
+            fname_fwd, surf_ori=True, use_cps=True)
+        forward_fixed = _read_forward_solution_meg(
+            fname_fwd, force_fixed=True, surf_ori=True, use_cps=True)
+        forward_vol = _read_forward_solution_meg(
+            fname_fwd_vol, surf_ori=True, use_cps=False)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -49,9 +49,8 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
         forward_surf_ori = _read_forward_solution_meg(
             fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(
-            fname_fwd, force_fixed=True, surf_ori=True)
-        forward_vol = _read_forward_solution_meg(
-            fname_fwd_vol, surf_ori=True)
+            fname_fwd, force_fixed=True, surf_ori=True, use_cps=False)
+        forward_vol = _read_forward_solution_meg(fname_fwd_vol, surf_ori=True)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -50,7 +50,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
             fname_fwd, surf_ori=True)
         forward_fixed = _read_forward_solution_meg(
             fname_fwd, force_fixed=True, surf_ori=True, use_cps=False)
-        forward_vol = _read_forward_solution_meg(fname_fwd_vol, surf_ori=True)
+        forward_vol = _read_forward_solution_meg(fname_fwd_vol)
     else:
         forward_surf_ori = None
         forward_fixed = None

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -122,10 +122,9 @@ def test_rap_music_simulated():
     evoked, noise_cov = _get_data(ch_decim=16)
     forward = mne.read_forward_solution(fname_fwd)
     forward = mne.pick_channels_forward(forward, evoked.ch_names)
-    forward_surf_ori = mne.convert_forward_solution(forward, surf_ori=True,
-                                                    use_cps=True)
+    forward_surf_ori = mne.convert_forward_solution(forward, surf_ori=True)
     forward_fixed = mne.convert_forward_solution(forward, force_fixed=True,
-                                                 surf_ori=True, use_cps=True)
+                                                 surf_ori=True)
 
     n_dipoles = 2
     sim_evoked, stc = simu_data(evoked, forward_fixed, noise_cov,

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -124,7 +124,7 @@ def test_rap_music_simulated():
     forward = mne.pick_channels_forward(forward, evoked.ch_names)
     forward_surf_ori = mne.convert_forward_solution(forward, surf_ori=True)
     forward_fixed = mne.convert_forward_solution(forward, force_fixed=True,
-                                                 surf_ori=True)
+                                                 surf_ori=True, use_cps=True)
 
     n_dipoles = 2
     sim_evoked, stc = simu_data(evoked, forward_fixed, noise_cov,

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -122,9 +122,10 @@ def test_rap_music_simulated():
     evoked, noise_cov = _get_data(ch_decim=16)
     forward = mne.read_forward_solution(fname_fwd)
     forward = mne.pick_channels_forward(forward, evoked.ch_names)
-    forward_surf_ori = mne.convert_forward_solution(forward, surf_ori=True)
+    forward_surf_ori = mne.convert_forward_solution(forward, surf_ori=True,
+                                                    use_cps=True)
     forward_fixed = mne.convert_forward_solution(forward, force_fixed=True,
-                                                 surf_ori=True)
+                                                 surf_ori=True, use_cps=True)
 
     n_dipoles = 2
     sim_evoked, stc = simu_data(evoked, forward_fixed, noise_cov,

--- a/mne/forward/__init__.py
+++ b/mne/forward/__init__.py
@@ -10,8 +10,7 @@ from .forward import (Forward, read_forward_solution, write_forward_solution,
                       _restrict_gain_matrix, _stc_src_sel,
                       _fill_measurement_info, _apply_forward,
                       _subject_from_forward, convert_forward_solution,
-                      _to_fixed_ori, _merge_meg_eeg_fwds,
-                      _do_forward_solution)
+                      _merge_meg_eeg_fwds, _do_forward_solution)
 from ._make_forward import (make_forward_solution, _prepare_for_forward,
                             _prep_meg_channels, _prep_eeg_channels,
                             _to_forward_dict, _create_meg_coils,

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -682,7 +682,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
                                 verbose=verbose)
     # Convert from free orientations to fixed (in-place)
     convert_forward_solution(fwd, surf_ori=False, force_fixed=True,
-                             copy=False, verbose=None)
+                             copy=False, verbose=None, use_cps=True)
 
     # Check for omissions due to proximity to inner skull in
     # make_forward_solution, which will result in an exception

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -682,7 +682,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
                                 verbose=verbose)
     # Convert from free orientations to fixed (in-place)
     convert_forward_solution(fwd, surf_ori=False, force_fixed=True,
-                             copy=False, verbose=None, use_cps=True)
+                             copy=False, verbose=None)
 
     # Check for omissions due to proximity to inner skull in
     # make_forward_solution, which will result in an exception

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -682,7 +682,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
                                 verbose=verbose)
     # Convert from free orientations to fixed (in-place)
     convert_forward_solution(fwd, surf_ori=False, force_fixed=True,
-                             copy=False, verbose=None)
+                             copy=False, use_cps=False, verbose=None)
 
     # Check for omissions due to proximity to inner skull in
     # make_forward_solution, which will result in an exception

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -560,8 +560,8 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
                                  force_fixed=force_fixed, copy=False)
     else:
         if is_fixed_orient(fwd, orig=True):
-            fwd['source_nn'] = np.concatenate([s['nn'][s['vertno'], :]
-                                           for s in fwd['src']], axis=0)
+            fwd['source_nn'] = np.concatenate([_src['nn'][_src['vertno'], :]
+                                              for _src in fwd['src']], axis=0)
             fwd['source_ori'] = FIFF.FIFFV_MNE_FIXED_ORI
             fwd['surf_ori'] = True
         else:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -556,7 +556,8 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
             surf_ori = False
         if force_fixed is None:
             force_fixed = False
-        convert_forward_solution(fwd, surf_ori, force_fixed, copy=False)
+        convert_forward_solution(fwd, surf_ori=surf_ori,
+                                 force_fixed=force_fixed, copy=False)
     else:
         if is_fixed_orient(fwd, orig=True):
             fwd['source_nn'] = np.concatenate([s['nn'][s['vertno'], :]
@@ -606,11 +607,12 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
     if use_cps is None:
         if force_fixed:
             use_cps = False
-            warn('The application of cortical patch statistics (cps) will be '
-                 'modified in 0.16. The cps (if available) will then be '
-                 'applied by default for both generating forward operators '
-                 'with fixed orientations and surface-oriented forward '
-                 'operators with free orientations.', FutureWarning)
+            warn('The default settings controlling the the application of '
+                 'cortical patch statistics (cps) in the creation of forward '
+                 'operators with fixed orientation will be modified in 0.16. '
+                 'The cps (if available) will then be applied by default. '
+                 'To avoid this warning, set use_cps explicitly to False (the '
+                 'current default) or True (the new default).', FutureWarning)
         else:
             use_cps = True
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -380,7 +380,7 @@ def _merge_meg_eeg_fwds(megfwd, eegfwd, verbose=None):
 
 @verbose
 def read_forward_solution(fname, force_fixed=False, surf_ori=False,
-                          include=[], exclude=[], verbose=None):
+                          use_cps=True, include=[], exclude=[], verbose=None):
     """Read a forward solution a.k.a. lead field.
 
     Parameters
@@ -392,6 +392,9 @@ def read_forward_solution(fname, force_fixed=False, surf_ori=False,
     surf_ori : bool, optional (default False)
         Use surface-based source coordinate system? Note that force_fixed=True
         implies surf_ori=True.
+    use_cps : bool
+        Whether to use cortical patch statistics to define normal
+        orientations.
     include : list, optional
         List of names of channels to include. If empty all channels
         are included.
@@ -538,7 +541,8 @@ def read_forward_solution(fname, force_fixed=False, surf_ori=False,
     # deal with transformations, storing orig copies so transforms can be done
     # as necessary later
     fwd['_orig_source_ori'] = fwd['source_ori']
-    convert_forward_solution(fwd, surf_ori, force_fixed, copy=False)
+    convert_forward_solution(fwd, surf_ori, force_fixed, copy=False,
+                             use_cps=use_cps)
     fwd = pick_channels_forward(fwd, include=include, exclude=exclude)
 
     return Forward(fwd)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -803,7 +803,8 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
     else:
         sol_grad = None
 
-    if fwd['surf_ori'] is True and fwd['source_ori'] == FIFF.FIFFV_MNE_FREE_ORI:
+    if (fwd['surf_ori'] is True and
+            fwd['source_ori'] == FIFF.FIFFV_MNE_FREE_ORI):
         inv_rot = _inv_block_diag(fwd['source_nn'].T, 3)
         sol = sol * inv_rot
         if sol_grad is not None:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -410,6 +410,12 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
     See Also
     --------
     write_forward_solution, make_forward_solution
+
+    .. note:: Forward solutions with free orientation are always stored on disk
+              in X/Y/Z RAS coordinates. To obtain surface-oriented forward
+              operators after reading the forward solution with
+              read_forward_solution, please apply convert_forward_solution
+              with surf_ori=True.
     """
     if force_fixed is not None:
         warn('force_fixed is deprecated and will be removed in 0.16. '
@@ -778,6 +784,13 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
     See Also
     --------
     read_forward_solution
+
+    .. note:: Forward solutions with free orientation are always stored on disk
+              in X/Y/Z RAS coordinates. Transformations to surface-based local
+              coordinates (surface orientation) will be inverted. To obtain
+              surface-oriented forward operators after reading the forward
+              solution with read_forward_solution, please apply
+              convert_forward_solution with surf_ori=True.
     """
     check_fname(fname, 'forward', ('-fwd.fif', '-fwd.fif.gz'))
 
@@ -848,6 +861,13 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
 
     if (fwd['surf_ori'] is True and
             fwd['source_ori'] == FIFF.FIFFV_MNE_FREE_ORI):
+        warn('Please note that forward solutions with free orientation are '
+             'always stored on disk in X/Y/Z RAS coordinates. The '
+             'transformation to surface-based local coordinates '
+             '(surface orientation) is inverted now. To obtain a '
+             'surface-oriented forward operator after reading the forward '
+             'solution with read_forward_solution, please apply '
+             'convert_forward_solution with surf_ori=True.', RuntimeWarning)
         inv_rot = _inv_block_diag(fwd['source_nn'].T, 3)
         sol = sol * inv_rot
         if sol_grad is not None:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -556,12 +556,7 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
             surf_ori = False
         if force_fixed is None:
             force_fixed = False
-        if force_fixed:
-            use_cps = False
-        else:
-            use_cps = True
-        convert_forward_solution(fwd, surf_ori, force_fixed, copy=False,
-                                 use_cps=use_cps)
+        convert_forward_solution(fwd, surf_ori, force_fixed, copy=False)
     else:
         if is_fixed_orient(fwd, orig=True):
             fwd['source_nn'] = np.concatenate([s['nn'][s['vertno'], :]
@@ -609,13 +604,15 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
         The modified forward solution.
     """
     if use_cps is None:
-        warn('The application of cortical patch statistics (cps) will be '
-             'modified in 0.16. The cps (if available) will then be '
-             'applied by default for both generating forward operators with '
-             'fixed orientations and surface-oriented forward operators with '
-             'free orientations.', FutureWarning)
         if force_fixed:
             use_cps = False
+            warn('The application of cortical patch statistics (cps) will be '
+                 'modified in 0.16. The cps (if available) will then be '
+                 'applied by default for both generating forward operators '
+                 'with fixed orientations and surface-oriented forward '
+                 'operators with free orientations.', FutureWarning)
+        else:
+            use_cps = True
 
     fwd = fwd.copy() if copy else fwd
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -379,8 +379,9 @@ def _merge_meg_eeg_fwds(megfwd, eegfwd, verbose=None):
 
 
 @verbose
-def read_forward_solution(fname, force_fixed=False, surf_ori=False,
-                          use_cps=True, include=[], exclude=[], verbose=None):
+def _read_forward_solution(fname, force_fixed=False, surf_ori=False,
+                           use_cps=True, include=[], exclude=[],
+                           verbose=None):
     """Read a forward solution a.k.a. lead field.
 
     Parameters
@@ -394,7 +395,7 @@ def read_forward_solution(fname, force_fixed=False, surf_ori=False,
         implies surf_ori=True.
     use_cps : bool
         Whether to use cortical patch statistics to define normal
-        orientations.
+        orientations. Only used when surf_ori and/or force_fixed are True.
     include : list, optional
         List of names of channels to include. If empty all channels
         are included.
@@ -541,16 +542,54 @@ def read_forward_solution(fname, force_fixed=False, surf_ori=False,
     # deal with transformations, storing orig copies so transforms can be done
     # as necessary later
     fwd['_orig_source_ori'] = fwd['source_ori']
-    convert_forward_solution(fwd, surf_ori, force_fixed, copy=False,
-                             use_cps=use_cps)
+    _convert_forward_solution(fwd, surf_ori, force_fixed, copy=False,
+                              use_cps=use_cps)
     fwd = pick_channels_forward(fwd, include=include, exclude=exclude)
 
     return Forward(fwd)
 
 
+def read_forward_solution(fname, force_fixed=False, surf_ori=False,
+                          include=[], exclude=[], verbose=None):
+    """Read a forward solution a.k.a. lead field.
+
+    Parameters
+    ----------
+    fname : string
+        The file name, which should end with -fwd.fif or -fwd.fif.gz.
+    force_fixed : bool, optional (default False)
+        Force fixed source orientation mode?
+    surf_ori : bool, optional (default False)
+        Use surface-based source coordinate system? Note that force_fixed=True
+        implies surf_ori=True.
+    include : list, optional
+        List of names of channels to include. If empty all channels
+        are included.
+    exclude : list, optional
+        List of names of channels to exclude. If empty include all
+        channels.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    fwd : instance of Forward
+        The forward solution.
+
+    See Also
+    --------
+    write_forward_solution, make_forward_solution
+    """
+    return _read_forward_solution(fname, force_fixed=force_fixed,
+                                  surf_ori=surf_ori, use_cps=True,
+                                  include=include, exclude=exclude,
+                                  verbose=verbose)
+
+
 @verbose
-def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
-                             copy=True, use_cps=True, verbose=None):
+def _convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
+                              copy=True, use_cps=True, verbose=None):
     """Convert forward solution between different source orientations.
 
     Parameters
@@ -566,7 +605,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
         Whether to return a new instance or modify in place.
     use_cps : bool
         Whether to use cortical patch statistics to define normal
-        orientations.
+        orientations. Only used when surf_ori and/or force_fixed are True.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -681,6 +720,36 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
     logger.info('    [done]')
 
     return fwd
+
+
+@verbose
+def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
+                             copy=True, verbose=None):
+    """Convert forward solution between different source orientations.
+
+    Parameters
+    ----------
+    fwd : Forward
+        The forward solution to modify.
+    surf_ori : bool, optional (default False)
+        Use surface-based source coordinate system? Note that force_fixed=True
+        implies surf_ori=True.
+    force_fixed : bool, optional (default False)
+        Force fixed source orientation mode?
+    copy : bool
+        Whether to return a new instance or modify in place.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    fwd : Forward
+        The modified forward solution.
+    """
+    return _convert_forward_solution(fwd, surf_ori=surf_ori,
+                                     force_fixed=force_fixed, copy=copy,
+                                     use_cps=True, verbose=verbose)
 
 
 @verbose

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -565,11 +565,6 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
             fwd['surf_ori'] = True
         else:
             fwd['source_nn'] = np.kron(np.ones((fwd['nsource'], 1)), np.eye(3))
-            fwd['sol']['data'] = fwd['_orig_sol'].copy()
-            fwd['sol']['ncol'] = 3 * fwd['nsource']
-            if fwd['sol_grad'] is not None:
-                fwd['sol_grad']['data'] = fwd['_orig_sol_grad'].copy()
-                fwd['sol_grad']['ncol'] = 3 * fwd['nsource']
             fwd['source_ori'] = FIFF.FIFFV_MNE_FREE_ORI
             fwd['surf_ori'] = False
     return Forward(fwd)
@@ -702,7 +697,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
             if fwd['sol_grad'] is not None:
                 x = sparse.block_diag([surf_rot] * 3)
                 fwd['sol_grad']['data'] = fwd['_orig_sol_grad'] * x  # dot prod
-                fwd['sol_grad']['ncol'] = 3 * fwd['nsource']
+                fwd['sol_grad']['ncol'] = 9 * fwd['nsource']
             fwd['source_ori'] = FIFF.FIFFV_MNE_FREE_ORI
             fwd['surf_ori'] = True
 
@@ -713,7 +708,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
         fwd['sol']['ncol'] = 3 * fwd['nsource']
         if fwd['sol_grad'] is not None:
             fwd['sol_grad']['data'] = fwd['_orig_sol_grad'].copy()
-            fwd['sol_grad']['ncol'] = 3 * fwd['nsource']
+            fwd['sol_grad']['ncol'] = 9 * fwd['nsource']
         fwd['source_ori'] = FIFF.FIFFV_MNE_FREE_ORI
         fwd['surf_ori'] = False
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -628,7 +628,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     fwd = fwd.copy() if copy else fwd
 
-    if force_fixed:
+    if force_fixed is True:
         surf_ori = True
 
     if any([src['type'] == 'vol' for src in fwd['src']]) and force_fixed:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -518,12 +518,11 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
         raise ValueError('Only forward solutions computed in MRI or head '
                          'coordinates are acceptable')
 
-    nuse = 0
-
     # Transform each source space to the HEAD or MRI coordinate frame,
     # depending on the coordinate frame of the forward solution
     # NOTE: the function transform_surface_to will also work on discrete and
     # volume sources
+    nuse = 0
     for s in src:
         try:
             s = transform_surface_to(s, fwd['coord_frame'], mri_head_t)
@@ -809,7 +808,7 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
     else:
         sol_grad = None
 
-    if fwd['surf_ori'] is True:
+    if fwd['surf_ori'] is True and fwd['source_ori'] == FIFF.FIFFV_MNE_FREE_ORI:
         inv_rot = _inv_block_diag(fwd['source_nn'].T, 3)
         sol = sol * inv_rot
         if sol_grad is not None:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -859,10 +859,10 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
             warn('This forward solution is based on a forward solution with '
                  'free orientation. The original forward solution is stored '
                  'on disk in X/Y/Z RAS coordinates. Any transformation '
-                 '(surface orientation or fixed orientation) will be reverted. '
-                 'To reapply any transformation to the forward operator '
-                 'please apply convert_forward_solution after reading the '
-                 'forward solution with read_forward_solution.',
+                 '(surface orientation or fixed orientation) will be '
+                 'reverted. To reapply any transformation to the forward '
+                 'operator please apply convert_forward_solution after '
+                 'reading the forward solution with read_forward_solution.',
                  RuntimeWarning)
 
     #

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -411,11 +411,12 @@ def read_forward_solution(fname, force_fixed=None, surf_ori=None,
     --------
     write_forward_solution, make_forward_solution
 
-    .. note:: Forward solutions with free orientation are always stored on disk
-              in X/Y/Z RAS coordinates. To obtain surface-oriented forward
-              operators after reading the forward solution with
-              read_forward_solution, please apply convert_forward_solution
-              with surf_ori=True.
+    Notes
+    -----
+    Forward solutions with free orientation are always stored on disk in
+    X/Y/Z RAS coordinates. To obtain surface-oriented forward operators after
+    reading the forward solution with :func:`read_forward_solution`, please
+    apply :func:`convert_forward_solution` with surf_ori=True.
     """
     if force_fixed is not None:
         warn('force_fixed is deprecated and will be removed in 0.16. '
@@ -785,12 +786,14 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
     --------
     read_forward_solution
 
-    .. note:: Forward solutions with free orientation are always stored on disk
-              in X/Y/Z RAS coordinates. Transformations to surface-based local
-              coordinates (surface orientation) will be inverted. To obtain
-              surface-oriented forward operators after reading the forward
-              solution with read_forward_solution, please apply
-              convert_forward_solution with surf_ori=True.
+    Notes
+    -----
+    Forward solutions with free orientation are always stored on disk in X/Y/Z
+    RAS coordinates. Transformations to surface-based local coordinates
+    (surface orientation) will be inverted. To obtain surface-oriented forward
+    operators after reading the forward solution with
+    :func:`read_forward_solution`, please apply
+    :func:`convert_forward_solution` with surf_ori=True.
     """
     check_fname(fname, 'forward', ('-fwd.fif', '-fwd.fif.gz'))
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -593,7 +593,8 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
         nuse_total = sum([s['nuse'] for s in fwd['src']])
         fwd['source_nn'] = np.empty((3 * nuse_total, 3), dtype=np.float)
         logger.info('    Converting to surface-based source orientations...')
-        if fwd['src'][0]['patch_inds'] is not None:
+        if ('patch_inds' in fwd['src'][0] and
+                fwd['src'][0]['patch_inds'] is not None):
             use_ave_nn = True
             logger.info('    Average patch normals will be employed in the '
                         'rotation to the local surface coordinates....')
@@ -809,19 +810,6 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
 
     end_block(fid, FIFF.FIFFB_MNE)
     end_file(fid)
-
-
-def _to_fixed_ori(forward):
-    """Convert the forward solution to fixed ori from free."""
-    if not forward['surf_ori'] or is_fixed_orient(forward):
-        raise ValueError('Only surface-oriented, free-orientation forward '
-                         'solutions can be converted to fixed orientaton')
-    forward['sol']['data'] = forward['sol']['data'][:, 2::3]
-    forward['sol']['ncol'] = forward['sol']['ncol'] / 3
-    forward['source_ori'] = FIFF.FIFFV_MNE_FIXED_ORI
-    logger.info('    Converted the forward solution into the '
-                'fixed-orientation mode.')
-    return forward
 
 
 def is_fixed_orient(forward, orig=False):

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -668,7 +668,6 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     elif surf_ori:  # Free, surf-oriented
         #   Rotate the local source coordinate systems
-        nuse_total = sum([s['nuse'] for s in fwd['src']])
         fwd['source_nn'] = np.kron(np.ones((fwd['nsource'], 1)), np.eye(3))
         logger.info('    Converting to surface-based source orientations...')
         if (use_cps and 'patch_inds' in fwd['src'][0] and
@@ -902,11 +901,13 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
 def is_fixed_orient(forward, orig=False):
     """Check if the forward operator is fixed orientation."""
     if orig:  # if we want to know about the original version
-        fixed_ori = ((forward['_orig_source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI) or
-                     (forward['_orig_source_ori'] == FIFF.FIFFV_MNE_FIXED_CPS_ORI))
+        fixed_ori = (
+            (forward['_orig_source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI) or
+            (forward['_orig_source_ori'] == FIFF.FIFFV_MNE_FIXED_CPS_ORI))
     else:  # most of the time we want to know about the current version
-        fixed_ori = ((forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI) or
-                     (forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_CPS_ORI))
+        fixed_ori = (
+            (forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI) or
+            (forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_CPS_ORI))
     return fixed_ori
 
 

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -145,10 +145,13 @@ def test_io_forward():
                                    use_cps=False)
     write_forward_solution(fname_temp, fwd, overwrite=True)
     fwd_read = read_forward_solution(fname_temp)
+    fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
+                                        force_fixed=True, use_cps=False)
     assert_true(repr(fwd_read))
     assert_true(isinstance(fwd_read, Forward))
     assert_true(is_fixed_orient(fwd_read))
     compare_forwards(fwd, fwd_read)
+
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=True)
     leadfield = fwd['sol']['data']
@@ -160,6 +163,8 @@ def test_io_forward():
     assert_true(fwd['surf_ori'])
     write_forward_solution(fname_temp, fwd, overwrite=True)
     fwd_read = read_forward_solution(fname_temp)
+    fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
+                                        force_fixed=True, use_cps=True)
     assert_true(repr(fwd_read))
     assert_true(isinstance(fwd_read, Forward))
     assert_true(is_fixed_orient(fwd_read))
@@ -177,6 +182,8 @@ def test_io_forward():
     assert_true(fwd['surf_ori'])
     write_forward_solution(fname_temp, fwd, overwrite=True)
     fwd_read = read_forward_solution(fname_temp)
+    fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
+                                        force_fixed=True, use_cps=True)
     assert_true(repr(fwd_read))
     assert_true(isinstance(fwd_read, Forward))
     assert_true(is_fixed_orient(fwd_read))
@@ -298,6 +305,8 @@ def test_restrict_forward_to_stc():
     fname_copy = op.join(temp_dir, 'copy-fwd.fif')
     write_forward_solution(fname_copy, fwd_out, overwrite=True)
     fwd_out_read = read_forward_solution(fname_copy)
+    fwd_out_read = convert_forward_solution(fwd_out_read, surf_ori=True,
+                                            force_fixed=False)
     compare_forwards(fwd_out, fwd_out_read)
 
 

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -43,7 +43,7 @@ def compare_forwards(f1, f2):
     assert_allclose(f1['sol']['data'], f2['sol']['data'])
     assert_equal(f1['sol']['ncol'], f2['sol']['ncol'])
     assert_equal(f1['sol']['ncol'], f1['sol']['data'].shape[1])
-    assert_allclose(f1['source_nn'], f2['source_nn'], atol=1e-6, rtol=0.0)
+    assert_allclose(f1['source_nn'], f2['source_nn'])
     if f1['sol_grad'] is not None:
         assert_true(f2['sol_grad'] is not None)
         assert_allclose(f1['sol_grad']['data'], f2['sol_grad']['data'])
@@ -140,7 +140,7 @@ def test_io_forward():
     assert_true('mri_head_t' in fwd_read)
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
-    fwd = read_forward_solution(fname_meeg_grad)
+    fwd = read_forward_solution(fname_meeg)
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=False)
     write_forward_solution(fname_temp, fwd, overwrite=True)
@@ -149,6 +149,23 @@ def test_io_forward():
     assert_true(isinstance(fwd_read, Forward))
     assert_true(is_fixed_orient(fwd_read))
     compare_forwards(fwd, fwd_read)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
+    leadfield = fwd['sol']['data']
+    assert_equal(leadfield.shape, (n_channels, 1494 / 3))
+    assert_equal(len(fwd['sol']['row_names']), n_channels)
+    assert_equal(len(fwd['info']['chs']), n_channels)
+    assert_true('dev_head_t' in fwd['info'])
+    assert_true('mri_head_t' in fwd)
+    assert_true(fwd['surf_ori'])
+    write_forward_solution(fname_temp, fwd, overwrite=True)
+    fwd_read = read_forward_solution(fname_temp)
+    assert_true(repr(fwd_read))
+    assert_true(isinstance(fwd_read, Forward))
+    assert_true(is_fixed_orient(fwd_read))
+    compare_forwards(fwd, fwd_read)
+
+    fwd = read_forward_solution(fname_meeg_grad)
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=True)
     leadfield = fwd['sol']['data']

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -65,10 +65,12 @@ def test_convert_forward():
     assert_true(isinstance(fwd, Forward))
     # look at surface orientation
     fwd_surf = convert_forward_solution(fwd, surf_ori=True)
-    # This following test can be removed in 0.16
+
+    # The following test can be removed in 0.16
     fwd_surf_io = read_forward_solution(fname_meeg_grad, surf_ori=True)
     compare_forwards(fwd_surf, fwd_surf_io)
     del fwd_surf_io
+
     gc.collect()
     # go back
     fwd_new = convert_forward_solution(fwd_surf, surf_ori=False)
@@ -77,16 +79,17 @@ def test_convert_forward():
     compare_forwards(fwd, fwd_new)
     # now go to fixed
     fwd_fixed = convert_forward_solution(fwd_surf, surf_ori=False,
-                                         force_fixed=True)
+                                         force_fixed=True, use_cps=False)
     del fwd_surf
     gc.collect()
     assert_true(repr(fwd_fixed))
     assert_true(isinstance(fwd_fixed, Forward))
-    # This following test can be removed in 0.16
-    fwd_fixed_io = read_forward_solution(fname_meeg_grad, surf_ori=False,
-                                         force_fixed=True)
+
+    # The following test can be removed in 0.16
+    fwd_fixed_io = read_forward_solution(fname_meeg_grad, force_fixed=True)
     compare_forwards(fwd_fixed, fwd_fixed_io)
     del fwd_fixed_io
+
     gc.collect()
     # now go back to cartesian (original condition)
     fwd_new = convert_forward_solution(fwd_fixed, surf_ori=False,
@@ -129,7 +132,8 @@ def test_io_forward():
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
     fwd = read_forward_solution(fname_meeg_grad)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src / 3))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
@@ -164,7 +168,8 @@ def test_apply_forward():
     t_start = 0.123
 
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
     assert_true(isinstance(fwd, Forward))
 
@@ -214,7 +219,8 @@ def test_restrict_forward_to_stc():
     t_start = 0.123
 
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
@@ -260,7 +266,8 @@ def test_restrict_forward_to_label():
     """Test restriction of source space to label
     """
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     label_path = op.join(data_path, 'MEG', 'sample', 'labels')

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -43,7 +43,7 @@ def compare_forwards(f1, f2):
     assert_allclose(f1['sol']['data'], f2['sol']['data'])
     assert_equal(f1['sol']['ncol'], f2['sol']['ncol'])
     assert_equal(f1['sol']['ncol'], f1['sol']['data'].shape[1])
-    assert_allclose(f1['source_nn'], f2['source_nn'])
+    assert_allclose(f1['source_nn'], f2['source_nn'], atol=1e-6, rtol=0.0)
     if f1['sol_grad'] is not None:
         assert_true(f2['sol_grad'] is not None)
         assert_allclose(f1['sol_grad']['data'], f2['sol_grad']['data'])
@@ -141,6 +141,14 @@ def test_io_forward():
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
     fwd = read_forward_solution(fname_meeg_grad)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=False)
+    write_forward_solution(fname_temp, fwd, overwrite=True)
+    fwd_read = read_forward_solution(fname_temp)
+    assert_true(repr(fwd_read))
+    assert_true(isinstance(fwd_read, Forward))
+    assert_true(is_fixed_orient(fwd_read))
+    compare_forwards(fwd, fwd_read)
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=True)
     leadfield = fwd['sol']['data']

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -70,27 +70,35 @@ def test_convert_forward():
     fwd_surf_io = read_forward_solution(fname_meeg_grad, surf_ori=True)
     compare_forwards(fwd_surf, fwd_surf_io)
     del fwd_surf_io
-
     gc.collect()
+
     # go back
     fwd_new = convert_forward_solution(fwd_surf, surf_ori=False)
     assert_true(repr(fwd_new))
     assert_true(isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
+    del fwd_new
+    gc.collect()
+
     # now go to fixed
     fwd_fixed = convert_forward_solution(fwd_surf, surf_ori=False,
                                          force_fixed=True, use_cps=False)
-    del fwd_surf
-    gc.collect()
+    temp_dir = _TempDir()
+    fname_temp = op.join(temp_dir, 'test-fwd.fif')
+    write_forward_solution(fname_temp, fwd_fixed, overwrite=True)
     assert_true(repr(fwd_fixed))
     assert_true(isinstance(fwd_fixed, Forward))
+    fwd_fixed_io = read_forward_solution(fname_temp)
+    compare_forwards(fwd_fixed, fwd_fixed_io)
+    del fwd_fixed_io, fwd_surf
+    gc.collect()
 
     # The following test can be removed in 0.16
     fwd_fixed_io = read_forward_solution(fname_meeg_grad, force_fixed=True)
     compare_forwards(fwd_fixed, fwd_fixed_io)
     del fwd_fixed_io
-
     gc.collect()
+
     # now go back to cartesian (original condition)
     fwd_new = convert_forward_solution(fwd_fixed, surf_ori=False,
                                        force_fixed=False)

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -64,30 +64,33 @@ def test_convert_forward():
     assert_true(fwd_repr)
     assert_true(isinstance(fwd, Forward))
     # look at surface orientation
-    fwd_surf = convert_forward_solution(fwd, surf_ori=True)
+    fwd_surf = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    # This following test can be removed in 0.16
     fwd_surf_io = read_forward_solution(fname_meeg_grad, surf_ori=True)
     compare_forwards(fwd_surf, fwd_surf_io)
     del fwd_surf_io
     gc.collect()
     # go back
-    fwd_new = convert_forward_solution(fwd_surf, surf_ori=False)
+    fwd_new = convert_forward_solution(fwd_surf, surf_ori=False, use_cps=False)
     assert_true(repr(fwd_new))
     assert_true(isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
     # now go to fixed
     fwd_fixed = convert_forward_solution(fwd_surf, surf_ori=False,
-                                         force_fixed=True)
+                                         force_fixed=True, use_cps=False)
     del fwd_surf
     gc.collect()
     assert_true(repr(fwd_fixed))
     assert_true(isinstance(fwd_fixed, Forward))
+    # This following test can be removed in 0.16
     fwd_fixed_io = read_forward_solution(fname_meeg_grad, surf_ori=False,
                                          force_fixed=True)
     compare_forwards(fwd_fixed, fwd_fixed_io)
     del fwd_fixed_io
     gc.collect()
     # now go back to cartesian (original condition)
-    fwd_new = convert_forward_solution(fwd_fixed)
+    fwd_new = convert_forward_solution(fwd_fixed, surf_ori=False,
+                                       force_fixed=False, use_cps=False)
     assert_true(repr(fwd_new))
     assert_true(isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
@@ -105,15 +108,18 @@ def test_io_forward():
     n_channels, n_src = 366, 108
     fwd = read_forward_solution(fname_meeg_grad)
     assert_true(isinstance(fwd, Forward))
-    fwd = read_forward_solution(fname_meeg_grad, surf_ori=True)
+    fwd = read_forward_solution(fname_meeg_grad)
+    fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
     fname_temp = op.join(temp_dir, 'test-fwd.fif')
     write_forward_solution(fname_temp, fwd, overwrite=True)
 
-    fwd = read_forward_solution(fname_meeg_grad, surf_ori=True)
-    fwd_read = read_forward_solution(fname_temp, surf_ori=True)
+    fwd = read_forward_solution(fname_meeg_grad)
+    fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    fwd_read = read_forward_solution(fname_temp)
+    fwd_read = convert_forward_solution(fwd_read, surf_ori=True, use_cps=True)
     leadfield = fwd_read['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd_read['sol']['row_names']), n_channels)
@@ -122,7 +128,9 @@ def test_io_forward():
     assert_true('mri_head_t' in fwd_read)
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
-    fwd = read_forward_solution(fname_meeg_grad, force_fixed=True)
+    fwd = read_forward_solution(fname_meeg_grad)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src / 3))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
@@ -156,7 +164,9 @@ def test_apply_forward():
     sfreq = 10.0
     t_start = 0.123
 
-    fwd = read_forward_solution(fname_meeg, force_fixed=True)
+    fwd = read_forward_solution(fname_meeg)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
     assert_true(isinstance(fwd, Forward))
 
@@ -205,7 +215,9 @@ def test_restrict_forward_to_stc():
     sfreq = 10.0
     t_start = 0.123
 
-    fwd = read_forward_solution(fname_meeg, force_fixed=True)
+    fwd = read_forward_solution(fname_meeg)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
@@ -221,7 +233,9 @@ def test_restrict_forward_to_stc():
     assert_equal(fwd_out['src'][0]['vertno'], fwd['src'][0]['vertno'][0:15])
     assert_equal(fwd_out['src'][1]['vertno'], fwd['src'][1]['vertno'][0:5])
 
-    fwd = read_forward_solution(fname_meeg, force_fixed=False)
+    fwd = read_forward_solution(fname_meeg)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=False,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
@@ -249,7 +263,9 @@ def test_restrict_forward_to_stc():
 def test_restrict_forward_to_label():
     """Test restriction of source space to label
     """
-    fwd = read_forward_solution(fname_meeg, force_fixed=True)
+    fwd = read_forward_solution(fname_meeg)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                   use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     label_path = op.join(data_path, 'MEG', 'sample', 'labels')
@@ -275,7 +291,7 @@ def test_restrict_forward_to_label():
     assert_equal(fwd_out['src'][0]['vertno'], vertno_lh)
     assert_equal(fwd_out['src'][1]['vertno'], vertno_rh)
 
-    fwd = read_forward_solution(fname_meeg, force_fixed=False)
+    fwd = read_forward_solution(fname_meeg)
     fwd = pick_types_forward(fwd, meg=True)
 
     label_path = op.join(data_path, 'MEG', 'sample', 'labels')

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -64,20 +64,20 @@ def test_convert_forward():
     assert_true(fwd_repr)
     assert_true(isinstance(fwd, Forward))
     # look at surface orientation
-    fwd_surf = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    fwd_surf = convert_forward_solution(fwd, surf_ori=True)
     # This following test can be removed in 0.16
     fwd_surf_io = read_forward_solution(fname_meeg_grad, surf_ori=True)
     compare_forwards(fwd_surf, fwd_surf_io)
     del fwd_surf_io
     gc.collect()
     # go back
-    fwd_new = convert_forward_solution(fwd_surf, surf_ori=False, use_cps=False)
+    fwd_new = convert_forward_solution(fwd_surf, surf_ori=False)
     assert_true(repr(fwd_new))
     assert_true(isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
     # now go to fixed
     fwd_fixed = convert_forward_solution(fwd_surf, surf_ori=False,
-                                         force_fixed=True, use_cps=False)
+                                         force_fixed=True)
     del fwd_surf
     gc.collect()
     assert_true(repr(fwd_fixed))
@@ -90,7 +90,7 @@ def test_convert_forward():
     gc.collect()
     # now go back to cartesian (original condition)
     fwd_new = convert_forward_solution(fwd_fixed, surf_ori=False,
-                                       force_fixed=False, use_cps=False)
+                                       force_fixed=False)
     assert_true(repr(fwd_new))
     assert_true(isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
@@ -109,7 +109,7 @@ def test_io_forward():
     fwd = read_forward_solution(fname_meeg_grad)
     assert_true(isinstance(fwd, Forward))
     fwd = read_forward_solution(fname_meeg_grad)
-    fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True)
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
@@ -117,9 +117,9 @@ def test_io_forward():
     write_forward_solution(fname_temp, fwd, overwrite=True)
 
     fwd = read_forward_solution(fname_meeg_grad)
-    fwd = convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True)
     fwd_read = read_forward_solution(fname_temp)
-    fwd_read = convert_forward_solution(fwd_read, surf_ori=True, use_cps=True)
+    fwd_read = convert_forward_solution(fwd_read, surf_ori=True)
     leadfield = fwd_read['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd_read['sol']['row_names']), n_channels)
@@ -129,8 +129,7 @@ def test_io_forward():
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
     fwd = read_forward_solution(fname_meeg_grad)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
-                                   use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src / 3))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
@@ -165,8 +164,7 @@ def test_apply_forward():
     t_start = 0.123
 
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
-                                   use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
     fwd = pick_types_forward(fwd, meg=True)
     assert_true(isinstance(fwd, Forward))
 
@@ -216,8 +214,7 @@ def test_restrict_forward_to_stc():
     t_start = 0.123
 
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
-                                   use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
@@ -234,8 +231,7 @@ def test_restrict_forward_to_stc():
     assert_equal(fwd_out['src'][1]['vertno'], fwd['src'][1]['vertno'][0:5])
 
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=False,
-                                   use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=False)
     fwd = pick_types_forward(fwd, meg=True)
 
     vertno = [fwd['src'][0]['vertno'][0:15], fwd['src'][1]['vertno'][0:5]]
@@ -264,8 +260,7 @@ def test_restrict_forward_to_label():
     """Test restriction of source space to label
     """
     fwd = read_forward_solution(fname_meeg)
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
-                                   use_cps=True)
+    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
     fwd = pick_types_forward(fwd, meg=True)
 
     label_path = op.join(data_path, 'MEG', 'sample', 'labels')

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -57,10 +57,9 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
     _compare_source_spaces(fwd['src'], fwd_py['src'], mode='approx')
     for surf_ori, force_fixed in product([False, True], [False, True]):
         # use copy here to leave our originals unmodified
-        fwd = convert_forward_solution(fwd, surf_ori, force_fixed,
-                                       copy=True, use_cps=True)
+        fwd = convert_forward_solution(fwd, surf_ori, force_fixed, copy=True)
         fwd_py = convert_forward_solution(fwd_py, surf_ori, force_fixed,
-                                          copy=True, use_cps=True)
+                                          copy=True)
         check_src = n_src // 3 if force_fixed else n_src
 
         for key in ('nchan', 'source_rr', 'source_ori',

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -57,9 +57,10 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
     _compare_source_spaces(fwd['src'], fwd_py['src'], mode='approx')
     for surf_ori, force_fixed in product([False, True], [False, True]):
         # use copy here to leave our originals unmodified
-        fwd = convert_forward_solution(fwd, surf_ori, force_fixed, copy=True)
+        fwd = convert_forward_solution(fwd, surf_ori, force_fixed, copy=True,
+                                       use_cps=True)
         fwd_py = convert_forward_solution(fwd_py, surf_ori, force_fixed,
-                                          copy=True)
+                                          copy=True, use_cps=True)
         check_src = n_src // 3 if force_fixed else n_src
 
         for key in ('nchan', 'source_rr', 'source_ori',

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -58,9 +58,9 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
     for surf_ori, force_fixed in product([False, True], [False, True]):
         # use copy here to leave our originals unmodified
         fwd = convert_forward_solution(fwd, surf_ori, force_fixed,
-                                       copy=True)
+                                       copy=True, use_cps=True)
         fwd_py = convert_forward_solution(fwd_py, surf_ori, force_fixed,
-                                          copy=True)
+                                          copy=True, use_cps=True)
         check_src = n_src // 3 if force_fixed else n_src
 
         for key in ('nchan', 'source_rr', 'source_ori',

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -242,7 +242,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
     # make forward solution in fixed orientation if necessary
     if loose is None and not is_fixed_orient(forward):
         forward = convert_forward_solution(
-            forward, surf_ori=True, force_fixed=True, copy=True)
+            forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
 
     if is_fixed_orient(forward) or not xyz_same_gamma:
         group_size = 1

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -1,12 +1,11 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Martin Luessi <mluessi@nmr.mgh.harvard.edu>
 # License: Simplified BSD
-from copy import deepcopy
 
 import numpy as np
 from scipy import linalg
 
-from ..forward import is_fixed_orient
+from ..forward import is_fixed_orient, convert_forward_solution
 
 from ..minimum_norm.inverse import _check_reference
 from ..utils import logger, verbose, warn
@@ -242,7 +241,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     # make forward solution in fixed orientation if necessary
     if loose is None and not is_fixed_orient(forward):
-        forward = mne.convert_forward_solution(
+        forward = convert_forward_solution(
             forward, surf_ori=True, force_fixed=True, copy=True)
 
     if is_fixed_orient(forward) or not xyz_same_gamma:

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import numpy as np
 from scipy import linalg
 
-from ..forward import is_fixed_orient, _to_fixed_ori
+from ..forward import is_fixed_orient
 
 from ..minimum_norm.inverse import _check_reference
 from ..utils import logger, verbose, warn
@@ -242,8 +242,8 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     # make forward solution in fixed orientation if necessary
     if loose is None and not is_fixed_orient(forward):
-        forward = deepcopy(forward)
-        _to_fixed_ori(forward)
+        forward = mne.convert_forward_solution(
+            forward, surf_ori=True, force_fixed=True, copy=True)
 
     if is_fixed_orient(forward) or not xyz_same_gamma:
         group_size = 1

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -361,7 +361,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
         forward = convert_forward_solution(
-            forward, surf_ori=True, force_fixed=True, copy=True)
+            forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
         forward, evoked[0].info, noise_cov, pca, depth, loose, weights,
@@ -583,7 +583,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
         forward = convert_forward_solution(
-            forward, surf_ori=True, force_fixed=True, copy=True)
+            forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
 
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -3,14 +3,14 @@
 #
 # License: Simplified BSD
 
-from copy import deepcopy
 import numpy as np
 from scipy import linalg, signal
 
 from ..source_estimate import SourceEstimate
 from ..minimum_norm.inverse import combine_xyz, _prepare_forward
 from ..minimum_norm.inverse import _check_reference
-from ..forward import compute_orient_prior, is_fixed_orient
+from ..forward import (compute_orient_prior, is_fixed_orient,
+                       convert_forward_solution)
 from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
 from ..utils import logger, verbose
@@ -360,7 +360,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
-        forward = mne.convert_forward_solution(
+        forward = convert_forward_solution(
             forward, surf_ori=True, force_fixed=True, copy=True)
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
@@ -582,7 +582,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
 
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
-        forward = mne.convert_forward_solution(
+        forward = convert_forward_solution(
             forward, surf_ori=True, force_fixed=True, copy=True)
 
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -10,7 +10,7 @@ from scipy import linalg, signal
 from ..source_estimate import SourceEstimate
 from ..minimum_norm.inverse import combine_xyz, _prepare_forward
 from ..minimum_norm.inverse import _check_reference
-from ..forward import compute_orient_prior, is_fixed_orient, _to_fixed_ori
+from ..forward import compute_orient_prior, is_fixed_orient
 from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
 from ..utils import logger, verbose
@@ -360,8 +360,8 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose=0.2, depth=0.8,
 
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
-        forward = deepcopy(forward)
-        _to_fixed_ori(forward)
+        forward = mne.convert_forward_solution(
+            forward, surf_ori=True, force_fixed=True, copy=True)
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
         forward, evoked[0].info, noise_cov, pca, depth, loose, weights,
@@ -582,8 +582,8 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
 
     # put the forward solution in fixed orientation if it's not already
     if loose is None and not is_fixed_orient(forward):
-        forward = deepcopy(forward)
-        _to_fixed_ori(forward)
+        forward = mne.convert_forward_solution(
+            forward, surf_ori=True, force_fixed=True, copy=True)
 
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
 

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -55,8 +55,8 @@ def _check_stcs(stc1, stc2):
 def test_gamma_map():
     """Test Gamma MAP inverse"""
     forward = read_forward_solution(fname_fwd)
-    forward = read_forward_solution(forward, force_fixed=False,
-                                    surf_ori=True, use_cps=True)
+    forward = convert_forward_solution(forward, surf_ori=True)
+
     forward = pick_types_forward(forward, meg=False, eeg=True)
     evoked = read_evokeds(fname_evoked, condition=0, baseline=(None, 0),
                           proj=False)

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -11,7 +11,8 @@ from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_allclose)
 
 from mne.datasets import testing
-from mne import read_cov, read_forward_solution, read_evokeds
+from mne import (read_cov, read_forward_solution, read_evokeds,
+                 convert_forward_solution)
 from mne.cov import regularize
 from mne.inverse_sparse import gamma_map
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
@@ -53,8 +54,9 @@ def _check_stcs(stc1, stc2):
 @testing.requires_testing_data
 def test_gamma_map():
     """Test Gamma MAP inverse"""
-    forward = read_forward_solution(fname_fwd, force_fixed=False,
-                                    surf_ori=True)
+    forward = read_forward_solution(fname_fwd)
+    forward = read_forward_solution(forward, force_fixed=False,
+                                    surf_ori=True, use_cps=True)
     forward = pick_types_forward(forward, meg=False, eeg=True)
     evoked = read_evokeds(fname_evoked, condition=0, baseline=(None, 0),
                           proj=False)

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -59,8 +59,7 @@ def test_mxne_inverse():
     label = read_label(fname_label)
 
     forward = read_forward_solution(fname_fwd)
-    forward = read_forward_solution(forward, force_fixed=False,
-                                    surf_ori=True, use_cps=True)
+    forward = convert_forward_solution(forward, surf_ori=True)
 
     # Reduce source space to make test computation faster
     inverse_operator = make_inverse_operator(evoked_l21.info, forward, cov,

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -64,7 +64,7 @@ def test_mxne_inverse():
     # Reduce source space to make test computation faster
     inverse_operator = make_inverse_operator(evoked_l21.info, forward, cov,
                                              loose=loose, depth=depth,
-                                             fixed=True)
+                                             fixed=True, use_cps=True)
     stc_dspm = apply_inverse(evoked_l21, inverse_operator, lambda2=1. / 9.,
                              method='dSPM')
     stc_dspm.data[np.abs(stc_dspm.data) < 12] = 0.0

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -11,7 +11,8 @@ import pytest
 
 from mne.datasets import testing
 from mne.label import read_label
-from mne import read_cov, read_forward_solution, read_evokeds
+from mne import (read_cov, read_forward_solution, read_evokeds,
+                 convert_forward_solution)
 from mne.inverse_sparse import mixed_norm, tf_mixed_norm
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne.minimum_norm import apply_inverse, make_inverse_operator
@@ -57,8 +58,9 @@ def test_mxne_inverse():
     evoked_l21.crop(tmin=0.081, tmax=0.1)
     label = read_label(fname_label)
 
-    forward = read_forward_solution(fname_fwd, force_fixed=False,
-                                    surf_ori=True)
+    forward = read_forward_solution(fname_fwd)
+    forward = read_forward_solution(forward, force_fixed=False,
+                                    surf_ori=True, use_cps=True)
 
     # Reduce source space to make test computation faster
     inverse_operator = make_inverse_operator(evoked_l21.info, forward, cov,

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -564,7 +564,6 @@ FIFF.FIFF_DECOUPLER_MATRIX          = 800
 FIFF.FIFFV_MNE_UNKNOWN_ORI          = 0
 FIFF.FIFFV_MNE_FIXED_ORI            = 1
 FIFF.FIFFV_MNE_FREE_ORI             = 2
-FIFF.FIFFV_MNE_FIXED_CPS_ORI        = 3
 
 FIFF.FIFFV_MNE_MEG                  = 1
 FIFF.FIFFV_MNE_EEG                  = 2

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -564,6 +564,7 @@ FIFF.FIFF_DECOUPLER_MATRIX          = 800
 FIFF.FIFFV_MNE_UNKNOWN_ORI          = 0
 FIFF.FIFFV_MNE_FIXED_ORI            = 1
 FIFF.FIFFV_MNE_FREE_ORI             = 2
+FIFF.FIFFV_MNE_FIXED_CPS_ORI        = 3
 
 FIFF.FIFFV_MNE_MEG                  = 1
 FIFF.FIFFV_MNE_EEG                  = 2

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -65,7 +65,6 @@ class InverseOperator(dict):
 
         source_ori = {FIFF.FIFFV_MNE_UNKNOWN_ORI: 'Unknown',
                       FIFF.FIFFV_MNE_FIXED_ORI: 'Fixed',
-                      FIFF.FIFFV_MNE_FIXED_CPS_ORI: 'Fixed_CPS',
                       FIFF.FIFFV_MNE_FREE_ORI: 'Free'}
         entr += ' | Source orientation: %s' % source_ori[self['source_ori']]
         entr += '>'

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -65,6 +65,7 @@ class InverseOperator(dict):
 
         source_ori = {FIFF.FIFFV_MNE_UNKNOWN_ORI: 'Unknown',
                       FIFF.FIFFV_MNE_FIXED_ORI: 'Fixed',
+                      FIFF.FIFFV_MNE_FIXED_CPS_ORI: 'Fixed_CPS',
                       FIFF.FIFFV_MNE_FREE_ORI: 'Free'}
         entr += ' | Source orientation: %s' % source_ori[self['source_ori']]
         entr += '>'

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1222,7 +1222,7 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
 @verbose
 def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
                           fixed=False, limit_depth_chs=True, rank=None,
-                          verbose=None):
+                          use_cps=None, verbose=None):
     """Assemble inverse operator.
 
     Parameters
@@ -1252,6 +1252,9 @@ def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
         detected automatically. If int, the rank is specified for the MEG
         channels. A dictionary with entries 'eeg' and/or 'meg' can be used
         to specify the rank for each modality.
+    use_cps : None | bool (default None)
+        Whether to use cortical patch statistics to define normal
+        orientations. Only used when surf_ori and/or force_fixed are True.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`).
 
@@ -1372,7 +1375,8 @@ def make_inverse_operator(info, forward, noise_cov, loose=0.2, depth=0.8,
             # Convert to the fixed orientation forward solution now
             depth_prior = depth_prior[2::3]
             forward = convert_forward_solution(
-                forward, surf_ori=forward['surf_ori'], force_fixed=True)
+                forward, surf_ori=forward['surf_ori'], force_fixed=True,
+                use_cps=use_cps)
             is_fixed_ori = is_fixed_orient(forward)
             gain_info, gain, noise_cov, whitener, n_nzero = \
                 _prepare_forward(forward, info, noise_cov, verbose=False)

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -39,7 +39,7 @@ def _pick_leadfield(leadfield, forward, ch_names):
 @verbose
 def point_spread_function(inverse_operator, forward, labels, method='dSPM',
                           lambda2=1 / 9., pick_ori=None, mode='mean',
-                          n_svd_comp=1, verbose=None):
+                          n_svd_comp=1, use_cps=None, verbose=None):
     """Compute point-spread functions (PSFs) for linear estimators.
 
     Compute point-spread functions (PSF) in labels for a combination of inverse
@@ -77,6 +77,9 @@ def point_spread_function(inverse_operator, forward, labels, method='dSPM',
         Number of SVD components for which PSFs will be computed and output
         (irrelevant for 'sum' and 'mean'). Explained variances within
         sub-leadfields are shown in screen output.
+    use_cps : None | bool (default None)
+        Whether to use cortical patch statistics to define normal
+        orientations. Only used when surf_ori and/or force_fixed are True.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -105,7 +108,7 @@ def point_spread_function(inverse_operator, forward, labels, method='dSPM',
     logger.info("About to process %d labels" % len(labels))
 
     forward = convert_forward_solution(forward, force_fixed=False,
-                                       surf_ori=True)
+                                       surf_ori=True, use_cps=use_cps)
     info = _prepare_info(inverse_operator)
     leadfield = _pick_leadfield(forward['sol']['data'][:, 2::3], forward,
                                 info['ch_names'])
@@ -357,7 +360,7 @@ def _get_matrix_from_inverse_operator(inverse_operator, forward, labels=None,
 @verbose
 def cross_talk_function(inverse_operator, forward, labels,
                         method='dSPM', lambda2=1 / 9., signed=False,
-                        mode='mean', n_svd_comp=1, verbose=None):
+                        mode='mean', n_svd_comp=1, use_cps=None, verbose=None):
     """Compute cross-talk functions (CTFs) for linear estimators.
 
     Compute cross-talk functions (CTF) in labels for a combination of inverse
@@ -393,6 +396,9 @@ def cross_talk_function(inverse_operator, forward, labels,
         Number of SVD components for which CTFs will be computed and output
         (irrelevant for 'sum' and 'mean'). Explained variances within
         sub-inverses are shown in screen output.
+    use_cps : None | bool (default None)
+        Whether to use cortical patch statistics to define normal
+        orientations. Only used when surf_ori and/or force_fixed are True.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -406,7 +412,7 @@ def cross_talk_function(inverse_operator, forward, labels,
         The last sample is the summed CTF across all labels.
     """
     forward = convert_forward_solution(forward, force_fixed=True,
-                                       surf_ori=True)
+                                       surf_ori=True, use_cps=use_cps)
 
     # get the inverse matrix corresponding to inverse operator
     out = _get_matrix_from_inverse_operator(inverse_operator, forward,

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import numpy as np
 from scipy import linalg
 
+from ..io.constants import FIFF
 from ..io.pick import pick_channels
 from ..utils import logger, verbose
 from ..forward import convert_forward_solution
@@ -255,7 +256,8 @@ def _get_matrix_from_inverse_operator(inverse_operator, forward, labels=None,
     if not forward['surf_ori']:
         raise RuntimeError('Forward has to be surface oriented and '
                            'force_fixed=True.')
-    if not (forward['source_ori'] == 1):
+    if not ((forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI) or
+            (forward['source_ori'] == FIFF.FIFFV_MNE_FIXED_CPS_ORI)):
         raise RuntimeError('Forward has to be surface oriented and '
                            'force_fixed=True.')
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -179,7 +179,7 @@ def test_warn_inverse_operator():
     bad_info = copy.deepcopy(_get_evoked().info)
     bad_info['projs'] = list()
     fwd_op = read_forward_solution(fname_fwd)
-    fwd_op = convert_forward_solution(fwd_op, surf_ori=True, use_cps=True)
+    fwd_op = convert_forward_solution(fwd_op, surf_ori=True)
     noise_cov = read_cov(fname_cov)
     noise_cov['projs'].pop(-1)  # get rid of avg EEG ref proj
     with warnings.catch_warnings(record=True) as w:
@@ -195,7 +195,7 @@ def test_make_inverse_operator():
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
     inverse_operator = read_inverse_operator(fname_inv)
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
     my_inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                       loose=0.2, depth=0.8,
                                       limit_depth_chs=False)
@@ -329,7 +329,7 @@ def test_apply_inverse_operator():
 def test_make_inverse_operator_fixed():
     """Test MNE inverse computation (fixed orientation)."""
     fwd_1 = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                      force_fixed=False, use_cps=True)
+                                      force_fixed=False)
     fwd_2 = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                       force_fixed=True, use_cps=False)
     evoked = _get_evoked()
@@ -355,22 +355,12 @@ def test_make_inverse_operator_fixed():
 
 @testing.requires_testing_data
 def test_make_inverse_operator_free():
-<<<<<<< HEAD
     """Test MNE inverse computation (free orientation)."""
     fwd_surf = read_forward_solution_meg(fname_fwd, surf_ori=True)
     fwd_loose = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                           force_fixed=False)
     fwd_fixed = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                          force_fixed=True)
-=======
-    """Test MNE inverse computation (free orientation)
-    """
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
-    fwd_1 = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                      force_fixed=False, use_cps=True)
-    fwd_2 = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                      force_fixed=True, use_cps=False)
->>>>>>> read and convert forward solution mods
+                                          force_fixed=True, use_cps=False)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 
@@ -443,7 +433,7 @@ def test_make_inverse_operator_diag():
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov).as_diag()
     fwd_op = read_forward_solution(fname_fwd)
-    fwd_op = convert_forward_solution(fwd_op, surf_ori=True, use_cps=True)
+    fwd_op = convert_forward_solution(fwd_op, surf_ori=True)
     inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                    loose=0.2, depth=0.8)
     _compare_io(inv_op)
@@ -458,13 +448,13 @@ def test_make_inverse_operator_diag():
 def test_inverse_operator_noise_cov_rank():
     """Test MNE inverse operator with a specified noise cov rank
     """
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov, rank=64)
     assert_true(compute_rank_inverse(inv) == 64)
 
-    fwd_op = read_forward_solution_eeg(fname_fwd, surf_ori=True, use_cps=True)
+    fwd_op = read_forward_solution_eeg(fname_fwd, surf_ori=True)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                 rank=dict(eeg=20))
     assert_true(compute_rank_inverse(inv) == 20)
@@ -568,7 +558,7 @@ def test_apply_mne_inverse_fixed_raw():
 
     # create a fixed-orientation inverse operator
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=False,
-                                    surf_ori=True, use_cps=True)
+                                    surf_ori=True)
     noise_cov = read_cov(fname_cov)
     inv_op = make_inverse_operator(raw.info, fwd, noise_cov,
                                    loose=None, depth=0.8, fixed=True)
@@ -671,7 +661,7 @@ def test_apply_mne_inverse_epochs():
 @testing.requires_testing_data
 def test_make_inverse_operator_bads():
     """Test MNE inverse computation given a mismatch of bad channels."""
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -360,7 +360,7 @@ def test_make_inverse_operator_free():
     fwd_loose = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                           force_fixed=False)
     fwd_fixed = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                          force_fixed=True, use_cps=False)
+                                          force_fixed=True, use_cps=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 
@@ -561,7 +561,8 @@ def test_apply_mne_inverse_fixed_raw():
                                     surf_ori=True)
     noise_cov = read_cov(fname_cov)
     inv_op = make_inverse_operator(raw.info, fwd, noise_cov,
-                                   loose=None, depth=0.8, fixed=True)
+                                   loose=None, depth=0.8, fixed=True,
+                                   use_cps=True)
 
     inv_op2 = prepare_inverse_operator(inv_op, nave=1,
                                        lambda2=lambda2, method="dSPM")

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -17,6 +17,7 @@ from mne.source_estimate import read_source_estimate, VolSourceEstimate
 from mne import (read_cov, read_forward_solution, read_evokeds, pick_types,
                  pick_types_forward, make_forward_solution,
                  convert_forward_solution, Covariance, combine_evoked)
+from mne.forward.forward import _read_forward_solution
 from mne.io import read_raw_fif, Info
 from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       apply_inverse_raw, apply_inverse_epochs,
@@ -62,14 +63,14 @@ last_keys = [None] * 10
 
 def read_forward_solution_meg(*args, **kwargs):
     """Read MEG forward."""
-    fwd = read_forward_solution(*args, **kwargs)
+    fwd = _read_forward_solution(*args, **kwargs)
     fwd = pick_types_forward(fwd, meg=True, eeg=False)
     return fwd
 
 
 def read_forward_solution_eeg(*args, **kwargs):
     """Read EEG forward."""
-    fwd = read_forward_solution(*args, **kwargs)
+    fwd = _read_forward_solution(*args, **kwargs)
     fwd = pick_types_forward(fwd, meg=False, eeg=True)
     return fwd
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -63,14 +63,16 @@ last_keys = [None] * 10
 
 def read_forward_solution_meg(*args, **kwargs):
     """Read MEG forward."""
-    fwd = _read_forward_solution(*args, **kwargs)
+    fwd = read_forward_solution(*args)
+    fwd = convert_forward_solution(fwd, **kwargs)
     fwd = pick_types_forward(fwd, meg=True, eeg=False)
     return fwd
 
 
 def read_forward_solution_eeg(*args, **kwargs):
     """Read EEG forward."""
-    fwd = _read_forward_solution(*args, **kwargs)
+    fwd = read_forward_solution(*args)
+    fwd = convert_forward_solution(fwd, **kwargs)
     fwd = pick_types_forward(fwd, meg=False, eeg=True)
     return fwd
 
@@ -176,7 +178,8 @@ def test_warn_inverse_operator():
     """Test MNE inverse warning without average EEG projection."""
     bad_info = copy.deepcopy(_get_evoked().info)
     bad_info['projs'] = list()
-    fwd_op = read_forward_solution(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution(fname_fwd)
+    fwd_op = convert_forward_solution(fwd_op, surf_ori=True, use_cps=True)
     noise_cov = read_cov(fname_cov)
     noise_cov['projs'].pop(-1)  # get rid of avg EEG ref proj
     with warnings.catch_warnings(record=True) as w:
@@ -192,7 +195,7 @@ def test_make_inverse_operator():
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
     inverse_operator = read_inverse_operator(fname_inv)
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
     my_inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                       loose=0.2, depth=0.8,
                                       limit_depth_chs=False)
@@ -326,7 +329,7 @@ def test_apply_inverse_operator():
 def test_make_inverse_operator_fixed():
     """Test MNE inverse computation (fixed orientation)."""
     fwd_1 = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                      force_fixed=False)
+                                      force_fixed=False, use_cps=True)
     fwd_2 = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                       force_fixed=True, use_cps=False)
     evoked = _get_evoked()
@@ -352,12 +355,22 @@ def test_make_inverse_operator_fixed():
 
 @testing.requires_testing_data
 def test_make_inverse_operator_free():
+<<<<<<< HEAD
     """Test MNE inverse computation (free orientation)."""
     fwd_surf = read_forward_solution_meg(fname_fwd, surf_ori=True)
     fwd_loose = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                           force_fixed=False)
     fwd_fixed = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                           force_fixed=True)
+=======
+    """Test MNE inverse computation (free orientation)
+    """
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
+    fwd_1 = read_forward_solution_meg(fname_fwd, surf_ori=False,
+                                      force_fixed=False, use_cps=True)
+    fwd_2 = read_forward_solution_meg(fname_fwd, surf_ori=False,
+                                      force_fixed=True, use_cps=False)
+>>>>>>> read and convert forward solution mods
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 
@@ -429,7 +442,8 @@ def test_make_inverse_operator_diag():
     """
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov).as_diag()
-    fwd_op = read_forward_solution(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution(fname_fwd)
+    fwd_op = convert_forward_solution(fwd_op, surf_ori=True, use_cps=True)
     inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                    loose=0.2, depth=0.8)
     _compare_io(inv_op)
@@ -444,13 +458,13 @@ def test_make_inverse_operator_diag():
 def test_inverse_operator_noise_cov_rank():
     """Test MNE inverse operator with a specified noise cov rank
     """
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov, rank=64)
     assert_true(compute_rank_inverse(inv) == 64)
 
-    fwd_op = read_forward_solution_eeg(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution_eeg(fname_fwd, surf_ori=True, use_cps=True)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                 rank=dict(eeg=20))
     assert_true(compute_rank_inverse(inv) == 20)
@@ -554,7 +568,7 @@ def test_apply_mne_inverse_fixed_raw():
 
     # create a fixed-orientation inverse operator
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=False,
-                                    surf_ori=True)
+                                    surf_ori=True, use_cps=True)
     noise_cov = read_cov(fname_cov)
     inv_op = make_inverse_operator(raw.info, fwd, noise_cov,
                                    loose=None, depth=0.8, fixed=True)
@@ -657,7 +671,7 @@ def test_apply_mne_inverse_epochs():
 @testing.requires_testing_data
 def test_make_inverse_operator_bads():
     """Test MNE inverse computation given a mismatch of bad channels."""
-    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
+    fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True, use_cps=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -17,7 +17,6 @@ from mne.source_estimate import read_source_estimate, VolSourceEstimate
 from mne import (read_cov, read_forward_solution, read_evokeds, pick_types,
                  pick_types_forward, make_forward_solution,
                  convert_forward_solution, Covariance, combine_evoked)
-from mne.forward.forward import _read_forward_solution
 from mne.io import read_raw_fif, Info
 from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       apply_inverse_raw, apply_inverse_epochs,

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -327,7 +327,7 @@ def test_make_inverse_operator_fixed():
     fwd_1 = read_forward_solution_meg(fname_fwd, surf_ori=False,
                                       force_fixed=False)
     fwd_2 = read_forward_solution_meg(fname_fwd, surf_ori=False,
-                                      force_fixed=True)
+                                      force_fixed=True, use_cps=False)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
 
@@ -340,7 +340,7 @@ def test_make_inverse_operator_fixed():
 
     # now compare to C solution
     # note that the forward solution must not be surface-oriented
-    # to get equivalency (surf_ori=True changes the normals)
+    # to get equivalency (surf_ori=True changes the normals if use_cps=True)
     inv_op = make_inverse_operator(evoked.info, fwd_2, noise_cov, depth=None,
                                    loose=None, fixed=True)
     inverse_operator_nodepth = read_inverse_operator(fname_inv_fixed_nodepth)

--- a/mne/minimum_norm/tests/test_psf_ctf.py
+++ b/mne/minimum_norm/tests/test_psf_ctf.py
@@ -44,7 +44,7 @@ def test_psf_ctf():
             stc_psf, psf_ev = point_spread_function(
                 inverse_operator, forward, method=method, labels=labels,
                 lambda2=lambda2, pick_ori='normal', mode=mode,
-                n_svd_comp=n_svd_comp)
+                n_svd_comp=n_svd_comp, use_cps=True)
 
             n_vert, n_samples = stc_psf.shape
             should_n_vert = (inverse_operator['src'][1]['vertno'].shape[0] +
@@ -65,7 +65,7 @@ def test_psf_ctf():
             stc_ctf = cross_talk_function(
                 inverse_operator, forward, labels, method=method,
                 lambda2=lambda2, signed=False, mode=mode,
-                n_svd_comp=n_svd_comp)
+                n_svd_comp=n_svd_comp, use_cps=True)
 
             n_vert, n_samples = stc_ctf.shape
             should_n_vert = (inverse_operator['src'][1]['vertno'].shape[0] +

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -361,8 +361,8 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
         # must be fixed orientation
         # XXX eventually we could speed this up by allowing the forward
         # solution code to only compute the normal direction
-        fwd = convert_forward_solution(fwd, surf_ori=True,
-                                       force_fixed=True, verbose=False)
+        fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                       verbose=False)
         if blink:
             fwd_blink = fwd_blink['sol']['data']
             for ii in range(len(blink_rrs)):

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -45,7 +45,7 @@ def _log_ch(start, info, ch):
 def simulate_raw(raw, stc, trans, src, bem, cov='simple',
                  blink=False, ecg=False, chpi=False, head_pos=None,
                  mindist=1.0, interp='cos2', iir_filter=None, n_jobs=1,
-                 random_state=None, verbose=None):
+                 random_state=None, use_cps=None, verbose=None):
     u"""Simulate raw data.
 
     Head movements can optionally be simulated using the ``head_pos``
@@ -109,6 +109,9 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
     random_state : None | int | np.random.RandomState
         The random generator state used for blink, ECG, and sensor
         noise randomization.
+    use_cps : None | bool (default None)
+        Whether to use cortical patch statistics to define normal
+        orientations. Only used when surf_ori and/or force_fixed are True.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -362,7 +365,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
         # XXX eventually we could speed this up by allowing the forward
         # solution code to only compute the normal direction
         fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
-                                       verbose=False)
+                                       verbose=False, use_cps=use_cps)
         if blink:
             fwd_blink = fwd_blink['sol']['data']
             for ii in range(len(blink_rrs)):

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -10,12 +10,11 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 from nose.tools import assert_true, assert_raises
 import warnings
 
+from mne import (read_cov, read_forward_solution, convert_forward_solution,
+                 pick_types_forward, read_evokeds)
 from mne.datasets import testing
-from mne.forward.forward import _read_forward_solution
 from mne.simulation import simulate_sparse_stc, simulate_evoked
-from mne import read_cov
 from mne.io import read_raw_fif
-from mne import pick_types_forward, read_evokeds
 from mne.cov import regularize
 from mne.utils import run_tests_if_main
 
@@ -37,7 +36,8 @@ def test_simulate_evoked():
     """Test simulation of evoked data."""
 
     raw = read_raw_fif(raw_fname)
-    fwd = _read_forward_solution(fwd_fname, force_fixed=True, use_cps=False)
+    fwd = read_forward_solution(fwd_fname)
+    fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=False)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)
 

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -37,7 +37,7 @@ def test_simulate_evoked():
     """Test simulation of evoked data."""
 
     raw = read_raw_fif(raw_fname)
-    fwd = read_forward_solution(fwd_fname, force_fixed=True)
+    fwd = read_forward_solution(fwd_fname, force_fixed=True, use_cps=False)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)
 

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -11,7 +11,7 @@ from nose.tools import assert_true, assert_raises
 import warnings
 
 from mne.datasets import testing
-from mne import read_forward_solution
+from mne.forward.forward import _read_forward_solution
 from mne.simulation import simulate_sparse_stc, simulate_evoked
 from mne import read_cov
 from mne.io import read_raw_fif
@@ -37,7 +37,7 @@ def test_simulate_evoked():
     """Test simulation of evoked data."""
 
     raw = read_raw_fif(raw_fname)
-    fwd = read_forward_solution(fwd_fname, force_fixed=True, use_cps=False)
+    fwd = _read_forward_solution(fwd_fname, force_fixed=True, use_cps=False)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)
 

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -37,7 +37,7 @@ def test_simulate_evoked():
 
     raw = read_raw_fif(raw_fname)
     fwd = read_forward_solution(fwd_fname)
-    fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=False)
+    fwd = convert_forward_solution(fwd, force_fixed=True)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)
 

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -37,7 +37,7 @@ def test_simulate_evoked():
 
     raw = read_raw_fif(raw_fname)
     fwd = read_forward_solution(fwd_fname)
-    fwd = convert_forward_solution(fwd, force_fixed=True)
+    fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=False)
     fwd = pick_types_forward(fwd, meg=True, eeg=True, exclude=raw.info['bads'])
     cov = read_cov(cov_fname)
 

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -5,7 +5,8 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_raises, assert_equal
 
 from mne.datasets import testing
-from mne import read_label, read_forward_solution, pick_types_forward
+from mne import (read_label, read_forward_solution, pick_types_forward,
+                 convert_forward_solution)
 from mne.label import Label
 from mne.simulation.source import simulate_stc, simulate_sparse_stc
 from mne.utils import run_tests_if_main
@@ -21,7 +22,8 @@ subjects_dir = op.join(data_path, 'subjects')
 
 
 def read_forward_solution_meg(*args, **kwargs):
-    fwd = read_forward_solution(*args, **kwargs)
+    fwd = read_forward_solution(*args)
+    fwd = convert_forward_solution(fwd, **kwargs)
     fwd = pick_types_forward(fwd, meg=True, eeg=False)
     return fwd
 
@@ -29,7 +31,7 @@ def read_forward_solution_meg(*args, **kwargs):
 @testing.requires_testing_data
 def test_simulate_stc():
     """ Test generation of source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
     mylabels = []
@@ -99,7 +101,7 @@ def test_simulate_stc():
 @testing.requires_testing_data
 def test_simulate_sparse_stc():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
 
@@ -147,7 +149,7 @@ def test_simulate_sparse_stc():
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():
     """ Test generation of source estimate, single hemi """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels_single_hemi = [read_label(op.join(data_path, 'MEG', 'sample',
                                              'labels', '%s.label' % label))
                           for label in label_names_single_hemi]
@@ -208,7 +210,7 @@ def test_generate_stc_single_hemi():
 @testing.requires_testing_data
 def test_simulate_sparse_stc_single_hemi():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     n_times = 10
     tmin = 0
     tstep = 1e-3

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -31,7 +31,7 @@ def read_forward_solution_meg(*args, **kwargs):
 @testing.requires_testing_data
 def test_simulate_stc():
     """ Test generation of source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
     mylabels = []
@@ -101,7 +101,7 @@ def test_simulate_stc():
 @testing.requires_testing_data
 def test_simulate_sparse_stc():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
 
@@ -149,7 +149,7 @@ def test_simulate_sparse_stc():
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():
     """ Test generation of source estimate, single hemi """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
     labels_single_hemi = [read_label(op.join(data_path, 'MEG', 'sample',
                                              'labels', '%s.label' % label))
                           for label in label_names_single_hemi]
@@ -210,7 +210,7 @@ def test_generate_stc_single_hemi():
 @testing.requires_testing_data
 def test_simulate_sparse_stc_single_hemi():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
     n_times = 10
     tmin = 0
     tstep = 1e-3

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -31,7 +31,7 @@ def read_forward_solution_meg(*args, **kwargs):
 @testing.requires_testing_data
 def test_simulate_stc():
     """ Test generation of source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
     mylabels = []
@@ -101,7 +101,7 @@ def test_simulate_stc():
 @testing.requires_testing_data
 def test_simulate_sparse_stc():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
 
@@ -149,7 +149,7 @@ def test_simulate_sparse_stc():
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():
     """ Test generation of source estimate, single hemi """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels_single_hemi = [read_label(op.join(data_path, 'MEG', 'sample',
                                              'labels', '%s.label' % label))
                           for label in label_names_single_hemi]
@@ -210,7 +210,7 @@ def test_generate_stc_single_hemi():
 @testing.requires_testing_data
 def test_simulate_sparse_stc_single_hemi():
     """ Test generation of sparse source estimate """
-    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True)
+    fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     n_times = 10
     tmin = 0
     tstep = 1e-3

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -333,7 +333,7 @@ def test_simulate_calculate_chpi_positions():
     raw = simulate_raw(raw, stc, None, fwd['src'], sphere, cov=None,
                        blink=False, ecg=False, chpi=True,
                        head_pos=dev_head_pos, mindist=1.0, interp='zero',
-                       verbose=None)
+                       verbose=None, use_cps=True)
 
     quats = _calculate_chpi_positions(
         raw, t_step_min=raw.info['sfreq'] * head_pos_sfreq_quotient,

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -105,7 +105,8 @@ def test_dipole_fitting():
     fname_dtemp = op.join(tempdir, 'test.dip')
     fname_sim = op.join(tempdir, 'test-ave.fif')
     fwd = convert_forward_solution(read_forward_solution(fname_fwd),
-                                   surf_ori=False, force_fixed=True)
+                                   surf_ori=False, force_fixed=True,
+                                   use_cps=True)
     evoked = read_evokeds(fname_evo)[0]
     cov = read_cov(fname_cov)
     n_per_hemi = 5
@@ -300,7 +301,7 @@ def test_accuracy():
         src = read_source_spaces(fname_src)
 
         fwd = make_forward_solution(evoked.info, None, src, bem)
-        fwd = convert_forward_solution(fwd, force_fixed=True)
+        fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=True)
         vertices = [src[0]['vertno'], src[1]['vertno']]
         n_vertices = sum(len(v) for v in vertices)
         amp = 10e-9

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -105,8 +105,7 @@ def test_dipole_fitting():
     fname_dtemp = op.join(tempdir, 'test.dip')
     fname_sim = op.join(tempdir, 'test-ave.fif')
     fwd = convert_forward_solution(read_forward_solution(fname_fwd),
-                                   surf_ori=False, force_fixed=True,
-                                   use_cps=None)
+                                   surf_ori=False, force_fixed=True)
     evoked = read_evokeds(fname_evo)[0]
     cov = read_cov(fname_cov)
     n_per_hemi = 5
@@ -301,7 +300,7 @@ def test_accuracy():
         src = read_source_spaces(fname_src)
 
         fwd = make_forward_solution(evoked.info, None, src, bem)
-        fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=None)
+        fwd = convert_forward_solution(fwd, force_fixed=True)
         vertices = [src[0]['vertno'], src[1]['vertno']]
         n_vertices = sum(len(v) for v in vertices)
         amp = 10e-9

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -105,7 +105,8 @@ def test_dipole_fitting():
     fname_dtemp = op.join(tempdir, 'test.dip')
     fname_sim = op.join(tempdir, 'test-ave.fif')
     fwd = convert_forward_solution(read_forward_solution(fname_fwd),
-                                   surf_ori=False, force_fixed=True)
+                                   surf_ori=False, force_fixed=True,
+                                   use_cps=None)
     evoked = read_evokeds(fname_evo)[0]
     cov = read_cov(fname_cov)
     n_per_hemi = 5
@@ -300,7 +301,7 @@ def test_accuracy():
         src = read_source_spaces(fname_src)
 
         fwd = make_forward_solution(evoked.info, None, src, bem)
-        fwd = convert_forward_solution(fwd, force_fixed=True)
+        fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=None)
         vertices = [src[0]['vertno'], src[1]['vertno']]
         n_vertices = sum(len(v) for v in vertices)
         amp = 10e-9

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -103,7 +103,8 @@ def _check_warnings(raw, events, picks=None, count=3):
 @testing.requires_testing_data
 def test_sensitivity_maps():
     """Test sensitivity map computation."""
-    fwd = mne.read_forward_solution(fwd_fname, surf_ori=True)
+    fwd = mne.read_forward_solution(fwd_fname)
+    fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         projs = read_proj(eog_fname)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -104,7 +104,7 @@ def _check_warnings(raw, events, picks=None, count=3):
 def test_sensitivity_maps():
     """Test sensitivity map computation."""
     fwd = mne.read_forward_solution(fwd_fname)
-    fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+    fwd = mne.convert_forward_solution(fwd, surf_ori=True)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         projs = read_proj(eog_fname)

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -169,7 +169,7 @@ print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 # we can use the following:
 
 fwd_fixed = mne.convert_forward_solution(fwd, surf_ori=True,
-                                         force_fixed=True)
+                                         force_fixed=True, use_cps=True)
 leadfield = fwd_fixed['sol']['data']
 print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -168,8 +168,7 @@ print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 # the source space `fwd['src']` with cortical orientation constraint
 # we can use the following:
 
-fwd_fixed = mne.convert_forward_solution(fwd, surf_ori=True,
-                                         force_fixed=True, use_cps=True)
+fwd_fixed = mne.convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
 leadfield = fwd_fixed['sol']['data']
 print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -168,7 +168,8 @@ print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 # the source space `fwd['src']` with cortical orientation constraint
 # we can use the following:
 
-fwd_fixed = mne.convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+fwd_fixed = mne.convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                         use_cps=True)
 leadfield = fwd_fixed['sol']['data']
 print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -68,7 +68,8 @@ evoked.plot_white(noise_cov)
 # Read the forward solution and compute the inverse operator
 
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
-fwd = mne.read_forward_solution(fname_fwd, surf_ori=True)
+fwd = mne.read_forward_solution(fname_fwd)
+fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
 
 # Restrict forward solution as necessary for MEG
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=False)

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -69,7 +69,7 @@ evoked.plot_white(noise_cov)
 
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 fwd = mne.read_forward_solution(fname_fwd)
-fwd = mne.convert_forward_solution(fwd, surf_ori=True, use_cps=True)
+fwd = mne.convert_forward_solution(fwd, surf_ori=True)
 
 # Restrict forward solution as necessary for MEG
 fwd = mne.pick_types_forward(fwd, meg=True, eeg=False)

--- a/tutorials/plot_point_spread.py
+++ b/tutorials/plot_point_spread.py
@@ -53,7 +53,8 @@ fname_evoked = op.join(data_path, 'MEG', 'sample',
 # -----------------
 
 fwd = mne.read_forward_solution(fname_fwd)
-fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
+                                   use_cps=False)
 fwd['info']['bads'] = []
 inv_op = read_inverse_operator(fname_inv)
 

--- a/tutorials/plot_point_spread.py
+++ b/tutorials/plot_point_spread.py
@@ -52,8 +52,9 @@ fname_evoked = op.join(data_path, 'MEG', 'sample',
 # Load the MEG data
 # -----------------
 
-fwd = mne.read_forward_solution(fname_fwd, force_fixed=True,
-                                surf_ori=True)
+fwd = mne.read_forward_solution(fname_fwd)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True,
+                                   surf_ori=True, use_cps=True)
 fwd['info']['bads'] = []
 inv_op = read_inverse_operator(fname_inv)
 

--- a/tutorials/plot_point_spread.py
+++ b/tutorials/plot_point_spread.py
@@ -53,8 +53,7 @@ fname_evoked = op.join(data_path, 'MEG', 'sample',
 # -----------------
 
 fwd = mne.read_forward_solution(fname_fwd)
-fwd = mne.convert_forward_solution(fwd, force_fixed=True,
-                                   surf_ori=True, use_cps=True)
+fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
 fwd['info']['bads'] = []
 inv_op = read_inverse_operator(fname_inv)
 


### PR DESCRIPTION
As mentioned in #4368 the follwing two ways of converting a forward operator to fixed orientation in mne do not give the same result, which is due to use of patch info in convert_forward_solution (if available):
```
# only use convert_forward_solution
forward_convert = convert_forward_solution(
    forward_ori, surf_ori=True, force_fixed=True, copy=True)
```
```
# use convert_forward_solution and _to_fixed_ori
forward_fixed = convert_forward_solution(
    forward_ori, surf_ori=True, force_fixed=False, copy=True)
forward_fixed = _to_fixed_ori(forward_fixed)
```
This PR modifies `convert_forward_solution` by adding a use_cps parameter to indicate whether cps is to be applied or not, and removes _to_fixed_ori.

Still ToDo:
- [x] replace use of `_to_fixed_ori` with `convert_forward_solution` and remove `_to_fixed_ori`

- [x] add use_cps

- [x] adapt tests using use_cps (which might fail now as the way a fixed fwd is computed is changed in this PR)

This closes #4393, closes #4368