### PR TITLE
MRG: Fix permutations without replacement

### DIFF
--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -127,6 +127,7 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
     std0 = np.sqrt(X2 - mu0 ** 2) * dof_scaling  # get std with var splitting
     T_obs = np.mean(X, axis=0) / (std0 / sqrt(n_samples))
 
+    # XXX Someday this should be refactored with the cluster code
     if do_exact:
         perms = bin_perm_rep(n_samples, a=1, b=-1)[1:, :]
     else:
@@ -148,8 +149,6 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
         p_values = 1.0 - np.searchsorted(H0, -T_obs) / scaling
 
     return T_obs, p_values, H0
-
-permutation_t_test.__test__ = False  # for nosetests
 
 
 def _bootstrap_ci(arr, ci=.95, n_bootstraps=2000, statfun='mean',

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -84,7 +84,7 @@ def test_cache_dir():
             del os.environ['MNE_MEMMAP_MIN_SIZE']
 
 
-def test_perumation_large_n_samples():
+def test_permutation_large_n_samples():
     """Test that non-replacement works with large N."""
     X = np.random.RandomState(0).randn(72, 1) + 1
     for n_samples in (11, 72):

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -84,6 +84,18 @@ def test_cache_dir():
             del os.environ['MNE_MEMMAP_MIN_SIZE']
 
 
+def test_perumation_large_n_samples():
+    """Test that non-replacement works with large N."""
+    X = np.random.RandomState(0).randn(72, 1) + 1
+    for n_samples in (11, 72):
+        tails = (0, 1) if n_samples <= 20 else (0,)
+        for tail in tails:
+            H0 = permutation_cluster_1samp_test(
+                X[:n_samples], threshold=1e-4, tail=tail)[-1]
+            assert H0.shape == (1024,)
+            assert len(np.unique(H0)) >= 1024 - (H0 == 0).sum()
+
+
 def test_permutation_step_down_p():
     """Test cluster level permutations with step_down_p."""
     try:


### PR DESCRIPTION
In practice the prevention of collisions is probably a bit overkill, but this should ensure we sample without replacement. But even in the intermediate range `20 < n_samples < 64` the `rng.choice` call was a bit rough on memory usage, so this fixes that, too.

Closes #4551.

@nbara can you see if it fixes your problem?