### PR TITLE
Deprecating picks in beamformers

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -194,6 +194,9 @@ API
 
     - :func:`mne.time_frequency.psd_welch` and :func:`mne.time_frequency.psd_array_welch` now use a Hamming window (instead of a Hann window) by `Clemens Brunner`_
 
+    - ``picks`` parameter in :func:`mne.beamformer.lcmv`, :func:`mne.beamformer.lcmv_epochs`, :func:`mne.beamformer.lcmv_raw`, :func:`mne.beamformer.tf_lcmv` and :func:`mne.beamformer.rap_music` is now deprecated and will be removed in 0.16, by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.
+
+
 .. _changes_0_14:
 
 Version 0.14

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -196,7 +196,6 @@ API
 
     - ``picks`` parameter in :func:`mne.beamformer.lcmv`, :func:`mne.beamformer.lcmv_epochs`, :func:`mne.beamformer.lcmv_raw`, :func:`mne.beamformer.tf_lcmv` and :func:`mne.beamformer.rap_music` is now deprecated and will be removed in 0.16, by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.
 
-
 .. _changes_0_14:
 
 Version 0.14

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -172,7 +172,7 @@ def dics(evoked, forward, noise_csd, data_csd, reg=0.05, label=None,
     data = evoked.data
     tmin = evoked.times[0]
 
-    picks = _setup_picks(picks=None, info=info, forward=forward)
+    picks = _setup_picks(info=info, forward=forward)
     data = data[picks]
 
     stc = _apply_dics(data, info, tmin, forward, noise_csd, data_csd, reg=reg,
@@ -244,7 +244,7 @@ def dics_epochs(epochs, forward, noise_csd, data_csd, reg=0.05, label=None,
     info = epochs.info
     tmin = epochs.times[0]
 
-    picks = _setup_picks(picks=None, info=info, forward=forward)
+    picks = _setup_picks(info=info, forward=forward)
     data = epochs.get_data()[:, picks, :]
 
     stcs = _apply_dics(data, info, tmin, forward, noise_csd, data_csd, reg=reg,
@@ -349,7 +349,7 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
     else:
         fstep = 1  # dummy value
 
-    picks = _setup_picks(picks=None, info=info, forward=forward)
+    picks = _setup_picks(info=info, forward=forward)
 
     is_free_ori, _, proj, vertno, G =\
         _prepare_beamformer_input(info, forward, label, picks=picks,

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -32,6 +32,7 @@ def _deprecate_picks(info, picks):
              DeprecationWarning)
 
         info = pick_info(info, picks)
+    return info
 
 
 def _reg_pinv(x, reg):
@@ -677,7 +678,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     info = evoked.info
-    _deprecate_picks(info, picks)
+    info = _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -774,7 +775,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     info = epochs.info
-    _deprecate_picks(info, picks)
+    info= _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -875,7 +876,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     info = raw.info
-    _deprecate_picks(info, picks)
+    info = _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -1065,7 +1066,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
            brain imaging (2008) Springer Science & Business Media
     """
     info = epochs.info
-    _deprecate_picks(info, picks)
+    info = _deprecate_picks(info, picks)
 
     _check_reference(epochs)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -52,19 +52,19 @@ def _reg_pinv(x, reg):
 
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):
     # get a list of all channel names:
-    fwd_ch_names = set([ch['ch_name'] for ch in forward['info']['chs']])
+    fwd_ch_names = forward['info']['ch_names']
 
     # handle channels from forward model and info:
     ch_names = _compare_ch_names(info['ch_names'], fwd_ch_names, info['bads'])
 
     # inform about excluding channels:
     if (data_cov is not None and set(info['bads']) != set(data_cov['bads']) and
-            (set(ch_names) & set(data_cov['bads']))):
+            (len(set(ch_names).intersection(data_cov['bads'])) > 0)):
         logger.info('info["bads"] and data_cov["bads"] do not match, '
                     'excluding bad channels from both.')
     if (noise_cov is not None and
             set(info['bads']) != set(noise_cov['bads']) and
-            (set(ch_names) & set(noise_cov['bads']))):
+            (len(set(ch_names).intersection(noise_cov['bads'])) > 0)):
         logger.info('info["bads"] and noise_cov["bads"] do not match, '
                     'excluding bad channels from both.')
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -24,14 +24,14 @@ from ..externals import six
 from ..channels.channels import _contains_ch_type
 
 
-def _deprecate_picks(data_obj, picks):
+def _deprecate_picks(info, picks):
     if picks is not None:
         warn('Specifying picks is deprecated and will be removed in 0.16. '
              'Specifying the selection of channels in info and setting picks '
              'to None will remove this warning.',
              DeprecationWarning)
 
-        data_obj.info = pick_info(data_obj.info, picks)
+        info = pick_info(info, picks)
 
 
 def _reg_pinv(x, reg):
@@ -676,13 +676,14 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    _deprecate_picks(evoked, picks)
+    info = evoked.info
+    _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
 
     # construct spatial filter
-    filters = make_lcmv(info=evoked.info, forward=forward, data_cov=data_cov,
+    filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
@@ -772,13 +773,14 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    _deprecate_picks(epochs, picks)
+    info = epochs.info
+    _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
 
     # construct spatial filter
-    filters = make_lcmv(info=epochs.info, forward=forward, data_cov=data_cov,
+    filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
@@ -872,13 +874,14 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    _deprecate_picks(raw, picks)
+    info = raw.info
+    _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
 
     # construct spatial filter
-    filters = make_lcmv(info=raw.info, forward=forward, data_cov=data_cov,
+    filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
@@ -1061,7 +1064,8 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    _deprecate_picks(epochs, picks)
+    info = epochs.info
+    _deprecate_picks(info, picks)
 
     _check_reference(epochs)
 
@@ -1086,14 +1090,14 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                          'underlying raw instance to this function')
 
     if noise_covs is None:
-        picks = _setup_picks(epochs.info, forward, data_cov=None)
+        picks = _setup_picks(info, forward, data_cov=None)
     else:
-        picks = _setup_picks(epochs.info, forward, data_cov=None,
+        picks = _setup_picks(info, forward, data_cov=None,
                              noise_cov=noise_covs[0])
     ch_names = [epochs.ch_names[k] for k in picks]
 
     # check number of sensor types present in the data
-    _check_one_ch_type(epochs.info, picks, noise_covs)
+    _check_one_ch_type(info, picks, noise_covs)
 
     # Use picks from epochs for picking channels in the raw object
     raw_picks = [raw.ch_names.index(c) for c in ch_names]

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -53,13 +53,13 @@ def _setup_picks(info, forward, data_cov=None, noise_cov=None):
     if data_cov is not None:
         ch_names = [c for c in ch_names
                     if c not in data_cov['bads'] and
-                       c in data_cov.ch_names]
+                    c in data_cov.ch_names]
 
     # handle channels from noise cov if noise cov available:
     if noise_cov is not None:
         ch_names = [c for c in ch_names
                     if c not in noise_cov['bads'] and
-                       c in noise_cov.ch_names]
+                    c in noise_cov.ch_names]
 
     # inform about excluding channels:
     if data_cov is not None and set(info['bads']) != set(data_cov['bads']):
@@ -1085,7 +1085,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
              'to None will remove this warning.',
              DeprecationWarning)
 
-        info = pick_info(info, picks)
+        epochs.info = pick_info(epochs.info, picks)
 
     _check_reference(epochs)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -51,6 +51,7 @@ def _reg_pinv(x, reg):
 
 
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):
+    """Return good channels common to forward model and covariance matrices."""
     # get a list of all channel names:
     fwd_ch_names = forward['info']['ch_names']
 
@@ -85,14 +86,13 @@ def _setup_picks(info, forward, data_cov=None, noise_cov=None):
 
 
 def _compare_ch_names(names1, names2, bads):
-    """Return channel names common to both lists but not in bads"""
+    """Return channel names of common and good channels."""
     ch_names = [ch for ch in names1 if ch not in bads and ch in names2]
     return ch_names
 
 
 def _check_one_ch_type(info, picks, noise_cov):
-    # check number of sensor types present in the data and presence of
-    # noise covariance matrix
+    """Check number of sensor types and presence of noise covariance matrix."""
     info_pick = pick_info(info, sel=picks)
     ch_types =\
         [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -51,7 +51,7 @@ def _reg_pinv(x, reg):
 
 
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):
-    """Return good channels common to forward model and covariance matrices."""
+    """Returns good channels common to forward model and cov. matrices."""
     # get a list of all channel names:
     fwd_ch_names = forward['info']['ch_names']
 
@@ -86,13 +86,13 @@ def _setup_picks(info, forward, data_cov=None, noise_cov=None):
 
 
 def _compare_ch_names(names1, names2, bads):
-    """Return channel names of common and good channels."""
+    """Returns channel names of common and good channels."""
     ch_names = [ch for ch in names1 if ch not in bads and ch in names2]
     return ch_names
 
 
 def _check_one_ch_type(info, picks, noise_cov):
-    """Check number of sensor types and presence of noise covariance matrix."""
+    """Checks number of sensor types and presence of noise cov. matrix."""
     info_pick = pick_info(info, sel=picks)
     ch_types =\
         [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
@@ -103,7 +103,7 @@ def _check_one_ch_type(info, picks, noise_cov):
 
 
 def _pick_channels_spatial_filter(ch_names, filters):
-    """Return data channel indices to be used with spatial filter.
+    """Returns data channel indices to be used with spatial filter.
 
     Unlike ``pick_channels``, this respects the order of ch_names.
     """
@@ -129,7 +129,7 @@ def _check_cov_matrix(data_cov):
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
               pick_ori=None, rank=None,
               weight_norm='unit-noise-gain', verbose=None):
-    """Compute LCMV spatial filter.
+    """Computes LCMV spatial filter.
 
     Parameters
     ----------
@@ -317,12 +317,12 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
 
 
 def _subject_from_filter(filters):
-    """Get subject id from inverse operator."""
+    """Gets subject id from inverse operator."""
     return filters['src'][0].get('subject_his_id', None)
 
 
 def _check_proj_match(info, filters):
-    """Check whether SSP projections in data and spatial filter match."""
+    """Checks whether SSP projections in data and spatial filter match."""
     proj_data, _, _ = make_projector(info['projs'],
                                      filters['ch_names'])
     if not np.array_equal(proj_data, filters['proj']):
@@ -332,7 +332,7 @@ def _check_proj_match(info, filters):
 
 
 def _apply_lcmv(data, filters, info, tmin, max_ori_out):
-    """Apply LCMV spatial filter to data for source reconstruction."""
+    """Applies LCMV spatial filter to data for source reconstruction."""
     if max_ori_out == 'abs':
         warn('max_ori_out and the return of absolute values is deprecated and '
              'will be removed in 0.16. Set it to "signed" to remove this '

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -775,7 +775,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     info = epochs.info
-    info= _deprecate_picks(info, picks)
+    info = _deprecate_picks(info, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -39,7 +39,7 @@ def _reg_pinv(x, reg):
     return linalg.pinv(x), d
 
 
-def _setup_picks(info, forward, data_cov, noise_cov=None):
+def _setup_picks(info, forward, data_cov=None, noise_cov=None):
     # get a list of all channel names:
     fwd_ch_names = set([c['ch_name'] for c in forward['info']['chs']])
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -24,6 +24,16 @@ from ..externals import six
 from ..channels.channels import _contains_ch_type
 
 
+def _deprecate_picks(data_obj, picks):
+    if picks is not None:
+        warn('Specifying picks is deprecated and will be removed in 0.16. '
+             'Specifying the selection of channels in info and setting picks '
+             'to None will remove this warning.',
+             DeprecationWarning)
+
+        data_obj.info = pick_info(data_obj.info, picks)
+
+
 def _reg_pinv(x, reg):
     """Compute a regularized pseudoinverse of a square array."""
     if reg == 0:
@@ -48,6 +58,17 @@ def _setup_picks(info, forward, data_cov=None, noise_cov=None):
                 if c['ch_name'] not in info['bads'] and
                 c['ch_name'] in fwd_ch_names]
 
+    # inform about excluding channels:
+    if (data_cov is not None and set(info['bads']) != set(data_cov['bads']) and
+            (set(ch_names) & set(data_cov['bads']))):
+        logger.info('info["bads"] and data_cov["bads"] do not match, '
+                    'excluding bad channels from both.')
+    if (noise_cov is not None and
+            set(info['bads']) != set(noise_cov['bads']) and
+            (set(ch_names) & set(noise_cov['bads']))):
+        logger.info('info["bads"] and noise_cov["bads"] do not match, '
+                    'excluding bad channels from both.')
+
     # handle channels from data cov if data cov is not None
     # Note: data cov is supposed to be None in tf_lcmv
     if data_cov is not None:
@@ -60,14 +81,6 @@ def _setup_picks(info, forward, data_cov=None, noise_cov=None):
         ch_names = [c for c in ch_names
                     if c not in noise_cov['bads'] and
                     c in noise_cov.ch_names]
-
-    # inform about excluding channels:
-    if data_cov is not None and set(info['bads']) != set(data_cov['bads']):
-        logger.info('info["bads"] and data_cov["bads"] do not match, '
-                    'excluding bad channels from both.')
-    if noise_cov is not None and set(info['bads']) != set(noise_cov['bads']):
-        logger.info('info["bads"] and noise_cov["bads"] do not match, '
-                    'excluding bad channels from both.')
 
     picks = [info['ch_names'].index(k) for k in ch_names if k in
              info['ch_names']]
@@ -663,13 +676,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        evoked.info = pick_info(evoked.info, picks)
+    _deprecate_picks(evoked, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -765,13 +772,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        epochs.info = pick_info(epochs.info, picks)
+    _deprecate_picks(epochs, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -871,13 +872,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        raw.info = pick_info(raw.info, picks)
+    _deprecate_picks(raw, picks)
 
     # check whether data covariance is supplied
     _check_cov_matrix(data_cov)
@@ -1066,13 +1061,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        epochs.info = pick_info(epochs.info, picks)
+    _deprecate_picks(epochs, picks)
 
     _check_reference(epochs)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -111,7 +111,7 @@ def _check_cov_matrix(data_cov):
 
 @verbose
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
-              picks=None, pick_ori=None, rank=None,
+              pick_ori=None, rank=None,
               weight_norm='unit-noise-gain', verbose=None):
     """Compute LCMV spatial filter.
 
@@ -132,11 +132,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         gradiometers with magnetometers or EEG with MEG.
     label : Label
         Restricts the LCMV solution to a given label.
-    picks : array-like of int
-        Channel indices to use for beamforming (if None all channels
-        are used except bad channels).
-        picks is deprecated and will be removed in 0.16, specify the selection
-        of channels in info instead.
     pick_ori : None | 'normal' | 'max-power'
         If 'normal', rather than pooling the orientations by taking the norm,
         only the radial component is kept. If 'max-power', the source
@@ -171,14 +166,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        info = pick_info(info, picks)
-
     picks = _setup_picks(info, forward, data_cov, noise_cov)
 
     is_free_ori, ch_names, proj, vertno, G = \
@@ -689,7 +676,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
 
     # construct spatial filter
     filters = make_lcmv(info=evoked.info, forward=forward, data_cov=data_cov,
-                        reg=reg, noise_cov=noise_cov, label=label, picks=None,
+                        reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
     # apply spatial filter to evoked data
@@ -791,7 +778,7 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     # construct spatial filter
     filters = make_lcmv(info=epochs.info, forward=forward, data_cov=data_cov,
-                        reg=reg, noise_cov=noise_cov, label=label, picks=None,
+                        reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
     # apply spatial filter to epochs
@@ -897,7 +884,7 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
 
     # construct spatial filter
     filters = make_lcmv(info=raw.info, forward=forward, data_cov=data_cov,
-                        reg=reg, noise_cov=noise_cov, label=label, picks=None,
+                        reg=reg, noise_cov=noise_cov, label=label,
                         pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
 
     # apply spatial filter to epochs

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -632,8 +632,8 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     picks : array-like of int
         Channel indices to use for beamforming (if None all channels
         are used except bad channels).
-        picks is deprecated and will be removed in 0.16, specify the selection
-        of channels in info instead.
+        picks is deprecated and will be removed in 0.16, use pick_channels or
+        pick_types instead.
     rank : None | int | dict
         Specified rank of the noise covariance matrix. If None, the rank is
         detected automatically. If int, the rank is specified for the MEG
@@ -729,8 +729,8 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     picks : array-like of int
         Channel indices to use for beamforming (if None all channels
         are used except bad channels).
-        picks is deprecated and will be removed in 0.16, specify the selection
-        of channels in info instead.
+        picks is deprecated and will be removed in 0.16, use pick_channels or
+        pick_types instead.
     rank : None | int | dict
         Specified rank of the noise covariance matrix. If None, the rank is
         detected automatically. If int, the rank is specified for the MEG
@@ -826,8 +826,8 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     picks : array-like of int
         Channel indices to use for beamforming (if None all channels
         are used except bad channels).
-        picks is deprecated and will be removed in 0.16, specify the selection
-        of channels in info instead.
+        picks is deprecated and will be removed in 0.16, use pick_channels or
+        pick_types instead.
     pick_ori : None | 'normal' | 'max-power'
         If 'normal', rather than pooling the orientations by taking the norm,
         only the radial component is kept. If 'max-power', the source
@@ -1032,8 +1032,8 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     picks : array-like of int
         Channel indices to use for beamforming (if None all channels
         are used except bad channels).
-        picks is deprecated and will be removed in 0.16, specify the selection
-        of channels in info instead.
+        picks is deprecated and will be removed in 0.16, use pick_channels
+        or pick_types instead.
     rank : None | int | dict
         Specified rank of the noise covariance matrix. If None, the rank is
         detected automatically. If int, the rank is specified for the MEG

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -245,11 +245,11 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
 
     .. versionadded:: 0.9.0
     """
-    _deprecate_picks(evoked, picks)
-
     info = evoked.info
     data = evoked.data
     times = evoked.times
+
+    _deprecate_picks(info, picks)
 
     picks = _setup_picks(info, forward, data_cov=None, noise_cov=noise_cov)
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -8,9 +8,9 @@
 import numpy as np
 from scipy import linalg
 
-from ..io.pick import pick_channels_evoked
+from ..io.pick import pick_channels_evoked, pick_info
 from ..cov import compute_whitener
-from ..utils import logger, verbose
+from ..utils import logger, verbose, warn
 from ..dipole import Dipole
 from ._lcmv import _prepare_beamformer_input, _setup_picks
 
@@ -211,6 +211,8 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
     picks : array-like of int | None
         Indices (in info) of data channels. If None, MEG and EEG data channels
         (without bad channels) will be used.
+        picks is deprecated and will be removed in 0.16, specify the selection
+        of channels in info instead.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -247,7 +249,15 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
     data = evoked.data
     times = evoked.times
 
-    picks = _setup_picks(picks, info, forward, noise_cov)
+    if picks is not None:
+        warn('Specifying picks is deprecated and will be removed in 0.16. '
+             'Specifying the selection of channels in info and setting picks '
+             'to None will remove this warning.',
+             DeprecationWarning)
+
+        info = pick_info(info, picks)
+
+    picks = _setup_picks(info, forward, data_cov=None, noise_cov=noise_cov)
 
     data = data[picks]
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -8,11 +8,11 @@
 import numpy as np
 from scipy import linalg
 
-from ..io.pick import pick_channels_evoked, pick_info
+from ..io.pick import pick_channels_evoked
 from ..cov import compute_whitener
-from ..utils import logger, verbose, warn
+from ..utils import logger, verbose
 from ..dipole import Dipole
-from ._lcmv import _prepare_beamformer_input, _setup_picks
+from ._lcmv import _prepare_beamformer_input, _setup_picks, _deprecate_picks
 
 
 def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2,
@@ -245,17 +245,11 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
 
     .. versionadded:: 0.9.0
     """
+    _deprecate_picks(evoked, picks)
+
     info = evoked.info
     data = evoked.data
     times = evoked.times
-
-    if picks is not None:
-        warn('Specifying picks is deprecated and will be removed in 0.16. '
-             'Specifying the selection of channels in info and setting picks '
-             'to None will remove this warning.',
-             DeprecationWarning)
-
-        info = pick_info(info, picks)
 
     picks = _setup_picks(info, forward, data_cov=None, noise_cov=noise_cov)
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -249,7 +249,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
     data = evoked.data
     times = evoked.times
 
-    _deprecate_picks(info, picks)
+    info = _deprecate_picks(info, picks)
 
     picks = _setup_picks(info, forward, data_cov=None, noise_cov=noise_cov)
 


### PR DESCRIPTION
Remove the picks parameter from beamformer functions (LCMV and RAP-MUSIC) to make input consistent with other inverse functions: channel selection will be handled via ``info`` in the future.

@agramfort and @dengemann 