### PR TITLE
[MRG+1]: Fix Xdawn rank deficiency

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1515,7 +1515,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
     return cov
 
 
-def _regularized_covariance(data, reg=None, method_params=None):
+def _regularized_covariance(data, reg=None, method_params=None, info=None):
     """Compute a regularized covariance from data using sklearn.
 
     This is a convenience wrapper for mne.decoding functions, which
@@ -1544,7 +1544,7 @@ def _regularized_covariance(data, reg=None, method_params=None):
                          % (reg, type(reg)))
     method, method_params = _check_method_params(reg, method_params,
                                                  name='reg', allow_auto=False)
-    info = create_info(data.shape[-2], 1000., 'eeg')
+    info = create_info(data.shape[-2], 1000., 'eeg') if info is None else info
     picks_list = _picks_by_type(info)
     scalings = _handle_default('scalings_cov_rank', None)
     cov = _compute_covariance_auto(


### PR DESCRIPTION
The recent unification got us 90% of the way to being able to use Xdawn with `maxwell_filter`ed data. This should get us all the way there. Fixes:

1. Update docstring of `Xdawn` itself.
2. Pass `method_params` and `info` so cov can be computed properly by auto methods, including `diagonal_fixed`, which needs to know channel types.