### PR TITLE
[WIP] Remove montages with set_montage(None)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ Changelog
 
 - Add support for multiple head position files and plotting of sensors in :func:`mne.viz.plot_head_positions` by `Eric Larson`_
 
+- Add option to unset a montage by passing `None` to :meth:`mne.io.Raw.set_montage` by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -480,8 +480,8 @@ class SetChannelsMixin(object):
 
         Parameters
         ----------
-        montage : instance of Montage or DigMontage
-            The montage to use.
+        montage : instance of Montage | instance of DigMontage | None
+            The montage to use (None removes any location information).
         set_dig : bool
             If True, update the digitization information (``info['dig']``)
             in addition to the channel positions (``info['chs'][idx]['loc']``).

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -879,9 +879,8 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
                 warn('Did not set %s channel positions:\n%s'
                      % (len(did_not_set), ', '.join(did_not_set)))
     elif montage is None:
-        loc = np.zeros(12)
         for ch in info['chs']:
-            ch['loc'] = loc.copy()
+            ch['loc'] = np.zeros(12)
         if set_dig:
             info['dig'] = None
     else:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -778,8 +778,8 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
     ----------
     info : instance of Info
         The measurement info to update.
-    montage : instance of Montage | instance of DigMontage
-        The montage to apply.
+    montage : instance of Montage | instance of DigMontage | None
+        The montage to apply (None removes any location information).
     update_ch_names : bool
         If True, overwrite the info channel names with the ones from montage.
         Defaults to False.
@@ -878,6 +878,10 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
             if len(did_not_set) > 0:
                 warn('Did not set %s channel positions:\n%s'
                      % (len(did_not_set), ', '.join(did_not_set)))
+    elif montage is None:
+        loc = np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(float)
+        for ch in info["chs"]:
+            ch["loc"] = loc.copy()
     else:
         raise TypeError("Montage must be a 'Montage' or 'DigMontage' "
                         "instead of '%s'." % type(montage))

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -879,9 +879,11 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
                 warn('Did not set %s channel positions:\n%s'
                      % (len(did_not_set), ', '.join(did_not_set)))
     elif montage is None:
-        loc = np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(float)
-        for ch in info["chs"]:
-            ch["loc"] = loc.copy()
+        loc = np.zeros(12)
+        for ch in info['chs']:
+            ch['loc'] = loc.copy()
+        if set_dig:
+            info['dig'] = None
     else:
         raise TypeError("Montage must be a 'Montage' or 'DigMontage' "
                         "instead of '%s'." % type(montage))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1723,7 +1723,7 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
                          '(%s != %s)' % (len(ch_types), nchan))
     info = _empty_info(sfreq)
     info['meas_date'] = np.array([0, 0], np.int32)
-    loc = np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(np.float32)
+    loc = np.zeros(12)
     for ci, (name, kind) in enumerate(zip(ch_names, ch_types)):
         if not isinstance(name, string_types):
             raise TypeError('each entry in ch_names must be a string')

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1723,7 +1723,6 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
                          '(%s != %s)' % (len(ch_types), nchan))
     info = _empty_info(sfreq)
     info['meas_date'] = np.array([0, 0], np.int32)
-    loc = np.zeros(12)
     for ci, (name, kind) in enumerate(zip(ch_names, ch_types)):
         if not isinstance(name, string_types):
             raise TypeError('each entry in ch_names must be a string')
@@ -1733,7 +1732,7 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
             raise KeyError('kind must be one of %s, not %s'
                            % (list(_kind_dict.keys()), kind))
         kind = _kind_dict[kind]
-        chan_info = dict(loc=loc.copy(), unit_mul=0, range=1., cal=1.,
+        chan_info = dict(loc=np.zeros(12), unit_mul=0, range=1., cal=1.,
                          kind=kind[0], coil_type=kind[1],
                          unit=kind[2], coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                          ch_name=name, scanno=ci + 1, logno=ci + 1)


### PR DESCRIPTION
Fixes #4841.

Questions:

1. Do we care about the `set_dig` argument?
2. I'm not sure what the correct default value for `info["chs"][idx]["loc"]` is. `mne.create_info` fills this entry with `np.concatenate((np.zeros(3), np.eye(3).ravel())).astype(float)`, whereas `mne.io.read_raw_edf` seems to fill it with all zeros.