### PR TITLE
Add support for Morlet wavelets that are longer than the signal

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os.path as op
+import warnings
 
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
@@ -212,9 +213,12 @@ def test_time_frequency():
                   n_cycles=n_cycles, use_fft=True, return_itc=True,
                   decim='decim')
 
-    # When convolving in time, wavelets must not be shorter than the data
+    # When convolving in time, wavelets must not be longer than the data
     assert_raises(ValueError, cwt, data[0, :, :Ws[0].size - 1], Ws,
                   use_fft=False)
+    with warnings.catch_warnings(record=True) as w:
+        cwt(data[0, :, :Ws[0].size - 1], Ws, use_fft=True)
+    assert_equal(len(w), 1)
 
     # Check for off-by-one errors when using wavelets with an even number of
     # samples

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1,5 +1,7 @@
 import numpy as np
 import os.path as op
+import warnings
+
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
@@ -210,6 +212,11 @@ def test_time_frequency():
     assert_raises(TypeError, tfr_morlet, epochs, freqs=freqs,
                   n_cycles=n_cycles, use_fft=True, return_itc=True,
                   decim='decim')
+
+    # Test warning if wavelet is longer than signal
+    with warnings.catch_warnings(record=True) as w:
+        cwt(data[0, :, :Ws[0].size - 1], Ws, use_fft=False, mode='same')
+    assert_equal(len(w), 1)
 
 
 def test_dpsswavelet():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -204,11 +204,6 @@ def test_time_frequency():
     assert_raises(ValueError, cwt, data[0, :, :], Ws, mode='foo')
     for use_fft in [True, False]:
         for mode in ['same', 'valid', 'full']:
-            # XXX JRK: full wavelet decomposition needs to be implemented
-            if (not use_fft) and mode == 'full':
-                assert_raises(ValueError, cwt, data[0, :, :], Ws,
-                              use_fft=use_fft, mode=mode)
-                continue
             cwt(data[0, :, :], Ws, use_fft=use_fft, mode=mode)
 
     # Test decim parameter checks

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os.path as op
-import warnings
 
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
@@ -206,17 +205,21 @@ def test_time_frequency():
     assert_raises(ValueError, cwt, data[0, :, :], Ws, mode='foo')
     for use_fft in [True, False]:
         for mode in ['same', 'valid', 'full']:
-            cwt(data[0, :, :], Ws, use_fft=use_fft, mode=mode)
+            cwt(data[0], Ws, use_fft=use_fft, mode=mode)
 
     # Test decim parameter checks
     assert_raises(TypeError, tfr_morlet, epochs, freqs=freqs,
                   n_cycles=n_cycles, use_fft=True, return_itc=True,
                   decim='decim')
 
-    # Test warning if wavelet is longer than signal
-    with warnings.catch_warnings(record=True) as w:
-        cwt(data[0, :, :Ws[0].size - 1], Ws, use_fft=False, mode='same')
-    assert_equal(len(w), 1)
+    # When convolving in time, wavelets must not be shorter than the data
+    assert_raises(ValueError, cwt, data[0, :, :Ws[0].size - 1], Ws,
+                  use_fft=False)
+
+    # Check for off-by-one errors when using wavelets with an even number of
+    # samples
+    psd = cwt(data[0], [Ws[0][:-1]], use_fft=False, mode='full')
+    assert_equal(psd.shape, (2, 1, 420))
 
 
 def test_dpsswavelet():

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -12,7 +12,6 @@ Morlet code inspired by Matlab code from Sheraz Khan & Brainstorm & SPM
 from copy import deepcopy
 from functools import partial
 from math import sqrt
-from warnings import warn
 
 import numpy as np
 from scipy import linalg
@@ -208,10 +207,10 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
     for i, W in enumerate(Ws):
         if use_fft:
             fft_Ws[i] = fft(W, fsize)
-        elif mode == 'same' and len(W) > n_times:
-            warn("At least one of the wavelets is longer than the "
-                 "signal. Switching to 'full' convolution mode.")
-            mode = 'full'
+        elif len(W) > n_times:
+            raise ValueError('At least one of the wavelets is longer than the '
+                             'signal. Use a longer signal or shorter '
+                             'wavelets.')
 
     # Make generator looping across signals
     tfr = np.zeros((n_freqs, n_times_out), dtype=np.complex128)
@@ -236,7 +235,9 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
                     ret = _centered(ret, sz)
                 tfr[ii, this_slice] = ret[decim]
             elif mode == 'full' and not use_fft:
-                ret = ret[(W.size // 2):len(ret) - (W.size // 2)]
+                start = int(np.ceil(W.size / 2.))
+                end = len(ret) - (W.size // 2) + 1
+                ret = ret[start:end]
                 tfr[ii, :] = ret[decim]
             else:
                 if use_fft:

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -242,7 +242,7 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
                     ret = _centered(ret, sz)
                 tfr[ii, this_slice] = ret[decim]
             elif mode == 'full' and not use_fft:
-                start = int(np.ceil(W.size / 2.))
+                start = (W.size + 1) // 2
                 end = len(ret) - (W.size // 2) + 1
                 ret = ret[start:end]
                 tfr[ii, :] = ret[decim]

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -12,6 +12,7 @@ Morlet code inspired by Matlab code from Sheraz Khan & Brainstorm & SPM
 from copy import deepcopy
 from functools import partial
 from math import sqrt
+from warnings import warn
 
 import numpy as np
 from scipy import linalg
@@ -204,13 +205,19 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
     # precompute FFTs of Ws
     if use_fft:
         fft_Ws = np.empty((n_freqs, fsize), dtype=np.complex128)
+
+    warn_me = True
     for i, W in enumerate(Ws):
         if use_fft:
             fft_Ws[i] = fft(W, fsize)
-        elif len(W) > n_times:
-            raise ValueError('At least one of the wavelets is longer than the '
-                             'signal. Use a longer signal or shorter '
-                             'wavelets.')
+        if len(W) > n_times and warn_me:
+            msg = ('At least one of the wavelets is longer than the signal. '
+                   'Consider padding the signal or using shorter wavelets.')
+            if use_fft:
+                warn(msg)
+                warn_me = False  # Suppress further warnings
+            else:
+                raise ValueError(msg)
 
     # Make generator looping across signals
     tfr = np.zeros((n_freqs, n_times_out), dtype=np.complex128)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -12,6 +12,7 @@ Morlet code inspired by Matlab code from Sheraz Khan & Brainstorm & SPM
 from copy import deepcopy
 from functools import partial
 from math import sqrt
+from warnings import warn
 
 import numpy as np
 from scipy import linalg
@@ -207,6 +208,10 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
     for i, W in enumerate(Ws):
         if use_fft:
             fft_Ws[i] = fft(W, fsize)
+        elif mode == 'same' and len(W) > n_times:
+            warn("At least one of the wavelets is longer than the "
+                 "signal. Switching to 'full' convolution mode.")
+            mode = 'full'
 
     # Make generator looping across signals
     tfr = np.zeros((n_freqs, n_times_out), dtype=np.complex128)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -242,8 +242,8 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
                     ret = _centered(ret, sz)
                 tfr[ii, this_slice] = ret[decim]
             elif mode == 'full' and not use_fft:
-                start = (W.size + 1) // 2
-                end = len(ret) - (W.size // 2) + 1
+                start = (W.size + 1) // 2 - 1
+                end = len(ret) - (W.size // 2)
                 ret = ret[start:end]
                 tfr[ii, :] = ret[decim]
             else:

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -242,7 +242,7 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
                     ret = _centered(ret, sz)
                 tfr[ii, this_slice] = ret[decim]
             elif mode == 'full' and not use_fft:
-                start = (W.size + 1) // 2 - 1
+                start = (W.size - 1) // 2
                 end = len(ret) - (W.size // 2)
                 ret = ret[start:end]
                 tfr[ii, :] = ret[decim]


### PR DESCRIPTION
Found a fixme in the code, so fixed it.

I verified that:

    np.allclose(cwt(X, Ws, use_fft=True, mode='full'), cwt(X, Ws, use_fft=False, mode='full'))

@kingjr thoughts?