### PR TITLE
ENH add gantry angle IO to FIFF consts and meas_info

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
 - Left and right arrow keys now scroll by 25% of the visible data, whereas Shift+left/right scroll by a whole page in :meth:`mne.io.Raw.plot` by `Clemens Brunner`_
 
+- Add support for gantry tilt angle determination from Elekta FIF file header by `Chris Bailey`_
+
 Bug
 ~~~
 

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -142,6 +142,7 @@ FIFF.FIFF_NAME           = 233          # Intended to be a short name.
 FIFF.FIFF_DESCRIPTION    = FIFF.FIFF_COMMENT # (Textual) Description of an object
 FIFF.FIFF_DIG_STRING     = 234          # String of digitized points
 FIFF.FIFF_LINE_FREQ      = 235    # Line frequency
+FIFF.FIFF_GANTRY_ANGLE   = 282    # Recording gantry angle (Triux)
 
 #
 # HPI fitting program tags

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -142,7 +142,7 @@ FIFF.FIFF_NAME           = 233          # Intended to be a short name.
 FIFF.FIFF_DESCRIPTION    = FIFF.FIFF_COMMENT # (Textual) Description of an object
 FIFF.FIFF_DIG_STRING     = 234          # String of digitized points
 FIFF.FIFF_LINE_FREQ      = 235    # Line frequency
-FIFF.FIFF_GANTRY_ANGLE   = 282    # Recording gantry angle (Triux)
+FIFF.FIFF_GANTRY_ANGLE   = 282    # Tilt angle of the gantry in degrees.
 
 #
 # HPI fitting program tags

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -143,7 +143,7 @@ class Info(dict):
     line_freq : float | None
         Frequency of the power line in Hertz.
     gantry_angle : float | None
-        Gantry angle during recording.
+        Tilt angle of the gantry in degrees.
     lowpass : float | None
         Lowpass corner frequency in Hertz.
     meas_date : list of int

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -142,6 +142,8 @@ class Info(dict):
         See Notes for details.
     line_freq : float | None
         Frequency of the power line in Hertz.
+    gantry_angle : float | None
+        Gantry angle during recording.
     lowpass : float | None
         Lowpass corner frequency in Hertz.
     meas_date : list of int
@@ -896,6 +898,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
     proj_id = None
     proj_name = None
     line_freq = None
+    gantry_angle = None
     custom_ref_applied = False
     xplotter_layout = None
     kit_system_id = None
@@ -948,6 +951,9 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
         elif kind == FIFF.FIFF_LINE_FREQ:
             tag = read_tag(fid, pos)
             line_freq = float(tag.data)
+        elif kind == FIFF.FIFF_GANTRY_ANGLE:
+            tag = read_tag(fid, pos)
+            gantry_angle = float(tag.data)
         elif kind in [FIFF.FIFF_MNE_CUSTOM_REF, 236]:  # 236 used before v0.11
             tag = read_tag(fid, pos)
             custom_ref_applied = bool(tag.data)
@@ -1208,6 +1214,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
     info['highpass'] = highpass if highpass is not None else 0.
     info['lowpass'] = lowpass if lowpass is not None else info['sfreq'] / 2.0
     info['line_freq'] = line_freq
+    info['gantry_angle'] = gantry_angle
 
     #   Add the channel information and make a list of channel names
     #   for convenience
@@ -1388,6 +1395,8 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         write_float(fid, FIFF.FIFF_HIGHPASS, info['highpass'])
     if info.get('line_freq') is not None:
         write_float(fid, FIFF.FIFF_LINE_FREQ, info['line_freq'])
+    if info.get('gantry_angle') is not None:
+        write_float(fid, FIFF.FIFF_GANTRY_ANGLE, info['gantry_angle'])
     if data_type is not None:
         write_int(fid, FIFF.FIFF_DATA_PACK, data_type)
     if info.get('custom_ref_applied'):
@@ -1638,7 +1647,7 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
                     'experimenter', 'file_id', 'highpass',
                     'hpi_results', 'hpi_meas', 'hpi_subsystem', 'events',
                     'line_freq', 'lowpass', 'meas_date', 'meas_id',
-                    'proj_id', 'proj_name', 'projs', 'sfreq',
+                    'proj_id', 'proj_name', 'projs', 'sfreq', 'gantry_angle',
                     'subject_info', 'sfreq', 'xplotter_layout', 'proc_history']
     for k in other_fields:
         info[k] = _merge_dict_values(infos, k)
@@ -1756,7 +1765,7 @@ RAW_INFO_FIELDS = (
     'file_id', 'highpass', 'hpi_meas', 'hpi_results',
     'hpi_subsystem', 'kit_system_id', 'line_freq', 'lowpass', 'meas_date',
     'meas_id', 'nchan', 'proj_id', 'proj_name', 'projs', 'sfreq',
-    'subject_info', 'xplotter_layout', 'proc_history',
+    'subject_info', 'xplotter_layout', 'proc_history', 'gantry_angle',
 )
 
 
@@ -1768,7 +1777,7 @@ def _empty_info(sfreq):
         'dev_ctf_t', 'dig', 'experimenter',
         'file_id', 'highpass', 'hpi_subsystem', 'kit_system_id',
         'line_freq', 'lowpass', 'meas_date', 'meas_id', 'proj_id', 'proj_name',
-        'subject_info', 'xplotter_layout',
+        'subject_info', 'xplotter_layout', 'gantry_angle',
     )
     _list_keys = ('bads', 'chs', 'comps', 'events', 'hpi_meas', 'hpi_results',
                   'projs', 'proc_history')

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -183,11 +183,17 @@ def test_read_write_info():
     info['proc_history'][0]['creator'] = creator
     info['hpi_meas'][0]['creator'] = creator
     info['subject_info']['his_id'] = creator
+
+    if info['gantry_angle'] is None:  # future testing data may include it
+        info['gantry_angle'] = 0.  # Elekta supine position
+    gantry_angle = info['gantry_angle']
+
     write_info(temp_file, info)
     info = read_info(temp_file)
     assert_equal(info['proc_history'][0]['creator'], creator)
     assert_equal(info['hpi_meas'][0]['creator'], creator)
     assert_equal(info['subject_info']['his_id'], creator)
+    assert_equal(info['gantry_angle'], gantry_angle)
 
 
 def test_io_dig_points():


### PR DESCRIPTION
Elekta's official `fiff_support` libs have included (amongst others) a tag for gantry position.

```c
#define FIFF_GANTRY_ANGLE          282    /* Tilt angle of the gantry in degrees. */
```

Presumably this is included in all subsequent DACQ versions, so practically all VectorView __and__ Triux files will have this tag set. Notably, `sample` doesn't ;)

For this PR I simply followed the tag `line_freq` down the code in `meas_info.py`, and added a new key `gantry_angle` everywhere.

BTW, it's useful to know the angle when diagnosing far-away noise sources and EAS (some directions are better compensated than others).