### PR TITLE
MRG: fix vlines in epochs image

### DIFF
--- a/examples/visualization/plot_roi_erpimage_by_rt.py
+++ b/examples/visualization/plot_roi_erpimage_by_rt.py
@@ -68,4 +68,5 @@ for pick, channel in enumerate(epochs.ch_names):
 for combine_measures in ('gfp', 'median'):
     epochs.plot_image(group_by=rois, order=order, overlay_times=rts / 1000.,
                       vmin=lambda x: x.min(), sigma=1.5,
-                      combine=combine_measures)
+                      combine=combine_measures,
+                      ts_args=dict(vlines=[0, rts.mean() / 1000.]))

--- a/examples/visualization/plot_roi_erpimage_by_rt.py
+++ b/examples/visualization/plot_roi_erpimage_by_rt.py
@@ -67,6 +67,5 @@ for pick, channel in enumerate(epochs.ch_names):
 # The actual plots
 for combine_measures in ('gfp', 'median'):
     epochs.plot_image(group_by=rois, order=order, overlay_times=rts / 1000.,
-                      vmin=lambda x: x.min(), sigma=1.5,
-                      combine=combine_measures,
+                      sigma=1.5, combine=combine_measures,
                       ts_args=dict(vlines=[0, rts.mean() / 1000.]))

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -169,7 +169,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         picks = np.atleast_1d(picks)
 
     manual_ylims = "ylim" in ts_args
-    vlines = ts_args.get("vlines", [0.])
+    vlines = ts_args.get(
+        "vlines", [0] if (epochs.times[0] < 0 < epochs.times[-1]) else [])
 
     # input checks
     if (combine is None and (fig is not None or axes is not None) and
@@ -266,7 +267,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             ax = axes_dict["evoked"]
             if not manual_ylims:
                 ax.set_ylim(ylims[ch_type])
-            if epochs_.times[0] < 0 < epochs_.times[-1]:
+            if len(vlines) > 0:
                 upper_v, lower_v = ylims[ch_type]
                 if overlay_times is not None:
                     overlay = {overlay_times.mean(), np.median(overlay_times)}

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -268,7 +268,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                 ax.set_ylim(ylims[ch_type])
             if epochs_.times[0] < 0 < epochs_.times[-1]:
                 upper_v, lower_v = ylims[ch_type]
-                overlay = (overlay_times.mean(), np.median(overlay_times))
+                if overlay_times is not None:
+                    overlay = {overlay_times.mean(), np.median(overlay_times)}
+                else:
+                    overlay = {}
                 for line in vlines:
                     ax.vlines(line, upper_v, lower_v, colors='k',
                               linestyles='-' if line in overlay  else "--",

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -99,7 +99,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         If ``group_by`` is a dict, this cannot be a list, but it can be a dict
         of lists of axes, with the keys matching those of ``group_by``. In that
         case, the provided axes will be used for the corresponding groups.
-        Defaults to None.
+        Defaults to `None`.
     overlay_times : array-like, shape (n_epochs,) | None
         If not None the parameter is interpreted as time instants in seconds
         and is added to the image. It is typically useful to display reaction
@@ -112,12 +112,12 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         standard deviation or the GFP over channels are plotted.
         array (n_epochs, n_times).
         If callable, it must accept one positional input, the data
-        in the format (n_epochs, n_channels, n_times). It must return an
-        array (n_epochs, n_times). For example::
+        in the format `(n_epochs, n_channels, n_times)`. It must return an
+        array `(n_epochs, n_times)`. For example::
 
-            combine = lambda data: np.median(data, 1)
+            combine = lambda data: np.median(data, axis=1)
 
-        Defaults to None if picks are given, otherwise 'gfp'.
+        Defaults to `None` if picks are provided, otherwise 'gfp'.
     group_by : None | str | dict
         If not None, combining happens over channel groups defined by this
         parameter.
@@ -130,8 +130,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
 
             group_by=dict(Left_ROI=[1, 2, 3, 4], Right_ROI=[5, 6, 7, 8])
 
-        If not None, combine must not be None. Defaults to None if picks are
-        given, otherwise 'type'.
+        If not None, combine must not be None. Defaults to `None` if picks are
+        provided, otherwise 'type'.
 
     evoked : Bool
         Draw the ER[P/F] below the image or not.
@@ -139,7 +139,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         Arguments passed to a call to `mne.viz.plot_compare_evoked` to style
         the evoked plot below the image. Defaults to an empty dictionary,
         meaning `plot_compare_evokeds` will be called with default parameters
-        (although yaxis truncation will be turned off).
+        (yaxis truncation will be turned off).
     title : None | str
         If str, will be plotted as figure title. Else, the channels will be
         indicated.
@@ -265,6 +265,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         for group, axes_dict in zip(groups, axes_list):
             ch_type = group[1]
             ax = axes_dict["evoked"]
+            if not manual_ylims:
+                ax.set_ylim(ylims[ch_type])
             if len(vlines) > 0:
                 upper_v, lower_v = ylims[ch_type]
                 if overlay_times is not None:
@@ -275,8 +277,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                     ax.vlines(line, upper_v, lower_v, colors='k',
                               linestyles='-' if line in overlay else "--",
                               linewidth=2. if line in overlay else 1.)
-            if not manual_ylims:
-                ax.set_ylim(ylims[ch_type])
 
     plt_show(show)
     return figs

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -274,7 +274,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                     overlay = {}
                 for line in vlines:
                     ax.vlines(line, upper_v, lower_v, colors='k',
-                              linestyles='-' if line in overlay  else "--",
+                              linestyles='-' if line in overlay else "--",
                               linewidth=2. if line in overlay else 1.)
     plt_show(show)
     return figs

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -169,6 +169,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         picks = np.atleast_1d(picks)
 
     manual_ylims = "ylim" in ts_args
+    vlines = ts_args.get("vlines", [0.])
 
     # input checks
     if (combine is None and (fig is not None or axes is not None) and
@@ -259,11 +260,19 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             curr_min, curr_max = ylims[ch_type]
             ylims[ch_type] = min(curr_min, this_min), max(curr_max, this_max),
 
-    if evoked is True and not manual_ylims:
+    if evoked is True:  # adjust ylims
         for group, axes_dict in zip(groups, axes_list):
             ch_type = group[1]
-            axes_dict["evoked"].set_ylim(ylims[ch_type])
-
+            ax = axes_dict["evoked"]
+            if not manual_ylims:
+                ax.set_ylim(ylims[ch_type])
+            if epochs_.times[0] < 0 < epochs_.times[-1]:
+                upper_v, lower_v = ylims[ch_type]
+                overlay = (overlay_times.mean(), np.median(overlay_times))
+                for line in vlines
+                    ax.vlines(line, upper_v, lower_v, colors='k',
+                              linestyles='-' if line in overlay  else "--",
+                              linewidth=2. if line in overlay else 1.)
     plt_show(show)
     return figs
 
@@ -417,6 +426,8 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
     ts_args_ = dict(colors={"cond": "black"}, ylim=ylim, picks=[0], title='',
                     truncate_yaxis=False, truncate_xaxis=False, show=False)
     ts_args_.update(**ts_args)
+    if "vlines" in ts_args_:
+        del ts_args_["vlines"]
 
     return [data * scaling, overlay_times, vmin * scaling, vmax * scaling,
             ts_args_]
@@ -488,7 +499,7 @@ def _plot_epochs_image(epochs, data, ch_type, vmin=None, vmax=None,
         from mne.viz import plot_compare_evokeds
         plot_compare_evokeds(
             {"cond": list(epochs.iter_evoked())}, axes=axes_dict["evoked"],
-            **ts_args)
+            vlines=[], **ts_args)
         axes_dict["evoked"].set_xlim(epochs.times[[0, -1]])
         ax.set_xticks(())
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -269,7 +269,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             if epochs_.times[0] < 0 < epochs_.times[-1]:
                 upper_v, lower_v = ylims[ch_type]
                 overlay = (overlay_times.mean(), np.median(overlay_times))
-                for line in vlines
+                for line in vlines:
                     ax.vlines(line, upper_v, lower_v, colors='k',
                               linestyles='-' if line in overlay  else "--",
                               linewidth=2. if line in overlay else 1.)
@@ -426,8 +426,7 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
     ts_args_ = dict(colors={"cond": "black"}, ylim=ylim, picks=[0], title='',
                     truncate_yaxis=False, truncate_xaxis=False, show=False)
     ts_args_.update(**ts_args)
-    if "vlines" in ts_args_:
-        del ts_args_["vlines"]
+    ts_args_["vlines"] = []
 
     return [data * scaling, overlay_times, vmin * scaling, vmax * scaling,
             ts_args_]
@@ -499,7 +498,7 @@ def _plot_epochs_image(epochs, data, ch_type, vmin=None, vmax=None,
         from mne.viz import plot_compare_evokeds
         plot_compare_evokeds(
             {"cond": list(epochs.iter_evoked())}, axes=axes_dict["evoked"],
-            vlines=[], **ts_args)
+            **ts_args)
         axes_dict["evoked"].set_xlim(epochs.times[[0, -1]])
         ax.set_xticks(())
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -265,8 +265,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         for group, axes_dict in zip(groups, axes_list):
             ch_type = group[1]
             ax = axes_dict["evoked"]
-            if not manual_ylims:
-                ax.set_ylim(ylims[ch_type])
             if len(vlines) > 0:
                 upper_v, lower_v = ylims[ch_type]
                 if overlay_times is not None:
@@ -277,6 +275,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                     ax.vlines(line, upper_v, lower_v, colors='k',
                               linestyles='-' if line in overlay else "--",
                               linewidth=2. if line in overlay else 1.)
+            if not manual_ylims:
+                ax.set_ylim(ylims[ch_type])
+
     plt_show(show)
     return figs
 


### PR DESCRIPTION
Sorry, I somehow missed this ...
In some configurations, the ylims of the evoked plot for epochs.plot_image are readjusted. This means the vlines have to be adjusted too, otherwise they will end up truncated. This PR fixes that.

@mmagnuski can you maybe take a quick look later? Need to do some checks first.