### PR TITLE
MINOR: fix corrmap fig titles

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2297,8 +2297,8 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     specific ICs across subjects.
 
     The specific procedure consists of two iterations. In a first step, the
-    maps best correlating with the template are identified. In the step, the
-    analysis is repeated with the mean of the maps identified in the first
+    maps best correlating with the template are identified. In the next step,
+    the analysis is repeated with the mean of the maps identified in the first
     stage.
 
     Run with `plot` and `show` set to `True` and `label=False` to find

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2231,7 +2231,7 @@ def _find_max_corrs(all_maps, target, threshold):
 
 
 def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
-                  layout, cmap, contours, template=True):
+                  layout, cmap, contours, template=False):
     """Customize ica.plot_components for corrmap."""
     if not template:
         title = 'Detected components'
@@ -2414,7 +2414,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
                                          icas[0].copy(), "Template",
                                          outlines=outlines, cmap=cmap,
                                          contours=contours, layout=layout,
-                                         show=show, template=True)
+                                         show=show)
         template_fig.subplots_adjust(top=0.8)
         template_fig.canvas.draw()
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2414,7 +2414,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
                                          icas[0].copy(), "Template",
                                          outlines=outlines, cmap=cmap,
                                          contours=contours, layout=layout,
-                                         show=show)
+                                         show=show, template=True)
         template_fig.subplots_adjust(top=0.8)
         template_fig.canvas.draw()
 

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -208,7 +208,7 @@ from mne.preprocessing.ica import corrmap  # noqa
 # data sets instead.
 
 # We'll start by simulating a group of subjects or runs from a subject
-start, stop = [0, len(raw.times) - 1]
+start, stop = [0, raw.times[-1]]
 intervals = np.linspace(start, stop, 4, dtype=int)
 icas_from_other_data = list()
 raw.pick_types(meg=True, eeg=False)  # take only MEG channels

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -209,7 +209,7 @@ from mne.preprocessing.ica import corrmap  # noqa
 
 # We'll start by simulating a group of subjects or runs from a subject
 start, stop = [0, raw.times[-1]]
-intervals = np.linspace(start, stop, 4, dtype=int)
+intervals = np.linspace(start, stop, 4, dtype=np.float)
 icas_from_other_data = list()
 raw.pick_types(meg=True, eeg=False)  # take only MEG channels
 for ii, start in enumerate(intervals):


### PR DESCRIPTION
Weird bug in corrmap where the non-template figures got the template title.

I had a weird local error when testing this tutorial, let's see what Travis says.