### PR TITLE
MRG: Fix annotation handling

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -90,6 +90,8 @@ Bug
 
 - Fix bug in :func:`mne.preprocessing.maxwell_filter` where homogeneous fields were not removed for CTF systems by `Eric Larson`_
 
+- Fix bug in writing ``raw.annotations`` where empty annotations could not be written to disk, by `Eric Larson`_
+
 - Fix support for writing FIF files with acquisition skips by using empty buffers rather than writing zeros by `Eric Larson`_
 
 API

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -282,18 +282,13 @@ def _write_annotations(fid, annotations):
     end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
 
 
-def read_annotations(fname, on_empty='empty'):
+def read_annotations(fname):
     """Read annotations from a FIF file.
 
     Parameters
     ----------
     fname : str
         The filename.
-    on_empty : bool
-        How to handle empty annotations that are read from disk. Can be
-        ``'raise'`` to raise an error, None to return ``None``, or
-        ``'empty'`` (default) to return an empty :class:`mne.Annotations`
-        object.
 
     Returns
     -------
@@ -303,19 +298,8 @@ def read_annotations(fname, on_empty='empty'):
     ff, tree, _ = fiff_open(fname, preload=False)
     with ff as fid:
         annotations = _read_annotations(fid, tree)
-    if not (on_empty is None or isinstance(on_empty, string_types)):
-        raise TypeError('on_empty must be None or a string, got %s'
-                        % (type(on_empty),))
     if annotations is None:
         raise IOError('No annotation data found in file "%s"' % fname)
-    if len(annotations) == 0 and on_empty != 'empty':
-        if on_empty is None:
-            annotations = None
-        elif on_empty == 'raise':
-            raise ValueError('No annotations found in file:\n%s' % (fname,))
-        else:
-            raise ValueError('on_empty must be None, "raise", or "empty", '
-                             'got %s' % (on_empty,))
     return annotations
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2336,7 +2336,7 @@ def _start_writing_raw(name, info, sel=None, data_type=FIFF.FIFFT_FLOAT,
     #
     # Annotations
     #
-    if annotations is not None and len(annotations.onset) > 0:
+    if annotations is not None:  # allow saving empty annotations
         _write_annotations(fid, annotations)
 
     #

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -27,7 +27,7 @@ def test_annotations():
     """Test annotation class."""
     raw = read_raw_fif(fif_fname)
     assert raw.annotations is None
-    assert_raises(ValueError, read_annotations, fif_fname)
+    assert_raises(IOError, read_annotations, fif_fname)
     onset = np.array(range(10))
     duration = np.ones(10)
     description = np.repeat('test', 10)
@@ -109,6 +109,25 @@ def test_annotations():
         assert_allclose(getattr(annot_read, attr),
                         getattr(raw.annotations, attr))
     assert_array_equal(annot_read.description, raw.annotations.description)
+    annot = Annotations((), (), ())
+    annot.save(fname)
+    assert_raises(ValueError, read_annotations, fname)
+    annot = read_annotations(fname, on_empty=None)
+    assert annot is None
+    annot = read_annotations(fname, on_empty='empty')
+    assert isinstance(annot, Annotations)
+    assert len(annot) == 0
+    # Test that empty annotations can be saved with an object
+    fname = op.join(tempdir, 'test_raw.fif')
+    raw.annotations = annot
+    raw.save(fname)
+    raw_read = read_raw_fif(fname)
+    assert isinstance(raw_read.annotations, Annotations)
+    assert len(raw_read.annotations) == 0
+    raw.annotations = None
+    raw.save(fname, overwrite=True)
+    raw_read = read_raw_fif(fname)
+    assert raw_read.annotations is None
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -111,10 +111,8 @@ def test_annotations():
     assert_array_equal(annot_read.description, raw.annotations.description)
     annot = Annotations((), (), ())
     annot.save(fname)
-    assert_raises(ValueError, read_annotations, fname)
-    annot = read_annotations(fname, on_empty=None)
-    assert annot is None
-    annot = read_annotations(fname, on_empty='empty')
+    assert_raises(IOError, read_annotations, fif_fname)  # none in old raw
+    annot = read_annotations(fname)
     assert isinstance(annot, Annotations)
     assert len(annot) == 0
     # Test that empty annotations can be saved with an object


### PR DESCRIPTION
This allows saving and reading empty annotations. It also makes it so that raw instances can have empty annotations.

This also fixes what I consider a bug -- if one does:
```
raw.annotations = Annotations(...)
raw.save(fname)
raw_read = read_raw_fif(fname)
```
it shouldn't matter what is in the `...`, they should have `isinstance(raw_read.annotations, Annotations)` after such round-trip I/O.