### PR TITLE
FIX psd_array_welch:  1d input arrays

### DIFF
--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -129,7 +129,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     # Combining, reducing windows and reshaping to original data shape
     psds = np.concatenate([np.nanmean(f_s, axis=-1)
                            for f_s in f_spectrogram], axis=0)
-    psds.shape = np.hstack([dshape, -1])
+    psds.shape = dshape + (-1,)
     return psds, freqs
 
 

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -26,6 +26,11 @@ def test_psd_nan():
         x, float(n_fft), n_fft=n_fft, n_overlap=n_overlap)
     assert_allclose(freqs, freqs_2)
     assert_allclose(psds, psds_2)
+    # 1-d
+    psds_2, freqs_2 = psd_array_welch(
+        x[0], float(n_fft), n_fft=n_fft, n_overlap=n_overlap)
+    assert_allclose(freqs, freqs_2)
+    assert_allclose(psds[0], psds_2)
 
 
 def test_psd():


### PR DESCRIPTION
For 1d-arrays, `dshape` is `()`, leading to `hstack` inferring `dtype` `float`