### PR TITLE
Make warning about high-pass filters more specific

### DIFF
--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -74,9 +74,12 @@ raw.plot_psd(area_mode='range', tmax=10.0, picks=picks, average=False)
 #
 # To remove slow drifts, you can high pass.
 #
-# .. warning:: There can be issues using high-passes greater than 0.1 Hz
-#              (see examples in :ref:`tut_filtering_hp_problems`),
-#              so apply high-pass filters with caution.
+# .. warning:: In event-related potential (ERP) analysis, high-pass filters
+#              with cutoff frequencies greater than 0.1 Hz are usually
+#              considered problematic, since they significantly change the
+#              shape of the resulting averaged waveform (see examples in
+#              :ref:`tut_filtering_hp_problems`). In such applications, apply
+#              high-pass filters with caution.
 
 raw.filter(1., None, fir_design='firwin')
 raw.plot_psd(area_mode='range', tmax=10.0, picks=picks, average=False)


### PR DESCRIPTION
The warning can be confusing because it really only applies in ERP analysis, where higher cutoff frequencies significantly "distort" the signal in the time domain. In other applications, this warning can be confusing, for example ICA preprocessing is usually done with a high-pass filter of 1Hz (or even 2Hz).