### PR TITLE
Add savefig to circle graphs for #4714

### DIFF
--- a/examples/connectivity/plot_mixed_source_space_connectivity.py
+++ b/examples/connectivity/plot_mixed_source_space_connectivity.py
@@ -15,6 +15,7 @@ is ordered based on the locations of the regions.
 import os.path as op
 import numpy as np
 import mne
+import matplotlib.pyplot as plt
 
 from mne.datasets import sample
 from mne import setup_volume_source_space, setup_source_space
@@ -173,7 +174,22 @@ node_angles = circular_layout(label_names, node_order, start_pos=90,
 # Plot the graph using node colors from the FreeSurfer parcellation. We only
 # show the 300 strongest connections.
 conmat = con[:, :, 0]
+fig = plt.figure(num=None, figsize=(8, 8), facecolor='black')
 plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
-                               'Condition (PLI)')
+                         'Condition (PLI)', fig=fig, interactive=False, 
+                         show=False)
+
+plt.show()
+
+###############################################################################
+# Save the figure (optional)
+# --------------------------
+#
+# By default matplotlib does not save using the facecolor, even though this was
+# set when the figure was generated. If not set via savefig, the labels, title,
+# and legend will be cut off from the output png file.
+
+#fname_fig = data_path + '/MEG/sample/plot_mixed_connect.png'
+#plt.savefig(fname_fig, facecolor='black')

--- a/examples/connectivity/plot_mixed_source_space_connectivity.py
+++ b/examples/connectivity/plot_mixed_source_space_connectivity.py
@@ -178,10 +178,7 @@ fig = plt.figure(num=None, figsize=(8, 8), facecolor='black')
 plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
-                         'Condition (PLI)', fig=fig, interactive=False, 
-                         show=False)
-
-plt.show()
+                         'Condition (PLI)', fig=fig, interactive=False)
 
 ###############################################################################
 # Save the figure (optional)
@@ -191,5 +188,5 @@ plt.show()
 # set when the figure was generated. If not set via savefig, the labels, title,
 # and legend will be cut off from the output png file.
 
-#fname_fig = data_path + '/MEG/sample/plot_mixed_connect.png'
-#plt.savefig(fname_fig, facecolor='black')
+# fname_fig = data_path + '/MEG/sample/plot_mixed_connect.png'
+# plt.savefig(fname_fig, facecolor='black')

--- a/examples/connectivity/plot_mne_inverse_label_connectivity.py
+++ b/examples/connectivity/plot_mne_inverse_label_connectivity.py
@@ -166,3 +166,14 @@ for ii, method in enumerate(con_methods):
                              fig=fig, subplot=(1, 2, ii + 1))
 
 plt.show()
+
+###############################################################################
+# Save the figure (optional)
+# --------------------------
+#
+# By default matplotlib does not save using the facecolor, even though this was
+# set when the figure was generated. If not set via savefig, the labels, title,
+# and legend will be cut off from the output png file.
+
+#fname_fig = data_path + '/MEG/sample/plot_inverse_connect.png'
+#fig.savefig(fname_fig, facecolor='black')

--- a/examples/connectivity/plot_mne_inverse_label_connectivity.py
+++ b/examples/connectivity/plot_mne_inverse_label_connectivity.py
@@ -175,5 +175,5 @@ plt.show()
 # set when the figure was generated. If not set via savefig, the labels, title,
 # and legend will be cut off from the output png file.
 
-#fname_fig = data_path + '/MEG/sample/plot_inverse_connect.png'
-#fig.savefig(fname_fig, facecolor='black')
+# fname_fig = data_path + '/MEG/sample/plot_inverse_connect.png'
+# fig.savefig(fname_fig, facecolor='black')

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -139,8 +139,8 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     This code is based on the circle graph example by Nicolas P. Rougier
     http://www.labri.fr/perso/nrougier/coding/.
     
-    By default, ``matplotlib`` does take ``facecolor`` into account, even if 
-    set when a figure is generated. This can be addressed via 
+    By default, ``matplotlib`` does not take ``facecolor`` into account, even
+    if set when a figure is generated. This can be addressed via 
     :func:`matplotlib.pyplot.savefig`, e.g.::
     
         >>> fig.savefig(fname_fig, facecolor='black')

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -143,7 +143,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     if set when a figure is generated. This can be addressed via 
     :func:`matplotlib.pyplot.savefig`, e.g.::
     
-    >>> fig.savefig(fname_fig, facecolor='black')
+    >>> fig.savefig(fname_fig, facecolor='black') # doctest:+SKIP
         
     If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the 
     figure labels, title, and legend may be cut off in the output figure.

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -143,7 +143,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     if set when a figure is generated. This can be addressed via 
     :func:`matplotlib.pyplot.savefig`, e.g.::
     
-        >>> fig.savefig(fname_fig, facecolor='black')
+    >>> fig.savefig(fname_fig, facecolor='black')
         
     If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the 
     figure labels, title, and legend may be cut off in the output figure.

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -134,20 +134,6 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                              node_linewidth=2., show=True):
     """Visualize connectivity as a circular graph.
 
-    Notes:
-
-    This code is based on the circle graph example by Nicolas P. Rougier
-    http://www.labri.fr/perso/nrougier/coding/.
-
-    By default, ``matplotlib`` does not take ``facecolor`` into account, even
-    if set when a figure is generated. This can be addressed via
-    :func:`matplotlib.pyplot.savefig`, e.g.::
-
-    >>> fig.savefig(fname_fig, facecolor='black') # doctest:+SKIP
-
-    If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the
-    figure labels, title, and legend may be cut off in the output figure.
-
     Parameters
     ----------
     con : array
@@ -223,6 +209,20 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
         The figure handle.
     axes : instance of matplotlib.axes.PolarAxesSubplot
         The subplot handle.
+
+    Notes
+    -----
+    This code is based on the circle graph example by Nicolas P. Rougier
+    http://www.labri.fr/perso/nrougier/coding/.
+
+    By default, :func:`matplotlib.pyplot.savefig` does not take ``facecolor``
+    into account when saving, even if set when a figure is generated. This
+    can be addressed via, e.g.::
+
+    >>> fig.savefig(fname_fig, facecolor='black') # doctest:+SKIP
+
+    If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the
+    figure labels, title, and legend may be cut off in the output figure.
     """
     import matplotlib.pyplot as plt
     import matplotlib.path as m_path

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -143,7 +143,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     set when a figure is generated. This can be addressed via 
     :func:`matplotlib.pyplot.savefig`, e.g.::
     
-        >>> fig.savefig(fname_fig, facecolor='black'))
+        >>> fig.savefig(fname_fig, facecolor='black')
         
     If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the 
     figure labels, title, and legend may be cut off in the output figure.

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -134,8 +134,19 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                              node_linewidth=2., show=True):
     """Visualize connectivity as a circular graph.
 
-    Note: This code is based on the circle graph example by Nicolas P. Rougier
+    Notes: 
+    
+    This code is based on the circle graph example by Nicolas P. Rougier
     http://www.labri.fr/perso/nrougier/coding/.
+    
+    By default, ``matplotlib`` does take ``facecolor`` into account, even if 
+    set when a figure is generated. This can be addressed via 
+    :func:`matplotlib.pyplot.savefig`, e.g.::
+    
+        >>> fig.savefig(fname_fig, facecolor='black'))
+        
+    If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the 
+    figure labels, title, and legend may be cut off in the output figure.
 
     Parameters
     ----------

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -134,18 +134,18 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                              node_linewidth=2., show=True):
     """Visualize connectivity as a circular graph.
 
-    Notes: 
-    
+    Notes:
+
     This code is based on the circle graph example by Nicolas P. Rougier
     http://www.labri.fr/perso/nrougier/coding/.
-    
+
     By default, ``matplotlib`` does not take ``facecolor`` into account, even
-    if set when a figure is generated. This can be addressed via 
+    if set when a figure is generated. This can be addressed via
     :func:`matplotlib.pyplot.savefig`, e.g.::
-    
+
     >>> fig.savefig(fname_fig, facecolor='black') # doctest:+SKIP
-        
-    If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the 
+
+    If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the
     figure labels, title, and legend may be cut off in the output figure.
 
     Parameters


### PR DESCRIPTION
For plot_mne_inverse_label_connectivity.py this only adds the explanation and commented commands.  For plot_mixed_source_space_connectivity.py I tweaked things a bit so that plt is used even when the savefig line is commented out.