### PR TITLE
[MRG] Change show_names to True by default in montage.plot

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -84,7 +84,7 @@ class Montage(object):
         return _pol_to_cart(_cart_to_sph(self.pos)[:, 1:][:, ::-1])
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, kind='topomap',
+    def plot(self, scale_factor=20, show_names=True, kind='topomap',
              show=True):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show)


### PR DESCRIPTION
We've recently added a topomap-like montage plot method #4276 #4399. I found another inconsistency: `mne.viz.montage.plot_montage` has `show_names=True` whereas `mne.channels.montage.Montage.plot` has `show_names=False`. This should be fixed, and a topomap without channel names doesn't make much sense for a montage plot.