### PR TITLE
MRG: Fix picks for raw.plot_psd

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -170,6 +170,8 @@ Bug
 
 - Fix bug when passing ``show_sensors=1`` to :func:`mne.viz.plot_compare_evokeds` resulted in sensors legend placed in lower right of the figure (position 4 in matplotlib), not upper right by `Mikołaj Magnuski`_
 
+- Fix bug in :meth:`mne.io.Raw.plot_psd` when ``picks is not None`` and ``picks`` spans more than one channel type by `Eric Larson`_
+
 - Fix bug in :class:`mne.make_forward_solution` when passing data with compensation channels (e.g. CTF) that contain bad channels by `Alex Gramfort`_
 
 API

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -307,6 +307,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
     """Plot data as butterfly plot."""
     from matplotlib import patheffects
     from matplotlib.widgets import SpanSelector
+    assert len(axes) == len(ch_types_used)
     texts = list()
     idxs = list()
     lines = list()
@@ -2069,7 +2070,7 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
                 raise TypeError("show_sensors must be numeric, str or bool, "
                                 "not " + str(type(show_sensors)))
             show_sensors = _check_loc_legal(show_sensors, "show_sensors")
-            _plot_legend(pos, ["k" for _ in picks], ax, list(), outlines,
+            _plot_legend(pos, ["k"] * len(picks), ax, list(), outlines,
                          show_sensors, size=25)
 
     # the condition legend

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -290,6 +290,13 @@ def test_plot_raw_psd():
     raw.plot_psd(reject_by_annotation=True)
     raw.plot_psd(reject_by_annotation=False)
 
+    # gh-5046
+    raw = read_raw_fif(raw_fname, preload=True).crop(0, 1)
+    picks = pick_types(raw.info)
+    raw.plot_psd(picks=picks, average=False)
+    raw.plot_psd(picks=picks, average=True)
+    plt.close('all')
+
 
 def test_plot_sensors():
     """Test plotting of sensor array."""


### PR DESCRIPTION
Closes #5046.

Using the snippet from #5046:
```
import mne
from mne.datasets import sample

data_path = sample.data_path()
fname = data_path + "/MEG/sample/sample_audvis_raw.fif"
raw = mne.io.read_raw_fif(fname)
picks = mne.pick_types(raw.info, meg=True, eeg=False, stim=False)
raw.plot_psd(picks=picks, average=False)
```
We now get this instead of an error:

![screenshot from 2018-04-04 16-12-03](https://user-images.githubusercontent.com/2365790/38332061-098c8108-3823-11e8-9cc4-59a625ed6e29.png)

