### PR TITLE
MRG: More compact evoked repr

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -180,11 +180,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         write_evokeds(fname, self)
 
     def __repr__(self):  # noqa: D105
-        s = "comment : '%s'" % self.comment
-        s += ', kind : %s' % self.kind
-        s += ", time : [%f, %f]" % (self.times[0], self.times[-1])
-        s += ", n_epochs : %d" % self.nave
-        s += ", n_channels x n_times : %s x %s" % self.data.shape
+        _kind_swap = dict(average='mean', standard_error='SEM')
+        s = "'%s' (%s, N=%s)" % (self.comment, _kind_swap[self.kind],
+                                 self.nave)
+        s += ", [%0.5g, %0.5g] sec" % (self.times[0], self.times[-1])
+        s += ", %s ch" % self.data.shape[0]
         s += ", ~%s" % (sizeof_fmt(self._size),)
         return "<Evoked  |  %s>" % s
 

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -9,6 +9,7 @@ from math import sqrt
 import numpy as np
 from scipy import linalg
 
+from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..io.open import fiff_open
 from ..io.tag import find_tag
@@ -1463,7 +1464,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
 
     logger.info('Computing SVD of whitened and weighted lead field '
                 'matrix.')
-    eigen_fields, sing, eigen_leads = linalg.svd(gain, full_matrices=False)
+    eigen_fields, sing, eigen_leads = _safe_svd(gain, full_matrices=False)
     logger.info('    largest singular value = %g' % np.max(sing))
     logger.info('    scaling factor to adjust the trace = %g' % trace_GRGT)
 


### PR DESCRIPTION
Currently on `master` this is what I get for an `evoked.__repr__`:
```
<Evoked  |  comment : 'vis/learn/faces/incorrect', kind : standard_error, time : [-0.100000, 0.748000], n_epochs : 22, n_channels x n_times : 306 x 213, ~7.5 MB>
```
This is too long to be displayed even on a fairly wide terminal, making it hard to find relevant information when, especially when looking at multiple `evoked` instances. This PR changes it to a more compact representation (while removing the "number of time points" information, which did not seem that useful given that the time window is already given, and it can be obtained with `evoked.data.shape[1]`):
```
<Evoked  |  'vis/learn/faces/incorrect' (SEM, N=22), [-0.1, 0.748] sec, 306 ch, ~7.5 MB>
```

I also tucked in an unrelated `_safe_svd` fix, might as well run Travis on it.