### PR TITLE
[MRG] Correctly delete previous event texts

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,7 @@ Bug
 ~~~
 
 - Fix bug in :meth:`mne.io.set_eeg_reference` to remove an average reference projector when setting the reference to ``[]`` (i.e. do not change the existing reference) by `Clemens Brunner`_
+
 - Fix bug in :meth:`mne.io.Raw.plot` to correctly display event types when annotations are present by `Clemens Brunner`_
 
 API

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,7 @@ Bug
 ~~~
 
 - Fix bug in :meth:`mne.io.set_eeg_reference` to remove an average reference projector when setting the reference to ``[]`` (i.e. do not change the existing reference) by `Clemens Brunner`_
+- Fix bug in :meth:`mne.io.Raw.plot` to correctly display event types when annotations are present by `Clemens Brunner`_
 
 API
 ~~~

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -1013,16 +1013,20 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 line.set_xdata([])
                 line.set_ydata([])
         if len(event_times) <= 50:
-            params['ax'].texts = []
+            if 'n_prev_events' in params:
+                for i in range(params['n_prev_events']):
+                    params['ax'].texts.pop(0)  # delete previous events
             for ev_time, ev_num in zip(event_times, event_nums):
                 if -1 in event_color or ev_num in event_color:
                     params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
                                       ha='center')
+            # store number of events to be deleted next time
+            params['n_prev_events'] = len(event_times)
 
     if 'segments' in params:
         while len(params['ax'].collections) > 0:
-            params['ax'].collections.pop(0)
-            params['ax'].texts.pop(0)
+            params['ax'].collections.pop(-1)
+            params['ax'].texts.pop(-1)
         segments = params['segments']
         times = params['times']
         ylim = params['ax'].get_ylim()

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -915,7 +915,6 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
 
     # default key to close window
     params['close_key'] = 'escape'
-    params['n_prev_events'] = 0  # number of previously drawn events
 
 
 def _plot_raw_traces(params, color, bad_color, event_lines=None,
@@ -1014,23 +1013,17 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 line.set_xdata([])
                 line.set_ydata([])
 
-        # events are added first, so we remove events from the beginning
-        for i in range(params['n_prev_events']):
-            params['ax'].texts.pop(0)  # delete previous event texts
+        params['ax'].texts = []   # delete event and annotation texts
         # don't add event numbers for more than 50 visible events
         if len(event_times) <= 50:
             for ev_time, ev_num in zip(event_times, event_nums):
                 if -1 in event_color or ev_num in event_color:
                     params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
                                       ha='center')
-            # number of event texts to be deleted next time
-            params['n_prev_events'] = len(event_times)
 
     if 'segments' in params:
-        # annotations are added last, so we remove events from the end
         while len(params['ax'].collections) > 0:  # delete previous annotations
             params['ax'].collections.pop(-1)
-            params['ax'].texts.pop(-1)
         segments = params['segments']
         times = params['times']
         ylim = params['ax'].get_ylim()

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -1014,6 +1014,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 line.set_xdata([])
                 line.set_ydata([])
 
+        # events are added first, so we remove events from the beginning
         for i in range(params['n_prev_events']):
             params['ax'].texts.pop(0)  # delete previous event texts
         # don't add event numbers for more than 50 visible events
@@ -1026,6 +1027,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             params['n_prev_events'] = len(event_times)
 
     if 'segments' in params:
+        # annotations are added last, so we remove events from the end
         while len(params['ax'].collections) > 0:  # delete previous annotations
             params['ax'].collections.pop(-1)
             params['ax'].texts.pop(-1)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -915,6 +915,7 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
 
     # default key to close window
     params['close_key'] = 'escape'
+    params['n_prev_events'] = 0  # number of previously drawn events
 
 
 def _plot_raw_traces(params, color, bad_color, event_lines=None,
@@ -1012,19 +1013,20 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             else:
                 line.set_xdata([])
                 line.set_ydata([])
+
+        for i in range(params['n_prev_events']):
+            params['ax'].texts.pop(0)  # delete previous event texts
+        # don't add event numbers for more than 50 visible events
         if len(event_times) <= 50:
-            if 'n_prev_events' in params:
-                for i in range(params['n_prev_events']):
-                    params['ax'].texts.pop(0)  # delete previous events
             for ev_time, ev_num in zip(event_times, event_nums):
                 if -1 in event_color or ev_num in event_color:
                     params['ax'].text(ev_time, -0.05, ev_num, fontsize=8,
                                       ha='center')
-            # store number of events to be deleted next time
+            # number of event texts to be deleted next time
             params['n_prev_events'] = len(event_times)
 
     if 'segments' in params:
-        while len(params['ax'].collections) > 0:
+        while len(params['ax'].collections) > 0:  # delete previous annotations
             params['ax'].collections.pop(-1)
             params['ax'].texts.pop(-1)
         segments = params['segments']

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1829,10 +1829,6 @@ def _plot_annotations(raw, params):
 
     while len(params['ax_hscroll'].collections) > 0:
         params['ax_hscroll'].collections.pop()
-    while len(params['ax'].collections) > 0:  # delete previous annotations
-        params['ax'].collections.pop(-1)
-        params['ax'].texts.pop(-1)
-
     segments = list()
     # sort the segments by start time
     ann_order = raw.annotations.onset.argsort(axis=0)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1829,6 +1829,9 @@ def _plot_annotations(raw, params):
 
     while len(params['ax_hscroll'].collections) > 0:
         params['ax_hscroll'].collections.pop()
+    while len(params['ax'].collections) > 0:  # delete previous annotations
+        params['ax'].collections.pop(-1)
+        params['ax'].texts.pop(-1)
 
     segments = list()
     # sort the segments by start time


### PR DESCRIPTION
Fix #4690 - this is a first try and I think a step into the right direction. When adding new annotations ('a' key), some annotation texts are still overplotted.