### PR TITLE
Fix stim channel detection in BDF and EDF+

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -428,7 +428,7 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     # Check that stimulus channel exists in dataset
     if not ('stim_data' in edf_info or
             'EDF Annotations' in ch_names) and stim_channel == 'auto':
-        stim_channel = None
+        stim_channel = None if ext == 'gdf' else -1
     if stim_channel is not None:
         stim_channel = _check_stim_channel(stim_channel, ch_names, include)
 
@@ -494,7 +494,7 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
             edf_info['units'][idx] = 1
             if isinstance(stim_channel, str):
                 stim_channel = idx
-        if tal_channel is not None and idx in tal_channel:
+        elif tal_channel is not None and idx in tal_channel:
             chan_info['range'] = 1
             chan_info['cal'] = 1
             chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -425,10 +425,6 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
         cals[idx] = 1
     if 'stim_data' in edf_info and stim_channel == 'auto':  # For GDF events.
         cals = np.append(cals, 1)
-    # Check that stimulus channel exists in dataset
-    if not ('stim_data' in edf_info or
-            'EDF Annotations' in ch_names) and stim_channel == 'auto':
-        stim_channel = None if ext == 'gdf' else -1
     if stim_channel is not None:
         stim_channel = _check_stim_channel(stim_channel, ch_names, include)
 
@@ -494,12 +490,12 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
             edf_info['units'][idx] = 1
             if isinstance(stim_channel, str):
                 stim_channel = idx
-        elif tal_channel is not None and idx in tal_channel:
+        if tal_channel is not None and idx in tal_channel:
             chan_info['range'] = 1
             chan_info['cal'] = 1
             chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
             chan_info['unit'] = FIFF.FIFF_UNIT_NONE
-            chan_info['kind'] = FIFF.FIFFV_MISC_CH
+            chan_info['kind'] = FIFF.FIFFV_STIM_CH
             pick_mask[idx] = False
         chs.append(chan_info)
     edf_info['stim_channel'] = stim_channel

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -24,6 +24,7 @@ from mne.externals.six import iterbytes
 from mne.utils import run_tests_if_main, requires_pandas, _TempDir
 from mne.io import read_raw_edf
 from mne.io.tests.test_raw import _test_raw_reader
+from mne.io.pick import channel_type
 from mne.io.edf.edf import _parse_tal_channel, find_edf_events
 from mne.event import find_events
 
@@ -72,6 +73,12 @@ def test_bdf_data():
     assert_true((raw_py.info['chs'][0]['loc']).any())
     assert_true((raw_py.info['chs'][25]['loc']).any())
     assert_true((raw_py.info['chs'][63]['loc']).any())
+
+
+def test_bdf_stim_channel():
+    """Test if last channel is detected as STIM by default."""
+    raw_py = _test_raw_reader(read_raw_edf, input_fname=bdf_path)
+    assert_true(channel_type(raw_py.info, raw_py.info["nchan"] - 1) == 'stim')
 
 
 @testing.requires_testing_data
@@ -244,6 +251,10 @@ def test_edf_annotations():
 
 def test_edf_stim_channel():
     """Test stim channel for edf file."""
+    # test if stim channel is automatically detected
+    raw = read_raw_edf(edf_path, preload=True)
+    assert_true(channel_type(raw.info, raw.info["nchan"] - 1) == 'stim')
+
     raw = read_raw_edf(edf_stim_channel_path, preload=True,
                        stim_channel=-1)
     true_data = np.loadtxt(edf_txt_stim_channel_path).T


### PR DESCRIPTION
After GDF support was added, the stim channel in BDF files is not detected automatically anymore. The previous default used to be `stim_channel=-1` (the last channel), but this changed to `stim_channel='auto'`.

In EDF+ files, the TAL channel (containing annotations and therefore the stim channel) was assigned MISC - I changed this to STIM.

The whole thing is still a bit messy, mostly due to the mix of EDF/BDF/GDF. Maybe a future PR could try to disentangle these file formats better. However, my quick fix hopefully solves the most important issue, namely that automatic stim channel detection for BDF files is broken.

Fixes #4710, fixes #4757.