### PR TITLE
[MRG] Fix SourceEstimate.get_peak() method

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -184,6 +184,8 @@ Bug
 
 - Fix bug in :class:`mne.make_forward_solution` when passing data with compensation channels (e.g. CTF) that contain bad channels by `Alex Gramfort`_
 
+- Fix bug in :meth:`mne.SourceEstimate.get_peak` and :meth:`mne.VolumeSourceEstimate.get_peak` when there is only a single time point by `Marijn van Vliet`_
+
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -184,7 +184,7 @@ Bug
 
 - Fix bug in :class:`mne.make_forward_solution` when passing data with compensation channels (e.g. CTF) that contain bad channels by `Alex Gramfort`_
 
-- Fix bug in :meth:`mne.SourceEstimate.get_peak` and :meth:`mne.VolumeSourceEstimate.get_peak` when there is only a single time point by `Marijn van Vliet`_
+- Fix bug in :meth:`mne.SourceEstimate.get_peak` and :meth:`mne.VolSourceEstimate.get_peak` when there is only a single time point by `Marijn van Vliet`_
 
 API
 ~~~

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1266,7 +1266,7 @@ def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):
         raise ValueError('The tmax value is out of bounds. It must be '
                          'within {0} and {1}'.format(times.min(), times.max()))
     if tmin > tmax:
-        raise ValueError('The tmin must be smaller to equal to tmax')
+        raise ValueError('The tmin must be smaller or equal to tmax')
 
     time_win = (times >= tmin) & (times <= tmax)
     mask = np.ones_like(data).astype(np.bool)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1263,10 +1263,10 @@ def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):
         raise ValueError('The tmin value is out of bounds. It must be '
                          'within {0} and {1}'.format(times.min(), times.max()))
     if tmax > times.max():
-        raise ValueError('The tmin value is out of bounds. It must be '
+        raise ValueError('The tmax value is out of bounds. It must be '
                          'within {0} and {1}'.format(times.min(), times.max()))
-    if tmin >= tmax:
-        raise ValueError('The tmin must be smaller than tmax')
+    if tmin > tmax:
+        raise ValueError('The tmin must be smaller to equal to tmax')
 
     time_win = (times >= tmin) & (times <= tmax)
     mask = np.ones_like(data).astype(np.bool)


### PR DESCRIPTION
The `.get_peak()` method of `SourceEstimate` and `VolumeSourceEstimate` objects failed if there is only a single time point. This is for example common when computing DICS power maps.