### PR TITLE
WIP: Dont center points in head coords

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -15,8 +15,7 @@ import os.path as op
 
 import numpy as np
 
-from ..transforms import _pol_to_cart, _cart_to_sph
-from ..bem import fit_sphere_to_headshape
+from ..transforms import _pol_to_cart, _cart_to_sph, apply_trans
 from ..io.pick import pick_types
 from ..io.constants import FIFF
 from ..io.meas_info import Info
@@ -612,7 +611,7 @@ def _find_topomap_coords(info, picks, layout=None):
         pos = [layout.pos[layout.names.index(ch['ch_name'])] for ch in chs]
         pos = np.asarray(pos)
     else:
-        pos = _auto_topomap_coords(info, picks)
+        pos = _auto_topomap_coords(info, picks)  # will do to_sphere=True
 
     return pos
 
@@ -647,7 +646,12 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
     chs = [info['chs'][i] for i in picks]
 
     # Use channel locations if available
-    locs3d = np.array([ch['loc'][:3] for ch in chs])
+    locs3d = np.empty((len(chs), 3))
+    for ci, ch in enumerate(chs):
+        if ch['kind'] == FIFF.FIFFV_MEG_CH:
+            locs3d[ci] = apply_trans(info['dev_head_t'], ch['loc'][:3])
+        else:
+            locs3d[ci] = ch['loc'][:3]
 
     # If electrode locations are not available, use digization points
     if len(locs3d) == 0 or (~np.isfinite(locs3d)).all() or \
@@ -674,7 +678,8 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
             raise RuntimeError('No digitization points found.')
 
         locs3d = np.array([point['r'] for point in info['dig']
-                           if point['kind'] == FIFF.FIFFV_POINT_EEG])
+                           if point['kind'] == FIFF.FIFFV_POINT_EEG and
+                           point['coord_frame'] == FIFF.FIFFV_COORD_HEAD])
 
         if len(locs3d) == 0:
             raise RuntimeError('Did not find any digitization points of '
@@ -685,13 +690,6 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
             raise ValueError("Number of EEG digitization points (%d) "
                              "doesn't match the number of EEG channels "
                              "(%d)" % (len(locs3d), len(eeg_ch_names)))
-
-        # Center digitization points on head origin
-        dig_kinds = (FIFF.FIFFV_POINT_CARDINAL,
-                     FIFF.FIFFV_POINT_EEG,
-                     FIFF.FIFFV_POINT_EXTRA)
-        _, origin_head, _ = fit_sphere_to_headshape(info, dig_kinds, units='m')
-        locs3d -= origin_head
 
         # Match the digitization points with the requested
         # channels.
@@ -712,8 +710,10 @@ def _auto_topomap_coords(info, picks, ignore_overlap=False, to_sphere=True):
 
     if to_sphere:
         # use spherical (theta, pol) as (r, theta) for polar->cartesian
-        return _pol_to_cart(_cart_to_sph(locs3d)[:, 1:][:, ::-1])
-    return _pol_to_cart(_cart_to_sph(locs3d))
+        out = _pol_to_cart(_cart_to_sph(locs3d)[:, 1:][:, ::-1])
+    else:
+        out = _pol_to_cart(_cart_to_sph(locs3d))
+    return out
 
 
 def _topo_to_sphere(pos, eegs):

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -24,7 +24,6 @@ from mne.utils import run_tests_if_main
 from mne import pick_types, pick_info
 from mne.io import read_raw_kit, _empty_info, read_info
 from mne.io.constants import FIFF
-from mne.bem import fit_sphere_to_headshape
 from mne.utils import _TempDir
 matplotlib.use('Agg')  # for testing don't use X server
 
@@ -92,15 +91,6 @@ def test_auto_topomap_coords():
     # with the EEG channels
     del info['dig'][85]
 
-    # Remove head origin from channel locations, so mapping with digitization
-    # points yields the same result
-    dig_kinds = (FIFF.FIFFV_POINT_CARDINAL,
-                 FIFF.FIFFV_POINT_EEG,
-                 FIFF.FIFFV_POINT_EXTRA)
-    _, origin_head, _ = fit_sphere_to_headshape(info, dig_kinds, units='m')
-    for ch in info['chs']:
-        ch['loc'][:3] -= origin_head
-
     # Use channel locations
     l0 = _auto_topomap_coords(info, picks)
 
@@ -117,7 +107,8 @@ def test_auto_topomap_coords():
     assert_raises(ValueError, _auto_topomap_coords, info, mag_picks)
 
     # Test function with too many EEG digitization points: it should fail
-    info['dig'].append({'r': [1, 2, 3], 'kind': FIFF.FIFFV_POINT_EEG})
+    info['dig'].append({'r': [1, 2, 3], 'kind': FIFF.FIFFV_POINT_EEG,
+                        'coord_frame': FIFF.FIFFV_COORD_HEAD})
     assert_raises(ValueError, _auto_topomap_coords, info, picks)
 
     # Test function with too little EEG digitization points: it should fail


### PR DESCRIPTION
So far:

- [x] Apply `dev_head_t` to MEG in `topomap_coords` to get correct Head<->sensor relationship
- [ ] Use voronoi or similar to choose the bounds for plotting
- [ ] Make `dev_head_t` application optional?
- [ ] Change defaults?
- [ ] Fix #4880 (probably `montage.plot` and `plot_sensors`)
- [ ] Fix #5315 (spurious values at boundary due to extrapolation artifacts)

Closes #3987.

Running this code:
```
import mne
data_path = mne.datasets.sample.data_path()
raw = mne.io.read_raw_fif(data_path + '/MEG/sample/sample_audvis_raw.fif')
raw.load_data().pick_types(meg=True, stim=True)
events = mne.find_events(raw, 'STI 014')
epochs = mne.Epochs(raw, events, proj='delayed')
evoked = epochs.average()
selection = mne.read_selection('Left-temporal')
kwargs = dict(times=[0., 0.1, 0.2], vmin=-240, vmax=240, layout='auto',
              head_pos=dict(center=(0., 0.), scale=(1., 1.)))
evoked.plot_topomap(**kwargs)
evoked.copy().pick_types(selection=selection).plot_topomap(**kwargs)
```
Gives (ignore the broad smearing plotting "artifact" due to channel subselection in the second one, we can fix this eventually), note that the subselected channels stay put, and that the sensors are rotated relative to the head (in accordance with `dev_head_t` for this dataset):

![screenshot from 2018-04-03 14-27-30](https://user-images.githubusercontent.com/2365790/38268164-6cc160d2-374b-11e8-9933-bfa7c8e82ef9.png)
![screenshot from 2018-04-03 14-27-32](https://user-images.githubusercontent.com/2365790/38268168-6e5fe1f2-374b-11e8-85a3-55913212cfb3.png)

Omitting the `head_pos` argument (which basically means "center and scale to fit the circle") the second plot gives the sort of thing that has been confusing people in #3987 and elsewhere:

![screenshot from 2018-04-03 14-27-58](https://user-images.githubusercontent.com/2365790/38268176-7124ee8c-374b-11e8-9537-48af879f164c.png)

Assuming we have geometry information properly in the head coordinate frame (and I would argue we should make people corrrect theirs if they do not), this is incorrect. I'm thinking that we should change the default for `head_pos` to this (or similar) scheme. Thoughts @jona-sassenhagen ?
