### PR TITLE
Checking paths in mne_freeviewer_bem_surfaces 

### DIFF
--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -88,6 +88,10 @@ def run():
     subjects_dir = options.subjects_dir
     method = options.method
 
+    if (subjects_dir is None or subject is None or 
+        not os.path.isdir(os.path.join( subjects_dir, subject))):
+        raise ValueError("Wrong path. Check subjects-dir or subject argument.")
+    
     freeview_bem_surfaces(subject, subjects_dir, method)
 
 

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -30,9 +30,12 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
-    if (subject is None or
-            not os.path.isdir(os.path.join(subjects_dir, subject))):
-        raise ValueError("Wrong path. Check subjects-dir or subject argument.")
+    if subject is None:
+        raise ValueError("subject argument is None.")
+    if not op.isdir(op.join(subjects_dir, subject)):
+        raise ValueError("Wrong path: '{}'. Check subjects-dir or"
+                         "subject argument.".format(op.join(subjects_dir,
+                                                            subject)))
 
     env = os.environ.copy()
     env['SUBJECT'] = subject

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -31,7 +31,7 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
     if (subject is None or
-        not os.path.isdir(os.path.join( subjects_dir, subject))):
+            not os.path.isdir(os.path.join(subjects_dir, subject))):
         raise ValueError("Wrong path. Check subjects-dir or subject argument.")
 
     env = os.environ.copy()
@@ -91,7 +91,7 @@ def run():
     subject = options.subject
     subjects_dir = options.subjects_dir
     method = options.method
-    
+
     freeview_bem_surfaces(subject, subjects_dir, method)
 
 

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -32,10 +32,12 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
 
     if subject is None:
         raise ValueError("subject argument is None.")
-    if not op.isdir(op.join(subjects_dir, subject)):
+
+    subject_dir = op.join(subjects_dir, subject)
+
+    if not op.isdir(subject_dir):
         raise ValueError("Wrong path: '{}'. Check subjects-dir or"
-                         "subject argument.".format(op.join(subjects_dir,
-                                                            subject)))
+                         "subject argument.".format(subject_dir))
 
     env = os.environ.copy()
     env['SUBJECT'] = subject
@@ -44,8 +46,8 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
     if 'FREESURFER_HOME' not in env:
         raise RuntimeError('The FreeSurfer environment needs to be set up.')
 
-    mri_dir = op.join(subjects_dir, subject, 'mri')
-    bem_dir = op.join(subjects_dir, subject, 'bem')
+    mri_dir = op.join(subject_dir, 'mri')
+    bem_dir = op.join(subject_dir, 'bem')
     mri = op.join(mri_dir, 'T1.mgz')
 
     if method == 'watershed':

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -30,6 +30,10 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
+    if (subject is None or
+        not os.path.isdir(os.path.join( subjects_dir, subject))):
+        raise ValueError("Wrong path. Check subjects-dir or subject argument.")
+
     env = os.environ.copy()
     env['SUBJECT'] = subject
     env['SUBJECTS_DIR'] = subjects_dir
@@ -87,10 +91,6 @@ def run():
     subject = options.subject
     subjects_dir = options.subjects_dir
     method = options.method
-
-    if (subjects_dir is None or subject is None or 
-        not os.path.isdir(os.path.join( subjects_dir, subject))):
-        raise ValueError("Wrong path. Check subjects-dir or subject argument.")
     
     freeview_bem_surfaces(subject, subjects_dir, method)
 


### PR DESCRIPTION
While calling from command line `mne freeviewer_bem_surfaces` and given wrong path or no arguments, I receive error:
```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

which is not very informative. This PR aims to deal with that by checking if path was specified and whether it exists.