### PR TITLE
FIX: CTF Projector comp

### DIFF
--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -183,8 +183,14 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
             _safe_del_key(flat, 'eog')
 
     # exclude bad channels from projection
-    picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=False,
-                       exclude='bads')
+    if len(my_info['comps']) > 0:
+        # Keep reference channels if compensation channels are present
+        picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=True,
+                           exclude='bads')
+    else:
+        picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=False,
+                           exclude='bads')
+
     raw.filter(l_freq, h_freq, picks=picks, filter_length=filter_length,
                n_jobs=n_jobs, method=filter_method, iir_params=iir_params,
                l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -183,13 +183,10 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
             _safe_del_key(flat, 'eog')
 
     # exclude bad channels from projection
-    if len(my_info['comps']) > 0:
-        # Keep reference channels if compensation channels are present
-        picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=True,
-                           exclude='bads')
-    else:
-        picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=False,
-                           exclude='bads')
+    # keep reference channels if compensation channels are present
+    ref_meg = len(my_info['comps']) > 0
+    picks = pick_types(my_info, meg=True, eeg=True, eog=True, ref_meg=ref_meg,
+                       exclude='bads')
 
     raw.filter(l_freq, h_freq, picks=picks, filter_length=filter_length,
                n_jobs=n_jobs, method=filter_method, iir_params=iir_params,

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -126,8 +126,9 @@ def test_compute_proj_parallel():
     assert_array_almost_equal(projs, projs_2, 10)
 
 
+@testing.requires_testing_data
 def test_compute_proj_ctf():
-    """Trivial Test to show that projector code completes on CTF data"""
+    """Test to show that projector code completes on CTF data"""
     raw = read_raw_ctf(ctf_fname)
     raw.load_data()
 
@@ -140,7 +141,7 @@ def test_compute_proj_ctf():
                                          l_freq=None, h_freq=None,
                                          reject=None, tmax=dur_use,
                                          filter_length=6000)
-        assert_true(len(projs) == (5 + n_projs_init))
+        assert len(projs) == (5 + n_projs_init)
 
         projs, events = compute_proj_ecg(raw, n_mag=1, n_grad=1, n_eeg=2,
                                          average=average,
@@ -149,7 +150,7 @@ def test_compute_proj_ctf():
                                          l_freq=None, h_freq=None,
                                          reject=None, tmax=dur_use,
                                          filter_length=6000)
-        assert_true(len(projs) == (4 + n_projs_init))
+        assert len(projs) == (4 + n_projs_init)
 
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -10,6 +10,7 @@ from mne.io.proj import make_projector, activate_proj
 from mne.preprocessing.ssp import compute_proj_ecg, compute_proj_eog
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
+from mne import pick_types
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -127,31 +128,54 @@ def test_compute_proj_parallel():
     assert_array_almost_equal(projs, projs_2, 10)
 
 
+def _check_projs_for_expected_channels(projs, n_mags, n_grads, n_eegs):
+    for p in projs:
+        if 'planar' in p['desc']:
+            assert len(p['data']['col_names']) == n_grads
+        elif 'axial' in p['desc']:
+            assert len(p['data']['col_names']) == n_mags
+        elif 'eeg' in p['desc']:
+            assert len(p['data']['col_names']) == n_eegs
+
+
 @testing.requires_testing_data
 def test_compute_proj_ctf():
-    """Test to show that projector code completes on CTF data"""
+    """Test to show that projector code completes on CTF data."""
     raw = read_raw_ctf(ctf_fname)
     raw.load_data()
 
-    for average in [False, True]:
-        n_projs_init = len(raw.info['projs'])
-        projs, events = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
-                                         average=average,
-                                         ch_name='EEG059',
-                                         avg_ref=True, no_proj=False,
-                                         l_freq=None, h_freq=None,
-                                         reject=None, tmax=dur_use,
-                                         filter_length=6000)
-        assert len(projs) == (5 + n_projs_init)
+    # expected channels per projector type
+    n_mags = len(pick_types(raw.info, meg='mag', ref_meg=False,
+                            exclude='bads'))
+    n_grads = len(pick_types(raw.info, meg='grad', ref_meg=False,
+                             exclude='bads'))
+    n_eegs = len(pick_types(raw.info, meg=False, eeg=True, ref_meg=False,
+                            exclude='bads'))
 
-        projs, events = compute_proj_ecg(raw, n_mag=1, n_grad=1, n_eeg=2,
-                                         average=average,
-                                         ch_name='EEG059',
-                                         avg_ref=True, no_proj=False,
-                                         l_freq=None, h_freq=None,
-                                         reject=None, tmax=dur_use,
-                                         filter_length=6000)
-        assert len(projs) == (4 + n_projs_init)
+    # Test with and without gradient compensation
+    for c in [0, 1]:
+        raw.apply_gradient_compensation(c)
+        for average in [False, True]:
+            n_projs_init = len(raw.info['projs'])
+            projs, events = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                             average=average,
+                                             ch_name='EEG059',
+                                             avg_ref=True, no_proj=False,
+                                             l_freq=None, h_freq=None,
+                                             reject=None, tmax=dur_use,
+                                             filter_length=6000)
+            _check_projs_for_expected_channels(projs, n_mags, n_grads, n_eegs)
+            assert len(projs) == (5 + n_projs_init)
+
+            projs, events = compute_proj_ecg(raw, n_mag=1, n_grad=1, n_eeg=2,
+                                             average=average,
+                                             ch_name='EEG059',
+                                             avg_ref=True, no_proj=False,
+                                             l_freq=None, h_freq=None,
+                                             reject=None, tmax=dur_use,
+                                             filter_length=6000)
+            _check_projs_for_expected_channels(projs, n_mags, n_grads, n_eegs)
+            assert len(projs) == (4 + n_projs_init)
 
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -18,7 +18,8 @@ raw_fname = op.join(data_path, 'test_raw.fif')
 dur_use = 5.0
 eog_times = np.array([0.5, 2.3, 3.6, 14.5])
 
-ctf_fname = op.join(testing.data_path(download=False), 'CTF', 'testdata_ctf.ds')
+ctf_fname = op.join(testing.data_path(download=False), 'CTF',
+                    'testdata_ctf.ds')
 
 
 def test_compute_proj_ecg():

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -5,10 +5,11 @@ from nose.tools import assert_true, assert_equal
 from numpy.testing import assert_array_almost_equal
 import numpy as np
 
-from mne.io import read_raw_fif
+from mne.io import read_raw_fif, read_raw_ctf
 from mne.io.proj import make_projector, activate_proj
 from mne.preprocessing.ssp import compute_proj_ecg, compute_proj_eog
 from mne.utils import run_tests_if_main
+from mne.datasets import testing
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
@@ -16,6 +17,8 @@ data_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(data_path, 'test_raw.fif')
 dur_use = 5.0
 eog_times = np.array([0.5, 2.3, 3.6, 14.5])
+
+ctf_fname = op.join(testing.data_path(download=False), 'CTF', 'testdata_ctf.ds')
 
 
 def test_compute_proj_ecg():
@@ -121,5 +124,32 @@ def test_compute_proj_parallel():
     projs_2, _, _ = make_projector(projs_2, raw_2.info['ch_names'],
                                    bads=['MEG 2443'])
     assert_array_almost_equal(projs, projs_2, 10)
+
+
+def test_compute_proj_ctf():
+    """Trivial Test to show that projector code completes on CTF data"""
+    raw = read_raw_ctf(ctf_fname)
+    raw.load_data()
+
+    for average in [False, True]:
+        n_projs_init = len(raw.info['projs'])
+        projs, events = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
+                                         average=average,
+                                         ch_name='EEG059',
+                                         avg_ref=True, no_proj=False,
+                                         l_freq=None, h_freq=None,
+                                         reject=None, tmax=dur_use,
+                                         filter_length=6000)
+        assert_true(len(projs) == (5 + n_projs_init))
+
+        projs, events = compute_proj_ecg(raw, n_mag=1, n_grad=1, n_eeg=2,
+                                         average=average,
+                                         ch_name='EEG059',
+                                         avg_ref=True, no_proj=False,
+                                         l_freq=None, h_freq=None,
+                                         reject=None, tmax=dur_use,
+                                         filter_length=6000)
+        assert_true(len(projs) == (4 + n_projs_init))
+
 
 run_tests_if_main()


### PR DESCRIPTION
Closes #5124 

When computing ssp projection operators, include the meg_ref channels for data objects that include compensation channels (i.e CTF data), otherwise creating epochs raises an exception.