### PR TITLE
FIX: Remove unused argument and refactor

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -187,6 +187,8 @@ API
 
 - Channels with unknown locations are now assigned position ``[np.nan, np.nan, np.nan]`` instead of ``[0., 0., 0.]``, by `Eric Larson`_
 
+- Removed unused ``image_mask`` argument from :func:`mne.viz.plot_topomap` by `Eric Larson`_
+
 - Unknown measurement dates are now stored as ``info['meas_date'] = None`` rather than using the current date. ``None`` is also now used when anonymizing data and when determining the machine ID for writing files, by `Mainak Jas`_ and `Eric Larson`_
 
 - :meth:`mne.Evoked.plot` will now append the number of epochs averaged for the evoked data in the first plot title, by `Eric Larson`_

--- a/tutorials/plot_dipole_fit.py
+++ b/tutorials/plot_dipole_fit.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-==========================================
-Source localization with single dipole fit
-==========================================
+============================================================
+Source localization with equivalent current dipole (ECD) fit
+============================================================
 
 This shows how to fit a dipole using mne-python.
 
@@ -10,10 +10,6 @@ For a comparison of fits between MNE-C and mne-python, see:
 
     https://gist.github.com/Eric89GXL/ca55f791200fe1dc3dd2
 
-Note that for 3D graphics you may need to choose a specific IPython
-backend, such as:
-
-`%matplotlib qt` or `%matplotlib wx`
 """
 
 from os import path as op

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -173,7 +173,7 @@ mne.viz.plot_evoked_topo(evoked, title=title % 'Left/Right Auditory/Visual',
 ###############################################################################
 # Visualizing field lines in 3D
 # -----------------------------
-# We now compute the field maps to project MEG and EEG data to MEG helmet
+# We now compute the field maps to project MEG and EEG data to the MEG helmet
 # and scalp surface.
 #
 # To do this, we need coregistration information. See


### PR DESCRIPTION
I think we have some code path cruft that has built up in `mne/viz/topomap.py`.

1. `image_mask` is never used to modify the plots, so I removed it.
2. `_make_image_mask` both set up the (unused) `image_mask` and modified `pos` based on `autoshrink`, so I renamed it to `_autoshrink`.
3. `outlines` gets set by `_check_outlines` to always be a dict. So I removed the conditionals having to do with `if outlines is None` that happen afterward.

This is a step toward #5085. Simplifying this first and getting feedback should make the subsequent steps easier.