### PR TITLE
[MRG] Fix rereferencing (again)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Changelog
 Bug
 ~~~
 
-- Nothing yet
+- Fix bug in :meth:`mne.io.set_eeg_reference` to remove an average reference projector when setting the reference to ``[]`` (i.e. do not change the existing reference) by `Clemens Brunner`_
 
 API
 ~~~

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -49,7 +49,7 @@ evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'),
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
-raw.set_eeg_reference('average', projection=False)
+raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
 evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'), show=False)

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -3,7 +3,7 @@
 Re-referencing the EEG signal
 =============================
 
-Load raw data and apply some EEG referencing schemes.
+This example shows how to load raw data and apply some EEG referencing schemes.
 """
 # Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
@@ -31,11 +31,11 @@ events = mne.read_events(event_fname)
 picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True, exclude='bads')
 
 ###############################################################################
-# Apply different EEG referencing schemes and plot the resulting evoked
-# potentials. Note that when we construct epochs with `mne.Epochs`, we specify
-# the `proj=True` argument. This means that any available projectors are
-# applied automatically. Specifically, if there is an average reference
-# projector set by `raw.set_eeg_reference('average', projection=True)`, MNE
+# We will now apply different EEG referencing schemes and plot the resulting
+# evoked potentials. Note that when we construct epochs with ``mne.Epochs``, we
+# supply the ``proj=True`` argument. This means that any available projectors
+# are applied automatically. Specifically, if there is an average reference
+# projector set by ``raw.set_eeg_reference('average', projection=True)``, MNE
 # applies this projector when creating epochs.
 
 reject = dict(eog=150e-6)

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -35,7 +35,7 @@ picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True, exclude='bads')
 
 reject = dict(eog=150e-6)
 epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
-                     picks=picks, reject=reject)
+                     picks=picks, reject=reject, proj=True)
 
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -64,6 +64,4 @@ evoked_car.plot(axes=ax2, titles=dict(eeg='Average reference'), show=False)
 raw.set_eeg_reference(['EEG 001', 'EEG 002'])
 evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
-evoked_custom.plot(axes=ax3, titles=dict(eeg='Custom reference'), show=False)
-
-fig.show()
+evoked_custom.plot(axes=ax3, titles=dict(eeg='Custom reference'))

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -50,22 +50,20 @@ fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 raw.set_eeg_reference([])
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
-evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'),
-                   show=False)
+evoked_no_ref.plot(axes=ax1, titles=dict(eeg='Original reference'), show=False)
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
 raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
-evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'), show=False)
+evoked_car.plot(axes=ax2, titles=dict(eeg='Average reference'), show=False)
 
 # Re-reference from an average reference to the mean of channels EEG 001 and
 # EEG 002.
 raw.set_eeg_reference(['EEG 001', 'EEG 002'])
 evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
-evoked_custom.plot(axes=ax3, titles=dict(eeg='EEG Custom reference'),
-                   show=False)
+evoked_custom.plot(axes=ax3, titles=dict(eeg='Custom reference'), show=False)
 
 fig.show()

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -44,18 +44,22 @@ fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 raw.set_eeg_reference([])
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
-evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'))
+evoked_no_ref.plot(axes=ax1, titles=dict(eeg='EEG Original reference'),
+                   show=False)
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
-raw.set_eeg_reference('average', projection=True)
+raw.set_eeg_reference('average', projection=False)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
-evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'))
+evoked_car.plot(axes=ax2, titles=dict(eeg='EEG Average reference'), show=False)
 
 # Re-reference from an average reference to the mean of channels EEG 001 and
 # EEG 002.
 raw.set_eeg_reference(['EEG 001', 'EEG 002'])
 evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
-evoked_custom.plot(axes=ax3, titles=dict(eeg='EEG Custom reference'))
+evoked_custom.plot(axes=ax3, titles=dict(eeg='EEG Custom reference'),
+                   show=False)
+
+fig.show()

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -31,7 +31,12 @@ events = mne.read_events(event_fname)
 picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=True, exclude='bads')
 
 ###############################################################################
-# Apply different EEG referencing schemes and plot the resulting evokeds.
+# Apply different EEG referencing schemes and plot the resulting evoked
+# potentials. Note that when we construct epochs with `mne.Epochs`, we specify
+# the `proj=True` argument. This means that any available projectors are
+# applied automatically. Specifically, if there is an average reference
+# projector set by `raw.set_eeg_reference('average', projection=True)`, MNE
+# applies this projector when creating epochs.
 
 reject = dict(eog=150e-6)
 epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
@@ -40,7 +45,8 @@ epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
 # No reference. This assumes that the EEG has already been referenced properly.
-# This explicitly prevents MNE from adding a default EEG reference.
+# This explicitly prevents MNE from adding a default EEG reference. Any average
+# reference projector is automatically removed.
 raw.set_eeg_reference([])
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -361,6 +361,9 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         raise ValueError('Setting a reference is only supported for instances '
                          'of Raw, Epochs or Evoked.')
 
+    if ref_channels is None:
+        ref_channels = 'average'
+
     if ref_channels != 'average' and projection:
         raise ValueError('Setting projection=True is only supported for '
                          'ref_channels="average".')
@@ -401,11 +404,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         logger.info('EEG data marked as already having the desired reference. '
                     'Preventing automatic future re-referencing to an average '
                     'reference.')
-        inst.info['custom_ref_applied'] = True
-        return inst, None
     else:
         logger.info('Applying a custom EEG reference.')
-        return _apply_reference(inst, ref_channels)
+
+    return _apply_reference(inst, ref_channels)
 
 
 @verbose

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -224,8 +224,6 @@ def test_set_eeg_reference():
     assert_raises(ValueError, set_eeg_reference, raw, ['EEG 001'], True, True)
 
 
-
-
 @testing.requires_testing_data
 def test_set_bipolar_reference():
     """Test bipolar referencing."""

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -197,8 +197,14 @@ def test_set_eeg_reference():
     assert_equal(reref.info['custom_ref_applied'], True)
 
     # Test that disabling the reference does not change anything
-    reref, ref_data = set_eeg_reference(raw, [])
+    reref, _ = set_eeg_reference(raw, [])
     assert_array_equal(raw._data, reref._data)
+
+    # make sure ref_channels=[] removes average reference projectors
+    reref, _ = set_eeg_reference(raw, 'average', projection=True)
+    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    reref, _ = set_eeg_reference(reref, [])
+    assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
 
     # Test that average reference gives identical results when calculated
     # via SSP projection (projection=True) or directly (projection=False)
@@ -216,6 +222,8 @@ def test_set_eeg_reference():
     # projection=True only works for ref_channels='average'
     assert_raises(ValueError, set_eeg_reference, raw, [], True, True)
     assert_raises(ValueError, set_eeg_reference, raw, ['EEG 001'], True, True)
+
+
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
`ref_channels=[]` didn't remove existing average projectors. Fixes #4382.