### PR TITLE
MRG: Dont require git for env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,11 +32,11 @@ dependencies:
   # https://github.com/enthought/mayavi/issues/624
   - pyqt5==5.9.2
   - vtk>=8
-  - "git+https://github.com/enthought/traits.git@a99b3f64d50c5f7f28ffc01bf69419b061f9e976"
-  - "git+https://github.com/enthought/pyface.git@6a0cac149d56293482bb828a7d98122667c773be"
-  - "git+https://github.com/enthought/traitsui.git@e366ad3886d3c39bedb96e83bab447d31c4ab725"
-  - "git+https://github.com/enthought/mayavi.git"
-  - "git+https://github.com/nipy/PySurfer.git"
+  - "https://api.github.com/repos/enthought/traits/zipball/a99b3f64d50c5f7f28ffc01bf69419b061f9e976"
+  - "https://api.github.com/repos/enthought/pyface/zipball/6a0cac149d56293482bb828a7d98122667c773be"
+  - "https://api.github.com/repos/enthought/traitsui/zipball/e366ad3886d3c39bedb96e83bab447d31c4ab725"
+  - "https://api.github.com/repos/enthought/mayavi/zipball/master"
+  - "https://api.github.com/repos/nipy/PySurfer/zipball/master"
   - nitime
   - nibabel
   - nilearn

--- a/environment.yml
+++ b/environment.yml
@@ -45,5 +45,5 @@ dependencies:
   - pytest-faulthandler
   - pydocstyle
   - sphinx_bootstrap_theme
-  - git+https://github.com/sphinx-gallery/sphinx-gallery.git
+  - "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master"
   - python-picard


### PR DESCRIPTION
It turns out `git+` URLs require `git`, which is not something we want (esp. for Windows users).

This is also quite a bit faster because it only pulls the relevant commit code, rather than `git clone`ing the repo then checking out a commit. Some of those `enthought` repos were big.