### PR TITLE
MRG : better detect type of src for making an stc

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -129,7 +129,6 @@ File I/O
    read_surface
    read_trans
    read_tri
-   save_stc_as_volume
    write_labels_to_annot
    write_bem_solution
    write_bem_surfaces

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,9 @@ API
 
 - Removed blocking (waiting for new epochs) in :meth:`mne.realtime.RtEpochs.get_data()` by `Henrich Kolkhorst`_
 
+- Deprecated save_stc_as_volume function in favor of :meth:`mne.VolSourceEstimate.as_volume` and
+   :meth:`mne.VolSourceEstimate.save_as_volume` by `Alex Gramfort`_
+
 .. _changes_0_16:
 
 Version 0.16

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ API
 - Deprecated save_stc_as_volume function in favor of :meth:`mne.VolSourceEstimate.as_volume` and
    :meth:`mne.VolSourceEstimate.save_as_volume` by `Alex Gramfort`_
 
+- `src.kind` now equals to `'mixed'` (and not `'combined'`) for a mixed source space (made of surfaces and volume grids) by `Alex Gramfort`_
+
 .. _changes_0_16:
 
 Version 0.16

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,9 @@ Bug
 
 - Fix bug in :func:`mne.viz.plot_snr_estimate` and :func:`mne.minimum_norm.estimate_snr` where the inverse rank was not properly utilized (especially affecting SSS'ed MEG data) by `Eric Larson`_
 
+- Fix error when saving stc as nifti image when using volume source space formed by more than one label by `Alex Gramfort`_
+
+
 API
 ~~~
 

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -101,8 +101,7 @@ stc.save('lcmv-vol')
 stc.crop(0.0, 0.2)
 
 # Save result in a 4D nifti file
-img = mne.save_stc_as_volume('lcmv_inverse.nii.gz', stc,
-                             forward['src'], mri_resolution=False)
+img = stc.as_volume(forward['src'], mri_resolution=False)
 
 t1_fname = data_path + '/subjects/sample/mri/T1.mgz'
 

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -368,6 +368,7 @@ def _apply_dics(data, filters, info, tmin):
 
             tstep = 1.0 / info['sfreq']
 
+            # XXX we should pass src to _make_stc
             stcs.append(_make_stc(sol, vertices=filters['vertices'], tmin=tmin,
                                   tstep=tstep, subject=subject))
         if one_freq:
@@ -567,6 +568,7 @@ def apply_dics_csd(csd, filters, verbose=None):
 
     logger.info('[done]')
 
+    # XXX we should pass src to _make_stc
     return (_make_stc(source_power.reshape(-1, n_freqs), vertices=vertices,
                       tmin=0, tstep=1, subject=subject), frequencies)
 
@@ -654,6 +656,7 @@ def _apply_old_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
         tstep = 1.0 / info['sfreq']
         if np.iscomplexobj(sol):
             sol = np.abs(sol)  # XXX : STC cannot contain (yet?) complex values
+        # XXX we should pass src to _make_stc
         yield _make_stc(sol, vertices=vertno, tmin=tmin, tstep=tstep,
                         subject=subject)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -344,6 +344,7 @@ def _apply_lcmv(data, filters, info, tmin, max_ori_out):
                 sol = np.abs(sol)
 
         tstep = 1.0 / info['sfreq']
+        # XXX we should pass src to _make_stc
         yield _make_stc(sol, vertices=filters['vertices'], tmin=tmin,
                         tstep=tstep, subject=subject, vector=vector,
                         source_nn=filters['source_nn'])

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1229,6 +1229,7 @@ def apply_inverse_epochs(epochs, inverse_operator, lambda2, method="dSPM",
     return stcs
 
 
+# XXX what is this???
 '''
 def _xyz2lf(Lf_xyz, normals):
     """Reorient leadfield to one component matching the normal to the cortex

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -947,7 +947,8 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
     subject = _subject_from_inverse(inverse_operator)
 
     stc = _make_stc(sol, vertno, tmin=tmin, tstep=tstep, subject=subject,
-                    vector=(pick_ori == 'vector'), source_nn=source_nn)
+                    vector=(pick_ori == 'vector'), source_nn=source_nn,
+                    src=inverse_operator['src'])
     logger.info('[done]')
 
     return stc
@@ -1086,7 +1087,8 @@ def apply_inverse_raw(raw, inverse_operator, lambda2, method="dSPM",
     tstep = 1.0 / raw.info['sfreq']
     subject = _subject_from_inverse(inverse_operator)
     stc = _make_stc(sol, vertno, tmin=tmin, tstep=tstep, subject=subject,
-                    vector=(pick_ori == 'vector'), source_nn=source_nn)
+                    vector=(pick_ori == 'vector'), source_nn=source_nn,
+                    src=inverse_operator['src'])
     logger.info('[done]')
 
     return stc
@@ -1153,7 +1155,8 @@ def _apply_inverse_epochs_gen(epochs, inverse_operator, lambda2, method='dSPM',
                 sol = np.dot(K, e[sel])
 
         stc = _make_stc(sol, vertno, tmin=tmin, tstep=tstep, subject=subject,
-                        vector=(pick_ori == 'vector'), source_nn=source_nn)
+                        vector=(pick_ori == 'vector'), source_nn=source_nn,
+                        src=inverse_operator['src'])
 
         yield stc
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1816,8 +1816,8 @@ class VolSourceEstimate(_BaseSourceEstimate):
         -----
         .. versionadded:: 0.9.0
         """
-        save_stc_as_volume(fname, self, src, dest=dest,
-                           mri_resolution=mri_resolution)
+        _save_stc_as_volume(fname, self, src, dest=dest,
+                            mri_resolution=mri_resolution)
 
     def as_volume(self, src, dest='mri', mri_resolution=False):
         """Export volume source estimate as a nifti object.
@@ -1844,8 +1844,8 @@ class VolSourceEstimate(_BaseSourceEstimate):
         -----
         .. versionadded:: 0.9.0
         """
-        return save_stc_as_volume(None, self, src, dest=dest,
-                                  mri_resolution=mri_resolution)
+        return _save_stc_as_volume(None, self, src, dest=dest,
+                                   mri_resolution=mri_resolution)
 
     def __repr__(self):  # noqa: D105
         if isinstance(self.vertices, list):

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -14,6 +14,7 @@ import numpy as np
 from scipy import linalg, sparse
 from scipy.sparse import coo_matrix, block_diag as sparse_block_diag
 
+from .utils import deprecated
 from .filter import resample
 from .fixes import einsum
 from .evoked import _get_peak
@@ -3078,7 +3079,41 @@ def _get_ico_tris(grade, verbose=None, return_surf=False):
         return ico
 
 
+@deprecated("This function is deprecated and will be removed in version 0.18. "
+            "Use instead stc.as_volume or stc.save_as_volume methods.")
 def save_stc_as_volume(fname, stc, src, dest='mri', mri_resolution=False):
+    """Save a volume source estimate in a NIfTI file.
+
+    This function is DEPRECATED.
+
+    Parameters
+    ----------
+    fname : string | None
+        The name of the generated nifti file. If None, the image is only
+        returned and not saved.
+    stc : instance of VolSourceEstimate
+        The source estimate
+    src : list
+        The list of source spaces (should actually be of length 1)
+    dest : 'mri' | 'surf'
+        If 'mri' the volume is defined in the coordinate system of
+        the original T1 image. If 'surf' the coordinate system
+        of the FreeSurfer surface is used (Surface RAS).
+    mri_resolution: bool
+        It True the image is saved in MRI resolution.
+        WARNING: if you have many time points the file produced can be
+        huge.
+
+    Returns
+    -------
+    img : instance Nifti1Image
+        The image object.
+    """
+    return _save_stc_as_volume(fname, stc, src, dest='mri',
+                               mri_resolution=False)
+
+
+def _save_stc_as_volume(fname, stc, src, dest='mri', mri_resolution=False):
     """Save a volume source estimate in a NIfTI file.
 
     Parameters

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1796,7 +1796,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
         fname : string
             The name of the generated nifti file.
         src : list
-            The list of source spaces (should actually be of length 1)
+            The list of source spaces (should all be of type volume).
         dest : 'mri' | 'surf'
             If 'mri' the volume is defined in the coordinate system of
             the original T1 image. If 'surf' the coordinate system
@@ -1824,7 +1824,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
         Parameters
         ----------
         src : list
-            The list of source spaces (should actually be of length 1)
+            The list of source spaces (should all be of type volume).
         dest : 'mri' | 'surf'
             If 'mri' the volume is defined in the coordinate system of
             the original T1 image. If 'surf' the coordinate system

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -370,10 +370,10 @@ def _get_src_type(src, vertices):
                 and len(vertices) == 1:
             src_type = 'volume'
         elif isinstance(vertices, list) and len(vertices) > 2:
-            src_type = 'combined'
+            src_type = 'mixed'
     else:
         src_type = src.kind
-    assert src_type in ['surface', 'volume', 'combined']
+    assert src_type in ['surface', 'volume', 'mixed']
     return src_type
 
 
@@ -410,7 +410,7 @@ def _make_stc(data, vertices, src=None, tmin=None, tstep=None, subject=None,
             data = data.reshape((-1, 3, data.shape[-1]))
         stc = VolSourceEstimate(data, vertices=vertices, tmin=tmin,
                                 tstep=tstep, subject=subject)
-    elif src_type == 'combined':
+    elif src_type == 'mixed':
         # make a mixed source estimate
         stc = MixedSourceEstimate(data, vertices=vertices, tmin=tmin,
                                   tstep=tstep, subject=subject)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -205,10 +205,10 @@ class SourceSpaces(list):
 
     @property
     def kind(self):
-        """The kind of source space (surface, volume, discrete)."""
+        """The kind of source space (surface, volume, discrete, mixed)."""
         ss_types = list(set([ss['type'] for ss in self]))
         if len(ss_types) != 1:
-            return 'combined'
+            return 'mixed'
         return _src_kind_dict[ss_types[0]]
 
     def __add__(self, other):

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -611,7 +611,7 @@ def test_combine_source_spaces():
     src_from_file = read_source_spaces(src_out_name)
     _compare_source_spaces(src, src_from_file, mode='approx')
     assert_equal(repr(src), repr(src_from_file))
-    assert_equal(src.kind, 'combined')
+    assert_equal(src.kind, 'mixed')
 
     # test that all source spaces are in MRI coordinates
     coord_frames = np.array([s['coord_frame'] for s in src])


### PR DESCRIPTION
closes #5224 

to debug

```
import os.path as op
import matplotlib.pyplot as plt
import mne
from mne.datasets import sample
from mne import setup_volume_source_space
from mne import make_forward_solution
from mne.minimum_norm import make_inverse_operator, apply_inverse
from nilearn.plotting import plot_stat_map
from nilearn.image import index_img

# Set dir
data_path = sample.data_path()
subject = 'sample'
data_dir = op.join(data_path, 'MEG', subject)
subjects_dir = op.join(data_path, 'subjects')
bem_dir = op.join(subjects_dir, subject, 'bem')
# Set file names
fname_aseg = op.join(subjects_dir, subject, 'mri', 'aseg.mgz')
fname_model = op.join(bem_dir, '%s-5120-bem.fif' % subject)
fname_bem = op.join(bem_dir, '%s-5120-bem-sol.fif' % subject)
fname_evoked = data_dir + '/sample_audvis-ave.fif'
fname_trans = data_dir + '/sample_audvis_raw-trans.fif'
fname_fwd = data_dir + '/sample_audvis-meg-oct-6-mixed-fwd.fif'
fname_cov = data_dir + '/sample_audvis-shrunk-cov.fif'
#########################################################################
labels_vol = ['Left-Hippocampus']  # labels_vol = ['Left-Hippocampus', ‘Right-Hippocampus’]
labels_vol = ['Left-Hippocampus', 'Right-Hippocampus']
sphere = (0, 0, 0, 120)
src = setup_volume_source_space(subject, mri=fname_aseg, pos=2.0, sphere=sphere,
                                        volume_label=labels_vol, subjects_dir=subjects_dir, 
                                        verbose=True)
fwd = make_forward_solution(fname_evoked, fname_trans, src, fname_bem, mindist=5.0,  
                            meg=True, eeg=False, n_jobs=1)
src_fwd = fwd['src']
n = sum(src_fwd[i]['nuse'] for i in range(len(src_fwd)))
print('the fwd src space contains %d spaces and %d points' % (len(src_fwd), n))
# Compute inverse solution 
snr = 3.0           
inv_method = 'MNE' # or MNE
lambda2 = 1.0 / snr ** 2
# Load data
condition = 'Left Auditory'
evoked = mne.read_evokeds(fname_evoked, condition=condition,
                          baseline=(None, 0))
noise_cov = mne.read_cov(fname_cov)
# Compute inverse operator
inverse_operator = make_inverse_operator(evoked.info, fwd, noise_cov,
                                         depth=None, fixed=False)
stcs = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
                     pick_ori=None)
######################################################################
src = fwd['src']
img = stcs.as_volume(src, mri_resolution=False)  # set True for full MRI resolution
t1_fname = data_path + '/subjects/sample/mri/T1.mgz'
# Plotting with nilearn ######################################################
plot_stat_map(index_img(img, 200), t1_fname, threshold=2*1e-9,
              title='%s (t=%.1f s.)' % (inv_method, stcs.times[61]))
plt.show()
```