### PR TITLE
[MRG] Tighter dual scaling in TFMxNE

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -81,6 +81,8 @@ Changelog
 
 - Add reader for manual annotations of raw data produced by Brainstorm by `Anne-Sophie Dubarry`_
 
+- Tighter duality gap computation in ``mne.inverse_sparse.tf_mxne_optim`` and new parametrization with ``alpha`` and  ``l1_ratio`` instead of ``alpha_space`` and ``alpha_time`` by `Mathurin Massias`_ and `Daniel Strohmeier`_
+
 Bug
 ~~~
 

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -71,7 +71,7 @@ forward = mne.read_forward_solution(fwd_fname)
 # Run solver
 
 # alpha_space regularization parameter is between 0 and 100 (100 is high)
-alpha_space = 35.  # spatial regularization parameter
+alpha_space = 30.  # spatial regularization parameter
 # alpha_time parameter promotes temporal smoothness
 # (0 means no temporal regularization)
 alpha_time = 1.  # temporal regularization parameter

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -86,10 +86,10 @@ stc_dspm = apply_inverse(evoked, inverse_operator, lambda2=1. / 9.,
 
 # Compute TF-MxNE inverse solution with dipole output
 dipoles, residual = tf_mixed_norm(
-    evoked, forward, cov, None, None, loose=loose, depth=depth,
-    maxit=200, tol=1e-6, weights=stc_dspm, weights_min=8., debias=True,
-    wsize=16, tstep=4, window=0.05, return_as_dipoles=True,
-    return_residual=True, alpha=alpha, l1_ratio=l1_ratio)
+    evoked, forward, cov, alpha=alpha, l1_ratio=l1_ratio, loose=loose,
+    depth=depth, maxit=200, tol=1e-6, weights=stc_dspm, weights_min=8.,
+    debias=True, wsize=16, tstep=4, window=0.05, return_as_dipoles=True,
+    return_residual=True)
 
 # Crop to remove edges
 for dip in dipoles:

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -70,11 +70,11 @@ forward = mne.read_forward_solution(fwd_fname)
 ###############################################################################
 # Run solver
 
-# alpha_space regularization parameter is between 0 and 100 (100 is high)
-alpha_space = 30.  # spatial regularization parameter
-# alpha_time parameter promotes temporal smoothness
+# alpha parameter is between 0 and 100 (100 gives 0 active source)
+alpha = 40.  # general regularization parameter
+# l1_ratio parameter between 0 and 1 promotes temporal smoothness
 # (0 means no temporal regularization)
-alpha_time = 1.  # temporal regularization parameter
+l1_ratio = 0.03  # temporal regularization parameter
 
 loose, depth = 0.2, 0.9  # loose orientation & depth weighting
 
@@ -86,10 +86,10 @@ stc_dspm = apply_inverse(evoked, inverse_operator, lambda2=1. / 9.,
 
 # Compute TF-MxNE inverse solution with dipole output
 dipoles, residual = tf_mixed_norm(
-    evoked, forward, cov, alpha_space, alpha_time, loose=loose, depth=depth,
+    evoked, forward, cov, None, None, loose=loose, depth=depth,
     maxit=200, tol=1e-6, weights=stc_dspm, weights_min=8., debias=True,
     wsize=16, tstep=4, window=0.05, return_as_dipoles=True,
-    return_residual=True)
+    return_residual=True, alpha=alpha, l1_ratio=l1_ratio)
 
 # Crop to remove edges
 for dip in dipoles:

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -71,7 +71,7 @@ forward = mne.read_forward_solution(fwd_fname)
 # Run solver
 
 # alpha_space regularization parameter is between 0 and 100 (100 is high)
-alpha_space = 30.  # spatial regularization parameter
+alpha_space = 35.  # spatial regularization parameter
 # alpha_time parameter promotes temporal smoothness
 # (0 means no temporal regularization)
 alpha_time = 1.  # temporal regularization parameter

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -504,8 +504,8 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
                   loose='auto', depth=0.8, maxit=3000, tol=1e-4,
                   weights=None, weights_min=None, pca=True, debias=True,
                   wsize=64, tstep=4, window=0.02, return_residual=False,
-                  return_as_dipoles=False, verbose=None, alpha=None,
-                  l1_ratio=None):
+                  return_as_dipoles=False, alpha=None, l1_ratio=None,
+                  verbose=None):
     """Time-Frequency Mixed-norm estimate (TF-MxNE).
 
     Compute L1/L2 + L1 mixed-norm solution on time-frequency

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -630,9 +630,9 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     M = np.dot(whitener, M)
 
     # Scaling to make setting of alpha easy
-    n_step = int(np.ceil(M.shape[1] / float(tstep)))
-    n_freq = wsize // 2 + 1
-    n_coefs = n_step * n_freq
+    n_steps = int(np.ceil(M.shape[1] / float(tstep)))
+    n_freqs = wsize // 2 + 1
+    n_coefs = n_steps * n_freqs
     phi = _Phi(wsize, tstep, n_coefs)
     l1_ratio = alpha_time / (alpha_space + alpha_time)
     alpha_max = norm_epsilon_inf(gain, M, phi, l1_ratio, n_dip_per_pos)

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -567,11 +567,13 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
     alpha : float in [0, 100] or None
-        If not None and l1_ratio is not None, alpha_space and alpha_time are overriden by
-        alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max * l1_ratio.
+        If alpha and l1_ratio are not None, alpha_space and alpha_time are
+        overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
+        * l1_ratio.
     l1_ratio : float in [0, 1] or None
-        If not None, alpha_space and alpha_time are overriden by
-        alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max * l1_ratio.
+        If l1_ratio and alpha are not None, alpha_space and alpha_time are
+        overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
+        * l1_ratio.
 
 
     Returns

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -296,8 +296,9 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
         Forward operator.
     noise_cov : instance of Covariance
         Noise covariance to compute whitener.
-    alpha : float
-        Regularization parameter.
+    alpha : float in range [0, 100)
+        Regularization parameter. 0 means no regularization, 100 would give 0
+        active dipole.
     loose : float in [0, 1] | 'auto'
         Value that weights the source variances of the dipole components
         that are parallel (tangential) to the cortical surface. If loose
@@ -367,6 +368,9 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
        MEG/EEG Source Reconstruction", IEEE Transactions of Medical Imaging,
        Volume 35 (10), pp. 2218-2228, 2016.
     """
+    if not (0. <= alpha < 100.):
+        raise ValueError('alpha must be in [0, 100). '
+                         'Got alpha = %f' % alpha)
     if n_mxne_iter < 1:
         raise ValueError('MxNE has to be computed at least 1 time. '
                          'Requires n_mxne_iter >= 1, got %d' % n_mxne_iter)
@@ -563,14 +567,14 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         If True, the residual is returned as an Evoked instance.
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
-    alpha : float in [0, 100] or None
+    alpha : float in [0, 100) or None
         If alpha and l1_ratio are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
-        * l1_ratio.
+        * l1_ratio. 0 means no regularization, 100 would give 0 active dipole.
     l1_ratio : float in [0, 1] or None
         If l1_ratio and alpha are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
-        * l1_ratio.
+        * l1_ratio. 0 means no time regularization aka MxNE.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -611,9 +615,10 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     if alpha is not None and l1_ratio is not None:
         old_parametrization = False
 
-        if not (0. <= alpha <= 100.):
-            raise ValueError('alpha must be in range [0, 100].'
-                             ' Got alpha = %f' % alpha)
+        if not (0. <= alpha < 100.):
+            raise ValueError('alpha must be in [0, 100). '
+                             'Got alpha = %f' % alpha)
+
         if not (0. <= l1_ratio <= 1.):
             raise ValueError('l1_ratio must be in range [0, 1].'
                              ' Got l1_ratio = %f' % l1_ratio)

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -525,11 +525,13 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         Noise covariance to compute whitener.
     alpha_space : float in [0, 100]
         Regularization parameter for spatial sparsity. If larger than 100,
-        then no source will be active.
+        then no source will be active. alpha_space is deprecated in favor
+        of alpha and l1_ratio, and will be removed in 0.17.
     alpha_time : float in [0, 100]
         Regularization parameter for temporal sparsity. It set to 0,
         no temporal regularization is applied. It this case, TF-MxNE is
-        equivalent to MxNE with L21 norm.
+        equivalent to MxNE with L21 norm. alpha_time is deprecated in favor
+        of alpha and l1_ratio, and will be removed in 0.17.
     loose : float in [0, 1] | 'auto'
         Value that weights the source variances of the dipole components
         that are parallel (tangential) to the cortical surface. If loose
@@ -568,10 +570,12 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
     alpha : float in [0, 100) or None
+        Overall regularization parameter.
         If alpha and l1_ratio are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
         * l1_ratio. 0 means no regularization, 100 would give 0 active dipole.
     l1_ratio : float in [0, 1] or None
+        Proportion of temporal regularization.
         If l1_ratio and alpha are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
         * l1_ratio. 0 means no time regularization aka MxNE.

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -370,7 +370,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     """
     if not (0. <= alpha < 100.):
         raise ValueError('alpha must be in [0, 100). '
-                         'Got alpha = %f' % alpha)
+                         'Got alpha = %s' % alpha)
     if n_mxne_iter < 1:
         raise ValueError('MxNE has to be computed at least 1 time. '
                          'Requires n_mxne_iter >= 1, got %d' % n_mxne_iter)
@@ -504,12 +504,12 @@ def _window_evoked(evoked, size):
 
 
 @verbose
-def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
-                  loose='auto', depth=0.8, maxit=3000, tol=1e-4,
-                  weights=None, weights_min=None, pca=True, debias=True,
-                  wsize=64, tstep=4, window=0.02, return_residual=False,
-                  return_as_dipoles=False, alpha=None, l1_ratio=None,
-                  verbose=None):
+def tf_mixed_norm(evoked, forward, noise_cov, alpha_space=None,
+                  alpha_time=None, loose='auto', depth=0.8, maxit=3000,
+                  tol=1e-4, weights=None, weights_min=None, pca=True,
+                  debias=True, wsize=64, tstep=4, window=0.02,
+                  return_residual=False, return_as_dipoles=False,
+                  alpha=None, l1_ratio=None, verbose=None):
     """Time-Frequency Mixed-norm estimate (TF-MxNE).
 
     Compute L1/L2 + L1 mixed-norm solution on time-frequency
@@ -621,11 +621,11 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
 
         if not (0. <= alpha < 100.):
             raise ValueError('alpha must be in [0, 100). '
-                             'Got alpha = %f' % alpha)
+                             'Got alpha = %s' % alpha)
 
         if not (0. <= l1_ratio <= 1.):
             raise ValueError('l1_ratio must be in range [0, 1].'
-                             ' Got l1_ratio = %f' % l1_ratio)
+                             ' Got l1_ratio = %s' % l1_ratio)
         alpha_space = alpha * (1. - l1_ratio)
         alpha_time = alpha * l1_ratio
     else:
@@ -636,11 +636,11 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
     if (alpha_space < 0.) or (alpha_space > 100.):
         old_parametrization = True
         raise ValueError('alpha_space must be in range [0, 100].'
-                         ' Got alpha_space = %f' % alpha_space)
+                         ' Got alpha_space = %s' % alpha_space)
 
     if (alpha_time < 0.) or (alpha_time > 100.):
         raise ValueError('alpha_time must be in range [0, 100].'
-                         ' Got alpha_time = %f' % alpha_time)
+                         ' Got alpha_time = %s' % alpha_time)
 
     loose, forward = _check_loose_forward(loose, forward)
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -612,11 +612,11 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         old_parametrization = False
 
         if not (0. <= alpha <= 100.):
-            raise Exception('alpha must be in range [0, 100].'
-                            ' Got alpha = %f' % alpha)
+            raise ValueError('alpha must be in range [0, 100].'
+                             ' Got alpha = %f' % alpha)
         if not (0. <= l1_ratio <= 1.):
-            raise Exception('l1_ratio must be in range [0, 1].'
-                            ' Got l1_ratio = %f' % l1_ratio)
+            raise ValueError('l1_ratio must be in range [0, 1].'
+                             ' Got l1_ratio = %f' % l1_ratio)
         alpha_space = alpha * (1. - l1_ratio)
         alpha_time = alpha * l1_ratio
     else:
@@ -626,12 +626,12 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
 
     if (alpha_space < 0.) or (alpha_space > 100.):
         old_parametrization = True
-        raise Exception('alpha_space must be in range [0, 100].'
-                        ' Got alpha_space = %f' % alpha_space)
+        raise ValueError('alpha_space must be in range [0, 100].'
+                         ' Got alpha_space = %f' % alpha_space)
 
     if (alpha_time < 0.) or (alpha_time > 100.):
-        raise Exception('alpha_time must be in range [0, 100].'
-                        ' Got alpha_time = %f' % alpha_time)
+        raise ValueError('alpha_time must be in range [0, 100].'
+                         ' Got alpha_time = %f' % alpha_time)
 
     loose, forward = _check_loose_forward(loose, forward)
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -563,9 +563,6 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         If True, the residual is returned as an Evoked instance.
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
     alpha : float in [0, 100] or None
         If alpha and l1_ratio are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
@@ -574,6 +571,9 @@ def tf_mixed_norm(evoked, forward, noise_cov, alpha_space, alpha_time,
         If l1_ratio and alpha are not None, alpha_space and alpha_time are
         overriden by alpha * alpha_max * (1. - l1_ratio) and alpha * alpha_max
         * l1_ratio.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
 
     Returns

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -834,10 +834,13 @@ def norm_epsilon(Y, l1_ratio, n_freqs):
     exit = False
     for k in range(K - 1):
         # process entry k once or twice:
-        for _ in range(weights[k]):
+        for ll in range(weights[k]):
             p_sum += Y[k]
             p_sum_2 += Y[k] ** 2
-            upper = p_sum_2 / Y[k + 1] ** 2 - 2. * p_sum / Y[k + 1] + k + 1
+            if (weights[k] == 2) and (ll == 0):
+                upper = p_sum_2 / Y[k] ** 2 - 2. * p_sum / Y[k] + kk + 1
+            else:
+                upper = p_sum_2 / Y[k + 1] ** 2 - 2. * p_sum / Y[k + 1] + kk + 1
             if lower <= (1. - l1_ratio) ** 2 / l1_ratio ** 2 < upper:
                 j = kk + 1
                 exit = True

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -941,10 +941,9 @@ def dgap_l21l1(M, G, Z, active_set, alpha_space, alpha_time, phi, phiT, shape,
        gradient methods", Physics in Medicine and Biology, 2012.
        https://doi.org/10.1088/0031-9155/57/7/1937
 
-    .. [2] J. Wang, J. Ye,
-       "Two-layer feature reduction for sparse-group lasso via decomposition of
-       convex sets", Advances in Neural Information Processing Systems (NIPS),
-       vol. 27, pp. 2132-2140, 2014.
+    .. [2] E. Ndiaye, O. Fercoq, A. Gramfort, J. Salmon,
+       "GAP Safe Screening Rules for Sparse-Group Lasso", Advances in Neural
+       Information Processing Systems (NIPS), 2016.
     """
     X = phiT(Z)
     GX = np.dot(G[:, active_set], X)

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -123,13 +123,14 @@ def test_mxne_inverse():
     assert_equal(stc.vertices, [[63152], [79017]])
 
     # Do with TF-MxNE for test memory savings
-    alpha_space = 60.  # spatial regularization parameter
-    alpha_time = 1.  # temporal regularization parameter
+    alpha = 60.  # overall regularization parameter
+    l1_ratio = 0.01  # temporal regularization proportion
 
-    stc, _ = tf_mixed_norm(evoked, forward, cov, alpha_space, alpha_time,
+    stc, _ = tf_mixed_norm(evoked, forward, cov, None, None,
                            loose=loose, depth=depth, maxit=100, tol=1e-4,
                            tstep=4, wsize=16, window=0.1, weights=stc_dspm,
-                           weights_min=weights_min, return_residual=True)
+                           weights_min=weights_min, return_residual=True,
+                           alpha=alpha, l1_ratio=l1_ratio)
     assert_array_almost_equal(stc.times, evoked.times, 5)
     assert_true(stc.vertices[1][0] in label.vertices)
 
@@ -191,13 +192,12 @@ def test_mxne_vol_sphere():
     assert_true(np.abs(np.dot(dip_fit.ori[0], dip_mxne.ori[0])) > 0.99)
 
     # Do with TF-MxNE for test memory savings
-    alpha_space = 60.  # spatial regularization parameter
-    alpha_time = 1.  # temporal regularization parameter
+    alpha = 60.  # overall regularization parameter
+    l1_ratio = 0.01  # temporal regularization proportion
 
-    stc, _ = tf_mixed_norm(evoked, fwd, cov, alpha_space, alpha_time,
-                           maxit=3, tol=1e-4,
-                           tstep=16, wsize=32, window=0.1,
-                           return_residual=True)
+    stc, _ = tf_mixed_norm(evoked, fwd, cov, None, None,  maxit=3, tol=1e-4,
+                           tstep=16, wsize=32, window=0.1, alpha=alpha,
+                           l1_ratio=l1_ratio, return_residual=True)
     assert_true(isinstance(stc, VolSourceEstimate))
     assert_array_almost_equal(stc.times, evoked.times, 5)
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -134,6 +134,13 @@ def test_mxne_inverse():
     assert_array_almost_equal(stc.times, evoked.times, 5)
     assert_true(stc.vertices[1][0] in label.vertices)
 
+    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 101., 3.)
+    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 50, 101.)
+    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, None, None,
+                  alpha=101, l1_ratio=0.03)
+    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, None, None,
+                  alpha=50., l1_ratio=1.01)
+
 
 @pytest.mark.slowtest
 @testing.requires_testing_data

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -136,9 +136,11 @@ def test_mxne_inverse():
     assert_true(stc.vertices[1][0] in label.vertices)
 
     with warnings.catch_warnings(record=True) as w:
-      assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 101., 3.)
-      assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 50, 101.)
-      assert_true(len(w) == 2)
+        assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov,
+                      101., 3.)
+        assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov,
+                      50, 101.)
+        assert_true(len(w) == 2)
 
     assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, None, None,
                   alpha=101, l1_ratio=0.03)
@@ -206,7 +208,7 @@ def test_mxne_vol_sphere():
     alpha = 60.  # overall regularization parameter
     l1_ratio = 0.01  # temporal regularization proportion
 
-    stc, _ = tf_mixed_norm(evoked, fwd, cov, None, None,  maxit=3, tol=1e-4,
+    stc, _ = tf_mixed_norm(evoked, fwd, cov, maxit=3, tol=1e-4,
                            tstep=16, wsize=32, window=0.1, alpha=alpha,
                            l1_ratio=l1_ratio, return_residual=True)
     assert_true(isinstance(stc, VolSourceEstimate))

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -4,6 +4,7 @@
 # License: Simplified BSD
 
 import os.path as op
+import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from nose.tools import assert_true, assert_equal, assert_raises
@@ -134,8 +135,11 @@ def test_mxne_inverse():
     assert_array_almost_equal(stc.times, evoked.times, 5)
     assert_true(stc.vertices[1][0] in label.vertices)
 
-    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 101., 3.)
-    assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 50, 101.)
+    with warnings.catch_warnings(record=True) as w:
+      assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 101., 3.)
+      assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, 50, 101.)
+      assert_true(len(w) == 2)
+
     assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, None, None,
                   alpha=101, l1_ratio=0.03)
     assert_raises(ValueError, tf_mixed_norm, evoked, forward, cov, None, None,

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -122,7 +122,6 @@ def test_tf_mxne():
 
 def test_dgapl21l1():
     """Test duality gap for L21 + L1 regularization."""
-    l1_ratio = 0.3
     n_orient = 2
     M, G, active_set = _generate_tf_data()
     n_times = M.shape[1]
@@ -134,32 +133,33 @@ def test_dgapl21l1():
     phi = _Phi(wsize, tstep, n_coefs)
     phiT = _PhiT(tstep, n_freq, n_step, n_times)
 
-    alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient, n_freq)
-    alpha_space = (1. - l1_ratio) * alpha_max
-    alpha_time = l1_ratio * alpha_max
+    for l1_ratio in [0.1, 0.3, 0.5, 0.8]:
+        alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient, n_freq)
+        alpha_space = (1. - l1_ratio) * alpha_max
+        alpha_time = l1_ratio * alpha_max
 
-    Z = np.zeros([n_sources, n_coefs])
-    shape = (-1, n_step, n_freq)
-    # for alpha = alpha_max, Z = 0 is the solution so the associated dgap is 0
-    gap = dgap_l21l1(M, G, Z, np.ones(n_sources, dtype=bool),
-                     alpha_space, alpha_time, phi, phiT, shape, n_orient,
-                     -np.inf)[0]
+        Z = np.zeros([n_sources, n_coefs])
+        shape = (-1, n_step, n_freq)
+        # for alpha = alpha_max, Z = 0 is the solution so the dgap is 0
+        gap = dgap_l21l1(M, G, Z, np.ones(n_sources, dtype=bool),
+                         alpha_space, alpha_time, phi, phiT, shape, n_orient,
+                         -np.inf)[0]
 
-    assert_allclose(0., gap)
-    # check that solution for alpha smaller than alpha_max is non 0:
-    X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
-        M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
-        verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
-        wsize=wsize, return_gap=True)
-    assert_array_less(0, gap)
-    assert_array_less(1, len(active_set_hat_tf))
+        assert_allclose(0., gap)
+        # check that solution for alpha smaller than alpha_max is non 0:
+        X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
+            M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
+            verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
+            wsize=wsize, return_gap=True)
+        assert_array_less(0, gap)
+        assert_array_less(1, len(active_set_hat_tf))
 
-    X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
-        M, G, alpha_space / 10, alpha_time / 10, maxit=200, tol=1e-8,
-        verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
-        wsize=wsize, return_gap=True)
-    assert_array_less(0, gap)
-    assert_array_less(1, len(active_set_hat_tf))
+        X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
+            M, G, alpha_space / 10, alpha_time / 10, maxit=200, tol=1e-8,
+            verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
+            wsize=wsize, return_gap=True)
+        assert_array_less(0, gap)
+        assert_array_less(1, len(active_set_hat_tf))
 
 
 def test_tf_mxne_vs_mxne():

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -133,7 +133,7 @@ def test_dgapl21l1():
     phi = _Phi(wsize, tstep, n_coefs)
     phiT = _PhiT(tstep, n_freqs, n_steps, n_times)
 
-    for l1_ratio in [0.1, 0.3, 0.5, 0.8]:
+    for l1_ratio in [0.05, 0.1]:
         alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient)
         alpha_space = (1. - l1_ratio) * alpha_max
         alpha_time = l1_ratio * alpha_max
@@ -157,7 +157,7 @@ def test_dgapl21l1():
         assert_array_less(1, len(active_set_hat_tf))
 
         X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
-            M, G, alpha_space / 10, alpha_time / 10, maxit=200, tol=1e-8,
+            M, G, alpha_space / 5., alpha_time / 5., maxit=200, tol=1e-8,
             verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
             wsize=wsize, return_gap=True)
         assert_array_less(-1e-10, gap)

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -127,19 +127,19 @@ def test_dgapl21l1():
     n_times = M.shape[1]
     n_sources = G.shape[1]
     tstep, wsize = 4, 32
-    n_step = int(np.ceil(n_times / float(tstep)))
-    n_freq = wsize // 2 + 1
-    n_coefs = n_step * n_freq
+    n_steps = int(np.ceil(n_times / float(tstep)))
+    n_freqs = wsize // 2 + 1
+    n_coefs = n_steps * n_freqs
     phi = _Phi(wsize, tstep, n_coefs)
-    phiT = _PhiT(tstep, n_freq, n_step, n_times)
+    phiT = _PhiT(tstep, n_freqs, n_steps, n_times)
 
     for l1_ratio in [0.1, 0.3, 0.5, 0.8]:
-        alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient, n_freq)
+        alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient)
         alpha_space = (1. - l1_ratio) * alpha_max
         alpha_time = l1_ratio * alpha_max
 
         Z = np.zeros([n_sources, n_coefs])
-        shape = (-1, n_step, n_freq)
+        shape = (-1, n_steps, n_freqs)
         # for alpha = alpha_max, Z = 0 is the solution so the dgap is 0
         gap = dgap_l21l1(M, G, Z, np.ones(n_sources, dtype=bool),
                          alpha_space, alpha_time, phi, phiT, shape, n_orient,
@@ -151,14 +151,16 @@ def test_dgapl21l1():
             M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
             verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
             wsize=wsize, return_gap=True)
-        assert_array_less(0, gap)
+        assert_array_less(-1e-10, gap)
+        assert_array_less(gap, 1e-8)
         assert_array_less(1, len(active_set_hat_tf))
 
         X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
             M, G, alpha_space / 10, alpha_time / 10, maxit=200, tol=1e-8,
             verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
             wsize=wsize, return_gap=True)
-        assert_array_less(0, gap)
+        assert_array_less(-1e-10, gap)
+        assert_array_less(gap, 1e-8)
         assert_array_less(1, len(active_set_hat_tf))
 
 

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -151,6 +151,7 @@ def test_dgapl21l1():
             M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
             verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
             wsize=wsize, return_gap=True)
+        # allow possible small numerical errors (negative gap)
         assert_array_less(-1e-10, gap)
         assert_array_less(gap, 1e-8)
         assert_array_less(1, len(active_set_hat_tf))

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -122,7 +122,7 @@ def test_tf_mxne():
 
 def test_dgapl21l1():
     """Test duality gap for L21 + L1 regularization."""
-    l1_ratio = 0.7
+    l1_ratio = 0.8
     n_orient = 2
     M, G, active_set = _generate_tf_data()
     n_times = M.shape[1]
@@ -149,6 +149,13 @@ def test_dgapl21l1():
     # check that solution for alpha smaller than alpha_max is non 0:
     X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
         M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
+        verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
+        wsize=wsize, return_gap=True)
+    assert_array_less(0, gap)
+    assert_array_less(1, len(active_set_hat_tf))
+
+    X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
+        M, G, alpha_space / 10, alpha_time / 10, maxit=200, tol=1e-8,
         verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
         wsize=wsize, return_gap=True)
     assert_array_less(0, gap)

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -122,8 +122,8 @@ def test_tf_mxne():
 
 def test_dgapl21l1():
     """Test duality gap for L21 + L1 regularization."""
-    l2_ratio = 0.6
-    n_orient = 1
+    l1_ratio = 0.7
+    n_orient = 2
     M, G, active_set = _generate_tf_data()
     n_times = M.shape[1]
     n_sources = G.shape[1]
@@ -134,9 +134,9 @@ def test_dgapl21l1():
     phi = _Phi(wsize, tstep, n_coefs)
     phiT = _PhiT(tstep, n_freq, n_step, n_times)
 
-    alpha_max = norm_epsilon_inf(G, M, phi, l2_ratio, n_orient)
-    alpha_space = l2_ratio * alpha_max
-    alpha_time = (1. - l2_ratio) * alpha_max
+    alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient)
+    alpha_space = (1. - l1_ratio) * alpha_max
+    alpha_time = l1_ratio * alpha_max
 
     Z = np.zeros([n_sources, n_coefs])
     shape = (-1, n_step, n_freq)

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -122,7 +122,7 @@ def test_tf_mxne():
 
 def test_dgapl21l1():
     """Test duality gap for L21 + L1 regularization."""
-    l1_ratio = 0.8
+    l1_ratio = 0.3
     n_orient = 2
     M, G, active_set = _generate_tf_data()
     n_times = M.shape[1]
@@ -134,7 +134,7 @@ def test_dgapl21l1():
     phi = _Phi(wsize, tstep, n_coefs)
     phiT = _PhiT(tstep, n_freq, n_step, n_times)
 
-    alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient)
+    alpha_max = norm_epsilon_inf(G, M, phi, l1_ratio, n_orient, n_freq)
     alpha_space = (1. - l1_ratio) * alpha_max
     alpha_time = l1_ratio * alpha_max
 

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -10,7 +10,9 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 
 from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            tf_mixed_norm_solver,
-                                           iterative_mixed_norm_solver)
+                                           iterative_mixed_norm_solver,
+                                           norm_epsilon_inf, _Phi, _PhiT,
+                                           dgap_l21l1)
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -116,6 +118,41 @@ def test_tf_mxne():
         n_orient=1, tstep=4, wsize=32, return_gap=True)
     assert_array_less(gap_tfmxne, 1e-8)
     assert_array_equal(np.where(active_set_hat_tf)[0], active_set)
+
+
+def test_dgapl21l1():
+    """Test duality gap for L21 + L1 regularization."""
+    l2_ratio = 0.6
+    n_orient = 1
+    M, G, active_set = _generate_tf_data()
+    n_times = M.shape[1]
+    n_sources = G.shape[1]
+    tstep, wsize = 4, 32
+    n_step = int(np.ceil(n_times / float(tstep)))
+    n_freq = wsize // 2 + 1
+    n_coefs = n_step * n_freq
+    phi = _Phi(wsize, tstep, n_coefs)
+    phiT = _PhiT(tstep, n_freq, n_step, n_times)
+
+    alpha_max = norm_epsilon_inf(G, M, phi, l2_ratio, n_orient)
+    alpha_space = l2_ratio * alpha_max
+    alpha_time = (1. - l2_ratio) * alpha_max
+
+    Z = np.zeros([n_sources, n_coefs])
+    shape = (-1, n_step, n_freq)
+    # for alpha = alpha_max, Z = 0 is the solution so the associated dgap is 0
+    gap = dgap_l21l1(M, G, Z, np.ones(n_sources, dtype=bool),
+                     alpha_space, alpha_time, phi, phiT, shape, n_orient,
+                     -np.inf)[0]
+
+    assert_allclose(0., gap)
+    # check that solution for alpha smaller than alpha_max is non 0:
+    X_hat_tf, active_set_hat_tf, E, gap = tf_mixed_norm_solver(
+        M, G, alpha_space / 1.01, alpha_time / 1.01, maxit=200, tol=1e-8,
+        verbose=True, debias=False, n_orient=n_orient, tstep=tstep,
+        wsize=wsize, return_gap=True)
+    assert_array_less(0, gap)
+    assert_array_less(1, len(active_set_hat_tf))
 
 
 def test_tf_mxne_vs_mxne():


### PR DESCRIPTION
I've implemented the closed-form solution for the epsilon_inf norm (dual norm of L21 + L1), which allows us to compute alpha_max for TFMxNE in closed-form, as well as a tight scaling of residuals (current solution is only tight at optimum).

I have added one test, `test_dgapL21l1`, which currently fails as a negative dgap is returned. However, when I pick `l2_ratio = 0.5`, it passes. 
This probably means I have messed up between `alpha_space` and `alpha_time` at some point, or between `l2_ratio` and `1. - l2_ratio`

@agramfort @joewalter @yousrabk 