### PR TITLE
MRG: Fix for odd EDF file

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -463,6 +463,7 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     for idx, ch_info in enumerate(zip(ch_names, physical_ranges, cals)):
         ch_name, physical_range, cal = ch_info
         chan_info = {}
+        logger.debug('  %s: range=%s cal=%s' % (ch_name, physical_range, cal))
         chan_info['cal'] = cal
         chan_info['logno'] = idx + 1
         chan_info['scanno'] = idx + 1
@@ -614,13 +615,8 @@ def _read_edf_header(fname, annot, annotmap, exclude):
         subtype = os.path.splitext(fname)[1][1:].lower()
 
         n_records = int(fid.read(8).decode())
-        record_length = fid.read(8)
-        try:
-            record_length = float(record_length)
-        except:
-            record_length = float(record_length.split()[0])
-
-        record_length = np.array([record_length, 1.])  # in seconds
+        record_length = fid.read(8).strip('\x00').strip()
+        record_length = np.array([float(record_length), 1.])  # in seconds
         if record_length[0] == 0:
             record_length = record_length[0] = 1.
             warn('Header information is incorrect for record length. Default '

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -539,7 +539,12 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
         elif highpass[0] == 'DC':
             info['highpass'] = 0.
         else:
-            info['highpass'] = float(highpass[0])
+            hp = highpass[0]
+            try:
+                hp = float(hp)
+            except:
+                hp = 0.
+            info['highpass'] = hp
     else:
         info['highpass'] = float(np.max(highpass))
         warn('Channels contain different highpass filters. Highest filter '
@@ -609,7 +614,13 @@ def _read_edf_header(fname, annot, annotmap, exclude):
         subtype = os.path.splitext(fname)[1][1:].lower()
 
         n_records = int(fid.read(8).decode())
-        record_length = np.array([float(fid.read(8)), 1.])  # in seconds
+        record_length = fid.read(8)
+        try:
+            record_length = float(record_length)
+        except:
+            record_length = float(record_length.split()[0])
+
+        record_length = np.array([record_length, 1.])  # in seconds
         if record_length[0] == 0:
             record_length = record_length[0] = 1.
             warn('Header information is incorrect for record length. Default '


### PR DESCRIPTION
Closes #4553.

@agramfort your file has incorrect scalings, as indicated by the filename. See:
```
import mne
raw = mne.io.read_raw_edf('EEG_170711_142159.edf', stim_channel=None, preload=True)
raw.plot(scalings=dict(eeg=100.), n_channels=4)
```
Produces:

![screenshot from 2018-04-04 16-27-43](https://user-images.githubusercontent.com/2365790/38332928-22c7b316-3825-11e8-9c17-80b3a9bc4335.png)
