### PR TITLE
MRG: Fix maxfilter and cHPI

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -118,6 +118,8 @@ Bug
 
 - Fix bug in the ``mne make_scalp_surfaces`` command where ``--force`` (to bypass topology check failures) was ignored by `Eric Larson`_
 
+- Fix bug in :func:`mne.preprocessing.maxwell_filter` when providing ``origin`` in ``'meg'`` coordinate frame for recordings with a MEG to head transform (i.e., non empty-room recordings) by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1024,8 +1024,13 @@ def _check_origin(origin, info, coord_frame='head', disp=False):
         raise ValueError('origin must be a 3-element array')
     if disp:
         origin_str = ', '.join(['%0.1f' % (o * 1000) for o in origin])
-        logger.info('    Using origin %s mm in the %s frame'
-                    % (origin_str, coord_frame))
+        msg = ('    Using origin %s mm in the %s frame'
+               % (origin_str, coord_frame))
+        if coord_frame == 'meg' and info['dev_head_t'] is not None:
+            o_dev = apply_trans(info['dev_head_t'], origin)
+            origin_str = ', '.join('%0.1f' % (o * 1000,) for o in o_dev)
+            msg += ' (%s mm in the head frame)' % (origin_str,)
+        logger.info(msg)
     return origin
 
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -153,37 +153,36 @@ def head_pos_to_trans_rot_t(quats):
 def _get_hpi_info(info, verbose=None):
     """Get HPI information from raw."""
     if len(info['hpi_meas']) == 0 or \
-            ('coil_freq' not in info['hpi_meas'][0]['hpi_coils'][0]) or \
-            info.get('hpi_subsystem') is None:
+            ('coil_freq' not in info['hpi_meas'][0]['hpi_coils'][0]):
         raise RuntimeError('Appropriate cHPI information not found in'
                            'info["hpi_meas"] and info["hpi_subsystem"], '
                            'cannot process cHPI')
     hpi_coils = sorted(info['hpi_meas'][-1]['hpi_coils'],
                        key=lambda x: x['number'])  # ascending (info) order
 
-    # how cHPI active is indicated in the FIF file
-    hpi_sub = info['hpi_subsystem']
-    if 'event_channel' in hpi_sub:
-        hpi_pick = pick_channels(info['ch_names'],
-                                 [hpi_sub['event_channel']])
-        hpi_pick = hpi_pick[0] if len(hpi_pick) > 0 else None
-    else:
-        hpi_pick = None  # there is no pick!
-
-    # grab codes indicating a coil is active
-    hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]
-    # not all HPI coils will actually be used
-    hpi_on = np.array([hpi_on[hc['number'] - 1] for hc in hpi_coils])
-
     # get frequencies
     hpi_freqs = np.array([float(x['coil_freq']) for x in hpi_coils])
     logger.info('Using %s HPI coils: %s Hz'
                 % (len(hpi_freqs), ' '.join(str(int(s)) for s in hpi_freqs)))
 
-    # mask for coils that may be active
-    hpi_mask = np.array([event_bit != 0 for event_bit in hpi_on])
-    hpi_on = hpi_on[hpi_mask]
-    hpi_freqs = hpi_freqs[hpi_mask]
+    # how cHPI active is indicated in the FIF file
+    hpi_sub = info['hpi_subsystem']
+    hpi_pick = None  # there is no pick!
+    if hpi_sub is not None:
+        if 'event_channel' in hpi_sub:
+            hpi_pick = pick_channels(info['ch_names'],
+                                     [hpi_sub['event_channel']])
+            hpi_pick = hpi_pick[0] if len(hpi_pick) > 0 else None
+        # grab codes indicating a coil is active
+        hpi_on = [coil['event_bits'][0] for coil in hpi_sub['hpi_coils']]
+        # not all HPI coils will actually be used
+        hpi_on = np.array([hpi_on[hc['number'] - 1] for hc in hpi_coils])
+        # mask for coils that may be active
+        hpi_mask = np.array([event_bit != 0 for event_bit in hpi_on])
+        hpi_on = hpi_on[hpi_mask]
+        hpi_freqs = hpi_freqs[hpi_mask]
+    else:
+        hpi_on = np.zeros(len(hpi_freqs))
 
     return hpi_freqs, hpi_pick, hpi_on
 

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -427,6 +427,14 @@ def test_basic():
                 for x in [raw_sss, sss_erm_std]]
         assert_equal(vals[0], vals[1])
 
+    # Two equivalent things: at device origin in device coords (0., 0., 0.)
+    # and at device origin at head coords info['dev_head_t'][:3, 3]
+    raw_sss_meg = maxwell_filter(
+        raw, coord_frame='meg', origin=(0., 0., 0.))
+    raw_sss_head = maxwell_filter(
+        raw, origin=raw.info['dev_head_t']['trans'][:3, 3])
+    assert_meg_snr(raw_sss_meg, raw_sss_head, 100., 900.)
+
     # Check against SSS functions from proc_history
     sss_info = raw_sss.info['proc_history'][0]['max_info']
     assert_equal(_get_n_moments(int_order),

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -197,7 +197,7 @@ def test_calculate_chpi_positions():
     raw_no_chpi = read_raw_fif(test_fif_fname)
     assert_raises(RuntimeError, _calculate_chpi_positions, raw_no_chpi)
     raw_bad = raw.copy()
-    raw_bad.info['hpi_subsystem'] = None
+    del raw_bad.info['hpi_meas'][0]['hpi_coils'][0]['coil_freq']
     assert_raises(RuntimeError, _calculate_chpi_positions, raw_bad)
     raw_bad = raw.copy()
     for d in raw_bad.info['dig']:

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -188,7 +188,8 @@ def test_calculate_chpi_positions():
     # something.
     raw_dec = _decimate_chpi(raw, 15)
     with catch_logging() as log:
-        py_quats = _calculate_chpi_positions(raw_dec, verbose='debug')
+        py_quats = _calculate_chpi_positions(raw_dec, t_step_max=1.,
+                                             verbose='debug')
     assert_true(log.getvalue().startswith('HPIFIT'))
     _assert_quats(py_quats, mf_quats, dist_tol=0.004, angle_tol=2.5)
 


### PR DESCRIPTION
Fixes a few small bugs found while working on head position correction:

1. Computation of coil location goodness of fit in the private function `_calculate_chpi_positions`.
2. Computation of high-correlation segments to avoid re-fitting.
3. Remove demean step for HPI coil fits (the model has a DC term).
4. `maxwell_filter` with `coord_frame='meg', origin=(...)` wasn't being converted properly to the head coordinate frame for recordings that have a MEG<->head transform. Fortunately this use case should be pretty rare (usually origins should be provided relative to the head location for such non-empty-room recordings). This is the only public-facing change so it's the only one in `whats_new.rst`.

@bloyl you might be interested in some of this because it touches the HPI fitting code (which should now be faster for primarily stationary coils).