### PR TITLE
MRG: Fix eLORETA sphere model (more)

### DIFF
--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -117,7 +117,10 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
         W_inv[:] = 1. / W
     else:
         for ii in range(n_src):
-            W_inv[ii] = linalg.pinv2(W[ii])
+            # Here we use a single-precision-suitable `rcond` (given our
+            # 3x3 matrix size) because the inv could be saved in single
+            # precision.
+            W_inv[ii] = linalg.pinv2(W[ii], rcond=1e-7)
 
     # Weight the gain matrix
     W_inv_Gt = np.empty_like(G).T


### PR DESCRIPTION
One more corner-case fix for eLORETA on sphere model after saving `inv` to disk. Pretty straightforward (needed `single`-type `rcond` in two places rather than one), now with assertion of zero localization bias.

I'll merge and backport once the CIs come back happy.