### PR TITLE
MRG: Use environment.yml in CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,18 @@ matrix:
 
         # Full (Linux, 2.7)
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
+          env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=0
         - os: linux
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
+          env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=1
 
         # OSX
         - os: osx
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
+          env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=0
         - os: osx
-          env: CONDA_DEPENDENCIES="numpy scipy matplotlib pandas scikit-learn h5py pillow statsmodels mayavi nose pytest pytest-cov"
-               PIP_DEPENDENCIES="git+git://github.com/nipy/PySurfer.git nitime faulthandler joblib nibabel codecov pytest-sugar pytest-faulthandler"
+          env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=1
 
         # Py3k + non-default stim channel
@@ -79,6 +75,9 @@ matrix:
 before_install:
     - git clone https://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
+    - if [ ! -z $CONDA_ENVIRONMENT ]; then
+        pip uninstall --yes mne;
+      fi;
     # Don't source mne_setup_sh here because changing PATH etc. can't be done in a script
     - if [ "${DEPS}" == "" ]; then
         export MNE_ROOT="${PWD}/minimal_cmds";

--- a/doc/manual/channel_interpolation.rst
+++ b/doc/manual/channel_interpolation.rst
@@ -58,7 +58,7 @@ where :math:`G_{ds} \in R^{M \times N}` computes :math:`g_{m}(\boldsymbol{r_i}, 
 
 To interpolate bad channels, one can simply do:
 
-	>>> evoked.interpolate_bads(reset_bads=False)
+	>>> evoked.interpolate_bads(reset_bads=False)  # doctest: +SKIP
 
 and the bad channel will be fixed
 

--- a/doc/manual/cookbook.rst
+++ b/doc/manual/cookbook.rst
@@ -48,7 +48,7 @@ Sometimes some MEG or EEG channels are not functioning properly
 for various reasons. These channels should be excluded from
 analysis by marking them bad as::
 
-    >>> raw.info['bads'] = ['MEG2443']
+    >>> raw.info['bads'] = ['MEG2443']  # doctest: +SKIP
 
 Especially if a channel does not show
 a signal at all (flat) it is important to exclude it from the
@@ -122,17 +122,17 @@ Epoching of raw data is done using events, which define a ``t=0`` for your
 data chunks. Event times stamped to the acquisition software can be extracted
 using :func:`mne.find_events`::
 
-    >>> events = mne.find_events(raw)
+    >>> events = mne.find_events(raw)  # doctest: +SKIP
 
 The ``events`` array can then be modified, extended, or changed if necessary.
 If the original trigger codes and trigger times are correct for the analysis
 of interest, :class:`mne.Epochs` for the first event type (``1``) can be
 constructed using::
 
-    >>> reject = dict(grad=4000e-13, mag=4e-12, eog=150e-6)
-    >>> epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.5,
-    >>>                     proj=True, picks=picks, baseline=(None, 0),
-    >>>                     preload=True, reject=reject)
+    >>> reject = dict(grad=4000e-13, mag=4e-12, eog=150e-6)  # doctest: +SKIP
+    >>> epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.5,  # doctest: +SKIP
+    >>>                     proj=True, picks=picks, baseline=(None, 0),  # doctest: +SKIP
+    >>>                     preload=True, reject=reject)  # doctest: +SKIP
 
 .. note:: The rejection thresholds (set with argument ``reject``) are defined
           in T / m for gradiometers, T for magnetometers and V for EEG and EOG
@@ -151,7 +151,7 @@ information.
 Once the :class:`mne.Epochs` are constructed, they can be averaged to obtain
 :class:`mne.Evoked` data as::
 
-    >>> evoked = epochs.average()
+    >>> evoked = epochs.average()  # doctest: +SKIP
 
 
 Source localization
@@ -210,8 +210,8 @@ has been completed as described in :ref:`CHDBBCEJ`.
 For example, to create the reconstruction geometry for ``subject='sample'``
 with a ~5-mm spacing between the grid points, say::
 
-    >>> src = setup_source_space('sample', spacing='oct6')
-    >>> write_source_spaces('sample-oct6-src.fif', src)
+    >>> src = setup_source_space('sample', spacing='oct6')  # doctest: +SKIP
+    >>> write_source_spaces('sample-oct6-src.fif', src)  # doctest: +SKIP
 
 This creates the source spaces and writes them to disk.
 
@@ -259,8 +259,8 @@ Setting up the boundary-element model
 This stage sets up the subject-dependent data for computing
 the forward solutions:"
 
-    >>> model = make_bem_model('sample')
-    >>> write_bem_surfaces('sample-5120-5120-5120-bem.fif', model)
+    >>> model = make_bem_model('sample')  # doctest: +SKIP
+    >>> write_bem_surfaces('sample-5120-5120-5120-bem.fif', model)  # doctest: +SKIP
 
 Where ``surfaces`` is a list of BEM surfaces that have each been read using
 :func:`mne.read_surface`. This step also checks that the input surfaces
@@ -290,8 +290,8 @@ segmentation.
 Using this model, the BEM solution can be computed using
 :func:`mne.make_bem_solution` as::
 
-    >>> bem_sol = make_bem_solution(model)
-    >>> write_bem_solution('sample-5120-5120-5120-bem-sol.fif', bem_sol)
+    >>> bem_sol = make_bem_solution(model)  # doctest: +SKIP
+    >>> write_bem_solution('sample-5120-5120-5120-bem-sol.fif', bem_sol)  # doctest: +SKIP
 
 After the BEM is set up it is advisable to check that the
 BEM model meshes are correctly positioned using *e.g.*
@@ -344,7 +344,7 @@ potentials at the measurement sensors and electrodes due to dipole
 sources located on the cortex, can be calculated with help of
 :func:`mne.make_forward_solution` as::
 
-    >>> fwd = make_forward_solution(raw.info, fname_trans, src, bem_sol)
+    >>> fwd = make_forward_solution(raw.info, fname_trans, src, bem_sol)  # doctest: +SKIP
 
 .. _BABDEEEB:
 
@@ -365,14 +365,14 @@ ways:
   This is the recommended approach for evoked responses, *e.g.* using
   :func:`mne.compute_covariance`::
 
-      >>> cov = mne.compute_covariance(epochs, method='auto')
+      >>> cov = mne.compute_covariance(epochs, method='auto')  # doctest: +SKIP
 
 - Employ empty room data (collected without the subject) to
   calculate the full noise covariance matrix. This is recommended
   for analyzing ongoing spontaneous activity. This can be done using
   :func:`mne.compute_raw_covariance` as::
 
-      >>> cov = mne.compute_raw_covariance(raw_erm)
+      >>> cov = mne.compute_raw_covariance(raw_erm)  # doctest: +SKIP
 
 - Employ a section of continuous raw data collected in the presence
   of the subject to calculate the full noise covariance matrix. This
@@ -402,7 +402,7 @@ please consult :ref:`CBBDJFBJ`.
 This computation stage can be done by using
 :func:`mne.minimum_norm.make_inverse_operator` as::
 
-    >>> inv = mne.minimum_norm.make_inverse_operator(raw.info, fwd, cov, loose=0.2)
+    >>> inv = mne.minimum_norm.make_inverse_operator(raw.info, fwd, cov, loose=0.2)  # doctest: +SKIP
 
 Creating source estimates
 -------------------------
@@ -411,11 +411,11 @@ Once all the preprocessing steps described above have been
 completed, the inverse operator computed can be applied to the MEG
 and EEG data as::
 
-    >>> stc = mne.minimum_norm.apply_inverse(evoked, inv, lambda2=1. / 9.)
+    >>> stc = mne.minimum_norm.apply_inverse(evoked, inv, lambda2=1. / 9.)  # doctest: +SKIP
 
 And the results can be viewed as::
 
-    >>> stc.plot()
+    >>> stc.plot()  # doctest: +SKIP
 
 The interactive analysis tool :ref:`mne_analyze` can also
 be used to explore the data and to produce quantitative analysis
@@ -428,6 +428,6 @@ Group analyses
 Group analysis is facilitated by morphing source estimates, which can be
 done *e.g.*, to ``subject='fsaverage'`` as::
 
-    >>> stc_fsaverage = stc.morph('fsaverage')
+    >>> stc_fsaverage = stc.morph('fsaverage')  # doctest: +SKIP
 
 See :ref:`ch_morph` for more information.

--- a/doc/manual/decoding.rst
+++ b/doc/manual/decoding.rst
@@ -115,8 +115,8 @@ The columns of the matrix :math:`(W^{-1})^T` are called spatial patterns. This i
 
 Plotting a pattern is as simple as doing::
 
-    >>> info = epochs.info
-    >>> model.plot_patterns(info)  # model is an instantiation of an estimator described in this section
+    >>> info = epochs.info  # doctest: +SKIP
+    >>> model.plot_patterns(info)  # model is an instantiation of an estimator described in this section  # doctest: +SKIP
 
 .. image:: ../../_images/sphx_glr_plot_linear_model_patterns_001.png
    :align: center
@@ -124,7 +124,7 @@ Plotting a pattern is as simple as doing::
 
 To plot the corresponding filter, you can do::
 
-    >>> model.plot_filters(info)
+    >>> model.plot_filters(info)  # doctest: +SKIP
 
 .. image:: ../../_images/sphx_glr_plot_linear_model_patterns_002.png
    :align: center

--- a/doc/manual/preprocessing/ssp.rst
+++ b/doc/manual/preprocessing/ssp.rst
@@ -167,12 +167,12 @@ Adding/removing projectors
 
 To explicitly add a ``proj``, use ``add_proj``. For example::
 
-    >>> projs = mne.read_proj('proj_a.fif')
-    >>> evoked.add_proj(projs)
+    >>> projs = mne.read_proj('proj_a.fif')  # doctest: +SKIP
+    >>> evoked.add_proj(projs)  # doctest: +SKIP
 
 If projectors are already present in the raw `fif` file, it will be added to the ``info`` dictionary automatically. To remove existing projectors, you can do::
 
-	>>> evoked.add_proj([], remove_existing=True)
+	>>> evoked.add_proj([], remove_existing=True)  # doctest: +SKIP
 
 Applying projectors
 -------------------
@@ -181,7 +181,7 @@ Projectors can be applied at any stage of the pipeline. When the ``raw`` data is
 
 To apply explicitly projs at any stage of the pipeline, use ``apply_proj``. For example::
 
-	>>> evoked.apply_proj()
+	>>> evoked.apply_proj()  # doctest: +SKIP
 
 The projectors might not be applied if data are not :ref:`preloaded <memory>`. In this case, it's the ``_projector`` attribute that indicates if a projector will be applied when the data is loaded in memory. If the data is already in memory, then the projectors applied to it are the ones marked as `active`. As soon as you've applied the projectors, it will stay active in the remaining pipeline.
 

--- a/doc/manual/sample_dataset.rst
+++ b/doc/manual/sample_dataset.rst
@@ -65,7 +65,7 @@ Setting up
 
 The sample dataset can be downloaded automatically by doing::
 
-    >>> mne.datasets.sample.data_path(verbose=True)
+    >>> mne.datasets.sample.data_path(verbose=True)  # doctest: +SKIP
 
 Contents of the data set
 ########################

--- a/doc/tutorials/report.rst
+++ b/doc/tutorials/report.rst
@@ -48,14 +48,14 @@ To properly render `trans` and `covariance` files, add the measurement informati
 
 .. code-block:: bash
 
-    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \ 
+    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \
           --subject sample --subjects-dir MNE-sample-data/subjects --verbose
 
 To render whitened `evoked` files with baseline correction, add the noise covariance file:
-    
+
 .. code-block:: bash
 
-    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \ 
+    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \
           --cov MNE-sample-data/MEG/sample/sample_audvis-cov.fif --bmax 0 --subject sample \
           --subjects-dir MNE-sample-data/subjects --verbose
 
@@ -63,7 +63,7 @@ To generate the report in parallel:
 
 .. code-block:: bash
 
-    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \ 
+    $ mne report --path MNE-sample-data/ --info MNE-sample-data/MEG/sample/sample_audvis-ave.fif \
           --subject sample --subjects-dir MNE-sample-data/subjects --verbose --jobs 6
 
 The report rendered on sample-data is shown below:
@@ -121,12 +121,12 @@ Save the report as an html, but do not open the html in a browser::
     >>> report.save('report.html', overwrite=True, open_browser=False) # doctest:+SKIP
     Rendering : Table of Contents...
 
-There is greater flexibility compared to the command line interface. 
+There is greater flexibility compared to the command line interface.
 Custom plots can be added to the report. Let us first generate a custom plot::
 
     >>> from mne import read_evokeds
     >>> fname = path + '/MEG/sample/sample_audvis-ave.fif'
-    >>> evoked = read_evokeds(fname, condition='Left Auditory', baseline=(None, 0), verbose=True) # doctest:+ELLIPSIS
+    >>> evoked = read_evokeds(fname, condition='Left Auditory', baseline=(None, 0), verbose=True)  # doctest: +ELLIPSIS
     Reading ...
         Read a total of 4 projection items:
             PCA-v1 (1 x 102) active
@@ -138,7 +138,7 @@ Custom plots can be added to the report. Let us first generate a custom plot::
             0 CTF compensation matrices available
             nave = 55 - aspect type = 100
     Projections have already been applied. Setting proj attribute to True.
-    Applying baseline correction ... (mode: mean)
+    Applying baseline correction (mode: mean)
     >>> fig = evoked.plot() # doctest: +SKIP
 
 To add the custom plot to the report, do::
@@ -148,8 +148,8 @@ To add the custom plot to the report, do::
     Rendering : Table of Contents...
 
 The MNE report command internally manages the sections so that plots belonging to the same section
-are rendered consecutively. Within a section, the plots are ordered in the same order that they were 
-added using the `add_figs_to_section` command. Each section is identified by a toggle button in the navigation 
+are rendered consecutively. Within a section, the plots are ordered in the same order that they were
+added using the `add_figs_to_section` command. Each section is identified by a toggle button in the navigation
 bar of the report which can be used to show or hide the contents of the section.
 
 That's it!

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,33 @@
+name: mne
+channels:
+- defaults
+dependencies:
+- numpy
+- scipy
+- matplotlib
+- pandas
+- scikit-learn
+- h5py
+- pillow
+- statsmodels
+- mayavi
+- nose
+- pytest
+- pytest-cov
+- sphinx
+- wxpython
+- faulthandler
+- joblib
+- psutil
+- numpydoc
+- pip:
+  - mne
+  - pysurfer
+  - nitime
+  - nibabel
+  - nilearn
+  - neo
+  - pytest-sugar
+  - pytest-faulthandler
+  - sphinx_bootstrap_theme
+  - git+https://github.com/sphinx-gallery/sphinx-gallery.git

--- a/mne/datasets/hf_sef/hf_sef.py
+++ b/mne/datasets/hf_sef/hf_sef.py
@@ -13,7 +13,7 @@ from ..utils import _get_path, logger, _do_path_update
 
 @verbose
 def data_path(dataset='evoked', path=None, force_update=False,
-              update_path=None, verbose=None):
+              update_path=True, verbose=None):
     u"""Get path to local copy of the high frequency SEF dataset.
 
     Gets a local copy of the high frequency SEF MEG dataset [1]_.


### PR DESCRIPTION
This should be nearly equivalent to what we already do, just with fewer lines and using an `environment.yml` file. This moves us toward more easily testing things like #4523 when we think Py3k might actually be ready for primetime.