### PR TITLE
MRG redo truncating y axis on plot_compare_evokeds

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -146,6 +146,8 @@ BUG
 
     - Fix writing a forward solution after being processed by :func:`mne.forward.restrict_forward_to_label` or :func:`mne.forward.restrict_forward_to_stc` by `Marijn van Vliet`_
 
+    - Fix bug in plot_compare_evokeds where previously, truncate_yaxis was ignore. It should work now. By `Jona Sassenhagen`_
+
 API
 ~~~
     - Add :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.apply_lcmv`, :func:`mne.beamformer.apply_lcmv_epochs`, and :func:`mne.beamformer.apply_lcmv_raw` to enable the separate computation and application of LCMV beamformer weights by `Britta Westner'_, `Alex Gramfort`_, and `Denis Engemann`_.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1413,7 +1413,7 @@ def _truncate_yaxis(axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
 
 def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
                          linestyles=['-'], styles=None, vlines=[0.], ci=0.95,
-                         truncate_yaxis=True, ylim=dict(), invert_y=False,
+                         truncate_yaxis=False, ylim=dict(), invert_y=False,
                          axes=None, title=None, show=True):
     """Plot evoked time courses for one or multiple channels and conditions.
 
@@ -1582,7 +1582,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     scaling = _handle_default("scalings")[ch_type]
     unit = _handle_default("units")[ch_type]
 
-    if ch_type == 'grad' and gfp is not True and len(picks) > 1:  # deal with grad pairs
+    if ch_type == 'grad' and gfp is not True:  # deal with grad pairs
         from ..channels.layout import _merge_grad_data, _pair_grad_sensors
         picked_chans = list()
         pairpicks = _pair_grad_sensors(example.info, topomap_coords=False)
@@ -1594,7 +1594,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
         picks = list(sorted(set(picked_chans)))
         ch_names = [example.ch_names[pick] for pick in picks]
 
-    if ymin is None and (gfp is True or (ch_type == 'grad' and len(picks) > 1)):
+    if ymin is None and (gfp is True or ch_type == 'grad'):
         ymin = 0.  # 'grad' and GFP are plotted as all-positive
 
     # deal with dict/list of lists and the CI
@@ -1731,7 +1731,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
 
     fraction = 2 if axes.get_ylim()[0] >= 0 else 3
 
-    if truncate_yaxis and ymin is None:  # and not (ymin > 0):
+    if truncate_yaxis is True:
         _, ymax_bound = _truncate_yaxis(
             axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
             any_positive, any_negative)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1582,7 +1582,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     scaling = _handle_default("scalings")[ch_type]
     unit = _handle_default("units")[ch_type]
 
-    if ch_type == 'grad' and gfp is not True:  # deal with grad pairs
+    if ch_type == 'grad' and gfp is not True and len(picks) > 1:  # deal with grad pairs
         from ..channels.layout import _merge_grad_data, _pair_grad_sensors
         picked_chans = list()
         pairpicks = _pair_grad_sensors(example.info, topomap_coords=False)
@@ -1594,7 +1594,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
         picks = list(sorted(set(picked_chans)))
         ch_names = [example.ch_names[pick] for pick in picks]
 
-    if ymin is None and (gfp is True or ch_type == 'grad'):
+    if ymin is None and (gfp is True or (ch_type == 'grad' and len(picks) > 1)):
         ymin = 0.  # 'grad' and GFP are plotted as all-positive
 
     # deal with dict/list of lists and the CI
@@ -1731,7 +1731,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
 
     fraction = 2 if axes.get_ylim()[0] >= 0 else 3
 
-    if truncate_yaxis and ymin is not None and not (ymin > 0):
+    if truncate_yaxis and ymin is None:  # and not (ymin > 0):
         _, ymax_bound = _truncate_yaxis(
             axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
             any_positive, any_negative)

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -132,6 +132,7 @@ def test_plot_evoked():
         red.data *= 1.1
         blue.data *= 0.9
         plot_compare_evokeds([red, blue], picks=3)  # list of evokeds
+        plot_compare_evokeds([red, blue], picks=3, truncate_yaxis=True)
         plot_compare_evokeds([[red, evoked], [blue, evoked]],
                              picks=3)  # list of lists
         # test picking & plotting grads


### PR DESCRIPTION
This is a bit weird. plot_compare_evokeds doesn't currently disable the y axis, even though there is a lot of code for that purpose (and it looks very nice). I forgot if I did that on purpose, or if it's just a mistake on my part?
Anyway, this is what the evoked viz tutorial looks like with this fix.

<img width="747" alt="screenshot 2017-07-19 16 18 53" src="https://user-images.githubusercontent.com/4321826/28372117-20c68dfa-6c9f-11e7-8302-91aae7c9de92.png">