### PR TITLE
Refine high-pass filter warning in tutorial

### DIFF
--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -74,10 +74,11 @@ raw.plot_psd(area_mode='range', tmax=10.0, picks=picks, average=False)
 #
 # To remove slow drifts, you can high pass.
 #
-# .. warning:: In event-related potential (ERP) analysis, high-pass filters
-#              with cutoff frequencies greater than 0.1 Hz are usually
-#              considered problematic, since they significantly change the
-#              shape of the resulting averaged waveform (see examples in
+# .. warning:: In several applications such as event-related potential (ERP)
+#              and event-related field (ERF) analysis, high-pass filters with
+#              cutoff frequencies greater than 0.1 Hz are usually considered
+#              problematic since they significantly change the shape of the
+#              resulting averaged waveform (see examples in
 #              :ref:`tut_filtering_hp_problems`). In such applications, apply
 #              high-pass filters with caution.
 


### PR DESCRIPTION
As discussed in #4394 with @jona-sassenhagen, I changed the text in order to not imply that HP filtering is problematic _only_  for ERP/ERF analysis.