### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -46,11 +46,11 @@ How do I cite MNE?
 If you use the implementations provided by the MNE software in your research,
 you should cite:
 
-    - A. Gramfort, M. Luessi, E. Larson, D. Engemann, D. Strohmeier, C. Brodbeck, L. Parkkonen, M. Hämäläinen, `MNE software for processing MEG and EEG data <http://www.ncbi.nlm.nih.gov/pubmed/24161808>`_, NeuroImage, Volume 86, 1 February 2014, Pages 446-460, ISSN 1053-8119, `[DOI] <http://dx.doi.org/10.1016/j.neuroimage.2013.10.027>`__
+    - A. Gramfort, M. Luessi, E. Larson, D. Engemann, D. Strohmeier, C. Brodbeck, L. Parkkonen, M. Hämäläinen, `MNE software for processing MEG and EEG data <http://www.ncbi.nlm.nih.gov/pubmed/24161808>`_, NeuroImage, Volume 86, 1 February 2014, Pages 446-460, ISSN 1053-8119, `[DOI] <https://doi.org/10.1016/j.neuroimage.2013.10.027>`__
 
 If you use the Python code you should cite as well:
 
-    - A. Gramfort, M. Luessi, E. Larson, D. Engemann, D. Strohmeier, C. Brodbeck, R. Goj, M. Jas, T. Brooks, L. Parkkonen, M. Hämäläinen, `MEG and EEG data analysis with MNE-Python <http://journal.frontiersin.org/article/10.3389/fnins.2013.00267/abstract>`_, Frontiers in Neuroscience, Volume 7, 2013, ISSN 1662-453X, `[DOI] <http://dx.doi.org/10.3389/fnins.2013.00267>`__
+    - A. Gramfort, M. Luessi, E. Larson, D. Engemann, D. Strohmeier, C. Brodbeck, R. Goj, M. Jas, T. Brooks, L. Parkkonen, M. Hämäläinen, `MEG and EEG data analysis with MNE-Python <http://journal.frontiersin.org/article/10.3389/fnins.2013.00267/abstract>`_, Frontiers in Neuroscience, Volume 7, 2013, ISSN 1662-453X, `[DOI] <https://doi.org/10.3389/fnins.2013.00267>`__
 
 To cite specific versions of the software, you can use the DOIs provided by
 `Zenodo <https://zenodo.org/search?ln=en&p=mne-python>`_.

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -13,7 +13,7 @@ References
 .. [1] Gramfort A., Kowalski M. and Hamalainen, M.
    "Mixed-norm estimates for the M/EEG inverse problem using accelerated
    gradient methods", Physics in Medicine and Biology, 2012.
-   http://dx.doi.org/10.1088/0031-9155/57/7/1937.
+   https://doi.org/10.1088/0031-9155/57/7/1937.
 
 .. [2] Strohmeier D., Haueisen J., and Gramfort A.
    "Improved MEG/EEG source localization with reweighted mixed-norms",

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -11,7 +11,7 @@ References
 .. [1] J.C. Mosher and R.M. Leahy. 1999. Source localization using recursively
        applied and projected (RAP) MUSIC. Trans. Sig. Proc. 47, 2
        (February 1999), 332-340.
-       DOI=10.1109/78.740118 http://dx.doi.org/10.1109/78.740118
+       DOI=10.1109/78.740118 https://doi.org/10.1109/78.740118
 """
 
 # Author: Yousra Bekhti <yousra.bekhti@gmail.com>

--- a/examples/visualization/plot_sensor_noise_level.py
+++ b/examples/visualization/plot_sensor_noise_level.py
@@ -11,7 +11,7 @@ References
 ----------
 .. [1] Khan S, Cohen D (2013). Note: Magnetic noise from the inner wall of
    a magnetically shielded room. Review of Scientific Instruments 84:56101.
-   http://dx.doi.org/10.1063/1.4802845
+   https://doi.org/10.1063/1.4802845
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>
 #

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -231,7 +231,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
         J.C. Mosher and R.M. Leahy. 1999. Source localization using recursively
         applied and projected (RAP) MUSIC. Signal Processing, IEEE Trans. 47, 2
         (February 1999), 332-340.
-        DOI=10.1109/78.740118 http://dx.doi.org/10.1109/78.740118
+        DOI=10.1109/78.740118 https://doi.org/10.1109/78.740118
 
         Mosher, J.C.; Leahy, R.M., EEG and MEG source localization using
         recursively applied (RAP) MUSIC, Signals, Systems and Computers, 1996.

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -361,7 +361,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     .. [1] A. Gramfort, M. Kowalski, M. Hamalainen,
        "Mixed-norm estimates for the M/EEG inverse problem using accelerated
        gradient methods", Physics in Medicine and Biology, 2012.
-       http://dx.doi.org/10.1088/0031-9155/57/7/1937
+       https://doi.org/10.1088/0031-9155/57/7/1937
 
     .. [2] D. Strohmeier, Y. Bekhti, J. Haueisen, A. Gramfort,
        "The Iterative Reweighted Mixed-Norm Estimate for Spatio-Temporal

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -207,7 +207,7 @@ def dgap_l21(M, G, X, active_set, alpha, n_orient):
     .. [1] A. Gramfort, M. Kowalski, M. Hamalainen,
        "Mixed-norm estimates for the M/EEG inverse problem using accelerated
        gradient methods", Physics in Medicine and Biology, 2012.
-       http://dx.doi.org/10.1088/0031-9155/57/7/1937
+       https://doi.org/10.1088/0031-9155/57/7/1937
     """
     GX = np.dot(G[:, active_set], X)
     R = M - GX
@@ -427,7 +427,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
     .. [1] A. Gramfort, M. Kowalski, M. Hamalainen,
        "Mixed-norm estimates for the M/EEG inverse problem using accelerated
        gradient methods", Physics in Medicine and Biology, 2012.
-       http://dx.doi.org/10.1088/0031-9155/57/7/1937
+       https://doi.org/10.1088/0031-9155/57/7/1937
 
     .. [2] D. Strohmeier, Y. Bekhti, J. Haueisen, A. Gramfort,
        "The Iterative Reweighted Mixed-Norm Estimate for Spatio-Temporal
@@ -814,7 +814,7 @@ def dgap_l21l1(M, G, Z, active_set, alpha_space, alpha_time, phi, phiT, shape,
     .. [1] A. Gramfort, M. Kowalski, M. Hamalainen,
        "Mixed-norm estimates for the M/EEG inverse problem using accelerated
        gradient methods", Physics in Medicine and Biology, 2012.
-       http://dx.doi.org/10.1088/0031-9155/57/7/1937
+       https://doi.org/10.1088/0031-9155/57/7/1937
 
     .. [2] J. Wang, J. Ye,
        "Two-layer feature reduction for sparse-group lasso via decomposition of

--- a/tutorials/plot_dipole_orientations.py
+++ b/tutorials/plot_dipole_orientations.py
@@ -199,7 +199,7 @@ brain = stc.plot(surface='white', subjects_dir=subjects_dir,
 # .. [1] Hämäläinen, M. S., Hari, R., Ilmoniemi, R. J., Knuutila, J., &
 #    Lounasmaa, O. V. "Magnetoencephalography - theory, instrumentation, and
 #    applications to noninvasive studies of the working human brain", Reviews
-#    of Modern Physics, 1993. http://dx.doi.org/10.1103/RevModPhys.65.413
+#    of Modern Physics, 1993. https://doi.org/10.1103/RevModPhys.65.413
 #
 # .. [2] Lin, F. H., Belliveau, J. W., Dale, A. M., & Hämäläinen, M. S. (2006).
 #    Distributed current estimates using cortical orientation constraints.


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR suggests that change.

Cheers :-)