### PR TITLE
MRG: Fix corner cases for mne.make_fixed_length_events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,7 +62,7 @@ Bug
 
 - Fix bug in :meth:`mne.io.Raw.plot_psd` to correctly deal with ``reject_by_annotation=False`` by `Clemens Brunner`_
 
-- Fix bug in :func:`mne.make_fixed_length_events` when hitting corner case problems rounding to sample numbers by `Eric Larson`
+- Fix bug in :func:`mne.make_fixed_length_events` when hitting corner case problems rounding to sample numbers by `Eric Larson`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,6 +62,8 @@ Bug
 
 - Fix bug in :meth:`mne.io.Raw.plot_psd` to correctly deal with ``reject_by_annotation=False`` by `Clemens Brunner`_
 
+- Fix bug in :func:`mne.make_fixed_length_events` when hitting corner case problems rounding to sample numbers by `Eric Larson`
+
 API
 ~~~
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -861,9 +861,9 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.,
     if not isinstance(duration, (int, float)):
         raise ValueError('duration must be an integer of a float, '
                          'got %s instead.' % (type(duration)))
-    start = raw.time_as_index(start)[0]
+    start = raw.time_as_index(start, use_rounding=True)[0]
     if stop is not None:
-        stop = raw.time_as_index(stop)[0]
+        stop = raw.time_as_index(stop, use_rounding=True)[0]
     else:
         stop = raw.last_samp + 1
     if first_samp:
@@ -872,7 +872,7 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1.,
     else:
         stop = min([stop, len(raw.times)])
     # Make sure we don't go out the end of the file:
-    stop -= int(np.ceil(raw.info['sfreq'] * duration))
+    stop -= int(np.round(raw.info['sfreq'] * duration))
     # This should be inclusive due to how we generally use start and stop...
     ts = np.arange(start, stop + 1, raw.info['sfreq'] * duration).astype(int)
     n_events = len(ts)

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -412,10 +412,10 @@ def test_make_fixed_length_events():
     assert_raises(ValueError, make_fixed_length_events, raw, 23, tmin, tmax,
                   'abc')
 
-    # Let's try some ugly sample rate and sample counts
+    # Let's try some ugly sample rate/sample count combos
     data = np.random.RandomState(0).randn(1, 27768)
 
-    # This breaking unless np.round() is used in make_fixed_length_events
+    # This breaks unless np.round() is used in make_fixed_length_events
     info = create_info(1, 155.4499969482422)
     raw = RawArray(data, info)
     events = make_fixed_length_events(raw, 1, duration=raw.times[-1])

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -9,7 +9,7 @@ import warnings
 
 from mne import (read_events, write_events, make_fixed_length_events,
                  find_events, pick_events, find_stim_steps, pick_channels,
-                 read_evokeds, Epochs, create_info)
+                 read_evokeds, Epochs, create_info, compute_raw_covariance)
 from mne.io import read_raw_fif, RawArray
 from mne.tests.common import assert_naming
 from mne.utils import _TempDir, run_tests_if_main
@@ -411,6 +411,27 @@ def test_make_fixed_length_events():
     assert_raises(ValueError, make_fixed_length_events, 'not raw', 2)
     assert_raises(ValueError, make_fixed_length_events, raw, 23, tmin, tmax,
                   'abc')
+
+    # Let's try some ugly sample rate and sample counts
+    data = np.random.RandomState(0).randn(1, 27768)
+
+    # This breaking unless np.round() is used in make_fixed_length_events
+    info = create_info(1, 155.4499969482422)
+    raw = RawArray(data, info)
+    events = make_fixed_length_events(raw, 1, duration=raw.times[-1])
+    assert events[0, 0] == 0
+    assert len(events) == 1
+
+    # Without use_rounding=True this breaks
+    raw = RawArray(data[:, :21216], info)
+    events = make_fixed_length_events(raw, 1, duration=raw.times[-1])
+    assert events[0, 0] == 0
+    assert len(events) == 1
+
+    # Make sure it gets used properly by compute_raw_covariance
+    cov = compute_raw_covariance(raw, tstep=None)
+    expected = np.cov(data[:, :21216])
+    np.testing.assert_allclose(cov['data'], expected, atol=1e-12)
 
 
 def test_define_events():


### PR DESCRIPTION
Fixes some corner cases of `mne.compute_raw_covariance` I found when investigating #4808.