### PR TITLE
don't force good channels' labels to black

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -989,7 +989,8 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                     label.set_color('black')
             else:
                 # set label color
-                this_color = bad_color if ch_name in info['bads'] else 'black'
+                this_color = (bad_color if ch_name in info['bads'] else
+                              this_color)
                 labels[ii].set_color(this_color)
             lines[ii].set_zorder(this_z)
         else:


### PR DESCRIPTION
Motivation: when using `matplotlib.pyplot.style.use('dark_background')` the good channel labels are all invisible.  This fixes that by using the same color for the good channel labels as for the good channel data (also more consistent with the behavior of bad / stim channels, which already match label and data colors).

cc: @jaeilepp @larsoner 