### PR TITLE
Fixed p val in example Spatiotemporal permutation F-test

### DIFF
--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -95,7 +95,7 @@ plt.title('Between-sensor adjacency')
 # set cluster threshold
 threshold = 50.0  # very high, but the test is quite sensitive on this data
 # set family-wise p-value
-p_accept = 0.001
+p_accept = 0.01
 
 cluster_stats = spatio_temporal_cluster_test(X, n_permutations=1000,
                                              threshold=threshold, tail=1,


### PR DESCRIPTION
I just changed the p_value for accepted clusters in the  [ spatiotemporal permutation F-test example](https://martinos.org/mne/dev/auto_tutorials/plot_stats_spatio_temporal_cluster_sensors.html) so it can actually find some clusters to plot (there is no cluster figures showing up as it currently is on the website). 