### PR TITLE
VIZ, ENH: plot_compare_evokeds sensor legend

### DIFF
--- a/examples/visualization/plot_channel_epochs_image.py
+++ b/examples/visualization/plot_channel_epochs_image.py
@@ -9,7 +9,7 @@ potential / field (ERP/ERF) image.
 2 images are produced. One with a good channel and one with a channel
 that does not see any evoked field.
 
-It is also demonstrated how to reorder the epochs using a 1d spectral
+It is also demonstrated how to reorder the epochs using a 1D spectral
 embedding as described in:
 
 Graph-based variability estimation in single-trial event-related neural

--- a/examples/visualization/plot_roi_erpimage_by_rt.py
+++ b/examples/visualization/plot_roi_erpimage_by_rt.py
@@ -6,7 +6,8 @@ Plot single trial activity, grouped by ROI and sorted by RT
 This will produce what is sometimes called an event related
 potential / field (ERP/ERF) image.
 
-The EEGLAB example file is read in and response times are calculated.
+The EEGLAB example file - containing an experiment with button press responses
+to simple visual stimuli - is read in and response times are calculated.
 ROIs are determined by the channel types (in 10/20 channel notation,
 even channels are right, odd are left, and 'z' are central). The
 median and the Global Field Power within each channel group is calculated,

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -699,7 +699,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
 
     # Duplicate points cause all kinds of trouble during visualization
     dist = pdist(locs3d)
-    if np.min(dist) < 1e-10 and not ignore_overlap:
+    if len(locs3d) > 1 and np.min(dist) < 1e-10 and not ignore_overlap:
         problematic_electrodes = [
             chs[elec_i]['ch_name']
             for elec_i in squareform(dist < 1e-10).any(axis=0).nonzero()[0]

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1496,16 +1496,13 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
     invert_y : bool
         If True, negative values are plotted up (as is sometimes done
         for ERPs out of tradition). Defaults to False.
-    show_sensors: None|  bool | int | float | tuple
+    show_sensors: bool | int | None
         If not False, channel locations are plotted on a small head circle.
-        If an int > 1, the position of the axes (forwarded to
+        If an int, the position of the axes (forwarded to
         ``mpl_toolkits.axes_grid1.inset_locator.inset_axes``).
-        If a float, the size of the legend relative to the axes.
-        If a tuple, must be one integer and one float, and will be interpreted
-        as (loc, size).
         If None, defaults to True if ``gfp`` is False, else to False.
     show_legend : bool | int
-        If not False, show a legend If an int > 1, the position of the axes
+        If not False, show a legend. If int, the position of the axes
         (forwarded to ``mpl_toolkits.axes_grid1.inset_locator.inset_axes``).
     axes : None | `matplotlib.axes.Axes` instance | list of `axes`
         What axes to plot to. If None, a new axes is created.
@@ -1789,20 +1786,19 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
             pos, outlines = _check_outlines(
                     pos, np.array([1, 1]), {'center': (0, 0),
                                  'scale': (0.5, 0.5)})
-            try:
-                loc, size = show_sensors
-            except (ValueError, TypeError):  # duck type iterable of len 2
-                if not isinstance(show_sensors, (np.int, np.float)):
-                    raise TypeError("`show_sensors` must be numeric or of ",
-                                     "length 2, not" + str(type(show_sensors)))
-                loc = show_sensors if int(show_sensors) > 1 else 2
-                size = .2 if isinstance(show_sensors, int) else show_sensors
-            _plot_legend(pos, ["k" for _ in picks], axes, [], outlines, loc,
-                         size=size * 100)
+            if not isinstance(show_sensors, (np.int, bool)):
+                raise TypeError("`show_sensors` must be numeric or of ",
+                                 "length 2, not" + str(type(show_sensors)))
+            if show_sensors is True:
+                show_sensors = 2
+            _plot_legend(pos, ["k" for _ in picks], axes, list(), outlines,
+                         show_sensors, size=20)
 
     if show_legend and len(conditions) > 1:
-        loc = show_legend if int(show_legend) > 1 else 1
-        axes.legend(loc='best', ncol=1 + (len(conditions) // 5), frameon=True)
+        if show_legend is True:
+            show_legend = 'best'
+        axes.legend(loc=show_legend, ncol=1 + (len(conditions) // 5),
+                    frameon=True)
 
     plt_show(show)
     return fig

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -166,13 +166,8 @@ def _plot_legend(pos, colors, axis, bads, outlines, loc, size=30):
     ratio = bbox.width / bbox.height
     ax = inset_axes(axis, width=str(size / ratio) + '%',
                     height=str(size) + '%', loc=loc)
-#    if not show_bads:
-#            not_in_bads = [x for x in range(len(pos)) if x not in bads]
-#            colors = np.array(colors[not_in_bads])
-#            pos = pos[not_in_bads]
     pos_x, pos_y = _prepare_topomap(pos, ax)
     ax.scatter(pos_x, pos_y, color=colors, s=size * .8, marker='.', zorder=1)
-#    if bads and show_bads:
     if bads:
         bads = np.array(bads)
         ax.scatter(pos_x[bads], pos_y[bads], s=size / 6, marker='.', color='w',

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1480,9 +1480,11 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
         it must take as its single argument an array (observations x times) and
         return the upper and lower confidence bands.
         If None, no confidence band is plotted.
-    truncate_yaxis : bool
-        If True, the left y axis is truncated to half the max absolute value
-        and rounded to .25 to reduce visual clutter. Defaults to False.
+    truncate_yaxis : bool | str
+        If True, the left y axis spine is truncated to reduce visual clutter.
+        If 'max_ticks', the spine is truncated at the minimum and maximum
+        ticks. Else, it is truncated to half the max absolute value, rounded to
+        .25. Defaults to False.
     truncate_xaxis : bool
         If True, the x axis is truncated to span from the first to the last.
         xtick. Defaults to True.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1779,20 +1779,26 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
                      truncate_xaxis)
 
     if show_sensors:
-        pos = _auto_topomap_coords(example.info, picks, ignore_overlap=True,
-                                   to_sphere=True)
-        pos, outlines = _check_outlines(
-                pos, np.array([1, 1]), {'center': (0, 0), 'scale': (0.5, 0.5)})
         try:
-            loc, size = show_sensors
-        except (ValueError, TypeError):  # duck type iterable of len 2
-            if not isinstance(show_sensors, (np.int, np.float)):
-                raise TypeError("`show_sensors` must be a tuple of length 2",
-                                 "or numeric, not" + str(type(show_sensors)))
-            loc = show_sensors if int(show_sensors) > 1 else 2
-            size = .2 if isinstance(show_sensors, int) else show_sensors
-        _plot_legend(pos, ["k" for _ in picks], axes, [], outlines, loc,
-                     size=size * 100)
+            pos = _auto_topomap_coords(example.info, picks,
+                                       ignore_overlap=True, to_sphere=True)
+        except ValueError:
+            warn("Cannot find channel coordinates in the supplied Evokeds. "
+                 "Not showing channel locations.")
+        else:
+            pos, outlines = _check_outlines(
+                    pos, np.array([1, 1]), {'center': (0, 0),
+                                 'scale': (0.5, 0.5)})
+            try:
+                loc, size = show_sensors
+            except (ValueError, TypeError):  # duck type iterable of len 2
+                if not isinstance(show_sensors, (np.int, np.float)):
+                    raise TypeError("`show_sensors` must be numeric or of ",
+                                     "length 2, not" + str(type(show_sensors)))
+                loc = show_sensors if int(show_sensors) > 1 else 2
+                size = .2 if isinstance(show_sensors, int) else show_sensors
+            _plot_legend(pos, ["k" for _ in picks], axes, [], outlines, loc,
+                         size=size * 100)
 
     if show_legend and len(conditions) > 1:
         loc = show_legend if int(show_legend) > 1 else 1

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1401,6 +1401,8 @@ def _truncate_yaxis(axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
         ymin_bound, ymax_bound = ticks[[1, -2]]
         if ymin_bound > 0:
             ymin_bound = 0
+        ymin_bound = ymin if ymin is not None else ymin_bound
+        ymax_bound = ymax if ymax is not None else ymax_bound
     axes.spines['left'].set_bounds(ymin_bound, ymax_bound)
     return ymin_bound, ymax_bound
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1384,7 +1384,8 @@ def _truncate_yaxis(axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
             ymax_ = ymax
         yticks = (ymin_ if any_negative else 0, ymax_ if any_positive else 0)
         axes.set_yticks(yticks)
-        ymin_bound, ymax_bound = (-(abs_lims // fraction), abs_lims // fraction)
+        ymin_bound, ymax_bound = (-(abs_lims // fraction),
+                                  abs_lims // fraction)
         # user supplied ymin and ymax still overwrite everything
         if ymin is not None and ymin > ymin_bound:
             ymin_bound = ymin
@@ -1778,15 +1779,14 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
             warn("Cannot find channel coordinates in the supplied Evokeds. "
                  "Not showing channel locations.")
         else:
-            pos, outlines = _check_outlines(
-                    pos, np.array([1, 1]), {'center': (0, 0),
-                                 'scale': (0.5, 0.5)})
+            head_pos = {'center': (0, 0), 'scale': (0.5, 0.5)}
+            pos, outlines = _check_outlines(pos, np.array([1, 1]), head_pos)
             if not isinstance(show_sensors, (np.int, bool)):
                 raise TypeError("`show_sensors` must be numeric or bool, not" +
                                 str(type(show_sensors)))
             if show_sensors is True:
                 show_sensors = 2
-            _plot_legend(pos, ["k" for _ in picks], axes, list(), outlines,
+            _plot_legend(pos, ["k" for pick in picks], axes, list(), outlines,
                          show_sensors, size=20)
 
     if show_legend and len(conditions) > 1:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1782,8 +1782,8 @@ def plot_compare_evokeds(evokeds, picks=list(), gfp=False, colors=None,
                     pos, np.array([1, 1]), {'center': (0, 0),
                                  'scale': (0.5, 0.5)})
             if not isinstance(show_sensors, (np.int, bool)):
-                raise TypeError("`show_sensors` must be numeric or of ",
-                                 "length 2, not" + str(type(show_sensors)))
+                raise TypeError("`show_sensors` must be numeric or bool, not" +
+                                str(type(show_sensors)))
             if show_sensors is True:
                 show_sensors = 2
             _plot_legend(pos, ["k" for _ in picks], axes, list(), outlines,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -212,7 +212,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     psd_args = dict() if psd_args is None else psd_args
     topomap_args = dict() if topomap_args is None else topomap_args
     image_args = dict() if image_args is None else image_args
-    image_args["ts_args"] = dict(truncate_xaxis=False)
+    image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
     for d in (psd_args, topomap_args, image_args):
         if not isinstance(d, dict):
             raise ValueError('topomap_args, image_args and psd_args have to be'

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -150,11 +150,13 @@ def test_plot_epochs_image():
     epochs.plot_image(group_by={"1": [1, 2], "2": [1, 2]}, combine='mean')
     epochs.plot_image(vmin=lambda x: x.min())
     assert_raises(ValueError, epochs.plot_image, axes=1, fig=2)
+    ts_args = dict(show_sensors=False)
     with warnings.catch_warnings(record=True) as w:
-        epochs.plot_image(overlay_times=[1.1], combine="gfp")
-        assert_raises(ValueError, epochs.plot_image, combine='error')
+        epochs.plot_image(overlay_times=[1.1], combine="gfp", ts_args=ts_args)
+        assert_raises(ValueError, epochs.plot_image, combine='error',
+                      ts_args=ts_args)
         warnings.simplefilter('always')
-    assert_equal(len(w), 5)
+    assert_equal(len(w), 4)
 
     plt.close('all')
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -154,7 +154,7 @@ def test_plot_epochs_image():
         epochs.plot_image(overlay_times=[1.1], combine="gfp")
         assert_raises(ValueError, epochs.plot_image, combine='error')
         warnings.simplefilter('always')
-    assert_equal(len(w), 4)
+    assert_equal(len(w), 5)
 
     plt.close('all')
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -168,7 +168,8 @@ def test_plot_evoked():
         contrast["red/stim"] = red
         contrast["blue/stim"] = blue
         plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],
-                             ylim=dict(mag=(1, 10)), ci=_parametric_ci)
+                             ylim=dict(mag=(1, 10)), ci=_parametric_ci,
+                             truncate_yaxis='max_ticks')
 
         # Hack to test plotting of maxfiltered data
         evoked_sss = evoked.copy()

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -147,7 +147,8 @@ def test_plot_evoked():
         plot_compare_evokeds(contrast, colors=colors, linestyles=linestyles,
                              picks=[0, 2], vlines=[.01, -.04], invert_y=True,
                              truncate_yaxis=False, ylim=dict(mag=(-10, 10)),
-                             styles={"red/stim": {"linewidth": 1}})
+                             styles={"red/stim": {"linewidth": 1}},
+                             show_sensors=(1, .1))
         assert_raises(ValueError, plot_compare_evokeds,
                       contrast, picks='str')  # bad picks: not int
         assert_raises(ValueError, plot_compare_evokeds, evoked, picks=3,
@@ -162,6 +163,8 @@ def test_plot_evoked():
                       gfp=True)  # no single-channel GFP
         assert_raises(TypeError, plot_compare_evokeds, evoked, picks=3,
                       ci='fake')  # ci must be float or None
+        assert_raises(TypeError, plot_compare_evokeds, evoked, picks=3,
+                      show_sensors='a')  # ci must be float or None
         contrast["red/stim"] = red
         contrast["blue/stim"] = blue
         plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -164,7 +164,7 @@ def test_plot_evoked():
         assert_raises(TypeError, plot_compare_evokeds, evoked, picks=3,
                       ci='fake')  # ci must be float or None
         assert_raises(TypeError, plot_compare_evokeds, evoked, picks=3,
-                      show_sensors='a')  # ci must be float or None
+                      show_sensors='a')  # show_sensors must be int or bool
         contrast["red/stim"] = red
         contrast["blue/stim"] = blue
         plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -148,7 +148,7 @@ def test_plot_evoked():
                              picks=[0, 2], vlines=[.01, -.04], invert_y=True,
                              truncate_yaxis=False, ylim=dict(mag=(-10, 10)),
                              styles={"red/stim": {"linewidth": 1}},
-                             show_sensors=(1, .1))
+                             show_sensors=True)
         assert_raises(ValueError, plot_compare_evokeds,
                       contrast, picks='str')  # bad picks: not int
         assert_raises(ValueError, plot_compare_evokeds, evoked, picks=3,

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -148,8 +148,8 @@ colors = dict(Left="Crimson", Right="CornFlowerBlue")
 linestyles = dict(Auditory='-', visual='--')
 pick = evoked_dict["Left/Auditory"].ch_names.index('MEG 1811')
 
-mne.viz.plot_compare_evokeds(evoked_dict, picks=pick,
-                             colors=colors, linestyles=linestyles)
+mne.viz.plot_compare_evokeds(evoked_dict, picks=pick, colors=colors,
+                             linestyles=linestyles)
 
 ###############################################################################
 # We can also plot the activations as images. The time runs along the x-axis


### PR DESCRIPTION
```
import os.path as op
import numpy as np
import mne
data_path = mne.datasets.sample.data_path()
fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
evoked = mne.read_evokeds(fname, baseline=(None, 0), proj=True)

conditions = ["Left Auditory", "Right Auditory", "Left visual", "Right visual"]
evoked_dict = dict()
for condition in conditions:
    evoked_dict[condition.replace(" ", "/")] = mne.read_evokeds(
        fname, baseline=(None, 0), proj=True, condition=condition)
print(evoked_dict)

colors = dict(Left="Crimson", Right="CornFlowerBlue")
linestyles = dict(Auditory='-', visual='--')
picks = np.arange(20)

mne.viz.plot_compare_evokeds(evoked_dict, picks=picks, colors=colors,
                             show_sensors=True,
                             truncate_yaxis="max_ticks",
                             linestyles=linestyles)
```

<img width="500" alt="screenshot 2017-09-19 12 24 47" src="https://user-images.githubusercontent.com/4321826/30588367-b312d9c6-9d36-11e7-87f8-98d6b0854f4a.png">

Show what channels are plotted in a small topomap (by leveraging spatial_colors code). Inherently also works for epochs images.
Also gives the ability to manually position legend and sensor legend, which I fear is necessary.