### PR TITLE
FIX: Run PySurfer on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
       CONDA_DEPENDENCIES: "setuptools numpy scipy matplotlib scikit-learn nose mayavi pandas h5py PIL pyside"
-      PIP_DEPENDENCIES: "nibabel nitime nose-timer nose-faulthandler"
+      PIP_DEPENDENCIES: "git+git://github.com/nipy/PySurfer.git nibabel nitime nose-timer nose-faulthandler"
   matrix:
       - PYTHON_VERSION: "2.7"
         PYTHON_ARCH: "64"


### PR DESCRIPTION
There is probably a reason we haven't been running PySurfer on AppVeyor, but let's find out.