### PR TITLE
MRG: Minor fixes to testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,78 +13,78 @@ matrix:
     include:
         # Full (Linux, 2.7) first half
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi pytest"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
+               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS=". beamformer channels commands connectivity datasets decoding forward gui inverse_sparse io"
                OPTION=""
         # Full (Linux, 2.7) second half
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi pytest"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
+               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS="minimum_norm preprocessing realtime simulation stats time_frequency viz"
                OPTION=""
 
         # OSX first half
         - os: osx
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi pytest"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
+               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS=". beamformer channels commands connectivity datasets decoding forward gui inverse_sparse io"
                OPTION=""
         # OSX second half
         - os: osx
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi pytest"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
+               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS="minimum_norm preprocessing realtime simulation stats time_frequency viz"
                OPTION=""
 
         # Py3k + non-default stim channel first half
         - os: linux
           env: PYTHON_VERSION=3.6 TEST_LOCATION=install MNE_STIM_CHANNEL=STI101
-               CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels nose pytest"
-               PIP_DEPENDENCIES="nitime joblib nibabel codecov nose-timer pytest-sugar pytest-cov pytest-attrib"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels nose pytest pytest-cov"
+               PIP_DEPENDENCIES="nitime joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS=". beamformer channels commands connectivity datasets decoding forward gui inverse_sparse io"
                OPTION=""
         # Py3k + non-default stim channel second half
         - os: linux
           env: PYTHON_VERSION=3.6 TEST_LOCATION=install MNE_STIM_CHANNEL=STI101
-               CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels nose pytest"
-               PIP_DEPENDENCIES="nitime joblib nibabel codecov nose-timer pytest-sugar pytest-cov pytest-attrib"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels nose pytest pytest-cov"
+               PIP_DEPENDENCIES="nitime joblib nibabel codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS="minimum_norm preprocessing realtime simulation stats time_frequency viz"
                OPTION=""
 
         # Old dependencies first half
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.12 scikit-learn=0.14 pytest"
-               PIP_DEPENDENCIES="codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.12 scikit-learn=0.14 nose pytest pytest-cov"
+               PIP_DEPENDENCIES="codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS=". beamformer channels commands connectivity datasets decoding forward gui inverse_sparse io"
                OPTION=""
         # Old dependencies second half
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.12 scikit-learn=0.14 pytest"
-               PIP_DEPENDENCIES="codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+          env: CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.12 scikit-learn=0.14 nose pytest pytest-cov"
+               PIP_DEPENDENCIES="codecov pytest-sugar pytest-faulthandler"
                MNE_DIRS="minimum_norm preprocessing realtime simulation stats time_frequency viz"
                OPTION=""
 
         # Minimal first half
         - os: linux
           env: DEPS=minimial
-               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest"
-               PIP_DEPENDENCIES="codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib nose pytest pytest-cov"
+               PIP_DEPENDENCIES="codecov faulthandler pytest-sugar pytest-faulthandler"
                MNE_DIRS=". beamformer channels commands connectivity datasets decoding forward gui inverse_sparse io"
                OPTION=""
         # Minimal second half
         - os: linux
           env: DEPS=minimial
-               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest"
-               PIP_DEPENDENCIES="codecov nose-timer nose-faulthandler pytest-sugar pytest-cov pytest-attrib"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib nose pytest pytest-cov"
+               PIP_DEPENDENCIES="codecov faulthandler pytest-sugar pytest-faulthandler"
                MNE_DIRS="minimum_norm preprocessing realtime simulation stats time_frequency viz"
                OPTION=""
 
         # No data + style testing
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
-               CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx pytest"
-               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov nose-timer nose-faulthandler check-manifest pytest-sugar pytest-cov pytest-attrib"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx nose pytest pytest-cov"
+               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest pytest-sugar"
                MNE_DIRS=""
                OPTION="--doctest-ignore-import-errors"
 
@@ -162,6 +162,7 @@ script:
       else
         CONDITION='not ultra_slow_test';
       fi;
+    - python -c "import mne; print(mne.sys_info())"
     # Determine directories to test
     - if [ "${MNE_DIRS}" != "" ]; then
         USE_DIRS="";
@@ -171,8 +172,8 @@ script:
       else
         USE_DIRS="mne/";
       fi;
-    - echo py.test --doctest-modules -a "\"${CONDITION}\"" ${OPTION} --cov=mne --showlocals --durations=20 ${USE_DIRS};
-    - py.test --doctest-modules -a "\"${CONDITION}\"" ${OPTION} --cov=mne --showlocals --durations=20 ${USE_DIRS};
+    - echo py.test -m "\"${CONDITION}\"" ${OPTION} ${USE_DIRS};
+    - py.test -a "\"${CONDITION}\"" ${OPTION} ${USE_DIRS};
     - if [ "${DEPS}" == "nodata" ]; then
         make pep;
         check-manifest --ignore doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data;
@@ -180,8 +181,5 @@ script:
 
 after_success:
     # Need to run from source dir to exectue "git" commands
-    - if [ "${TEST_LOCATION}" == "src" ]; then
-        echo "Running codecov";
-        cd ${SRC_DIR};
-        codecov;
-      fi;
+    - cd ${SRC_DIR};
+    - codecov;

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ script:
         USE_DIRS="mne/";
       fi;
     - echo py.test -m "\"${CONDITION}\"" ${OPTION} ${USE_DIRS};
-    - py.test -a "\"${CONDITION}\"" ${OPTION} ${USE_DIRS};
+    - py.test -m "\"${CONDITION}\"" ${OPTION} ${USE_DIRS};
     - if [ "${DEPS}" == "nodata" ]; then
         make pep;
         check-manifest --ignore doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data;

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,15 @@ testing_data:
 
 test: in
 	rm -f .coverage
-	$(PYTESTS) -a 'not ultra_slow_test' mne
+	$(PYTESTS) -m 'not ultraslowtest' mne
 
 test-verbose: in
 	rm -f .coverage
-	$(PYTESTS) -a 'not ultra_slow_test' mne --verbose
+	$(PYTESTS) -m 'not ultraslowtest' mne --verbose
 
 test-fast: in
 	rm -f .coverage
-	$(PYTESTS) -a 'not slow_test' mne
+	$(PYTESTS) -m 'not slowtest' mne
 
 test-full: in
 	rm -f .coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   global:
       PYTHON: "C:\\conda"
-      CONDA_DEPENDENCIES: "setuptools numpy scipy matplotlib scikit-learn mayavi pandas h5py PIL pyside pytest"
-      PIP_DEPENDENCIES: "git+git://github.com/nipy/PySurfer.git nibabel nitime nose-timer nose-faulthandler pytest-attrib"
+      CONDA_DEPENDENCIES: "setuptools numpy scipy matplotlib scikit-learn mayavi pandas h5py PIL pyside pytest pytest-cov"
+      PIP_DEPENDENCIES: "git+git://github.com/nipy/PySurfer.git nibabel nitime codecov"
   matrix:
       - PYTHON_VERSION: "2.7"
         PYTHON_ARCH: "64"
@@ -13,7 +13,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
   - "python setup.py develop"
-  - "SET MNE_SKIP_NETWORK_TESTS=1"
+  - "python -c \"import mne; print(mne.sys_info())\""
   - "SET MNE_FORCE_SERIAL=true"  # otherwise joblib will bomb
   - "SET MNE_LOGGING_LEVEL=warning"
   - "python -c \"import mne; mne.datasets.testing.data_path()\""
@@ -22,4 +22,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Run the project tests, but (sadly) exclude ones that take a long time
-  - "py.test --doctest-modules -a \"not slow_test\" --showlocals --durations=20 mne"
+  - "py.test -m \"not ultraslowtest\" mne "
+
+on_success:
+  - "codecov"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   global:
       PYTHON: "C:\\conda"
-      CONDA_DEPENDENCIES: "setuptools numpy scipy matplotlib scikit-learn mayavi pandas h5py PIL pyside pytest pytest-cov"
+      CONDA_DEPENDENCIES: "setuptools numpy scipy matplotlib scikit-learn mayavi pandas h5py PIL pyside nose pytest pytest-cov"
       PIP_DEPENDENCIES: "git+git://github.com/nipy/PySurfer.git nibabel nitime codecov"
   matrix:
       - PYTHON_VERSION: "2.7"

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -64,7 +64,7 @@ You can test if MNE CUDA support is working by running the associated test:
 
 .. code-block:: bash
 
-    $ nosetests mne/tests/test_filter.py
+    $ pytest mne/tests/test_filter.py
 
 If ``MNE_USE_CUDA=true`` and all tests pass with none skipped, then
 MNE-Python CUDA support works.

--- a/doc/configure_git.rst
+++ b/doc/configure_git.rst
@@ -152,7 +152,7 @@ These steps can be broken out to be more explicit as:
 
 #. Ensure unit tests pass
 
-   Make sure before starting to code that all unit tests pass with `nose`_:
+   Make sure before starting to code that all unit tests pass with `pytest`_:
 
    .. code-block:: bash
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -55,7 +55,7 @@ Code guidelines
 
   .. code-block:: bash
 
-     $ nosetests mne/tests/test_evoked.py:test_io_evoked -x --verbose
+     $ pytest mne/tests/test_evoked.py:test_io_evoked -x --verbose
 
   Make sure you have the testing dataset, which you can get by doing::
 
@@ -70,7 +70,7 @@ Pull requests
 ^^^^^^^^^^^^^
 * Address one issue per pull request (PR).
 * Avoid unnecessary cosmetic changes in PRs.
-* Minimize test timing while maximizing coverage. Use ``nosetests --with-timer`` on modified tests.
+* Minimize test timing while maximizing coverage. Use ``pytest --durations=20`` on modified tests.
 * Update the ``doc/whats_new.rst`` file last, just before merge to avoid merge conflicts.
 
 Naming

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -81,7 +81,6 @@ reporting a bug, which should look something like this::
     nibabel:       Not found
     nitime:        Not found
     mayavi:        Not found
-    nose:          1.3.7
     pandas:        Not found
     pycuda:        Not found
     skcuda:        Not found

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -62,8 +62,6 @@
 .. _pep8: https://pypi.python.org/pypi/pep8
 .. _pyflakes: https://pypi.python.org/pypi/pyflakes
 .. _coverage: https://pypi.python.org/pypi/coverage
-.. _nose-timer: https://pypi.python.org/pypi/nose-timer
-.. _nosetests: https://nose.readthedocs.org/en/latest/
 .. _mayavi: http://mayavi.sourceforge.net/
 .. _nitime: http://nipy.org/nitime/
 .. _joblib: https://pypi.python.org/pypi/joblib

--- a/doc/known_projects.inc
+++ b/doc/known_projects.inc
@@ -50,8 +50,8 @@
 .. _Astropy: http://www.astropy.org
 .. _`Astropy GitHub`: http://github.com/astropy/astropy
 
-.. Nose
-.. _Nose: https://nose.readthedocs.io/
+.. Pytest
+.. _pytest: https://docs.pytest.org/
 
 .. Flake8
 .. _Flake8: http://flake8.pycqa.org/

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 import os.path as op
 
-
+import pytest
 from nose.tools import assert_true, assert_raises
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -15,7 +15,7 @@ from mne.beamformer import (make_lcmv, apply_lcmv, apply_lcmv_raw, lcmv,
                             lcmv_epochs, lcmv_raw, tf_lcmv)
 from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv
 from mne.externals.six import advance_iterator
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 
 
 data_path = testing.data_path(download=False)
@@ -97,7 +97,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
         forward_surf_ori, forward_fixed, forward_vol
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_lcmv():
     """Test LCMV with evoked data and single trials."""

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -3,11 +3,12 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal)
+import pytest
 from nose.tools import assert_raises, assert_equal, assert_true
 
 from mne import io, pick_types, pick_channels, read_events, Epochs
 from mne.channels.interpolation import _make_interpolation_matrix
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -41,7 +42,7 @@ def _load_data():
     return raw, epochs, epochs_eeg, epochs_meg
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_interpolation():
     """Test interpolation"""
     raw, epochs, epochs_eeg, epochs_meg = _load_data()

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -4,6 +4,7 @@ from os import path as op
 import shutil
 import glob
 import warnings
+import pytest
 from nose.tools import assert_true, assert_raises
 from numpy.testing import assert_equal, assert_allclose
 
@@ -19,7 +20,7 @@ from mne.datasets import testing, sample
 from mne.io import read_raw_fif
 from mne.utils import (run_tests_if_main, _TempDir, requires_mne, requires_PIL,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
-                       ArgvSetter, slow_test, ultra_slow_test)
+                       ArgvSetter)
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -41,7 +42,7 @@ def check_usage(module, force_help=False):
         assert_true('Usage: ' in out.stdout.getvalue())
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_browse_raw():
     """Test mne browse_raw."""
     check_usage(mne_browse_raw)
@@ -84,7 +85,7 @@ def test_clean_eog_ecg():
     assert_true(len(fnames) == 3)  # raw plus two projs
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_compute_proj_ecg_eog():
     """Test mne compute_proj_ecg/eog."""
     for fun in (mne_compute_proj_ecg, mne_compute_proj_eog):
@@ -177,7 +178,7 @@ def test_maxfilter():
             assert_true(check in out.stdout.getvalue(), check)
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_mayavi
 @requires_PIL
 @testing.requires_testing_data
@@ -199,7 +200,8 @@ def test_surf2bem():
     check_usage(mne_surf2bem)
 
 
-@ultra_slow_test
+@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @requires_freesurfer
 @testing.requires_testing_data
 def test_watershed_bem():
@@ -223,7 +225,8 @@ def test_watershed_bem():
         mne_watershed_bem.run()
 
 
-@ultra_slow_test
+@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @requires_freesurfer
 @sample.requires_sample_data
 def test_flash_bem():

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -2,13 +2,14 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import pytest
 from nose.tools import assert_true, assert_raises
 
 from mne.connectivity import spectral_connectivity
 from mne.connectivity.spectral import _CohEst, _get_n_epochs
 
 from mne import SourceEstimate
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 from mne.filter import filter_data
 
 warnings.simplefilter('always')
@@ -30,7 +31,7 @@ def _stc_gen(data, sfreq, tmin, combo=False):
             yield (arr, stc)
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_spectral_connectivity():
     """Test frequency-domain connectivity methods"""
     # Use a case known to have no spurious correlations (it would bad if

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1150,7 +1150,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
         spacing = src_name  # spacing in mm
         src_pattern = src_fname
     else:
-        match = re.match("(oct|ico)-?(\d+)$", src_name)
+        match = re.match(r"(oct|ico)-?(\d+)$", src_name)
         if match:
             spacing = '-'.join(match.groups())
             src_pattern = src_fname

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import time
 import numbers
 from ..parallel import parallel_func
-from ..fixes import BaseEstimator
+from ..fixes import BaseEstimator, is_classifier
 from ..utils import check_version, logger, warn
 
 
@@ -209,8 +209,6 @@ class LinearModel(BaseEstimator):
 
 def _set_cv(cv, estimator=None, X=None, y=None):
     """Set the default CV depending on whether clf is classifier/regressor."""
-    from sklearn.base import is_classifier
-
     # Detect whether classification or regression
     if estimator in ['classifier', 'regressor']:
         est_is_classifier = estimator == 'classifier'
@@ -426,7 +424,7 @@ def cross_val_multiscore(estimator, X, y=None, groups=None, scoring=None,
     """
     # This code is copied from sklearn
 
-    from sklearn.base import is_classifier, clone
+    from sklearn.base import clone
     from sklearn.utils import indexable
     from sklearn.metrics.scorer import check_scoring
     from sklearn.model_selection._split import check_cv

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from .base import get_coef, BaseEstimator, _check_estimator
 from .time_delaying_ridge import TimeDelayingRidge
+from ..fixes import is_regressor
 from ..externals.six import string_types
 
 
@@ -147,7 +148,7 @@ class ReceptiveField(BaseEstimator):
         if self.scoring not in _SCORERS.keys():
             raise ValueError('scoring must be one of %s, got'
                              '%s ' % (sorted(_SCORERS.keys()), self.scoring))
-        from sklearn.base import is_regressor, clone
+        from sklearn.base import clone
         X, y, _, self._y_dim = self._check_dimensions(X, y)
 
         # Initialize delays

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -6,7 +6,8 @@
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal, assert_raises
-from mne.utils import requires_sklearn_0_15
+from mne.fixes import is_regressor, is_classifier
+from mne.utils import requires_version
 from mne.decoding.base import (_get_inverse_funcs, LinearModel, get_coef,
                                cross_val_multiscore)
 from mne.decoding.search_light import SlidingEstimator
@@ -52,13 +53,10 @@ def _make_data(n_samples=1000, n_features=5, n_targets=3):
     return X, Y, A
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_get_coef():
-    """Test the retrieval of linear coefficients (filters and patterns) from
-    simple and pipeline estimators.
-    """
+    """Test getting linear coefficients (filters/patterns) from estimators."""
     from sklearn.base import TransformerMixin, BaseEstimator
-    from sklearn.base import is_classifier, is_regressor
     from sklearn.pipeline import make_pipeline
     from sklearn.preprocessing import StandardScaler
     from sklearn.linear_model import Ridge, LinearRegression
@@ -164,10 +162,9 @@ def test_get_coef():
             assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.15')
 def test_linearmodel():
-    """Test LinearModel class for computing filters and patterns.
-    """
+    """Test LinearModel class for computing filters and patterns."""
     from sklearn.linear_model import LinearRegression
     np.random.seed(42)
     clf = LinearModel()
@@ -189,10 +186,9 @@ def test_linearmodel():
     assert_raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.18')
 def test_cross_val_multiscore():
-    """Test cross_val_multiscore for computing scores on decoding over time.
-    """
+    """Test cross_val_multiscore for computing scores on decoding over time."""
     from sklearn.model_selection import KFold, cross_val_score
     from sklearn.linear_model import LogisticRegression
 

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -8,12 +8,13 @@
 import os.path as op
 
 from nose.tools import assert_true, assert_raises, assert_equal, assert_greater
+import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from mne import io, Epochs, read_events, pick_types
 from mne.decoding.csp import CSP, _ajd_pham, SPoC
-from mne.utils import requires_sklearn, slow_test
+from mne.utils import requires_sklearn
 
 data_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(data_dir, 'test_raw.fif')
@@ -46,7 +47,7 @@ def simulate_data(target, n_trials=100, n_channels=10, random_state=42):
     return X, mixing_mat
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_csp():
     """Test Common Spatial Patterns algorithm on epochs
     """

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_equal, assert_raises
 
 from mne import io, Epochs, read_events, pick_types
-from mne.utils import requires_sklearn_0_15, check_version, run_tests_if_main
+from mne.utils import requires_version, check_version, run_tests_if_main
 from mne.decoding import compute_ems, EMS
 
 data_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -21,7 +21,7 @@ tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.15')
 def test_ems():
     """Test event-matched spatial filters."""
     raw = io.read_raw_fif(raw_fname, preload=False)
@@ -86,5 +86,6 @@ def test_ems():
     assert_equal(ems.__repr__(), '<EMS: fitted with 4 filters on 2 classes.>')
     assert_array_almost_equal(filters, np.mean(coefs, axis=0))
     assert_array_almost_equal(surrogates, np.vstack(Xt))
+
 
 run_tests_if_main()

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 from mne import io, pick_types
-from mne.utils import requires_sklearn_0_15, run_tests_if_main
+from mne.utils import requires_version, run_tests_if_main
 from mne.decoding import ReceptiveField, TimeDelayingRidge
 from mne.decoding.receptive_field import (_delay_time_series, _SCORERS,
                                           _times_to_delays, _delays_to_slice)
@@ -59,7 +59,7 @@ def test_compute_reg_neighbors():
                     err_msg='%s: %s' % (reg_type, (n_ch_x, n_delays)))
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_rank_deficiency():
     """Test signals that are rank deficient."""
     # See GH#4253
@@ -117,7 +117,7 @@ def test_time_delay():
         assert_equal(X_delayed.shape[-1], (tmax - tmin) * isfreq + 1)
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_receptive_field():
     """Test model prep and fitting."""
     from sklearn.linear_model import Ridge
@@ -296,7 +296,7 @@ def test_time_delaying_fast_calc():
             assert_allclose(x_xt, x_xt_true, atol=1e-7, err_msg=(smin, smax))
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_receptive_field_fast():
     """Test that the fast solving works like Ridge."""
     from sklearn.linear_model import Ridge

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -6,7 +6,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 from nose.tools import assert_raises, assert_true, assert_equal
-from mne.utils import requires_sklearn_0_15
+from mne.utils import requires_version
 from mne.decoding.search_light import SlidingEstimator, GeneralizingEstimator
 from mne.decoding.transformer import Vectorizer
 
@@ -22,7 +22,7 @@ def make_data():
     return X, y
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_search_light():
     """Test SlidingEstimator"""
     from sklearn.linear_model import Ridge, LogisticRegression
@@ -149,7 +149,7 @@ def test_search_light():
         assert_true(isinstance(pipe.estimators_[0], BaggingClassifier))
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.17')
 def test_generalization_light():
     """Test GeneralizingEstimator"""
     from sklearn.pipeline import make_pipeline

--- a/mne/decoding/tests/test_time_gen.py
+++ b/mne/decoding/tests/test_time_gen.py
@@ -7,12 +7,14 @@ import copy
 import os.path as op
 
 from nose.tools import assert_equal, assert_true, assert_raises
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
 from mne import io, Epochs, read_events, pick_types
-from mne.utils import (requires_sklearn, requires_sklearn_0_15, slow_test,
-                       run_tests_if_main, check_version, use_log_level)
+from mne.fixes import is_classifier
+from mne.utils import (requires_version, run_tests_if_main, check_version,
+                       use_log_level)
 from mne.decoding import GeneralizationAcrossTime, TimeDecoding
 
 
@@ -42,13 +44,11 @@ def make_epochs():
     return epochs
 
 
-@slow_test
-@requires_sklearn_0_15
+@pytest.mark.slowtest
+@requires_version('sklearn', '0.17')
 def test_generalization_across_time():
-    """Test time generalization decoding
-    """
+    """Test time generalization decoding."""
     from sklearn.svm import SVC
-    from sklearn.base import is_classifier
     # KernelRidge is used for testing 1) regression analyses 2) n-dimensional
     # predictions.
     from sklearn.kernel_ridge import KernelRidge
@@ -429,7 +429,7 @@ def test_generalization_across_time():
                         assert_equal(scorer_name, scorer.__name__)
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_decoding_time():
     """Test TimeDecoding."""
     from sklearn.svm import SVR

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -15,7 +15,7 @@ from mne import io, read_events, Epochs, pick_types
 from mne.decoding import (Scaler, FilterEstimator, PSDEstimator, Vectorizer,
                           UnsupervisedSpatialFilter, TemporalFilter)
 from mne.defaults import DEFAULTS
-from mne.utils import requires_sklearn_0_15, run_tests_if_main, check_version
+from mne.utils import requires_version, run_tests_if_main, check_version
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -179,7 +179,7 @@ def test_vectorizer():
                   np.random.rand(102, 12, 12))
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.15')
 def test_unsupervised_spatial_filter():
     """Test unsupervised spatial filter."""
     from sklearn.decomposition import PCA

--- a/mne/decoding/time_gen.py
+++ b/mne/decoding/time_gen.py
@@ -12,7 +12,8 @@ from .base import _set_cv
 from ..io.pick import _pick_data_channels
 from ..viz.decoding import plot_gat_matrix, plot_gat_times
 from ..parallel import parallel_func, check_n_jobs
-from ..utils import warn, check_version, deprecated
+from ..utils import warn, deprecated
+from ..fixes import is_classifier, is_regressor
 
 
 class _DecodingTime(dict):
@@ -355,13 +356,7 @@ class _GeneralizationAcrossTime(object):
             n_test_time, n_folds).
         """
         import sklearn.metrics
-        from sklearn.base import is_classifier
         from sklearn.metrics import accuracy_score, mean_squared_error
-        if check_version('sklearn', '0.17'):
-            from sklearn.base import is_regressor
-        else:
-            def is_regressor(clf):
-                return False
 
         # Run predictions if not already done
         if epochs is not None:
@@ -829,7 +824,6 @@ def _predict(X, estimators, vectorize_times, predict_method):
         Classifier's prediction for each trial.
     """
     from scipy import stats
-    from sklearn.base import is_classifier
     # Initialize results:
 
     orig_shape = X.shape

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1063,6 +1063,39 @@ def _serialize_volume_info(volume_info):
 ##############################################################################
 # adapted from scikit-learn
 
+
+def is_classifier(estimator):
+    """Returns True if the given estimator is (probably) a classifier.
+
+    Parameters
+    ----------
+    estimator : object
+        Estimator object to test.
+
+    Returns
+    -------
+    out : bool
+        True if estimator is a classifier and False otherwise.
+    """
+    return getattr(estimator, "_estimator_type", None) == "classifier"
+
+
+def is_regressor(estimator):
+    """Returns True if the given estimator is (probably) a regressor.
+
+    Parameters
+    ----------
+    estimator : object
+        Estimator object to test.
+
+    Returns
+    -------
+    out : bool
+        True if estimator is a regressor and False otherwise.
+    """
+    return getattr(estimator, "_estimator_type", None) == "regressor"
+
+
 class BaseEstimator(object):
     """Base class for all estimators in scikit-learn
 

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_allclose, assert_array_equal, assert_equal,
                            assert_array_almost_equal)
 from scipy.interpolate import interp1d
 from nose.tools import assert_raises, assert_true
+import pytest
 
 from mne.forward import _make_surface_mapping, make_field_map
 from mne.forward._lead_dots import (_comp_sum_eeg, _comp_sums_meg,
@@ -16,7 +17,7 @@ from mne.surface import get_meg_helmet_surf, get_head_surf
 from mne.datasets import testing
 from mne import read_evokeds, pick_types
 from mne.externals.six.moves import zip
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -116,7 +117,7 @@ def test_make_field_map_eeg():
 
 
 @testing.requires_testing_data
-@slow_test
+@pytest.mark.slowtest
 def test_make_field_map_meg():
     """Test interpolation of MEG field onto helmet | head."""
     evoked = read_evokeds(evoked_fname, condition='Left Auditory')

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -4,6 +4,7 @@ import warnings
 import gc
 
 from nose.tools import assert_true, assert_raises
+import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_array_equal, assert_allclose)
@@ -16,7 +17,7 @@ from mne import (read_forward_solution, apply_forward, apply_forward_raw,
 from mne.tests.common import assert_naming
 from mne.label import read_label
 from mne.utils import (requires_mne, run_subprocess, _TempDir,
-                       run_tests_if_main, slow_test)
+                       run_tests_if_main)
 from mne.forward import (restrict_forward_to_stc, restrict_forward_to_label,
                          Forward)
 
@@ -94,7 +95,7 @@ def test_convert_forward():
     gc.collect()
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_io_forward():
     """Test IO for forward solutions

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -6,6 +6,7 @@ import os.path as op
 import warnings
 
 from nose.tools import assert_raises, assert_true
+import pytest
 import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
 
@@ -18,7 +19,7 @@ from mne import (read_forward_solution, make_forward_solution,
                  pick_types_forward, pick_info, pick_types, Transform,
                  read_evokeds, read_cov, read_dipole)
 from mne.utils import (requires_mne, requires_nibabel, _TempDir,
-                       run_tests_if_main, slow_test, run_subprocess)
+                       run_tests_if_main, run_subprocess)
 from mne.forward._make_forward import _create_meg_coils, make_forward_dipole
 from mne.forward._compute_forward import _magnetic_dipole_field_vec
 from mne.forward import Forward, _do_forward_solution
@@ -202,7 +203,7 @@ def test_make_forward_solution_kit():
     _compare_forwards(fwd, fwd_py, 274, n_src)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_make_forward_solution():
     """Test making M-EEG forward solution from python."""
@@ -244,7 +245,7 @@ def test_make_forward_solution_sphere():
                         1.0, rtol=1e-3)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_nibabel(False)
 def test_forward_mixed_source_space():
@@ -293,7 +294,7 @@ def test_forward_mixed_source_space():
                   mri_resolution=True, trans=vox_mri_t)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_make_forward_dipole():
     """Test forward-projecting dipoles."""

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -5,6 +5,7 @@
 import os.path as op
 
 from nose.tools import assert_true
+import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_allclose)
@@ -15,7 +16,7 @@ from mne.cov import regularize
 from mne.inverse_sparse import gamma_map
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne import pick_types_forward
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 from mne.dipole import Dipole
 
 data_path = testing.data_path(download=False)
@@ -48,7 +49,7 @@ def _check_stcs(stc1, stc2):
     assert_allclose(stc1.tstep, stc2.tstep)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_gamma_map():
     """Test Gamma MAP inverse"""
@@ -84,5 +85,6 @@ def test_gamma_map():
                     xyz_same_gamma=False, update_mode=2,
                     loose=None, return_residual=False)
     _check_stc(stc, evoked, 85739, 20)
+
 
 run_tests_if_main()

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -7,6 +7,7 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from nose.tools import assert_true, assert_equal
+import pytest
 
 from mne.datasets import testing
 from mne.label import read_label
@@ -14,7 +15,7 @@ from mne import read_cov, read_forward_solution, read_evokeds
 from mne.inverse_sparse import mixed_norm, tf_mixed_norm
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne.minimum_norm import apply_inverse, make_inverse_operator
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 from mne.dipole import Dipole
 
 
@@ -38,7 +39,7 @@ def _check_stcs(stc1, stc2):
     assert_allclose(stc1.tstep, stc2.tstep)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mxne_inverse():
     """Test (TF-)MxNE inverse computation"""

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -9,13 +9,14 @@ import matplotlib
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from nose.tools import assert_equal, assert_raises, assert_true
+import pytest
 
 from mne import find_events, Epochs, pick_types, channels
 from mne.io import read_raw_fif
 from mne.io.array import RawArray
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.meas_info import create_info, _kind_dict
-from mne.utils import slow_test, requires_version, run_tests_if_main
+from mne.utils import requires_version, run_tests_if_main
 
 matplotlib.use('Agg')  # for testing don't use X server
 
@@ -25,7 +26,7 @@ base_dir = op.join(op.dirname(__file__), '..', '..', 'tests', 'data')
 fif_fname = op.join(base_dir, 'test_raw.fif')
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_version('scipy', '0.12')
 def test_array_raw():
     """Test creating raw from array."""

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose)
 from nose.tools import assert_true, assert_raises, assert_equal
+import pytest
 
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_bti
@@ -23,7 +24,7 @@ from mne.tests.common import assert_dig_allclose
 from mne.io.pick import pick_info
 from mne.io.constants import FIFF
 from mne import pick_types
-from mne.utils import run_tests_if_main, slow_test
+from mne.utils import run_tests_if_main
 from mne.transforms import Transform, combine_transforms, invert_transform
 from mne.externals import six
 
@@ -97,7 +98,7 @@ def test_transforms():
         assert_array_equal(dev_head_t_new['trans'], dev_head_t_old['trans'])
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_raw():
     """Test bti conversion to Raw object."""
     for pdf, config, hs, exported in zip(pdf_fnames, config_fnames, hs_fnames,

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -10,13 +10,14 @@ import warnings
 import numpy as np
 from nose.tools import assert_raises, assert_true, assert_false
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+import pytest
 
 from mne import pick_types
 # from mne.tests.common import assert_dig_allclose
 from mne.transforms import apply_trans
 from mne.io import read_raw_fif, read_raw_ctf
 from mne.io.tests.test_raw import _test_raw_reader
-from mne.utils import _TempDir, run_tests_if_main, slow_test
+from mne.utils import _TempDir, run_tests_if_main
 from mne.datasets import testing, spm_face
 from mne.io.constants import FIFF
 
@@ -44,7 +45,7 @@ single_trials = (
 ctf_fnames = tuple(sorted(block_sizes.keys()))
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_read_ctf():
     """Test CTF reader"""

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -14,6 +14,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 from nose.tools import assert_true, assert_raises, assert_not_equal
+import pytest
 
 from mne.datasets import testing
 from mne.io.constants import FIFF
@@ -21,7 +22,7 @@ from mne.io import RawArray, concatenate_raws, read_raw_fif
 from mne.io.tests.test_raw import _test_concat, _test_raw_reader
 from mne import (concatenate_events, find_events, equalize_channels,
                  compute_proj_raw, pick_types, pick_channels, create_info)
-from mne.utils import (_TempDir, requires_pandas, slow_test, object_diff,
+from mne.utils import (_TempDir, requires_pandas, object_diff,
                        requires_mne, run_subprocess, run_tests_if_main)
 from mne.externals.six.moves import zip, cPickle as pickle
 from mne.io.proc_history import _get_sss_rank
@@ -155,7 +156,7 @@ def test_copy_append():
     assert_equal(data.shape[1], 2 * raw._data.shape[1])
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_rank_estimation():
     """Test raw rank estimation."""
@@ -217,7 +218,7 @@ def _compare_combo(raw, new, times, n_times):
         assert_allclose(orig, new[:, ti][0])
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_multiple_files():
     """Test loading multiple files simultaneously."""
@@ -468,7 +469,7 @@ def test_load_bad_channels():
     assert_equal([], raw_new.info['bads'])
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_io_raw():
     """Test IO for raw data (Neuromag + CTF + gz)."""
@@ -750,7 +751,7 @@ def test_preload_modify():
         assert_allclose(data, data_new)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_filter():
     """Test filtering (FIR and IIR) and Raw.apply_function interface."""

--- a/mne/io/tests/test_apply_function.py
+++ b/mne/io/tests/test_apply_function.py
@@ -4,10 +4,11 @@
 
 import numpy as np
 from nose.tools import assert_equal, assert_raises, assert_true
+import pytest
 
 from mne import create_info
 from mne.io import RawArray
-from mne.utils import logger, catch_logging, slow_test, run_tests_if_main
+from mne.utils import logger, catch_logging, run_tests_if_main
 
 
 def bad_1(x):
@@ -23,7 +24,7 @@ def printer(x):
     return x
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_apply_function_verbose():
     """Test apply function verbosity
     """
@@ -45,5 +46,6 @@ def test_apply_function_verbose():
         assert_true(out is raw)
         raw.apply_function(printer, verbose=True)
         assert_equal(sio.getvalue().count('\n'), n_chan)
+
 
 run_tests_if_main()

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -466,4 +466,5 @@ def test_add_reference():
     assert_raises(RuntimeError, add_reference_channels, raw_np, ['Ref'])
     assert_raises(ValueError, add_reference_channels, raw, 1)
 
+
 run_tests_if_main()

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -5,6 +5,7 @@ from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_allclose, assert_array_equal)
 from scipy import sparse
 from nose.tools import assert_true, assert_raises
+import pytest
 import copy
 import warnings
 
@@ -24,7 +25,7 @@ from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       compute_rank_inverse,
                                       prepare_inverse_operator)
 from mne.tests.common import assert_naming
-from mne.utils import _TempDir, run_tests_if_main, slow_test
+from mne.utils import _TempDir, run_tests_if_main
 from mne.externals import six
 
 test_path = testing.data_path(download=False)
@@ -182,7 +183,7 @@ def test_warn_inverse_operator():
     assert_equal(len(w), 1)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_make_inverse_operator():
     """Test MNE inverse computation (precomputed and non-precomputed)."""
@@ -207,7 +208,7 @@ def test_make_inverse_operator():
     assert_true('mri_head_t' in my_inv_op)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_inverse_operator_channel_ordering():
     """Test MNE inverse computation is immune to channel reorderings."""
@@ -263,7 +264,7 @@ def test_inverse_operator_channel_ordering():
     assert_allclose(stc_1.data, stc_3.data, rtol=1e-5, atol=1e-5)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_apply_inverse_operator():
     """Test MNE inverse application."""
@@ -471,7 +472,7 @@ def test_inverse_operator_volume():
     assert_array_almost_equal(stc.times, stc2.times)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_io_inverse_operator():
     """Test IO of inverse_operator

--- a/mne/minimum_norm/tests/test_psf_ctf.py
+++ b/mne/minimum_norm/tests/test_psf_ctf.py
@@ -1,11 +1,12 @@
-
 import os.path as op
+import pytest
+
 import mne
 from mne.datasets import testing
 from mne import read_forward_solution
 from mne.minimum_norm import (read_inverse_operator,
                               point_spread_function, cross_talk_function)
-from mne.utils import slow_test, run_tests_if_main
+from mne.utils import run_tests_if_main
 
 from nose.tools import assert_true
 
@@ -24,7 +25,7 @@ snr = 3.0
 lambda2 = 1.0 / snr ** 2
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_psf_ctf():
     """Test computation of PSFs and CTFs for linear estimators

--- a/mne/preprocessing/tests/test_eeglab_infomax.py
+++ b/mne/preprocessing/tests/test_eeglab_infomax.py
@@ -2,6 +2,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 
 from scipy.linalg import svd, pinv
 import scipy.io as sio
@@ -9,7 +10,7 @@ import scipy.io as sio
 from mne.io import read_raw_fif
 from mne import pick_types
 from mne.preprocessing.infomax_ import infomax
-from mne.utils import random_permutation, slow_test, run_tests_if_main
+from mne.utils import random_permutation, run_tests_if_main
 from mne.datasets import testing
 
 base_dir = op.join(op.dirname(__file__), 'data')
@@ -58,7 +59,7 @@ def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
     return Y
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mne_python_vs_eeglab():
     """ Test eeglab vs mne_python infomax code."""

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -11,6 +11,7 @@ import warnings
 
 from nose.tools import (assert_true, assert_raises, assert_equal, assert_false,
                         assert_not_equal, assert_is_none)
+import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose)
@@ -28,7 +29,7 @@ from mne.io import read_raw_fif, Info, RawArray
 from mne.io.meas_info import _kind_dict
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
 from mne.tests.common import assert_naming
-from mne.utils import (catch_logging, _TempDir, requires_sklearn, slow_test,
+from mne.utils import (catch_logging, _TempDir, requires_sklearn,
                        run_tests_if_main)
 
 # Set our plotters to test mode
@@ -274,7 +275,7 @@ def test_ica_core():
     assert_raises(ValueError, ica.apply, offender)
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_sklearn
 def test_ica_additional():
     """Test additional ICA functionality."""

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -7,6 +7,7 @@ import warnings
 import numpy as np
 
 from numpy.testing import assert_equal, assert_allclose
+import pytest
 from nose.tools import assert_true, assert_raises
 
 from mne import compute_raw_covariance, pick_types
@@ -22,7 +23,7 @@ from mne.preprocessing.maxwell import (
     _bases_real_to_complex, _prep_mf_coils)
 from mne.fixes import _get_sph_harm
 from mne.tests.common import assert_meg_snr
-from mne.utils import (_TempDir, run_tests_if_main, slow_test, catch_logging,
+from mne.utils import (_TempDir, run_tests_if_main, catch_logging,
                        requires_version, object_diff, buggy_mkl_svd)
 
 warnings.simplefilter('always')  # Always throw warnings
@@ -119,7 +120,7 @@ def read_crop(fname, lims=(0, None)):
     return read_raw_fif(fname, allow_maxshield='yes').crop(*lims)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_movement_compensation():
     """Test movement compensation."""
@@ -205,7 +206,7 @@ def test_movement_compensation():
                    chpi_med_tol=5)
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_other_systems():
     """Test Maxwell filtering on KIT, BTI, and CTF files."""
     # KIT
@@ -479,7 +480,7 @@ def test_maxwell_filter_additional():
     assert_equal(cov_sss_rank, _get_n_moments(int_order))
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_bads_reconstruction():
     """Test Maxwell filter reconstruction of bad channels."""
@@ -536,7 +537,7 @@ def test_spatiotemporal():
                   st_correlation=0.)
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_spatiotemporal_only():
@@ -638,7 +639,7 @@ def test_fine_calibration():
                   calibration=fine_cal_fname)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_regularization():
     """Test Maxwell filter regularization."""
@@ -771,7 +772,7 @@ def _assert_shielding(raw_sss, erm_power, shielding_factor, meg='mag'):
 
 
 @buggy_mkl_svd
-@slow_test
+@pytest.mark.slowtest
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_shielding_factor():
@@ -888,7 +889,7 @@ def test_shielding_factor():
     _assert_shielding(raw_sss, erm_power, 44)
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_all():
@@ -923,7 +924,7 @@ def test_all():
         assert_meg_snr(sss_py, sss_mf, mins[ii], meds[ii], msg=rf)
 
 
-@slow_test
+@pytest.mark.slowtest
 @requires_svd_convergence
 @testing.requires_testing_data
 def test_triux():

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 from nose.tools import assert_true, assert_raises, assert_equal
+import pytest
 
 from mne import (read_source_spaces, pick_types, read_trans, read_cov,
                  make_sphere_model, create_info, setup_volume_source_space,
@@ -22,7 +23,7 @@ from mne.datasets import testing
 from mne.simulation import simulate_sparse_stc, simulate_raw
 from mne.io import read_raw_fif, RawArray
 from mne.time_frequency import psd_welch
-from mne.utils import _TempDir, run_tests_if_main, slow_test
+from mne.utils import _TempDir, run_tests_if_main
 
 
 warnings.simplefilter('always')
@@ -187,7 +188,7 @@ def test_simulate_raw_sphere():
                   blink=True)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_simulate_raw_bem():
     """Test simulation of raw data with BEM."""
@@ -234,7 +235,7 @@ def test_simulate_raw_bem():
         assert_true(med_diff < tol, msg='%s: %s' % (bem, med_diff))
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_simulate_raw_chpi():
     """Test simulation of raw data with cHPI."""

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -10,6 +10,7 @@ import warnings
 
 import numpy as np
 from nose.tools import assert_raises, assert_true
+import pytest
 from numpy.testing import assert_equal, assert_allclose
 
 from mne import (make_bem_model, read_bem_surfaces, write_bem_surfaces,
@@ -19,7 +20,7 @@ from mne.preprocessing.maxfilter import fit_sphere_to_headshape
 from mne.io.constants import FIFF
 from mne.transforms import translation
 from mne.datasets import testing
-from mne.utils import (run_tests_if_main, _TempDir, slow_test, catch_logging,
+from mne.utils import (run_tests_if_main, _TempDir, catch_logging,
                        requires_freesurfer)
 from mne.bem import (_ico_downsample, _get_ico_map, _order_surfaces,
                      _assert_complete_surface, _assert_inside,
@@ -134,7 +135,7 @@ def test_bem_model():
                   conductivity=[0.3, 0.006], subjects_dir=subjects_dir)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_bem_solution():
     """Test making a BEM solution from Python with I/O"""

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -3,11 +3,12 @@
 # License: BSD (3-clause)
 
 import os.path as op
+import warnings
+
 import numpy as np
 from numpy.testing import assert_allclose
 from nose.tools import assert_raises, assert_equal, assert_true
-import warnings
-
+import pytest
 
 from mne import (pick_types, Dipole, make_sphere_model, make_forward_dipole,
                  pick_info)
@@ -20,7 +21,7 @@ from mne.chpi import (_calculate_chpi_positions, _calculate_chpi_coil_locs,
 from mne.fixes import assert_raises_regex
 from mne.transforms import rot_to_quat, _angle_between_quats
 from mne.simulation import simulate_raw
-from mne.utils import run_tests_if_main, _TempDir, catch_logging, slow_test
+from mne.utils import run_tests_if_main, _TempDir, catch_logging
 from mne.datasets import testing
 from mne.tests.common import assert_meg_snr
 
@@ -175,7 +176,7 @@ def _decimate_chpi(raw, decim=4):
     return raw_dec
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_calculate_chpi_positions():
     """Test calculation of cHPI positions."""
@@ -244,7 +245,7 @@ def test_calculate_chpi_positions_on_chpi5_in_one_second_steps():
     _assert_quats(py_quats, mf_quats, dist_tol=0.0008, angle_tol=.5)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_calculate_chpi_positions_on_chpi5_in_shorter_steps():
     """Comparing estimated cHPI positions with MF results (smaller steps)."""

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -4,15 +4,16 @@
 # License: BSD (3-clause)
 
 import os.path as op
+import itertools as itt
+import warnings
 
 from nose.tools import assert_true
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal, assert_allclose)
 from nose.tools import assert_raises
+import pytest
 import numpy as np
 from scipy import linalg
-import warnings
-import itertools as itt
 
 from mne.cov import (regularize, whiten_evoked, _estimate_rank_meeg_cov,
                      _auto_low_rank_model, _apply_scaling_cov,
@@ -25,8 +26,7 @@ from mne import (read_cov, write_cov, Epochs, merge_events,
                  pick_channels_cov, pick_types, pick_info, make_ad_hoc_cov)
 from mne.io import read_raw_fif, RawArray, read_info
 from mne.tests.common import assert_naming, assert_snr
-from mne.utils import (_TempDir, slow_test, requires_sklearn_0_15,
-                       run_tests_if_main)
+from mne.utils import _TempDir, requires_version, run_tests_if_main
 from mne.io.proc_history import _get_sss_rank
 from mne.io.pick import channel_type, _picks_by_type
 
@@ -223,8 +223,8 @@ def test_cov_estimation_on_raw():
                                      reject=dict(eog=1000e-6))
 
 
-@slow_test
-@requires_sklearn_0_15
+@pytest.mark.slowtest
+@requires_version('sklearn', '0.15')
 def test_cov_estimation_on_raw_reg():
     """Test estimation from raw with regularization."""
     raw = read_raw_fif(raw_fname, preload=True)
@@ -248,7 +248,7 @@ def _assert_cov(cov, cov_desired, tol=0.005, nfree=True):
         assert_equal(cov.nfree, cov_desired.nfree)
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_cov_estimation_with_triggers():
     """Test estimation from raw with triggers."""
     tempdir = _TempDir()
@@ -377,7 +377,7 @@ def test_whiten_evoked():
     assert_raises(RuntimeError, whiten_evoked, evoked, cov_bad, picks)
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_rank():
     """Test cov rank estimation."""
     # Test that our rank estimation works properly on a simple case
@@ -501,7 +501,7 @@ def test_cov_scaling():
     assert_allclose(data, evoked.data, atol=1e-20)
 
 
-@requires_sklearn_0_15
+@requires_version('sklearn', '0.15')
 def test_auto_low_rank():
     """Test probabilistic low rank estimators."""
     n_samples, n_features, rank = 400, 10, 5
@@ -548,8 +548,8 @@ def test_auto_low_rank():
                   n_jobs=n_jobs, method_params=method_params, cv=cv)
 
 
-@slow_test
-@requires_sklearn_0_15
+@pytest.mark.slowtest
+@requires_version('sklearn', '0.15')
 def test_compute_covariance_auto_reg():
     """Test automated regularization."""
     raw = read_raw_fif(raw_fname, preload=True)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_allclose, assert_array_equal
+import pytest
 
 from mne import (read_dipole, read_forward_solution,
                  convert_forward_solution, read_evokeds, read_cov,
@@ -15,8 +16,7 @@ from mne import (read_dipole, read_forward_solution,
 from mne.dipole import get_phantom_dipoles
 from mne.simulation import simulate_evoked
 from mne.datasets import testing
-from mne.utils import (run_tests_if_main, _TempDir, slow_test, requires_mne,
-                       run_subprocess)
+from mne.utils import run_tests_if_main, _TempDir, requires_mne, run_subprocess
 from mne.proj import make_eeg_average_ref_proj
 
 from mne.io import read_raw_fif, read_raw_ctf
@@ -94,7 +94,7 @@ def test_dipole_fitting_ctf():
     fit_dipole(evoked, cov, sphere)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_mne
 def test_dipole_fitting():

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -3,10 +3,8 @@ from __future__ import print_function
 import inspect
 import os.path as op
 import sys
+from unittest import SkipTest
 import warnings
-
-from nose.tools import assert_true
-from nose.plugins.skip import SkipTest
 
 from pkgutil import walk_packages
 from inspect import getsource
@@ -179,9 +177,9 @@ def test_tabs():
                 source = getsource(mod)
             except IOError:  # user probably should have run "make clean"
                 continue
-            assert_true('\t' not in source,
-                        '"%s" has tabs, please remove them or add it to the'
-                        'ignore list' % modname)
+            assert '\t' not in source, ('"%s" has tabs, please remove them '
+                                        'or add it to the ignore list'
+                                        % modname)
 
 
 documented_ignored_mods = (

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from nose.tools import (assert_true, assert_equal, assert_raises,
                         assert_not_equal)
-
+import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_allclose)
 import numpy as np
@@ -26,7 +26,7 @@ from mne.preprocessing import maxwell_filter
 from mne.epochs import (
     bootstrap, equalize_epoch_counts, combine_event_ids, add_channels_epochs,
     EpochsArray, concatenate_epochs, BaseEpochs, average_movements)
-from mne.utils import (_TempDir, requires_pandas, slow_test,
+from mne.utils import (_TempDir, requires_pandas,
                        run_tests_if_main, requires_version)
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 
@@ -94,7 +94,7 @@ def test_hierarchical():
     assert_array_equal(epochs.get_data(), epochs_all.get_data())
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_average_movements():
     """Test movement averaging algorithm."""
@@ -560,7 +560,7 @@ def test_read_epochs_bad_events():
     warnings.resetwarnings()
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_read_write_epochs():
     """Test epochs from raw files with IO as fif file."""
     raw, events, picks = _get_data(preload=True)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -14,6 +14,7 @@ from scipy import fftpack
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_array_equal, assert_allclose)
 from nose.tools import assert_true, assert_raises, assert_not_equal
+import pytest
 
 from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
                  grand_average, combine_evoked, create_info, read_events,
@@ -21,7 +22,7 @@ from mne import (equalize_channels, pick_types, read_evokeds, write_evokeds,
 from mne.evoked import _get_peak, Evoked, EvokedArray
 from mne.io import read_raw_fif
 from mne.tests.common import assert_naming
-from mne.utils import (_TempDir, requires_pandas, slow_test, requires_version,
+from mne.utils import (_TempDir, requires_pandas, requires_version,
                        run_tests_if_main)
 from mne.externals.six.moves import cPickle as pickle
 
@@ -109,7 +110,7 @@ def test_hash_evoked():
     assert_not_equal(hash(ave), hash(ave_2))
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_io_evoked():
     """Test IO for evoked data (fif + gz) with integer and str args."""
     tempdir = _TempDir()

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
                            assert_array_equal, assert_allclose)
 from nose.tools import assert_equal, assert_true, assert_raises
+import pytest
 from scipy.signal import resample as sp_resample, butter
 from scipy.fftpack import fft, fftfreq
 
@@ -15,7 +16,7 @@ from mne.filter import (filter_data, resample, _resample_stim_channels,
                         _overlap_add_filter, _smart_pad, design_mne_c_filter,
                         estimate_ringing_samples, create_filter, _Interp2)
 
-from mne.utils import (sum_squared, run_tests_if_main, slow_test,
+from mne.utils import (sum_squared, run_tests_if_main,
                        catch_logging, requires_version, _TempDir,
                        requires_mne, run_subprocess)
 
@@ -279,7 +280,7 @@ def test_resample_stim_channel():
 
 
 @requires_version('scipy', '0.16')
-@slow_test
+@pytest.mark.slowtest
 def test_filters():
     """Test low-, band-, high-pass, and band-stop filters plus resampling."""
     sfreq = 100

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -9,6 +9,7 @@ from scipy import sparse
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+import pytest
 
 from mne.datasets import testing
 from mne import (read_label, stc_to_label, read_source_estimate,
@@ -17,7 +18,7 @@ from mne import (read_label, stc_to_label, read_source_estimate,
                  read_surface)
 from mne.label import Label, _blend_colors, label_sign_flip
 from mne.utils import (_TempDir, requires_sklearn, get_subjects_dir,
-                       run_tests_if_main, slow_test)
+                       run_tests_if_main)
 from mne.fixes import assert_is, assert_is_not
 from mne.label import _n_colors
 from mne.source_space import SourceSpaces
@@ -628,7 +629,7 @@ def test_split_label():
                  [16181, 7022, 5965, 5300, 823] + [1] * 23)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_sklearn
 def test_stc_to_label():
@@ -690,7 +691,7 @@ def test_stc_to_label():
         assert_labels_equal(l1, l2, decimal=4)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_morph():
     """Test inter-subject label morphing."""

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -5,7 +5,7 @@
 
 import os
 from nose.tools import assert_raises
-from nose.plugins.skip import SkipTest
+from unittest import SkipTest
 from os import path as op
 import sys
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_allclose,
                            assert_equal)
+import pytest
 
 import copy as cp
 
@@ -19,7 +20,7 @@ from mne.io.proj import (make_projector, activate_proj,
 from mne.proj import (read_proj, write_proj, make_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj)
 from mne.tests.common import assert_naming
-from mne.utils import _TempDir, run_tests_if_main, slow_test
+from mne.utils import _TempDir, run_tests_if_main
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -225,7 +226,7 @@ def test_compute_proj_epochs():
     assert_naming(w, 'test_proj.py', 2)
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_compute_proj_raw():
     """Test SSP computation on raw"""
     tempdir = _TempDir()

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -10,13 +10,14 @@ import shutil
 import warnings
 
 from nose.tools import assert_true, assert_equal, assert_raises
+import pytest
 
 from mne import Epochs, read_events, read_evokeds
 from mne.io import read_raw_fif
 from mne.datasets import testing
 from mne.report import Report
 from mne.utils import (_TempDir, requires_mayavi, requires_nibabel,
-                       requires_PIL, run_tests_if_main, slow_test)
+                       requires_PIL, run_tests_if_main)
 from mne.viz import plot_alignment
 
 import matplotlib
@@ -43,7 +44,7 @@ evoked_fname = op.join(base_dir, 'test-ave.fif')
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_PIL
 def test_render_report():
@@ -185,7 +186,7 @@ def test_render_add_sections():
     assert_true(repr(report))
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_mayavi
 @requires_nibabel()

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
-
+import pytest
 from scipy.fftpack import fft
 
 from mne.datasets import testing
@@ -24,7 +24,7 @@ from mne.source_estimate import (compute_morph_matrix, grade_to_vertices,
 from mne.minimum_norm import read_inverse_operator, apply_inverse
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (_TempDir, requires_pandas, requires_sklearn,
-                       requires_h5py, run_tests_if_main, slow_test)
+                       requires_h5py, run_tests_if_main)
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -85,7 +85,7 @@ def test_spatial_inter_hemi_connectivity():
         assert_true(set(use_labels) - set(good_labels) == set())
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_stc():
     """Test volume STCs."""
@@ -358,7 +358,7 @@ def test_stc_arithmetic():
                        np.mean(vec_stc.data, 2)[:, :, None])
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_stc_methods():
     """Test stc methods lh_data, rh_data, bin(), resample()."""
@@ -523,7 +523,7 @@ def test_extract_label_time_course():
     assert_true(x.size == 0)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_morph_data():
     """Test morphing of data."""

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -2,8 +2,9 @@ from __future__ import print_function
 
 import os
 import os.path as op
+from unittest import SkipTest
 from nose.tools import assert_true, assert_raises
-from nose.plugins.skip import SkipTest
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 import warnings
@@ -14,7 +15,7 @@ from mne import (read_source_spaces, vertex_to_mni, write_source_spaces,
                  add_source_space_distances, read_bem_surfaces,
                  morph_source_spaces, SourceEstimate)
 from mne.utils import (_TempDir, requires_fs_or_nibabel, requires_nibabel,
-                       requires_freesurfer, run_subprocess, slow_test,
+                       requires_freesurfer, run_subprocess,
                        requires_mne, requires_version, run_tests_if_main)
 from mne.surface import _accumulate_normals, _triangle_neighbors
 from mne.source_space import _get_mri_header, _get_mgz_header
@@ -125,7 +126,7 @@ def test_add_source_space_distances_limited():
         assert_allclose(np.zeros_like(d.data), d.data, rtol=0, atol=1e-6)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_version('scipy', '0.11')
 def test_add_source_space_distances():
@@ -210,7 +211,7 @@ def test_discrete_source_space():
             os.remove(temp_name)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_source_space():
     """Test setting up volume source spaces."""
@@ -324,7 +325,7 @@ def test_accumulate_normals():
     assert_allclose(nn, this['nn'], rtol=1e-7, atol=1e-7)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_setup_source_space():
     """Test setting up ico, oct, and all source spaces."""
@@ -401,7 +402,7 @@ def test_read_source_spaces():
     assert_true(rh_use_faces.max() <= rh_points.shape[0] - 1)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_write_source_space():
     """Test reading and writing of source spaces."""
@@ -614,7 +615,7 @@ def test_morph_source_spaces():
     _compare_source_spaces(src_morph, src_morph_py, mode='approx')
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_morphed_source_space_return():
     """Test returning a morphed source space to the original subject."""
@@ -674,6 +675,7 @@ def test_morphed_source_space_return():
     src = read_source_spaces(fname)  # wrong source space
     assert_raises(RuntimeError, stc_morph.to_original_src,
                   src, subjects_dir=subjects_dir)
+
 
 run_tests_if_main()
 

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -6,6 +6,7 @@ import warnings
 from shutil import copyfile
 from scipy import sparse
 from nose.tools import assert_true, assert_raises
+import pytest
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
 from mne.datasets import testing
@@ -14,7 +15,7 @@ from mne.surface import (read_morph_map, _compute_nearest,
                          fast_cross_3d, get_head_surf, read_curvature,
                          get_meg_helmet_surf)
 from mne.utils import (_TempDir, requires_mayavi, requires_tvtk,
-                       run_tests_if_main, slow_test, object_diff)
+                       run_tests_if_main, object_diff)
 from mne.io import read_info
 from mne.transforms import _get_trans
 
@@ -86,7 +87,7 @@ def test_compute_nearest():
         assert_array_equal(nn1, nn2)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_make_morph_maps():
     """Test reading and creating morph maps."""

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -51,7 +51,7 @@ def clean_lines(lines=[]):
 
 def test_buggy_mkl():
     """Test decorator for buggy MKL issues."""
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
 
     @buggy_mkl_svd
     def foo(a, b):

--- a/mne/time_frequency/tests/test_ar.py
+++ b/mne/time_frequency/tests/test_ar.py
@@ -7,14 +7,15 @@ from scipy.signal import lfilter
 
 from mne import io
 from mne.time_frequency.ar import _yule_walker, fit_iir_model_raw
-from mne.utils import requires_statsmodels, run_tests_if_main
+from mne.utils import requires_version, run_tests_if_main
 
 
 raw_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data',
                     'test_raw.fif')
 
 
-@requires_statsmodels
+# 0.7 attempts to import nonexistent TimeSeries from Pandas 0.20
+@requires_version('statsmodels', '0.8')
 def test_yule_walker():
     """Test Yule-Walker against statsmodels."""
     from statsmodels.regression.linear_model import yule_walker as sm_yw

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -3,10 +3,11 @@ import os.path as op
 from numpy.testing import (assert_array_almost_equal, assert_raises,
                            assert_allclose)
 from nose.tools import assert_true, assert_equal
+import pytest
 
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
-from mne.utils import slow_test, run_tests_if_main
+from mne.utils import run_tests_if_main
 from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -155,7 +156,7 @@ def test_psd():
         assert_true(psds_ev.shape == (len(kws['picks']), len(freqs)))
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_compares_psd():
     """Test PSD estimation on raw for plt.psd and scipy.signal.welch."""
     raw = read_raw_fif(raw_fname)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -4,12 +4,12 @@ import warnings
 
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
+import pytest
 
 import mne
 from mne import Epochs, read_events, pick_types, create_info, EpochsArray
 from mne.io import read_raw_fif
-from mne.utils import (_TempDir, run_tests_if_main, slow_test, requires_h5py,
-                       grand_average)
+from mne.utils import _TempDir, run_tests_if_main, requires_h5py, grand_average
 from mne.time_frequency.tfr import (morlet, tfr_morlet, _make_dpss,
                                     tfr_multitaper, AverageTFR, read_tfrs,
                                     write_tfrs, combine_tfr, cwt, _compute_tfr,
@@ -240,7 +240,7 @@ def test_dpsswavelet():
     assert_true(len(Ws[0]) == len(freqs))  # As many wavelets as asked for
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_tfr_multitaper():
     """Test tfr_multitaper."""
     sfreq = 200.0

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1609,6 +1609,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
         coords = surf['rr'][inuse]
         shape = faces.shape
         faces = stats.rankdata(faces, 'dense').reshape(shape) - 1
+        faces = np.round(faces).astype(int)  # should really be int-like anyway
     del surf
     vertices = stc.vertices[hemi_idx]
     n_verts = len(vertices)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -56,6 +56,7 @@ sqd_fname = op.join(io_dir, 'kit', 'tests', 'data', 'test.sqd')
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
+@requires_version('matplotlib', '1.5')  # pivot kwarg
 def test_plot_head_positions():
     """Test plotting of head positions."""
     import matplotlib.pyplot as plt
@@ -127,6 +128,7 @@ def test_plot_evoked_field():
 
 @testing.requires_testing_data
 @requires_mayavi
+@requires_version('matplotlib', '1.5')  # pivot kwarg
 def test_plot_alignment():
     """Test plotting of -trans.fif files and MEG sensor layouts."""
     # generate fiducials file for testing
@@ -320,6 +322,7 @@ def test_stc_mpl():
 
 @testing.requires_testing_data
 @requires_nibabel()
+@requires_version('matplotlib', '1.5')  # pivot kwarg
 def test_plot_dipole_mri_orthoview():
     """Test mpl dipole plotting."""
     import matplotlib.pyplot as plt

--- a/mne/viz/tests/test_decoding.py
+++ b/mne/viz/tests/test_decoding.py
@@ -14,7 +14,7 @@ from mne.epochs import equalize_epoch_counts, concatenate_epochs
 from mne.decoding import GeneralizationAcrossTime
 from mne import Epochs, read_events, pick_types
 from mne.io import read_raw_fif
-from mne.utils import requires_sklearn, run_tests_if_main
+from mne.utils import requires_version, run_tests_if_main
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
 
@@ -53,7 +53,7 @@ def _get_data(tmin=-0.2, tmax=0.5, event_id=dict(aud_l=1, vis_l=3),
     return gat
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_gat_plot_matrix():
     """Test GAT matrix plot."""
     gat = _get_data()
@@ -62,7 +62,7 @@ def test_gat_plot_matrix():
     assert_raises(RuntimeError, gat.plot)
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_gat_plot_diagonal():
     """Test GAT diagonal plot."""
     gat = _get_data()
@@ -71,7 +71,7 @@ def test_gat_plot_diagonal():
     assert_raises(RuntimeError, gat.plot)
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_gat_plot_times():
     """Test GAT times plot."""
     gat = _get_data()
@@ -97,7 +97,7 @@ def chance(ax):
     return ax.get_children()[1].get_lines()[0].get_ydata()[0]
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_gat_chance_level():
     """Test GAT plot_times chance level."""
     gat = _get_data()
@@ -114,7 +114,7 @@ def test_gat_chance_level():
     assert_raises(RuntimeError, gat.plot)
 
 
-@requires_sklearn
+@requires_version('sklearn', '0.17')
 def test_gat_plot_nonsquared():
     """Test GAT diagonal plot."""
     gat = _get_data(test_times=dict(start=0.))

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -166,13 +166,6 @@ def test_plot_evoked():
         contrast["blue/stim"] = blue
         plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],
                              ylim=dict(mag=(1, 10)), ci=_parametric_ci)
-        # isolated test of CI functions
-        arr = np.linspace(0, 1, 1000)[..., np.newaxis]
-        assert_allclose(_ci(arr, method="parametric"),
-                        _ci(arr, method="bootstrap"), rtol=.005)
-        assert_allclose(_bootstrap_ci(arr, statfun="median", random_state=0),
-                        _bootstrap_ci(arr, statfun="mean", random_state=0),
-                        rtol=.1)
 
         # Hack to test plotting of maxfiltered data
         evoked_sss = evoked.copy()

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -14,11 +14,12 @@ import warnings
 import numpy as np
 from numpy.testing import assert_raises, assert_equal
 from nose.tools import assert_true
+import pytest
 
 from mne import read_events, Epochs, pick_types, read_cov
 from mne.channels import read_layout
 from mne.io import read_raw_fif
-from mne.utils import slow_test, run_tests_if_main
+from mne.utils import run_tests_if_main
 from mne.viz.evoked import _line_plot_onselect, plot_compare_evokeds
 from mne.viz.utils import _fake_click
 from mne.stats import _parametric_ci
@@ -72,7 +73,7 @@ def _get_epochs_delayed_ssp():
     return epochs_delayed_ssp
 
 
-@slow_test
+@pytest.mark.slowtest
 def test_plot_evoked():
     """Test plotting of evoked."""
     import matplotlib.pyplot as plt
@@ -165,6 +166,13 @@ def test_plot_evoked():
         contrast["blue/stim"] = blue
         plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],
                              ylim=dict(mag=(1, 10)), ci=_parametric_ci)
+        # isolated test of CI functions
+        arr = np.linspace(0, 1, 1000)[..., np.newaxis]
+        assert_allclose(_ci(arr, method="parametric"),
+                        _ci(arr, method="bootstrap"), rtol=.005)
+        assert_allclose(_bootstrap_ci(arr, statfun="median", random_state=0),
+                        _bootstrap_ci(arr, statfun="mean", random_state=0),
+                        rtol=.1)
 
         # Hack to test plotting of maxfiltered data
         evoked_sss = evoked.copy()

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -12,6 +12,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_raises
+import pytest
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)
@@ -21,8 +22,7 @@ from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
                      plot_snr_estimate, plot_filter)
-from mne.utils import (requires_nibabel, run_tests_if_main, slow_test,
-                       requires_version)
+from mne.utils import requires_nibabel, run_tests_if_main, requires_version
 
 # Set our plotters to test mode
 import matplotlib
@@ -149,7 +149,7 @@ def test_plot_source_spectrogram():
                   [[1, 2], [3, 4]], tmax=7)
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_plot_snr():
     """Test plotting SNR estimate."""
@@ -163,5 +163,6 @@ def test_plot_dipole_amplitudes():
     """Test plotting dipole amplitudes."""
     dipoles = read_dipole(dip_fname)
     dipoles.plot_amplitudes(show=False)
+
 
 run_tests_if_main()

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.testing import assert_raises, assert_array_equal
 
 from nose.tools import assert_true, assert_equal
-
+import pytest
 
 from mne import read_evokeds, read_proj
 from mne.io import read_raw_fif, read_info
@@ -22,7 +22,7 @@ from mne.io.pick import pick_info, channel_indices_by_type
 from mne.channels import read_layout, make_eeg_layout
 from mne.datasets import testing
 from mne.time_frequency.tfr import AverageTFR
-from mne.utils import slow_test, run_tests_if_main
+from mne.utils import run_tests_if_main
 
 from mne.viz import plot_evoked_topomap, plot_projs_topomap
 from mne.viz.topomap import (_check_outlines, _onselect, plot_topomap,
@@ -49,7 +49,7 @@ event_name = op.join(base_dir, 'test-eve.fif')
 layout = read_layout('Vectorview-all')
 
 
-@slow_test
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_plot_topomap():
     """Test topomap plotting."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,19 +14,8 @@ release = egg_info -RDb ''
 [bdist_rpm]
 doc-files = doc
 
-[nosetests]
-# with-coverage = 1
-# cover-html = 1
-# cover-html-dir = coverage
-cover-package = mne
-ignore-files = (?:^\.|^_,|^conf\.py$|^_\w*_gui.py|^_file_traits.py|^_viewer.py)
-
-detailed-errors = 1
-with-doctest = 1
-doctest-tests = 1
-doctest-extension = rst
-doctest-fixtures = _fixture
-#doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
+[tool:pytest]
+addopts = --cov=mne --showlocals --durations=20 --doctest-modules -rs --cov-report=
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py


### PR DESCRIPTION
This PR:

1. Gets rid of some `nose` cruft
2. Moves to standard `pytest` slow-test markers
3. Fixes our decorators for `sklearn` that had incorrect versions
4. Makes AppVeyor a little bit nicer

Closes #4518.