### PR TITLE
[MRG] Remove sep from tutorials.

### DIFF
--- a/tutorials/plot_object_epochs.py
+++ b/tutorials/plot_object_epochs.py
@@ -66,7 +66,8 @@ print(epochs)
 # information, as well as a number of attributes unique to the events contained
 # within the object.
 
-print(epochs.events[:3], epochs.event_id, sep='\n\n')
+print(epochs.events[:3])
+print(epochs.event_id)
 
 ###############################################################################
 # You can select subsets of epochs by indexing the :class:`Epochs <mne.Epochs>`

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -89,7 +89,10 @@ grad_only = raw.copy().pick_types(meg='grad')
 # Or you can use custom channel names
 pick_chans = ['MEG 0112', 'MEG 0111', 'MEG 0122', 'MEG 0123']
 specific_chans = raw.copy().pick_channels(pick_chans)
-print(meg_only, eeg_only, grad_only, specific_chans, sep='\n')
+print(meg_only)
+print(eeg_only)
+print(grad_only)
+print(specific_chans)
 
 ###############################################################################
 # Notice the different scalings of these types


### PR DESCRIPTION
For some reason the ``print_function`` doesn't seem to work on [circle](https://circleci.com/gh/mne-tools/mne-python/5245?utm_campaign=build-failed&utm_medium=email&utm_source=notification).

This should fix it.