### PR TITLE
MRG: group_by to evoked.plot_image

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -333,6 +333,7 @@ Projections:
    equalize_channels
    rename_channels
    generate_2d_layout
+   make_1020_channel_selections
 
 :py:mod:`mne.preprocessing`:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,8 @@ Changelog
 
 - Add ability to pass a precomputed forward solution to :func:`mne.simulation.simulate_raw` by `Eric Larson`_
 
+- Add :func:`mne.channels.make_1020_channel_selections` to group 10/20-named EEG channels by location, `Jona Sassenhagen`_
+
 Bug
 ~~~
 
@@ -50,6 +52,8 @@ API
 ~~~
 
 - Prepare transition to Python 3. This release will be the last release compatible with Python 2. The next version will be Python 3 only.
+
+- :meth:`mne.Evoked.plot_image` has gained the ability to ``show_names``, and if a selection is provided to ``group_by``, ``axes`` can now receive a `dict`, by `Jona Sassenhagen`_
 
 .. _changes_0_16:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Changelog
 
 - Add ability to pass a precomputed forward solution to :func:`mne.simulation.simulate_raw` by `Eric Larson`_
 
-- Add :func:`mne.channels.make_1020_channel_selections` to group 10/20-named EEG channels by location, `Jona Sassenhagen`_
+- Add :func:`mne.channels.make_1020_channel_selections` to group 10/20-named EEG channels by location, by `Jona Sassenhagen`_
 
 Bug
 ~~~

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -312,13 +312,13 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                    scalings=None, titles=None, axes=None, cmap='RdBu_r',
                    colorbar=True, mask=None, mask_style=None,
                    mask_cmap='Greys', mask_alpha=.25, time_unit='s',
-                   show_names=None):
+                   show_names=None, group_by=group_by):
         return plot_evoked_image(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             clim=clim, xlim=xlim, proj=proj, units=units, scalings=scalings,
             titles=titles, axes=axes, cmap=cmap, colorbar=colorbar, mask=mask,
             mask_style=mask_style, mask_cmap=mask_cmap, mask_alpha=mask_alpha,
-            time_unit=time_unit, show_names=show_names)
+            time_unit=time_unit, show_names=show_names, group_by=group_by)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
     def plot_topo(self, layout=None, layout_scale=0.945, color=None,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -312,7 +312,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                    scalings=None, titles=None, axes=None, cmap='RdBu_r',
                    colorbar=True, mask=None, mask_style=None,
                    mask_cmap='Greys', mask_alpha=.25, time_unit='s',
-                   show_names=None, group_by=group_by):
+                   show_names=None, group_by=None):
         return plot_evoked_image(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             clim=clim, xlim=xlim, proj=proj, units=units, scalings=scalings,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -213,23 +213,34 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
             raise TypeError( "If either `axes` or `group_by` is a dict, "
                              "the other must be, too.")
         _validate_if_list_of_axes(list(axes.values()))
-        for sel in group_by:  # ... we loop over selections
+        remove_xlabels = any([ax.is_last_row() for ax in axes.values()])
+        for ii, sel in enumerate(group_by):  # ... we loop over selections
             if sel not in axes:
                 raise ValueError(sel + " present in `group_by`, but not "
                                  "found in `axes`")
+            ax = axes[sel]
             # the unwieldly dict comp below defaults the title to the sel
             _plot_evoked(evoked, group_by[sel], exclude, unit, show, ylim,
                          proj, xlim, hline, units, scalings,
                          (titles if titles is not None else
                           {channel_type(evoked.info, idx): sel
                            for idx in group_by[sel]}),
-                         axes[sel], plot_type, cmap=cmap, gfp=gfp,
+                         ax, plot_type, cmap=cmap, gfp=gfp,
                          window_title=window_title,
                          set_tight_layout=set_tight_layout,
                          selectable=selectable, noise_cov=noise_cov,
                          colorbar=colorbar, mask=mask,
                          mask_style=mask_style, mask_cmap=mask_cmap,
-                         mask_alpha=mask_alpha, time_unit=time_unit)
+                         mask_alpha=mask_alpha, time_unit=time_unit,
+                         show_names=show_names)
+            if remove_xlabels and not ax.is_last_row():
+                ax.set_xticklabels([])
+                ax.set_xlabel("")
+        ims = [ax.images[0] for ax in axes.values()]
+        clims = np.array([im.get_clim() for im in ims])
+        min, max = clims.min(), clims.max()
+        for im in ims:
+            im.set_clim(min, max)
         return axes[sel].get_figure()
 
     time_unit, times = _check_time_unit(time_unit, evoked.times)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -214,12 +214,12 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                             "the other must be, too.")
         _validate_if_list_of_axes(list(axes.values()))
         remove_xlabels = any([ax.is_last_row() for ax in axes.values()])
-        for ii, sel in enumerate(group_by):  # ... we loop over selections
+        for sel in group_by:  # ... we loop over selections
             if sel not in axes:
                 raise ValueError(sel + " present in `group_by`, but not "
                                  "found in `axes`")
             ax = axes[sel]
-            # the unwieldly dict comp below defaults the title to the sel
+            # the unwieldy dict comp below defaults the title to the sel
             _plot_evoked(evoked, group_by[sel], exclude, unit, show, ylim,
                          proj, xlim, hline, units, scalings,
                          (titles if titles is not None else

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -213,9 +213,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
             for sel in group_by:
                 plt.figure()
                 axes[sel] = plt.axes()
-        elif isinstance(axes, dict):
-            pass
-        else:
+        if not isinstance(axes, dict):
             raise ValueError("If `group_by` is a dict, `axes` must be "
                              "a dict of axes or None.")
         _validate_if_list_of_axes(list(axes.values()))
@@ -253,7 +251,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
         else:
             return figs
     elif isinstance(axes, dict):
-        raise ValueError("If `group_by` isn't a dict, neither can `axes` be.")
+        raise ValueError("If `group_by` is not a dict, "
+                         "`axes` must not be a dict either.")
 
     time_unit, times = _check_time_unit(time_unit, evoked.times)
     info = evoked.info
@@ -894,8 +893,8 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
-        If ``group_by`` is a dict, this cannot be a list, but it can be a dict
-        of lists of axes, with the keys matching those of ``group_by``. In that
+        If `group_by` is a dict, this cannot be a list, but it can be a dict
+        of lists of axes, with the keys matching those of `group_by`. In that
         case, the provided axes will be used for the corresponding groups.
         Defaults to `None`.
     cmap : matplotlib colormap | (colormap, bool) | 'interactive'

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -210,8 +210,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
     if plot_type == "image" and any(isinstance(thing, dict)
                                     for thing in (axes, group_by)):
         if not all(isinstance(thing, dict) for thing in (axes, group_by)):
-            raise TypeError( "If either `axes` or `group_by` is a dict, "
-                             "the other must be, too.")
+            raise TypeError("If either `axes` or `group_by` is a dict, "
+                            "the other must be, too.")
         _validate_if_list_of_axes(list(axes.values()))
         remove_xlabels = any([ax.is_last_row() for ax in axes.values()])
         for ii, sel in enumerate(group_by):  # ... we loop over selections

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -162,6 +162,11 @@ def test_plot_evoked():
         assert_true(tick_target in str(tick_observed))
     evoked.plot_image(show_names=True, time_unit='s')
 
+    # test groupby
+    evoked.plot_image(group_by=dict(sel=[0, 7]), axes=dict(sel=plt.axes()))
+    plt.close('all')
+
+    # test plot_topo
     evoked.plot_topo()  # should auto-find layout
     _line_plot_onselect(0, 200, ['mag', 'grad'], evoked.info, evoked.data,
                         evoked.times)

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -167,7 +167,7 @@ def test_plot_evoked():
     evoked.plot_image(group_by=dict(sel=[0, 7]), axes=dict(sel=plt.axes()))
     plt.close('all')
     for group_by, axes in (("something", dict()), (dict(), "something")):
-        assert_raises(TypeError, evoked.plot_image, group_by=group_by,
+        assert_raises(ValueError, evoked.plot_image, group_by=group_by,
                       axes=axes)
 
     # test plot_topo

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -133,6 +133,7 @@ def test_plot_evoked():
     assert_raises(ValueError, evoked.plot, gfp='foo', time_unit='s')
 
     evoked.plot_image(proj=True, time_unit='ms')
+
     # test mask
     evoked.plot_image(picks=[1, 2], mask=evoked.data > 0, time_unit='s')
     evoked.plot_image(picks=[1, 2], mask_cmap=None, colorbar=False,
@@ -165,6 +166,9 @@ def test_plot_evoked():
     # test groupby
     evoked.plot_image(group_by=dict(sel=[0, 7]), axes=dict(sel=plt.axes()))
     plt.close('all')
+    for group_by, axes in (("something", dict()), (dict(), "something")):
+        assert_raises(TypeError, evoked.plot_image, group_by=group_by,
+                      axes=axes)
 
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout

--- a/tutorials/plot_stats_cluster_erp.py
+++ b/tutorials/plot_stats_cluster_erp.py
@@ -117,7 +117,7 @@ selections = make_1020_channel_selections(evoked.info, midline="12z")
 
 # Visualize the results
 fig, axes = plt.subplots(nrows=3, figsize=(8, 8))
-axes = {sel: ax for sel, ax in zip(selections, axes.ravel().tolist())}
+axes = {sel: ax for sel, ax in zip(selections, axes.ravel())}
 evoked.plot_image(axes=axes, group_by=selections, colorbar=False, show=False,
                   mask=significant_points, show_names="all", titles=None,
                   **time_unit)

--- a/tutorials/plot_stats_cluster_erp.py
+++ b/tutorials/plot_stats_cluster_erp.py
@@ -39,8 +39,8 @@ name = "NumberOfLetters"
 
 # Split up the data by the median length in letters via the attached metadata
 median_value = str(epochs.metadata[name].median())
-long = epochs[name + " > " + median_value]
-short = epochs[name + " < " + median_value]
+long_words = epochs[name + " > " + median_value]
+short_words = epochs[name + " < " + median_value]
 
 #############################################################################
 # If we have a specific point in space and time we wish to test, it can be
@@ -60,8 +60,8 @@ print(epochs.to_data_frame()[elecs].head())
 report = "{elec}, time: {tmin}-{tmax} s; t({df})={t_val:.3f}, p={p:.3f}"
 print("\nTargeted statistical test results:")
 for (tmin, tmax) in time_windows:
-    long_df = long.copy().crop(tmin, tmax).to_data_frame()
-    short_df = short.copy().crop(tmin, tmax).to_data_frame()
+    long_df = long_words.copy().crop(tmin, tmax).to_data_frame()
+    short_df = short_words.copy().crop(tmin, tmax).to_data_frame()
     for elec in elecs:
         # extract data
         A = long_df[elec].groupby("condition").mean()
@@ -89,12 +89,12 @@ con = find_ch_connectivity(epochs.info, "eeg")
 # Extract data: transpose because the cluster test requires channels to be last
 # In this case, inference is done over items. In the same manner, we could
 # also conduct the test over, e.g., subjects.
-X = [long.get_data().transpose(0, 2, 1),
-     short.get_data().transpose(0, 2, 1)]
+X = [long_words.get_data().transpose(0, 2, 1),
+     short_words.get_data().transpose(0, 2, 1)]
 tfce = dict(start=.2, step=.2)
 
 t_obs, clusters, cluster_pv, h0 = spatio_temporal_cluster_test(
-    X, tfce, n_permutations=100)
+    X, tfce, n_permutations=100)  # a more standard number would be 1000+
 significant_points = cluster_pv.reshape(t_obs.shape).T < .05
 print(str(significant_points.sum()) + " points selected by TFCE ...")
 
@@ -106,7 +106,7 @@ print(str(significant_points.sum()) + " points selected by TFCE ...")
 # effects on the head.
 
 # We need an evoked object to plot the image to be masked
-evoked = mne.combine_evoked([long.average(), -short.average()],
+evoked = mne.combine_evoked([long_words.average(), -short_words.average()],
                             weights='equal')  # calculate difference wave
 time_unit = dict(time_unit="s")
 evoked.plot_joint(title="Long vs. short words", ts_args=time_unit,
@@ -117,21 +117,11 @@ selections = make_1020_channel_selections(evoked.info, midline="12z")
 
 # Visualize the results
 fig, axes = plt.subplots(nrows=3, figsize=(8, 8))
-vmax = np.abs(evoked.data).max() * 1e6
-
-# Iterate over ROIs and axes
-axes = axes.ravel().tolist()
-for selection_name, ax in zip(sorted(selections.keys()), axes):
-    picks = selections[selection_name]
-    evoked.plot_image(picks=picks, axes=ax, colorbar=False, show=False,
-                      clim=dict(eeg=(-vmax, vmax)), mask=significant_points,
-                      **time_unit, show_names="all")
-    evoked.nave = None  # to suppress printing trial count for other images
-    if not ax.is_last_row():  # remove xticklabels for all but bottom axis
-        ax.set(xlabel='', xticklabels=[])
-    ax.set(ylabel='', title=selection_name)
-
-fig.colorbar(ax.images[-1], ax=axes, fraction=.1, aspect=20,
-             pad=.05, shrink=2 / 3, label="uV", orientation="vertical")
+axes = {sel: ax for sel, ax in zip(selections, axes.ravel().tolist())}
+evoked.plot_image(axes=axes, group_by=selections, colorbar=False, show=False,
+                  mask=significant_points, show_names="all", titles=None,
+                  **time_unit)
+plt.colorbar(axes["Left"].images[-1], ax=list(axes.values()), shrink=.3,
+             label="uV")
 
 plt.show()


### PR DESCRIPTION
And the last one for `evoked.plot_image` from #5170

Adds a group_by option to evoked.plot_image that allows feeding a dict to `axes`. I.e., for making a channel selection with `make_1020_selection`.