### PR TITLE
in io.read_meas_info we prevent highpass and lowpass from being nans

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -917,10 +917,12 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
             chs.append(tag.data)
         elif kind == FIFF.FIFF_LOWPASS:
             tag = read_tag(fid, pos)
-            lowpass = float(tag.data)
+            if not np.isnan(tag.data):
+                lowpass = float(tag.data)
         elif kind == FIFF.FIFF_HIGHPASS:
             tag = read_tag(fid, pos)
-            highpass = float(tag.data)
+            if not np.isnan(tag.data):
+                highpass = float(tag.data)
         elif kind == FIFF.FIFF_MEAS_DATE:
             tag = read_tag(fid, pos)
             meas_date = tag.data


### PR DESCRIPTION
Regarding issue #4984 .
Now it's possible to call:
```
raw.plot()
```

after exporting the data from FT in this way: http://www.fieldtriptoolbox.org/development/integrate_with_mne.