### PR TITLE
ENH: Allow to construct events from annotations

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -931,7 +931,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             return data, times
         return data
 
-    def events_from_annot(self, event_id=None, regexp=None):
+    @verbose
+    def events_from_annot(self, event_id=None, regexp=None, verbose=None):
         """Get events and event_id from Annotations.
 
         .. note:: Some EEG systems come with multiple annotation channels
@@ -951,6 +952,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         regexp : str | None
             Regular expression used to filter the annotations whose
             descriptions is a match.
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more). Defaults to self.verbose.
 
         Returns
         -------
@@ -964,6 +969,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self.annotations.onset, use_rounding=True) + self.first_samp
 
         unique_keys = np.unique(self.annotations.description)
+
+        logger.info('Annotations descriptions: %s' % unique_keys)
+
         if regexp is not None:
             pat = re.compile(regexp)
             unique_keys = [kk for kk in unique_keys if pat.match(kk)]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -932,7 +932,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return data
 
     def events_from_annot(self, event_id=None, regexp=None):
-        """Get events and event id from Annotatations.
+        """Get events and event_id from Annotations.
 
         .. note:: Some EEG systems come with multiple annotation channels
                   such that different annotations can share time stamps.
@@ -945,16 +945,19 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         event_id : dict | None
             Dictionary of string keys and integer values as used in mne.Epochs
             to map annotation descriptions to integer event codes. If None,
-            All event descriptions are mapped and assigned arbitrary unique
-            integer values. Else, only the keys passed will be mapped and
-            the events output will be limited to the annotations matching the
-            events.
+            all descriptions of annotations are mapped and assigned arbitrary
+            unique integer values. Else, only the keys present will be mapped
+            and and the annotations with other descriptions will be ignored.
         regexp : str | None
-            String used for regular expression matching of descriptions.
-            If not None, only matching events are returned.
+            Regular expression used to filter the annotations whose
+            descriptions is a match.
 
         Returns
         -------
+        events : array of int, shape (n_events, 3)
+            The events
+        event_id : dict
+            The event_id that can be used with the events array.
         """
         import re
         inds = self.time_as_index(
@@ -967,8 +970,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if event_id is None:
             event_id_ = dict(
-                zip(unique_keys,
-                    np.arange(len(unique_keys)).astype(np.int) + 1))
+                zip(unique_keys, np.arange(1, 1 + len(unique_keys))))
         else:
             event_id_ = {k: v for k, v in event_id.items()
                          if k in unique_keys}


### PR DESCRIPTION
In preparation for improved NEO integration this PR proposes a new method for BaseRaw that allows to create events and event_id from existing annotations. As we currently do not yet have testing data and readers which parse annotations in the relevant way, I do not yet propose examples. Instead I wrote a series of tests based on Annotations that I created from events.

@agramfort @massich please feel free to push / continue.