### PR TITLE
[MRG] Support for initial event in mne.find_events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 
 - Add to :func:`mne.viz.plot_alignment` plotting of coordinate frame axes via ``show_axes`` and terrain-style interaction via ``interaction``, by `Eric Larson`_
 
+- Add option ``initial_event`` to :func:`mne.find_events` by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -563,17 +563,17 @@ def find_events(raw, stim_channel=None, output='onset',
         in MNE-C.
 
         .. versionadded:: 0.12
+    mask_type: 'and' | 'not_and'
+        The type of operation between the mask and the trigger.
+        Choose 'and' (default) for MNE-C masking behavior.
+
+        .. versionadded:: 0.13
     initial_event : bool
         If True (default False), an event is created if the stim channel has a
         value different from 0 as its first sample. This is useful if an event
         at t=0s is present.
 
         .. versionadded:: 0.16
-    mask_type: 'and' | 'not_and'
-        The type of operation between the mask and the trigger.
-        Choose 'and' (default) for MNE-C masking behavior.
-
-        .. versionadded:: 0.13
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/event.py
+++ b/mne/event.py
@@ -444,12 +444,14 @@ def _find_events(data, first_samp, verbose=None, output='onset',
         data = np.abs(data)  # make sure trig channel is positive
 
     events = _find_stim_steps(data, first_samp, pad_stop=0, merge=merge)
-    if data[0, 0] != 0:
+    initial_value = data[0, 0]
+    if initial_value != 0:
         if initial_event:
-            events = np.insert(events, 0, [0, 0, data[0, 0]], axis=0)
+            events = np.insert(events, 0, [0, 0, initial_value], axis=0)
         else:
-            warn('Trigger channel has a non-zero initial value (consider using'
-                 ' initial_event=True to detect this event)')
+            logger.info('Trigger channel has a non-zero initial value of {} '
+                        '(consider using initial_event=True to detect this '
+                        'event)'.format(initial_value))
 
     events = _mask_trigs(events, mask, mask_type)
 
@@ -560,13 +562,13 @@ def find_events(raw, stim_channel=None, output='onset',
         turns data into e.g. -32768), similar to ``mne_fix_stim14 --32``
         in MNE-C.
 
-        .. versionadded:: 0.16
+        .. versionadded:: 0.12
     initial_event : bool
         If True (default False), an event is created if the stim channel has a
         value different from 0 as its first sample. This is useful if an event
         at t=0s is present.
 
-        .. versionadded:: 0.12
+        .. versionadded:: 0.16
     mask_type: 'and' | 'not_and'
         The type of operation between the mask and the trigger.
         Choose 'and' (default) for MNE-C masking behavior.

--- a/mne/event.py
+++ b/mne/event.py
@@ -444,8 +444,13 @@ def _find_events(data, first_samp, verbose=None, output='onset',
         data = np.abs(data)  # make sure trig channel is positive
 
     events = _find_stim_steps(data, first_samp, pad_stop=0, merge=merge)
-    if initial_event and data[0, 0] != 0:
-        events = np.insert(events, 0, [0, 0, data[0, 0]], axis=0)
+    if data[0, 0] != 0:
+        if initial_event:
+            events = np.insert(events, 0, [0, 0, data[0, 0]], axis=0)
+        else:
+            warn('Trigger channel has a non-zero initial value (consider using'
+                 ' initial_event=True to detect this event)')
+
     events = _mask_trigs(events, mask, mask_type)
 
     # Determine event onsets and offsets

--- a/mne/event.py
+++ b/mne/event.py
@@ -495,7 +495,7 @@ def _find_events(data, first_samp, verbose=None, output='onset',
         raise ValueError("Invalid output parameter %r" % output)
 
     logger.info("%s events found" % len(events))
-    logger.info("Events id: %s" % np.unique(events[:, 2]))
+    logger.info("Event IDs: %s" % np.unique(events[:, 2]))
 
     return events
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -437,8 +437,7 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     tal_chs = np.where(np.array(ch_names) == tal_ch_name)[0]
     if len(tal_chs) > 0:
         logger.info('EDF annotations detected (consider using '
-                    'raw.find_edf_events() to extract events from these '
-                    'annotations)')
+                    'raw.find_edf_events() to extract them)')
         if len(tal_chs) > 1:
             warn('Channel names are not unique, found duplicates for: %s. '
                  'Adding running numbers to duplicate channel names.'

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -152,15 +152,15 @@ class RawEDF(BaseRaw):
     def __init__(self, input_fname, montage, eog=None, misc=None,
                  stim_channel='auto', annot=None, annotmap=None, exclude=(),
                  preload=False, verbose=None):  # noqa: D102
-        logger.info('Extracting EDF Parameters from %s...' % input_fname)
+        logger.info('Extracting EDF parameters from %s...' % input_fname)
         input_fname = os.path.abspath(input_fname)
         info, edf_info = _get_info(input_fname, stim_channel, annot,
                                    annotmap, eog, misc, exclude, preload)
-        logger.info('Created Raw.info structure...')
+        logger.info('Creating raw.info structure...')
         _check_update_montage(info, montage)
 
         if bool(annot) != bool(annotmap):
-            warn("Stimulus Channel will not be annotated. Both 'annot' and "
+            warn("Stimulus channel will not be annotated. Both 'annot' and "
                  "'annotmap' must be specified.")
 
         # Raw attributes
@@ -168,8 +168,6 @@ class RawEDF(BaseRaw):
         super(RawEDF, self).__init__(
             info, preload, filenames=[input_fname], raw_extras=[edf_info],
             last_samps=last_samps, orig_format='int', verbose=verbose)
-
-        logger.info('Ready.')
 
     @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -152,7 +152,7 @@ class RawEDF(BaseRaw):
     def __init__(self, input_fname, montage, eog=None, misc=None,
                  stim_channel='auto', annot=None, annotmap=None, exclude=(),
                  preload=False, verbose=None):  # noqa: D102
-        logger.info('Extracting edf Parameters from %s...' % input_fname)
+        logger.info('Extracting EDF Parameters from %s...' % input_fname)
         input_fname = os.path.abspath(input_fname)
         info, edf_info = _get_info(input_fname, stim_channel, annot,
                                    annotmap, eog, misc, exclude, preload)
@@ -438,6 +438,9 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     tal_ch_name = 'EDF Annotations'
     tal_chs = np.where(np.array(ch_names) == tal_ch_name)[0]
     if len(tal_chs) > 0:
+        logger.info('EDF annotations detected (consider using '
+                    'raw.find_edf_events() to extract events from these '
+                    'annotations)')
         if len(tal_chs) > 1:
             warn('Channel names are not unique, found duplicates for: %s. '
                  'Adding running numbers to duplicate channel names.'

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -9,8 +9,8 @@ import warnings
 
 from mne import (read_events, write_events, make_fixed_length_events,
                  find_events, pick_events, find_stim_steps, pick_channels,
-                 read_evokeds, Epochs)
-from mne.io import read_raw_fif
+                 read_evokeds, Epochs, create_info)
+from mne.io import read_raw_fif, RawArray
 from mne.tests.common import assert_naming
 from mne.utils import _TempDir, run_tests_if_main
 from mne.event import define_target_events, merge_events, AcqParserFIF
@@ -358,6 +358,16 @@ def test_find_events():
     events = find_events(raw, stim_channel=['STI 014', stim_channel2])
     assert_array_equal(events[::2], events2)
     assert_array_equal(events[1::2], events1)
+
+    # test initial_event argument
+    info = create_info(['MYSTI'], 1000, 'stim')
+    data = np.zeros((1, 1000))
+    raw = RawArray(data, info)
+    data[0, :10] = 100
+    data[0, 30:40] = 200
+    assert_array_equal(find_events(raw, 'MYSTI'), [[30, 0, 200]])
+    assert_array_equal(find_events(raw, 'MYSTI', initial_event=True),
+                       [[0, 0, 100], [30, 0, 200]])
 
 
 def test_pick_events():


### PR DESCRIPTION
As discussed with @larsoner in #4340, this PR adds support for initial events to `mne.find_events` with the argument `initial_event=False`. If set to `True`, initial events are only added if the value of the stim channel(s) are non-zero. If set to `False` (default), a warning is generated if non-zero initial values in stim channel(s) are found. Finally, I'm issuing an info if an EDF file contains EDF annotations (slightly unrelated, but still kinda fits in here).

One question I have is that I'm assuming `data` in `_find_events` is one stim channel (as opposed to potentially several stim channels in `find_events`) - which is why I'm doing `data[0, 0]` to get the initial value (no idea why this array doesn't get squeezed before). Is this assumption correct?