### PR TITLE
Workaround for a display bug in plot_ica_scores

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -525,7 +525,7 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
         if len(my_range) != len(this_scores):
             raise ValueError('The length of `scores` must equal the '
                              'number of ICA components.')
-        ax.bar(my_range, this_scores, color='w', edgecolor='k')
+        ax.bar(my_range, this_scores, color='gray', edgecolor='k')
         for excl in exclude:
             ax.bar(my_range[excl], this_scores[excl], color='r', edgecolor='k')
         if axhline is not None:


### PR DESCRIPTION
Sometimes the function plot_ica_scores shows white bar and seems to ignore the `edgecolor='k'`option, resulting in scores not showing up (for example in the online tutorial https://martinos.org/mne/dev/auto_tutorials/plot_ica_from_raw.html, after 2.) ).

This is a simple workaround, where the color of the bar is now gray by default.