### PR TITLE
WIP: Progress bar for sliding estimator

### DIFF
--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -7,6 +7,7 @@ import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator, _check_estimator
 from ..parallel import parallel_func
+from ..utils import logger, logging, ProgressBar
 
 
 class SlidingEstimator(BaseEstimator, TransformerMixin):
@@ -303,10 +304,13 @@ def _sl_fit(estimator, X, y, **fit_params):
     """
     from sklearn.base import clone
     estimators_ = list()
+    progress = ProgressBar(X.shape[-1], spinner=True)
     for ii in range(X.shape[-1]):
+        progress.update(ii)
         est = clone(estimator)
         est.fit(X[..., ii], y, **fit_params)
         estimators_.append(est)
+    progress.update(X.shape[-1])
     return estimators_
 
 


### PR DESCRIPTION
It would be great to avoid the potentially dramatic joblib verbose, and provides a progressbar to inform subjects how far their decoding pipeline is.

Currently, each job prints its own progressbar. Thus, the progress is noisy: e.g. goes from 0 to 5, back to 4, back to 5, then 6, back to 5, then 7 etc. 

Overall, it's still informative because each job tends to go at the same speed.

However, I'm not sure it's the best way to implement this. I tried to understand how the progressbar worked for the cluster stats, but I didn't managed. Tips welcome.