### PR TITLE
MRG: fill_value in ReceptiveField

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -319,7 +319,8 @@ sphinx_gallery_conf = {
     'plot_gallery': 'True',  # Avoid annoying Unicode/bool default warning
     'download_section_examples': False,
     'thumbnail_size': (160, 112),
-    }
+    'min_reported_time': 1.,
+}
 
 numpydoc_class_members_toctree = False
 

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -431,7 +431,7 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
     auto_examples/inverse/plot_tf_dics.rst
     auto_examples/inverse/plot_tf_lcmv.rst
     auto_examples/inverse/plot_time_frequency_mixed_norm_inverse.rst
-    auto_examples/inverse/plot_vector_source_estimate.rst
+    auto_examples/inverse/plot_vector_mne_solution.rst
 
 .. raw:: html
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -837,7 +837,7 @@ class InterpolationMixin(object):
         reset_bads : bool
             If True, remove the bads from info.
         mode : str
-            Either `'accurate'` or `'fast'`, determines the quality of the
+            Either ``'accurate'`` or ``'fast'``, determines the quality of the
             Legendre polynomial expansion used for interpolation of MEG
             channels.
         verbose : bool, str, int, or None

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -411,7 +411,7 @@ def _delay_time_series(X, tmin, tmax, sfreq, newaxis=0, axis=0,
         fill_value = X.mean(axis=axis, keepdims=True)
         if epoch_axis is not None:
             fill_value = np.mean(fill_value, axis=epoch_axis, keepdims=True)
-            delayed[...] = fill_value
+        delayed[...] = fill_value
     for ii, ix_delay in enumerate(delays):
         take = [slice(None)] * X.ndim
         put = [slice(None)] * X.ndim

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -315,8 +315,8 @@ def _delay_time_series(X, tmin, tmax, sfreq, fill_mean=False):
 
     Parameters
     ----------
-    X : array, shape (n_times[, n_epochs][, n_features])
-        The time series to delay.
+    X : array, shape (n_times[, n_epochs], n_features)
+        The time series to delay. Must be 2D or 3D.
     tmin : int | float
         The starting lag. Negative values correspond to times in the past.
     tmax : int | float

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -364,7 +364,7 @@ def _delay_time_series(X, tmin, tmax, sfreq, fill_mean=False):
 
     Parameters
     ----------
-    X : array, shape (n_times[, n_epochs], n_features)
+    X : array, shape (n_times[, n_epochs][, n_features])
         The time series to delay.
     tmin : int | float
         The starting lag. Negative values correspond to times in the past.
@@ -379,7 +379,7 @@ def _delay_time_series(X, tmin, tmax, sfreq, fill_mean=False):
 
     Returns
     -------
-    delayed : array, shape(n_times,[, n_epochs], n_features, n_delays)
+    delayed : array, shape(n_times[, n_epochs][, n_features], n_delays)
         The delayed data. It has the same shape as X, with an extra dimension
         appended to the end.
 
@@ -390,10 +390,11 @@ def _delay_time_series(X, tmin, tmax, sfreq, fill_mean=False):
     >>> x = np.arange(1, 6)
     >>> x_del = _delay_time_series(x, tmin, tmax, sfreq)
     >>> print(x_del)
-    [[ 0.  0.  1.  2.  3.]
-     [ 0.  1.  2.  3.  4.]
-     [ 1.  2.  3.  4.  5.]
-     [ 2.  3.  4.  5.  0.]]
+    [[ 0.  0.  1.  2.]
+     [ 0.  1.  2.  3.]
+     [ 1.  2.  3.  4.]
+     [ 2.  3.  4.  5.]
+     [ 3.  4.  5.  0.]]
     """
     _check_delayer_params(tmin, tmax, sfreq)
     delays = _times_to_delays(tmin, tmax, sfreq)

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -123,6 +123,12 @@ def test_receptive_field():
     rf.fit(X, y)
     assert_array_equal(rf.delays_, np.arange(tmin, tmax + 1))
 
+    # Testing fill mean
+    rf = ReceptiveField(tmin, tmax, 1, feature_names, fill_mean=True,
+                        estimator=mod)
+    rf.fit(X, y)
+    assert_array_equal(rf.delays_, np.arange(tmin, tmax + 1))
+
     y_pred = rf.predict(X)
     assert_allclose(y[rf.valid_samples_], y_pred[rf.valid_samples_], atol=1e-2)
     scores = rf.score(X, y)

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -201,6 +201,7 @@ def test_time_delaying_fast_calc():
     # all negative
     smin, smax = -2, -1
     X_del = _delay_time_series(X, smin, smax, 1.)
+    # (n_times, n_features, n_delays) -> (n_times, n_features * n_delays)
     X_del.shape = (X.shape[0], -1)
     expected = np.array([[0, 0, 1], [0, 1, 2], [0, 0, 5], [0, 5, 7]]).T
     assert_allclose(X_del, expected)
@@ -239,7 +240,7 @@ def test_time_delaying_fast_calc():
     x_xt = _compute_corrs(X, np.zeros((X.shape[0], 1)), -smax, -smin + 1)[0]
     assert_allclose(x_xt, expected)
 
-    # slightly harder
+    # slightly harder to get the non-Toeplitz correction correct
     X = np.array([[1, 2, 3, 5]]).T
     smin, smax = -3, 0
     X_del = _delay_time_series(X, smin, smax, 1.)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -41,7 +41,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     epochs : instance of Epochs
         The epochs.
     picks : int | array-like of int | None
-        The indices of the channels to consider. If None and ``combine` is
+        The indices of the channels to consider. If None and ``combine`` is
         also None, the first five good channels are plotted.
     sigma : float
         The standard deviation of the Gaussian smoothing to apply along

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1525,7 +1525,7 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     invert_y : bool
         If True, negative values are plotted up (as is sometimes done
         for ERPs out of tradition). Defaults to False.
-    axes : None | `matplotlib.pyplot.axes` instance | list of `axes`
+    axes : None | `matplotlib.axes.Axes` instance | list of `axes`
         What axes to plot to. If None, a new axes is created.
         When plotting multiple channel types, can also be a list of axes, one
         per channel type.

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1258,7 +1258,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         Plot a colorbar in the rightmost column of the figure.
         None (default) is the same as True, but emits a warning if custom
         ``axes`` are provided to remind the user that the colorbar will
-        occupy the last :class:`matplotlib.pyplot.Axes` instance.
+        occupy the last :class:`matplotlib.axes.Axes` instance.
     scale : dict | float | None
         Scale the data for plotting. If None, defaults to 1e6 for eeg, 1e13
         for grad and 1e15 for mag.

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -44,6 +44,8 @@ modeling with continuous inputs is described in:
 #
 # License: BSD (3-clause)
 
+# sphinx_gallery_thumbnail_number = 7
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -339,17 +341,18 @@ xlim = times[[0, -1]]
 for ii, (rf_lap, rf, i_alpha) in enumerate(zip(models_lap, models, alphas)):
     ax = plt.subplot2grid([3, len(alphas)], [0, ii], 1, 1)
     ax.pcolormesh(times, rf_lap.feature_names, rf_lap.coef_[0], **kwargs)
-    ax.set(xticks=[], yticks=[])
+    ax.set(xticks=[], yticks=[], xlim=xlim)
     if ii == 0:
         ax.set(ylabel='Laplacian')
     ax = plt.subplot2grid([3, len(alphas)], [1, ii], 1, 1)
     ax.pcolormesh(times, rf.feature_names, rf.coef_[0], **kwargs)
-    ax.set(xticks=[], yticks=[], xlim=times[[0, -1]])
+    ax.set(xticks=[], yticks=[], xlim=xlim)
     if ii == 0:
         ax.set(ylabel='Ridge')
 fig.suptitle('Model coefficients / scores for laplacian regularization', y=1)
 mne.viz.tight_layout()
 
+###############################################################################
 # Plot the original STRF, and the one that we recovered with modeling.
 rf = models[ix_best_alpha]
 rf_lap = models_lap[ix_best_alpha_lap]


### PR DESCRIPTION
This code:

* [x] Fixes some `fill_value` logic for the delaying
* [x] Cleans up the logic for delaying
* [x] Fixes / improves the logic for `Laplacian`, simultaneously making it easier in the future to do Laplacian of arbitrary neighbors (instead of just `grid_to_graph`)
* [x] Fixes a bug with TDR having to do with edge effects in the autocorrelation matrix terms.