### PR TITLE
Minor edit to base docstring.

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1649,6 +1649,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         overwrite : bool
             If True, the destination file (if it exists) will be overwritten.
             If False (default), an error will be raised if the file exists.
+            If True and destination file exists data must be preloaded to
+            overwrite existing file.
         split_size : string | int
             Large raw files are automatically split into multiple pieces. This
             parameter specifies the maximum size of each piece. If the

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1649,8 +1649,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         overwrite : bool
             If True, the destination file (if it exists) will be overwritten.
             If False (default), an error will be raised if the file exists.
-            If True and destination file exists data must be preloaded to
-            overwrite existing file.
+            To overwrite original file (the same one that was loaded),
+            data must be preloaded upon reading.
         split_size : string | int
             Large raw files are automatically split into multiple pieces. This
             parameter specifies the maximum size of each piece. If the


### PR DESCRIPTION
Overwriting raw file without preloading throws...

> ValueError: You cannot save data to the same file. Please use a different filename.

 Noted in doc string.
