### PR TITLE
[MRG, Minor] Disallow invert_y input to epochs.plot_image

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -176,7 +176,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
 
     if "invert_y" in ts_args:
         raise NotImplementedError("'invert_y' found in 'ts_args'. "
-                                  "This currently not implemented.")
+                                  "This is currently not implemented.")
 
     manual_ylims = "ylim" in ts_args
     vlines = ts_args.get(

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -139,7 +139,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         Arguments passed to a call to `mne.viz.plot_compare_evoked` to style
         the evoked plot below the image. Defaults to an empty dictionary,
         meaning `plot_compare_evokeds` will be called with default parameters
-        (yaxis truncation will be turned off).
+        (yaxis truncation will be turned off, and inversion of the y axis
+        via `invert_y=True` will raise an error).
     title : None | str
         If str, will be plotted as figure title. Else, the channels will be
         indicated.
@@ -172,6 +173,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             picks = picks[:5]  # take 5 picks to prevent spawning many figs
     else:
         picks = np.atleast_1d(picks)
+
+    if "invert_y" in ts_args:
+        raise NotImplementedError("'invert_y' found in 'ts_args'. "
+                                  "This currently")
 
     manual_ylims = "ylim" in ts_args
     vlines = ts_args.get(

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -176,7 +176,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
 
     if "invert_y" in ts_args:
         raise NotImplementedError("'invert_y' found in 'ts_args'. "
-                                  "This currently")
+                                  "This currently not implemented.")
 
     manual_ylims = "ylim" in ts_args
     vlines = ts_args.get(

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -12,6 +12,7 @@ from nose.tools import assert_raises
 
 import numpy as np
 from numpy.testing import assert_equal
+import pytest
 
 from mne import read_events, Epochs, pick_types, read_cov
 from mne.channels import read_layout
@@ -171,7 +172,8 @@ def test_plot_epochs_image():
                       ts_args=ts_args)
         warnings.simplefilter('always')
     assert_equal(len(w), 1)
-    epochs.plot_image(ts_args=dict(invert_y=True))
+    with pytest.raises(NotImplementedError, match='currently'):
+        epochs.plot_image(ts_args=dict(invert_y=True))
 
     plt.close('all')
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -171,6 +171,7 @@ def test_plot_epochs_image():
                       ts_args=ts_args)
         warnings.simplefilter('always')
     assert_equal(len(w), 1)
+    epochs.plot_image(ts_args=dict(invert_y=True))
 
     plt.close('all')
 


### PR DESCRIPTION
closes #5240

Eventually, `epochs.plot_image` should be able to handle y axis inversion for the ERP, but I don't have the capacity to handle it right now.