### PR TITLE
Fix morphing to original subject when two vertices map to the same target vertex

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -168,6 +168,8 @@ BUG
 
     - Fix bug in :func:`mne.io.read_raw_brainvision`, changed default to read coordinate information if available and added test, by `Jesper Duemose Nielsen`_
 
+    - Fix bug in :meth:`mne.SourceEstimate.to_original_src` where morphing failed if two vertices map to the same target vertex, by `Marijn van Vliet`_
+
 API
 ~~~
     - Add ``skip_by_annotation`` to :meth:`mne.io.Raw.filter` to process data concatenated with e.g. :func:`mne.concatenate_raws` separately. This parameter will default to the old behavior (treating all data as a single block) in 0.15 but will change to ``skip_by_annotation='edge'``, which will separately filter the concatenated chunks separately, in 0.16. This should help prevent potential problems with filter-induced ringing in concatenated files, by `Eric Larson`_

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2518,8 +2518,12 @@ def _get_vertex_map_nn(fro_src, subject_from, subject_to, hemi, subjects_dir,
     regs = [op.join(subjects_dir, s, 'surf', '%s.sphere.reg' % hemi)
             for s in (subject_from, subject_to)]
     reg_fro, reg_to = [read_surface(r, return_dict=True)[-1] for r in regs]
-    if to_neighbor_tri is None:
-        to_neighbor_tri = _triangle_neighbors(reg_to['tris'], reg_to['np'])
+    if to_neighbor_tri is not None:
+        reg_to['neighbor_tri'] = to_neighbor_tri
+    if 'neighbor_tri' not in reg_to:
+        reg_to['neighbor_tri'] = _triangle_neighbors(reg_to['tris'],
+                                                     reg_to['np'])
+
     morph_inuse = np.zeros(len(reg_to['rr']), bool)
     best = np.zeros(fro_src['np'], int)
     ones = _compute_nearest(reg_to['rr'], reg_fro['rr'][fro_src['vertno']])
@@ -2564,9 +2568,9 @@ def morph_source_spaces(src_from, subject_to, surf='white', subject_from=None,
     subject_from : str | None
         The "from" subject. For most source spaces this shouldn't need
         to be provided, since it is stored in the source space itself.
-    subjects_dir : string, or None
+    subjects_dir : str | None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
+    verbose : bool | str | int | None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
 

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -660,6 +660,14 @@ def test_morphed_source_space_return():
                        stc_morph_morph.data[:, 0])[0, 1]
     assert_true(corr > 0.99, corr)
 
+    # Explicitly test having two vertices map to the same target vertex. We
+    # simulate this by having two vertices be at the same position.
+    src_fs2 = src_fs.copy()
+    vert1, vert2 = src_fs2[0]['vertno'][:2]
+    src_fs2[0]['rr'][vert1] = src_fs2[0]['rr'][vert2]
+    stc_morph_return = stc_morph.to_original_src(
+        src_fs2, subjects_dir=subjects_dir)
+
     # Degenerate cases
     stc_morph.subject = None  # no .subject provided
     assert_raises(ValueError, stc_morph.to_original_src,


### PR DESCRIPTION
This doesn't happen often. In fact, it happens so rarely we hadn't noticed yet some of the logic was broken. This PR adds a test and fixes the logic.