### PR TITLE
MRG: Fix interpolation truncation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -148,6 +148,8 @@ BUG
 
     - Fix bug in :func:`mne.viz.plot_compare_evokeds` where ``truncate_yaxis`` was ignored (default is now ``False``), by `Jona Sassenhagen`_
 
+    - Fix field mapping :func:`mne.make_field_map` and MEG bad channel interpolation functions (e.g., :meth:`mne.Evoked.interpolate_bads`) to choose a better number of components during pseudoinversion when few channels are available, by `Eric Larson`_
+
 API
 ~~~
     - Add :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.apply_lcmv`, :func:`mne.beamformer.apply_lcmv_epochs`, and :func:`mne.beamformer.apply_lcmv_raw` to enable the separate computation and application of LCMV beamformer weights by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -820,7 +820,9 @@ class UpdateChannelsMixin(object):
 class InterpolationMixin(object):
     """Mixin class for Raw, Evoked, Epochs."""
 
-    def interpolate_bads(self, reset_bads=True, mode='accurate'):
+    @verbose
+    def interpolate_bads(self, reset_bads=True, mode='accurate',
+                         verbose=None):
         """Interpolate bad MEG and EEG channels.
 
         Operates in place.
@@ -833,6 +835,10 @@ class InterpolationMixin(object):
             Either `'accurate'` or `'fast'`, determines the quality of the
             Legendre polynomial expansion used for interpolation of MEG
             channels.
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more).
 
         Returns
         -------

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.polynomial.legendre import legval
 from scipy import linalg
 
-from ..utils import logger, warn
+from ..utils import logger, warn, verbose
 from ..io.pick import pick_types, pick_channels, pick_info
 from ..surface import _normalize_vectors
 from ..bem import _fit_sphere
@@ -104,7 +104,8 @@ def _do_interp_dots(inst, interpolation, goods_idx, bads_idx):
                          .format(type(inst)))
 
 
-def _interpolate_bads_eeg(inst):
+@verbose
+def _interpolate_bads_eeg(inst, verbose=None):
     """Interpolate bad EEG channels.
 
     Operates in place.
@@ -153,6 +154,7 @@ def _interpolate_bads_eeg(inst):
     _do_interp_dots(inst, interpolation, goods_idx, bads_idx)
 
 
+@verbose
 def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
     """Interpolate bad channels from data in good channels.
 

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -92,6 +92,18 @@ def test_interpolation():
         inst.info['bads'] = [inst.ch_names[1]]
         assert_raises(ValueError, inst.interpolate_bads)
 
+    # check that interpolation works with few channels
+    raw_few = raw.copy().crop(0, 0.1).load_data()
+    raw_few.pick_channels(raw_few.ch_names[:1] + raw_few.ch_names[3:4])
+    assert_equal(len(raw_few.ch_names), 2)
+    raw_few.del_proj()
+    raw_few.info['bads'] = [raw_few.ch_names[-1]]
+    orig_data = raw_few[1][0]
+    raw_few.interpolate_bads(reset_bads=False)
+    new_data = raw_few[1][0]
+    assert_true((new_data == 0).mean() < 0.5)
+    assert_true(np.corrcoef(new_data, orig_data)[0, 1] > 0.1)
+
     # check that interpolation works when non M/EEG channels are present
     # before MEG channels
     with warnings.catch_warnings(record=True):  # change of units
@@ -130,5 +142,6 @@ def test_interpolation():
     evoked.info.normalize_proj()
     data2 = evoked.interpolate_bads().data[pick]
     assert_true(np.corrcoef(data1, data2)[0, 1] > thresh)
+
 
 run_tests_if_main()

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -78,8 +78,10 @@ def _compute_mapping_matrix(fmd, info):
     # Eigenvalue truncation
     sumk = np.cumsum(sing)
     sumk /= sumk[-1]
-    fmd['nest'] = np.where(sumk > (1.0 - fmd['miss']))[0][0]
-    logger.info('    [Truncate at %d missing %g]' % (fmd['nest'], fmd['miss']))
+    fmd['nest'] = np.where(sumk > (1.0 - fmd['miss']))[0][0] + 1
+    logger.info('    Truncating at %d/%d components to omit less than %g '
+                '(%0.2g)' % (fmd['nest'], len(sing), fmd['miss'],
+                             1. - sumk[fmd['nest'] - 1]))
     sing = 1.0 / sing[:fmd['nest']]
 
     # Put the inverse together

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -176,17 +176,20 @@ def test_make_field_map_meeg():
     evoked.pick_channels([evoked.ch_names[p] for p in picks])
     evoked.info.normalize_proj()
     maps = make_field_map(evoked, trans_fname, subject='sample',
-                          subjects_dir=subjects_dir, n_jobs=1)
+                          subjects_dir=subjects_dir, n_jobs=1, verbose='debug')
     assert_equal(maps[0]['data'].shape, (642, 6))  # EEG->Head
     assert_equal(maps[1]['data'].shape, (304, 31))  # MEG->Helmet
     # reasonable ranges
-    for map_ in maps:
-        assert_true(0.5 < map_['data'].max() < 2)
-        assert_true(-2 < map_['data'].min() < -0.5)
+    maxs = (1.2, 2.0)  # before #4418, was (1.1, 2.0)
+    mins = (-0.8, -1.3)  # before #4418, was (-0.6, -1.2)
+    assert_equal(len(maxs), len(maps))
+    for map_, max_, min_ in zip(maps, maxs, mins):
+        assert_allclose(map_['data'].max(), max_, rtol=5e-2)
+        assert_allclose(map_['data'].min(), min_, rtol=5e-2)
     # calculated from correct looking mapping on 2015/12/26
-    assert_allclose(np.sqrt(np.sum(maps[0]['data'] ** 2)), 16.6088,
+    assert_allclose(np.sqrt(np.sum(maps[0]['data'] ** 2)), 19.0903,  # 16.6088,
                     atol=1e-3, rtol=1e-3)
-    assert_allclose(np.sqrt(np.sum(maps[1]['data'] ** 2)), 20.1245,
+    assert_allclose(np.sqrt(np.sum(maps[1]['data'] ** 2)), 19.4748,  # 20.1245,
                     atol=1e-3, rtol=1e-3)
 
 


### PR DESCRIPTION
I'm not actually sure if we want to do +1 here (which means "missing less than 0.0001") or do `max(old_val, 1)`, which means "missing at least 0.0001 but keeping at least one component". The former seemed nicer to me but is a bit bigger of a change.

Closes #4377.