### PR TITLE
ICA prepared for start/stop arguments and higher precision for CTPS

### DIFF
--- a/mne/preprocessing/ctps_.py
+++ b/mne/preprocessing/ctps_.py
@@ -151,9 +151,9 @@ def _prob_kuiper(d, n_eff, dtype='f8'):
     j2 = (np.arange(n_points) + 1) ** 2
     j2 = j2.repeat(n_time_slices).reshape(n_points, n_time_slices)
     fact = 4. * j2 * l2 - 1.
-    expo = np.exp(-2. * j2 * l2)
+    expo = np.exp(-2. * j2 * l2, dtype='float128')
     term = 2. * fact * expo
-    pk = term.sum(axis=0, dtype=dtype)
+    pk = term.sum(axis=0)
 
     # Normalized pK to range [0,1]
     pk_norm = np.zeros(n_time_slices)  # init pk_norm
@@ -166,4 +166,4 @@ def _prob_kuiper(d, n_eff, dtype='f8'):
     # check for round off errors
     pk_norm = np.where(pk_norm > 1.0, 1.0, pk_norm)
 
-    return pk_norm
+    return pk_norm.astype(dtype)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1048,6 +1048,15 @@ class ICA(ContainsMixin):
             if threshold is None:
                 threshold = 0.25
             if isinstance(inst, BaseRaw):
+                reject_by_annotation = 'omit' if reject_by_annotation else None
+                start, stop = _check_start_stop(inst, start, stop)
+
+                # update the instance with new data
+                _data = inst.get_data(picks=None, start=start, stop=stop,
+                                      reject_by_annotation=reject_by_annotation)
+                inst._data = _data  # Could be done directly?
+
+                # create ECG epochs
                 sources = self.get_sources(create_ecg_epochs(
                     inst, ch_name, keep_ecg=False,
                     reject_by_annotation=reject_by_annotation)).get_data()


### PR DESCRIPTION
@agramfort @dengemann @pravsripad   issue #4768

1) in ica.py the function find_bads_ecg() is now prepared to take and process the start/stop arguments when the "method" argument is set to <method='CTPS'>. An additional problem was that the "reject_by_annotation" argument was also ignored. The problem here is that the qrs_detector() in ecg.py is not prepared to take these arguments. Thanks to @pravsripad we have solution that can handle both (start/stop and reject_by_annotation). Have a look at the code, maybe there is a better way to handle the two problems. Note, we have tested this using the MNE-example files and our own data files.

2) CTPS: inside _prob_kuiper() the function computes the significance values with dtype='float128', which was import to not get overflows using np.exp(). After computation the pk_norm values will have the default dtype.