### PR TITLE
MRG: Fix loc

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -93,6 +93,8 @@ Bug
 API
 ~~~
 
+- Channels with unknown locations are now assigned position ``[np.nan, np.nan, np.nan]`` instead of ``[0., 0., 0.]``, by `Eric Larson`_
+
 - Changed the line width in :func:`mne.viz.plot_bem` from 2.0 to 1.0 for better visibility of underlying structures, by `Eric Larson`_
 
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -650,7 +650,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
     locs3d = np.array([ch['loc'][:3] for ch in chs])
 
     # If electrode locations are not available, use digization points
-    if len(locs3d) == 0 or np.allclose(locs3d, 0):
+    if len(locs3d) == 0 or (~np.isfinite(locs3d)).any():
         logging.warning('Did not find any electrode locations the info, '
                         'will attempt to use digitization points instead. '
                         'However, if digitization points do not correspond to '

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -650,7 +650,8 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
     locs3d = np.array([ch['loc'][:3] for ch in chs])
 
     # If electrode locations are not available, use digization points
-    if len(locs3d) == 0 or (~np.isfinite(locs3d)).any():
+    if len(locs3d) == 0 or (~np.isfinite(locs3d)).all() or \
+            np.allclose(locs3d, 0.):
         logging.warning('Did not find any electrode locations the info, '
                         'will attempt to use digitization points instead. '
                         'However, if digitization points do not correspond to '
@@ -705,9 +706,9 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
             for elec_i in squareform(dist < 1e-10).any(axis=0).nonzero()[0]
         ]
 
-        raise ValueError('The following electrodes have overlapping positions:'
-                         '\n    ' + str(problematic_electrodes) + '\nThis '
-                         'causes problems during visualization.')
+        raise ValueError('The following electrodes have overlapping positions,'
+                         ' which causes problems during visualization:\n' +
+                         ', '.join(problematic_electrodes))
 
     if to_sphere:
         # use spherical (theta, pol) as (r, theta) for polar->cartesian

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -880,8 +880,7 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
                      % (len(did_not_set), ', '.join(did_not_set)))
     elif montage is None:
         for ch in info['chs']:
-            ch['loc'] = np.empty(12)
-            ch['loc'].fill(np.nan)
+            ch['loc'] = np.full(12, np.nan)
         if set_dig:
             info['dig'] = None
     else:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -880,7 +880,8 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
                      % (len(did_not_set), ', '.join(did_not_set)))
     elif montage is None:
         for ch in info['chs']:
-            ch['loc'] = np.zeros(12)
+            ch['loc'] = np.empty(12)
+            ch['loc'].fill(np.nan)
         if set_dig:
             info['dig'] = None
     else:

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -107,7 +107,7 @@ def test_auto_topomap_coords():
     # Remove electrode position information, use digitization points from now
     # on.
     for ch in info['chs']:
-        ch['loc'].fill(0)
+        ch['loc'].fill(np.nan)
 
     l1 = _auto_topomap_coords(info, picks)
     assert_allclose(l1, l0, atol=1e-3)

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -496,7 +496,9 @@ def test_fif_dig_montage():
             # C actually says it's unknown, but it's not (?):
             # assert_equal(ch_py['coord_frame'], ch_c['coord_frame'])
             assert_equal(ch_py['coord_frame'], FIFF.FIFFV_COORD_HEAD)
-            assert_allclose(ch_py['loc'], ch_c['loc'], atol=1e-7)
+            c_loc = ch_c['loc'].copy()
+            c_loc[c_loc == 0] = np.nan
+            assert_allclose(ch_py['loc'], c_loc, atol=1e-7)
         assert_dig_allclose(raw_bv.info, evoked.info)
 
     # Roundtrip of non-FIF start

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1270,12 +1270,14 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         data = np.array([out[1], out[3]])
         out_info = deepcopy(info)
         loc = np.concatenate([pos, ori, np.zeros(6)])
+        empty_loc = np.empty(12)
+        empty_loc.fill(np.nan)
         out_info['chs'] = [
             dict(ch_name='dip 01', loc=loc, kind=FIFF.FIFFV_DIPOLE_WAVE,
                  coord_frame=FIFF.FIFFV_COORD_UNKNOWN, unit=FIFF.FIFF_UNIT_AM,
                  coil_type=FIFF.FIFFV_COIL_DIPOLE,
                  unit_mul=0, range=1, cal=1., scanno=1, logno=1),
-            dict(ch_name='goodness', loc=np.zeros(12),
+            dict(ch_name='goodness', loc=empty_loc,
                  kind=FIFF.FIFFV_GOODNESS_FIT, unit=FIFF.FIFF_UNIT_AM,
                  coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                  coil_type=FIFF.FIFFV_COIL_NONE,

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1271,14 +1271,12 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         data = np.array([out[1], out[3]])
         out_info = deepcopy(info)
         loc = np.concatenate([pos, ori, np.zeros(6)])
-        empty_loc = np.empty(12)
-        empty_loc.fill(np.nan)
         out_info['chs'] = [
             dict(ch_name='dip 01', loc=loc, kind=FIFF.FIFFV_DIPOLE_WAVE,
                  coord_frame=FIFF.FIFFV_COORD_UNKNOWN, unit=FIFF.FIFF_UNIT_AM,
                  coil_type=FIFF.FIFFV_COIL_DIPOLE,
                  unit_mul=0, range=1, cal=1., scanno=1, logno=1),
-            dict(ch_name='goodness', loc=empty_loc,
+            dict(ch_name='goodness', loc=np.full(12, np.nan),
                  kind=FIFF.FIFFV_GOODNESS_FIT, unit=FIFF.FIFF_UNIT_AM,
                  coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                  coil_type=FIFF.FIFFV_COIL_NONE,

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -597,6 +597,7 @@ def _dipole_forwards(fwd_data, whitener, rr, n_jobs=1):
     """Compute the forward solution and do other nice stuff."""
     B = _compute_forwards_meeg(rr, fwd_data, n_jobs, verbose=False)
     B = np.concatenate(B, axis=1)
+    assert np.isfinite(B).all()
     B_orig = B.copy()
 
     # Apply projection and whiten (cov has projections already)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2488,7 +2488,8 @@ def concatenate_raws(raws, preload=None, events_list=None):
         return raws[0], events
 
 
-def _check_update_montage(info, montage, path=None, update_ch_names=False):
+def _check_update_montage(info, montage, path=None, update_ch_names=False,
+                          raise_missing=True):
     """Help eeg readers to add montage."""
     if montage is not None:
         if not isinstance(montage, (string_types, Montage)):
@@ -2505,11 +2506,11 @@ def _check_update_montage(info, montage, path=None, update_ch_names=False):
                        FIFF.FIFFV_STIM_CH)
             for ch in info['chs']:
                 if not ch['kind'] in exclude:
-                    if np.unique(ch['loc']).size == 1:
+                    if not np.isfinite(ch['loc'][:3]).all():
                         missing_positions.append(ch['ch_name'])
 
             # raise error if positions are missing
-            if missing_positions:
+            if missing_positions and raise_missing:
                 raise KeyError(
                     "The following positions are missing from the montage "
                     "definitions: %s. If those channels lack positions "

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -711,9 +711,11 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             kind = FIFF.FIFFV_EEG_CH
             coil_type = FIFF.FIFFV_COIL_EEG
             unit = FIFF.FIFF_UNIT_V
+        loc = np.empty(12)
+        loc.fill(np.nan)
         info['chs'].append(dict(
             ch_name=ch_name, coil_type=coil_type, kind=kind, logno=idx + 1,
-            scanno=idx + 1, cal=cals[idx], range=ranges[idx], loc=np.zeros(12),
+            scanno=idx + 1, cal=cals[idx], range=ranges[idx], loc=loc,
             unit=unit, unit_mul=0.,  # always zero- mne manual pg. 273
             coord_frame=FIFF.FIFFV_COORD_HEAD))
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -711,11 +711,10 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             kind = FIFF.FIFFV_EEG_CH
             coil_type = FIFF.FIFFV_COIL_EEG
             unit = FIFF.FIFF_UNIT_V
-        loc = np.empty(12)
-        loc.fill(np.nan)
         info['chs'].append(dict(
             ch_name=ch_name, coil_type=coil_type, kind=kind, logno=idx + 1,
-            scanno=idx + 1, cal=cals[idx], range=ranges[idx], loc=loc,
+            scanno=idx + 1, cal=cals[idx], range=ranges[idx],
+            loc=np.full(12, np.nan),
             unit=unit, unit_mul=0.,  # always zero- mne manual pg. 273
             coord_frame=FIFF.FIFFV_COORD_HEAD))
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -270,8 +270,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     eegs = [idx for idx, ch in enumerate(chs) if
             ch['coil_type'] == FIFF.FIFFV_COIL_EEG]
     coords = _topo_to_sphere(pos, eegs)
-    locs = np.empty((len(chs), 12), dtype=float)
-    locs.fill(np.nan)
+    locs = np.full((len(chs), 12), np.nan)
     locs[:, :3] = coords
     for ch, loc in zip(chs, locs):
         ch.update(loc=loc)

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -270,7 +270,8 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     eegs = [idx for idx, ch in enumerate(chs) if
             ch['coil_type'] == FIFF.FIFFV_COIL_EEG]
     coords = _topo_to_sphere(pos, eegs)
-    locs = np.zeros((len(chs), 12), dtype=float)
+    locs = np.empty((len(chs), 12), dtype=float)
+    locs.fill(np.nan)
     locs[:, :3] = coords
     for ch, loc in zip(chs, locs):
         ch.update(loc=loc)

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -153,7 +153,9 @@ def _convert_channel_info(res4, t, use_eeg_pos):
     this_comp = None
     for k, cch in enumerate(res4['chs']):
         cal = float(1. / (cch['proper_gain'] * cch['qgain']))
-        ch = dict(scanno=k + 1, range=1., cal=cal, loc=np.zeros(12),
+        loc = np.empty(12)
+        loc.fill(np.nan)
+        ch = dict(scanno=k + 1, range=1., cal=cal, loc=loc,
                   unit_mul=FIFF.FIFF_UNITM_NONE, ch_name=cch['ch_name'][:15],
                   coil_type=FIFF.FIFFV_COIL_NONE)
         del k

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -161,8 +161,6 @@ def _convert_channel_info(res4, t, use_eeg_pos):
         del k
         chs.append(ch)
         # Create the channel position information
-        pos = dict(r0=ch['loc'][:3], ex=ch['loc'][3:6], ey=ch['loc'][6:9],
-                   ez=ch['loc'][9:12])
         if cch['sensor_type_index'] in (CTF.CTFV_REF_MAG_CH,
                                         CTF.CTFV_REF_GRAD_CH,
                                         CTF.CTFV_MEG_CH):
@@ -181,12 +179,12 @@ def _convert_channel_info(res4, t, use_eeg_pos):
                 continue
             ch['unit'] = FIFF.FIFF_UNIT_T
             # Set up the local coordinate frame
-            pos['r0'][:] = cch['coil']['pos'][0]
-            pos['ez'][:] = cch['coil']['norm'][0]
+            r0 = cch['coil']['pos'][0].copy()
+            ez = cch['coil']['norm'][0].copy()
             # It turns out that positive proper_gain requires swapping
             # of the normal direction
             if cch['proper_gain'] > 0.0:
-                pos['ez'] *= -1
+                ez *= -1
             # Check how the other vectors should be defined
             off_diag = False
             # Default: ex and ey are arbitrary in the plane normal to ez
@@ -200,21 +198,23 @@ def _convert_channel_info(res4, t, use_eeg_pos):
                 if size > 0.:
                     diff /= size
                 # Is ez normal to the line joining the coils?
-                if np.abs(np.dot(diff, pos['ez'])) < 1e-3:
+                if np.abs(np.dot(diff, ez)) < 1e-3:
                     off_diag = True
                     # Handle the off-diagonal gradiometer coordinate system
-                    pos['r0'] -= size * diff / 2.0
-                    pos['ex'][:] = diff
-                    pos['ey'][:] = np.cross(pos['ez'], pos['ex'])
+                    r0 -= size * diff / 2.0
+                    ex = diff
+                    ey = np.cross(ez, ex)
                 else:
-                    pos['ex'][:], pos['ey'][:] = _get_plane_vectors(pos['ez'])
+                    ex, ey = _get_plane_vectors(ez)
             else:
-                pos['ex'][:], pos['ey'][:] = _get_plane_vectors(pos['ez'])
+                ex, ey = _get_plane_vectors(ez)
             # Transform into a Neuromag-like device coordinate system
-            pos['r0'][:] = apply_trans(t['t_ctf_dev_dev'], pos['r0'])
-            for key in ('ex', 'ey', 'ez'):
-                pos[key][:] = apply_trans(t['t_ctf_dev_dev'], pos[key],
-                                          move=False)
+            loc[:] = np.concatenate([
+                apply_trans(t['t_ctf_dev_dev'], r0),
+                apply_trans(t['t_ctf_dev_dev'], ex, move=False),
+                apply_trans(t['t_ctf_dev_dev'], ey, move=False),
+                apply_trans(t['t_ctf_dev_dev'], ez, move=False)])
+            del r0, ex, ey, ez
             # Set the coil type
             if cch['sensor_type_index'] == CTF.CTFV_REF_MAG_CH:
                 ch['kind'] = FIFF.FIFFV_REF_MEG_CH
@@ -246,16 +246,16 @@ def _convert_channel_info(res4, t, use_eeg_pos):
             if use_eeg_pos:
                 # EEG electrode coordinates may be present but in the
                 # CTF head frame
-                pos['r0'][:] = cch['coil']['pos'][0]
-                if not _at_origin(pos['r0']):
+                loc[:3] = cch['coil']['pos'][0]
+                loc[3:6] = 0.  # XXX Fix fwd!
+                if not _at_origin(loc[:3]):
                     if t['t_ctf_head_head'] is None:
                         warn('EEG electrode (%s) location omitted because of '
                              'missing HPI information' % ch['ch_name'])
-                        pos['r0'][:] = np.zeros(3)
+                        loc.fill(np.nan)
                         coord_frame = FIFF.FIFFV_COORD_CTF_HEAD
                     else:
-                        pos['r0'][:] = apply_trans(t['t_ctf_head_head'],
-                                                   pos['r0'])
+                        loc[:3] = apply_trans(t['t_ctf_head_head'], loc[:3])
             neeg += 1
             ch.update(logno=neeg, kind=FIFF.FIFFV_EEG_CH,
                       unit=FIFF.FIFF_UNIT_V, coord_frame=coord_frame)

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -158,10 +158,17 @@ def test_read_ctf():
             for key in ('loc',):
                 if c1['ch_name'] == 'RMSP' and 'catch-alp-good-f' in fname:
                     continue
-                assert_allclose(c1[key][:3], c2[key][:3], atol=1e-6, rtol=1e-4,
+                if (c2[key][:3] == 0.).all():
+                    check = [np.nan] * 3
+                else:
+                    check = c2[key][:3]
+                assert_allclose(c1[key][:3], check, atol=1e-6, rtol=1e-4,
                                 err_msg='raw.info["chs"][%d][%s]' % (ii, key))
-                assert_allclose(c1[key][9:12], c2[key][9:12], atol=1e-6,
-                                rtol=1e-4,
+                if (c2[key][3:] == 0.).all():
+                    check = [np.nan] * 3
+                else:
+                    check = c2[key][9:12]
+                assert_allclose(c1[key][9:12], check, atol=1e-6, rtol=1e-4,
                                 err_msg='raw.info["chs"][%d][%s]' % (ii, key))
         if fname.endswith('catch-alp-good-f.ds'):  # omit points from .pos file
             raw.info['dig'] = raw.info['dig'][:-10]

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -105,8 +105,9 @@ def _get_info(eeg, montage, eog=()):
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
-        _check_update_montage(info, montage, path=path,
-                              update_ch_names=update_ch_names)
+        _check_update_montage(
+            info, montage, path=path, update_ch_names=update_ch_names,
+            raise_missing=False)
 
     info['buffer_size_sec'] = 1.  # reasonable default
     # update the info dict
@@ -339,10 +340,12 @@ class RawEEGLAB(BaseRaw):
         last_samps = [eeg.pnts - 1]
         info = _get_info(eeg, montage, eog=eog)
 
+        loc = np.empty(12)
+        loc.fill(np.nan)
         stim_chan = dict(ch_name='STI 014', coil_type=FIFF.FIFFV_COIL_NONE,
                          kind=FIFF.FIFFV_STIM_CH, logno=len(info["chs"]) + 1,
                          scanno=len(info["chs"]) + 1, cal=1., range=1.,
-                         loc=np.zeros(12), unit=FIFF.FIFF_UNIT_NONE,
+                         loc=loc, unit=FIFF.FIFF_UNIT_NONE,
                          unit_mul=0., coord_frame=FIFF.FIFFV_COORD_UNKNOWN)
         info['chs'].append(stim_chan)
         info._update_redundant()

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -340,12 +340,10 @@ class RawEEGLAB(BaseRaw):
         last_samps = [eeg.pnts - 1]
         info = _get_info(eeg, montage, eog=eog)
 
-        loc = np.empty(12)
-        loc.fill(np.nan)
         stim_chan = dict(ch_name='STI 014', coil_type=FIFF.FIFFV_COIL_NONE,
                          kind=FIFF.FIFFV_STIM_CH, logno=len(info["chs"]) + 1,
                          scanno=len(info["chs"]) + 1, cal=1., range=1.,
-                         loc=loc, unit=FIFF.FIFF_UNIT_NONE,
+                         loc=np.full(12, np.nan), unit=FIFF.FIFF_UNIT_NONE,
                          unit_mul=0., coord_frame=FIFF.FIFFV_COORD_UNKNOWN)
         info['chs'].append(stim_chan)
         info._update_redundant()

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -187,7 +187,7 @@ def test_io_set():
                                      chanlocs[i]['X'],
                                      chanlocs[i]['Z']]))
     # position of the last channel should be zero
-    assert_array_equal(raw.info['chs'][-1]['loc'][:3], np.array([0., 0., 0.]))
+    assert_array_equal(raw.info['chs'][-1]['loc'][:3], [np.nan] * 3)
 
     # test reading channel names from set and positions from montage
     with warnings.catch_warnings(record=True) as w:
@@ -198,7 +198,7 @@ def test_io_set():
     assert_equal(len(w), 1)
 
     # when montage was passed - channel positions should be taken from there
-    correct_pos = [[-0.56705965, 0.67706631, 0.46906776], [0., 0., 0.],
+    correct_pos = [[-0.56705965, 0.67706631, 0.46906776], [np.nan] * 3,
                    [0., 0.99977915, -0.02101571]]
     for ch_ind in range(3):
         assert_array_almost_equal(raw.info['chs'][ch_ind]['loc'][:3],

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -213,12 +213,10 @@ class RawKIT(BaseRaw):
 
             # modify info
             nchan = self._raw_extras[0]['nchan'] + 1
-            loc = np.empty(12)
-            loc.fill(np.nan)
             info['chs'].append(dict(
                 cal=KIT.CALIB_FACTOR, logno=nchan, scanno=nchan, range=1.0,
                 unit=FIFF.FIFF_UNIT_NONE, unit_mul=0, ch_name='STI 014',
-                coil_type=FIFF.FIFFV_COIL_NONE, loc=loc,
+                coil_type=FIFF.FIFFV_COIL_NONE, loc=np.full(12, np.nan),
                 kind=FIFF.FIFFV_STIM_CH))
             info._update_redundant()
 

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -213,10 +213,12 @@ class RawKIT(BaseRaw):
 
             # modify info
             nchan = self._raw_extras[0]['nchan'] + 1
+            loc = np.empty(12)
+            loc.fill(np.nan)
             info['chs'].append(dict(
                 cal=KIT.CALIB_FACTOR, logno=nchan, scanno=nchan, range=1.0,
                 unit=FIFF.FIFF_UNIT_NONE, unit_mul=0, ch_name='STI 014',
-                coil_type=FIFF.FIFFV_COIL_NONE, loc=np.zeros(12),
+                coil_type=FIFF.FIFFV_COIL_NONE, loc=loc,
                 kind=FIFF.FIFFV_STIM_CH))
             info._update_redundant()
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1742,9 +1742,7 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
             raise KeyError('kind must be one of %s, not %s'
                            % (list(_kind_dict.keys()), kind))
         kind = _kind_dict[kind]
-        loc = np.empty(12)
-        loc.fill(np.nan)
-        chan_info = dict(loc=loc, unit_mul=0, range=1., cal=1.,
+        chan_info = dict(loc=np.full(12, np.nan), unit_mul=0, range=1., cal=1.,
                          kind=kind[0], coil_type=kind[1],
                          unit=kind[2], coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                          ch_name=name, scanno=ci + 1, logno=ci + 1)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -503,8 +503,8 @@ class Info(dict):
 
 def _simplify_info(info):
     """Return a simplified info structure to speed up picking."""
-    chs =  [{key: ch[key] for key in ('ch_name', 'kind', 'unit', 'coil_type',
-                                     'loc')}
+    chs = [{key: ch[key]
+            for key in ('ch_name', 'kind', 'unit', 'coil_type', 'loc')}
            for ch in info['chs']]
     sub_info = Info(chs=chs, bads=info['bads'], comps=info['comps'])
     sub_info._update_redundant()

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -503,7 +503,7 @@ class Info(dict):
 
 def _simplify_info(info):
     """Return a simplified info structure to speed up picking."""
-    chs = [{key: ch[key] for key in ('ch_name', 'kind', 'unit', 'coil_type',
+    chs =  [{key: ch[key] for key in ('ch_name', 'kind', 'unit', 'coil_type',
                                      'loc')}
            for ch in info['chs']]
     sub_info = Info(chs=chs, bads=info['bads'], comps=info['comps'])
@@ -1742,7 +1742,9 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
             raise KeyError('kind must be one of %s, not %s'
                            % (list(_kind_dict.keys()), kind))
         kind = _kind_dict[kind]
-        chan_info = dict(loc=np.zeros(12), unit_mul=0, range=1., cal=1.,
+        loc = np.empty(12)
+        loc.fill(np.nan)
+        chan_info = dict(loc=loc, unit_mul=0, range=1., cal=1.,
                          kind=kind[0], coil_type=kind[1],
                          unit=kind[2], coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                          ch_name=name, scanno=ci + 1, logno=ci + 1)

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -196,7 +196,9 @@ def _coil_trans_to_loc(coil_trans):
 
 def _loc_to_eeg_loc(loc):
     """Convert a loc to an EEG loc."""
-    if loc[3:6].any():
+    if not np.isfinite(loc[:3]).all():
+        raise RuntimeError('Missing EEG channel location')
+    if np.isfinite(loc[3:6]).all() and (loc[3:6]).any():
         return np.array([loc[0:3], loc[3:6]]).T
     else:
         return loc[0:3][:, np.newaxis].copy()

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -22,6 +22,7 @@ from .io.write import (start_block, end_block, write_int,
                        write_float_matrix, write_int_matrix,
                        write_coord_trans, start_file, end_file, write_id)
 from .bem import read_bem_surfaces, ConductorModel
+from .fixes import _get_args
 from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _tessellate_sphere_surf, _get_surf_neighbors,
                       _normalize_vectors, _get_solids, _triangle_neighbors,
@@ -41,10 +42,13 @@ def _get_lut():
     """Get the FreeSurfer LUT."""
     data_dir = op.join(op.dirname(__file__), 'data')
     lut_fname = op.join(data_dir, 'FreeSurferColorLUT.txt')
+    kwargs = dict()
+    if 'encoding' in _get_args(np.genfromtxt):
+        kwargs['encoding'] = 'ascii'
     return np.genfromtxt(lut_fname, dtype=None,
                          usecols=(0, 1, 2, 3, 4, 5),
                          names=['id', 'name', 'R', 'G', 'B', 'A'],
-                         encoding='ascii')
+                         **kwargs)
 
 
 def _get_lut_id(lut, label, use_lut):

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -43,7 +43,8 @@ def _get_lut():
     lut_fname = op.join(data_dir, 'FreeSurferColorLUT.txt')
     return np.genfromtxt(lut_fname, dtype=None,
                          usecols=(0, 1, 2, 3, 4, 5),
-                         names=['id', 'name', 'R', 'G', 'B', 'A'])
+                         names=['id', 'name', 'R', 'G', 'B', 'A'],
+                         encoding='ascii')
 
 
 def _get_lut_id(lut, label, use_lut):

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -253,7 +253,11 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
             node_colors = cycle(node_colors)
     else:
         # assign colors using colormap
-        node_colors = [plt.cm.spectral(i / float(n_nodes))
+        try:
+            spectral = plt.cm.spectral
+        except AttributeError:
+            spectral = plt.cm.Spectral
+        node_colors = [spectral(i / float(n_nodes))
                        for i in range(n_nodes)]
 
     # handle 1D and 2D connectivity information

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -533,7 +533,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     ax.set_xlabel(xlabel)
     ax.set_ylabel('Events id')
 
-    ax.grid('on')
+    ax.grid(True)
 
     fig = fig if fig is not None else plt.gcf()
     if event_id is not None:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2172,7 +2172,7 @@ def _setup_ax_spines(axes, vlines, tmin, tmax, invert_y=False,
         axes.spines['top'].set_bounds(tmin, tmax)
 
     axes.tick_params(direction='out')
-    axes.tick_params(right="off")
+    axes.tick_params(right=False)
 
     current_ymin = axes.get_ylim()[0]
 


### PR DESCRIPTION
We should assign `np.nan` for unknown locations instead of `[0., 0., 0.]`. This PR moves us in that direction. I need to see what other internal checks this breaks, and fix them.

Closes #4855.