### PR TITLE
MRG: Improve ProgressBar in parallel processing

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,8 @@ What's new
 Current
 -------
 
+- Add progress bar support to :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` by `Eric Larson`_
+
 Changelog
 ~~~~~~~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,8 +16,6 @@ What's new
 Current
 -------
 
-- Add progress bar support to :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` by `Eric Larson`_
-
 Changelog
 ~~~~~~~~~
 
@@ -40,6 +38,8 @@ Changelog
 - Add support for raw PSD plots in :meth:`mne.Report.parse_folder` via ``raw_psd`` argument of :class:`mne.Report` by `Eric Larson`_
 
 - Add `trig_shift_by_type` parameter in :func:`mne.io.read_raw_brainvision` to allow to specify offsets for arbitrary marker types by `Henrich Kolkhorst`_
+
+- Add progress bar support to :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` by `Eric Larson`_
 
 - Add :func:`mne.head_to_mri` to convert positions from head coordinates to MRI RAS coordinates, by `Joan Massich`_ and `Alex Gramfort`_
 

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -51,20 +51,24 @@ epochs = mne.Epochs(raw, events, event_id=event_id, tmin=tmin, tmax=tmax,
                     proj=True, picks=picks, baseline=None, preload=True,
                     reject=dict(mag=5e-12), decim=decim)
 
+###############################################################################
 # We will train the classifier on all left visual vs auditory trials
 # and test on all right visual vs auditory trials.
 clf = make_pipeline(StandardScaler(), LogisticRegression())
-time_gen = GeneralizingEstimator(clf, scoring='roc_auc', n_jobs=1)
+time_gen = GeneralizingEstimator(clf, scoring='roc_auc', n_jobs=2,
+                                 verbose=True)
 
 # Fit classifiers on the epochs where the stimulus was presented to the left.
 # Note that the experimental condition y indicates auditory or visual
 time_gen.fit(X=epochs['Left'].get_data(),
              y=epochs['Left'].events[:, 2] > 2)
 
+###############################################################################
 # Score on the epochs where the stimulus was presented to the right.
 scores = time_gen.score(X=epochs['Right'].get_data(),
                         y=epochs['Right'].events[:, 2] > 2)
 
+###############################################################################
 # Plot
 fig, ax = plt.subplots(1)
 im = ax.matshow(scores, vmin=0, vmax=1., cmap='RdBu_r', origin='lower',

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -55,7 +55,7 @@ epochs = mne.Epochs(raw, events, event_id=event_id, tmin=tmin, tmax=tmax,
 # We will train the classifier on all left visual vs auditory trials
 # and test on all right visual vs auditory trials.
 clf = make_pipeline(StandardScaler(), LogisticRegression())
-time_gen = GeneralizingEstimator(clf, scoring='roc_auc', n_jobs=2,
+time_gen = GeneralizingEstimator(clf, scoring='roc_auc', n_jobs=1,
                                  verbose=True)
 
 # Fit classifiers on the epochs where the stimulus was presented to the left.

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -432,6 +432,10 @@ class GeneralizingEstimator(SlidingEstimator):
     n_jobs : int, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
         If -1, then the number of jobs is set to the number of cores.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see
+        :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+        for more).
     """
 
     def __repr__(self):  # noqa: D105

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -145,7 +145,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
                                                  verbose=False)
         n_jobs = min(n_jobs, X.shape[-1])
         X_splits = np.array_split(X, n_jobs, axis=-1)
-        idx, est_splits = array_split_idx(self.estimators_, n_jobs)
+        idx, est_splits = zip(*array_split_idx(self.estimators_, n_jobs))
         y_pred = parallel(p_func(est, x, method, pb, pb_idx)
                           for pb_idx, est, x in zip(idx, est_splits, X_splits))
 

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -334,7 +334,7 @@ def _sl_fit(estimator, X, y, pb, **fit_params):
         est = clone(estimator)
         est.fit(X[..., ii], y, **fit_params)
         estimators_.append(est)
-        pb.finished(ii)
+        pb.update(ii + 1)
     return estimators_
 
 
@@ -365,7 +365,7 @@ def _sl_transform(estimators, X, method, pb):
         if ii == 0:
             y_pred = _sl_init_pred(_y_pred, X)
         y_pred[:, ii, ...] = _y_pred
-        pb.finished(ii)
+        pb.update(ii + 1)
     return y_pred
 
 
@@ -629,7 +629,7 @@ def _gl_transform(estimators, X, method, pb):
         if ii == 0:
             y_pred = _gl_init_pred(_y_pred, X, len(estimators))
         y_pred[:, ii, ...] = _y_pred
-        pb.finished(slice(ii * n_iter, (ii + 1) * n_iter))
+        pb.update((ii + 1) * n_iter)
     return y_pred
 
 
@@ -679,7 +679,7 @@ def _gl_score(estimators, scoring, X, y, pb):
                 dtype = type(_score)
                 score = np.zeros(score_shape, dtype)
             score[ii, jj, ...] = _score
-            pb.finished(jj * len(estimators) + ii)
+            pb.update(jj * len(estimators) + ii + 1)
     return score
 
 

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -89,12 +89,11 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         parallel, p_func, n_jobs = parallel_func(_sl_fit, self.n_jobs,
                                                  verbose=False)
         n_jobs = min(n_jobs, X.shape[-1])
-        pb = ProgressBar(X.shape[-1], verbose_bool='auto',
-                         mesg='Fitting %s' % (self.__class__.__name__,))
-        estimators = parallel(
-            p_func(self.base_estimator, split, y, pb, pb_idx, **fit_params)
-            for pb_idx, split in array_split_idx(X, n_jobs, axis=-1))
-        pb.cleanup()
+        with ProgressBar(X.shape[-1], verbose_bool='auto',
+                         mesg='Fitting %s' % (self.__class__.__name__,)) as pb:
+            estimators = parallel(
+                p_func(self.base_estimator, split, y, pb, pb_idx, **fit_params)
+                for pb_idx, split in array_split_idx(X, n_jobs, axis=-1))
 
         # Each parallel job can have a different number of training estimators
         # We can't directly concatenate them because of sklearn's Bagging API

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -42,21 +42,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         Use None to disable memmaping of large arrays. Use 'auto' to
         use the value set using mne.set_memmap_min_size.
     pre_dispatch : int, or string, optional
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-            - None, in which case all the jobs are immediately
-              created and spawned. Use this for lightweight and
-              fast-running jobs, to avoid delays due to on-demand
-              spawning of the jobs
-
-            - An int, giving the exact number of total jobs that are
-              spawned
-
-            - A string, giving an expression as a function of n_jobs,
-              as in '2*n_jobs'
+        See :class:`joblib.Parallel`.
     total : int | None
         If int, use a progress bar to display the progress.
         If None (default), do not.
@@ -75,7 +61,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         Parallel, delayed = _get_parallel()
         if Parallel is None:
             warn('joblib not installed. Cannot run in parallel.')
-        n_jobs = 1
+            n_jobs = 1
     if n_jobs == 1:
         n_jobs = 1
         my_func = func

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -58,13 +58,17 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
     n_jobs: int
         Number of jobs >= 0
     """
-    # for a single job, we don't need joblib
     should_print = (logger.level <= logging.INFO)
+    # for a single job, we don't need joblib
     if n_jobs != 1:
-        Parallel, delayed = _get_parallel()
-        if Parallel is None:
-            warn('joblib not installed. Cannot run in parallel.')
-            n_jobs = 1
+        try:
+            from joblib import Parallel, delayed
+        except ImportError:
+            try:
+                from sklearn.externals.joblib import Parallel, delayed
+            except ImportError:
+                warn('joblib not installed. Cannot run in parallel.')
+                n_jobs = 1
     if n_jobs == 1:
         n_jobs = 1
         my_func = func
@@ -112,17 +116,6 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
     else:
         parallel_out = parallel
     return parallel_out, my_func, n_jobs
-
-
-def _get_parallel():
-    try:
-        from joblib import Parallel, delayed
-    except ImportError:
-        try:
-            from sklearn.externals.joblib import Parallel, delayed
-        except ImportError:
-            Parallel = delayed = None
-    return Parallel, delayed
 
 
 def check_n_jobs(n_jobs, allow_cuda=False):

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -59,6 +59,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         Number of jobs >= 0
     """
     # for a single job, we don't need joblib
+    should_print = (logger.level <= logging.INFO)
     if n_jobs != 1:
         Parallel, delayed = _get_parallel()
         if Parallel is None:
@@ -90,7 +91,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
                     'in large memory savings.')
 
         # create keyword arguments for Parallel
-        kwargs = {'verbose': 5 if logger.level <= logging.INFO else 0}
+        kwargs = {'verbose': 5 if should_print and total is None else 0}
         kwargs['pre_dispatch'] = pre_dispatch
 
         if joblib_mmap:
@@ -105,7 +106,8 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
 
     if total is not None:
         def parallel_progress(op_iter):
-            return parallel(ProgressBar(total)(op_iter))
+            pb = ProgressBar(total, verbose_bool=should_print)
+            return parallel(pb(op_iter))
         parallel_out = parallel_progress
     else:
         parallel_out = parallel

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -44,8 +44,10 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
     pre_dispatch : int, or string, optional
         See :class:`joblib.Parallel`.
     total : int | None
-        If int, use a progress bar to display the progress.
-        If None (default), do not.
+        If int, use a progress bar to display the progress of dispatched
+        jobs. This should only be used when directly iterating, not when
+        using ``split_list`` or :func:`np.array_split`.
+        If None (default), do not add a progress bar.
 
     Returns
     -------

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -31,10 +31,6 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         A function
     n_jobs: int
         Number of jobs to run in parallel
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). INFO or DEBUG
-        will print parallel status, others will not.
     max_nbytes : int, str, or None
         Threshold on the minimum size of arrays passed to the workers that
         triggers automated memory mapping. Can be an int in Bytes,
@@ -48,6 +44,10 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         jobs. This should only be used when directly iterating, not when
         using ``split_list`` or :func:`np.array_split`.
         If None (default), do not add a progress bar.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more). INFO or DEBUG
+        will print parallel status, others will not.
 
     Returns
     -------

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -851,7 +851,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     del rng
     total = len(orders) if logger.level <= logging.INFO else None
     parallel, my_do_perm_func, _ = parallel_func(
-        do_perm_func, n_jobs, pre_dispatch=n_jobs, total=total)
+        do_perm_func, n_jobs, total=total, verbose=False)
 
     if len(clusters) == 0:
         warn('No clusters found, returning empty H0, clusters, and cluster_pv')

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -580,7 +580,7 @@ def _do_permutations(X_full, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[seed_idx] = 0
 
-        progress_bar.finished(seed_idx)
+        progress_bar.update(seed_idx + 1)
 
     return max_cluster_sums
 
@@ -651,7 +651,7 @@ def _do_1samp_permutations(X, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[seed_idx] = 0
 
-        progress_bar.finished(seed_idx)
+        progress_bar.update(seed_idx + 1)
 
     return max_cluster_sums
 

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -10,8 +10,6 @@
 #
 # License: Simplified BSD
 
-import logging
-
 import numpy as np
 from scipy import sparse
 
@@ -526,7 +524,7 @@ def _setup_connectivity(connectivity, n_vertices, n_times):
 
 def _do_permutations(X_full, slices, threshold, tail, connectivity, stat_fun,
                      max_step, include, partitions, t_power, orders,
-                     sample_shape, buffer_size, progress_bar, pb_idx):
+                     sample_shape, buffer_size, pb, pb_idx):
     n_samp, n_vars = X_full.shape
 
     if buffer_size is not None and n_vars <= buffer_size:
@@ -582,15 +580,14 @@ def _do_permutations(X_full, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[oi] = 0
 
-        if progress_bar is not None:
-            progress_bar[pb_idx[oi]] = True
+        pb[pb_idx[oi]] = True
 
     return max_cluster_sums
 
 
 def _do_1samp_permutations(X, slices, threshold, tail, connectivity, stat_fun,
                            max_step, include, partitions, t_power, orders,
-                           sample_shape, buffer_size, progress_bar, pb_idx):
+                           sample_shape, buffer_size, pb, pb_idx):
     n_samp, n_vars = X.shape
     assert slices is None  # should be None for the 1 sample case
 
@@ -654,8 +651,7 @@ def _do_1samp_permutations(X, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[oi] = 0
 
-        if progress_bar is not None:
-            progress_bar[pb_idx[oi]] = True
+        pb[pb_idx[oi]] = True
 
     return max_cluster_sums
 
@@ -872,7 +868,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     n_step_downs = 0
 
     while n_removed > 0:
-        pb = ProgressBar(len(orders)) if logger.level <= logging.INFO else None
+        pb = ProgressBar(len(orders), verbose_bool='auto')
         # actually do the clustering for each partition
         if include is not None:
             if step_down_include is not None:
@@ -915,8 +911,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
                         'cluster%s to exclude from subsequent iterations'
                         % (n_step_downs, n_removed, a_text,
                            _pl(n_removed)))
-        if pb is not None:
-            pb.cleanup()
+        pb.cleanup()
     logger.info('Done.')
     # The clusters should have the same shape as the samples
     clusters = _reshape_clusters(clusters, sample_shape)

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -524,7 +524,7 @@ def _setup_connectivity(connectivity, n_vertices, n_times):
 
 def _do_permutations(X_full, slices, threshold, tail, connectivity, stat_fun,
                      max_step, include, partitions, t_power, orders,
-                     sample_shape, buffer_size, pb, pb_idx):
+                     sample_shape, buffer_size, pb):
     n_samp, n_vars = X_full.shape
 
     if buffer_size is not None and n_vars <= buffer_size:
@@ -580,14 +580,14 @@ def _do_permutations(X_full, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[oi] = 0
 
-        pb[pb_idx[oi]] = True
+        pb.finished(oi)
 
     return max_cluster_sums
 
 
 def _do_1samp_permutations(X, slices, threshold, tail, connectivity, stat_fun,
                            max_step, include, partitions, t_power, orders,
-                           sample_shape, buffer_size, pb, pb_idx):
+                           sample_shape, buffer_size, pb):
     n_samp, n_vars = X.shape
     assert slices is None  # should be None for the 1 sample case
 
@@ -651,7 +651,7 @@ def _do_1samp_permutations(X, slices, threshold, tail, connectivity, stat_fun,
         else:
             max_cluster_sums[oi] = 0
 
-        pb[pb_idx[oi]] = True
+        pb.finished(oi)
 
     return max_cluster_sums
 
@@ -868,50 +868,50 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     n_step_downs = 0
 
     while n_removed > 0:
-        with ProgressBar(len(orders), verbose_bool='auto') as pb:
-            # actually do the clustering for each partition
-            if include is not None:
-                if step_down_include is not None:
-                    this_include = np.logical_and(include, step_down_include)
-                else:
-                    this_include = include
+        # actually do the clustering for each partition
+        if include is not None:
+            if step_down_include is not None:
+                this_include = np.logical_and(include, step_down_include)
             else:
-                this_include = step_down_include
-            logger.info('Permuting %d times%s...' % (len(orders), extra))
+                this_include = include
+        else:
+            this_include = step_down_include
+        logger.info('Permuting %d times%s...' % (len(orders), extra))
+        with ProgressBar(len(orders), verbose_bool='auto') as pb:
             H0 = parallel(my_do_perm_func(X_full, slices, threshold, tail,
                           connectivity, stat_fun, max_step, this_include,
                           partitions, t_power, order, sample_shape,
-                          buffer_size, pb, idx)
+                          buffer_size, pb.subset(idx))
                           for idx, order in split_list(
                               orders, n_jobs, idx=True))
-            # include original (true) ordering
-            if tail == -1:  # up tail
-                orig = cluster_stats.min()
-            elif tail == 1:
-                orig = cluster_stats.max()
-            else:
-                orig = abs(cluster_stats).max()
-            H0.insert(0, [orig])
-            H0 = np.concatenate(H0)
-            logger.info('Computing cluster p-values')
-            cluster_pv = _pval_from_histogram(cluster_stats, H0, tail)
+        # include original (true) ordering
+        if tail == -1:  # up tail
+            orig = cluster_stats.min()
+        elif tail == 1:
+            orig = cluster_stats.max()
+        else:
+            orig = abs(cluster_stats).max()
+        H0.insert(0, [orig])
+        H0 = np.concatenate(H0)
+        logger.info('Computing cluster p-values')
+        cluster_pv = _pval_from_histogram(cluster_stats, H0, tail)
 
-            # figure out how many new ones will be removed for step-down
-            to_remove = np.where(cluster_pv < step_down_p)[0]
-            n_removed = to_remove.size - total_removed
-            total_removed = to_remove.size
-            step_down_include = np.ones(n_tests, dtype=bool)
-            for ti in to_remove:
-                step_down_include[clusters[ti]] = False
-            if connectivity is None and connectivity is not False:
-                step_down_include.shape = sample_shape
-            n_step_downs += 1
-            if step_down_p > 0:
-                a_text = 'additional ' if n_step_downs > 1 else ''
-                logger.info('Step-down-in-jumps iteration #%i found %i %s'
-                            'cluster%s to exclude from subsequent iterations'
-                            % (n_step_downs, n_removed, a_text,
-                               _pl(n_removed)))
+        # figure out how many new ones will be removed for step-down
+        to_remove = np.where(cluster_pv < step_down_p)[0]
+        n_removed = to_remove.size - total_removed
+        total_removed = to_remove.size
+        step_down_include = np.ones(n_tests, dtype=bool)
+        for ti in to_remove:
+            step_down_include[clusters[ti]] = False
+        if connectivity is None and connectivity is not False:
+            step_down_include.shape = sample_shape
+        n_step_downs += 1
+        if step_down_p > 0:
+            a_text = 'additional ' if n_step_downs > 1 else ''
+            logger.info('Step-down-in-jumps iteration #%i found %i %s'
+                        'cluster%s to exclude from subsequent iterations'
+                        % (n_step_downs, n_removed, a_text,
+                           _pl(n_removed)))
     logger.info('Done.')
     # The clusters should have the same shape as the samples
     clusters = _reshape_clusters(clusters, sample_shape)

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -790,7 +790,7 @@ def test_progressbar_parallel_basic(capsys):
 
 def _identity_block(x, pb):
     for ii in range(len(x)):
-        pb.finished(ii)
+        pb.update(ii + 1)
     return x
 
 
@@ -817,7 +817,7 @@ def test_progressbar_parallel_advanced(capsys):
 def _identity_block_wide(x, pb):
     for ii in range(len(x)):
         for jj in range(2):
-            pb.finished(ii * 2 + jj)
+            pb.update(ii * 2 + jj + 1)
     return x, pb.idx
 
 

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -781,7 +781,8 @@ def identity(x):
 def test_progressbar_parallel_basic(capsys):
     """Test ProgressBar with parallel computing, basic version."""
     assert capsys.readouterr().out == ''
-    parallel, p_fun, _ = parallel_func(identity, total=10, n_jobs=2)
+    parallel, p_fun, _ = parallel_func(identity, total=10, n_jobs=2,
+                                       verbose=True)
     out = parallel(p_fun(x) for x in range(10))
     assert out == list(range(10))
     assert '100.00%' in capsys.readouterr().out

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -804,11 +804,40 @@ def test_progressbar_parallel_advanced(capsys):
                    for pb_idx, x in array_split_idx(arr, 2))
     assert op.isfile(pb._mmap_fname)
     sum_ = np.memmap(pb._mmap_fname, dtype='bool', mode='r', shape=10).sum()
-    assert sum_ == 10
+    assert sum_ == len(arr)
     pb.cleanup()
     assert not op.isfile(pb._mmap_fname)
     out = np.concatenate(out)
     assert_array_equal(out, arr)
+    assert '100.00%' in capsys.readouterr().out
+
+
+def identity_block_wide(x, pb, pb_idx):
+    for ii in range(len(x)):
+        for jj in range(2):
+            pb[pb_idx[ii * 2 + jj]] = True
+    return x, pb_idx
+
+
+def test_progressbar_parallel_more(capsys):
+    """Test ProgressBar with parallel computing, advanced version."""
+    assert capsys.readouterr().out == ''
+    # This must be "1" because "capsys" won't get stdout properly otherwise
+    parallel, p_fun, _ = parallel_func(identity_block_wide, n_jobs=1,
+                                       verbose=False)
+    arr = np.arange(10)
+    pb = ProgressBar(len(arr) * 2, verbose_bool=True)
+    out = parallel(p_fun(x, pb, pb_idx)
+                   for pb_idx, x in array_split_idx(arr, 2, n_per_split=2))
+    idxs = np.concatenate([o[1] for o in out])
+    assert_array_equal(idxs, np.arange(len(arr) * 2))
+    out = np.concatenate([o[0] for o in out])
+    assert op.isfile(pb._mmap_fname)
+    sum_ = np.memmap(pb._mmap_fname, dtype='bool', mode='r',
+                     shape=len(arr) * 2).sum()
+    assert sum_ == len(arr) * 2
+    pb.cleanup()
+    assert not op.isfile(pb._mmap_fname)
     assert '100.00%' in capsys.readouterr().out
 
 

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -781,7 +781,7 @@ def _identity(x):
 def test_progressbar_parallel_basic(capsys):
     """Test ProgressBar with parallel computing, basic version."""
     assert capsys.readouterr().out == ''
-    parallel, p_fun, _ = parallel_func(_identity, total=10, n_jobs=2,
+    parallel, p_fun, _ = parallel_func(_identity, total=10, n_jobs=1,
                                        verbose=True)
     out = parallel(p_fun(x) for x in range(10))
     assert out == list(range(10))

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1814,6 +1814,12 @@ class ProgressBar(object):
             yield obj
             self.update_with_increment_value(1)
 
+    def __call__(self, seq):
+        """Call the ProgressBar in a joblib-friendly way."""
+        while True:
+            yield next(seq)
+            self.update_with_increment_value(1)
+
 
 def _get_terminal_width():
     """Get the terminal width."""

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1747,12 +1747,9 @@ class ProgressBar(object):
             max_chars = min(max(max_total_width - 40, 10), 60)
         self.max_chars = int(max_chars)
         self.cur_rate = 0
-        if 'buffering' in _get_args(tempfile.NamedTemporaryFile):
-            kwargs = dict(buffering=0)
-        else:
-            kwargs = dict(bufsize=0)
-        self._mmap_fname = tempfile.NamedTemporaryFile(
-            'wb', prefix='tmp_mne_progress', **kwargs).name
+        tf = tempfile.NamedTemporaryFile('wb', prefix='tmp_mne_progress')
+        self._mmap_fname = tf.name
+        del tf  # should remove the file
         self._mmap = None
 
     def update(self, cur_value, mesg=None):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1845,6 +1845,21 @@ class ProgressBar(object):
             else:
                 self.update_with_increment_value(1)
 
+    def subset(self, idx):
+        """Make a joblib-friendly index subset updater.
+
+        Parameters
+        ----------
+        idx : ndarray
+            List of indices for this subset.
+
+        Returns
+        -------
+        updater : instance of PBSubsetUpdater
+            Class with a ``.update(ii)`` method.
+        """
+        return _PBSubsetUpdater(self, idx)
+
     def __setitem__(self, idx, val):
         """Use alternative, mmap-based incrementing (max_value must be int)."""
         if not self._do_print:
@@ -1856,7 +1871,7 @@ class ProgressBar(object):
         self._mmap[idx] = True
         self.update(self._mmap.sum())
 
-    def __enter__(self):
+    def __enter__(self):  # noqa: D105
         return self
 
     def __exit__(self, type, value, traceback):  # noqa: D105
@@ -1866,6 +1881,16 @@ class ProgressBar(object):
         if self._mmap is not None:
             self._mmap = None
             os.remove(self._mmap_fname)
+
+
+class _PBSubsetUpdater(object):
+
+    def __init__(self, pb, idx):
+        self.pb = pb
+        self.idx = idx
+
+    def finished(self, ii):
+        self.pb[self.idx[ii]] = True
 
 
 def _get_terminal_width():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -309,10 +309,15 @@ def split_list(l, n, idx=False):
     yield (np.arange(start, tot), l[start:]) if idx else l[start]
 
 
-def array_split_idx(ary, indices_or_sections, axis=0):
+def array_split_idx(ary, indices_or_sections, axis=0, n_per_split=1):
     """Do what numpy.array_split does, but add indices."""
-    return zip(np.array_split(np.arange(ary.shape[axis]), indices_or_sections),
-               np.array_split(ary, indices_or_sections, axis=axis))
+    # this only works for indices_or_sections as int
+    indices_or_sections = _ensure_int(indices_or_sections)
+    ary_split = np.array_split(ary, indices_or_sections, axis=axis)
+    idx_split = np.array_split(np.arange(ary.shape[axis]), indices_or_sections)
+    idx_split = (np.arange(sp[0] * n_per_split, (sp[-1] + 1) * n_per_split)
+                 for sp in idx_split)
+    return zip(idx_split, ary_split)
 
 
 def create_chunks(sequence, size):
@@ -1841,7 +1846,7 @@ class ProgressBar(object):
                 self.update_with_increment_value(1)
 
     def __setitem__(self, idx, val):
-        """Use alterative, mmap-based incrementing (max_value must be int)."""
+        """Use alternative, mmap-based incrementing (max_value must be int)."""
         if not self._do_print:
             return
         assert val is True

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1724,7 +1724,7 @@ class ProgressBar(object):
     """
 
     spinner_symbols = ['|', '/', '-', '\\']
-    template = '\r[{0}{1}] {2:.02f}% {4} {3}   '
+    template = '\r[{0}{1}] {2:6.02f}% {4} {3}   '
 
     def __init__(self, max_value, initial_value=0, mesg='', max_chars='auto',
                  progress_character='.', spinner=False,
@@ -1865,22 +1865,23 @@ class ProgressBar(object):
         if not self._do_print:
             return
         assert val is True
-        if self._mmap is None:
-            self._mmap = np.memmap(self._mmap_fname, bool, 'w+',
-                                   shape=self.max_value)
         self._mmap[idx] = True
         self.update(self._mmap.sum())
 
     def __enter__(self):  # noqa: D105
+        if op.isfile(self._mmap_fname):
+            os.remove(self._mmap_fname)
+        self._mmap = np.memmap(self._mmap_fname, bool, 'w+',
+                               shape=self.max_value)
         return self
 
     def __exit__(self, type, value, traceback):  # noqa: D105
         """Clean up memmapped file."""
         # we can't put this in __del__ b/c then each worker will delete the
         # file, which is not so good
-        if self._mmap is not None:
-            self._mmap = None
-            os.remove(self._mmap_fname)
+        self._mmap = None
+        os.remove(self._mmap_fname)
+        print('')
 
 
 class _PBSubsetUpdater(object):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1856,7 +1856,10 @@ class ProgressBar(object):
         self._mmap[idx] = True
         self.update(self._mmap.sum())
 
-    def cleanup(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):  # noqa: D105
         """Clean up memmapped file."""
         # we can't put this in __del__ b/c then each worker will delete the
         # file, which is not so good

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1889,8 +1889,8 @@ class _PBSubsetUpdater(object):
         self.pb = pb
         self.idx = idx
 
-    def finished(self, ii):
-        self.pb[self.idx[ii]] = True
+    def update(self, ii):
+        self.pb[self.idx[:ii]] = True
 
 
 def _get_terminal_width():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1817,8 +1817,12 @@ class ProgressBar(object):
     def __call__(self, seq):
         """Call the ProgressBar in a joblib-friendly way."""
         while True:
-            yield next(seq)
-            self.update_with_increment_value(1)
+            try:
+                yield next(seq)
+            except StopIteration:
+                return
+            else:
+                self.update_with_increment_value(1)
 
 
 def _get_terminal_width():

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1752,8 +1752,8 @@ class ProgressBar(object):
             max_chars = min(max(max_total_width - 40, 10), 60)
         self.max_chars = int(max_chars)
         self.cur_rate = 0
-        tf = tempfile.NamedTemporaryFile('wb', prefix='tmp_mne_progress')
-        self._mmap_fname = tf.name
+        with tempfile.NamedTemporaryFile('wb', prefix='tmp_mne_prog') as tf:
+            self._mmap_fname = tf.name
         del tf  # should remove the file
         self._mmap = None
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1871,8 +1871,9 @@ class ProgressBar(object):
     def __enter__(self):  # noqa: D105
         if op.isfile(self._mmap_fname):
             os.remove(self._mmap_fname)
+        # prevent corner cases where self.max_value == 0
         self._mmap = np.memmap(self._mmap_fname, bool, 'w+',
-                               shape=self.max_value)
+                               shape=max(self.max_value, 1))
         return self
 
     def __exit__(self, type, value, traceback):  # noqa: D105

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -87,7 +87,7 @@ plt.show()
 # You can retrieve the spatial filters and spatial patterns if you explicitly
 # use a LinearModel
 clf = make_pipeline(StandardScaler(), LinearModel(LogisticRegression()))
-time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc')
+time_decod = SlidingEstimator(clf, n_jobs=2, scoring='roc_auc', verbose=True)
 time_decod.fit(X, y)
 
 coef = get_coef(time_decod, 'patterns_', inverse_transform=True)
@@ -107,7 +107,8 @@ evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns',
 # generalizes to any other time point.
 
 # define the Temporal Generalization object
-time_gen = GeneralizingEstimator(clf, n_jobs=1, scoring='roc_auc')
+time_gen = GeneralizingEstimator(clf, n_jobs=1, scoring='roc_auc',
+                                 verbose=True)
 
 scores = cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=1)
 

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -67,8 +67,7 @@ y = epochs.events[:, 2]  # target: Audio left or right
 clf = make_pipeline(StandardScaler(), LogisticRegression())
 
 time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc', verbose=True)
-
-scores = cross_val_multiscore(time_decod, X, y, cv=5, n_jobs=2)
+scores = cross_val_multiscore(time_decod, X, y, cv=5, n_jobs=1)
 
 # Mean scores across cross-validation splits
 scores = np.mean(scores, axis=0)
@@ -88,7 +87,7 @@ plt.show()
 # You can retrieve the spatial filters and spatial patterns if you explicitly
 # use a LinearModel
 clf = make_pipeline(StandardScaler(), LinearModel(LogisticRegression()))
-time_decod = SlidingEstimator(clf, n_jobs=2, scoring='roc_auc', verbose=True)
+time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc', verbose=True)
 time_decod.fit(X, y)
 
 coef = get_coef(time_decod, 'patterns_', inverse_transform=True)
@@ -111,7 +110,7 @@ evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns',
 time_gen = GeneralizingEstimator(clf, n_jobs=1, scoring='roc_auc',
                                  verbose=True)
 
-scores = cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=2)
+scores = cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=1)
 
 # Mean scores across cross-validation splits
 scores = np.mean(scores, axis=0)

--- a/tutorials/plot_sensors_decoding.py
+++ b/tutorials/plot_sensors_decoding.py
@@ -66,9 +66,9 @@ y = epochs.events[:, 2]  # target: Audio left or right
 
 clf = make_pipeline(StandardScaler(), LogisticRegression())
 
-time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc')
+time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc', verbose=True)
 
-scores = cross_val_multiscore(time_decod, X, y, cv=5, n_jobs=1)
+scores = cross_val_multiscore(time_decod, X, y, cv=5, n_jobs=2)
 
 # Mean scores across cross-validation splits
 scores = np.mean(scores, axis=0)
@@ -84,6 +84,7 @@ ax.axvline(.0, color='k', linestyle='-')
 ax.set_title('Sensor space decoding')
 plt.show()
 
+###############################################################################
 # You can retrieve the spatial filters and spatial patterns if you explicitly
 # use a LinearModel
 clf = make_pipeline(StandardScaler(), LinearModel(LogisticRegression()))
@@ -110,7 +111,7 @@ evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns',
 time_gen = GeneralizingEstimator(clf, n_jobs=1, scoring='roc_auc',
                                  verbose=True)
 
-scores = cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=1)
+scores = cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=2)
 
 # Mean scores across cross-validation splits
 scores = np.mean(scores, axis=0)

--- a/tutorials/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/plot_stats_cluster_spatio_temporal.py
@@ -160,7 +160,8 @@ t_threshold = -stats.distributions.t.ppf(p_threshold / 2., n_subjects - 1)
 print('Clustering.')
 T_obs, clusters, cluster_p_values, H0 = clu = \
     spatio_temporal_cluster_1samp_test(X, connectivity=connectivity, n_jobs=1,
-                                       threshold=t_threshold, buffer_size=None)
+                                       threshold=t_threshold, buffer_size=None,
+                                       verbose=True)
 #    Now select the clusters that are sig. at p < 0.05 (note that this value
 #    is multiple-comparisons corrected).
 good_cluster_inds = np.where(cluster_p_values < 0.05)[0]


### PR DESCRIPTION
This PR fixes a problem with the ProgressBar during clustering where numbers can jump down in addition to going up. It does this by using one of two new modes:

1. "Easy" mode: if you do `parallel_func` without `array_split`, you can now do `parallel_func(..., total=10)` and it will automatically update as each dispatched job finishes.
2. Because "easy" mode won't be useful with `array_split` jobs, I added a mode to `ProgressBar` (along with helper `array_split_idx`) that uses memmapping to allow each job to write to a shared array when it finishes its work. Whenever a given pickled version of `ProgressBar` gets updated, it will `.sum()` this array and use this to update the progress to `stdout`, thereby ensuring monotonicaly increasing updates.

It also:

1. adds a `verbose_bool='auto'` to `ProgressBar`, which controls whether or not it actually prints based on the current `verbose` level, to simplify some logic in functions.
2. Simplifies a bit of logic in `parallel_func` to reduce code duplication (regarding `n_jobs == 1` and `joblib` being unavailable)

@kingjr can you see if this allows you to do what you want with `SlidingEstimator`? I didn't do all instances of `parallel_func`, but you hopefully get the idea in case you want to extend it.