### PR TITLE
Fix issue with complex eigenspectrum in LCMV

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -50,6 +50,19 @@ def _reg_pinv(x, reg):
     return linalg.pinv(x), d
 
 
+def _eig_inv(x, signalspace):
+    """Compute a pseudoinverse with smallest component set to zero."""
+    U, s, V = linalg.svd(x)
+
+    # pseudoinverse is computed by setting eigenvalues not included in
+    # signalspace to zero
+    s_inv = np.zeros(s.shape)
+    s_inv[signalspace] = 1 / s[signalspace]
+
+    x_inv = np.dot(V.T, np.dot(np.diag(s_inv), U.T))
+    return x_inv
+
+
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):
     """Return good channels common to forward model and covariance matrices."""
     # get a list of all channel names:

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -182,6 +182,8 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     reduce_rank : bool | int
         If specified, the rank of the leadfield will be reduced. True will
         reduce the rank by 1. The rank can also be specified as integer.
+        Setting reduce_rank to True is typically necessary if you use a single
+        sphere model for MEG.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -256,7 +258,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     # leadfield rank and optional rank reduction
     if reduce_rank is not False:
         if not pick_ori == 'max-power':
-            raise NotImplementedError('The computation of a rank reduced'
+            raise NotImplementedError('The computation of a rank reduced '
                                       'leadfield with reduce_rank is not yet '
                                       'implemented with free or fixed '
                                       'orientation of the forward solution.')
@@ -715,6 +717,8 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     reduce_rank : bool | int
         If specified, the rank of the leadfield will be reduced. True will
         reduce the rank by 1. The rank can also be specified as integer.
+        Setting reduce_rank to True is typically necessary if you use a single
+        sphere model for MEG.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -821,6 +825,8 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     reduce_rank : bool | int
         If specified, the rank of the leadfield will be reduced. True will
         reduce the rank by 1. The rank can also be specified as integer.
+        Setting reduce_rank to True is typically necessary if you use a single
+        sphere model for MEG.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -932,6 +938,8 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     reduce_rank : bool | int
         If specified, the rank of the leadfield will be reduced. True will
         reduce the rank by 1. The rank can also be specified as integer.
+        Setting reduce_rank to True is typically necessary if you use a single
+        sphere model for MEG.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -140,8 +140,8 @@ def _check_cov_matrix(data_cov):
 
 @verbose
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
-              pick_ori=None, rank=None,
-              weight_norm='unit-noise-gain', verbose=None):
+              pick_ori=None, rank=None, weight_norm='unit-noise-gain',
+              reduce_rank=False, verbose=None):
     """Compute LCMV spatial filter.
 
     Parameters
@@ -179,6 +179,9 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
         if 'nai', the Neural Activity Index [1]_ will be computed,
         if None, the unit-gain LCMV beamformer [2]_ will be computed.
+    reduce_rank : bool | int
+        If specified, the rank of the leadfield will be reduced. True will
+        reduce the rank by 1. The rank can also be specified as integer.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -250,8 +253,21 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
 
     del Cm
 
-    # detect leadfield rank on first voxel for now
-    rank_G = estimate_rank(G[:, 0:3], tol='auto')
+    # leadfield rank and optional rank reduction
+    if reduce_rank is not False:
+        if not pick_ori == 'max-power':
+            raise NotImplementedError('Leadfield rank reduction is not yet '
+                                      'implemented with free or fixed '
+                                      'orientation.')
+        if isinstance(reduce_rank, int):
+            rank_G = reduce_rank
+        else:
+            rank_G = estimate_rank(G[:, 0:3], tol='auto') - 1
+
+        if rank_G <= 0:
+            raise ValueError('Cannot reduce rank of leadfield to %i.' % rank_G)
+    else:
+        rank_G = estimate_rank(G[:, 0:3], tol='auto')
 
     # Compute spatial filters
     W = np.dot(G.T, Cm_inv)
@@ -278,12 +294,16 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
                     eig_vals, eig_vecs = linalg.eig(np.dot(linalg.inv(tmp),
                                                     np.dot(Wk, Gk)))
                 else:
-                    # use pseudo inverse computation setting smalles component
+                    # use pseudo inverse computation setting smallest component
                     # to zero if the leadfield is not full rank
                     eig_vals, eig_vecs = linalg.eig(np.dot(
                                                     _eig_inv(tmp,
                                                              range(rank_G)),
                                                     np.dot(Wk, Gk)))
+
+                if np.iscomplex(eig_vecs).any():
+                    raise ValueError('The eigenspectrum of the leadfield at '
+                                     'this voxel is complex.')
 
                 idx_max = eig_vals.argmax()
                 max_ori = eig_vecs[:, idx_max]
@@ -638,7 +658,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='abs',
 @verbose
 def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
          pick_ori=None, picks=None, rank=None, weight_norm='unit-noise-gain',
-         max_ori_out='abs', verbose=None):
+         max_ori_out='abs', reduce_rank=False, verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer.
 
     Compute Linearly Constrained Minimum Variance (LCMV) beamformer
@@ -690,6 +710,9 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
         if 'signed', the signed source space time series will be returned.
         'abs' is deprecated and will be removed in 0.16. Set max_ori_out to
         'signed' to remove this warning.
+    reduce_rank : bool | int
+        If specified, the rank of the leadfield will be reduced. True will
+        reduce the rank by 1. The rank can also be specified as integer.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -725,7 +748,8 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
     # construct spatial filter
     filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
-                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
+                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm,
+                        reduce_rank=reduce_rank)
 
     # apply spatial filter to evoked data
     stc = apply_lcmv(evoked=evoked, filters=filters, max_ori_out=max_ori_out)
@@ -737,7 +761,7 @@ def lcmv(evoked, forward, noise_cov=None, data_cov=None, reg=0.05, label=None,
 def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
                 pick_ori=None, return_generator=False, picks=None, rank=None,
                 weight_norm='unit-noise-gain', max_ori_out='abs',
-                verbose=None):
+                reduce_rank=False, verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer.
 
     Compute Linearly Constrained Minimum Variance (LCMV) beamformer
@@ -792,6 +816,9 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
         if 'signed', the signed source space time series will be returned.
         'abs' is deprecated and will be removed in 0.16. Set max_ori_out to
         'signed' to remove this warning.
+    reduce_rank : bool | int
+        If specified, the rank of the leadfield will be reduced. True will
+        reduce the rank by 1. The rank can also be specified as integer.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -827,7 +854,8 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
     # construct spatial filter
     filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
-                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
+                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm,
+                        reduce_rank=reduce_rank)
 
     # apply spatial filter to epochs
     stcs = apply_lcmv_epochs(epochs=epochs, filters=filters,
@@ -840,7 +868,8 @@ def lcmv_epochs(epochs, forward, noise_cov, data_cov, reg=0.05, label=None,
 @verbose
 def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
              start=None, stop=None, picks=None, pick_ori=None, rank=None,
-             weight_norm='unit-noise-gain', max_ori_out='abs', verbose=None):
+             weight_norm='unit-noise-gain', max_ori_out='abs',
+             reduce_rank=False, verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer.
 
     Compute Linearly Constrained Minimum Variance (LCMV) beamformer
@@ -898,6 +927,9 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
         if 'signed', the signed source space time series will be returned.
         'abs' is deprecated and will be removed in 0.16. Set max_ori_out to
         'signed' to remove this warning.
+    reduce_rank : bool | int
+        If specified, the rank of the leadfield will be reduced. True will
+        reduce the rank by 1. The rank can also be specified as integer.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -933,7 +965,8 @@ def lcmv_raw(raw, forward, noise_cov, data_cov, reg=0.05, label=None,
     # construct spatial filter
     filters = make_lcmv(info=info, forward=forward, data_cov=data_cov,
                         reg=reg, noise_cov=noise_cov, label=label,
-                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm)
+                        pick_ori=pick_ori, rank=rank, weight_norm=weight_norm,
+                        reduce_rank=reduce_rank)
 
     # apply spatial filter to epochs
     stc = apply_lcmv_raw(raw=raw, filters=filters, start=start, stop=stop,

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -259,10 +259,10 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
             raise NotImplementedError('Leadfield rank reduction is not yet '
                                       'implemented with free or fixed '
                                       'orientation.')
-        if isinstance(reduce_rank, int):
-            rank_G = reduce_rank
-        else:
+        if isinstance(reduce_rank, bool):
             rank_G = estimate_rank(G[:, 0:3], tol='auto') - 1
+        else:
+            rank_G = reduce_rank
 
         if rank_G <= 0:
             raise ValueError('Cannot reduce rank of leadfield to %i.' % rank_G)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -13,7 +13,7 @@ from mne import compute_covariance
 from mne.datasets import testing
 from mne.beamformer import (make_lcmv, apply_lcmv, apply_lcmv_raw, lcmv,
                             lcmv_epochs, lcmv_raw, tf_lcmv)
-from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv
+from mne.beamformer._lcmv import _lcmv_source_power, _reg_pinv, _eig_inv
 from mne.externals.six import advance_iterator
 from mne.utils import run_tests_if_main
 
@@ -172,6 +172,29 @@ def test_lcmv():
                                   np.concatenate(stc_max_power.data))
         assert_almost_equal(pearsoncorr[0, 1], 1.)
 
+    # Test sphere head model with unit-noise gain beamformer and orientation
+    # selection and rank reduction of the leadfield
+    sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.080)
+    src = mne.setup_volume_source_space(subject=None, pos=15., mri=None,
+                                        sphere=(0.0, 0.0, 0.0, 80.0),
+                                        bem=None, mindist=5.0, exclude=2.0)
+
+    fwd_sphere = mne.make_forward_solution(evoked.info, trans=None, src=src,
+                                           bem=sphere, eeg=False, meg=True)
+
+    stc_sphere = lcmv(evoked, fwd_sphere, noise_cov, data_cov, reg=0.1,
+                      weight_norm='unit-noise-gain', pick_ori="max-power",
+                      reduce_rank=2)
+    stc_sphere.crop(0.02, None)
+
+    stc_pow = np.sum(np.abs(stc_sphere.data), axis=1)
+    idx = np.argmax(stc_pow)
+    max_stc = stc_sphere.data[idx]
+    tmax = stc_sphere.times[np.argmax(max_stc)]
+
+    assert_true(0.08 < tmax < 0.11, tmax)
+    assert_true(0.4 < np.max(max_stc) < 2., np.max(max_stc))
+
     # Test if fixed forward operator is detected when picking normal or
     # max-power orientation
     assert_raises(ValueError, lcmv, evoked, forward_fixed, noise_cov, data_cov,
@@ -227,6 +250,15 @@ def test_lcmv():
     raw_proj.del_proj()
     assert_raises(ValueError, apply_lcmv_raw, raw_proj, filters,
                   max_ori_out='signed')
+
+    # Test if setting reduce_rank to True returns an error with not-yet-
+    # implemented orientation selections
+    assert_raises(NotImplementedError, lcmv, evoked, forward_vol, noise_cov,
+                  data_cov, pick_ori=None, weight_norm='nai', reduce_rank=True,
+                  max_ori_out='signed')
+    assert_raises(NotImplementedError, lcmv, evoked, forward_surf_ori,
+                  noise_cov, data_cov, pick_ori='normal', weight_norm='nai',
+                  reduce_rank=True, max_ori_out='signed')
 
     # Now test single trial using fixed orientation forward solution
     # so we can compare it to the evoked solution
@@ -464,6 +496,18 @@ def test_reg_pinv():
     with warnings.catch_warnings(record=True) as w:
         _reg_pinv(a, reg=0.)
     assert_true(any('deficient' in str(ww.message) for ww in w))
+
+
+def test_eig_inv():
+    """Test matrix pseudoinversion with setting smallest eigenvalue to zero."""
+    # create rank-deficient array
+    a = np.array([[1., 0., 1.], [0., 1., 0.], [1., 0., 1.]])
+
+    # test inversion
+    a_inv = np.linalg.pinv(a)
+    a_inv_eig = _eig_inv(a, 2)
+
+    assert_almost_equal(a_inv, a_inv_eig)
 
 
 run_tests_if_main()


### PR DESCRIPTION
This fixes the issue with complex eigenvalues when computing the orientation selection in LCMV with spherical head models, see https://github.com/mne-tools/mne-python/pull/4506 
Furthermore, it allows to reduce the rank of the leadfield (so far only for the scalar beamformer). 

To Do: 
- [ ] tests

ping @agramfort @sarangnemo @dengemann 
