### PR TITLE
Update docstring for save definition in evoked.py

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -171,7 +171,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         Parameters
         ----------
         fname : string
-            Name of the file where to save the data.
+            The name of the file, which should end with -ave.fif or
+            -ave.fif.gz.
 
         Notes
         -----


### PR DESCRIPTION
Including the hint to the appropriate file ending to the docstring of save definition. Matches to https://github.com/stfnrpplngr/mne-python/blob/master/mne/epochs.py