### PR TITLE
WIP: tfmxne solver edits

### DIFF
--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -6,7 +6,7 @@
 import numpy as np
 import warnings
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_allclose, assert_array_less)
+                           assert_allclose, assert_array_less, assert_equal)
 
 from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            tf_mixed_norm_solver,
@@ -119,7 +119,16 @@ def test_tf_mxne():
         n_orient=1, tstep=4, wsize=32, return_gap=True)
     assert_array_less(gap_tfmxne, 1e-8)
     assert_array_equal(np.where(active_set_hat_tf)[0], active_set)
-
+    
+    alpha_space = 1e8
+    alpha_time = 1e8
+    X_hat_tf, active_set_hat_tf, E, gap_tfmxne = tf_mixed_norm_solver(
+        M, G, alpha_space, alpha_time, maxit=200, tol=1e-8, verbose=True,
+        n_orient=1, tstep=4, wsize=32, return_gap=True)
+    assert_array_less(gap_tfmxne, 1e-8)
+    assert_equal(X_hat_tf.shape[0], 0)
+    assert_equal(np.any(active_set_hat_tf), False)
+    
 
 def test_norm_epsilon():
     """Test computation of espilon norm on TF coefficients."""

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -119,7 +119,7 @@ def test_tf_mxne():
         n_orient=1, tstep=4, wsize=32, return_gap=True)
     assert_array_less(gap_tfmxne, 1e-8)
     assert_array_equal(np.where(active_set_hat_tf)[0], active_set)
-    
+
     alpha_space = 1e8
     alpha_time = 1e8
     X_hat_tf, active_set_hat_tf, E, gap_tfmxne = tf_mixed_norm_solver(
@@ -128,7 +128,7 @@ def test_tf_mxne():
     assert_array_less(gap_tfmxne, 1e-8)
     assert_equal(X_hat_tf.shape[0], 0)
     assert_equal(np.any(active_set_hat_tf), False)
-    
+
 
 def test_norm_epsilon():
     """Test computation of espilon norm on TF coefficients."""

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -101,10 +101,17 @@ def test_l21_mxne():
     with warnings.catch_warnings(record=True):  # coordinate-ascent warning
         X_hat_cd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, n_orient=5, solver='cd')
-
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
     assert_array_equal(X_hat_bcd, X_hat_cd)
     assert_allclose(X_hat_bcd, X_hat_prox, rtol=1e-2)
+
+    args = (M, G, 1000., 100, 1e-8)
+    X_hat_cd, active_set, _, gap_cd = mixed_norm_solver(
+        *args, active_set_size=None,
+        debias=True, solver='cd', return_gap=True)
+    assert_array_less(gap_cd, 1e-8)
+    assert_equal(X_hat_cd.shape[0], 0)
+    assert_equal(np.any(active_set), False)
 
 
 def test_tf_mxne():


### PR DESCRIPTION
Following the discussion with @mathurinm, this PR modifies `tf_mixed_norm_solver` in mxne_optim.py such that it doesn't crash for alpha >= alpha_max, but return an empty array (similar to mixed_norm_solver). Tests are added.

This PR is relevant only for the integrity of the solver. We want the solver functions to simply solve the optimization problem (for every regularization parameter). In practical applications, we still check in mxne_inverse.py that alpha < 100. Hence, tfmxne_solver will not be called with alpha >=100, so the PR is not really relevant for practical applications.