### PR TITLE
ENH: allow SlidingEstimator and gat to get **fit_params at fit

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -85,6 +85,8 @@ Changelog
 
     - Add function :func:`mne.channels.get_builtin_montages` to list all built-in montages by `Clemens Brunner`_
 
+    - :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` now accept **fit_params at fitting by `Jean-Remi King`_
+
 BUG
 ~~~
 
@@ -149,7 +151,7 @@ BUG
     - Fix bug in :func:`mne.viz.plot_compare_evokeds` where ``truncate_yaxis`` was ignored (default is now ``False``), by `Jona Sassenhagen`_
 
     - Fix bug in :func:`mne.viz.plot_evoked` where all xlabels were removed when using ``spatial_colors=True``, by `Jesper Duemose Nielsen`_
-    
+
 API
 ~~~
     - Add :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.apply_lcmv`, :func:`mne.beamformer.apply_lcmv_epochs`, and :func:`mne.beamformer.apply_lcmv_raw` to enable the separate computation and application of LCMV beamformer weights by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -41,6 +41,7 @@ def test_search_light():
     assert_equal(sl.__repr__()[-28:], ', fitted with 10 estimators>')
     assert_raises(ValueError, sl.fit, X[1:], y)
     assert_raises(ValueError, sl.fit, X[:, :, 0], y)
+    sl.fit(X, y, sample_weight=np.ones_like(y))
 
     # transforms
     assert_raises(ValueError, sl.predict, X[:, :, :2])
@@ -152,6 +153,7 @@ def test_generalization_light():
     gl = GeneralizingEstimator(LogisticRegression())
     assert_equal(repr(gl)[:23], '<GeneralizingEstimator(')
     gl.fit(X, y)
+    gl.fit(X, y, sample_weight=np.ones_like(y))
 
     assert_equal(gl.__repr__()[-28:], ', fitted with 10 estimators>')
     # transforms


### PR DESCRIPTION
such that one can do e.g.

```python
clf = SlidingEstimator(LinearModel())
clf.fit(X, y, sample_weights=np.random.rand(len(X))
```