### PR TITLE
ENH: Add sample weight test LinearModel

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -62,7 +62,7 @@ class LinearModel(BaseEstimator):
         self.model = model
         self._estimator_type = getattr(model, "_estimator_type", None)
 
-    def fit(self, X, y):
+    def fit(self, X, y, **fit_params):
         """Estimate the coefficients of the linear model.
 
         Save the coefficients in the attribute ``filters_`` and
@@ -74,6 +74,8 @@ class LinearModel(BaseEstimator):
             The training input samples to estimate the linear coefficients.
         y : array, shape (n_samples, [n_targets])
             The target values.
+        **fit_params : dict of string -> object
+            Parameters to pass to the fit method of the estimator.
 
         Returns
         -------
@@ -89,7 +91,7 @@ class LinearModel(BaseEstimator):
                              'got %s instead.' % (y.shape,))
 
         # fit the Model
-        self.model.fit(X, y)
+        self.model.fit(X, y, **fit_params)
 
         # Computes patterns using Haufe's trick: A = Cov_X . W . Precision_Y
 

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -162,6 +162,9 @@ def test_get_coef():
             lm = LinearModel(Ridge(alpha=1)).fit(X, Y)
             assert_array_almost_equal(A, lm.patterns_.T, decimal=2)
 
+    # Check can pass fitting parameters
+    lm.fit(X, Y, sample_weight=np.ones(len(Y)))
+
 
 @requires_version('sklearn', '0.15')
 def test_linearmodel():


### PR DESCRIPTION
Adds **kwargs to fit ala scikit-learn to make it compatible with `sample_weight`

e.g.

```python
LinearModel().fit(X, y, sample_weight=sample_weight)
```