### PR TITLE
MRG: Modify make_ad_hoc_cov to accept dict as input

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add possibility to pass dict of floats as argument to :func:`mne.cov.make_ad_hoc_cov` by `Nathalie Gayraud`_
+
 - Add support for metadata in :class:`mne.Epochs` by `Chris Holdgraf`_, `Alex Gramfort`_, `Jona Sassenhagen`_, and `Eric Larson`_
 
 - Add support for plotting a dense head in :func:`mne.viz.plot_alignment` by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Add possibility to pass dict of floats as argument to :func:`mne.cov.make_ad_hoc_cov` by `Nathalie Gayraud`_
+- Add possibility to pass dict of floats as argument to :func:`mne.make_ad_hoc_cov` by `Nathalie Gayraud`_
 
 - Add support for metadata in :class:`mne.Epochs` by `Chris Holdgraf`_, `Alex Gramfort`_, `Jona Sassenhagen`_, and `Eric Larson`_
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -265,13 +265,18 @@ def read_cov(fname, verbose=None):
 # Estimate from data
 
 @verbose
-def make_ad_hoc_cov(info, verbose=None):
+def make_ad_hoc_cov(info, std=None, verbose=None):
     """Create an ad hoc noise covariance.
 
     Parameters
     ----------
     info : instance of Info
         Measurement info.
+    std : dict of ndarray | None
+        Standard_deviations of the diagonal elements. If dict, keys should be
+        `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
+        channels. The ndarrays must have the same number of elements as the
+        sensors denoted by their keys.
     verbose : bool, str, int, or None (default None)
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -283,26 +288,19 @@ def make_ad_hoc_cov(info, verbose=None):
 
     Notes
     -----
-    This uses values of 5 fT/cm, 20 fT, and 0.2 uV for gradiometers,
+    The default noise values are 5 fT/cm, 20 fT, and 0.2 uV for gradiometers,
     magnetometers, and EEG channels, respectively.
 
     .. versionadded:: 0.9.0
     """
     picks = pick_types(info, meg=True, eeg=True, exclude=())
-
-    # Standard deviations to be used
-    grad_std = 5e-13
-    mag_std = 20e-15
-    eeg_std = 0.2e-6
-    logger.info('Using standard noise values '
-                '(MEG grad : %6.1f fT/cm MEG mag : %6.1f fT EEG : %6.1f uV)'
-                % (1e13 * grad_std, 1e15 * mag_std, 1e6 * eeg_std))
+    std = _handle_default('noise_std', std)
 
     data = np.zeros(len(picks))
     for meg, eeg, val in zip(('grad', 'mag', False), (False, False, True),
-                             (grad_std, mag_std, eeg_std)):
+                             (std['grad'], std['mag'], std['eeg'])):
         these_picks = pick_types(info, meg=meg, eeg=eeg)
-        data[np.searchsorted(picks, these_picks)] = val * val
+        data[np.searchsorted(picks, these_picks)] = np.multiply(val, val)
     ch_names = [info['ch_names'][pick] for pick in picks]
     return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -272,11 +272,10 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
     ----------
     info : instance of Info
         Measurement info.
-    std : dict of ndarray | None
-        Standard_deviations of the diagonal elements. If dict, keys should be
+    std : dict of float | None
+        Standard_deviation of the diagonal elements. If dict, keys should be
         `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
-        channels. The ndarrays must have the same number of elements as the
-        sensors denoted by their keys.
+        channels. If None, default values will be used.
     verbose : bool, str, int, or None (default None)
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -289,7 +288,7 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
     Notes
     -----
     The default noise values are 5 fT/cm, 20 fT, and 0.2 uV for gradiometers,
-    magnetometers, and EEG channels, respectively.
+    magnetometers, and EEG channels respectively.
 
     .. versionadded:: 0.9.0
     """
@@ -300,7 +299,7 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
     for meg, eeg, val in zip(('grad', 'mag', False), (False, False, True),
                              (std['grad'], std['mag'], std['eeg'])):
         these_picks = pick_types(info, meg=meg, eeg=eeg)
-        data[np.searchsorted(picks, these_picks)] = np.multiply(val, val)
+        data[np.searchsorted(picks, these_picks)] = val * val
     ch_names = [info['ch_names'][pick] for pick in picks]
     return Covariance(data, ch_names, info['bads'], info['projs'], nfree=0)
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -275,7 +275,7 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
     std : dict of float | None
         Standard_deviation of the diagonal elements. If dict, keys should be
         `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
-        channels. If None, default values will be used.
+        channels. If None, default values will be used (see Notes).
     verbose : bool, str, int, or None (default None)
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -59,6 +59,7 @@ DEFAULTS = dict(
         nasion_color=(0., 1., 0.),
         rpa_color=(0., 0., 1.),
     ),
+    noise_std=dict(grad=5e-13, mag=20e-15, eeg=0.2e-6),
 )
 
 

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -35,7 +35,7 @@ from ..externals.six import string_types
 
 def _check_cov(info, cov):
     """Check that the user provided a valid covariance matrix for the noise."""
-    if isinstance(cov, Covariance):
+    if isinstance(cov, Covariance) or cov is None:
         pass
     elif isinstance(cov, dict):
         cov = make_ad_hoc_cov(info, cov, verbose=False)
@@ -47,7 +47,7 @@ def _check_cov(info, cov):
     else:
         raise TypeError('Covariance matrix type not recognized. Valid input '
                         'types are: instance of Covariance, dict, str, None. '
-                        ', got %s' % cov)
+                        ', got %s' % (cov,))
     return cov
 
 
@@ -97,7 +97,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
         be a filename or 'simple'. If 'simple', an ad hoc covariance matrix
         will be generated with default values. If dict, an ad hoc covariance
         matrix will be generated with the values specified by the dict entries.
-        If None, no noise sill be added.
+        If None, no noise will be added.
     blink : bool
         If true, add simulated blink artifacts. See Notes for details.
     ecg : bool
@@ -258,8 +258,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
     src = _ensure_src(src, verbose=False)
     if isinstance(bem, string_types):
         bem = read_bem_solution(bem, verbose=False)
-    if cov is not None:
-        cov = _check_cov(info, cov)
+    cov = _check_cov(info, cov)
     approx_events = int((len(times) / info['sfreq']) /
                         (stc.times[-1] - stc.times[0]))
     logger.info('Provided parameters will provide approximately %s event%s'

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -110,6 +110,23 @@ def test_simulate_raw_sphere():
                              blink=True, ecg=True, random_state=seed,
                              use_cps=True)
     assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
+    std = dict(grad=2e-13, mag=10e-15, eeg=0.1e-6)
+    raw_sim = simulate_raw(raw, stc, trans, src, sphere,
+                           make_ad_hoc_cov(raw.info, std=std),
+                           head_pos=head_pos_sim, blink=True, ecg=True,
+                           random_state=seed, use_cps=True)
+    raw_sim_2 = simulate_raw(raw, stc, trans_fname, src_fname, sphere,
+                             cov=std, head_pos=head_pos_sim, blink=True,
+                             ecg=True, random_state=seed, use_cps=True)
+    assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
+    raw_sim = simulate_raw(raw, stc, trans, src, sphere,
+                           make_ad_hoc_cov(raw.info, std=None),
+                           head_pos=head_pos_sim, blink=True, ecg=True,
+                           random_state=seed, use_cps=True)
+    raw_sim_2 = simulate_raw(raw, stc, trans_fname, src_fname, sphere,
+                             cov='simple', head_pos=head_pos_sim, blink=True,
+                             ecg=True, random_state=seed, use_cps=True)
+    assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
     # Test IO on processed data
     tempdir = _TempDir()
     test_outname = op.join(tempdir, 'sim_test_raw.fif')
@@ -187,6 +204,8 @@ def test_simulate_raw_sphere():
     stc_bad.tstep += 0.1
     assert_raises(ValueError, simulate_raw, raw, stc_bad, trans, src, sphere,
                   use_cps=True)
+    assert_raises(TypeError, simulate_raw, raw, stc, trans, src, sphere,
+                  cov=0, use_cps=True)  # wrong covariance type
     assert_raises(RuntimeError, simulate_raw, raw, stc, trans, src, sphere,
                   chpi=True, use_cps=True)  # no cHPI info
     assert_raises(ValueError, simulate_raw, raw, stc, trans, src, sphere,

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -132,6 +132,12 @@ def test_ad_hoc_cov():
     assert_true('Covariance' in repr(cov))
     cov2 = read_cov(out_fname)
     assert_array_almost_equal(cov['data'], cov2['data'])
+    std = dict(grad=2e-13, mag=10e-15, eeg=0.1e-6)
+    cov = make_ad_hoc_cov(evoked.info, std)
+    cov.save(out_fname)
+    assert_true('Covariance' in repr(cov))
+    cov2 = read_cov(out_fname)
+    assert_array_almost_equal(cov['data'], cov2['data'])
 
 
 def test_io_cov():


### PR DESCRIPTION
Modified `make_ad_hoc_cov` so that it accepts a dictionary of standard deviations as input.

Related to issue #5058 