### PR TITLE
MRG: Fix raw sim with BEM and use_cps=True

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,10 @@ Bug
 
 - Fix bug in :meth:`mne.io.Raw.plot` to correctly display event types when annotations are present by `Clemens Brunner`_
 
+- Fix bug in :func:`mne.simulation.simulate_raw` with ``use_cps=True`` where CPS was not actually used by `Eric Larson`_
+
+- Fix bug in :func:`mne.simulation.simulate_raw` where 1- and 3-layer BEMs were not properly transformed using ``trans`` by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -219,13 +219,15 @@ def _create_eeg_els(chs):
 
 @verbose
 def _setup_bem(bem, bem_extra, neeg, mri_head_t, verbose=None):
-    """Set up a BEM for forward computation."""
+    """Set up a BEM for forward computation, making a copy and modifying."""
     logger.info('')
     if isinstance(bem, string_types):
         logger.info('Setting up the BEM model using %s...\n' % bem_extra)
         bem = read_bem_solution(bem)
-    if not isinstance(bem, ConductorModel):
-        raise TypeError('bem must be a string or ConductorModel')
+    else:
+        if not isinstance(bem, ConductorModel):
+            raise TypeError('bem must be a string or ConductorModel')
+        bem = bem.copy()
     if bem['is_sphere']:
         logger.info('Using the sphere model.\n')
         if len(bem['layers']) == 0 and neeg > 0:
@@ -234,6 +236,10 @@ def _setup_bem(bem, bem_extra, neeg, mri_head_t, verbose=None):
         if bem['coord_frame'] != FIFF.FIFFV_COORD_HEAD:
             raise RuntimeError('Spherical model is not in head coordinates')
     else:
+        if bem['surfs'][0]['coord_frame'] != FIFF.FIFFV_COORD_MRI:
+            raise RuntimeError(
+                'BEM is in %s coordinates, should be in MRI'
+                % (_coord_frame_name(bem['surfs'][0]['coord_frame']),))
         if neeg > 0 and len(bem['surfs']) == 1:
             raise RuntimeError('Cannot use a homogeneous model in EEG '
                                'calculations')
@@ -558,7 +564,10 @@ def make_forward_solution(info, trans, src, bem, meg=True, eeg=True,
     # read the transformation from MRI to HEAD coordinates
     # (could also be HEAD to MRI)
     mri_head_t, trans = _get_trans(trans)
-    bem_extra = 'dict' if isinstance(bem, dict) else bem
+    if isinstance(bem, ConductorModel):
+        bem_extra = 'instance of ConductorModel'
+    else:
+        bem_extra = bem
     if not isinstance(info, (Info, string_types)):
         raise TypeError('info should be an instance of Info or string')
     if isinstance(info, string_types):
@@ -569,15 +578,15 @@ def make_forward_solution(info, trans, src, bem, meg=True, eeg=True,
     n_jobs = check_n_jobs(n_jobs)
 
     # Report the setup
-    logger.info('Source space                 : %s' % src)
-    logger.info('MRI -> head transform source : %s' % trans)
-    logger.info('Measurement data             : %s' % info_extra)
-    if isinstance(bem, dict) and bem['is_sphere']:
-        logger.info('Sphere model                 : origin at %s mm'
+    logger.info('Source space          : %s' % src)
+    logger.info('MRI -> head transform : %s' % trans)
+    logger.info('Measurement data      : %s' % info_extra)
+    if isinstance(bem, ConductorModel) and bem['is_sphere']:
+        logger.info('Sphere model      : origin at %s mm'
                     % (bem['r0'],))
         logger.info('Standard field computations')
     else:
-        logger.info('BEM model                    : %s' % bem_extra)
+        logger.info('Conductor model   : %s' % bem_extra)
         logger.info('Accurate field computations')
     logger.info('Do computations in %s coordinates',
                 _coord_frame_name(FIFF.FIFFV_COORD_HEAD))

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -615,8 +615,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     if surf_ori:
         if use_cps is True:
-            if ('patch_inds' in fwd['src'][0] and
-                    fwd['src'][0]['patch_inds'] is not None):
+            if fwd['src'][0].get('patch_inds') is not None:
                 use_ave_nn = True
                 logger.info('    Average patch normals will be employed in '
                             'the rotation to the local surface coordinates..'

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2171,14 +2171,21 @@ def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
             logger.info('%d source space point%s omitted because of the '
                         '%6.1f-mm distance limit.' % tuple(extras))
         # Adjust the patch inds as well if necessary
-        if omit + omit_outside > 0 and s.get('patch_inds') is not None:
-            if s['nearest'] is None:
-                # This shouldn't happen, but if it does, we can probably come
-                # up with a more clever solution
-                raise RuntimeError('Cannot adjust patch information properly, '
-                                   'please contact the mne-python developers')
-            _add_patch_info(s)
+        if omit + omit_outside > 0:
+            _adjust_patch_info(s)
     logger.info('Thank you for waiting.')
+
+
+@verbose
+def _adjust_patch_info(s, verbose=None):
+    """Adjust patch information in place after vertex omission."""
+    if s.get('patch_inds') is not None:
+        if s['nearest'] is None:
+            # This shouldn't happen, but if it does, we can probably come
+            # up with a more clever solution
+            raise RuntimeError('Cannot adjust patch information properly, '
+                               'please contact the mne-python developers')
+        _add_patch_info(s)
 
 
 @verbose

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -61,9 +61,7 @@ def test_get_trans():
     trans = read_trans(fname)
     trans = invert_transform(trans)  # starts out as head->MRI, so invert
     trans_2 = _get_trans(fname_trans)[0]
-    assert_equal(trans['from'], trans_2['from'])
-    assert_equal(trans['to'], trans_2['to'])
-    assert_allclose(trans['trans'], trans_2['trans'], rtol=1e-5, atol=1e-5)
+    assert trans.__eq__(trans_2, atol=1e-5)
 
 
 @testing.requires_testing_data
@@ -79,9 +77,7 @@ def test_io_trans():
     trans1 = read_trans(fname1)
 
     # check all properties
-    assert_true(trans0['from'] == trans1['from'])
-    assert_true(trans0['to'] == trans1['to'])
-    assert_array_equal(trans0['trans'], trans1['trans'])
+    assert trans0 == trans1
 
     # check reading non -trans.fif files
     assert_raises(IOError, read_trans, fname_eve)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -396,9 +396,9 @@ def _get_trans(trans, fro='mri', to='head'):
                 raise RuntimeError('File "%s" did not have 4x4 entries'
                                    % trans)
             fro_to_t = Transform(to, fro, t)
-    elif isinstance(trans, dict):
+    elif isinstance(trans, Transform):
         fro_to_t = trans
-        trans = 'dict'
+        trans = 'instance of Transform'
     elif trans is None:
         fro_to_t = Transform(fro, to)
         trans = 'identity'

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -104,6 +104,32 @@ class Transform(dict):
                 % (_coord_frame_name(self['from']),
                    _coord_frame_name(self['to']), self['trans']))
 
+    def __eq__(self, other, rtol=0., atol=0.):
+        """Check for equality.
+
+        Parameter
+        ---------
+        other : instance of Transform
+            The other transform.
+        rtol : float
+            Relative tolerance.
+        atol : float
+            Absolute tolerance.
+
+        Returns
+        -------
+        eq : bool
+            True if the transforms are equal.
+        """
+        return (isinstance(other, Transform) and
+                self['from'] == other['from'] and
+                self['to'] == other['to'] and
+                np.allclose(self['trans'], other['trans'], rtol=rtol,
+                            atol=atol))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @property
     def from_str(self):
         """The "from" frame as a string."""

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -127,8 +127,24 @@ class Transform(dict):
                 np.allclose(self['trans'], other['trans'], rtol=rtol,
                             atol=atol))
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    def __ne__(self, other, rtol=0., atol=0.):
+        """Check for inequality.
+
+        Parameter
+        ---------
+        other : instance of Transform
+            The other transform.
+        rtol : float
+            Relative tolerance.
+        atol : float
+            Absolute tolerance.
+
+        Returns
+        -------
+        eq : bool
+            True if the transforms are not equal.
+        """
+        return not self == other
 
     @property
     def from_str(self):


### PR DESCRIPTION
Fixes a bug when using a BEM where:

1. Corner case: the BEM surface was transformed without copy for the purposes of forward omission testing, so on return if `bem` was passed directly it was modified.
2. Fix accounting of `src[ii]['patch_info']` and `src[ii]['pinfo']`, instead of delete recreate after reducing source space as in `_make_forward.py` so that patch stats can actually be used.

Still need to:

- [x] add round-trip testing for forward w/identity
- [x] add non-modification-of-BEM test