### PR TITLE
FIX: BUG (typo) in apply_inverse

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -679,7 +679,7 @@ def _assemble_kernel(inv, label, method, pick_ori, verbose=None):
             raise ValueError('Picking normal orientation can only be done '
                              'with a free orientation inverse operator.')
 
-        is_loose = 0 < inv['orient_prior']['data'][0] < 1
+        is_loose = 0 < inv['orient_prior']['data'][0] <= 1
         if not is_loose:
             raise ValueError('Picking normal orientation can only be done '
                              'when working with loose orientations.')

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -346,9 +346,8 @@ def test_apply_inverse_operator():
 
     # Test that no errors are raised with loose inverse ops and picking normals
     noise_cov = read_cov(fname_cov)
-    fwd_orig = make_forward_solution(evoked.info, fname_trans, src_fname,
-                                     fname_bem, eeg=False, mindist=5.0)
-    inv_op2 = make_inverse_operator(evoked.info, fwd_orig, noise_cov, loose=1,
+    fwd = read_forward_solution_meg(fname_fwd)
+    inv_op2 = make_inverse_operator(evoked.info, fwd, noise_cov, loose=1,
                                     fixed='auto', depth=None)
     apply_inverse(evoked, inv_op2, 1 / 9., method='MNE',
                   pick_ori='normal')

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -344,6 +344,15 @@ def test_apply_inverse_operator():
     assert_true(label_stc.subject == 'sample')
     assert_allclose(stc_label.data, label_stc.data)
 
+    # Test that no errors are raised with loose inverse ops and picking normals
+    noise_cov = read_cov(fname_cov)
+    fwd_orig = make_forward_solution(evoked.info, fname_trans, src_fname,
+                                     fname_bem, eeg=False, mindist=5.0)
+    inv_op2 = make_inverse_operator(evoked.info, fwd_orig, noise_cov, loose=1,
+                                    fixed='auto', depth=None)
+    apply_inverse(evoked, inv_op2, 1 / 9., method='MNE',
+                  pick_ori='normal')
+
     # Test we get errors when using custom ref or no average proj is present
     evoked.info['custom_ref_applied'] = True
     assert_raises(ValueError, apply_inverse, evoked, inv_op, lambda2, "MNE")


### PR DESCRIPTION
When calling apply_inverse with `pick_ori='normal'` and a fully free inverse_operator (`loose=1`) it raises an exception because of what i think was a typo in checking the loose parameter.

The test I added is somewhat clumsy but i couldn't find a better/cleaner place to added it.