### PR TITLE
MRG: Add joint projection for SSS

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,7 +57,7 @@ Changelog
 
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
-- Add option to SSP preprocessing functions like :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs` to process MEG channels jointly with ``meg='joint'`` by `Eric Larson`_
+- Add option to SSP preprocessing functions (e.g., :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs`) to process MEG channels jointly with ``meg='combined'`` by `Eric Larson`_
 
 - Add Epoch selection and metadata functionality to :class:`mne.time_frequency.EpochsTFR` using new mixin class by `Keith Doelling`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,8 @@ Changelog
 
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
+- Add option to SSP preprocessing functions like :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs` to process MEG channels jointly with ``meg='joint'`` by `Eric Larson`_
+
 - Add Epoch selection and metadata functionality to :class:`mne.time_frequency.EpochsTFR` using new mixin class by `Keith Doelling`_
 
 - Add ``reject_by_annotation`` argument to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -31,7 +31,8 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
                       average, filter_length, n_jobs, ch_name,
                       reject, flat, bads, avg_ref, no_proj, event_id,
                       exg_l_freq, exg_h_freq, tstart, qrs_threshold,
-                      filter_method, iir_params, return_drop_log, copy):
+                      filter_method, iir_params, return_drop_log, copy,
+                      meg, verbose):
     """Compute SSP/PCA projections for ECG or EOG artifacts."""
     raw = raw.copy() if copy else raw
     del copy
@@ -124,10 +125,10 @@ def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
     if average:
         evoked = epochs.average()
         ev_projs = compute_proj_evoked(evoked, n_grad=n_grad, n_mag=n_mag,
-                                       n_eeg=n_eeg)
+                                       n_eeg=n_eeg, meg=meg)
     else:
         ev_projs = compute_proj_epochs(epochs, n_grad=n_grad, n_mag=n_mag,
-                                       n_eeg=n_eeg, n_jobs=n_jobs)
+                                       n_eeg=n_eeg, n_jobs=n_jobs, meg=meg)
 
     for p in ev_projs:
         p['desc'] = mode + "-" + p['desc']
@@ -147,7 +148,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                      no_proj=False, event_id=999, ecg_l_freq=5, ecg_h_freq=35,
                      tstart=0., qrs_threshold='auto', filter_method='fir',
                      iir_params=None, copy=True, return_drop_log=False,
-                     verbose=None):
+                     meg='separate', verbose=None):
     """Compute SSP/PCA projections for ECG artifacts.
 
     .. note:: raw data will be loaded if it is not already.
@@ -214,6 +215,13 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         If True, return the drop log.
 
         .. versionadded:: 0.15
+    meg : str
+        Can be 'separate' (default) or 'joint' to compute projectors
+        for magnetometers and gradiometers separately or jointly.
+        If 'joint', ``n_mag == n_grad`` is required and the number of
+        projectors computed for MEG will be ``n_mag``.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -241,7 +249,8 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         'ECG', raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg,
         l_freq, h_freq, average, filter_length, n_jobs, ch_name, reject, flat,
         bads, avg_ref, no_proj, event_id, ecg_l_freq, ecg_h_freq, tstart,
-        qrs_threshold, filter_method, iir_params, return_drop_log, copy)
+        qrs_threshold, filter_method, iir_params, return_drop_log, copy,
+        meg, verbose)
 
 
 @verbose
@@ -253,7 +262,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      avg_ref=False, no_proj=False, event_id=998, eog_l_freq=1,
                      eog_h_freq=10, tstart=0., filter_method='fir',
                      iir_params=None, ch_name=None, copy=True,
-                     return_drop_log=False, verbose=None):
+                     return_drop_log=False, meg='separate', verbose=None):
     """Compute SSP/PCA projections for EOG artifacts.
 
     .. note:: raw data must be preloaded.
@@ -316,6 +325,13 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         If True, return the drop log.
 
         .. versionadded:: 0.15
+    meg : str
+        Can be 'separate' (default) or 'joint' to compute projectors
+        for magnetometers and gradiometers separately or jointly.
+        If 'joint', ``n_mag == n_grad`` is required and the number of
+        projectors computed for MEG will be ``n_mag``.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -343,4 +359,5 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         'EOG', raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg,
         l_freq, h_freq, average, filter_length, n_jobs, ch_name, reject, flat,
         bads, avg_ref, no_proj, event_id, eog_l_freq, eog_h_freq, tstart,
-        'auto', filter_method, iir_params, return_drop_log, copy)
+        'auto', filter_method, iir_params, return_drop_log, copy, meg,
+        verbose)

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -216,9 +216,9 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
 
         .. versionadded:: 0.15
     meg : str
-        Can be 'separate' (default) or 'joint' to compute projectors
+        Can be 'separate' (default) or 'combined' to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'joint', ``n_mag == n_grad`` is required and the number of
+        If 'combined', ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18
@@ -326,9 +326,9 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
 
         .. versionadded:: 0.15
     meg : str
-        Can be 'separate' (default) or 'joint' to compute projectors
+        Can be 'separate' (default) or 'combined' to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'joint', ``n_mag == n_grad`` is required and the number of
+        If 'combined', ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -78,14 +78,15 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
     eeg_ind = pick_types(info, meg=False, eeg=True, ref_meg=False,
                          exclude='bads')
 
-    if meg not in ('separate', 'joint'):
-        raise ValueError('sss must be "separate" or "joint", got %r' % (meg,))
-    if meg == 'joint':
-        _get_rank_sss(info, msg='sss="joint" can only be used with '
+    if meg not in ('separate', 'combined'):
+        raise ValueError('meg must be "separate" or "combined", '
+                         'got %r' % (meg,))
+    if meg == 'combined':
+        _get_rank_sss(info, msg='meg="combined" can only be used with '
                       'Maxfiltered data', verbose=False)
         if n_grad != n_mag:
             raise ValueError('n_grad (%d) must be equal to n_mag (%d) when '
-                             'using sss="joint"')
+                             'using meg="combined"')
         kinds = ['meg', '', 'eeg']
         n_mag = 0
         grad_ind = pick_types(info, meg=True, ref_meg=False, exclude='bads')
@@ -158,9 +159,9 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
         The description prefix to use. If None, one will be created based on
         the event_id, tmin, and tmax.
     meg : str
-        Can be 'separate' (default) or 'joint' to compute projectors
+        Can be 'separate' (default) or 'combined' to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'joint', ``n_mag == n_grad`` is required and the number of
+        If 'combined', ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18
@@ -225,9 +226,9 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
 
         .. versionadded:: 0.17
     meg : str
-        Can be 'separate' (default) or 'joint' to compute projectors
+        Can be 'separate' (default) or 'combined' to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'joint', ``n_mag == n_grad`` is required and the number of
+        If 'combined', ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18
@@ -280,9 +281,9 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
     n_jobs : int
         Number of jobs to use to compute covariance.
     meg : str
-        Can be 'separate' (default) or 'joint' to compute projectors
+        Can be 'separate' (default) or 'combined' to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'joint', ``n_mag == n_grad`` is required and the number of
+        If 'combined', ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -16,6 +16,7 @@ from .forward import (is_fixed_orient, _subject_from_forward,
                       convert_forward_solution)
 from .source_estimate import SourceEstimate, VolSourceEstimate
 from .io.proj import make_projector, make_eeg_average_ref_proj
+from .rank import _get_rank_sss
 
 
 def read_proj(fname):
@@ -70,11 +71,30 @@ def write_proj(fname, projs):
 
 
 @verbose
-def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix, verbose=None):
-    mag_ind = pick_types(info, meg='mag', ref_meg=False, exclude='bads')
+def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
+                  meg='separate', verbose=None):
     grad_ind = pick_types(info, meg='grad', ref_meg=False, exclude='bads')
+    mag_ind = pick_types(info, meg='mag', ref_meg=False, exclude='bads')
     eeg_ind = pick_types(info, meg=False, eeg=True, ref_meg=False,
                          exclude='bads')
+
+    if meg not in ('separate', 'joint'):
+        raise ValueError('sss must be "separate" or "joint", got %r' % (meg,))
+    if meg == 'joint':
+        _get_rank_sss(info, msg='sss="joint" can only be used with '
+                      'Maxfiltered data', verbose=False)
+        if n_grad != n_mag:
+            raise ValueError('n_grad (%d) must be equal to n_mag (%d) when '
+                             'using sss="joint"')
+        kinds = ['meg', '', 'eeg']
+        n_mag = 0
+        grad_ind = pick_types(info, meg=True, ref_meg=False, exclude='bads')
+        if (n_grad > 0) and len(grad_ind) == 0:
+            logger.info("No MEG channels found for joint estimation. "
+                        "Forcing n_grad=n_mag=0")
+            n_grad = 0
+    else:
+        kinds = ['planar', 'axial', 'eeg']
 
     if (n_grad > 0) and len(grad_ind) == 0:
         logger.info("No gradiometers found. Forcing n_grad to 0")
@@ -95,7 +115,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix, verbose=None):
     for n, ind, names, desc in zip([n_grad, n_mag, n_eeg],
                                    [grad_ind, mag_ind, eeg_ind],
                                    [grad_names, mag_names, eeg_names],
-                                   ['planar', 'axial', 'eeg']):
+                                   kinds):
         if n == 0:
             continue
         data_ind = data[ind][:, ind]
@@ -119,7 +139,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix, verbose=None):
 
 @verbose
 def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
-                        desc_prefix=None, verbose=None):
+                        desc_prefix=None, meg='separate', verbose=None):
     """Compute SSP (spatial space projection) vectors on Epochs.
 
     Parameters
@@ -137,6 +157,13 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
     desc_prefix : str | None
         The description prefix to use. If None, one will be created based on
         the event_id, tmin, and tmax.
+    meg : str
+        Can be 'separate' (default) or 'joint' to compute projectors
+        for magnetometers and gradiometers separately or jointly.
+        If 'joint', ``n_mag == n_grad`` is required and the number of
+        projectors computed for MEG will be ``n_mag``.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -159,7 +186,8 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
         event_id = 'Multiple-events'
     if desc_prefix is None:
         desc_prefix = "%s-%-.3f-%-.3f" % (event_id, epochs.tmin, epochs.tmax)
-    return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, desc_prefix)
+    return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, desc_prefix,
+                         meg=meg)
 
 
 def _compute_cov_epochs(epochs, n_jobs):
@@ -178,7 +206,7 @@ def _compute_cov_epochs(epochs, n_jobs):
 
 @verbose
 def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
-                        verbose=None):
+                        meg='separate', verbose=None):
     """Compute SSP (spatial space projection) vectors on Evoked.
 
     Parameters
@@ -196,6 +224,13 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
         tmin and tmax.
 
         .. versionadded:: 0.17
+    meg : str
+        Can be 'separate' (default) or 'joint' to compute projectors
+        for magnetometers and gradiometers separately or jointly.
+        If 'joint', ``n_mag == n_grad`` is required and the number of
+        projectors computed for MEG will be ``n_mag``.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -210,12 +245,14 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
     data = np.dot(evoked.data, evoked.data.T)  # compute data covariance
     if desc_prefix is None:
         desc_prefix = "%-.3f-%-.3f" % (evoked.times[0], evoked.times[-1])
-    return _compute_proj(data, evoked.info, n_grad, n_mag, n_eeg, desc_prefix)
+    return _compute_proj(data, evoked.info, n_grad, n_mag, n_eeg, desc_prefix,
+                         meg=meg)
 
 
 @verbose
 def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
-                     n_eeg=0, reject=None, flat=None, n_jobs=1, verbose=None):
+                     n_eeg=0, reject=None, flat=None, n_jobs=1, meg='separate',
+                     verbose=None):
     """Compute SSP (spatial space projection) vectors on Raw.
 
     Parameters
@@ -242,6 +279,13 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
         Epoch flat configuration (see Epochs).
     n_jobs : int
         Number of jobs to use to compute covariance.
+    meg : str
+        Can be 'separate' (default) or 'joint' to compute projectors
+        for magnetometers and gradiometers separately or jointly.
+        If 'joint', ``n_mag == n_grad`` is required and the number of
+        projectors computed for MEG will be ``n_mag``.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -277,7 +321,8 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
         stop = stop / raw.info['sfreq']
 
     desc_prefix = "Raw-%-.3f-%-.3f" % (start, stop)
-    projs = _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix)
+    projs = _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
+                          meg=meg)
     return projs
 
 

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -206,7 +206,9 @@ def _estimate_rank_meeg_cov(data, info, scalings, tol='auto',
     return out
 
 
-def _get_rank_sss(inst):
+@verbose
+def _get_rank_sss(inst, msg='You should use data-based rank estimate instead',
+                  verbose=None):
     """Look up rank from SSS data.
 
     .. note::
@@ -234,9 +236,8 @@ def _get_rank_sss(inst):
         logger.info('Found multiple SSS records. Using the first.')
     if len(proc_info) == 0 or 'max_info' not in proc_info[0] or \
             'in_order' not in proc_info[0]['max_info']['sss_info']:
-        raise ValueError(
-            'Did not find any SSS record. You should use data-based '
-            'rank estimate instead')
+        raise ValueError('Could not find Maxfilter information in '
+                         'info["proc_history"]. %s' % msg)
     proc_info = proc_info[0]
     max_info = proc_info['max_info']
     inside = max_info['sss_info']['in_order']

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -343,12 +343,12 @@ def test_sss_proj():
     raw.crop(0, 1.0).load_data().pick_types(exclude=())
     raw.pick_channels(raw.ch_names[:51]).del_proj()
     with pytest.raises(ValueError, match='can only be used with Maxfiltered'):
-        compute_proj_raw(raw, meg='joint')
+        compute_proj_raw(raw, meg='combined')
     raw_sss = maxwell_filter(raw, int_order=5, ext_order=2)
     sss_rank = 21  # really low due to channel picking
     assert len(raw_sss.info['projs']) == 0
     for meg, n_proj, want_rank in (('separate', 6, sss_rank),
-                                   ('joint', 3, sss_rank - 3)):
+                                   ('combined', 3, sss_rank - 3)):
         proj = compute_proj_raw(raw_sss, n_grad=3, n_mag=3, meg=meg,
                                 verbose='error')
         this_raw = raw_sss.copy().add_proj(proj).apply_proj()
@@ -359,7 +359,7 @@ def test_sss_proj():
                                              return_rank=True)
         assert ch_names == this_raw.ch_names
         assert want_rank == sss_proj_rank == rank  # proper reduction
-        if meg == 'joint':
+        if meg == 'combined':
             assert this_raw.info['projs'][0]['data']['col_names'] == ch_names
         else:
             mag_names = ch_names[2::3]

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -19,6 +19,7 @@ from mne.io.proj import (make_projector, activate_proj,
 from mne.preprocessing import maxwell_filter
 from mne.proj import (read_proj, write_proj, make_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj)
+from mne.rank import _compute_rank_int
 from mne.utils import _TempDir, run_tests_if_main
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
@@ -352,7 +353,7 @@ def test_sss_proj():
                                 verbose='error')
         this_raw = raw_sss.copy().add_proj(proj).apply_proj()
         assert len(this_raw.info['projs']) == n_proj
-        sss_proj_rank = this_raw.estimate_rank()
+        sss_proj_rank = _compute_rank_int(this_raw)
         cov = compute_raw_covariance(this_raw, verbose='error')
         W, ch_names, rank = compute_whitener(cov, this_raw.info,
                                              return_rank=True)

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -7,14 +7,16 @@ import pytest
 
 import copy as cp
 
-import mne
-from mne.datasets import testing
-from mne.io import read_raw_fif
 from mne import (compute_proj_epochs, compute_proj_evoked, compute_proj_raw,
                  pick_types, read_events, Epochs, sensitivity_map,
-                 read_source_estimate)
+                 read_source_estimate, compute_raw_covariance,
+                 read_forward_solution, convert_forward_solution)
+from mne.cov import regularize, compute_whitener
+from mne.datasets import testing
+from mne.io import read_raw_fif
 from mne.io.proj import (make_projector, activate_proj,
                          _needs_eeg_average_ref_proj)
+from mne.preprocessing import maxwell_filter
 from mne.proj import (read_proj, write_proj, make_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj)
 from mne.utils import _TempDir, run_tests_if_main
@@ -72,15 +74,15 @@ def test_bad_proj():
     raw = read_raw_fif(raw_fname).crop(0, 1)
     raw.set_eeg_reference(projection=True)
     raw.info['bads'] = ['MEG 0111']
-    meg_picks = mne.pick_types(raw.info, meg=True, exclude=())
+    meg_picks = pick_types(raw.info, meg=True, exclude=())
     ch_names = [raw.ch_names[pick] for pick in meg_picks]
     for p in raw.info['projs'][:-1]:
         data = np.zeros((1, len(ch_names)))
         idx = [ch_names.index(ch_name) for ch_name in p['data']['col_names']]
         data[:, idx] = p['data']['data']
         p['data'].update(ncol=len(meg_picks), col_names=ch_names, data=data)
-    mne.cov.regularize(mne.compute_raw_covariance(raw, verbose='error'),
-                       raw.info, rank=None)
+    # smoke test for no warnings during reg
+    regularize(compute_raw_covariance(raw, verbose='error'), raw.info)
 
 
 def _check_warnings(raw, events, picks=None, count=3):
@@ -95,8 +97,8 @@ def _check_warnings(raw, events, picks=None, count=3):
 @testing.requires_testing_data
 def test_sensitivity_maps():
     """Test sensitivity map computation."""
-    fwd = mne.read_forward_solution(fwd_fname)
-    fwd = mne.convert_forward_solution(fwd, surf_ori=True)
+    fwd = read_forward_solution(fwd_fname)
+    fwd = convert_forward_solution(fwd, surf_ori=True)
     projs = read_proj(eog_fname)
     projs.extend(read_proj(ecg_fname))
     decim = 6
@@ -137,7 +139,7 @@ def test_sensitivity_maps():
     pytest.raises(RuntimeError, sensitivity_map, fwd, projs=[], mode='angle')
     # test volume source space
     fname = op.join(sample_path, 'sample_audvis_trunc-meg-vol-7-fwd.fif')
-    fwd = mne.read_forward_solution(fname)
+    fwd = read_forward_solution(fname)
     sensitivity_map(fwd)
 
 
@@ -280,7 +282,7 @@ def test_compute_proj_raw():
 def test_make_eeg_average_ref_proj():
     """Test EEG average reference projection."""
     raw = read_raw_fif(raw_fname, preload=True)
-    eeg = mne.pick_types(raw.info, meg=False, eeg=True)
+    eeg = pick_types(raw.info, meg=False, eeg=True)
 
     # No average EEG reference
     assert not np.all(raw._data[eeg].mean(axis=0) < 1e-19)
@@ -332,6 +334,35 @@ def test_needs_eeg_average_ref_proj():
     raw = read_raw_fif(raw_fname)
     raw.info['custom_ref_applied'] = True
     assert not _needs_eeg_average_ref_proj(raw.info)
+
+
+def test_sss_proj():
+    """Test `meg` proj option."""
+    raw = read_raw_fif(raw_fname)
+    raw.crop(0, 1.0).load_data().pick_types(exclude=())
+    raw.pick_channels(raw.ch_names[:51]).del_proj()
+    with pytest.raises(ValueError, match='can only be used with Maxfiltered'):
+        compute_proj_raw(raw, meg='joint')
+    raw_sss = maxwell_filter(raw, int_order=5, ext_order=2)
+    sss_rank = 21  # really low due to channel picking
+    assert len(raw_sss.info['projs']) == 0
+    for meg, n_proj, want_rank in (('separate', 6, sss_rank),
+                                   ('joint', 3, sss_rank - 3)):
+        proj = compute_proj_raw(raw_sss, n_grad=3, n_mag=3, meg=meg,
+                                verbose='error')
+        this_raw = raw_sss.copy().add_proj(proj).apply_proj()
+        assert len(this_raw.info['projs']) == n_proj
+        sss_proj_rank = this_raw.estimate_rank()
+        cov = compute_raw_covariance(this_raw, verbose='error')
+        W, ch_names, rank = compute_whitener(cov, this_raw.info,
+                                             return_rank=True)
+        assert ch_names == this_raw.ch_names
+        assert want_rank == sss_proj_rank == rank  # proper reduction
+        if meg == 'joint':
+            assert this_raw.info['projs'][0]['data']['col_names'] == ch_names
+        else:
+            mag_names = ch_names[2::3]
+            assert this_raw.info['projs'][3]['data']['col_names'] == mag_names
 
 
 run_tests_if_main()

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -72,11 +72,12 @@ def test_rank_estimation():
 
 
 @pytest.mark.slowtest
+@pytest.mark.parametrize('meg', ('separate', 'joint'))
 @pytest.mark.parametrize('rank_method, proj', [('info', True),
                                                ('info', False),
                                                (None, True),
                                                (None, False)])
-def test_cov_rank_estimation(rank_method, proj):
+def test_cov_rank_estimation(rank_method, proj, meg):
     """Test cov rank estimation."""
     # Test that our rank estimation works properly on a simple case
     evoked = read_evokeds(ave_fname, condition=0, baseline=(None, 0),
@@ -94,15 +95,13 @@ def test_cov_rank_estimation(rank_method, proj):
 
     raw_sss = read_raw_fif(hp_fif_fname)
     assert not _has_eeg_average_ref_proj(raw_sss.info['projs'])
-    raw_sss.add_proj(compute_proj_raw(raw_sss))
+    raw_sss.add_proj(compute_proj_raw(raw_sss, meg=meg))
 
     cov_sample = compute_raw_covariance(raw_sample)
-    cov_sample_proj = compute_raw_covariance(
-        raw_sample.copy().apply_proj())
+    cov_sample_proj = compute_raw_covariance(raw_sample.copy().apply_proj())
 
     cov_sss = compute_raw_covariance(raw_sss)
-    cov_sss_proj = compute_raw_covariance(
-        raw_sss.copy().apply_proj())
+    cov_sss_proj = compute_raw_covariance(raw_sss.copy().apply_proj())
 
     picks_all_sample = pick_types(raw_sample.info, meg=True, eeg=True)
     picks_all_sss = pick_types(raw_sss.info, meg=True, eeg=True)
@@ -157,7 +156,7 @@ def test_cov_rank_estimation(rank_method, proj):
 
             expected_rank = n_meg + n_eeg
             if rank_method is None:
-                if not has_sss:  # XXX see below and gh-5146
+                if meg == 'joint' or not has_sss:
                     if proj:
                         expected_rank -= n_projs_info
                     else:
@@ -174,18 +173,22 @@ def test_cov_rank_estimation(rank_method, proj):
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname, rank_orig', ((hp_fif_fname, 120),
                                               (mf_fif_fname, 67)))
-@pytest.mark.parametrize('n_proj', (0, 10))
-def test_maxfilter_get_rank(n_proj, fname, rank_orig):
+@pytest.mark.parametrize('n_proj, meg', ((0, 'joint'),
+                                         (10, 'joint'),
+                                         (10, 'separate')))
+def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg):
     """Test maxfilter rank lookup."""
     raw = read_raw_fif(fname).crop(0, 5).load_data().pick_types()
     assert raw.info['projs'] == []
     mf = raw.info['proc_history'][0]['max_info']
     assert mf['sss_info']['nfree'] == rank_orig
     assert _get_rank_sss(raw) == rank_orig
-    rank = rank_orig - 2 * n_proj
+    mult = 1 + (meg == 'separate')
+    rank = rank_orig - mult * n_proj
     if n_proj > 0:
         # Let's do some projection
-        raw.add_proj(compute_proj_raw(raw, n_mag=n_proj, n_grad=n_proj))
+        raw.add_proj(compute_proj_raw(raw, n_mag=n_proj, n_grad=n_proj,
+                                      meg=meg, verbose=True))
     raw.apply_proj()
     data_orig = raw[:][0]
 
@@ -195,8 +198,7 @@ def test_maxfilter_get_rank(n_proj, fname, rank_orig):
     with pytest.raises(TypeError, match='must be a string or a number'):
         _estimate_rank_raw(raw, tol=None)
 
-    # XXX this should be "rank" not "rank_orig", see gh-5146
-    allowed_rank = [rank_orig]
+    allowed_rank = [rank_orig if meg == 'separate' else rank]
     if fname == mf_fif_fname:
         # Here we permit a -1 because for mf_fif_fname we miss by 1, which is
         # probably acceptable. If we use the entire duration instead of 5 sec

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -72,7 +72,7 @@ def test_rank_estimation():
 
 
 @pytest.mark.slowtest
-@pytest.mark.parametrize('meg', ('separate', 'joint'))
+@pytest.mark.parametrize('meg', ('separate', 'combined'))
 @pytest.mark.parametrize('rank_method, proj', [('info', True),
                                                ('info', False),
                                                (None, True),
@@ -156,7 +156,7 @@ def test_cov_rank_estimation(rank_method, proj, meg):
 
             expected_rank = n_meg + n_eeg
             if rank_method is None:
-                if meg == 'joint' or not has_sss:
+                if meg == 'combined' or not has_sss:
                     if proj:
                         expected_rank -= n_projs_info
                     else:
@@ -173,8 +173,8 @@ def test_cov_rank_estimation(rank_method, proj, meg):
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname, rank_orig', ((hp_fif_fname, 120),
                                               (mf_fif_fname, 67)))
-@pytest.mark.parametrize('n_proj, meg', ((0, 'joint'),
-                                         (10, 'joint'),
+@pytest.mark.parametrize('n_proj, meg', ((0, 'combined'),
+                                         (10, 'combined'),
                                          (10, 'separate')))
 def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg):
     """Test maxfilter rank lookup."""


### PR DESCRIPTION
It's probably not great that `N` projectors reduce the rank by `N` for non-SSS'ed data, but generally by `< N` (often `0`) for SSS'ed data. In other words, once SSS makes mag and grad correlated, computing SSP projectors for them separately might not make sense.

This PR adds support for `sss='separate'` (default, current `master` behavior) and `'joint'` for SSS'ed data. I didn't do anything special about the scaling between mag+grad, but I *think* it shouldn't matter because of the correlation structure in the data.

@agramfort @dengemann WDYT? You can look at the test I added at the bottom of the diff to see how this should work, or recreated here in fuller form in case you want to try it:
```
import mne
data_path = mne.datasets.sample.data_path()
raw = mne.io.read_raw_fif(data_path + '/MEG/sample/sample_audvis_raw.fif')
raw.crop(0, 1.0).load_data().pick_types(exclude=())
raw_sss = mne.preprocessing.maxwell_filter(raw, regularize=None)
sss_rank = 80
assert len(raw_sss.info['projs']) == 0
for sss, n_proj, want_rank in (('separate', 6, sss_rank),
                               ('joint', 3, sss_rank - 3)):
    proj = mne.compute_proj_raw(raw_sss, n_grad=3, n_mag=3, sss=sss,
                                verbose='error')
    this_raw = raw_sss.copy().add_proj(proj).apply_proj()
    assert len(this_raw.info['projs']) == n_proj
    sss_proj_rank = this_raw.estimate_rank()
    cov = mne.compute_raw_covariance(this_raw, verbose='error')
    W, ch_names, rank = mne.cov.compute_whitener(cov, this_raw.info,
                                                 return_rank=True)
    assert ch_names == this_raw.ch_names
    assert want_rank == sss_proj_rank == rank  # proper reduction
    if sss == 'joint':
        assert this_raw.info['projs'][0]['data']['col_names'] == ch_names
    else:
        mag_names = ch_names[2::3]
        assert this_raw.info['projs'][3]['data']['col_names'] == mag_names
```