### PR TITLE
WIP: Add Xdawn for SSP

### DIFF
--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -233,8 +233,7 @@ def test_compute_proj_xdawn():
             ('epochs_reg', proj_epochs_reg, [0.00, 0.01], [0.9, 0.95]),  # bad
             ('evoked', proj_evoked, [0.2, 0.3], [0.97, 0.99]),  # better
             ('xdawn', proj_xdawn, [0.2, 0.3], [0.15, 0.2]),  # better
-            ('xdawn_reg', proj_xdawn_reg, [0.3, 0.4], [0.01, 0.03]),  # best
-            ):
+            ('xdawn_reg', proj_xdawn_reg, [0.3, 0.4], [0.01, 0.03])):  # best
         exp_var = proj['explained_var']
         assert v_lim[0] <= exp_var <= v_lim[1], kind
         proj = proj['data']['data'][0]

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -142,10 +142,9 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
         except np.linalg.LinAlgError as exp:
             raise ValueError('Could not compute eigenvalues, ensure '
                              'proper regularization (%s)' % (exp,))
-        order = np.argsort(evals)[::-1]
-        evecs = evecs[:, order]  # sort eigenvectors
+        evecs = evecs[:, ::-1]  # sort eigenvectors
         evecs /= np.apply_along_axis(np.linalg.norm, 0, evecs)
-        evals = np.abs(evals[order])
+        evals = np.abs(evals[::-1])
         evals /= evals.sum()
         _patterns = np.linalg.pinv(evecs.T)
         filters.append(evecs[:, :n_components].T)


### PR DESCRIPTION
Adding `xdawn` as a way to compute projectors.

Currently has a test showing superior performance via regularization. Also unifies approaches to computing covariance.

Todo:

- [ ] add tests of `compute_e*g_projs`
- [ ] add test of SSS'ed data (reg?)
- [ ] add failure mode tests
- [ ] add to the SSP tutorial
- [ ] update `whats_new.rst`

Closes #5148.