### PR TITLE
FIX : list of stim channels in find_events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -212,6 +212,8 @@ BUG
 
     - Fix treatment of vector inverse in :func:`mne.minimum_norm.apply_inverse_epochs` by `Emily Stephen`_
 
+    - Fix :func:`mne.find_events` when passing a list as stim_channel parameter by `Alex Gramfort`_
+
 API
 ~~~
     - Add ``skip_by_annotation`` to :meth:`mne.io.Raw.filter` to process data concatenated with e.g. :func:`mne.concatenate_raws` separately. This parameter will default to the old behavior (treating all data as a single block) in 0.15 but will change to ``skip_by_annotation='edge'``, which will separately filter the concatenated chunks separately, in 0.16. This should help prevent potential problems with filter-induced ringing in concatenated files, by `Eric Larson`_

--- a/mne/event.py
+++ b/mne/event.py
@@ -675,10 +675,11 @@ def find_events(raw, stim_channel=None, output='onset',
 
     events_list = []
     for d in data:
-        events = _find_events(d[None, :], raw.first_samp, verbose=verbose,
-                              output=output, consecutive=consecutive,
-                              min_samples=min_samples, mask=mask,
-                              uint_cast=uint_cast, mask_type=mask_type)
+        events = _find_events(d[np.newaxis, :], raw.first_samp,
+                              verbose=verbose, output=output,
+                              consecutive=consecutive, min_samples=min_samples,
+                              mask=mask, uint_cast=uint_cast,
+                              mask_type=mask_type)
         # add safety check for spurious events (for ex. from neuromag syst.) by
         # checking the number of low sample events
         n_short_events = np.sum(np.diff(events[:, 0]) < shortest_event)

--- a/mne/event.py
+++ b/mne/event.py
@@ -495,7 +495,7 @@ def _find_events(data, first_samp, verbose=None, output='onset',
 
 
 def _find_unique_events(events):
-    """Uniquify events (ie remove duplicated rows"""
+    """Uniquify events (ie remove duplicated rows."""
     e = np.ascontiguousarray(events).view(
         np.dtype((np.void, events.dtype.itemsize * events.shape[1])))
     _, idx = np.unique(e, return_index=True)

--- a/mne/event.py
+++ b/mne/event.py
@@ -425,6 +425,8 @@ def _find_events(data, first_samp, verbose=None, output='onset',
                  consecutive='increasing', min_samples=0, mask=None,
                  uint_cast=False, mask_type=None):
     """Help find events."""
+    assert data.shape[0] == 1  # data should be only a row vector
+
     if min_samples > 0:
         merge = int(min_samples // 1)
         if merge == min_samples:

--- a/mne/event.py
+++ b/mne/event.py
@@ -492,6 +492,18 @@ def _find_events(data, first_samp, verbose=None, output='onset',
     return events
 
 
+def _find_unique_events(events):
+    """Uniquify events (ie remove duplicated rows"""
+    e = np.ascontiguousarray(events).view(
+        np.dtype((np.void, events.dtype.itemsize * events.shape[1])))
+    _, idx = np.unique(e, return_index=True)
+    n_dupes = len(events) - len(idx)
+    if n_dupes > 0:
+        warn("Some events are duplicated in your different stim channels."
+             " %d events were ignored during deduplication." % n_dupes)
+    return events[idx]
+
+
 @verbose
 def find_events(raw, stim_channel=None, output='onset',
                 consecutive='increasing', min_duration=0,
@@ -508,11 +520,13 @@ def find_events(raw, stim_channel=None, output='onset',
         The raw data.
     stim_channel : None | string | list of string
         Name of the stim channel or all the stim channels
-        affected by the trigger. If None, the config variables
+        affected by triggers. If None, the config variables
         'MNE_STIM_CHANNEL', 'MNE_STIM_CHANNEL_1', 'MNE_STIM_CHANNEL_2',
         etc. are read. If these are not found, it will fall back to
         'STI 014' if present, then fall back to the first channel of type
-        'stim', if present.
+        'stim', if present. If multiple channels are provided
+        then the returned events are the union of all the events
+        extracted from individual stim channels.
     output : 'onset' | 'offset' | 'step'
         Whether to report when events start, when events end, or both.
     consecutive : bool | 'increasing'
@@ -652,25 +666,33 @@ def find_events(raw, stim_channel=None, output='onset',
     # pull stim channel from config if necessary
     stim_channel = _get_stim_channel(stim_channel, raw.info)
 
-    pick = pick_channels(raw.info['ch_names'], include=stim_channel)
-    if len(pick) == 0:
+    picks = pick_channels(raw.info['ch_names'], include=stim_channel)
+    if len(picks) == 0:
         raise ValueError('No stim channel found to extract event triggers.')
-    data, _ = raw[pick, :]
+    data, _ = raw[picks, :]
 
-    events = _find_events(data, raw.first_samp, verbose=verbose, output=output,
-                          consecutive=consecutive, min_samples=min_samples,
-                          mask=mask, uint_cast=uint_cast, mask_type=mask_type)
+    events_list = []
+    for d in data:
+        events = _find_events(d[None, :], raw.first_samp, verbose=verbose,
+                              output=output, consecutive=consecutive,
+                              min_samples=min_samples, mask=mask,
+                              uint_cast=uint_cast, mask_type=mask_type)
+        # add safety check for spurious events (for ex. from neuromag syst.) by
+        # checking the number of low sample events
+        n_short_events = np.sum(np.diff(events[:, 0]) < shortest_event)
+        if n_short_events > 0:
+            raise ValueError("You have %i events shorter than the "
+                             "shortest_event. These are very unusual and you "
+                             "may want to set min_duration to a larger value "
+                             "e.g. x / raw.info['sfreq']. Where x = 1 sample "
+                             "shorter than the shortest event "
+                             "length." % (n_short_events))
 
-    # add safety check for spurious events (for ex. from neuromag syst.) by
-    # checking the number of low sample events
-    n_short_events = np.sum(np.diff(events[:, 0]) < shortest_event)
-    if n_short_events > 0:
-        raise ValueError("You have %i events shorter than the "
-                         "shortest_event. These are very unusual and you "
-                         "may want to set min_duration to a larger value e.g."
-                         " x / raw.info['sfreq']. Where x = 1 sample shorter "
-                         "than the shortest event length." % (n_short_events))
+        events_list.append(events)
 
+    events = np.concatenate(events_list, axis=0)
+    events = _find_unique_events(events)
+    events = events[np.argsort(events[:, 0])]
     return events
 
 
@@ -955,7 +977,7 @@ class AcqParserFIF(object):
     _event_vars_compat = ('Comment', 'Delay')
 
     _cat_vars = ('Comment', 'Display', 'Start', 'State', 'End', 'Event',
-                 'Nave', 'ReqEvent', 'ReqWhen', 'ReqWithin',  'SubAve')
+                 'Nave', 'ReqEvent', 'ReqWhen', 'ReqWithin', 'SubAve')
 
     # new versions only (DACQ >= 3.4)
     _dacq_vars = _dacq_vars_compat + ('magMax', 'magMin', 'magNoise',

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -360,7 +360,6 @@ def test_find_events():
     assert_array_equal(events[1::2], events1)
 
 
-
 def test_pick_events():
     """Test pick events in a events ndarray."""
     events = np.array([[1, 0, 1],

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -343,7 +343,7 @@ def test_find_events():
         if o is not None:
             os.environ['MNE_STIM_CHANNEL%s' % s] = o
 
-    # # Test with list of stim channels
+    # Test with list of stim channels
     raw._data[stim_channel_idx, 1:101] = np.zeros(100)
     raw._data[stim_channel_idx, 10:11] = 1
     raw._data[stim_channel_idx, 30:31] = 3

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -343,6 +343,23 @@ def test_find_events():
         if o is not None:
             os.environ['MNE_STIM_CHANNEL%s' % s] = o
 
+    # # Test with list of stim channels
+    raw._data[stim_channel_idx, 1:101] = np.zeros(100)
+    raw._data[stim_channel_idx, 10:11] = 1
+    raw._data[stim_channel_idx, 30:31] = 3
+    stim_channel2 = 'STI 015'
+    stim_channel2_idx = pick_channels(raw.info['ch_names'],
+                                      include=[stim_channel2])
+    raw._data[stim_channel2_idx, :] = 0
+    raw._data[stim_channel2_idx, :100] = raw._data[stim_channel_idx, 5:105]
+    events1 = find_events(raw, stim_channel='STI 014')
+    events2 = events1.copy()
+    events2[:, 0] -= 5
+    events = find_events(raw, stim_channel=['STI 014', stim_channel2])
+    assert_array_equal(events[::2], events2)
+    assert_array_equal(events[1::2], events1)
+
+
 
 def test_pick_events():
     """Test pick events in a events ndarray."""


### PR DESCRIPTION
the list option for stim_channel was not event tested AFAIK

closes #4674