### PR TITLE
Fix data channel selection in LCMV

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -121,7 +121,7 @@ def _pick_channels_spatial_filter(ch_names, filters):
     Unlike ``pick_channels``, this respects the order of ch_names.
     """
     sel = []
-    # first check for channel discrapancies between filter and data:
+    # first check for channel discrepancies between filter and data:
     for ch_name in filters['ch_names']:
         if ch_name not in ch_names:
             raise ValueError('The spatial filter was computed with channel %s '

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -121,13 +121,16 @@ def _pick_channels_spatial_filter(ch_names, filters):
     Unlike ``pick_channels``, this respects the order of ch_names.
     """
     sel = []
-    for ii, ch_name in enumerate(filters['ch_names']):
+    # first check for channel discrapancies between filter and data:
+    for ch_name in filters['ch_names']:
         if ch_name not in ch_names:
             raise ValueError('The spatial filter was computed with channel %s '
                              'which is not present in the data. You should '
                              'compute a new spatial filter restricted to the '
                              'good data channels.' % ch_name)
-        else:
+    # then compare list of channels and get selection based on data:
+    for ii, ch_name in enumerate(ch_names):
+        if ch_name in filters['ch_names']:
             sel.append(ii)
     return sel
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -259,7 +259,7 @@ def test_lcmv():
     # handled correctly in apply_lcmv
     # make filter with data where first channel was removed
     filters = make_lcmv(evoked_ch.info, forward_vol, data_cov, reg=0.01,
-                      noise_cov=noise_cov)
+                        noise_cov=noise_cov)
     # applying that filter to the full data set should automatically exclude
     # this channel from the data
     stc = apply_lcmv(evoked, filters)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -249,11 +249,24 @@ def test_lcmv():
 
     # Test if wrong channel selection is detected in application of filter
     evoked_ch = deepcopy(evoked)
-    evoked_ch.pick_channels(evoked_ch.ch_names[:-1])
+    evoked_ch.pick_channels(evoked_ch.ch_names[1:])
     filters = make_lcmv(evoked.info, forward_vol, data_cov, reg=0.01,
                         noise_cov=noise_cov)
     assert_raises(ValueError, apply_lcmv, evoked_ch, filters,
                   max_ori_out='signed')
+
+    # Test if discrepancies in channel selection of data and fwd model are
+    # handled correctly in apply_lcmv
+    # make filter with data where first channel was removed
+    filters = make_lcmv(evoked_ch.info, forward_vol, data_cov, reg=0.01,
+                      noise_cov=noise_cov)
+    # applying that filter to the full data set should automatically exclude
+    # this channel from the data
+    stc = apply_lcmv(evoked, filters)
+    # the result should be equal to applying this filter to a dataset without
+    # this channel:
+    stc_ch = apply_lcmv(evoked_ch, filters)
+    assert_array_almost_equal(stc.data, stc_ch.data)
 
     # Test if non-matching SSP projection is detected in application of filter
     raw_proj = deepcopy(raw)


### PR DESCRIPTION
Fixes a bug with channel selection within the ``lcmv`` functions. 
The channel selection on the data (based on a comparison to the forward model) failed in particular cases, e.g., when the data contained reference channels - as reported by @kingjr in https://github.com/mne-tools/mne-python/issues/4663 .
