### PR TITLE
minor: fix example in docstring, use np.ceil instead of math.ceil

### DIFF
--- a/mne/preprocessing/peak_finder.py
+++ b/mne/preprocessing/peak_finder.py
@@ -1,5 +1,4 @@
 import numpy as np
-from math import ceil
 
 from .. utils import logger, verbose
 
@@ -38,10 +37,10 @@ def peak_finder(x0, thresh=None, extrema=1, verbose=None):
 
     Example
     -------
-    t = 0:.0001:10;
-    x = 12*sin(10*2*pi*t)-3*sin(.1*2*pi*t)+randn(1,numel(t));
-    x(1250:1255) = max(x);
-    peak_finder(x)
+    t = np.arange(0, 3, 0.01)
+    x = np.sin(np.pi*t) - np.sin(0.5*np.pi*t)
+    peak_locs, peak_mags = mne.preprocessing.peak_finder.peak_finder(x)
+
     """
     x0 = np.asanyarray(x0)
     s = x0.size
@@ -97,7 +96,7 @@ def peak_finder(x0, thresh=None, extrema=1, verbose=None):
                 length -= 1
 
         # Preallocate max number of maxima
-        maxPeaks = int(ceil(length / 2.0))
+        maxPeaks = int(np.ceil(length / 2.0))
         peak_loc = np.zeros(maxPeaks, dtype=np.int)
         peak_mag = np.zeros(maxPeaks)
         c_ind = 0


### PR DESCRIPTION
The example was still in Matlab syntax. I fixed it to work in Python.

Furthermore, the module imported math for its `ceil` function and numpy ... I dropped math and use `np.ceil` instead.

