### PR TITLE
Remove unused code path in custom solver

### DIFF
--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -109,7 +109,6 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     # Whiten data
     M = np.dot(whitener, M)
 
-    n_orient = 1 if is_fixed_orient(forward) else 3
     X, active_set = solver(M, gain, n_orient)
     X = _reapply_source_weighting(X, source_weighting, active_set)
 

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -109,6 +109,7 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     # Whiten data
     M = np.dot(whitener, M)
 
+    n_orient = 1 if is_fixed_orient(forward) else 3
     X, active_set = solver(M, gain, n_orient)
     X = _reapply_source_weighting(X, source_weighting, active_set)
 

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -97,11 +97,6 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
 
     loose, forward = _check_loose_forward(loose, forward)
 
-    # put the forward solution in fixed orientation if it's not already
-    if loose == 0. and not is_fixed_orient(forward):
-        forward = mne.convert_forward_solution(
-            forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
-
     # Handle depth weighting and whitening (here is no weights)
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
         forward, evoked.info, noise_cov, pca=False, depth=depth,

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -111,7 +111,7 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
 
     n_orient = 1 if is_fixed_orient(forward) else 3
     X, active_set = solver(M, gain, n_orient)
-    X = _reapply_source_weighting(X, source_weighting, active_set, n_orient)
+    X = _reapply_source_weighting(X, source_weighting, active_set)
 
     stc = _make_sparse_stc(X, active_set, forward, tmin=evoked.times[0],
                            tstep=1. / evoked.info['sfreq'])

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -278,8 +278,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
 
     # Reapply weights to have correct unit
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
-    X = _reapply_source_weighting(X, source_weighting,
-                                  active_set, n_dip_per_pos)
+    X = _reapply_source_weighting(X, source_weighting, active_set)
 
     if return_residual:
         residual = _compute_residual(forward, evoked, X, active_set,

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -277,7 +277,6 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
     M_estimated = np.dot(gain[:, active_set], X)
 
     # Reapply weights to have correct unit
-    n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
     X = _reapply_source_weighting(X, source_weighting, active_set)
 
     if return_residual:

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -110,8 +110,7 @@ def _prepare_gain(forward, info, noise_cov, pca, depth, loose, weights,
     return gain, gain_info, whitener, source_weighting, mask
 
 
-def _reapply_source_weighting(X, source_weighting, active_set,
-                              n_dip_per_pos):
+def _reapply_source_weighting(X, source_weighting, active_set):
     X *= source_weighting[active_set][:, None]
     return X
 
@@ -443,8 +442,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
         raise Exception("No active dipoles found. alpha is too big.")
 
     # Reapply weights to have correct unit
-    X = _reapply_source_weighting(X, source_weighting,
-                                  active_set, n_dip_per_pos)
+    X = _reapply_source_weighting(X, source_weighting, active_set)
 
     outs = list()
     residual = list()
@@ -655,8 +653,7 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         active_set = active_set_tmp
         del active_set_tmp
 
-    X = _reapply_source_weighting(
-        X, source_weighting, active_set, n_dip_per_pos)
+    X = _reapply_source_weighting(X, source_weighting, active_set)
 
     if return_residual:
         residual = _compute_residual(


### PR DESCRIPTION
This PR contains two small changes. If you don't feel it's worth merging them I wouldn't blame you, but I figured I'd at least give you a heads up.

1. The [example for custom solvers](https://martinos.org/mne/stable/auto_examples/inverse/plot_custom_inverse_solver.html#sphx-glr-auto-examples-inverse-plot-custom-inverse-solver-py) contains a chunk of code around [line 100 - 104](https://github.com/mne-tools/mne-python/blob/239c83dfe0686084d1c96c945579dc8cc10e895c/examples/inverse/plot_custom_inverse_solver.py#L100-L103) with an if statement that will never be executed because the immediately previous call to [_check_loose_forward](https://github.com/mne-tools/mne-python/blob/239c83dfe0686084d1c96c945579dc8cc10e895c/mne/minimum_norm/inverse.py#L735-L765) handles the case the if statement checks for. 

2. The [_reapply_source_weighting](https://github.com/mne-tools/mne-python/blob/239c83dfe0686084d1c96c945579dc8cc10e895c/mne/inverse_sparse/mxne_inverse.py#L113-L116) method in `mxne_inverse.py` contained an un-used `n_dip_per_pos` that I removed. It was used in about 4 places so I updated those call locations as well.

Was the `n_dip_per_pos` argument added in anticipation of some future change? Or is it a remnant of a previous implementation?