### PR TITLE
WIP: 2-step API for LCMV: make and apply spatial filter

### DIFF
--- a/mne/beamformer/__init__.py
+++ b/mne/beamformer/__init__.py
@@ -1,5 +1,7 @@
 """Beamformers for source localization."""
 
-from ._lcmv import make_lcmv_filter, apply_lcmv_filter, apply_lcmv_filter_epochs, apply_lcmv_filter_raw, tf_lcmv
+from ._lcmv import (make_lcmv_filter, apply_lcmv_filter,
+                    apply_lcmv_filter_epochs, apply_lcmv_filter_raw, lcmv,
+                    lcmv_epochs, lcmv_raw, tf_lcmv)
 from ._dics import dics, dics_epochs, dics_source_power, tf_dics
 from ._rap_music import rap_music

--- a/mne/beamformer/__init__.py
+++ b/mne/beamformer/__init__.py
@@ -1,7 +1,6 @@
 """Beamformers for source localization."""
 
-from ._lcmv import (make_lcmv_filter, apply_lcmv_filter,
-                    apply_lcmv_filter_epochs, apply_lcmv_filter_raw, lcmv,
-                    lcmv_epochs, lcmv_raw, tf_lcmv)
+from ._lcmv import (make_lcmv, apply_lcmv, apply_lcmv_epochs, apply_lcmv_raw,
+                    lcmv, lcmv_epochs, lcmv_raw, tf_lcmv)
 from ._dics import dics, dics_epochs, dics_source_power, tf_dics
 from ._rap_music import rap_music

--- a/mne/beamformer/__init__.py
+++ b/mne/beamformer/__init__.py
@@ -1,5 +1,5 @@
 """Beamformers for source localization."""
 
-from ._lcmv import lcmv, lcmv_epochs, lcmv_raw, tf_lcmv
+from ._lcmv import make_lcmv_filter, apply_lcmv_filter, apply_lcmv_filter_epochs, apply_lcmv_filter_raw, tf_lcmv
 from ._dics import dics, dics_epochs, dics_source_power, tf_dics
 from ._rap_music import rap_music

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -50,7 +50,7 @@ def _setup_picks(picks, info, forward, noise_cov=None):
 
     if noise_cov is not None and set(info['bads']) != set(noise_cov['bads']):
         logger.info('info["bads"] and noise_cov["bads"] do not match, '
-                    'excluding bad channels from both')
+                    'excluding bad channels from both.')
 
     bads = set(info['bads'])
     if noise_cov is not None:
@@ -83,16 +83,15 @@ def _pick_channels_spatial_filter(ch_names, filters):
 
     Unlike ``pick_channels``, this respects the order of ch_names.
     """
-    ch_names = set(ch_names)
     sel = []
-    for k, ch_name in enumerate(filters['ch_names']):
+    for ii, ch_name in enumerate(filters['ch_names']):
         if ch_name not in ch_names:
             raise ValueError('The spatial filter was computed with channel %s '
                              'which is not present in the data. You should '
                              'compute a new spatial filter restricted to the '
                              'good data channels.' % ch_name)
         else:
-            sel.append(k)
+            sel.append(ii)
     return sel
 
 
@@ -114,9 +113,9 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         The measurement info to specify the channels to include.
         Bad channels in info['bads'] are not used.
     forward : dict
-        Forward operator
+        Forward operator.
     data_cov : Covariance
-        The data covariance
+        The data covariance.
     reg : float
         The regularization for the whitened data covariance.
     noise_cov : Covariance
@@ -124,7 +123,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         noise covariance is mandatory if you mix sensor types, e.g.
         gradiometers with magnetometers or EEG with MEG.
     label : Label
-        Restricts the LCMV solution to a given label
+        Restricts the LCMV solution to a given label.
     picks : array-like of int
         Channel indices to use for beamforming (if None all channels
         are used except bad channels).
@@ -140,7 +139,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     weight_norm: 'unit-noise-gain'| 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
-        if 'nai', the Neural Activity Index [1]_ will be computed
+        if 'nai', the Neural Activity Index [1]_ will be computed.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -152,7 +151,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
 
     Notes
     -----
-    The original reference is [1]_
+    The original reference is [1]_.
 
     References
     ----------
@@ -353,7 +352,7 @@ def _apply_lcmv(data, filters, info, tmin, max_ori_out):
         else:
             # Linear inverse: do computation here or delayed
             if (M.shape[0] < W.shape[0] and
-               filters['pick_ori'] != 'max-power'):
+                    filters['pick_ori'] != 'max-power'):
                 sol = (W, M)
             else:
                 sol = np.dot(W, M)
@@ -436,9 +435,9 @@ def apply_lcmv(evoked, filters, max_ori_out='abs', verbose=None):
     Parameters
     ----------
     evoked : Evoked
-        Evoked data to invert
+        Evoked data to invert.
     filters : dict
-        LCMV spatial filter (beamformer weights)
+        LCMV spatial filter (beamformer weights).
         Filter weights returned from `make_lcmv`.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
@@ -454,7 +453,7 @@ def apply_lcmv(evoked, filters, max_ori_out='abs', verbose=None):
     Returns
     -------
     stc : SourceEstimate | VolSourceEstimate
-        Source time courses
+        Source time courses.
 
     See Also
     --------
@@ -511,7 +510,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='abs',
     Returns
     -------
     stc: list | generator of (SourceEstimate | VolSourceEstimate)
-        The source estimates for all epochs
+        The source estimates for all epochs.
 
     See Also
     --------
@@ -549,7 +548,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='abs',
     raw : mne.io.Raw
         Raw data to invert.
     filters : dict
-        LCMV spatial filter (beamformer weights)
+        LCMV spatial filter (beamformer weights).
         Filter weights returned from `make_lcmv`.
     start : int
         Index of first time sample (index not time is seconds).
@@ -569,7 +568,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='abs',
     Returns
     -------
     stc : SourceEstimate | VolSourceEstimate
-        Source time courses
+        Source time courses.
 
     See Also
     --------
@@ -603,19 +602,19 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     Parameters
     ----------
     evoked : Evoked
-        Evoked data to invert
+        Evoked data to invert.
     forward : dict
-        Forward operator
+        Forward operator.
     noise_cov : Covariance
         The noise covariance. If provided, whitening will be done. Providing a
         noise covariance is mandatory if you mix sensor types, e.g.
         gradiometers with magnetometers or EEG with MEG.
     data_cov : Covariance
-        The data covariance
+        The data covariance.
     reg : float
         The regularization for the whitened data covariance.
     label : Label
-        Restricts the LCMV solution to a given label
+        Restricts the LCMV solution to a given label.
     pick_ori : None | 'normal' | 'max-power'
         If 'normal', rather than pooling the orientations by taking the norm,
         only the radial component is kept. If 'max-power', the source
@@ -631,7 +630,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     weight_norm: 'unit-noise-gain'| 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
-        if 'nai', the Neural Activity Index [1]_ will be computed
+        if 'nai', the Neural Activity Index [1]_ will be computed.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
         If 'abs', the absolute value of the source space time series will be
@@ -646,7 +645,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     Returns
     -------
     stc : SourceEstimate | VolSourceEstimate
-        Source time courses
+        Source time courses.
 
     See Also
     --------
@@ -655,11 +654,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
 
     Notes
     -----
-    The original reference is [1]_
-    The reference for finding the max-power orientation is:
-    Sekihara et al. Asymptotic SNR of scalar and vector minimum-variance
-    beamformers for neuromagnetic source reconstruction.
-    Biomedical Engineering (2004) vol. 51 (10) pp. 1726--34
+    The original reference is [1]_.
 
     References
     ----------
@@ -729,7 +724,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     weight_norm: 'unit-noise-gain'| 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
-        if 'nai', the Neural Activity Index [1]_ will be computed
+        if 'nai', the Neural Activity Index [1]_ will be computed.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
         If 'abs', the absolute value of the source space time series will be
@@ -744,7 +739,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     Returns
     -------
     stc: list | generator of (SourceEstimate | VolSourceEstimate)
-        The source estimates for all epochs
+        The source estimates for all epochs.
 
     See Also
     --------
@@ -753,11 +748,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     Notes
     -----
-    The original reference is [1]_
-    The reference for finding the max-power orientation is:
-    Sekihara et al. Asymptotic SNR of scalar and vector minimum-variance
-    beamformers for neuromagnetic source reconstruction.
-    Biomedical Engineering (2004) vol. 51 (10) pp. 1726--34
+    The original reference is [1]_.
 
     References
     ----------
@@ -829,7 +820,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     weight_norm: 'unit-noise-gain'| 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
-        if 'nai', the Neural Activity Index [1]_ will be computed
+        if 'nai', the Neural Activity Index [1]_ will be computed.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
         If 'abs', the absolute value of the source space time series will be
@@ -844,7 +835,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     Returns
     -------
     stc : SourceEstimate | VolSourceEstimate
-        Source time courses
+        Source time courses.
 
     See Also
     --------
@@ -853,11 +844,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     Notes
     -----
-    The original reference is [1]_
-    The reference for finding the max-power orientation is:
-    Sekihara et al. Asymptotic SNR of scalar and vector minimum-variance
-    beamformers for neuromagnetic source reconstruction.
-    Biomedical Engineering (2004) vol. 51 (10) pp. 1726--34
+    The original reference is [1]_.
 
     References
     ----------
@@ -1042,7 +1029,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
            time-frequency dynamics of cortical activity.
            NeuroImage (2008) vol. 40 (4) pp. 1686-1700
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
-       brain imaging (2008) Springer Science & Business Media
+           brain imaging (2008) Springer Science & Business Media
     """
     _check_reference(epochs)
 
@@ -1063,7 +1050,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     if raw is None:
         raise ValueError('The provided epochs object does not contain the '
                          'underlying raw object. Please use preload=False '
-                         'when constructing the epochs object')
+                         'when constructing the epochs object.')
 
     if noise_covs is None:
         picks = _setup_picks(picks, epochs.info, forward)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -439,7 +439,7 @@ def apply_lcmv(evoked, filters, max_ori_out='abs', verbose=None):
         Evoked data to invert
     filters : dict
         LCMV spatial filter (beamformer weights)
-        Filter weights returned from `make_lcmv_filter`.
+        Filter weights returned from `make_lcmv`.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
         If 'abs', the absolute value of the source space time series will be
@@ -492,7 +492,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='abs',
         Single trial epochs.
     filters : dict
         LCMV spatial filter (beamformer weights)
-        Filter weights returned from `make_lcmv_filter`.
+        Filter weights returned from `make_lcmv`.
     max_ori_out: 'abs' | 'signed'
         Specify in case of pick_ori='max-power'.
         If 'abs', the absolute value of the source space time series will be
@@ -550,7 +550,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='abs',
         Raw data to invert.
     filters : dict
         LCMV spatial filter (beamformer weights)
-        Filter weights returned from `make_lcmv_filter`.
+        Filter weights returned from `make_lcmv`.
     start : int
         Index of first time sample (index not time is seconds).
     stop : int

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -323,10 +323,18 @@ def _apply_lcmv(data, filters, info, tmin, max_ori_out):
         if not return_single:
             logger.info("Processing epoch : %d" % (i + 1))
 
-        # TODO: do we need to check whether data + filter proj match
-        # SSP and whitening
         if filters['is_ssp']:
+            # check whether data and filter projs match
+            proj_data, _, _ = make_projector(info['projs'],
+                                             filters['ch_names'])
+            if not np.array_equal(proj_data, filters['proj']):
+                    raise ValueError('The SSP projections present in the data '
+                                     'do not match the projections used when '
+                                     'calculating the spatial filter.')
+
+            # apply projection
             M = np.dot(filters['proj'], M)
+
         if filters['whitener'] is not None:
             M = np.dot(filters['whitener'], M)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -675,6 +675,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
                 weight_norm='unit-noise-gain', max_ori_out='abs',
                 verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer.
+
     Compute Linearly Constrained Minimum Variance (LCMV) beamformer
     on single trial data.
     .. note:: This implementation has not been heavily tested so please
@@ -773,6 +774,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
              start=None, stop=None, picks=None, pick_ori=None, rank=None,
              weight_norm='unit-noise-gain', max_ori_out='abs', verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer.
+
     Compute Linearly Constrained Minimum Variance (LCMV) beamformer
     on raw data.
     NOTE : This implementation has not been heavily tested so please

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -186,6 +186,8 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         G = np.dot(whitener, G)
         # whiten  data covariance
         Cm = np.dot(whitener, np.dot(Cm, whitener.T))
+    else:
+        whitener = None
 
     # Tikhonov regularization using reg parameter d to control for
     # trade-off between spatial resolution and noise sensitivity

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -301,6 +301,16 @@ def _subject_from_filter(filters):
     return filters['src'][0].get('subject_his_id', None)
 
 
+def _check_proj_match(info, filters):
+    """Check whether SSP projections in data and spatial filter match."""
+    proj_data, _, _ = make_projector(info['projs'],
+                                     filters['ch_names'])
+    if not np.array_equal(proj_data, filters['proj']):
+            raise ValueError('The SSP projections present in the data '
+                             'do not match the projections used when '
+                             'calculating the spatial filter.')
+
+
 def _apply_lcmv(data, filters, info, tmin, max_ori_out):
     """Apply LCMV spatial filter to data for source reconstruction."""
     if max_ori_out == 'abs':
@@ -327,13 +337,7 @@ def _apply_lcmv(data, filters, info, tmin, max_ori_out):
 
         if filters['is_ssp']:
             # check whether data and filter projs match
-            proj_data, _, _ = make_projector(info['projs'],
-                                             filters['ch_names'])
-            if not np.array_equal(proj_data, filters['proj']):
-                    raise ValueError('The SSP projections present in the data '
-                                     'do not match the projections used when '
-                                     'calculating the spatial filter.')
-
+            _check_proj_match(info, filters)
             # apply projection
             M = np.dot(filters['proj'], M)
 
@@ -454,7 +458,7 @@ def apply_lcmv(evoked, filters, max_ori_out='abs', verbose=None):
 
     See Also
     --------
-    apply_lcmv_filter_raw, apply_lcmv_filter_epochs
+    apply_lcmv_raw, apply_lcmv_epochs
     """
     _check_reference(evoked)
 
@@ -511,7 +515,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='abs',
 
     See Also
     --------
-    apply_lcmv_filter_raw, apply_lcmv_filter
+    apply_lcmv_raw, apply_lcmv
     """
     _check_reference(epochs)
 
@@ -569,7 +573,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='abs',
 
     See Also
     --------
-    apply_lcmv_filter_epochs, apply_lcmv_filter
+    apply_lcmv_epochs, apply_lcmv
     """
     _check_reference(raw)
 
@@ -646,7 +650,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
 
     See Also
     --------
-    make_lcmv_filter, apply_lcmv_filter
+    make_lcmv, apply_lcmv
     lcmv_raw, lcmv_epochs
 
     Notes
@@ -744,7 +748,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     See Also
     --------
-    make_lcmv_filter, apply_lcmv_filter_epochs
+    make_lcmv, apply_lcmv_epochs
     lcmv_raw, lcmv
 
     Notes
@@ -844,7 +848,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     See Also
     --------
-    make_lcmv_filter, apply_lcmv_raw
+    make_lcmv, apply_lcmv_raw
     lcmv, lcmv_epochs
 
     Notes

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -10,9 +10,8 @@ from copy import deepcopy
 import mne
 from mne import compute_covariance
 from mne.datasets import testing
-from mne.beamformer import (make_lcmv_filter, apply_lcmv_filter,
-                            apply_lcmv_filter_epochs, apply_lcmv_filter_raw,
-                            tf_lcmv)
+from mne.beamformer import (make_lcmv_filter, apply_lcmv_filter, lcmv,
+                            lcmv_epochs, lcmv_raw, tf_lcmv)
 from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv
 from mne.externals.six import advance_iterator
 from mne.utils import run_tests_if_main, slow_test
@@ -105,9 +104,8 @@ def test_lcmv():
         forward_surf_ori, forward_fixed, forward_vol = _get_data()
 
     for fwd in [forward, forward_vol]:
-        sfilter = make_lcmv_filter(evoked.info, fwd, data_cov, reg=0.01,
-                                   noise_cov=noise_cov)
-        stc = apply_lcmv_filter(evoked, sfilter, max_ori_out='signed')
+        stc = lcmv(evoked, fwd, noise_cov, data_cov, reg=0.01,
+                   max_ori_out='signed')
         stc.crop(0.02, None)
 
         stc_pow = np.sum(np.abs(stc.data), axis=1)
@@ -120,12 +118,8 @@ def test_lcmv():
 
         if fwd is forward:
             # Test picking normal orientation (surface source space only)
-            sfilter_normal = make_lcmv_filter(evoked.info, forward_surf_ori,
-                                              data_cov, reg=0.01,
-                                              noise_cov=noise_cov,
-                                              pick_ori='normal')
-            stc_normal = apply_lcmv_filter(evoked, sfilter_normal,
-                                           max_ori_out='signed')
+            stc_normal = lcmv(evoked, forward_surf_ori, noise_cov,
+                              data_cov, reg=0.01, pick_ori="normal")
             stc_normal.crop(0.02, None)
 
             stc_pow = np.sum(np.abs(stc_normal.data), axis=1)
@@ -141,11 +135,8 @@ def test_lcmv():
             assert_true((np.abs(stc_normal.data) <= stc.data).all())
 
         # Test picking source orientation maximizing output source power
-        sfilter_maxp = make_lcmv_filter(evoked.info, fwd, data_cov, reg=0.01,
-                                        noise_cov=noise_cov,
-                                        pick_ori='max-power')
-        stc_max_power = apply_lcmv_filter(evoked, sfilter_maxp,
-                                          max_ori_out='signed')
+        stc_max_power = lcmv(evoked, fwd, noise_cov, data_cov, reg=0.01,
+                             pick_ori="max-power", max_ori_out='signed')
         stc_max_power.crop(0.02, None)
         stc_pow = np.sum(np.abs(stc_max_power.data), axis=1)
         idx = np.argmax(stc_pow)
@@ -170,10 +161,9 @@ def test_lcmv():
             assert_true((np.abs(mean_stc - mean_stc_max_pow) < 0.5).all())
 
         # Test NAI weight normalization:
-        sfilter_nai = make_lcmv_filter(evoked.info, fwd, data_cov, reg=0.01,
-                                       noise_cov=noise_cov,
-                                       pick_ori='max-power', weight_norm='nai')
-        stc_nai = apply_lcmv_filter(evoked, sfilter_nai, max_ori_out='signed')
+        stc_nai = lcmv(evoked, fwd, noise_cov=noise_cov, data_cov=data_cov,
+                       reg=0.01, pick_ori='max-power', weight_norm='nai',
+                       max_ori_out='signed')
         stc_nai.crop(0.02, None)
 
         # Test whether unit-noise-gain solution is a scaled version of NAI
@@ -183,55 +173,60 @@ def test_lcmv():
 
     # Test if fixed forward operator is detected when picking normal or
     # max-power orientation
-    assert_raises(ValueError, make_lcmv_filter, evoked.info, forward_fixed,
-                  data_cov, reg=0.01, noise_cov=noise_cov, pick_ori='normal')
-    assert_raises(ValueError, make_lcmv_filter, evoked.info, forward_fixed,
-                  data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori='max-power')
+    assert_raises(ValueError, lcmv, evoked, forward_fixed, noise_cov, data_cov,
+                  reg=0.01, pick_ori="normal")
+    assert_raises(ValueError, lcmv, evoked, forward_fixed, noise_cov, data_cov,
+                  reg=0.01, pick_ori="max-power", max_ori_out='signed')
 
     # Test if non-surface oriented forward operator is detected when picking
     # normal orientation
-    assert_raises(ValueError, make_lcmv_filter, evoked.info, forward, data_cov,
-                  reg=0.01, noise_cov=noise_cov, pick_ori="normal")
+    assert_raises(ValueError, lcmv, evoked, forward, noise_cov, data_cov,
+                  reg=0.01, pick_ori="normal")
 
     # Test if volume forward operator is detected when picking normal
     # orientation
-    assert_raises(ValueError, make_lcmv_filter, evoked.info, forward_vol,
-                  data_cov, reg=0.01, noise_cov=noise_cov, pick_ori="normal")
+    assert_raises(ValueError, lcmv, evoked, forward_vol, noise_cov, data_cov,
+                  reg=0.01, pick_ori="normal")
+
+    # Test if missing of data covariance matrix is detected
+    assert_raises(ValueError, lcmv, evoked, forward_vol, noise_cov=noise_cov,
+                  data_cov=None, reg=0.01, pick_ori="max-power",
+                  max_ori_out='signed')
 
     # Test if missing of noise covariance matrix is detected when more than
     # one channel type is present in the data
-    assert_raises(ValueError, make_lcmv_filter, evoked.info, forward_vol,
-                  data_cov, reg=0.01, noise_cov=None, pick_ori="max-power")
+    assert_raises(ValueError, lcmv, evoked, forward_vol, noise_cov=None,
+                  data_cov=data_cov, reg=0.01, pick_ori="max-power",
+                  max_ori_out='signed')
 
     # Test if not-yet-implemented orientation selections raise error with
     # neural activity index
-    assert_raises(NotImplementedError, make_lcmv_filter, evoked.info,
-                  forward_surf_ori, data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori="normal", weight_norm='nai')
-    assert_raises(NotImplementedError, make_lcmv_filter, evoked.info,
-                  forward_vol, data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori=None, weight_norm='nai')
+    assert_raises(NotImplementedError, lcmv, evoked, forward_surf_ori,
+                  noise_cov, data_cov, reg=0.01, pick_ori="normal",
+                  weight_norm='nai')
+    assert_raises(NotImplementedError, lcmv, evoked, forward_vol, noise_cov,
+                  data_cov, reg=0.01, pick_ori=None, weight_norm='nai')
 
     # Test if no weight-normalization and max-power source orientation throw
     # an error
-    assert_raises(NotImplementedError, make_lcmv_filter, evoked.info,
-                  forward_vol, data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori="max-power", weight_norm=None)
+    assert_raises(NotImplementedError, lcmv, evoked, forward_vol, noise_cov,
+                  data_cov, reg=0.01, pick_ori="max-power", weight_norm=None,
+                  max_ori_out='signed')
 
     # Test if wrong channel selection is detected in application of filter
     evoked_ch = deepcopy(evoked)
     evoked_ch.pick_channels(evoked_ch.ch_names[:-1])
+    sfilter = make_lcmv_filter(evoked.info, forward_vol, data_cov, reg=0.01,
+                               noise_cov=noise_cov)
     assert_raises(ValueError, apply_lcmv_filter, evoked_ch, sfilter,
                   max_ori_out='signed')
 
     # Now test single trial using fixed orientation forward solution
     # so we can compare it to the evoked solution
-    sfilter_fixed = make_lcmv_filter(epochs.info, forward_fixed, data_cov,
-                                     reg=0.01, noise_cov=noise_cov)
-    stcs = apply_lcmv_filter_epochs(epochs, sfilter_fixed)
-    stcs_ = apply_lcmv_filter_epochs(epochs, sfilter_fixed,
-                                     return_generator=True)
+    stcs = lcmv_epochs(epochs, forward_fixed, noise_cov, data_cov,
+                       reg=0.01)
+    stcs_ = lcmv_epochs(epochs, forward_fixed, noise_cov, data_cov,
+                        reg=0.01, return_generator=True)
     assert_array_equal(stcs[0].data, advance_iterator(stcs_).data)
 
     epochs.drop_bad()
@@ -244,14 +239,13 @@ def test_lcmv():
     stc_avg /= len(stcs)
 
     # compare it to the solution using evoked with fixed orientation
-    stc_fixed = apply_lcmv_filter(evoked, sfilter_fixed)
+    stc_fixed = lcmv(evoked, forward_fixed, noise_cov, data_cov, reg=0.01)
     assert_array_almost_equal(stc_avg, stc_fixed.data)
 
     # use a label so we have few source vertices and delayed computation is
     # not used
-    sfilter_label = make_lcmv_filter(epochs.info, forward_fixed, data_cov,
-                                     reg=0.01, noise_cov=noise_cov, label=label)
-    stcs_label = apply_lcmv_filter_epochs(epochs, sfilter_label)
+    stcs_label = lcmv_epochs(epochs, forward_fixed, noise_cov, data_cov,
+                             reg=0.01, label=label)
 
     assert_array_almost_equal(stcs_label[0].data, stcs[0].in_label(label).data)
 
@@ -267,9 +261,8 @@ def test_lcmv_raw():
 
     # use only the left-temporal MEG channels for LCMV
     data_cov = mne.compute_raw_covariance(raw, tmin=tmin, tmax=tmax)
-    sfilter = make_lcmv_filter(raw.info, forward, data_cov, reg=0.01,
-                               noise_cov=noise_cov, label=label)
-    stc = apply_lcmv_filter_raw(raw, sfilter, start=start, stop=stop)
+    stc = lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.01,
+                   label=label, start=start, stop=stop)
 
     assert_array_almost_equal(np.array([tmin, tmax]),
                               np.array([stc.times[0], stc.times[-1]]),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -10,8 +10,8 @@ from copy import deepcopy
 import mne
 from mne import compute_covariance
 from mne.datasets import testing
-from mne.beamformer import (make_lcmv, apply_lcmv, lcmv, lcmv_epochs, lcmv_raw,
-                            tf_lcmv)
+from mne.beamformer import (make_lcmv, apply_lcmv, apply_lcmv_raw, lcmv,
+                            lcmv_epochs, lcmv_raw, tf_lcmv)
 from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv
 from mne.externals.six import advance_iterator
 from mne.utils import run_tests_if_main, slow_test
@@ -219,6 +219,12 @@ def test_lcmv():
     filters = make_lcmv(evoked.info, forward_vol, data_cov, reg=0.01,
                         noise_cov=noise_cov)
     assert_raises(ValueError, apply_lcmv, evoked_ch, filters,
+                  max_ori_out='signed')
+
+    # Test if non-matching SSP projection is detected in application of filter
+    raw_proj = deepcopy(raw)
+    raw_proj.del_proj()
+    assert_raises(ValueError, apply_lcmv_raw, raw_proj, filters,
                   max_ori_out='signed')
 
     # Now test single trial using fixed orientation forward solution

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -10,8 +10,8 @@ from copy import deepcopy
 import mne
 from mne import compute_covariance
 from mne.datasets import testing
-from mne.beamformer import (make_lcmv_filter, apply_lcmv_filter, lcmv,
-                            lcmv_epochs, lcmv_raw, tf_lcmv)
+from mne.beamformer import (make_lcmv, apply_lcmv, lcmv, lcmv_epochs, lcmv_raw,
+                            tf_lcmv)
 from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv
 from mne.externals.six import advance_iterator
 from mne.utils import run_tests_if_main, slow_test
@@ -216,9 +216,9 @@ def test_lcmv():
     # Test if wrong channel selection is detected in application of filter
     evoked_ch = deepcopy(evoked)
     evoked_ch.pick_channels(evoked_ch.ch_names[:-1])
-    sfilter = make_lcmv_filter(evoked.info, forward_vol, data_cov, reg=0.01,
-                               noise_cov=noise_cov)
-    assert_raises(ValueError, apply_lcmv_filter, evoked_ch, sfilter,
+    filters = make_lcmv(evoked.info, forward_vol, data_cov, reg=0.01,
+                        noise_cov=noise_cov)
+    assert_raises(ValueError, apply_lcmv, evoked_ch, filters,
                   max_ori_out='signed')
 
     # Now test single trial using fixed orientation forward solution


### PR DESCRIPTION
Creating two separate functions to make and apply the LCMV spatial filter (following the logic of `make_inverse_operator` and `apply_inverse`). 
This enables the application of the weights to separate data, which is needed for example when comparing conditions.

Note: examples etc. not adapted yet.

@agramfort and @dengemann 