### PR TITLE
[MRG] change the threshold for the rank in RAP-MUSIC

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -206,6 +206,8 @@ BUG
 
     - Fix depth weighting of sparse solvers (:func:`mne.inverse_sparse.mixed_norm`, :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.gamma_map`) with free orientation source spaces to improve orientation estimation by `Alex Gramfort`_ and `Yousra Bekhti`_
 
+    - Fix the threshold in :func:`mne.beamformer.rap_music` to properly estimate the rank by `Yousra Bekhti`_
+
 
 API
 ~~~

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -168,7 +168,7 @@ def _compute_subcorr(G, phi_sig):
     # in G and handle the fact that it might be rank defficient
     # eg. when using MEG and a sphere model for which the
     # radial component will be truly 0.
-    rank = np.sum(Sg > (Sg[0] * 1e-12))
+    rank = np.sum(Sg > (Sg[0] * 1e-6))
     if rank == 0:
         return 0, np.zeros(len(G))
     rank = max(rank, 2)  # rank cannot be 1

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -174,6 +174,10 @@ def test_rap_music_sphere():
     assert_equal((pos[:, 0] > 0).sum(), 1)
     # Check the amplitude scale
     assert_true(1e-10 < dipoles[0].amplitude[0] < 1e-7)
+    # Check the orientation
+    dip_fit = mne.fit_dipole(evoked, noise_cov, sphere)[0]
+    assert_true(np.max(np.abs(np.dot(dip_fit.ori, dipoles[0].ori[0]))) > 0.99)
+    assert_true(np.max(np.abs(np.dot(dip_fit.ori, dipoles[1].ori[0]))) > 0.99)
 
 
 run_tests_if_main()


### PR DESCRIPTION
When using another set of phantom data, the threshold used to estimate the rank is not good. It makes the rank=3 which is not possible in sphere models causing wrong estimation of dipole orientation.

