### PR TITLE
[MRG+1] Make stc.times read-only

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,6 +77,8 @@ Changelog
 
     - Add confidence intervals, number of free parameters, and χ² to :func:`mne.fit_dipole` and :func:`mne.read_dipole` by `Eric Larson`_
 
+    - :attr:`mne.SourceEstimate.data` is now writable, writing to it will also update :attr:`mne.SourceEstimate.times` by `Marijn van Vliet`_
+
 BUG
 ~~~
 
@@ -129,6 +131,8 @@ BUG
     - Fix bug in :meth:`to_data_frame <mne.io.Raw.to_data_frame>` where non-consecutive picks would make the function crash by `Jaakko Leppakangas`_
 
     - Fix channel picking and drop in :class:`mne.time_frequency.EpochsTFR` by `Lukáš Hejtmánek`_
+
+    - Fix :func:`mne.SourceEstimate.transform` to properly update :attr:`mne.SourceEstimate.times` by `Marijn van Vliet`_
 
 API
 ~~~

--- a/mne/simulation/tests/test_metrics.py
+++ b/mne/simulation/tests/test_metrics.py
@@ -44,7 +44,7 @@ def test_metrics():
     stc_bad = stc2.copy().crop(0, 0.5)
     assert_raises(ValueError, source_estimate_quantification, stc1, stc_bad)
     stc_bad = stc2.copy()
-    stc_bad.times -= 0.1
+    stc_bad.tmin -= 0.1
     assert_raises(ValueError, source_estimate_quantification, stc1, stc_bad)
     assert_raises(ValueError, source_estimate_quantification, stc1, stc2,
                   metric='foo')


### PR DESCRIPTION
The `.times` attribute of `_BaseSourceEstimate` is a function of the number of time samples, `tmin` and `tstep`. It should therefore be a read-only property. Because otherwise, we make mistakes and forget to call `_update_times()` and this happens:

```python
import numpy as np
from nose.tools import assert_equal
import mne

# Generate an STC with random data
rng = np.random.RandomState(0)
n_verts_lh, n_verts_rh, n_times = 10, 10, 10
vertices = [np.arange(n_verts_lh), n_verts_lh + np.arange(n_verts_rh)]
data = rng.randn(n_verts_lh + n_verts_rh, n_times)
stc = mne.SourceEstimate(data, vertices=vertices, tmin=-0.1, tstep=0.1)

# Perform a simple transform on part of the data
stc.transform(np.abs, tmin=-50, tmax=500, copy=False)

# Oops... this fails on current master!
assert_equal(len(stc.times), stc.data.shape[1])
```

This PR makes `.times` a property and fixes `_BaseSourceEstimate.transform()`. From reading the tests and the code, I assume the desired behavior is for the `tmax` parameter of `transform()` to be inclusive (just like with `crop()`).