### PR TITLE
[WIP] Refactor and extend cross-spectral density (CSD) functionality

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -340,6 +340,7 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
     auto_examples/time_frequency/plot_temporal_whitening.rst
     auto_examples/time_frequency/plot_time_frequency_global_field_power.rst
     auto_examples/time_frequency/plot_time_frequency_simulated.rst
+    auto_examples/time_frequency/plot_compute_csd.rst
 
 .. raw:: html
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -808,6 +808,7 @@ Time-Frequency
 
    AverageTFR
    EpochsTFR
+   CrossSpectralDensity
 
 Functions that operate on mne-python objects:
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -237,6 +237,7 @@ Visualization
    plot_bem
    plot_connectivity_circle
    plot_cov
+   plot_csd
    plot_dipole_amplitudes
    plot_dipole_locations
    plot_drop_log
@@ -814,16 +815,17 @@ Functions that operate on mne-python objects:
    :toctree: generated/
    :template: function.rst
 
-   csd_epochs
+   csd_fourier
+   csd_multitaper
+   csd_morlet
+   pick_channels_csd
+   read_csd
+   fit_iir_model_raw
    psd_welch
    psd_multitaper
-   fit_iir_model_raw
    tfr_morlet
    tfr_multitaper
    tfr_stockwell
-   tfr_array_morlet
-   tfr_array_multitaper
-   tfr_array_stockwell
    read_tfrs
    write_tfrs
 
@@ -833,7 +835,9 @@ Functions that operate on ``np.ndarray`` objects:
    :toctree: generated/
    :template: function.rst
 
-   csd_array
+   csd_array_fourier
+   csd_array_multitaper
+   csd_array_morlet
    dpss_windows
    morlet
    stft
@@ -841,6 +845,9 @@ Functions that operate on ``np.ndarray`` objects:
    stftfreq
    psd_array_multitaper
    psd_array_welch
+   tfr_array_morlet
+   tfr_array_multitaper
+   tfr_array_stockwell
 
 
 :py:mod:`mne.time_frequency.tfr`:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,8 @@ Changelog
 
 - Add support for reading Eximia files by `Eric Larson`_ and `Federico Raimondo`_
 
+- Add :func:`mne.time_frequency.csd_morlet` and :func:`mne.time_frequency.csd_array_morlet` to estimate cross-spectral density using Morlet wavelets, by `Marijn van Vliet`_
+
 Bug
 ~~~
 
@@ -156,6 +158,10 @@ API
 - Changed the line width in :func:`mne.viz.plot_bem` from 2.0 to 1.0 for better visibility of underlying structures, by `Eric Larson`_
 
 - Changed the behavior of :meth:`mne.io.Raw.pick_channels` and similar methods to be consistent with :func:`mne.pick_channels` to treat channel list as a set (ignoring order) -- if reordering is necessary use ``inst.reorder_channels``, by `Eric Larson`_
+
+- :func:`mne.time_frequency.csd_epochs` has been refactored into :func:`mne.time_frequency.csd_fourier` and :func:`mne.time_frequency.csd_multitaper`, by `Marijn van Vliet`_
+
+- :func:`mne.time_frequency.csd_array` has been refactored into :func:`mne.time_frequency.csd_array_fourier` and :func:`mne.time_frequency.csd_array_multitaper`, by `Marijn van Vliet`_
 
 .. _changes_0_15:
 

--- a/examples/inverse/plot_dics_beamformer.py
+++ b/examples/inverse/plot_dics_beamformer.py
@@ -13,7 +13,7 @@ References
        interactions in the human brain. PNAS (2001) vol. 98 (2) pp. 694-699
 """
 # Author: Roman Goj <roman.goj@gmail.com>
-#
+#         Marijn van Vliet <w.m.vanvliet@gmail.com>
 # License: BSD (3-clause)
 
 import mne
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from mne.datasets import sample
-from mne.time_frequency import csd_epochs
+from mne.time_frequency import csd_multitaper
 from mne.beamformer import dics
 
 print(__doc__)
@@ -55,13 +55,15 @@ evoked = epochs.average()
 # Read forward operator
 forward = mne.read_forward_solution(fname_fwd)
 
-# Computing the data and noise cross-spectral density matrices
-# The time-frequency window was chosen on the basis of spectrograms from
-# example time_frequency/plot_time_frequency.py
-data_csd = csd_epochs(epochs, mode='multitaper', tmin=0.04, tmax=0.15,
-                      fmin=6, fmax=10)
-noise_csd = csd_epochs(epochs, mode='multitaper', tmin=-0.11, tmax=0.0,
-                       fmin=6, fmax=10)
+# Computing the data and noise cross-spectral density matrices using
+# multitapers. The time-frequency window was chosen on the basis of
+# spectrograms from example time_frequency/plot_time_frequency.py
+data_csd = csd_multitaper(epochs, tmin=0.04, tmax=0.15, fmin=6, fmax=10)
+noise_csd = csd_multitaper(epochs, tmin=-0.11, tmax=0.0, fmin=6, fmax=10)
+
+# Average the CSDs across the frequencies
+data_csd = data_csd.mean()
+noise_csd = noise_csd.mean()
 
 evoked = epochs.average()
 

--- a/examples/inverse/plot_tf_dics.py
+++ b/examples/inverse/plot_tf_dics.py
@@ -13,13 +13,13 @@ References
        NeuroImage (2008) vol. 40 (4) pp. 1686-1700
 """
 # Author: Roman Goj <roman.goj@gmail.com>
-#
+#         Marijn van Vliet <w.m.vanvliet@gmail.com>
 # License: BSD (3-clause)
 
 import mne
 from mne.event import make_fixed_length_events
 from mne.datasets import sample
-from mne.time_frequency import csd_epochs
+from mne.time_frequency import csd_fourier
 from mne.beamformer import tf_dics
 from mne.viz import plot_source_spectrogram
 
@@ -106,10 +106,10 @@ subtract_evoked = False
 # from the baseline period in the data, change epochs_noise to epochs
 noise_csds = []
 for freq_bin, win_length, n_fft in zip(freq_bins, win_lengths, n_ffts):
-    noise_csd = csd_epochs(epochs_noise, mode='fourier',
-                           fmin=freq_bin[0], fmax=freq_bin[1],
-                           fsum=True, tmin=-win_length, tmax=0,
-                           n_fft=n_fft)
+    noise_csd = csd_fourier(epochs_noise, fmin=freq_bin[0], fmax=freq_bin[1],
+                            tmin=-win_length, tmax=0, n_fft=n_fft)
+    # Sum the noise CSD across the frequencies in the bin
+    noise_csd = noise_csd.sum()
     noise_csds.append(noise_csd)
 
 # Computing DICS solutions for time-frequency windows in a label in source

--- a/examples/time_frequency/plot_compute_csd.py
+++ b/examples/time_frequency/plot_compute_csd.py
@@ -77,11 +77,12 @@ csd_wav = csd_morlet(epochs, frequencies, decim=10, n_jobs=n_jobs)
 ###############################################################################
 # The resulting :class:`mne.time_frequency.CrossSpectralDensity` objects have a
 # plotting function we can use to compare the results of the different methods.
-csd_fft.plot()
-plt.suptitle('CSDs computed using short-term Fourier transform')
+# We're plotting the mean CSD across frequencies.
+csd_fft.mean().plot()
+plt.suptitle('short-term Fourier transform')
 
-csd_mt.plot()
-plt.suptitle('CSDs computed using adaptive multitapers')
+csd_mt.mean().plot()
+plt.suptitle('adaptive multitapers')
 
-csd_wav.plot()
-plt.suptitle('CSDs computed using Morlet wavelet transform')
+csd_wav.mean().plot()
+plt.suptitle('Morlet wavelet transform')

--- a/examples/time_frequency/plot_compute_csd.py
+++ b/examples/time_frequency/plot_compute_csd.py
@@ -1,0 +1,87 @@
+"""
+==================================================
+Compute a cross-spectral density (CSD) matrix
+==================================================
+
+A cross-spectral density (CSD) matrix is similar to a covariance matrix, but in
+the time-frequency domain. It is the first step towards computing
+sensor-to-sensor coherence or a DICS beamformer.
+
+This script demonstrates the three methods that MNE-Python provides to compute
+the CSD:
+
+1. Using short-term Fourier transform: :func:`mne.time_frequency.csd_fourier`
+2. Using a multitaper approach: :func:`mne.time_frequency.csd_multitaper`
+3. Using Morlet wavelets: :func:`mne.time_frequency.csd_morlet`
+"""
+# Author: Marijn van Vliet <w.m.vanvliet@gmail.com>
+# License: BSD (3-clause)
+from matplotlib import pyplot as plt
+
+import mne
+from mne.datasets import sample
+from mne.time_frequency import csd_fourier, csd_multitaper, csd_morlet
+
+print(__doc__)
+
+###############################################################################
+# In the following example, the computation of the CSD matrices can be
+# performed using multiple cores. Set ``n_jobs`` to a value >1 to select the
+# number of cores to use.
+n_jobs = 1
+
+###############################################################################
+# Loading the sample dataset.
+data_path = sample.data_path()
+fname_raw = data_path + '/MEG/sample/sample_audvis_raw.fif'
+fname_event = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
+raw = mne.io.read_raw_fif(fname_raw)
+events = mne.read_events(fname_event)
+
+###############################################################################
+# By default, CSD matrices are computed using all MEG/EEG channels. When
+# interpreting a CSD matrix with mixed sensor types, be aware that the
+# measurement units, and thus the scalings, differ across sensors. In this
+# example, for speed and clarity, we select a single channel type:
+# gradiometers.
+picks = mne.pick_types(raw.info, meg='grad')
+
+# Make some epochs, based on events with trigger code 1
+epochs = mne.Epochs(raw, events, event_id=1, tmin=0, tmax=1,
+                    picks=picks, baseline=(None, 0),
+                    reject=dict(grad=4000e-13), preload=True)
+
+###############################################################################
+# Computing CSD matrices using short-term Fourier transform and (adaptive)
+# multitapers is straightforward:
+csd_fft = csd_fourier(epochs, fmin=15, fmax=20, n_jobs=n_jobs)
+csd_mt = csd_multitaper(epochs, fmin=15, fmax=20, adaptive=True, n_jobs=n_jobs)
+
+###############################################################################
+# When computing the CSD with Morlet wavelets, you specify the exact
+# frequencies at which to compute it. For each frequency, a corresponding
+# wavelet will be constructed and convolved with the signal, resulting in a
+# time-frequency decomposition.
+#
+# The CSD is constructed by computing the correlation between the
+# time-frequency representations between all sensor-to-sensor pairs. The
+# time-frequency decomposition originally has the same sampling rate as the
+# signal, in our case ~600Hz. This means the decomposition is over-specified in
+# time and we may not need to use all samples during our CSD computation, just
+# enough to get a reliable correlation statistic. By specifying ``decim=10``,
+# we use every 10th sample, which will greatly speed up the computation and
+# will have a minimal effect on the CSD.
+frequencies = [16, 17, 18, 19, 20]
+csd_wav = csd_morlet(epochs, frequencies, decim=10, n_jobs=n_jobs)
+
+###############################################################################
+# The resulting :class:`mne.time_frequency.CrossSpectralDensity` objects have a
+# plotting function we can use to compare the results of the different methods.
+csd_fft.plot()
+plt.suptitle('CSDs computed using short-term Fourier transform')
+
+csd_mt.plot()
+plt.suptitle('CSDs computed using adaptive multitapers')
+
+csd_wav.plot()
+plt.suptitle('CSDs computed using Morlet wavelet transform')

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -7,13 +7,12 @@
 from copy import deepcopy
 
 import numpy as np
-from scipy import linalg
 
 from ..utils import logger, verbose, warn
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc
-from ..time_frequency import CrossSpectralDensity, csd_epochs
+from ..time_frequency import csd_fourier, csd_multitaper
 from ._lcmv import _prepare_beamformer_input, _setup_picks, _reg_pinv
 from ..externals import six
 
@@ -23,10 +22,17 @@ def _apply_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
                 label=None, picks=None, pick_ori=None, real_filter=False,
                 verbose=None):
     """Dynamic Imaging of Coherent Sources (DICS)."""
+    from scipy import linalg  # Local import to keep 'import mne' fast
+
+    if len(noise_csd.frequencies) > 1 or len(data_csd.frequencies) > 1:
+        raise ValueError('CSD matrix object should only contain one '
+                         'frequency.')
+
     is_free_ori, _, proj, vertno, G =\
         _prepare_beamformer_input(info, forward, label, picks, pick_ori)
 
-    Cm = data_csd.data.copy()
+    Cm = data_csd.get_data(index=0)
+    Cm_noise = noise_csd.get_data(index=0)
 
     # Take real part of Cm to compute real filters
     if real_filter:
@@ -48,10 +54,6 @@ def _apply_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
         Gk = G[:, n_orient * k: n_orient * k + n_orient]
         Ck = np.dot(Wk, Gk)
 
-        # TODO: max-power is not implemented yet, however DICS does employ
-        # orientation picking when one eigen value is much larger than the
-        # other
-
         if is_free_ori:
             # Free source orientation
             Wk[:] = np.dot(linalg.pinv(Ck, 0.1), Wk)
@@ -60,7 +62,7 @@ def _apply_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
             Wk /= Ck
 
         # Noise normalization
-        noise_norm = np.dot(np.dot(Wk.conj(), noise_csd.data), Wk.T)
+        noise_norm = np.dot(np.dot(Wk.conj(), Cm_noise), Wk.T)
         noise_norm = np.abs(noise_norm).trace()
         Wk /= np.sqrt(noise_norm)
 
@@ -276,12 +278,12 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
         Measurement info, e.g. epochs.info.
     forward : dict
         Forward operator.
-    noise_csds : instance or list of instances of CrossSpectralDensity
-        The noise cross-spectral density matrix for a single frequency or a
-        list of matrices for multiple frequencies.
-    data_csds : instance or list of instances of CrossSpectralDensity
-        The data cross-spectral density matrix for a single frequency or a list
-        of matrices for multiple frequencies.
+    noise_csds : CrossSpectralDensity
+        The noise cross-spectral density matrices for a single frequency or
+        multiple frequencies.
+    data_csds : CrossSpectralDensity
+        The data cross-spectral density matrix for a frequency or multiple
+        frequencies.
     reg : float
         The regularization for the cross-spectral density.
     label : Label | None
@@ -307,44 +309,28 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
     Gross et al. Dynamic imaging of coherent sources: Studying neural
     interactions in the human brain. PNAS (2001) vol. 98 (2) pp. 694-699
     """
-    if isinstance(data_csds, CrossSpectralDensity):
-        data_csds = [data_csds]
-
-    if isinstance(noise_csds, CrossSpectralDensity):
-        noise_csds = [noise_csds]
-
-    def csd_shapes(x):
-        return tuple(c.data.shape for c in x)
-
-    if (csd_shapes(data_csds) != csd_shapes(noise_csds) or
-       any(len(set(csd_shapes(c))) > 1 for c in [data_csds, noise_csds])):
+    from scipy import linalg
+    if data_csds.n_channels != noise_csds.n_channels:
         raise ValueError('One noise CSD matrix should be provided for each '
                          'data CSD matrix and vice versa. All CSD matrices '
                          'should have identical shape.')
 
-    frequencies = []
-    for data_csd, noise_csd in zip(data_csds, noise_csds):
-        if not np.allclose(data_csd.freqs, noise_csd.freqs):
-            raise ValueError('Data and noise CSDs should be calculated at '
-                             'identical frequencies')
+    if not np.allclose(data_csds.frequencies, noise_csds.frequencies):
+        raise ValueError('Data and noise CSDs should be calculated at '
+                         'identical frequencies')
 
-        # If CSD is summed over multiple frequencies, take the average
-        # frequency
-        if(len(data_csd.freqs) > 1):
-            frequencies.append(np.mean(data_csd.freqs))
-        else:
-            frequencies.append(data_csd.freqs[0])
+    # If CSD is summed over multiple frequencies, take the average frequency
+    frequencies = [np.mean(dfreq) for dfreq in data_csds.frequencies]
+    n_freqs = len(frequencies)
     fmin = frequencies[0]
 
-    if len(frequencies) > 2:
-        fstep = []
-        for i in range(len(frequencies) - 1):
-            fstep.append(frequencies[i + 1] - frequencies[i])
-        if not np.allclose(fstep, np.mean(fstep), 1e-5):
+    if n_freqs > 2:
+        fstep = np.diff(frequencies)
+        if np.var(fstep) > 1e-5:
             warn('Uneven frequency spacing in CSD object, frequencies in the '
                  'resulting stc file will be inaccurate.')
         fstep = fstep[0]
-    elif len(frequencies) > 1:
+    elif n_freqs > 1:
         fstep = frequencies[1] - frequencies[0]
     else:
         fstep = 1  # dummy value
@@ -357,16 +343,15 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
 
     n_orient = 3 if is_free_ori else 1
     n_sources = G.shape[1] // n_orient
-    source_power = np.zeros((n_sources, len(data_csds)))
-    n_csds = len(data_csds)
+    source_power = np.zeros((n_sources, n_freqs))
 
     logger.info('Computing DICS source power...')
-    for i, (data_csd, noise_csd) in enumerate(zip(data_csds, noise_csds)):
-        if n_csds > 1:
+    for i in range(n_freqs):
+        if n_freqs > 1:
             logger.info('    computing DICS spatial filter %d out of %d' %
-                        (i + 1, n_csds))
+                        (i + 1, n_freqs))
 
-        Cm = data_csd.data.copy()
+        Cm = data_csds.get_data(index=i)
 
         # Take real part of Cm to compute real filters
         if real_filter:
@@ -380,6 +365,12 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
 
         # Compute spatial filters
         W = np.dot(G.T, Cm_inv)
+
+        # Make new copies of the CSDs that are not converted to real values
+        data_Cm = data_csds.get_data(index=i)
+        noise_Cm = noise_csds.get_data(index=i)
+
+        # Apply spatial filters to CSDs
         for k in range(n_sources):
             Wk = W[n_orient * k: n_orient * k + n_orient]
             Gk = G[:, n_orient * k: n_orient * k + n_orient]
@@ -393,11 +384,11 @@ def dics_source_power(info, forward, noise_csds, data_csds, reg=0.05,
                 Wk /= Ck
 
             # Noise normalization
-            noise_norm = np.dot(np.dot(Wk.conj(), noise_csd.data), Wk.T)
+            noise_norm = np.dot(np.dot(Wk.conj(), noise_Cm), Wk.T)
             noise_norm = np.abs(noise_norm).trace()
 
             # Calculating source power
-            sp_temp = np.dot(np.dot(Wk.conj(), data_csd.data), Wk.T)
+            sp_temp = np.dot(np.dot(Wk.conj(), data_Cm), Wk.T)
             sp_temp /= max(noise_norm, 1e-40)  # Avoid division by 0
 
             if pick_ori == 'normal':
@@ -534,7 +525,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
 
         # Scale noise CSD to allow data and noise CSDs to have different length
         noise_csd = deepcopy(noise_csd)
-        noise_csd.data /= noise_csd.n_fft
+        noise_csd._data /= noise_csd.n_fft
 
         sol_single = []
         sol_overlap = []
@@ -564,14 +555,24 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
                 win_tmax = win_tmax + 1e-10
 
                 # Calculating data CSD in current time window
-                data_csd = csd_epochs(
-                    epochs, mode=mode, fmin=freq_bin[0], fmax=freq_bin[1],
-                    fsum=True, tmin=win_tmin, tmax=win_tmax, n_fft=n_fft,
-                    mt_bandwidth=mt_bandwidth, mt_low_bias=mt_low_bias)
+                if mode == 'fourier':
+                    data_csd = csd_fourier(
+                        epochs, fmin=freq_bin[0], fmax=freq_bin[1],
+                        tmin=win_tmin, tmax=win_tmax, n_fft=n_fft)
+                elif mode == 'multitaper':
+                    data_csd = csd_multitaper(
+                        epochs, fmin=freq_bin[0], fmax=freq_bin[1],
+                        tmin=win_tmin, tmax=win_tmax, n_fft=n_fft,
+                        mt_bandwidth=mt_bandwidth, mt_low_bias=mt_low_bias)
+                else:
+                    raise ValueError('Invalid mode, choose either '
+                                     "'fourier' or 'multitaper'")
+
+                data_csd = data_csd.sum()
 
                 # Scale data CSD to allow data and noise CSDs to have different
                 # length
-                data_csd.data /= data_csd.n_fft
+                data_csd._data /= data_csd.n_fft
 
                 stc = dics_source_power(
                     epochs.info, forward, noise_csd, data_csd, reg=reg,

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -3,7 +3,10 @@
 from .tfr import (morlet, tfr_morlet, AverageTFR, tfr_multitaper,
                   read_tfrs, write_tfrs, EpochsTFR, tfr_array_morlet)
 from .psd import psd_welch, psd_multitaper, psd_array_welch
-from .csd import CrossSpectralDensity, csd_epochs, csd_array
+from .csd import (CrossSpectralDensity, csd_fourier, csd_multitaper,
+                  csd_morlet, csd_array_fourier, csd_array_multitaper,
+                  csd_array_morlet, csd_epochs, csd_array, read_csd,
+                  pick_channels_csd)
 from .ar import fit_iir_model_raw
 from .multitaper import (dpss_windows, psd_array_multitaper,
                          tfr_array_multitaper)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -1,56 +1,512 @@
-# Author: Roman Goj <roman.goj@gmail.com>
+# -*- coding: utf-8 -*-
+# Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
+#          Susanna Aro <susanna.aro@aalto.fi>
+#          Roman Goj <roman.goj@gmail.com>
 #
 # License: BSD (3-clause)
 
 import copy as cp
+import numbers
 
 import numpy as np
-
-from ..io.pick import pick_types
-from ..utils import logger, verbose, warn
+from .tfr import cwt, morlet
+from ..io.pick import pick_channels
+from ..utils import (logger, verbose, warn, copy_function_doc_to_method_doc,
+                     deprecated)
+from ..viz.misc import plot_csd
 from ..time_frequency.multitaper import (dpss_windows, _mt_spectra,
                                          _csd_from_mt, _psd_from_mt_adaptive)
-
-from ..externals.six.moves import xrange as range
+from ..parallel import parallel_func
+from ..externals.h5io import read_hdf5, write_hdf5
 
 
 class CrossSpectralDensity(object):
     """Cross-spectral density.
 
+    Given a list of time series, the CSD matrix denotes for each pair of time
+    series, the cross-spectral density. This matrix is symmetric and internally
+    stored as a vector.
+
+    This object can store multiple CSD matrices: one for each frequency.
+    Use ``.get_data(freq)`` to obtain an CSD matrix as an ndarray.
+
     Parameters
     ----------
-    data : array of shape (n_channels, n_channels)
-        The cross-spectral density matrix.
+    data : ndarray, shape ((n_channels**2 + n_channels) / 2, n_frequencies)
+        For each frequency, the cross-spectral density matrix in vector format.
     ch_names : list of string
-        List of channels' names.
-    projs :
-        List of projectors used in CSD calculation.
-    bads :
-        List of bad channels.
-    freqs : float | list of float
-        Frequency or frequencies for which the CSD matrix was calculated. If a
-        list is passed, data is a sum across CSD matrices for all frequencies.
+        List of string names for each channel.
+    tmin : float
+        Start of the time window for which CSD was calculated in seconds.
+    tmax : float
+        End of the time window for which CSD was calculated in seconds.
+    frequencies : float | list of float | list of list of float
+        Frequency or frequencies for which the CSD matrix was calculated. When
+        averaging across frequencies (see the :func:`CrossSpectralDensity.mean`
+        function), this will be a list of lists that contains for each
+        frequency bin, the frequencies that were averaged. Frequencies should
+        always be sorted.
     n_fft : int
-        Length of the FFT used when calculating the CSD matrix.
+        The number of FFT points or samples that have been used in the
+        computation of this CSD.
+    projs : list of Projection | None
+        List of projectors to apply to timeseries data when using this CSD
+        object to compute a DICS beamformer. Defaults to ``None``, which means
+        no projectors will be applied.
+
+    See Also
+    --------
+    csd_epochs
+    csd_array
     """
 
-    def __init__(self, data, ch_names, projs, bads, freqs,
-                 n_fft):  # noqa: D102
-        self.data = data
-        self.dim = len(data)
-        self.ch_names = cp.deepcopy(ch_names)
-        self.projs = cp.deepcopy(projs)
-        self.bads = cp.deepcopy(bads)
-        self.freqs = np.atleast_1d(np.copy(freqs))
+    def __init__(self, data, ch_names, tmin, tmax, frequencies, n_fft,
+                 projs=None):
+        data = np.asarray(data)
+        if data.ndim == 1:
+            data = data[:, np.newaxis]
+        elif data.ndim > 2:
+            raise ValueError('`data` should be either a 1D or 2D array.')
+        self._data = data
+
+        if len(ch_names) != _n_dims_from_triu(len(data)):
+            raise ValueError('Number of ch_names does not match the number of '
+                             'time series in the CSD matrix.')
+        self.ch_names = ch_names
+        self.tmin = tmin
+        self.tmax = tmax
+
+        if isinstance(frequencies, numbers.Number):
+            frequencies = [frequencies]
+        if len(frequencies) != data.shape[1]:
+            raise ValueError('Number of frequencies does not match the number '
+                             'of CSD matrices in the data array (%d != %d).' %
+                             (len(frequencies), data.shape[1]))
+        self.frequencies = frequencies
+
         self.n_fft = n_fft
+        self.projs = cp.deepcopy(projs)
+
+    @property
+    def n_channels(self):
+        """Number of time series defined in this CSD object."""
+        return len(self.ch_names)
+
+    @property
+    def is_sum(self):
+        """Whether the CSD matrix represents a sum (or average) of freqs."""
+        # If the CSD is an average, the frequencies will be stored as a list
+        # of lists (or like-like objects) instead of plain numbers.
+        return not isinstance(self.frequencies[0], numbers.Number)
 
     def __repr__(self):  # noqa: D105
-        s = 'frequencies : %s' % self.freqs
-        s += ', size : %s x %s' % self.data.shape
-        s += ', data : %s' % self.data
-        return '<CrossSpectralDensity  |  %s>' % s
+        # Make a pretty string representation of the frequencies
+        freq_strs = []
+        for f in self.frequencies:
+            if isinstance(f, numbers.Number):
+                freq_strs.append(str(f))
+            elif len(f) == 1:
+                freq_strs.append(str(f[0]))
+            else:
+                freq_strs.append('{}-{}'.format(np.min(f), np.max(f)))
+        freq_str = ', '.join(freq_strs) + ' Hz.'
+
+        return (
+            '<CrossSpectralDensity  |  '
+            'n_channels={}, time={} to {} s, frequencies={}>'
+        ).format(self.n_channels, self.tmin, self.tmax, freq_str)
+
+    def sum(self, fmin=None, fmax=None):
+        """Calculate the sum CSD in the given frequency range(s).
+
+        If the exact given frequencies are not available, the nearest
+        frequencies will be chosen.
+
+        Parameters
+        ----------
+        fmin : float | list of float | None
+            Lower bound of the frequency range in Hertz. Defaults to the lowest
+            frequency available. When a list of frequencies is given, these are
+            used as the lower bounds (inclusive) of frequency bins and the sum
+            is taken for each bin.
+        fmax : float | list of float | None
+            Upper bound of the frequency range in Hertz. Defaults to the
+            highest frequency available. When a list of frequencies is given,
+            these are used as the upper bounds (inclusive) of frequency bins
+            and the sum is taken for each bin.
+
+        Returns
+        -------
+        csd : Instance of CrossSpectralDensity
+            The CSD matrix, summed across the given frequency range(s).
+        """
+        if self.is_sum:
+            raise RuntimeError('This CSD matrix already represents a mean or '
+                               'sum across frequencies.')
+
+        # Deal with the various ways in which fmin and fmax can be specified
+        if fmin is None and fmax is None:
+            fmin = [self.frequencies[0]]
+            fmax = [self.frequencies[-1]]
+        else:
+            if isinstance(fmin, numbers.Number):
+                fmin = [fmin]
+            if isinstance(fmax, numbers.Number):
+                fmax = [fmax]
+            if fmin is None:
+                fmin = [self.frequencies[0]] * len(fmax)
+            if fmax is None:
+                fmax = [self.frequencies[-1]] * len(fmin)
+
+        if any(fmin_ > fmax_ for fmin_, fmax_ in zip(fmin, fmax)):
+            raise ValueError('Some lower bounds are higher than the '
+                             'corresponding upper bounds.')
+
+        # Find the index of the lower bound of each frequency bin
+        fmin_inds = [self._get_frequency_index(f) for f in fmin]
+        fmax_inds = [self._get_frequency_index(f) + 1 for f in fmax]
+
+        if len(fmin_inds) != len(fmax_inds):
+            raise ValueError('The length of fmin does not match the '
+                             'length of fmax.')
+
+        # Sum across each frequency bin
+        n_bins = len(fmin_inds)
+        new_data = np.zeros((self._data.shape[0], n_bins),
+                            dtype=self._data.dtype)
+        new_frequencies = []
+        for i, (min_ind, max_ind) in enumerate(zip(fmin_inds, fmax_inds)):
+            new_data[:, i] = self._data[:, min_ind:max_ind].sum(axis=1)
+            new_frequencies.append(self.frequencies[min_ind:max_ind])
+
+        csd_out = CrossSpectralDensity(data=new_data, ch_names=self.ch_names,
+                                       tmin=self.tmin, tmax=self.tmax,
+                                       frequencies=new_frequencies,
+                                       n_fft=self.n_fft)
+        return csd_out
+
+    def mean(self, fmin=None, fmax=None):
+        """Calculate the mean CSD in the given frequency range(s).
+
+        Parameters
+        ----------
+        fmin : float | list of float | None
+            Lower bound of the frequency range in Hertz. Defaults to the lowest
+            frequency available. When a list of frequencies is given, these are
+            used as the lower bounds (inclusive) of frequency bins and the mean
+            is taken for each bin.
+        fmax : float | list of float | None
+            Upper bound of the frequency range in Hertz. Defaults to the
+            highest frequency available. When a list of frequencies is given,
+            these are used as the upper bounds (inclusive) of frequency bins
+            and the mean is taken for each bin.
+
+        Returns
+        -------
+        csd : Instance of CrossSpectralDensity
+            The CSD matrix, averaged across the given frequency range(s).
+        """
+        csd = self.sum(fmin, fmax)
+        for i, f in enumerate(csd.frequencies):
+            csd._data[:, i] /= len(f)
+        return csd
+
+    def _get_frequency_index(self, freq):
+        """Find the index of the given frequency in ``self.frequencies``.
+
+        If the exact given frequency is not available, the nearest frequencies
+        will be chosen, up to a difference of 1 Hertz.
+
+        Parameters
+        ----------
+        freq : float
+            The frequency to find the index for
+
+        Returns
+        -------
+        index : int
+            The index of the frequency nearest to the requested frequency.
+        """
+        if self.is_sum:
+            raise ValueError('This CSD object represents a mean across '
+                             'frequencies. Cannot select a specific '
+                             'frequency.')
+
+        distance = np.abs(np.asarray(self.frequencies) - freq)
+        index = np.argmin(distance)
+        min_dist = distance[index]
+        if min_dist > 1:
+            raise IndexError('Frequency %f is not available.' % freq)
+        return index
+
+    def pick_frequency(self, freq=None, index=None):
+        """Get a CrossSpectralDensity object with only the given frequency.
+
+        Parameters
+        ----------
+        freq : float | None
+            Return the CSD matrix for a specific frequency. Only available
+            when no averaging across frequencies has been done.
+        index : int | None
+            Return the CSD matrix for the frequency or frequency-bin with the
+            given index.
+
+        Returns
+        -------
+        csd : instance of CrossSpectralDensity
+            A CSD object containing a single CSD matrix that corresponds to the
+            requested frequency or frequency-bin.
+
+        See Also
+        --------
+        get_data
+        """
+        if freq is None and index is None:
+            raise ValueError('Use either the "freq" or "index" parameter to '
+                             'select the desired frequency.')
+
+        elif freq is not None:
+            if index is not None:
+                raise ValueError('Cannot specify both a frequency and index.')
+
+            index = self._get_frequency_index(freq)
+
+        return self[index]
+
+    def get_data(self, frequency=None, index=None):
+        """Get the CSD matrix for a given frequency as NumPy array.
+
+        If there is only one matrix defined in the CSD object, calling this
+        method without any parameters will return it. If multiple matrices are
+        defined, use either the ``frequency`` or ``index`` parameter to select
+        one.
+
+        Parameters
+        ----------
+        frequency : float | None
+            Return the CSD matrix for a specific frequency. Only available when
+            no averaging across frequencies has been done.
+        index : int | None
+            Return the CSD matrix for the frequency or frequency-bin with the
+            given index.
+
+        Returns
+        -------
+        csd : ndarray, shape (n_channels, n_channels)
+            The CSD matrix corresponding to the requested frequency.
+
+        See Also
+        --------
+        pick_frequency
+        """
+        if frequency is None and index is None:
+            if self._data.shape[1] > 1:
+                raise ValueError('Specify either the frequency or index of '
+                                 'the frequency bin for which to obtain the '
+                                 'CSD matrix.')
+            index = 0
+        elif frequency is not None:
+            if index is not None:
+                raise ValueError('Cannot specify both a frequency and index.')
+            index = self._get_frequency_index(frequency)
+
+        return _vector_to_sym_mat(self._data[:, index])
+
+    @copy_function_doc_to_method_doc(plot_csd)
+    def plot(self, info=None, mode='csd', colorbar=True, cmap='viridis',
+             n_cols=None, show=True):
+        return plot_csd(self, info=info, mode=mode, colorbar=colorbar,
+                        cmap=cmap, n_cols=n_cols, show=show)
+
+    def __setstate__(self, state):  # noqa: D105
+        self._data = state['data']
+        self.tmin = state['tmin']
+        self.tmax = state['tmax']
+        self.ch_names = state['ch_names']
+        self.frequencies = state['frequencies']
+        self.n_fft = state['n_fft']
+
+    def __getstate__(self):  # noqa: D105
+        return dict(
+            data=self._data,
+            tmin=self.tmin,
+            tmax=self.tmax,
+            ch_names=self.ch_names,
+            frequencies=self.frequencies,
+            n_fft=self.n_fft,
+        )
+
+    def __getitem__(self, sel):  # noqa: D105
+        return CrossSpectralDensity(
+            data=self._data[:, sel], ch_names=self.ch_names, tmin=self.tmin,
+            tmax=self.tmax,
+            frequencies=np.atleast_1d(self.frequencies)[sel].tolist(),
+            n_fft=self.n_fft,
+        )
+
+    def save(self, fname):
+        """Save the CSD to an HDF5 file.
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file to save the CSD to. The extension '.h5' will
+            be appended if the given filename doesn't have it already.
+
+        See Also
+        --------
+        read_csd : For reading CSD objects from a file.
+        """
+        if not fname.endswith('.h5'):
+            fname += '.h5'
+
+        write_hdf5(fname, self.__getstate__(), overwrite=True, title='conpy')
+
+    def copy(self):
+        """Return copy of the CrossSpectralDensity object."""
+        return cp.deepcopy(self)
 
 
+def _n_dims_from_triu(n):
+    """Compute matrix dims from number of elements in the upper triangle.
+
+    Parameters
+    ----------
+    n : int
+        Number of elements in the upper triangle of the symmetric matrix.
+
+    Returns
+    -------
+    dim : int
+        The dimensions of the symmetric matrix.
+    """
+    return int(np.ceil(np.sqrt(n * 2))) - 1
+
+
+def _vector_to_sym_mat(vec):
+    """Convert vector to a symmetric matrix.
+
+    The upper triangle of the matrix (including the diagonal) will be filled
+    with the values of the vector.
+
+    Parameters
+    ----------
+    vec : list or 1d-array
+        The vector to convert to a symmetric matrix.
+
+    Returns
+    -------
+    mat : 2d-array
+        The symmetric matrix.
+
+    See Also
+    --------
+    _sym_mat_to_vector
+    """
+    dim = _n_dims_from_triu(len(vec))
+    mat = np.zeros((dim, dim) + vec.shape[1:], dtype=vec.dtype)
+
+    # Fill the upper triangle of the matrix
+    mat[np.triu_indices(dim)] = vec
+
+    # Fill out the lower triangle (make conjugate to ensure matix is hermitian)
+    mat = mat + np.rollaxis(mat, 1).conj()
+
+    # We counted the diagonal twice
+    if np.issubdtype(mat.dtype, np.integer):
+        mat[np.diag_indices(dim)] //= 2
+    else:
+        mat[np.diag_indices(dim)] /= 2
+
+    return mat
+
+
+def _sym_mat_to_vector(mat):
+    """Convert a symmetric matrix to a vector.
+
+    The upper triangle of the matrix (including the diagonal) will be used
+    as the values of the vector.
+
+    Parameters
+    ----------
+    mat : 2d-array
+        The symmetric matrix to convert to a vector
+
+    Returns
+    -------
+    vec : 1d-array
+        A vector consisting of the values of the upper triangle of the matrix.
+
+    See Also
+    --------
+    _vector_to_sym_mat
+    """
+    return mat[np.triu_indices_from(mat)]
+
+
+def read_csd(fname):
+    """Read a CrossSpectralDensity object from an HDF5 file.
+
+    Parameters
+    ----------
+    fname : str
+        The name of the file to read the CSD from. The extension '.h5' will be
+        appended if the given filename doesn't have it already.
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The CSD that was stored in the file.
+
+    See Also
+    --------
+    CrossSpectralDensity.save : For saving CSD objects
+    """
+    if not fname.endswith('.h5'):
+        fname += '.h5'
+
+    csd_dict = read_hdf5(fname, title='conpy')
+    return CrossSpectralDensity(**csd_dict)
+
+
+def pick_channels_csd(csd, include=[], exclude=[]):
+    """Pick channels from covariance matrix.
+
+    Parameters
+    ----------
+    csd : instance of CrossSpectralDensity
+        The CSD object to select the channels from.
+    include : list of string
+        List of channels to include (if empty, include all available).
+    exclude : list of string
+        Channels to exclude (if empty, do not exclude any).
+
+    Returns
+    -------
+    res : instance of CrossSpectralDensity
+        Cross-spectral density restricted to selected channels.
+    """
+    sel = pick_channels(csd.ch_names, include=include, exclude=exclude)
+    data = []
+    for vec in csd._data.T:
+        mat = _vector_to_sym_mat(vec)
+        mat = mat[sel, :][:, sel]
+        data.append(_sym_mat_to_vector(mat))
+    ch_names = [csd.ch_names[i] for i in sel]
+
+    return CrossSpectralDensity(
+        data=np.array(data).T,
+        ch_names=ch_names,
+        tmin=csd.tmin,
+        tmax=csd.tmax,
+        frequencies=csd.frequencies,
+        n_fft=csd.n_fft,
+    )
+
+
+@deprecated('This function will be removed in 0.17, please use one of the '
+            '[csd_fourier, csd_multitaper, csd_morlet] '
+            'functions instead.')
 @verbose
 def csd_epochs(epochs, mode='multitaper', fmin=0, fmax=np.inf,
                fsum=True, tmin=None, tmax=None, n_fft=None,
@@ -77,8 +533,7 @@ def csd_epochs(epochs, mode='multitaper', fmin=0, fmax=np.inf,
     fsum : bool
         Sum CSD values for the frequencies of interest. Summing is performed
         instead of averaging so that accumulated power is comparable to power
-        in the time domain. If True, a single CSD matrix will be returned. If
-        False, the output will be a list of CSD matrices.
+        in the time domain.
     tmin : float | None
         Minimum time instant to consider. If None start at first sample.
     tmax : float | None
@@ -96,8 +551,8 @@ def csd_epochs(epochs, mode='multitaper', fmin=0, fmax=np.inf,
         Only use tapers with more than 90% spectral concentration within
         bandwidth. Only used in 'multitaper' mode.
     projs : list of Projection | None
-        List of projectors to use in CSD calculation, or None to indicate that
-        the projectors from the epochs should be inherited.
+        List of projectors to use in CSD calculation, or ``None`` to indicate
+        that the projectors from the epochs should be inherited.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -106,110 +561,32 @@ def csd_epochs(epochs, mode='multitaper', fmin=0, fmax=np.inf,
     -------
     csd : instance of CrossSpectralDensity
         The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array
     """
-    # Portions of this code adapted from mne/connectivity/spectral.py
-
-    # Check correctness of input data and parameters
-    if fmax < fmin:
-        raise ValueError('fmax must be larger than fmin')
-    tstep = epochs.times[1] - epochs.times[0]
-    if tmin is not None and tmin < epochs.times[0] - tstep:
-        raise ValueError('tmin should be larger than the smallest data time '
-                         'point')
-    if tmax is not None and tmax > epochs.times[-1] + tstep:
-        raise ValueError('tmax should be smaller than the largest data time '
-                         'point')
-    if tmax is not None and tmin is not None:
-        if tmax < tmin:
-            raise ValueError('tmax must be larger than tmin')
-    if epochs.baseline is None and epochs.info['highpass'] < 0.1:
-        warn('Epochs are not baseline corrected or enough highpass filtered. '
-             'Cross-spectral density may be inaccurate.')
-
-    if projs is None:
-        projs = cp.deepcopy(epochs.info['projs'])
+    if mode == 'fourier':
+        csd = csd_fourier(epochs, fmin=fmin, fmax=fmax, tmin=tmin, tmax=tmax,
+                          n_fft=n_fft, verbose=verbose)
+    elif mode == 'multitaper':
+        csd = csd_multitaper(epochs, fmin=fmin, fmax=fmax, tmin=tmin,
+                             tmax=tmax, n_fft=n_fft, bandwidth=mt_bandwidth,
+                             adaptive=mt_adaptive, low_bias=mt_low_bias,
+                             verbose=verbose)
     else:
-        projs = cp.deepcopy(projs)
+        raise ValueError("Invalid mode selected, choose either 'fourier' or "
+                         "'multitaper'.")
 
-    picks_meeg = pick_types(epochs[0].info, meg=True, eeg=True, eog=False,
-                            ref_meg=False, exclude='bads')
-    ch_names = [epochs.ch_names[k] for k in picks_meeg]
-
-    # Preparing time window slice
-    tstart, tend = None, None
-    if tmin is not None:
-        tstart = np.where(epochs.times >= tmin)[0][0]
-    if tmax is not None:
-        tend = np.where(epochs.times <= tmax)[0][-1] + 1
-    tslice = slice(tstart, tend, None)
-    n_times = len(epochs.times[tslice])
-    n_fft = n_times if n_fft is None else n_fft
-
-    # Preparing frequencies of interest
-    sfreq = epochs.info['sfreq']
-    orig_freqs = np.fft.rfftfreq(n_fft, 1. / sfreq)
-    freq_mask = (orig_freqs > fmin) & (orig_freqs < fmax)
-    freqs = orig_freqs[freq_mask]
-    n_freqs = len(freqs)
-
-    if n_freqs == 0:
-        raise ValueError('No discrete fourier transform results within '
-                         'the given frequency window. Please widen either '
-                         'the frequency window or the time window')
-
-    # Preparing for computing CSD
-    logger.info('Computing cross-spectral density from epochs...')
-    window_fun, eigvals, n_tapers, mt_adaptive = _compute_csd_params(
-        n_times, sfreq, mode, mt_bandwidth, mt_low_bias, mt_adaptive)
-
-    csds_mean = np.zeros((len(ch_names), len(ch_names), n_freqs),
-                         dtype=complex)
-
-    # Picking frequencies of interest
-    freq_mask_mt = freq_mask[orig_freqs >= 0]
-
-    # Compute CSD for each epoch
-    n_epochs = 0
-    for epoch in epochs:
-        epoch = epoch[picks_meeg][:, tslice]
-
-        # Calculating Fourier transform using multitaper module
-        csds_epoch = _csd_array(epoch, sfreq, window_fun, eigvals, freq_mask,
-                                freq_mask_mt, n_fft, mode, mt_adaptive)
-
-        # Scaling by number of samples and compensating for loss of power due
-        # to windowing (see section 11.5.2 in Bendat & Piersol).
-        if mode == 'fourier':
-            csds_epoch /= n_times
-            csds_epoch *= 8 / 3.
-
-        # Scaling by sampling frequency for compatibility with Matlab
-        csds_epoch /= sfreq
-
-        csds_mean += csds_epoch
-        n_epochs += 1
-
-    csds_mean /= n_epochs
-
-    logger.info('[done]')
-
-    # Summing over frequencies of interest or returning a list of separate CSD
-    # matrices for each frequency
-    if fsum is True:
-        csd_mean_fsum = np.sum(csds_mean, 2)
-        csd = CrossSpectralDensity(csd_mean_fsum, ch_names, projs,
-                                   epochs.info['bads'],
-                                   freqs=freqs, n_fft=n_fft)
+    if fsum:
+        return csd.sum()
+    else:
         return csd
-    else:
-        csds = []
-        for i in range(n_freqs):
-            csds.append(CrossSpectralDensity(csds_mean[:, :, i], ch_names,
-                                             projs, epochs.info['bads'],
-                                             freqs=freqs[i], n_fft=n_fft))
-        return csds
 
 
+@deprecated('This function will be removed in 0.17, please use one of the '
+            '[csd_array_fourier, csd_array_multitaper, csd_array_morlet] '
+            'functions instead.')
 @verbose
 def csd_array(X, sfreq, mode='multitaper', fmin=0, fmax=np.inf,
               fsum=True, n_fft=None, mt_bandwidth=None,
@@ -237,8 +614,7 @@ def csd_array(X, sfreq, mode='multitaper', fmin=0, fmax=np.inf,
     fsum : bool
         Sum CSD values for the frequencies of interest. Summing is performed
         instead of averaging so that accumulated power is comparable to power
-        in the time domain. If True, a single CSD matrix will be returned. If
-        False, the output will be an array of CSD matrices.
+        in the time domain.
     n_fft : int | None
         Length of the FFT. If None the exact number of samples between tmin and
         tmax will be used.
@@ -256,73 +632,634 @@ def csd_array(X, sfreq, mode='multitaper', fmin=0, fmax=np.inf,
 
     Returns
     -------
-    csd : array, shape (n_freqs, n_series, n_series) if fsum is True, otherwise (n_series, n_series).
-        The computed cross spectral-density (either summed or not).
-    freqs : array
-        Frequencies the cross spectral-density is evaluated at.
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
     """  # noqa: E501
-    # Check correctness of input data and parameters
-    if fmax < fmin:
-        raise ValueError('fmax must be larger than fmin')
+    if mode == 'fourier':
+        csd = csd_array_fourier(X, sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft,
+                                verbose=verbose)
+    elif mode == 'multitaper':
+        csd = csd_array_multitaper(X, sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft,
+                                   bandwidth=mt_bandwidth,
+                                   adaptive=mt_adaptive, low_bias=mt_low_bias,
+                                   verbose=verbose)
+    else:
+        raise ValueError('Invalid mode selected, choose one of: '
+                         "['fourier', 'multitaper']")
 
-    X = np.asarray(X, dtype=float)
-    if X.ndim != 3:
-        raise ValueError("X must be n_replicates x n_series x n_times.")
-    n_replicates, n_series, n_times = X.shape
+    if fsum:
+        return csd.sum()
+    else:
+        return csd
+
+
+@verbose
+def csd_fourier(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None, picks=None,
+                n_fft=None, projs=None, n_jobs=1, verbose=None):
+    """Estimate cross-spectral density from an array using short-time fourier.
+
+    Parameters
+    ----------
+    epochs : instance of Epochs
+        The epochs to compute the CSD for.
+    fmin : float
+        Minimum frequency of interest, in Hertz.
+    fmax : float | np.inf
+        Maximum frequency of interest, in Hertz.
+    tmin : float | None
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    picks : list of str | None
+        The names of the channels to use during CSD computation. Defaults to
+        all good MEG/EEG channels.
+    n_fft : int | None
+        Length of the FFT. If ``None``, the exact number of samples between
+        ``tmin`` and ``tmax`` will be used.
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means the projectors defined in the Epochs object will by copied.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_fourier
+    csd_array_morlet
+    csd_array_multitaper
+    csd_morlet
+    csd_multitaper
+    """
+    epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
+    return csd_array_fourier(epochs.get_data(), sfreq=epochs.info['sfreq'],
+                             t0=epochs.tmin, fmin=fmin, fmax=fmax, tmin=tmin,
+                             tmax=tmax, n_fft=n_fft, projs=projs,
+                             n_jobs=n_jobs, verbose=verbose)
+
+
+@verbose
+def csd_array_fourier(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
+                      tmax=None, ch_names=None, n_fft=None, projs=None,
+                      n_jobs=1, verbose=None):
+    """Estimate cross-spectral density from an array using short-time fourier.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_epochs, n_channels, n_times)
+        The time series data consisting of n_epochs separate observations
+        of signals with n_channels time-series of length n_times.
+    sfreq : float
+        Sampling frequency of observations.
+    t0 : float
+        Time of the first sample relative to the onset of the epoch, in
+        seconds. Defaults to 0.
+    fmin : float
+        Minimum frequency of interest, in Hertz.
+    fmax : float | np.inf
+        Maximum frequency of interest, in Hertz.
+    tmin : float | None
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    ch_names : list of str | None
+        A name for each time series. If ``None`` (the default), the series will
+        be named 'SERIES###'.
+    n_fft : int | None
+        Length of the FFT. If ``None``, the exact number of samples between
+        ``tmin`` and ``tmax`` will be used.
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means no projectors are stored.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_morlet
+    csd_array_multitaper
+    csd_fourier
+    csd_morlet
+    csd_multitaper
+    """
+    # Local import to keep "import mne" fast
+    # from scipy.fftpack import fftfreq
+
+    X, times, tmin, tmax, fmin, fmax = _prepare_csd_array(
+        X, sfreq, t0, tmin, tmax, fmin, fmax)
+
+    # Slice X to the requested time window
+    tstart = None if tmin is None else np.searchsorted(times, tmin - 1e-10)
+    tstop = None if tmax is None else np.searchsorted(times, tmax + 1e-10)
+    X = X[:, :, tstart:tstop]
+    times = times[tstart:tstop]
+    n_times = len(times)
+    n_fft = n_times if n_fft is None else n_fft
 
     # Preparing frequencies of interest
-    n_fft = n_times if n_fft is None else n_fft
-    orig_freqs = np.fft.rfftfreq(n_fft, 1. / sfreq)
-    freq_mask = (orig_freqs > fmin) & (orig_freqs < fmax)
-    freqs = orig_freqs[freq_mask]
-    n_freqs = len(freqs)
+    # orig_frequencies = fftfreq(n_fft, 1. / sfreq)
+    orig_frequencies = np.fft.rfftfreq(n_fft, 1. / sfreq)
+    freq_mask = (orig_frequencies > fmin) & (orig_frequencies < fmax)
+    frequencies = orig_frequencies[freq_mask]
 
-    if n_freqs == 0:
+    if len(frequencies) == 0:
         raise ValueError('No discrete fourier transform results within '
                          'the given frequency window. Please widen either '
                          'the frequency window or the time window')
 
-    # Preparing for computing CSD
-    logger.info('Computing cross-spectral density from array...')
-    window_fun, eigvals, n_tapers, mt_adaptive = _compute_csd_params(
-        n_times, sfreq, mode, mt_bandwidth, mt_low_bias, mt_adaptive)
+    # Compute the CSD
+    return _execute_csd_function(X, times, frequencies, _csd_fourier,
+                                 params=[sfreq, n_times, freq_mask, n_fft],
+                                 n_fft=n_fft, ch_names=ch_names, projs=projs,
+                                 n_jobs=n_jobs, verbose=verbose)
 
-    csds_mean = np.zeros((n_series, n_series, n_freqs), dtype=complex)
 
-    # Picking frequencies of interest
-    freq_mask_mt = freq_mask[orig_freqs >= 0]
+@verbose
+def csd_multitaper(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
+                   picks=None, n_fft=None, bandwidth=None, adaptive=False,
+                   low_bias=True, projs=None, n_jobs=1, verbose=None):
+    """Estimate cross-spectral density from epochs using Morlet wavelets.
+
+    Parameters
+    ----------
+    epochs : instance of Epochs
+        The epochs to compute the CSD for.
+    fmin : float | None
+        Minimum frequency of interest, in Hertz.
+    fmax : float | np.inf
+        Maximum frequency of interest, in Hertz.
+    tmin : float
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    picks : list of str | None
+        The ch_names of the channels to use during CSD computation. Defaults to
+        all good MEG/EEG channels.
+    n_fft : int | None
+        Length of the FFT. If ``None``, the exact number of samples between
+        ``tmin`` and ``tmax`` will be used.
+    bandwidth : float | None
+        The bandwidth of the multitaper windowing function in Hz.
+    adaptive : bool
+        Use adaptive weights to combine the tapered spectra into PSD.
+    low_bias : bool
+        Only use tapers with more than 90% spectral concentration within
+        bandwidth.
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means the projectors defined in the Epochs object will by copied.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_fourier
+    csd_array_morlet
+    csd_array_multitaper
+    csd_fourier
+    csd_morlet
+    """
+    epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
+    return csd_array_multitaper(epochs.get_data(), sfreq=epochs.info['sfreq'],
+                                t0=epochs.tmin, fmin=fmin, fmax=fmax,
+                                tmin=tmin, tmax=tmax, n_fft=n_fft,
+                                bandwidth=bandwidth, adaptive=adaptive,
+                                low_bias=low_bias, projs=projs, n_jobs=n_jobs,
+                                verbose=verbose)
+
+
+@verbose
+def csd_array_multitaper(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
+                         tmax=None, ch_names=None, n_fft=None, bandwidth=None,
+                         adaptive=False, low_bias=True, projs=None, n_jobs=1,
+                         verbose=None):
+    """Estimate cross-spectral density from an array using Morlet wavelets.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_epochs, n_channels, n_times)
+        The time series data consisting of n_epochs separate observations
+        of signals with n_channels time-series of length n_times.
+    sfreq : float
+        Sampling frequency of observations.
+    t0 : float
+        Time of the first sample relative to the onset of the epoch, in
+        seconds. Defaults to 0.
+    fmin : float
+        Minimum frequency of interest, in Hertz.
+    fmax : float | np.inf
+        Maximum frequency of interest, in Hertz.
+    tmin : float | None
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    ch_names : list of str | None
+        A name for each time series. If ``None`` (the default), the series will
+        be named 'SERIES###'.
+    n_fft : int | None
+        Length of the FFT. If ``None``, the exact number of samples between
+        ``tmin`` and ``tmax`` will be used.
+    bandwidth : float | None
+        The bandwidth of the multitaper windowing function in Hz.
+    adaptive : bool
+        Use adaptive weights to combine the tapered spectra into PSD.
+    low_bias : bool
+        Only use tapers with more than 90% spectral concentration within
+        bandwidth.
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means no projectors are stored.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_fourier
+    csd_array_morlet
+    csd_fourier
+    csd_morlet
+    csd_multitaper
+    """
+    X, times, tmin, tmax, fmin, fmax = _prepare_csd_array(
+        X, sfreq, t0, tmin, tmax, fmin, fmax)
+
+    # Slice X to the requested time window
+    tstart = None if tmin is None else np.searchsorted(times, tmin - 1e-10)
+    tstop = None if tmax is None else np.searchsorted(times, tmax + 1e-10)
+    X = X[:, :, tstart:tstop]
+    times = times[tstart:tstop]
+    n_times = len(times)
+    n_fft = n_times if n_fft is None else n_fft
+
+    window_fun, eigvals, n_tapers, mt_adaptive = _compute_mt_params(
+        n_times, sfreq, bandwidth, low_bias, adaptive)
+
+    # Preparing frequencies of interest
+    orig_frequencies = np.fft.rfftfreq(n_fft, 1. / sfreq)
+    freq_mask = (orig_frequencies > fmin) & (orig_frequencies < fmax)
+    frequencies = orig_frequencies[freq_mask]
+
+    if len(frequencies) == 0:
+        raise ValueError('No discrete fourier transform results within '
+                         'the given frequency window. Please widen either '
+                         'the frequency window or the time window')
+
+    # Compute the CSD
+    return _execute_csd_function(X, times, frequencies, _csd_multitaper,
+                                 params=[sfreq, n_times, window_fun, eigvals,
+                                         freq_mask, n_fft, adaptive],
+                                 n_fft=n_fft, ch_names=ch_names, projs=projs,
+                                 n_jobs=n_jobs, verbose=verbose)
+
+
+@verbose
+def csd_morlet(epochs, frequencies=None, tmin=None, tmax=None, picks=None,
+               n_cycles=7, use_fft=True, decim=1, projs=None, n_jobs=1,
+               verbose=None):
+    """Estimate cross-spectral density from epochs using Morlet wavelets.
+
+    Parameters
+    ----------
+    epochs : instance of Epochs
+        The epochs to compute the CSD for.
+    frequencies : list of float | None
+        The frequencies of interest, in Hertz.
+    tmin : float | None
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    picks : list of str | None
+        The ch_names of the channels to use during CSD computation. Defaults to
+        all good MEG/EEG channels.
+    n_cycles: float | list of float | None
+        Number of cycles to use when constructing Morlet wavelets. Fixed number
+        or one per frequency. Defaults to 7.
+    use_fft : bool
+        Whether to use FFT-based convolution to compute the wavelet transform.
+        Defaults to True.
+    decim : int | slice
+        To reduce memory usage, decimation factor during time-frequency
+        decomposition. Defaults to 1 (no decimation).
+
+        If `int`, uses tfr[..., ::decim].
+        If `slice`, uses tfr[..., decim].
+
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means the projectors defined in the Epochs object will be copied.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_fourier
+    csd_array_morlet
+    csd_array_multitaper
+    csd_fourier
+    csd_multitaper
+    """
+    epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
+    return csd_array_morlet(epochs.get_data(), sfreq=epochs.info['sfreq'],
+                            t0=epochs.tmin, frequencies=frequencies, tmin=tmin,
+                            tmax=tmax, n_cycles=n_cycles, use_fft=use_fft,
+                            decim=decim, projs=projs, n_jobs=n_jobs,
+                            verbose=verbose)
+
+
+@verbose
+def csd_array_morlet(X, sfreq, t0=0, frequencies=None, tmin=None, tmax=None,
+                     ch_names=None, n_cycles=7, use_fft=True, decim=1,
+                     projs=None, n_jobs=1, verbose=None):
+    """Estimate cross-spectral density from an array using Morlet wavelets.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_epochs, n_channels, n_times)
+        The time series data consisting of n_epochs separate observations
+        of signals with n_channels time-series of length n_times.
+    sfreq : float
+        Sampling frequency of observations.
+    t0 : float
+        Time of the first sample relative to the onset of the epoch, in
+        seconds. Defaults to 0.
+    frequencies : list of float | None
+        The frequencies of interest, in Hertz.
+    tmin : float | None
+        Minimum time instant to consider, in seconds. If ``None`` start at
+        first sample.
+    tmax : float | None
+        Maximum time instant to consider, in seconds. If ``None`` end at last
+        sample.
+    ch_names : list of str | None
+        A name for each time series. If ``None`` (the default), the series will
+        be named 'SERIES###'.
+    n_cycles: float | list of float | None
+        Number of cycles to use when constructing Morlet wavelets. Fixed number
+        or one per frequency. Defaults to 7.
+    use_fft : bool
+        Whether to use FFT-based convolution to compute the wavelet transform.
+        Defaults to True.
+    decim : int | slice
+        To reduce memory usage, decimation factor during time-frequency
+        decomposition. Defaults to 1 (no decimation).
+
+        If `int`, uses tfr[..., ::decim].
+        If `slice`, uses tfr[..., decim].
+
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means the projectors defined in the Epochs object will be copied.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+
+    See Also
+    --------
+    csd_array_fourier
+    csd_array_multitaper
+    csd_fourier
+    csd_morlet
+    csd_multitaper
+    """
+    X, times, tmin, tmax, _, _ = _prepare_csd_array(X, sfreq, t0, tmin, tmax)
+    n_times = len(times)
+
+    # Construct the appropriate Morlet wavelets
+    wavelets = morlet(sfreq, frequencies, n_cycles)
+
+    # Slice X to the requested time window + half the length of the longest
+    # wavelet.
+    wave_length = len(wavelets[np.argmin(frequencies)]) // 2
+    tstart = tstop = None
+    if tmin is not None:
+        tstart = np.searchsorted(times, tmin)
+        tstart = max(0, tstart - wave_length)
+    if tmax is not None:
+        tstop = np.searchsorted(times, tmax)
+        tstop = min(n_times, tstop + wave_length)
+    X = X[:, :, tstart:tstop]
+    times = times[tstart:tstop]
+
+    # After CSD computation, we slice again to the requested time window.
+    csd_tstart = None if tmin is None else np.searchsorted(times, tmin - 1e-10)
+    csd_tstop = None if tmax is None else np.searchsorted(times, tmax + 1e-10)
+    csd_tslice = slice(csd_tstart, csd_tstop)
+
+    # Compute the CSD
+    return _execute_csd_function(X, times, frequencies, _csd_morlet,
+                                 params=[sfreq, wavelets, csd_tslice, use_fft,
+                                         decim],
+                                 n_fft=1, ch_names=ch_names, projs=projs,
+                                 n_jobs=n_jobs, verbose=verbose)
+
+
+def _prepare_csd(epochs, tmin=None, tmax=None, picks=None, projs=None):
+    """Do some checking and preprocessing of common csd_* parameters.
+
+    See the csd_* functions for documentation of the parameters.
+    """
+    tstep = epochs.times[1] - epochs.times[0]
+    if tmin is not None and tmin < epochs.times[0] - tstep:
+        raise ValueError('tmin should be larger than the smallest data time '
+                         'point')
+    if tmax is not None and tmax > epochs.times[-1] + tstep:
+        raise ValueError('tmax should be smaller than the largest data time '
+                         'point')
+    if tmax is not None and tmin is not None:
+        if tmax < tmin:
+            raise ValueError('tmax must be larger than tmin')
+    if epochs.baseline is None and epochs.info['highpass'] < 0.1:
+        warn('Epochs are not baseline corrected or enough highpass filtered. '
+             'Cross-spectral density may be inaccurate.')
+
+    if picks is None:
+        epochs = epochs.copy().pick_types(
+            meg=True, eeg=True, eog=False, ref_meg=False, exclude='bads')
+    else:
+        epochs = epochs.copy().pick_channels(picks)
+
+    if projs is None:
+        projs = epochs.info['projs']
+
+    return epochs, projs
+
+
+def _prepare_csd_array(X, sfreq, t0, tmin, tmax, fmin=None, fmax=None):
+    """Do some checking and preprocessing of common csd_r=array_* parameters.
+
+    See the csd_array_* functions for documentation of the parameters.
+    """
+    X = np.asarray(X, dtype=float)
+    if X.ndim != 3:
+        raise ValueError("X must be n_epochs x n_channels x n_times.")
+
+    n_times = X.shape[2]
+    tstep = 1. / sfreq
+    times = np.arange(n_times) * tstep + t0
+
+    # Check tmin and tmax
+    if tmax is None:
+        tmax = times.max()
+    if tmin is None:
+        tmin = times.min()
+    if tmax <= tmin:
+            raise ValueError('tmax must be larger than tmin')
+    if tmin < times[0] - tstep:
+        raise ValueError('tmin should be larger than the smallest data time '
+                         'point')
+    if tmax > times[-1] + tstep:
+        raise ValueError('tmax should be smaller than the largest data time '
+                         'point')
+
+    # Check fmin and fmax
+    if fmax is not None and fmin is not None and fmax <= fmin:
+        raise ValueError('fmax must be larger than fmin')
+
+    return X, times, tmin, tmax, fmin, fmax
+
+
+@verbose
+def _execute_csd_function(X, times, frequencies, csd_function, params, n_fft,
+                          ch_names=None, projs=None, n_jobs=1, verbose=None):
+    """Estimate cross-spectral density with a given function.
+
+    This function will apply the given CSD function in parallel across epochs.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_epochs, n_channels, n_times)
+        The time series data consisting of n_epochs separate observations
+        of signals with n_channels time-series of length n_times.
+    times : float
+        Timestamps for each sample.
+    frequencies : list of float
+        The frequencies of interest for which the CSD is going to be computed.
+    csd_function : function
+        Function that performs the actual CSD computation
+    params : list
+        List of parameters to pass the CSD function.
+    n_fft : int
+        Number of FFT points. This is stored in the CSD object.
+    ch_names : list of str | None
+        A name for each time series. If ``None`` (the default), the series will
+        be named 'SERIES###'.
+    projs : list of Projection | None
+        List of projectors to store in the CSD object. Defaults to ``None``,
+        which means the projectors defined in the Epochs object will be copied.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    verbose : bool | str | int | None
+        If not ``None``, override default verbose level
+        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
+
+    Returns
+    -------
+    csd : instance of CrossSpectralDensity
+        The computed cross-spectral density.
+    """
+    n_epochs, n_channels, _ = X.shape
+
+    logger.info('Computing cross-spectral density from epochs...')
+
+    n_freqs = len(frequencies)
+    csds_mean = np.zeros((n_channels * (n_channels + 1) // 2, n_freqs),
+                         dtype=np.complex)
+
+    # Prepare the function that does the actual CSD computation for parallel
+    # execution.
+    parallel, my_csd, _ = parallel_func(csd_function, n_jobs, verbose=verbose)
 
     # Compute CSD for each trial
-    for xi in X:
+    n_blocks = int(np.ceil(n_epochs / float(n_jobs)))
+    for i in range(n_blocks):
+        epoch_block = X[i * n_jobs:(i + 1) * n_jobs]
+        if n_jobs > 1:
+            logger.info('    Computing CSD matrices for epochs %d..%d'
+                        % (i * n_jobs + 1, (i + 1) * n_jobs))
+        else:
+            logger.info('    Computing CSD matrix for epoch %d' % (i + 1))
 
-        csds_trial = _csd_array(xi, sfreq, window_fun, eigvals, freq_mask,
-                                freq_mask_mt, n_fft, mode, mt_adaptive)
+        csds = parallel(my_csd(this_epoch, *params)
+                        for this_epoch in epoch_block)
 
-        # Scaling by number of trials and compensating for loss of power due
-        # to windowing (see section 11.5.2 in Bendat & Piersol).
-        if mode == 'fourier':
-            csds_trial /= n_times
-            csds_trial *= 8 / 3.
+        # Add CSD matrices in-place
+        csds_mean += np.sum(csds, axis=0)
 
-        # Scaling by sampling frequency for compatibility with Matlab
-        csds_trial /= sfreq
-
-        csds_mean += csds_trial
-
-    csds_mean /= n_replicates
-
+    csds_mean /= n_epochs
     logger.info('[done]')
 
-    # Summing over frequencies of interest or returning a list of separate CSD
-    # matrices for each frequency
-    if fsum is True:
-        csds_mean = np.sum(csds_mean, 2)
+    if ch_names is None:
+        ch_names = ['SERIES%03d' % (i + 1) for i in range(n_channels)]
 
-    return csds_mean, freqs
+    return CrossSpectralDensity(csds_mean, ch_names=ch_names, tmin=times[0],
+                                tmax=times[-1], frequencies=frequencies,
+                                n_fft=n_fft, projs=projs)
 
 
-def _compute_csd_params(n_times, sfreq, mode, mt_bandwidth, mt_low_bias,
-                        mt_adaptive):
+def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive):
     """Compute windowing and multitaper parameters.
 
     Parameters
@@ -331,90 +1268,74 @@ def _compute_csd_params(n_times, sfreq, mode, mt_bandwidth, mt_low_bias,
         Number of time points.
     s_freq : int
         Sampling frequency of signal.
-    mode : str
-        Spectrum estimation mode can be either: 'multitaper' or 'fourier'.
-    mt_bandwidth : float | None
+    bandwidth : float | None
         The bandwidth of the multitaper windowing function in Hz.
-        Only used in 'multitaper' mode.
-    mt_low_bias : bool
+    low_bias : bool
         Only use tapers with more than 90% spectral concentration within
-        bandwidth. Only used in 'multitaper' mode.
-    mt_adaptive : bool
+        bandwidth.
+    adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD.
-        Only used in 'multitaper' mode.
 
     Returns
     -------
-    window_fun : array
-        Window function(s) of length n_times. When 'multitaper' mode is used
-        will correspond to first output of `dpss_windows` and when 'fourier'
-        mode is used will be a Hanning window of length `n_times`.
-    eigvals : array | float
-        Eigenvalues associated with wondow functions. Only needed when mode is
-        'multitaper'. When the mode 'fourier' is used this is set to 1.
+    window_fun : ndarray
+        Window function(s) of lengths n_times. This corresponds to first output
+        of `dpss_windows`.
+    eigvals : ndarray | float
+        Eigenvalues associated with window functions.
     n_tapers : int | None
-        Number of tapers to use. Only used when mode is 'multitaper'.
-    ret_mt_adaptive : bool
-        Updated value of `mt_adaptive` argument as certain parameter values
+        Number of tapers to use.
+    adaptive : bool
+        Updated value of the `adaptive` argument as certain parameter values
         will not allow adaptive spectral estimators.
     """
-    ret_mt_adaptive = mt_adaptive
-    if mode == 'multitaper':
-        # Compute standardized half-bandwidth
-        if mt_bandwidth is not None:
-            half_nbw = float(mt_bandwidth) * n_times / (2. * sfreq)
-        else:
-            half_nbw = 2.
-
-        # Compute DPSS windows
-        n_tapers_max = int(2 * half_nbw)
-        window_fun, eigvals = dpss_windows(n_times, half_nbw, n_tapers_max,
-                                           low_bias=mt_low_bias)
-        n_tapers = len(eigvals)
-        logger.info('    using multitaper spectrum estimation with %d DPSS '
-                    'windows' % n_tapers)
-
-        if mt_adaptive and len(eigvals) < 3:
-            warn('Not adaptively combining the spectral estimators due to a '
-                 'low number of tapers.')
-            ret_mt_adaptive = False
-    elif mode == 'fourier':
-        logger.info('    using FFT with a Hanning window to estimate spectra')
-        window_fun = np.hanning(n_times)
-        ret_mt_adaptive = False
-        eigvals = 1.
-        n_tapers = None
+    # Compute standardized half-bandwidth
+    if bandwidth is not None:
+        half_nbw = float(bandwidth) * n_times / (2. * sfreq)
     else:
-        raise ValueError('Mode has an invalid value.')
+        half_nbw = 2.
 
-    return window_fun, eigvals, n_tapers, ret_mt_adaptive
+    # Compute DPSS windows
+    n_tapers_max = int(2 * half_nbw)
+    window_fun, eigvals = dpss_windows(n_times, half_nbw, n_tapers_max,
+                                       low_bias=low_bias)
+    n_tapers = len(eigvals)
+    logger.info('    using multitaper spectrum estimation with %d DPSS '
+                'windows' % n_tapers)
+
+    if adaptive and len(eigvals) < 3:
+        warn('Not adaptively combining the spectral estimators due to a '
+             'low number of tapers.')
+        adaptive = False
+
+    return window_fun, eigvals, n_tapers, adaptive
 
 
-def _csd_array(x, sfreq, window_fun, eigvals, freq_mask, freq_mask_mt, n_fft,
-               mode, mt_adaptive):
-    """Calculate Fourier transform using multitaper module.
+def _csd_fourier(X, sfreq, n_times, freq_mask, n_fft):
+    """Compute cross spectral density (CSD) using short-time fourier transform.
 
-    The arguments correspond to the values in `compute_csd_epochs` and
-    `csd_array`.
+    Computes the CSD for a single epoch of data.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_channels, n_times)
+        The time series data consisting of n_channels time-series of length
+        n_times.
+    sfreq : float
+        The sampling frequency of the data in Hertz.
+    n_times : int
+        Number of time samples
+    freq_mask : ndarray
+        Which frequencies to use.
+    n_fft : int
+        Length of the FFT.
     """
-    x_mt, _ = _mt_spectra(x, window_fun, sfreq, n_fft)
+    x_mt, _ = _mt_spectra(X, np.hanning(n_times), sfreq, n_fft)
 
-    if mt_adaptive:
-        # Compute adaptive weights
-        _, weights = _psd_from_mt_adaptive(x_mt, eigvals, freq_mask,
-                                           return_weights=True)
-        # Tiling weights so that we can easily use _csd_from_mt()
-        weights = weights[:, np.newaxis, :, :]
-        weights = np.tile(weights, [1, x_mt.shape[0], 1, 1])
-    else:
-        # Do not use adaptive weights
-        if mode == 'multitaper':
-            weights = np.sqrt(eigvals)[np.newaxis, np.newaxis, :, np.newaxis]
-        else:
-            # Hack so we can sum over axis=-2
-            weights = np.array([1.])[:, np.newaxis, np.newaxis, np.newaxis]
+    # Hack so we can sum over axis=-2
+    weights = np.array([1.])[:, np.newaxis, np.newaxis, np.newaxis]
 
-    x_mt = x_mt[:, :, freq_mask_mt]
+    x_mt = x_mt[:, :, freq_mask]
 
     # Calculating CSD
     # Tiling x_mt so that we can easily use _csd_from_mt()
@@ -423,5 +1344,141 @@ def _csd_array(x, sfreq, window_fun, eigvals, freq_mask, freq_mask_mt, n_fft,
     y_mt = np.transpose(x_mt, axes=[1, 0, 2, 3])
     weights_y = np.transpose(weights, axes=[1, 0, 2, 3])
     csds = _csd_from_mt(x_mt, y_mt, weights, weights_y)
+
+    # FIXME: don't compute full matrix in the first place
+    csds = np.array([_sym_mat_to_vector(csds[:, :, i])
+                     for i in range(csds.shape[-1])]).T
+
+    # Scaling by number of samples and compensating for loss of power
+    # due to windowing (see section 11.5.2 in Bendat & Piersol).
+    csds /= n_times
+    csds *= 8 / 3.
+
+    # Scaling by sampling frequency for compatibility with Matlab
+    csds /= sfreq
+
+    return csds
+
+
+def _csd_multitaper(X, sfreq, n_times, window_fun, eigvals, freq_mask, n_fft,
+                    adaptive):
+    """Compute cross spectral density (CSD) using multitaper module.
+
+    Computes the CSD for a single epoch of data.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_channels, n_times)
+        The time series data consisting of n_channels time-series of length
+        n_times.
+    sfreq : float
+        The sampling frequency of the data in Hertz.
+    n_times : int
+        Number of time samples
+    window_fun : ndarray
+        Window function(s) of length n_times. This corresponds to first output
+        of `dpss_windows`.
+    eigvals : ndarray | float
+        Eigenvalues associated with window functions.
+    freq_mask : ndarray
+        Which frequencies to use.
+    n_fft : int
+        Length of the FFT.
+    adaptive : bool
+        Use adaptive weights to combine the tapered spectra into PSD.
+    """
+    x_mt, _ = _mt_spectra(X, window_fun, sfreq, n_fft)
+
+    if adaptive:
+        # Compute adaptive weights
+        _, weights = _psd_from_mt_adaptive(x_mt, eigvals, freq_mask,
+                                           return_weights=True)
+        # Tiling weights so that we can easily use _csd_from_mt()
+        weights = weights[:, np.newaxis, :, :]
+        weights = np.tile(weights, [1, x_mt.shape[0], 1, 1])
+    else:
+        # Do not use adaptive weights
+        weights = np.sqrt(eigvals)[np.newaxis, np.newaxis, :, np.newaxis]
+
+    x_mt = x_mt[:, :, freq_mask]
+
+    # Calculating CSD
+    # Tiling x_mt so that we can easily use _csd_from_mt()
+    x_mt = x_mt[:, np.newaxis, :, :]
+    x_mt = np.tile(x_mt, [1, x_mt.shape[0], 1, 1])
+    y_mt = np.transpose(x_mt, axes=[1, 0, 2, 3])
+    weights_y = np.transpose(weights, axes=[1, 0, 2, 3])
+    csds = _csd_from_mt(x_mt, y_mt, weights, weights_y)
+
+    # FIXME: don't compute full matrix in the first place
+    csds = np.array([_sym_mat_to_vector(csds[:, :, i])
+                     for i in range(csds.shape[-1])]).T
+
+    # Scaling by sampling frequency for compatibility with Matlab
+    csds /= sfreq
+
+    return csds
+
+
+def _csd_morlet(data, sfreq, wavelets, tslice=None, use_fft=True, decim=1):
+    """Compute cross spectral density (CSD) using the given Morlet wavelets.
+
+    Computes the CSD for a single epoch of data.
+
+    Parameters
+    ----------
+    data : ndarray, shape (n_channels, n_times)
+        The time series data consisting of n_channels time-series of length
+        n_times.
+    sfreq : float
+        The sampling frequency of the data in Hertz.
+    wavelets : list of ndarray
+        The Morlet wavelets for which to compute the CSD's. These have been
+        created by the `mne.time_frequency.tfr.morlet` function.
+    tslice : slice | None
+        The desired time samples to compute the CSD over. If None, defaults to
+        including all time samples.
+    use_fft : bool
+        Whether to use FFT-based convolution to compute the wavelet transform.
+        Defaults to True.
+    decim : int | slice
+        To reduce memory usage, decimation factor during time-frequency
+        decomposition. Defaults to 1 (no decimation).
+        Only used in 'cwt_morlet' mode.
+
+        If `int`, uses tfr[..., ::decim].
+        If `slice`, uses tfr[..., decim].
+
+    Returns
+    -------
+    csd : ndarray, shape ((n_channels**2 + n_channels) / 2 , n_wavelets)
+        For each wavelet, the upper triangle of the cross spectral density
+        matrix.
+
+    See Also
+    --------
+    _vector_to_sym_mat : For converting the CSD to a full matrix
+    """
+    # Compute PSD
+    psds = cwt(data, wavelets, use_fft=use_fft, decim=decim)
+
+    if tslice is not None:
+        tstart = None if tslice.start is None else tslice.start // decim
+        tstop = None if tslice.stop is None else tslice.stop // decim
+        tstep = None if tslice.step is None else tslice.step // decim
+        tslice = slice(tstart, tstop, tstep)
+        psds = psds[:, :, tslice]
+
+    psds_conj = np.conj(psds)
+
+    # Compute the spectral density between all pairs of series
+    n_channels = data.shape[0]
+    csds = np.vstack([psds[[i]] * psds_conj[i:] for i in range(n_channels)])
+
+    # Average along time dimension
+    csds = csds.mean(axis=2)
+
+    # Scaling by sampling frequency for compatibility with Matlab
+    csds /= sfreq
 
     return csds

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -1485,10 +1485,8 @@ def _csd_morlet(data, sfreq, wavelets, tslice=None, use_fft=True, decim=1):
 
     # Compute the spectral density between all pairs of series
     n_channels = data.shape[0]
-    csds = np.vstack([psds[[i]] * psds_conj[i:] for i in range(n_channels)])
-
-    # Average along time dimension
-    csds = csds.mean(axis=2)
+    csds = np.vstack([np.mean(psds[[i]] * psds_conj[i:], axis=2)
+                      for i in range(n_channels)])
 
     # Scaling by sampling frequency for compatibility with Matlab
     csds /= sfreq

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -72,7 +72,7 @@ class CrossSpectralDensity(object):
         if len(ch_names) != _n_dims_from_triu(len(data)):
             raise ValueError('Number of ch_names does not match the number of '
                              'time series in the CSD matrix.')
-        self.ch_names = ch_names
+        self.ch_names = list(ch_names)
         self.tmin = tmin
         self.tmax = tmax
 

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -1,14 +1,21 @@
 import numpy as np
-from nose.tools import assert_raises, assert_equal, assert_true
-from numpy.testing import assert_array_equal
+from pytest import raises
+from numpy.testing import assert_array_equal, assert_allclose
 from os import path as op
 import warnings
+import pickle
+from itertools import product
 
 import mne
-
 from mne.io import read_raw_fif
-from mne.utils import sum_squared, run_tests_if_main
-from mne.time_frequency import csd_epochs, csd_array, tfr_morlet
+from mne.utils import sum_squared, run_tests_if_main, _TempDir, requires_h5py
+from mne.time_frequency import (csd_fourier, csd_multitaper,
+                                csd_morlet, csd_array_fourier,
+                                csd_array_multitaper, csd_array_morlet,
+                                csd_epochs, csd_array, tfr_morlet,
+                                CrossSpectralDensity, read_csd,
+                                pick_channels_csd)
+from mne.time_frequency.csd import _sym_mat_to_vector, _vector_to_sym_mat
 
 warnings.simplefilter('always')
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -16,62 +23,565 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 event_fname = op.join(base_dir, 'test-eve.fif')
 
 
-def _get_data(mode='real'):
-    """Get data."""
+def _make_csd():
+    """Make a simple CrossSpectralDensity object."""
+    frequencies = [1., 2., 3., 4.]
+    n_freqs = len(frequencies)
+    names = ['CH1', 'CH2', 'CH3']
+    tmin, tmax = (0., 1.)
+    data = np.arange(6. * n_freqs).reshape(n_freqs, 6).T
+    return CrossSpectralDensity(data, names, tmin, tmax, frequencies, 1)
+
+
+def test_csd():
+    """Test constructing a CrossSpectralDensity."""
+    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'], tmin=0, tmax=1,
+                               frequencies=1, n_fft=1)
+    assert_array_equal(csd._data, [[1], [2], [3]])  # Conversion to 2D array
+    assert_array_equal(csd.frequencies, [1])  # Conversion to 1D array
+
+    # Channels don't match
+    raises(ValueError, CrossSpectralDensity, [1, 2, 3],
+           ['CH1', 'CH2', 'Too many!'], tmin=0, tmax=1, frequencies=1, n_fft=1)
+    raises(ValueError, CrossSpectralDensity, [1, 2, 3], ['too little'],
+           tmin=0, tmax=1, frequencies=1, n_fft=1)
+
+    # Frequencies don't match
+    raises(ValueError, CrossSpectralDensity,
+           [[1, 2], [3, 4], [5, 6]], ['CH1', 'CH2'],
+           tmin=0, tmax=1, frequencies=1, n_fft=1)
+
+    # Invalid dims
+    raises(ValueError, CrossSpectralDensity, [[[1]]], ['CH1'], tmin=0, tmax=1,
+           frequencies=1, n_fft=1)
+
+
+def test_csd_repr():
+    """Test string representation of CrossSpectralDensity."""
+    csd = _make_csd()
+    assert str(csd) == ('<CrossSpectralDensity  |  n_channels=3, time=0.0 to '
+                        '1.0 s, frequencies=1.0, 2.0, 3.0, 4.0 Hz.>')
+
+    assert str(csd.mean()) == ('<CrossSpectralDensity  |  n_channels=3, '
+                               'time=0.0 to 1.0 s, frequencies=1.0-4.0 Hz.>')
+
+    csd_binned = csd.mean(fmin=[1, 3], fmax=[2, 4])
+    assert str(csd_binned) == ('<CrossSpectralDensity  |  n_channels=3, '
+                               'time=0.0 to 1.0 s, frequencies=1.0-2.0, '
+                               '3.0-4.0 Hz.>')
+
+    csd_binned = csd.mean(fmin=[1, 2], fmax=[1, 4])
+    assert str(csd_binned) == ('<CrossSpectralDensity  |  n_channels=3, '
+                               'time=0.0 to 1.0 s, frequencies=1.0, 2.0-4.0 '
+                               'Hz.>')
+
+
+def test_csd_mean():
+    """Test averaging frequency bins of CrossSpectralDensity."""
+    csd = _make_csd()
+
+    # Test different ways to average across all frequencies
+    avg = [[9], [10], [11], [12], [13], [14]]
+    assert_array_equal(csd.mean()._data, avg)
+    assert_array_equal(csd.mean(fmin=None, fmax=4)._data, avg)
+    assert_array_equal(csd.mean(fmin=1, fmax=None)._data, avg)
+    assert_array_equal(csd.mean(fmin=0, fmax=None)._data, avg)
+    assert_array_equal(csd.mean(fmin=1, fmax=4)._data, avg)
+
+    # Test averaging across frequency bins
+    csd_binned = csd.mean(fmin=[1, 3], fmax=[2, 4])
+    assert_array_equal(
+        csd_binned._data,
+        [[3, 15],
+         [4, 16],
+         [5, 17],
+         [6, 18],
+         [7, 19],
+         [8, 20]],
+    )
+
+    csd_binned = csd.mean(fmin=[1, 3], fmax=[1, 4])
+    assert_array_equal(
+        csd_binned._data,
+        [[0, 15],
+         [1, 16],
+         [2, 17],
+         [3, 18],
+         [4, 19],
+         [5, 20]],
+    )
+
+    # This flag should be set after averaging
+    assert csd.mean().is_sum
+
+    # Test construction of .frequency attribute
+    assert csd.mean().frequencies == [[1, 2, 3, 4]]
+    assert (csd.mean(fmin=[1, 3], fmax=[2, 4]).frequencies ==
+            [[1, 2], [3, 4]])
+
+    # Test invalid inputs
+    raises(ValueError, csd.mean, fmin=1, fmax=[2, 3])
+    raises(ValueError, csd.mean, fmin=[1, 2], fmax=[3])
+    raises(ValueError, csd.mean, fmin=[1, 2], fmax=[1, 1])
+
+    # Taking the mean twice should raise an error
+    raises(RuntimeError, csd.mean().mean)
+
+
+def test_csd_get_frequency_index():
+    """Test the _get_frequency_index method of CrossSpectralDensity."""
+    csd = _make_csd()
+
+    assert csd._get_frequency_index(1) == 0
+    assert csd._get_frequency_index(2) == 1
+    assert csd._get_frequency_index(4) == 3
+
+    assert csd._get_frequency_index(0.9) == 0
+    assert csd._get_frequency_index(2.1) == 1
+    assert csd._get_frequency_index(4.1) == 3
+
+    # Frequency can be off by a maximum of 1
+    raises(IndexError, csd._get_frequency_index, csd.frequencies[-1] + 1.0001)
+
+
+def test_csd_pick_frequency():
+    """Test the pick_frequency method of CrossSpectralDensity."""
+    csd = _make_csd()
+
+    csd2 = csd.pick_frequency(freq=2)
+    assert csd2.frequencies == [2]
+    assert_array_equal(
+        csd2.get_data(),
+        [[6, 7, 8],
+         [7, 9, 10],
+         [8, 10, 11]]
+    )
+
+    csd2 = csd.pick_frequency(index=1)
+    assert csd2.frequencies == [2]
+    assert_array_equal(
+        csd2.get_data(),
+        [[6, 7, 8],
+         [7, 9, 10],
+         [8, 10, 11]]
+    )
+
+    # Nonexistent frequency
+    raises(IndexError, csd.pick_frequency, -1)
+
+    # Nonexistent index
+    raises(IndexError, csd.pick_frequency, index=10)
+
+    # Invalid parameters
+    raises(ValueError, csd.pick_frequency)
+    raises(ValueError, csd.pick_frequency, freq=2, index=1)
+
+
+def test_csd_get_data():
+    """Test the get_data method of CrossSpectralDensity."""
+    csd = _make_csd()
+
+    # CSD matrix corresponding to 2 Hz.
+    assert_array_equal(
+        csd.get_data(frequency=2),
+        [[6, 7, 8],
+         [7, 9, 10],
+         [8, 10, 11]]
+    )
+
+    # Mean CSD matrix
+    assert_array_equal(
+        csd.mean().get_data(),
+        [[9, 10, 11],
+         [10, 12, 13],
+         [11, 13, 14]]
+    )
+
+    # Average across frequency bins, select bin
+    assert_array_equal(
+        csd.mean(fmin=[1, 3], fmax=[2, 4]).get_data(index=1),
+        [[15, 16, 17],
+         [16, 18, 19],
+         [17, 19, 20]]
+    )
+
+    # Invalid inputs
+    raises(ValueError, csd.get_data)
+    raises(ValueError, csd.get_data, frequency=1, index=1)
+    raises(IndexError, csd.get_data, frequency=15)
+    raises(ValueError, csd.mean().get_data, frequency=1)
+    raises(IndexError, csd.mean().get_data, index=15)
+
+
+@requires_h5py
+def test_csd_save():
+    """Test saving and loading a CrossSpectralDensity."""
+    csd = _make_csd()
+    tempdir = _TempDir()
+    fname = op.join(tempdir, 'csd.h5')
+    csd.save(fname)
+    csd2 = read_csd(fname)
+    assert_array_equal(csd._data, csd2._data)
+    assert csd.tmin == csd2.tmin
+    assert csd.tmax == csd2.tmax
+    assert csd.ch_names == csd2.ch_names
+    assert csd.frequencies == csd2.frequencies
+    assert csd.is_sum == csd2.is_sum
+
+
+def test_csd_pickle():
+    """Test pickling and unpickling a CrossSpectralDensity."""
+    csd = _make_csd()
+    tempdir = _TempDir()
+    fname = op.join(tempdir, 'csd.dat')
+    with open(fname, 'wb') as f:
+        pickle.dump(csd, f)
+    with open(fname, 'rb') as f:
+        csd2 = pickle.load(f)
+    assert_array_equal(csd._data, csd2._data)
+    assert csd.tmin == csd2.tmin
+    assert csd.tmax == csd2.tmax
+    assert csd.ch_names == csd2.ch_names
+    assert csd.frequencies == csd2.frequencies
+    assert csd.is_sum == csd2.is_sum
+
+
+def test_pick_channels_csd():
+    """Test selecting channels from a CrossSpectralDensity."""
+    csd = _make_csd()
+    csd = pick_channels_csd(csd, ['CH1', 'CH3'])
+    assert csd.ch_names == ['CH1', 'CH3']
+    assert_array_equal(csd._data, [[0, 6, 12, 18],
+                                   [2, 8, 14, 20],
+                                   [5, 11, 17, 23]])
+
+
+def test_sym_mat_to_vector():
+    """Test converting between vectors and symmetric matrices."""
+    mat = np.array([[0, 1, 2, 3],
+                    [1, 4, 5, 6],
+                    [2, 5, 7, 8],
+                    [3, 6, 8, 9]])
+    assert_array_equal(_sym_mat_to_vector(mat),
+                       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    vec = np.arange(10)
+    assert_array_equal(_vector_to_sym_mat(vec),
+                       [[0, 1, 2, 3],
+                        [1, 4, 5, 6],
+                        [2, 5, 7, 8],
+                        [3, 6, 8, 9]])
+
+    # Test complex values: diagonals should be complex conjugates
+    comp_vec = np.arange(3) + 1j
+    assert_array_equal(_vector_to_sym_mat(comp_vec),
+                       [[0. + 0.j,  1. + 1.j],
+                        [1. - 1.j,  2. + 0.j]])
+
+    # Test preservation of data type
+    assert _sym_mat_to_vector(mat.astype(np.int8)).dtype == np.int8
+    assert _vector_to_sym_mat(vec.astype(np.int8)).dtype == np.int8
+    assert _sym_mat_to_vector(mat.astype(np.float16)).dtype == np.float16
+    assert _vector_to_sym_mat(vec.astype(np.float16)).dtype == np.float16
+
+
+def _generate_coherence_data():
+    """Create an epochs object with coherence at 22Hz between channels 1 and 3.
+
+    A base 10 Hz sine wave is generated for all channels, but with different
+    phases, which means no actual coherence. A  22Hz sine wave is laid on top
+    for channels 1 and 3, with the same phase, so there is coherence between
+    these channels.
+    """
+    ch_names = ['CH1', 'CH2', 'CH3']
+    sfreq = 50.
+    info = mne.create_info(ch_names, sfreq, 'eeg')
+    tstep = 1. / sfreq
+    n_samples = int(10 * sfreq)  # 10 seconds of data
+    times = np.arange(n_samples) * tstep
+    events = np.array([[0, 1, 1]])  # one event
+
+    # Phases for the signals
+    phases = np.arange(info['nchan']) * 0.3 * np.pi
+
+    # Generate 10 Hz sine waves with different phases
+    signal = np.vstack([np.sin(times * 2 * np.pi * 10 + phase)
+                        for phase in phases])
+
+    data = np.zeros((1, info['nchan'], n_samples))
+    data[0, :, :] = signal
+
+    # Generate 22Hz sine wave at the first and last electrodes with the same
+    # phase.
+    signal = np.sin(times * 2 * np.pi * 22)
+    data[0, [0, -1], :] += signal
+
+    return mne.EpochsArray(data, info, events, baseline=(0, times[-1]))
+
+
+def _test_csd_matrix(csd):
+    """Perform a suite of tests on a CSD matrix."""
+    # Check shape of the CSD matrix
+    n_chan = len(csd.ch_names)
+    n_freqs = len(csd.frequencies)
+    assert n_chan == 3
+    assert n_freqs == 3
+    assert csd._data.shape == (6, 3)  # Only upper triangle of CSD matrix
+
+    # Extract CSD ndarrays. Diagonals are PSDs.
+    csd_10 = csd.get_data(index=0)
+    csd_22 = csd.get_data(index=2)
+    power_10 = np.diag(csd_10)
+    power_22 = np.diag(csd_22)
+
+    # Check if the CSD matrices are hermitian
+    assert np.all(np.tril(csd_10).T.conj() == np.triu(csd_10))
+    assert np.all(np.tril(csd_22).T.conj() == np.triu(csd_22))
+
+    # Off-diagonals show phase difference
+    assert np.abs(csd_10[0, 1].imag) > 0.4
+    assert np.abs(csd_10[0, 2].imag) > 0.4
+    assert np.abs(csd_10[1, 2].imag) > 0.4
+
+    # No phase differences at 22 Hz
+    assert np.all(np.abs(csd_22[0, 2].imag) < 1E-3)
+
+    # Test CSD between the two channels that have a 20Hz signal and the one
+    # that has only a 10 Hz signal
+    assert np.abs(csd_22[0, 2]) > np.abs(csd_22[0, 1])
+    assert np.abs(csd_22[0, 2]) > np.abs(csd_22[1, 2])
+
+    # Check that electrodes/frequency combinations with signal have more
+    # power than frequencies without signal.
+    power_15 = np.diag(csd.get_data(index=1))
+    assert np.all(power_10 > power_15)
+    assert np.all(power_22[[0, -1]] > power_15[[0, -1]])
+
+
+def _test_fourier_multitaper_parameters(epochs, csd_epochs, csd_array):
+    """Parameter tests for csd_*_fourier and csd_*_multitaper."""
+    raises(ValueError, csd_epochs, epochs, fmin=20, fmax=10)
+    raises(ValueError, csd_array, epochs._data, epochs.info['sfreq'],
+           epochs.tmin, fmin=20, fmax=10)
+    raises(ValueError, csd_epochs, epochs, fmin=20, fmax=20.1)
+    raises(ValueError, csd_array, epochs._data, epochs.info['sfreq'],
+           epochs.tmin, fmin=20, fmax=20.1)
+    raises(ValueError, csd_epochs, epochs, tmin=0.15, tmax=0.1)
+    raises(ValueError, csd_array, epochs._data, epochs.info['sfreq'],
+           epochs.tmin, tmin=0.15, tmax=0.1)
+    raises(ValueError, csd_epochs, epochs, tmin=-1, tmax=10)
+    raises(ValueError, csd_array, epochs._data, epochs.info['sfreq'],
+           epochs.tmin, tmin=-1, tmax=10)
+    raises(ValueError, csd_epochs, epochs, tmin=10, tmax=11)
+    raises(ValueError, csd_array, epochs._data, epochs.info['sfreq'],
+           epochs.tmin, tmin=10, tmax=11)
+
+    # Test checks for data types and sizes
+    diff_types = [np.random.randn(3, 5), "error"]
+    err_data = [np.random.randn(3, 5), np.random.randn(2, 4)]
+    raises(ValueError, csd_array, err_data, sfreq=1)
+    raises(ValueError, csd_array, diff_types, sfreq=1)
+    raises(ValueError, csd_array, np.random.randn(3), sfreq=1)
+
+
+def test_csd_fourier():
+    """Test computing cross-spectral density using short-term Fourier."""
+    epochs = _generate_coherence_data()
+    sfreq = epochs.info['sfreq']
+    _test_fourier_multitaper_parameters(epochs, csd_fourier, csd_array_fourier)
+
+    # Compute CSDs using various parameters
+    times = [(None, None), (1, 9)]
+    as_arrays = [False, True]
+    parameters = product(times, as_arrays)
+    for (tmin, tmax), as_array in parameters:
+        if as_array:
+            csd = csd_array_fourier(epochs.get_data(), sfreq, epochs.tmin,
+                                    fmin=9, fmax=23, tmin=tmin, tmax=tmax)
+        else:
+            csd = csd_fourier(epochs, fmin=9, fmax=23, tmin=tmin, tmax=tmax)
+
+        csd = csd.mean([9.9, 14.9, 21.9], [10.1, 15.1, 22.1])
+        _test_csd_matrix(csd)
+
+    # For the next test, generate a simple sine wave with a known power
+    times = np.arange(20 * sfreq) / sfreq  # 20 seconds of signal
+    signal = np.sin(2 * np.pi * 10 * times)[None, None, :]  # 10 Hz wave
+    signal_power_per_sample = sum_squared(signal) / len(times)
+
+    # Power per sample should not depend on time window length
+    for tmax in [12, 18]:
+        t_mask = (times <= tmax)
+        n_samples = sum(t_mask)
+
+        # Power per sample should not depend on number of FFT points
+        for add_n_fft in [0, 30]:
+            n_fft = n_samples + add_n_fft
+            csd = csd_array_fourier(signal, sfreq, tmax=tmax,
+                                    n_fft=n_fft).sum().get_data()
+            first_samp = csd[0, 0]
+            fourier_power_per_sample = np.abs(first_samp) * sfreq / n_fft
+            assert abs(signal_power_per_sample -
+                       fourier_power_per_sample) < 0.001
+
+
+def test_csd_multitaper():
+    """Test computing cross-spectral density using multitapers."""
+    epochs = _generate_coherence_data()
+    sfreq = epochs.info['sfreq']
+    _test_fourier_multitaper_parameters(epochs, csd_multitaper,
+                                        csd_array_multitaper)
+
+    # Compute CSDs using various parameters
+    times = [(None, None), (1, 9)]
+    as_arrays = [False, True]
+    adaptives = [False, True]
+    parameters = product(times, as_arrays, adaptives)
+    for (tmin, tmax), as_array, adaptive in parameters:
+        if as_array:
+            csd = csd_array_multitaper(epochs.get_data(), sfreq, epochs.tmin,
+                                       adaptive=adaptive, fmin=9, fmax=23,
+                                       tmin=tmin, tmax=tmax)
+        else:
+            csd = csd_multitaper(epochs, adaptive=adaptive, fmin=9, fmax=23,
+                                 tmin=tmin, tmax=tmax)
+        csd = csd.mean([9.9, 14.9, 21.9], [10.1, 15.1, 22.1])
+        _test_csd_matrix(csd)
+
+    # For the next test, generate a simple sine wave with a known power
+    times = np.arange(20 * sfreq) / sfreq  # 20 seconds of signal
+    signal = np.sin(2 * np.pi * 10 * times)[None, None, :]  # 10 Hz wave
+    signal_power_per_sample = sum_squared(signal) / len(times)
+
+    # Power per sample should not depend on time window length
+    for tmax in [12, 18]:
+        t_mask = (times <= tmax)
+        n_samples = sum(t_mask)
+        n_fft = len(times)
+
+        # Power per sample should not depend on number of tapers
+        for n_tapers in [1, 2, 5]:
+            bandwidth = sfreq / float(n_samples) * (n_tapers + 1)
+            csd_mt = csd_array_multitaper(signal, sfreq, tmax=tmax,
+                                          bandwidth=bandwidth,
+                                          n_fft=n_fft).sum().get_data()
+            mt_power_per_sample = np.abs(csd_mt[0, 0]) * sfreq / n_fft
+            assert abs(signal_power_per_sample - mt_power_per_sample) < 0.001
+
+
+def test_csd_morlet():
+    """Test computing cross-spectral density using Morlet wavelets."""
+    epochs = _generate_coherence_data()
+    sfreq = epochs.info['sfreq']
+
+    # Compute CSDs by a variety of methods
+    freqs = [10, 15, 22]
+    n_cycles = [20, 30, 44]
+    times = [(None, None), (1, 9)]
+    as_arrays = [False, True]
+    parameters = product(times, as_arrays)
+    for (tmin, tmax), as_array in parameters:
+        if as_array:
+            csd = csd_array_morlet(epochs.get_data(), sfreq,
+                                   epochs.tmin, frequencies=freqs,
+                                   n_cycles=n_cycles, tmin=tmin, tmax=tmax)
+        else:
+            csd = csd_morlet(epochs, frequencies=freqs, n_cycles=n_cycles,
+                             tmin=tmin, tmax=tmax)
+        _test_csd_matrix(csd)
+
+    # CSD diagonals should contain PSD
+    tfr = tfr_morlet(epochs, freqs, n_cycles, return_itc=False)
+    power = np.mean(tfr.data, 2)
+    csd = csd_morlet(epochs, frequencies=freqs, n_cycles=n_cycles)
+    assert_allclose(csd._data[[0, 3, 5]] * sfreq, power)
+
+    # Test using plain convolution instead of FFT
+    csd = csd_morlet(epochs, frequencies=freqs, n_cycles=n_cycles,
+                     use_fft=False)
+    assert_allclose(csd._data[[0, 3, 5]] * sfreq, power)
+
+    # Test baselining warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        epochs_nobase = epochs.copy()
+        epochs_nobase.baseline = None
+        epochs_nobase.info['highpass'] = 0
+        csd = csd_morlet(epochs_nobase, frequencies=[10], decim=20)
+    assert len(w) == 1
+
+
+###############################################################################
+# Old CSD tests. These can be removed for version 0.17.
+
+def _get_real_data():
+    """Get some real MEG data."""
     raw = read_raw_fif(raw_fname)
     events = mne.read_events(event_fname)[0:100]
-    if mode == 'real':
-        # Read raw data
-        raw.info['bads'] = ['MEG 2443', 'EEG 053']  # 2 bads channels
 
-        # Set picks
-        picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,
-                               stim=False, exclude='bads')
+    # Read raw data
+    raw.info['bads'] = ['MEG 2443', 'EEG 053']  # 2 bads channels
 
-        # Read several epochs
-        event_id, tmin, tmax = 1, -0.2, 0.5
-        epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                            preload=True,
-                            reject=dict(grad=4000e-13, mag=4e-12))
-    elif mode == 'sin':
-        # Create an epochs object with one epoch and one channel of artificial
-        # data
-        event_id, tmin, tmax = 1, 0.0, 1.0
-        epochs = mne.Epochs(raw, events[0:5], event_id, tmin, tmax,  picks=[0],
-                            preload=True, reject=dict(grad=4000e-13))
-        freq = 10
-        epochs._data = np.sin(2 * np.pi * freq *
-                              epochs.times)[None, None, :]
+    # Set picks
+    picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,
+                           stim=False, exclude='bads')
 
+    # Read several epochs
+    event_id, tmin, tmax = 1, -0.2, 0.5
+    return mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
+                      preload=True, reject=dict(grad=4000e-13, mag=4e-12))
+
+
+def _generate_simple_data():
+    """Create an epochs object with one epoch of 10 Hz sine wave."""
+    event_id, tmin, tmax = 1, 0.0, 1.0
+    raw = read_raw_fif(raw_fname)
+    events = mne.read_events(event_fname)[0:5]
+    epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=[0],
+                        preload=True, reject=dict(grad=4000e-13))
+    freq = 10
+    epochs._data = np.sin(2 * np.pi * freq *
+                          epochs.times)[None, None, :]
     return epochs
 
 
 def test_csd_epochs():
     """Test computing cross-spectral density from epochs."""
-    epochs = _get_data(mode='real')
-    # Check that wrong parameters are recognized
-    assert_raises(ValueError, csd_epochs, epochs, mode='notamode')
-    assert_raises(ValueError, csd_epochs, epochs, fmin=20, fmax=10)
-    assert_raises(ValueError, csd_epochs, epochs, fmin=20, fmax=20.1)
-    assert_raises(ValueError, csd_epochs, epochs, tmin=0.15, tmax=0.1)
-    assert_raises(ValueError, csd_epochs, epochs, tmin=0, tmax=10)
-    assert_raises(ValueError, csd_epochs, epochs, tmin=10, tmax=11)
+    # Ignore deprecation warnings for this the test
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
 
-    data_csd_mt = csd_epochs(epochs, mode='multitaper', fmin=8, fmax=12,
+    epochs = _get_real_data()
+
+    # Check that wrong parameters are recognized
+    raises(ValueError, csd_epochs, epochs, mode='notamode')
+    raises(ValueError, csd_epochs, epochs, fmin=20, fmax=10)
+    raises(ValueError, csd_epochs, epochs, fmin=20, fmax=20.1)
+    raises(ValueError, csd_epochs, epochs, tmin=0.15, tmax=0.1)
+    raises(ValueError, csd_epochs, epochs, tmin=0, tmax=10)
+    raises(ValueError, csd_epochs, epochs, tmin=10, tmax=11)
+
+    # Test deprecation warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        csd_mt = csd_epochs(epochs, mode='multitaper', fmin=8, fmax=12,
+                            tmin=0.04, tmax=0.15)
+    assert len(w) == 1
+
+    csd_fourier = csd_epochs(epochs, mode='fourier', fmin=8, fmax=12,
                              tmin=0.04, tmax=0.15)
-    data_csd_fourier = csd_epochs(epochs, mode='fourier', fmin=8, fmax=12,
-                                  tmin=0.04, tmax=0.15)
 
     # Check shape of the CSD matrix
-    n_chan = len(data_csd_mt.ch_names)
-    assert_equal(data_csd_mt.data.shape, (n_chan, n_chan))
-    assert_equal(data_csd_fourier.data.shape, (n_chan, n_chan))
+    n_chan = len(csd_mt.ch_names)
+    csd_mt_data = csd_mt.get_data()
+    csd_fourier_data = csd_fourier.get_data()
+    assert csd_mt_data.shape == (n_chan, n_chan)
+    assert csd_fourier_data.shape == (n_chan, n_chan)
 
     # Check if the CSD matrix is hermitian
-    assert_array_equal(np.tril(data_csd_mt.data).T.conj(),
-                       np.triu(data_csd_mt.data))
-    assert_array_equal(np.tril(data_csd_fourier.data).T.conj(),
-                       np.triu(data_csd_fourier.data))
+    assert_array_equal(np.tril(csd_mt_data).T.conj(),
+                       np.triu(csd_mt_data))
+    assert_array_equal(np.tril(csd_fourier_data).T.conj(),
+                       np.triu(csd_fourier_data))
 
     # Computing induced power for comparison
     epochs.crop(tmin=0.04, tmax=0.15)
@@ -80,39 +590,41 @@ def test_csd_epochs():
 
     # Maximum PSD should occur for specific channel
     max_ch_power = power.argmax()
-    max_ch_mt = data_csd_mt.data.diagonal().argmax()
-    max_ch_fourier = data_csd_fourier.data.diagonal().argmax()
-    assert_equal(max_ch_mt, max_ch_power)
-    assert_equal(max_ch_fourier, max_ch_power)
+    max_ch_mt = csd_mt_data.diagonal().argmax()
+    max_ch_fourier = csd_fourier_data.diagonal().argmax()
+    assert max_ch_mt == max_ch_power
+    assert max_ch_fourier == max_ch_power
 
     # Maximum CSD should occur for specific channel
-    ch_csd_mt = np.abs(data_csd_mt.data[max_ch_power])
+    ch_csd_mt = np.abs(csd_mt_data[max_ch_power])
     ch_csd_mt[max_ch_power] = 0.
     max_ch_csd_mt = np.argmax(ch_csd_mt)
-    ch_csd_fourier = np.abs(data_csd_fourier.data[max_ch_power])
+    ch_csd_fourier = np.abs(csd_fourier_data[max_ch_power])
     ch_csd_fourier[max_ch_power] = 0.
     max_ch_csd_fourier = np.argmax(ch_csd_fourier)
-    assert_equal(max_ch_csd_mt, max_ch_csd_fourier)
+    assert max_ch_csd_mt == max_ch_csd_fourier
 
     # Check a list of CSD matrices is returned for multiple frequencies within
     # a given range when fsum=False
     csd_fsum = csd_epochs(epochs, mode='fourier', fmin=8, fmax=20, fsum=True)
     csds = csd_epochs(epochs, mode='fourier', fmin=8, fmax=20, fsum=False)
-    freqs = [csd.freqs[0] for csd in csds]
+    assert len(csd_fsum.frequencies) == 1
+    assert len(csds.frequencies) == 2
+    assert_array_equal(csd_fsum.frequencies[0], csds.frequencies)
 
-    csd_sum = np.zeros_like(csd_fsum.data)
-    for csd in csds:
-        csd_sum += csd.data
+    csd_sum = csds._data.sum(axis=1, keepdims=True)
+    assert_array_equal(csd_fsum._data, csd_sum)
 
-    assert_equal(len(csds), 2)
-    assert_equal(len(csd_fsum.freqs), 2)
-    assert_array_equal(csd_fsum.freqs, freqs)
-    assert_array_equal(csd_fsum.data, csd_sum)
+    # Turn deprecation warnings back on
+    warnings.simplefilter('always')
 
 
 def test_csd_epochs_on_artificial_data():
     """Test computing CSD on artificial data."""
-    epochs = _get_data(mode='sin')
+    # Ignore deprecation warnings for this test
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+    epochs = _generate_simple_data()
     sfreq = epochs.info['sfreq']
 
     # Computing signal power in the time domain
@@ -120,51 +632,55 @@ def test_csd_epochs_on_artificial_data():
     signal_power_per_sample = signal_power / len(epochs.times)
 
     # Computing signal power in the frequency domain
-    data_csd_fourier = csd_epochs(epochs, mode='fourier')
-    data_csd_mt = csd_epochs(epochs, mode='multitaper')
-    fourier_power = np.abs(data_csd_fourier.data[0, 0]) * sfreq
-    mt_power = np.abs(data_csd_mt.data[0, 0]) * sfreq
-    assert_true(abs(fourier_power - signal_power) <= 0.5)
-    assert_true(abs(mt_power - signal_power) <= 1)
+    csd_fourier = csd_epochs(epochs, mode='fourier').get_data()
+    csd_mt = csd_epochs(epochs, mode='multitaper').get_data()
+
+    fourier_power = np.abs(csd_fourier[0, 0]) * sfreq
+    mt_power = np.abs(csd_mt[0, 0]) * sfreq
+    assert abs(fourier_power - signal_power) <= 0.5
+    assert abs(mt_power - signal_power) <= 1
 
     # Power per sample should not depend on time window length
     for tmax in [0.2, 0.8]:
+        t_mask = (epochs.times >= 0) & (epochs.times <= tmax)
+        n_samples = sum(t_mask)
         for add_n_fft in [0, 30]:
-            t_mask = (epochs.times >= 0) & (epochs.times <= tmax)
-            n_samples = sum(t_mask)
             n_fft = n_samples + add_n_fft
-
-            data_csd_fourier = csd_epochs(epochs, mode='fourier',
-                                          tmin=None, tmax=tmax, fmin=0,
-                                          fmax=np.inf, n_fft=n_fft)
-            first_samp = data_csd_fourier.data[0, 0]
+            csd_fourier = csd_epochs(
+                epochs, mode='fourier', tmin=None, tmax=tmax, fmin=0,
+                fmax=np.inf, n_fft=n_fft
+            ).get_data()
+            first_samp = csd_fourier[0, 0]
             fourier_power_per_sample = np.abs(first_samp) * sfreq / n_fft
-            assert_true(abs(signal_power_per_sample -
-                            fourier_power_per_sample) < 0.003)
+            assert abs(signal_power_per_sample -
+                       fourier_power_per_sample) < 0.003
         # Power per sample should not depend on number of tapers
         for n_tapers in [1, 2, 5]:
-            for add_n_fft in [0, 30]:
-                mt_bandwidth = sfreq / float(n_samples) * (n_tapers + 1)
-                data_csd_mt = csd_epochs(epochs, mode='multitaper',
-                                         tmin=None, tmax=tmax, fmin=0,
-                                         fmax=np.inf,
-                                         mt_bandwidth=mt_bandwidth,
-                                         n_fft=n_fft)
-                mt_power_per_sample = np.abs(data_csd_mt.data[0, 0]) *\
-                    sfreq / data_csd_mt.n_fft
-                # The estimate of power gets worse for small time windows when
-                # more tapers are used
-                if n_tapers == 5 and tmax == 0.2:
-                    delta = 0.05
-                else:
-                    delta = 0.004
-                assert_true(abs(signal_power_per_sample -
-                                mt_power_per_sample) < delta)
+            mt_bandwidth = sfreq / float(n_samples) * (n_tapers + 1)
+            csd_mt = csd_epochs(
+                epochs, mode='multitaper', tmin=None, tmax=tmax, fmin=0,
+                fmax=np.inf, mt_bandwidth=mt_bandwidth, n_fft=n_fft
+            ).get_data()
+            mt_power_per_sample = np.abs(csd_mt[0, 0]) * sfreq / n_fft
+            # The estimate of power gets worse for small time windows when more
+            # tapers are used
+            if n_tapers == 5 and tmax == 0.2:
+                delta = 0.05
+            else:
+                delta = 0.004
+            assert abs(signal_power_per_sample -
+                       mt_power_per_sample) < delta
+
+    # Turn deprecation warnings back on
+    warnings.simplefilter('always')
 
 
 def test_compute_csd():
     """Test computing cross-spectral density from ndarray."""
-    epochs = _get_data(mode='real')
+    # Ignore deprecation warnings for this the test
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+    epochs = _get_real_data()
 
     tmin = 0.04
     tmax = 0.15
@@ -186,43 +702,45 @@ def test_compute_csd():
     # Check data types and sizes are checked
     diff_types = [np.random.randn(3, 5), "error"]
     err_data = [np.random.randn(3, 5), np.random.randn(2, 4)]
-    assert_raises(ValueError, csd_array, err_data, sfreq)
-    assert_raises(ValueError, csd_array, diff_types, sfreq)
-    assert_raises(ValueError, csd_array, np.random.randn(3), sfreq)
+    raises(ValueError, csd_array, err_data, sfreq)
+    raises(ValueError, csd_array, diff_types, sfreq)
+    raises(ValueError, csd_array, np.random.randn(3), sfreq)
 
     # Check that wrong parameters are recognized
-    assert_raises(ValueError, csd_array, X, sfreq, mode='notamode')
-    assert_raises(ValueError, csd_array, X, sfreq, fmin=20, fmax=10)
-    assert_raises(ValueError, csd_array, X, sfreq, fmin=20, fmax=20.1)
+    raises(ValueError, csd_array, X, sfreq, mode='notamode')
+    raises(ValueError, csd_array, X, sfreq, fmin=20, fmax=10)
+    raises(ValueError, csd_array, X, sfreq, fmin=20, fmax=20.1)
 
-    data_csd_mt, freqs_mt = csd_array(X, sfreq, mode='multitaper',
-                                      fmin=8, fmax=12)
-    data_csd_fourier, freqs_fft = csd_array(X, sfreq, mode='fourier',
-                                            fmin=8, fmax=12)
+    # Test deprecation warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        csd_mt = csd_array(X, sfreq, mode='multitaper', fmin=8, fmax=12)
+    assert len(w) == 1
+
+    csd_fourier = csd_array(X, sfreq, mode='fourier', fmin=8, fmax=12)
 
     # Test as list too
-    data_csd_mt_list, freqs_mt_list = csd_array(X_list, sfreq,
-                                                mode='multitaper',
-                                                fmin=8, fmax=12)
-    data_csd_fourier_list, freqs_fft_list = csd_array(X_list, sfreq,
-                                                      mode='fourier',
-                                                      fmin=8, fmax=12)
+    csd_mt_list = csd_array(X_list, sfreq, mode='multitaper', fmin=8, fmax=12)
+    csd_fourier_list = csd_array(X_list, sfreq, mode='fourier', fmin=8,
+                                 fmax=12)
 
-    assert_array_equal(data_csd_mt, data_csd_mt_list)
-    assert_array_equal(data_csd_fourier, data_csd_fourier_list)
-    assert_array_equal(freqs_mt, freqs_mt_list)
-    assert_array_equal(freqs_fft, freqs_fft_list)
+    assert_array_equal(csd_mt._data, csd_mt_list._data)
+    assert_array_equal(csd_fourier._data, csd_fourier_list._data)
+    assert_array_equal(csd_mt.frequencies, csd_mt_list.frequencies)
+    assert_array_equal(csd_fourier.frequencies, csd_fourier_list.frequencies)
 
     # Check shape of the CSD matrix
     n_chan = len(epochs.ch_names)
-    assert_equal(data_csd_mt.shape, (n_chan, n_chan))
-    assert_equal(data_csd_fourier.shape, (n_chan, n_chan))
+    csd_mt_data = csd_mt.get_data()
+    csd_fourier_data = csd_fourier.get_data()
+    assert csd_mt_data.shape == (n_chan, n_chan)
+    assert csd_fourier_data.shape == (n_chan, n_chan)
 
     # Check if the CSD matrix is hermitian
-    assert_array_equal(np.tril(data_csd_mt).T.conj(),
-                       np.triu(data_csd_mt))
-    assert_array_equal(np.tril(data_csd_fourier).T.conj(),
-                       np.triu(data_csd_fourier))
+    assert_array_equal(np.tril(csd_mt_data).T.conj(),
+                       np.triu(csd_mt_data))
+    assert_array_equal(np.tril(csd_fourier_data).T.conj(),
+                       np.triu(csd_fourier_data))
 
     # Computing induced power for comparison
     epochs.crop(tmin=0.04, tmax=0.15)
@@ -231,38 +749,39 @@ def test_compute_csd():
 
     # Maximum PSD should occur for specific channel
     max_ch_power = power.argmax()
-    max_ch_mt = data_csd_mt.diagonal().argmax()
-    max_ch_fourier = data_csd_fourier.diagonal().argmax()
-    assert_equal(max_ch_mt, max_ch_power)
-    assert_equal(max_ch_fourier, max_ch_power)
+    max_ch_mt = csd_mt_data.diagonal().argmax()
+    max_ch_fourier = csd_fourier_data.diagonal().argmax()
+    assert max_ch_mt == max_ch_power
+    assert max_ch_fourier == max_ch_power
 
     # Maximum CSD should occur for specific channel
-    ch_csd_mt = np.abs(data_csd_mt[max_ch_power])
+    ch_csd_mt = np.abs(csd_mt_data[max_ch_power])
     ch_csd_mt[max_ch_power] = 0.
     max_ch_csd_mt = np.argmax(ch_csd_mt)
-    ch_csd_fourier = np.abs(data_csd_fourier[max_ch_power])
+    ch_csd_fourier = np.abs(csd_fourier_data[max_ch_power])
     ch_csd_fourier[max_ch_power] = 0.
     max_ch_csd_fourier = np.argmax(ch_csd_fourier)
-    assert_equal(max_ch_csd_mt, max_ch_csd_fourier)
+    assert max_ch_csd_mt == max_ch_csd_fourier
 
     # Check a list of CSD matrices is returned for multiple frequencies within
     # a given range when fsum=False
-    csd_fsum, freqs_fsum = csd_array(X, sfreq, mode='fourier', fmin=8,
-                                     fmax=20, fsum=True)
-    csds, freqs = csd_array(X, sfreq, mode='fourier', fmin=8, fmax=20,
-                            fsum=False)
+    csd_fsum = csd_array(X, sfreq, mode='fourier', fmin=8, fmax=20, fsum=True)
+    csds = csd_array(X, sfreq, mode='fourier', fmin=8, fmax=20, fsum=False)
 
-    csd_sum = np.sum(csds, axis=2)
+    assert csds._data.shape[1] == 2
+    assert len(csds.frequencies) == 2
+    assert_array_equal(csd_fsum.frequencies[0], csds.frequencies)
+    assert_array_equal(csd_fsum._data, csds._data.sum(axis=1, keepdims=True))
 
-    assert_equal(csds.shape[2], 2)
-    assert_equal(len(freqs), 2)
-    assert_array_equal(freqs_fsum, freqs)
-    assert_array_equal(csd_fsum, csd_sum)
+    # Turn deprecation warnings back on
+    warnings.simplefilter('always')
 
 
 def test_csd_on_artificial_data():
     """Test computing CSD on artificial data. """
-    epochs = _get_data(mode='sin')
+    # Ignore deprecation warnings for this test
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+    epochs = _generate_simple_data()
     sfreq = epochs.info['sfreq']
 
     # Computing signal power in the time domain
@@ -270,15 +789,13 @@ def test_csd_on_artificial_data():
     signal_power_per_sample = signal_power / len(epochs.times)
 
     # Computing signal power in the frequency domain
-    data_csd_mt, freqs_mt = csd_array(epochs._data, sfreq,
-                                      mode='multitaper')
-    data_csd_fourier, freqs_fft = csd_array(epochs._data, sfreq,
-                                            mode='fourier')
+    csd_mt = csd_array(epochs._data, sfreq, mode='multitaper').get_data()
+    csd_fourier = csd_array(epochs._data, sfreq, mode='fourier').get_data()
 
-    fourier_power = np.abs(data_csd_fourier[0, 0]) * sfreq
-    mt_power = np.abs(data_csd_mt[0, 0]) * sfreq
-    assert_true(abs(fourier_power - signal_power) <= 0.5)
-    assert_true(abs(mt_power - signal_power) <= 1)
+    fourier_power = np.abs(csd_fourier[0, 0]) * sfreq
+    mt_power = np.abs(csd_mt[0, 0]) * sfreq
+    assert abs(fourier_power - signal_power) <= 0.5
+    assert abs(mt_power - signal_power) <= 1
 
     # Power per sample should not depend on time window length
     for tmax in [0.2, 0.8]:
@@ -289,30 +806,33 @@ def test_csd_on_artificial_data():
             n_samples = sum(t_mask)
             n_fft = n_samples + add_n_fft
 
-            data_csd_fourier, _ = csd_array(epochs._data[:, :, tslice],
-                                            sfreq, mode='fourier',
-                                            fmin=0, fmax=np.inf, n_fft=n_fft)
+            csd_fourier = csd_array(epochs._data[:, :, tslice], sfreq,
+                                    mode='fourier', fmin=0, fmax=np.inf,
+                                    n_fft=n_fft).get_data()
 
-            first_samp = data_csd_fourier[0, 0]
+            first_samp = csd_fourier[0, 0]
             fourier_power_per_sample = np.abs(first_samp) * sfreq / n_fft
-            assert_true(abs(signal_power_per_sample -
-                            fourier_power_per_sample) < 0.003)
+            assert abs(signal_power_per_sample -
+                       fourier_power_per_sample) < 0.003
         # Power per sample should not depend on number of tapers
         for n_tapers in [1, 2, 5]:
-            for add_n_fft in [0, 30]:
-                mt_bandwidth = sfreq / float(n_samples) * (n_tapers + 1)
-                data_csd_mt, _ = csd_array(epochs._data[:, :, tslice],
-                                           sfreq, mt_bandwidth=mt_bandwidth,
-                                           n_fft=n_fft)
-                mt_power_per_sample = np.abs(data_csd_mt[0, 0]) *\
-                    sfreq / n_fft
-                # The estimate of power gets worse for small time windows when
-                # more tapers are used
-                if n_tapers == 5 and tmax == 0.2:
-                    delta = 0.05
-                else:
-                    delta = 0.004
-                assert_true(abs(signal_power_per_sample -
-                                mt_power_per_sample) < delta)
+            mt_bandwidth = sfreq / float(n_samples) * (n_tapers + 1)
+            csd_mt = csd_array(
+                epochs._data[:, :, tslice], sfreq,
+                mt_bandwidth=mt_bandwidth, n_fft=n_fft
+            ).get_data()
+            mt_power_per_sample = np.abs(csd_mt[0, 0]) * sfreq / n_fft
+            # The estimate of power gets worse for small time windows when more
+            # tapers are used
+            if n_tapers == 5 and tmax == 0.2:
+                delta = 0.05
+            else:
+                delta = 0.004
+            assert abs(signal_power_per_sample -
+                       mt_power_per_sample) < delta
+
+    # Turn deprecation warnings back on
+    warnings.simplefilter('always')
+
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -29,13 +29,13 @@ def _make_csd():
     names = ['CH1', 'CH2', 'CH3']
     tmin, tmax = (0., 1.)
     data = np.arange(6. * n_freqs).reshape(n_freqs, 6).T
-    return CrossSpectralDensity(data, names, tmin, tmax, frequencies, 1)
+    return CrossSpectralDensity(data, names, frequencies, 1, tmin, tmax)
 
 
 def test_csd():
     """Test constructing a CrossSpectralDensity."""
-    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'], tmin=0, tmax=1,
-                               frequencies=1, n_fft=1)
+    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'], frequencies=1,
+                               n_fft=1, tmin=0, tmax=1)
     assert_array_equal(csd._data, [[1], [2], [3]])  # Conversion to 2D array
     assert_array_equal(csd.frequencies, [1])  # Conversion to 1D array
 
@@ -51,8 +51,8 @@ def test_csd():
            tmin=0, tmax=1, frequencies=1, n_fft=1)
 
     # Invalid dims
-    raises(ValueError, CrossSpectralDensity, [[[1]]], ['CH1'], tmin=0, tmax=1,
-           frequencies=1, n_fft=1)
+    raises(ValueError, CrossSpectralDensity, [[[1]]], ['CH1'], frequencies=1,
+           n_fft=1, tmin=0, tmax=1)
 
 
 def test_csd_repr():
@@ -73,6 +73,14 @@ def test_csd_repr():
     assert str(csd_binned) == ('<CrossSpectralDensity  |  n_channels=3, '
                                'time=0.0 to 1.0 s, frequencies=1.0, 2.0-4.0 '
                                'Hz.>')
+
+    csd_no_time = csd.copy()
+    csd_no_time.tmin = None
+    csd_no_time.tmax = None
+    assert str(csd_no_time) == (
+        '<CrossSpectralDensity  |  n_channels=3, time=unknown, '
+        'frequencies=1.0, 2.0, 3.0, 4.0 Hz.>'
+    )
 
 
 def test_csd_mean():
@@ -111,7 +119,7 @@ def test_csd_mean():
     )
 
     # This flag should be set after averaging
-    assert csd.mean().is_sum
+    assert csd.mean()._is_sum
 
     # Test construction of .frequency attribute
     assert csd.mean().frequencies == [[1, 2, 3, 4]]
@@ -225,7 +233,7 @@ def test_csd_save():
     assert csd.tmax == csd2.tmax
     assert csd.ch_names == csd2.ch_names
     assert csd.frequencies == csd2.frequencies
-    assert csd.is_sum == csd2.is_sum
+    assert csd._is_sum == csd2._is_sum
 
 
 def test_csd_pickle():
@@ -242,7 +250,7 @@ def test_csd_pickle():
     assert csd.tmax == csd2.tmax
     assert csd.ch_names == csd2.ch_names
     assert csd.frequencies == csd2.frequencies
-    assert csd.is_sum == csd2.is_sum
+    assert csd._is_sum == csd2._is_sum
 
 
 def test_pick_channels_csd():

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -17,7 +17,6 @@ from mne.time_frequency import (csd_fourier, csd_multitaper,
                                 pick_channels_csd)
 from mne.time_frequency.csd import _sym_mat_to_vector, _vector_to_sym_mat
 
-warnings.simplefilter('always')
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 event_fname = op.join(base_dir, 'test-eve.fif')
@@ -547,9 +546,6 @@ def _generate_simple_data():
 
 def test_csd_epochs():
     """Test computing cross-spectral density from epochs."""
-    # Ignore deprecation warnings for this the test
-    warnings.filterwarnings('ignore', category=DeprecationWarning)
-
     epochs = _get_real_data()
 
     # Check that wrong parameters are recognized
@@ -561,11 +557,12 @@ def test_csd_epochs():
     raises(ValueError, csd_epochs, epochs, tmin=10, tmax=11)
 
     # Test deprecation warning
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter('always')
         csd_mt = csd_epochs(epochs, mode='multitaper', fmin=8, fmax=12,
                             tmin=0.04, tmax=0.15)
-    assert len(w) == 1
+    assert len([w for w in ws
+                if issubclass(w.category, DeprecationWarning)]) == 1
 
     csd_fourier = csd_epochs(epochs, mode='fourier', fmin=8, fmax=12,
                              tmin=0.04, tmax=0.15)
@@ -615,15 +612,9 @@ def test_csd_epochs():
     csd_sum = csds._data.sum(axis=1, keepdims=True)
     assert_array_equal(csd_fsum._data, csd_sum)
 
-    # Turn deprecation warnings back on
-    warnings.simplefilter('always')
-
 
 def test_csd_epochs_on_artificial_data():
     """Test computing CSD on artificial data."""
-    # Ignore deprecation warnings for this test
-    warnings.filterwarnings('ignore', category=DeprecationWarning)
-
     epochs = _generate_simple_data()
     sfreq = epochs.info['sfreq']
 
@@ -671,15 +662,9 @@ def test_csd_epochs_on_artificial_data():
             assert abs(signal_power_per_sample -
                        mt_power_per_sample) < delta
 
-    # Turn deprecation warnings back on
-    warnings.simplefilter('always')
-
 
 def test_compute_csd():
     """Test computing cross-spectral density from ndarray."""
-    # Ignore deprecation warnings for this the test
-    warnings.filterwarnings('ignore', category=DeprecationWarning)
-
     epochs = _get_real_data()
 
     tmin = 0.04
@@ -712,10 +697,11 @@ def test_compute_csd():
     raises(ValueError, csd_array, X, sfreq, fmin=20, fmax=20.1)
 
     # Test deprecation warning
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter('always')
         csd_mt = csd_array(X, sfreq, mode='multitaper', fmin=8, fmax=12)
-    assert len(w) == 1
+    assert len([w for w in ws
+                if issubclass(w.category, DeprecationWarning)]) == 1
 
     csd_fourier = csd_array(X, sfreq, mode='fourier', fmin=8, fmax=12)
 
@@ -773,14 +759,10 @@ def test_compute_csd():
     assert_array_equal(csd_fsum.frequencies[0], csds.frequencies)
     assert_array_equal(csd_fsum._data, csds._data.sum(axis=1, keepdims=True))
 
-    # Turn deprecation warnings back on
-    warnings.simplefilter('always')
-
 
 def test_csd_on_artificial_data():
     """Test computing CSD on artificial data. """
     # Ignore deprecation warnings for this test
-    warnings.filterwarnings('ignore', category=DeprecationWarning)
     epochs = _generate_simple_data()
     sfreq = epochs.info['sfreq']
 
@@ -830,9 +812,6 @@ def test_csd_on_artificial_data():
                 delta = 0.004
             assert abs(signal_power_per_sample -
                        mt_power_per_sample) < delta
-
-    # Turn deprecation warnings back on
-    warnings.simplefilter('always')
 
 
 run_tests_if_main()

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -10,9 +10,10 @@ from ._3d import (plot_sparse_source_estimates, plot_source_estimates,
                   plot_vector_source_estimates, plot_evoked_field,
                   plot_dipole_locations, snapshot_brain_montage,
                   plot_head_positions, plot_alignment)
-from .misc import (plot_cov, plot_bem, plot_events, plot_source_spectrogram,
-                   _get_presser, plot_dipole_amplitudes, plot_ideal_filter,
-                   plot_filter, adjust_axes)
+from .misc import (plot_cov, plot_csd, plot_bem, plot_events,
+                   plot_source_spectrogram, _get_presser,
+                   plot_dipole_amplitudes, plot_ideal_filter, plot_filter,
+                   adjust_axes)
 from .evoked import (plot_evoked, plot_evoked_image, plot_evoked_white,
                      plot_snr_estimate, plot_evoked_topo,
                      plot_evoked_joint, plot_compare_evokeds)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1004,7 +1004,7 @@ def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,
                            vmax=vmax)
             ax.set_xticks([])
             ax.set_yticks([])
-            if csd.is_sum:
+            if csd._is_sum:
                 ax.set_title('%.1f-%.1f Hz.' % (np.min(freq),
                                                 np.max(freq)))
             else:

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -107,19 +107,30 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
                         'channels.')
 
     import matplotlib.pyplot as plt
+    from matplotlib.colors import Normalize
 
     fig_cov, axes = plt.subplots(1, len(idx_names), squeeze=False,
-                                 figsize=(2.5 * len(idx_names), 2.7))
+                                 figsize=(3.8 * len(idx_names), 3.7))
     for k, (idx, name, _, _) in enumerate(idx_names):
-        axes[0, k].imshow(C[idx][:, idx], interpolation="nearest",
-                          cmap='RdBu_r')
+        vlim = np.max(np.abs(C[idx][:, idx]))
+        im = axes[0, k].imshow(C[idx][:, idx], interpolation="nearest",
+                               norm=Normalize(vmin=-vlim, vmax=vlim),
+                               cmap='RdBu_r')
         axes[0, k].set(title=name)
+
+        if colorbar:
+            from mpl_toolkits.axes_grid1 import make_axes_locatable
+            divider = make_axes_locatable(axes[0, k])
+            cax = divider.append_axes("right", size="5.5%", pad=0.05)
+            plt.colorbar(im, cax=cax, format='%.0e')
+
     fig_cov.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.2, 0.26)
     tight_layout(fig=fig_cov)
 
     fig_svd = None
     if show_svd:
-        fig_svd, axes = plt.subplots(1, len(idx_names), squeeze=False)
+        fig_svd, axes = plt.subplots(1, len(idx_names), squeeze=False,
+                                     figsize=(3.8 * len(idx_names), 3.7))
         for k, (idx, name, unit, scaling) in enumerate(idx_names):
             s = linalg.svd(C[idx][:, idx], compute_uv=False)
             # Protect against true zero singular values
@@ -131,6 +142,7 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
         tight_layout(fig=fig_svd)
 
     plt_show(show)
+
     return fig_cov, fig_svd
 
 

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -27,6 +27,7 @@ from mne.time_frequency import CrossSpectralDensity
 
 # Set our plotters to test mode
 import matplotlib
+from matplotlib import pyplot as plt
 matplotlib.use('Agg')  # for testing don't use X server
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -87,6 +88,7 @@ def test_plot_cov():
     cov = read_cov(cov_fname)
     with warnings.catch_warnings(record=True):  # bad proj
         fig1, fig2 = cov.plot(raw.info, proj=True, exclude=raw.ch_names[6:])
+    plt.close('all')
 
 
 @testing.requires_testing_data
@@ -128,6 +130,7 @@ def test_plot_events():
                       raw.first_samp, event_id={'aud_l': 1}, color=color)
         assert_raises(ValueError, plot_events, events, raw.info['sfreq'],
                       raw.first_samp, event_id={'aud_l': 111}, color=color)
+    plt.close('all')
 
 
 @testing.requires_testing_data
@@ -148,6 +151,7 @@ def test_plot_source_spectrogram():
                   [[1, 2], [3, 4]], tmin=0)
     assert_raises(ValueError, plot_source_spectrogram, [stc, stc],
                   [[1, 2], [3, 4]], tmax=7)
+    plt.close('all')
 
 
 @pytest.mark.slowtest
@@ -157,6 +161,7 @@ def test_plot_snr():
     inv = read_inverse_operator(inv_fname)
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     plot_snr_estimate(evoked, inv)
+    plt.close('all')
 
 
 @testing.requires_testing_data
@@ -164,6 +169,7 @@ def test_plot_dipole_amplitudes():
     """Test plotting dipole amplitudes."""
     dipoles = read_dipole(dip_fname)
     dipoles.plot_amplitudes(show=False)
+    plt.close('all')
 
 
 def test_plot_csd():
@@ -172,6 +178,7 @@ def test_plot_csd():
                                frequencies=[(10, 20)], n_fft=1)
     plot_csd(csd, mode='csd')  # Plot cross-spectral density
     plot_csd(csd, mode='coh')  # Plot coherence
+    plt.close('all')
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -21,8 +21,9 @@ from mne.filter import create_filter
 from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
-                     plot_snr_estimate, plot_filter)
+                     plot_snr_estimate, plot_filter, plot_csd)
 from mne.utils import requires_nibabel, run_tests_if_main, requires_version
+from mne.time_frequency import CrossSpectralDensity
 
 # Set our plotters to test mode
 import matplotlib
@@ -163,6 +164,14 @@ def test_plot_dipole_amplitudes():
     """Test plotting dipole amplitudes."""
     dipoles = read_dipole(dip_fname)
     dipoles.plot_amplitudes(show=False)
+
+
+def test_plot_csd():
+    """Test plotting of CSD matrices."""
+    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'], tmin=0, tmax=1,
+                               frequencies=[(10, 20)], n_fft=1)
+    plot_csd(csd, mode='csd')  # Plot cross-spectral density
+    plot_csd(csd, mode='coh')  # Plot coherence
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -174,8 +174,9 @@ def test_plot_dipole_amplitudes():
 
 def test_plot_csd():
     """Test plotting of CSD matrices."""
-    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'], tmin=0, tmax=1,
-                               frequencies=[(10, 20)], n_fft=1)
+    csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'],
+                               frequencies=[(10, 20)], n_fft=1,
+                               tmin=0, tmax=1,)
     plot_csd(csd, mode='csd')  # Plot cross-spectral density
     plot_csd(csd, mode='coh')  # Plot coherence
     plt.close('all')


### PR DESCRIPTION
## Relation to the DICS PR

This overhaul of the CSD functionality was started in #4797, but is now split off into it's own PR. In this PR, the DICS code has been left untouched, except for some minor modifications to use the new CSD objects.

## New CSD object

The CrossSpectralDensity object has been extended. It can now contain multiple CSD matrices. Since it is a very common use case to want to compute the CSD for multiple frequency bands, the intended workflow is now:

 - Compute the CSD for all desired frequencies once
 - Save it to avoid recomputing this beast
 - Use `csd.mean` to average across frequency bands at will
 - Feed the CSD object into `dics_source_power` to obtain an STC with the desired frequency bands as the "time" dimension.

`CrossSpectralDensity` objects have a `save` method and there is now a `read_csd` function.

## Refactoring of the old csd functions

The `csd_epochs` and `csd_array` functions have been refactored to mimic the `tfr_*` functions. Instead of using `mode="..."` we now have:
 - `csd_fourier`
 - `csd_multitaper`
 - `csd_array_fourier`
 - `csd_array_multitaper`

The old functions still remain with the `@deprecated` flag and simply delegate to the new functions. The old unit tests also still remain (and pass).

## New functionality

The ability of using Morlet wavelets to estimate the CSD has been added, so now we also have:
 - `csd_morlet`
 - `csd_array_morlet`

CSD objects have a shiny plotting function to visually verify the result. It can also plot the channel-to-channel coherence (`mode='coh'`) which is useful for debugging your connectivity results.

