### PR TITLE
WIP: orientation selection for unit-gain LCMV

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -333,7 +333,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
                 # finding the optimal orientation:
                 tmp = np.dot(Gk.T, np.dot(Cm_inv, Gk))
                 tmp_inv = _ori_selection_inv(tmp, reduce_rank)
-                U, _, _ = linalg.svd(tmp)
+                U, _, _ = linalg.svd(tmp_inv)
                 max_ori = U[:, 0]
                 Wk[:] = np.dot(max_ori, Wk)
                 Gk = np.dot(Gk, max_ori)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -241,12 +241,6 @@ def test_lcmv():
     assert_raises(NotImplementedError, lcmv, evoked, forward_vol, noise_cov,
                   data_cov, reg=0.01, pick_ori=None, weight_norm='nai')
 
-    # Test if no weight-normalization and max-power source orientation throw
-    # an error
-    assert_raises(NotImplementedError, lcmv, evoked, forward_vol, noise_cov,
-                  data_cov, reg=0.01, pick_ori="max-power", weight_norm=None,
-                  max_ori_out='signed')
-
     # Test if wrong channel selection is detected in application of filter
     evoked_ch = deepcopy(evoked)
     evoked_ch.pick_channels(evoked_ch.ch_names[:-1])


### PR DESCRIPTION
Filling in the gaps in the ``lcmv`` code: this computes the optimal selection for the unit-gain LCMV beamformer if ``pick_ori='max_power'``, which was before only implemented for the unit-noise-gain LCMV.

@agramfort @dengemann @sarangnemo
