### PR TITLE
MRG allow passing axes to evoked.plot_joint

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,8 @@ Changelog
 
 - Add possibility to save :class:`mne.VolSourceEstimate` and :class:`mne.MixedSourceEstimate` to HDF5 format (file extension .h5) with :meth:`mne.VolSourceEstimate.save` and :meth:`mne.MixedSourceEstimate.save` by `Alex Gramfort`_
 
+- Add ability to pass ``axes`` to ``ts_args`` and ``topomap_args`` of :meth:`mne.viz.plot_evoked_joint` by `Jona Sassenhagen`_
+
 - Add ability to pass a precomputed forward solution to :func:`mne.simulation.simulate_raw` by `Eric Larson`_
 
 Bug

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -30,7 +30,7 @@ from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
                     _connection_line, COLORS, _setup_ax_spines,
                     _setup_plot_projector, _prepare_joint_axes,
                     _set_title_multiple_electrodes, _check_time_unit,
-                    _plot_masked_image, _validate_if_list_of_axes)
+                    _plot_masked_image)
 from ..utils import logger, _clean_names, warn, _pl, verbose, _validate_type
 
 from .topo import _plot_evoked_topo

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -94,6 +94,13 @@ def test_plot_topo():
     assert_raises(ValueError, evoked.plot_joint, ts_args=dict(axes=True,
                                                               time_unit='s'))
 
+    axes = plt.subplots(nrows=3)[-1].flatten().tolist()
+    evoked.plot_joint(times=[0], picks=[6, 7, 8],  ts_args=dict(axes=axes[0]),
+                      topomap_args={"axes": axes[1:], "time_unit": "s"})
+    plt.close()
+    assert_raises(ValueError, evoked.plot_joint, picks=[6, 7, 8],
+                  ts_args=dict(axes=axes[0]), topomap_args=dict(axes=axes[2:]))
+
     warnings.simplefilter('always', UserWarning)
     picked_evoked = evoked.copy().pick_channels(evoked.ch_names[:3])
     picked_evoked_eeg = evoked.copy().pick_types(meg=False, eeg=True)


### PR DESCRIPTION
evoked.plot_joint is a figure-level function. There is no easy way around this. But currently, we make it unnecessarily hard to embed if with other figures, by checking for axes keywords for the dict args. This removes that check, and allows manually forwarding axes. Thus, composite images are possible.
However, this is rather complicated to use ...

Not sure about it to be honest. I use it locally, but it might not be useful for others due to the complexity.