### PR TITLE
MRG: Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ matrix:
           env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=1
 
-        # OSX
-        - os: osx
-          env: CONDA_ENVIRONMENT="environment.yml"
-               SPLIT=0
-        - os: osx
-          env: CONDA_ENVIRONMENT="environment.yml"
-               SPLIT=1
+        # OSX (as of 2018/01/19, fails to run/install 90% of the time, and takes hours to do so)
+        #- os: osx
+        #  env: CONDA_ENVIRONMENT="environment.yml"
+        #       SPLIT=0
+        #- os: osx
+        #  env: CONDA_ENVIRONMENT="environment.yml"
+        #       SPLIT=1
 
         # 2.7 + non-default stim channel
         - os: linux


### PR DESCRIPTION
Disabling the OSX builds for now. They fail 90% of the time to run, install Anaconda, or finish the tests, *and* they often take hours to do so, which is tough for feedback. Maybe we'll try again in a couple of months to see if the situation has improved.