### PR TITLE
MRG: Fix bug with apply_proj

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,8 @@ Bug
 
 - Allow vector data for :class:`mne.VolSourceEstimate` by `Christian Brodbeck`_
 
+- Fix bug in ``inst.apply_proj()`` where an average EEG reference was always added by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -229,7 +229,7 @@ def test_rank_estimation():
         n_proj = len(raw.info['projs'])
         assert_array_equal(raw.estimate_rank(tstart=0, tstop=3.,
                                              scalings=scalings),
-                           expected_rank - (1 if 'sss' in fname else n_proj))
+                           expected_rank - (0 if 'sss' in fname else n_proj))
 
 
 @testing.requires_testing_data

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -234,8 +234,8 @@ class ProjMixin(object):
                         'Setting proj attribute to True.')
             return self
 
-        _projector, info = setup_proj(deepcopy(self.info), activate=True,
-                                      verbose=self.verbose)
+        _projector, info = setup_proj(deepcopy(self.info), add_eeg_ref=False,
+                                      activate=True, verbose=self.verbose)
         # let's not raise a RuntimeError here, otherwise interactive plotting
         if _projector is None:  # won't be fun.
             logger.info('The projections don\'t apply to these data.'
@@ -276,8 +276,9 @@ class ProjMixin(object):
         if any(self.info['projs'][ii]['active'] for ii in idx):
             raise ValueError('Cannot remove projectors that have already '
                              'been applied')
-        self.info['projs'] = [p for pi, p in enumerate(self.info['projs'])
-                              if pi not in idx]
+        keep = np.ones(len(self.info['projs']))
+        keep[idx] = False  # works with negative indexing and does checks
+        self.info['projs'] = [p for p, k in zip(self.info['projs'], keep) if k]
         return self
 
     def plot_projs_topomap(self, ch_type=None, layout=None, axes=None):

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -30,6 +30,7 @@ from mne.tests.common import assert_naming, assert_snr
 from mne.utils import _TempDir, requires_version, run_tests_if_main
 from mne.io.proc_history import _get_sss_rank
 from mne.io.pick import channel_type, _picks_by_type, _DATA_CH_TYPES_SPLIT
+from mne.io.proj import _has_eeg_average_ref_proj
 from mne.datasets import testing
 from mne.event import make_fixed_length_events
 
@@ -406,8 +407,10 @@ def test_rank():
 
     # Now do some more comprehensive tests
     raw_sample = read_raw_fif(raw_fname)
+    assert not _has_eeg_average_ref_proj(raw_sample.info['projs'])
 
     raw_sss = read_raw_fif(hp_fif_fname)
+    assert not _has_eeg_average_ref_proj(raw_sss.info['projs'])
     raw_sss.add_proj(compute_proj_raw(raw_sss))
 
     cov_sample = compute_raw_covariance(raw_sample)
@@ -460,10 +463,6 @@ def test_rank():
             n_eeg, n_mag, n_grad = [ch_types.count(k) for k in
                                     ['eeg', 'mag', 'grad']]
             n_meg = n_mag + n_grad
-            if ch_type in ('all', 'eeg'):
-                n_projs_eeg = 1
-            else:
-                n_projs_eeg = 0
 
             # check sss
             if len(this_very_info['proc_history']) > 0:
@@ -473,8 +472,6 @@ def test_rank():
                     n_free = 0
                 # - n_projs XXX clarify
                 expected_rank = n_free + n_eeg
-                if n_projs > 0 and ch_type in ('all', 'eeg'):
-                    expected_rank -= n_projs_eeg
             else:
                 expected_rank = n_meg + n_eeg - n_projs
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -150,12 +150,12 @@ def test_volume_stc():
         with warnings.catch_warnings(record=True):  # nib<->numpy
             img = nib.load(vol_fname)
         assert_true(img.shape == t1_img.shape + (len(stc.times),))
-        assert_array_almost_equal(img.affine, t1_img.affine, decimal=5)
+        assert_allclose(img.affine, t1_img.affine, atol=1e-5)
 
         # export without saving
         img = stc.as_volume(src, dest='mri', mri_resolution=True)
         assert_true(img.shape == t1_img.shape + (len(stc.times),))
-        assert_array_almost_equal(img.affine, t1_img.affine, decimal=5)
+        assert_allclose(img.affine, t1_img.affine, atol=1e-5)
 
     except ImportError:
         print('Save as nifti test skipped, needs NiBabel')


### PR DESCRIPTION
Whenever `inst.apply_proj()` was called it would add an average EEG ref proj even if one was not present. This fixes it. We'll see if it breaks any test -- if so it probably means we need some `set_eeg_reference`.

Also allows negative indexing for projectors in `del_proj`.

Ready for merge. Tests pass locally so the CIs should also be happy.