### PR TITLE
[MRG] Add get_pos2d method to Montage

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,8 @@ Changelog
 
     - Add option to use matplotlib backend when plotting with :func:`mne.viz.plot_source_estimates` by `Jaakko Leppakangas`_
 
+    - Add :meth:`mne.channels.Montage.get_pos2d` to get the 2D positions of channels in a montage by `Clemens Brunner`_
+
 BUG
 ~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -30,6 +30,8 @@ from ..utils import _check_fname, warn, copy_function_doc_to_method_doc
 from ..externals.six import string_types
 from ..externals.six.moves import map
 
+from .layout import _pol_to_cart, _cart_to_sph
+
 
 class Montage(object):
     """Montage for standard EEG electrode locations.
@@ -71,6 +73,10 @@ class Montage(object):
         s = ('<Montage | %s - %d channels: %s ...>'
              % (self.kind, len(self.ch_names), ', '.join(self.ch_names[:3])))
         return s
+
+    @property
+    def pos2d(self):
+        return _pol_to_cart(_cart_to_sph(self.pos)[:, 1:][:, ::-1])
 
     @copy_function_doc_to_method_doc(plot_montage)
     def plot(self, scale_factor=20, show_names=False, kind='topomap',

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -74,8 +74,8 @@ class Montage(object):
              % (self.kind, len(self.ch_names), ', '.join(self.ch_names[:3])))
         return s
 
-    @property
-    def pos2d(self):
+    def get_pos2d(self):
+        """Return positions converted to 2D."""
         return _pol_to_cart(_cart_to_sph(self.pos)[:, 1:][:, ::-1])
 
     @copy_function_doc_to_method_doc(plot_montage)

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -267,7 +267,7 @@ def test_montage():
     # test get_pos2d method
     montage = read_montage("standard_1020")
     c3 = montage.get_pos2d()[montage.ch_names.index("C3")]
-    c4 = montage.get_pos2d()[montage.ch_names.index("C3")]
+    c4 = montage.get_pos2d()[montage.ch_names.index("C4")]
     fz = montage.get_pos2d()[montage.ch_names.index("Fz")]
     oz = montage.get_pos2d()[montage.ch_names.index("Oz")]
     f1 = montage.get_pos2d()[montage.ch_names.index("F1")]

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -264,6 +264,21 @@ def test_montage():
         _set_montage(info, montage)
         assert_true(len(w) == 1)
 
+    # test get_pos2d method
+    montage = read_montage("standard_1020")
+    c3 = montage.get_pos2d()[montage.ch_names.index("C3")]
+    c4 = montage.get_pos2d()[montage.ch_names.index("C3")]
+    fz = montage.get_pos2d()[montage.ch_names.index("Fz")]
+    oz = montage.get_pos2d()[montage.ch_names.index("Oz")]
+    f1 = montage.get_pos2d()[montage.ch_names.index("F1")]
+    assert_true(c3[0] < 0)  # left hemisphere
+    assert_true(c4[0] > 0)  # right hemisphere
+    assert_true(fz[1] > 0)  # frontal
+    assert_true(oz[1] < 0)  # occipital
+    assert_allclose(fz[0], 0, atol=1e-2)  # midline
+    assert_allclose(oz[0], 0, atol=1e-2)  # midline
+    assert_true(f1[0] < 0 and f1[1] > 0)  # left frontal
+
 
 @testing.requires_testing_data
 def test_read_locs():


### PR DESCRIPTION
This is useful to quickly get the 3D positions stored in `self.pos` converted to 2D (e.g. to create a quick topomap, which requires 2D positions).