### PR TITLE
[MRG+1] Add function for random parcellation

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -772,6 +772,7 @@ Source Space Data
    grade_to_tris
    grade_to_vertices
    grow_labels
+   random_parcellation
    label_sign_flip
    morph_data
    morph_data_precomputed

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -772,10 +772,10 @@ Source Space Data
    grade_to_tris
    grade_to_vertices
    grow_labels
-   random_parcellation
    label_sign_flip
    morph_data
    morph_data_precomputed
+   random_parcellation
    read_labels_from_annot
    read_dipole
    read_label

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -73,7 +73,7 @@ from .epochs import (BaseEpochs, Epochs, EpochsArray, read_epochs,
 from .evoked import Evoked, EvokedArray, read_evokeds, write_evokeds, combine_evoked
 from .label import (read_label, label_sign_flip,
                     write_label, stc_to_label, grow_labels, Label, split_label,
-                    BiHemiLabel, read_labels_from_annot, write_labels_to_annot)
+                    BiHemiLabel, read_labels_from_annot, write_labels_to_annot, random_parcellation)
 from .misc import parse_config, read_reject_parameters
 from .coreg import (create_default_subject, scale_bem, scale_mri, scale_labels,
                     scale_source_space)

--- a/mne/label.py
+++ b/mne/label.py
@@ -1712,7 +1712,7 @@ def random_parcellation(subject, n_parcel, hemis, subjects_dir=None,
 def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
     """Random cortex parcellation"""
     labels = []
-    parcel_size = np.floor((len(vertices_[hemis[0]]) +
+    parcel_size = np.floor((len(vertices_[hemis[0]]) + 
                             len(vertices_[hemis[1]]))/n_parcel)
     parc_both = []
     for hemi in set(hemis):
@@ -1730,7 +1730,7 @@ def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
         edge = [s]  # queue of vertices to process
         parc[s] = label_idx
         label_size = 1
-        rest = len(parc)-1
+        rest = len(parc) - 1
         # grow from sources
         while rest:
             if not edge:
@@ -1805,7 +1805,7 @@ def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
         # convert parc to labels
         for i in xrange(n_labels):
             vertices = np.nonzero(parc == label_id[i])[0]
-            name = 'label_'+str(i)
+            name = 'label_' + str(i)
             label_ = Label(vertices, hemi=hemi, name=name, subject=subject)
             labels.append(label_)
         parc_both += [parc]

--- a/mne/label.py
+++ b/mne/label.py
@@ -1710,7 +1710,7 @@ def random_parcellation(subject, n_parcel, hemis, subjects_dir=None,
 
 
 def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
-    """Random cortex parcellation"""
+    """Random cortex parcellation."""
     labels = []
     parcel_size = np.floor((len(vertices_[hemis[0]]) +
                             len(vertices_[hemis[1]])) / n_parcel)

--- a/mne/label.py
+++ b/mne/label.py
@@ -13,6 +13,7 @@ import re
 
 import numpy as np
 from scipy import linalg, sparse
+import random
 
 from .utils import get_subjects_dir, _check_subject, logger, verbose, warn
 from .source_estimate import (morph_data, SourceEstimate, _center_of_mass,
@@ -1655,6 +1656,159 @@ def _grow_nonoverlapping_labels(subject, seeds_, extents_, hemis, vertices_,
             name = str(names[i])
             label_ = Label(vertices, hemi=hemi, name=name, subject=subject)
             labels.append(label_)
+
+    return labels
+
+
+def random_parcellation(subject, n_parcel, hemis, subjects_dir=None,
+                        surface='white'):
+    """Generate random cortex parcellation by growing labels.
+
+        This function generates a number of labels which don't intersect and
+        cover the whole surface. Regions are growing around randomly chosen
+        seeds.
+
+        Parameters
+        ----------
+        subject : string
+            Name of the subject as in SUBJECTS_DIR.
+        n_parcel : int
+            Total number of cortical parcels
+        hemis : array | int
+            Hemispheres to use for the labels (0: left, 1: right).
+        subjects_dir : string
+            Path to SUBJECTS_DIR if not set in the environment.
+        surface : string
+            The surface used to grow the labels, defaults to the white surface.
+
+        Returns
+        -------
+        labels : list of Label
+            Random cortex parcellation
+        """
+    subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+    hemis = np.atleast_1d(hemis)
+    hemis = np.array(['lh' if h == 0 else 'rh' for h in hemis])
+
+    # load the surfaces and create the distance graphs
+    tris, vert, dist = {}, {}, {}
+    for hemi in set(hemis):
+        surf_fname = op.join(subjects_dir, subject, 'surf', hemi + '.' +
+                             surface)
+        vert[hemi], tris[hemi] = read_surface(surf_fname)
+        dist[hemi] = mesh_dist(tris[hemi], vert[hemi])
+
+    # create the patches
+    labels = _cortex_parcellation(subject, n_parcel, hemis, vert, dist)
+
+    # add a unique color to each label
+    colors = _n_colors(len(labels))
+    for label, color in zip(labels, colors):
+        label.color = color
+
+    return labels
+
+
+def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
+    """Random cortex parcellation"""
+    labels = []
+    parcel_size = np.floor((len(vertices_[hemis[0]]) +
+                            len(vertices_[hemis[1]]))/n_parcel)
+    parc_both = []
+    for hemi in set(hemis):
+        graph = graphs[hemi]  # distance graph
+        n_vertices = len(vertices_[hemi])
+
+        # prepare parcellation
+        parc = np.empty(n_vertices, dtype='int32')
+        parc[:] = -1
+
+        # initialize active sources
+        s = 0
+        s = random.choice(range(n_vertices))
+        label_idx = 0
+        edge = [s]  # queue of vertices to process
+        parc[s] = label_idx
+        label_size = 1
+        rest = len(parc)-1
+        # grow from sources
+        while rest:
+            if not edge:
+                rest_idx = np.where(parc < 0)[0]
+                s = random.choice(rest_idx)
+                edge = [s]
+                label_idx += 1
+                label_size = 1
+                parc[s] = label_idx
+                rest -= 1
+
+            vert_from = edge.pop(0)
+
+            # add neighbors within allowable distance
+            row = graph[vert_from, :]
+            for vert_to, dist in zip(row.indices, row.data):
+                vert_to_label = parc[vert_to]
+
+                # abort if the vertex is already occupied
+                if vert_to_label >= 0:
+                    continue
+
+                # abort if outside of extent
+                if label_size > parcel_size:
+                    label_idx += 1
+                    label_size = 1
+                    edge = [vert_to]
+                    parc[vert_to] = label_idx
+                    rest -= 1
+                    break
+
+                # assign label value
+                parc[vert_to] = label_idx
+                label_size += 1
+                edge.append(vert_to)
+                rest -= 1
+
+        # merging small labels
+        # label connectivity matrix
+        n_labels = label_idx + 1
+        label_sizes = np.empty(n_labels, dtype=int)
+        label_conn = np.zeros([n_labels, n_labels], dtype='bool')
+        for i in range(n_labels):
+            vertices = np.nonzero(parc == i)[0]
+            label_sizes[i] = len(vertices)
+            neighbor_vertices = graph[vertices, :].indices
+            neighbor_labels = np.unique(np.array(parc[neighbor_vertices]))
+            label_conn[i, neighbor_labels] = 1
+        np.fill_diagonal(label_conn, 0)
+
+        # merging
+        label_id = range(n_labels)
+        while n_labels > n_parcel / 2:
+            # smallest label and its smallest neighbor
+            i = np.argmin(label_sizes)
+            neighbors = np.nonzero(label_conn[i, :])[0]
+            j = neighbors[np.argmin(label_sizes[neighbors])]
+
+            # merging two labels
+            label_conn[j, :] += label_conn[i, :]
+            label_conn[:, j] += label_conn[:, i]
+            label_conn = np.delete(label_conn, i, 0)
+            label_conn = np.delete(label_conn, i, 1)
+            label_conn[j, j] = 0
+            label_sizes[j] += label_sizes[i]
+            label_sizes = np.delete(label_sizes, i, 0)
+            n_labels -= 1
+            vertices = np.nonzero(parc == label_id[i])[0]
+            parc[vertices] = label_id[j]
+            label_id = np.delete(label_id, i, 0)
+
+        # convert parc to labels
+        for i in xrange(n_labels):
+            vertices = np.nonzero(parc == label_id[i])[0]
+            name = 'label_'+str(i)
+            label_ = Label(vertices, hemi=hemi, name=name, subject=subject)
+            labels.append(label_)
+        parc_both += [parc]
 
     return labels
 

--- a/mne/label.py
+++ b/mne/label.py
@@ -1719,6 +1719,7 @@ def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs,
                          random_state=None):
     """Random cortex parcellation."""
     labels = []
+    rng = check_random_state(random_state)
     for hemi in set(hemis):
         parcel_size = len(hemis) * len(vertices_[hemi]) // n_parcel
         graph = graphs[hemi]  # distance graph
@@ -1728,7 +1729,6 @@ def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs,
         parc = np.full(n_vertices, -1, dtype='int32')
 
         # initialize active sources
-        rng = check_random_state(random_state)
         s = rng.choice(range(n_vertices))
         label_idx = 0
         edge = [s]  # queue of vertices to process
@@ -1737,6 +1737,7 @@ def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs,
         rest = len(parc) - 1
         # grow from sources
         while rest:
+            # if there are not free neighbors, start new parcel
             if not edge:
                 rest_idx = np.where(parc < 0)[0]
                 s = rng.choice(rest_idx)

--- a/mne/label.py
+++ b/mne/label.py
@@ -1664,28 +1664,28 @@ def random_parcellation(subject, n_parcel, hemis, subjects_dir=None,
                         surface='white'):
     """Generate random cortex parcellation by growing labels.
 
-        This function generates a number of labels which don't intersect and
-        cover the whole surface. Regions are growing around randomly chosen
-        seeds.
+    This function generates a number of labels which don't intersect and
+    cover the whole surface. Regions are growing around randomly chosen
+    seeds.
 
-        Parameters
-        ----------
-        subject : string
-            Name of the subject as in SUBJECTS_DIR.
-        n_parcel : int
-            Total number of cortical parcels
-        hemis : array | int
-            Hemispheres to use for the labels (0: left, 1: right).
-        subjects_dir : string
-            Path to SUBJECTS_DIR if not set in the environment.
-        surface : string
-            The surface used to grow the labels, defaults to the white surface.
+    Parameters
+    ----------
+    subject : string
+        Name of the subject as in SUBJECTS_DIR.
+    n_parcel : int
+        Total number of cortical parcels
+    hemis : array | int
+        Hemispheres to use for the labels (0: left, 1: right).
+    subjects_dir : string
+        Path to SUBJECTS_DIR if not set in the environment.
+    surface : string
+        The surface used to grow the labels, defaults to the white surface.
 
-        Returns
-        -------
-        labels : list of Label
-            Random cortex parcellation
-        """
+    Returns
+    -------
+    labels : list of Label
+        Random cortex parcellation
+    """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     hemis = np.atleast_1d(hemis)
     hemis = np.array(['lh' if h == 0 else 'rh' for h in hemis])
@@ -1712,8 +1712,8 @@ def random_parcellation(subject, n_parcel, hemis, subjects_dir=None,
 def _cortex_parcellation(subject, n_parcel, hemis, vertices_, graphs):
     """Random cortex parcellation"""
     labels = []
-    parcel_size = np.floor((len(vertices_[hemis[0]]) + 
-                            len(vertices_[hemis[1]]))/n_parcel)
+    parcel_size = np.floor((len(vertices_[hemis[0]]) +
+                            len(vertices_[hemis[1]])) / n_parcel)
     parc_both = []
     for hemi in set(hemis):
         graph = graphs[hemi]  # distance graph

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -777,10 +777,11 @@ def test_random_parcellation():
     subject = 'sample'
 
     # Parcellation
-    labels = random_parcellation(subject, n_parcel, hemis, subjects_dir, surface=surface)
+    labels = random_parcellation(subject, n_parcel, hemis, subjects_dir,
+                                 surface=surface)
 
     # test number of labels
-    assert_equal(len(labels),n_parcel)
+    assert_equal(len(labels), n_parcel)
 
     hemis = np.array(['lh' if h == 0 else 'rh' for h in hemis])
     for hemi in set(hemis):

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -771,19 +771,21 @@ def test_grow_labels():
 @testing.requires_testing_data
 def test_random_parcellation():
     """Test generation of random cortical parcellation."""
-    hemis = [0, 1]
+    hemi = 'both'
     n_parcel = 50
     surface = 'white'
     subject = 'sample'
+    rng = np.random.RandomState(0)
 
     # Parcellation
-    labels = random_parcellation(subject, n_parcel, hemis, subjects_dir,
-                                 surface=surface)
+    labels = random_parcellation(subject, n_parcel, hemi, subjects_dir,
+                                 surface=surface, random_state=rng)
 
     # test number of labels
     assert_equal(len(labels), n_parcel)
-
-    hemis = np.array(['lh' if h == 0 else 'rh' for h in hemis])
+    if hemi == 'both':
+        hemi = ['lh', 'rh']
+    hemis = np.atleast_1d(hemi)
     for hemi in set(hemis):
         vertices_total = []
         for label in labels:


### PR DESCRIPTION
@agramfort @massich @mathurinm 
This PR add the new function to produce random parcellation of the cortex. It grows a number (input parameter) of random not intersecting cortical regions which cover the whole surface. 

Here is example of use (you should change annotation file names):

```
from pyface.qt import QtGui, QtCore
%matplotlib qt

import copy
import mne
from mne.datasets import sample
from surfer import Brain

subject_dir = sample.data_path() + '/subjects'
subject = 'sample'

n_parcel = 150
hemis = [0, 1]

# Parcellation
labels = mne.random_parcellation(subject, n_parcel, hemis, subject_dir, surface='white')

# Labels to annotations
annot_fname_lh = '/user/kmaksyme/home/tmp/lh.test.annot'
mne.label.write_labels_to_annot(labels,annot_fname=annot_fname_lh,hemi='lh',overwrite=True)
annot_fname_rh = '/user/kmaksyme/home/tmp/rh.test.annot'
mne.label.write_labels_to_annot(labels,annot_fname=annot_fname_rh,hemi='rh',overwrite=True)

# Visu
brain = Brain(subjects_dir=subject_dir,subject_id = subject,hemi="both",surf='inflated')
brain.add_annotation(annot_fname_lh, hemi='lh', borders=True)
brain.add_annotation(annot_fname_rh, hemi='rh', borders=True, remove_existing=False)
```