### PR TITLE
Fix for Issue #4660. 

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -206,6 +206,7 @@ BUG
 
     - Fix depth weighting of sparse solvers (:func:`mne.inverse_sparse.mixed_norm`, :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.gamma_map`) with free orientation source spaces to improve orientation estimation by `Alex Gramfort`_ and `Yousra Bekhti`_
 
+    - Fix treatment of vector inverse in :func:`mne.minimum_norm.apply_inverse_epochs` by `Emily Stephen`_
 
 API
 ~~~
@@ -2340,3 +2341,5 @@ of commits):
 .. _Nicolas Barascud: https://github.com/nbara
 
 .. _Alejandro Weinstein: http://ocam.cl
+
+.. _Emily Stephen: http://github.com/emilyps14

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1040,7 +1040,7 @@ def _apply_inverse_epochs_gen(epochs, inverse_operator, lambda2, method='dSPM',
     tmin = epochs.times[0]
 
     is_free_ori = (inverse_operator['source_ori'] ==
-                   FIFF.FIFFV_MNE_FREE_ORI and pick_ori is None)
+                   FIFF.FIFFV_MNE_FREE_ORI and pick_ori != 'normal')
 
     if pick_ori == 'vector' and noise_norm is not None:
         noise_norm = noise_norm.repeat(3, axis=0)
@@ -1064,7 +1064,7 @@ def _apply_inverse_epochs_gen(epochs, inverse_operator, lambda2, method='dSPM',
                 sol *= noise_norm
         else:
             # Linear inverse: do computation here or delayed
-            if len(sel) < K.shape[0]:
+            if len(sel) < K.shape[1]:
                 sol = (K, e[sel])
             else:
                 sol = np.dot(K, e[sel])

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -13,7 +13,7 @@ from scipy.fftpack import fft
 from mne.datasets import testing
 from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  VolSourceEstimate, Label, read_source_spaces,
-                 read_evokeds, MixedSourceEstimate,
+                 read_evokeds, MixedSourceEstimate, find_events, Epochs,
                  read_source_estimate, morph_data, extract_label_time_course,
                  spatio_temporal_tris_connectivity,
                  spatio_temporal_src_connectivity,
@@ -22,10 +22,12 @@ from mne import (stats, SourceEstimate, VectorSourceEstimate,
 from mne.source_estimate import (compute_morph_matrix, grade_to_vertices,
                                  grade_to_tris, _get_vol_mask)
 
-from mne.minimum_norm import read_inverse_operator, apply_inverse
+from mne.minimum_norm import (read_inverse_operator, apply_inverse,
+                              apply_inverse_epochs)
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (_TempDir, requires_pandas, requires_sklearn,
                        requires_h5py, run_tests_if_main, requires_nibabel)
+from mne.io import read_raw_fif
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -35,6 +37,7 @@ fname_inv = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc-meg-eeg-oct-6-meg-inv.fif')
 fname_evoked = op.join(data_path, 'MEG', 'sample',
                        'sample_audvis_trunc-ave.fif')
+fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
 fname_t1 = op.join(data_path, 'subjects', 'sample', 'mri', 'T1.mgz')
 fname_src = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc-meg-eeg-oct-6-fwd.fif')
@@ -884,6 +887,39 @@ def test_vec_stc():
     # Vector components projected onto the vertex normals
     normal = stc.normal(src)
     assert_array_equal(normal.data[:, 0], [1, 2, 0, np.sqrt(3)])
+
+
+def test_epochs_vector_inverse():
+    """Test vector inverse consistency between evoked and epochs"""
+
+    raw = read_raw_fif(fname_raw)
+    events = find_events(raw, stim_channel='STI 014')
+    event_id = dict(aud_l=1)  # event trigger and conditions
+    tmin = -0.2  # start of each epoch (200ms before the trigger)
+    tmax = 0.5  # end of each epoch (500ms after the trigger)
+    raw.info['bads'] = ['MEG 2443', 'EEG 053']
+    baseline = (None, 0)  # means from the first instant to t = 0
+    reject = dict(grad=2000e-13, mag=4e-12, eog=150e-6)
+
+    epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=baseline,
+                    reject=reject, preload=True).crop(0, 0.01)
+    evoked = epochs.average(picks=range(len(epochs.ch_names)))
+    # only differs from evoked in STI 001 and STI 014 (not rounded in original)
+
+    inv = read_inverse_operator(fname_inv)
+
+    method = "MNE"
+    snr = 3.
+    lambda2 = 1. / snr ** 2
+
+    stcs_epo = apply_inverse_epochs(epochs, inv, lambda2, method=method,
+                                    pick_ori='vector', return_generator=False)
+    stc_epo = np.mean(stcs_epo)
+
+    stc_evo = apply_inverse(evoked, inv, lambda2, method=method,
+                            pick_ori='vector')
+
+    assert(np.allclose(stc_epo.data,stc_evo.data))
 
 
 @requires_sklearn

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -916,7 +916,7 @@ def test_epochs_vector_inverse():
     stc_evo = apply_inverse(evoked, inv, lambda2, method=method,
                             pick_ori='vector')
 
-    assert_allclose(stc_epo.data, stc_evo.data, rtol=1e-10, atol=0)
+    assert_allclose(stc_epo.data, stc_evo.data, rtol=1e-9, atol=0)
 
 
 @requires_sklearn

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -888,7 +888,7 @@ def test_vec_stc():
     normal = stc.normal(src)
     assert_array_equal(normal.data[:, 0], [1, 2, 0, np.sqrt(3)])
 
-
+@testing.requires_testing_data
 def test_epochs_vector_inverse():
     """Test vector inverse consistency between evoked and epochs"""
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -893,18 +893,15 @@ def test_epochs_vector_inverse():
     """Test vector inverse consistency between evoked and epochs"""
 
     raw = read_raw_fif(fname_raw)
-    events = find_events(raw, stim_channel='STI 014')
-    event_id = dict(aud_l=1)  # event trigger and conditions
-    tmin = -0.2  # start of each epoch (200ms before the trigger)
-    tmax = 0.5  # end of each epoch (500ms after the trigger)
-    raw.info['bads'] = ['MEG 2443', 'EEG 053']
-    baseline = (None, 0)  # means from the first instant to t = 0
+    events = find_events(raw, stim_channel='STI 014')[:2]
     reject = dict(grad=2000e-13, mag=4e-12, eog=150e-6)
 
-    epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=baseline,
-                    reject=reject, preload=True).crop(0, 0.01)
+    epochs = Epochs(raw, events, None, 0, 0.01, baseline=None,
+                    reject=reject, preload=True)
+
+    assert_equal(len(epochs), 2)
+
     evoked = epochs.average(picks=range(len(epochs.ch_names)))
-    # only differs from evoked in STI 001 and STI 014 (not rounded in original)
 
     inv = read_inverse_operator(fname_inv)
 
@@ -919,7 +916,7 @@ def test_epochs_vector_inverse():
     stc_evo = apply_inverse(evoked, inv, lambda2, method=method,
                             pick_ori='vector')
 
-    assert(np.allclose(stc_epo.data,stc_evo.data))
+    assert_allclose(stc_epo.data, stc_evo.data, rtol=1e-10, atol=0)
 
 
 @requires_sklearn


### PR DESCRIPTION
Correcting bugs in _apply_inverse_epochs_gen, and adding a test to make sure apply_inverse and apply_inverse_epochs are consistent.

I see that the testing data doesn't have any *-epo.fif. The test here creates an Epochs on the fly from sample_audvis_trunc_raw.fif, and compares apply_inverse to apply_inverse_epochs with it. Would it be better to save the Epochs to the testing dataset and load it in the test?

Closes #4660 