### PR TITLE
[WIP] ENH coreg-gui:  compact view

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,8 @@ Changelog
 
     - Add option to use matplotlib backend when plotting with :func:`mne.viz.plot_source_estimates` by `Jaakko Leppakangas`_
 
+    - Add ``--compact`` option to coregistration GUI for small screens by `Christian Brodbeck`_
+
 BUG
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,8 +69,6 @@ Changelog
 
     - Add option to use matplotlib backend when plotting with :func:`mne.viz.plot_source_estimates` by `Jaakko Leppakangas`_
 
-    - Add ``--compact`` option to coregistration GUI for small screens by `Christian Brodbeck`_
-
 BUG
 ~~~
 

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -24,6 +24,11 @@ def run():
                       help="Subject name")
     parser.add_option("-f", "--fiff", dest="inst", default=None,
                       help="FIFF file with digitizer data for coregistration")
+    parser.add_option("-c", "--compact", dest="compact", action="store_true",
+                      default=False, help="Layout for small screens: Combine "
+                      "the data source panel and the coregistration panel "
+                      "into a single panel with tabs, and make them vertically "
+                                          "scrollable.")
     parser.add_option("-t", "--tabbed", dest="tabbed", action="store_true",
                       default=False, help="Option for small screens: Combine "
                       "the data source panel and the coregistration panel "
@@ -61,13 +66,15 @@ def run():
         head_high_res = None
 
     with ETSContext():
-        mne.gui.coregistration(options.tabbed, inst=options.inst,
+        mne.gui.coregistration(options.tabbed or options.compact,
+                               inst=options.inst,
                                subject=options.subject,
                                subjects_dir=options.subjects_dir,
                                guess_mri_subject=options.guess_mri_subject,
                                head_opacity=options.head_opacity,
                                head_high_res=head_high_res,
                                trans=options.trans,
+                               scrollable=options.compact,
                                verbose=options.verbose)
     if is_main:
         sys.exit(0)

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -24,9 +24,6 @@ def run():
                       help="Subject name")
     parser.add_option("-f", "--fiff", dest="inst", default=None,
                       help="FIFF file with digitizer data for coregistration")
-    parser.add_option("-c", "--compact", dest="compact", action="store_true",
-                      default=False, help="Layout for small screens, entails "
-                      "--tabbed.")
     parser.add_option("-t", "--tabbed", dest="tabbed", action="store_true",
                       default=False, help="Option for small screens: Combine "
                       "the data source panel and the coregistration panel "
@@ -64,7 +61,7 @@ def run():
         head_high_res = None
 
     with ETSContext():
-        mne.gui.coregistration(options.tabbed or options.compact,
+        mne.gui.coregistration(options.tabbed,
                                inst=options.inst,
                                subject=options.subject,
                                subjects_dir=options.subjects_dir,
@@ -72,7 +69,7 @@ def run():
                                head_opacity=options.head_opacity,
                                head_high_res=head_high_res,
                                trans=options.trans,
-                               scrollable=options.compact,
+                               scrollable=True,
                                verbose=options.verbose)
     if is_main:
         sys.exit(0)

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -25,10 +25,8 @@ def run():
     parser.add_option("-f", "--fiff", dest="inst", default=None,
                       help="FIFF file with digitizer data for coregistration")
     parser.add_option("-c", "--compact", dest="compact", action="store_true",
-                      default=False, help="Layout for small screens: Combine "
-                      "the data source panel and the coregistration panel "
-                      "into a single panel with tabs, and make them vertically "
-                                          "scrollable.")
+                      default=False, help="Layout for small screens, entails "
+                      "--tabbed.")
     parser.add_option("-t", "--tabbed", dest="tabbed", action="store_true",
                       default=False, help="Option for small screens: Combine "
                       "the data source panel and the coregistration panel "

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -86,7 +86,7 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     trans : str | None
         The transform file to use.
     scrollable : bool
-        Make the coregistration panel vertically scrollable (default True)?
+        Make the coregistration panel vertically scrollable (default True).
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -38,7 +38,7 @@ def combine_kit_markers():
 def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
                    subject=None, subjects_dir=None, guess_mri_subject=None,
                    scene_height=None, head_opacity=None, head_high_res=None,
-                   trans=None, verbose=None):
+                   trans=None, scrollable=False, verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -85,6 +85,8 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
         (which defaults to True).
     trans : str | None
         The transform file to use.
+    scrollable : bool
+        Make the main panels vertically scrollable (default False)?
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -121,7 +123,7 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     from ._backend import _check_backend
     _check_backend()
     from ._coreg_gui import CoregFrame, _make_view
-    view = _make_view(tabbed, split, scene_width, scene_height)
+    view = _make_view(tabbed, split, scene_width, scene_height, scrollable)
     frame = CoregFrame(inst, subject, subjects_dir, guess_mri_subject,
                        head_opacity, head_high_res, trans, config)
     return _initialize_gui(frame, view)

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -38,7 +38,7 @@ def combine_kit_markers():
 def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
                    subject=None, subjects_dir=None, guess_mri_subject=None,
                    scene_height=None, head_opacity=None, head_high_res=None,
-                   trans=None, scrollable=False, verbose=None):
+                   trans=None, scrollable=True, verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -86,7 +86,7 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     trans : str | None
         The transform file to use.
     scrollable : bool
-        Make the main panels vertically scrollable (default False)?
+        Make the coregistration panel vertically scrollable (default True)?
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1176,7 +1176,7 @@ class NewMriDialog(HasPrivateTraits):
 
 
 def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
-               scrollable=False):
+               scrollable=True):
     """Create a view for the CoregFrame.
 
     Parameters
@@ -1190,7 +1190,7 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
     scene_width : int
         Specify a minimum width for the 3d scene (in pixels).
     scrollable : bool
-        Make the main panels vertically scrollable (default False)?
+        Make the coregistration panel vertically scrollable (default True).
 
     Returns
     -------

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1234,7 +1234,9 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
     # object; hence we use a special InstanceEditor to set the parameter
     # programmatically:
     coreg_panel = VGroup(
-        Item('coreg_panel', style='custom', width=400 if scrollable else 1,
+        # width=410 is optimized for macOS to avoid a horizontal scroll-bar;
+        # might benefit from platform-specific values
+        Item('coreg_panel', style='custom', width=410 if scrollable else 1,
              editor=InstanceEditor(view=_make_view_coreg_panel(scrollable))),
         label="Coregistration", show_border=not scrollable, show_labels=False,
         enabled_when="fid_panel.locked")

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -52,7 +52,7 @@ from traits.api import (Bool, Button, cached_property, DelegatesTo, Directory,
                         Enum, Float, HasTraits, HasPrivateTraits, Instance,
                         Int, on_trait_change, Property, Str)
 from traitsui.api import (View, Item, Group, HGroup, VGroup, VGrid, EnumEditor,
-                          Handler, Label, TextEditor, Spring)
+                          Handler, Label, TextEditor, Spring, InstanceEditor)
 from traitsui.menu import Action, UndoButton, CancelButton, NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
@@ -607,77 +607,8 @@ class CoregFrameHandler(Handler):
             return True
 
 
-class CoregPanel(HasPrivateTraits):
-    """Coregistration panel for Head<->MRI with scaling."""
-
-    model = Instance(CoregModel)
-
-    # parameters
-    reset_params = Button(label='Reset')
-    grow_hair = DelegatesTo('model')
-    n_scale_params = DelegatesTo('model')
-    scale_step = Float(0.01)
-    scale_x = DelegatesTo('model')
-    scale_x_dec = Button('-')
-    scale_x_inc = Button('+')
-    scale_y = DelegatesTo('model')
-    scale_y_dec = Button('-')
-    scale_y_inc = Button('+')
-    scale_z = DelegatesTo('model')
-    scale_z_dec = Button('-')
-    scale_z_inc = Button('+')
-    rot_step = Float(0.01)
-    rot_x = DelegatesTo('model')
-    rot_x_dec = Button('-')
-    rot_x_inc = Button('+')
-    rot_y = DelegatesTo('model')
-    rot_y_dec = Button('-')
-    rot_y_inc = Button('+')
-    rot_z = DelegatesTo('model')
-    rot_z_dec = Button('-')
-    rot_z_inc = Button('+')
-    trans_step = Float(0.001)
-    trans_x = DelegatesTo('model')
-    trans_x_dec = Button('-')
-    trans_x_inc = Button('+')
-    trans_y = DelegatesTo('model')
-    trans_y_dec = Button('-')
-    trans_y_inc = Button('+')
-    trans_z = DelegatesTo('model')
-    trans_z_dec = Button('-')
-    trans_z_inc = Button('+')
-
-    # fitting
-    has_fid_data = DelegatesTo('model')
-    has_pts_data = DelegatesTo('model')
-    has_eeg_data = DelegatesTo('model')
-    # fitting with scaling
-    fits_hsp_points = Button(label='Fit Head Shape')
-    fits_fid = Button(label='Fit Fiducials')
-    fits_ap = Button(label='Fit LPA/RPA')
-    # fitting without scaling
-    fit_hsp_points = Button(label='Fit Head Shape')
-    fit_fid = Button(label='Fit Fiducials')
-    fit_ap = Button(label='Fit LPA/RPA')
-
-    # fit info
-    fid_eval_str = DelegatesTo('model')
-    points_eval_str = DelegatesTo('model')
-
-    # saving
-    can_prepare_bem_model = DelegatesTo('model')
-    can_save = DelegatesTo('model')
-    scale_labels = DelegatesTo('model')
-    copy_annot = DelegatesTo('model')
-    prepare_bem_model = DelegatesTo('model')
-    save = Button(label="Save As...")
-    load_trans = Button(label='Load trans...')
-    queue = Instance(queue.Queue, ())
-    queue_feedback = Str('')
-    queue_current = Str('')
-    queue_len = Int(0)
-    queue_len_str = Property(Str, depends_on=['queue_len'])
-
+def _make_view_coreg_panel(scrollable=False):
+    "Generate View for CoregPanel"
     view = View(VGroup(Item('grow_hair', show_label=True),
                        Item('n_scale_params', label='MRI Scaling',
                             style='custom', show_label=True,
@@ -828,7 +759,82 @@ class CoregPanel(HasPrivateTraits):
                        Item('queue_current', style='readonly'),
                        Item('queue_len_str', style='readonly'),
                        show_labels=False),
-                kind='panel', buttons=[UndoButton])
+                kind='panel', buttons=[UndoButton], scrollable=scrollable)
+    return view
+
+
+class CoregPanel(HasPrivateTraits):
+    """Coregistration panel for Head<->MRI with scaling."""
+
+    model = Instance(CoregModel)
+
+    # parameters
+    reset_params = Button(label='Reset')
+    grow_hair = DelegatesTo('model')
+    n_scale_params = DelegatesTo('model')
+    scale_step = Float(0.01)
+    scale_x = DelegatesTo('model')
+    scale_x_dec = Button('-')
+    scale_x_inc = Button('+')
+    scale_y = DelegatesTo('model')
+    scale_y_dec = Button('-')
+    scale_y_inc = Button('+')
+    scale_z = DelegatesTo('model')
+    scale_z_dec = Button('-')
+    scale_z_inc = Button('+')
+    rot_step = Float(0.01)
+    rot_x = DelegatesTo('model')
+    rot_x_dec = Button('-')
+    rot_x_inc = Button('+')
+    rot_y = DelegatesTo('model')
+    rot_y_dec = Button('-')
+    rot_y_inc = Button('+')
+    rot_z = DelegatesTo('model')
+    rot_z_dec = Button('-')
+    rot_z_inc = Button('+')
+    trans_step = Float(0.001)
+    trans_x = DelegatesTo('model')
+    trans_x_dec = Button('-')
+    trans_x_inc = Button('+')
+    trans_y = DelegatesTo('model')
+    trans_y_dec = Button('-')
+    trans_y_inc = Button('+')
+    trans_z = DelegatesTo('model')
+    trans_z_dec = Button('-')
+    trans_z_inc = Button('+')
+
+    # fitting
+    has_fid_data = DelegatesTo('model')
+    has_pts_data = DelegatesTo('model')
+    has_eeg_data = DelegatesTo('model')
+    # fitting with scaling
+    fits_hsp_points = Button(label='Fit Head Shape')
+    fits_fid = Button(label='Fit Fiducials')
+    fits_ap = Button(label='Fit LPA/RPA')
+    # fitting without scaling
+    fit_hsp_points = Button(label='Fit Head Shape')
+    fit_fid = Button(label='Fit Fiducials')
+    fit_ap = Button(label='Fit LPA/RPA')
+
+    # fit info
+    fid_eval_str = DelegatesTo('model')
+    points_eval_str = DelegatesTo('model')
+
+    # saving
+    can_prepare_bem_model = DelegatesTo('model')
+    can_save = DelegatesTo('model')
+    scale_labels = DelegatesTo('model')
+    copy_annot = DelegatesTo('model')
+    prepare_bem_model = DelegatesTo('model')
+    save = Button(label="Save As...")
+    load_trans = Button(label='Load trans...')
+    queue = Instance(queue.Queue, ())
+    queue_feedback = Str('')
+    queue_current = Str('')
+    queue_len = Int(0)
+    queue_len_str = Property(Str, depends_on=['queue_len'])
+
+    view = _make_view_coreg_panel()
 
     def __init__(self, *args, **kwargs):  # noqa: D102
         super(CoregPanel, self).__init__(*args, **kwargs)
@@ -1169,7 +1175,8 @@ class NewMriDialog(HasPrivateTraits):
             self.can_overwrite = False
 
 
-def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400):
+def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
+               scrollable=False):
     """Create a view for the CoregFrame.
 
     Parameters
@@ -1182,6 +1189,8 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400):
         unnecessary for wx backend).
     scene_width : int
         Specify a minimum width for the 3d scene (in pixels).
+    scrollable : bool
+        Make the main panels vertically scrollable (default False)?
 
     Returns
     -------
@@ -1220,8 +1229,11 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400):
                show_labels=False),
         show_labels=False, label="Data Source")
 
+    # placing `scrollable=scrollable` inside a Group has no effect (macOS), in
+    # order to be effective the parametr has to be in a View objects
     coreg_panel = VGroup(
-        Item('coreg_panel', style='custom', width=1),
+        Item('coreg_panel', style='custom', width=1,
+             editor=InstanceEditor(view=_make_view_coreg_panel(scrollable))),
         label="Coregistration", show_border=True, show_labels=False,
         enabled_when="fid_panel.locked")
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1229,8 +1229,10 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
                show_labels=False),
         show_labels=False, label="Data Source")
 
-    # placing `scrollable=scrollable` inside a Group has no effect (macOS), in
-    # order to be effective the parametr has to be in a View objects
+    # Setting `scrollable=True` for a Group does not seem to have any effect
+    # (macOS), in order to be effective the parameter has to be set for a View
+    # object; hence we use a special InstanceEditor to set the parameter
+    # programmatically:
     coreg_panel = VGroup(
         Item('coreg_panel', style='custom', width=1,
              editor=InstanceEditor(view=_make_view_coreg_panel(scrollable))),

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -608,7 +608,7 @@ class CoregFrameHandler(Handler):
 
 
 def _make_view_coreg_panel(scrollable=False):
-    "Generate View for CoregPanel"
+    """Generate View for CoregPanel."""
     view = View(VGroup(Item('grow_hair', show_label=True),
                        Item('n_scale_params', label='MRI Scaling',
                             style='custom', show_label=True,

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1234,9 +1234,9 @@ def _make_view(tabbed=False, split=False, scene_width=500, scene_height=400,
     # object; hence we use a special InstanceEditor to set the parameter
     # programmatically:
     coreg_panel = VGroup(
-        Item('coreg_panel', style='custom', width=1,
+        Item('coreg_panel', style='custom', width=400 if scrollable else 1,
              editor=InstanceEditor(view=_make_view_coreg_panel(scrollable))),
-        label="Coregistration", show_border=True, show_labels=False,
+        label="Coregistration", show_border=not scrollable, show_labels=False,
         enabled_when="fid_panel.locked")
 
     main_layout = 'split' if split else 'normal'


### PR DESCRIPTION
Addressing #4411 @agramfort 

~~Start the GUI with `mne coreg --compact`~~

It's not pretty, but it should do the job. 

It only makes the second panel scrollable, but since that is the larger one this should be fine for pretty small screens (height < 800 pixels on macOS); there seems to be a bug in traitsui in that it only allows making `View`s scrollable, not `Group`s, and since the first panel is composed of multiple views it would be more complex to build a single view for it.