### PR TITLE
MRG+1: Add reduced set of labels for HCPMMP

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -109,6 +109,8 @@ Changelog
 
     - Add high frequency somatosensory MEG dataset by `Jussi Nurminen`_
 
+    - Add reduced set of labels for HCPMMP-1.0 parcellation in :func:`mne.datasets.fetch_hcp_mmp_parcellation` by `Eric Larson`_
+
     - Enable morphing between hemispheres with :func:`mne.compute_morph_matrix` by `Christian Brodbeck`_
 
 BUG

--- a/examples/visualization/plot_parcellation.py
+++ b/examples/visualization/plot_parcellation.py
@@ -38,3 +38,10 @@ brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
 brain.add_annotation('HCPMMP1')
 aud_label = [label for label in labels if label.name == 'L_A1_ROI-lh'][0]
 brain.add_label(aud_label, borders=False)
+
+###############################################################################
+# We can also plot a combined set of labels (23 per hemisphere).
+
+brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
+              cortex='low_contrast', background='white', size=(800, 600))
+brain.add_annotation('HCPMMP1_combined')

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -8,8 +8,7 @@ from mne.utils import _TempDir, run_tests_if_main, requires_good_network
 
 
 def test_datasets():
-    """Test simple dataset functions
-    """
+    """Test simple dataset functions."""
     for dname in ('sample', 'somato', 'spm_face', 'testing',
                   'bst_raw', 'bst_auditory', 'bst_resting',
                   'visual_92_categories', 'fieldtrip_cmc'):
@@ -34,8 +33,7 @@ def test_datasets():
 
 @requires_good_network
 def test_megsim():
-    """Test MEGSIM URL handling
-    """
+    """Test MEGSIM URL handling."""
     data_dir = _TempDir()
     paths = datasets.megsim.load_data(
         'index', 'text', 'text', path=data_dir, update_path=False)
@@ -45,8 +43,7 @@ def test_megsim():
 
 @requires_good_network
 def test_downloads():
-    """Test dataset URL handling
-    """
+    """Test dataset URL handling."""
     # Try actually downloading a dataset
     data_dir = _TempDir()
     path = datasets._fake.data_path(path=data_dir, update_path=False)

--- a/mne/label.py
+++ b/mne/label.py
@@ -203,7 +203,7 @@ class Label(object):
         # check parameters
         if not isinstance(hemi, string_types):
             raise ValueError('hemi must be a string, not %s' % type(hemi))
-        vertices = np.asarray(vertices)
+        vertices = np.asarray(vertices, int)
         if np.any(np.diff(vertices.astype(int)) <= 0):
             raise ValueError('Vertices must be ordered in increasing order.')
 
@@ -1063,7 +1063,7 @@ def _split_label_contig(label_to_split, subject=None, subjects_dir=None):
     labels = []
     for div, name, color in zip(label_divs, names, colors):
         # Get indices of dipoles within this division of the label
-        verts = np.array(sorted(list(div)))
+        verts = np.array(sorted(list(div)), int)
         vert_indices = np.in1d(verts_arr, verts, assume_unique=True)
 
         # Set label attributes
@@ -1430,8 +1430,8 @@ def _verts_within_dist(graph, sources, max_dist):
                         verts_added.append(j)
         verts_added_last = verts_added
 
-    verts = np.sort(np.array(list(dist_map.keys()), dtype=np.int))
-    dist = np.array([dist_map[v] for v in verts])
+    verts = np.sort(np.array(list(dist_map.keys()), int))
+    dist = np.array([dist_map[v] for v in verts], int)
 
     return verts, dist
 
@@ -1790,7 +1790,7 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     labels : list of Label
         The labels, sorted by label name (ascending).
     """
-    logger.info('Reading labels from parcellation..')
+    logger.info('Reading labels from parcellation...')
 
     subjects_dir = get_subjects_dir(subjects_dir)
 
@@ -1845,7 +1845,6 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
             msg += ' Maybe the regular expression %r did not match?' % regexp
         raise RuntimeError(msg)
 
-    logger.info('[done]')
     return labels
 
 
@@ -1935,7 +1934,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
     Vertices that are not covered by any of the labels are assigned to a label
     named "unknown".
     """
-    logger.info('Writing labels to parcellation..')
+    logger.info('Writing labels to parcellation...')
 
     subjects_dir = get_subjects_dir(subjects_dir)
 
@@ -2119,5 +2118,3 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
     for fname, annot, ctab, hemi_names in to_save:
         logger.info('   writing %d labels to %s' % (len(hemi_names), fname))
         _write_annot(fname, annot, ctab, hemi_names)
-
-    logger.info('[done]')


### PR DESCRIPTION
This adds the combined labels (23 per hemi) for the HCPMMP parcellation.

There is no test because downloading the (only 4MB!) parcellation can actually be pretty slow, but it is effectively tested by CircleCI (just as before).