### PR TITLE
MRG: Unify around time_unit="s"

### DIFF
--- a/doc/tutorials/report.rst
+++ b/doc/tutorials/report.rst
@@ -139,7 +139,7 @@ Custom plots can be added to the report. Let us first generate a custom plot::
             nave = 55 - aspect type = 100
     Projections have already been applied. Setting proj attribute to True.
     Applying baseline correction (mode: mean)
-    >>> fig = evoked.plot(show=False)
+    >>> fig = evoked.plot(show=False, time_unit='s')
 
 To add the custom plot to the report, do::
 

--- a/examples/datasets/plot_brainstorm_data.py
+++ b/examples/datasets/plot_brainstorm_data.py
@@ -72,4 +72,5 @@ evoked.shift_time(-0.004)
 evoked.plot(time_unit='s')
 
 # show topomaps
-evoked.plot_topomap(times=np.array([0.016, 0.030, 0.060, 0.070]))
+evoked.plot_topomap(times=np.array([0.016, 0.030, 0.060, 0.070]),
+                    time_unit='s')

--- a/examples/datasets/plot_brainstorm_data.py
+++ b/examples/datasets/plot_brainstorm_data.py
@@ -69,7 +69,7 @@ mne.preprocessing.fix_stim_artifact(evoked)
 evoked.shift_time(-0.004)
 
 # plot the result
-evoked.plot()
+evoked.plot(time_unit='s')
 
 # show topomaps
 evoked.plot_topomap(times=np.array([0.016, 0.030, 0.060, 0.070]))

--- a/examples/datasets/plot_megsim_data.py
+++ b/examples/datasets/plot_megsim_data.py
@@ -45,8 +45,8 @@ event_id, tmin, tmax = 9, -0.2, 0.5
 epochs = Epochs(raw, events, event_id, tmin, tmax, baseline=(None, 0),
                 picks=picks, reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
 evoked = epochs.average()  # average epochs and get an Evoked dataset.
-evoked.plot()
+evoked.plot(time_unit='s')
 
 # Compare to the simulated data (use verbose='error' b/c of naming)
 evoked_sim = read_evokeds(evoked_fnames[0], condition=0, verbose='error')
-evoked_sim.plot()
+evoked_sim.plot(time_unit='s')

--- a/examples/datasets/plot_megsim_data_single_trial.py
+++ b/examples/datasets/plot_megsim_data_single_trial.py
@@ -33,4 +33,4 @@ evokeds = [read_evokeds(f, verbose='error')[0] for f in epochs_fnames]
 mean_evoked = combine_evoked(evokeds, weights='nave')
 
 # Visualize the average
-mean_evoked.plot()
+mean_evoked.plot(time_unit='s')

--- a/examples/decoding/plot_decoding_unsupervised_spatial_filter.py
+++ b/examples/decoding/plot_decoding_unsupervised_spatial_filter.py
@@ -53,7 +53,7 @@ pca_data = pca.fit_transform(X)
 ev = mne.EvokedArray(np.mean(pca_data, axis=0),
                      mne.create_info(30, epochs.info['sfreq'],
                                      ch_types='eeg'), tmin=tmin)
-ev.plot(show=False, window_title="PCA")
+ev.plot(show=False, window_title="PCA", time_unit='s')
 
 ##############################################################################
 # Transform data with ICA computed on the raw epochs (no averaging)
@@ -62,6 +62,6 @@ ica_data = ica.fit_transform(X)
 ev1 = mne.EvokedArray(np.mean(ica_data, axis=0),
                       mne.create_info(30, epochs.info['sfreq'],
                                       ch_types='eeg'), tmin=tmin)
-ev1.plot(show=False, window_title='ICA')
+ev1.plot(show=False, window_title='ICA', time_unit='s')
 
 plt.show()

--- a/examples/decoding/plot_ems_filtering.py
+++ b/examples/decoding/plot_ems_filtering.py
@@ -121,7 +121,7 @@ plt.show()
 
 # Visualize spatial filters across time
 evoked = EvokedArray(filters, epochs.info, tmin=epochs.tmin)
-evoked.plot_topomap()
+evoked.plot_topomap(time_unit='s')
 
 #############################################################################
 # Note that a similar transformation can be applied with `compute_ems`

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -90,7 +90,7 @@ for name, coef in (('patterns', model.patterns_), ('filters', model.filters_)):
 
     # Plot
     evoked = EvokedArray(coef, meg_epochs.info, tmin=epochs.tmin)
-    evoked.plot_topomap(title='MEG %s' % name)
+    evoked.plot_topomap(title='MEG %s' % name, time_unit='s')
 
 ###############################################################################
 # Let's do the same on EEG data using a scikit-learn pipeline
@@ -111,4 +111,4 @@ for name in ('patterns_', 'filters_'):
     # contained in the pipeline, in reverse order.
     coef = get_coef(clf, name, inverse_transform=True)
     evoked = EvokedArray(coef, epochs.info, tmin=epochs.tmin)
-    evoked.plot_topomap(title='EEG %s' % name[:-1])
+    evoked.plot_topomap(title='EEG %s' % name[:-1], time_unit='s')

--- a/examples/inverse/plot_gamma_map_inverse.py
+++ b/examples/inverse/plot_gamma_map_inverse.py
@@ -73,11 +73,11 @@ plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
 ylim = dict(grad=[-120, 120])
 evoked.pick_types(meg='grad', exclude='bads')
 evoked.plot(titles=dict(grad='Evoked Response Gradiometers'), ylim=ylim,
-            proj=True)
+            proj=True, time_unit='s')
 
 residual.pick_types(meg='grad', exclude='bads')
 residual.plot(titles=dict(grad='Residuals Gradiometers'), ylim=ylim,
-              proj=True)
+              proj=True, time_unit='s')
 
 ###############################################################################
 # Generate stc from dipoles

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -61,7 +61,7 @@ forward = mne.convert_forward_solution(forward, surf_ori=True)
 noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk')
 data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
                                   method='shrunk')
-evoked.plot()
+evoked.plot(time_unit='s')
 
 ###############################################################################
 # Run beamformers and look at maximum outputs

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -60,7 +60,8 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
 evoked = epochs.average()
 
 # Visualize sensor space data
-evoked.plot_joint()
+evoked.plot_joint(ts_args=dict(time_unit='s'),
+                  topomap_args=dict(time_unit='s'))
 
 ###############################################################################
 # Compute covariance matrices, fit and apply  spatial filter.

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -92,9 +92,9 @@ plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
 # Plot residual
 ylim = dict(eeg=[-10, 10], grad=[-400, 400], mag=[-600, 600])
 evoked.pick_types(meg=True, eeg=True, exclude='bads')
-evoked.plot(ylim=ylim, proj=True)
+evoked.plot(ylim=ylim, proj=True, time_unit='s')
 residual.pick_types(meg=True, eeg=True, exclude='bads')
-residual.plot(ylim=ylim, proj=True)
+residual.plot(ylim=ylim, proj=True, time_unit='s')
 
 ###############################################################################
 # Generate stc from dipoles

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -53,5 +53,7 @@ plot_dipole_locations(dipoles, trans, 'sample', subjects_dir=subjects_dir)
 plot_dipole_amplitudes(dipoles)
 
 # Plot the evoked data and the residual.
-evoked.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]))
-residual.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]))
+evoked.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]),
+            time_unit='s')
+residual.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]),
+              time_unit='s')

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -118,11 +118,11 @@ plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
 ylim = dict(grad=[-120, 120])
 evoked.pick_types(meg='grad', exclude='bads')
 evoked.plot(titles=dict(grad='Evoked Response: Gradiometers'), ylim=ylim,
-            proj=True)
+            proj=True, time_unit='s')
 
 residual.pick_types(meg='grad', exclude='bads')
 residual.plot(titles=dict(grad='Residuals: Gradiometers'), ylim=ylim,
-              proj=True)
+              proj=True, time_unit='s')
 
 ###############################################################################
 # Generate stc from dipoles

--- a/examples/io/plot_elekta_epochs.py
+++ b/examples/io/plot_elekta_epochs.py
@@ -65,4 +65,4 @@ newcat['index'] = 9  # can be set freely
 cond = raw.acqparser.get_condition(raw, newcat)
 epochs = mne.Epochs(raw, reject=raw.acqparser.reject,
                     flat=raw.acqparser.flat, **cond)
-epochs.average().plot()
+epochs.average().plot(time_unit='s')

--- a/examples/io/plot_objects_from_arrays.py
+++ b/examples/io/plot_objects_from_arrays.py
@@ -97,7 +97,7 @@ evoked_data = np.mean(epochs_data, axis=0)
 evokeds = mne.EvokedArray(evoked_data, info=info, tmin=-0.2,
                           comment='Arbitrary', nave=nave)
 evokeds.plot(picks=picks, show=True, units={'mag': '-'},
-             titles={'mag': 'sin and cos averaged'})
+             titles={'mag': 'sin and cos averaged'}, time_unit='s')
 
 ###############################################################################
 # Create epochs by windowing the raw data.

--- a/examples/io/plot_read_epochs.py
+++ b/examples/io/plot_read_epochs.py
@@ -45,4 +45,4 @@ evoked = epochs.average()  # average epochs to get the evoked response
 
 ###############################################################################
 # Show result
-evoked.plot()
+evoked.plot(time_unit='s')

--- a/examples/io/plot_read_evoked.py
+++ b/examples/io/plot_read_evoked.py
@@ -26,10 +26,10 @@ evoked = read_evokeds(fname, condition=condition, baseline=(None, 0),
 ###############################################################################
 # Show result as a butterfly plot:
 # By using exclude=[] bad channels are not excluded and are shown in red
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], time_unit='s')
 
 # Show result as a 2D image (x: time, y: channels, color: amplitude)
-evoked.plot_image(exclude=[])
+evoked.plot_image(exclude=[], time_unit='s')
 
 ###############################################################################
 # Use :func:`mne.Evoked.save` or :func:`mne.write_evokeds` to write the evoked

--- a/examples/preprocessing/plot_define_target_events.py
+++ b/examples/preprocessing/plot_define_target_events.py
@@ -86,13 +86,9 @@ early, late = [epochs[k].average() for k in event_id]
 times = 1e3 * epochs.times  # time in milliseconds
 title = 'Evoked response followed by %s button press'
 
-plt.clf()
-ax = plt.subplot(2, 1, 1)
-early.plot(axes=ax)
-plt.title(title % 'late')
-plt.ylabel('Evoked field (fT)')
-ax = plt.subplot(2, 1, 2)
-late.plot(axes=ax)
-plt.title(title % 'early')
-plt.ylabel('Evoked field (fT)')
+fig, axes = plt.subplots(2, 1)
+early.plot(axes=axes[0], time_unit='s')
+axes[0].set(title=title % 'late', ylabel='Evoked field (fT)')
+late.plot(axes=axes[1], time_unit='s')
+axes[1].set(title=title % 'early', ylabel='Evoked field (fT)')
 plt.show()

--- a/examples/preprocessing/plot_interpolate_bad_channels.py
+++ b/examples/preprocessing/plot_interpolate_bad_channels.py
@@ -34,10 +34,10 @@ evoked = mne.read_evokeds(fname, condition='Left Auditory',
                           baseline=(None, 0))
 
 # plot with bads
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], time_unit='s')
 
 # compute interpolation (also works with Raw and Epochs objects)
 evoked.interpolate_bads(reset_bads=False, verbose=False)
 
 # plot interpolated (previous bads)
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], time_unit='s')

--- a/examples/preprocessing/plot_metadata_query.py
+++ b/examples/preprocessing/plot_metadata_query.py
@@ -52,7 +52,7 @@ for ev in events:
 
 # Here's a helper function we'll use later
 def plot_query_results(query):
-    fig = epochs[query].average().plot(show=False)
+    fig = epochs[query].average().plot(show=False, time_unit='s')
     title = fig.axes[0].get_title()
     add = 'Query: {}\nNum Epochs: {}'.format(query, len(epochs[query]))
     fig.axes[0].set(title='\n'.join([add, title]))

--- a/examples/preprocessing/plot_movement_compensation.py
+++ b/examples/preprocessing/plot_movement_compensation.py
@@ -52,7 +52,8 @@ events = mne.find_events(raw, stim_channel='STI 014')
 events[:, 2] = 1
 raw.plot(events=events)
 
-topo_kwargs = dict(times=[0, 0.1, 0.2], ch_type='mag', vmin=-500, vmax=500)
+topo_kwargs = dict(times=[0, 0.1, 0.2], ch_type='mag', vmin=-500, vmax=500,
+                   time_unit='s')
 
 ###############################################################################
 # First, take the average of stationary data (bilateral auditory patterns).

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -50,18 +50,21 @@ fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 raw.set_eeg_reference([])
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
-evoked_no_ref.plot(axes=ax1, titles=dict(eeg='Original reference'), show=False)
+evoked_no_ref.plot(axes=ax1, titles=dict(eeg='Original reference'), show=False,
+                   time_unit='s')
 
 # Average reference. This is normally added by default, but can also be added
 # explicitly.
 raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 
-evoked_car.plot(axes=ax2, titles=dict(eeg='Average reference'), show=False)
+evoked_car.plot(axes=ax2, titles=dict(eeg='Average reference'), show=False,
+                time_unit='s')
 
 # Re-reference from an average reference to the mean of channels EEG 001 and
 # EEG 002.
 raw.set_eeg_reference(['EEG 001', 'EEG 002'])
 evoked_custom = mne.Epochs(raw, **epochs_params).average()
 
-evoked_custom.plot(axes=ax3, titles=dict(eeg='Custom reference'))
+evoked_custom.plot(axes=ax3, titles=dict(eeg='Custom reference'),
+                   time_unit='s')

--- a/examples/preprocessing/plot_shift_evoked.py
+++ b/examples/preprocessing/plot_shift_evoked.py
@@ -30,18 +30,18 @@ picks = mne.pick_channels(ch_names=ch_names, include=["MEG 2332"])
 # Create subplots
 f, (ax1, ax2, ax3) = plt.subplots(3)
 evoked.plot(exclude=[], picks=picks, axes=ax1,
-            titles=dict(grad='Before time shifting'))
+            titles=dict(grad='Before time shifting'), time_unit='s')
 
 # Apply relative time-shift of 500 ms
 evoked.shift_time(0.5, relative=True)
 
 evoked.plot(exclude=[], picks=picks, axes=ax2,
-            titles=dict(grad='Relative shift: 500 ms'))
+            titles=dict(grad='Relative shift: 500 ms'), time_unit='s')
 
 # Apply absolute time-shift of 500 ms
 evoked.shift_time(0.5, relative=False)
 
 evoked.plot(exclude=[], picks=picks, axes=ax3,
-            titles=dict(grad='Absolute shift: 500 ms'))
+            titles=dict(grad='Absolute shift: 500 ms'), time_unit='s')
 
 tight_layout()

--- a/examples/preprocessing/plot_virtual_evoked.py
+++ b/examples/preprocessing/plot_virtual_evoked.py
@@ -28,12 +28,12 @@ evoked = mne.read_evokeds(fname, condition='Left Auditory', baseline=(None, 0))
 
 # go from grad + mag to mag
 virt_evoked = evoked.as_type('mag')
-evoked.plot_topomap(ch_type='mag', title='mag (original)')
+evoked.plot_topomap(ch_type='mag', title='mag (original)', time_unit='s')
 virt_evoked.plot_topomap(ch_type='mag',
                          title='mag (interpolated from mag + grad)')
 
 # go from grad + mag to grad
 virt_evoked = evoked.as_type('grad')
-evoked.plot_topomap(ch_type='grad', title='grad (original)')
-virt_evoked.plot_topomap(ch_type='grad',
+evoked.plot_topomap(ch_type='grad', title='grad (original)', time_unit='s')
+virt_evoked.plot_topomap(ch_type='grad', time_unit='s',
                          title='grad (interpolated from mag + grad)')

--- a/examples/preprocessing/plot_virtual_evoked.py
+++ b/examples/preprocessing/plot_virtual_evoked.py
@@ -29,7 +29,7 @@ evoked = mne.read_evokeds(fname, condition='Left Auditory', baseline=(None, 0))
 # go from grad + mag to mag
 virt_evoked = evoked.as_type('mag')
 evoked.plot_topomap(ch_type='mag', title='mag (original)', time_unit='s')
-virt_evoked.plot_topomap(ch_type='mag',
+virt_evoked.plot_topomap(ch_type='mag', time_unit='s',
                          title='mag (interpolated from mag + grad)')
 
 # go from grad + mag to grad

--- a/examples/realtime/ftclient_rt_average.py
+++ b/examples/realtime/ftclient_rt_average.py
@@ -82,7 +82,8 @@ with FieldTripClient(host='localhost', port=1972,
         plot_events(rt_epochs.events[-5:], sfreq=ev.info['sfreq'],
                     first_samp=-rt_client.tmin_samp, axes=ax[0])
 
-        evoked.plot(axes=ax[1], selectable=False)  # plot on second subplot
+        # plot on second subplot
+        evoked.plot(axes=ax[1], selectable=False, time_unit='s')
         ax[1].set_title('Evoked response for gradiometer channels'
                         '(event_id = %d)' % event_id)
 

--- a/examples/realtime/plot_compute_rt_average.py
+++ b/examples/realtime/plot_compute_rt_average.py
@@ -57,5 +57,5 @@ for ii, ev in enumerate(rt_epochs.iter_evoked()):
     else:
         evoked = mne.combine_evoked([evoked, ev], weights='nave')
     plt.clf()  # clear canvas
-    evoked.plot(axes=plt.gca())  # plot on current figure
+    evoked.plot(axes=plt.gca(), time_unit='s')  # plot on current figure
     plt.pause(0.05)

--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -74,4 +74,4 @@ plot_sparse_source_estimates(fwd['src'], stc, bgcolor=(1, 1, 1),
 plt.figure()
 plt.psd(evoked.data[0])
 
-evoked.plot()
+evoked.plot(time_unit='s')

--- a/examples/simulation/plot_simulate_raw_data.py
+++ b/examples/simulation/plot_simulate_raw_data.py
@@ -80,4 +80,4 @@ epochs = Epochs(raw_sim, events, 1, -0.2, epoch_duration)
 cov = compute_covariance(epochs, tmax=0., method='empirical',
                          verbose='error')  # quick calc
 evoked = epochs.average()
-evoked.plot_white(cov)
+evoked.plot_white(cov, time_unit='s')

--- a/examples/stats/plot_linear_regression_raw.py
+++ b/examples/stats/plot_linear_regression_raw.py
@@ -53,7 +53,8 @@ evokeds = linear_regression_raw(raw, events=events, event_id=event_id,
 # plot both results, and their difference
 cond = "Aud/L"
 fig, (ax1, ax2, ax3) = plt.subplots(3, 1)
-params = dict(spatial_colors=True, show=False, ylim=dict(grad=(-200, 200)))
+params = dict(spatial_colors=True, show=False, ylim=dict(grad=(-200, 200)),
+              time_unit='s')
 epochs[cond].average().plot(axes=ax1, **params)
 evokeds[cond].plot(axes=ax2, **params)
 contrast = mne.combine_evoked([evokeds[cond], -epochs[cond].average()],

--- a/examples/stats/plot_sensor_permutation_test.py
+++ b/examples/stats/plot_sensor_permutation_test.py
@@ -67,4 +67,5 @@ mask = p_values[:, np.newaxis] <= 0.05
 evoked.plot_topomap(ch_type='grad', times=[0], scalings=1,
                     time_format=None, cmap='Reds', vmin=0., vmax=np.max,
                     units='-log10(p)', cbar_fmt='-%0.1f', mask=mask,
-                    size=3, show_names=lambda x: x[4:] + ' ' * 20)
+                    size=3, show_names=lambda x: x[4:] + ' ' * 20,
+                    time_unit='s')

--- a/examples/stats/plot_sensor_regression.py
+++ b/examples/stats/plot_sensor_regression.py
@@ -67,7 +67,8 @@ plot_compare_evokeds(evokeds, colors=colors, split_legend=True,
 names = ["Intercept", name]
 res = linear_regression(epochs, epochs.metadata[names], names=names)
 for cond in names:
-    res[cond].beta.plot_joint(title=cond)
+    res[cond].beta.plot_joint(title=cond, ts_args=dict(time_unit='s'),
+                              topomap_args=dict(time_unit='s'))
 
 ##############################################################################
 # Because the `linear_regression` function also estimates p values, we can --

--- a/examples/stats/plot_sensor_regression.py
+++ b/examples/stats/plot_sensor_regression.py
@@ -80,4 +80,4 @@ for cond in names:
 # by dark contour lines.
 reject_H0, fdr_pvals = fdr_correction(res["Concreteness"].p_val.data)
 evoked = res["Concreteness"].beta
-evoked.plot_image(mask=reject_H0)
+evoked.plot_image(mask=reject_H0, time_unit='s')

--- a/examples/time_frequency/plot_time_frequency_erds.py
+++ b/examples/time_frequency/plot_time_frequency_erds.py
@@ -99,7 +99,8 @@ n_cycles = freqs  # use constant t/f resolution
 vmin, vmax = -1, 1.5  # set min and max ERDS values in plot
 baseline = [-1, 0]  # baseline interval (in s)
 cmap = center_cmap(plt.cm.RdBu, vmin, vmax)  # zero maps to white
-kwargs = dict(n_permutations=100, step_down_p=0.05, seed=1)  # for cluster test
+kwargs = dict(n_permutations=100, step_down_p=0.05, seed=1,
+              buffer_size=None)  # for cluster test
 
 for event in event_ids:
     tfr = tfr_multitaper(epochs[event], freqs=freqs, n_cycles=n_cycles,

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -30,19 +30,21 @@ times = np.arange(0.05, 0.15, 0.01)
 # If times is set to None only 10 regularly spaced topographies will be shown
 
 # plot magnetometer data as topomaps
-evoked.plot_topomap(times, ch_type='mag')
+evoked.plot_topomap(times, ch_type='mag', time_unit='s')
 
 # compute a 50 ms bin to stabilize topographies
-evoked.plot_topomap(times, ch_type='mag', average=0.05)
+evoked.plot_topomap(times, ch_type='mag', average=0.05, time_unit='s')
 
 # plot gradiometer data (plots the RMS for each pair of gradiometers)
-evoked.plot_topomap(times, ch_type='grad')
+evoked.plot_topomap(times, ch_type='grad', time_unit='s')
 
 # plot magnetometer data as an animation
-evoked.animate_topomap(ch_type='mag', times=times, frame_rate=10)
+evoked.animate_topomap(ch_type='mag', times=times, frame_rate=10,
+                       time_unit='s')
 
 # plot magnetometer data as topomap at 1 time point : 100 ms
 # and add channel labels and title
 evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
-                    size=6, res=128, title='Auditory response')
+                    size=6, res=128, title='Auditory response',
+                    time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)

--- a/examples/visualization/plot_evoked_whitening.py
+++ b/examples/visualization/plot_evoked_whitening.py
@@ -70,7 +70,7 @@ for c in noise_covs:
 
 evoked = epochs.average()
 
-evoked.plot()  # plot evoked response
+evoked.plot(time_unit='s')  # plot evoked response
 
 ###############################################################################
 # We can then show whitening for our various noise covariance estimates.
@@ -81,4 +81,4 @@ evoked.plot()  # plot evoked response
 #
 # For the Global field power we expect a value of 1.
 
-evoked.plot_white(noise_covs)
+evoked.plot_white(noise_covs, time_unit='s')

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -425,7 +425,7 @@ class CSP(TransformerMixin, BaseEstimator):
             times=components, ch_type=ch_type, layout=layout,
             vmin=vmin, vmax=vmax, cmap=cmap, colorbar=colorbar, res=res,
             cbar_fmt=cbar_fmt, sensors=sensors,
-            scalings=scalings, units=units, scaling_time=1,
+            scalings=scalings, units=units, time_unit='s',
             time_format=name_format, size=size, show_names=show_names,
             title=title, mask_params=mask_params, mask=mask, outlines=outlines,
             contours=contours, image_interp=image_interp, show=show,

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -461,13 +461,18 @@ class DipoleFixed(object):
                     ('.fif', '.fif.gz'))
         _write_evokeds(fname, self, check=False)
 
-    def plot(self, show=True):
+    def plot(self, show=True, time_unit=None):
         """Plot dipole data.
 
         Parameters
         ----------
         show : bool
             Call pyplot.show() at the end or not.
+        time_unit : str
+            The units for the time axis, can be "ms" (default in 0.16)
+            or "s" (will become the default in 0.17).
+
+            .. versionadded:: 0.16
 
         Returns
         -------
@@ -478,7 +483,8 @@ class DipoleFixed(object):
                             ylim=None, xlim='tight', proj=False, hline=None,
                             units=None, scalings=None, titles=None, axes=None,
                             gfp=False, window_title=None, spatial_colors=False,
-                            plot_type="butterfly", selectable=False)
+                            plot_type="butterfly", selectable=False,
+                            time_unit=time_unit)
 
 
 # #############################################################################

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -21,8 +21,8 @@ from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     SizeMixin, copy_function_doc_to_method_doc)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
-from .viz.evoked import (plot_evoked_white, plot_evoked_joint,
-                         _animate_evoked_topomap)
+from .viz.evoked import plot_evoked_white, plot_evoked_joint
+from .viz.topomap import _topomap_animation
 
 from .externals.six import string_types
 
@@ -382,7 +382,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                  topomap_args=topomap_args)
 
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
-                        butterfly=False, blit=True, show=True):
+                        butterfly=False, blit=True, show=True, time_unit=None):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -411,6 +411,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Defaults to True.
         show : bool
             Whether to show the animation. Defaults to True.
+        time_unit : str
+            The units for the time axis, can be "ms" (default in 0.16)
+            or "s" (will become the default in 0.17).
+
+            .. versionadded:: 0.16
 
         Returns
         -------
@@ -423,10 +428,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         -----
         .. versionadded:: 0.12.0
         """
-        return _animate_evoked_topomap(self, ch_type=ch_type, times=times,
-                                       frame_rate=frame_rate,
-                                       butterfly=butterfly, blit=blit,
-                                       show=show)
+        return _topomap_animation(
+            self, ch_type=ch_type, times=times, frame_rate=frame_rate,
+            butterfly=butterfly, blit=blit, show=show, time_unit=time_unit)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -298,27 +298,27 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
              xlim='tight', proj=False, hline=None, units=None, scalings=None,
              titles=None, axes=None, gfp=False, window_title=None,
              spatial_colors=False, zorder='unsorted', selectable=True,
-             noise_cov=None, verbose=None):
+             noise_cov=None, time_unit=None, verbose=None):
         return plot_evoked(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             ylim=ylim, proj=proj, xlim=xlim, hline=hline, units=units,
             scalings=scalings, titles=titles, axes=axes, gfp=gfp,
             window_title=window_title, spatial_colors=spatial_colors,
             zorder=zorder, selectable=selectable, noise_cov=noise_cov,
-            verbose=verbose)
+            time_unit=time_unit, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_evoked_image)
     def plot_image(self, picks=None, exclude='bads', unit=True, show=True,
                    clim=None, xlim='tight', proj=False, units=None,
                    scalings=None, titles=None, axes=None, cmap='RdBu_r',
                    colorbar=True, mask=None, mask_style=None,
-                   mask_cmap='Greys', mask_alpha=.25):
-        return plot_evoked_image(self, picks=picks, exclude=exclude, unit=unit,
-                                 show=show, clim=clim, xlim=xlim, proj=proj,
-                                 units=units, scalings=scalings, titles=titles,
-                                 axes=axes, cmap=cmap, colorbar=colorbar,
-                                 mask=mask, mask_style=mask_style,
-                                 mask_cmap=mask_cmap, mask_alpha=mask_alpha)
+                   mask_cmap='Greys', mask_alpha=.25, time_unit=None):
+        return plot_evoked_image(
+            self, picks=picks, exclude=exclude, unit=unit, show=show,
+            clim=clim, xlim=xlim, proj=proj, units=units, scalings=scalings,
+            titles=titles, axes=axes, cmap=cmap, colorbar=colorbar, mask=mask,
+            mask_style=mask_style, mask_cmap=mask_cmap, mask_alpha=mask_alpha,
+            time_unit=time_unit)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
     def plot_topo(self, layout=None, layout_scale=0.945, color=None,
@@ -342,8 +342,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @copy_function_doc_to_method_doc(plot_evoked_topomap)
     def plot_topomap(self, times="auto", ch_type=None, layout=None, vmin=None,
                      vmax=None, cmap=None, sensors=True, colorbar=True,
-                     scalings=None, scaling_time=1e3, units=None, res=64,
-                     size=1, cbar_fmt="%3.1f", time_format='%01d ms',
+                     scalings=None, scaling_time=None, units=None, res=64,
+                     size=1, cbar_fmt="%3.1f",
+                     time_unit=None, time_format=None,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
@@ -352,11 +353,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
             scalings=scalings, scaling_time=scaling_time, units=units, res=res,
-            size=size, cbar_fmt=cbar_fmt, time_format=time_format,
-            proj=proj, show=show, show_names=show_names, title=title,
-            mask=mask, mask_params=mask_params, outlines=outlines,
-            contours=contours, image_interp=image_interp, average=average,
-            head_pos=head_pos, axes=axes)
+            size=size, cbar_fmt=cbar_fmt, time_unit=time_unit,
+            time_format=time_format, proj=proj, show=show,
+            show_names=show_names, title=title, mask=mask,
+            mask_params=mask_params, outlines=outlines, contours=contours,
+            image_interp=image_interp, average=average, head_pos=head_pos,
+            axes=axes)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',
@@ -365,9 +367,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                  time_label=time_label, n_jobs=n_jobs)
 
     @copy_function_doc_to_method_doc(plot_evoked_white)
-    def plot_white(self, noise_cov, show=True, rank=None, verbose=None):
-        return plot_evoked_white(self, noise_cov=noise_cov,
-                                 rank=rank, show=show, verbose=verbose)
+    def plot_white(self, noise_cov, show=True, rank=None, time_unit=None,
+                   verbose=None):
+        return plot_evoked_white(
+            self, noise_cov=noise_cov, rank=rank, show=show,
+            time_unit=time_unit, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_evoked_joint)
     def plot_joint(self, times="peaks", title='', picks=None,

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -111,7 +111,7 @@ def test_array_raw():
     epochs.plot_drop_log()
     epochs.plot()
     evoked = epochs.average()
-    evoked.plot()
+    evoked.plot(time_unit='s')
     assert_equal(evoked.nave, len(events) - 1)
     plt.close('all')
 

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -382,8 +382,12 @@ def f_mway_rm(data, factor_levels, effects='all', alpha=0.05,
 
 def _parametric_ci(arr, ci=.95):
     """Calculate the `ci`% parametric confidence interval for `arr`."""
+    mean = arr.mean(0)
+    if len(arr) < 2:  # can't compute standard error
+        sigma = np.full_like(mean, np.nan)
+        return mean, sigma
     from scipy import stats
-    mean, sigma = arr.mean(0), stats.sem(arr, 0)
+    sigma = stats.sem(arr, 0)
     # This is highly convoluted to support 17th century Scipy
     # XXX Fix when Scipy 0.12 support is dropped!
     # then it becomes just:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1912,7 +1912,7 @@ def _chunk_write(chunk, local_file, progress):
 
 @verbose
 def _fetch_file(url, file_name, print_destination=True, resume=True,
-                hash_=None, timeout=10., verbose=None):
+                hash_=None, timeout=30., verbose=None):
     """Load requested file, downloading it if needed or requested.
 
     Parameters

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -41,7 +41,7 @@ from ..utils import (get_subjects_dir, logger, _check_subject, verbose, warn,
                      _import_mlab, SilenceStdout, has_nibabel, check_version,
                      _ensure_int)
 from .utils import (mne_analyze_colormap, _prepare_trellis, COLORS, plt_show,
-                    tight_layout, figure_nobar)
+                    tight_layout, figure_nobar, _check_time_unit)
 from ..bem import (ConductorModel, _bem_find_surface, _surf_dict, _surf_name,
                    read_bem_surfaces)
 
@@ -1317,14 +1317,7 @@ def _handle_time(time_label, time_unit, times):
             time_label = 'time=%0.3fs'
         elif time_unit == 'ms':
             time_label = 'time=%0.1fms'
-    if time_unit == 's':
-        times = times
-    elif time_unit == 'ms':
-        times = 1e3 * times
-    else:
-        raise ValueError("time_unit needs to be 's' or 'ms', got %r" %
-                         (time_unit,))
-
+    _, times = _check_time_unit(time_unit, times)
     return time_label, times
 
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -34,8 +34,7 @@ from ..utils import logger, _clean_names, warn, _pl, verbose
 
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
-                      _draw_outlines, _prepare_topomap, _topomap_animation,
-                      _set_contour_locator)
+                      _draw_outlines, _prepare_topomap, _set_contour_locator)
 from ..channels.layout import _pair_grad_sensors, _auto_topomap_coords
 
 
@@ -819,54 +818,6 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
                              font_color=font_color, merge_grads=merge_grads,
                              legend=legend, axes=axes, show=show,
                              noise_cov=noise_cov)
-
-
-def _animate_evoked_topomap(evoked, ch_type='mag', times=None, frame_rate=None,
-                            butterfly=False, blit=True, show=True):
-    """Make animation of evoked data as topomap timeseries.
-
-    The animation can be paused/resumed with left mouse button.
-    Left and right arrow keys can be used to move backward or forward in
-    time.
-
-    Parameters
-    ----------
-    evoked : instance of Evoked
-        The evoked data.
-    ch_type : str | None
-        Channel type to plot. Accepted data types: 'mag', 'grad', 'eeg'.
-        If None, first available channel type from ('mag', 'grad', 'eeg') is
-        used. Defaults to None.
-    times : array of floats | None
-        The time points to plot. If None, 10 evenly spaced samples are
-        calculated over the evoked time series. Defaults to None.
-    frame_rate : int | None
-        Frame rate for the animation in Hz. If None, frame rate = sfreq / 10.
-        Defaults to None.
-    butterfly : bool
-        Whether to plot the data as butterfly plot under the topomap.
-        Defaults to False.
-    blit : bool
-        Whether to use blit to optimize drawing. In general, it is recommended
-        to use blit in combination with ``show=True``. If you intend to save
-        the animation it is better to disable blit. Defaults to True.
-    show : bool
-        Whether to show the animation. Defaults to True.
-
-    Returns
-    -------
-    fig : instance of matplotlib figure
-        The figure.
-    anim : instance of matplotlib FuncAnimation
-        Animation of the topomap.
-
-    Notes
-    -----
-    .. versionadded:: 0.12.0
-    """
-    return _topomap_animation(evoked, ch_type=ch_type, times=times,
-                              frame_rate=frame_rate, butterfly=butterfly,
-                              blit=blit, show=show)
 
 
 def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -696,12 +696,12 @@ def _plot_ica_overlay_evoked(evoked, evoked_cln, title, show):
     fig.suptitle('Average signal before (red) and after (black) ICA')
     axes = axes.flatten() if isinstance(axes, np.ndarray) else axes
 
-    evoked.plot(axes=axes, show=show)
+    evoked.plot(axes=axes, show=show, time_unit='s')
     for ax in fig.axes:
         for l in ax.get_lines():
             l.set_color('r')
     fig.canvas.draw()
-    evoked_cln.plot(axes=axes, show=show)
+    evoked_cln.plot(axes=axes, show=show, time_unit='s')
     tight_layout(fig=fig)
 
     fig.subplots_adjust(top=0.90)

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -80,18 +80,18 @@ def test_plot_evoked_cov():
     evoked = _get_epochs().average()
     cov = read_cov(cov_fname)
     cov['projs'] = []  # avoid warnings
-    evoked.plot(noise_cov=cov)
+    evoked.plot(noise_cov=cov, time_unit='s')
     with pytest.raises(TypeError, match='Covariance'):
-        evoked.plot(noise_cov=1.)
+        evoked.plot(noise_cov=1., time_unit='s')
     with pytest.raises(IOError, match='No such file'):
-        evoked.plot(noise_cov='nonexistent-cov.fif')
+        evoked.plot(noise_cov='nonexistent-cov.fif', time_unit='s')
     raw = read_raw_fif(raw_sss_fname)
     events = make_fixed_length_events(raw)
     epochs = Epochs(raw, events)
     cov = compute_covariance(epochs)
     evoked_sss = epochs.average()
     with warnings.catch_warnings(record=True) as w:
-        evoked_sss.plot(noise_cov=cov)
+        evoked_sss.plot(noise_cov=cov, time_unit='s')
     plt.close('all')
     assert any('relative scal' in str(ww.message) for ww in w)
 
@@ -102,7 +102,8 @@ def test_plot_evoked():
     import matplotlib.pyplot as plt
     rng = np.random.RandomState(0)
     evoked = _get_epochs().average()
-    fig = evoked.plot(proj=True, hline=[1], exclude=[], window_title='foo')
+    fig = evoked.plot(proj=True, hline=[1], exclude=[], window_title='foo',
+                      time_unit='s')
     # Test a click
     ax = fig.get_axes()[0]
     line = ax.lines[0]
@@ -111,43 +112,47 @@ def test_plot_evoked():
     _fake_click(fig, ax,
                 [ax.get_xlim()[0], ax.get_ylim()[1]], 'data')
     # plot with bad channels excluded & spatial_colors & zorder
-    evoked.plot(exclude='bads')
+    evoked.plot(exclude='bads', time_unit='s')
 
     # test selective updating of dict keys is working.
-    evoked.plot(hline=[1], units=dict(mag='femto foo'))
+    evoked.plot(hline=[1], units=dict(mag='femto foo'), time_unit='s')
     evoked_delayed_ssp = _get_epochs_delayed_ssp().average()
-    evoked_delayed_ssp.plot(proj='interactive')
+    evoked_delayed_ssp.plot(proj='interactive', time_unit='s')
     evoked_delayed_ssp.apply_proj()
     assert_raises(RuntimeError, evoked_delayed_ssp.plot,
-                  proj='interactive')
+                  proj='interactive', time_unit='s')
     evoked_delayed_ssp.info['projs'] = []
     assert_raises(RuntimeError, evoked_delayed_ssp.plot,
-                  proj='interactive')
+                  proj='interactive', time_unit='s')
     assert_raises(RuntimeError, evoked_delayed_ssp.plot,
-                  proj='interactive', axes='foo')
+                  proj='interactive', axes='foo', time_unit='s')
     plt.close('all')
 
     # test GFP only
-    evoked.plot(gfp='only')
-    assert_raises(ValueError, evoked.plot, gfp='foo')
+    evoked.plot(gfp='only', time_unit='s')
+    assert_raises(ValueError, evoked.plot, gfp='foo', time_unit='s')
 
-    evoked.plot_image(proj=True)
+    evoked.plot_image(proj=True, time_unit='ms')
     # test mask
-    evoked.plot_image(picks=[1, 2], mask=evoked.data > 0)
+    evoked.plot_image(picks=[1, 2], mask=evoked.data > 0, time_unit='s')
     evoked.plot_image(picks=[1, 2], mask_cmap=None, colorbar=False,
-                      mask=np.ones(evoked.data.shape).astype(bool))
+                      mask=np.ones(evoked.data.shape).astype(bool),
+                      time_unit='s')
 
     with warnings.catch_warnings(record=True) as w:
-        evoked.plot_image(picks=[1, 2], mask=None, mask_style="both")
-    assert(len(w) == 2)
-    assert_raises(ValueError, evoked.plot_image, mask=evoked.data[1:, 1:] > 0)
+        evoked.plot_image(picks=[1, 2], mask=None, mask_style="both",
+                          time_unit='s')
+    assert len(w) == 2
+    assert_raises(ValueError, evoked.plot_image, mask=evoked.data[1:, 1:] > 0,
+                  time_unit='s')
 
     # plot with bad channels excluded
-    evoked.plot_image(exclude='bads', cmap='interactive')
-    evoked.plot_image(exclude=evoked.info['bads'])  # does the same thing
+    evoked.plot_image(exclude='bads', cmap='interactive', time_unit='s')
+    evoked.plot_image(exclude=evoked.info['bads'], time_unit='s')  # same thing
     plt.close('all')
 
-    assert_raises(ValueError, evoked.plot_image, picks=[0, 0])  # duplicates
+    assert_raises(ValueError, evoked.plot_image, picks=[0, 0],
+                  time_unit='s')  # duplicates
 
     evoked.plot_topo()  # should auto-find layout
     _line_plot_onselect(0, 200, ['mag', 'grad'], evoked.info, evoked.data,
@@ -156,17 +161,18 @@ def test_plot_evoked():
 
     cov = read_cov(cov_fname)
     cov['method'] = 'empirical'
+    cov['projs'] = []  # avoid warnings
     # test rank param.
-    evoked.plot_white(cov, rank={'mag': 101, 'grad': 201})
-    evoked.plot_white(cov, rank={'mag': 101})  # test rank param.
-    evoked.plot_white(cov, rank={'grad': 201})  # test rank param.
+    evoked.plot_white(cov, rank={'mag': 101, 'grad': 201}, time_unit='s')
+    evoked.plot_white(cov, rank={'mag': 101}, time_unit='s')  # test rank param
+    evoked.plot_white(cov, rank={'grad': 201}, time_unit='s')
     assert_raises(
         ValueError, evoked.plot_white, cov,
-        rank={'mag': 101, 'grad': 201, 'meg': 306})
+        rank={'mag': 101, 'grad': 201, 'meg': 306}, time_unit='s')
     assert_raises(
-        ValueError, evoked.plot_white, cov, rank={'meg': 306})
+        ValueError, evoked.plot_white, cov, rank={'meg': 306}, time_unit='s')
 
-    evoked.plot_white([cov, cov])
+    evoked.plot_white([cov, cov], time_unit='s')
 
     # plot_compare_evokeds: test condition contrast, CI, color assignment
     plot_compare_evokeds(evoked.copy().pick_types(meg='mag'))
@@ -275,17 +281,19 @@ def test_plot_evoked():
     evoked_sss = evoked.copy()
     sss = dict(sss_info=dict(in_order=80, components=np.arange(80)))
     evoked_sss.info['proc_history'] = [dict(max_info=sss)]
-    evoked_sss.plot_white(cov, rank={'meg': 64})
+    evoked_sss.plot_white(cov, rank={'meg': 64}, time_unit='s')
     assert_raises(
-        ValueError, evoked_sss.plot_white, cov, rank={'grad': 201})
-    evoked_sss.plot_white(cov_fname)
+        ValueError, evoked_sss.plot_white, cov, rank={'grad': 201},
+        time_unit='s')
+    evoked_sss.plot_white(cov, time_unit='s')
 
     # plot with bad channels excluded, spatial_colors, zorder & pos. layout
     evoked.rename_channels({'MEG 0133': 'MEG 0000'})
     evoked.plot(exclude=evoked.info['bads'], spatial_colors=True, gfp=True,
-                zorder='std')
-    evoked.plot(exclude=[], spatial_colors=True, zorder='unsorted')
-    assert_raises(TypeError, evoked.plot, zorder='asdf')
+                zorder='std', time_unit='s')
+    evoked.plot(exclude=[], spatial_colors=True, zorder='unsorted',
+                time_unit='s')
+    assert_raises(TypeError, evoked.plot, zorder='asdf', time_unit='s')
     plt.close('all')
 
     evoked.plot_sensors()  # Test plot_sensors
@@ -293,7 +301,7 @@ def test_plot_evoked():
 
     evoked.pick_channels(evoked.ch_names[:4])
     with catch_logging() as log_file:
-        evoked.plot(verbose=True)
+        evoked.plot(verbose=True, time_unit='s')
     assert_true('Need more than one' in log_file.getvalue())
 
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -148,7 +148,7 @@ def test_plot_topomap():
 
     # Test animation
     _, anim = evoked.animate_topomap(ch_type='grad', times=[0, 0.1],
-                                     butterfly=False)
+                                     butterfly=False, time_unit='s')
     anim._func(1)  # _animate has to be tested separately on 'Agg' backend.
     plt.close('all')
 
@@ -428,7 +428,8 @@ def test_ctf_plotting():
     assert len(events) > 10
     evoked = Epochs(raw, events, tmin=0, tmax=0.01, baseline=None).average()
     assert get_current_comp(evoked.info) == 3
-    evoked.plot_topomap()  # smoke test that compensation does not matter
+    # smoke test that compensation does not matter
+    evoked.plot_topomap(time_unit='s')
 
 
 run_tests_if_main()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2172,7 +2172,10 @@ def _animate(frame, ax, ax_line, params):
         frame = params['frame']
     time_idx = params['frames'][frame]
 
-    title = '%6.0f ms' % (params['times'][frame] * 1e3)
+    if params['time_unit'] == 'ms':
+        title = '%6.0f ms' % (params['times'][frame] * 1e3,)
+    else:
+        title = '%6.3f s' % (params['times'][frame],)
     if params['blit']:
         text = params['text']
     else:
@@ -2233,7 +2236,7 @@ def _key_press(event, params):
 
 
 def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
-                       butterfly=False, blit=True, show=True):
+                       butterfly=False, blit=True, show=True, time_unit=None):
     """Make animation of evoked data as topomap timeseries.
 
     Animation can be paused/resumed with left mouse button.
@@ -2264,6 +2267,9 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
         disabled. Defaults to True.
     show : bool
         Whether to show the animation. Defaults to True.
+    time_unit : str
+        The units for the time axis, can be "ms" (default in 0.16)
+        or "s" (will become the default in 0.17).
 
     Returns
     -------
@@ -2282,6 +2288,7 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
     if ch_type not in ('mag', 'grad', 'eeg'):
         raise ValueError("Channel type not supported. Supported channel "
                          "types include 'mag', 'grad' and 'eeg'.")
+    time_unit, _ = _check_time_unit(time_unit, evoked.times, allow_none=True)
     if times is None:
         times = np.linspace(evoked.times[0], evoked.times[-1], 10)
     times = np.array(times)
@@ -2312,9 +2319,9 @@ def _topomap_animation(evoked, ch_type='mag', times=None, frame_rate=None,
     ax_cbar = plt.axes([0.85, 0.1, 0.05, 0.8])
     ax_cbar.set_title(_handle_default('units')[ch_type], fontsize=10)
 
-    params = {'data': data, 'pos': pos, 'all_times': evoked.times, 'frame': 0,
-              'frames': frames, 'butterfly': butterfly, 'blit': blit,
-              'pause': False, 'times': times}
+    params = dict(data=data, pos=pos, all_times=evoked.times, frame=0,
+                  frames=frames, butterfly=butterfly, blit=blit,
+                  pause=False, times=times, time_unit=time_unit)
     init_func = partial(_init_anim, ax=ax, ax_cbar=ax_cbar, ax_line=ax_line,
                         params=params, merge_grads=merge_grads)
     animate_func = partial(_animate, ax=ax, ax_line=ax_line, params=params)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2510,3 +2510,21 @@ def _set_title_multiple_electrodes(title, combine, ch_names, max_chans=6,
             title += ", ...\n({} of {}{} sensors)".format(
                 combine, len(ch_names), ch_type,)
     return title
+
+
+def _check_time_unit(time_unit, times, allow_none=False):
+    if not (isinstance(time_unit, string_types) or
+            (time_unit is None and allow_none)):
+        raise TypeError('time_unit must be str, got %s' % (type(time_unit),))
+    if time_unit is None:
+        warn('time_unit defaults to "ms" in 0.16 but will change to "s" in '
+             '0.17, set it explicitly to avoid this warning',
+             DeprecationWarning)
+        time_unit = 'ms'
+    if time_unit == 's':
+        times = times
+    elif time_unit == 'ms':
+        times = 1e3 * times
+    else:
+        raise ValueError("time_unit must be 's' or 'ms', got %r" % time_unit)
+    return time_unit, times

--- a/tutorials/plot_artifacts_correction_maxwell_filtering.py
+++ b/tutorials/plot_artifacts_correction_maxwell_filtering.py
@@ -41,4 +41,4 @@ for r, kind in zip((raw, raw_sss), ('Raw data', 'Maxwell filtered data')):
                         baseline=(None, 0), reject=dict(eog=150e-6))
     evoked = epochs.average()
     evoked.plot(window_title=kind, ylim=dict(grad=(-200, 250),
-                                             mag=(-600, 700)))
+                                             mag=(-600, 700)), time_unit='s')

--- a/tutorials/plot_artifacts_correction_rejection.py
+++ b/tutorials/plot_artifacts_correction_rejection.py
@@ -82,7 +82,7 @@ evoked = mne.read_evokeds(fname, condition='Left Auditory',
 evoked.pick_types(meg=True, eeg=True, exclude=[])
 
 # plot with bads
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], time_unit='s')
 
 print(evoked.info['bads'])
 
@@ -92,7 +92,7 @@ evoked.interpolate_bads(reset_bads=False, verbose=False)
 
 ###############################################################################
 # Let's plot the cleaned data
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], time_unit='s')
 
 ###############################################################################
 # .. note::

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -62,12 +62,12 @@ event_id = {'auditory/left': 1}
 
 epochs_no_proj = mne.Epochs(raw, events, event_id, tmin=-0.2, tmax=0.5,
                             proj=False, baseline=(None, 0), reject=reject)
-epochs_no_proj.average().plot(spatial_colors=True)
+epochs_no_proj.average().plot(spatial_colors=True, time_unit='s')
 
 
 epochs_proj = mne.Epochs(raw, events, event_id, tmin=-0.2, tmax=0.5, proj=True,
                          baseline=(None, 0), reject=reject)
-epochs_proj.average().plot(spatial_colors=True)
+epochs_proj.average().plot(spatial_colors=True, time_unit='s')
 
 ##############################################################################
 # Looks cool right? It is however often not clear how many components you
@@ -81,7 +81,7 @@ evoked = mne.Epochs(raw, events, event_id, tmin=-0.2, tmax=0.5,
 # set time instants in seconds (from 50 to 150ms in a step of 10ms)
 times = np.arange(0.05, 0.15, 0.01)
 
-fig = evoked.plot_topomap(times, proj='interactive')
+fig = evoked.plot_topomap(times, proj='interactive', time_unit='s')
 
 ##############################################################################
 # now you should see checkboxes. Remove a few SSP and see how the auditory

--- a/tutorials/plot_artifacts_detection.py
+++ b/tutorials/plot_artifacts_detection.py
@@ -107,7 +107,9 @@ raw.plot_psd(tmax=np.inf, fmax=250)
 
 average_ecg = create_ecg_epochs(raw).average()
 print('We found %i ECG events' % average_ecg.nave)
-average_ecg.plot_joint()
+joint_kwargs = dict(ts_args=dict(time_unit='s'),
+                    topomap_args=dict(time_unit='s'))
+average_ecg.plot_joint(**joint_kwargs)
 
 ###############################################################################
 # we can see typical time courses and non dipolar topographies
@@ -120,7 +122,7 @@ average_ecg.plot_joint()
 
 average_eog = create_eog_epochs(raw).average()
 print('We found %i EOG events' % average_eog.nave)
-average_eog.plot_joint()
+average_eog.plot_joint(**joint_kwargs)
 
 ###############################################################################
 # Knowing these artifact patterns is of paramount importance when

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -446,8 +446,9 @@ def plot_signal(x, offset):
     mask = freqs >= 0
     X = X[mask]
     freqs = freqs[mask]
-    axes[1].plot(freqs, 20 * np.log10(np.abs(X)))
+    axes[1].plot(freqs, 20 * np.log10(np.maximum(np.abs(X), 1e-16)))
     axes[1].set(xlim=flim)
+
 
 yticks = np.arange(7) / -30.
 yticklabels = ['Original', 'Noisy', 'FIR-firwin (0.16)', 'FIR-firwin2 (0.14)',

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -263,8 +263,8 @@ for evoked in (evoked_std, evoked_dev):
 # is visible in deviant condition only (decision making in preparation of the
 # button press). You can view the topographies from a certain time span by
 # painting an area with clicking and holding the left mouse button.
-evoked_std.plot(window_title='Standard', gfp=True)
-evoked_dev.plot(window_title='Deviant', gfp=True)
+evoked_std.plot(window_title='Standard', gfp=True, time_unit='s')
+evoked_dev.plot(window_title='Deviant', gfp=True, time_unit='s')
 
 
 ###############################################################################

--- a/tutorials/plot_brainstorm_auditory.py
+++ b/tutorials/plot_brainstorm_auditory.py
@@ -270,15 +270,15 @@ evoked_dev.plot(window_title='Deviant', gfp=True, time_unit='s')
 ###############################################################################
 # Show activations as topography figures.
 times = np.arange(0.05, 0.301, 0.025)
-evoked_std.plot_topomap(times=times, title='Standard')
-evoked_dev.plot_topomap(times=times, title='Deviant')
+evoked_std.plot_topomap(times=times, title='Standard', time_unit='s')
+evoked_dev.plot_topomap(times=times, title='Deviant', time_unit='s')
 
 ###############################################################################
 # We can see the MMN effect more clearly by looking at the difference between
 # the two conditions. P50 and N100 are no longer visible, but MMN/P200 and
 # P300 are emphasised.
 evoked_difference = combine_evoked([evoked_dev, -evoked_std], weights='equal')
-evoked_difference.plot(window_title='Difference', gfp=True)
+evoked_difference.plot(window_title='Difference', gfp=True, time_unit='s')
 
 ###############################################################################
 # Source estimation.

--- a/tutorials/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/plot_brainstorm_phantom_ctf.py
@@ -84,7 +84,7 @@ tmax = -tmin
 epochs = mne.Epochs(raw, events, event_id=1, tmin=tmin, tmax=tmax,
                     baseline=(None, None))
 evoked = epochs.average()
-evoked.plot()
+evoked.plot(time_unit='s')
 evoked.crop(0., 0.)
 
 ###############################################################################

--- a/tutorials/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/plot_brainstorm_phantom_elekta.py
@@ -81,7 +81,7 @@ tmin, tmax = -0.1, 0.1
 event_id = list(range(1, 33))
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax, baseline=(None, -0.01),
                     decim=3, preload=True)
-epochs['1'].average().plot()
+epochs['1'].average().plot(time_unit='s')
 
 ###############################################################################
 # Let's use a sphere head geometry model and let's see the coordinate

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -119,7 +119,7 @@ noise_cov_reg = mne.compute_covariance(epochs, tmax=0., method='auto')
 # of freedom, e.g. ``ddof=3`` with 2 active SSP vectors):
 
 evoked = epochs.average()
-evoked.plot_white(noise_cov_reg)
+evoked.plot_white(noise_cov_reg, time_unit='s')
 
 ###############################################################################
 # This plot displays both, the whitened evoked signals for each channels and
@@ -146,7 +146,7 @@ evoked.plot_white(noise_cov_reg)
 
 noise_covs = mne.compute_covariance(
     epochs, tmax=0., method=('empirical', 'shrunk'), return_estimators=True)
-evoked.plot_white(noise_covs)
+evoked.plot_white(noise_covs, time_unit='s')
 
 
 ##############################################################################
@@ -163,7 +163,7 @@ noise_cov_meg = mne.pick_channels_cov(noise_cov_baseline, evoked_meg.ch_names)
 noise_cov['method'] = 'empty_room'
 noise_cov_meg['method'] = 'baseline'
 
-evoked_meg.plot_white([noise_cov_meg, noise_cov])
+evoked_meg.plot_white([noise_cov_meg, noise_cov], time_unit='s')
 
 
 ##############################################################################

--- a/tutorials/plot_creating_data_structures.py
+++ b/tutorials/plot_creating_data_structures.py
@@ -165,7 +165,7 @@ custom_epochs = mne.EpochsArray(data, info, events, tmin, event_id)
 print(custom_epochs)
 
 # We can treat the epochs object as we would any other
-_ = custom_epochs['smiling'].average().plot()
+_ = custom_epochs['smiling'].average().plot(time_unit='s')
 
 ###############################################################################
 # ---------------------------------------------
@@ -189,4 +189,4 @@ comment = "Smiley faces"
 evoked_array = mne.EvokedArray(data_evoked, info, tmin,
                                comment=comment, nave=nave)
 print(evoked_array)
-_ = evoked_array.plot()
+_ = evoked_array.plot(time_unit='s')

--- a/tutorials/plot_dipole_fit.py
+++ b/tutorials/plot_dipole_fit.py
@@ -66,7 +66,7 @@ vmin, vmax = -400, 400  # make sure each plot has same colour range
 
 # first plot the topography at the time of the best fitting (single) dipole
 plot_params = dict(times=best_time, ch_type='mag', outlines='skirt',
-                   colorbar=False)
+                   colorbar=False, time_unit='s')
 evoked.plot_topomap(time_format='Measured field', axes=axes[0], **plot_params)
 
 # compare this to the predicted field
@@ -85,4 +85,4 @@ plt.suptitle('Comparison of measured and predicted fields '
 # orientation (the one that maximized GOF) over the entire interval
 dip_fixed = mne.fit_dipole(evoked_full, fname_cov, fname_bem, fname_trans,
                            pos=dip.pos[best_idx], ori=dip.ori[best_idx])[0]
-dip_fixed.plot()
+dip_fixed.plot(time_unit='s')

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -155,7 +155,9 @@ print(epochs)
 left, right = epochs["left"].average(), epochs["right"].average()
 
 # create and plot difference ERP
-mne.combine_evoked([left, -right], weights='equal').plot_joint()
+joint_kwargs = dict(ts_args=dict(time_unit='s'),
+                    topomap_args=dict(time_unit='s'))
+mne.combine_evoked([left, -right], weights='equal').plot_joint(**joint_kwargs)
 
 ###############################################################################
 # This is an equal-weighting difference. If you have imbalanced trial numbers,
@@ -179,8 +181,8 @@ print(all_evokeds)
 
 # Then, we construct and plot an unweighted average of left vs. right trials
 # this way, too:
-mne.combine_evoked(all_evokeds,
-                   weights=(0.25, -0.25, 0.25, -0.25)).plot_joint()
+mne.combine_evoked(
+    all_evokeds, weights=(0.25, -0.25, 0.25, -0.25)).plot_joint(**joint_kwargs)
 
 ###############################################################################
 # Often, it makes sense to store Evoked objects in a dictionary or a list -
@@ -197,4 +199,4 @@ print(all_evokeds['left/auditory'])
 
 # Besides for explicit access, this can be used for example to set titles.
 for cond in all_evokeds:
-    all_evokeds[cond].plot_joint(title=cond)
+    all_evokeds[cond].plot_joint(title=cond, **joint_kwargs)

--- a/tutorials/plot_eeg_erp.py
+++ b/tutorials/plot_eeg_erp.py
@@ -105,8 +105,8 @@ evoked_no_ref = mne.Epochs(raw_no_ref, **epochs_params).average()
 del raw_no_ref  # save memory
 
 title = 'EEG Original reference'
-evoked_no_ref.plot(titles=dict(eeg=title))
-evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title)
+evoked_no_ref.plot(titles=dict(eeg=title), time_unit='s')
+evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
 # **Average reference**: This is normally added by default, but can also
@@ -117,8 +117,8 @@ evoked_car = mne.Epochs(raw_car, **epochs_params).average()
 del raw_car  # save memory
 
 title = 'EEG Average reference'
-evoked_car.plot(titles=dict(eeg=title))
-evoked_car.plot_topomap(times=[0.1], size=3., title=title)
+evoked_car.plot(titles=dict(eeg=title), time_unit='s')
+evoked_car.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
 # **Custom reference**: Use the mean of channels EEG 001 and EEG 002 as
@@ -128,8 +128,8 @@ evoked_custom = mne.Epochs(raw_custom, **epochs_params).average()
 del raw_custom  # save memory
 
 title = 'EEG Custom reference'
-evoked_custom.plot(titles=dict(eeg=title))
-evoked_custom.plot_topomap(times=[0.1], size=3., title=title)
+evoked_custom.plot(titles=dict(eeg=title), time_unit='s')
+evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
 # Evoked arithmetics

--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -163,5 +163,5 @@ evoked_left = epochs['Left/Auditory'].average(picks=picks)
 #   information.
 #
 # Finally, let's plot the evoked responses.
-evoked_left.plot()
-evoked_right.plot()
+evoked_left.plot(time_unit='s')
+evoked_right.plot(time_unit='s')

--- a/tutorials/plot_introduction.py
+++ b/tutorials/plot_introduction.py
@@ -256,7 +256,7 @@ saved_epochs = mne.read_epochs('sample-epo.fif')
 
 evoked = epochs['aud_l'].average()
 print(evoked)
-evoked.plot()
+evoked.plot(time_unit='s')
 
 ##############################################################################
 # .. topic:: Exercise

--- a/tutorials/plot_metadata_epochs.py
+++ b/tutorials/plot_metadata_epochs.py
@@ -52,8 +52,10 @@ print(epochs.metadata.head(10))
 av1 = epochs['Concreteness < 5 and WordFrequency < 2'].average()
 av2 = epochs['Concreteness > 5 and WordFrequency > 2'].average()
 
-av1.plot_joint(show=False)
-av2.plot_joint(show=False)
+joint_kwargs = dict(ts_args=dict(time_unit='s'),
+                    topomap_args=dict(time_unit='s'))
+av1.plot_joint(show=False, **joint_kwargs)
+av2.plot_joint(show=False, **joint_kwargs)
 
 ###############################################################################
 # Next we'll choose a subset of words to keep.
@@ -63,7 +65,7 @@ epochs['WORD in {}'.format(words)].plot_image(show=False)
 ###############################################################################
 # Note that traditional epochs sub-selection still works. The traditional
 # MNE methods for selecting epochs will supersede the rich metadata querying.
-epochs['cent'].average().plot(show=False)
+epochs['cent'].average().plot(show=False, time_unit='s')
 
 ###############################################################################
 # Below we'll show a more involved example that leverages the metadata

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -56,10 +56,11 @@ fig_cov, fig_spectra = mne.viz.plot_cov(noise_cov, raw.info)
 
 evoked = epochs.average()
 evoked.plot(time_unit='s')
-evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag')
+evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag',
+                    time_unit='s')
 
 # Show whitening
-evoked.plot_white(noise_cov)
+evoked.plot_white(noise_cov, time_unit='s')
 
 ###############################################################################
 # Inverse modeling: MNE/dSPM on evoked and raw data

--- a/tutorials/plot_mne_dspm_source_localization.py
+++ b/tutorials/plot_mne_dspm_source_localization.py
@@ -55,7 +55,7 @@ fig_cov, fig_spectra = mne.viz.plot_cov(noise_cov, raw.info)
 # ---------------------------
 
 evoked = epochs.average()
-evoked.plot()
+evoked.plot(time_unit='s')
 evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag')
 
 # Show whitening

--- a/tutorials/plot_object_epochs.py
+++ b/tutorials/plot_object_epochs.py
@@ -132,8 +132,8 @@ ev_right = epochs['Auditory/Right'].average()
 
 f, axs = plt.subplots(3, 2, figsize=(10, 5))
 _ = f.suptitle('Left / Right auditory', fontsize=20)
-_ = ev_left.plot(axes=axs[:, 0], show=False)
-_ = ev_right.plot(axes=axs[:, 1], show=False)
+_ = ev_left.plot(axes=axs[:, 0], show=False, time_unit='s')
+_ = ev_right.plot(axes=axs[:, 1], show=False, time_unit='s')
 plt.tight_layout()
 
 ###############################################################################

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -69,7 +69,7 @@ print(data[10])
 # the data and some info about the evoked data. For more information, see
 # :ref:`tut_creating_data_structures`.
 evoked = mne.EvokedArray(data, evoked.info, tmin=evoked.times[0])
-evoked.plot()
+evoked.plot(time_unit='s')
 
 ###############################################################################
 # To write an evoked dataset to a file, use the :meth:`mne.Evoked.save` method.

--- a/tutorials/plot_phantom_4DBTi.py
+++ b/tutorials/plot_phantom_4DBTi.py
@@ -42,7 +42,7 @@ for ii in range(4):
     epochs = mne.Epochs(raw, events=events, event_id=8192, tmin=-0.2, tmax=0.4,
                         preload=True)
     evoked = epochs.average()
-    evoked.plot()
+    evoked.plot(time_unit='s')
     cov = mne.compute_covariance(epochs, tmax=0.)
     dip = mne.fit_dipole(evoked.copy().crop(t0, t0), cov, sphere)[0]
     pos[ii] = dip.pos[0]

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -92,7 +92,10 @@ time_decod.fit(X, y)
 
 coef = get_coef(time_decod, 'patterns_', inverse_transform=True)
 evoked = mne.EvokedArray(coef, epochs.info, tmin=epochs.times[0])
-evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns')
+joint_kwargs = dict(ts_args=dict(time_unit='s'),
+                    topomap_args=dict(time_unit='s'))
+evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns',
+                  **joint_kwargs)
 
 ###############################################################################
 # Temporal Generalization

--- a/tutorials/plot_stats_cluster_1samp_test_time_frequency.py
+++ b/tutorials/plot_stats_cluster_1samp_test_time_frequency.py
@@ -121,5 +121,5 @@ plt.ylabel('Frequency (Hz)')
 plt.title('Induced power (%s)' % ch_name)
 
 ax2 = plt.subplot(2, 1, 2)
-evoked.plot(axes=[ax2])
+evoked.plot(axes=[ax2], time_unit='s')
 plt.show()

--- a/tutorials/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/plot_stats_cluster_spatio_temporal.py
@@ -162,7 +162,7 @@ t_threshold = -stats.distributions.t.ppf(p_threshold / 2., n_subjects - 1)
 print('Clustering.')
 T_obs, clusters, cluster_p_values, H0 = clu = \
     spatio_temporal_cluster_1samp_test(X, connectivity=connectivity, n_jobs=1,
-                                       threshold=t_threshold)
+                                       threshold=t_threshold, buffer_size=None)
 #    Now select the clusters that are sig. at p < 0.05 (note that this value
 #    is multiple-comparisons corrected).
 good_cluster_inds = np.where(cluster_p_values < 0.05)[0]

--- a/tutorials/plot_stats_cluster_time_frequency.py
+++ b/tutorials/plot_stats_cluster_time_frequency.py
@@ -132,6 +132,6 @@ plt.title('Induced power (%s)' % ch_name)
 ax2 = plt.subplot(2, 1, 2)
 evoked_contrast = mne.combine_evoked([evoked_condition_1, evoked_condition_2],
                                      weights=[1, -1])
-evoked_contrast.plot(axes=ax2)
+evoked_contrast.plot(axes=ax2, time_unit='s')
 
 plt.show()

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -39,7 +39,7 @@ evoked_r_vis = evoked[3]
 # set the ``exclude`` parameter to show the bad channels in red. All plotting
 # functions of MNE-python return a handle to the figure instance. When we have
 # the handle, we can customise the plots to our liking.
-fig = evoked_l_aud.plot(exclude=())
+fig = evoked_l_aud.plot(exclude=(), time_unit='s')
 
 ###############################################################################
 # All plotting functions of MNE-python return a handle to the figure instance.
@@ -57,7 +57,7 @@ fig.tight_layout()
 # to show the sensor positions - specifically, the x, y, and z locations of
 # the sensors are transformed into R, G and B values.
 picks = mne.pick_types(evoked_l_aud.info, meg=True, eeg=False, eog=False)
-evoked_l_aud.plot(spatial_colors=True, gfp=True, picks=picks)
+evoked_l_aud.plot(spatial_colors=True, gfp=True, picks=picks, time_unit='s')
 
 ###############################################################################
 # Notice the legend on the left. The colors would suggest that there may be two
@@ -65,17 +65,17 @@ evoked_l_aud.plot(spatial_colors=True, gfp=True, picks=picks)
 # Try painting the slopes with left mouse button. It should open a new window
 # with topomaps (scalp plots) of the average over the painted area. There is
 # also a function for drawing topomaps separately.
-evoked_l_aud.plot_topomap()
+evoked_l_aud.plot_topomap(time_unit='s')
 
 ###############################################################################
 # By default the topomaps are drawn from evenly spread out points of time over
 # the evoked data. We can also define the times ourselves.
 times = np.arange(0.05, 0.151, 0.05)
-evoked_r_aud.plot_topomap(times=times, ch_type='mag')
+evoked_r_aud.plot_topomap(times=times, ch_type='mag', time_unit='s')
 
 ###############################################################################
 # Or we can automatically select the peaks.
-evoked_r_aud.plot_topomap(times='peaks', ch_type='mag')
+evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 
 ###############################################################################
 # You can take a look at the documentation of :func:`mne.Evoked.plot_topomap`
@@ -86,7 +86,7 @@ evoked_r_aud.plot_topomap(times='peaks', ch_type='mag')
 # axes in a single figure and plot all of our evoked categories next to each
 # other.
 fig, ax = plt.subplots(1, 5, figsize=(8, 2))
-kwargs = dict(times=0.1, show=False, vmin=-300, vmax=300)
+kwargs = dict(times=0.1, show=False, vmin=-300, vmax=300, time_unit='s')
 evoked_l_aud.plot_topomap(axes=ax[0], colorbar=True, **kwargs)
 evoked_r_aud.plot_topomap(axes=ax[1], colorbar=False, **kwargs)
 evoked_l_vis.plot_topomap(axes=ax[2], colorbar=False, **kwargs)
@@ -118,8 +118,8 @@ plt.show()
 # ``ts_args`` arguments, here, topomaps at specific time points
 # (90 and 200 ms) are shown, sensors are not plotted (via an argument
 # forwarded to `plot_topomap`), and the Global Field Power is shown:
-ts_args = dict(gfp=True)
-topomap_args = dict(sensors=False)
+ts_args = dict(gfp=True, time_unit='s')
+topomap_args = dict(sensors=False, time_unit='s')
 evoked_r_aud.plot_joint(title='right auditory', times=[.09, .20],
                         ts_args=ts_args, topomap_args=topomap_args)
 
@@ -160,7 +160,7 @@ mne.viz.plot_compare_evokeds(evoked_dict, picks=pick, colors=colors,
 # the amplitudes from negative to positive translates to shift from blue to
 # red. White means zero amplitude. You can use the ``cmap`` parameter to define
 # the color map yourself. The accepted values include all matplotlib colormaps.
-evoked_r_aud.plot_image(picks=picks)
+evoked_r_aud.plot_image(picks=picks, time_unit='s')
 
 ###############################################################################
 # Finally we plot the sensor data as a topographical view. In the simple case

--- a/tutorials/plot_whitened.py
+++ b/tutorials/plot_whitened.py
@@ -2,7 +2,7 @@
 Plotting whitened data
 ======================
 
-This tutorial demonstrates how to plot whitened data.
+This tutorial demonstrates how to plot whitened evoked data.
 
 Data are whitened for many processes, including dipole fitting, source
 localization and some decoding algorithms. Viewing whitened data thus gives
@@ -50,8 +50,8 @@ epochs.plot(noise_cov=noise_cov)
 # --------------------------
 
 evoked = epochs.average()
-evoked.plot()
-evoked.plot(noise_cov=noise_cov)
+evoked.plot(time_unit='s')
+evoked.plot(noise_cov=noise_cov, time_unit='s')
 
 ###############################################################################
 # Evoked data with scaled whitening
@@ -60,7 +60,7 @@ evoked.plot(noise_cov=noise_cov)
 # scaling the whitened plots to show how well the assumption of Gaussian
 # noise is satisfied by the data:
 
-evoked.plot_white(noise_cov=noise_cov)
+evoked.plot_white(noise_cov=noise_cov, time_unit='s')
 
 ###############################################################################
 # Topographic plot with whitening


### PR DESCRIPTION
Closes #3164.

This moves `evoked.plot` and `evoked.plot_topomap` toward using `time_unit='s'` as the default, consistent with all other MNE plotters. This means adding the param to both, deprecating `ms`->`s`, and also deprecating the `scaling_time` parameter in `evoked.plot_topomap`.

This will emit some warnings in examples and tests, I hope to fix most of them after inspecting CI output.

@jona-sassenhagen @mmagnuski @cbrnr agree this is a good plan?