### PR TITLE
MRG: Error about rank-deficient inputs in Xdawn

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -170,7 +170,7 @@ BUG
 
     - Fix bug in :meth:`mne.SourceEstimate.to_original_src` where morphing failed if two vertices map to the same target vertex, by `Marijn van Vliet`_
 
-    - Fix :class:`mne.preprocessing.Xdawn` to handle rank deficiency and handle transforming :class:`mne.Evoked`, by `Eric Larson`_
+    - Fix :class:`mne.preprocessing.Xdawn` to give verbose error messages about rank deficiency and handle transforming :class:`mne.Evoked`, by `Eric Larson`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -170,6 +170,8 @@ BUG
 
     - Fix bug in :meth:`mne.SourceEstimate.to_original_src` where morphing failed if two vertices map to the same target vertex, by `Marijn van Vliet`_
 
+    - Fix :class:`mne.preprocessing.Xdawn` to handle rank deficiency and handle transforming :class:`mne.Evoked`, by `Eric Larson`_
+
 API
 ~~~
     - Add ``skip_by_annotation`` to :meth:`mne.io.Raw.filter` to process data concatenated with e.g. :func:`mne.concatenate_raws` separately. This parameter will default to the old behavior (treating all data as a single block) in 0.15 but will change to ``skip_by_annotation='edge'``, which will separately filter the concatenated chunks separately, in 0.16. This should help prevent potential problems with filter-induced ringing in concatenated files, by `Eric Larson`_

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -157,7 +157,9 @@ def test_xdawn_regularization():
     assert_raises(ValueError, xd.fit, epochs)
     # With rank-deficient input
     epochs.set_eeg_reference(['EEG 001'])
-    xd = Xdawn(correct_overlap=False)
+    xd = Xdawn(correct_overlap=False, reg=None)
+    assert_raises(ValueError, xd.fit, epochs)
+    xd = Xdawn(correct_overlap=False, reg=0.5)
     xd.fit(epochs)
 
 

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -104,10 +104,13 @@ def test_xdawn_apply_transform():
     # Apply on other thing should raise an error
     assert_raises(ValueError, xd.apply, 42)
 
-    # Transform on epochs
+    # Transform on Epochs
     xd.transform(epochs)
+    # Transform on Evoked
+    xd.transform(epochs.average())
     # Transform on ndarray
     xd.transform(epochs._data)
+    xd.transform(epochs._data[0])
     # Transform on someting else
     assert_raises(ValueError, xd.transform, 42)
 
@@ -152,6 +155,10 @@ def test_xdawn_regularization():
     xd = Xdawn(n_components=2, correct_overlap=False,
                signal_cov=np.eye(len(picks)), reg=2)
     assert_raises(ValueError, xd.fit, epochs)
+    # With rank-deficient input
+    epochs.set_eeg_reference(['EEG 001'])
+    xd = Xdawn(correct_overlap=False)
+    xd.fit(epochs)
 
 
 @requires_sklearn

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -178,9 +178,9 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
         # Fit spatial filters
         try:
             evals, evecs = linalg.eigh(evo_cov, signal_cov)
-        except linalg.LinAlgError:  # rank-deficient inputs
-            evals, evecs = linalg.eig(evo_cov, signal_cov)
-            evals = evals.real
+        except np.linalg.LinAlgError as exp:
+            raise ValueError('Could not compute eigenvalues, ensure '
+                             'proper regularization (%s)' % (exp,))
         evecs = evecs[:, np.argsort(evals)[::-1]]  # sort eigenvectors
         evecs /= np.apply_along_axis(np.linalg.norm, 0, evecs)
         _patterns = np.linalg.pinv(evecs.T)

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -176,7 +176,11 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
         evo_cov = np.matrix(_regularized_covariance(evo, reg))
 
         # Fit spatial filters
-        evals, evecs = linalg.eigh(evo_cov, signal_cov)
+        try:
+            evals, evecs = linalg.eigh(evo_cov, signal_cov)
+        except linalg.LinAlgError:  # rank-deficient inputs
+            evals, evecs = linalg.eig(evo_cov, signal_cov)
+            evals = evals.real
         evecs = evecs[:, np.argsort(evals)[::-1]]  # sort eigenvectors
         evecs /= np.apply_along_axis(np.linalg.norm, 0, evecs)
         _patterns = np.linalg.pinv(evecs.T)
@@ -461,23 +465,27 @@ class Xdawn(_XdawnTransformer):
             self.evokeds_[eid] = evoked
         return self
 
-    def transform(self, epochs):
+    def transform(self, inst):
         """Apply Xdawn dim reduction.
 
         Parameters
         ----------
-        epochs : Epochs | ndarray, shape (n_epochs, n_channels, n_times)
+        inst : Epochs | Evoked | ndarray, shape ([n_epochs, ]n_channels, n_times)
             Data on which Xdawn filters will be applied.
 
         Returns
         -------
-        X : ndarray, shape (n_epochs, n_components * n_event_types, n_times)
+        X : ndarray, shape ([n_epochs, ]n_components * n_event_types, n_times)
             Spatially filtered signals.
-        """
-        if isinstance(epochs, BaseEpochs):
-            X = epochs.get_data()
-        elif isinstance(epochs, np.ndarray):
-            X = epochs
+        """  # noqa: E501
+        if isinstance(inst, BaseEpochs):
+            X = inst.get_data()
+        elif isinstance(inst, Evoked):
+            X = inst.data
+        elif isinstance(inst, np.ndarray):
+            X = inst
+            if X.ndim not in (2, 3):
+                raise ValueError('X must be 2D or 3D, got %s' % (X.ndim,))
         else:
             raise ValueError('Data input must be of Epoch type or numpy array')
 
@@ -485,7 +493,9 @@ class Xdawn(_XdawnTransformer):
                    for filt in itervalues(self.filters_)]
         filters = np.concatenate(filters, axis=0)
         X = np.dot(filters, X)
-        return X.transpose((1, 0, 2))
+        if X.ndim == 3:
+            X = X.transpose((1, 0, 2))
+        return X
 
     def apply(self, inst, event_id=None, include=None, exclude=None):
         """Remove selected components from the signal.


### PR DESCRIPTION
I hit a case where `proj` broke `Xdawn`. This should make it work for positive semidefinite instead of only positive definite matrices. 