### PR TITLE
ENH: Add sign flipping for BiHemiLabel

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -1214,9 +1214,9 @@ def label_sign_flip(label, src):
 
     Parameters
     ----------
-    label : Label
+    label : Label | BiHemiLabel
         A label.
-    src : list of dict
+    src : SourceSpaces
         The source space over which the label is defined.
 
     Returns
@@ -1231,18 +1231,20 @@ def label_sign_flip(label, src):
     rh_vertno = src[1]['vertno']
 
     # get source orientations
-    if label.hemi == 'lh':
-        vertno_sel = np.intersect1d(lh_vertno, label.vertices)
-        if len(vertno_sel) == 0:
-            return np.array([], int)
-        ori = src[0]['nn'][vertno_sel]
-    elif label.hemi == 'rh':
-        vertno_sel = np.intersect1d(rh_vertno, label.vertices)
-        if len(vertno_sel) == 0:
-            return np.array([], int)
-        ori = src[1]['nn'][vertno_sel]
-    else:
-        raise Exception("Unknown hemisphere type")
+    ori = list()
+    if label.hemi in ('lh', 'both'):
+        vertices = label.vertices if label.hemi == 'lh' else label.lh.vertices
+        vertno_sel = np.intersect1d(lh_vertno, vertices)
+        ori.append(src[0]['nn'][vertno_sel])
+    if label.hemi in ('rh', 'both'):
+        vertices = label.vertices if label.hemi == 'rh' else label.rh.vertices
+        vertno_sel = np.intersect1d(rh_vertno, vertices)
+        ori.append(src[1]['nn'][vertno_sel])
+    if len(ori) == 0:
+        raise Exception('Unknown hemisphere type "%s"' % (label.hemi,))
+    ori = np.concatenate(ori, axis=0)
+    if len(ori) == 0:
+        return np.array([], int)
 
     _, _, Vh = linalg.svd(ori, full_matrices=False)
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1490,7 +1490,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
 
         Parameters
         ----------
-        labels : Label | list of Label
+        labels : Label | BiHemiLabel | list of Label or BiHemiLabel
             The labels for which to extract the time courses.
         src : list
             Source spaces for left and right hemisphere.
@@ -3089,8 +3089,6 @@ def _get_label_flip(labels, label_vertidx, src):
     # get the sign-flip vector for every label
     label_flip = list()
     for label, vertidx in zip(labels, label_vertidx):
-        if label.hemi == 'both':
-            raise ValueError('BiHemiLabel not supported when using sign-flip')
         if vertidx is not None:
             flip = label_sign_flip(label, src)[:, None]
         else:
@@ -3273,7 +3271,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
     ----------
     stcs : SourceEstimate | list (or generator) of SourceEstimate
         The source estimates from which to extract the time course.
-    labels : Label | list of Label
+    labels : Label | BiHemiLabel | list of Label or BiHemiLabel
         The labels for which to extract the time course.
     src : list
         Source spaces for left and right hemisphere.

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -781,9 +781,16 @@ def test_label_sign_flip():
     known_flips = np.array([1, 1, np.nan, 1, 1])
     idx = [0, 1, 3, 4]  # indices that are usable (third row is orthognoal)
     flip = label_sign_flip(label, src)
-    # Need the abs here because the direction is arbitrary
-    assert_array_almost_equal(np.abs(np.dot(flip[idx], known_flips[idx])),
-                              len(idx))
+    assert_array_almost_equal(np.dot(flip[idx], known_flips[idx]), len(idx))
+    bi_label = label + Label(vertices=src[1]['vertno'][:5], hemi='rh')
+    src[1]['nn'][src[1]['vertno'][:5]] = -src[0]['nn'][label.vertices]
+    flip = label_sign_flip(bi_label, src)
+    known_flips = np.array([1, 1, np.nan, 1, 1, 1, 1, np.nan, 1, 1])
+    idx = [0, 1, 3, 4, 5, 6, 8, 9]
+    assert_array_almost_equal(np.dot(flip[idx], known_flips[idx]), 0.)
+    src[1]['nn'][src[1]['vertno'][:5]] *= -1
+    flip = label_sign_flip(bi_label, src)
+    assert_array_almost_equal(np.dot(flip[idx], known_flips[idx]), len(idx))
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
This is useful e.g. when concatenating labels in the medial wall.