### PR TITLE
[MRG] Event lines should not overplot raw traces

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -1011,6 +1011,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                     ys += [0, ylim[0], np.nan]
                 line.set_xdata(xs)
                 line.set_ydata(ys)
+                line.set_zorder(0)
             else:
                 line.set_xdata([])
                 line.set_ydata([])


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/4377312/34108692-5820c200-e401-11e7-9193-346ab072725a.png)

After:
![after](https://user-images.githubusercontent.com/4377312/34108695-5c31a1a2-e401-11e7-851e-a38789da0964.png)

Alternatively, we could make event lines transparent instead of pushing them to the bottom of the z order.