### PR TITLE
[MRG] Don't use deprecated imp module in Python versions >= 3.3

### DIFF
--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -15,12 +15,12 @@ import mne
 def load_module(name, path):
     if sys.version_info < (3, 3):
         import imp
-        if path.endswidth('.pyc'):
+        if path.endswith('.pyc'):
             return imp.load_compiled(name, path)
         else:
             return imp.load_source(name, path)
     elif sys.version_info < (3, 5):
-        if path.endswidth('.pyc'):
+        if path.endswith('.pyc'):
             from importlib.machinery import SourcelessFileLoader
             return SourcelessFileLoader(name, path).load_module()
         else:

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -13,6 +13,20 @@ import mne
 
 
 def load_module(name, path):
+    """Load module from .py/.pyc file.
+
+    Parameters
+    ----------
+    name : str
+        Name of the module.
+    path : str
+        Path to .py/.pyc file.
+
+    Returns
+    -------
+    mod : module
+        Imported module.
+    """
     if sys.version_info < (3, 3):
         import imp
         if path.endswith('.pyc'):

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -4,12 +4,27 @@
 #
 # License: BSD (3-clause)
 
-import imp
+import sys
 import os
 import re
 from optparse import OptionParser
 
 import mne
+
+
+def load_module(name, path):
+    if sys.version_info < (3, 3):
+        import imp
+        return imp.load_source(name, path)
+    elif sys.version_info < (3, 5):
+        from importlib.machinery import SourceFileLoader
+        return SourceFileLoader(name, path).load_module()
+    else:  # Python 3.5 or greater
+        from importlib.util import spec_from_file_location, module_from_spec
+        spec = spec_from_file_location(name, path)
+        mod = module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
 
 
 def get_optparser(cmdpath, usage=None):
@@ -21,10 +36,7 @@ def get_optparser(cmdpath, usage=None):
         command = command[4:-4]
 
     # Fetch description
-    if cmdpath.endswith('.pyc'):
-        mod = imp.load_compiled('__temp', cmdpath)
-    else:
-        mod = imp.load_source('__temp', cmdpath)
+    mod = load_module('__temp', cmdpath)
     if mod.__doc__:
         doc, description, epilog = mod.__doc__, None, None
 

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -15,10 +15,17 @@ import mne
 def load_module(name, path):
     if sys.version_info < (3, 3):
         import imp
-        return imp.load_source(name, path)
+        if path.endswidth('.pyc'):
+            return imp.load_compiled(name, path)
+        else:
+            return imp.load_source(name, path)
     elif sys.version_info < (3, 5):
-        from importlib.machinery import SourceFileLoader
-        return SourceFileLoader(name, path).load_module()
+        if path.endswidth('.pyc'):
+            from importlib.machinery import SourcelessFileLoader
+            return SourcelessFileLoader(name, path).load_module()
+        else:
+            from importlib.machinery import SourceFileLoader
+            return SourceFileLoader(name, path).load_module()
     else:  # Python 3.5 or greater
         from importlib.util import spec_from_file_location, module_from_spec
         spec = spec_from_file_location(name, path)


### PR DESCRIPTION
Fixes #4378.

I've also removed the condition to distinguish between .py and .pyc files - is this needed? I only have .py files in the command folder. If this is not needed, the other condition involving regexes could also be removed.