### PR TITLE
MRG: Fix minor bugs with Xdawn and create_ecg_epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -180,6 +180,8 @@ Bug
 
 - Fix handling of annotations when cropping and concatenating raw data by `Alex Gramfort`_ and `Eric Larson`_
 
+- Fix bug in :func:`mne.preprocessing.create_ecg_epochs` where ``keep_ecg=False`` was ignored by `Eric Larson`_
+
 - Fix bug in :meth:`mne.io.Raw.plot_psd` when ``picks is not None`` and ``picks`` spans more than one channel type by `Eric Larson`_
 
 - Fix bug in :class:`mne.make_forward_solution` when passing data with compensation channels (e.g. CTF) that contain bad channels by `Alex Gramfort`_

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -308,6 +308,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
 
     # Load raw data so that add_channels works
     raw.load_data()
+    picks = np.arange(len(raw.ch_names)) if picks is None else picks
 
     if not has_ecg:
         ecg_raw = RawArray(

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1021,7 +1021,7 @@ def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,
         plt.subplots_adjust(top=0.8)
 
         if colorbar:
-            cb = plt.colorbar(im, ax=[a for ax in axes for a in ax])
+            cb = plt.colorbar(im, ax=[a for ax_ in axes for a in ax_])
             if mode == 'csd':
                 label = u'CSD'
                 if ch_type in units:


### PR DESCRIPTION
Fixes:

1. bug with Xdawn where non-data-channels broke things
2. `create_ecg_epochs` where `picks=None` plus `keep_ecg=False` would not work.
3. minor PEP8 problem with `mne/viz/misc.py`
4. updates some tests to `pytest` (someday we will eliminate `nose`!)