### PR TITLE
Feature: Simulation of signals

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -546,6 +546,7 @@ Covariance computation
    make_ad_hoc_cov
    read_cov
    write_cov
+   make_custom_cov
 
 
 MRI Processing
@@ -970,11 +971,18 @@ Simulation
    :toctree: generated/
    :template: function.rst
 
+   Simulation 
    simulate_evoked
    simulate_raw
    simulate_stc
    simulate_sparse_stc
    select_source_in_label
+   simulate_raw_signal
+   get_events
+   waveform_p300_nontarget
+   waveform_p300_target
+   waveform_sin
+   get_waveform
 
 
 .. _api_decoding:
@@ -1089,3 +1097,4 @@ Logging and Configuration
    :template: function.rst
 
    init_cuda
+

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -546,7 +546,6 @@ Covariance computation
    make_ad_hoc_cov
    read_cov
    write_cov
-   make_custom_cov
 
 
 MRI Processing

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -37,7 +37,8 @@ from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)
 from .cov import (read_cov, write_cov, Covariance, compute_raw_covariance,
-                  compute_covariance, whiten_evoked, make_ad_hoc_cov)
+                  compute_covariance, whiten_evoked, make_ad_hoc_cov,
+                  make_custom_cov)
 from .event import (read_events, write_events, find_events, merge_events,
                     pick_events, make_fixed_length_events, concatenate_events,
                     find_stim_steps, AcqParserFIF)

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -37,8 +37,7 @@ from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
                   read_bem_surfaces, write_bem_surfaces,
                   read_bem_solution, write_bem_solution)
 from .cov import (read_cov, write_cov, Covariance, compute_raw_covariance,
-                  compute_covariance, whiten_evoked, make_ad_hoc_cov,
-                  make_custom_cov)
+                  compute_covariance, whiten_evoked, make_ad_hoc_cov)
 from .event import (read_events, write_events, find_events, merge_events,
                     pick_events, make_fixed_length_events, concatenate_events,
                     find_stim_steps, AcqParserFIF)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -265,13 +265,18 @@ def read_cov(fname, verbose=None):
 # Estimate from data
 
 @verbose
-def make_ad_hoc_cov(info, verbose=None):
+def make_ad_hoc_cov(info, std=None, verbose=None):
     """Create an ad hoc noise covariance.
 
     Parameters
     ----------
     info : instance of Info
         Measurement info.
+    std : dict of ndarray | None
+        Standard_deviations of the diagonal elements. If dict, keys should be
+        `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
+        channels. The ndarrays must have the same number of elements as the
+        sensors denoted by their keys.
     verbose : bool, str, int, or None (default None)
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -283,75 +288,20 @@ def make_ad_hoc_cov(info, verbose=None):
 
     Notes
     -----
-    This uses values of 5 fT/cm, 20 fT, and 0.2 uV for gradiometers,
+    The default noise values are 5 fT/cm, 20 fT, and 0.2 uV for gradiometers,
     magnetometers, and EEG channels, respectively.
 
     .. versionadded:: 0.9.0
     """
     picks = pick_types(info, meg=True, eeg=True, exclude=())
-
-    # Standard deviations to be used
-    grad_std = 5e-13
-    mag_std = 20e-15
-    eeg_std = 0.2e-6
-    logger.info('Using standard noise values '
-                '(MEG grad : %6.1f fT/cm MEG mag : %6.1f fT EEG : %6.1f uV)'
-                % (1e13 * grad_std, 1e15 * mag_std, 1e6 * eeg_std))
+    std = _handle_default('noise_std', std)
 
     data = np.zeros(len(picks))
     for meg, eeg, val in zip(('grad', 'mag', False), (False, False, True),
-                             (grad_std, mag_std, eeg_std)):
-        these_picks = pick_types(info, meg=meg, eeg=eeg)
-        data[np.searchsorted(picks, these_picks)] = val * val
-    ch_names = [info['ch_names'][pick] for pick in picks]
-    return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
-
-
-##############################################################################
-# Create from array
-# TODO: add test for this
-@verbose
-def make_custom_cov(info, standard_deviations, verbose=None):
-    """Create an ad hoc noise covariance.
-
-    Parameters
-    ----------
-    info : instance of Info
-        Measurement info.
-    standard_deviations : dict of string : (numpy) array
-        stds of the diagonal elements
-        keys must be eeg, grad and mag
-    verbose : bool, str, int, or None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
-
-    Returns
-    -------
-    cov : instance of Covariance
-        The ad hoc diagonal noise covariance for the M/EEG data channels.
-
-    Notes
-    -----
-    None for the moment.
-
-    """
-    picks = pick_types(info, meg=True, eeg=True, exclude=())
-
-    # Standard deviations to be used
-    # TODO: implement easy creation of data
-    grad_std = standard_deviations['grad']
-    mag_std = standard_deviations['mag']
-    eeg_std = standard_deviations['eeg']
-    # TODO a lot to do here, like check values
-
-    data = np.zeros(len(picks))
-    for meg, eeg, val in zip(('grad', 'mag', False), (False, False, True),
-                             (grad_std, mag_std, eeg_std)):
+                             (std['grad'], std['mag'], std['eeg'])):
         these_picks = pick_types(info, meg=meg, eeg=eeg)
         data[np.searchsorted(picks, these_picks)] = np.multiply(val, val)
-
     ch_names = [info['ch_names'][pick] for pick in picks]
-
     return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
 
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -307,6 +307,54 @@ def make_ad_hoc_cov(info, verbose=None):
     return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
 
 
+##############################################################################
+# Create from array
+# TODO: add test for this
+@verbose
+def make_custom_cov(info, standard_deviations, verbose=None):
+    """Create an ad hoc noise covariance.
+
+    Parameters
+    ----------
+    info : instance of Info
+        Measurement info.
+    standard_deviations : dict of string : (numpy) array
+        stds of the diagonal elements
+        keys must be eeg, grad and mag
+    verbose : bool, str, int, or None (default None)
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    cov : instance of Covariance
+        The ad hoc diagonal noise covariance for the M/EEG data channels.
+
+    Notes
+    -----
+    None for the moment.
+
+    """
+    picks = pick_types(info, meg=True, eeg=True, exclude=())
+
+    # Standard deviations to be used
+    # TODO: implement easy creation of data
+    grad_std = standard_deviations['grad']
+    mag_std = standard_deviations['mag']
+    eeg_std = standard_deviations['eeg']
+    # TODO a lot to do here, like check values
+
+    data = np.zeros(len(picks))
+    for meg, eeg, val in zip(('grad', 'mag', False), (False, False, True),
+                             (grad_std, mag_std, eeg_std)):
+        these_picks = pick_types(info, meg=meg, eeg=eeg)
+        data[np.searchsorted(picks, these_picks)] = np.multiply(val, val)
+
+    ch_names = [info['ch_names'][pick] for pick in picks]
+
+    return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
+
+
 def _check_n_samples(n_samples, n_chan):
     """Check to see if there are enough samples for reliable cov calc."""
     n_samples_min = 10 * (n_chan + 1) // 2

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -59,6 +59,7 @@ DEFAULTS = dict(
         nasion_color=(0., 1., 0.),
         rpa_color=(0., 0., 1.),
     ),
+    noise_std=dict(grad=5e-13, mag=20e-15, eeg=0.2e-6),
 )
 
 

--- a/mne/simulation/__init__.py
+++ b/mne/simulation/__init__.py
@@ -4,3 +4,7 @@ from .evoked import simulate_evoked, simulate_noise_evoked
 from .raw import simulate_raw
 from .source import select_source_in_label, simulate_stc, simulate_sparse_stc
 from .metrics import source_estimate_quantification
+from .waveforms import waveform_sin, waveform_p300_target
+from .waveforms import waveform_p300_nontarget, get_waveform
+from .simulation import Simulation, simulate_raw_signal, get_events
+

--- a/mne/simulation/noise.py
+++ b/mne/simulation/noise.py
@@ -5,29 +5,25 @@
 import warnings
 import numpy as np
 
-from ..cov import make_ad_hoc_cov, read_cov, make_custom_cov
-from ..externals.six import string_types
+from ..cov import make_ad_hoc_cov, read_cov, Covariance
 from ..io.pick import pick_channels_cov
 from ..utils import check_random_state
-
-from mne.cov import Covariance
 
 
 def _check_cov(info, cov):
     """Check that the user provided a valid covariance matrix for the noise."""
-    if isinstance(cov, string_types):
+    if isinstance(cov, dict) and not isinstance(cov, Covariance):
+        cov = make_ad_hoc_cov(info, cov, verbose=False)
+    elif isinstance(cov, str) or isinstance(cov, unicode):
         if cov == 'simple':
-            cov = make_ad_hoc_cov(info, verbose=False)
+            cov = make_ad_hoc_cov(info, None, verbose=False)
         else:
             cov = read_cov(cov, verbose=False)
     elif isinstance(cov, Covariance):
         pass
-    elif isinstance(cov, dict):
-        cov = make_custom_cov(info, cov, verbose=False)
     else:
-        raise ValueError('Covariance Matrix type not recognized. Valid input'
-                         'types are: instance of Covariance, array'
-                         'string(covariance filename | \'simple\'')
+        raise ValueError('Covariance matrix type not recognized. Valid input '
+                         'types are: instance of Covariance, dict, str, None')
     return cov
 
 
@@ -42,6 +38,7 @@ def generate_noise_data(info, cov, n_samples, random_state, iir_filter=None,
         If 'simple', a basic (diagonal) ad-hoc noise covariance will be used.
         If a string (filename), then the covariance will be loaded.
         If dict, a covariance matrix will be generated from it.
+        Add the rest of the description here.
     """
     from scipy.signal import lfilter
 

--- a/mne/simulation/noise.py
+++ b/mne/simulation/noise.py
@@ -1,0 +1,81 @@
+# author: ngayraud
+#
+# Created on Fri Mar 16 10:31:51 2018.
+
+import warnings
+import numpy as np
+
+from ..cov import make_ad_hoc_cov, read_cov, make_custom_cov
+from ..externals.six import string_types
+from ..io.pick import pick_channels_cov
+from ..utils import check_random_state
+
+from mne.cov import Covariance
+
+
+def _check_cov(info, cov):
+    """Check that the user provided a valid covariance matrix for the noise."""
+    if isinstance(cov, string_types):
+        if cov == 'simple':
+            cov = make_ad_hoc_cov(info, verbose=False)
+        else:
+            cov = read_cov(cov, verbose=False)
+    elif isinstance(cov, Covariance):
+        pass
+    elif isinstance(cov, dict):
+        cov = make_custom_cov(info, cov, verbose=False)
+    else:
+        raise ValueError('Covariance Matrix type not recognized. Valid input'
+                         'types are: instance of Covariance, array'
+                         'string(covariance filename | \'simple\'')
+    return cov
+
+
+def generate_noise_data(info, cov, n_samples, random_state, iir_filter=None,
+                        zi=None):
+    """Create spatially colored and temporally IIR-filtered noise.
+
+    Parameters
+    ----------
+    cov : instance of Covariance | str
+        The sensor covariance matrix used to generate noise.
+        If 'simple', a basic (diagonal) ad-hoc noise covariance will be used.
+        If a string (filename), then the covariance will be loaded.
+        If dict, a covariance matrix will be generated from it.
+    """
+    from scipy.signal import lfilter
+
+    # All checks here
+    cov = _check_cov(info, cov)
+    rng = check_random_state(random_state)
+
+    noise_cov = pick_channels_cov(cov, include=info['ch_names'], exclude=[])
+
+    if set(info['ch_names']) != set(noise_cov.ch_names):
+        raise ValueError('Info and covariance channel names are not '
+                         'identical. Cannot generate the noise matrix. '
+                         'Channels missing in covariance %s.' %
+                         np.setdiff1d(info['ch_names'], noise_cov.ch_names))
+
+    noise_cov['data'] = (np.diag(noise_cov.data) if noise_cov['diag'] else
+                         noise_cov.data)
+
+    # Parameters
+    n_channels = len(noise_cov.data)
+    mu_channels = np.zeros(n_channels)
+
+    # Generate the noise
+    # we almost always get a positive semidefinite warning here, so squash it
+    with warnings.catch_warnings(record=True):
+        noise = rng.multivariate_normal(mu_channels, noise_cov.data,
+                                        n_samples).T
+
+    # Apply the filter if any
+    if iir_filter is not None:
+        if zi is None:
+            zi = np.zeros((n_channels, len(iir_filter) - 1))
+        noise, zf = lfilter([1], iir_filter, noise, axis=-1, zi=zi)
+    else:
+        zf = None
+
+    return noise, zf

--- a/mne/simulation/simulation.py
+++ b/mne/simulation/simulation.py
@@ -1,0 +1,336 @@
+# author: ngayraud.
+#
+# Created on Tue Feb 20 11:14:54 2018.
+
+import numpy as np
+
+from .source import simulate_sparse_stc
+from ..forward import apply_forward_raw
+from ..utils import warn, logger
+from ..io import RawArray
+from ..io.constants import FIFF
+
+from .waveforms import get_waveform
+from .noise import generate_noise_data
+
+
+class Simulation(dict):
+    """Simulation of meg/eeg data.
+
+    Parameters
+    ----------
+    fwd : Forward
+        a forward solution containing an instance of Info and src
+    n_dipoles : int
+        Number of dipoles to simulate.
+    labels : None | list of Labels
+        The labels. The default is None, otherwise its size must be n_dipoles.
+    location : str
+        The label location to choose a dipole from. Can be ``random`` (default)
+        or ``center`` to use :func:`mne.Label.center_of_mass`. Note that for
+        ``center`` mode the label values are used as weights.
+    subject : string | None
+        The subject the label is defined for.
+        Only used with location=``center``.
+    subjects_dir : str, or None
+        Path to the SUBJECTS_DIR. If None, the path is obtained by using the
+        environment variable SUBJECTS_DIR. Only used with location=``center``.
+    waveform: list of callables/str of length n_dipoles | str | callable
+        To simulate a waveform (activity) on each dipole. If it is a string or
+        a callable, the same activity will be generated over all dipoles
+    window_times : array | list | str
+        time window(s) to generate activity. If list, its size should be
+        len(waveform). If str, should be ``all`` (default)
+
+    Notes
+    -----
+    Some notes.
+    """
+
+    def __init__(self, fwd, n_dipoles=2, labels=None, location='random',
+                 subject=None, subjects_dir=None, waveform='sin',
+                 window_times='all'):
+        self.fwd = fwd  # TODO: check fwd
+        labels, n_dipoles = self._get_sources(labels, n_dipoles)
+        self.update(n_dipoles=n_dipoles, labels=labels, subject=subject,
+                    subjects_dir=subjects_dir, location=location,
+                    info=self.fwd['info'])
+        self['info']['projs'] = []
+        self['info']['bads'] = []
+        self['info']['sfreq'] = None
+        self.waveforms = self._get_waveform(waveform)
+        self.window_times = self._get_window_times(window_times)
+
+    def _get_sources(self, labels, n_dipoles):
+        """Get labels and number of dipoles. Can be upgraded to do more.
+
+        Return a list of labels or None and the number of dipoles.
+        """
+        if labels is None:
+            return labels, n_dipoles
+
+        n_labels = min(n_dipoles, len(labels))
+        if n_dipoles != len(labels):
+            warn('The number of labels is different from the number of '
+                 'dipoles. %s dipole(s) will be generated.'
+                 % n_labels)
+        labels = labels[:n_labels]
+        return labels, n_labels
+
+    def _get_waveform(self, waveform):
+        """Check the waveform given as imput wrt the number of dipoles.
+
+        Return a list of callables.
+        """
+        if isinstance(waveform, str):
+            return [get_waveform(waveform)]
+
+        elif isinstance(waveform, list):
+
+            if len(waveform) > self['n_dipoles']:
+                warn('The number of waveforms is greater from the number of '
+                     'dipoles. %s waveform(s) will be generated.'
+                     % self['n_dipoles'])
+                waveform = waveform[:self['n_dipoles']]
+
+            elif len(waveform) < self['n_dipoles']:
+                raise ValueError('Found fewer waveforms than dipoles.')
+            return [get_waveform(f) for f in waveform]
+
+        else:
+            raise TypeError('Unrecognised type. Accepted inputs: str, list, '
+                            'callable, or list containing any of the above.')
+
+    def _check_window_time(self, w_t):
+        """Check if window time has the correct value and frequency."""
+        if isinstance(w_t, np.ndarray):
+            freq = np.floor(1. / (w_t[-1] - w_t[-2]))
+            _check_frequency(self['info'], freq, 'The frequency of the '
+                             'time windows is not the same')
+        elif w_t is 'all':
+            pass
+        else:
+            raise TypeError('Unrecognised type. Accepted inputs: array, '
+                            '\'all\'')
+        return w_t
+
+    def _get_window_times(self, window_times):
+        """Get a list of window_times."""
+        if isinstance(window_times, list):
+
+            if len(window_times) > len(self.waveforms):
+                n_func = len(self.waveforms)
+                warn('The number of window times is greater than the number '
+                     'of waveforms. %s waveform(s) will be generated.'
+                     % n_func)
+                window_times = window_times[:n_func]
+
+            elif len(window_times) < len(self.waveforms):
+                pad = len(self.waveforms) - len(window_times)
+                warn('The number of window times is smaller than the number '
+                     'of waveforms. Assuming that the last ones are \'all\'')
+                window_times = window_times + ['all'] * pad
+        else:
+            window_times = [window_times]
+
+        return [self._check_window_time(w_t) for w_t in window_times]
+
+
+def _check_frequency(info, freq, error_message):
+    """Compare two frequency values and assert they are the same."""
+    if info['sfreq'] is not None:
+        if info['sfreq'] != freq:
+            raise ValueError(error_message)
+    else:
+        info['sfreq'] = freq
+    return True
+
+
+def _correct_window_times(w_t, e_t, times):
+    """Check if window time has the correct length."""
+    if (isinstance(w_t, str) and w_t == 'all') or e_t is None:
+        return times
+    else:
+        if len(w_t) > len(times):
+            warn('Window is too large, will be cut to match the '
+                 'length of parameter \'times\'')
+        return w_t[:len(times)]
+
+
+def _iterate_simulation_sources(sim, events, times):
+    """Iterate over all stimulation waveforms."""
+    if len(sim.waveforms) == 1:
+        yield (sim['n_dipoles'], sim['labels'],
+               _correct_window_times(sim.window_times[0], events[0], times),
+               events[0], sim.waveforms[0])
+    else:
+        dipoles = 1
+        for index, waveform in enumerate(sim.waveforms):
+            n_wt = min(index, len(sim.window_times) - 1)
+            n_ev = min(index, len(events) - 1)
+            labels = None
+            if sim['labels'] is not None:
+                labels = [sim['labels'][index]]
+            yield (dipoles, labels,
+                   _correct_window_times(sim.window_times[n_wt], events[n_ev],
+                                         times), events[n_ev], waveform)
+
+
+def _check_event(event, times):
+    """Check if event array has the correct shape/length."""
+    if isinstance(event, np.ndarray) and event.shape[1] == 3:
+        if np.max(event) > len(times) - 1:
+            warn('The indices in the event array is not the same as '
+                 'the time points in the simulations.')
+            event[np.where(event > len(times) - 1), 0] = len(times) - 1
+        return np.array(event)
+    elif event is not None:
+        warn('Urecognized type. Will generated signal without events.')
+    return None
+
+
+def get_events(sim, times, events):
+    """Get a list of events.
+
+    Checks if the input events correspond to the simulation times.
+
+    Parameters
+    ----------
+    sim : instance of Simulation
+        Initialized Simulation object with parameters
+    times : array
+        Time array
+    events : array,  | list of arrays | None
+        events corresponding to some stimulation. If array, its size should be
+        shape=(len(times), 3). If list, its size should be len(n_dipoles). If
+        None, defaults to no event (default)
+
+    Returns
+    -------
+    events : list | None
+        a list of events of type array, shape=(n_events, 3)
+    """
+    if isinstance(events, list):
+        n_waveforms = len(sim.waveforms)
+        if len(events) > n_waveforms:
+            warn('The number of event arrays is greater than the number '
+                 'of waveforms. %s event arrays(s) will be generated.'
+                 % n_waveforms)
+            events = events[:n_waveforms]
+        elif len(events) < n_waveforms:
+            pad = len(sim.waveforms) - len(events)
+            warn('The number of event arrays is smaller than the number '
+                 'of waveforms. Assuming that the last ones are None')
+            events = events + [None] * pad
+    else:
+        events = [events]
+
+    return [_check_event(event, times) for event in events]
+
+
+def simulate_raw_signal(sim, times, cov=None, events=None, random_state=None,
+                        verbose=None):
+    """Simulate a raw signal.
+
+    Parameters
+    ----------
+    sim : instance of Simulation
+        Initialized Simulation object with parameters
+    times : array
+        Time array
+    cov : Covariance | string | dict | None
+        Covariance of the noise
+    events : array, shape = (n_events, 3) | list of arrays | None
+        events corresponding to some stimulation.
+        If list, its size should be len(n_dipoles)
+        If None, defaults to no event (default)
+    random_state : None | int | np.random.RandomState
+        To specify the random generator state.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    raw : instance of RawArray
+        The simulated raw file.
+    """
+    if len(times) <= 2:  # to ensure event encoding works
+        raise ValueError('stc must have at least three time points')
+
+    info = sim['info'].copy()
+    freq = np.floor(1. / (times[-1] - times[-2]))
+    _check_frequency(info, freq, 'The frequency of the time windows is not '
+                     'the same as the experiment time. ')
+    info['projs'] = []
+    info['lowpass'] = None
+
+    # TODO: generate data for blinks and other physiological noise
+
+    raw_data = np.zeros((len(info['ch_names']), len(times)))
+
+    events = get_events(sim, times, events)
+
+    logger.info('Simulating signal from %s sources' % sim['n_dipoles'])
+
+    for dipoles, labels, window_time, event, data_fun in \
+            _iterate_simulation_sources(sim, events, times):
+
+        source_data = simulate_sparse_stc(sim.fwd['src'], dipoles,
+                                          window_time, data_fun, labels,
+                                          None, sim['location'],
+                                          sim['subject'], sim['subjects_dir'])
+
+        propagation = _get_propagation(event, times, window_time)
+        source_data.data = np.dot(source_data.data, propagation)
+        raw_data += apply_forward_raw(sim.fwd, source_data, info,
+                                      verbose=verbose).get_data()
+
+    # Noise
+    if cov is not None:
+        raw_data += generate_noise_data(info, cov, len(times), random_state)[0]
+
+    # Add an empty stimulation channel
+    raw_data = np.vstack((raw_data, np.zeros((1, len(times)))))
+    stim_chan = dict(ch_name='STI 014', coil_type=FIFF.FIFFV_COIL_NONE,
+                     kind=FIFF.FIFFV_STIM_CH, logno=len(info["chs"]) + 1,
+                     scanno=len(info["chs"]) + 1, cal=1., range=1.,
+                     loc=np.full(12, np.nan), unit=FIFF.FIFF_UNIT_NONE,
+                     unit_mul=0., coord_frame=FIFF.FIFFV_COORD_UNKNOWN)
+    info['chs'].append(stim_chan)
+    info._update_redundant()
+
+    # Create RawArray object with all data
+    raw = RawArray(raw_data, info, first_samp=times[0], verbose=verbose)
+
+    # Update the stimulation channel with stimulations
+    stimulations = [event for event in events if event is not None]
+    if len(stimulations) != 0:
+        stimulations = np.unique(np.vstack(stimulations), axis=0)
+        # Add events onto a stimulation channel
+        raw.add_events(stimulations, stim_channel='STI 014')
+
+    logger.info('Done')
+    return raw
+
+
+def _get_propagation(event, times, window_time):
+    """Return the matrix that propagates the waveforms."""
+    propagation = 1.0
+
+    if event is not None:
+
+        # generate stimulation timeline
+        stimulation_timeline = np.zeros(len(times))
+        stimulation_indices = np.array(event[:, 0], dtype=int)
+        stimulation_timeline[stimulation_indices] = event[:, 2]
+
+        from scipy.linalg import toeplitz
+        # Create toeplitz array. Equivalent to convoluting the signal with the
+        # stimulation timeline
+        index = stimulation_timeline != 0
+        trig = np.zeros((len(times)))
+        trig[index] = 1
+        propagation = toeplitz(trig[0:len(window_time)], trig)
+
+    return propagation

--- a/mne/simulation/tests/test_simulation.py
+++ b/mne/simulation/tests/test_simulation.py
@@ -1,0 +1,156 @@
+# author: ngayraud
+#
+# Created on Mon Mar 12 15:53:38 2018.
+
+import warnings
+import numpy as np
+from numpy.testing import assert_equal
+from nose.tools import assert_true, assert_raises
+
+from mne.simulation import Simulation, simulate_raw_signal
+from mne import (datasets, read_forward_solution, pick_types_forward,
+                 convert_forward_solution, read_label)
+
+from mne.utils import run_tests_if_main
+from mne.datasets import testing
+
+
+def _same(times, fwd_f, n_dipoles, labels, location, subject, subjects_dir,
+          waveform, events):
+    sim_1 = Simulation(fwd_f, n_dipoles=n_dipoles, labels=labels,
+                       location=location, subject=subject,
+                       subjects_dir=subjects_dir, waveform=waveform)
+    raw_1 = simulate_raw_signal(sim_1, times, cov=None, events=events,
+                                verbose=0)
+    data_1, _ = raw_1[:]
+    sim_2 = Simulation(fwd_f, n_dipoles=n_dipoles, labels=labels,
+                       location=location, subject=subject,
+                       subjects_dir=subjects_dir, waveform=waveform)
+    raw_2 = simulate_raw_signal(sim_2, times, cov=None, events=events,
+                                verbose=0)
+    data_2, _ = raw_2[:]
+
+    # This should work
+    assert_equal(data_1, data_2)
+    assert_true(~np.isnan(np.sum(data_1)) or ~np.isinf(np.sum(data_1)))
+    assert_true(~np.isnan(np.sum(data_2)) or ~np.isinf(np.sum(data_1)))
+
+
+def _without_events(fwd_f, labels, subject, subjects_dir):
+
+    freq = 256.0
+    time = 2.0
+    times = np.arange(0, time, 1.0 / freq)
+
+    # Should work
+    _same(times, fwd_f, n_dipoles=2, labels=labels, location='center',
+          subject=subject, subjects_dir=subjects_dir, waveform='sin',
+          events=None)
+    _same(times, fwd_f, n_dipoles=2, labels=labels, location='center',
+          subject=subject, subjects_dir=subjects_dir,
+          waveform=['p300_target', 'sin'], events=None)
+
+    # These should raise warnings
+    warnings.simplefilter("error")
+    # different labels and dipoles
+    assert_raises(RuntimeWarning, Simulation, fwd_f, n_dipoles=1,
+                  labels=labels, waveform='sin')
+    assert_raises(RuntimeWarning, Simulation, fwd_f, n_dipoles=3,
+                  labels=labels, waveform='sin')
+    # different waveforms and dipoles
+    assert_raises(RuntimeWarning, Simulation, fwd_f, n_dipoles=2,
+                  labels=labels, waveform=['sin', 'p300_target', 'sin'])
+    assert_raises(ValueError, Simulation, fwd_f, n_dipoles=2,
+                  labels=labels, waveform=['sin'])
+    # different window times and waveforms
+    assert_raises(RuntimeWarning, Simulation, fwd_f, n_dipoles=2,
+                  labels=labels, subjects_dir=subjects_dir,
+                  waveform=['sin', 'p300_target'],
+                  window_times=['all', 'all', 'all'])
+    assert_raises(RuntimeWarning, Simulation, fwd_f, n_dipoles=2,
+                  labels=labels, subjects_dir=subjects_dir,
+                  waveform=['sin', 'p300_target'], window_times=['all'])
+    warnings.simplefilter("always")
+
+
+def _with_events(fwd_f, labels, subject, subjects_dir):
+
+    freq = 256.0
+    waveform = ['p300_target', 'sin']
+    time = 2.0
+    times = np.arange(0, time, 1.0 / freq)
+    window_times = np.arange(0, time / 3.0, 1.0 / freq)
+    indices = np.array([0, np.floor(len(times) / 4)])
+    events = np.zeros((len(indices), 3))
+    events[:, 0] = indices
+    events[:, 2] = 1
+
+    # These should work
+    _same(times, fwd_f, n_dipoles=2, labels=labels, location='center',
+          subject=subject, subjects_dir=subjects_dir,
+          waveform=waveform, events=[np.array(events)] * 2)
+    _same(times, fwd_f, n_dipoles=2, labels=labels, location='center',
+          subject=subject, subjects_dir=subjects_dir,
+          waveform=waveform, events=events)
+
+    # These should raise warnings
+    warnings.simplefilter("error")
+
+    # wrong number of events
+    sim = Simulation(fwd_f, n_dipoles=2, labels=labels, location='center',
+                     subject=subject, subjects_dir=subjects_dir,
+                     waveform=waveform)
+    assert_raises(RuntimeWarning, simulate_raw_signal, sim, times, cov=0,
+                  events=[events], verbose=0)
+    assert_raises(RuntimeWarning, simulate_raw_signal, sim, times, cov=0,
+                  events=[events, events, events], verbose=0)
+    # Too large window
+    window_times = np.arange(0, time + 1.0, 1.0 / freq)
+    sim = Simulation(fwd_f, n_dipoles=2, labels=labels, location='center',
+                     subject=subject, subjects_dir=subjects_dir,
+                     waveform=waveform, window_times=['all', window_times])
+    assert_raises(RuntimeWarning, simulate_raw_signal, sim, times, cov=0,
+                  events=events, verbose=0)
+    # add an index that is too large
+    events[0, 0] = len(times)
+    sim = Simulation(fwd_f, n_dipoles=2, labels=labels, location='center',
+                     subject=subject, subjects_dir=subjects_dir,
+                     waveform=waveform)
+    assert_raises(RuntimeWarning, simulate_raw_signal, sim, times, cov=0,
+                  events=events, verbose=0)
+
+    warnings.simplefilter("always")
+
+# Initialize
+data_path = data_path = datasets.sample.data_path()
+raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
+subjects_dir = data_path + '/subjects'
+trans = data_path + '/MEG/sample/sample_audvis_raw-trans.fif'
+fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
+
+subject = 'sample'
+
+
+@testing.requires_testing_data
+def test_simulate_raw():
+    """Test simulation of raw data.
+    """
+    # Get forward model
+
+    fwd = read_forward_solution(fwd_fname)
+    fwd = pick_types_forward(fwd, meg=True, eeg=True)
+    fwd_f = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
+                                     use_cps=True)
+
+    label_names = ['Aud-lh', 'Aud-rh']
+
+    label_names = ['Vis-lh', 'Vis-rh']
+    labels = [read_label(data_path + '/MEG/sample/labels/%s.label' % ln)
+              for ln in label_names]
+    for label in labels:
+        label.values[:] = 1
+
+    _without_events(fwd_f, labels, subject, subjects_dir)
+    _with_events(fwd_f, labels, subject, subjects_dir)
+    # TODO: add test for noise
+run_tests_if_main()

--- a/mne/simulation/waveforms.py
+++ b/mne/simulation/waveforms.py
@@ -1,0 +1,90 @@
+# author: ngayraud
+#
+# Created on Wed Feb 21 11:13:50 2018.
+
+import numpy as np
+
+
+def get_waveform(waveform):
+    """Check waveform exists and return the callable.
+
+    Returns a simple sinusoide if not found.
+
+    Parameters
+    ----------
+    waveform : str | callable
+        If str, mus be one of the known waveforms: 'sin', 'p300_target,
+        'p300_nontarget'.
+    """
+    known_waveforms = {
+        'sin': waveform_sin,
+        'p300_target': waveform_p300_target,
+        'p300_nontarget': waveform_p300_nontarget,
+    }
+    if isinstance(waveform, str) and waveform in known_waveforms.keys():
+        return known_waveforms[waveform]
+    elif hasattr(waveform, "__call__"):
+        return waveform
+    else:
+        raise TypeError('Unrecognised type. Accepted inputs: str, callable. '
+                        'List of accepted str: sin, p300_target, '
+                        'p300_nontarget.')
+
+
+def waveform_sin(times, amplitude=1e-8, freq=10., phase=0.):
+    """Generate a sinusoide waveform.    .
+
+    Returns a simple sinusoide
+
+    Parameters
+    ----------
+    times : array
+        Array of times
+    amplitude : float
+        amplitude of the sinusoide
+    freq : float
+        ordinary frequency of the sinusoide
+    phase : float
+        phase of the sinusoide
+    """
+    return amplitude * np.sin(2. * np.pi * freq * times + phase)
+
+
+def waveform_p300_target(times, peak=0.3, amplitude=15.0):
+    """Generate a p300 target waveform.
+
+    Create a p300 target waveform.
+
+    Parameters
+    ----------
+    times : array
+        Array of times
+    peak : float
+        peak of the p300
+    amplitude : array
+        amplitude of the p300
+    """
+    return (1e-9 * amplitude * np.cos(14. * (times - peak)) *
+            np.exp(-(times - peak + 0.04)**2 / 0.02) +
+            1e-9 * amplitude / 6.0 * np.sin(22. * (times - peak)) *
+            np.exp(-(times - peak + 0.24)**2 / 0.02))
+
+
+def waveform_p300_nontarget(times, peak=0.3, amplitude=15.0):
+    """Generate a p300 nontarget waveform.
+
+    Create a p300 nontarget waveform.
+
+    Parameters
+    ----------
+    times : array
+        Array of times
+    peak : float
+        peak of the p300
+    amplitude : array
+        amplitude of the p300
+    """
+    return (1e-9 * (amplitude / 4.0) * np.cos(14. * (times - peak)) *
+            np.exp(-(times - peak + 0.04)**2 / 0.05) +
+            1e-9 * (amplitude / 6.0) * np.sin(22. * (times - peak)) *
+            np.exp(-(times - peak + 0.24)**2 / 0.02))


### PR DESCRIPTION
Related to issue #5058 

The implementation I coded is i think generic enough to allow for other types of simulations. I looked a lot into the existing MNE code and tried to make mine as close as possible to the way things are implemented. I have used many of the existing functions, added some that I needed and couldn’t find, and tried to design the whole thing in an “easy to use” way.

Some documentation about new files and functions.

**_simulation/simulation.py_**

This file contains the Simulation object and functions to generate raw (Raw object) simulated data. The main idea can be summarized as this:

Simulation mostly handles things that are happening at a source level. So: the number of dipoles, the selection of dipoles (to be implemented in a better way), the kind of activity that will be associated to each dipole (waveforms) and if it is a waveform that models a response to a stimulus, the time window associated to the response (time array).

simulate_raw_signal corresponds more to the “external” parameters of the simulation. The most important input parameters are an initialized Simulation object, the stimuli (events), the noise, and time length of the experiment. The number of events must however be either a single array that will be applied to all types of waveforms, or a list that has the same length as the number of dipoles.

_**simulation/waveforms.py**_    

This file contains some waveforms that can be parameterized. More can be added. The user can also create his own waveform and provide it as input.

**_simulation/noise.py_**

This file contains some functions to handle noise simulations.
I needed to be able to generate noise with specific parameters, and also I think that this function (generate_noise_data) should exist separately, so I took the existing private function in evoked.py and copied it (and minimally changed it).

_Also added: some tests in the simulation/tests folder._

Finally, I added a function in _cov.py_ to create a covariance matrix from an array that represents the variance of each random variable, called _make_custom_cov.py_. It’s a fast solution that I don’t like but for now it does the job. 

======================

**Notes:** 

Concerning the events, the idea is to use them to convolute the basic waveform with the stimulus occurence to obtain the source signal. After discussing with colleagues from the BCI-Lift project, they have implemented the same idea for simulations under Matlab (a paper is under publication).

**Example:**

Several kinds of experiments can be simulated, as long as the user understand that the lists of parameters must have the same order. For example, I want to simulate the recordings of an auditory p300 speller with 10 dipoles, 5 on the left and 5 on the right auditory cortex, and on one of these dipoles I want to put a sinusoid. Among others, I have to  input the following (bold for the Simulation object, italics for the simulation function):

**Label**   =   Aud-rh X 5, Aud-lh X 5
**Waveform** = P300_nontarget, P300_target, P300_nontarget, P300_target, P300_nontarget, P300_target, P300_nontarget, P300_target, P300_nontarget, sin
**Waveform time window** = array from 0 to 0.5 sec
_Event_ = nontarget_stimuli, target_stimuli, nontarget_stimuli, target_stimuli, nontarget_stimuli, target_stimuli, nontarget_stimuli, target_stimuli, nontarget_stimuli, target_stimuli

And here is the code you can run to check out how it works:
```
"""
Simulation example of two p300 speller experiments.
The differences are the events simulated, and the noise
"""

import numpy as np
import mne
from mne.forward import convert_forward_solution

from mne import (read_forward_solution, pick_types_forward, read_label,
                 pick_types, make_custom_cov)
from mne.simulation import Simulation, simulate_raw_signal, waveforms
from mne.datasets import sample

# Load a sample forward solution
# Forward solution should have fixed orientation
data_path = sample.data_path()

fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
fwd = read_forward_solution(fwd_fname)
fwd = pick_types_forward(fwd, meg=True, eeg=True)
fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                               use_cps=True)


# Create the simulation type. This only needs to be generated once, since the
# simulated experiment is the same. 
# The simulation will include 10 dipoles, 5 on the left auditory and 5 on the 
# right, at random positions.

n_dipoles = 10

label_names = ['Aud-lh', 'Aud-rh']
labels = [read_label(data_path + '/MEG/sample/labels/%s.label' % ln)
          for ln in label_names]

# each dipole will simulate a different waveform.
# A sinusoide has been added to the last dipole.
labels = [labels[0]]*5 + [labels[1]]*5

waveforms = ['p300_target', 'p300_nontarget' ,'p300_target', 'p300_nontarget',
             'p300_target', 'p300_target', 'p300_nontarget' ,'p300_target', 
             'p300_nontarget', 'sin']

# Only one time window needs to be defined since it will be the same for all 
# waveforms (except the sinusoide, but this will be defined through the event matrix)
freq = 256
time_window_duration = 0.5 #(sec) 
window_times=np.arange(0.,time_window_duration,1./freq)

sim = Simulation(fwd, n_dipoles=n_dipoles, labels=labels, waveform=waveforms,
                 window_times=window_times)

# Functions to generate events that are specific to a p300 speller experiment
def get_events_array(stim_channel, n_sample, label):
    events = np.zeros((n_sample, 3))
    events[:,0] = np.array(np.squeeze(np.argwhere(stim_channel == 1)))
    events[:,2] = label
    return np.array(events)


def generate_p300speller_events(times, freq, interval = 0.3, ratio = 6):    
    """ Generate events that simulate a p300 experiment"""
    stim_channel_target = np.zeros((len(times)))
    stim_channel_nontarget = np.zeros((len(times)))

    counter, n_target, n_nontarget = (0, 0, 0)

    for i in range(1,len(times),int(np.ceil(freq*interval))):
        if counter==0:
            target = np.random.randint(0,ratio)
        if counter == target:
            stim_channel_target[i] = 1
            n_target += 1
        else:
            stim_channel_nontarget[i] = 1
            n_nontarget += 1
        counter += 1
        if counter == ratio:
            counter = 0
    
    events_target = get_events_array(stim_channel_target, n_target, 1)
    events_nontarget = get_events_array(stim_channel_nontarget, n_nontarget, 2)


    return np.array(events_target), np.array(events_nontarget)

# Experiment Parameters

experiment_duration = 60 #(sec)
times = np.arange(0.,experiment_duration,1./freq)

# Noise parameters 

chnames = sim['info']['ch_names']
n_eeg = len(pick_types(sim['info'], meg=False, eeg=True))
n_mag = len(pick_types(sim['info'], meg='mag', eeg=False))
n_grad = len(pick_types(sim['info'], meg='grad', eeg=False))


rng = np.random.RandomState(41)
events_p300_target, events_p300_nontarget = generate_p300speller_events(times, freq, interval = 0.4)

events_p300=[]

#By adding "None" for the sinusoide, we make sure that it will be generated for the entire duration
for w in waveforms:
    if w == 'p300_target':
        events_p300.append(events_p300_target)
    elif w == 'p300_nontarget':
        events_p300.append(events_p300_nontarget)
    else:
        events_p300.append(None)

# We will make two experiments with diferent kinds of noise
standard_deviations = dict(eeg=[0.8e-6]*n_eeg, grad=[2e-13]*n_grad, mag=[5e-15]*n_mag)
cov1 = make_custom_cov(sim['info'], standard_deviations)
standard_deviations = dict(eeg=[1.3e-6]*n_eeg, grad=[11e-13]*n_grad, mag=[26e-15]*n_mag)
cov2 = make_custom_cov(sim['info'], standard_deviations)


# Simulating two experiments
raw1 = simulate_raw_signal(sim, times, cov1, events_p300, verbose=False)
raw2 = simulate_raw_signal(sim, times, cov2, events_p300, verbose=False)


# Now create epochs out of the raw data
event_id = dict(target=1, nontarget=2)  # event trigger and conditions
tmin = 0  # start of each epoch (trigger)
tmax = time_window_duration  # end of each epoch (600ms after the trigger)

def plot_experiment_data(raw):
    events = mne.find_events(raw, stim_channel="STI 014")
    epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                        baseline=None, reject=None, preload=True)

    epochs.plot(show=True)
    evoked = epochs['target'].average()
    evoked.plot(show=True)
    evoked = epochs['nontarget'].average()
    evoked.plot(show=True)

plot_experiment_data(raw1)
plot_experiment_data(raw2)
```
