### PR TITLE
MRG+1: Fix mean flip sign ambiguity

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,17 +39,17 @@ clean:
 	-rm -rf *.nii.gz
 
 html_stable:
-	$(SPHINXBUILD) -D raise_gallery=1 -b html $(ALLSPHINXOPTS) _build/html_stable
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html_stable
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html_stable."
 
 html_dev:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D raise_gallery=1 -D abort_on_example_error=1 -b html $(ALLSPHINXOPTS) _build/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html"
 
 html_dev-pattern:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=1 -D raise_gallery=1 -D abort_on_example_error=1 -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -b html $(ALLSPHINXOPTS) _build/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=1 -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -b html $(ALLSPHINXOPTS) _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -322,6 +322,7 @@ sphinx_gallery_conf = {
     'download_section_examples': False,
     'thumbnail_size': (160, 112),
     'min_reported_time': 1.,
+    'abort_on_example_error': False,
 }
 
 numpydoc_class_members_toctree = False

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -248,6 +248,8 @@ API
 
     - ``loose`` parameter in inverse solvers has now a default value ``'auto'`` depending if the source space is a surface, volume, or discrete type by `Alex Gramfort`_ and `Yousra Bekhti`_
 
+    - The behavior of ``'mean_flip'`` label-flipping in :meth:`stc.extract_label_time_course` and related functions has been changed such that the flip, instead of having arbitrary sign, maximally aligns in the positive direction of the normals of the label, by `Eric Larson`_
+
     - Deprecate force_fixed and surf_ori in :func:`mne.forward.read_forward_solution` by `Daniel Strohmeier`_
 
     - :func:`mne.forward.convert_forward_solution` has a new argument ``use_cps``, which controls wether information on cortical patch statistics is applied while generating surface-oriented forward solutions with free and fixed orientation by `Daniel Strohmeier`_

--- a/examples/connectivity/plot_mixed_source_space_connectivity.py
+++ b/examples/connectivity/plot_mixed_source_space_connectivity.py
@@ -147,11 +147,12 @@ for name in lh_labels:
     label_ypos_lh.append(ypos)
 try:
     idx = label_names.index('Brain-Stem')
+except ValueError:
+    pass
+else:
     ypos = np.mean(labels[idx].pos[:, 1])
     lh_labels.append('Brain-Stem')
     label_ypos_lh.append(ypos)
-except ValueError:
-    pass
 
 
 # Reorder the labels based on their location
@@ -176,9 +177,3 @@ plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
                                'Condition (PLI)')
-
-# Uncomment the following line to save the figure
-'''
-import matplotlib.pyplot as plt
-plt.savefig('circle.png', facecolor='black')
-'''

--- a/examples/connectivity/plot_mne_inverse_connectivity_spectrum.py
+++ b/examples/connectivity/plot_mne_inverse_connectivity_spectrum.py
@@ -4,7 +4,7 @@ Compute full spectrum source space connectivity between labels
 ==============================================================
 
 The connectivity is computed between 4 labels across the spectrum
-between 5 and 40 Hz.
+between 7.5 and 40 Hz.
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #
@@ -62,7 +62,7 @@ src = inverse_operator['src']
 label_ts = mne.extract_label_time_course(stcs, labels, src, mode='mean_flip',
                                          return_generator=True)
 
-fmin, fmax = 5., 40.
+fmin, fmax = 7.5, 40.
 sfreq = raw.info['sfreq']  # the sampling frequency
 
 con, freqs, times, n_epochs, n_tapers = spectral_connectivity(
@@ -71,7 +71,6 @@ con, freqs, times, n_epochs, n_tapers = spectral_connectivity(
 
 n_rows, n_cols = con.shape[:2]
 fig, axes = plt.subplots(n_rows, n_cols, sharex=True, sharey=True)
-plt.suptitle('Between labels connectivity')
 for i in range(n_rows):
     for j in range(i + 1):
         if i == j:
@@ -86,11 +85,12 @@ for i in range(n_rows):
             axes[0, i].set_title(names[i])
         if i == (n_rows - 1):
             axes[i, j].set_xlabel(names[j])
-        axes[i, j].set_xlim([fmin, fmax])
-        axes[j, i].set_xlim([fmin, fmax])
+        axes[i, j].set(xlim=[fmin, fmax], ylim=[-0.2, 1])
+        axes[j, i].set(xlim=[fmin, fmax], ylim=[-0.2, 1])
 
         # Show band limits
         for f in [8, 12, 18, 35]:
             axes[i, j].axvline(f, color='k')
             axes[j, i].axvline(f, color='k')
+plt.tight_layout()
 plt.show()

--- a/examples/connectivity/plot_mne_inverse_label_connectivity.py
+++ b/examples/connectivity/plot_mne_inverse_label_connectivity.py
@@ -149,7 +149,6 @@ plot_connectivity_circle(con_res['pli'], label_names, n_lines=300,
                          node_angles=node_angles, node_colors=label_colors,
                          title='All-to-All Connectivity left-Auditory '
                                'Condition (PLI)')
-plt.savefig('circle.png', facecolor='black')
 
 ###############################################################################
 # Make two connectivity plots in the same figure

--- a/examples/connectivity/plot_mne_inverse_psi_visual.py
+++ b/examples/connectivity/plot_mne_inverse_psi_visual.py
@@ -3,7 +3,7 @@
 Compute Phase Slope Index (PSI) in source space for a visual stimulus
 =====================================================================
 
-This example demonstrates how the Phase Slope Index (PSI) [1] can be computed
+This example demonstrates how the Phase Slope Index (PSI) [1]_ can be computed
 in source space based on single trial dSPM source estimates. In addition,
 the example shows advanced usage of the connectivity estimation routines
 by first extracting a label time course for each epoch and then combining
@@ -15,9 +15,9 @@ widespread activity (a postivive PSI means the label time course is leading).
 
 References
 ----------
-[1] Nolte et al. "Robustly Estimating the Flow Direction of Information in
-Complex Physical Systems", Physical Review Letters, vol. 100, no. 23,
-pp. 1-4, Jun. 2008.
+.. [1] Nolte et al. "Robustly Estimating the Flow Direction of Information in
+       Complex Physical Systems", Physical Review Letters, vol. 100, no. 23,
+       pp. 1-4, Jun. 2008.
 """
 # Author: Martin Luessi <mluessi@nmr.mgh.harvard.edu>
 #

--- a/examples/inverse/plot_compute_mne_inverse_epochs_in_label.py
+++ b/examples/inverse/plot_compute_mne_inverse_epochs_in_label.py
@@ -5,7 +5,6 @@ Compute MNE-dSPM inverse solution on single epochs
 
 Compute dSPM inverse solution on single trial epochs restricted
 to a brain label.
-
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #

--- a/examples/inverse/plot_label_from_stc.py
+++ b/examples/inverse/plot_label_from_stc.py
@@ -9,7 +9,6 @@ Here we compare the average time course in the anatomical label obtained
 by FreeSurfer segmentation and the average time course from the
 functional label. As expected the time course in the functional
 label yields higher values.
-
 """
 # Author: Luke Bloy <luke.bloy@gmail.com>
 #         Alex Gramfort <alexandre.gramfort@telecom-paristech.fr>

--- a/examples/inverse/plot_label_source_activations.py
+++ b/examples/inverse/plot_label_source_activations.py
@@ -3,11 +3,10 @@
 Extracting the time series of activations in a label
 ====================================================
 
-We first apply a dSPM inverse operator to get signed activations
-in a label (with positive and negative values) and we then
-compare different strategies to average the times series
-in a label. We compare a simple average, with an averaging
-using the dipoles normal (flip mode) and then a PCA,
+We first apply a dSPM inverse operator to get signed activations in a label
+(with positive and negative values) and we then compare different strategies
+to average the times series in a label. We compare a simple average, with an
+averaging using the dipoles normal (flip mode) and then a PCA,
 also using a sign flip.
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -3,8 +3,7 @@
 Compute MNE inverse solution on evoked data in a mixed source space
 =======================================================================
 
-Create a mixed source space and compute MNE inverse solution on evoked dataset
-
+Create a mixed source space and compute MNE inverse solution on evoked dataset.
 """
 # Author: Annalisa Pascarella <a.pascarella@iac.cnr.it>
 #

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -118,8 +118,7 @@ lambda2 = 1.0 / snr ** 2
 
 # Compute inverse operator
 inverse_operator = make_inverse_operator(evoked.info, fwd, noise_cov,
-                                         loose=None, depth=None,
-                                         fixed=False)
+                                         depth=None, fixed=False)
 
 stcs = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
                      pick_ori=None)

--- a/mne/label.py
+++ b/mne/label.py
@@ -1246,8 +1246,14 @@ def label_sign_flip(label, src):
 
     _, _, Vh = linalg.svd(ori, full_matrices=False)
 
+    # The sign of Vh is ambiguous, so we should align to the max-positive
+    # (outward) direction
+    dots = np.dot(ori, Vh[0])
+    if np.mean(dots) < 0:
+        dots *= -1
+
     # Comparing to the direction of the first right singular vector
-    flip = np.sign(np.dot(ori, Vh[0]))
+    flip = np.sign(dots)
     return flip
 
 

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -207,6 +207,7 @@ def _get_clusters_st(x_in, neighbors, max_step=1):
 
 def _get_components(x_in, connectivity, return_list=True):
     """Get connected components from a mask and a connectivity matrix."""
+    from scipy.sparse.csgraph import connected_components
     mask = np.logical_and(x_in[connectivity.row], x_in[connectivity.col])
     data = connectivity.data[mask]
     row = connectivity.row[mask]
@@ -217,7 +218,7 @@ def _get_components(x_in, connectivity, return_list=True):
     col = np.concatenate((col, idx))
     data = np.concatenate((data, np.ones(len(idx), dtype=data.dtype)))
     connectivity = sparse.coo_matrix((data, (row, col)), shape=shape)
-    _, components = sparse.csgraph.connected_components(connectivity)
+    _, components = connected_components(connectivity)
     if return_list:
         start = np.min(components)
         stop = np.max(components)


### PR DESCRIPTION
In `master` the `mean_flip` has an ambiguous sign because it relies on SVD (I think). This fixes the ambiguity by choosing the overall sign based on what maximally aligns with the "outward" (positive) direction of the label.

I made minor changes to the various examples that use `mean_flip` so we can see the result.