### PR TITLE
Fix default colormap for VectorSourceEstimate.plot()

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1959,7 +1959,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
                               self.subject, self.verbose)
 
     @copy_function_doc_to_method_doc(plot_vector_source_estimates)
-    def plot(self, subject=None, hemi='lh', colormap='auto', time_label='auto',
+    def plot(self, subject=None, hemi='lh', colormap='hot', time_label='auto',
              smoothing_steps=10, transparent=None, brain_alpha=0.4,
              overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
              time_viewer=False, subjects_dir=None, figure=None, views='lat',

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1715,7 +1715,7 @@ def _get_ps_kwargs(initial_time, require='0.6'):
     return initial_time, ad_kwargs, sd_kwargs
 
 
-def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='auto',
+def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                                  time_label='auto', smoothing_steps=10,
                                  transparent=None, brain_alpha=0.4,
                                  overlay_alpha=None, vector_alpha=1.0,
@@ -1745,8 +1745,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='auto',
     colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
         Name of colormap to use or a custom look up table. If array, must
         be (n x 3) or (n x 4) array for with RGB or RGBA values between
-        0 and 255. If 'auto' (default), either 'hot' or 'mne' will be chosen
-        based on whether 'lims' or 'pos_lims' are specified in ``clim``.
+        0 and 255.
     time_label : str | callable | None
         Format of the time label (a format string, a function that maps
         floating point time values to strings, or None for no label). The


### PR DESCRIPTION
For some reason, the `'mne'` colormap is chosen during vector source estimate plotting, resulting in this:

https://www.martinos.org/mne/stable/auto_examples/inverse/plot_vector_mne_solution.html#sphx-glr-auto-examples-inverse-plot-vector-mne-solution-py

The default colormap for `VectorSourceEstimate.plot()` should always be `'hot'`, since the colormap codes vector magnitudes, which are always positive, even if some data in `vec_stc.data` is negative.