### PR TITLE
MRG: Fix permutation bug

### DIFF
--- a/examples/stats/plot_sensor_permutation_test.py
+++ b/examples/stats/plot_sensor_permutation_test.py
@@ -60,7 +60,7 @@ print("Sensors names : %s" % significant_sensors_names)
 evoked = mne.EvokedArray(-np.log10(p_values)[:, np.newaxis],
                          epochs.info, tmin=0.)
 
-# Extract mask and indices of active sensors in layout
+# Extract mask and indices of active sensors in the layout
 stats_picks = mne.pick_channels(evoked.ch_names, significant_sensors_names)
 mask = p_values[:, np.newaxis] <= 0.05
 

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -95,13 +95,14 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
     parallel, my_max_stat, n_jobs = parallel_func(_max_stat, n_jobs)
     max_abs = np.concatenate(parallel(my_max_stat(X, X2, p, dof_scaling)
                                       for p in np.array_split(perms, n_jobs)))
+    max_abs = np.concatenate((max_abs, [np.abs(T_obs).max()]))
     H0 = np.sort(max_abs)
     if tail == 0:
-        p_values = (H0 > np.abs(T_obs[:, np.newaxis])).mean(-1)
+        p_values = (H0 >= np.abs(T_obs[:, np.newaxis])).mean(-1)
     elif tail == 1:
-        p_values = (H0 > T_obs[:, np.newaxis]).mean(-1)
+        p_values = (H0 >= T_obs[:, np.newaxis]).mean(-1)
     elif tail == -1:
-        p_values = (-H0 < T_obs[:, np.newaxis]).mean(-1)
+        p_values = (-H0 <= T_obs[:, np.newaxis]).mean(-1)
     return T_obs, p_values, H0
 
 

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -2,8 +2,7 @@
 #
 # License: BSD (3-clause)
 
-from numpy.testing import (assert_array_equal, assert_almost_equal,
-                           assert_allclose)
+from numpy.testing import assert_array_equal, assert_allclose
 import numpy as np
 from scipy import stats
 
@@ -48,8 +47,8 @@ def test_permutation_t_test():
     X = np.random.randn(18, 1)
     t_obs, p_values, H0 = permutation_t_test(X[:, [0]], n_permutations='all')
     t_obs_scipy, p_values_scipy = stats.ttest_1samp(X[:, 0], 0)
-    assert_almost_equal(t_obs[0], t_obs_scipy, 8)
-    assert_almost_equal(p_values[0], p_values_scipy, 2)
+    assert_allclose(t_obs[0], t_obs_scipy, 8)
+    assert_allclose(p_values[0], p_values_scipy, rtol=1e-2)
 
 
 def test_ci():

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -19,17 +19,31 @@ def test_permutation_t_test():
     X = np.random.randn(n_samples, n_tests)
     X[:, :2] += 1
 
-    t_obs, p_values, H0 = permutation_t_test(X, n_permutations=999, tail=0)
+    t_obs, p_values, H0 = permutation_t_test(
+        X, n_permutations=999, tail=0, seed=0)
+    assert (p_values > 0).all()
+    assert len(H0) == 999
     is_significant = p_values < 0.05
     assert_array_equal(is_significant, [True, True, False, False, False])
 
-    t_obs, p_values, H0 = permutation_t_test(X, n_permutations=999, tail=1)
+    t_obs, p_values, H0 = permutation_t_test(
+        X, n_permutations=999, tail=1, seed=0)
+    assert (p_values > 0).all()
+    assert len(H0) == 999
     is_significant = p_values < 0.05
     assert_array_equal(is_significant, [True, True, False, False, False])
 
-    t_obs, p_values, H0 = permutation_t_test(X, n_permutations=999, tail=-1)
+    t_obs, p_values, H0 = permutation_t_test(
+        X, n_permutations=999, tail=-1, seed=0)
     is_significant = p_values < 0.05
     assert_array_equal(is_significant, [False, False, False, False, False])
+
+    t_obs, p_values, H0 = permutation_t_test(
+        -X, n_permutations=999, tail=-1, seed=0)
+    assert (p_values > 0).all()
+    assert len(H0) == 999
+    is_significant = p_values < 0.05
+    assert_array_equal(is_significant, [True, True, False, False, False])
 
     X = np.random.randn(18, 1)
     t_obs, p_values, H0 = permutation_t_test(X[:, [0]], n_permutations='all')


### PR DESCRIPTION
Fixes minor bug introduced in #4743 (0.16 cycle) with `permutation_t_test` that has broken CircleCI on `master` lately.