### PR TITLE
FIX: ctf dig pnts coord_frame

### DIFF
--- a/mne/io/ctf/eeg.py
+++ b/mne/io/ctf/eeg.py
@@ -86,7 +86,7 @@ def _read_pos(directory, transformations):
                     ident = i
                     i += 1
                 dig = dict(kind=FIFF.FIFFV_POINT_EXTRA, ident=ident, r=list(),
-                           coord_frame=FIFF.FIFFV_MNE_COORD_CTF_HEAD)
+                           coord_frame=FIFF.FIFFV_COORD_HEAD)
                 r = np.array([float(p) for p in parts[-3:]]) / 100.  # cm to m
                 if (r * r).sum() > 1e-4:
                     r = apply_trans(transformations['t_ctf_head_head'], r)

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -170,6 +170,12 @@ def test_read_ctf():
                     check = c2[key][9:12]
                 assert_allclose(c1[key][9:12], check, atol=1e-6, rtol=1e-4,
                                 err_msg='raw.info["chs"][%d][%s]' % (ii, key))
+
+        # Make sure all digitization points are in the MNE head coord frame
+        for p in raw.info['dig']:
+            assert_equal(p['coord_frame'], FIFF.FIFFV_COORD_HEAD,
+                         err_msg='dig points must be in FIFF.FIFFV_COORD_HEAD')
+
         if fname.endswith('catch-alp-good-f.ds'):  # omit points from .pos file
             raw.info['dig'] = raw.info['dig'][:-10]
 


### PR DESCRIPTION
@larsoner 
When loading digitizer points from a ctf DS file, the points are being read in in the CTF_HEAD frame however they are immediately (Line 92) transformed to the MNE_HEAD frame. so the dig structure should reflect that.
 
While I haven't dug through everything, the code else where (viz._3d.plot_alignment / coreg) seems to treat these points as if there are in COORD_HEAD already, ie they never try to apply info['ctf_head_t'] 
