### PR TITLE
Change default 'kind' argument to 'topomap' (like in function)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -112,6 +112,8 @@ BUG
 
     - Fix :func:`mne.io.read_raw_edf` to infer sampling rate correctly when reading EDF+ files where tal-channel has a higher sampling frequency by `Jaakko Leppakangas`_
 
+    - Fix default value of ``kind='topomap'`` in :meth:`mne.channels.Montage.plot` to be consistent with :func:`mne.viz.plot_montage` by `Clemens Brunner`_
+
 API
 ~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -73,7 +73,8 @@ class Montage(object):
         return s
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True):
+    def plot(self, scale_factor=20, show_names=False, kind='topomap',
+             show=True):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show)
 


### PR DESCRIPTION
The function `mne.viz.plot_montage` uses `kind='topomap'`, but the method `Montage.plot` uses `kind='3d'`. This is inconsistent, so I suggest to set `kind='topomap'` also for the method.