### PR TITLE
MRG+2: Make raw.filter annotation-aware

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -150,6 +150,8 @@ BUG
 
 API
 ~~~
+    - Add ``skip_by_annotation`` to :meth:`mne.io.Raw.filter` to process data concatenated with e.g. :func:`mne.concatenate_raws` separately. This parameter will default to the old behavior (treating all data as a single block) in 0.15 but will change to ``skip_by_annotation='edge'``, which will separately filter the concatenated chunks separately, in 0.16. This should help prevent potential problems with filter-induced ringing in concatenated files, by `Eric Larson`_
+
     - Add :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.apply_lcmv`, :func:`mne.beamformer.apply_lcmv_epochs`, and :func:`mne.beamformer.apply_lcmv_raw` to enable the separate computation and application of LCMV beamformer weights by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.
 
     - Add ``weight_norm`` parameter to enable both unit-noise-gain beamformer and neural activity index (weight normalization) and make whitening optional by allowing ``noise_cov=None`` in :func:`mne.beamformer.lcmv`, :func:`mne.beamformer.lcmv_epochs`, and :func:`mne.beamformer.lcmv_raw`, by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -85,6 +85,14 @@ class Annotations(object):
         self.duration = duration
         self.description = np.array(description, dtype=str)
 
+    def __repr__(self):
+        """Show the representation."""
+        kinds = sorted(set(['"%s"' % d.split(' ')[0]
+                            for d in self.description]))
+        kinds = ', '.join(kinds[:3]) + ('' if len(kinds) <= 3 else '...')
+        return ('<Annotations  |  %s segments : {%s} types>'
+                % (len(self.onset), kinds))
+
     def __len__(self):
         """Return the number of annotations."""
         return len(self.duration)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -7,6 +7,7 @@ import time
 
 import numpy as np
 
+from .utils import _pl
 from .externals.six import string_types
 
 
@@ -87,11 +88,15 @@ class Annotations(object):
 
     def __repr__(self):
         """Show the representation."""
-        kinds = sorted(set(['"%s"' % d.split(' ')[0]
-                            for d in self.description]))
+        kinds = sorted(set('%s' % d.split(' ')[0].lower()
+                           for d in self.description))
+        kinds = ['%s (%s)' % (kind, sum(d.lower().startswith(kind)
+                                        for d in self.description))
+                 for kind in kinds]
         kinds = ', '.join(kinds[:3]) + ('' if len(kinds) <= 3 else '...')
-        return ('<Annotations  |  %s segments : {%s} types>'
-                % (len(self.onset), kinds))
+        kinds = (': ' if len(kinds) > 0 else '') + kinds
+        return ('<Annotations  |  %s segment%s %s >'
+                % (len(self.onset), _pl(len(self.onset)), kinds))
 
     def __len__(self):
         """Return the number of annotations."""

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1192,7 +1192,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             .. versionadded:: 0.15
 
         skip_by_annotation : str | list of str
-            If a string (or list of str), any annotation segments that begin
+            If a string (or list of str), any annotation segment that begins
             with the given string will not be included in filtering, and
             segments on either side of the given excluded annotated segment
             will be filtered separately (i.e., as independent signals).

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -3,14 +3,16 @@
 # License: BSD 3 clause
 
 from datetime import datetime
+import os.path as op
+import warnings
+
 from nose.tools import assert_raises, assert_true
 from numpy.testing import (assert_equal, assert_array_equal,
-                           assert_array_almost_equal)
-import os.path as op
+                           assert_array_almost_equal, assert_allclose)
 
 import numpy as np
 
-from mne import create_info
+from mne import create_info, Epochs
 from mne.utils import run_tests_if_main
 from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.annotations import Annotations, _sync_onset
@@ -42,10 +44,12 @@ def test_annotations():
     orig_time = (meas_date[0] + meas_date[1] * 0.000001 +
                  raw2.first_samp / raw2.info['sfreq'])
     annot = Annotations(onset, duration, description, orig_time)
+    assert_true(' segments' in repr(annot))
     raw2.annotations = annot
     assert_array_equal(raw2.annotations.onset, onset)
     concatenate_raws([raw, raw2])
-    raw.annotations.delete(-1)  # remove boundary annotation
+    raw.annotations.delete(-1)  # remove boundary annotations
+    raw.annotations.delete(-1)
     assert_array_almost_equal(onset + 20., raw.annotations.onset, decimal=2)
     assert_array_equal(annot.duration, raw.annotations.duration)
     assert_array_equal(raw.annotations.description, np.repeat('test', 10))
@@ -69,6 +73,9 @@ def test_annotations():
     boundary_idx = np.where(raw.annotations.description == 'BAD boundary')[0]
     assert_equal(len(boundary_idx), 3)
     raw.annotations.delete(boundary_idx)
+    boundary_idx = np.where(raw.annotations.description == 'EDGE boundary')[0]
+    assert_equal(len(boundary_idx), 3)
+    raw.annotations.delete(boundary_idx)
     assert_array_equal(raw.annotations.onset, [1., 2., 11., 12., 21., 22.,
                                                31.])
     raw.annotations.delete(2)
@@ -86,7 +93,8 @@ def test_annotations():
     raw.annotations = Annotations([45.], [3], 'test', raw.info['meas_date'])
     raw2.annotations = Annotations([2.], [3], 'BAD', None)
     raw = concatenate_raws([raw, raw2])
-    raw.annotations.delete(-1)  # remove boundary annotation
+    raw.annotations.delete(-1)  # remove boundary annotations
+    raw.annotations.delete(-1)
     assert_array_almost_equal(raw.annotations.onset, [45., 2. + last_time],
                               decimal=2)
 
@@ -96,7 +104,8 @@ def test_raw_reject():
     """Test raw data getter with annotation reject."""
     info = create_info(['a', 'b', 'c', 'd', 'e'], 100, ch_types='eeg')
     raw = RawArray(np.ones((5, 15000)), info)
-    raw.annotations = Annotations([2, 100, 105, 148], [2, 8, 5, 8], 'BAD')
+    with warnings.catch_warnings(record=True):  # one outside range
+        raw.annotations = Annotations([2, 100, 105, 148], [2, 8, 5, 8], 'BAD')
     data = raw.get_data([0, 1, 3, 4], 100, 11200, 'omit')
     assert_array_equal(data.shape, (4, 9900))
 
@@ -123,6 +132,59 @@ def test_raw_reject():
     assert_array_almost_equal(onsets, times - raw.first_samp /
                               raw.info['sfreq'])
     assert_array_almost_equal(times, _sync_onset(raw, onsets, True))
+
+
+def test_annotation_filtering():
+    """Test that annotations work properly with filtering."""
+    # Create data with just a DC component
+    data = np.ones((1, 1000))
+    info = create_info(1, 1000., 'eeg')
+    raws = [RawArray(data * (ii + 1), info) for ii in range(4)]
+    kwargs_pass = dict(l_freq=None, h_freq=50., fir_design='firwin')
+    kwargs_stop = dict(l_freq=50., h_freq=None, fir_design='firwin')
+    # lowpass filter, which should not modify the data
+    raws_pass = [raw.copy().filter(**kwargs_pass) for raw in raws]
+    # highpass filter, which should zero it out
+    raws_stop = [raw.copy().filter(**kwargs_stop) for raw in raws]
+    # concat the original and the filtered segments
+    raws_concat = concatenate_raws([raw.copy() for raw in raws])
+    raws_zero = raws_concat.copy().apply_function(lambda x: x * 0)
+    raws_pass_concat = concatenate_raws(raws_pass)
+    raws_stop_concat = concatenate_raws(raws_stop)
+    # make sure we did something reasonable with our individual-file filtering
+    assert_allclose(raws_concat[0][0], raws_pass_concat[0][0], atol=1e-14)
+    assert_allclose(raws_zero[0][0], raws_stop_concat[0][0], atol=1e-14)
+    # ensure that our Annotations cut up the filtering properly
+    raws_concat_pass = raws_concat.copy().filter(skip_by_annotation='edge',
+                                                 **kwargs_pass)
+    assert_allclose(raws_concat[0][0], raws_concat_pass[0][0], atol=1e-14)
+    raws_concat_stop = raws_concat.copy().filter(skip_by_annotation='edge',
+                                                 **kwargs_stop)
+    assert_allclose(raws_zero[0][0], raws_concat_stop[0][0], atol=1e-14)
+    # one last test: let's cut out a section entirely:
+    # here the 1-3 second window should be skipped
+    raw = raws_concat.copy()
+    raw.annotations.append(1., 2., 'foo')
+    raw.filter(l_freq=50., h_freq=None, fir_design='firwin',
+               skip_by_annotation='foo')
+    # our filter will zero out anything not skipped:
+    mask = np.concatenate((np.zeros(1000), np.ones(2000), np.zeros(1000)))
+    expected_data = raws_concat[0][0][0] * mask
+    assert_allclose(raw[0][0][0], expected_data, atol=1e-14)
+
+
+def test_annotation_epoching():
+    """Test that annotations work properly with concatenated edges."""
+    # Create data with just a DC component
+    data = np.ones((1, 1000))
+    info = create_info(1, 1000., 'eeg')
+    raw = concatenate_raws([RawArray(data, info) for ii in range(3)])
+    events = np.array([[a, 0, 1] for a in [0, 500, 1000, 1500, 2000]])
+    epochs = Epochs(raw, events, tmin=0, tmax=0.999, baseline=None,
+                    preload=True)  # 1000 samples long
+    assert_equal(len(epochs.drop_log), len(events))
+    assert_equal(len(epochs), 3)
+    assert_equal([0, 2, 4], epochs.selection)
 
 
 run_tests_if_main()

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1857,7 +1857,7 @@ def _setup_annotation_colors(params):
     for idx, key in enumerate(color_keys):
         if key in segment_colors:
             continue
-        elif key.lower().startswith('bad'):
+        elif key.lower().startswith('bad') or key.lower().startswith('edge'):
             segment_colors[key] = 'red'
         else:
             segment_colors[key] = next(color_cycle)

--- a/tutorials/plot_artifacts_correction_rejection.py
+++ b/tutorials/plot_artifacts_correction_rejection.py
@@ -130,6 +130,7 @@ onset = eog_events[:, 0] / raw.info['sfreq'] - 0.25
 duration = np.repeat(0.5, n_blinks)
 raw.annotations = mne.Annotations(onset, duration, ['bad blink'] * n_blinks,
                                   orig_time=raw.info['meas_date'])
+print(raw.annotations)  # to get information about what annotations we have
 raw.plot(events=eog_events)  # To see the annotated segments.
 
 ###############################################################################


### PR DESCRIPTION
* Adds `skip_by_annotation` as discussed in #4353, with deprecation cycle to get people on board
* fixes a small bug with `Annotations` where the `BAD segment` wasn't actually being put in the correct spot
* changes `BAD segment` to have zero duration
* adds `EDGE segment` that is equivalent to `BAD segment`
* adds `__repr__` to `Annotations`

Ready for review/merge from my end.

Closes #4353.