### PR TITLE
WIP: Inverse-transform ReceptiveField

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,6 +53,8 @@ Changelog
 
     - Add ``background_color`` parameter to :meth:`mne.Evoked.plot_topo` and :func:`mne.viz.plot_evoked_topo` and improve axes rendering as done in :func:`mne.viz.plot_compare_evokeds` by `Alex Gramfort`_
 
+    - Add support for GDF files in :func:`mne.io.read_raw_edf` by `Nicolas Barascud`_
+
     - Add :func:`mne.io.find_edf_events` for getting the events as they are in the EDF/GDF header by `Jaakko Leppakangas`_
 
     - Speed up :meth:`mne.io.Raw.plot` and :meth:`mne.Epochs.plot` using (automatic) decimation based on low-passing with ``decim='auto'`` parameter by `Eric Larson`_ and `Jaakko Leppakangas`_
@@ -226,6 +228,8 @@ API
     - ``picks`` parameter in :func:`mne.beamformer.lcmv`, :func:`mne.beamformer.lcmv_epochs`, :func:`mne.beamformer.lcmv_raw`, :func:`mne.beamformer.tf_lcmv` and :func:`mne.beamformer.rap_music` is now deprecated and will be removed in 0.16, by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.
 
     - The keyword argument ``frequencies`` has been deprecated in favor of ``freqs`` in various time-frequency functions, e.g. :func:`mne.time_frequency.tfr.tfr_array_morlet`, by `Eric Larson`_
+
+    - Add ``patterns=False`` parameter in :class:`mne.decoding.ReceptiveField`. Turn on to compute inverse model coefficients.
 
 .. _changes_0_14:
 
@@ -2290,3 +2294,5 @@ of commits):
 .. _Stefan Repplinger: https://github.com/stfnrpplngr
 
 .. _Okba Bekhelifi: https://github.com/okbalefthanded
+
+.. _Nicolas Barascud: https://github.com/nbara

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -229,7 +229,7 @@ API
 
     - The keyword argument ``frequencies`` has been deprecated in favor of ``freqs`` in various time-frequency functions, e.g. :func:`mne.time_frequency.tfr.tfr_array_morlet`, by `Eric Larson`_
 
-    - Add ``patterns=False`` parameter in :class:`mne.decoding.ReceptiveField`. Turn on to compute inverse model coefficients.
+    - Add ``patterns=False`` parameter in :class:`mne.decoding.ReceptiveField`. Turn on to compute inverse model coefficients, by `Nicolas Barascud`_
 
 .. _changes_0_14:
 

--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -86,7 +86,7 @@ mne.viz.tight_layout()
 # --------------------------------------
 #
 # We will construct an encoding model to find the linear relationship between
-# the EEG signal and a time-delayed version of the speech envelope. This allows
+# a time-delayed version of the speech envelope and the EEG signal. This allows
 # us to make predictions about the response to new stimuli.
 
 # Define the delays that we will use in the receptive field
@@ -163,22 +163,23 @@ mne.viz.tight_layout()
 # Create and fit a stimulus reconstruction model
 # ----------------------------------------------
 #
-# We will now demonstrate another use case for the ReceptiveField module as we
-# try to predict the stimulus activity from the EEG data. This is known in the
-# literature as a decoding, or stimulus reconstruction model [1]_. A decoding
-# model aims to find the linear relationship between the speech signal and a
-# time-delayed version of the EEG. This can be useful as we exploit all of the
-# available neural data in a multivariate context, compared to the encoding
-# case which treats each M/EEG channel as an independent feature. Therefore,
-# decoding models might provide a better quality of fit, especially for low SNR
-# stimuli such as speech.
+# We will now demonstrate another use case for the for the
+# :class:`mne.decoding.ReceptiveField` class as we try to predict the stimulus
+# activity from the EEG data. This is known in the literature as a decoding, or
+# stimulus reconstruction model [1]_. A decoding model aims to find the
+# relationship between the speech signal and a time-delayed version of the EEG.
+# This can be useful as we exploit all of the available neural data in a
+# multivariate context, compared to the encoding case which treats each M/EEG
+# channel as an independent feature. Therefore, decoding models might provide a
+# better quality of fit (at the expense of not controlling for stimulus
+# covariance), especially for low SNR stimuli such as speech.
 
 # We use the same lags as in [1]
 tmin, tmax = -.2, 0.
 
 # Initialize the model. Here the features are the EEG data. We also specify
 # ``patterns=True`` to compute inverse-transformed coefficients during model
-# fitting (cf. next section). We'll use a ridge regression estimator with a
+# fitting (cf. next section). We'll use a ridge regression estimator with an
 # alpha value similar to [1].
 sr = ReceptiveField(tmin, tmax, sfreq, feature_names=raw.ch_names,
                     estimator=1e4, scoring='corrcoef', patterns=True)
@@ -233,7 +234,7 @@ mne.viz.tight_layout()
 #
 # Finally, we will look at how the decoding model coefficients are distributed
 # across the scalp. We will attempt to recreate `figure 5`_ from [1]_. The
-# backward model weights reflect the channels that contribute most toward
+# decoding model weights reflect the channels that contribute most toward
 # reconstructing the stimulus signal, but are not directly interpretable in a
 # neurophysiological sense. Here we also look at the coefficients obtained
 # via an inversion procedure [2]_, which have a more straightforward

--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -18,8 +18,8 @@ References
        A MATLAB Toolbox for Relating Neural Signals to Continuous Stimuli.
        Frontiers in Human Neuroscience 10, 604. doi:10.3389/fnhum.2016.00604
 
-.. [2] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
-       Blankertz, B., & Bießmann, F. (2014). On the interpretation of weight
+.. [2] Haufe, S., Meinecke, F., Goergen, K., Daehne, S., Haynes, J.-D.,
+       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
        96–110. doi:10.1016/j.neuroimage.2013.10.067
 
@@ -104,16 +104,16 @@ cv = KFold(n_splits)
 
 # Prepare model data (make time the first dimension)
 speech = speech.T
-EEG, _ = raw[:]  # Outputs for the model
-EEG = EEG.T
+Y, _ = raw[:]  # Outputs for the model
+Y = Y.T
 
 # Iterate through splits, fit the model, and predict/test on held-out data
 coefs = np.zeros((n_splits, n_channels, n_delays))
 scores = np.zeros((n_splits, n_channels))
 for ii, (train, test) in enumerate(cv.split(speech)):
     print('split %s / %s' % (ii + 1, n_splits))
-    rf.fit(speech[train], EEG[train])
-    scores[ii] = rf.score(speech[test], EEG[test])
+    rf.fit(speech[train], Y[train])
+    scores[ii] = rf.score(speech[test], Y[test])
     # coef_ is shape (n_outputs, n_features, n_delays). we only have 1 feature
     coefs[ii] = rf.coef_[:, 0, :]
 times = rf.delays_ / float(rf.sfreq)
@@ -192,8 +192,8 @@ patterns = coefs.copy()
 scores = np.zeros((n_splits,))
 for ii, (train, test) in enumerate(cv.split(speech)):
     print('split %s / %s' % (ii + 1, n_splits))
-    sr.fit(EEG[train], speech[train])
-    scores[ii] = sr.score(EEG[test], speech[test])[0]
+    sr.fit(Y[train], speech[train])
+    scores[ii] = sr.score(Y[test], speech[test])[0]
     # coef_ is shape (n_outputs, n_features, n_delays). we have 128 features
     coefs[ii] = sr.coef_[0, :, :]
     patterns[ii] = sr.patterns_[0, :, :]
@@ -212,7 +212,7 @@ max_patterns = np.abs(mean_patterns).max()
 # To get a sense of our model performance, we can plot the actual and predicted
 # stimulus envelopes side by side.
 
-y_pred = sr.predict(EEG[test])
+y_pred = sr.predict(Y[test])
 time = np.linspace(0, 2., 5 * int(sfreq))
 fig, ax = plt.subplots(figsize=(8, 4))
 ax.plot(time, speech[test][sr.valid_samples_][:int(5 * sfreq)],
@@ -228,10 +228,10 @@ mne.viz.tight_layout()
 #
 # Finally, we will look at how the linear coefficients (sometimes
 # referred to as beta values) are distributed across the scalp. We will
-# recreate `figure 5`_ from [1]_. The backward model weights reﬂect the
+# recreate `figure 5`_ from [1]_. The backward model weights reflect the
 # channels that contribute most toward reconstructing the stimulus signal, but
 # are not directly interpretable in a neurophysiological sense. Here we also
-# look at the inversed model weights, which are easier to understand [2]_
+# look at the inversed model weights, which are easier to understand [2]_.
 
 time_plot = (-.140, -.125)  # To average between two timepoints.
 ix_plot = np.arange(np.argmin(np.abs(time_plot[0] - times)),

--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -6,10 +6,10 @@ Receptive Field Estimation and Prediction
 This example reproduces figures from Lalor et al's mTRF toolbox in
 matlab [1]_. We will show how the :class:`mne.decoding.ReceptiveField` class
 can perform a similar function along with scikit-learn. We will first fit a
-linear encoding (or forward) model using the continuously-varying speech
-envelope to predict activity of a 128 channel EEG system. Then, we will take
-the reverse approach and try to predict the speech envelope from the EEG (known
-in the litterature as backward model, or stimulus reconstruction).
+linear encoding model using the continuously-varying speech envelope to predict
+activity of a 128 channel EEG system. Then, we will take the reverse approach
+and try to predict the speech envelope from the EEG (known in the litterature
+as a decoding model, or simply stimulus reconstruction).
 
 References
 ----------
@@ -21,7 +21,7 @@ References
 .. [2] Haufe, S., Meinecke, F., Goergen, K., Daehne, S., Haynes, J.-D.,
        Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
        vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
-       96–110. doi:10.1016/j.neuroimage.2013.10.067
+       96-110. doi:10.1016/j.neuroimage.2013.10.067
 
 .. _figure 1: http://journal.frontiersin.org/article/10.3389/fnhum.2016.00604/full#F1
 .. _figure 2: http://journal.frontiersin.org/article/10.3389/fnhum.2016.00604/full#F2
@@ -82,11 +82,11 @@ ax.set(title="Sample activity", xlabel="Time (s)")
 mne.viz.tight_layout()
 
 ###############################################################################
-# Create and fit a receptive field model (a.k.a. forward model)
-# -------------------------------------------------------------
+# Create and fit a receptive field model
+# --------------------------------------
 #
-# We will construct a model to find the linear relationship between the EEG
-# signal and a time-delayed version of the speech envelope. This allows
+# We will construct an encoding model to find the linear relationship between
+# the EEG signal and a time-delayed version of the speech envelope. This allows
 # us to make predictions about the response to new stimuli.
 
 # Define the delays that we will use in the receptive field
@@ -130,9 +130,9 @@ ax.axhline(0, ls='--', color='r')
 ax.set(title="Mean prediction score", xlabel="Channel", ylabel="Score ($r$)")
 mne.viz.tight_layout()
 
+###############################################################################
 # Investigate model coefficients
-# ------------------------------
-#
+# ==============================
 # Finally, we will look at how the linear coefficients (sometimes
 # referred to as beta values) are distributed across time delays as well as
 # across the scalp. We will recreate `figure 1`_ and `figure 2`_ from [1]_.
@@ -160,23 +160,26 @@ mne.viz.tight_layout()
 
 
 ###############################################################################
-# Create and fit a stimulus reconstruction model (a.k.a. backward model)
-# ----------------------------------------------------------------------
+# Create and fit a stimulus reconstruction model
+# ----------------------------------------------
 #
-# We will now construct a model to find the linear relationship between the
-# speech signal and a time-delayed version of the EEG. This can be advantageous
-# as we exploit all of the available neural data in a multivariate context,
-# compared to the forward case which treats each M/EEG channel as an
-# independent feature. Therefore, low SNR stimuli such as speech will likely
-# have better backward models.
+# We will now demonstrate another use case for the ReceptiveField module as we
+# try to predict the stimulus activity from the EEG data. This is known in the
+# literature as a decoding, or stimulus reconstruction model [1]_. A decoding
+# model aims to find the linear relationship between the speech signal and a
+# time-delayed version of the EEG. This can be useful as we exploit all of the
+# available neural data in a multivariate context, compared to the encoding
+# case which treats each M/EEG channel as an independent feature. Therefore,
+# decoding models might provide a better quality of fit, especially for low SNR
+# stimuli such as speech.
 
-# We use the same lags as in [1]_
+# We use the same lags as in [1]
 tmin, tmax = -.2, 0.
 
 # Initialize the model. Here the features are the EEG data. We also specify
-# ``patterns=True`` to compute forward-transformed coefficients during model
-# fitting (cf. next section). We'll use a Ridge regression estimator with a
-# alpha value as in [1]_.
+# ``patterns=True`` to compute inverse-transformed coefficients during model
+# fitting (cf. next section). We'll use a ridge regression estimator with a
+# alpha value similar to [1].
 sr = ReceptiveField(tmin, tmax, sfreq, feature_names=raw.ch_names,
                     estimator=1e4, scoring='corrcoef', patterns=True)
 # We'll have (tmax - tmin) * sfreq delays
@@ -194,7 +197,7 @@ for ii, (train, test) in enumerate(cv.split(speech)):
     print('split %s / %s' % (ii + 1, n_splits))
     sr.fit(Y[train], speech[train])
     scores[ii] = sr.score(Y[test], speech[test])[0]
-    # coef_ is shape (n_outputs, n_features, n_delays). we have 128 features
+    # coef_ is shape (n_outputs, n_features, n_delays). We have 128 features
     coefs[ii] = sr.coef_[0, :, :]
     patterns[ii] = sr.patterns_[0, :, :]
 times = sr.delays_ / float(sr.sfreq)
@@ -206,8 +209,9 @@ mean_scores = scores.mean(axis=0)
 max_coef = np.abs(mean_coefs).max()
 max_patterns = np.abs(mean_patterns).max()
 
+###############################################################################
 # Visualize stimulus reconstruction
-# ---------------------------------
+# =================================
 #
 # To get a sense of our model performance, we can plot the actual and predicted
 # stimulus envelopes side by side.
@@ -223,15 +227,18 @@ ax.set(title="Stimulus reconstruction")
 ax.set_xlabel('Time (s)')
 mne.viz.tight_layout()
 
+###############################################################################
 # Investigate model coefficients
-# ------------------------------
+# ==============================
 #
-# Finally, we will look at how the linear coefficients (sometimes
-# referred to as beta values) are distributed across the scalp. We will
-# recreate `figure 5`_ from [1]_. The backward model weights reflect the
-# channels that contribute most toward reconstructing the stimulus signal, but
-# are not directly interpretable in a neurophysiological sense. Here we also
-# look at the inversed model weights, which are easier to understand [2]_.
+# Finally, we will look at how the decoding model coefficients are distributed
+# across the scalp. We will attempt to recreate `figure 5`_ from [1]_. The
+# backward model weights reflect the channels that contribute most toward
+# reconstructing the stimulus signal, but are not directly interpretable in a
+# neurophysiological sense. Here we also look at the coefficients obtained
+# via an inversion procedure [2]_, which have a more straightforward
+# interpretation as their value (and sign) directly relates to the stimulus
+# signal's strength (and effect direction).
 
 time_plot = (-.140, -.125)  # To average between two timepoints.
 ix_plot = np.arange(np.argmin(np.abs(time_plot[0] - times)),
@@ -240,12 +247,14 @@ fig, ax = plt.subplots(1, 2)
 mne.viz.plot_topomap(np.mean(mean_coefs[:, ix_plot], axis=1),
                      pos=info, axes=ax[0], show=False,
                      vmin=-max_coef, vmax=max_coef)
-ax[0].set(title="Backward model coefficients")
+ax[0].set(title="Model coefficients\nbetween delays %s and %s"
+          % (time_plot[0], time_plot[1]))
 
 mne.viz.plot_topomap(np.mean(mean_patterns[:, ix_plot], axis=1),
                      pos=info, axes=ax[1],
                      show=False, vmin=-max_patterns, vmax=max_patterns)
-ax[1].set(title="Forward-transformed coefficients")
+ax[1].set(title="Inverse-transformed coefficients\nbetween delays %s and %s"
+          % (time_plot[0], time_plot[1]))
 mne.viz.tight_layout()
 
 plt.show()

--- a/examples/decoding/plot_receptive_field.py
+++ b/examples/decoding/plot_receptive_field.py
@@ -174,7 +174,11 @@ mne.viz.tight_layout()
 # better quality of fit (at the expense of not controlling for stimulus
 # covariance), especially for low SNR stimuli such as speech.
 
-# We use the same lags as in [1]
+# We use the same lags as in [1]. Negative lags now index the relationship
+# between the neural response and the speech envelope earlier in time, whereas
+# positive lags would index how a unit change in the amplitude of the EEG would
+# affect later stimulus activity (obviously this should have an amplitude of
+# zero).
 tmin, tmax = -.2, 0.
 
 # Initialize the model. Here the features are the EEG data. We also specify

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -213,18 +213,18 @@ class ReceptiveField(BaseEstimator):
             shape.insert(0, -1)
         self.coef_ = coef.reshape(shape)
 
+        # Inverse-transform model weights.
+        # inv_coef has shape = (n_feats * n_delays, n_outputs)
+        coef = np.reshape(self.coef_, (n_feats * n_delays, n_outputs))
         if not isinstance(self.estimator_, TimeDelayingRidge):
-            # inverse-transform model weights.
-            coef = np.reshape(self.coef_, (n_feats * n_delays, n_outputs))
-            # inv_coef is of shape = (n_feats * n_delays, n_outputs)
-            inv_coef = np.linalg.multi_dot([np.dot(X.T, X),
-                                            coef,
+            inv_coef = np.linalg.multi_dot([np.dot(X.T, X), coef,
                                             np.linalg.inv(np.dot(y.T, y))])
-            # Reshape coef back to (n_feats, n_delays, n_outputs)
-            self.inverse_coef_ = inv_coef.reshape(shape)
         else:
-            pass  # TODO
+            inv_coef = np.linalg.multi_dot([self.estimator_.x_xt_, coef,
+                                            np.linalg.inv(np.dot(y.T, y))])
 
+        # reshape to (n_feats, n_delays, n_outputs)
+        self.inverse_coef_ = inv_coef.reshape(shape)
         del X, y
 
         return self

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -18,9 +18,9 @@ from ..externals.six import string_types
 class ReceptiveField(BaseEstimator):
     """Fit a receptive field model.
 
-    This allows you to fit an encoding model (stimulus to brain) using
-    time-lagged input features. For example, a spectro- or spatio-temporal
-    receptive field (STRF).
+    This allows you to fit an encoding model (stimulus to brain) or a decoding
+    model (brain to stimulus) using time-lagged input features (for example, a
+    spectro- or spatio-temporal receptive field, or STRF).
 
     Parameters
     ----------

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -101,10 +101,10 @@ class ReceptiveField(BaseEstimator):
            enhance speech intelligibility. Nature Communications,
            7, 13654 (2016). doi:10.1038/ncomms13654
 
-    .. [5] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
-           Blankertz, B., & Bießmann, F. (2014). On the interpretation of
+    .. [5] Haufe, S., Meinecke, F., Goergen, K., Daehne, S., Haynes, J.-D.,
+           Blankertz, B., & Biessmann, F. (2014). On the interpretation of
            weight vectors of linear models in multivariate neuroimaging.
-           NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
+           NeuroImage, 87, 96-110. doi:10.1016/j.neuroimage.2013.10.067
     """
 
     def __init__(self, tmin, tmax, sfreq, feature_names=None, estimator=None,

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -49,8 +49,9 @@ class ReceptiveField(BaseEstimator):
         'r2' (coefficient of determination) or 'corrcoef' (the correlation
         coefficient).
     patterns : bool
-        If True, inverse coefficients will be computed upon fitting according
-        to the procedure described by Haufe et al. [5]_. Defaults to False.
+        If True, inverse coefficients will be computed upon fitting using the
+        covariance matrix of the inputs, and the cross-covariance of the
+        inputs/outputs, according to [5]_. Defaults to False.
 
     Attributes
     ----------
@@ -237,10 +238,11 @@ class ReceptiveField(BaseEstimator):
             del X
 
             # Inverse output covariance
-            inv_Y = 1. / float(n_times * n_epochs - 1)
             if y.ndim == 2 and y.shape[1] != 1:
                 y = y - y.mean(0, keepdims=True)
                 inv_Y = linalg.pinv(np.cov(y.T))
+            else:
+                inv_Y = 1. / float(n_times * n_epochs - 1)
             del y
 
             # Inverse coef according to Haufe's method

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -510,13 +510,6 @@ def test_inverse_coef():
         c1 = rf.patterns_.reshape(n_targets, n_feats * n_delays)
         assert_allclose(np.dot(c0, c1.T), np.eye(c0.shape[0]), atol=0.1)
 
-        # TODO this fails.
-        # Shouldn't we have rf.coef_ ~ inv_rf.patterns_ and vice versa ?
-        # assert_allclose(inv_rf.coef_, np.transpose(rf.patterns_, (1, 0, 2)),
-        #                 rtol=0.1)
-        # assert_allclose(rf.coef_, np.transpose(inv_rf.patterns_, (1, 0, 2)),
-        #                 atol=0.1)
-
     # Check that warnings are issued when no regularization is applied
     n_feats, n_targets, n_samples = 5, 60, 50
     X, y = make_data(n_feats, n_targets, n_samples, tmin, tmax)

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -80,7 +80,7 @@ def test_rank_deficiency():
     y += rng.randn(*y.shape) * 100
 
     for est in (Ridge(reg), reg):
-        rf = ReceptiveField(tmin, tmax, fs, estimator=est)
+        rf = ReceptiveField(tmin, tmax, fs, estimator=est, patterns=True)
         rf.fit(eeg, y)
         pred = rf.predict(eeg)
         assert_equal(y.shape, pred.shape)
@@ -171,7 +171,8 @@ def test_receptive_field():
 
     # Fit the model and test values
     feature_names = ['feature_%i' % ii for ii in [0, 1, 2]]
-    rf = ReceptiveField(tmin, tmax, 1, feature_names, estimator=mod)
+    rf = ReceptiveField(tmin, tmax, 1, feature_names, estimator=mod,
+                        patterns=True)
     rf.fit(X, y)
     assert_array_equal(rf.delays_, np.arange(tmin, tmax + 1))
 
@@ -197,26 +198,26 @@ def test_receptive_field():
     assert_raises(ValueError, rf.fit, X, y[:-2])
     # Float becomes ridge
     rf = ReceptiveField(tmin, tmax, 1, ['one', 'two', 'three'],
-                        estimator=0)
+                        estimator=0, patterns=True)
     str(rf)  # repr works before fit
     rf.fit(X, y)
     assert_true(isinstance(rf.estimator_, TimeDelayingRidge))
     str(rf)  # repr works after fit
-    rf = ReceptiveField(tmin, tmax, 1, ['one'], estimator=0)
+    rf = ReceptiveField(tmin, tmax, 1, ['one'], estimator=0, patterns=True)
     rf.fit(X[:, [0]], y)
     str(rf)  # repr with one feature
     # Should only accept estimators or floats
-    rf = ReceptiveField(tmin, tmax, 1, estimator='foo')
+    rf = ReceptiveField(tmin, tmax, 1, estimator='foo', patterns=True)
     assert_raises(ValueError, rf.fit, X, y)
     rf = ReceptiveField(tmin, tmax, 1, estimator=np.array([1, 2, 3]))
     assert_raises(ValueError, rf.fit, X, y)
     # tmin must be <= tmax
-    rf = ReceptiveField(5, 4, 1)
+    rf = ReceptiveField(5, 4, 1, patterns=True)
     assert_raises(ValueError, rf.fit, X, y)
     # scorers
     for key, val in _SCORERS.items():
         rf = ReceptiveField(tmin, tmax, 1, ['one'],
-                            estimator=0, scoring=key)
+                            estimator=0, scoring=key, patterns=True)
         rf.fit(X[:, [0]], y)
         y_pred = rf.predict(X[:, [0]]).T.ravel()[:, np.newaxis]
         assert_allclose(val(y[:, np.newaxis], y_pred),
@@ -469,6 +470,7 @@ def test_receptive_field_nd():
         assert_true(score > 0.6, msg=score)
 
 
+@requires_version('sklearn', '0.17')
 def test_inverse_coef():
     """Test inverse coefficients computation."""
     from sklearn.linear_model import Ridge
@@ -487,13 +489,15 @@ def test_inverse_coef():
         y = np.dot(X_del, w)
         return X, y
 
-    # Check coefficient dims
+    # Check coefficient dims, for all estimator types
     X, y = make_data(n_feats, n_targets, n_samples, tmin, tmax)
     tdr = TimeDelayingRidge(tmin, tmax, 1., 0.1, 'laplacian')
     for estimator in (0., 0.01, Ridge(alpha=0.), tdr):
-        rf = ReceptiveField(tmin, tmax, 1., estimator=estimator)
+        rf = ReceptiveField(tmin, tmax, 1., estimator=estimator,
+                            patterns=True)
         rf.fit(X, y)
-        inv_rf = ReceptiveField(tmin, tmax, 1., estimator=estimator)
+        inv_rf = ReceptiveField(tmin, tmax, 1., estimator=estimator,
+                                patterns=True)
         inv_rf.fit(y, X)
 
         assert_array_equal(rf.coef_.shape, rf.patterns_.shape,
@@ -506,14 +510,18 @@ def test_inverse_coef():
         c1 = rf.patterns_.reshape(n_targets, n_feats * n_delays)
         assert_allclose(np.dot(c0, c1.T), np.eye(c0.shape[0]), atol=0.1)
 
-        # we should have rf.coef_ ~ inv_rf.patterns_ and vice versa
-        # TODO
+        # TODO this fails.
+        # Shouldn't we have rf.coef_ ~ inv_rf.patterns_ and vice versa ?
+        # assert_allclose(inv_rf.coef_, np.transpose(rf.patterns_, (1, 0, 2)),
+        #                 rtol=0.1)
+        # assert_allclose(rf.coef_, np.transpose(inv_rf.patterns_, (1, 0, 2)),
+        #                 atol=0.1)
 
     # Check that warnings are issued when no regularization is applied
     n_feats, n_targets, n_samples = 5, 60, 50
     X, y = make_data(n_feats, n_targets, n_samples, tmin, tmax)
     for estimator in (0., Ridge(alpha=0.)):
-        rf = ReceptiveField(tmin, tmax, 1., estimator=estimator)
+        rf = ReceptiveField(tmin, tmax, 1., estimator=estimator, patterns=True)
         with warnings.catch_warnings(record=True) as w:
             rf.fit(y, X)
             assert_equal(len(w), 1)

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -299,8 +299,8 @@ class TimeDelayingRidge(BaseEstimator):
             y = y - y_offset
         else:
             X_offset = y_offset = 0.
-        self.x_xt_, x_y_, n_ch_x = _compute_corrs(X, y, self._smin, self._smax)
-        self.coef_ = _fit_corrs(self.x_xt_, x_y_, n_ch_x,
+        self.cov_, x_y_, n_ch_x = _compute_corrs(X, y, self._smin, self._smax)
+        self.coef_ = _fit_corrs(self.cov_, x_y_, n_ch_x,
                                 self.reg_type, self.alpha, n_ch_x)
         # This is the sklearn formula from LinearModel (will be 0. for no fit)
         if self.fit_intercept:

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -299,8 +299,8 @@ class TimeDelayingRidge(BaseEstimator):
             y = y - y_offset
         else:
             X_offset = y_offset = 0.
-        x_xt, x_y, n_ch_x = _compute_corrs(X, y, self._smin, self._smax)
-        self.coef_ = _fit_corrs(x_xt, x_y, n_ch_x,
+        self.x_xt_, x_y_, n_ch_x = _compute_corrs(X, y, self._smin, self._smax)
+        self.coef_ = _fit_corrs(self.x_xt_, x_y_, n_ch_x,
                                 self.reg_type, self.alpha, n_ch_x)
         # This is the sklearn formula from LinearModel (will be 0. for no fit)
         if self.fit_intercept:


### PR DESCRIPTION
This is an attempt to implement inverse coefficient computation according to [1], which has been discussed in #3884 . This is mostly useful to visualise weights for backward models (aka stimulus reconstruction).

ATM the computation is done in `ReceptiveField.fit()`, so I had to expose the data covariance `x_xt_` in `TimeDelayingRidge()`. I can compute the inverse coefficients directly inside TDR if you prefer.

These are specific points where your input would be appreciated:
- [x] proper unit tests. I was thinking to compute a forward model, and compare the coefficients to an inverse-transformed backward model, but do we have any idea how close these two sets of coefficient should be numerically?
- [x] API compatibility with the decoding framework in MNE (cf https://github.com/mne-tools/mne-python/issues/3884#issuecomment-328371598). Since the inverse coefs are computed by default here, is it just a matter of renaming `inverse_coefs_ ` to `patterns_` ?
- [x] Do I need to handle intercept explicitly before the final dot product?
- [x] Update example

Thanks in advance.


[1] | Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D., Blankertz, B., & Bießmann, F. (2014). On the interpretation of weight vectors of linear models in multivariate neuroimaging. NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067