### PR TITLE
Update to environment.yml (conda-forge support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ matrix:
           env: CONDA_ENVIRONMENT="environment.yml"
                SPLIT=1
 
-        # OSX
-        - os: osx
-          env: CONDA_ENVIRONMENT="environment.yml"
-               SPLIT=0
-        - os: osx
-          env: CONDA_ENVIRONMENT="environment.yml"
-               SPLIT=1
+        # OSX (as of 2018/01/19, fails to run/install 90% of the time, and takes hours to do so)
+        #- os: osx
+        #  env: CONDA_ENVIRONMENT="environment.yml"
+        #       SPLIT=0
+        #- os: osx
+        #  env: CONDA_ENVIRONMENT="environment.yml"
+        #       SPLIT=1
 
         # 2.7 + non-default stim channel
         - os: linux

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - numpy
 - scipy
 - matplotlib
-- pyqt=5
+- pyqt
 - vtk>=7
 - pandas
 - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - scipy
 - matplotlib
 - pyqt=5
-- vtk=7
+- vtk>=7
 - pandas
 - scikit-learn
 - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -26,19 +26,19 @@ dependencies:
 - numpydoc
 - flake8
 - spyder
-- nitime
-- nibabel
-- nilearn
 - pytest-sugar
 - pytest-faulthandler
 - pydocstyle
 - mayavi
-- pysurfer
 - traits
 - traitsui
 - pyface
 - sphinx_bootstrap_theme
 - pip:
+  - nitime
+  - nibabel
+  - nilearn
+  - pysurfer
   - mne
   - neo
   - git+https://github.com/sphinx-gallery/sphinx-gallery.git

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - numpy
 - scipy
 - matplotlib
-- pyqt
+- pyqt=5
 - vtk>=7
 - pandas
 - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -32,13 +32,13 @@ dependencies:
 - pytest-sugar
 - pytest-faulthandler
 - pydocstyle
+- mayavi
+- pysurfer
+- traits
+- traitsui
+- pyface
+- sphinx_bootstrap_theme
 - pip:
   - mne
-  - "git+https://github.com/enthought/traits.git@a7a83182048c08923953e302658b51b68c802132"
-  - "git+https://github.com/enthought/pyface.git@13a064de48adda3c880350545717d8cf8929afad"
-  - "git+https://github.com/enthought/traitsui.git@ee8ef0a34dfc1db18a8e2c0301cc18d96b7a3e2f"
-  - "git+https://github.com/enthought/mayavi.git"
-  - "git+https://github.com/nipy/PySurfer.git"
   - neo
-  - sphinx_bootstrap_theme
   - git+https://github.com/sphinx-gallery/sphinx-gallery.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: mne
 channels:
 - defaults
-- clinicalgraphics  # Needed for VTK
+- conda-forge
 dependencies:
 - python=3.6.1
 - pip

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - scipy
 - matplotlib
 - pyqt=5
-- vtk>=7
+- vtk=7
 - pandas
 - scikit-learn
 - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,12 @@ dependencies:
 - numpydoc
 - flake8
 - spyder
+- nitime
+- nibabel
+- nilearn
+- pytest-sugar
+- pytest-faulthandler
+- pydocstyle
 - pip:
   - mne
   - "git+https://github.com/enthought/traits.git@a7a83182048c08923953e302658b51b68c802132"
@@ -33,12 +39,6 @@ dependencies:
   - "git+https://github.com/enthought/traitsui.git@ee8ef0a34dfc1db18a8e2c0301cc18d96b7a3e2f"
   - "git+https://github.com/enthought/mayavi.git"
   - "git+https://github.com/nipy/PySurfer.git"
-  - nitime
-  - nibabel
-  - nilearn
   - neo
-  - pytest-sugar
-  - pytest-faulthandler
-  - pydocstyle
   - sphinx_bootstrap_theme
   - git+https://github.com/sphinx-gallery/sphinx-gallery.git

--- a/environment.yml
+++ b/environment.yml
@@ -29,16 +29,16 @@ dependencies:
 - pytest-sugar
 - pytest-faulthandler
 - pydocstyle
-- mayavi
-- traits
-- traitsui
-- pyface
 - sphinx_bootstrap_theme
 - pip:
+  - "git+https://github.com/enthought/traits.git@a7a83182048c08923953e302658b51b68c802132"		
+  - "git+https://github.com/enthought/pyface.git@13a064de48adda3c880350545717d8cf8929afad"		
+  - "git+https://github.com/enthought/traitsui.git@ee8ef0a34dfc1db18a8e2c0301cc18d96b7a3e2f"		
+  - "git+https://github.com/enthought/mayavi.git"
   - nitime
   - nibabel
   - nilearn
   - pysurfer
-  - mne
   - neo
+  - mne
   - git+https://github.com/sphinx-gallery/sphinx-gallery.git


### PR DESCRIPTION
opened PR as suggested in issue #4853 
- removed pyqt version requirement (as mayavi and pysurfer require pyqt 4 and not 5)
- moved everything possible to conda instead of pip
- removed clinicalgraphics channel and added conda-forge channel instead