### PR TITLE
[MRG] Fix calculation of samples to avoid incorrect file

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -333,7 +333,7 @@ class RawEDF(BaseRaw):
 def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):
     """Read a number of samples for a single channel."""
     # BDF
-    if subtype in ('24BIT', 'bdf'):
+    if subtype == 'bdf':
         ch_data = np.fromfile(fid, dtype=dtype, count=samp * dtype_byte)
         ch_data = ch_data.reshape(-1, 3).astype(np.int32)
         ch_data = ((ch_data[:, 0]) +
@@ -594,9 +594,8 @@ def _read_edf_header(fname, annot, annotmap, exclude):
 
         header_nbytes = int(fid.read(8).decode())
 
-        subtype = fid.read(44).strip().decode()[:5]
-        if len(subtype) == 0:
-            subtype = os.path.splitext(fname)[1][1:].lower()
+        fid.read(44)  # reserved header field (unused here)
+        subtype = os.path.splitext(fname)[1][1:].lower()
 
         n_records = int(fid.read(8).decode())
         record_length = np.array([float(fid.read(8)), 1.])  # in seconds
@@ -669,7 +668,7 @@ def _read_edf_header(fname, annot, annotmap, exclude):
                  ' Inferring from the file size.')
             edf_info['n_records'] = n_records = read_records
 
-        if subtype in ('24BIT', 'bdf'):
+        if subtype == 'bdf':
             edf_info['dtype_byte'] = 3  # 24-bit (3 byte) integers
             edf_info['dtype_np'] = np.uint8
         else:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -660,7 +660,7 @@ def _read_edf_header(fname, annot, annotmap, exclude):
         fid.seek(0, 2)
         n_bytes = fid.tell()
         n_data_bytes = n_bytes - header_nbytes
-        total_samps = (n_data_bytes // 3 if subtype == '24BIT'
+        total_samps = (n_data_bytes // 3 if subtype == 'bdf'
                        else n_data_bytes // 2)
         read_records = total_samps // np.sum(n_samps)
         if n_records != read_records:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -594,7 +594,12 @@ def _read_edf_header(fname, annot, annotmap, exclude):
 
         header_nbytes = int(fid.read(8).decode())
 
-        fid.read(44)  # reserved header field (unused here)
+        # The following 44 bytes sometimes identify the file type, but this is
+        # not guaranteed. Therefore, we skip this field and use the file
+        # extension to determine the subtype (EDF or BDF, which differ in the
+        # number of bytes they use for the data records; EDF uses 2 bytes
+        # whereas BDF uses 3 bytes).
+        fid.read(44)
         subtype = os.path.splitext(fname)[1][1:].lower()
 
         n_records = int(fid.read(8).decode())


### PR DESCRIPTION
Commit https://github.com/mne-tools/mne-python/commit/847347d14b858b86e5aac347a9db1bcf44b554d6#diff-825d45683d0be02fad23614151867e02 introduced a regression which I think is pretty serious. I cannot load specific files that worked OK prior to this commit. Now I get a warning introduced by this commit ("Number of records from the header does not match the file size (perhaps the recording was not stopped before exiting). Inferring from the file size."), and the resulting file size is incorrect. I can load the file just fine before this change and with other tools such as pyedflib or biosig. Although there were some edits after this commit, this issue has not been resolved.

I hope that it really is just the tiny change I made - let's see what the CIs think.