### PR TITLE
MRG: Fix hash

### DIFF
--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -273,6 +273,9 @@ def test_hash():
     y = 0
     assert_true('type mismatch' in object_diff(x, y))
 
+    # smoke test for gh-4796
+    assert object_hash(np.int64(1)) == 197036202616119346312054009116900811862
+
 
 def test_md5sum():
     """Test md5sum calculation."""

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -274,7 +274,8 @@ def test_hash():
     assert_true('type mismatch' in object_diff(x, y))
 
     # smoke test for gh-4796
-    assert object_hash(np.int64(1)) == 197036202616119346312054009116900811862
+    assert object_hash(np.int64(1)) != 0
+    assert object_hash(np.bool_(True)) != 0
 
 
 def test_md5sum():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -158,7 +158,7 @@ def object_hash(x, h=None):
     elif isinstance(x, (string_types, float, int, type(None))):
         h.update(str(type(x)).encode('utf-8'))
         h.update(str(x).encode('utf-8'))
-    elif isinstance(x, np.ndarray):
+    elif isinstance(x, (np.ndarray, np.number, np.bool_)):
         x = np.asarray(x)
         h.update(str(x.shape).encode('utf-8'))
         h.update(str(x.dtype).encode('utf-8'))


### PR DESCRIPTION
Closes #4796.

I can't reproduce this locally. Maybe it is NumPy version dependent. We'll see if the CIs agree there is no bug :)