### PR TITLE
MRG: Capture a bunch of warnings

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -944,6 +944,10 @@ class InterpolationMixin(object):
         if getattr(self, 'preload', None) is False:
             raise ValueError('Data must be preloaded.')
 
+        if len(self.info['bads']) == 0:
+            warn('No bad channels to interpolate. Doing nothing...')
+            return self
+
         _interpolate_bads_eeg(self)
         _interpolate_bads_meg(self, mode=mode)
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -124,7 +124,6 @@ def _interpolate_bads_eeg(inst, verbose=None):
     bads_idx[picks] = [inst.ch_names[ch] in inst.info['bads'] for ch in picks]
 
     if len(picks) == 0 or bads_idx.sum() == 0:
-        warn('No bad channels to interpolate. Doing nothing...')
         return
 
     goods_idx[picks] = True

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -107,7 +107,9 @@ def test_interpolation():
     raw_few.del_proj()
     raw_few.info['bads'] = [raw_few.ch_names[-1]]
     orig_data = raw_few[1][0]
-    raw_few.interpolate_bads(reset_bads=False)
+    with warnings.catch_warnings(record=True) as w:
+        raw_few.interpolate_bads(reset_bads=False)
+    assert len(w) == 0
     new_data = raw_few[1][0]
     assert_true((new_data == 0).mean() < 0.5)
     assert_true(np.corrcoef(new_data, orig_data)[0, 1] > 0.1)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -573,7 +573,7 @@ class CSP(TransformerMixin, BaseEstimator):
             times=components, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, colorbar=colorbar, res=res,
             cbar_fmt=cbar_fmt, sensors=sensors, scalings=scalings, units=units,
-            scaling_time=1, time_format=name_format, size=size,
+            time_unit='s', time_format=name_format, size=size,
             show_names=show_names, title=title, mask_params=mask_params,
             mask=mask, outlines=outlines, contours=contours,
             image_interp=image_interp, show=show, average=average,

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -222,9 +222,11 @@ def test_read_ctf():
 def test_rawctf_clean_names():
     """Test RawCTF _clean_names method."""
     # read test data
-    raw = read_raw_ctf(op.join(ctf_dir, ctf_fname_catch))
-    raw_cleaned = read_raw_ctf(op.join(ctf_dir, ctf_fname_catch),
-                               clean_names=True)
+    with warnings.catch_warnings(record=True) as w:
+        raw = read_raw_ctf(op.join(ctf_dir, ctf_fname_catch))
+        raw_cleaned = read_raw_ctf(op.join(ctf_dir, ctf_fname_catch),
+                                   clean_names=True)
+    assert any('MEG ref channel RMSP did not' in str(ww.message) for ww in w)
     test_channel_names = _clean_names(raw.ch_names)
     test_info_comps = copy.deepcopy(raw.info['comps'])
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1049,7 +1049,7 @@ def test_resample():
 
     # decimation of multiple stim channels
     raw = RawArray(2 * [stim], create_info(2, len(stim), 2 * ['stim']))
-    assert_allclose(raw.resample(8., npad='auto')._data,
+    assert_allclose(raw.resample(8., npad='auto', verbose='error')._data,
                     [[1, 1, 0, 0, 1, 1, 0, 0],
                      [1, 1, 0, 0, 1, 1, 0, 0]])
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -398,7 +398,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         logger.info('Applying average reference.')
         eeg_idx = pick_types(inst.info, eeg=True, meg=False, ref_meg=False)
         ref_from = [inst.ch_names[i] for i in eeg_idx]
-        return _apply_reference(inst, ref_from)
+        ref_channels = ref_from
 
     if ref_channels == []:
         logger.info('EEG data marked as already having the desired reference. '

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -193,17 +193,19 @@ def test_set_eeg_reference():
     # Test moving from average to custom reference
     reref, ref_data = set_eeg_reference(raw, projection=True)
     reref, _ = set_eeg_reference(reref, ['EEG 001', 'EEG 002'])
-    assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
+    assert not _has_eeg_average_ref_proj(reref.info['projs'])
+    assert len(reref.info['projs']) == 0
     assert_equal(reref.info['custom_ref_applied'], True)
 
-    # Test that disabling the reference does not change anything
+    # Test that disabling the reference does not change the data
+    assert _has_eeg_average_ref_proj(raw.info['projs'])
     reref, _ = set_eeg_reference(raw, [])
     assert_array_equal(raw._data, reref._data)
+    assert not _has_eeg_average_ref_proj(reref.info['projs'])
 
     # make sure ref_channels=[] removes average reference projectors
-    reref, _ = set_eeg_reference(raw, 'average', projection=True)
-    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
-    reref, _ = set_eeg_reference(reref, [])
+    assert _has_eeg_average_ref_proj(raw.info['projs'])
+    reref, _ = set_eeg_reference(raw, [])
     assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
 
     # Test that average reference gives identical results when calculated

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -379,7 +379,7 @@ def test_ica_additional(method):
     # test retrieval of component maps as arrays
     components = ica.get_components()
     template = components[:, 0]
-    EvokedArray(components, ica.info, tmin=0.).plot_topomap([0])
+    EvokedArray(components, ica.info, tmin=0.).plot_topomap([0], time_unit='s')
 
     corrmap([ica, ica3], template, threshold='auto', label='blinks', plot=True,
             ch_type="mag")
@@ -632,10 +632,10 @@ def test_ica_additional(method):
         assert_true(ncomps_ == expected)
 
     ica = ICA(method=method)
-    ica.fit(raw, picks=picks[:5])
-    with warnings.catch_warnings(record=True):  # filter length
+    with warnings.catch_warnings(record=True) as w:  # convergence and filter
+        ica.fit(raw, picks=picks[:5])
         ica.find_bads_ecg(raw)
-    ica.find_bads_eog(epochs, ch_name='MEG 0121')
+        ica.find_bads_eog(epochs, ch_name='MEG 0121')
     assert_array_equal(raw_data, raw[:][0])
 
     raw.drop_channels(['MEG 0122'])

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -31,6 +31,10 @@ def _run_buffer(kill_signal, neuromag2ft_fname):
     # Let measurement continue for the entire duration
     kill_signal.get(timeout=10.0)
     process.terminate()
+    with warnings.catch_warnings(record=True):  # still running
+        process.stderr.close()
+        process.stdout.close()
+        del process
 
 
 @requires_neuromag2ft

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -22,15 +22,17 @@ def test_dpss_windows():
     Kmax = int(2 * half_nbw)
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, low_bias=False)
-    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
+    with warnings.catch_warnings(record=True):  # conversions
+        dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
 
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, interp_from=200,
                               low_bias=False)
-    dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax,
-                                                  interp_from=200)
+    with warnings.catch_warnings(record=True):  # conversions
+        dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax,
+                                                      interp_from=200)
 
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1310,7 +1310,7 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
 
     # butterfly/time series plot
     # most of this code is about passing defaults on demand
-    ts_ax = fig.add_subplot(212)
+    ts_ax = fig.add_subplot(212, label='timeaxes')
     ts_args_def = dict(picks=None, unit=True, ylim=None, xlim='tight',
                        proj=False, hline=None, units=None, scalings=None,
                        titles=None, gfp=False, window_title=None,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1310,7 +1310,6 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
 
     # butterfly/time series plot
     # most of this code is about passing defaults on demand
-    ts_ax = fig.add_subplot(212, label='timeaxes')
     ts_args_def = dict(picks=None, unit=True, ylim=None, xlim='tight',
                        proj=False, hline=None, units=None, scalings=None,
                        titles=None, gfp=False, window_title=None,

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -331,10 +331,11 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
 
         # and then plot the contours on top
         for surf, color in surfs:
-            ax.tricontour(surf['rr'][:, x], surf['rr'][:, y],
-                          surf['tris'], surf['rr'][:, z],
-                          levels=[sl], colors=color, linewidths=1.0,
-                          zorder=1)
+            with warnings.catch_warnings(record=True):  # ignore contour warn
+                ax.tricontour(surf['rr'][:, x], surf['rr'][:, y],
+                              surf['tris'], surf['rr'][:, z],
+                              levels=[sl], colors=color, linewidths=1.0,
+                              zorder=1)
 
         for sources in src_points:
             in_slice = np.logical_and(sources[:, z] > sl - 0.5,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -291,7 +291,9 @@ def test_plot_instance_components():
         fig.canvas.key_press_event(key)
     ax = fig.get_axes()[0]
     line = ax.lines[0]
-    _fake_click(fig, ax, [line.get_xdata()[0], line.get_ydata()[0]], 'data')
+    with warnings.catch_warnings(record=True):  # Can only plot ICA components
+        _fake_click(fig, ax, [line.get_xdata()[0], line.get_ydata()[0]],
+                    'data')
     _fake_click(fig, ax, [-0.1, 0.9])  # click on y-label
     fig.canvas.key_press_event('escape')
     plt.close('all')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -70,7 +70,7 @@ def test_plot_topomap_interactive():
     ax = fig.gca()
 
     kwargs = dict(vmin=-240, vmax=240, times=[0.1], colorbar=False, axes=ax,
-                  res=8)
+                  res=8, time_unit='s')
     evoked.copy().plot_topomap(proj=False, **kwargs)
     canvas.draw()
     image_noproj = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -1,6 +1,4 @@
 """
-.. _tut_viz_evoked:
-
 =====================
 Visualize Evoked data
 =====================


### PR DESCRIPTION
Looking through our Travis logs it's annoying to scroll back through pages of warnings. This should get rid of them at least on the modern `environment.yml` builds.