### PR TITLE
[MRG] Add annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
 - Left and right arrow keys now scroll by 25% of the visible data, whereas Shift+left/right scroll by a whole page in :meth:`mne.io.Raw.plot` by `Clemens Brunner`_
 
+- Add possibility to concatenate `mne.Annotations` objects with ``+`` or ``+=`` operators by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -105,14 +105,12 @@ class Annotations(object):
 
     def __add__(self, other):
         """Add (concatencate) two Annotation objects."""
-        new = deepcopy(self)
-        new.append(other.onset, other.duration, other.description)
-        return new
+        return self.copy().append(other.onset, other.duration,
+                                  other.description)
 
     def __iadd__(self, other):
         """Add (concatencate) two Annotation objects in-place."""
-        self.append(other.onset, other.duration, other.description)
-        return self
+        return self.append(other.onset, other.duration, other.description)
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.
@@ -127,10 +125,20 @@ class Annotations(object):
         description : str
             Description for the annotation. To reject epochs, use description
             starting with keyword 'bad'
+
+        Returns
+        -------
+        self : mne.Annotations
+            The modified Annotations object.
         """
         self.onset = np.append(self.onset, onset)
         self.duration = np.append(self.duration, duration)
         self.description = np.append(self.description, description)
+        return self
+
+    def copy(self):
+        """Return a deep copy of self."""
+        return deepcopy(self)
 
     def delete(self, idx):
         """Remove an annotation. Operates inplace.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -4,6 +4,7 @@
 
 from datetime import datetime
 import time
+from copy import deepcopy
 
 import numpy as np
 
@@ -101,6 +102,17 @@ class Annotations(object):
     def __len__(self):
         """Return the number of annotations."""
         return len(self.duration)
+
+    def __add__(self, other):
+        """Add (concatencate) two Annotation objects."""
+        new = deepcopy(self)
+        new.append(other.onset, other.duration, other.description)
+        return new
+
+    def __iadd__(self, other):
+        """Add (concatencate) two Annotation objects."""
+        self.append(other.onset, other.duration, other.description)
+        return self
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -110,7 +110,7 @@ class Annotations(object):
         return new
 
     def __iadd__(self, other):
-        """Add (concatencate) two Annotation objects."""
+        """Add (concatencate) two Annotation objects in-place."""
         self.append(other.onset, other.duration, other.description)
         return self
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -212,4 +212,27 @@ def test_annotation_epoching():
     assert_equal([0, 2, 4], epochs.selection)
 
 
+def test_annotation_concat():
+    """Test if two Annotations objects can be concatenated."""
+    a = Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
+    b = Annotations([11, 12, 13], [1, 2, 2], ["x", "y", "z"])
+
+    # test + operator (does not modify a or b)
+    c = a + b
+    assert_array_equal(c.onset, [1, 2, 3, 11, 12, 13])
+    assert_array_equal(c.duration, [5, 5, 8, 1, 2, 2])
+    assert_array_equal(c.description, ["a", "b", "c", "x", "y", "z"])
+    assert_equal(len(a), 3)
+    assert_equal(len(b), 3)
+    assert_equal(len(c), 6)
+
+    # test += operator (modifies a in place)
+    a += b
+    assert_array_equal(a.onset, [1, 2, 3, 11, 12, 13])
+    assert_array_equal(a.duration, [5, 5, 8, 1, 2, 2])
+    assert_array_equal(a.description, ["a", "b", "c", "x", "y", "z"])
+    assert_equal(len(a), 6)
+    assert_equal(len(b), 3)
+
+
 run_tests_if_main()


### PR DESCRIPTION
I thought it would be handy if I could add two `Annotations` objects like this:

```python
import mne
a = mne.Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
b = mne.Annotations([11, 12, 13], [1, 2, 2], ["x", "y", "z"])
c = a + b
```

Or in-place like this:

```python
a += b
```

Currently, this can only be done in-place with a slightly more verbose syntax:

```python
a.append(b.onset, b.duration, b.description)
```