### PR TITLE
allow data=None in filter.create_filter

### DIFF
--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1832,11 +1832,12 @@ def _triage_filter_params(x, sfreq, l_freq, h_freq,
             raise ValueError('filter_length must be a str, int, or None, got '
                              '%s' % (type(filter_length),))
 
-    if phase == 'zero' and method == 'fir':
-        filter_length += (filter_length % 2 == 0)
-    if filter_length <= 0:
-        raise ValueError('filter_length must be positive, got %s'
-                         % (filter_length,))
+    if filter_length is not 'auto':
+        if phase == 'zero' and method == 'fir':
+            filter_length += (filter_length % 2 == 0)
+        if filter_length <= 0:
+            raise ValueError('filter_length must be positive, got %s'
+                             % (filter_length,))
 
     # If we have data supplied, do a sanity check
     if x is not None:

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1055,7 +1055,7 @@ def create_filter(data=None, sfreq=None, l_freq=None, h_freq=None,
     # checks
     if data is None:
         logger.info('No data specified. No sanity checks performed.')
-        data = np.empty(sfreq**2)
+        data = np.empty(int(sfreq ** 2))
     if h_freq is not None:
         h_freq = np.array(h_freq, float).ravel()
         if (h_freq > (sfreq / 2.)).any():

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -872,10 +872,11 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
 
 @verbose
-def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
-                  l_trans_bandwidth='auto', h_trans_bandwidth='auto',
-                  method='fir', iir_params=None, phase='zero',
-                  fir_window='hamming', fir_design='firwin', verbose=None):
+def create_filter(data=None, sfreq=None, l_freq=None, h_freq=None,
+                  filter_length='auto', l_trans_bandwidth='auto',
+                  h_trans_bandwidth='auto', method='fir', iir_params=None,
+                  phase='zero', fir_window='hamming', fir_design='firwin',
+                  verbose=None):
     r"""Create a FIR or IIR filter.
 
     ``l_freq`` and ``h_freq`` are the frequencies below which and above
@@ -888,9 +889,9 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
 
     Parameters
     ----------
-    data : ndarray, shape (..., n_times)
+    data : ndarray, shape (..., n_times) | None
         The data that will be filtered. This is used for sanity checking
-        only.
+        only. If None, no sanity checking will be performed.
     sfreq : float
         The sample frequency in Hz.
     l_freq : float | None
@@ -1045,9 +1046,15 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
 
     .. versionadded:: 0.14
     """
-    sfreq = float(sfreq)
-    if sfreq < 0:
+    if sfreq is None or float(sfreq) < 0:
         raise ValueError('sfreq must be positive')
+    else:
+        sfreq = float(sfreq)
+    # If no data specified, sanity checking is invalid
+    # perform it on a dummy array that will never fail sanity checks
+    if data is None:
+        logger.info('No data specified. No sanity checks performed.')
+        data = np.random.random(1, sfreq * 100)
     if h_freq is not None:
         h_freq = np.array(h_freq, float).ravel()
         if (h_freq > (sfreq / 2.)).any():

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -890,7 +890,8 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
     ----------
     data : ndarray, shape (..., n_times) | None
         The data that will be filtered. This is used for sanity checking
-        only. If None, no sanity checking will be performed.
+        only. If None, no sanity checking related to the length of the signal
+        relative to the filter order will be performed.
     sfreq : float
         The sample frequency in Hz.
     l_freq : float | None
@@ -1050,7 +1051,9 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
         raise ValueError('sfreq must be positive')
     # If no data specified, sanity checking will be skipped
     if data is None:
-        logger.info('No data specified. Sanity checks will be skipped.')
+        logger.info('No data specified. Sanity checks related to the length of'
+                    ' the signal relative to the filter order will be'
+                    ' skipped.')
     if h_freq is not None:
         h_freq = np.array(h_freq, float).ravel()
         if (h_freq > (sfreq / 2.)).any():
@@ -1832,7 +1835,7 @@ def _triage_filter_params(x, sfreq, l_freq, h_freq,
             raise ValueError('filter_length must be a str, int, or None, got '
                              '%s' % (type(filter_length),))
 
-    if filter_length is not 'auto':
+    if filter_length != 'auto':
         if phase == 'zero' and method == 'fir':
             filter_length += (filter_length % 2 == 0)
         if filter_length <= 0:

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1051,10 +1051,11 @@ def create_filter(data=None, sfreq=None, l_freq=None, h_freq=None,
     else:
         sfreq = float(sfreq)
     # If no data specified, sanity checking is invalid
-    # perform it on a dummy array that will never fail sanity checks
+    # perform it on a dummy array that is long enough to never fail sanity
+    # checks
     if data is None:
         logger.info('No data specified. No sanity checks performed.')
-        data = np.random.random(1, sfreq * 100)
+        data = np.empty(sfreq**2)
     if h_freq is not None:
         h_freq = np.array(h_freq, float).ravel()
         if (h_freq > (sfreq / 2.)).any():

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -872,11 +872,10 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
 
 @verbose
-def create_filter(data, sfreq, l_freq, h_freq,
-                  filter_length='auto', l_trans_bandwidth='auto',
-                  h_trans_bandwidth='auto', method='fir', iir_params=None,
-                  phase='zero', fir_window='hamming', fir_design='firwin',
-                  verbose=None):
+def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
+                  l_trans_bandwidth='auto', h_trans_bandwidth='auto',
+                  method='fir', iir_params=None, phase='zero',
+                  fir_window='hamming', fir_design='firwin', verbose=None):
     r"""Create a FIR or IIR filter.
 
     ``l_freq`` and ``h_freq`` are the frequencies below which and above

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -305,6 +305,7 @@ def test_filters():
     assert_raises(ValueError, filter_data, a, sfreq, -1, None, None,
                   100, 1.0, 1.0, fir_design='firwin')
     # these should work
+    create_filter(None, sfreq)
     create_filter(a, sfreq, None, None, fir_design='firwin')
     create_filter(a, sfreq, None, None, method='iir')
 

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -305,7 +305,7 @@ def test_filters():
     assert_raises(ValueError, filter_data, a, sfreq, -1, None, None,
                   100, 1.0, 1.0, fir_design='firwin')
     # these should work
-    create_filter(None, sfreq)
+    create_filter(None, sfreq, None, None)
     create_filter(a, sfreq, None, None, fir_design='firwin')
     create_filter(a, sfreq, None, None, method='iir')
 


### PR DESCRIPTION
This PR is part of a bunch of issues around the reporting of filters, see #5226 .

Addressing the comment by @larsoner:

> mne.filter.create_filter will create the filter and give these log messages. You can pass it a dummy data array. Actually we should proably make data=None a possibility, meaning "skip length checks/warnings".