### PR TITLE
Fix for EGI PSG signal bug

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
 - Left and right arrow keys now scroll by 25% of the visible data, whereas Shift+left/right scroll by a whole page in :meth:`mne.io.Raw.plot` by `Clemens Brunner`_
 
+- Workaround for reading EGI MFF files with physiological signals that also present a bug from the EGI system in :class:`mne.io.egi.egimff.RawMff` by `Fede Raimondo`_
+
 Bug
 ~~~
 

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -234,7 +234,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.41', misc='0.3')
+    releases = dict(testing='0.42', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -311,7 +311,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='fc2d5b9eb0a144b1d6ba84dc3b983602',
         somato='f3e3a8441477bb5bacae1d0c6e0964fb',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='6e7f0f2506b98cad0f2161162ef5f9f3',
+        testing='cde862722ec8fcc9e59d84bb816f7469',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         visual_92_categories=['74f50bbeb65740903eadc229c9fa759f',
                               '203410a98afc9df9ae8ba9f933370e20'],

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -553,7 +553,7 @@ class RawMff(BaseRaw):
                         # We are in the presense of the EEG bug
                         # fill with zeros and break the loop
                         data_view = data[n_data1_channels:, -1] = 0
-                        logger.warning('This file has the EGI PSG sample bug')
+                        warn('This file has the EGI PSG sample bug')
                         if self.annotations is None:
                             self.annotations = Annotations((), (), ())
                         an_start = current_data_sample

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -16,6 +16,7 @@ from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..utils import _create_chs
 from ...utils import verbose, logger, warn
+from ...annotations import Annotations, _sync_onset
 
 
 def _read_mff_header(filepath):
@@ -553,6 +554,12 @@ class RawMff(BaseRaw):
                         # fill with zeros and break the loop
                         data_view = data[n_data1_channels:, -1] = 0
                         logger.warning('This file has the EGI PSG sample bug')
+                        if self.annotations is None:
+                            self.annotations = Annotations((), (), ())
+                        an_start = current_data_sample
+                        self.annotations.append(
+                            _sync_onset(self, an_start / self.info['sfreq']),
+                            1 / self.info['sfreq'], 'BAD_EGI_PSG')
                         break
 
                     this_block_info = _block_r(fid)

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -531,6 +531,10 @@ class RawMff(BaseRaw):
 
             samples_to_read = stop - start
             with open(pns_filepath, 'rb', buffering=0) as fid:
+                # Check file size
+                fid.seek(0, 2)
+                file_size = fid.tell()
+                fid.seek(0)
                 # Go to starting block
                 current_block = 0
                 current_block_info = None
@@ -544,6 +548,13 @@ class RawMff(BaseRaw):
 
                 # Start reading samples
                 while samples_to_read > 0:
+                    if samples_to_read == 1 and fid.tell() == file_size:
+                        # We are in the presense of the EEG bug
+                        # fill with zeros and break the loop
+                        data_view = data[n_data1_channels:, -1] = 0
+                        logger.warning('This file has the EGI PSG sample bug')
+                        break
+
                     this_block_info = _block_r(fid)
                     if this_block_info is not None:
                         current_block_info = this_block_info

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -550,7 +550,7 @@ class RawMff(BaseRaw):
                 # Start reading samples
                 while samples_to_read > 0:
                     if samples_to_read == 1 and fid.tell() == file_size:
-                        # We are in the presense of the EEG bug
+                        # We are in the presence of the EEG bug
                         # fill with zeros and break the loop
                         data_view = data[n_data1_channels:, -1] = 0
                         warn('This file has the EGI PSG sample bug')

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -158,7 +158,7 @@ def test_io_egi_pns_mff():
 
 
 @requires_testing_data
-def test_io_egi_pns_mff():
+def test_io_egi_pns_mff_bug():
     """Test importing EGI MFF with PNS data (BUG)"""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
     raw = read_raw_egi(egi_fname_mff, include=None, preload=True,

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -161,8 +161,10 @@ def test_io_egi_pns_mff():
 def test_io_egi_pns_mff_bug():
     """Test importing EGI MFF with PNS data (BUG)"""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
-    raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
-                       verbose='error')
+    with warnings.catch_warnings(record=True) as w:
+        raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
+                           verbose='warning')
+    assert any('EGI PSG sample bug' in str(ww.message) for ww in w)
     egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -157,4 +157,39 @@ def test_io_egi_pns_mff():
         assert_array_equal(mat_data, raw_data)
 
 
+@requires_testing_data
+def test_io_egi_pns_mff():
+    """Test importing EGI MFF with PNS data (BUG)"""
+    egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
+    raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
+                       verbose='error')
+    egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
+    mc = sio.loadmat(egi_fname_mat)
+    pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)
+    pns_names = ['Resp. Temperature'[:15],
+                 'Resp. Pressure',
+                 'ECG',
+                 'Body Position',
+                 'Resp. Effort Chest'[:15],
+                 'Resp. Effort Abdomen'[:15],
+                 'EMG-Leg']
+    mat_names = [
+        'Resp_Temperature'[:15],
+        'Resp_Pressure',
+        'ECG',
+        'Body_Position',
+        'Resp_Effort_Chest'[:15],
+        'Resp_Effort_Abdomen'[:15],
+        'EMGLeg'
+
+    ]
+    for ch_name, ch_idx, mat_name in zip(pns_names, pns_chans, mat_names):
+        print('Testing {}'.format(ch_name))
+        mc_key = [x for x in mc.keys() if mat_name in x][0]
+        cal = raw.info['chs'][ch_idx]['cal']
+        mat_data = mc[mc_key] * cal
+        mat_data[:, -1] = 0  # The MFF has one less sample, the last one
+        raw_data = raw[ch_idx][0]
+        assert_array_equal(mat_data, raw_data)
+
 run_tests_if_main()


### PR DESCRIPTION
Not the happiest solution, but just a workaround for the problem EGI has.

Basically the MFF container has a signal1.bin and signal2.bin. Sometimes (and that's why it did not show up before), the signal2.bin has 1 sample less than what's indicated in the header and in the signal1.bin. EGI people knows about that, but their response is "you do not use our API".

I guess they have a major problem somewhere.

This proposed fix checks to see if we reached the end of the file and we still need to read 1 sample. If that's the case, the last sample is filled with 0s.

This is the headers from signal1.bin (40 blocks like first line, the last one is shorter):
```
{'nc': 257, 'hl': 1052672, 'nsamples': 4096, 'block_size': 4210688, 'header_size': 2100, 'sfreq': 250}
{'nc': 257, 'hl': 752239, 'nsamples': 2927, 'block_size': 3008956, 'header_size': 2076, 'sfreq': 250}
```

And this is from signal2.bin:
```
{'nc': 8, 'hl': 32768, 'nsamples': 4096, 'block_size': 131072, 'header_size': 108, 'sfreq': 250}
{'nc': 8, 'hl': 23408, 'nsamples': 2926, 'block_size': 93632, 'header_size': 84, 'sfreq': 250}
```