### PR TITLE
MRG+1: Allow standalone Annotations IO

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -456,6 +456,7 @@ Events
    merge_events
    parse_config
    pick_events
+   read_annotations
    read_events
    write_events
    concatenate_epochs

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ Changelog
 
 - Add support for multiple head position files and plotting of sensors in :func:`mne.viz.plot_head_positions` by `Eric Larson`_
 
+- Add ability to read and write :class:`Annotations` separate from :class:`mne.io.Raw` instances via :meth:`Annotations.save` and :func:`read_annotations` by `Eric Larson`_
+
 - Add option to unset a montage by passing `None` to :meth:`mne.io.Raw.set_montage` by `Clemens Brunner`_
 
 - Add :func:`mne.io.pick.get_channel_types` which returns all available channel types in MNE by `Clemens Brunner`_

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -67,7 +67,7 @@ from .source_space import (read_source_spaces, vertex_to_mni,
                            add_source_space_distances, morph_source_spaces,
                            get_volume_labels_from_aseg,
                            get_volume_labels_from_src)
-from .annotations import Annotations
+from .annotations import Annotations, read_annotations
 from .epochs import (BaseEpochs, Epochs, EpochsArray, read_epochs,
                      concatenate_epochs)
 from .evoked import Evoked, EvokedArray, read_evokeds, write_evokeds, combine_evoked

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 import numpy as np
 
-from .utils import _pl
+from .utils import _pl, check_fname
 from .externals.six import string_types
 from .io.write import (start_block, end_block, write_float, write_name_list,
                        write_double, start_file)
@@ -170,6 +170,7 @@ class Annotations(object):
         fname : str
             The filename to use.
         """
+        check_fname(fname, 'annotations', ('-annot.fif', '-annot.fif.gz'))
         with start_file(fname) as fid:
             _write_annotations(fid, self)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -26,9 +26,9 @@ from .compensator import set_current_comp, make_compensator
 from .write import (start_file, end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
-                    write_id, write_string, write_name_list, _get_split_size)
+                    write_id, write_string, _get_split_size)
 
-from ..annotations import _annotations_starts_stops
+from ..annotations import _annotations_starts_stops, _write_annotations
 from ..filter import (filter_data, notch_filter, resample, next_fast_len,
                       _resample_stim_channels, _filt_check_picks,
                       _filt_update_info)
@@ -2306,16 +2306,7 @@ def _start_writing_raw(name, info, sel=None, data_type=FIFF.FIFFT_FLOAT,
     # Annotations
     #
     if annotations is not None and len(annotations.onset) > 0:
-        start_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
-        write_float(fid, FIFF.FIFF_MNE_BASELINE_MIN, annotations.onset)
-        write_float(fid, FIFF.FIFF_MNE_BASELINE_MAX,
-                    annotations.duration + annotations.onset)
-        # To allow : in description, they need to be replaced for serialization
-        write_name_list(fid, FIFF.FIFF_COMMENT, [d.replace(':', ';') for d in
-                                                 annotations.description])
-        if annotations.orig_time is not None:
-            write_double(fid, FIFF.FIFF_MEAS_DATE, annotations.orig_time)
-        end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
+        _write_annotations(fid, annotations)
 
     #
     # Start the raw data

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -102,7 +102,7 @@ def test_annotations():
 
     # Test IO
     tempdir = _TempDir()
-    fname = op.join(tempdir, 'test.fif')
+    fname = op.join(tempdir, 'test-annot.fif')
     raw.annotations.save(fname)
     annot_read = read_annotations(fname)
     for attr in ('onset', 'duration', 'orig_time'):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -12,8 +12,8 @@ from numpy.testing import (assert_equal, assert_array_equal,
 
 import numpy as np
 
-from mne import create_info, Epochs
-from mne.utils import run_tests_if_main
+from mne import create_info, Epochs, read_annotations
+from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.annotations import Annotations, _sync_onset
 from mne.datasets import testing
@@ -26,6 +26,8 @@ fif_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 def test_annotations():
     """Test annotation class."""
     raw = read_raw_fif(fif_fname)
+    assert raw.annotations is None
+    assert_raises(ValueError, read_annotations, fif_fname)
     onset = np.array(range(10))
     duration = np.ones(10)
     description = np.repeat('test', 10)
@@ -97,6 +99,16 @@ def test_annotations():
     raw.annotations.delete(-1)
     assert_array_almost_equal(raw.annotations.onset, [45., 2. + last_time],
                               decimal=2)
+
+    # Test IO
+    tempdir = _TempDir()
+    fname = op.join(tempdir, 'test.fif')
+    raw.annotations.save(fname)
+    annot_read = read_annotations(fname)
+    for attr in ('onset', 'duration', 'orig_time'):
+        assert_allclose(getattr(annot_read, attr),
+                        getattr(raw.annotations, attr))
+    assert_array_equal(annot_read.description, raw.annotations.description)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
With this PR, `Annotations` themselves can be saved and loaded, and applied to files when necessary. This is useful e.g. when creating annotations that have expensive computation time and need to be used for multiple purposes.