### PR TITLE
MRG: Unify axis labeling

### DIFF
--- a/doc/manual/cookbook.rst
+++ b/doc/manual/cookbook.rst
@@ -145,8 +145,8 @@ Rejection using annotations
 The reject keyword of :class:`mne.Epochs` is used for rejecting bad epochs
 based on peak-to-peak thresholds. Bad segments of data can also be rejected
 by marking segments of raw data with annotations. See
-:ref:`tut_artifacts_reject` and :class:`mne.Annotations` for more
-information.
+:ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_rejection.py`
+and :class:`mne.Annotations` for more .
 
 Once the :class:`mne.Epochs` are constructed, they can be averaged to obtain
 :class:`mne.Evoked` data as::

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,7 +95,7 @@ Changelog
 
 - Add the Picard algorithm to perform ICA for :class:`mne.preprocessing.ICA`, by `Pierre Ablin`_ and `Alex Gramfort`_
 
-- Add ability to supply a mask to the plot in :func:`mne.viz.plot_evoked_image` by `Jona Sassenhagen`.
+- Add ability to supply a mask to the plot in :func:`mne.viz.plot_evoked_image` by `Jona Sassenhagen`_
 
 - Add :func:`mne.time_frequency.csd_morlet` and :func:`mne.time_frequency.csd_array_morlet` to estimate cross-spectral density using Morlet wavelets, by `Marijn van Vliet`_
 
@@ -174,6 +174,8 @@ API
 - Changed the line width in :func:`mne.viz.plot_bem` from 2.0 to 1.0 for better visibility of underlying structures, by `Eric Larson`_
 
 - Changed the behavior of :meth:`mne.io.Raw.pick_channels` and similar methods to be consistent with :func:`mne.pick_channels` to treat channel list as a set (ignoring order) -- if reordering is necessary use ``inst.reorder_channels``, by `Eric Larson`_
+
+- Changed the labeling of some plotting functions to use more standard capitalization and units, e.g. "Time (s)" instead of "time [sec]" by `Eric Larson`_
 
 - ``mne.time_frequency.csd_epochs`` has been refactored into :func:`mne.time_frequency.csd_fourier` and :func:`mne.time_frequency.csd_multitaper`, by `Marijn van Vliet`_
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -625,8 +625,10 @@ def construct_iir_filter(iir_params, f_pass=None, f_stop=None, sfreq=None,
     >>> print((iir_params['b'], iir_params['a'], iir_params['padlen']))  # doctest:+SKIP
     (array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]), [1, 0], 0)
 
-    For more information, see the tutorials :ref:`tut_background_filtering`
-    and :ref:`tut_artifacts_filter`.
+    For more information, see the tutorials
+    :ref:`sphx_glr_auto_tutorials_plot_background_filtering.py`
+    and
+    :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`.
     """  # noqa: E501
     from scipy.signal import iirfilter, iirdesign
     known_filters = ('bessel', 'butter', 'butterworth', 'cauer', 'cheby1',
@@ -851,8 +853,10 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
     Notes
     -----
-    For more information, see the tutorials :ref:`tut_background_filtering`
-    and :ref:`tut_artifacts_filter`, and :func:`mne.filter.create_filter`.
+    For more information, see the tutorials
+    :ref:`sphx_glr_auto_tutorials_plot_background_filtering.py`
+    and
+    :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`.
     """
     if not isinstance(data, np.ndarray):
         raise ValueError('data must be an array')

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1240,8 +1240,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         Notes
         -----
-        For more information, see the tutorials :ref:`tut_background_filtering`
-        and :ref:`tut_artifacts_filter`.
+        For more information, see the tutorials
+        :ref:`sphx_glr_auto_tutorials_plot_background_filtering.py`
+        and
+        :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`.
         """
         _check_preload(self, 'raw.filter')
         update_info, picks = _filt_check_picks(self.info, picks,

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -923,10 +923,8 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                             color=color, alpha=area_alpha)
         if make_label:
             if ii == len(picks_list) - 1:
-                ax.set_xlabel('Freq (Hz)')
-            ax.set_ylabel(ylabel)
-            ax.set_title(title)
-            ax.set_xlim(freqs[0], freqs[-1])
+                ax.set_xlabel('Frequency (Hz)')
+            ax.set(ylabel=ylabel, title=title, xlim=(freqs[0], freqs[-1]))
     if make_label:
         tight_layout(pad=0.1, h_pad=0.1, w_pad=0.1, fig=fig)
     plt_show(show)
@@ -1955,7 +1953,7 @@ def _plot_histogram(params):
     for idx in range(len(types)):
         ax = plt.subplot(len(types), 1, idx + 1)
         plt.xlabel(units[types[idx]])
-        plt.ylabel('count')
+        plt.ylabel('Count')
         color = colors[types[idx]]
         rej = None
         if epochs.reject is not None and types[idx] in epochs.reject.keys():

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -273,8 +273,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                     units, scalings, hline, gfp, types, zorder, xlim, ylim,
                     times, bad_ch_idx, titles, ch_types_used, selectable,
                     False, line_alpha=1.)
-        for ax in axes:
-            ax.set_xlabel('Time (ms)')
+        plt.setp(axes, xlabel='Time (ms)')
 
     elif plot_type == 'image':
         for ax, this_type in zip(axes, ch_types_used):
@@ -292,8 +291,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                       plot_type=plot_type)
         _draw_proj_checkbox(None, params)
 
-    for ax in fig.axes[:len(ch_types_used) - 1]:
-        ax.set_xlabel('')
+    plt.setp(fig.axes[:len(ch_types_used) - 1], xlabel='')
     fig.canvas.draw()  # for axes plots update axes.
     if set_tight_layout:
         tight_layout(fig=fig)
@@ -548,7 +546,6 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if xlim == 'tight':
             xlim = (times[0], times[-1])
         ax.set_xlim(xlim)
-    ax.set_xlabel('Time (ms)')
 
     if colorbar:
         cbar = plt.colorbar(im, ax=ax)
@@ -556,7 +553,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if cmap[1]:
             ax.CB = DraggableColorbar(cbar, im)
 
-    ax.set_ylabel('Channels (index)')
+    ax.set(ylabel='Channel (index)', xlabel='Time (ms)')
 
     if (draw_mask or draw_contour) and mask is not None:
         if mask.all():
@@ -1152,8 +1149,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
 
             ax = ax_gfp[i]
             ax.set_title(title if n_columns > 1 else
-                         'whitened global field power (GFP),'
-                         ' method = "%s"' % label)
+                         'Whitened GFP, method = "%s"' % label)
 
             data = evoked_white.data[sub_picks]
             gfp = whitened_gfp(data, rank=this_rank)
@@ -1161,7 +1157,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True):
                     label=label if n_columns > 1 else title,
                     color=color if n_columns > 1 else ch_colors[ch],
                     lw=0.5)
-            ax.set(xlabel='times [ms]', ylabel='GFP [chi^2]',
+            ax.set(xlabel='Time (ms)', ylabel='GFP ($\chi^2$)',
                    xlim=[times[0], times[-1]], ylim=(0, 10))
             ax.axhline(1, color='red', linestyle='--', lw=2.)
             if n_columns > 1:
@@ -1216,10 +1212,7 @@ def plot_snr_estimate(evoked, inv, show=True):
     #  http://bconnelly.net/2013/10/creating-colorblind-friendly-figures/
     ax.plot(evoked.times, snr_est, color=[0.0, 0.6, 0.5])
     ax.plot(evoked.times, snr, color=[0.8, 0.4, 0.0])
-    ax.set_xlim(lims[:2])
-    ax.set_ylim(lims[2:])
-    ax.set_ylabel('SNR')
-    ax.set_xlabel('Time (sec)')
+    ax.set(xlim=lims[:2], ylim=lims[2:], ylabel='SNR', xlabel='Time (s)')
     if evoked.comment is not None:
         ax.set_title(evoked.comment)
     plt.draw()
@@ -2105,8 +2098,7 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
             ax_cb.set_yticks(np.arange(len(the_colors)))
             ax_cb.set_yticklabels(np.array(color_conds)[color_order])
         ax_cb.yaxis.tick_right()
-        ax_cb.set_xticks(())
-        ax_cb.set_ylabel(cmap_label)
+        ax_cb.set(xticks=(), ylabel=cmap_label)
 
     plt_show(show)
     return ax.figure

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Functions to make simple plots with M/EEG data."""
 
 from __future__ import print_function
@@ -137,7 +138,7 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
             s[s <= 0] = 1e-10 * s[s > 0].min()
             s = np.sqrt(s) * scaling
             axes[0, k].plot(s)
-            axes[0, k].set(ylabel='Noise std (%s)' % unit, yscale='log',
+            axes[0, k].set(ylabel=u'Noise σ (%s)' % unit, yscale='log',
                            xlabel='Eigenvalue index', title=name)
         tight_layout(fig=fig_svd)
 
@@ -224,9 +225,7 @@ def plot_source_spectrogram(stcs, freq_bins, tmin=None, tmax=None,
                cmap='Reds')
     ax = plt.gca()
 
-    plt.title('Time-frequency source power')
-    plt.xlabel('Time (s)')
-    plt.ylabel('Frequency (Hz)')
+    ax.set(title='Source power', xlabel='Time (s)', ylabel='Frequency (Hz)')
 
     time_tick_labels = [str(np.round(t, 2)) for t in time_bounds]
     n_skip = 1 + len(time_bounds) // 10
@@ -481,7 +480,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     """
     if sfreq is None:
         sfreq = 1.0
-        xlabel = 'samples'
+        xlabel = 'Samples'
     else:
         xlabel = 'Time (s)'
 
@@ -542,8 +541,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     else:
         ax.set_ylim([min_event - 1, max_event + 1])
 
-    ax.set_xlabel(xlabel)
-    ax.set_ylabel('Events id')
+    ax.set(xlabel=xlabel, ylabel='Events id')
 
     ax.grid(True)
 
@@ -599,9 +597,7 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
         ax.plot(dip.times, dip.amplitude * 1e9, color=color, linewidth=1.5)
         xlim[0] = min(xlim[0], dip.times[0])
         xlim[1] = max(xlim[1], dip.times[-1])
-    ax.set_xlim(xlim)
-    ax.set_xlabel('Time (sec)')
-    ax.set_ylabel('Amplitude (nAm)')
+    ax.set(xlim=xlim, xlabel='Time (sec)', ylabel='Amplitude (nAm)')
     if show:
         fig.show(warn=False)
     return fig
@@ -760,7 +756,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     f = omega * sfreq / (2 * np.pi)
     axes[0].plot(t, h, color=color)
     axes[0].set(xlim=t[[0, -1]], xlabel='Time (sec)',
-                ylabel='Amplitude h(n)', title=title)
+                ylabel='Amplitude', title=title)
     mag = 10 * np.log10(np.maximum((H * H.conj()).real, 1e-20))
     axes[1].plot(f, mag, color=color, linewidth=2, zorder=4)
     if freq is not None and gain is not None:
@@ -769,12 +765,12 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     axes[1].set(ylabel='Magnitude (dB)', xlabel='', xscale=fscale)
     sl = slice(0 if fscale == 'linear' else 1, None, None)
     axes[2].plot(f[sl], gd[sl], color=color, linewidth=2, zorder=4)
-    axes[2].set(xlim=flim, ylabel='Group delay (sec)', xlabel='Frequency (Hz)',
+    axes[2].set(xlim=flim, ylabel='Group delay (s)', xlabel='Frequency (Hz)',
                 xscale=fscale)
     xticks, xticklabels = _filter_ticks(flim, fscale)
     dlim = [0, 1.05 * gd[1:].max()]
     for ax, ylim, ylabel in zip(axes[1:], (alim, dlim),
-                                ('Amplitude (dB)', 'Delay (sec)')):
+                                ('Amplitude (dB)', 'Delay (s)')):
         if xticks is not None:
             ax.set(xticks=xticks)
             ax.set(xticklabels=xticklabels)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -751,31 +751,32 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
             gd = group_delay((h, [1.]), omega)[1]
         title = 'FIR filter' if title is None else title
     gd /= sfreq
-    fig, axes = plt.subplots(3)  # eventually axes could be a parameter
+    # eventually axes could be a parameter
+    fig, (ax_time, ax_freq, ax_delay) = plt.subplots(3)
     t = np.arange(len(h)) / sfreq
     f = omega * sfreq / (2 * np.pi)
-    axes[0].plot(t, h, color=color)
-    axes[0].set(xlim=t[[0, -1]], xlabel='Time (sec)',
+    ax_time.plot(t, h, color=color)
+    ax_time.set(xlim=t[[0, -1]], xlabel='Time (s)',
                 ylabel='Amplitude', title=title)
     mag = 10 * np.log10(np.maximum((H * H.conj()).real, 1e-20))
-    axes[1].plot(f, mag, color=color, linewidth=2, zorder=4)
+    ax_freq.plot(f, mag, color=color, linewidth=2, zorder=4)
     if freq is not None and gain is not None:
-        plot_ideal_filter(freq, gain, axes[1], fscale=fscale,
+        plot_ideal_filter(freq, gain, ax_freq, fscale=fscale,
                           title=None, show=False)
-    axes[1].set(ylabel='Magnitude (dB)', xlabel='', xscale=fscale)
+    ax_freq.set(ylabel='Magnitude (dB)', xlabel='', xscale=fscale)
     sl = slice(0 if fscale == 'linear' else 1, None, None)
-    axes[2].plot(f[sl], gd[sl], color=color, linewidth=2, zorder=4)
-    axes[2].set(xlim=flim, ylabel='Group delay (s)', xlabel='Frequency (Hz)',
-                xscale=fscale)
+    ax_delay.plot(f[sl], gd[sl], color=color, linewidth=2, zorder=4)
+    ax_delay.set(xlim=flim, ylabel='Group delay (s)', xlabel='Frequency (Hz)',
+                 xscale=fscale)
     xticks, xticklabels = _filter_ticks(flim, fscale)
     dlim = [0, 1.05 * gd[1:].max()]
-    for ax, ylim, ylabel in zip(axes[1:], (alim, dlim),
-                                ('Amplitude (dB)', 'Delay (s)')):
+    for ax, ylim, ylabel in ((ax_freq, alim, 'Amplitude (dB)'),
+                             (ax_delay, dlim, 'Delay (s)')):
         if xticks is not None:
             ax.set(xticks=xticks)
             ax.set(xticklabels=xticklabels)
         ax.set(xlim=flim, ylim=ylim, xlabel='Frequency (Hz)', ylabel=ylabel)
-    adjust_axes(axes)
+    adjust_axes([ax_time, ax_freq, ax_delay])
     tight_layout()
     plt_show(show)
     return fig

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -597,7 +597,7 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
         ax.plot(dip.times, dip.amplitude * 1e9, color=color, linewidth=1.5)
         xlim[0] = min(xlim[0], dip.times[0])
         xlim[1] = max(xlim[1], dip.times[-1])
-    ax.set(xlim=xlim, xlabel='Time (sec)', ylabel='Amplitude (nAm)')
+    ax.set(xlim=xlim, xlabel='Time (s)', ylabel='Amplitude (nAm)')
     if show:
         fig.show(warn=False)
     return fig

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -116,7 +116,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     events : array | None
         Events to show with vertical bars.
     duration : float
-        Time window (sec) to plot. The lesser of this value and the duration
+        Time window (s) to plot. The lesser of this value and the duration
         of the raw file will be used.
     start : float
         Initial time to show (can be changed dynamically once plotted). If
@@ -633,10 +633,7 @@ def _convert_psds(psds, dB, estimate, scaling, unit, ch_names):
         warn(msg)
 
     if estimate == 'auto':
-        if dB:
-            estimate = 'power'
-        else:
-            estimate = 'amplitude'
+        estimate = 'power' if dB else 'amplitude'
 
     if estimate == 'amplitude':
         np.sqrt(psds, out=psds)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -142,8 +142,7 @@ def _iter_topography(info, layout, on_pick, fig, fig_facecolor='k',
             ax = plt.axes(pos[idx])
             ax.patch.set_facecolor(axis_facecolor)
             plt.setp(list(ax.spines.values()), color=axis_spinecolor)
-            ax.set_xticklabels([])
-            ax.set_yticklabels([])
+            ax.set(xticklabels=[], yticklabels=[])
             plt.setp(ax.get_xticklines(), visible=False)
             plt.setp(ax.get_yticklines(), visible=False)
             ax._mne_ch_name = name
@@ -408,7 +407,7 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
             ax.plot(times, data_[ch_idx], color=color_)
 
     if x_label is not None:
-        plt.xlabel(x_label)
+        ax.set(xlabel=x_label)
 
     if y_label is not None:
         if isinstance(y_label, list):

--- a/tutorials/plot_artifacts_correction_filtering.py
+++ b/tutorials/plot_artifacts_correction_filtering.py
@@ -1,6 +1,4 @@
 """
-.. _tut_artifacts_filter:
-
 Filtering and resampling data
 =============================
 
@@ -16,7 +14,8 @@ the power-line frequency, e.g. 100Hz, 150Hz, ... (or 120Hz, 180Hz, ...).
 
 This tutorial covers some basics of how to filter data in MNE-Python.
 For more in-depth information about filter design in general and in
-MNE-Python in particular, check out :ref:`tut_background_filtering`.
+MNE-Python in particular, check out
+:ref:`sphx_glr_auto_tutorials_plot_background_filtering.py`.
 """
 
 import numpy as np

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -1,7 +1,4 @@
 """
-
-.. _tut_artifacts_correct_ica:
-
 Artifact Correction with ICA
 ============================
 
@@ -41,7 +38,7 @@ picks_meg = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,
 
 ###############################################################################
 # Before applying artifact correction please learn about your actual artifacts
-# by reading :ref:`tut_artifacts_detect`.
+# by reading :ref:`sphx_glr_auto_tutorials_plot_artifacts_detection.py`.
 #
 # .. warning:: ICA is sensitive to low-frequency drifts and therefore
 #              requires the data to be high-pass filtered prior to fitting.
@@ -299,7 +296,7 @@ eog_component = reference_ica.get_components()[:, eog_inds[0]]
 # You can also use SSP to correct for artifacts. It is a bit simpler and
 # faster but also less precise than ICA and requires that you know the event
 # timing of your artifact.
-# See :ref:`tut_artifacts_correct_ssp`.
+# See :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_ssp.py`.
 
 ###############################################################################
 # References

--- a/tutorials/plot_artifacts_correction_rejection.py
+++ b/tutorials/plot_artifacts_correction_rejection.py
@@ -1,6 +1,4 @@
 """
-.. _tut_artifacts_reject:
-
 Rejecting bad data (channels and segments)
 ==========================================
 
@@ -135,7 +133,8 @@ raw.plot(events=eog_events)  # To see the annotated segments.
 
 ###############################################################################
 # It is also possible to draw bad segments interactively using
-# :meth:`raw.plot <mne.io.Raw.plot>` (see :ref:`tut_viz_raw`).
+# :meth:`raw.plot <mne.io.Raw.plot>` (see
+# :ref:`sphx_glr_auto_tutorials_plot_visualize_raw.py`).
 #
 # As the data is epoched, all the epochs overlapping with segments whose
 # description starts with 'bad' are rejected by default. To turn rejection off,

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -1,7 +1,4 @@
 """
-
-.. _tut_artifacts_correct_ssp:
-
 Artifact Correction with SSP
 ============================
 

--- a/tutorials/plot_artifacts_detection.py
+++ b/tutorials/plot_artifacts_detection.py
@@ -1,6 +1,4 @@
 """
-.. _tut_artifacts_detect:
-
 Introduction to artifacts and artifact detection
 ================================================
 
@@ -49,11 +47,14 @@ to detect the artifacts: it just depends on the data properties and your
 own preferences.
 
 In this tutorial we show how to detect artifacts visually and automatically.
-For how to correct artifacts by rejection see :ref:`tut_artifacts_reject`.
+For how to correct artifacts by rejection see
+:ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_rejection.py`.
 To discover how to correct certain artifacts by filtering see
-:ref:`tut_artifacts_filter` and to learn how to correct artifacts
-with subspace methods like SSP and ICA see :ref:`tut_artifacts_correct_ssp`
-and :ref:`tut_artifacts_correct_ica`.
+:ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`
+and to learn how to correct artifacts
+with subspace methods like SSP and ICA see
+:ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_ssp.py`
+and :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_ica.py`.
 
 
 Artifacts Detection
@@ -96,7 +97,7 @@ raw.plot_psd(tmax=np.inf, fmax=250)
 # biological artifacts such as ECG. These can be most easily detected in the
 # time domain using MNE helper functions
 #
-# See :ref:`tut_artifacts_filter`.
+# See :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`.
 
 ###############################################################################
 # ECG
@@ -130,6 +131,6 @@ average_eog.plot_joint()
 # to artifacts.
 #
 # Consider the following tutorials for correcting this class of artifacts:
-#     - :ref:`tut_artifacts_filter`
-#     - :ref:`tut_artifacts_correct_ica`
-#     - :ref:`tut_artifacts_correct_ssp`
+#     - :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`
+#     - :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_ica.py`
+#     - :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_ssp.py`

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 r"""
-.. _tut_background_filtering:
-
 ===================================
 Background information on filtering
 ===================================
@@ -13,7 +11,8 @@ filter design can be found in Parks & Burrus [1]_ and
 Ifeachor and Jervis [2]_, and for filtering in an
 M/EEG context we recommend reading Widmann *et al.* 2015 [7]_.
 To see how to use the default filters in MNE-Python on actual data, see
-the :ref:`tut_artifacts_filter` tutorial.
+the :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`
+tutorial.
 
 .. contents::
     :local:
@@ -732,6 +731,7 @@ def baseline_plot(x):
     plt.suptitle(title)
     plt.show()
 
+
 baseline_plot(x)
 
 ###############################################################################
@@ -853,7 +853,8 @@ baseline_plot(x)
 #
 # For more information on how to use the
 # MNE-Python filtering functions with real data, consult the preprocessing
-# tutorial on :ref:`tut_artifacts_filter`.
+# tutorial on
+# :ref:`sphx_glr_auto_tutorials_plot_artifacts_correction_filtering.py`.
 #
 # Defaults in MNE-C
 # -----------------

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -1,6 +1,4 @@
 """
-.. _tut_viz_raw:
-
 Visualize Raw data
 ==================
 

--- a/tutorials/plot_whitened.py
+++ b/tutorials/plot_whitened.py
@@ -2,7 +2,7 @@
 Plotting whitened data
 ======================
 
-The aim of this tutorial is to show you how to plot whitened data.
+This tutorial demonstrates how to plot whitened data.
 
 Data are whitened for many processes, including dipole fitting, source
 localization and some decoding algorithms. Viewing whitened data thus gives


### PR DESCRIPTION
Closes #4534.

This PR:

- Unifies axis labeling to "Time (s)" form from others like "time [sec]". Turns out there were a lot of places we already used the former standard so the changeset wasn't so bad.
- Unifies handling of unit naming in ICA property plots to fit with e.g. `raw.plot_psd()`.
- Unifies `sphx_glr_*`-based linking rather than custom `tut_` ones to make things more standard.
