### PR TITLE
[MRG] Plot event numbers

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -98,6 +98,8 @@ Changelog
     - Add bootstrapped confidence intervals to :func:`mne.viz.plot_compare_evokeds` (that can for now also be accessed as :func:`mne.stats._boostrap_ci`) by `Jona Sassenhagen`_ and `Denis Engemann`_
 
     - Add support for volume source spaces to :func:`spatial_src_connectivity` and :func:`spatio_temporal_src_connectivity` by `Alex Gramfort`_
+    
+    - Plotting raw data (:func:`mne.viz.plot_raw` or :meth:`mne.io.Raw.plot`) with events now includes event numbers (if there are not more than 50 events on a page) by `Clemens Brunner`_
 
 BUG
 ~~~

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -972,9 +972,11 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             else:
                 line.set_xdata([])
                 line.set_ydata([])
+        params['ax'].texts = []
         for ev_time, ev_num in zip(event_times, event_nums):
             if -1 in event_color or ev_num in event_color:
-                params['ax'].text(ev_time, -0.05, ev_num, fontsize=8, ha='center')
+                params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
+                                  ha='center')
 
     if 'segments' in params:
         while len(params['ax'].collections) > 0:

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -968,6 +968,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 for tt in t:
                     xs += [tt, tt, np.nan]
                     ys += [0, ylim[0], np.nan]
+                    params['ax'].text(tt, 0, ev_num, fontsize=6, ha='center')
                 line.set_xdata(xs)
                 line.set_ydata(ys)
             else:

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -972,11 +972,12 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             else:
                 line.set_xdata([])
                 line.set_ydata([])
-        params['ax'].texts = []
-        for ev_time, ev_num in zip(event_times, event_nums):
-            if -1 in event_color or ev_num in event_color:
-                params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
-                                  ha='center')
+        if len(event_times) <= 50:
+            params['ax'].texts = []
+            for ev_time, ev_num in zip(event_times, event_nums):
+                if -1 in event_color or ev_num in event_color:
+                    params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
+                                      ha='center')
 
     if 'segments' in params:
         while len(params['ax'].collections) > 0:

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -786,9 +786,8 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
         size = tuple([float(s) for s in size])
 
     fig = figure_nobar(facecolor=bgcolor, figsize=size)
-    fig.canvas.set_window_title('mne_browse_raw')
+    fig.canvas.set_window_title(title)
     ax = plt.subplot2grid((10, 10), (0, 1), colspan=8, rowspan=9)
-    ax.set_title(title, fontsize=12)
     ax_hscroll = plt.subplot2grid((10, 10), (9, 1), colspan=8)
     ax_hscroll.get_yaxis().set_visible(False)
     ax_hscroll.set_xlabel('Time (s)')
@@ -975,7 +974,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 line.set_ydata([])
         for ev_time, ev_num in zip(event_times, event_nums):
             if -1 in event_color or ev_num in event_color:
-                params['ax'].text(ev_time, 0, ev_num, fontsize=6, ha='center')
+                params['ax'].text(ev_time, -0.05, ev_num, fontsize=8, ha='center')
 
     if 'segments' in params:
         while len(params['ax'].collections) > 0:

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -968,12 +968,14 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 for tt in t:
                     xs += [tt, tt, np.nan]
                     ys += [0, ylim[0], np.nan]
-                    params['ax'].text(tt, 0, ev_num, fontsize=6, ha='center')
                 line.set_xdata(xs)
                 line.set_ydata(ys)
             else:
                 line.set_xdata([])
                 line.set_ydata([])
+        for ev_time, ev_num in zip(event_times, event_nums):
+            if -1 in event_color or ev_num in event_color:
+                params['ax'].text(ev_time, 0, ev_num, fontsize=6, ha='center')
 
     if 'segments' in params:
         while len(params['ax'].collections) > 0:


### PR DESCRIPTION
I think it would be useful if the event numbers were plotted (and not just encoded by color).

This would look like as follows:
![screen shot 2017-07-31 at 15 38 25](https://user-images.githubusercontent.com/4377312/28780439-02fded60-7607-11e7-9c16-9f0f6c1dc1d0.png)

Two issues:
1. There is not much space between the title and the main axes. Sometimes the event labels overlap with the title. How could this be improved?
2. Sometimes the label of an earlier event which should not be visible in the current view is shown (see attached screenshot, the event label "11" occurs in the previous page) - does anyone spot the error in my code?