### PR TITLE
WIP: add note about %gui qt magic to python install page

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -21,7 +21,15 @@ Help! I can't get Python and MNE-Python working!
 Check out our section on how to get Anaconda up and running over at the
 :ref:`getting started page <install_python_and_mne_python>`.
 
-**Windows users:** If Mayavi plotting in Jupyter Notebooks doesn't work  
+I still can't get it to work!
+-----------------------------
+For analysis talk, join the `MNE mailing list`_. File specific feature
+requests or bug reports `on GitHub <https://github.com/mne-tools/mne-python/issues/>`_.
+You can also chat with developers `on Gitter <https://gitter.im/mne-tools/mne-python>`_.
+
+I can't get Mayavi/3D plotting to work under Windows.
+-----------------------------------------------------
+If Mayavi plotting in Jupyter Notebooks doesn't work
 well, using the IPython magic ``%gui qt`` after importing MNE/Mayavi/PySurfer 
 should `help <https://github.com/ipython/ipython/issues/10384>`_.
    
@@ -30,11 +38,6 @@ should `help <https://github.com/ipython/ipython/issues/10384>`_.
    from mayavi import mlab
    %gui qt
 
-I still can't get it to work!
------------------------------
-For analysis talk, join the `MNE mailing list`_. File specific feature
-requests or bug reports `on GitHub <https://github.com/mne-tools/mne-python/issues/>`_.
-You can also chat with developers `on Gitter <https://gitter.im/mne-tools/mne-python>`_.
 
 .. _cite:
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -21,6 +21,15 @@ Help! I can't get Python and MNE-Python working!
 Check out our section on how to get Anaconda up and running over at the
 :ref:`getting started page <install_python_and_mne_python>`.
 
+**Windows users:** If Mayavi plotting in Jupyter Notebooks doesn't work  
+well, using the IPython magic ``%gui qt`` after importing MNE/Mayavi/PySurfer 
+should `help <https://github.com/ipython/ipython/issues/10384>`_.
+   
+.. code:: ipython
+   
+   from mayavi import mlab
+   %gui qt
+
 I still can't get it to work!
 -----------------------------
 For analysis talk, join the `MNE mailing list`_. File specific feature

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -62,7 +62,7 @@ Install Python and MNE-Python
                   <pre><span></span><span class="gp">$</span> curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml<br><span class="gp">$</span> conda env create -f environment.yml<br><span class="gp">$</span> source activate mne</pre>
                 </div>
               </div>
-              <p>If Mayavi plotting in Jupyter Notebooks doesn't work well, using the IPython magic "%gui qt" after importing MNE/Mayavi/PySurfer may 
+              <p>If Mayavi plotting in Jupyter Notebooks doesn't work well, using the IPython magic <code class="docutils literal"><span class="pre">%gui qt</span></code> after importing MNE/Mayavi/PySurfer may 
               <a class="reference external" href="https://github.com/ipython/ipython/issues/10384">help</a>.
               </p>
             </div>

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -62,9 +62,6 @@ Install Python and MNE-Python
                   <pre><span></span><span class="gp">$</span> curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml<br><span class="gp">$</span> conda env create -f environment.yml<br><span class="gp">$</span> source activate mne</pre>
                 </div>
               </div>
-              <p>If Mayavi plotting in Jupyter Notebooks doesn't work well, using the IPython magic <code class="docutils literal"><span class="pre">%gui qt</span></code> after importing MNE/Mayavi/PySurfer may 
-              <a class="reference external" href="https://github.com/ipython/ipython/issues/10384">help</a>.
-              </p>
             </div>
           </div>
         </div>
@@ -75,6 +72,18 @@ Install Python and MNE-Python
       >>> import mne
 
   If you get a new prompt with no error messages, you should be good to go!
+
+  .. note::
+
+     **Windows users:** If Mayavi plotting in Jupyter Notebooks doesn't work  
+     well, using the IPython magic `%gui qt` after importing  
+     MNE/Mayavi/PySurfer may
+     `help <https://github.com/ipython/ipython/issues/10384>`_.
+   
+     .. code:: ipython
+   
+        from mayavi import mlab
+        %gui qt
 
 * For advanced topics like how to get NVIDIA :ref:`CUDA` support or if you're
   having trouble, visit :ref:`advanced_setup`.

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -73,10 +73,13 @@ Install Python and MNE-Python
 
   If you get a new prompt with no error messages, you should be good to go!
 
+* For advanced topics like how to get NVIDIA :ref:`CUDA` support or if you're
+  having trouble, visit :ref:`advanced_setup`.
+
   .. note::
 
      **Windows users:** If Mayavi plotting in Jupyter Notebooks doesn't work  
-     well, using the IPython magic `%gui qt` after importing  
+     well, using the IPython magic ``%gui qt`` after importing  
      MNE/Mayavi/PySurfer may
      `help <https://github.com/ipython/ipython/issues/10384>`_.
    
@@ -84,6 +87,3 @@ Install Python and MNE-Python
    
         from mayavi import mlab
         %gui qt
-
-* For advanced topics like how to get NVIDIA :ref:`CUDA` support or if you're
-  having trouble, visit :ref:`advanced_setup`.

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -80,7 +80,7 @@ Install Python and MNE-Python
 
      **Windows users:** If Mayavi plotting in Jupyter Notebooks doesn't work  
      well, using the IPython magic ``%gui qt`` after importing  
-     MNE/Mayavi/PySurfer may
+     MNE/Mayavi/PySurfer should
      `help <https://github.com/ipython/ipython/issues/10384>`_.
    
      .. code:: ipython

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -62,6 +62,9 @@ Install Python and MNE-Python
                   <pre><span></span><span class="gp">$</span> curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml<br><span class="gp">$</span> conda env create -f environment.yml<br><span class="gp">$</span> source activate mne</pre>
                 </div>
               </div>
+              <p>If Mayavi plotting in Jupyter Notebooks doesn't work well, using the IPython magic "%gui qt" after importing MNE/Mayavi/PySurfer may 
+              <a class="reference external" href="https://github.com/ipython/ipython/issues/10384">help</a>.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
@agramfort @larsoner Here is an attempt at adding the suggestion of using the IPython magic %gui qt in Python 3 Jupyter notebooks. It wasn't clear where to put it so I added it to the Experimental Python 3.6 pulldown on the Python install page.
![python3_pulldown](https://user-images.githubusercontent.com/9488985/35781982-e53b36c2-09b6-11e8-9c55-d6bc9867e1e3.jpg)
