### PR TITLE
MRG: Fix --noflash30

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug with ``mne flash_bem`` when ``flash30`` is not used by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1709,7 +1709,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
             files = glob.glob("mef05*u.mgz")
         else:
             files = glob.glob("mef05*.mgz")
-        cmd = ['mri_average', '-noconform', files, 'flash5.mgz']
+        cmd = ['mri_average', '-noconform'] + files + ['flash5.mgz']
         run_subprocess(cmd, env=env)
         if op.exists('flash5_reg.mgz'):
             os.remove('flash5_reg.mgz')

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1668,7 +1668,11 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
                     echos_done += 1
     # Step 1b : Run grad_unwarp on converted files
     os.chdir(op.join(mri_dir, "flash"))
-    files = glob.glob("mef*.mgz")
+    template = "mef*.mgz"
+    files = glob.glob(template)
+    if len(files) == 0:
+        raise ValueError('No suitable source files found (%s)'
+                         % op.join(os.getcwd(), template))
     if unwarp:
         logger.info("\n---- Unwarp mgz data sets ----")
         for infile in files:
@@ -1705,10 +1709,11 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
     else:
         logger.info("\n---- Averaging flash5 echoes ----")
         os.chdir('parameter_maps')
-        if unwarp:
-            files = glob.glob("mef05*u.mgz")
-        else:
-            files = glob.glob("mef05*.mgz")
+        template = "mef05*u.mgz" if unwarp else "mef05*.mgz"
+        files = glob.glob(template)
+        if len(files) == 0:
+            raise ValueError('No suitable source files found (%s)'
+                             % op.join(os.getcwd(), template))
         cmd = ['mri_average', '-noconform'] + files + ['flash5.mgz']
         run_subprocess(cmd, env=env)
         if op.exists('flash5_reg.mgz'):


### PR DESCRIPTION
Using `mne flash_bem --noflash30` which eventually calls `convert_flash_mris` fails because the `glob.glob` list result is not correctly inserted in the `cmd` list. This fixes it.

I don't see a way to add a test because this relies on `freesurfer` calls.