### PR TITLE
MRG+1: Better epochs repr

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1362,18 +1362,22 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     def __repr__(self):
         """Build string representation."""
-        s = 'n_events : %s ' % len(self.events)
+        s = ' %s events ' % len(self.events)
         s += '(all good)' if self._bad_dropped else '(good & bad)'
-        s += ', tmin : %s (s)' % self.tmin
-        s += ', tmax : %s (s)' % self.tmax
-        s += ', baseline : %s' % str(self.baseline)
+        s += ', %g - %g sec' % (self.tmin, self.tmax)
+        s += ', baseline '
+        if self.baseline is None:
+            s += 'off'
+        else:
+            s += '[%s, %s]' % tuple(['None' if b is None else ('%g' % b)
+                                     for b in self.baseline])
         s += ', ~%s' % (sizeof_fmt(self._size),)
         s += ', data%s loaded' % ('' if self.preload else ' not')
-        s += ' with metadata' if self.metadata is not None else ''
-        if len(self.event_id) > 1:
-            counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                      for k, v in sorted(self.event_id.items())]
-            s += ',\n %s' % ', '.join(counts)
+        s += ', with metadata' if self.metadata is not None else ''
+        counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
+                  for k, v in sorted(self.event_id.items())]
+        if len(self.event_id) > 0:
+            s += ',' + '\n '.join([''] + counts)
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name
         return '<%s  |  %s>' % (class_name, s)


### PR DESCRIPTION
Updates `epochs` repr to be hopefully a bit nicer.

`master`:
```
<Epochs  |  n_events : 320 (good & bad), tmin : -0.19979521315838786 (s), tmax : 0.49948803289596966 (s), baseline : (None, 0), ~3.7 MB, data not loaded,
 'auditory/left': 72, 'auditory/right': 73, 'button': 16, 'smiley': 15, 'visual/left': 73, 'visual/right': 71>
<Epochs  |  n_events : 72 (good & bad), tmin : -0.19979521315838786 (s), tmax : 0.49948803289596966 (s), baseline : (None, 0), ~3.7 MB, data not loaded>
```
On this PR:
```
<Epochs  |   320 events (good & bad), -0.199795 - 0.499488 sec, baseline [None, 0], ~3.7 MB, data not loaded,
 'auditory/left': 72
 'auditory/right': 73
 'button': 16
 'smiley': 15
 'visual/left': 73
 'visual/right': 71>
<Epochs  |   72 events (good & bad), -0.199795 - 0.499488 sec, baseline [None, 0], ~3.7 MB, data not loaded,
 'auditory/left': 72>
```
For this code:
```
import mne
raw = mne.datasets.sample.data_path() + '/MEG/sample/sample_audvis_raw.fif'
raw = mne.io.read_raw_fif(raw)
events = mne.find_events(raw, 'STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'smiley': 5, 'button': 32}
epochs = mne.Epochs(raw, events, event_id=event_id)
print(epochs)
epochs_one = epochs['auditory/left']
print(epochs_one)
```