### PR TITLE
MRG: compatibility with bagging classifiers

### DIFF
--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -82,7 +82,12 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         estimators = parallel(
             p_func(self.base_estimator, split, y, **fit_params)
             for split in np.array_split(X, n_jobs, axis=-1))
-        self.estimators_ = np.concatenate(estimators, 0)
+        self.estimators_ = np.empty(X.shape[-1], dtype=object)
+        idx = 0
+        for job_estimators in estimators:
+            for est in job_estimators:
+                self.estimators_[idx] = est
+                idx += 1
         return self
 
     def fit_transform(self, X, y, **fit_params):

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -82,6 +82,10 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         estimators = parallel(
             p_func(self.base_estimator, split, y, **fit_params)
             for split in np.array_split(X, n_jobs, axis=-1))
+
+        # Each parallel job can have a different number of training estimators
+        # We can't directly concatenate them because of sklearn's Bagging API
+        # (see scikit-learn #9720)
         self.estimators_ = np.empty(X.shape[-1], dtype=object)
         idx = 0
         for job_estimators in estimators:

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -142,9 +142,11 @@ def test_search_light():
 
     # Bagging classifiers
     X = np.random.rand(10, 3, 4)
-    pipe = SlidingEstimator(BaggingClassifier(None, 2))
-    pipe.fit(X, y)
-    pipe.score(X, y)
+    for n_jobs in (1, 2):
+        pipe = SlidingEstimator(BaggingClassifier(None, 2), n_jobs=n_jobs)
+        pipe.fit(X, y)
+        pipe.score(X, y)
+        assert_true(isinstance(pipe.estimators_[0], BaggingClassifier))
 
 
 @requires_sklearn_0_15

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -28,6 +28,7 @@ def test_search_light():
     from sklearn.linear_model import Ridge, LogisticRegression
     from sklearn.pipeline import make_pipeline
     from sklearn.metrics import roc_auc_score, make_scorer
+    from sklearn.ensemble import BaggingClassifier
 
     X, y = make_data()
     n_epochs, _, n_time = X.shape
@@ -138,6 +139,12 @@ def test_search_light():
         features_shape = pipe.estimators_[0].steps[0][1].features_shape_
         assert_array_equal(features_shape, [3, 4])
     assert_array_equal(y_preds[0], y_preds[1])
+
+    # Bagging classifiers
+    X = np.random.rand(10, 3, 4)
+    pipe = SlidingEstimator(BaggingClassifier(None, 2))
+    pipe.fit(X, y)
+    pipe.score(X, y)
 
 
 @requires_sklearn_0_15


### PR DESCRIPTION
Fix bug when using ensemble estimators with `SlidingEstimator` or `GeneralizingEstimator` caused by sklearn internal inconsistency, https://github.com/scikit-learn/scikit-learn/issues/9720