### PR TITLE
MRG: Axis divider in a few places

### DIFF
--- a/examples/visualization/plot_channel_epochs_image.py
+++ b/examples/visualization/plot_channel_epochs_image.py
@@ -6,7 +6,7 @@ Visualize channel over epochs as an image
 This will produce what is sometimes called an event related
 potential / field (ERP/ERF) image.
 
-2 images are produced, one with a good channel and one with a channel
+Two images are produced, one with a good channel and one with a channel
 that does not show any evoked field.
 
 It is also demonstrated how to reorder the epochs using a 1D spectral

--- a/examples/visualization/plot_roi_erpimage_by_rt.py
+++ b/examples/visualization/plot_roi_erpimage_by_rt.py
@@ -11,7 +11,7 @@ to simple visual stimuli - is read in and response times are calculated.
 Regions of Interest are determined by the channel types (in 10/20 channel
 notation, even channels are right, odd are left, and 'z' are central). The
 median and the Global Field Power within each channel group is calculated,
-and the trials are plotted, sorted by response time.
+and the trials are plotted, sorting by response time.
 """
 # Authors: Jona Sassenhagen <jona.sassenhagen@gmail.com>
 #

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -4,6 +4,7 @@
 #          Denis Engemann <denis.engemann@gmail.com>
 #          Andrew Dykstra <andrew.r.dykstra@gmail.com>
 #          Mads Jensen <mje.mads@gmail.com>
+#          Jona Sassenhagen <jona.sassenhagen@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -268,16 +268,19 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         for group, axes_dict in zip(groups, axes_list):
             ch_type = group[1]
             ax = axes_dict["evoked"]
+            this_ymin, this_ymax = these_ylims = ylims[ch_type]
+            ax.set_ylim(these_ylims)
+            yticks = np.array(ax.get_yticks())
+            max_height = yticks[yticks < this_ymax][-1]
             if not manual_ylims:
-                ax.set_ylim(ylims[ch_type])
+                ax.spines["left"].set_bounds(this_ymin, max_height)
             if len(vlines) > 0:
-                upper_v, lower_v = ylims[ch_type]
                 if overlay_times is not None:
                     overlay = {overlay_times.mean(), np.median(overlay_times)}
                 else:
                     overlay = {}
                 for line in vlines:
-                    ax.vlines(line, upper_v, lower_v, colors='k',
+                    ax.vlines(line, this_ymin, max_height, colors='k',
                               linestyles='-' if line in overlay else "--",
                               linewidth=2. if line in overlay else 1.)
 
@@ -451,7 +454,7 @@ def _make_epochs_image_axis_grid(axes_dict=dict(), colorbar=False,
         divider = make_axes_locatable(axes_dict["image"])
         if colorbar:
             axes_dict["colorbar"] = axes_dict.get(
-                "colorbar", divider.append_axes("right", size="7%", pad="3%"))
+                "colorbar", divider.append_axes("right", size="3%", pad="3%"))
         if evoked:
             axes_dict["evoked"] = axes_dict.get(
                 "evoked", divider.append_axes("bottom", size="35%", pad="5%"))

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -442,6 +442,23 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
             ts_args_]
 
 
+def _make_epochs_image_axis_grid(axes_dict=dict(), colorbar=False,
+                                 evoked=False):
+    """Set up a dictionary of axes for epochs images."""
+    import matplotlib.pyplot as plt
+    axes_dict["image"] = axes_dict.get("image", plt.axes())
+    if any((colorbar, evoked)):
+        from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
+        divider = make_axes_locatable(axes_dict["image"])
+    if colorbar:
+        axes_dict["colorbar"] = axes_dict.get(
+            "colorbar", divider.append_axes("right", size="7%", pad="3%"))
+    if evoked:
+        axes_dict["evoked"] = axes_dict.get(
+            "evoked", divider.append_axes("bottom", size="35%", pad="5%"))
+    return axes_dict
+
+
 def _prepare_epochs_image_axes(axes, fig, colorbar, evoked):
     """Prepare axes for image plotting. Helper for plot_epochs_image."""
     import matplotlib.pyplot as plt
@@ -451,15 +468,7 @@ def _prepare_epochs_image_axes(axes, fig, colorbar, evoked):
         if fig is None:
             fig = plt.figure()
         plt.figure(fig.number)
-        axes_dict["image"] = plt.subplot2grid(
-            (3, 10), (0, 0), colspan=9 if colorbar else 10,
-            rowspan=2 if evoked else 3)
-        if evoked:
-            axes_dict["evoked"] = plt.subplot2grid(
-                (3, 10), (2, 0), colspan=9 if colorbar else 10, rowspan=1)
-        if colorbar:
-            axes_dict["colorbar"] = plt.subplot2grid((3, 10), (0, 9),
-                                                     colspan=1, rowspan=3)
+        axes_dict = _make_epochs_image_axis_grid(axes_dict, colorbar, evoked)
     else:
         if fig is not None:
             raise ValueError('Both figure and axes were passed, please'

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -443,10 +443,10 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
 
 
 def _make_epochs_image_axis_grid(axes_dict=dict(), colorbar=False,
-                                 evoked=False):
+                                 evoked=False, fig=None):
     """Set up a dictionary of axes for epochs images."""
     import matplotlib.pyplot as plt
-    axes_dict["image"] = axes_dict.get("image", plt.axes())
+    axes_dict["image"] = axes_dict.get("image", fig.add_subplot(111))
     if any((colorbar, evoked)):
         from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
         divider = make_axes_locatable(axes_dict["image"])
@@ -468,7 +468,8 @@ def _prepare_epochs_image_axes(axes, fig, colorbar, evoked):
         if fig is None:
             fig = plt.figure()
         plt.figure(fig.number)
-        axes_dict = _make_epochs_image_axis_grid(axes_dict, colorbar, evoked)
+        axes_dict = _make_epochs_image_axis_grid(
+            axes_dict, colorbar, evoked, fig)
     else:
         if fig is not None:
             raise ValueError('Both figure and axes were passed, please'

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -445,17 +445,16 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
 def _make_epochs_image_axis_grid(axes_dict=dict(), colorbar=False,
                                  evoked=False, fig=None):
     """Set up a dictionary of axes for epochs images."""
-    import matplotlib.pyplot as plt
     axes_dict["image"] = axes_dict.get("image", fig.add_subplot(111))
     if any((colorbar, evoked)):
         from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
         divider = make_axes_locatable(axes_dict["image"])
-    if colorbar:
-        axes_dict["colorbar"] = axes_dict.get(
-            "colorbar", divider.append_axes("right", size="7%", pad="3%"))
-    if evoked:
-        axes_dict["evoked"] = axes_dict.get(
-            "evoked", divider.append_axes("bottom", size="35%", pad="5%"))
+        if colorbar:
+            axes_dict["colorbar"] = axes_dict.get(
+                "colorbar", divider.append_axes("right", size="7%", pad="3%"))
+        if evoked:
+            axes_dict["evoked"] = axes_dict.get(
+                "evoked", divider.append_axes("bottom", size="35%", pad="5%"))
     return axes_dict
 
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -446,18 +446,18 @@ def _prepare_epochs_image_im_data(epochs, ch_type, overlay_times, order,
 
 
 def _make_epochs_image_axis_grid(axes_dict=dict(), colorbar=False,
-                                 evoked=False, fig=None):
-    """Set up a dictionary of axes for epochs images."""
-    axes_dict["image"] = axes_dict.get("image", fig.add_subplot(111))
-    if any((colorbar, evoked)):
-        from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
-        divider = make_axes_locatable(axes_dict["image"])
-        if colorbar:
-            axes_dict["colorbar"] = axes_dict.get(
-                "colorbar", divider.append_axes("right", size="3%", pad="3%"))
-        if evoked:
-            axes_dict["evoked"] = axes_dict.get(
-                "evoked", divider.append_axes("bottom", size="35%", pad="5%"))
+                                 evoked=False):
+    """Create axes for image plotting. Helper for plot_epochs_image."""
+    import matplotlib.pyplot as plt
+    axes_dict["image"] = axes_dict.get("image", plt.subplot2grid(
+        (3, 10), (0, 0), colspan=9 if colorbar else 10,
+        rowspan=2 if evoked else 3))
+    if evoked:
+        axes_dict["evoked"] = plt.subplot2grid(
+            (3, 10), (2, 0), colspan=9 if colorbar else 10, rowspan=1)
+    if colorbar:
+        axes_dict["colorbar"] = plt.subplot2grid(
+            (3, 10), (0, 9), colspan=1, rowspan=2 if evoked else 3)
     return axes_dict
 
 
@@ -471,7 +471,7 @@ def _prepare_epochs_image_axes(axes, fig, colorbar, evoked):
             fig = plt.figure()
         plt.figure(fig.number)
         axes_dict = _make_epochs_image_axis_grid(
-            axes_dict, colorbar, evoked, fig)
+            axes_dict, colorbar, evoked)
     else:
         if fig is not None:
             raise ValueError('Both figure and axes were passed, please'

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1998,8 +1998,8 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     for condition in conditions:
         # plot the actual data ('d') as a line
         d = data_dict[condition].T
-        ax.plot(times, d, zorder=1000, label=condition, **styles[condition],
-                clip_on=False)
+        ax.plot(times, d, zorder=1000, label=condition, clip_on=False,
+                **styles[condition])
         if np.any(d > 0) or all_positive:
             any_positive = True
         if np.any(d < 0):

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1808,7 +1808,6 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     one_evoked = evokeds[conditions[0]][0]
     times = one_evoked.times
     info = one_evoked.info
-    ch_names = one_evoked.ch_names
     tmin, tmax = times[0], times[-1]
 
     if vlines == "auto" and (tmin < 0 and tmax > 0):
@@ -1999,7 +1998,8 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     for condition in conditions:
         # plot the actual data ('d') as a line
         d = data_dict[condition].T
-        ax.plot(times, d, zorder=1000, label=condition, **styles[condition])
+        ax.plot(times, d, zorder=1000, label=condition, **styles[condition],
+                clip_on=False)
         if np.any(d > 0) or all_positive:
             any_positive = True
         if np.any(d < 0):
@@ -2009,7 +2009,8 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
         if _ci_fun is not None:
             ci_ = ci_dict[condition]
             ax.fill_between(times, ci_[0].flatten(), ci_[1].flatten(),
-                            zorder=9, color=styles[condition]['c'], alpha=.3)
+                            zorder=9, color=styles[condition]['c'], alpha=.3,
+                            clip_on=False)
 
     # truncate the y axis
     orig_ymin, orig_ymax = ax.get_ylim()

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1446,14 +1446,18 @@ def _truncate_yaxis(axes, ymin, ymax, orig_ymin, orig_ymax, fraction,
             ymin_bound = round(ymin_bound / precision) * precision
         if ymin is None:
             ymax_bound = round(ymax_bound / precision) * precision
-    else:
-        ticks = axes.get_yticks()
-        ymin_bound, ymax_bound = ticks[[1, -2]]
-        if ymin_bound > 0:
-            ymin_bound = 0
-        ymin_bound = ymin if ymin is not None else ymin_bound
-        ymax_bound = ymax if ymax is not None else ymax_bound
-    axes.spines['left'].set_bounds(ymin_bound, ymax_bound)
+        axes.spines['left'].set_bounds(ymin_bound, ymax_bound)
+    else:  # code stolen from seaborn
+        yticks = axes.get_yticks()
+        firsttick = np.compress(yticks >= min(axes.get_ylim()),
+                                yticks)[0]
+        lasttick = np.compress(yticks <= max(axes.get_ylim()),
+                               yticks)[-1]
+        axes.spines['left'].set_bounds(firsttick, lasttick)
+        newticks = yticks.compress(yticks <= lasttick)
+        newticks = newticks.compress(newticks >= firsttick)
+        axes.set_yticks(newticks)
+        ymin_bound, ymax_bound = newticks[[0, -1]]
     return ymin_bound, ymax_bound
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2499,14 +2499,17 @@ def _check_cov(noise_cov, info):
 def _set_title_multiple_electrodes(title, combine, ch_names, max_chans=6,
                                    all=False, ch_type=None, ):
     """Prepare a title string for multiple electrodes."""
-    title = ", ".join(ch_names[:max_chans]) if title is None else title
-    if ch_type is not None:
-        ch_type = " " + ch_type[0].upper() + ch_type[1:]
-    if all is True and isinstance(combine, string_types):
-        combine = combine[0].upper() + combine[1:]
-        title = "{} of {}{} sensors".format(combine, len(ch_names), ch_type)
-    elif len(ch_names) > max_chans and combine is not "gfp":
-        warn("More than {} channels, truncating title ...".format(max_chans))
-        title += ", ...\n({} of {}{} sensors)".format(combine, len(ch_names),
-                                                      ch_type,)
+    if title is None:
+        title = ", ".join(ch_names[:max_chans])
+        if ch_type is not None:
+            ch_type = " " + ch_type[0].upper() + ch_type[1:]
+        if all is True and isinstance(combine, string_types):
+            combine = combine[0].upper() + combine[1:]
+            title = "{} of {}{} sensors".format(
+                combine, len(ch_names), ch_type)
+        elif len(ch_names) > max_chans and combine is not "gfp":
+            warn("More than {} channels, truncating title ...".format(
+                max_chans))
+            title += ", ...\n({} of {}{} sensors)".format(
+                combine, len(ch_names), ch_type,)
     return title

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -16,6 +16,7 @@ Caveat for the interpretation of "significant" clusters: see
 the `FieldTrip website`_.
 """
 # Authors: Denis Engemann <denis.engemann@gmail.com>
+#          Jona Sassenhagen <jona.sassenhagen@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -185,7 +186,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 # - What is the smallest p-value you can obtain, given the finite number of
 #   permutations?
 # - use an F distribution to compute the threshold by traditional significance
-#   levels. Hint: take a look at :class:`scipy.stats.distributions.f`
+#   levels. Hint: take a look at :obj:`scipy.stats.distributions.f`
 #
 # References
 # ==========

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -28,6 +28,7 @@ import mne
 from mne.stats import spatio_temporal_cluster_test
 from mne.datasets import sample
 from mne.channels import find_ch_connectivity
+from mne.viz import plot_compare_evokeds
 
 print(__doc__)
 
@@ -37,7 +38,7 @@ print(__doc__)
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
-event_id = {'Aud_L': 1, 'Aud_R': 2, 'Vis_L': 3, 'Vis_R': 4}
+event_id = {'Aud/L': 1, 'Aud/R': 2, 'Vis/L': 3, 'Vis/R': 4}
 tmin = -0.2
 tmax = 0.5
 
@@ -59,8 +60,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
 epochs.drop_channels(['EOG 061'])
 epochs.equalize_event_counts(event_id)
 
-condition_names = 'Aud_L', 'Aud_R', 'Vis_L', 'Vis_R'
-X = [epochs[k].get_data() for k in condition_names]  # as 3D matrix
+X = [epochs[k].get_data() for k in event_id]  # as 3D matrix
 X = [np.transpose(x, (0, 2, 1)) for x in X]  # transpose for clustering
 
 
@@ -118,14 +118,14 @@ good_cluster_inds = np.where(p_values < p_accept)[0]
 
 # configure variables for visualization
 times = epochs.times * 1e3
-colors = 'r', 'r', 'steelblue', 'steelblue'
-linestyles = '-', '--', '-', '--'
-
-# grand average as numpy arrray
-grand_ave = np.array(X).mean(axis=1)
+colors = {"Aud": "crimson", "Vis": 'steelblue'}
+linestyles = {"L": '-', "R": '--'}
 
 # get sensor positions via layout
 pos = mne.find_layout(epochs.info).pos
+
+# organize data for plotting
+evokeds = {cond: epochs[cond].average() for cond in event_id}
 
 # loop over clusters
 for i_clu, clu_idx in enumerate(good_cluster_inds):
@@ -138,8 +138,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     f_map = T_obs[time_inds, ...].mean(axis=0)
 
     # get signals at the sensors contributing to the cluster
-    signals = grand_ave[..., ch_inds].mean(axis=-1)
-    sig_times = times[time_inds]
+    sig_times = epochs.times[time_inds]
 
     # create spatial mask
     mask = np.zeros((f_map.shape[0], 1), dtype=bool)
@@ -147,43 +146,33 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 
     # initialize figure
     fig, ax_topo = plt.subplots(1, 1, figsize=(10, 3))
-    title = 'Cluster #{0}'.format(i_clu + 1)
-    fig.suptitle(title, fontsize=14)
 
     # plot average test statistic and mark significant sensors
-    image, _ = plot_topomap(f_map, pos, mask=mask, axes=ax_topo,
-                            cmap='Reds', vmin=np.min, vmax=np.max,
-                            show=False)
+    image, _ = plot_topomap(f_map, pos, mask=mask, axes=ax_topo, cmap='Reds',
+                            vmin=np.min, vmax=np.max, show=False)
 
-    # advanced matplotlib for showing image with figure and colorbar
-    # in one plot
+    # create additional axes (for ERF and colorbar)
     divider = make_axes_locatable(ax_topo)
 
     # add axes for colorbar
     ax_colorbar = divider.append_axes('right', size='5%', pad=0.05)
     plt.colorbar(image, cax=ax_colorbar)
-    ax_topo.set_xlabel('Averaged F-map ({:0.1f} - {:0.1f} ms)'.format(
-        *sig_times[[0, -1]]
-    ))
+    ax_topo.set_xlabel(
+        'Averaged F-map ({:0.1f} - {:0.1f} ms)'.format(*sig_times[[0, -1]]))
 
     # add new axis for time courses and plot time courses
     ax_signals = divider.append_axes('right', size='300%', pad=1.2)
-    for signal, name, col, ls in zip(signals, condition_names, colors,
-                                     linestyles):
-        ax_signals.plot(times, signal, color=col, linestyle=ls, label=name)
+    title = 'Cluster #{0}, {1} sensor'.format(i_clu + 1, len(ch_inds))
+    if len(ch_inds) > 1:
+        title += "s"
+    plot_compare_evokeds(evokeds, title=title, picks=ch_inds, axes=ax_signals,
+                         colors=colors, linestyles=linestyles, show=False,
+                         split_legend=True)
 
-    # add information
-    ax_signals.axvline(0, color='k', linestyle=':', label='stimulus onset')
-    ax_signals.set_xlim([times[0], times[-1]])
-    ax_signals.set_xlabel('time [ms]')
-    ax_signals.set_ylabel('evoked magnetic fields [fT]')
-
-    # plot significant time range
+    # plot temporal cluster extent
     ymin, ymax = ax_signals.get_ylim()
     ax_signals.fill_betweenx((ymin, ymax), sig_times[0], sig_times[-1],
                              color='orange', alpha=0.3)
-    ax_signals.legend(loc='lower right')
-    ax_signals.set_ylim(ymin, ymax)
 
     # clean up viz
     mne.viz.tight_layout(fig=fig)
@@ -195,9 +184,9 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 # ----------
 #
 # - What is the smallest p-value you can obtain, given the finite number of
-#    permutations?
+#   permutations?
 # - use an F distribution to compute the threshold by traditional significance
-#    levels. Hint: take a look at ``scipy.stats.distributions.f``
+#   levels. Hint: take a look at ``scipy.stats.distributions.f``
 #
 # References
 # ==========

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -149,7 +149,8 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 
     # plot average test statistic and mark significant sensors
     image, _ = plot_topomap(f_map, pos, mask=mask, axes=ax_topo,
-                            cmap='Reds', vmin=np.min, vmax=np.max)
+                            cmap='Reds', vmin=np.min, vmax=np.max,
+                            show=False)
 
     # advanced matplotlib for showing image with figure and colorbar
     # in one plot

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -186,7 +186,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 # - What is the smallest p-value you can obtain, given the finite number of
 #   permutations?
 # - use an F distribution to compute the threshold by traditional significance
-#   levels. Hint: take a look at :obj:`scipy.stats.distributions.f`
+#   levels. Hint: take a look at :obj:`scipy.stats.f`
 #
 # References
 # ==========

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -9,8 +9,11 @@ Tests for differential evoked responses in at least
 one condition using a permutation clustering test.
 The FieldTrip neighbor templates will be used to determine
 the adjacency between sensors. This serves as a spatial prior
-to the clustering. Significant spatiotemporal clusters will then
+to the clustering. Spatiotemporal clusters will then
 be visualized using custom matplotlib code.
+
+Caveat for the interpretation of "significant" clusters: see
+the `FieldTrip website`_.
 """
 # Authors: Denis Engemann <denis.engemann@gmail.com>
 #
@@ -124,7 +127,7 @@ grand_ave = np.array(X).mean(axis=1)
 # get sensor positions via layout
 pos = mne.find_layout(epochs.info).pos
 
-# loop over significant clusters
+# loop over clusters
 for i_clu, clu_idx in enumerate(good_cluster_inds):
     # unpack cluster information, get unique indices
     time_inds, space_inds = np.squeeze(clusters[clu_idx])
@@ -134,7 +137,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     # get topography for F stat
     f_map = T_obs[time_inds, ...].mean(axis=0)
 
-    # get signals at significant sensors
+    # get signals at the sensors contributing to the cluster
     signals = grand_ave[..., ch_inds].mean(axis=-1)
     sig_times = times[time_inds]
 
@@ -195,3 +198,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 #    permutations?
 # - use an F distribution to compute the threshold by traditional significance
 #    levels. Hint: take a look at ``scipy.stats.distributions.f``
+#
+# References
+# ==========
+# .. _fieldtrip website: http://www.fieldtriptoolbox.org/faq/how_not_to_interpret_results_from_a_cluster-based_permutation_test  # noqa

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -158,13 +158,13 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     ax_colorbar = divider.append_axes('right', size='5%', pad=0.05)
     plt.colorbar(image, cax=ax_colorbar)
     ax_topo.set_xlabel(
-        'Averaged F-map ({:0.1f} - {:0.1f} ms)'.format(*sig_times[[0, -1]]))
+        'Averaged F-map ({:0.3f} - {:0.3f} s)'.format(*sig_times[[0, -1]]))
 
     # add new axis for time courses and plot time courses
     ax_signals = divider.append_axes('right', size='300%', pad=1.2)
     title = 'Cluster #{0}, {1} sensor'.format(i_clu + 1, len(ch_inds))
     if len(ch_inds) > 1:
-        title += "s"
+        title += "s (mean)"
     plot_compare_evokeds(evokeds, title=title, picks=ch_inds, axes=ax_signals,
                          colors=colors, linestyles=linestyles, show=False,
                          split_legend=True, truncate_yaxis='max_ticks')

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -117,7 +117,6 @@ good_cluster_inds = np.where(p_values < p_accept)[0]
 # ------------------
 
 # configure variables for visualization
-times = epochs.times * 1e3
 colors = {"Aud": "crimson", "Vis": 'steelblue'}
 linestyles = {"L": '-', "R": '--'}
 
@@ -186,7 +185,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
 # - What is the smallest p-value you can obtain, given the finite number of
 #   permutations?
 # - use an F distribution to compute the threshold by traditional significance
-#   levels. Hint: take a look at ``scipy.stats.distributions.f``
+#   levels. Hint: take a look at :class:`scipy.stats.distributions.f`
 #
 # References
 # ==========

--- a/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/plot_stats_spatio_temporal_cluster_sensors.py
@@ -167,7 +167,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
         title += "s"
     plot_compare_evokeds(evokeds, title=title, picks=ch_inds, axes=ax_signals,
                          colors=colors, linestyles=linestyles, show=False,
-                         split_legend=True)
+                         split_legend=True, truncate_yaxis='max_ticks')
 
     # plot temporal cluster extent
     ymin, ymax = ax_signals.get_ylim()


### PR DESCRIPTION
1. @dengemann suggested in #2897 we use the axis divider pattern instead of plt.subplot calls. I've refactored epochs.plot_image accordingly. Besides for slightly neater code, the main benefit is that this should in principle allow 3-axis epochs image plots in a topographical layout.

2. The very appealing example for the pattern in the tutorials has been broken for a few versions now because someone forgot to turn off `show`:
http://martinos.org/mne/stable/auto_tutorials/plot_stats_spatio_temporal_cluster_sensors.html
http://martinos.org/mne/dev/auto_tutorials/plot_stats_spatio_temporal_cluster_sensors.html
This fixes it.

3. Also working on the "significant clusters" terminology ...

4. Also the example can be simplified substantially now thanks to plot_compare_evokeds