### PR TITLE
[MRG+1] ENH:  morph between hemispheres

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -287,6 +287,7 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
     auto_examples/visualization/plot_ssp_projs_sensitivity_map.rst
     auto_examples/visualization/plot_topo_compare_conditions.rst
     auto_examples/visualization/plot_topo_customized.rst
+    auto_examples/visualization/plot_xhemi.rst
 
 .. raw:: html
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -109,6 +109,8 @@ Changelog
 
     - Add high frequency somatosensory MEG dataset by `Jussi Nurminen`_
 
+    - Enable morphing between hemispheres with :func:`mne.compute_morph_matrix` by `Christian Brodbeck`_
+
 BUG
 ~~~
 

--- a/examples/visualization/plot_xhemi.py
+++ b/examples/visualization/plot_xhemi.py
@@ -35,10 +35,13 @@ mm = mne.compute_morph_matrix(
     subjects_dir=subjects_dir)
 
 # SourceEstimate on the left hemisphere:
-stc_lh = mne.SourceEstimate(stc.lh_data, [stc.vertices[0], []], stc.tmin, stc.tstep, stc.subject)
+stc_lh = mne.SourceEstimate(stc.lh_data, [stc.vertices[0], []], stc.tmin,
+                            stc.tstep, stc.subject)
 # SourceEstimate of the right hemisphere, morphed to the left:
-stc_rh_on_lh = mne.SourceEstimate(mm * stc.rh_data, [stc.vertices[0], []], stc.tmin, stc.tstep, stc.subject)
+stc_rh_on_lh = mne.SourceEstimate(mm * stc.rh_data, [stc.vertices[0], []],
+                                  stc.tmin, stc.tstep, stc.subject)
 # Since both STCs are now on the same hemisphere we can subtract them:
 diff = stc_lh - stc_rh_on_lh
 
-diff.plot(hemi='lh', subjects_dir=subjects_dir, initial_time=0.07, size=(800, 600))
+diff.plot(hemi='lh', subjects_dir=subjects_dir, initial_time=0.07,
+          size=(800, 600))

--- a/examples/visualization/plot_xhemi.py
+++ b/examples/visualization/plot_xhemi.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+===========================
+Cross-hemisphere comparison
+===========================
+
+This example illustrates how to visualize the difference between activity in
+the left and the right hemisphere. The data from the right hemisphere is
+mapped to the left hemisphere, and then the difference is plotted. For more
+information see :func:`mne.compute_morph_matrix`.
+"""
+# Author: Christian Brodbeck <christianbrodbeck@nyu.edu>
+#
+# License: BSD (3-clause)
+
+import mne
+
+
+subjects_dir = mne.datasets.testing.data_path() + '/subjects'
+data_dir = mne.datasets.sample.data_path()
+stc_path = data_dir + '/MEG/sample/sample_audvis-meg-eeg'
+
+stc = mne.read_source_estimate(stc_path, 'sample')
+
+# First, morph the data to fsaverage because we have left-righ registrations
+# for fsaverage:
+stc = stc.morph('fsaverage', subjects_dir=subjects_dir)
+
+# Compute a morph-matrix mapping the right to the left hemisphere. Use the
+# vertices parameters to determine source and target hemisphere:
+mm = mne.compute_morph_matrix(
+    'fsaverage', 'fsaverage', xhemi=True,  # cross-hemisphere morphing
+    vertices_from=[[], stc.vertices[1]],  # from the right hemisphere
+    vertices_to=[stc.vertices[0], []],  # to the left hemisphere
+    subjects_dir=subjects_dir)
+
+# SourceEstimate on the left hemisphere:
+stc_lh = mne.SourceEstimate(stc.lh_data, [stc.vertices[0], []], stc.tmin, stc.tstep, stc.subject)
+# SourceEstimate of the right hemisphere, morphed to the left:
+stc_rh_on_lh = mne.SourceEstimate(mm * stc.rh_data, [stc.vertices[0], []], stc.tmin, stc.tstep, stc.subject)
+# Since both STCs are now on the same hemisphere we can subtract them:
+diff = stc_lh - stc_rh_on_lh
+
+diff.plot(hemi='lh', subjects_dir=subjects_dir, initial_time=0.07, size=(800, 600))

--- a/examples/visualization/plot_xhemi.py
+++ b/examples/visualization/plot_xhemi.py
@@ -24,7 +24,7 @@ stc = mne.read_source_estimate(stc_path, 'sample')
 
 # First, morph the data to fsaverage_sym, for which we have left_right
 # registrations:
-stc = stc.morph('fsaverage_sym', subjects_dir=subjects_dir)
+stc = stc.morph('fsaverage_sym', subjects_dir=subjects_dir, smooth=5)
 
 # Compute a morph-matrix mapping the right to the left hemisphere. Use the
 # vertices parameters to determine source and target hemisphere:

--- a/examples/visualization/plot_xhemi.py
+++ b/examples/visualization/plot_xhemi.py
@@ -16,20 +16,20 @@ information see :func:`mne.compute_morph_matrix`.
 import mne
 
 
-subjects_dir = mne.datasets.testing.data_path() + '/subjects'
 data_dir = mne.datasets.sample.data_path()
+subjects_dir = data_dir + '/subjects'
 stc_path = data_dir + '/MEG/sample/sample_audvis-meg-eeg'
 
 stc = mne.read_source_estimate(stc_path, 'sample')
 
-# First, morph the data to fsaverage because we have left-righ registrations
-# for fsaverage:
-stc = stc.morph('fsaverage', subjects_dir=subjects_dir)
+# First, morph the data to fsaverage_sym, for which we have left_right
+# registrations:
+stc = stc.morph('fsaverage_sym', subjects_dir=subjects_dir)
 
 # Compute a morph-matrix mapping the right to the left hemisphere. Use the
 # vertices parameters to determine source and target hemisphere:
 mm = mne.compute_morph_matrix(
-    'fsaverage', 'fsaverage', xhemi=True,  # cross-hemisphere morphing
+    'fsaverage_sym', 'fsaverage_sym', xhemi=True,  # cross-hemisphere morphing
     vertices_from=[[], stc.vertices[1]],  # from the right hemisphere
     vertices_to=[stc.vertices[0], []],  # to the left hemisphere
     subjects_dir=subjects_dir)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -8,7 +8,6 @@
 import copy
 import os.path as op
 from math import ceil
-import re
 import warnings
 
 import numpy as np
@@ -19,7 +18,7 @@ from .filter import resample
 from .evoked import _get_peak
 from .parallel import parallel_func
 from .surface import (read_surface, _get_ico_surface, read_morph_map,
-                      _reg_args, _compute_nearest, mesh_edges)
+                      _compute_nearest, mesh_edges)
 from .source_space import (_ensure_src, _get_morph_src_reordering,
                            _ensure_src_subject, SourceSpaces)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -461,10 +461,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
                                  'dimensions')
 
         if isinstance(vertices, list):
-            if not all(isinstance(v, np.ndarray) for v in vertices):
-                raise ValueError('Vertices, if a list, must contain numpy '
-                                 'arrays')
-
+            vertices = [np.asarray(v) for v in vertices]
             if any(np.any(np.diff(v.astype(int)) <= 0) for v in vertices):
                 raise ValueError('Vertices must be ordered in increasing '
                                  'order.')

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2483,8 +2483,14 @@ def compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
 
     Notes
     -----
-    This function can be used to morph data from one hemisphere to the other
-    by setting ``xhemi=True``. This requires appropriate ``sphere.left_right``
+    This function can be used to morph data between hemispheres by setting
+    ``xhemi=True``. The full cross-hemisphere morph matrix maps left to right
+    and right to left. A matrix for cross-mapping only one hemisphere can be
+    constructed by specifying the appropriate vertices, for example, to map the
+    right hemisphere to the left:
+    ``vertices_from=[[], vert_rh], vertices_to=[vert_lh, []]``.
+
+    Cross-hemisphere mapping requires appropriate ``sphere.left_right``
     morph-maps in the subject's directory. These morph maps are included
     with the ``fsaverage_sym`` FreeSurfer subject, and can be created for other
     subjects with the ``mris_left_right_register`` FreeSurfer command. The

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2470,7 +2470,7 @@ def compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
     warn : bool
         If True, warn if not all vertices were used.
     xhemi : bool
-        Morph across hemisphere. Currenly only implemented for
+        Morph across hemisphere. Currently only implemented for
         ``subject_to == subject_from``. Requires appropriate
         ``sphere.left_right`` morph-maps, which are included with the
         ``fsaverage_sym`` FreeSurfer subject and can be created for other

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2454,27 +2454,24 @@ def compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
     Parameters
     ----------
     subject_from : string
-        Name of the original subject as named in the SUBJECTS_DIR
+        Name of the original subject as named in the SUBJECTS_DIR.
     subject_to : string
-        Name of the subject on which to morph as named in the SUBJECTS_DIR
+        Name of the subject on which to morph as named in the SUBJECTS_DIR.
     vertices_from : list of arrays of int
-        Vertices for each hemisphere (LH, RH) for subject_from
+        Vertices for each hemisphere (LH, RH) for subject_from.
     vertices_to : list of arrays of int
-        Vertices for each hemisphere (LH, RH) for subject_to
+        Vertices for each hemisphere (LH, RH) for subject_to.
     smooth : int or None
         Number of iterations for the smoothing of the surface data.
         If None, smooth is automatically defined to fill the surface
         with non-zero values.
     subjects_dir : string
-        Path to SUBJECTS_DIR is not set in the environment
+        Path to SUBJECTS_DIR is not set in the environment.
     warn : bool
         If True, warn if not all vertices were used.
     xhemi : bool
         Morph across hemisphere. Currently only implemented for
-        ``subject_to == subject_from``. Requires appropriate
-        ``sphere.left_right`` morph-maps, which are included with the
-        ``fsaverage_sym`` FreeSurfer subject and can be created for other
-        subjects with the ``mris_left_right_register`` FreeSurfer command.
+        ``subject_to == subject_from``. See notes below.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -2482,7 +2479,27 @@ def compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
     Returns
     -------
     morph_matrix : sparse matrix
-        matrix that morphs data from subject_from to subject_to
+        matrix that morphs data from ``subject_from`` to ``subject_to``.
+
+    Notes
+    -----
+    This function can be used to morph data from one hemisphere to the other
+    by setting ``xhemi=True``. This requires appropriate ``sphere.left_right``
+    morph-maps in the subject's directory. These morph maps are included
+    with the ``fsaverage_sym`` FreeSurfer subject, and can be created for other
+    subjects with the ``mris_left_right_register`` FreeSurfer command. The
+    ``fsaverage_sym`` subject is included with FreeSurfer > 5.1 and can be
+    obtained as described `here
+    <http://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi>`_. For statistical
+    comparisons between hemispheres, use of the symmetric ``fsaverage_sym``
+    model is recommended to minimize bias [1]_.
+
+    References
+    ----------
+    .. [1] Greve D. N., Van der Haegen L., Cai Q., Stufflebeam S., Sabuncu M.
+           R., Fischl B., Brysbaert M.
+           A Surface-based Analysis of Language Lateralization and Cortical
+           Asymmetry. Journal of Cognitive Neuroscience 25(9), 1477-1492, 2013.
     """
     logger.info('Computing morph matrix...')
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -837,7 +837,7 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
     subjects_dir : string
         Path to SUBJECTS_DIR is not set in the environment.
     xhemi : bool
-        Morph across hemisphere. Currenly only implemented for
+        Morph across hemisphere. Currently only implemented for
         ``subject_to == subject_from``. Requires appropriate
         ``sphere.left_right`` morph-maps, which are included with the
         ``fsaverage_sym`` FreeSurfer subject and can be created for other
@@ -934,7 +934,7 @@ def _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2):
 
 
 def _read_morph_map(fname, subject_from, subject_to):
-    """Read a morph map from disk"""
+    """Read a morph map from disk."""
     f, tree, _ = fiff_open(fname)
     with f as fid:
         # Locate all maps
@@ -1018,7 +1018,7 @@ def _make_morph_map(subject_from, subject_to, subjects_dir, xhemi):
 
 def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from,
                          reg_to):
-    """Construct morph map for one hemisphere"""
+    """Construct morph map for one hemisphere."""
     # add speedy short-circuit for self-maps
     if subject_from == subject_to and reg_from == reg_to:
         fname = op.join(subjects_dir, subject_from, 'surf', reg_from)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1011,7 +1011,7 @@ def _make_morph_map(subject_from, subject_to, subjects_dir, xhemi):
         reg = '%s.sphere.reg'
         hemis = (('lh', 'lh'), ('rh', 'rh'))
 
-    return [_make_morph_map_hemi(subject_to, subject_from, subjects_dir,
+    return [_make_morph_map_hemi(subject_from, subject_to, subjects_dir,
                                  reg % hemi_from, reg % hemi_to)
             for hemi_from, hemi_to in hemis]
 

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -502,7 +502,7 @@ def read_surface(fname, read_metadata=False, return_dict=False, verbose=None):
     volume_info : dict-like
         If read_metadata is true, key-value pairs found in the geometry file.
     surf : dict
-        The surface parameters. Only returned if read_dict is True.
+        The surface parameters. Only returned if ``return_dict`` is True.
 
     See Also
     --------

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -838,10 +838,8 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
         Path to SUBJECTS_DIR is not set in the environment.
     xhemi : bool
         Morph across hemisphere. Currently only implemented for
-        ``subject_to == subject_from``. Requires appropriate
-        ``sphere.left_right`` morph-maps, which are included with the
-        ``fsaverage_sym`` FreeSurfer subject and can be created for other
-        subjects with the ``mris_left_right_register`` FreeSurfer command.
+        ``subject_to == subject_from``. See notes at
+        :func:`mne.compute_morph_matrix`.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -9,7 +9,6 @@ from distutils.version import LooseVersion
 from glob import glob
 import os
 from os import path as op
-import re
 import sys
 from struct import pack
 
@@ -899,23 +898,6 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
         raise ValueError('Could not find both hemispheres in %s' % fname)
 
     return left_map, right_map
-
-
-def _reg_args(reg_from, reg_to):
-    pattern = re.compile("(?:(lh|rh)\.)?(sphere\.(?:reg|left_right))")
-    match = pattern.match(reg_from)
-    if match is None:
-        raise ValueError("from_reg=%r" % (reg_from,))
-    hemi_from, regname_from = match.groups()
-    match = pattern.match(reg_to)
-    if match is None:
-        raise ValueError("to_reg=%r" % (reg_to,))
-    hemi_to, regname_to = match.groups()
-    if (hemi_from is None) != (hemi_to is None):
-        raise ValueError(
-            "Hemisphere has to be specified in both or neither of reg_from "
-            "and reg_to; got from_reg=%r, to_reg=%r" % (reg_from, reg_to))
-    return hemi_from, hemi_to, regname_from, regname_to
 
 
 def _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -867,12 +867,14 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
             raise NotImplementedError(
                 "Morph-maps between hemispheres are currently only "
                 "implemented for subject_to == subject_from")
-        map_names = [subject_from + '-xhemi']
+        map_name_temp = '%s-%s-xhemi'
         log_msg = 'Creating morph map %s -> %s xhemi'
     else:
-        map_names = ['-'.join((subject_from, subject_to)),
-                     '-'.join((subject_to, subject_from))]
+        map_name_temp = '%s-%s'
         log_msg = 'Creating morph map %s -> %s'
+
+    map_names = [map_name_temp % (subject_from, subject_to),
+                 map_name_temp % (subject_to, subject_from)]
 
     # find existing file, otherwise make it
     for map_name in map_names:

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -874,28 +874,24 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
     map_names = [map_name_temp % (subject_from, subject_to),
                  map_name_temp % (subject_to, subject_from)]
 
-    # find existing file, otherwise make it
+    # find existing file
     for map_name in map_names:
         fname = op.join(mmap_dir, '%s-morph.fif' % map_name)
         if op.exists(fname):
-            break
+            return _read_morph_map(fname, subject_from, subject_to)
+    # if file does not exist, make it
+    warn('Morph map "%s" does not exist, creating it and saving it to '
+         'disk (this may take a few minutes)' % fname)
+    logger.info(log_msg % (subject_from, subject_to))
+    mmap_1 = _make_morph_map(subject_from, subject_to, subjects_dir, xhemi)
+    if subject_to == subject_from:
+        mmap_2 = None
     else:
-        warn('Morph map "%s" does not exist, creating it and saving it to '
-             'disk (this may take a few minutes)' % fname)
-        logger.info(log_msg % (subject_from, subject_to))
-        mmap_1 = _make_morph_map(subject_from, subject_to, subjects_dir, xhemi)
-        if subject_to == subject_from:
-            mmap_2 = None
-        else:
-            logger.info(log_msg % (subject_to, subject_from))
-            mmap_2 = _make_morph_map(subject_to, subject_from, subjects_dir,
-                                     xhemi)
-        _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2)
-        return mmap_1
-
-    left_map, right_map = _read_morph_map(fname, subject_from, subject_to)
-
-    return left_map, right_map
+        logger.info(log_msg % (subject_to, subject_from))
+        mmap_2 = _make_morph_map(subject_to, subject_from, subjects_dir,
+                                 xhemi)
+    _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2)
+    return mmap_1
 
 
 def _read_morph_map(fname, subject_from, subject_to):

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -96,20 +96,27 @@ def test_make_morph_maps():
     for subject in ('sample', 'sample_ds', 'fsaverage_ds'):
         os.mkdir(op.join(tempdir, subject))
         os.mkdir(op.join(tempdir, subject, 'surf'))
+        regs = ('reg', 'left_right') if subject == 'fsaverage_ds' else ('reg',)
         for hemi in ['lh', 'rh']:
-            args = [subject, 'surf', hemi + '.sphere.reg']
-            copyfile(op.join(subjects_dir, *args),
-                     op.join(tempdir, *args))
+            for reg in regs:
+                args = [subject, 'surf', hemi + '.sphere.' + reg]
+                copyfile(op.join(subjects_dir, *args),
+                         op.join(tempdir, *args))
 
-    # this should trigger the creation of morph-maps dir and create the map
-    with warnings.catch_warnings(record=True):
-        mmap = read_morph_map('fsaverage_ds', 'sample_ds', tempdir)
-    mmap2 = read_morph_map('fsaverage_ds', 'sample_ds', subjects_dir)
-    assert_equal(len(mmap), len(mmap2))
-    for m1, m2 in zip(mmap, mmap2):
-        # deal with sparse matrix stuff
-        diff = (m1 - m2).data
-        assert_allclose(diff, np.zeros_like(diff), atol=1e-3, rtol=0)
+    for subject_from, subject_to, xhemi in (
+            ('fsaverage_ds', 'sample_ds', False),
+            ('fsaverage_ds', 'fsaverage_ds', True)):
+        # trigger the creation of morph-maps dir and create the map
+        with warnings.catch_warnings(record=True):
+            mmap = read_morph_map(subject_from, subject_to, tempdir,
+                                  xhemi=xhemi)
+        mmap2 = read_morph_map(subject_from, subject_to, subjects_dir,
+                               xhemi=xhemi)
+        assert_equal(len(mmap), len(mmap2))
+        for m1, m2 in zip(mmap, mmap2):
+            # deal with sparse matrix stuff
+            diff = (m1 - m2).data
+            assert_allclose(diff, np.zeros_like(diff), atol=1e-3, rtol=0)
 
     # This will also trigger creation, but it's trivial
     with warnings.catch_warnings(record=True):


### PR DESCRIPTION
Addresses #4360 

@Eric89GXL what do you think of the API? An example is below.

The `'lh'`/`'rh'` tags allow specifying which direction to map (I don't think mirroring both hemispheres will be useful). An alternative would be that the user should specify vertices for only the required hemispheres, like `[[], rh_vertices], [lh_vertices, []]` to morph from right to left; in that case we could actually remove the reg_from and reg_to parameters if all we want to add is xhemi morphing, but this solution is less explicit than the parameters.

Concerning testing, actually testing the x-hemi registration would require adding a new registration file to the dataset. Alternatively I could just add a test loading a morph matrix for only one hemisphere.

<img width="621" alt="screen shot 2017-07-14 at 12 36 15 pm" src="https://user-images.githubusercontent.com/145771/28221468-5b50a9f4-6891-11e7-9a04-2f4778ab07dc.png">


```
# Data from examples/MNE-sample-data/MEG/sample
import mne

sdir = '/Applications/freesurfer/subjects'

stc = mne.read_source_estimate('fsaverage_audvis-meg-eeg-lh.stc', 'fsaverage')
stc_sym = stc.morph('fsaverage_sym', 3, subjects_dir=sdir)

mm = mne.compute_morph_matrix('fsaverage_sym', 'fsaverage_sym', stc.vertices, stc.vertices, subjects_dir=sdir, reg_from='rh.sphere.left_right', reg_to='lh.sphere.left_right')
stc_rh_on_lh = mne.SourceEstimate(mm * stc_sym.rh_data, [stc.vertices[0], np.empty(0)], stc.tmin, stc.tstep, 'fsaverage_sym')

# plot
size = (300, 300)
brain_rh = stc_sym.plot(hemi='rh', subjects_dir=sdir, initial_time=0.09, size=size)
brain_lh = stc_rh_on_lh.plot(hemi='lh', subjects_dir=sdir, initial_time=0.09, size=size)

```