### PR TITLE
WIP start/stop kwargs also to epochs and evoked to_data_frame

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -206,7 +206,6 @@ class ToDataFrameMixin(object):
         if (isinstance(self, (BaseEpochs, Evoked)) and
                 start is not None or stop is not None):
             from ..utils import _is_numeric
-            print("hii9iiiiiii\n\n\n", start, stop, self.times[[0, 1, -2, -1]], "hii9iiiiiii\n\n\n")
 
             query = " time "
             if start is not None:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -87,13 +87,13 @@ class ToDataFrameMixin(object):
         copy : bool
             If true, data will be copied. Else data may be modified in place.
         start : int | None
-            If it is a Raw object, this defines a starting index for creating
-            the dataframe from a slice. The times will be interpolated from the
-            index and the sampling rate of the signal.
+            This defines a starting index for creating the dataframe from a
+            slice. The times will be interpolated from the index and the
+            sampling rate of the signal.
         stop : int | None
-            If it is a Raw object, this defines a stop index for creating
-            the dataframe from a slice. The times will be interpolated from the
-            index and the sampling rate of the signal.
+            This defines a stop index for creating the dataframe from a slice.
+            The times will be interpolated from the index and the sampling rate
+            of the signal.
 
         Returns
         -------
@@ -202,6 +202,32 @@ class ToDataFrameMixin(object):
             df.set_index(index, inplace=True)
         if all(i in default_index for i in index):
             df.columns.name = 'signal'
+
+        if (isinstance(self, (BaseEpochs, Evoked)) and
+                start is not None or stop is not None):
+            from ..utils import _is_numeric
+            print("hii9iiiiiii\n\n\n", start, stop, self.times[[0, 1, -2, -1]], "hii9iiiiiii\n\n\n")
+
+            query = " time "
+            if start is not None:
+                if not _is_numeric(start):
+                    raise TypeError("start must be numeric, not %s"
+                                    % type(start))
+                if start < self.times[0] or start > self.times[-2]:
+                    raise ValueError("start must not exceed time limits")
+                query = str(start) + " < " + query
+            if stop is not None:
+                if not _is_numeric(stop):
+                    raise TypeError("stop must be numeric, not %s"
+                                    % type(stop))
+                if stop < self.times[1] or stop > self.times[-1]:
+                    raise ValueError("stop must not exceed time limits")
+                query += " < " + str(stop)
+            if stop is not None and start is not None:
+                if start > stop:
+                    raise ValueError("start must be smaller than stop.")
+            df = df.query(query)
+
         return df
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -80,7 +80,7 @@ class ToDataFrameMixin(object):
             are 'epoch', 'time' and 'condition'. If None, all three info
             columns will be included in the table as categorial data.
         scaling_time : float
-            Scaling to be applied to time units.
+            Scaling to be applied to time units. Defaults to 1e3, i.e., msec.
         scalings : dict | None
             Scaling to be applied to the channels picked. If None, defaults to
             ``scalings=dict(eeg=1e6, grad=1e13, mag=1e15, misc=1.0)``.
@@ -90,11 +90,12 @@ class ToDataFrameMixin(object):
             This defines a starting index for creating the dataframe from a
             slice. The times will be interpolated from the index and the
             sampling rate of the signal.
+            Note that due to the default of scaling_time, this defaults to msec.
         stop : int | None
             This defines a stop index for creating the dataframe from a slice.
             The times will be interpolated from the index and the sampling rate
             of the signal.
-
+            Note that due to the default of scaling_time, this defaults to msec.
         Returns
         -------
         df : instance of pandas.core.DataFrame
@@ -212,15 +213,17 @@ class ToDataFrameMixin(object):
                 if not _is_numeric(start):
                     raise TypeError("start must be numeric, not %s"
                                     % type(start))
-                if start < self.times[0] or start > self.times[-2]:
-                    raise ValueError("start must not exceed time limits")
+                if (start < self.times[0]  * scaling_time or
+                    start > self.times[-2] * scaling_time):
+                        raise ValueError("start must not exceed time limits")
                 query = str(start) + " < " + query
             if stop is not None:
                 if not _is_numeric(stop):
                     raise TypeError("stop must be numeric, not %s"
                                     % type(stop))
-                if stop < self.times[1] or stop > self.times[-1]:
-                    raise ValueError("stop must not exceed time limits")
+                if (stop < self.times[1] * scaling_time or
+                    stop > self.times[-1] * scaling_time):
+                        raise ValueError("stop must not exceed time limits")
                 query += " < " + str(stop)
             if stop is not None and start is not None:
                 if start > stop:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -89,13 +89,17 @@ class ToDataFrameMixin(object):
         start : int | None
             This defines a starting index for creating the dataframe from a
             slice. The times will be interpolated from the index and the
-            sampling rate of the signal.
-            Note that due to the default of scaling_time, this defaults to msec.
+            sampling rate of the signal. For Raw objects, this is in samples;
+            for Epochs and Evoked objects, its unit correspond to that of the
+            Dataframe that is returned. Note that due to the default of
+            scaling_time, this defaults to msec.
         stop : int | None
             This defines a stop index for creating the dataframe from a slice.
             The times will be interpolated from the index and the sampling rate
-            of the signal.
-            Note that due to the default of scaling_time, this defaults to msec.
+            of the signal. For Raw objects, this is in samples;
+            for Epochs and Evoked objects, its unit correspond to that of the
+            Dataframe that is returned. Note that due to the default of
+            scaling_time, this defaults to msec.
         Returns
         -------
         df : instance of pandas.core.DataFrame

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -100,6 +100,7 @@ class ToDataFrameMixin(object):
             for Epochs and Evoked objects, its unit correspond to that of the
             Dataframe that is returned. Note that due to the default of
             scaling_time, this defaults to msec.
+
         Returns
         -------
         df : instance of pandas.core.DataFrame

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1600,6 +1600,14 @@ def test_to_data_frame():
     assert_true((df.columns == epochs.ch_names).all())
     assert_array_equal(df.values[:, 0], data[0] * 1e13)
     assert_array_equal(df.values[:, 2], data[2] * 1e15)
+
+    start, stop = epochs.times[[1, -2]]
+    df_startstop = epochs.to_data_frame(start=start, stop=stop)
+    df_startstop2 = df2.query(str(start) + " < time < " + str(stop))
+    assert_array_equal(df_startstop.values, df_startstop2.values)
+    assert_raises(ValueError, epochs.to_data_frame, start=epochs.times[-1] + 1)
+    assert_raises(TypeError, epochs.to_data_frame, stop='a string')
+
     for ind in ['time', ['condition', 'time'], ['condition', 'time', 'epoch']]:
         df = epochs.to_data_frame(picks=[11, 12, 14], index=ind)
         assert_true(df.index.names == ind if isinstance(ind, list) else [ind])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1601,11 +1601,12 @@ def test_to_data_frame():
     assert_array_equal(df.values[:, 0], data[0] * 1e13)
     assert_array_equal(df.values[:, 2], data[2] * 1e15)
 
-    start, stop = epochs.times[[1, -2]]
+    start, stop = epochs.times[[1, -2]] * 1e3
     df_startstop = epochs.to_data_frame(start=start, stop=stop)
     df_startstop2 = df2.query(str(start) + " < time < " + str(stop))
     assert_array_equal(df_startstop.values, df_startstop2.values)
-    assert_raises(ValueError, epochs.to_data_frame, start=epochs.times[-1] + 1)
+    assert_raises(ValueError, epochs.to_data_frame,
+                  start=1e3 * (epochs.times[-1] + 1))
     assert_raises(TypeError, epochs.to_data_frame, stop='a string')
 
     for ind in ['time', ['condition', 'time'], ['condition', 'time', 'epoch']]:

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -20,7 +20,8 @@ from scipy.fftpack import fft, ifft
 
 from ..baseline import rescale
 from ..parallel import parallel_func
-from ..utils import logger, verbose, _time_mask, check_fname, sizeof_fmt
+from ..utils import (logger, verbose, _time_mask, check_fname, sizeof_fmt,
+                     _is_numeric)
 from ..channels.channels import ContainsMixin, UpdateChannelsMixin
 from ..channels.layout import _pair_grad_sensors
 from ..io.pick import (pick_info, pick_types, _pick_data_channels,
@@ -2250,10 +2251,6 @@ def read_tfrs(fname, condition=None):
         inst = AverageTFR if is_average else EpochsTFR
         out = [inst(**d) for d in list(zip(*tfr_data))[1]]
     return out
-
-
-def _is_numeric(n):
-    return isinstance(n, (np.integer, np.floating, int, float))
 
 
 def _get_timefreqs(tfr, timefreqs):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2754,3 +2754,7 @@ def _validate_type(item, types, item_name, type_name=None):
     if not isinstance(item, types):
         raise TypeError(item_name, ' must be an instance of ', type_name,
                         ', got %s instead.' % (type(item),))
+
+
+def _is_numeric(n):
+    return isinstance(n, (np.integer, np.floating, int, float))

--- a/tutorials/plot_stats_cluster_erp.py
+++ b/tutorials/plot_stats_cluster_erp.py
@@ -60,14 +60,12 @@ print(epochs.to_data_frame()[elecs].head())
 report = "{elec}, time: {tmin}-{tmax} msec; t({df})={t_val:.3f}, p={p:.3f}"
 print("\nTargeted statistical test results:")
 for (tmin, tmax) in time_windows:
+    A = long.to_data_frame(start=tmin, stop=tmax)
+    B = short.to_data_frame(start=tmin, stop=tmax)
     for elec in elecs:
-        # extract data
-        time_win = "{} < time < {}".format(tmin, tmax)
-        A = long.to_data_frame().query(time_win)[elec].groupby("condition")
-        B = short.to_data_frame().query(time_win)[elec].groupby("condition")
-
         # conduct t test
-        t, p = ttest_ind(A.mean(), B.mean())
+        t, p = ttest_ind(A[elec].groupby("condition").mean(),
+                         B[elec].groupby("condition").mean())
 
         # display results
         format_dict = dict(elec=elec, tmin=tmin, tmax=tmax,

--- a/tutorials/plot_stats_cluster_erp.py
+++ b/tutorials/plot_stats_cluster_erp.py
@@ -57,7 +57,7 @@ elecs = ["Fz", "Cz", "Pz"]
 # display the EEG data in Pandas format (first 5 rows)
 print(epochs.to_data_frame()[elecs].head())
 
-report = "{elec}, time: {tmin}-{tmax} msec; t({df})={t_val:.3f}, p={p:.3f}"
+report = "{elec}, time: {tmin}-{tmax} s; t({df})={t_val:.3f}, p={p:.3f}"
 print("\nTargeted statistical test results:")
 for (tmin, tmax) in time_windows:
     A = long.to_data_frame(start=tmin, stop=tmax)


### PR DESCRIPTION
plot_stats_cluster_erp.py is too complicated.

only `raw.to_data_frame` can deal with start and stop, not epochs and evokeds.

This adds start and stop to epochs and evoked `to_data_frame`, which makes plot_stats_cluster_erp.py a bit simpler.