### PR TITLE
[MRG] Fix browse raw error when raw has no title

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -834,10 +834,7 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
         size = tuple([float(s) for s in size])
 
     fig = figure_nobar(facecolor=bgcolor, figsize=size)
-    if title:
-        fig.canvas.set_window_title(title)
-    else:
-        fig.canvas.set_window_title("Raw")
+    fig.canvas.set_window_title(title if title else "Raw")
     ax = plt.subplot2grid((10, 10), (0, 1), colspan=8, rowspan=9)
     ax_hscroll = plt.subplot2grid((10, 10), (9, 1), colspan=8)
     ax_hscroll.get_yaxis().set_visible(False)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -834,7 +834,10 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
         size = tuple([float(s) for s in size])
 
     fig = figure_nobar(facecolor=bgcolor, figsize=size)
-    fig.canvas.set_window_title(title)
+    if title:
+        fig.canvas.set_window_title(title)
+    else:
+        fig.canvas.set_window_title("Raw")
     ax = plt.subplot2grid((10, 10), (0, 1), colspan=8, rowspan=9)
     ax_hscroll = plt.subplot2grid((10, 10), (9, 1), colspan=8)
     ax_hscroll.get_yaxis().set_visible(False)


### PR DESCRIPTION
When a `raw` object doesn't have a title (e.g. when creating from scratch with `mne.io.RawArray`), the window title cannot be set. If possible, this should go into 0.15...