### PR TITLE
Fix check compensation on ica with EEG

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -657,7 +657,6 @@ class ICA(ContainsMixin):
             data = raw[picks, start:stop][0]
 
         # remove comp matrices
-        assert(raw.compensation_grade == self.compensation_grade)
         info = raw.info.copy()
         if info['comps']:
             info['comps'] = []
@@ -680,7 +679,6 @@ class ICA(ContainsMixin):
                                'ica.ch_names' % (len(self.ch_names),
                                                  len(picks)))
         # remove comp matrices
-        assert(epochs.compensation_grade == self.compensation_grade)
         info = epochs.info.copy()
         if info['comps']:
             info['comps'] = []
@@ -711,7 +709,6 @@ class ICA(ContainsMixin):
                                                  len(picks)))
 
         # remove comp matrices
-        assert(evoked.compensation_grade == self.compensation_grade)
         info = evoked.info.copy()
         if info['comps']:
             info['comps'] = []
@@ -762,13 +759,16 @@ class ICA(ContainsMixin):
             The ICA sources time series.
         """
         if isinstance(inst, BaseRaw):
-            _check_compensation_grade(self, inst, 'ICA', 'Raw')
+            _check_compensation_grade(self, inst, 'ICA', 'Raw',
+                                      ch_names=self.ch_names)
             sources = self._sources_as_raw(inst, add_channels, start, stop)
         elif isinstance(inst, BaseEpochs):
-            _check_compensation_grade(self, inst, 'ICA', 'Epochs')
+            _check_compensation_grade(self, inst, 'ICA', 'Epochs',
+                                      ch_names=self.ch_names)
             sources = self._sources_as_epochs(inst, add_channels, False)
         elif isinstance(inst, Evoked):
-            _check_compensation_grade(self, inst, 'ICA', 'Evoked')
+            _check_compensation_grade(self, inst, 'ICA', 'Evoked',
+                                      ch_names=self.ch_names)
             sources = self._sources_as_evoked(inst, add_channels)
         else:
             raise ValueError('Data input must be of Raw, Epochs or Evoked '
@@ -925,14 +925,17 @@ class ICA(ContainsMixin):
             scores for each source as returned from score_func
         """
         if isinstance(inst, BaseRaw):
-            _check_compensation_grade(self, inst, 'ICA', 'Raw')
+            _check_compensation_grade(self, inst, 'ICA', 'Raw',
+                                      ch_names=self.ch_names)
             sources = self._transform_raw(inst, start, stop,
                                           reject_by_annotation)
         elif isinstance(inst, BaseEpochs):
-            _check_compensation_grade(self, inst, 'ICA', 'Epochs')
+            _check_compensation_grade(self, inst, 'ICA', 'Epochs',
+                                      ch_names=self.ch_names)
             sources = self._transform_epochs(inst, concatenate=True)
         elif isinstance(inst, Evoked):
-            _check_compensation_grade(self, inst, 'ICA', 'Evoked')
+            _check_compensation_grade(self, inst, 'ICA', 'Evoked',
+                                      ch_names=self.ch_names)
             sources = self._transform_evoked(inst)
         else:
             raise ValueError('Data input must be of Raw, Epochs or Evoked '
@@ -1240,18 +1243,21 @@ class ICA(ContainsMixin):
             The processed data.
         """
         if isinstance(inst, BaseRaw):
-            _check_compensation_grade(self, inst, 'ICA', 'Raw')
+            _check_compensation_grade(self, inst, 'ICA', 'Raw',
+                                      ch_names=self.ch_names)
             out = self._apply_raw(raw=inst, include=include,
                                   exclude=exclude,
                                   n_pca_components=n_pca_components,
                                   start=start, stop=stop)
         elif isinstance(inst, BaseEpochs):
-            _check_compensation_grade(self, inst, 'ICA', 'Epochs')
+            _check_compensation_grade(self, inst, 'ICA', 'Epochs',
+                                      ch_names=self.ch_names)
             out = self._apply_epochs(epochs=inst, include=include,
                                      exclude=exclude,
                                      n_pca_components=n_pca_components)
         elif isinstance(inst, Evoked):
-            _check_compensation_grade(self, inst, 'ICA', 'Evoked')
+            _check_compensation_grade(self, inst, 'ICA', 'Evoked',
+                                      ch_names=self.ch_names)
             out = self._apply_evoked(evoked=inst, include=include,
                                      exclude=exclude,
                                      n_pca_components=n_pca_components)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -963,7 +963,6 @@ def test_ica_eeg():
         for picks in [picks_meg, picks_eeg, picks_all]:
             if len(picks) == 0:
                 continue
-
             # test fit
             for inst in [raw, epochs]:
                 ica = ICA(n_components=2, random_state=0, max_iter=2,
@@ -975,7 +974,6 @@ def test_ica_eeg():
             for inst in [raw, epochs, evoked]:
                 ica.apply(inst)
                 ica.get_sources(inst)
-
 
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -922,7 +922,6 @@ def test_ica_ctf():
 @testing.requires_testing_data
 def test_ica_eeg():
     method = 'fastica'
-    reject = {}
     raw_fif = read_raw_fif(fif_fname, preload=True)
     with warnings.catch_warnings(record=True):  # events etc.
         raw_eeglab = read_raw_eeglab(input_fname=eeglab_fname,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -26,7 +26,7 @@ from mne.preprocessing import (ICA, ica_find_ecg_events, ica_find_eog_events,
                                read_ica, run_ica)
 from mne.preprocessing.ica import (get_score_funcs, corrmap, _sort_components,
                                    _ica_explained_variance)
-from mne.io import read_raw_fif, Info, RawArray, read_raw_ctf
+from mne.io import read_raw_fif, Info, RawArray, read_raw_ctf, read_raw_eeglab
 from mne.io.meas_info import _kind_dict
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
 from mne.tests.common import assert_naming
@@ -46,8 +46,13 @@ raw_fname = op.join(data_dir, 'test_raw.fif')
 event_name = op.join(data_dir, 'test-eve.fif')
 test_cov_name = op.join(data_dir, 'test-cov.fif')
 
-ctf_fname = op.join(testing.data_path(download=False), 'CTF',
-                    'testdata_ctf.ds')
+test_base_dir = testing.data_path(download=False)
+ctf_fname = op.join(test_base_dir, 'CTF', 'testdata_ctf.ds')
+
+fif_fname = op.join(test_base_dir, 'MEG', 'sample',
+                    'sample_audvis_trunc_raw.fif')
+eeglab_fname = op.join(test_base_dir, 'EEGLAB', 'test_raw.set')
+eeglab_montage = op.join(test_base_dir, 'EEGLAB', 'test_chans.locs')
 
 event_id, tmin, tmax = 1, -0.2, 0.2
 # if stop is too small pca may fail in some cases, but we're okay on this file
@@ -909,6 +914,39 @@ def test_ica_ctf():
             ica.apply(inst)
         with pytest.raises(RuntimeError, match='Compensation grade of ICA'):
             ica.get_sources(inst)
+
+
+@requires_sklearn
+@testing.requires_testing_data
+def test_ica_eeg():
+    method = 'fastica'
+
+    raw_fif = read_raw_fif(fif_fname, preload=True)
+    raw_eeglab = read_raw_eeglab(input_fname=eeglab_fname,
+                                 montage=eeglab_montage, preload=True)
+
+    for raw in [raw_eeglab, raw_fif]:
+        events = make_fixed_length_events(raw, 99999)
+        picks_meg = pick_types(raw.info, meg=True, eeg=False)
+        picks_eeg = pick_types(raw.info, meg=False, eeg=True)
+        picks_all = pick_types(raw.info, meg=True, eeg=True)
+        for picks in [picks_meg, picks_eeg, picks_all]:
+            if len(picks) == 0:
+                continue
+            epochs = Epochs(raw, events, None, -0.2, 0.2, preload=True)
+            evoked = epochs.average()
+
+            # test fit
+            for inst in [raw, epochs]:
+                ica = ICA(n_components=2, random_state=0, max_iter=2,
+                          method=method)
+                with warnings.catch_warnings(record=True):  # convergence
+                    ica.fit(inst, picks=picks)
+
+            # test apply and get_sources
+            for inst in [raw, epochs, evoked]:
+                ica.apply(inst)
+                ica.get_sources(inst)
 
 
 run_tests_if_main()

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2205,12 +2205,19 @@ def _check_compensation_grade(inst, inst2, name, name2, ch_names=None):
         grade = inst.compensation_grade
         grade2 = inst2.compensation_grade
     else:
-        picks = pick_channels(inst.info['ch_names'], ch_names)
-        info = pick_info(inst.info, picks, copy=True)
-        picks = pick_channels(inst2.info['ch_names'], ch_names)
-        info2 = pick_info(inst2.info, picks, copy=True)
+        info = inst.info.copy()
+        info2 = inst2.info.copy()
+        # pick channels
+        for t_info in [info, info2]:
+            if t_info['comps']:
+                t_info['comps'] = []
+            picks = pick_channels(t_info['ch_names'], ch_names)
+            pick_info(t_info, picks, copy=False)
+        # get compensation grades
         grade = get_current_comp(info)
         grade2 = get_current_comp(info2)
+
+    # perform check
     if grade != grade2:
         msg = 'Compensation grade of %s (%d) and %s (%d) don\'t match'
         raise RuntimeError(msg % (name, inst.compensation_grade,

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2193,13 +2193,28 @@ def _check_preload(inst, msg):
                 '%s.load_data().' % (name, name))
 
 
-def _check_compensation_grade(inst, inst2, name, name2):
-    """Ensure that objects have same compenstation_grade."""
-    if (None not in [inst.info, inst2.info]) and (inst.compensation_grade !=
-                                                  inst2.compensation_grade):
-            msg = ('Compensation grade of %s (%d) and %s (%d) don\'t match')
-            raise RuntimeError(msg % (name, inst.compensation_grade,
-                                      name2, inst2.compensation_grade))
+def _check_compensation_grade(inst, inst2, name, name2, ch_names=None):
+    """Ensure that objects have same compensation_grade."""
+    from .io.pick import pick_channels, pick_info
+    from .io.compensator import get_current_comp
+
+    if None in [inst.info, inst2.info]:
+        return
+
+    if ch_names is None:
+        grade = inst.compensation_grade
+        grade2 = inst2.compensation_grade
+    else:
+        picks = pick_channels(inst.info['ch_names'], ch_names)
+        info = pick_info(inst.info, picks, copy=True)
+        picks = pick_channels(inst2.info['ch_names'], ch_names)
+        info2 = pick_info(inst2.info, picks, copy=True)
+        grade = get_current_comp(info)
+        grade2 = get_current_comp(info2)
+    if grade != grade2:
+        msg = 'Compensation grade of %s (%d) and %s (%d) don\'t match'
+        raise RuntimeError(msg % (name, inst.compensation_grade,
+                                  name2, inst2.compensation_grade))
 
 
 def _check_pandas_installed(strict=True):


### PR DESCRIPTION
closes #5265.

The problem arises because the ica object inherits the `info` of the object used to fit it with supplied 'picks' applied. however to avoid making a copy of time domain data the picks are never applied to the supplied object. This causes a discrepancy between the channels in `ica.info` and `raw.info` (or `epoch.info`) and the check fails.

I modified the `_check_compensation_grade` to accept channel names so the infos of both objects are mapped to the same channels before computing `compensation_grade`.

one case not tested is a ctf/eeg test where compensation can be applied. Are there any datasets like that which we could include in the test data?

