### PR TITLE
WIP: [MINOR, BUG] Extent bug in evoked_image

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -223,7 +223,9 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
             raise ValueError('exclude has to be a list of channel names or '
                              '"bads"')
 
-        picks = list(set(picks).difference(exclude))
+        picks = [pick for pick in picks if pick not in exclude]
+    if len(picks) != len(set(picks)):
+        picks = set(picks)
     picks = np.array(picks)
 
     types = np.array([channel_type(info, idx) for idx in picks])

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -210,6 +210,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
 
     if picks is None:
         picks = list(range(info['nchan']))
+    if len(picks) != len(set(picks)):
+        raise ValueError("`picks` are not unique. Please remove duplicates.")
 
     bad_ch_idx = [info['ch_names'].index(ch) for ch in info['bads']
                   if ch in info['ch_names']]
@@ -220,12 +222,10 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
               all(isinstance(ch, string_types) for ch in exclude)):
             exclude = [info['ch_names'].index(ch) for ch in exclude]
         else:
-            raise ValueError('exclude has to be a list of channel names or '
-                             '"bads"')
+            raise ValueError(
+                'exclude has to be a list of channel names or "bads"')
 
         picks = [pick for pick in picks if pick not in exclude]
-    if len(picks) != len(set(picks)):
-        picks = set(picks)
     picks = np.array(picks)
 
     types = np.array([channel_type(info, idx) for idx in picks])
@@ -560,7 +560,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if mask.all():
             t_end = ", all points masked)"
         else:
-            fraction = 1 - (np.float(mask.sum()) / np.float(mask.size))
+            fraction = 1. - np.mean(mask)
             percent = np.floor(fraction * 100).astype(int)
             t_end = ", " + str(percent) + "% of points masked)"
     else:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -525,7 +525,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         vmin = -vmax
     else:
         vmin, vmax = ylim[this_type]
-    extent = [times[0], times[-1], 0, data.shape[0]]
+    extent = [times[0], times[-1], 0, len(data)]
     im_args = dict(interpolation='nearest', origin='lower',
                    extent=extent, aspect='auto', vmin=vmin, vmax=vmax)
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -560,7 +560,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if mask.all():
             t_end = ", all points masked)"
         else:
-            fraction = np.float(mask.sum()) / np.float(mask.size)
+            fraction =  1 - (np.float(mask.sum()) / np.float(mask.size))
             percent = np.floor(fraction * 100).astype(int)
             t_end = ", " + str(percent) + "% of points masked)"
     else:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -560,7 +560,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if mask.all():
             t_end = ", all points masked)"
         else:
-            fraction =  1 - (np.float(mask.sum()) / np.float(mask.size))
+            fraction = 1 - (np.float(mask.sum()) / np.float(mask.size))
             percent = np.floor(fraction * 100).astype(int)
             t_end = ", " + str(percent) + "% of points masked)"
     else:

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -147,6 +147,8 @@ def test_plot_evoked():
     evoked.plot_image(exclude=evoked.info['bads'])  # does the same thing
     plt.close('all')
 
+    assert_raises(ValueError, evoked.plot_image, picks=[0, 0])  # duplicates
+
     evoked.plot_topo()  # should auto-find layout
     _line_plot_onselect(0, 200, ['mag', 'grad'], evoked.info, evoked.data,
                         evoked.times)


### PR DESCRIPTION
A tiny, subtle bug in evoked.plot_image I introduced: if the extent is given as floats, the ticklabels can be wrong.