### PR TITLE
MRG: Allow complex TFR output

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -104,6 +104,8 @@ def test_time_frequency():
                                       output="complex", average=False,
                                       return_itc=False)
     epochs_power_2 = abs(epochs_power_complex)
+    epochs_power_3 = epochs_power_2.copy()
+    epochs_power_3.data[:] = np.inf  # test that it's actually copied
     assert_array_almost_equal(epochs_power_2.data, epochs_power_picks.data)
     power_2 = epochs_power_2.average()
     assert_array_almost_equal(power_2.data, power.data)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -95,6 +95,18 @@ def test_time_frequency():
     assert_array_almost_equal(power.data, power_picks_avg.data)
     assert_array_almost_equal(itc.data, itc_picks.data)
     assert_array_almost_equal(power.data, power_evoked.data)
+    # complex output
+    assert_raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
+                  return_itc=False, average=True, output="complex")
+    assert_raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
+                  output="complex", average=False, return_itc=True)
+    epochs_power_complex = tfr_morlet(epochs, freqs, n_cycles,
+                                      output="complex", average=False,
+                                      return_itc=False)
+    epochs_power_2 = abs(epochs_power_complex)
+    assert_array_almost_equal(epochs_power_2.data, epochs_power_picks.data)
+    power_2 = epochs_power_2.average()
+    assert_array_almost_equal(power_2.data, power.data)
 
     print(itc)  # test repr
     print(itc.ch_names)  # test property

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1542,6 +1542,7 @@ class EpochsTFR(_BaseTFR):
         return "<EpochsTFR  |  %s>" % s
 
     def __abs__(self):
+        """Take the absolute value."""
         return EpochsTFR(info=self.info.copy(), data=np.abs(self.data),
                          times=self.times.copy(), freqs=self.freqs.copy(),
                          method=self.method, comment=self.comment)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1542,9 +1542,9 @@ class EpochsTFR(_BaseTFR):
         return "<EpochsTFR  |  %s>" % s
 
     def __abs__(self):
-        out = self.copy()
-        np.abs(out.data, out=out.data)
-        return out
+        return EpochsTFR(info=self.info.copy(), data=np.abs(self.data),
+                         times=self.times.copy(), freqs=self.freqs.copy(),
+                         method=self.method, comment=self.comment)
 
     def copy(self):
         """Give a copy of the EpochsTFR.
@@ -1554,10 +1554,9 @@ class EpochsTFR(_BaseTFR):
         tfr : instance of EpochsTFR
             The copy.
         """
-        out = EpochsTFR(info=self.info.copy(), data=self.data.copy(),
-                        times=self.times.copy(), freqs=self.freqs.copy(),
-                        method=self.method, comment=self.comment)
-        return out
+        return EpochsTFR(info=self.info.copy(), data=self.data.copy(),
+                         times=self.times.copy(), freqs=self.freqs.copy(),
+                         method=self.method, comment=self.comment)
 
     def average(self):
         """Average the data across epochs.


### PR DESCRIPTION
This allows for `EpochsTFR` to contain the (linear) complex outputs from `tfr_morlet`, like you can get from `tfr_array_morlet`. Eventually this could be useful for putting through an inverse, for example. In the meantime this incremental change is ready for review/merge from my end.