### PR TITLE
MRG: Remove double-backticks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -158,6 +158,7 @@ html_theme_options = {
         ("Examples", "auto_examples/index"),
         ("Contribute", "contributing"),
     ],
+    'nosidebar': True,  # fix col-md-9 vs col-md-12
     }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -158,7 +158,6 @@ html_theme_options = {
         ("Examples", "auto_examples/index"),
         ("Contribute", "contributing"),
     ],
-    'nosidebar': True,  # fix col-md-9 vs col-md-12
     }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -25,7 +25,7 @@ from ..externals import six
 from ..channels.channels import _contains_ch_type
 
 depr_message = ("This function is deprecated and will be removed in 0.17, "
-                "please use `make_lcmv` and `%s` instead.")
+                "please use :func:`make_lcmv` and :func:`%s` instead.")
 
 
 def _reg_pinv(x, reg):
@@ -520,7 +520,7 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
 
     See Also
     --------
-    apply_lcmv_raw, apply_lcmv_epochs
+    make_lcmv, apply_lcmv_raw, apply_lcmv_epochs
     """
     _check_reference(evoked)
 
@@ -569,7 +569,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='signed',
 
     See Also
     --------
-    apply_lcmv_raw, apply_lcmv
+    make_lcmv, apply_lcmv_raw, apply_lcmv
     """
     _check_reference(epochs)
 
@@ -622,7 +622,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
 
     See Also
     --------
-    apply_lcmv_epochs, apply_lcmv
+    make_lcmv, apply_lcmv_epochs, apply_lcmv
     """
     _check_reference(raw)
 

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -31,9 +31,9 @@ class LinearModel(BaseEstimator):
 
     Attributes
     ----------
-    ``filters_`` : ndarray, shape ([n_targets], n_features)
+    filters_ : ndarray, shape ([n_targets], n_features)
         If fit, the filters used to decompose the data.
-    ``patterns_`` : ndarray, shape ([n_targets], n_features)
+    patterns_ : ndarray, shape ([n_targets], n_features)
         If fit, the patterns used to restore M/EEG signals.
 
     Notes

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -63,13 +63,13 @@ class CSP(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    ``filters_`` : ndarray, shape (n_components, n_channels)
+    filters_ :  ndarray, shape (n_components, n_channels)
         If fit, the CSP components used to decompose the data, else None.
-    ``patterns_`` : ndarray, shape (n_components, n_channels)
+    patterns_ : ndarray, shape (n_components, n_channels)
         If fit, the CSP patterns used to restore M/EEG signals, else None.
-    ``mean_`` : ndarray, shape (n_components,)
+    mean_ : ndarray, shape (n_components,)
         If fit, the mean squared power for each component.
-    ``std_`` : ndarray, shape (n_components,)
+    std_ : ndarray, shape (n_components,)
         If fit, the std squared power for each component.
 
     See Also
@@ -702,13 +702,13 @@ class SPoC(CSP):
 
     Attributes
     ----------
-    ``filters_`` : ndarray, shape (n_components, n_channels)
+    filters_ : ndarray, shape (n_components, n_channels)
         If fit, the SPoC spatial filters, else None.
-    ``patterns_`` : ndarray, shape (n_components, n_channels)
+    patterns_ : ndarray, shape (n_components, n_channels)
         If fit, the SPoC spatial patterns, else None.
-    ``mean_`` : ndarray, shape (n_components,)
+    mean_ : ndarray, shape (n_components,)
         If fit, the mean squared power for each component.
-    ``std_`` : ndarray, shape (n_components,)
+    std_ : ndarray, shape (n_components,)
         If fit, the std squared power for each component.
 
     See Also

--- a/mne/decoding/ems.py
+++ b/mne/decoding/ems.py
@@ -28,9 +28,9 @@ class EMS(TransformerMixin, EstimatorMixin):
 
     Attributes
     ----------
-    ``filters_`` : ndarray, shape (n_channels, n_times)
+    filters_ : ndarray, shape (n_channels, n_times)
         The set of spatial filters.
-    ``classes_`` : ndarray, shape (n_classes,)
+    classes_ : ndarray, shape (n_classes,)
         The target classes.
 
     References

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -61,7 +61,7 @@ class ReceptiveField(BaseEstimator):
         dimension (time), the ``n_outputs`` dimension here is omitted.
     patterns_ : array, shape ([n_outputs, ]n_features, n_delays)
         If fit, the inverted coefficients from the model.
-    delays_: array, shape (n_delays,), dtype int
+    delays_ : array, shape (n_delays,), dtype int
         The delays used to fit the model, in indices. To return the delays
         in seconds, use ``self.delays_ / self.sfreq``
     valid_samples_ : slice
@@ -292,9 +292,9 @@ class ReceptiveField(BaseEstimator):
     def score(self, X, y):
         """Score predictions generated with a receptive field.
 
-        This calls `self.predict`, then masks the output of this
-        and `y` with `self.mask_prediction_`. Finally, it passes
-        this to a `sklearn` scorer.
+        This calls ``self.predict``, then masks the output of this
+        and ``y` with ``self.mask_prediction_``. Finally, it passes
+        this to a :mod:`sklearn.metrics` scorer.
 
         Parameters
         ----------

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -55,16 +55,16 @@ class ReceptiveField(BaseEstimator):
 
     Attributes
     ----------
-    ``coef_`` : array, shape ([n_outputs, ]n_features, n_delays)
+    coef_ : array, shape ([n_outputs, ]n_features, n_delays)
         The coefficients from the model fit, reshaped for easy visualization.
         During :meth:`mne.decoding.ReceptiveField.fit`, if ``y`` has one
         dimension (time), the ``n_outputs`` dimension here is omitted.
-    ``patterns_`` : array, shape ([n_outputs, ]n_features, n_delays)
+    patterns_ : array, shape ([n_outputs, ]n_features, n_delays)
         If fit, the inverted coefficients from the model.
-    ``delays_``: array, shape (n_delays,), dtype int
+    delays_: array, shape (n_delays,), dtype int
         The delays used to fit the model, in indices. To return the delays
         in seconds, use ``self.delays_ / self.sfreq``
-    ``valid_samples_`` : slice
+    valid_samples_ : slice
         The rows to keep during model fitting after removing rows with
         missing values due to time delaying. This can be used to get an
         output equivalent to using :func:`numpy.convolve` or

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -33,7 +33,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    ``estimators_`` : array-like, shape (n_tasks,)
+    estimators_ : array-like, shape (n_tasks,)
         List of fitted scikit-learn estimators (one per task).
     """
 

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -233,7 +233,7 @@ class Vectorizer(TransformerMixin):
 
     Attributes
     ----------
-    ``features_shape_`` : tuple
+    features_shape_ : tuple
          Stores the original shape of data.
     """
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1557,7 +1557,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         last_samp are set accordingly.
 
         Thus function operates in-place on the instance.
-        Use :meth:`mne.Raw.copy` if operation on a copy is desired.
+        Use :meth:`mne.io.Raw.copy` if operation on a copy is desired.
 
         Parameters
         ----------

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -206,7 +206,7 @@ class ICA(ContainsMixin):
     ch_names : list-like
         Channel names resulting from initial picking.
         The number of components used for ICA decomposition.
-    ``n_components_`` : int
+    n_components_ : int
         If fit, the actual number of components used for ICA decomposition.
     n_pca_components : int
         See above.
@@ -214,15 +214,15 @@ class ICA(ContainsMixin):
         The number of components used for PCA dimensionality reduction.
     verbose : bool, str, int, or None
         See above.
-    ``pca_components_`` : ndarray
+    pca_components_ : ndarray
         If fit, the PCA components
-    ``pca_mean_`` : ndarray
+    pca_mean_ : ndarray
         If fit, the mean vector used to center the data before doing the PCA.
-    ``pca_explained_variance_`` : ndarray
+    pca_explained_variance_ : ndarray
         If fit, the variance explained by each PCA component
-    ``mixing_matrix_`` : ndarray
+    mixing_matrix_ : ndarray
         If fit, the mixing matrix to restore observed data, else None.
-    ``unmixing_matrix_`` : ndarray
+    unmixing_matrix_ : ndarray
         If fit, the matrix to unmix observed data, else None.
     exclude : list
         List of sources indices to exclude, i.e. artifact components identified
@@ -234,9 +234,9 @@ class ICA(ContainsMixin):
         again. To dump this 'artifact memory' say: ica.exclude = []
     info : None | instance of Info
         The measurement info copied from the object fitted.
-    ``n_samples_`` : int
+    n_samples_ : int
         the number of samples used on fit.
-    ``labels_`` : dict
+    labels_ : dict
         A dictionary of independent component indices, grouped by types of
         independent components. This attribute is set by some of the artifact
         detection functions.

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -364,15 +364,15 @@ class Xdawn(_XdawnTransformer):
 
     Attributes
     ----------
-    ``filters_`` : dict of ndarray
+    filters_ : dict of ndarray
         If fit, the Xdawn components used to decompose the data for each event
         type, else empty.
-    ``patterns_`` : dict of ndarray
+    patterns_ : dict of ndarray
         If fit, the Xdawn patterns used to restore the signals for each event
         type, else empty.
-    ``evokeds_`` : dict of evoked instance
+    evokeds_ : dict of evoked instance
         If fit, the evoked response for each event type.
-    ``event_id_`` : dict of event id
+    event_id_ : dict of event id
         The event id.
     ``correct_overlap_``: bool
         Whether overlap correction was applied.

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -374,7 +374,7 @@ class Xdawn(_XdawnTransformer):
         If fit, the evoked response for each event type.
     event_id_ : dict of event id
         The event id.
-    ``correct_overlap_``: bool
+    correct_overlap_ : bool
         Whether overlap correction was applied.
 
     Notes

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -671,7 +671,7 @@ class deprecated(object):
         if self.extra:
             newdoc = "%s: %s" % (newdoc, self.extra)
         if olddoc:
-            newdoc = "%s\n\n%s" % (newdoc, olddoc)
+            newdoc = "%s\n\n    %s" % (newdoc, olddoc)
         return newdoc
 
 


### PR DESCRIPTION
Closes #5118

So far it looks locally like the double-backtics are no longer necessary on `var_` names in `Attributes` sections. We'll see if CircleCI agrees.

I still need to fix the CSS width problem.