### PR TITLE
Workaround for MNE-C byte swapping bug in RCS matrices

### DIFF
--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -314,8 +314,18 @@ def _read_matrix(fid, tag, shape, rlims, matrix_coding):
                                      sparse_ptrs), shape=shape)
         else:
             #    RCS
-            sparse_indices = np.fromstring(fid.read(4 * nnz), dtype='>i4')
-            sparse_ptrs = np.fromstring(fid.read(4 * (nrow + 1)), dtype='>i4')
+            tmp_indices = fid.read(4 * nnz)
+            sparse_indices = np.fromstring(tmp_indices, dtype='>i4')
+            tmp_ptrs = fid.read(4 * (nrow + 1))
+            sparse_ptrs = np.fromstring(tmp_ptrs, dtype='>i4')
+            if (sparse_ptrs[-1] > len(sparse_indices) or
+                    np.any(sparse_ptrs < 0)):
+                # There was a bug in MNE-C that caused some data to be
+                # stored without byte swapping
+                sparse_indices = np.concatenate(
+                    (np.fromstring(tmp_indices[:4 * (ncol + 1)], dtype='>i4'),
+                     np.fromstring(tmp_indices[4 * (ncol + 1):], dtype='<i4')))
+                sparse_ptrs = np.fromstring(tmp_ptrs, dtype='<i4')
             data = sparse.csr_matrix((sparse_data, sparse_indices,
                                      sparse_ptrs), shape=shape)
     else:


### PR DESCRIPTION
The is a bug in MNE-C where sometimes data is stored without proper byte-swapping. A workaround was implemented in MNE-Python to still be able to read these files. However, the workaround was only implemented for CCS sparse matrices. I now have a file with a broken RCS sparse matrix. This PR applies the same workaround. This seems to work fine on my data.

@larsoner Git blame tells me you wrote the original workaround. Right now, I've copy-pasted the code and changed `nrow` to `ncol`. However, since my matrices are symmetric, I don't have a good way of testing whether this is necessary or not. Could you take a good look at lines 326-327?

If the code is correct I can do another pass to DRY the code. I'm leaving it copy-pasted for now so it is more straightforward to follow the logic.