### PR TITLE
Added unused tuple as an argument

### DIFF
--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -111,7 +111,7 @@ picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=True)
 baseline = (None, 0.0)
 reject = {'mag': 4e-12, 'eog': 200e-6}
 epochs = mne.Epochs(raw, events=events, event_id=event_id, tmin=tmin,
-                    tmax=tmax, reject=reject, picks=picks)
+                    tmax=tmax, baseline=baseline, reject=reject, picks=picks)
 
 ###############################################################################
 # Let's plot the epochs to see the results. The number at the top refers to the


### PR DESCRIPTION
In the tutorial on [Epochs and Averaging](https://martinos.org/mne/stable/auto_tutorials/plot_epoching_and_averaging.html#tut-epoching-and-averaging), there is place where a `baseline` tuple is defined, but it never gets passed into `Epochs()` on the following line. This is small fix for that.

The value used is the same as the default value, so the result doesn't actually change or anything.