### PR TITLE
MRG: Fix mne browse_raw

### DIFF
--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -39,9 +39,9 @@ def run():
     parser.add_option("-n", "--n_channels", dest="n_channels", type="int",
                       help="Number of channels to plot at a time",
                       default=20)
-    parser.add_option("-o", "--order", dest="order",
-                      help="Order for plotting ('type' or 'original')",
-                      default='type')
+    parser.add_option("-o", "--order", dest="group_by",
+                      help="Order to use for grouping during plotting "
+                      "('type' or 'original')", default='type')
     parser.add_option("-p", "--preload", dest="preload",
                       help="Preload raw data (for faster navigaton)",
                       default=False)
@@ -72,7 +72,7 @@ def run():
     duration = options.duration
     start = options.start
     n_channels = options.n_channels
-    order = options.order
+    group_by = options.group_by
     preload = options.preload
     show_options = options.show_options
     proj_in = options.proj_in
@@ -108,7 +108,7 @@ def run():
     lowpass = None if lowpass < 0 or filtorder <= 0 else lowpass
     filtorder = 4 if filtorder <= 0 else filtorder
     raw.plot(duration=duration, start=start, n_channels=n_channels,
-             order=order, show_options=show_options, events=events,
+             group_by=group_by, show_options=show_options, events=events,
              highpass=highpass, lowpass=lowpass, filtorder=filtorder,
              clipping=clipping)
     plt.show(block=True)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -46,6 +46,8 @@ def check_usage(module, force_help=False):
 def test_browse_raw():
     """Test mne browse_raw."""
     check_usage(mne_browse_raw)
+    with ArgvSetter(('--raw', raw_fname)):
+        mne_browse_raw.run()
 
 
 def test_bti2fiff():

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -329,7 +329,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         # put back to original order first, then use new order
         inds = inds[reord][order]
     elif order is not None:
-        raise ValueError('Unkown order type. Got %s.' % type(order))
+        raise ValueError('Unkown order, should be array-like. '
+                         'Got "%s" (%s).' % (order, type(order)))
 
     if group_by in ['selection', 'position']:
         selections, fig_selection = _setup_browser_selection(raw, group_by)


### PR DESCRIPTION
Fixes a bug with `mne browse_raw`. Should only affect 0.16+ because that's when we did the deprecation for `order` IIRC, so no need for `whats_new.rst` update.