### PR TITLE
WIP: update status bar according to data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+    - Add time cursor and category/amplitude status message into the single-channel evoked plot by `Jussi Nurminen`_
+
     - :meth:`mne.channels.Layout.plot` and :func:`mne.viz.plot_layout` now allows plotting a subset of channels with ``picks`` argument by `Jaakko Leppakangas`_
 
     - Add .bvef extension (BrainVision Electrodes File) to :func:`mne.channels.read_montage` by `Jean-Baptiste Schiratti`_

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 
 import numpy as np
 from numpy.testing import assert_raises, assert_equal
+from nose.tools import assert_true
 
 from mne import read_events, Epochs, pick_channels_evoked
 from mne.channels import read_layout
@@ -128,6 +129,22 @@ def test_plot_topo():
     for ax, idx in iter_topography(evoked.info):
         ax.plot(evoked.data[idx], color='red')
     plt.close('all')
+
+
+def test_plot_topo_single_ch():
+    """Test single channel topoplot with time cursor"""
+    import matplotlib.pyplot as plt
+    evoked = _get_epochs().average()
+    fig = plot_evoked_topo(evoked)
+    num_figures_before = len(plt.get_fignums())
+    _fake_click(fig, fig.axes[0], (0.08, 0.65))
+    assert_equal(num_figures_before + 1, len(plt.get_fignums()))
+    fig = plt.gcf()
+    ax = plt.gca()
+    _fake_click(fig, ax, (.5, .5), kind='motion')  # cursor should appear
+    assert_true(isinstance(ax._cursorline, matplotlib.lines.Line2D))
+    _fake_click(fig, ax, (1.5, 1.5), kind='motion')  # cursor should disappear
+    assert_equal(ax._cursorline, None)
 
 
 def test_plot_topo_image_epochs():

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -393,6 +393,18 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     ax.format_coord = lambda x, y: _format_coord(x, y, labels=labels)
 
+    def _cursor_vline(event):
+        if not event.inaxes:
+            return
+        if event.inaxes._cursorline:
+            event.inaxes._cursorline.remove()
+        event.inaxes._cursorline = event.inaxes.axvline(event.xdata,
+                                                        color='w')
+        event.inaxes.figure.canvas.draw()
+
+    ax._cursorline = None
+    plt.connect('motion_notify_event', _cursor_vline)
+
     _setup_ax_spines(ax, vline, tmin, tmax)
     ax.figure.set_facecolor('k' if hvline_color is 'w' else 'w')
     ax.spines['bottom'].set_color(hvline_color)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -379,21 +379,27 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
         else:
             ax.set_ylabel(y_label)
 
-    def _format_coord(x, y, labels):
+    def _format_coord(x, y, labels, ax):
         """Create status string based on cursor coordinates."""
         idx = np.abs(times - x).argmin()
         ylabel = ax.get_ylabel()
         unit = (ylabel[ylabel.find('(') + 1:ylabel.find(')')]
                 if '(' in ylabel and ')' in ylabel else '')
-        s = '%.3f s: ' % times[idx]
         labels = [''] * len(data) if labels is None else labels
+        # try to estimate whether to truncate condition labels
+        slen = 10 + sum([12 + len(unit) + len(label) for label in labels])
+        bar_width = (ax.figure.get_size_inches() * ax.figure.dpi)[0] / 5.5
+        trunc_labels = bar_width < slen
+        s = '%6.3f s: ' % times[idx]
         for data_, label in zip(data, labels):
             s += '%7.2f %s' % (data_[ch_idx, idx], unit)
-            label = label if len(label) <= 10 else label[:8]+'..'  # truncate
+            if trunc_labels:
+                label = (label if len(label) <= 10 else
+                         '%s..%s' % (label[:7], label[-1]))
             s += ' [%s] ' % label if label else ' '
         return s
 
-    ax.format_coord = lambda x, y: _format_coord(x, y, labels=labels)
+    ax.format_coord = lambda x, y: _format_coord(x, y, labels=labels, ax=ax)
 
     def _cursor_vline(event):
         """Draw cursor (vertical line)."""

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -360,7 +360,6 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
                      colorbar=False, hline=None, hvline_color='w',
                      labels=None):
     """Show time series on topo split across multiple axes."""
-
     import matplotlib.pyplot as plt
     picker_flag = False
     for data_, color_ in zip(data, color):

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -420,7 +420,7 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
-    bg_br = np.dot(ax.get_axis_bgcolor()[:3], [299, 587, 114])
+    bg_br = np.dot(ax.get_axis_bgcolor()[:3], np.array([299, 587, 114]))
     ax._cursorcolor = 'white' if bg_br < 150 else 'black'
 
     plt.connect('motion_notify_event', _cursor_vline)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -395,7 +395,7 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
             s += '%7.2f %s' % (data_[ch_idx, idx], unit)
             if trunc_labels:
                 label = (label if len(label) <= 10 else
-                         '%s..%s' % (label[:7], label[-1]))
+                         '%s..%s' % (label[:6], label[-2:]))
             s += ' [%s] ' % label if label else ' '
         return s
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -411,11 +411,20 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
         ax._cursorline = ax.axvline(event.xdata, color=ax._cursorcolor)
         ax.figure.canvas.draw()
 
+    def _rm_cursor(event):
+        ax = event.inaxes
+        if ax._cursorline is not None:
+            ax._cursorline.remove()
+            ax._cursorline = None
+        ax.figure.canvas.draw()
+        
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
     bg_br = np.dot(ax.get_facecolor()[:3], [299, 587, 114])
     ax._cursorcolor = 'white' if bg_br < 150 else 'black'
+
     plt.connect('motion_notify_event', _cursor_vline)
+    plt.connect('axes_leave_event', _rm_cursor)
 
     _setup_ax_spines(ax, vline, tmin, tmax)
     ax.figure.set_facecolor('k' if hvline_color is 'w' else 'w')

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 from functools import partial
 from itertools import cycle
 from copy import deepcopy
-
+from matplotlib.colors import colorConverter
 import numpy as np
 
 from ..io.constants import Bunch
@@ -360,6 +360,7 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
                      colorbar=False, hline=None, hvline_color='w',
                      labels=None):
     """Show time series on topo split across multiple axes."""
+
     import matplotlib.pyplot as plt
     picker_flag = False
     for data_, color_ in zip(data, color):
@@ -420,8 +421,9 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
-    bg_br = np.dot(ax.get_axis_bgcolor()[:3], np.array([299, 587, 114]))
-    ax._cursorcolor = 'white' if bg_br < 150 else 'black'
+    facecol = colorConverter.to_rgb(ax.get_axis_bgcolor())
+    face_brightness = np.dot(facecol, np.array([299, 587, 114]))
+    ax._cursorcolor = 'white' if face_brightness < 150 else 'black'
 
     plt.connect('motion_notify_event', _cursor_vline)
     plt.connect('axes_leave_event', _rm_cursor)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -378,6 +378,18 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
         else:
             ax.set_ylabel(y_label)
 
+    def _format_coord(x, y):
+        idx = np.abs(times - x).argmin()
+        ylabel = ax.get_ylabel()
+        unit = (ylabel[ylabel.find('(')+1:ylabel.find(')')]
+                if '(' in ylabel and ')' in ylabel else '')
+        s = '%.3f s: ' % times[idx]
+        for data_ in data:
+            s += '%.2f %s ' % (data_[ch_idx, idx], unit)
+        return s
+
+    ax.format_coord = _format_coord
+
     _setup_ax_spines(ax, vline, tmin, tmax)
     ax.figure.set_facecolor('k' if hvline_color is 'w' else 'w')
     ax.spines['bottom'].set_color(hvline_color)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -417,10 +417,10 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
             ax._cursorline.remove()
             ax._cursorline = None
         ax.figure.canvas.draw()
-        
+
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
-    bg_br = np.dot(ax.get_facecolor()[:3], [299, 587, 114])
+    bg_br = np.dot(ax.get_axis_bgcolor()[:3], [299, 587, 114])
     ax._cursorcolor = 'white' if bg_br < 150 else 'black'
 
     plt.connect('motion_notify_event', _cursor_vline)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -388,7 +388,8 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
         s = '%.3f s: ' % times[idx]
         labels = [''] * len(data) if labels is None else labels
         for data_, label in zip(data, labels):
-            s += '%.2f %s' % (data_[ch_idx, idx], unit)
+            s += '%7.2f %s' % (data_[ch_idx, idx], unit)
+            label = label if len(label) <= 10 else label[:8]+'..'  # truncate
             s += ' [%s] ' % label if label else ' '
         return s
 


### PR DESCRIPTION
In the single channel plot that you get from `plot_evoked_topo()`, there is currently no easy way to get response amplitudes. This patch would update the matplotlib status bar according to data, like so:

![oncursor](https://user-images.githubusercontent.com/8491321/30916402-05cf21da-a3a2-11e7-82d4-441b67ecc5ba.png)
