### PR TITLE
MRG: Better EDF range checks

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -412,11 +412,17 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     nchan = edf_info['nchan']
     physical_ranges = edf_info['physical_max'] - edf_info['physical_min']
     cals = edf_info['digital_max'] - edf_info['digital_min']
-    if np.any(~np.isfinite(cals)):
-        idx = np.where(~np.isfinite(cals))[0]
+    idx = np.where((~np.isfinite(cals)) | (cals == 0))[0]
+    if len(idx) > 0:
         warn('Scaling factor is not defined in following channels:\n' +
              ', '.join(ch_names[i] for i in idx))
         cals[idx] = 1
+    idx = np.where(physical_ranges == 0)[0]
+    if len(idx) > 0:
+        warn('Physical range is not defined in following channels:\n' +
+             ', '.join(ch_names[i] for i in idx))
+        physical_ranges[idx] = 1
+    del idx
     if 'stim_data' in edf_info and stim_channel == 'auto':  # For GDF events.
         cals = np.append(cals, 1)
     if stim_channel is not None:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -412,17 +412,16 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
     nchan = edf_info['nchan']
     physical_ranges = edf_info['physical_max'] - edf_info['physical_min']
     cals = edf_info['digital_max'] - edf_info['digital_min']
-    idx = np.where((~np.isfinite(cals)) | (cals == 0))[0]
-    if len(idx) > 0:
+    bad_idx = np.where((~np.isfinite(cals)) | (cals == 0))[0]
+    if len(bad_idx) > 0:
         warn('Scaling factor is not defined in following channels:\n' +
-             ', '.join(ch_names[i] for i in idx))
-        cals[idx] = 1
-    idx = np.where(physical_ranges == 0)[0]
-    if len(idx) > 0:
+             ', '.join(ch_names[i] for i in bad_idx))
+        cals[bad_idx] = 1
+    bad_idx = np.where(physical_ranges == 0)[0]
+    if len(bad_idx) > 0:
         warn('Physical range is not defined in following channels:\n' +
-             ', '.join(ch_names[i] for i in idx))
-        physical_ranges[idx] = 1
-    del idx
+             ', '.join(ch_names[i] for i in bad_idx))
+        physical_ranges[bad_idx] = 1
     if 'stim_data' in edf_info and stim_channel == 'auto':  # For GDF events.
         cals = np.append(cals, 1)
     if stim_channel is not None:


### PR DESCRIPTION
Improves style of one bit of code, and adds an additional check that turns a downstream error (cals equal zero) into a warning so you can still read the file. This was encountered on a SMA EEG file converted to EDF format using EEGLAB+BioSig. No test because this is such a weird corner case.

@cbrnr do you have time to look?