### PR TITLE
MRG: Add projection to surface for coreg

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,8 @@ Changelog
 
 - Add ability to exclude components interactively by clicking on their labels in :meth:`mne.preprocessing.ICA.plot_components` by `Mikołaj Magnuski`_
 
+- Add projection of EEG electrodes to the head surface in ``mne coreg`` / :func:`mne.gui.coregistration` by `Eric Larson`_
+
 - Add reader for manual annotations of raw data produced by Brainstorm by `Anne-Sophie Dubarry`_
 
 Bug

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -6,6 +6,7 @@
 example usage:  $ mne coreg
 """
 
+import os.path as op
 import sys
 
 import mne
@@ -45,6 +46,9 @@ def run():
                       help="Use a low-resolution head surface.")
     parser.add_option('--trans', dest='trans', default=None,
                       help='Head<->MRI transform FIF file ("-trans.fif")')
+    parser.add_option('--project-eeg', dest='project_eeg',
+                      action='store_true', default=False,
+                      help="Project EEG electrodes to the head surface")
     parser.add_option('--verbose', action='store_true', dest='verbose',
                       help='Turn on verbose mode.')
 
@@ -61,18 +65,17 @@ def run():
         head_high_res = None
 
     with ETSContext():
-        mne.gui.coregistration(options.tabbed,
-                               inst=options.inst,
-                               subject=options.subject,
-                               subjects_dir=options.subjects_dir,
-                               guess_mri_subject=options.guess_mri_subject,
-                               head_opacity=options.head_opacity,
-                               head_high_res=head_high_res,
-                               trans=options.trans,
-                               scrollable=True,
-                               verbose=options.verbose)
+        # expanduser allows ~ for --subjects-dir
+        mne.gui.coregistration(
+            options.tabbed, inst=options.inst, subject=options.subject,
+            subjects_dir=op.expanduser(options.subjects_dir),
+            guess_mri_subject=options.guess_mri_subject,
+            head_opacity=options.head_opacity, head_high_res=head_high_res,
+            trans=op.expanduser(options.trans), scrollable=True,
+            project_eeg=options.project_eeg, verbose=options.verbose)
     if is_main:
         sys.exit(0)
+
 
 is_main = (__name__ == '__main__')
 if is_main:

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -64,14 +64,20 @@ def run():
     else:
         head_high_res = None
 
+    # expanduser allows ~ for --subjects-dir
+    subjects_dir = options.subjects_dir
+    if subjects_dir is not None:
+        subjects_dir = op.expanduser(subjects_dir)
+    trans = options.trans
+    if trans is not None:
+        trans = op.expanduser(trans)
     with ETSContext():
-        # expanduser allows ~ for --subjects-dir
         mne.gui.coregistration(
             options.tabbed, inst=options.inst, subject=options.subject,
-            subjects_dir=op.expanduser(options.subjects_dir),
+            subjects_dir=subjects_dir,
             guess_mri_subject=options.guess_mri_subject,
             head_opacity=options.head_opacity, head_high_res=head_high_res,
-            trans=op.expanduser(options.trans), scrollable=True,
+            trans=trans, scrollable=True,
             project_eeg=options.project_eeg, verbose=options.verbose)
     if is_main:
         sys.exit(0)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -42,7 +42,9 @@ head_bem_fname = pformat(bem_fname, name='head')
 fid_fname = pformat(bem_fname, name='fiducials')
 fid_fname_general = os.path.join(bem_dirname, "{head}-fiducials.fif")
 src_fname = os.path.join(bem_dirname, '{subject}-{spacing}-src.fif')
-_head_fnames = (head_bem_fname, pformat(bem_fname, name='head-medium'))
+_head_fnames = (os.path.join(bem_dirname, 'outer_skin.surf'),
+                head_bem_fname,
+                pformat(bem_fname, name='head-medium'))
 _high_res_head_fnames = (os.path.join(bem_dirname, '{subject}-head-dense.fif'),
                          os.path.join(surf_dirname, 'lh.seghead'),
                          os.path.join(surf_dirname, 'lh.smseghead'))

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -38,7 +38,8 @@ def combine_kit_markers():
 def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
                    subject=None, subjects_dir=None, guess_mri_subject=None,
                    scene_height=None, head_opacity=None, head_high_res=None,
-                   trans=None, scrollable=True, verbose=None):
+                   trans=None, scrollable=True, project_eeg=False,
+                   verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -87,6 +88,11 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
         The transform file to use.
     scrollable : bool
         Make the coregistration panel vertically scrollable (default True).
+    project_eeg : bool
+        If True (default False), project EEG electrodes to nearest
+        head surface vertex.
+
+        .. versionadded:: 0.16
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -125,7 +131,8 @@ def coregistration(tabbed=False, split=True, scene_width=None, inst=None,
     from ._coreg_gui import CoregFrame, _make_view
     view = _make_view(tabbed, split, scene_width, scene_height, scrollable)
     frame = CoregFrame(inst, subject, subjects_dir, guess_mri_subject,
-                       head_opacity, head_high_res, trans, config)
+                       head_opacity, head_high_res, trans, config,
+                       project_eeg=project_eeg)
     return _initialize_gui(frame, view)
 
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1457,9 +1457,9 @@ class CoregFrame(HasTraits):
         self.model.hsp.sync_trait('eeg_points', p, 'points', mutual=False)
         self.model.sync_trait('head_mri_trans', p, 'trans', mutual=False)
         self.sync_trait('hsp_visible', p, 'visible', mutual=False)
-        self.model.mri.sync_trait('points', p, 'project_to_points',
-                                  mutual=False)
         self.model.mri.sync_trait('tris', p, 'project_to_tris', mutual=False)
+        self.model.sync_trait('transformed_mri_points', p, 'project_to_points',
+                              mutual=False)
 
         # Digitizer Fiducials
         point_scale = defaults['dig_fid_scale']

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -331,7 +331,7 @@ class CoregModel(HasPrivateTraits):
     def _get_point_distance(self):
         if (len(self.transformed_hsp_points) == 0 or
                 len(self.transformed_mri_points) == 0):
-            return
+            return None
         dists = cdist(self.transformed_hsp_points, self.transformed_mri_points,
                       'euclidean')
         dists = np.min(dists, 1)
@@ -1349,10 +1349,12 @@ class CoregFrame(HasTraits):
 
     def __init__(self, raw=None, subject=None, subjects_dir=None,
                  guess_mri_subject=True, head_opacity=1.,
-                 head_high_res=True, trans=None, config=None):  # noqa: D102
+                 head_high_res=True, trans=None, config=None,
+                 project_eeg=False):  # noqa: D102
         self._config = config or {}
         super(CoregFrame, self).__init__(guess_mri_subject=guess_mri_subject)
         self.subject_panel.model.use_high_res_head = head_high_res
+        self._initial_project_eeg = project_eeg
         if not 0 <= head_opacity <= 1:
             raise ValueError(
                 "head_opacity needs to be a floating point number between 0 "
@@ -1448,11 +1450,16 @@ class CoregFrame(HasTraits):
         color = defaults['eeg_color']
         point_scale = defaults['eeg_scale']
         p = PointObject(view='cloud', scene=self.scene, color=color,
-                        point_scale=point_scale, resolution=5, name='EEG')
+                        point_scale=point_scale, resolution=20, name='EEG',
+                        projectable=True,
+                        project_to_surface=self._initial_project_eeg)
         self.eeg_obj = p
         self.model.hsp.sync_trait('eeg_points', p, 'points', mutual=False)
         self.model.sync_trait('head_mri_trans', p, 'trans', mutual=False)
         self.sync_trait('hsp_visible', p, 'visible', mutual=False)
+        self.model.mri.sync_trait('points', p, 'project_to_points',
+                                  mutual=False)
+        self.model.mri.sync_trait('tris', p, 'project_to_tris', mutual=False)
 
         # Digitizer Fiducials
         point_scale = defaults['dig_fid_scale']

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -139,8 +139,8 @@ class Object(HasPrivateTraits):
     opacity = Range(low=0., high=1., value=1.)
     visible = Bool(True)
 
-    # don't put project_to_points here, just always set project_to_tris second
-    @on_trait_change('trans,points,project_to_surface,project_to_tris')  # noqa: E501
+    # don't put project_to_tris here, just always set project_to_points second
+    @on_trait_change('trans,points,project_to_surface,project_to_points')
     def _update_points(self):
         """Update the location of the plotted points."""
         if not hasattr(self.src, 'data'):

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -18,7 +18,8 @@ from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
 from traitsui.api import View, Item, HGroup, VGrid, VGroup
 from tvtk.api import tvtk
 
-from ..surface import complete_surface_info
+from ..defaults import DEFAULTS
+from ..surface import complete_surface_info, _project_onto_surface
 from ..transforms import apply_trans
 from ..utils import SilenceStdout
 from ..viz._3d import _create_mesh_surf, _toggle_mlab_render
@@ -120,8 +121,14 @@ class Object(HasPrivateTraits):
     """Represent a 3d object in a mayavi scene."""
 
     points = Array(float, shape=(None, 3))
+    nn = Array(float, shape=(None, 3))
     trans = Array()
     name = Str
+
+    # projection onto a surface
+    project_to_points = Array(float, shape=(None, 3))
+    project_to_tris = Array(int, shape=(None, 3))
+    project_to_surface = Bool(False, label='Project')
 
     scene = Instance(MlabSceneModel, ())
     src = Instance(VTKDataSource)
@@ -132,7 +139,8 @@ class Object(HasPrivateTraits):
     opacity = Range(low=0., high=1., value=1.)
     visible = Bool(True)
 
-    @on_trait_change('trans,points')
+    # don't put project_to_points here, just always set project_to_tris second
+    @on_trait_change('trans,points,project_to_surface,project_to_tris')  # noqa: E501
     def _update_points(self):
         """Update the location of the plotted points."""
         if not hasattr(self.src, 'data'):
@@ -155,7 +163,18 @@ class Object(HasPrivateTraits):
         else:
             pts = self.points
 
+        # Do the projection if required
+        nn = None
+        if self.project_to_surface and len(self.project_to_points) > 1:
+            surf = dict(rr=np.array(self.project_to_points),
+                        tris=np.array(self.project_to_tris))
+            method = 'accurate' if len(surf['rr']) <= 20484 else 'nearest'
+            pts, nn = _project_onto_surface(
+                    pts, surf, project_rrs=True, return_nn=True,
+                    method=method)[2:4]
         self.src.data.points = pts
+        self.src.data.point_data.normals = nn
+        self.src.data.point_data.update()
         return True
 
 
@@ -172,7 +191,7 @@ class PointObject(Object):
                        Item('color', show_label=False),
                        Item('opacity')))
 
-    def __init__(self, view='points', *args, **kwargs):
+    def __init__(self, view='points', projectable=False, *args, **kwargs):
         """Init.
 
         Parameters
@@ -182,6 +201,7 @@ class PointObject(Object):
             or a point cloud.
         """
         self._view = view
+        self._projectable = projectable
         super(PointObject, self).__init__(*args, **kwargs)
 
     def default_traits_view(self):  # noqa: D102
@@ -189,13 +209,15 @@ class PointObject(Object):
         scale = Item('point_scale', label='Size')
         if self._view == 'points':
             visible = Item('visible', label='Show', show_label=True)
-            view = View(HGroup(visible, color, scale, 'label'))
+            views = (visible, color, scale, 'label')
         elif self._view == 'cloud':
             visible = Item('visible', show_label=False)
-            view = View(HGroup(visible, color, scale))
+            views = (visible, color, scale)
         else:
             raise ValueError("PointObject(view = %r)" % self._view)
-        return view
+        if self._projectable:
+            views = views + (Item('project_to_surface', show_label=True),)
+        return View(HGroup(*views))
 
     @on_trait_change('label')
     def _show_labels(self, show):
@@ -237,10 +259,11 @@ class PointObject(Object):
             return
         # fig.scene.engine.current_object is scatter
         glyph = pipeline.glyph(scatter, color=self.color,
-                               figure=fig,
-                               scale_factor=self.point_scale, opacity=1.,
-                               resolution=self.resolution)
+                               figure=fig, scale_factor=self.point_scale,
+                               opacity=1., resolution=self.resolution,
+                               mode='sphere')
         glyph.actor.property.backface_culling = True
+        glyph.glyph.glyph.vector_mode = 'use_normal'
         self.src = scatter
         self.glyph = glyph
 
@@ -249,16 +272,40 @@ class PointObject(Object):
         self.sync_trait('visible', self.glyph)
         self.sync_trait('opacity', self.glyph.actor.property)
         self.on_trait_change(self._update_points, 'points')
+        self._update_project_to_surface()
         _toggle_mlab_render(self, True)
 
 #         self.scene.camera.parallel_scale = _scale
+
+    @on_trait_change('project_to_surface')
+    def _update_project_to_surface(self):
+        if not self.glyph:
+            return
+        defaults = DEFAULTS['coreg']
+        gs = self.glyph.glyph.glyph_source
+        res = getattr(gs.glyph_source, 'theta_resolution',
+                      getattr(gs.glyph_source, 'resolution', None))
+        if self.project_to_surface:
+            gs.glyph_source = tvtk.CylinderSource()
+            gs.glyph_source.height = defaults['eegp_height']
+            gs.glyph_source.center = (0., -defaults['eegp_height'], 0)
+            gs.glyph_source.resolution = res
+        else:
+            gs.glyph_source = tvtk.SphereSource()
+            gs.glyph_source.phi_resolution = res
+            gs.glyph_source.theta_resolution = res
+        self.glyph.glyph.scale_mode = 'data_scaling_off'
 
     def _resolution_changed(self, new):
         if not self.glyph:
             return
 
-        self.glyph.glyph.glyph_source.glyph_source.phi_resolution = new
-        self.glyph.glyph.glyph_source.glyph_source.theta_resolution = new
+        gs = self.glyph.glyph.glyph_source.glyph_source
+        if isinstance(gs, tvtk.SphereSource):
+            gs.phi_resolution = new
+            gs.theta_resolution = new
+        else:
+            gs.resolution = new
 
 
 class SurfaceObject(Object):

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -164,7 +164,6 @@ class Object(HasPrivateTraits):
             pts = self.points
 
         # Do the projection if required
-        nn = None
         if self.project_to_surface and len(self.project_to_points) > 1:
             surf = dict(rr=np.array(self.project_to_points),
                         tris=np.array(self.project_to_tris))
@@ -172,8 +171,8 @@ class Object(HasPrivateTraits):
             pts, nn = _project_onto_surface(
                     pts, surf, project_rrs=True, return_nn=True,
                     method=method)[2:4]
+            self.src.data.point_data.normals = nn
         self.src.data.points = pts
-        self.src.data.point_data.normals = nn
         self.src.data.point_data.update()
         return True
 

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -169,8 +169,8 @@ class Object(HasPrivateTraits):
                         tris=np.array(self.project_to_tris))
             method = 'accurate' if len(surf['rr']) <= 20484 else 'nearest'
             pts, nn = _project_onto_surface(
-                    pts, surf, project_rrs=True, return_nn=True,
-                    method=method)[2:4]
+                pts, surf, project_rrs=True, return_nn=True,
+                method=method)[2:4]
             self.src.data.point_data.normals = nn
         self.src.data.points = pts
         self.src.data.point_data.update()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -65,6 +65,7 @@ def test_coreg_model():
     assert_allclose(model.hsp.rpa, [[+7.527e-2, 0, 5.588e-9]], 1e-4)
     assert_allclose(model.hsp.nasion, [[+3.725e-9, 1.026e-1, 4.191e-9]], 1e-4)
     assert_true(model.has_fid_data)
+    assert len(model.hsp.eeg_points) > 1
 
     lpa_distance = model.lpa_distance
     nasion_distance = model.nasion_distance
@@ -160,6 +161,7 @@ def test_coreg_gui():
                       subjects_dir=subjects_dir)
 
         from pyface.api import GUI
+        from tvtk.api import tvtk
         gui = GUI()
 
         # avoid modal dialog if SUBJECTS_DIR is set to a directory that
@@ -175,6 +177,11 @@ def test_coreg_gui():
         frame.model.mri.rpa = [[0.08, 0, 0]]
         assert_true(frame.model.mri.fid_ok)
         frame.raw_src.file = raw_path
+        assert isinstance(frame.eeg_obj.glyph.glyph.glyph_source.glyph_source,
+                          tvtk.SphereSource)
+        frame.view_options_panel.eeg_obj.project_to_surface = True
+        assert isinstance(frame.eeg_obj.glyph.glyph.glyph_source.glyph_source,
+                          tvtk.CylinderSource)
 
         # grow hair (high-res head has no norms)
         assert_true(frame.model.mri.use_high_res_head)


### PR DESCRIPTION
This PR:

1. Adds a button to project EEG electrodes to the scalp in `mne coreg`.
2. Fixes a bug where `--low-res-head` didn't always use a low res head (fixed by first looking for `outer_skin.surf` if it exists; `subject-head.fif` is now second, as it can be a dense head).
3. Adds support for normals when surfaces are loaded, enabling hair growing with e.g. `outer_skin.surf` files.
4. Adds support for `~` in the `--subjects-dir` and `--trans` paths using `expanduser`.

@christianbrodbeck do you have time to look and try? Example that shows all of these changes at once:
```
mne coreg --subjects-dir=~/mne_data/MNE-sample-data/subjects -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif --no-guess-mri -s sample --low-res-head --project-eeg
```

![screenshot from 2018-02-13 14-52-21](https://user-images.githubusercontent.com/2365790/36170505-92baa216-10cd-11e8-9bd1-dee6dae0ed97.png)

Closes #3700.