### PR TITLE
Plot TFR x-axis in seconds instead of milliseconds

### DIFF
--- a/examples/time_frequency/plot_time_frequency_erds.py
+++ b/examples/time_frequency/plot_time_frequency_erds.py
@@ -109,13 +109,10 @@ for event in event_ids:
         power.plot([i], baseline=[-1, 0], mode="percent", vmin=vmin, vmax=vmax,
                    cmap=(cmap, False), axes=ax[i], colorbar=False, show=False)
         ax[i].set_title(epochs.ch_names[i], fontsize=10)
-        ax[i].set_xlabel("t (ms)")
         ax[i].axvline(0, linewidth=1, color="black", linestyle=":")  # event
         if i > 0:
             ax[i].set_ylabel("")
             ax[i].set_yticklabels("")
-        else:
-            ax[i].set_ylabel("f (Hz)")
     fig.colorbar(ax[0].collections[0], cax=ax[-1])
     fig.suptitle("ERDS ({})".format(event))
     fig.show()

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1151,7 +1151,7 @@ class AverageTFR(_BaseTFR):
                                         mode=mode, layout=layout)
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
                         ylim=None, tfr=data[idx: idx + 1], freq=freqs,
-                        x_label='Time (ms)', y_label='Frequency (Hz)',
+                        x_label='t (s)', y_label='f (Hz)',
                         colorbar=colorbar, cmap=cmap, yscale=yscale)
             if title:
                 fig.suptitle(title)
@@ -1164,8 +1164,8 @@ class AverageTFR(_BaseTFR):
         from ..viz import plot_tfr_topomap
         if abs(eclick.x - erelease.x) < .1 or abs(eclick.y - erelease.y) < .1:
             return
-        tmin = round(min(eclick.xdata, erelease.xdata) / 1000., 5)  # ms to s
-        tmax = round(max(eclick.xdata, erelease.xdata) / 1000., 5)
+        tmin = round(min(eclick.xdata, erelease.xdata), 5)  # s
+        tmax = round(max(eclick.xdata, erelease.xdata), 5)
         fmin = round(min(eclick.ydata, erelease.ydata), 5)  # Hz
         fmax = round(max(eclick.ydata, erelease.ydata), 5)
         tmin = min(self.times, key=lambda x: abs(x - tmin))  # find closest
@@ -1318,7 +1318,7 @@ class AverageTFR(_BaseTFR):
                          click_func=click_fun, layout=layout,
                          colorbar=colorbar, vmin=vmin, vmax=vmax, cmap=cmap,
                          layout_scale=layout_scale, title=title, border=border,
-                         x_label='Time (ms)', y_label='Frequency (Hz)',
+                         x_label='t (s)', y_label='f (Hz)',
                          fig_facecolor=fig_facecolor, font_color=font_color,
                          unified=True, img=True)
 
@@ -1739,7 +1739,6 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     # crop data
     data = data[:, ifmin:ifmax, itmin:itmax]
 
-    times *= 1e3
     if dB:
         data = 10 * np.log10((data * data.conj()).real)
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1151,7 +1151,7 @@ class AverageTFR(_BaseTFR):
                                         mode=mode, layout=layout)
             _imshow_tfr(ax, 0, tmin, tmax, vmin, vmax, onselect_callback,
                         ylim=None, tfr=data[idx: idx + 1], freq=freqs,
-                        x_label='t (s)', y_label='f (Hz)',
+                        x_label='Time (s)', y_label='Frequency (Hz)',
                         colorbar=colorbar, cmap=cmap, yscale=yscale)
             if title:
                 fig.suptitle(title)
@@ -1318,7 +1318,7 @@ class AverageTFR(_BaseTFR):
                          click_func=click_fun, layout=layout,
                          colorbar=colorbar, vmin=vmin, vmax=vmax, cmap=cmap,
                          layout_scale=layout_scale, title=title, border=border,
-                         x_label='t (s)', y_label='f (Hz)',
+                         x_label='Time (s)', y_label='Frequency (Hz)',
                          fig_facecolor=fig_facecolor, font_color=font_color,
                          unified=True, img=True)
 


### PR DESCRIPTION
Change time axis scale to seconds in `AverageTFT.plot` and `AverageTFR.plot_topo`.