### PR TITLE
[MRG] Add projection argument to set_eeg_reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -141,6 +141,8 @@ API
 
     - :meth:`mne.io.Raw.plot_psd` now rejects data annotated bad by default. Turn off with ``reject_by_annotation=False``, by `Eric Larson`_
 
+    - :func:`mne.set_eeg_reference` has a new argument ``projection``, which if set to False directly applies an average reference instead of adding an SSP projector, by `Clemens Brunner`_
+
 .. _changes_0_14:
 
 Version 0.14

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -141,7 +141,7 @@ API
 
     - :meth:`mne.io.Raw.plot_psd` now rejects data annotated bad by default. Turn off with ``reject_by_annotation=False``, by `Eric Larson`_
 
-    - :func:`mne.set_eeg_reference` has a new argument ``projection``, which if set to False directly applies an average reference instead of adding an SSP projector, by `Clemens Brunner`_
+    - :func:`mne.set_eeg_reference` and the related methods :meth:`mne.io.Raw.set_eeg_reference`, :meth:`mne.io.Epochs.set_eeg_reference`, and :meth:`mne.io.Evoked.set_eeg_reference` have a new argument ``projection``, which if set to False directly applies an average reference instead of adding an SSP projector, by `Clemens Brunner`_
 
 .. _changes_0_14:
 

--- a/examples/datasets/plot_brainstorm_data.py
+++ b/examples/datasets/plot_brainstorm_data.py
@@ -39,7 +39,7 @@ raw.plot()
 
 # set EOG channel
 raw.set_channel_types({'EEG058': 'eog'})
-raw.set_eeg_reference()
+raw.set_eeg_reference('average', projection=True)
 
 # show power line interference and remove it
 raw.plot_psd(tmax=60.)

--- a/examples/inverse/plot_compute_mne_inverse_raw_in_label.py
+++ b/examples/inverse/plot_compute_mne_inverse_raw_in_label.py
@@ -35,7 +35,7 @@ raw = mne.io.read_raw_fif(fname_raw)
 inverse_operator = read_inverse_operator(fname_inv)
 label = mne.read_label(fname_label)
 
-raw.set_eeg_reference()  # set average reference.
+raw.set_eeg_reference('average', projection=True)  # set average reference.
 start, stop = raw.time_as_index([0, 15])  # read the first 15s of data
 
 # Compute inverse solution

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -48,7 +48,7 @@ evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'))
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
-raw.set_eeg_reference()
+raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
 evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'))

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -276,9 +276,10 @@ class SetChannelsMixin(object):
             mastoid reference, when using the 10-20 naming scheme, set
             ``ref_channels=['M1', 'M2']``.
 
-        .. note:: In case of average reference (`ref_channels='average'``), the
-                  reference is added as a projection and it is not applied
-                  automatically. For it to take effect, apply with method
+        .. note:: In case of average reference `ref_channels='average'`` in
+                  combination with `projection=True`, the reference is added as
+                  a projection and it is not applied automatically. For it to
+                  take effect, apply with method
                   :meth:`apply_proj <mne.io.Raw.apply_proj>`. Other references
                   are directly applied (this behavior will change in MNE 0.16).
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -239,40 +239,40 @@ class SetChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs."""
 
     @verbose
-    def set_eeg_reference(self, ref_channels=None, verbose=None):
+    def set_eeg_reference(self, ref_channels='average', projection=False,
+                          verbose=None):
         """Specify which reference to use for EEG data.
 
-        By default, MNE-Python will automatically re-reference the EEG signal
-        to use an average reference (see below). Use this function to
-        explicitly specify the desired reference for EEG. This can be either an
-        existing electrode or a new virtual channel. This function will
-        re-reference the data according to the desired reference and prevent
-        MNE-Python from automatically adding an average reference.
+        By default, MNE-Python will automatically re-reference the EEG signal to
+        use an average reference (see below). Use this function to explicitly
+        specify the desired reference for EEG. This can be either an existing
+        electrode or a new virtual channel. This function will re-reference the
+        data according to the desired reference and prevent MNE-Python from
+        automatically adding an average reference.
 
         Some common referencing schemes and the corresponding value for the
         ``ref_channels`` parameter:
 
         No re-referencing:
             If the EEG data is already using the proper reference, set
-            ``ref_channels=[]``. This will prevent MNE-Python from
-            automatically re-referencing the data to an average reference.
+            ``ref_channels=[]``. This will prevent MNE-Python from automatically
+            re-referencing the data to an average reference.
 
         Average reference:
-            A new virtual reference electrode is created by averaging the
-            current EEG signal. Make sure that all bad EEG channels are
-            properly marked and set ``ref_channels=None``.
+            A new virtual reference electrode is created by averaging the current
+            EEG signal. Make sure that all bad EEG channels are properly marked
+            and set ``ref_channels='average'``.
 
         A single electrode:
-            Set ``ref_channels`` to the name of the channel that will act as
-            the new reference.
+            Set ``ref_channels`` to a list containing the name of the channel that
+            will act as the new reference, for example ``ref_channels=['Cz']`.
 
         The mean of multiple electrodes:
-            A new virtual reference electrode is created by computing the
-            average of the current EEG signal recorded from two or more
-            selected channels. Set ``ref_channels`` to a list of channel names,
-            indicating which channels to use. For example, to apply an average
-            mastoid reference, when using the 10-20 naming scheme, set
-            ``ref_channels=['M1', 'M2']``.
+            A new virtual reference electrode is created by computing the average
+            of the current EEG signal recorded from two or more selected channels.
+            Set ``ref_channels`` to a list of channel names, indicating which
+            channels to use. For example, to apply an average mastoid reference,
+            when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
 
         .. note:: In case of average reference (ref_channels=None), the
                   reference is added as an SSP projector and it is not applied
@@ -283,24 +283,37 @@ class SetChannelsMixin(object):
 
         Parameters
         ----------
-        ref_channels : list of str | None
-            The names of the channels to use to construct the reference. If
-            None (default), an average reference will be added as an SSP
-            projector but not immediately applied to the data. If an empty list
-            is specified, the data is assumed to already have a proper
+        inst : instance of Raw | Epochs | Evoked
+            Instance of Raw or Epochs with EEG channels and reference channel(s).
+        ref_channels : list of str | str
+            The names of the channels to use to construct the reference. To apply
+            an average reference, specify ``'average'`` here (default). If an empty
+            list is specified, the data is assumed to already have a proper
             reference and MNE will not attempt any re-referencing of the data.
-            Defaults to an average reference (None).
+            Defaults to an average reference.
+        copy : bool
+            Specifies whether the data will be copied (True) or modified in place
+            (False). Defaults to True.
+        projection : bool
+            If ``ref_channels='average'`` this argument specifies if the average
+            reference should be computed as a projection (True) or not (False). If
+            ``projection=True``, the average reference is added as an SSP projector
+            and is not applied to the data (it can be applied afterwards with the
+            ``apply_proj`` method. If ``projection=False`` (default), the average
+            reference is directly applied to the data.
         verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+            If not None, override default verbose level (see :func:`mne.verbose`
+            and :ref:`Logging documentation <tut_logging>` for more).
 
         Returns
         -------
         inst : instance of Raw | Epochs | Evoked
-            Data with EEG channels re-referenced. For ``ref_channels=None``,
-            an average projector will be added instead of directly subtarcting
-            data.
+            Data with EEG channels re-referenced. If ``ref_channels='average'`` and
+            ``projection=True`` an average SSP projector will be added instead of
+            directly re-referencing the data.
+        ref_data : array
+            Array of reference data subtracted from EEG channels. This will be
+            ``None`` if ``ref_channels='average'`` and ``projection=True``.
 
         Notes
         -----
@@ -310,23 +323,18 @@ class SetChannelsMixin(object):
         2. During source localization, the EEG signal should have an average
            reference.
 
-        3. In order to apply a reference other than an average reference, the
-           data must be preloaded.
+        3. In order to apply a reference, the data must be preloaded. This is not
+           necessary if ``ref_channels='average'`` and ``projection=True``.
 
-        4. Re-referencing to an average reference is done with an SSP
-           projector. This allows applying this reference without preloading
-           the data. Be aware that on preloaded data, SSP projectors are not
-           automatically applied. Use the ``apply_proj()`` method to apply
-           them.
-
-        .. versionadded:: 0.13.0
+        .. versionadded:: 0.9.0
 
         See Also
         --------
-        mne.set_bipolar_reference
+        set_bipolar_reference : Convenience function for creating bipolar
+                                references.
         """
         from ..io.reference import set_eeg_reference
-        return set_eeg_reference(self, ref_channels, copy=False)[0]
+        return set_eeg_reference(self, ref_channels, projection, copy=False)[0]
 
     def _get_channel_positions(self, picks=None):
         """Get channel locations from info.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -243,36 +243,37 @@ class SetChannelsMixin(object):
                           verbose=None):
         """Specify which reference to use for EEG data.
 
-        By default, MNE-Python will automatically re-reference the EEG signal to
-        use an average reference (see below). Use this function to explicitly
-        specify the desired reference for EEG. This can be either an existing
-        electrode or a new virtual channel. This function will re-reference the
-        data according to the desired reference and prevent MNE-Python from
-        automatically adding an average reference.
+        By default, MNE-Python will automatically re-reference the EEG
+        signal to use an average reference (see below). Use this function to
+        explicitly specify the desired reference for EEG. This can be either
+        an existing electrode or a new virtual channel. This function will
+        re-reference the data according to the desired reference and prevent
+        MNE-Python from automatically adding an average reference.
 
         Some common referencing schemes and the corresponding value for the
         ``ref_channels`` parameter:
 
         No re-referencing:
             If the EEG data is already using the proper reference, set
-            ``ref_channels=[]``. This will prevent MNE-Python from automatically
-            re-referencing the data to an average reference.
+            ``ref_channels=[]``. This will prevent MNE-Python from
+            automatically re-referencing the data to an average reference.
 
         Average reference:
-            A new virtual reference electrode is created by averaging the current
-            EEG signal. Make sure that all bad EEG channels are properly marked
-            and set ``ref_channels='average'``.
+            A new virtual reference electrode is created by averaging the
+            current EEG signal. Make sure that all bad EEG channels are
+            properly marked and set ``ref_channels='average'``.
 
         A single electrode:
-            Set ``ref_channels`` to a list containing the name of the channel that
-            will act as the new reference, for example ``ref_channels=['Cz']`.
+            Set ``ref_channels`` to a list containing the name of the channel
+            that will act as the new reference, for example
+            ``ref_channels=['Cz']`.
 
-        The mean of multiple electrodes:
-            A new virtual reference electrode is created by computing the average
-            of the current EEG signal recorded from two or more selected channels.
-            Set ``ref_channels`` to a list of channel names, indicating which
-            channels to use. For example, to apply an average mastoid reference,
-            when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
+        The mean of multiple electrodes: A new virtual reference electrode
+        is created by computing the average of the current EEG signal
+        recorded from two or more selected channels. Set ``ref_channels`` to
+        a list of channel names, indicating which channels to use. For
+        example, to apply an average mastoid reference, when using the 10-20
+        naming scheme, set ``ref_channels=['M1', 'M2']``.
 
         .. note:: In case of average reference (ref_channels=None), the
                   reference is added as an SSP projector and it is not applied
@@ -284,33 +285,32 @@ class SetChannelsMixin(object):
         Parameters
         ----------
         inst : instance of Raw | Epochs | Evoked
-            Instance of Raw or Epochs with EEG channels and reference channel(s).
+            Instance of Raw or Epochs with EEG channels and reference
+            channel(s).
         ref_channels : list of str | str
-            The names of the channels to use to construct the reference. To apply
-            an average reference, specify ``'average'`` here (default). If an empty
-            list is specified, the data is assumed to already have a proper
-            reference and MNE will not attempt any re-referencing of the data.
-            Defaults to an average reference.
-        copy : bool
-            Specifies whether the data will be copied (True) or modified in place
-            (False). Defaults to True.
+            The names of the channels to use to construct the reference. To
+            apply an average reference, specify ``'average'`` here (default).
+            If an empty list is specified, the data is assumed to already have
+            a proper reference and MNE will not attempt any re-referencing of
+            the data. Defaults to an average reference.
         projection : bool
-            If ``ref_channels='average'`` this argument specifies if the average
-            reference should be computed as a projection (True) or not (False). If
-            ``projection=True``, the average reference is added as an SSP projector
-            and is not applied to the data (it can be applied afterwards with the
-            ``apply_proj`` method. If ``projection=False`` (default), the average
-            reference is directly applied to the data.
+            If ``ref_channels='average'`` this argument specifies if the
+            average reference should be computed as a projection (True) or not
+            (False). If ``projection=True``, the average reference is added as
+            an SSP projector and is not applied to the data (it can be applied
+            afterwards with the ``apply_proj`` method. If ``projection=False``
+            (default), the average reference is directly applied to the data.
         verbose : bool, str, int, or None
-            If not None, override default verbose level (see :func:`mne.verbose`
-            and :ref:`Logging documentation <tut_logging>` for more).
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more).
 
         Returns
         -------
         inst : instance of Raw | Epochs | Evoked
-            Data with EEG channels re-referenced. If ``ref_channels='average'`` and
-            ``projection=True`` an average SSP projector will be added instead of
-            directly re-referencing the data.
+            Data with EEG channels re-referenced. If ``ref_channels='average'``
+            and ``projection=True`` an average SSP projector will be added
+            instead of directly re-referencing the data.
         ref_data : array
             Array of reference data subtracted from EEG channels. This will be
             ``None`` if ``ref_channels='average'`` and ``projection=True``.
@@ -323,8 +323,8 @@ class SetChannelsMixin(object):
         2. During source localization, the EEG signal should have an average
            reference.
 
-        3. In order to apply a reference, the data must be preloaded. This is not
-           necessary if ``ref_channels='average'`` and ``projection=True``.
+        3. In order to apply a reference, the data must be preloaded. This is
+           not necessary if ``ref_channels='average'`` and ``projection=True``.
 
         .. versionadded:: 0.9.0
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -239,16 +239,16 @@ class SetChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs."""
 
     @verbose
-    def set_eeg_reference(self, ref_channels='average', projection=False,
+    def set_eeg_reference(self, ref_channels='average', projection=None,
                           verbose=None):
         """Specify which reference to use for EEG data.
 
-        By default, MNE-Python will automatically re-reference the EEG
-        signal to use an average reference (see below). Use this function to
-        explicitly specify the desired reference for EEG. This can be either
-        an existing electrode or a new virtual channel. This function will
+        By default, MNE-Python will automatically re-reference the EEG signal
+        to use an average reference (see below). Use this function to
+        explicitly specify the desired reference for EEG. This can be either an
+        existing electrode or a new virtual channel. This function will
         re-reference the data according to the desired reference and prevent
-        MNE-Python from automatically adding an average reference.
+        MNE-Python from automatically adding an average reference projection.
 
         Some common referencing schemes and the corresponding value for the
         ``ref_channels`` parameter:
@@ -256,7 +256,7 @@ class SetChannelsMixin(object):
         No re-referencing:
             If the EEG data is already using the proper reference, set
             ``ref_channels=[]``. This will prevent MNE-Python from
-            automatically re-referencing the data to an average reference.
+            automatically adding an average reference projection.
 
         Average reference:
             A new virtual reference electrode is created by averaging the
@@ -268,35 +268,39 @@ class SetChannelsMixin(object):
             that will act as the new reference, for example
             ``ref_channels=['Cz']`.
 
-        The mean of multiple electrodes: A new virtual reference electrode
-        is created by computing the average of the current EEG signal
-        recorded from two or more selected channels. Set ``ref_channels`` to
-        a list of channel names, indicating which channels to use. For
-        example, to apply an average mastoid reference, when using the 10-20
-        naming scheme, set ``ref_channels=['M1', 'M2']``.
+        The mean of multiple electrodes:
+            A new virtual reference electrode is created by computing the
+            average of the current EEG signal recorded from two or more
+            selected channels. Set ``ref_channels`` to a list of channel names,
+            indicating which channels to use. For example, to apply an average
+            mastoid reference, when using the 10-20 naming scheme, set
+            ``ref_channels=['M1', 'M2']``.
 
-        .. note:: In case of average reference (ref_channels=None), the
-                  reference is added as an SSP projector and it is not applied
+        .. note:: In case of average reference (`ref_channels='average'``), the
+                  reference is added as a projection and it is not applied
                   automatically. For it to take effect, apply with method
-                  :meth:`apply_proj <mne.io.Raw.apply_proj>`.
-                  For custom reference (ref_channel is not None), this method
-                  operates in place.
+                  :meth:`apply_proj <mne.io.Raw.apply_proj>`. Other references
+                  are directly applied (this behavior will change in MNE 0.16).
 
         Parameters
         ----------
         ref_channels : list of str | str
-            The names of the channels to use to construct the reference. To
+            The name(s) of the channel(s) used to construct the reference. To
             apply an average reference, specify ``'average'`` here (default).
             If an empty list is specified, the data is assumed to already have
             a proper reference and MNE will not attempt any re-referencing of
             the data. Defaults to an average reference.
-        projection : bool
+        projection : bool | None
             If ``ref_channels='average'`` this argument specifies if the
             average reference should be computed as a projection (True) or not
             (False). If ``projection=True``, the average reference is added as
-            an SSP projector and is not applied to the data (it can be applied
-            afterwards with the ``apply_proj`` method. If ``projection=False``
-            (default), the average reference is directly applied to the data.
+            a projection and is not applied to the data (it can be applied
+            afterwards with the ``apply_proj`` method). If
+            ``projection=False``, the average reference is directly applied to
+            the data. Defaults to None, which means ``projection=True``, but
+            will change to ``projection=False`` in the next release.
+            If ``ref_channels`` is not ``'average'``, ``projection`` must be
+            set to ``False`` (the default in this case).
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -306,8 +310,8 @@ class SetChannelsMixin(object):
         -------
         inst : instance of Raw | Epochs | Evoked
             Data with EEG channels re-referenced. If ``ref_channels='average'``
-            and ``projection=True`` an average SSP projector will be added
-            instead of directly re-referencing the data.
+            and ``projection=True`` a projection will be added instead of
+            directly re-referencing the data.
         ref_data : array
             Array of reference data subtracted from EEG channels. This will be
             ``None`` if ``ref_channels='average'`` and ``projection=True``.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -284,9 +284,6 @@ class SetChannelsMixin(object):
 
         Parameters
         ----------
-        inst : instance of Raw | Epochs | Evoked
-            Instance of Raw or Epochs with EEG channels and reference
-            channel(s).
         ref_channels : list of str | str
             The names of the channels to use to construct the reference. To
             apply an average reference, specify ``'average'`` here (default).

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -334,7 +334,8 @@ class SetChannelsMixin(object):
                                 references.
         """
         from ..io.reference import set_eeg_reference
-        return set_eeg_reference(self, ref_channels, projection, copy=False)[0]
+        return set_eeg_reference(self, ref_channels=ref_channels, copy=False,
+                                 projection=projection)[0]
 
     def _get_channel_positions(self, picks=None):
         """Get channel locations from info.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -312,9 +312,6 @@ class SetChannelsMixin(object):
             Data with EEG channels re-referenced. If ``ref_channels='average'``
             and ``projection=True`` a projection will be added instead of
             directly re-referencing the data.
-        ref_data : array
-            Array of reference data subtracted from EEG channels. This will be
-            ``None`` if ``ref_channels='average'`` and ``projection=True``.
 
         Notes
         -----

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -263,7 +263,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
 
 @verbose
 def set_eeg_reference(inst, ref_channels='average', copy=True,
-                      projection=False, verbose=None):
+                      projection=None, verbose=None):
     """Specify which reference to use for EEG data.
 
     By default, MNE-Python will automatically re-reference the EEG signal to
@@ -317,13 +317,15 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     copy : bool
         Specifies whether the data will be copied (True) or modified in place
         (False). Defaults to True.
-    projection : bool
+    projection : bool | None
         If ``ref_channels='average'`` this argument specifies if the average
         reference should be computed as a projection (True) or not (False). If
         ``projection=True``, the average reference is added as an SSP projector
         and is not applied to the data (it can be applied afterwards with the
-        ``apply_proj`` method. If ``projection=False`` (default), the average
-        reference is directly applied to the data.
+        ``apply_proj`` method. If ``projection=False``, the average
+        reference is directly applied to the data. Defaults to None, which
+        means ``projection==True``, but will change to ``projection==False`` in
+        the next release.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -365,6 +367,16 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
              'deprecated and will be replaced by ref_channels="average" in '
              '0.16.', DeprecationWarning)
         ref_channels = 'average'
+
+    if projection is None:
+        warn('The behavior of set_eeg_reference will change in 0.16 when '
+             'computing the average reference. Currently, an SSP projector is '
+             'computed, which has to be applied manually with the apply_proj '
+             'method. In 0.16, the average reference will be directly applied. '
+             'Set projection=True if you want to retain the old behavior, or '
+             'set projection=False if you want the new behavior.',
+             DeprecationWarning)
+        projection=True
 
     if ref_channels != 'average' and projection:
         raise ValueError('Setting projection=True is only supported for '

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -409,6 +409,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     inst = inst.copy() if copy else inst
 
     if ref_channels == 'average' and not projection:  # apply average reference
+        logger.info('Applying average reference.')
         eeg_idx = pick_types(inst.info, eeg=True, meg=False, ref_meg=False)
         ref_from = [inst.ch_names[i] for i in eeg_idx]
         return _apply_reference(inst, ref_from)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -389,7 +389,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
                     logger.info('Average reference projection was added, '
                                 'but has not been applied yet. Use the '
                                 'apply_proj method to apply projections.')
-            except:  # TODO: which exception is caught here?
+            except Exception:  # TODO: which exception is caught here?
                 inst.info['custom_ref_applied'] = custom_ref_applied
                 raise  # TODO: re-raise specific exception
             return inst, None

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -399,7 +399,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     if ref_channels == 'average' and not projection:  # apply average reference
         if not inst.preload:
             raise RuntimeError('Data needs to be preloaded.')
-        inst.info['custom_ref_applied'] = False
         inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
         inst.apply_proj()
         return inst, None  # TODO: should we return None here?

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -372,8 +372,8 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         warn('The behavior of set_eeg_reference will change in 0.16 when '
              'computing the average reference. Currently, an SSP projector is '
              'computed, which has to be applied manually with the apply_proj '
-             'method. In 0.16, the average reference will be directly applied. '
-             'Set projection=True if you want to retain the old behavior, or '
+             'method. In 0.16, the average reference will be directly applied.'
+             ' Set projection=True if you want to retain the old behavior, or '
              'set projection=False if you want the new behavior.',
              DeprecationWarning)
         if ref_channels == 'average':

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -376,7 +376,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
              'Set projection=True if you want to retain the old behavior, or '
              'set projection=False if you want the new behavior.',
              DeprecationWarning)
-        projection=True
+        if ref_channels == 'average':
+            projection = True
+        else:
+            projection = False
 
     if ref_channels != 'average' and projection:
         raise ValueError('Setting projection=True is only supported for '

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -409,8 +409,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     inst = inst.copy() if copy else inst
 
     if ref_channels == 'average' and not projection:  # apply average reference
-        if not inst.preload:
-            raise RuntimeError('Data needs to be preloaded.')
         eeg_idx = pick_types(inst.info, eeg=True, meg=False, ref_meg=False)
         ref_from = [inst.ch_names[i] for i in eeg_idx]
         return _apply_reference(inst, ref_from)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -293,9 +293,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         channels to use. For example, to apply an average mastoid reference,
         when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
 
-    .. note:: In case of average reference (`ref_channels='average'``), the
-              reference is added as a projection and it is not applied
-              automatically. For it to take effect, apply with method
+    .. note:: In case of average reference `ref_channels='average'`` in
+              combination with `projection=True`, the reference is added as a
+              projection and it is not applied automatically. For it to take
+              effect, apply with method
               :meth:`apply_proj <mne.io.Raw.apply_proj>`. Other references are
               directly applied (this behavior will change in MNE 0.16).
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -388,10 +388,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
                 if inst.preload:
                     logger.info('Average reference projection was added, '
                                 'but has not been applied yet. Use the '
-                                'apply_proj method to apply projections.')
-            except Exception:  # TODO: which exception is caught here?
+                                'apply_proj method to apply it.')
+            except Exception:
                 inst.info['custom_ref_applied'] = custom_ref_applied
-                raise  # TODO: re-raise specific exception
+                raise
             return inst, None
 
     inst = inst.copy() if copy else inst
@@ -399,9 +399,9 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     if ref_channels == 'average' and not projection:  # apply average reference
         if not inst.preload:
             raise RuntimeError('Data needs to be preloaded.')
-        inst.add_proj(make_eeg_average_ref_proj(inst.info, activate=False))
-        inst.apply_proj()
-        return inst, None  # TODO: should we return None here?
+        eeg_idx = pick_types(inst.info, eeg=True, meg=False, ref_meg=False)
+        ref_from = [inst.ch_names[i] for i in eeg_idx]
+        return _apply_reference(inst, ref_from)
 
     if ref_channels == []:
         logger.info('EEG data marked as already having the desired reference. '

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -200,6 +200,23 @@ def test_set_eeg_reference():
     reref, ref_data = set_eeg_reference(raw, [])
     assert_array_equal(raw._data, reref._data)
 
+    # Test that average reference gives identical results when calculated
+    # via SSP projection (projection=True) or directly (projection=False)
+    raw.info['projs'] = []
+    reref_1, _ = set_eeg_reference(raw.copy(), projection=True)
+    reref_1.apply_proj()
+    reref_2, _ = set_eeg_reference(raw.copy(), projection=False)
+    assert_allclose(reref_1._data, reref_2._data, rtol=1e-6, atol=1e-15)
+
+    # Test average reference without projection
+    reref, ref_data = set_eeg_reference(raw.copy(), ref_channels="average",
+                                        projection=False)
+    _test_reference(raw, reref, ref_data, eeg_chans)
+
+    # projection=True only works for ref_channels='average'
+    assert_raises(ValueError, set_eeg_reference, raw, [], True, True)
+    assert_raises(ValueError, set_eeg_reference, raw, ['EEG 001'], True, True)
+
 
 @testing.requires_testing_data
 def test_set_bipolar_reference():

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -142,9 +142,9 @@ def test_set_eeg_reference():
     raw = read_raw_fif(fif_fname, preload=True)
     raw.info['projs'] = []
 
-    # Test setting an average reference
+    # Test setting an average reference projection
     assert_true(not _has_eeg_average_ref_proj(raw.info['projs']))
-    reref, ref_data = set_eeg_reference(raw)
+    reref, ref_data = set_eeg_reference(raw, projection=True)
     assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
     assert_true(not reref.info['projs'][0]['active'])
     assert_true(ref_data is None)
@@ -156,13 +156,13 @@ def test_set_eeg_reference():
 
     # Test setting an average reference when one was already present
     with warnings.catch_warnings(record=True):
-        reref, ref_data = set_eeg_reference(raw, copy=False)
+        reref, ref_data = set_eeg_reference(raw, copy=False, projection=True)
     assert_true(ref_data is None)
 
     # Test setting an average reference on non-preloaded data
     raw_nopreload = read_raw_fif(fif_fname, preload=False)
     raw_nopreload.info['projs'] = []
-    reref, ref_data = set_eeg_reference(raw_nopreload)
+    reref, ref_data = set_eeg_reference(raw_nopreload, projection=True)
     assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
     assert_true(not reref.info['projs'][0]['active'])
 
@@ -178,7 +178,7 @@ def test_set_eeg_reference():
 
     # Test moving from custom to average reference
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
-    reref, _ = set_eeg_reference(reref)
+    reref, _ = set_eeg_reference(reref, projection=True)
     assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
     assert_equal(reref.info['custom_ref_applied'], False)
 
@@ -187,11 +187,11 @@ def test_set_eeg_reference():
     reref = raw.copy()
     reref.info['custom_ref_applied'] = True
     reref.pick_types(eeg=False)  # Cause making average ref fail
-    assert_raises(ValueError, set_eeg_reference, reref)
+    assert_raises(ValueError, set_eeg_reference, reref, projection=True)
     assert_true(reref.info['custom_ref_applied'])
 
     # Test moving from average to custom reference
-    reref, ref_data = set_eeg_reference(raw)
+    reref, ref_data = set_eeg_reference(raw, projection=True)
     reref, _ = set_eeg_reference(reref, ['EEG 001', 'EEG 002'])
     assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
     assert_equal(reref.info['custom_ref_applied'], True)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -253,7 +253,7 @@ def test_cov_estimation_with_triggers():
     """Test estimation from raw with triggers."""
     tempdir = _TempDir()
     raw = read_raw_fif(raw_fname)
-    raw.set_eeg_reference().load_data()
+    raw.set_eeg_reference(projection=True).load_data()
     events = find_events(raw, stim_channel='STI 014')
     event_ids = [1, 2, 3, 4]
     reject = dict(grad=10000e-13, mag=4e-12, eeg=80e-6, eog=150e-6)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -82,7 +82,7 @@ def test_io_dipoles():
 @testing.requires_testing_data
 def test_dipole_fitting_ctf():
     """Test dipole fitting with CTF data."""
-    raw_ctf = read_raw_ctf(fname_ctf).set_eeg_reference()
+    raw_ctf = read_raw_ctf(fname_ctf).set_eeg_reference(projection=True)
     events = make_fixed_length_events(raw_ctf, 1)
     evoked = Epochs(raw_ctf, events, 1, 0, 0, baseline=None).average()
     cov = make_ad_hoc_cov(evoked.info)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -794,7 +794,7 @@ def test_epochs_proj():
                             eog=True, exclude=exclude)
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
-    epochs.set_eeg_reference().apply_proj()
+    epochs.set_eeg_reference(projection=True).apply_proj()
     assert_true(_has_eeg_average_ref_proj(epochs.info['projs']))
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
@@ -1548,7 +1548,7 @@ def test_epochs_proj_mixin():
     for preload in [True, False]:
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                         proj='delayed', preload=preload,
-                        reject=reject).set_eeg_reference()
+                        reject=reject).set_eeg_reference(projection=True)
         epochs_proj = Epochs(
             raw, events[:4], event_id, tmin, tmax, picks=picks,
             proj=True, preload=preload,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -839,7 +839,7 @@ def test_epochs_proj():
         epochs.set_eeg_reference().apply_proj()
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
         epochs = read_epochs(temp_fname, proj=False, preload=preload)
-        epochs.set_eeg_reference()
+        epochs.set_eeg_reference(projection=True)
         assert_raises(AssertionError, assert_allclose,
                       epochs.get_data().mean(axis=1), 0., atol=1e-15)
         epochs.apply_proj()
@@ -1552,7 +1552,7 @@ def test_epochs_proj_mixin():
         epochs_proj = Epochs(
             raw, events[:4], event_id, tmin, tmax, picks=picks,
             proj=True, preload=preload,
-            reject=reject).set_eeg_reference().apply_proj()
+            reject=reject).set_eeg_reference(projection=True).apply_proj()
 
         epochs_noproj = Epochs(
             raw, events[:4], event_id, tmin, tmax, picks=picks,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1064,7 +1064,7 @@ def test_comparision_with_c():
     c_evoked = read_evokeds(evoked_nf_name, condition=0)
     epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=None,
                     preload=True, proj=False)
-    evoked = epochs.set_eeg_reference().apply_proj().average()
+    evoked = epochs.set_eeg_reference(projection=True).apply_proj().average()
     sel = pick_channels(c_evoked.ch_names, evoked.ch_names)
     evoked_data = evoked.data
     c_evoked_data = c_evoked.data[sel]
@@ -1582,7 +1582,8 @@ def test_epochs_proj_mixin():
 
     # test mixin against manual application
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
-                    baseline=None, proj=False).set_eeg_reference()
+                    baseline=None,
+                    proj=False).set_eeg_reference(projection=True)
     data = epochs.get_data().copy()
     epochs.apply_proj()
     assert_allclose(np.dot(epochs._projector, data[0]), epochs._data[0])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -836,7 +836,7 @@ def test_epochs_proj():
     epochs.save(temp_fname)
     for preload in (True, False):
         epochs = read_epochs(temp_fname, proj=False, preload=preload)
-        epochs.set_eeg_reference().apply_proj()
+        epochs.set_eeg_reference(projection=True).apply_proj()
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
         epochs = read_epochs(temp_fname, proj=False, preload=preload)
         epochs.set_eeg_reference(projection=True)
@@ -1554,9 +1554,10 @@ def test_epochs_proj_mixin():
             proj=True, preload=preload,
             reject=reject).set_eeg_reference(projection=True).apply_proj()
 
-        epochs_noproj = Epochs(
-            raw, events[:4], event_id, tmin, tmax, picks=picks,
-            proj=False, preload=preload, reject=reject).set_eeg_reference()
+        epochs_noproj = Epochs(raw, events[:4], event_id, tmin, tmax,
+                               picks=picks, proj=False, preload=preload,
+                               reject=reject)
+        epochs_noproj.set_eeg_reference(projection=True)
 
         assert_allclose(epochs.copy().apply_proj().get_data(),
                         epochs_proj.get_data(), rtol=1e-10, atol=1e-25)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -318,7 +318,7 @@ def test_has_eeg_average_ref_proj():
     assert_true(not _has_eeg_average_ref_proj([]))
 
     raw = read_raw_fif(raw_fname)
-    raw.set_eeg_reference()
+    raw.set_eeg_reference(projection=True)
     assert_true(_has_eeg_average_ref_proj(raw.info['projs']))
 
 
@@ -327,7 +327,7 @@ def test_needs_eeg_average_ref_proj():
     raw = read_raw_fif(raw_fname)
     assert_true(_needs_eeg_average_ref_proj(raw.info))
 
-    raw.set_eeg_reference()
+    raw.set_eeg_reference(projection=True)
     assert_true(not _needs_eeg_average_ref_proj(raw.info))
 
     # No EEG channels

--- a/tutorials/plot_artifacts_correction_rejection.py
+++ b/tutorials/plot_artifacts_correction_rejection.py
@@ -13,7 +13,7 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw_fif(raw_fname)
-raw.set_eeg_reference()
+raw.set_eeg_reference('average', projection=True)
 
 ###############################################################################
 # .. _marking_bad_channels:

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -17,7 +17,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
-raw.set_eeg_reference()
+raw.set_eeg_reference('average', projection=True)
 raw.pick_types(meg=True, ecg=True, eog=True, stim=True)
 
 ##############################################################################

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -20,7 +20,7 @@ raw_empty_room_fname = op.join(
 raw_empty_room = mne.io.read_raw_fif(raw_empty_room_fname)
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(raw_fname)
-raw.set_eeg_reference()
+raw.set_eeg_reference('average', projection=True)
 raw.info['bads'] += ['EEG 053']  # bads + 1 more
 
 ###############################################################################

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -23,7 +23,7 @@ data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 
 ###############################################################################
 # Let's restrict the data to the EEG channels
@@ -111,7 +111,7 @@ evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title)
 ###############################################################################
 # **Average reference**: This is normally added by default, but can also
 # be added explicitly.
-raw_car, _ = mne.set_eeg_reference(raw)
+raw_car, _ = mne.set_eeg_reference(raw, 'average', projection=True)
 evoked_car = mne.Epochs(raw_car, **epochs_params).average()
 del raw_car  # save memory
 

--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -18,7 +18,7 @@ import mne
 data_path = mne.datasets.sample.data_path()
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(fname)
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 
 ###############################################################################
 # To create time locked epochs, we first need a set of events that contain the

--- a/tutorials/plot_epochs_to_data_frame.py
+++ b/tutorials/plot_epochs_to_data_frame.py
@@ -103,7 +103,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 
 raw = mne.io.read_raw_fif(raw_fname)
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 
 # For simplicity we will only consider the first 10 epochs
 events = mne.read_events(event_fname)[:10]

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -32,7 +32,7 @@ from matplotlib import pyplot as plt
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG',
                     'sample', 'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(data_path, preload=True)
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 
 # Give the sample rate
 print('sample rate:', raw.info['sfreq'], 'Hz')

--- a/tutorials/plot_visualize_epochs.py
+++ b/tutorials/plot_visualize_epochs.py
@@ -11,7 +11,7 @@ import mne
 
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
 raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'))
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
             'visual/right': 4, 'smiley': 5, 'button': 32}
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -13,7 +13,7 @@ import mne
 data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
 raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
                           preload=True)
-raw.set_eeg_reference()  # set EEG average reference
+raw.set_eeg_reference('average', projection=True)  # set EEG average reference
 events = mne.read_events(op.join(data_path, 'sample_audvis_raw-eve.fif'))
 
 ###############################################################################


### PR DESCRIPTION
Fix #4302 and #3998.

Added new argument `projection=False` to `set_eeg_reference`.