### PR TITLE
MRG: Fix RtEpochs to support saving

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,9 @@ API
 
 - :meth:`mne.Evoked.plot_image` has gained the ability to ``show_names``, and if a selection is provided to ``group_by``, ``axes`` can now receive a `dict`, by `Jona Sassenhagen`_
 
+- Calling :meth:`mne.Epochs.decimate` with ``decim=1`` no longer copies the data by `Henrich Kolkhorst`_
+
+
 .. _changes_0_16:
 
 Version 0.16

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,7 @@ API
 
 - Calling :meth:`mne.Epochs.decimate` with ``decim=1`` no longer copies the data by `Henrich Kolkhorst`_
 
+- Removed blocking (waiting for new epochs) in :meth:`mne.realtime.RtEpochs.get_data()` by `Henrich Kolkhorst`_
 
 .. _changes_0_16:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,8 @@ Bug
 
 - Fix bug in :meth:`mne.preprocessing.ICA.plot_overlay` and :func:`mne.make_field_map` for CTF data with compensation by `Eric Larson`_
 
+- Fix bug in :class:`mne.realtime.RtEpochs` where events during the buildup of the buffer were not correctly processed when incoming data buffers are smaller than the epochs by `Henrich Kolkhorst`_
+
 API
 ~~~
 
@@ -2771,3 +2773,5 @@ of commits):
 .. _Susanna Aro: https://www.linkedin.com/in/susanna-aro
 
 .. _Joan Massich: https://github.com/massich
+
+.. _Henrich Kolkhorst: https://github.com/hekolk

--- a/examples/realtime/ftclient_rt_average.py
+++ b/examples/realtime/ftclient_rt_average.py
@@ -12,7 +12,7 @@ neuromag2ft --file MNE-sample-data/MEG/sample/sample_audvis_raw.fif
 
 using a modified version of neuromag2ft available at
 
-http://neuro.hut.fi/~mainak/neuromag2ft-2.0.0.zip
+https://staff.washington.edu/larsoner/minimal_cmds.tar.gz
 
 to run the FieldTrip buffer. Then running this example acquires the
 data on the client side.

--- a/examples/realtime/ftclient_rt_compute_psd.py
+++ b/examples/realtime/ftclient_rt_compute_psd.py
@@ -17,6 +17,7 @@ get_data_as_epoch function.
 
 import numpy as np
 import matplotlib.pyplot as plt
+import time
 
 import mne
 from mne.realtime import FieldTripClient
@@ -41,6 +42,10 @@ with FieldTripClient(host='localhost', port=1972,
 
     n_fft = 256  # the FFT size. Ideally a power of 2
     n_samples = 2048  # time window on which to compute FFT
+
+    # make sure at least one epoch is available
+    time.sleep(n_samples / raw_info['sfreq'])
+
     for ii in range(20):
         epoch = rt_client.get_data_as_epoch(n_samples=n_samples, picks=picks)
         psd, freqs = psd_welch(epoch, fmin=2, fmax=200, n_fft=n_fft)

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -71,7 +71,7 @@ clf = SVC(C=1, kernel='linear')
 concat_classifier = Pipeline([('filter', filt), ('vector', vectorizer),
                               ('scaler', scaler), ('svm', clf)])
 
-data_picks = mne.pick_types(rt_epochs.info, meg='grad', eeg=False, eog=True,
+data_picks = mne.pick_types(rt_epochs.info, meg='grad', eeg=False, eog=False,
                             stim=False, exclude=raw.info['bads'])
 ax = plt.subplot(111)
 ax.set_xlabel('Trials')

--- a/examples/realtime/rt_feedback_client.py
+++ b/examples/realtime/rt_feedback_client.py
@@ -29,7 +29,7 @@ for a real experiment.
 # License: BSD (3-clause)
 
 from mne.realtime import StimClient
-from psychopy import visual, core
+import time
 
 print(__doc__)
 
@@ -40,32 +40,6 @@ print(__doc__)
 # because they do not require root permission.
 stim_client = StimClient('localhost', port=4218)
 
-# create a window
-mywin = visual.Window([800, 600], monitor="testMonitor", units="deg")
-
-# create the stimuli
-
-# right checkerboard stimuli
-right_cb = visual.RadialStim(mywin, tex='sqrXsqr', color=1, size=5,
-                             visibleWedge=[0, 180], radialCycles=4,
-                             angularCycles=8, interpolate=False,
-                             autoLog=False)
-
-# left checkerboard stimuli
-left_cb = visual.RadialStim(mywin, tex='sqrXsqr', color=1, size=5,
-                            visibleWedge=[180, 360], radialCycles=4,
-                            angularCycles=8, interpolate=False,
-                            autoLog=False)
-
-# fixation dot
-fixation = visual.PatchStim(mywin, color=-1, colorSpace='rgb', tex=None,
-                            mask='circle', size=0.2)
-
-# the most accurate method is using frame refresh periods
-# however, since the actual refresh rate is not known
-# we use the Clock
-timer1 = core.Clock()
-timer2 = core.Clock()
 
 ev_list = list()  # list of events displayed
 
@@ -73,6 +47,7 @@ ev_list = list()  # list of events displayed
 # because the ev_list.append(ev_list[-1]) will not work
 # if ev_list is empty.
 trig = 4
+stim_duration = 1.0
 
 # iterating over 50 epochs
 for ii in range(50):
@@ -84,32 +59,14 @@ for ii in range(50):
 
     # draw left or right checkerboard according to ev_list
     if ev_list[ii] == 3:
-        left_cb.draw()
+        print('Stimulus: left checkerboard')
     else:
-        right_cb.draw()
+        print('Stimulus: right checkerboard')
 
-    fixation.draw()  # draw fixation
-    mywin.flip()  # show the stimuli
+    last_stim_time = time.time()
+    trig = stim_client.get_trigger(timeout=(stim_duration - 0.05))
 
-    timer1.reset()  # reset timer
-    timer1.add(0.75)  # display stimuli for 0.75 sec
+    time.sleep(max(stim_duration - (time.time() - last_stim_time), 0))
 
-    # return within 0.2 seconds (< 0.75 seconds) to ensure good timing
-    trig = stim_client.get_trigger(timeout=0.2)
-
-    # wait till 0.75 sec elapses
-    while timer1.getTime() < 0:
-        pass
-
-    fixation.draw()  # draw fixation
-    mywin.flip()  # show fixation dot
-
-    timer2.reset()  # reset timer
-    timer2.add(0.25)  # display stimuli for 0.25 sec
-
-    # display fixation cross for 0.25 seconds
-    while timer2.getTime() < 0:
-        pass
-
-mywin.close()  # close the window
-core.quit()
+    print('Stimulus: Fixation Cross')
+    time.sleep(0.25)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -524,6 +524,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         Decimation can be done multiple times. For example,
         ``epochs.decimate(2).decimate(2)`` will be the same as
         ``epochs.decimate(4)``.
+        If `decim` is 1, this method does not copy the underlying data.
 
         .. versionadded:: 0.10.0
         """
@@ -535,8 +536,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         decim_slice = slice(i_start, None, self._decim)
         self.info['sfreq'] = new_sfreq
         if self.preload:
-            self._data = self._data[:, :, decim_slice].copy()
-            self._raw_times = self._raw_times[decim_slice].copy()
+            if decim != 1:
+                self._data = self._data[:, :, decim_slice].copy()
+                self._raw_times = self._raw_times[decim_slice].copy()
+            else:
+                self._data = np.ascontiguousarray(self._data)
             self._decim_slice = slice(None)
             self._decim = 1
             self.times = self._raw_times

--- a/mne/realtime/mockclient.py
+++ b/mne/realtime/mockclient.py
@@ -63,8 +63,12 @@ class MockRtClient(object):
         tmin_samp = int(round(sfreq * tmin))
         tmax_samp = int(round(sfreq * tmax))
 
-        iter_times = zip(list(range(tmin_samp, tmax_samp, buffer_size)),
-                         list(range(buffer_size, tmax_samp, buffer_size)))
+        iter_times = list(zip(
+            list(range(tmin_samp, tmax_samp, buffer_size)),
+            list(range(buffer_size, tmax_samp + 1, buffer_size))))
+        last_iter_sample = iter_times[-1][1] if iter_times else 0
+        if last_iter_sample < tmax_samp:
+            iter_times.append((last_iter_sample, tmax_samp))
 
         for ii, (start, stop) in enumerate(iter_times):
             # channels are picked in _append_epoch_to_queue. No need to pick

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -8,13 +8,25 @@ import threading
 import subprocess
 import warnings
 import os.path as op
+import contextlib
+import socket
 
-from nose.tools import assert_true, assert_equal
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+import pytest
 
-import mne
-from mne.utils import requires_neuromag2ft, run_tests_if_main
-from mne.realtime import FieldTripClient
+from mne import Epochs, find_events, pick_types
+from mne.io import read_raw_fif
+from mne.utils import requires_neuromag2ft
+from mne.utils import run_tests_if_main
+from mne.realtime import FieldTripClient, RtEpochs
 from mne.externals.six.moves import queue
+
+from .test_mockclient import _call_base_epochs_public_api
+
+# Set our plotters to test mode
+import matplotlib
+matplotlib.use('Agg')  # for testing don't use X server
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.realpath(op.join(base_dir, 'test_raw.fif'))
@@ -22,14 +34,27 @@ raw_fname = op.realpath(op.join(base_dir, 'test_raw.fif'))
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
-def _run_buffer(kill_signal, neuromag2ft_fname):
-    # Works with neuromag2ft-3.0.2
-    cmd = (neuromag2ft_fname, '--file', raw_fname, '--speed', '4.0')
+@pytest.fixture
+def free_tcp_port():
+    """Returns a free TCP port"""
+    with contextlib.closing(socket.socket()) as free_socket:
+        free_socket.bind(('127.0.0.1', 0))
+        return free_socket.getsockname()[1]
 
+
+def _run_buffer(kill_signal, server_port):
+    """Start a FieldTrip Buffer from FIF file as a subprocess."""
+    neuromag2ft_fname = op.realpath(op.join(os.environ['NEUROMAG2FT_ROOT'],
+                                    'neuromag2ft'))
+    # Works with neuromag2ft-3.0.2
+    cmd = (neuromag2ft_fname, '--file', raw_fname, '--speed', '8.0',
+           '--bufport', str(server_port))
+
+    # sleep to make sure everything is setup before playback starts
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     # Let measurement continue for the entire duration
-    kill_signal.get(timeout=10.0)
+    kill_signal.get(timeout=40.0)
     process.terminate()
     with warnings.catch_warnings(record=True):  # still running
         process.stderr.close()
@@ -37,41 +62,101 @@ def _run_buffer(kill_signal, neuromag2ft_fname):
         del process
 
 
-@requires_neuromag2ft
-def test_fieldtrip_client():
-    """Test fieldtrip_client"""
-
-    neuromag2ft_fname = op.realpath(op.join(os.environ['NEUROMAG2FT_ROOT'],
-                                    'neuromag2ft'))
-
-    kill_signal = queue.Queue()
-    thread = threading.Thread(target=_run_buffer, args=(kill_signal,
-                                                        neuromag2ft_fname))
+def _start_buffer_thread(buffer_port):
+    """Start a FieldTrip Buffer in a background thread."""
+    signal_queue = queue.Queue()
+    thread = threading.Thread(target=_run_buffer,
+                              args=(signal_queue, buffer_port))
     thread.daemon = True
     thread.start()
-    time.sleep(0.25)
+    return signal_queue
+
+
+@pytest.mark.slowtest
+@requires_neuromag2ft
+def test_fieldtrip_rtepochs(free_tcp_port, tmpdir):
+    raw_tmax = 7
+    raw = read_raw_fif(raw_fname, preload=True)
+    raw.crop(tmin=0, tmax=raw_tmax)
+    events_offline = find_events(raw, stim_channel='STI 014')
+    event_id = list(np.unique(events_offline[:, 2]))
+    tmin, tmax = -0.2, 0.5
+    epochs_offline = Epochs(raw, events_offline, event_id=event_id,
+                            tmin=tmin, tmax=tmax)
+    epochs_offline.drop_bad()
+    isi_max = (np.max(np.diff(epochs_offline.events[:, 0])) /
+               raw.info['sfreq']) + 1.0
+
+    kill_signal = _start_buffer_thread(free_tcp_port)
+
+    try:
+        data_rt = None
+        events_ids_rt = None
+        with FieldTripClient(host='localhost', port=free_tcp_port,
+                             tmax=raw_tmax, wait_max=2) as rt_client:
+            # get measurement info guessed by MNE-Python
+            raw_info = rt_client.get_measurement_info()
+            assert ([ch['ch_name'] for ch in raw_info['chs']] ==
+                    [ch['ch_name'] for ch in raw.info['chs']])
+
+            # create the real-time epochs object
+            epochs_rt = RtEpochs(rt_client, event_id, tmin, tmax,
+                                 stim_channel='STI 014', isi_max=isi_max)
+            epochs_rt.start()
+
+            time.sleep(0.5)
+            for ev_num, ev in enumerate(epochs_rt.iter_evoked()):
+                if ev_num == 0:
+                    data_rt = ev.data[None, :, :]
+                    events_ids_rt = int(
+                        ev.comment)  # comment attribute contains the event_id
+                else:
+                    data_rt = np.concatenate((data_rt, ev.data[None, :, :]),
+                                             axis=0)
+                    events_ids_rt = np.append(events_ids_rt, int(ev.comment))
+
+            _call_base_epochs_public_api(epochs_rt, tmpdir)
+            epochs_rt.stop()
+
+        assert_array_equal(events_ids_rt, epochs_rt.events[:, 2])
+        assert_array_equal(data_rt, epochs_rt.get_data())
+        assert len(epochs_rt) == len(epochs_offline)
+        assert_array_equal(events_ids_rt, epochs_offline.events[:, 2])
+        assert_allclose(epochs_rt.get_data(), epochs_offline.get_data(),
+                        rtol=1.e-5, atol=1.e-8)  # defaults of np.isclose
+    finally:
+        kill_signal.put(False)  # stop the buffer
+
+
+@requires_neuromag2ft
+def test_fieldtrip_client(free_tcp_port):
+    """Test fieldtrip_client"""
+
+    kill_signal = _start_buffer_thread(free_tcp_port)
+
+    time.sleep(0.5)
 
     try:
         # Start the FieldTrip buffer
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            with FieldTripClient(host='localhost', port=1972,
-                                 tmax=5, wait_max=1) as rt_client:
+            with FieldTripClient(host='localhost', port=free_tcp_port,
+                                 tmax=5, wait_max=2) as rt_client:
                 tmin_samp1 = rt_client.tmin_samp
 
         time.sleep(1)  # Pause measurement
-        assert_true(len(w) >= 1)
+        assert len(w) >= 1
 
         # Start the FieldTrip buffer again
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            with FieldTripClient(host='localhost', port=1972,
-                                 tmax=5, wait_max=1) as rt_client:
+            with FieldTripClient(host='localhost', port=free_tcp_port,
+                                 tmax=5, wait_max=2) as rt_client:
                 raw_info = rt_client.get_measurement_info()
 
                 tmin_samp2 = rt_client.tmin_samp
-                picks = mne.pick_types(raw_info, meg='grad', eeg=False,
-                                       stim=False, eog=False)
+                picks = pick_types(raw_info, meg='grad', eeg=False,
+                                   stim=False, eog=False)
                 epoch = rt_client.get_data_as_epoch(n_samples=5, picks=picks)
                 n_channels, n_samples = epoch.get_data().shape[1:]
 
@@ -81,16 +166,14 @@ def test_fieldtrip_client():
                 # case of picks=None
                 epoch = rt_client.get_data_as_epoch(n_samples=5)
 
-        assert_true(tmin_samp2 > tmin_samp1)
-        assert_true(len(w) >= 1)
-        assert_equal(n_samples, 5)
-        assert_equal(n_samples2, 5)
-        assert_equal(n_channels, len(picks))
-        assert_equal(n_channels2, len(picks))
+        assert tmin_samp2 > tmin_samp1
+        assert len(w) >= 1
+        assert n_samples == 5
+        assert n_samples2 == 5
+        assert n_channels == len(picks)
+        assert n_channels2 == len(picks)
+    finally:
         kill_signal.put(False)  # stop the buffer
-    except Exception:
-        kill_signal.put(False)  # stop the buffer even if tests fail
-        raise
 
 
 run_tests_if_main()

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -1,11 +1,11 @@
 import os.path as op
 
 from nose.tools import assert_true
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 
 import mne
 from mne import Epochs, read_events, pick_channels
-from mne.utils import run_tests_if_main
+from mne.utils import (run_tests_if_main, _TempDir)
 from mne.realtime import MockRtClient, RtEpochs
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -39,6 +39,16 @@ def test_mockclient():
 
     assert_true(rt_data.shape == data.shape)
     assert_array_equal(rt_data, data)
+    assert_true(len(rt_epochs) == len(epochs))
+
+    tempdir = _TempDir()  # will be removed up when out of scope
+    export_file = str(op.join(tempdir, 'test_rt-epo.fif'))
+    rt_epochs.save(export_file)
+
+    loaded_epochs = mne.read_epochs(export_file)
+    loaded_data = loaded_epochs.get_data()
+    assert_true(rt_data.shape == loaded_data.shape)
+    assert_allclose(loaded_data, rt_data)
 
 
 def test_get_event_data():


### PR DESCRIPTION
Fixes #5191: Make sure the epochs invariants hold  for ``RtEpochs``.

I'm not completely happy with the ``_get_data()`` method since it relies on the "online iteration and blocking" over epochs rather than just returning the data received so far (which I would prefer, but didn't implement for compability).  I had to move the check for the timeout since otherwise iteration is typically only possible once (depending on the ``isi_max``).
The inherited implementation of _get_item was broken (but is called by ``save``).