### PR TITLE
MRG: Deprecate unneeded and unused alpha parameter from f_mway_rm().

### DIFF
--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -9,6 +9,7 @@ from functools import reduce
 from string import ascii_uppercase
 
 from ..externals.six import string_types
+from ..utils import warn
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
@@ -274,8 +275,8 @@ def f_threshold_mway_rm(n_subjects, factor_levels, effects='A*B',
     return F_threshold if len(F_threshold) > 1 else F_threshold[0]
 
 
-def f_mway_rm(data, factor_levels, effects='all', correction=False,
-              return_pvals=True):
+def f_mway_rm(data, factor_levels, effects='all', alpha=None,
+              correction=False, return_pvals=True):
     """Compute M-way repeated measures ANOVA for fully balanced designs.
 
     Parameters
@@ -306,6 +307,8 @@ def f_mway_rm(data, factor_levels, effects='all', correction=False,
             * ``'all'``: all effects (equals 'A*B' in a 2 way design)
 
         If list, effect names are used: ``['A', 'B', 'A:B']``.
+    alpha : float
+        This argument is deprecated.
     correction : bool
         The correction method to be employed if one factor has more than two
         levels. If True, sphericity correction using the Greenhouse-Geisser
@@ -332,6 +335,11 @@ def f_mway_rm(data, factor_levels, effects='all', correction=False,
     .. versionadded:: 0.10
     """
     from scipy.stats import f
+
+    if alpha is not None:
+        warn('alpha is deprecated and will be removed in 0.18.',
+             DeprecationWarning)
+
     if data.ndim == 2:  # general purpose support, e.g. behavioural data
         data = data[:, :, np.newaxis]
     elif data.ndim > 3:  # let's allow for some magic here.

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -274,8 +274,8 @@ def f_threshold_mway_rm(n_subjects, factor_levels, effects='A*B',
     return F_threshold if len(F_threshold) > 1 else F_threshold[0]
 
 
-def f_mway_rm(data, factor_levels, effects='all', alpha=0.05,
-              correction=False, return_pvals=True):
+def f_mway_rm(data, factor_levels, effects='all', correction=False,
+              return_pvals=True):
     """Compute M-way repeated measures ANOVA for fully balanced designs.
 
     Parameters
@@ -306,8 +306,6 @@ def f_mway_rm(data, factor_levels, effects='all', alpha=0.05,
             * ``'all'``: all effects (equals 'A*B' in a 2 way design)
 
         If list, effect names are used: ``['A', 'B', 'A:B']``.
-    alpha : float
-        The significance threshold.
     correction : bool
         The correction method to be employed if one factor has more than two
         levels. If True, sphericity correction using the Greenhouse-Geisser


### PR DESCRIPTION
The function f_mway_rm() has a parameter alpha, which is not needed or used by the function. This fix removes the parameter.