### PR TITLE
WIP: Avoid info['hpi_meas'] and info['hpi_results'] duplication in _merge_info

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1692,7 +1692,7 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
     other_fields = ['acq_pars', 'acq_stim', 'bads', 'buffer_size_sec',
                     'comps', 'custom_ref_applied', 'description', 'dig',
                     'experimenter', 'file_id', 'highpass', 
-		    'hpi_subsystem', 'events',
+                    'hpi_subsystem', 'events',
                     'line_freq', 'lowpass', 'meas_date', 'meas_id',
                     'proj_id', 'proj_name', 'projs', 'sfreq', 'gantry_angle',
                     'subject_info', 'sfreq', 'xplotter_layout', 'proc_history']

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1674,9 +1674,9 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
     else:
         raise ValueError("Trying to merge channels from different KIT systems")
 
-    # hpi infos:
-    hpi_infos = ['hpi_results', 'hpi_meas']
-    for k in hpi_infos:
+    # hpi infos and digitization data:
+    fields = ['hpi_results', 'hpi_meas', 'dig']
+    for k in fields:
         values = [i[k] for i in infos if i[k]]
         if len(values) == 0:
             info[k] = []
@@ -1685,13 +1685,13 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
         elif all(object_diff(values[0], v) == '' for v in values[1:]):
             info[k] = values[0]
         else:
-            msg = ("Measurement infos provide mutually inconsistent %s" %k)
+            msg = ("Measurement infos are inconsistent for %s" % k)
             raise ValueError(msg)
 
     # other fields
     other_fields = ['acq_pars', 'acq_stim', 'bads', 'buffer_size_sec',
-                    'comps', 'custom_ref_applied', 'description', 'dig',
-                    'experimenter', 'file_id', 'highpass', 
+                    'comps', 'custom_ref_applied', 'description',
+                    'experimenter', 'file_id', 'highpass',
                     'hpi_subsystem', 'events',
                     'line_freq', 'lowpass', 'meas_date', 'meas_id',
                     'proj_id', 'proj_name', 'projs', 'sfreq', 'gantry_angle',

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1674,11 +1674,25 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
     else:
         raise ValueError("Trying to merge channels from different KIT systems")
 
+    # hpi infos:
+    hpi_infos = ['hpi_results', 'hpi_meas']
+    for k in hpi_infos:
+        values = [i[k] for i in infos if i[k]]
+        if len(values) == 0:
+            info[k] = []
+        elif len(values) == 1:
+            info[k] = values[0]
+        elif all(object_diff(values[0], v) == '' for v in values[1:]):
+            info[k] = values[0]
+        else:
+            msg = ("Measurement infos provide mutually inconsistent %s" %k)
+            raise ValueError(msg)
+
     # other fields
     other_fields = ['acq_pars', 'acq_stim', 'bads', 'buffer_size_sec',
                     'comps', 'custom_ref_applied', 'description', 'dig',
-                    'experimenter', 'file_id', 'highpass',
-                    'hpi_results', 'hpi_meas', 'hpi_subsystem', 'events',
+                    'experimenter', 'file_id', 'highpass', 
+		    'hpi_subsystem', 'events',
                     'line_freq', 'lowpass', 'meas_date', 'meas_id',
                     'proj_id', 'proj_name', 'projs', 'sfreq', 'gantry_angle',
                     'subject_info', 'sfreq', 'xplotter_layout', 'proc_history']

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -324,6 +324,18 @@ def test_merge_info():
     info_b['kit_system_id'] = 60
     pytest.raises(ValueError, _merge_info, (info_a, info_b))
 
+    # hpi infos
+    info_d = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None) 
+    info_merged = _merge_info([info_a, info_d])
+    assert not info_merged['hpi_meas']
+    assert not info_merged['hpi_results']
+    info_a['hpi_meas'] = [{'f1': 3, 'f2': 4}]
+    assert _merge_info([info_a, info_d])['hpi_meas'] == info_a['hpi_meas']
+    info_d['hpi_meas'] = [{'f1': 3, 'f2': 4}]
+    assert _merge_info([info_a, info_d])['hpi_meas'] == info_d['hpi_meas']
+    # This will break because of inconsistency 
+    info_d['hpi_meas'] = [{'f1': 3, 'f2': 5}]
+    pytest.raises(ValueError, _merge_info, [info_a, info_d])
 
 def test_check_consistency():
     """Test consistency check of Info objects."""

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -325,7 +325,7 @@ def test_merge_info():
     pytest.raises(ValueError, _merge_info, (info_a, info_b))
 
     # hpi infos
-    info_d = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None) 
+    info_d = create_info(ch_names=['d', 'e', 'f'], sfreq=1000., ch_types=None)
     info_merged = _merge_info([info_a, info_d])
     assert not info_merged['hpi_meas']
     assert not info_merged['hpi_results']
@@ -333,9 +333,10 @@ def test_merge_info():
     assert _merge_info([info_a, info_d])['hpi_meas'] == info_a['hpi_meas']
     info_d['hpi_meas'] = [{'f1': 3, 'f2': 4}]
     assert _merge_info([info_a, info_d])['hpi_meas'] == info_d['hpi_meas']
-    # This will break because of inconsistency 
+    # This will break because of inconsistency
     info_d['hpi_meas'] = [{'f1': 3, 'f2': 5}]
     pytest.raises(ValueError, _merge_info, [info_a, info_d])
+
 
 def test_check_consistency():
     """Test consistency check of Info objects."""


### PR DESCRIPTION
Tentative solution to #5200.

@larsoner this seems to me the less invasive way to proceed. 

I was wondering, which other fields of the info structure should be treated like this?
`comps`, `dig`, `events`, `proc_history`, `meas_data` are lists as well but I'm not sure which should be allowed to be different in the infos to be merged. 
