### PR TITLE
[MRG+1]: fix event sample indices read from eeglab files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -124,6 +124,8 @@ Bug
 
 - Fix bug in :func:`mne.viz.plot_cov` that ignored ``colorbar`` argument by `Nathalie Gayraud`_
 
+- Fix bug when reading event latencies (in samples) from eeglab files didn't translate indices to 0-based python indexing by `Mikołaj Magnuski`_
+
 
 API
 ~~~

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -717,7 +717,7 @@ def _read_annotations_eeglab(eeg):
         description = []
     elif isinstance(eeg.event, np.ndarray):
         description = [str(event.type) for event in eeg.event]
-        onset = [event.latency for event in eeg.event]
+        onset = [event.latency - 1 for event in eeg.event]
         if (len(onset) > 0) and hasattr(eeg.event[0], 'duration'):
             duration = [event.duration for event in eeg.event]
         else:
@@ -725,7 +725,7 @@ def _read_annotations_eeglab(eeg):
     else:
         # only one event - TypeError: 'mat_struct' object is not iterable
         description = [str(eeg.event.type)]
-        onset = [eeg.event.latency]
+        onset = [eeg.event.latency - 1]
         duration = getattr(eeg.event, 'duration', np.zeros(1))
 
     return Annotations(onset=onset, duration=duration, description=description)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -670,6 +670,10 @@ def read_events_eeglab(eeg, event_id=None, event_id_func='strip_to_integer',
         logger.info('No events found, returning empty stim channel ...')
         return np.zeros((0, 3))
 
+    if (latencies < 0).any():
+        raise ValueError('At least one event sample index is negative. Please'
+                         ' check if EEG.event.sample values are correct.')
+
     not_in_event_id = set(x for x in types if x not in event_id)
     not_purely_numeric = set(x for x in not_in_event_id if not x.isdigit())
     no_numbers = set([x for x in not_purely_numeric

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -125,7 +125,7 @@ def test_io_set():
                                event_id=event_id, preload=True)
 
     # test that sample indices are read python-wise (zero-based)
-    assert mne.find_events(test_raw)[0, -1] == eeg.event[0].latency - 1
+    assert mne.find_events(test_raw)[0, 0] == eeg.event[0].latency - 1
 
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -125,7 +125,7 @@ def test_io_set():
                                event_id=event_id, preload=True)
 
     # test that sample indices are read python-wise (zero-based)
-    assert find_events(test_raw)[0, 0] == eeg.event[0].latency - 1
+    assert find_events(test_raw)[0, 0] == round(eeg.event[0].latency) - 1
 
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -121,8 +121,11 @@ def test_io_set():
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     op.join(temp_dir, 'test_one_event.fdt'))
     event_id = {eeg.event[0].type: 1}
-    read_raw_eeglab(input_fname=one_event_fname, montage=montage,
-                    event_id=event_id, preload=True)
+    test_raw = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
+                               event_id=event_id, preload=True)
+
+    # test that sample indices are read python-wise (zero-based)
+    assert mne.find_events(test_raw)[0, -1] == eeg.event[0].latency - 1
 
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -130,7 +130,7 @@ def test_io_set():
     negative_latency_fname = op.join(temp_dir, 'test_negative_latency.set')
     evnts = eeg.event[0]
     evnts.latency = 0
-    io.savemat(one_event_fname, {'EEG':
+    io.savemat(negative_latency_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': evnt,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -125,7 +125,7 @@ def test_io_set():
                                event_id=event_id, preload=True)
 
     # test that sample indices are read python-wise (zero-based)
-    assert mne.find_events(test_raw)[0, 0] == eeg.event[0].latency - 1
+    assert find_events(test_raw)[0, 0] == eeg.event[0].latency - 1
 
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -118,7 +118,8 @@ def test_io_set():
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': eeg.event[0],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
-    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), one_event_fname)
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
+                    one_event_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
     test_raw = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
                                event_id=event_id, preload=True)
@@ -135,7 +136,8 @@ def test_io_set():
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': evnt,
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
-    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), negative_latency_fname)
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
+                    negative_latency_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
     assert_raises(ValueError, read_raw_eeglab, montage=montage, preload=True,
                   event_id=event_id, input_fname=negative_latency_fname)
@@ -148,7 +150,8 @@ def test_io_set():
                 'nbchan': eeg.nbchan, 'data': 'test_overlap_event.fdt',
                 'epoch': eeg.epoch, 'event': [eeg.event[0], eeg.event[0]],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
-    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), overlap_fname)
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
+                    overlap_fname.replace('.set', '.fdt'))
     event_id = {'rt': 1, 'square': 2}
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -134,7 +134,7 @@ def test_io_set():
     io.savemat(negative_latency_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
-                'epoch': eeg.epoch, 'event': evnt,
+                'epoch': eeg.epoch, 'event': evnts,
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     negative_latency_fname.replace('.set', '.fdt'))

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -3,6 +3,7 @@
 #
 # License: BSD (3-clause)
 
+from copy import deepcopy
 from distutils.version import LooseVersion
 import os.path as op
 import shutil
@@ -129,7 +130,7 @@ def test_io_set():
 
     # test negative event latencies
     negative_latency_fname = op.join(temp_dir, 'test_negative_latency.set')
-    evnts = eeg.event[0]
+    evnts = deepcopy(eeg.event[0])
     evnts.latency = 0
     io.savemat(negative_latency_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -118,14 +118,28 @@ def test_io_set():
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': eeg.event[0],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
-    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
-                    op.join(temp_dir, 'test_one_event.fdt'))
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), one_event_fname)
     event_id = {eeg.event[0].type: 1}
     test_raw = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
                                event_id=event_id, preload=True)
 
     # test that sample indices are read python-wise (zero-based)
     assert find_events(test_raw)[0, 0] == round(eeg.event[0].latency) - 1
+
+    # test negative event latencies
+    negative_latency_fname = op.join(temp_dir, 'test_negative_latency.set')
+    evnts = eeg.event[0]
+    evnts.latency = 0
+    io.savemat(one_event_fname, {'EEG':
+               {'trials': eeg.trials, 'srate': eeg.srate,
+                'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
+                'epoch': eeg.epoch, 'event': evnt,
+                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), negative_latency_fname)
+    event_id = {eeg.event[0].type: 1}
+    assert_raises(ValueError, read_raw_eeglab, montage=montage, preload=True,
+                  event_id=event_id, input_fname=negative_latency_fname)
+
 
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')
@@ -134,8 +148,7 @@ def test_io_set():
                 'nbchan': eeg.nbchan, 'data': 'test_overlap_event.fdt',
                 'epoch': eeg.epoch, 'event': [eeg.event[0], eeg.event[0]],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}})
-    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
-                    op.join(temp_dir, 'test_overlap_event.fdt'))
+    shutil.copyfile(op.join(base_dir, 'test_raw.fdt'), overlap_fname)
     event_id = {'rt': 1, 'square': 2}
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -143,7 +143,6 @@ def test_io_set():
     assert_raises(ValueError, read_raw_eeglab, montage=montage, preload=True,
                   event_id=event_id, input_fname=negative_latency_fname)
 
-
     # test overlapping events
     overlap_fname = op.join(temp_dir, 'test_overlap_event.set')
     io.savemat(overlap_fname, {'EEG':


### PR DESCRIPTION
fix event latency from matlab 1-based to python 0-based.
Fixes #4944.