### PR TITLE
MRG: Block points behind the head

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ Changelog
 
 - Add :meth:`mne.io.Raw.reorder_channels`, :meth:`mne.Evoked.reorder_channels`, etc. to reorder channels, by `Eric Larson`_
 
+- Improve visibility of points inside the head in ``mne coreg`` and :func:`mne.gui.coregistration` by `Eric Larson`_
+
 - Add ability to exclude components interactively by clicking on their labels in :meth:`mne.preprocessing.ICA.plot_components` by `Mikołaj Magnuski`_
 
 Bug

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1405,6 +1405,7 @@ class CoregFrame(HasTraits):
         self.mri_obj = SurfaceObject(points=self.model.transformed_mri_points,
                                      color=color, tri=self.model.mri.tris,
                                      scene=self.scene, name="MRI Scalp",
+                                     block_behind=False,
                                      # opacity=self._initial_head_opacity,
                                      # setting opacity here causes points to be
                                      # [[0, 0, 0]] -- why??

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -275,16 +275,23 @@ class SurfaceObject(Object):
     tri = Array(int, shape=(None, 3))
 
     surf = Instance(Surface)
+    surf_rear = Instance(Surface)
 
     view = View(HGroup(Item('visible', show_label=False),
                        Item('color', show_label=False),
                        Item('opacity')))
+
+    def __init__(self, block_behind=False, **kwargs):  # noqa: D102
+        self._block_behind = block_behind
+        super(SurfaceObject, self).__init__(**kwargs)
 
     def clear(self):  # noqa: D102
         if hasattr(self.src, 'remove'):
             self.src.remove()
         if hasattr(self.surf, 'remove'):
             self.surf.remove()
+        if hasattr(self.surf_rear, 'remove'):
+            self.surf_rear.remove()
         self.reset_traits(['src', 'surf'])
 
     @on_trait_change('scene.activated')
@@ -299,18 +306,26 @@ class SurfaceObject(Object):
         fig = self.scene.mayavi_scene
         surf = complete_surface_info(dict(rr=self.points, tris=self.tri),
                                      verbose='error')
-        src = _create_mesh_surf(surf, fig=fig)
+        self.src = _create_mesh_surf(surf, fig=fig)
         rep = 'wireframe' if self.rep == 'Wireframe' else 'surface'
-        surf = pipeline.surface(src, figure=fig, color=self.color,
-                                representation=rep, line_width=1)
+        surf = pipeline.surface(
+            self.src, figure=fig, color=self.color, representation=rep,
+            line_width=1)
         surf.actor.property.backface_culling = True
-
-        self.src = src
         self.surf = surf
-
         self.sync_trait('visible', self.surf, 'visible')
         self.sync_trait('color', self.surf.actor.property, mutual=False)
         self.sync_trait('opacity', self.surf.actor.property)
+        if self._block_behind:
+            surf_rear = pipeline.surface(
+                self.src, figure=fig, color=self.color, representation=rep,
+                line_width=1)
+            surf_rear.actor.property.frontface_culling = True
+            self.surf_rear = surf_rear
+            self.sync_trait('color', self.surf_rear.actor.property,
+                            mutual=False)
+            self.sync_trait('visible', self.surf_rear, 'visible')
+            self.surf_rear.actor.property.opacity = 1.
 
         self.scene.camera.parallel_scale = _scale
 


### PR DESCRIPTION
Even when the head is translucent, points behind it should be blocked (i.e., the *inside walls* of the head should be opaque). This makes it clearer which points are on the near side of the head when doing fits.

For example, look at the `sample` data:
```
mne coreg --subjects-dir=$HOME/mne_data/MNE-sample-data/subjects -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif --no-guess-mri -s sample --high-res-head --trans=$HOME/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw-trans.fif
```
Let's scale up the MRI by a factor of 1.1 to make it clear what we're talking about -- on `master` and this PR, this is what you'd see -- all points inside the head are appropriately alpha blended with the head:

![screenshot from 2018-02-13 16-55-17](https://user-images.githubusercontent.com/2365790/36176042-6218c400-10df-11e8-9504-ab17982143dd.png)

On the other hand, if scale MRI by a factor of 0.9 to shrink it, we get this on `master`, which makes it look like some points might be *inside* the head, but these are really just on the far side of it:

![screenshot from 2018-02-13 16-54-41](https://user-images.githubusercontent.com/2365790/36176098-856ec166-10df-11e8-9890-353c08e6b735.png)

However, these points are actually *outside* the head -- on the current PR the points on the far side of the head are "removed", making it clear that there are no points inside the head (and note the decreased size of the large purple ball, too, showing just the part that extends inside the head):

![screenshot from 2018-02-13 16-55-10](https://user-images.githubusercontent.com/2365790/36176128-9f1fecde-10df-11e8-878e-45133cfdd480.png)

Having done a number of surrogate MRI transformations, I think this could really help make it clearer when all the points are outside the head (as they should be), requiring a bit less rotating of the view.

@christianbrodbeck this is also ready for review from my end.