### PR TITLE
Fixes bug in picking channels in epochsTFR object

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -734,7 +734,7 @@ class UpdateChannelsMixin(object):
 
     def _pick_drop_channels(self, idx):
         # avoid circular imports
-        from ..time_frequency import AverageTFR
+        from ..time_frequency import AverageTFR, EpochsTFR
 
         _check_preload(self, 'adding or dropping channels')
 
@@ -751,7 +751,7 @@ class UpdateChannelsMixin(object):
 
         if self.preload:
             # All others (Evoked, Epochs, Raw) have chs axis=-2
-            axis = -3 if isinstance(self, AverageTFR) else -2
+            axis = -3 if isinstance(self, (AverageTFR, EpochsTFR)) else -2
             self._data = self._data.take(idx, axis=axis)
 
     def add_channels(self, add_list, force_update_info=False):


### PR DESCRIPTION
Epochs TFR as well as Average TFR object has channels on a -3 axis. Picking channels exited in a bug.