### PR TITLE
[MRG] Simplify cov code path

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -534,6 +534,7 @@ Covariance computation
    compute_covariance
    compute_raw_covariance
    cov.regularize
+   cov.compute_whitener
    make_ad_hoc_cov
    read_cov
    write_cov

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -47,7 +47,6 @@ from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import verbose, logger, use_log_level, _check_fname, warn
-from .defaults import _handle_default
 
 # Eventually we should add:
 #   hpicons
@@ -402,18 +401,16 @@ def _setup_hpi_struct(info, model_n_window,
         coils = _concatenate_coils(coils)
     else:  # == 'multipole'
         coils = _prep_mf_coils(info)
-    scale = make_ad_hoc_cov(info, verbose=False)
+    diag_cov = make_ad_hoc_cov(info, verbose=False)
 
-    scalings = _handle_default('scalings', None)
-    # WTF is the whitener called scale ! cc @larsoner...
-    scale, _ = compute_whitener(scale, info, picks=meg_picks,
-                                scalings=scalings, verbose=False)
+    diag_whitener, _ = compute_whitener(diag_cov, info, picks=meg_picks,
+                                        verbose=False)
 
     hpi = dict(meg_picks=meg_picks, hpi_pick=hpi_pick,
                model=model, inv_model=inv_model,
                on=hpi_ons, n_window=model_n_window, method=method,
                freqs=hpi_freqs, line_freqs=line_freqs, n_freqs=len(hpi_freqs),
-               scale=scale, coils=coils
+               scale=diag_whitener, coils=coils
                )
 
     return hpi

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -43,10 +43,11 @@ from .io.pick import pick_types, pick_channels
 from .io.constants import FIFF
 from .forward import (_magnetic_dipole_field_vec, _create_meg_coils,
                       _concatenate_coils, _read_coil_defs)
-from .cov import make_ad_hoc_cov, _get_whitener_data
+from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import verbose, logger, use_log_level, _check_fname, warn
+from .defaults import _handle_default
 
 # Eventually we should add:
 #   hpicons
@@ -183,7 +184,7 @@ def _get_hpi_info(info, verbose=None):
     hpi_on = hpi_on[hpi_mask]
     hpi_freqs = hpi_freqs[hpi_mask]
 
-    return hpi_freqs,  hpi_pick, hpi_on
+    return hpi_freqs, hpi_pick, hpi_on
 
 
 @verbose
@@ -402,7 +403,11 @@ def _setup_hpi_struct(info, model_n_window,
     else:  # == 'multipole'
         coils = _prep_mf_coils(info)
     scale = make_ad_hoc_cov(info, verbose=False)
-    scale = _get_whitener_data(info, scale, meg_picks, verbose=False)[0]
+
+    scalings = _handle_default('scalings', None)
+    # WTF is the whitener called scale ! cc @larsoner...
+    scale, _ = compute_whitener(scale, info, picks=meg_picks,
+                                scalings=scalings, verbose=False)
 
     hpi = dict(meg_picks=meg_picks, hpi_pick=hpi_pick,
                model=model, inv_model=inv_model,

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1692,7 +1692,6 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=False, rank=None,
     if picks is None:
         picks = pick_types(evoked.info, meg=True, eeg=True)
 
-    scalings = _handle_default('scalings', None)
     W, rank = compute_whitener(noise_cov, evoked.info, picks=picks,
                                diag=diag, rank=rank, scalings=scalings)
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1605,6 +1605,8 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
         .. versionadded:: 0.15
     diag : bool
         Use a diagonal approximation of the noise covariance.
+
+        .. versionadded:: 0.15
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -1615,6 +1617,8 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
         The whitening matrix.
     ch_names : list
         The channel names.
+    rank : int
+        Rank reduction of the whitener. Returned only if return_rank is True.
     """
     if picks is None:
         picks = pick_types(info, meg=True, eeg=True, ref_meg=False,
@@ -1694,28 +1698,6 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=False, rank=None,
 
     evoked.data[picks] = np.sqrt(evoked.nave) * np.dot(W, evoked.data[picks])
     return evoked
-
-
-# @verbose
-# def _get_whitener_data(info, noise_cov, picks, diag=False, rank=None,
-#                        scalings=None, verbose=None):
-#     """Get whitening matrix for a set of data."""
-#     ch_names = [info['ch_names'][k] for k in picks]
-#     # XXX this relies on pick_channels, which does not respect order,
-#     # so this could create problems if users have reordered their data
-#     noise_cov = pick_channels_cov(noise_cov, include=ch_names, exclude=[])
-#     if len(noise_cov['data']) != len(ch_names):
-#         missing = list(set(ch_names) - set(noise_cov['names']))
-#         raise RuntimeError('Not all channels present in noise covariance:\n%s'
-#                            % missing)
-#     if diag:
-#         noise_cov = noise_cov.copy()
-#         noise_cov['data'] = np.diag(np.diag(noise_cov['data']))
-
-#     scalings = _handle_default('scalings_cov_rank', scalings)
-#     W, _, rank = compute_whitener(noise_cov, info, picks=picks, rank=rank,
-#                                   scalings=scalings, return_rank=True)
-#     return W, rank
 
 
 @verbose

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1579,7 +1579,7 @@ def _regularized_covariance(data, reg=None):
 @verbose
 def compute_whitener(noise_cov, info, picks=None, rank=None,
                      scalings=None, return_rank=False,
-                     diag=False, verbose=None):
+                     verbose=None):
     """Compute whitening matrix.
 
     Parameters
@@ -1601,10 +1601,6 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
         ``prepare_noise_cov`` for details.
     return_rank : bool
         If True, return the rank used to compute the whitener.
-
-        .. versionadded:: 0.15
-    diag : bool
-        Use a diagonal approximation of the noise covariance.
 
         .. versionadded:: 0.15
     verbose : bool, str, int, or None
@@ -1634,10 +1630,6 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
         raise RuntimeError('Not all channels present in noise covariance:\n%s'
                            % missing)
 
-    if diag:
-        noise_cov = noise_cov.copy()
-        noise_cov['data'] = np.diag(np.diag(noise_cov['data']))
-
     scalings = _handle_default('scalings_cov_rank', scalings)
     W, noise_cov, n_nzero = _get_whitener(noise_cov, info, ch_names, rank,
                                           pca=False, scalings=scalings)
@@ -1651,7 +1643,7 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
 
 
 @verbose
-def whiten_evoked(evoked, noise_cov, picks=None, diag=False, rank=None,
+def whiten_evoked(evoked, noise_cov, picks=None, diag=None, rank=None,
                   scalings=None, verbose=None):
     """Whiten evoked data using given noise covariance.
 
@@ -1692,8 +1684,11 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=False, rank=None,
     if picks is None:
         picks = pick_types(evoked.info, meg=True, eeg=True)
 
+    if diag:
+        noise_cov = noise_cov.as_diag()
+
     W, rank = compute_whitener(noise_cov, evoked.info, picks=picks,
-                               diag=diag, rank=rank, scalings=scalings)
+                               rank=rank, scalings=scalings)
 
     evoked.data[picks] = np.sqrt(evoked.nave) * np.dot(W, evoked.data[picks])
     return evoked

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1245,7 +1245,7 @@ def _get_whitener(noise_cov, info, ch_names, rank, pca, scalings=None):
     #   Omit the zeroes due to projection
     eig = noise_cov['eig']
     nzero = (eig > 0)
-    n_nzero = sum(nzero)
+    n_nzero = np.sum(nzero)
 
     if pca:
         #   Rows of eigvec are the eigenvectors

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1209,8 +1209,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # whitener = np.dot(whitener, cov['eigvec'])
 
     scalings = _handle_default('scalings', None)
-    whitener, rank = compute_whitener(cov, info, picks=picks,
-                                      scalings=scalings)
+    whitener, _, rank = compute_whitener(cov, info, picks=picks,
+                                         scalings=scalings, return_rank=True)
 
     # Proceed to computing the fits (make_guess_data)
     if fixed_position:

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -13,7 +13,7 @@ import re
 import numpy as np
 from scipy import linalg
 
-from .cov import read_cov, _get_whitener_data
+from .cov import read_cov, compute_whitener
 from .io.constants import FIFF
 from .io.pick import pick_types, channel_type
 from .io.proj import make_projector, _needs_eeg_average_ref_proj
@@ -35,6 +35,7 @@ from .source_space import (_make_volume_source_space, SourceSpaces,
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl)
+from .defaults import _handle_default
 
 
 class Dipole(object):
@@ -1207,7 +1208,9 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # whitener[nzero, nzero] = 1.0 / np.sqrt(cov['eig'][nzero])
     # whitener = np.dot(whitener, cov['eigvec'])
 
-    whitener, rank = _get_whitener_data(info, cov, picks, verbose=False)
+    scalings = _handle_default('scalings', None)
+    whitener, rank = compute_whitener(cov, info, picks=picks,
+                                      scalings=scalings)
 
     # Proceed to computing the fits (make_guess_data)
     if fixed_position:

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -35,7 +35,6 @@ from .source_space import (_make_volume_source_space, SourceSpaces,
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl)
-from .defaults import _handle_default
 
 
 class Dipole(object):
@@ -1208,9 +1207,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # whitener[nzero, nzero] = 1.0 / np.sqrt(cov['eig'][nzero])
     # whitener = np.dot(whitener, cov['eigvec'])
 
-    scalings = _handle_default('scalings', None)
     whitener, _, rank = compute_whitener(cov, info, picks=picks,
-                                         scalings=scalings, return_rank=True)
+                                         return_rank=True)
 
     # Proceed to computing the fits (make_guess_data)
     if fixed_position:

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1221,7 +1221,8 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
     n_chan = len(ch_names)
     logger.info("Computing inverse operator with %d channels." % n_chan)
 
-    whitener, n_nzero = _get_whitener(noise_cov, info, ch_names, rank, pca)
+    whitener, noise_cov, n_nzero = _get_whitener(noise_cov, info, ch_names,
+                                                 rank, pca)
 
     gain = forward['sol']['data']
 

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -98,6 +98,7 @@ del fwd, epochs  # to save memory
 # -------------
 # View activation time-series
 
+plt.figure()
 plt.plot(1e3 * stc.times, stc.data[::100, :].T)
 plt.xlabel('time (ms)')
 plt.ylabel('%s value' % method)


### PR DESCRIPTION
a first attempt to give love to cov code by simplifying code path

you can see that dipole fit and LCMV use compute_whitener while make_inverse_operator is using _get_whitener so does not use scalings and does not back project (using eigvec).

this need further thinking...

.. note:: how a lunch with @dengemann ends up :)