### PR TITLE
MRG: Unify covariance code in mne/decoding and mne/cov.py

### DIFF
--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -1,7 +1,7 @@
 """
-=============================
- XDAWN Decoding From EEG data
-=============================
+============================
+XDAWN Decoding From EEG data
+============================
 
 ERP decoding with Xdawn ([1]_, [2]_). For each event type, a set of
 spatial Xdawn filters are trained and applied on the signal. Channels are

--- a/examples/preprocessing/plot_xdawn_denoising.py
+++ b/examples/preprocessing/plot_xdawn_denoising.py
@@ -1,7 +1,7 @@
 """
-================
- XDAWN Denoising
-================
+===============
+XDAWN Denoising
+===============
 
 XDAWN filters are trained from epochs, signal is projected in the sources
 space and then projected back in the sensor space using only the first two

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
-from distutils.version import LooseVersion
 import itertools as itt
 from math import log
 import os
@@ -22,7 +21,7 @@ from .io.pick import (pick_types, pick_channels_cov, pick_channels, pick_info,
                       _picks_by_type, _pick_data_channels)
 
 from .io.constants import FIFF
-from .io.meas_info import read_bad_channels, _simplify_info
+from .io.meas_info import read_bad_channels, _simplify_info, create_info
 from .io.proj import _read_proj, _write_proj
 from .io.tag import find_tag
 from .io.tree import dir_tree_find
@@ -38,7 +37,7 @@ from . import viz
 
 from .externals.six.moves import zip
 from .externals.six import string_types
-from .fixes import BaseEstimator
+from .fixes import BaseEstimator, EmpiricalCovariance, _logdet
 
 
 def _check_covs_algebra(cov1, cov2):
@@ -329,23 +328,6 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
     It is typically useful to estimate a noise covariance from empty room
     data or time intervals before starting the stimulation.
 
-    .. note:: This function will:
-
-                  1. Partition the data into evenly spaced, equal-length
-                     epochs.
-                  2. Load them into memory.
-                  3. Subtract the mean across all time points and epochs
-                     for each channel.
-                  4. Process the :class:`Epochs` by
-                     :func:`compute_covariance`.
-
-              This will produce a slightly different result compared to
-              using :func:`make_fixed_length_events`, :class:`Epochs`, and
-              :func:`compute_covariance` directly, since that would (with
-              the recommended baseline correction) subtract the mean across
-              time *for each epoch* (instead of across epochs) for each
-              channel.
-
     Parameters
     ----------
     raw : instance of Raw
@@ -383,45 +365,38 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         See :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.12
-
     method_params : dict | None (default None)
         Additional parameters to the estimation procedure.
         See :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.12
-
     cv : int | sklearn model_selection object (default 3)
         The cross validation method. Defaults to 3, which will
         internally trigger by default :class:`sklearn.model_selection.KFold`
         with 3 splits.
 
         .. versionadded:: 0.12
-
     scalings : dict | None (default None)
         Defaults to ``dict(mag=1e15, grad=1e13, eeg=1e6)``.
         These defaults will scale magnetometers and gradiometers
         at the same unit.
 
         .. versionadded:: 0.12
-
     n_jobs : int (default 1)
         Number of jobs to run in parallel.
 
         .. versionadded:: 0.12
-
     return_estimators : bool (default False)
         Whether to return all estimators or the best. Only considered if
         method equals 'auto' or is a list of str. Defaults to False
 
         .. versionadded:: 0.12
-
     reject_by_annotation : bool
         Whether to reject based on annotations. If True (default), epochs
         overlapping with segments whose description begins with ``'bad'`` are
         rejected. If False, no rejection based on annotations is performed.
 
         .. versionadded:: 0.14.0
-
     verbose : bool | str | int | None (default None)
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -437,6 +412,21 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
     See Also
     --------
     compute_covariance : Estimate noise covariance matrix from epochs
+
+    Notes
+    -----
+    This function will:
+
+    1. Partition the data into evenly spaced, equal-length epochs.
+    2. Load them into memory.
+    3. Subtract the mean across all time points and epochs for each channel.
+    4. Process the :class:`Epochs` by :func:`compute_covariance`.
+
+    This will produce a slightly different result compared to using
+    :func:`make_fixed_length_events`, :class:`Epochs`, and
+    :func:`compute_covariance` directly, since that would (with the recommended
+    baseline correction) subtract the mean across time *for each epoch*
+    (instead of across epochs) for each channel.
     """
     tmin = 0. if tmin is None else float(tmin)
     tmax = raw.times[-1] if tmax is None else float(tmax)
@@ -495,6 +485,61 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
                               return_estimators=return_estimators)
 
 
+def _check_method_params(method, method_params, keep_sample_mean=True,
+                         name='method', allow_auto=True):
+    """Check that method and method_params are usable."""
+    accepted_methods = ('auto', 'empirical', 'diagonal_fixed', 'ledoit_wolf',
+                        'oas', 'shrunk', 'pca', 'factor_analysis', 'shrinkage')
+    _method_params = {
+        'empirical': {'store_precision': False, 'assume_centered': True},
+        'diagonal_fixed': {'grad': 0.01, 'mag': 0.01, 'eeg': 0.0,
+                           'store_precision': False, 'assume_centered': True},
+        'ledoit_wolf': {'store_precision': False, 'assume_centered': True},
+        'oas': {'store_precision': False, 'assume_centered': True},
+        'shrinkage': {'shrinkage': 0.1, 'store_precision': False,
+                      'assume_centered': True},
+        'shrunk': {'shrinkage': np.logspace(-4, 0, 30),
+                   'store_precision': False, 'assume_centered': True},
+        'pca': {'iter_n_components': None},
+        'factor_analysis': {'iter_n_components': None}
+    }
+    if isinstance(method_params, dict):
+        for key, values in method_params.items():
+            if key not in _method_params:
+                raise ValueError('key (%s) must be "%s"' %
+                                 (key, '" or "'.join(_method_params)))
+
+            _method_params[key].update(method_params[key])
+        shrinkage = method_params.get('shrinkage', {}).get('shrinkage', 0.1)
+        if not 0 <= shrinkage <= 1:
+            raise ValueError('shrinkage must be between 0 and 1, got %s'
+                             % (shrinkage,))
+
+    if method is None:
+        method = ['empirical']
+    elif method == 'auto' and allow_auto:
+        method = ['shrunk', 'diagonal_fixed', 'empirical', 'factor_analysis']
+
+    if not isinstance(method, (list, tuple)):
+        method = [method]
+
+    if not all(k in accepted_methods for k in method):
+        raise ValueError(
+            'Invalid {name} ({method}). Accepted values (individually or '
+            'in a list) are any of "{accepted_methods}" or None.'.format(
+                name=name, method=method, accepted_methods=accepted_methods))
+
+    if not keep_sample_mean:
+        if len(method) != 1 or 'empirical' not in method:
+            raise ValueError('`keep_sample_mean=False` is only supported'
+                             'with %s="empirical"' % (name,))
+        for p, v in _method_params.items():
+            if v.get('assume_centered', None) is False:
+                raise ValueError('`assume_centered` must be True'
+                                 ' if `keep_sample_mean` is False')
+    return method, _method_params
+
+
 @verbose
 def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
                        projs=None, method='empirical', method_params=None,
@@ -502,8 +547,8 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
                        on_mismatch='raise', verbose=None):
     """Estimate noise covariance matrix from epochs.
 
-    The noise covariance is typically estimated on pre-stim periods
-    when the stim onset is defined from events.
+    The noise covariance is typically estimated on pre-stimulus periods
+    when the stimulus onset is defined from events.
 
     If the covariance is computed for multiple event types (events
     with different IDs), the following two options can be used and combined:
@@ -512,22 +557,6 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
            a list of Epochs is passed to this function.
         2. an Epochs object is created for multiple events and passed
            to this function.
-
-    .. note:: Baseline correction should be used when creating the Epochs.
-              Otherwise the computed covariance matrix will be inaccurate.
-
-    .. note:: For multiple event types, it is also possible to create a
-              single Epochs object with events obtained using
-              merge_events(). However, the resulting covariance matrix
-              will only be correct if keep_sample_mean is True.
-
-    .. note:: The covariance can be unstable if the number of samples is
-              not sufficient. In that case it is common to regularize a
-              covariance estimate. The ``method`` parameter of this
-              function allows to regularize the covariance in an
-              automated way. It also allows to select between different
-              alternative estimation algorithms which themselves achieve
-              regularization. Details are described in [1]_.
 
     Parameters
     ----------
@@ -549,51 +578,49 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         inherited. If None, then projectors from all epochs must match.
     method : str | list | None (default 'empirical')
         The method used for covariance estimation. If 'empirical' (default),
-        the sample covariance will be computed. A list can be passed to run a
-        set of the different methods.
+        the sample covariance will be computed. A list can be passed to
+        perform estimates using multiple methods.
         If 'auto' or a list of methods, the best estimator will be determined
         based on log-likelihood and cross-validation on unseen data as
         described in [1]_. Valid methods are:
 
-            * ``'empirical'``: the empirical or sample covariance
-            * ``'diagonal_fixed'``: a diagonal regularization as in
-              mne.cov.regularize (see MNE manual)
-            * ``'ledoit_wolf'``: the Ledoit-Wolf estimator [2]_
-            * ``'shrunk'``: like 'ledoit_wolf' with cross-validation for
-              optimal alpha (see scikit-learn documentation on covariance
-              estimation)
-            * ``'pca'``: probabilistic PCA with low rank [3]_
-            * ``'factor_analysis'``: Factor Analysis with low rank [4]_
+        * ``'empirical'``: the empirical or sample covariance (default)
+        * ``'diagonal_fixed'``: a diagonal regularization based on
+          channel types as in :func:`mne.cov.regularize`.
+        * ``'shrinkage'`` : covariance estimator with fixed shrinkage.
+
+          .. versionadded:: 0.16
+        * ``'ledoit_wolf'``: the Ledoit-Wolf estimator, which uses an
+          empirical formula for the optimal shrinkage value [2]_.
+        * ``'oas'``: the OAS estimator [5]_, which uses a different
+          empricial formula for the optimal shrinkage value.
+
+          .. versionadded:: 0.16
+        * ``'shrunk'``: like 'ledoit_wolf', but with cross-validation
+          for optimal alpha.
+        * ``'pca'``: probabilistic PCA with low rank [3]_.
+        * ``'factor_analysis'``: factor analysis with low rank [4]_.
 
         If ``'auto'``, this expands to::
 
              ['shrunk', 'diagonal_fixed', 'empirical', 'factor_analysis']
 
-        .. note:: ``'ledoit_wolf'`` and ``'pca'`` are similar to
-           ``'shrunk'`` and ``'factor_analysis'``, respectively. They are not
-           included to avoid redundancy. In most cases ``'shrunk'`` and
-           ``'factor_analysis'`` represent more appropriate default
-           choices.
-
         The ``'auto'`` mode is not recommended if there are many
         segments of data, since computation can take a long time.
 
         .. versionadded:: 0.9.0
-
     method_params : dict | None (default None)
         Additional parameters to the estimation procedure. Only considered if
-        method is not None. Keys must correspond to the value(s) of `method`.
-        If None (default), expands to::
+        method is not None. Keys must correspond to the value(s) of ``method``.
+        If None (default), expands to the following (with the addition of
+        ``{'store_precision': False, 'assume_centered': True} for all methods
+        except ``'factor_analysis'`` and ``'pca'``)::
 
-            'empirical': {'store_precision': False, 'assume_centered': True},
-            'diagonal_fixed': {'grad': 0.01, 'mag': 0.01, 'eeg': 0.0,
-                               'store_precision': False,
-                               'assume_centered': True},
-            'ledoit_wolf': {'store_precision': False, 'assume_centered': True},
-            'shrunk': {'shrinkage': np.logspace(-4, 0, 30),
-                       'store_precision': False, 'assume_centered': True},
-            'pca': {'iter_n_components': None},
-            'factor_analysis': {'iter_n_components': None}
+            {'diagonal_fixed': {'grad': 0.01, 'mag': 0.01, 'eeg': 0.0},
+             'shrinkage': {'shrikage': 0.1},
+             'shrunk': {'shrinkage': np.logspace(-4, 0, 30)},
+             'pca': {'iter_n_components': None},
+             'factor_analysis': {'iter_n_components': None}}
 
     cv : int | sklearn model_selection object (default 3)
         The cross validation method. Defaults to 3, which will
@@ -601,8 +628,8 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         with 3 splits.
     scalings : dict | None (default None)
         Defaults to ``dict(mag=1e15, grad=1e13, eeg=1e6)``.
-        These defaults will scale magnetometers and gradiometers
-        at the same unit.
+        These defaults will scale data to roughly the same order of
+        magnitude.
     n_jobs : int (default 1)
         Number of jobs to run in parallel.
     return_estimators : bool (default False)
@@ -632,6 +659,33 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
     --------
     compute_raw_covariance : Estimate noise covariance from raw data
 
+    Notes
+    -----
+    Baseline correction or sufficient high-passing should be used
+    when creating the :class:`Epochs` to ensure that the data are zero mean,
+    otherwise the computed covariance matrix will be inaccurate.
+
+    For multiple event types, it is also possible to create a
+    single :class:`Epochs` object with events obtained using
+    :func:`mne.merge_events`. However, the resulting covariance matrix
+    will only be correct if ``keep_sample_mean is True``.
+
+    The covariance can be unstable if the number of samples is small.
+    In that case it is common to regularize the covariance estimate.
+    The ``method`` parameter allows to regularize the covariance in an
+    automated way. It also allows to select between different alternative
+    estimation algorithms which themselves achieve regularization.
+    Details are described in [1]_.
+
+    ``'ledoit_wolf'`` and ``'pca'`` are similar to ``'shrunk'`` and
+    ``'factor_analysis'``, respectively, except that they use
+    cross validation (which is useful when samples are correlated, which
+    is often the case for M/EEG data). The former two are not included in
+    the ``'auto'`` mode to avoid redundancy.
+
+    For more information on the advanced estimation methods, see
+    :ref:`the sklearn manual <sklearn:covariance>`.
+
     References
     ----------
     .. [1] Engemann D. and Gramfort A. (2015) Automated model selection in
@@ -645,31 +699,15 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
            Series B (Statistical Methodology) 61 (3), 611 - 622.
     .. [4] Barber, D., (2012). Bayesian reasoning and machine learning.
            Cambridge University Press., Algorithm 21.1
+    .. [5] Chen et al. (2010). Shrinkage Algorithms for MMSE Covariance
+           Estimation. IEEE Trans. on Sign. Proc., Volume 58, Issue 10,
+           October 2010.
     """
-    accepted_methods = ('auto', 'empirical', 'diagonal_fixed', 'ledoit_wolf',
-                        'shrunk', 'pca', 'factor_analysis',)
-    msg = ('Invalid method ({method}). Accepted values (individually or '
-           'in a list) are "%s" or None.' % '" or "'.join(accepted_methods))
-
     # scale to natural unit for best stability with MEG/EEG
     scalings = _check_scalings_user(scalings)
-    _method_params = {
-        'empirical': {'store_precision': False, 'assume_centered': True},
-        'diagonal_fixed': {'grad': 0.01, 'mag': 0.01, 'eeg': 0.0,
-                           'store_precision': False, 'assume_centered': True},
-        'ledoit_wolf': {'store_precision': False, 'assume_centered': True},
-        'shrunk': {'shrinkage': np.logspace(-4, 0, 30),
-                   'store_precision': False, 'assume_centered': True},
-        'pca': {'iter_n_components': None},
-        'factor_analysis': {'iter_n_components': None}
-    }
-    if isinstance(method_params, dict):
-        for key, values in method_params.items():
-            if key not in _method_params:
-                raise ValueError('key (%s) must be "%s"' %
-                                 (key, '" or "'.join(_method_params)))
-
-            _method_params[key].update(method_params[key])
+    method, _method_params = _check_method_params(
+        method, method_params, keep_sample_mean)
+    del method_params
 
     # for multi condition support epochs is required to refer to a list of
     # epochs objects
@@ -736,27 +774,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
     ch_names = [epochs[0].ch_names[k] for k in picks_meeg]
     info = epochs[0].info  # we will overwrite 'epochs'
 
-    if method is None:
-        method = ['empirical']
-    elif method == 'auto':
-        method = ['shrunk', 'diagonal_fixed', 'empirical', 'factor_analysis']
-
-    if not isinstance(method, (list, tuple)):
-        method = [method]
-
-    ok_sklearn = check_version('sklearn', '0.15') is True
-    if not ok_sklearn and (len(method) != 1 or method[0] != 'empirical'):
-        raise ValueError('scikit-learn is not installed, `method` must be '
-                         '`empirical`')
-
-    if keep_sample_mean is False:
-        if len(method) != 1 or 'empirical' not in method:
-            raise ValueError('`keep_sample_mean=False` is only supported'
-                             'with `method="empirical"`')
-        for p, v in _method_params.items():
-            if v.get('assume_centered', None) is False:
-                raise ValueError('`assume_centered` must be True'
-                                 ' if `keep_sample_mean` is False')
+    if not keep_sample_mean:
         # prepare mean covs
         n_epoch_types = len(epochs)
         data_mean = [0] * n_epoch_types
@@ -778,9 +796,6 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         data_mean = [1.0 / n_epoch * np.dot(mean, mean.T) for n_epoch, mean
                      in zip(n_epochs, data_mean)]
 
-    if not all(k in accepted_methods for k in method):
-        raise ValueError(msg.format(method=method))
-
     info = pick_info(info, picks_meeg)
     tslice = _get_tslice(epochs[0], tmin, tmax)
     epochs = [ee.get_data()[:, picks_meeg, tslice] for ee in epochs]
@@ -797,23 +812,10 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
     _check_n_samples(n_samples_tot, len(picks_meeg))
 
     epochs = epochs.T  # sklearn | C-order
-    if ok_sklearn:
-        cov_data = _compute_covariance_auto(epochs, method=method,
-                                            method_params=_method_params,
-                                            info=info,
-                                            verbose=verbose,
-                                            cv=cv,
-                                            n_jobs=n_jobs,
-                                            # XXX expose later
-                                            stop_early=True,  # if needed.
-                                            picks_list=picks_list,
-                                            scalings=scalings)
-    else:
-        if _method_params['empirical']['assume_centered'] is True:
-            cov = epochs.T.dot(epochs) / n_samples_tot
-        else:
-            cov = np.cov(epochs.T, bias=1)
-        cov_data = {'empirical': {'data': cov}}
+    cov_data = _compute_covariance_auto(
+        epochs, method=method, method_params=_method_params, info=info,
+        cv=cv, n_jobs=n_jobs, stop_early=True, picks_list=picks_list,
+        scalings=scalings)
 
     if keep_sample_mean is False:
         cov = cov_data['empirical']['data']
@@ -835,7 +837,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         cov.update(method=this_method, **data)
         covs.append(cov)
 
-    if ok_sklearn and len(covs) > 1:
+    if len(covs) > 1:
         msg = ['log-likelihood on unseen data (descending order):']
         logliks = [(c['method'], c['loglik']) for c in covs]
         logliks.sort(reverse=True, key=lambda c: c[1])
@@ -843,13 +845,13 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
             msg.append('%s: %0.3f' % (k, v))
         logger.info('\n   '.join(msg))
 
-    if ok_sklearn and not return_estimators and len(covs) > 1:
-        keys, scores = zip(*[(c['method'], c['loglik']) for c in covs])
-        out = covs[np.argmax(scores)]
-        logger.info('selecting best estimator: {0}'.format(out['method']))
-    elif ok_sklearn and len(covs) > 1:
-        out = covs
-        out.sort(key=lambda c: c['loglik'], reverse=True)
+    if len(covs) > 1:
+        if return_estimators:
+            out = covs
+            out.sort(key=lambda c: c['loglik'], reverse=True)
+        else:
+            out = sorted(covs, lambda c: c['loglik'])[-1]
+            logger.info('selecting best estimator: {0}'.format(out['method']))
     else:
         out = covs[0]
 
@@ -870,90 +872,105 @@ def _check_scalings_user(scalings):
 
 
 def _compute_covariance_auto(data, method, info, method_params, cv,
-                             scalings, n_jobs, stop_early, picks_list,
-                             verbose):
+                             scalings, n_jobs, stop_early, picks_list):
     """Compute covariance auto mode."""
-    try:
-        from sklearn.model_selection import GridSearchCV
-    except Exception:  # XXX support sklearn < 0.18
-        from sklearn.grid_search import GridSearchCV
-    from sklearn.covariance import (LedoitWolf, ShrunkCovariance,
-                                    EmpiricalCovariance)
-
     # rescale to improve numerical stability
     _apply_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
     estimator_cov_info = list()
     msg = 'Estimating covariance using %s'
+
+    ok_sklearn = check_version('sklearn', '0.15')
+    if not ok_sklearn and (len(method) != 1 or method[0] != 'empirical'):
+        raise ValueError('scikit-learn is not installed, `method` must be '
+                         '`empirical`')
+
     for this_method in method:
         data_ = data.copy()
         name = this_method.__name__ if callable(this_method) else this_method
         logger.info(msg % name.upper())
+        mp = method_params[this_method]
+        _info = None
 
         if this_method == 'empirical':
-            est = EmpiricalCovariance(**method_params[this_method])
+            est = EmpiricalCovariance(**mp)
             est.fit(data_)
-            _info = None
             estimator_cov_info.append((est, est.covariance_, _info))
+            del est
 
         elif this_method == 'diagonal_fixed':
-            est = _RegCovariance(info=info, **method_params[this_method])
+            est = _RegCovariance(info=info, **mp)
             est.fit(data_)
-            _info = None
             estimator_cov_info.append((est, est.covariance_, _info))
+            del est
 
         elif this_method == 'ledoit_wolf':
+            from sklearn.covariance import LedoitWolf
             shrinkages = []
-            lw = LedoitWolf(**method_params[this_method])
+            lw = LedoitWolf(**mp)
 
             for ch_type, picks in picks_list:
                 lw.fit(data_[:, picks])
-                shrinkages.append((
-                    ch_type,
-                    lw.shrinkage_,
-                    picks
-                ))
-            sc = _ShrunkCovariance(shrinkage=shrinkages,
-                                   **method_params[this_method])
+                shrinkages.append((ch_type, lw.shrinkage_, picks))
+            sc = _ShrunkCovariance(shrinkage=shrinkages, **mp)
             sc.fit(data_)
-            _info = None
             estimator_cov_info.append((sc, sc.covariance_, _info))
+            del lw, sc
+
+        elif this_method == 'oas':
+            from sklearn.covariance import OAS
+            shrinkages = []
+            oas = OAS(**mp)
+
+            for ch_type, picks in picks_list:
+                oas.fit(data_[:, picks])
+                shrinkages.append((ch_type, oas.shrinkage_, picks))
+            sc = _ShrunkCovariance(shrinkage=shrinkages, **mp)
+            sc.fit(data_)
+            estimator_cov_info.append((sc, sc.covariance_, _info))
+            del oas, sc
+
+        elif this_method == 'shrinkage':
+            sc = _ShrunkCovariance(**mp)
+            sc.fit(data_)
+            estimator_cov_info.append((sc, sc.covariance_, _info))
+            del sc
 
         elif this_method == 'shrunk':
-            shrinkage = method_params[this_method].pop('shrinkage')
+            try:
+                from sklearn.model_selection import GridSearchCV
+            except Exception:  # support sklearn < 0.18
+                from sklearn.grid_search import GridSearchCV
+            from sklearn.covariance import ShrunkCovariance
+            shrinkage = mp.pop('shrinkage')
             tuned_parameters = [{'shrinkage': shrinkage}]
             shrinkages = []
-            gs = GridSearchCV(ShrunkCovariance(**method_params[this_method]),
+            gs = GridSearchCV(ShrunkCovariance(**mp),
                               tuned_parameters, cv=cv)
             for ch_type, picks in picks_list:
                 gs.fit(data_[:, picks])
-                shrinkages.append((
-                    ch_type,
-                    gs.best_estimator_.shrinkage,
-                    picks
-                ))
+                shrinkages.append((ch_type, gs.best_estimator_.shrinkage,
+                                   picks))
             shrinkages = [c[0] for c in zip(shrinkages)]
-            sc = _ShrunkCovariance(shrinkage=shrinkages,
-                                   **method_params[this_method])
+            sc = _ShrunkCovariance(shrinkage=shrinkages, **mp)
             sc.fit(data_)
-            _info = None
             estimator_cov_info.append((sc, sc.covariance_, _info))
+            del shrinkage, sc
 
         elif this_method == 'pca':
-            mp = method_params[this_method]
-            pca, _info = _auto_low_rank_model(data_, this_method,
-                                              n_jobs=n_jobs,
-                                              method_params=mp, cv=cv,
-                                              stop_early=stop_early)
+            pca, _info = _auto_low_rank_model(
+                data_, this_method, n_jobs=n_jobs, method_params=mp, cv=cv,
+                stop_early=stop_early)
             pca.fit(data_)
             estimator_cov_info.append((pca, pca.get_covariance(), _info))
+            del pca
 
         elif this_method == 'factor_analysis':
-            mp = method_params[this_method]
-            fa, _info = _auto_low_rank_model(data_, this_method, n_jobs=n_jobs,
-                                             method_params=mp, cv=cv,
-                                             stop_early=stop_early)
+            fa, _info = _auto_low_rank_model(
+                data_, this_method, n_jobs=n_jobs, method_params=mp, cv=cv,
+                stop_early=stop_early)
             fa.fit(data_)
             estimator_cov_info.append((fa, fa.get_covariance(), _info))
+            del fa
         else:
             raise ValueError('Oh no! Your estimator does not have'
                              ' a .fit method')
@@ -982,15 +999,6 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
             out[this_method].update(runtime_info)
 
     return out
-
-
-def _logdet(A):
-    """Compute the log det of a symmetric matrix."""
-    vals = linalg.eigh(A)[0]
-    # avoid negative (numerical errors) or zero (semi-definite matrix) values
-    tol = vals.max() * vals.size * np.finfo(np.float64).eps
-    vals = np.where(vals > tol, vals, tol)
-    return np.sum(np.log(vals))
 
 
 def _gaussian_loglik_scorer(est, X, y=None):
@@ -1511,18 +1519,11 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
     return cov
 
 
-def _regularized_covariance(data, reg=None):
+def _regularized_covariance(data, reg=None, method_params=None):
     """Compute a regularized covariance from data using sklearn.
 
-    Parameters
-    ----------
-    data : ndarray, shape (n_channels, n_times)
-        Data for covariance estimation.
-    reg : float | str | None (default None)
-        If not None, allow regularization for covariance estimation
-        if float, shrinkage covariance is used (0 <= shrinkage <= 1).
-        if str, optimal shrinkage using Ledoit-Wolf Shrinkage ('ledoit_wolf')
-        or Oracle Approximating Shrinkage ('oas').
+    This is a convenience wrapper for mne.decoding functions, which
+    adopted a slightly different covariance API.
 
     Returns
     -------
@@ -1530,57 +1531,30 @@ def _regularized_covariance(data, reg=None):
         The covariance matrix.
     """
     if reg is None:
-        # compute empirical covariance
-        cov = np.cov(data)
-    else:
-        no_sklearn_err = ('the scikit-learn package is missing and '
-                          'required for covariance regularization.')
-        # use sklearn covariance estimators
-        if isinstance(reg, float):
-            if (reg < 0) or (reg > 1):
-                raise ValueError('0 <= shrinkage <= 1 for '
-                                 'covariance regularization.')
-            try:
-                import sklearn
-                sklearn_version = LooseVersion(sklearn.__version__)
-                from sklearn.covariance import ShrunkCovariance
-            except ImportError:
-                raise Exception(no_sklearn_err)
-            if sklearn_version < '0.12':
-                skl_cov = ShrunkCovariance(shrinkage=reg,
-                                           store_precision=False)
-            else:
-                # init sklearn.covariance.ShrunkCovariance estimator
-                skl_cov = ShrunkCovariance(shrinkage=reg,
-                                           store_precision=False,
-                                           assume_centered=True)
-        elif isinstance(reg, string_types):
-            if reg == 'ledoit_wolf':
-                try:
-                    from sklearn.covariance import LedoitWolf
-                except ImportError:
-                    raise Exception(no_sklearn_err)
-                # init sklearn.covariance.LedoitWolf estimator
-                skl_cov = LedoitWolf(store_precision=False,
-                                     assume_centered=True)
-            elif reg == 'oas':
-                try:
-                    from sklearn.covariance import OAS
-                except ImportError:
-                    raise Exception(no_sklearn_err)
-                # init sklearn.covariance.OAS estimator
-                skl_cov = OAS(store_precision=False,
-                              assume_centered=True)
-            else:
-                raise ValueError("regularization parameter should be "
-                                 "'ledoit_wolf' or 'oas'")
-        else:
-            raise ValueError("regularization parameter should be "
-                             "of type str or int (got %s)." % type(reg))
-
-        # compute regularized covariance using sklearn
-        cov = skl_cov.fit(data.T).covariance_
-
+        reg = 'empirical'
+    try:
+        reg = float(reg)
+    except ValueError:
+        pass
+    if isinstance(reg, float):
+        if method_params is not None:
+            raise ValueError('If reg is a float, method_params must be None '
+                             '(got %s)' % (type(method_params),))
+        method_params = dict(shrinkage=dict(
+            shrinkage=reg, assume_centered=True, store_precision=False))
+        reg = 'shrinkage'
+    elif not isinstance(reg, string_types):
+        raise ValueError('reg must be a float, str, or None, got %s (%s)'
+                         % (reg, type(reg)))
+    method, method_params = _check_method_params(reg, method_params,
+                                                 name='reg', allow_auto=False)
+    info = create_info(data.shape[-2], 1000., 'eeg')
+    picks_list = _picks_by_type(info)
+    scalings = _handle_default('scalings_cov_rank', None)
+    cov = _compute_covariance_auto(
+        data.T, method=method, method_params=method_params,
+        info=info, cv=None, n_jobs=1, stop_early=True,
+        picks_list=picks_list, scalings=scalings)[reg]['data']
     return cov
 
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -31,12 +31,13 @@ class CSP(TransformerMixin, BaseEstimator):
     n_components : int, defaults to 4
         The number of components to decompose M/EEG signals.
         This number should be set by cross-validation.
-    reg : float | str | None, defaults to None
-        if not None, allow regularization for covariance estimation
-        if float, shrinkage covariance is used (0 <= shrinkage <= 1).
-        if str, optimal shrinkage using Ledoit-Wolf Shrinkage ('ledoit_wolf')
-        or Oracle Approximating Shrinkage ('oas').
-    log : None | bool, defaults to None
+    reg : float | str | None (default None)
+        If not None (same as ``'empirical'``, default), allow
+        regularization for covariance estimation.
+        If float, shrinkage is used (0 <= shrinkage <= 1).
+        For str options, ``reg`` will be passed to ``method`` to
+        :func:`mne.compute_covariance`.
+    log : None | bool (default None)
         If transform_into == 'average_power' and log is None or True, then
         applies a log transform to standardize the features, else the features
         are z-scored. If transform_into == 'csp_space', then log must be None.
@@ -55,6 +56,10 @@ class CSP(TransformerMixin, BaseEstimator):
         magnitude variations in the EEG between individuals. It is not applied
         in more recent work [2]_, [3]_ and can have a negative impact on
         patterns ordering.
+    method_params : dict | None
+        Parameters to pass to :func:`mne.compute_covariance`.
+
+        .. versionadded:: 0.16
 
     Attributes
     ----------
@@ -86,22 +91,14 @@ class CSP(TransformerMixin, BaseEstimator):
     """
 
     def __init__(self, n_components=4, reg=None, log=None, cov_est="concat",
-                 transform_into='average_power', norm_trace=False):
+                 transform_into='average_power', norm_trace=False,
+                 method_params=None):
         """Init of CSP."""
         # Init default CSP
         if not isinstance(n_components, int):
             raise ValueError('n_components must be an integer.')
         self.n_components = n_components
 
-        # Init default regularization
-        if (
-            (reg is not None) and
-            (reg not in ['oas', 'ledoit_wolf']) and
-            ((not isinstance(reg, (float, int))) or
-             (not ((reg <= 1.) and (reg >= 0.))))
-        ):
-            raise ValueError('reg must be None, "oas", "ledoit_wolf" or a '
-                             'float in between 0. and 1.')
         self.reg = reg
 
         # Init default cov_est
@@ -129,6 +126,7 @@ class CSP(TransformerMixin, BaseEstimator):
         if not isinstance(norm_trace, bool):
             raise ValueError('norm_trace must be a bool.')
         self.norm_trace = norm_trace
+        self.method_params = method_params
 
     def _check_Xy(self, X, y=None):
         """Aux. function to check input data."""
@@ -170,13 +168,15 @@ class CSP(TransformerMixin, BaseEstimator):
             if self.cov_est == "concat":  # concatenate epochs
                 class_ = np.transpose(X[y == this_class], [1, 0, 2])
                 class_ = class_.reshape(n_channels, -1)
-                cov = _regularized_covariance(class_, reg=self.reg)
+                cov = _regularized_covariance(
+                    class_, reg=self.reg, method_params=self.method_params)
                 weight = sum(y == this_class)
             elif self.cov_est == "epoch":
                 class_ = X[y == this_class]
                 cov = np.zeros((n_channels, n_channels))
                 for this_X in class_:
-                    cov += _regularized_covariance(this_X, reg=self.reg)
+                    cov += _regularized_covariance(
+                        this_X, reg=self.reg, method_params=self.method_params)
                 cov /= len(class_)
                 weight = len(class_)
 
@@ -232,7 +232,7 @@ class CSP(TransformerMixin, BaseEstimator):
         eigen_vectors = eigen_vectors[:, ix]
 
         self.filters_ = eigen_vectors.T
-        self.patterns_ = linalg.pinv(eigen_vectors)
+        self.patterns_ = linalg.pinv2(eigen_vectors)
 
         pick_filters = self.filters_[:self.n_components]
         X = np.asarray([np.dot(pick_filters, epoch) for epoch in X])
@@ -680,12 +680,13 @@ class SPoC(CSP):
     ----------
     n_components : int
         The number of components to decompose M/EEG signals.
-    reg : float | str | None, defaults to None
-        if not None, allow regularization for covariance estimation
-        if float, shrinkage covariance is used (0 <= shrinkage <= 1).
-        if str, optimal shrinkage using Ledoit-Wolf Shrinkage ('ledoit_wolf')
-        or Oracle Approximating Shrinkage ('oas').
-    log : None | bool, defaults to None
+    reg : float | str | None (default None)
+        If not None (same as ``'empirical'``, default), allow
+        regularization for covariance estimation.
+        If float, shrinkage is used (0 <= shrinkage <= 1).
+        For str options, ``reg`` will be passed to ``method`` to
+        :func:`mne.compute_covariance`.
+    log : None | bool (default None)
         If transform_into == 'average_power' and log is None or True, then
         applies a log transform to standardize the features, else the features
         are z-scored. If transform_into == 'csp_space', then log must be None.
@@ -693,6 +694,10 @@ class SPoC(CSP):
         If 'average_power' then self.transform will return the average power of
         each spatial filter. If 'csp_space' self.transform will return the data
         in CSP space. Defaults to 'average_power'.
+    method_params : dict | None
+        Parameters to pass to :func:`mne.compute_covariance`.
+
+        .. versionadded:: 0.16
 
     Attributes
     ----------
@@ -718,11 +723,12 @@ class SPoC(CSP):
     """
 
     def __init__(self, n_components=4, reg=None, log=None,
-                 transform_into='average_power'):
+                 transform_into='average_power', method_params=None):
         """Init of SPoC."""
         super(SPoC, self).__init__(n_components=n_components, reg=reg, log=log,
                                    cov_est="epoch", norm_trace=False,
-                                   transform_into=transform_into)
+                                   transform_into=transform_into,
+                                   method_params=method_params)
         # Covariance estimation have to be done on the single epoch level,
         # unlike CSP where covariance estimation can also be achieved through
         # concatenation of all epochs from the same class.
@@ -764,7 +770,8 @@ class SPoC(CSP):
         # Estimate single trial covariance
         covs = np.empty((n_epochs, n_channels, n_channels))
         for ii, epoch in enumerate(X):
-            covs[ii] = _regularized_covariance(epoch, reg=self.reg)
+            covs[ii] = _regularized_covariance(
+                epoch, reg=self.reg, method_params=self.method_params)
 
         C = covs.mean(0)
         Cz = np.mean(covs * target[:, np.newaxis, np.newaxis], axis=0)

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -66,7 +66,8 @@ def test_csp():
     # Init
     assert_raises(ValueError, CSP, n_components='foo', norm_trace=False)
     for reg in ['foo', -0.1, 1.1]:
-        assert_raises(ValueError, CSP, reg=reg, norm_trace=False)
+        csp = CSP(reg=reg, norm_trace=False)
+        assert_raises(ValueError, csp.fit, epochs_data, epochs.events[:, -1])
     for reg in ['oas', 'ledoit_wolf', 0, 0.5, 1.]:
         CSP(reg=reg, norm_trace=False)
     for cov_est in ['foo', None]:

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1222,6 +1222,287 @@ class BaseEstimator(object):
 
 
 ###############################################################################
+# Copied from sklearn to simplify code paths
+
+def empirical_covariance(X, assume_centered=False):
+    """Computes the Maximum likelihood covariance estimator
+
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_samples, n_features)
+        Data from which to compute the covariance estimate
+
+    assume_centered : Boolean
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False, data are centered before computation.
+
+    Returns
+    -------
+    covariance : 2D ndarray, shape (n_features, n_features)
+        Empirical covariance (Maximum Likelihood Estimator).
+
+    """
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = np.reshape(X, (1, -1))
+
+    if X.shape[0] == 1:
+        warnings.warn("Only one sample available. "
+                      "You may want to reshape your data array")
+
+    if assume_centered:
+        covariance = np.dot(X.T, X) / X.shape[0]
+    else:
+        covariance = np.cov(X.T, bias=1)
+
+    if covariance.ndim == 0:
+        covariance = np.array([[covariance]])
+    return covariance
+
+
+class EmpiricalCovariance(BaseEstimator):
+    """Maximum likelihood covariance estimator
+
+    Read more in the :ref:`User Guide <covariance>`.
+
+    Parameters
+    ----------
+    store_precision : bool
+        Specifies if the estimated precision is stored.
+
+    assume_centered : bool
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False (default), data are centered before computation.
+
+    Attributes
+    ----------
+    covariance_ : 2D ndarray, shape (n_features, n_features)
+        Estimated covariance matrix
+
+    precision_ : 2D ndarray, shape (n_features, n_features)
+        Estimated pseudo-inverse matrix.
+        (stored only if store_precision is True)
+
+    """
+    def __init__(self, store_precision=True, assume_centered=False):
+        self.store_precision = store_precision
+        self.assume_centered = assume_centered
+
+    def _set_covariance(self, covariance):
+        """Saves the covariance and precision estimates
+
+        Storage is done accordingly to `self.store_precision`.
+        Precision stored only if invertible.
+
+        Parameters
+        ----------
+        covariance : 2D ndarray, shape (n_features, n_features)
+            Estimated covariance matrix to be stored, and from which precision
+            is computed.
+
+        """
+        # covariance = check_array(covariance)
+        # set covariance
+        self.covariance_ = covariance
+        # set precision
+        if self.store_precision:
+            self.precision_ = linalg.pinvh(covariance)
+        else:
+            self.precision_ = None
+
+    def get_precision(self):
+        """Getter for the precision matrix.
+
+        Returns
+        -------
+        precision_ : array-like,
+            The precision matrix associated to the current covariance object.
+
+        """
+        if self.store_precision:
+            precision = self.precision_
+        else:
+            precision = linalg.pinvh(self.covariance_)
+        return precision
+
+    def fit(self, X, y=None):
+        """Fits the Maximum Likelihood Estimator covariance model
+        according to the given training data and parameters.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+          Training data, where n_samples is the number of samples and
+          n_features is the number of features.
+
+        y : not used, present for API consistence purpose.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        # X = check_array(X)
+        if self.assume_centered:
+            self.location_ = np.zeros(X.shape[1])
+        else:
+            self.location_ = X.mean(0)
+        covariance = empirical_covariance(
+            X, assume_centered=self.assume_centered)
+        self._set_covariance(covariance)
+
+        return self
+
+    def score(self, X_test, y=None):
+        """Computes the log-likelihood of a Gaussian data set with
+        `self.covariance_` as an estimator of its covariance matrix.
+
+        Parameters
+        ----------
+        X_test : array-like, shape = [n_samples, n_features]
+            Test data of which we compute the likelihood, where n_samples is
+            the number of samples and n_features is the number of features.
+            X_test is assumed to be drawn from the same distribution than
+            the data used in fit (including centering).
+
+        y : not used, present for API consistence purpose.
+
+        Returns
+        -------
+        res : float
+            The likelihood of the data set with `self.covariance_` as an
+            estimator of its covariance matrix.
+
+        """
+        # compute empirical covariance of the test set
+        test_cov = empirical_covariance(
+            X_test - self.location_, assume_centered=True)
+        # compute log likelihood
+        res = log_likelihood(test_cov, self.get_precision())
+
+        return res
+
+    def error_norm(self, comp_cov, norm='frobenius', scaling=True,
+                   squared=True):
+        """Computes the Mean Squared Error between two covariance estimators.
+        (In the sense of the Frobenius norm).
+
+        Parameters
+        ----------
+        comp_cov : array-like, shape = [n_features, n_features]
+            The covariance to compare with.
+
+        norm : str
+            The type of norm used to compute the error. Available error types:
+            - 'frobenius' (default): sqrt(tr(A^t.A))
+            - 'spectral': sqrt(max(eigenvalues(A^t.A))
+            where A is the error ``(comp_cov - self.covariance_)``.
+
+        scaling : bool
+            If True (default), the squared error norm is divided by n_features.
+            If False, the squared error norm is not rescaled.
+
+        squared : bool
+            Whether to compute the squared error norm or the error norm.
+            If True (default), the squared error norm is returned.
+            If False, the error norm is returned.
+
+        Returns
+        -------
+        The Mean Squared Error (in the sense of the Frobenius norm) between
+        `self` and `comp_cov` covariance estimators.
+
+        """
+        # compute the error
+        error = comp_cov - self.covariance_
+        # compute the error norm
+        if norm == "frobenius":
+            squared_norm = np.sum(error ** 2)
+        elif norm == "spectral":
+            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error)))
+        else:
+            raise NotImplementedError(
+                "Only spectral and frobenius norms are implemented")
+        # optionally scale the error norm
+        if scaling:
+            squared_norm = squared_norm / error.shape[0]
+        # finally get either the squared norm or the norm
+        if squared:
+            result = squared_norm
+        else:
+            result = np.sqrt(squared_norm)
+
+        return result
+
+    def mahalanobis(self, observations):
+        """Computes the squared Mahalanobis distances of given observations.
+
+        Parameters
+        ----------
+        observations : array-like, shape = [n_observations, n_features]
+            The observations, the Mahalanobis distances of the which we
+            compute. Observations are assumed to be drawn from the same
+            distribution than the data used in fit.
+
+        Returns
+        -------
+        mahalanobis_distance : array, shape = [n_observations,]
+            Squared Mahalanobis distances of the observations.
+
+        """
+        precision = self.get_precision()
+        # compute mahalanobis distances
+        centered_obs = observations - self.location_
+        mahalanobis_dist = np.sum(
+            np.dot(centered_obs, precision) * centered_obs, 1)
+
+        return mahalanobis_dist
+
+
+def log_likelihood(emp_cov, precision):
+    """Computes the sample mean of the log_likelihood under a covariance model
+
+    computes the empirical expected log-likelihood (accounting for the
+    normalization terms and scaling), allowing for universal comparison (beyond
+    this software package)
+
+    Parameters
+    ----------
+    emp_cov : 2D ndarray (n_features, n_features)
+        Maximum Likelihood Estimator of covariance
+
+    precision : 2D ndarray (n_features, n_features)
+        The precision matrix of the covariance model to be tested
+
+    Returns
+    -------
+    sample mean of the log-likelihood
+    """
+    p = precision.shape[0]
+    log_likelihood_ = - np.sum(emp_cov * precision) + _logdet(precision)
+    log_likelihood_ -= p * np.log(2 * np.pi)
+    log_likelihood_ /= 2.
+    return log_likelihood_
+
+
+# sklearn uses np.linalg for this, but ours is more robust to zero eigenvalues
+
+def _logdet(A):
+    """Compute the log det of a positive semidefinite matrix."""
+    vals = linalg.eigh(A)[0]
+    # avoid negative (numerical errors) or zero (semi-definite matrix) values
+    tol = vals.max() * vals.size * np.finfo(np.float64).eps
+    vals = np.where(vals > tol, vals, tol)
+    return np.sum(np.log(vals))
+
+
+###############################################################################
 # NumPy einsum backward compat (allow "optimize" arg and fix 1.14.0 bug)
 # XXX eventually we should hand-tune our `einsum` calls given our array sizes!
 

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -99,7 +99,7 @@ def _least_square_evoked(epochs_data, events, tmin, sfreq):
 
 
 def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
-               events=None, tmin=0., sfreq=1.):
+               events=None, tmin=0., sfreq=1., method_params=None):
     """Fit filters and coefs using Xdawn Algorithm.
 
     Xdawn is a spatial filtering method designed to improve the signal
@@ -117,10 +117,11 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
     n_components : int (default 2)
         The number of components to decompose the signals signals.
     reg : float | str | None (default None)
-        If not None, allow regularization for covariance estimation
-        if float, shrinkage covariance is used (0 <= shrinkage <= 1).
-        if str, optimal shrinkage using Ledoit-Wolf Shrinkage ('ledoit_wolf')
-        or Oracle Approximating Shrinkage ('oas').
+        If not None (same as ``'empirical'``, default), allow
+        regularization for covariance estimation.
+        If float, shrinkage is used (0 <= shrinkage <= 1).
+        For str options, ``reg`` will be passed as ``method`` to
+        :func:`mne.compute_covariance`.
     signal_cov : None | Covariance | array, shape (n_channels, n_channels)
         The signal covariance used for whitening of the data.
         if None, the covariance is estimated from the epochs signal.
@@ -210,13 +211,18 @@ class _XdawnTransformer(BaseEstimator, TransformerMixin):
     n_components : int (default 2)
         The number of components to decompose the signals.
     reg : float | str | None (default None)
-        If not None, allow regularization for covariance estimation
-        if float, shrinkage covariance is used (0 <= shrinkage <= 1).
-        if str, optimal shrinkage using Ledoit-Wolf Shrinkage ('ledoit_wolf')
-        or Oracle Approximating Shrinkage ('oas').
+        If not None (same as ``'empirical'``, default), allow
+        regularization for covariance estimation.
+        If float, shrinkage is used (0 <= shrinkage <= 1).
+        For str options, ``reg`` will be passed to ``method`` to
+        :func:`mne.compute_covariance`.
     signal_cov : None | Covariance | array, shape (n_channels, n_channels)
         The signal covariance used for whitening of the data.
         if None, the covariance is estimated from the epochs signal.
+    method_params : dict | None
+        Parameters to pass to :func:`mne.compute_covariance`.
+
+        .. versionadded:: 0.16
 
     Attributes
     ----------
@@ -228,11 +234,13 @@ class _XdawnTransformer(BaseEstimator, TransformerMixin):
         The Xdawn patterns used to restore the signals for each event type.
     """
 
-    def __init__(self, n_components=2, reg=None, signal_cov=None):
+    def __init__(self, n_components=2, reg=None, signal_cov=None,
+                 method_params=None):
         """Init."""
         self.n_components = n_components
         self.signal_cov = signal_cov
         self.reg = reg
+        self.method_params = method_params
 
     def fit(self, X, y=None):
         """Fit Xdawn spatial filters.
@@ -255,7 +263,7 @@ class _XdawnTransformer(BaseEstimator, TransformerMixin):
         self.classes_ = np.unique(y)
         self.filters_, self.patterns_, _ = _fit_xdawn(
             X, y, n_components=self.n_components, reg=self.reg,
-            signal_cov=self.signal_cov)
+            signal_cov=self.signal_cov, method_params=self.method_params)
         return self
 
     def transform(self, X):

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -605,16 +605,22 @@ def test_compute_covariance_auto_reg():
     logliks = [c['loglik'] for c in covs]
     assert_true(np.diff(logliks).max() <= 0)  # descending order
 
-    methods = ['empirical',
-               'factor_analysis',
-               'ledoit_wolf',
-               'pca']
+    methods = ['empirical', 'factor_analysis', 'ledoit_wolf', 'oas', 'pca',
+               'shrunk', 'shrinkage']
     cov3 = compute_covariance(epochs, method=methods,
                               method_params=method_params, projs=None,
                               return_estimators=True)
+    method_names = [cov['method'] for cov in cov3]
+    for method in ['factor_analysis', 'ledoit_wolf', 'oas', 'pca',
+                   'shrinkage']:
+        this_lik = cov3[method_names.index(method)]['loglik']
+        assert -55 < this_lik < -45
+    this_lik = cov3[method_names.index('empirical')]['loglik']
+    assert -110 < this_lik < -100
+    this_lik = cov3[method_names.index('shrunk')]['loglik']
+    assert -45 < this_lik < -35
 
-    assert_equal(set([c['method'] for c in cov3]),
-                 set(methods))
+    assert_equal(set([c['method'] for c in cov3]), set(methods))
 
     # invalid prespecified method
     assert_raises(ValueError, compute_covariance, epochs, method='pizza')


### PR DESCRIPTION
I've been trying to use some decoding functions (`XDawn`, `CSP`) on rank-reduced SSS'ed MEG data. I'd like to be able to use the simple / naive `mne.cov.regularize` function for this, because it seems like I don't get consistent results from the automated regularizers (though maybe I'm just being dumb). Adding a `reg=callable` possibility seems like the easiest way, then I can do e.g.:
```
def reg(data):
    raw = mne.io.RawArray(data, epochs.info)
    cov = mne.compute_raw_covariance(raw, step=None)
    return mne.cov.regularize(cov, raw.info)['data']
```
So this fits my use case pretty easily, and seems like a pretty simple extension.

Todo:

- [x] add tests
- [x] fix docstring of CSP refs

@kingjr @alexandrebarachant @agramfort does this seem like a reasonable addition to you? If so, I'll update all other docstrings and add some tests.