### PR TITLE
Fix overlay_times exceeding data range in epochs image

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -496,6 +496,8 @@ def _plot_epochs_image(epochs, data, ch_type, vmin=None, vmax=None,
     ax.set_ylabel('Epochs')
     ax.axis('auto')
     ax.axis('tight')
+    if overlay_times is not None:
+        ax.set_xlim(1e3 * epochs.times[0], 1e3 * epochs.times[-1])
     ax.axvline(0, color='k', linewidth=1, linestyle='--')
 
     # draw the evoked


### PR DESCRIPTION
Fixes bug 1 in #4232.

It simply reapplies the ylims to the erpimage. Should I add a warning ("some overlay_times exceed the data range and will not be displayed")?