### PR TITLE
fix pns_idx undefined error

### DIFF
--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -515,8 +515,8 @@ class RawMff(BaseRaw):
                 samples_to_read = samples_to_read - samples_read
                 current_data_sample = current_data_sample + samples_read
 
-        if 'pns_names' in egi_info:
-            # PNS Data is present
+        if 'pns_names' in egi_info and len(pns_chans) > 0:
+            # PNS Data is present and should be read:
             pns_filepath = egi_info['pns_filepath']
             n_pns_channels = egi_info['n_pns_channels']
             pns_info = egi_info['pns_sample_blocks']


### PR DESCRIPTION
only read the pns channels when they are required (i.e. in chs_to_read).