### PR TITLE
[MRG] Reduce linewidth of contours in plot_topomap

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -669,7 +669,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         cont = None  # can't make contours for constant-valued functions
     else:
         cont = ax.contour(Xi, Yi, Zi, contours, colors='k',
-                          linewidths=linewidth)
+                          linewidths=linewidth / 2)
     if no_contours and cont is not None:
         for col in cont.collections:
             col.set_visible(False)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -669,7 +669,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         cont = None  # can't make contours for constant-valued functions
     else:
         cont = ax.contour(Xi, Yi, Zi, contours, colors='k',
-                          linewidths=linewidth / 2)
+                          linewidths=linewidth / 2.)
     if no_contours and cont is not None:
         for col in cont.collections:
             col.set_visible(False)


### PR DESCRIPTION
The contours should not have the same width as the head geometry - using thinner lines separates the contours better from the head IMO.

Before:
![topo_before](https://user-images.githubusercontent.com/4377312/35976846-a5beb73e-0ce1-11e8-94e2-ba431dffd9df.png)

After:
![topo_after](https://user-images.githubusercontent.com/4377312/35976858-aa9f8b7a-0ce1-11e8-9856-6fa834d56fe8.png)
