### PR TITLE
[MRG+1] topomap - clean channel names in info['bads'] 

### DIFF
--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -308,7 +308,10 @@ def test_plot_topomap():
 
     # Test excluding bads channels
     evoked_grad.info['bads'] += [evoked_grad.info['ch_names'][0]]
+    orig_bads = evoked_grad.info['bads']
     evoked_grad.plot_topomap(ch_type='grad', times=[0])
+    assert_array_equal(evoked_grad.info['bads'], orig_bads)
+    plt.close('all')
 
 
 def test_plot_tfr_topomap():

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -306,6 +306,10 @@ def test_plot_topomap():
     assert_array_equal(_find_peaks(evoked, 10), evoked.times[[1, 95]])
     assert_array_equal(_find_peaks(evoked, 1), evoked.times[95])
 
+    # Test excluding bads channels
+    evoked_grad.info['bads'] += [evoked_grad.info['ch_names'][0]]
+    evoked_grad.plot_topomap(ch_type='grad', times=[0])
+
 
 def test_plot_tfr_topomap():
     """Test plotting of TFR data."""

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -46,6 +46,7 @@ def _prepare_topo_plot(inst, ch_type, layout):
     clean_ch_names = _clean_names(info['ch_names'])
     for ii, this_ch in enumerate(info['chs']):
         this_ch['ch_name'] = clean_ch_names[ii]
+    info['bads'] = _clean_names(info['bads'])
     info._update_redundant()
     info._check_consistency()
 


### PR DESCRIPTION
plot_topomap currently cleans the channel names, but fails to clean info['bads'], so an exception is raised when info['bads'] is non empty.
