### PR TITLE
MRG: Better verbosity for MF and anatomy

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -10,7 +10,6 @@ import glob
 import os
 import os.path as op
 import shutil
-import sys
 from copy import deepcopy
 
 import numpy as np

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1106,7 +1106,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                 'SUBJECT = %s\n'
                 'Results dir = %s\n' % (subjects_dir, subject, ws_dir))
     os.makedirs(op.join(ws_dir, 'ws'))
-    run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+    run_subprocess(cmd, env=env)
 
     if op.isfile(T1_mgz):
         new_info = _extract_volume_info(T1_mgz)
@@ -1653,8 +1653,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
                     logger.info("The file %s is already there")
                 else:
                     cmd = ['mri_convert', sample_file, dest_file]
-                    run_subprocess(cmd, env=env, stdout=sys.stdout,
-                                   stderr=sys.stderr)
+                    run_subprocess(cmd, env=env)
                     echos_done += 1
     # Step 1b : Run grad_unwarp on converted files
     os.chdir(op.join(mri_dir, "flash"))
@@ -1665,7 +1664,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
             outfile = infile.replace(".mgz", "u.mgz")
             cmd = ['grad_unwarp', '-i', infile, '-o', outfile, '-unwarp',
                    'true']
-            run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+            run_subprocess(cmd, env=env)
     # Clear parameter maps if some of the data were reconverted
     if echos_done > 0 and op.exists("parameter_maps"):
         shutil.rmtree("parameter_maps")
@@ -1679,7 +1678,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
             files = glob.glob("mef05*u.mgz")
         if len(os.listdir('parameter_maps')) == 0:
             cmd = ['mri_ms_fitparms'] + files + ['parameter_maps']
-            run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+            run_subprocess(cmd, env=env)
         else:
             logger.info("Parameter maps were already computed")
         # Step 3 : Synthesize the flash 5 images
@@ -1688,7 +1687,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
         if not op.exists('flash5.mgz'):
             cmd = ['mri_synthesize', '20 5 5', 'T1.mgz', 'PD.mgz',
                    'flash5.mgz']
-            run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+            run_subprocess(cmd, env=env)
             os.remove('flash5_reg.mgz')
         else:
             logger.info("Synthesized flash 5 volume is already there")
@@ -1700,7 +1699,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
         else:
             files = glob.glob("mef05*.mgz")
         cmd = ['mri_average', '-noconform', files, 'flash5.mgz']
-        run_subprocess(cmd, env=env, stdout=sys.stdout)
+        run_subprocess(cmd, env=env)
         if op.exists('flash5_reg.mgz'):
             os.remove('flash5_reg.mgz')
 
@@ -1776,7 +1775,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
             ref_volume = op.join(mri_dir, 'T1')
         cmd = ['fsl_rigid_register', '-r', ref_volume, '-i', flash5,
                '-o', flash5_reg]
-        run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+        run_subprocess(cmd, env=env)
     else:
         logger.info("Registered flash 5 image is already there")
     # Step 5a : Convert flash5 into COR
@@ -1785,7 +1784,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
     os.makedirs(op.join(mri_dir, 'flash5'))
     if not is_test:  # CIs don't have freesurfer, skipped when testing.
         cmd = ['mri_convert', flash5_reg, op.join(mri_dir, 'flash5')]
-        run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+        run_subprocess(cmd, env=env)
     # Step 5b and c : Convert the mgz volumes into COR
     os.chdir(mri_dir)
     convert_T1 = False
@@ -1800,7 +1799,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
             raise RuntimeError("Both T1 mgz and T1 COR volumes missing.")
         os.makedirs('T1')
         cmd = ['mri_convert', 'T1.mgz', 'T1']
-        run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+        run_subprocess(cmd, env=env)
     else:
         logger.info("T1 volume is already in COR format")
     logger.info("\n---- Converting brain volume into COR format ----")
@@ -1809,14 +1808,14 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
             raise RuntimeError("Both brain mgz and brain COR volumes missing.")
         os.makedirs('brain')
         cmd = ['mri_convert', 'brain.mgz', 'brain']
-        run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+        run_subprocess(cmd, env=env)
     else:
         logger.info("Brain volume is already in COR format")
     # Finally ready to go
     if not is_test:  # CIs don't have freesurfer, skipped when testing.
         logger.info("\n---- Creating the BEM surfaces ----")
         cmd = ['mri_make_bem_surfaces', subject]
-        run_subprocess(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+        run_subprocess(cmd, env=env)
 
     logger.info("\n---- Converting the tri files into surf files ----")
     os.chdir(bem_dir)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -411,7 +411,8 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
             logger.info('    Spatiotemporal window did not fit evenly into '
                         'raw object. The final %0.2f seconds were lumped '
                         'onto the previous window.'
-                        % ((read_lims[-1] - read_lims[-2]) / info['sfreq'],))
+                        % ((read_lims[-1] - read_lims[-2] - st_duration) /
+                           info['sfreq'],))
     assert len(read_lims) >= 2
     assert read_lims[0] == 0 and read_lims[-1] == len(raw_sss.times)
 
@@ -706,10 +707,11 @@ def _do_tSSS(clean_data, orig_in_data, resid, st_correlation,
     np.asarray_chkfinite(resid)
     t_proj = _overlap_projector(orig_in_data, resid, st_correlation)
     # Apply projector according to Eq. 12 in [2]_
-    msg = ('        Projecting %2d intersecting tSSS components '
-           'for %s' % (t_proj.shape[1], t_str))
+    msg = ('        Projecting %2d intersecting tSSS component%s '
+           'for %s' % (t_proj.shape[1], _pl(t_proj.shape[1], ' '), t_str))
     if n_positions > 1:
-        msg += ' (across %2d positions)' % n_positions
+        msg += ' (across %2d position%s)' % (n_positions,
+                                             _pl(n_positions, ' '))
     logger.info(msg)
     clean_data -= np.dot(np.dot(clean_data, t_proj), t_proj.T)
 
@@ -851,7 +853,6 @@ def _regularize(regularize, exp, S_decomp, mag_or_fine, t, verbose=None):
     n_in, n_out = _get_n_moments([int_order, ext_order])
     t_str = '%8.3f' % t
     if regularize is not None:  # regularize='in'
-        logger.info('    Computing regularization')
         in_removes, out_removes = _regularize_in(
             int_order, ext_order, S_decomp, mag_or_fine)
     else:

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2284,6 +2284,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
     the source space to disk, as the computed distances will automatically be
     stored along with the source space data for future use.
     """
+    from scipy.sparse.csgraph import dijkstra
     n_jobs = check_n_jobs(n_jobs)
     src = _ensure_src(src)
     if not np.isscalar(dist_limit):
@@ -2300,8 +2301,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
         # can't do introspection on dijkstra function because it's Cython,
         # so we'll just try quickly here
         try:
-            sparse.csgraph.dijkstra(sparse.csr_matrix(np.zeros((2, 2))),
-                                    limit=1.0)
+            dijkstra(sparse.csr_matrix(np.zeros((2, 2))), limit=1.0)
         except TypeError:
             raise RuntimeError('Cannot use "limit < np.inf" unless scipy '
                                '> 0.13 is installed')
@@ -2351,10 +2351,11 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
 
 def _do_src_distances(con, vertno, run_inds, limit):
     """Compute source space distances in chunks."""
+    from scipy.sparse.csgraph import dijkstra
     if limit < np.inf:
-        func = partial(sparse.csgraph.dijkstra, limit=limit)
+        func = partial(dijkstra, limit=limit)
     else:
-        func = sparse.csgraph.dijkstra
+        func = dijkstra
     chunk_size = 20  # save memory by chunking (only a little slower)
     lims = np.r_[np.arange(0, len(run_inds), chunk_size), len(run_inds)]
     n_chunks = len(lims) - 1


### PR DESCRIPTION
This makes the messaging better for `maxwell_filter`, as well as for `run_subprocess` calls (now just `freesurfer`).

- If `verbose='info'` stdout and stderr of the process are printed
- if `verbose='warning'`, just stderr is printed
- if `verbose='error'` nothing is printed

This is most consistent with our own internal behavior. Doing `verbose=None` makes nothing get printed, `verbose='info'` gives the `logger.info` messages plus FreeSurfer output. This is much nicer when doing reconstructions. If there is an error, the `stdout` and `stderr` get printed before an error is raised.