### PR TITLE
MRG: Fix examples

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,7 +97,7 @@ Changelog
 
     - Extend :func:`mne.viz.plot_epochs_image`/:meth:`mne.Epochs.plot_image` with regards to grouping by or aggregating over channels. See the new example at `examples/visualization/plot_roi_erpimage_by_rt.py` by `Jona Sassenhagen`_
 
-    - Add bootstrapped confidence intervals to :func:`mne.viz.plot_compare_evokeds` (that can for now also be accessed as :func:`mne.stats._boostrap_ci`) by `Jona Sassenhagen`_ and `Denis Engemann`_
+    - Add bootstrapped confidence intervals to :func:`mne.viz.plot_compare_evokeds` by `Jona Sassenhagen`_ and `Denis Engemann`_
 
     - Add example on how to plot ERDS maps (also known as ERSP) by `Clemens Brunner`_
 
@@ -105,7 +105,7 @@ Changelog
 
     - Plotting raw data (:func:`mne.viz.plot_raw` or :meth:`mne.io.Raw.plot`) with events now includes event numbers (if there are not more than 50 events on a page) by `Clemens Brunner`_
 
-    - Add filtering functions :meth:`mne.Epochs.filter` and :meth:`mne.Evoked.filter`, as well as ``pad`` argument to :meth:`mne.io.Raw.filter`` by `Eric Larson`_
+    - Add filtering functions :meth:`mne.Epochs.filter` and :meth:`mne.Evoked.filter`, as well as ``pad`` argument to :meth:`mne.io.Raw.filter` by `Eric Larson`_
 
 BUG
 ~~~
@@ -186,8 +186,9 @@ BUG
 
     - Fix default padding type for :meth:`mne.Epochs.resample` and :meth:`mne.Evoked.resample` to be ``'edge'`` by default, by `Eric Larson`_
 
-    - Fix :func:`mne.sparse_inverse.mxne_inverse`, :func:`mne.sparse_inverse.tf_mxne_inverse` and :func:`mne.sparse_inverse.gamma_map` to work with volume source space and sphere head models in MEG by `Alex Gramfort`_ and `Yousra Bekhti`_
+    - Fix :func:`mne.inverse_sparse.mixed_norm`, :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.gamma_map` to work with volume source space and sphere head models in MEG by `Alex Gramfort`_ and `Yousra Bekhti`_
 
+    - Fix :meth:`mne.Evoked.as_type` channel renaming to append ``'_v'`` instead of ``'_virtual'`` to channel names to comply with shorter naming (15 char) requirements, by `Eric Larson`_
 
 API
 ~~~
@@ -233,7 +234,7 @@ API
 
     - ``picks`` parameter in :func:`mne.beamformer.lcmv`, :func:`mne.beamformer.lcmv_epochs`, :func:`mne.beamformer.lcmv_raw`, :func:`mne.beamformer.tf_lcmv` and :func:`mne.beamformer.rap_music` is now deprecated and will be removed in 0.16, by `Britta Westner`_, `Alex Gramfort`_, and `Denis Engemann`_.
 
-    - The keyword argument ``frequencies`` has been deprecated in favor of ``freqs`` in various time-frequency functions, e.g. :func:`mne.time_frequency.tfr.tfr_array_morlet`, by `Eric Larson`_
+    - The keyword argument ``frequencies`` has been deprecated in favor of ``freqs`` in various time-frequency functions, e.g. :func:`mne.time_frequency.tfr_array_morlet`, by `Eric Larson`_
 
     - Add ``patterns=False`` parameter in :class:`mne.decoding.ReceptiveField`. Turn on to compute inverse model coefficients, by `Nicolas Barascud`_
 

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -103,8 +103,8 @@ print("Classification accuracy: %f / Chance level: %f" % (np.mean(scores),
 csp.fit_transform(epochs_data, labels)
 
 layout = read_layout('EEG1005')
-csp.plot_patterns(epochs.info, layout=layout, ch_type='eeg', scale=10,
-                  unit='Patterns (AU)', size=1.5)
+csp.plot_patterns(epochs.info, layout=layout, ch_type='eeg',
+                  units='Patterns (AU)', size=1.5)
 
 ###############################################################################
 # Look at performance over time

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -26,7 +26,7 @@ References
 import numpy as np
 import matplotlib.pyplot as plt
 
-from sklearn.cross_validation import StratifiedKFold
+from sklearn.model_selection import StratifiedKFold
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import classification_report, confusion_matrix
@@ -72,11 +72,11 @@ clf = make_pipeline(Xdawn(n_components=3),
 labels = epochs.events[:, -1]
 
 # Cross validator
-cv = StratifiedKFold(y=labels, n_folds=10, shuffle=True, random_state=42)
+cv = StratifiedKFold(n_splits=10, shuffle=True, random_state=42)
 
 # Do cross-validation
 preds = np.empty(len(labels))
-for train, test in cv:
+for train, test in cv.split(epochs, labels):
     clf.fit(epochs[train], labels[train])
     preds[test] = clf.predict(epochs[test])
 

--- a/examples/io/plot_elekta_epochs.py
+++ b/examples/io/plot_elekta_epochs.py
@@ -33,7 +33,7 @@ print(raw.acqparser)
 # Extract epochs corresponding to a category
 cond = raw.acqparser.get_condition(raw, 'Auditory right')
 epochs = mne.Epochs(raw, **cond)
-epochs.average().plot_topo()
+epochs.average().plot_topo(background_color='w')
 
 ###############################################################################
 # Get epochs from all conditions, average

--- a/examples/preprocessing/plot_virtual_evoked.py
+++ b/examples/preprocessing/plot_virtual_evoked.py
@@ -3,8 +3,8 @@
 Remap MEG channel types
 =======================
 
-In this example, MEG data are remapped from one
-channel type to another. This is useful to:
+In this example, MEG data are remapped from one channel type to another.
+This is useful to:
 
     - visualize combined magnetometers and gradiometers as magnetometers
       or gradiometers.

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -63,7 +63,7 @@ scores_x, scores, std_scores = [], [], []
 
 # don't highpass filter because it's epoched data and the signal length
 # is small
-filt = FilterEstimator(rt_epochs.info, None, 40)
+filt = FilterEstimator(rt_epochs.info, None, 40, fir_design='firwin')
 scaler = preprocessing.StandardScaler()
 vectorizer = Vectorizer()
 clf = SVC(C=1, kernel='linear')

--- a/examples/stats/plot_sensor_permutation_test.py
+++ b/examples/stats/plot_sensor_permutation_test.py
@@ -64,7 +64,7 @@ evoked = mne.EvokedArray(-np.log10(p_values)[:, np.newaxis],
 stats_picks = mne.pick_channels(evoked.ch_names, significant_sensors_names)
 mask = p_values[:, np.newaxis] <= 0.05
 
-evoked.plot_topomap(ch_type='grad', times=[0], scale=1,
+evoked.plot_topomap(ch_type='grad', times=[0], scalings=1,
                     time_format=None, cmap='Reds', vmin=0., vmax=np.max,
-                    unit='-log10(p)', cbar_fmt='-%0.1f', mask=mask,
+                    units='-log10(p)', cbar_fmt='-%0.1f', mask=mask,
                     size=3, show_names=lambda x: x[4:] + ' ' * 20)

--- a/examples/stats/plot_sensor_regression.py
+++ b/examples/stats/plot_sensor_regression.py
@@ -64,13 +64,14 @@ design_matrix = np.column_stack([intercept,  # intercept
 lm = linear_regression(epochs, design_matrix, names)
 
 
-def plot_topomap(x, unit):
-    x.plot_topomap(ch_type='mag', scale=1, size=1.5, vmax=np.max,
-                   unit=unit, times=np.linspace(0.1, 0.2, 5))
+def plot_topomap(x, units):
+    x.plot_topomap(ch_type='mag', scalings=1., size=1.5, vmax=np.max,
+                   units=units, times=np.linspace(0.1, 0.2, 5))
+
 
 trial_count = lm['trial-count']
 
-plot_topomap(trial_count.beta, unit='z (beta)')
-plot_topomap(trial_count.t_val, unit='t')
-plot_topomap(trial_count.mlog10_p_val, unit='-log10 p')
-plot_topomap(trial_count.stderr, unit='z (error)')
+plot_topomap(trial_count.beta, units='z (beta)')
+plot_topomap(trial_count.t_val, units='t')
+plot_topomap(trial_count.mlog10_p_val, units='-log10 p')
+plot_topomap(trial_count.stderr, units='z (error)')

--- a/examples/time_frequency/plot_compute_raw_data_spectrum.py
+++ b/examples/time_frequency/plot_compute_raw_data_spectrum.py
@@ -56,7 +56,7 @@ n_fft = 2048  # the FFT size (n_fft). Ideally a power of 2
 # channels first. Note that there are several parameters to the
 # :meth:`mne.io.Raw.plot_psd` method, some of which will be explained below.
 
-raw.plot_psd(area_mode='range', tmax=10.0, show=False)
+raw.plot_psd(area_mode='range', tmax=10.0, show=False, average=True)
 
 ###############################################################################
 # Plot a cleaned PSD
@@ -83,18 +83,18 @@ plt.figure()
 ax = plt.axes()
 raw.plot_psd(tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax, n_fft=n_fft,
              n_jobs=1, proj=False, ax=ax, color=(0, 0, 1),  picks=picks,
-             show=False)
+             show=False, average=True)
 
 raw.plot_psd(tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax, n_fft=n_fft,
              n_jobs=1, proj=True, ax=ax, color=(0, 1, 0), picks=picks,
-             show=False)
+             show=False, average=True)
 
 # And now do the same with SSP + notch filtering
 # Pick all channels for notch since the SSP projection mixes channels together
-raw.notch_filter(np.arange(60, 241, 60), n_jobs=1)
+raw.notch_filter(np.arange(60, 241, 60), n_jobs=1, fir_design='firwin')
 raw.plot_psd(tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax, n_fft=n_fft,
              n_jobs=1, proj=True, ax=ax, color=(1, 0, 0), picks=picks,
-             show=False)
+             show=False, average=True)
 
 ax.set_title('Four left-temporal magnetometers')
 plt.legend(ax.lines[::3], ['Without SSP', 'With SSP', 'SSP + Notch'])

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -290,12 +290,12 @@ class CSP(TransformerMixin, BaseEstimator):
 
     def plot_patterns(self, info, components=None, ch_type=None, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
-                      colorbar=True, scalings=None, unit='a.u.', res=64,
+                      colorbar=True, scalings=None, units='a.u.', res=64,
                       size=1, cbar_fmt='%3.1f', name_format='CSP%01d',
                       show=True, show_names=False, title=None, mask=None,
                       mask_params=None, outlines='head', contours=6,
                       image_interp='bilinear', average=None, head_pos=None,
-                      scale=None):
+                      scale=None, unit=None):
         """Plot topographic patterns of components.
 
         The patterns explain how the measured data was generated from the
@@ -350,7 +350,7 @@ class CSP(TransformerMixin, BaseEstimator):
         scalings : dict | float | None
             The scalings of the channel types to be applied for plotting.
             If None, defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
-        unit : dict | str | None
+        units : dict | str | None
             The unit of the channel type used for colorbar label. If
             scale is None the unit is automatically determined.
         res : int
@@ -431,19 +431,21 @@ class CSP(TransformerMixin, BaseEstimator):
             times=components, ch_type=ch_type, layout=layout,
             vmin=vmin, vmax=vmax, cmap=cmap, colorbar=colorbar, res=res,
             cbar_fmt=cbar_fmt, sensors=sensors,
-            scalings=scalings, unit=unit, scaling_time=1,
+            scalings=scalings, units=units, scaling_time=1,
             time_format=name_format, size=size, show_names=show_names,
             title=title, mask_params=mask_params, mask=mask, outlines=outlines,
             contours=contours, image_interp=image_interp, show=show,
-            average=average, head_pos=head_pos, scale=scale)
+            average=average, head_pos=head_pos, unit=unit,
+            scale=scale)
 
     def plot_filters(self, info, components=None, ch_type=None, layout=None,
                      vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
-                     colorbar=True, scalings=None, unit='a.u.', res=64, size=1,
-                     cbar_fmt='%3.1f', name_format='CSP%01d', show=True,
-                     show_names=False, title=None, mask=None, mask_params=None,
-                     outlines='head', contours=6, image_interp='bilinear',
-                     average=None, head_pos=None, scale=None):
+                     colorbar=True, scalings=None, units='a.u.', res=64,
+                     size=1, cbar_fmt='%3.1f', name_format='CSP%01d',
+                     show=True, show_names=False, title=None, mask=None,
+                     mask_params=None, outlines='head', contours=6,
+                     image_interp='bilinear', average=None, head_pos=None,
+                     scale=None, unit=None):
         """Plot topographic filters of components.
 
         The filters are used to extract discriminant neural sources from
@@ -498,7 +500,7 @@ class CSP(TransformerMixin, BaseEstimator):
         scalings : dict | float | None
             The scalings of the channel types to be applied for plotting.
             If None, defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
-        unit : dict | str | None
+        units : dict | str | None
             The unit of the channel type used for colorbar label. If
             scale is None the unit is automatically determined.
         res : int
@@ -578,12 +580,12 @@ class CSP(TransformerMixin, BaseEstimator):
         return filters.plot_topomap(
             times=components, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, colorbar=colorbar, res=res,
-            cbar_fmt=cbar_fmt, sensors=sensors, scalings=scalings, unit=unit,
+            cbar_fmt=cbar_fmt, sensors=sensors, scalings=scalings, units=units,
             scaling_time=1, time_format=name_format, size=size,
             show_names=show_names, title=title, mask_params=mask_params,
             mask=mask, outlines=outlines, contours=contours,
             image_interp=image_interp, show=show, average=average,
-            head_pos=head_pos, scale=scale)
+            head_pos=head_pos, unit=unit, scale=scale)
 
 
 def _ajd_pham(X, eps=1e-6, max_iter=15):

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -471,6 +471,14 @@ class FilterEstimator(TransformerMixin):
         Dictionary of parameters to use for IIR filtering.
         See mne.filter.construct_iir_filter for details. If iir_params
         is None and method="iir", 4th order Butterworth will be used.
+    fir_design : str
+        Can be "firwin" (default in 0.16) to use
+        :func:`scipy.signal.firwin`, or "firwin2" (default in 0.15 and
+        before) to use :func:`scipy.signal.firwin2`. "firwin" uses a
+        time-domain design technique that generally gives improved
+        attenuation using fewer samples than "firwin2".
+
+        ..versionadded:: 0.15
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more). Defaults to
@@ -483,7 +491,8 @@ class FilterEstimator(TransformerMixin):
 
     def __init__(self, info, l_freq, h_freq, picks=None, filter_length='auto',
                  l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
-                 method='fft', iir_params=None, verbose=None):  # noqa: D102
+                 method='fft', iir_params=None, fir_design=None,
+                 verbose=None):  # noqa: D102
         self.info = info
         self.l_freq = l_freq
         self.h_freq = h_freq
@@ -494,6 +503,7 @@ class FilterEstimator(TransformerMixin):
         self.n_jobs = n_jobs
         self.method = method
         self.iir_params = iir_params
+        self.fir_design = fir_design
 
     def fit(self, epochs_data, y):
         """Filter data.
@@ -568,7 +578,7 @@ class FilterEstimator(TransformerMixin):
             self.picks, self.filter_length, self.l_trans_bandwidth,
             self.h_trans_bandwidth, method=self.method,
             iir_params=self.iir_params, n_jobs=self.n_jobs, copy=False,
-            verbose=False)
+            fir_design=self.fir_design, verbose=False)
 
 
 class UnsupervisedSpatialFilter(TransformerMixin, BaseEstimator):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -457,7 +457,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """Compute virtual evoked using interpolated fields.
 
         .. Warning:: Using virtual evoked to compute inverse can yield
-            unexpected results. The virtual channels have `'_virtual'` appended
+            unexpected results. The virtual channels have `'_v'` appended
             at the end of the names to emphasize that the data contained in
             them are interpolated.
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -335,19 +335,20 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @copy_function_doc_to_method_doc(plot_evoked_topomap)
     def plot_topomap(self, times="auto", ch_type=None, layout=None, vmin=None,
                      vmax=None, cmap=None, sensors=True, colorbar=True,
-                     scalings=None, scaling_time=1e3, unit=None, res=64,
+                     scalings=None, scaling_time=1e3, units=None, res=64,
                      size=1, cbar_fmt="%3.1f", time_format='%01d ms',
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None, scale=None, scale_time=None):
+                     head_pos=None, axes=None, scale=None, scale_time=None,
+                     unit=None):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
-            scalings=scalings, scaling_time=scaling_time, unit=unit, res=res,
+            scalings=scalings, scaling_time=scaling_time, units=units, res=res,
             size=size, cbar_fmt=cbar_fmt, time_format=time_format,
             proj=proj, show=show, show_names=show_names, title=title,
-            mask=mask, mask_params=mask_params, outlines=outlines,
+            mask=mask, mask_params=mask_params, outlines=outlines, unit=unit,
             contours=contours, image_interp=image_interp, average=average,
             head_pos=head_pos, axes=axes, scale=scale, scale_time=scale_time)
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -825,7 +825,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
         ..versionadded:: 0.15
     pad : str
-        The type of padding to use. Supports all :func:`np.pad` ``mode``
+        The type of padding to use. Supports all :func:`numpy.pad` ``mode``
         options. Can also be "reflect_limited" (default), which pads with a
         reflected version of each vector mirrored on the first and last
         values of the vector, followed by zeros.
@@ -1255,7 +1255,7 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
 
         ..versionadded:: 0.15
     pad : str
-        The type of padding to use. Supports all :func:`np.pad` ``mode``
+        The type of padding to use. Supports all :func:`numpy.pad` ``mode``
         options. Can also be "reflect_limited" (default), which pads with a
         reflected version of each vector mirrored on the first and last
         values of the vector, followed by zeros.
@@ -1502,7 +1502,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
         Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
         is installed properly and CUDA is initialized.
     pad : str
-        The type of padding to use. Supports all :func:`np.pad` ``mode``
+        The type of padding to use. Supports all :func:`numpy.pad` ``mode``
         options. Can also be "reflect_limited" (default), which pads with a
         reflected version of each vector mirrored on the first and last
         values of the vector, followed by zeros.
@@ -2030,7 +2030,7 @@ class FilterMixin(object):
             time-domain design technique that generally gives improved
             attenuation using fewer samples than "firwin2".
         pad : str
-            The type of padding to use. Supports all :func:`np.pad` ``mode``
+            The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited", which pads with a
             reflected version of each vector mirrored on the first and last
             values of the vector, followed by zeros. The default is "edge",
@@ -2082,7 +2082,7 @@ class FilterMixin(object):
         n_jobs : int
             Number of jobs to run in parallel.
         pad : str
-            The type of padding to use. Supports all :func:`np.pad` ``mode``
+            The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited", which pads with a
             reflected version of each vector mirrored on the first and last
             values of the vector, followed by zeros. The default is "edge",

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -210,7 +210,7 @@ def _as_meg_type_evoked(evoked, ch_type='grad', mode='fast'):
 
     # change channel names to emphasize they contain interpolated data
     for ch in evoked.info['chs']:
-        ch['ch_name'] += '_virtual'
+        ch['ch_name'] += '_v'
     evoked.info._update_redundant()
     evoked.info._check_consistency()
     return evoked

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -218,7 +218,7 @@ def test_as_meg_type_evoked():
     virt_evoked = evoked.copy().pick_channels(ch_names=ch_names[:10:1])
     virt_evoked.info.normalize_proj()
     virt_evoked = virt_evoked.as_type('mag')
-    assert_true(all('_virt' in ch for ch in virt_evoked.info['ch_names']))
+    assert_true(all(ch.endswith('_v') for ch in virt_evoked.info['ch_names']))
 
     # pick from and to channels
     evoked_from = evoked.copy().pick_channels(ch_names=ch_names[2:10:3])

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1207,7 +1207,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             .. versionadded:: 0.16.
         pad : str
-            The type of padding to use. Supports all :func:`np.pad` ``mode``
+            The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited" (default), which pads with a
             reflected version of each vector mirrored on the first and last
             values of the vector, followed by zeros.
@@ -1358,7 +1358,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             ..versionadded:: 0.15
         pad : str
-            The type of padding to use. Supports all :func:`np.pad` ``mode``
+            The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited" (default), which pads with a
             reflected version of each vector mirrored on the first and last
             values of the vector, followed by zeros.
@@ -1448,7 +1448,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             An optional event matrix. When specified, the onsets of the events
             are resampled jointly with the data.
         pad : str
-            The type of padding to use. Supports all :func:`np.pad` ``mode``
+            The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited" (default), which pads with a
             reflected version of each vector mirrored on the first and last
             values of the vector, followed by zeros.

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2197,8 +2197,8 @@ def _clean_names(names, remove_whitespace=False, before_dash=True):
             name = name.replace(' ', '')
         if '-' in name and before_dash:
             name = name.split('-')[0]
-        if name.endswith('_virtual'):
-            name = name[:-8]
+        if name.endswith('_v'):
+            name = name[:-2]
         cleaned.append(name)
 
     return cleaned

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -171,7 +171,7 @@ if not use_precomputed:
     meg_picks = mne.pick_types(raw.info, meg=True, eeg=False)
     raw.plot_psd(tmax=np.inf, picks=meg_picks)
     notches = np.arange(60, 181, 60)
-    raw.notch_filter(notches)
+    raw.notch_filter(notches, phase='zero-double', fir_design='firwin2')
     raw.plot_psd(tmax=np.inf, picks=meg_picks)
 
 ###############################################################################
@@ -249,17 +249,13 @@ del epochs_standard, epochs_deviant
 
 ###############################################################################
 # Typical preprocessing step is the removal of power line artifact (50 Hz or
-# 60 Hz). Here we notch filter the data at 60, 120 and 180 to remove the
-# original 60 Hz artifact and the harmonics. Normally this would be done to
-# raw data (with :func:`mne.io.Raw.filter`), but to reduce memory consumption
-# of this tutorial, we do it at evoked stage.
-if use_precomputed:
-    sfreq = evoked_std.info['sfreq']
-    notches = [60, 120, 180]
-    for evoked in (evoked_std, evoked_dev):
-        evoked.data[:] = notch_filter(evoked.data, sfreq, notches)
-        evoked.data[:] = filter_data(evoked.data, sfreq, l_freq=None,
-                                     h_freq=100.)
+# 60 Hz). Here we lowpass filter the data at 40 Hz, which will remove all
+# line artifacts (and high frequency information). Normally this would be done
+# to raw data (with :func:`mne.io.Raw.filter`), but to reduce memory
+# consumption of this tutorial, we do it at evoked stage. (At the raw stage,
+# you could alternatively notch filter with :func:`mne.io.Raw.notch_filter`.)
+for evoked in (evoked_std, evoked_dev):
+    evoked.filter(l_freq=None, h_freq=40., fir_design='firwin')
 
 ###############################################################################
 # Here we plot the ERF of standard and deviant conditions. In both conditions

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -42,7 +42,6 @@ from mne import combine_evoked
 from mne.minimum_norm import apply_inverse
 from mne.datasets.brainstorm import bst_auditory
 from mne.io import read_raw_ctf
-from mne.filter import notch_filter, filter_data
 
 print(__doc__)
 

--- a/tutorials/plot_stats_cluster_time_frequency_repeated_measures_anova.py
+++ b/tutorials/plot_stats_cluster_time_frequency_repeated_measures_anova.py
@@ -101,7 +101,7 @@ for condition in [epochs[k] for k in event_id]:
 # factor levels for each factor.
 
 n_conditions = len(epochs.event_id)
-n_replications = epochs.events.shape[0] / n_conditions
+n_replications = epochs.events.shape[0] // n_conditions
 
 factor_levels = [2, 2]  # number of levels in each factor
 effects = 'A*B'  # this is the default signature for computing all effects


### PR DESCRIPTION
Closes #4605.
Closes #4607.

Fixes our doc builds:

- `_v` instead of `_virtual` for virtual evokeds
- fixes some linking errors in `whats_new.rst`
- fixes many deprecation warnings in examples