### PR TITLE
[MRG] Fix setting CSD ch_names

### DIFF
--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -719,8 +719,8 @@ def csd_fourier(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None, picks=None,
     epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
     return csd_array_fourier(epochs.get_data(), sfreq=epochs.info['sfreq'],
                              t0=epochs.tmin, fmin=fmin, fmax=fmax, tmin=tmin,
-                             tmax=tmax, n_fft=n_fft, projs=projs,
-                             n_jobs=n_jobs, verbose=verbose)
+                             tmax=tmax, ch_names=epochs.ch_names, n_fft=n_fft,
+                             projs=projs, n_jobs=n_jobs, verbose=verbose)
 
 
 @verbose
@@ -869,10 +869,10 @@ def csd_multitaper(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
     return csd_array_multitaper(epochs.get_data(), sfreq=epochs.info['sfreq'],
                                 t0=epochs.tmin, fmin=fmin, fmax=fmax,
-                                tmin=tmin, tmax=tmax, n_fft=n_fft,
-                                bandwidth=bandwidth, adaptive=adaptive,
-                                low_bias=low_bias, projs=projs, n_jobs=n_jobs,
-                                verbose=verbose)
+                                tmin=tmin, tmax=tmax, ch_names=epochs.ch_names,
+                                n_fft=n_fft, bandwidth=bandwidth,
+                                adaptive=adaptive, low_bias=low_bias,
+                                projs=projs, n_jobs=n_jobs, verbose=verbose)
 
 
 @verbose
@@ -1030,9 +1030,9 @@ def csd_morlet(epochs, frequencies=None, tmin=None, tmax=None, picks=None,
     epochs, projs = _prepare_csd(epochs, tmin, tmax, picks, projs)
     return csd_array_morlet(epochs.get_data(), sfreq=epochs.info['sfreq'],
                             t0=epochs.tmin, frequencies=frequencies, tmin=tmin,
-                            tmax=tmax, n_cycles=n_cycles, use_fft=use_fft,
-                            decim=decim, projs=projs, n_jobs=n_jobs,
-                            verbose=verbose)
+                            tmax=tmax, ch_names=epochs.ch_names,
+                            n_cycles=n_cycles, use_fft=use_fft, decim=decim,
+                            projs=projs, n_jobs=n_jobs, verbose=verbose)
 
 
 @verbose

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -330,8 +330,9 @@ def _test_csd_matrix(csd):
     """Perform a suite of tests on a CSD matrix."""
     # Check shape of the CSD matrix
     n_chan = len(csd.ch_names)
-    n_freqs = len(csd.frequencies)
     assert n_chan == 3
+    assert csd.ch_names == ['CH1', 'CH2', 'CH3']
+    n_freqs = len(csd.frequencies)
     assert n_freqs == 3
     assert csd._data.shape == (6, 3)  # Only upper triangle of CSD matrix
 
@@ -406,7 +407,8 @@ def test_csd_fourier():
     for (tmin, tmax), as_array in parameters:
         if as_array:
             csd = csd_array_fourier(epochs.get_data(), sfreq, epochs.tmin,
-                                    fmin=9, fmax=23, tmin=tmin, tmax=tmax)
+                                    fmin=9, fmax=23, tmin=tmin, tmax=tmax,
+                                    ch_names=epochs.ch_names)
         else:
             csd = csd_fourier(epochs, fmin=9, fmax=23, tmin=tmin, tmax=tmax)
 
@@ -450,7 +452,8 @@ def test_csd_multitaper():
         if as_array:
             csd = csd_array_multitaper(epochs.get_data(), sfreq, epochs.tmin,
                                        adaptive=adaptive, fmin=9, fmax=23,
-                                       tmin=tmin, tmax=tmax)
+                                       tmin=tmin, tmax=tmax,
+                                       ch_names=epochs.ch_names)
         else:
             csd = csd_multitaper(epochs, adaptive=adaptive, fmin=9, fmax=23,
                                  tmin=tmin, tmax=tmax)
@@ -502,7 +505,8 @@ def test_csd_morlet():
         if as_array:
             csd = csd_array_morlet(epochs.get_data(), sfreq,
                                    epochs.tmin, frequencies=freqs,
-                                   n_cycles=n_cycles, tmin=tmin, tmax=tmax)
+                                   n_cycles=n_cycles, tmin=tmin, tmax=tmax,
+                                   ch_names=epochs.ch_names)
         else:
             csd = csd_morlet(epochs, frequencies=freqs, n_cycles=n_cycles,
                              tmin=tmin, tmax=tmax)


### PR DESCRIPTION
Small bug that was introduced by the refactoring of the CSD code. When calling `csd_fourier`, `csd_multitaper` or `csd_morlet` the `ch_names` field of the resulting `CrossSpectralDensity` object was not properly set. It slipped through the unit tests at the time.