### PR TITLE
MRG: Fix acquisition skips

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,10 @@ Changelog
 
 - Workaround for reading EGI MFF files with physiological signals that also present a bug from the EGI system in :func:`mne.io.read_raw_egi` by `Federico Raimondo`_
 
+- Add support for reading subject height and weight in ``info['subject_info']`` by `Eric Larson`_
+
+- Improve online filtering of raw data when plotting with :meth:`mne.io.Raw.plot` to filter in segments in accordance with the default ``skip_by_annotation=('edge', 'bad_acq_skip')`` of :meth:`mne.io.Raw.filter` to avoid edge ringing by `Eric Larson`_
+
 - Add support for multiple head position files and plotting of sensors in :func:`mne.viz.plot_head_positions` by `Eric Larson`_
 
 Bug
@@ -73,6 +77,12 @@ Bug
 - Fix bug in :class:`mne.Epochs` when passing events as list with ``event_id=None``  by `Alex Gramfort`_
 
 - Fix bug in :meth:`mne.report.Report.add_figs_to_section` when passing :class:`numpy.ndarray` by `Eric Larson`_
+
+- Fix bug in :class:`Annotations` where annotations that extend to the end of a recording were not extended properly by `Eric Larson`_
+
+- Fix bug in :meth:`mne.io.Raw.filter` to properly raw data with acquisition skips in separate segments by `Eric Larson`_
+
+- Fix support for writing FIF files with acquisition skips by using empty buffers rather than writing zeros by `Eric Larson`_
 
 API
 ~~~

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -23,7 +23,7 @@ from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                  SetChannelsMixin, InterpolationMixin)
 from ..channels.montage import read_montage, _set_montage, Montage
 from .compensator import set_current_comp, make_compensator
-from .write import (start_file, end_file, start_block, end_block,
+from .write import (start_file, end_file, start_block, end_block, write_nop,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
                     write_id, write_string, write_name_list, _get_split_size)
@@ -703,9 +703,15 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                         duration = annotations.duration[ind] + onset
                         annotations.duration[ind] = duration
                         annotations.onset[ind] = self.times[0] - offset
-                elif onset + annotations.duration[ind] > self.times[-1]:
+                elif (onset + annotations.duration[ind] >
+                      self.times[-1] + 1.1 / self.info['sfreq']):
+                    # We have to permit onset+duration to appear to go one past
+                    # the last sample in order to actually include the last
+                    # sample...
                     limited += 1
-                    annotations.duration[ind] = self.times[-1] - onset
+                    annotations.duration[ind] = (self.times[-1] +
+                                                 1. / self.info['sfreq'] -
+                                                 onset)
             annotations.onset = np.delete(annotations.onset, omit_ind)
             annotations.duration = np.delete(annotations.duration, omit_ind)
             annotations.description = np.delete(annotations.description,
@@ -1093,7 +1099,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
                method='fir', iir_params=None, phase='zero',
                fir_window='hamming', fir_design='firwin',
-               skip_by_annotation='edge', pad='reflect_limited', verbose=None):
+               skip_by_annotation=('edge', 'bad_acq_skip'),
+               pad='reflect_limited', verbose=None):
         """Filter a subset of channels.
 
         Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
@@ -1195,9 +1202,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             with the given string will not be included in filtering, and
             segments on either side of the given excluded annotated segment
             will be filtered separately (i.e., as independent signals).
-            The default (``'edge'``) will separately filter any
-            segments that were concatenated by :func:`mne.concatenate_raws`
-            or :meth:`mne.io.Raw.append`. To disable, provide an empty list.
+            The default (``('edge', 'bad_acq_skip')`` will separately filter
+            any segments that were concatenated by :func:`mne.concatenate_raws`
+            or :meth:`mne.io.Raw.append`, or separated during acquisition.
+            To disable, provide an empty list.
 
             .. versionadded:: 0.16.
         pad : str
@@ -1235,15 +1243,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         update_info, picks = _filt_check_picks(self.info, picks,
                                                l_freq, h_freq)
         # Deal with annotations
-        onsets, ends = _annotations_starts_stops(self, skip_by_annotation,
-                                                 'skip_by_annotation')
-        if len(onsets) == 0 or onsets[0] != 0:
-            onsets = np.concatenate([[0], onsets])
-            ends = np.concatenate([[0], ends])
-        if len(ends) == 1 or ends[-1] != len(self.times):
-            onsets = np.concatenate([onsets, [len(self.times)]])
-            ends = np.concatenate([ends, [len(self.times)]])
-        for start, stop in zip(ends[:-1], onsets[1:]):
+        onsets, ends = _annotations_starts_stops(
+            self, skip_by_annotation, 'skip_by_annotation', invert=True)
+        for start, stop in zip(onsets, ends):
             filter_data(
                 self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,
                 picks, filter_length, l_trans_bandwidth, h_trans_bandwidth,
@@ -2186,9 +2188,38 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                          'value for split size: %s plus enough bytes for '
                          'the chosen buffer_size' % pos_prev)
     next_file_buffer = 2 ** 20  # extra cushion for last few post-data tags
-    for first in range(start, stop, buffer_size):
-        # Write blocks <= buffer_size in size
-        last = min(first + buffer_size, stop)
+
+    # Check to see if this has acquisition skips and, if so, if we can
+    # write out empty buffers instead of zeroes
+    firsts = list(range(start, stop, buffer_size))
+    lasts = np.array(firsts) + buffer_size
+    if lasts[-1] > stop:
+        lasts[-1] = stop
+    sk_onsets, sk_ends = _annotations_starts_stops(raw, 'bad_acq_skip')
+    do_skips = False
+    if len(sk_onsets) > 0:
+        if np.in1d(sk_onsets, firsts).all() and np.in1d(sk_ends, lasts).all():
+            do_skips = True
+        else:
+            if part_idx == 0:
+                warn('Acquisition skips detected but did not fit evenly into '
+                     'output buffer_size, will be written as zeroes.')
+
+    n_current_skip = 0
+    for first, last in zip(firsts, lasts):
+        if do_skips:
+            if ((first >= sk_onsets) & (last <= sk_ends)).any():
+                # Track how many we have
+                n_current_skip += 1
+                continue
+            elif n_current_skip > 0:
+                # Write out an empty buffer instead of data
+                write_int(fid, FIFF.FIFF_DATA_SKIP, n_current_skip)
+                # This NOP is probably optional (MaxFilter does not do it)
+                # but the acquisition machines have it, so might as well...
+                for ii in range(n_current_skip):
+                    write_nop(fid)
+                n_current_skip = 0
         data, times = raw[use_picks, first:last]
         assert len(times) == last - first
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -23,7 +23,7 @@ from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                  SetChannelsMixin, InterpolationMixin)
 from ..channels.montage import read_montage, _set_montage, Montage
 from .compensator import set_current_comp, make_compensator
-from .write import (start_file, end_file, start_block, end_block, write_nop,
+from .write import (start_file, end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
                     write_id, write_string, write_name_list, _get_split_size)
@@ -2215,10 +2215,10 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             elif n_current_skip > 0:
                 # Write out an empty buffer instead of data
                 write_int(fid, FIFF.FIFF_DATA_SKIP, n_current_skip)
-                # This NOP is probably optional (MaxFilter does not do it)
-                # but the acquisition machines have it, so might as well...
-                for ii in range(n_current_skip):
-                    write_nop(fid)
+                # These two NOPs appear to be optional (MaxFilter does not do
+                # it, but some acquisition machines do) so let's not bother.
+                # write_nop(fid)
+                # write_nop(fid)
                 n_current_skip = 0
         data, times = raw[use_picks, first:last]
         assert len(times) == last - first

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -228,8 +228,8 @@ FIFF.FIFF_SUBJ_LAST_NAME    = 403  # Last name of the subject
 FIFF.FIFF_SUBJ_BIRTH_DAY    = 404  # Birthday of the subject
 FIFF.FIFF_SUBJ_SEX          = 405  # Sex of the subject
 FIFF.FIFF_SUBJ_HAND         = 406  # Handedness of the subject
-FIFF.FIFF_SUBJ_WEIGHT       = 407  # Weight of the subject
-FIFF.FIFF_SUBJ_HEIGHT       = 408  # Height of the subject
+FIFF.FIFF_SUBJ_WEIGHT       = 407  # Weight of the subject in kg
+FIFF.FIFF_SUBJ_HEIGHT       = 408  # Height of the subject in m
 FIFF.FIFF_SUBJ_COMMENT      = 409  # Comment about the subject
 FIFF.FIFF_SUBJ_HIS_ID       = 410  # ID used in the Hospital Information System
 

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -126,10 +126,11 @@ class Raw(BaseRaw):
                     if self.annotations is None:
                         self.annotations = Annotations((), (), ())
                     start = skip['first'] - first_samp + offset
-                    stop = skip['last'] - first_samp - 1 + offset
+                    stop = skip['last'] - first_samp + offset
                     self.annotations.append(
                         _sync_onset(self, start / self.info['sfreq']),
-                        (stop - start) / self.info['sfreq'], 'BAD_ACQ_SKIP')
+                        (stop - start + 1) / self.info['sfreq'],
+                        'BAD_ACQ_SKIP')
         if preload:
             self._preload_data(preload)
         else:

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1153,6 +1153,12 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
             elif kind == FIFF.FIFF_SUBJ_HAND:
                 tag = read_tag(fid, pos)
                 si['hand'] = int(tag.data)
+            elif kind == FIFF.FIFF_SUBJ_WEIGHT:
+                tag = read_tag(fid, pos)
+                si['weight'] = tag.data
+            elif kind == FIFF.FIFF_SUBJ_HEIGHT:
+                tag = read_tag(fid, pos)
+                si['height'] = tag.data
     info['subject_info'] = si
 
     hpi_subsystem = dir_tree_find(meas_info, FIFF.FIFFB_HPI_SUBSYSTEM)
@@ -1434,6 +1440,10 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
             write_int(fid, FIFF.FIFF_SUBJ_SEX, si['sex'])
         if si.get('hand') is not None:
             write_int(fid, FIFF.FIFF_SUBJ_HAND, si['hand'])
+        if si.get('weight') is not None:
+            write_float(fid, FIFF.FIFF_SUBJ_WEIGHT, si['weight'])
+        if si.get('height') is not None:
+            write_float(fid, FIFF.FIFF_SUBJ_HEIGHT, si['height'])
         end_block(fid, FIFF.FIFFB_SUBJECT)
 
     if info.get('hpi_subsystem') is not None:

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -10,7 +10,7 @@ from gzip import GzipFile
 
 import numpy as np
 
-from .tag import read_tag_info, read_tag, read_big, Tag
+from .tag import read_tag_info, read_tag, read_big, Tag, _call_dict_names
 from .tree import make_dir_tree, dir_tree_find
 from .constants import FIFF
 from ..utils import logger, verbose
@@ -222,11 +222,13 @@ def _show_tree(fid, tree, indent, level, read_limit, max_str, tag_id):
 
     if tree['directory'] is not None:
         kinds = [ent.kind for ent in tree['directory']] + [-1]
+        types = [ent.type for ent in tree['directory']]
         sizes = [ent.size for ent in tree['directory']]
         poss = [ent.pos for ent in tree['directory']]
         counter = 0
         good = True
-        for k, kn, size, pos in zip(kinds[:-1], kinds[1:], sizes, poss):
+        for k, kn, size, pos, type_ in zip(kinds[:-1], kinds[1:], sizes, poss,
+                                           types):
             if not tag_found and k != tag_id:
                 continue
             tag = Tag(k, size, 0, pos)
@@ -263,8 +265,10 @@ def _show_tree(fid, tree, indent, level, read_limit, max_str, tag_id):
                     else:
                         postpend += ' ... type=' + str(type(tag.data))
                 postpend = '>' * 20 + 'BAD' if not good else postpend
+                type_ = _call_dict_names.get(type_, '?%s?' % (type_,))
                 out += [next_idt + prepend + str(k) + ' = ' +
-                        '/'.join(this_type) + ' (' + str(size) + ')' +
+                        '/'.join(this_type) +
+                        ' (' + str(size) + 'b %s)' % type_ +
                         postpend]
                 out[-1] = out[-1].replace('\n', u'¶')
                 counter = 0

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -45,11 +45,11 @@ class Tag(object):
         self.data = None
 
     def __repr__(self):  # noqa: D105
-        out = ("kind: %s - type: %s - size: %s - next: %s - pos: %s"
+        out = ("<Tag  |  kind %s - type %s - size %s - next %s - pos %s"
                % (self.kind, self.type, self.size, self.next, self.pos))
         if hasattr(self, 'data'):
-            out += " - data: %s" % self.data
-        out += "\n"
+            out += " - data %s" % self.data
+        out += ">"
         return out
 
     def __cmp__(self, tag):  # noqa: D105
@@ -460,6 +460,19 @@ _call_dict = {
     FIFF.FIFFT_DIR_ENTRY_STRUCT: _read_dir_entry_struct,
     FIFF.FIFFT_JULIAN: _read_julian,
 }
+_call_dict_names = {
+    FIFF.FIFFT_STRING: 'str',
+    FIFF.FIFFT_COMPLEX_FLOAT: 'c8',
+    FIFF.FIFFT_COMPLEX_DOUBLE: 'c16',
+    FIFF.FIFFT_ID_STRUCT: 'ids',
+    FIFF.FIFFT_DIG_POINT_STRUCT: 'dps',
+    FIFF.FIFFT_COORD_TRANS_STRUCT: 'cts',
+    FIFF.FIFFT_CH_INFO_STRUCT: 'cis',
+    FIFF.FIFFT_OLD_PACK: 'op_',
+    FIFF.FIFFT_DIR_ENTRY_STRUCT: 'dir',
+    FIFF.FIFFT_JULIAN: 'jul',
+    FIFF.FIFFT_VOID: 'nul',  # 0
+}
 
 #  Append the simple types
 _simple_dict = {
@@ -474,6 +487,7 @@ _simple_dict = {
 }
 for key, dtype in _simple_dict.items():
     _call_dict[key] = partial(_read_simple, dtype=dtype)
+    _call_dict_names[key] = dtype
 
 
 def read_tag(fid, pos=None, shape=None, rlims=None):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -190,6 +190,8 @@ def test_read_write_info():
     info['proc_history'][0]['creator'] = creator
     info['hpi_meas'][0]['creator'] = creator
     info['subject_info']['his_id'] = creator
+    info['subject_info']['weight'] = 11.1
+    info['subject_info']['height'] = 2.3
 
     if info['gantry_angle'] is None:  # future testing data may include it
         info['gantry_angle'] = 0.  # Elekta supine position
@@ -201,6 +203,8 @@ def test_read_write_info():
     assert_equal(info['hpi_meas'][0]['creator'], creator)
     assert_equal(info['subject_info']['his_id'], creator)
     assert_equal(info['gantry_angle'], gantry_angle)
+    assert info['subject_info']['height'] == 2.3
+    assert info['subject_info']['weight'] == 11.1
 
 
 def test_io_dig_points():

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -175,7 +175,7 @@ def read_str(fid, count=1):
     """Read string from a binary file in a python version compatible way."""
     dtype = np.dtype('>S%i' % count)
     string = fid.read(dtype.itemsize)
-    data = np.fromstring(string, dtype=dtype)[0]
+    data = np.frombuffer(string, dtype=dtype)[0]
     bytestr = b('').join([data[0:data.index(b('\x00')) if
                           b('\x00') in data else count]])
 

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -47,10 +47,13 @@ def _get_split_size(split_size):
     return split_size
 
 
-def write_nop(fid):
+def write_nop(fid, last=False):
     """Write a FIFF_NOP."""
-    _write(fid, [], FIFF.FIFF_NOP, FIFF.FIFFT_VOID,
-           FIFF.FIFFV_NEXT_NONE, '>i4')
+    fid.write(np.array(FIFF.FIFF_NOP, dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFFT_VOID, dtype='>i4').tostring())
+    fid.write(np.array(0, dtype='>i4').tostring())
+    next_ = FIFF.FIFFV_NEXT_NONE if last else FIFF.FIFFV_NEXT_SEQ
+    fid.write(np.array(next_, dtype='>i4').tostring())
 
 
 def write_int(fid, kind, data):
@@ -281,7 +284,7 @@ def check_fiff_length(fid, close=True):
 
 def end_file(fid):
     """Write the closing tags to a fif file and closes the file."""
-    write_nop(fid)
+    write_nop(fid, last=True)
     check_fiff_length(fid)
     fid.close()
 

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -47,6 +47,12 @@ def _get_split_size(split_size):
     return split_size
 
 
+def write_nop(fid):
+    """Write a FIFF_NOP."""
+    _write(fid, [], FIFF.FIFF_NOP, FIFF.FIFFT_VOID,
+           FIFF.FIFFV_NEXT_NONE, '>i4')
+
+
 def write_int(fid, kind, data):
     """Write a 32-bit integer tag to a fif file."""
     data_size = 4
@@ -275,11 +281,7 @@ def check_fiff_length(fid, close=True):
 
 def end_file(fid):
     """Write the closing tags to a fif file and closes the file."""
-    data_size = 0
-    fid.write(np.array(FIFF.FIFF_NOP, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_VOID, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_NONE, dtype='>i4').tostring())
+    write_nop(fid)
     check_fiff_length(fid)
     fid.close()
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -102,12 +102,18 @@ def test_annotations():
 @testing.requires_testing_data
 def test_raw_reject():
     """Test raw data getter with annotation reject."""
-    info = create_info(['a', 'b', 'c', 'd', 'e'], 100, ch_types='eeg')
+    sfreq = 100.
+    info = create_info(['a', 'b', 'c', 'd', 'e'], sfreq, ch_types='eeg')
     raw = RawArray(np.ones((5, 15000)), info)
     with warnings.catch_warnings(record=True):  # one outside range
         raw.annotations = Annotations([2, 100, 105, 148], [2, 8, 5, 8], 'BAD')
-    data = raw.get_data([0, 1, 3, 4], 100, 11200, 'omit')
-    assert_array_equal(data.shape, (4, 9900))
+    data, times = raw.get_data([0, 1, 3, 4], 100, 11200,  # 1-112 sec
+                               'omit', return_times=True)
+    bad_times = np.concatenate([np.arange(200, 400),
+                                np.arange(10000, 10800),
+                                np.arange(10500, 11000)])
+    expected_times = np.setdiff1d(np.arange(100, 11200), bad_times) / sfreq
+    assert_allclose(times, expected_times)
 
     # with orig_time and complete overlap
     raw = read_raw_fif(fif_fname)
@@ -121,7 +127,7 @@ def test_raw_reject():
     data, times = raw.get_data(range(10), 0, 6000, 'NaN', True)
     assert_array_equal(data.shape, (10, 6000))
     assert_equal(times[-1], raw.times[5999])
-    assert_true(np.isnan(data[:, 313:613]).all())  # 1s -2s
+    assert_true(np.isnan(data[:, 314:613]).all())  # 1s -2s
     assert_true(not np.isnan(data[:, 614].any()))
     assert_array_equal(data[:, -100:], raw[:10, 5900:6000][0])
     assert_array_equal(raw.get_data(), raw[:][0])
@@ -171,6 +177,31 @@ def test_annotation_filtering():
     mask = np.concatenate((np.zeros(1000), np.ones(2000), np.zeros(1000)))
     expected_data = raws_concat[0][0][0] * mask
     assert_allclose(raw[0][0][0], expected_data, atol=1e-14)
+
+    # Let's try another one
+    raw = raws[0].copy()
+    raw.annotations = Annotations([0.], [0.5], ['BAD_ACQ_SKIP'])
+    my_data, times = raw.get_data(reject_by_annotation='omit',
+                                  return_times=True)
+    assert_allclose(times, raw.times[500:])
+    assert my_data.shape == (1, 500)
+    raw_filt = raw.copy().filter(skip_by_annotation='bad_acq_skip',
+                                 **kwargs_stop)
+    expected = data.copy()
+    expected[:, 500:] = 0
+    assert_allclose(raw_filt[:][0], expected, atol=1e-14)
+
+    raw = raws[0].copy()
+    raw.annotations = Annotations([0.5], [0.5], ['BAD_ACQ_SKIP'])
+    my_data, times = raw.get_data(reject_by_annotation='omit',
+                                  return_times=True)
+    assert_allclose(times, raw.times[:500])
+    assert my_data.shape == (1, 500)
+    raw_filt = raw.copy().filter(skip_by_annotation='bad_acq_skip',
+                                 **kwargs_stop)
+    expected = data.copy()
+    expected[:, :500] = 0
+    assert_allclose(raw_filt[:][0], expected, atol=1e-14)
 
 
 def test_annotation_omit():

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -272,7 +272,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                         analog=False)
         sr, sp = _annotations_starts_stops(raw, ('edge', 'bad_acq_skip'),
                                            invert=True)
-        filt_bounds = np.unique([sr, sp])
+        filt_bounds = np.unique(np.concatenate([sr, sp]))
 
     # make a copy of info, remove projection (for now)
     info = raw.info.copy()

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1853,7 +1853,8 @@ def _plot_annotations(raw, params):
         params['ax_hscroll'].fill_betweenx(
             (0., 1.), annot_start, annot_end, alpha=0.3,
             color=params['segment_colors'][dscr])
-    params['segments'] = np.array(segments)
+    # Adjust half a sample backward to make it clear what is included
+    params['segments'] = np.array(segments) - 0.5 / raw.info['sfreq']
     params['annot_description'] = descriptions
 
 


### PR DESCRIPTION
This PR:

- Fixes a bug in `Annotations` when cropping to the last sample
- Fixes minor bugs in `bad_acq_skip` annotations
- Fixes `raw.filter` to respect acquisition skips
- Fixes `raw.save` to allow properly saving acquisition skips (assuming `buffer_size_sec` is conserved)
- Fixes `raw.plot(lowpass=...)` to respect boundaries the same way `raw.filter(...)` does by default
- Improves `Tag.__repr__`
- Improves `mne show_fiff` and `mne.viz.compare_fiff` visualization to include data types
- Fixes a `np.fromstring` -> `np.frombuffer` I missed earlier

And while I was fixing all this stuff I noticed a diff in a file, so I added support for reading subject height and weight.