### PR TITLE
Bug corrections for EGI MFF recordings with no events.

### DIFF
--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -71,7 +71,8 @@ def _read_mff_header(filepath):
     info_filepath = filepath + "/" + "info.xml"  # add with filepath
     tags = ['mffVersion', 'recordTime']
     version_and_date = _extract(tags, filepath=info_filepath)
-    summaryinfo.update(version=version_and_date['mffVersion'][0],
+    version = version_and_date['mffVersion'][0] if len(version_and_date['mffVersion']) else ""
+    summaryinfo.update(version=version,
                        date=version_and_date['recordTime'][0],
                        n_samples=n_samples, n_trials=n_trials,
                        chan_type=chan_type, chan_unit=chan_unit,
@@ -298,6 +299,9 @@ class RawMff(BaseRaw):
         else:
             # No events
             self.event_id = None
+            self._new_trigger = None
+            event_codes = []
+            
         info = _empty_info(egi_info['sfreq'])
         info['buffer_size_sec'] = 1.  # reasonable default
         my_time = datetime.datetime(

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -49,7 +49,11 @@ def _read_mff_events(filename, sfreq):
         orig[xml_type] = _parse_xml(xml_file)
     xml_files = orig.keys()
     xml_events = [x for x in xml_files if x[:7] == 'Events_']
-    start_time = _ns2py_time(orig['info'][1]['recordTime'])
+    
+    for item in orig['info']:
+        if 'recordTime' in item:
+            start_time = _ns2py_time(item['recordTime'])
+            break
     markers = []
     code = []
     for xml in xml_events:


### PR DESCRIPTION
Reading EGI MFF files containing no events was crashing, this pull request fix that. Also, in my recordings the field "mffVersion" is absent which also makes the reader crash. Here is what my "info.xml" files look like 
```
<fileInfo>
   <recordTime>2011-10-25T18:15:18.746000000+01:00</recordTime>  
   <movieDelta>152000000</movieDelta>
   <ampSerialNumber>A08130122</ampSerialNumber>
   <ampFirmwareVersion>FW(0/11), HW(2/0)  (Maj/Min)</ampFirmwareVersion>
</fileInfo>
```
As can be seen, no field "mffVersion" are available there. Thus, I this patch takes into consideration that the field version_and_date['mffVersion'] can in some cases be an empty list. 