### PR TITLE
Fix typo for sigmas in mne_surf2bem.py

### DIFF
--- a/mne/commands/mne_surf2bem.py
+++ b/mne/commands/mne_surf2bem.py
@@ -37,7 +37,7 @@ def run():
 
     print("Converting %s to BEM FIF file." % options.surf)
     surf = mne.bem._surfaces_to_bem([options.surf], [int(options.id)],
-                                    sigma=[1])
+                                    sigmas=[1])
     mne.write_bem_surfaces(options.fif, surf)
 
 


### PR DESCRIPTION
Tiny fix to take care of error "_surfaces_to_bem() got an unexpected keyword argument 'sigma'". 
