### PR TITLE
[MRG] VolSourceEstimate:  allow vector data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,8 @@ Bug
 
 - Fix bug in :class:`mne.io.Raw` where warnings were emitted when objects were deleted by `Eric Larson`_
 
+- Allow vector data for :class:`mne.VolSourceEstimate` by `Christian Brodbeck`_
+
 API
 ~~~
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -639,9 +639,9 @@ def test_inverse_operator_volume():
     """
     tempdir = _TempDir()
     evoked = _get_evoked()
-    inverse_operator_vol = read_inverse_operator(fname_vol_inv)
-    assert_true(repr(inverse_operator_vol))
-    stc = apply_inverse(evoked, inverse_operator_vol, lambda2, "dSPM")
+    inv_vol = read_inverse_operator(fname_vol_inv)
+    assert_true(repr(inv_vol))
+    stc = apply_inverse(evoked, inv_vol, lambda2, 'dSPM')
     assert_true(isinstance(stc, VolSourceEstimate))
     # volume inverses don't have associated subject IDs
     assert_true(stc.subject is None)
@@ -651,6 +651,10 @@ def test_inverse_operator_volume():
     assert_true(np.all(stc.data < 35))
     assert_array_almost_equal(stc.data, stc2.data)
     assert_array_almost_equal(stc.times, stc2.times)
+    # vector source estimate
+    stc_vec = apply_inverse(evoked, inv_vol, lambda2, 'dSPM', 'vector')
+    assert_true(repr(stc_vec))
+    assert_allclose(np.linalg.norm(stc_vec.data, axis=1), stc.data)
 
 
 @pytest.mark.slowtest

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -381,6 +381,8 @@ def _make_stc(data, vertices, tmin=None, tstep=None, subject=None,
                                  tstep=tstep, subject=subject)
     elif isinstance(vertices, np.ndarray) or isinstance(vertices, list)\
             and len(vertices) == 1:
+        if vector:
+            data = data.reshape((-1, 3, data.shape[-1]))
         stc = VolSourceEstimate(data, vertices=vertices, tmin=tmin,
                                 tstep=tstep, subject=subject)
     elif isinstance(vertices, list) and len(vertices) > 2:

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1819,7 +1819,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
         s += ", tmin : %s (ms)" % (1e3 * self.tmin)
         s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
         s += ", tstep : %s (ms)" % (1e3 * self.tstep)
-        s += ", data size : %s x %s" % self.shape
+        s += ", data size : %s" % ' x '.join(map(str, self.shape))
         return "<VolSourceEstimate  |  %s>" % s
 
     def get_peak(self, tmin=None, tmax=None, mode='abs',


### PR DESCRIPTION
This is the change I had to make to get vector volume source estimates. Should add a test.

CC: @agramfort @larsoner 