### PR TITLE
[MRG] Allow montage to be a str in raw.set_montage

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,8 +61,9 @@ Changelog
 
 - Plot sEEG electrodes in :func:`mne.viz.plot_alignment` by `Alex Gramfort`_
 
-- Add function :func:`mne.io.read_annotations_eeglab` to allow loading annotations from EEGLAB files, by `Alex Gramfort`_.
+- Add function :func:`mne.io.read_annotations_eeglab` to allow loading annotations from EEGLAB files, by `Alex Gramfort`_
 
+- :meth:`mne.io.Raw.set_montage` now accepts a string as its ``montage`` argument; this will set a builtin montage, by `Clemens Brunner`_
 
 Bug
 ~~~

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -480,7 +480,7 @@ class SetChannelsMixin(object):
 
         Parameters
         ----------
-        montage : instance of Montage | instance of DigMontage | None
+        montage : instance of Montage | instance of DigMontage | str | None
             The montage to use (None removes any location information).
         set_dig : bool
             If True, update the digitization information (``info['dig']``)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -789,7 +789,7 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
     -----
     This function will change the info variable in place.
     """
-    if isinstance(montage, str):  # load builtin montage
+    if isinstance(montage, string_types):  # load builtin montage
         montage = read_montage(montage)
 
     if isinstance(montage, Montage):

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -778,8 +778,9 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
     ----------
     info : instance of Info
         The measurement info to update.
-    montage : instance of Montage | instance of DigMontage | None
-        The montage to apply (None removes any location information).
+    montage : instance of Montage | instance of DigMontage | str | None
+        The montage to apply (None removes any location information). If
+        montage is a string, a builtin montage with that name will be used.
     update_ch_names : bool
         If True, overwrite the info channel names with the ones from montage.
         Defaults to False.
@@ -788,6 +789,9 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
     -----
     This function will change the info variable in place.
     """
+    if isinstance(montage, str):  # load builtin montage
+        montage = read_montage(montage)
+
     if isinstance(montage, Montage):
         if update_ch_names:
             info['chs'] = list()
@@ -884,5 +888,5 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
         if set_dig:
             info['dig'] = None
     else:
-        raise TypeError("Montage must be a 'Montage' or 'DigMontage' "
-                        "instead of '%s'." % type(montage))
+        raise TypeError("Montage must be a 'Montage', 'DigMontage', 'str' or "
+                        "'None' instead of '%s'." % type(montage))

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -545,22 +545,14 @@ def test_egi_dig_montage():
 def test_set_montage():
     """Test setting a montage."""
     raw = read_raw_fif(fif_fname)
-    mon = read_montage('mgh60')
     orig_pos = np.array([ch['loc'][:3] for ch in raw.info['chs']
                          if ch['ch_name'].startswith('EEG')])
-    raw.set_montage(mon)
+    raw.set_montage('mgh60')  # test loading with string argument
     new_pos = np.array([ch['loc'][:3] for ch in raw.info['chs']
                         if ch['ch_name'].startswith('EEG')])
     assert_true((orig_pos != new_pos).all())
     r0 = _fit_sphere(new_pos)[1]
     assert_allclose(r0, [0., -0.016, 0.], atol=1e-3)
-
-    # test if set_montage works with a string argument
-    raw1 = read_raw_fif(fif_fname)
-    raw1.set_montage('mgh60')
-    raw1_pos = np.array([ch['loc'][:3] for ch in raw1.info['chs']
-                         if ch['ch_name'].startswith('EEG')])
-    assert_allclose(new_pos, raw1_pos)
 
 
 def _check_roundtrip(montage, fname):

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -555,6 +555,13 @@ def test_set_montage():
     r0 = _fit_sphere(new_pos)[1]
     assert_allclose(r0, [0., -0.016, 0.], atol=1e-3)
 
+    # test if set_montage works with a string argument
+    raw1 = read_raw_fif(fif_fname)
+    raw1.set_montage('mgh60')
+    raw1_pos = np.array([ch['loc'][:3] for ch in raw1.info['chs']
+                         if ch['ch_name'].startswith('EEG')])
+    assert_allclose(new_pos, raw1_pos)
+
 
 def _check_roundtrip(montage, fname):
     """Check roundtrip writing."""


### PR DESCRIPTION
Which means that instead

    raw.set_montage(mne.channels.read_montage("biosemi64"))

one can simply type

    raw.set_montage("biosemi64")
