### PR TITLE
change rERP calculation of times to match Epochs calculation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -130,6 +130,8 @@ Bug
 
 - Fix bug when reading event latencies (in samples) from eeglab files didn't translate indices to 0-based python indexing by `Mikołaj Magnuski`_
 
+- Fix consistency between :class:`mne.Epochs` and :func:`mne.statistics.linear_regression_raw` in converting between samples and times (:func:`mne.statistics.linear_regression_raw` now rounds, instead of truncating) by `Phillip Alday`_
+
 
 API
 ~~~
@@ -2526,7 +2528,7 @@ of commits):
 
 .. _Chris Mullins: http://crmullins.com
 
-.. _Phillip Alday: http://palday.bitbucket.org
+.. _Phillip Alday: https://palday.bitbucket.io
 
 .. _Andreas Hojlund: https://github.com/ahoejlund
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -5,7 +5,7 @@
 #          Christian Brodbeck <christianbrodbeck@nyu.edu>
 #          Eric Larson <larson.eric.d@gmail.com>
 #          Jona Sassenhagen <jona.sassenhagen@gmail.com>
-#          Phillip Alday <phillip.alday@unisa.edu.au>
+#          Phillip Alday <phillip.alday@mpi.nl>
 #          Okba Bekhelifi <okba.bekhelifi@gmail.com>
 #
 # License: BSD (3-clause)

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -324,16 +324,17 @@ def _prepare_rerp_preds(n_samples, sfreq, events, event_id=None, tmin=-.1,
         conds += list(covariates)
 
     # time windows (per event type) are converted to sample points from times
+    # int(round()) to be safe and match Epochs constructor behavior
     if isinstance(tmin, (float, int)):
-        tmin_s = dict((cond, int(tmin * sfreq)) for cond in conds)
+        tmin_s = dict((cond, int(round(tmin * sfreq))) for cond in conds)
     else:
-        tmin_s = dict((cond, int(tmin.get(cond, -.1) * sfreq))
+        tmin_s = dict((cond, int(round(tmin.get(cond, -.1) * sfreq)))
                       for cond in conds)
     if isinstance(tmax, (float, int)):
         tmax_s = dict(
-            (cond, int((tmax * sfreq) + 1.)) for cond in conds)
+            (cond, int(round((tmax * sfreq)) + 1)) for cond in conds)
     else:
-        tmax_s = dict((cond, int((tmax.get(cond, 1.) * sfreq) + 1))
+        tmax_s = dict((cond, int(round(tmax.get(cond, 1.) * sfreq)) + 1)
                       for cond in conds)
 
     # Construct predictor matrix

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -19,7 +19,7 @@ from mne import read_source_estimate
 from mne.datasets import testing
 from mne.stats.regression import linear_regression, linear_regression_raw
 from mne.io import RawArray
-from mne.utils import requires_sklearn
+from mne.utils import requires_sklearn, run_tests_if_main
 
 warnings.simplefilter('always')
 
@@ -92,6 +92,12 @@ def test_continuous_regression_no_overlap():
 
     raw = mne.io.read_raw_fif(raw_fname, preload=True)
     raw.apply_proj()
+
+    # a sampling of frequency where rounding and truncation yield
+    # different results checks conversion from samples to times is
+    # consistent across Epochs and linear_regression_raw
+    raw.info['sfreq'] = 128
+
     events = mne.read_events(event_fname)
     event_id = dict(audio_l=1, audio_r=2)
 
@@ -156,3 +162,5 @@ def test_continuous_regression_with_overlap():
                       solver=solT)
     assert_raises(ValueError, linear_regression_raw, raw, events, solver='err')
     assert_raises(TypeError, linear_regression_raw, raw, events, solver=0)
+
+run_tests_if_main()


### PR DESCRIPTION
The use of `round()` in the `Epochs` class can lead to to slightly different answers than the default truncation used by `int()` typecast when the sampling frequency isn't a multiple of 10 (e.g. for BioSemi recordings, where the sampling rates are powers of 2). While the difference is trivial, it creates problems when e.g. combining `Evoked` objects computed from `linear_regression_raw` and `Epochs`. This makes `linear_regression_raw` behave consistently with `Epochs`.