### PR TITLE
MRG: Use stable versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,9 +28,9 @@ dependencies:
 - numexpr
 - pip:
   - mne
-  - "https://api.github.com/repos/enthought/traits/zipball/a99b3f64d50c5f7f28ffc01bf69419b061f9e976"
-  - "https://api.github.com/repos/enthought/pyface/zipball/6.0.0"
-  - "https://api.github.com/repos/enthought/traitsui/zipball/6.0.0"
+  - traits>=4.6.0
+  - pyface>=6
+  - traitsui>=6
   - "https://api.github.com/repos/enthought/mayavi/zipball/master"
   - "https://api.github.com/repos/nipy/PySurfer/zipball/master"
   - nitime

--- a/environment.yml
+++ b/environment.yml
@@ -29,8 +29,8 @@ dependencies:
 - pip:
   - mne
   - "https://api.github.com/repos/enthought/traits/zipball/a99b3f64d50c5f7f28ffc01bf69419b061f9e976"
-  - "https://api.github.com/repos/enthought/pyface/zipball/6a0cac149d56293482bb828a7d98122667c773be"
-  - "https://api.github.com/repos/enthought/traitsui/zipball/e366ad3886d3c39bedb96e83bab447d31c4ab725"
+  - "https://api.github.com/repos/enthought/pyface/zipball/6.0.0"
+  - "https://api.github.com/repos/enthought/traitsui/zipball/6.0.0"
   - "https://api.github.com/repos/enthought/mayavi/zipball/master"
   - "https://api.github.com/repos/nipy/PySurfer/zipball/master"
   - nitime

--- a/environment.yml
+++ b/environment.yml
@@ -26,11 +26,11 @@ dependencies:
 - flake8
 - spyder
 - numexpr
+- traits>=4.6.0
+- pyface>=6
+- traitsui>=6
 - pip:
   - mne
-  - traits>=4.6.0
-  - pyface>=6
-  - traitsui>=6
   - "https://api.github.com/repos/enthought/mayavi/zipball/master"
   - "https://api.github.com/repos/nipy/PySurfer/zipball/master"
   - nitime


### PR DESCRIPTION
6.0.0 for traitsui and pyface are out, let's see if this works. Also trying traits 4.6.0, but that might be too old and I'll have to revert that commit.