### PR TITLE
[MRG][ENH] A reader for Brainstorm events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,8 @@ Changelog
 
 - Add ability to exclude components interactively by clicking on their labels in :meth:`mne.preprocessing.ICA.plot_components` by `Mikołaj Magnuski`_
 
+- Add reader for manual annotations of raw data produced by Brainstorm by `Anne-Sophie Dubarry`_
+
 Bug
 ~~~
 
@@ -2573,3 +2575,5 @@ of commits):
 .. _Emily Stephen: http://github.com/emilyps14
 
 .. _Nathalie Gayraud: https://github.com/ngayraud
+
+.. _Anne-Sophie Dubarry: https://github.com/annesodub

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -318,7 +318,6 @@ def read_brainstorm_annotations(fname, orig_time=None):
         The annotations.
     """
     from scipy import io
-    list_annot = []
     onsets = []
     durations = []
     descriptions = []
@@ -335,8 +334,8 @@ def read_brainstorm_annotations(fname, orig_time=None):
 
     onsets = np.concatenate(onsets)
     durations = np.concatenate(durations)
-    annotations = Annotations(onsets, durations, descriptions, orig_time=orig_time)
-
+    annotations = Annotations(onsets, durations, descriptions,
+                              orig_time=orig_time)
     return annotations
 
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -301,6 +301,7 @@ def read_annotations(fname):
         raise IOError('No annotation data found in file "%s"' % fname)
     return annotations
 
+
 def read_brainstorm_annotations(fname, orig_time=None):
     """Read annotations from a Brainstorm events_ file.
 
@@ -326,7 +327,6 @@ def read_brainstorm_annotations(fname, orig_time=None):
     for label, _, _, _, times, _, _ in annot_data['events'][0]:
         n_annot = len(times[0])
         onsets.append(times[0])
-        print(times.shape)
         if times.shape[0] == 2:
             durations.append(times[1] - times[0])
         else:
@@ -338,6 +338,7 @@ def read_brainstorm_annotations(fname, orig_time=None):
     annotations = Annotations(onsets, durations, descriptions, orig_time=orig_time)
 
     return annotations
+
 
 def _read_annotations(fid, tree):
     """Read annotations."""

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -333,9 +333,9 @@ def read_brainstorm_annotations(fname, orig_time=None):
         n_annot = len(times[0])
         descriptions += [str(label[0])] * n_annot
 
-    return Annotations(onsets=np.concatenate(onsets),
-                       durations=np.concatenate(durations),
-                       descriptions=descriptions,
+    return Annotations(onset=np.concatenate(onsets),
+                       duration=np.concatenate(durations),
+                       description=descriptions,
                        orig_time=orig_time)
 
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -309,8 +309,14 @@ def read_brainstorm_annotations(fname, orig_time=None):
     ----------
     fname : str
         The filename
-    orig_time : meas_date
-        The 0 timestamp
+    orig_time : float | int | instance of datetime | array of int | None
+        A POSIX Timestamp, datetime or an array containing the timestamp as the
+        first element and microseconds as the second element. Determines the
+        starting time of annotation acquisition. If None (default),
+        starting time is determined from beginning of raw data acquisition.
+        In general, ``raw.info['meas_date']`` (or None) can be used for syncing
+        the annotations with raw data if their acquisiton is started at the
+        same time.
 
     Returns
     -------

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -301,6 +301,43 @@ def read_annotations(fname):
         raise IOError('No annotation data found in file "%s"' % fname)
     return annotations
 
+def read_brainstorm_annotations(fname, orig_time=None):
+    """Read annotations from a Brainstorm events_ file.
+
+    Parameters
+    ----------
+    fname : str
+        The filename
+    orig_time : meas_date
+        The 0 timestamp
+
+    Returns
+    -------
+    annot : instance of Annotations | None
+        The annotations.
+    """
+    from scipy import io
+    list_annot = []
+    onsets = []
+    durations = []
+    descriptions = []
+    annot_data = io.loadmat(fname)
+
+    for label, _, _, _, times, _, _ in annot_data['events'][0]:
+        n_annot = len(times[0])
+        onsets.append(times[0])
+        print(times.shape)
+        if times.shape[0] == 2:
+            durations.append(times[1] - times[0])
+        else:
+            durations.append(np.zeros(n_annot))
+        descriptions += [str(label[0])] * n_annot
+
+    onsets = np.concatenate(onsets)
+    durations = np.concatenate(durations)
+    annotations = Annotations(onsets, durations, descriptions, orig_time=orig_time)
+
+    return annotations
 
 def _read_annotations(fid, tree):
     """Read annotations."""

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -318,25 +318,25 @@ def read_brainstorm_annotations(fname, orig_time=None):
         The annotations.
     """
     from scipy import io
-    onsets = []
-    durations = []
-    descriptions = []
-    annot_data = io.loadmat(fname)
 
-    for label, _, _, _, times, _, _ in annot_data['events'][0]:
-        n_annot = len(times[0])
-        onsets.append(times[0])
-        if times.shape[0] == 2:
-            durations.append(times[1] - times[0])
+    def get_duration_from_times(t):
+        if t.shape[0] == 2:
+            return t[1] - t[0]
         else:
-            durations.append(np.zeros(n_annot))
+            return np.zeros(len(t[0]))
+
+    annot_data = io.loadmat(fname)
+    onsets, durations, descriptions = (list(), list(), list())
+    for label, _, _, _, times, _, _ in annot_data['events'][0]:
+        onsets.append(times[0])
+        durations.append(get_duration_from_times(times))
+        n_annot = len(times[0])
         descriptions += [str(label[0])] * n_annot
 
-    onsets = np.concatenate(onsets)
-    durations = np.concatenate(durations)
-    annotations = Annotations(onsets, durations, descriptions,
-                              orig_time=orig_time)
-    return annotations
+    return Annotations(onsets=np.concatenate(onsets),
+                       durations=np.concatenate(durations),
+                       descriptions=descriptions,
+                       orig_time=orig_time)
 
 
 def _read_annotations(fid, tree):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -16,6 +16,7 @@ from mne import create_info, Epochs, read_annotations
 from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.annotations import Annotations, _sync_onset
+from mne.annotations import read_brainstorm_annotations
 from mne.datasets import testing
 
 data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
@@ -126,6 +127,16 @@ def test_annotations():
     raw.save(fname, overwrite=True)
     raw_read = read_raw_fif(fname)
     assert raw_read.annotations is None
+
+
+@testing.requires_testing_data
+def test_read_brainstorm_annotations():
+    """Test reading for Brainstorm events file"""
+    fname = op.join(data_dir, 'events_sample_audvis_raw_bst.mat')
+    annot = read_brainstorm_annotations(fname)
+    assert len(annot) == 238
+    assert annot.onset.min() > 40  # takes into account first_samp
+    assert np.unique(annot.description).size == 5
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -138,6 +138,12 @@ def test_read_brainstorm_annotations():
     assert annot.onset.min() > 40  # takes into account first_samp
     assert np.unique(annot.description).size == 5
 
+    # Now test with orig_time
+    orig_time = np.array([1038942070, 720100], dtype=np.int32)
+    annot = read_brainstorm_annotations(fname, orig_time=orig_time)
+    orig_time_as_scalar = orig_time[0] + orig_time[1] / 1000000.
+    assert annot.orig_time == orig_time_as_scalar
+
 
 @testing.requires_testing_data
 def test_raw_reject():


### PR DESCRIPTION
This PR adds the necessary code to be able to read Brainstorm markers (events + annotations) from a `events_*.mat` file. 

The proposed user code would be : 

```py
import numpy as np
import mne 
from scipy import io 

raw_fname = '/Data_samples_In_MNE/sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(raw_fname)

annot_fname = '/Your/Path/events_sample_audvis_raw_ASD.mat'

raw.annotations = mne.annotations.read_brainstorm_annotations(annot_fname,raw.info['meas_date']) 

```
