### PR TITLE
MRG: Minor fixes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,10 @@ Bug
 
 - Fix bug in :func:`mne.preprocessing.ICA.apply` to handle arrays as `exclude` property by `Joan Massich`_
 
+- Fix bug in ``method='eLORETA'`` for :func:`mne.minimum_norm.apply_inverse` when using a sphere model and saved ``inv`` by `Eric Larson`_
+
+- Fix bug in :class:`mne.io.Raw` where warnings were emitted when objects were deleted by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -727,7 +727,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     def __del__(self):  # noqa: D105
         # remove file for memmap
-        if hasattr(self, '_data') and hasattr(self._data, 'filename'):
+        if hasattr(self, '_data') and \
+                getattr(self._data, 'filename') is not None:
             # First, close the file out; happens automatically on del
             filename = self._data.filename
             del self._data

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -138,7 +138,7 @@ def _sqrtm_sym(C):
     """Compute the square root of a symmetric matrix."""
     # Same as linalg.sqrtm(C) but faster, also yields the eigenvalues
     s, u = linalg.eigh(C)
-    mask = np.abs(s) > s.max() * 1e-12
+    mask = s > s.max() * 1e-7
     u = u[:, mask]
     s = np.sqrt(s[mask])
     a = np.dot(s * u, u.T)

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -18,8 +18,7 @@ from mne.source_estimate import read_source_estimate, VolSourceEstimate
 from mne import (read_cov, read_forward_solution, read_evokeds, pick_types,
                  pick_types_forward, make_forward_solution, EvokedArray,
                  convert_forward_solution, Covariance, combine_evoked,
-                 SourceEstimate, make_sphere_model, write_forward_solution,
-                 make_ad_hoc_cov)
+                 SourceEstimate, make_sphere_model, make_ad_hoc_cov)
 from mne.io import read_raw_fif, Info
 from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       apply_inverse_raw, apply_inverse_epochs,

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -456,7 +456,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
     stc : SourceEstimate | VolSourceEstimate
         The PSD (in dB) of each of the sources.
     """
-    from scipy.signal import hanning
+    from scipy.signal import hann
     _check_ori(pick_ori, inverse_operator['source_ori'])
 
     logger.info('Considering frequencies %g ... %g Hz' % (fmin, fmax))
@@ -473,7 +473,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
         stop = raw.time_as_index(tmax)[0] + 1
     n_fft = int(n_fft)
     Fs = raw.info['sfreq']
-    window = hanning(n_fft)
+    window = hann(n_fft)
     freqs = fftpack.fftfreq(n_fft, 1. / Fs)
     freqs_mask = (freqs >= 0) & (freqs >= fmin) & (freqs <= fmax)
     freqs = freqs[freqs_mask]


### PR DESCRIPTION
Fixes 3 minor problems:

1. eLORETA had threshold issues if `inv` was saved and loaded (threshes were for `float64` but I/O roundtrip makes them `float32`; also neg eigenvalues should be treated as zero)
2. `base.py` change should fix the issue brought up on the mailing list about coercing a filename `None` to unicode
3. Use `hann` instead of `hanning` as it's deprecated in `scipy`