### PR TITLE
Resample events fix

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -198,6 +198,8 @@ BUG
 
     - Fix treatment of CTF HPI coils as fiducial points in :func:`mne.gui.coregistration` by `Eric Larson`_
 
+    - Fix resampling of events along with raw in :func:`mne.io.base` to now take into consideration the value of ``first_samp`` by `Chris Bailey`_
+
 API
 ~~~
     - Add ``skip_by_annotation`` to :meth:`mne.io.Raw.filter` to process data concatenated with e.g. :func:`mne.concatenate_raws` separately. This parameter will default to the old behavior (treating all data as a single block) in 0.15 but will change to ``skip_by_annotation='edge'``, which will separately filter the concatenated chunks separately, in 0.16. This should help prevent potential problems with filter-induced ringing in concatenated files, by `Eric Larson`_

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1422,7 +1422,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                      If resampling the continuous data is desired, it is
                      recommended to construct events using the original data.
                      The event onsets can be jointly resampled with the raw
-                     data using the 'events' parameter.
+                     data using the 'events' parameter (a resampled copy is
+                     returned).
 
         Parameters
         ----------
@@ -1446,7 +1447,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             is installed properly and CUDA is initialized.
         events : 2D array, shape (n_events, 3) | None
             An optional event matrix. When specified, the onsets of the events
-            are resampled jointly with the data.
+            are resampled jointly with the data. NB: The input events are not
+            modified, but a new array is returned with the raw instead.
         pad : str
             The type of padding to use. Supports all :func:`numpy.pad` ``mode``
             options. Can also be "reflect_limited" (default), which pads with a
@@ -1463,6 +1465,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         -------
         raw : instance of Raw
             The resampled version of the raw object.
+        events : 2D array, shape (n_events, 3) | None
+            If events are jointly resampled, these are returned with the raw.
 
         See Also
         --------
@@ -1542,12 +1546,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             return self
         else:
-            if copy:
-                events = events.copy()
+            # always make a copy of events
+            events = events.copy()
 
             events[:, 0] = np.minimum(
                 np.round(events[:, 0] * ratio).astype(int),
-                self._data.shape[1]
+                self._data.shape[1] + self.first_samp
             )
             return self, events
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1030,7 +1030,8 @@ def test_resample():
     # test resampling events: this should no longer give a warning
     # we often have first_samp != 0, include it here too
     stim = [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]
-    o_sfreq, sfreq_ratio = len(stim), 0.5  # halve the sfreq
+    # test is on half the sfreq, but should work with trickier ones too
+    o_sfreq, sfreq_ratio = len(stim), 0.5
     n_sfreq = o_sfreq * sfreq_ratio
     first_samp = len(stim) // 2
     raw = RawArray([stim], create_info(1, o_sfreq, ['stim']),


### PR DESCRIPTION
As mentioned in the issue, `raw.first_samp` isn't being respected in the resampling of `events`. The `np.min`-call will (silently) return the `last_samp` for any events larger than the `new_length`.

Closes #4621 