### PR TITLE
FIX: add estimator type to LinearModel

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -60,6 +60,7 @@ class LinearModel(BaseEstimator):
             model = LogisticRegression()
 
         self.model = model
+        self._estimator_type = getattr(model, "_estimator_type", None)
 
     def fit(self, X, y):
         """Estimate the coefficients of the linear model.

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -40,7 +40,6 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
     def __init__(self, base_estimator, scoring=None, n_jobs=1):  # noqa: D102
         _check_estimator(base_estimator)
         self.base_estimator = base_estimator
-        self._estimator_type = getattr(base_estimator, "_estimator_type", None)
         self.n_jobs = n_jobs
         self.scoring = scoring
 

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -40,6 +40,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
     def __init__(self, base_estimator, scoring=None, n_jobs=1):  # noqa: D102
         _check_estimator(base_estimator)
         self.base_estimator = base_estimator
+        self._estimator_type = getattr(base_estimator, "_estimator_type", None)
         self.n_jobs = n_jobs
         self.scoring = scoring
 

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -58,11 +58,16 @@ def test_get_coef():
     simple and pipeline estimators.
     """
     from sklearn.base import TransformerMixin, BaseEstimator
+    from sklearn.base import is_classifier, is_regressor
     from sklearn.pipeline import make_pipeline
     from sklearn.preprocessing import StandardScaler
     from sklearn.linear_model import Ridge, LinearRegression
 
+    lm = LinearModel()
+    assert_true(is_classifier(lm))
+
     lm = LinearModel(Ridge())
+    assert_true(is_regressor(lm))
 
     # Define a classifier, an invertible transformer and an non-invertible one.
 


### PR DESCRIPTION
LinearModel didn't inherited from the classifier type of its base estimator, thus leading to failed detection of sklearn's `is_regressor` and `is_classifier`