### PR TITLE
ADD: threshold function to remove small clusters

### DIFF
--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1241,7 +1241,7 @@ def spatio_temporal_cluster_1samp_test(
         stat_fun=None, connectivity=None, n_jobs=1, seed=None,
         max_step=1, spatial_exclude=None, step_down_p=0, t_power=1,
         out_type='indices', check_disjoint=False, buffer_size=1000,
-        verbose=None):
+        verbose=None, min_size=None):
     """Non-parametric cluster-level 1 sample t-test for spatio-temporal data.
 
     This function provides a convenient wrapper for data organized in the form
@@ -1373,7 +1373,7 @@ def spatio_temporal_cluster_test(
         X, threshold=None, n_permutations=1024, tail=0, stat_fun=None,
         connectivity=None, verbose=None, n_jobs=1, seed=None, max_step=1,
         spatial_exclude=None, step_down_p=0, t_power=1, out_type='indices',
-        check_disjoint=False, buffer_size=1000):
+        check_disjoint=False, buffer_size=1000, min_size=None):
     """Non-parametric cluster-level test for spatio-temporal data.
 
     This function provides a convenient wrapper for data organized in the form

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1364,7 +1364,8 @@ def spatio_temporal_cluster_1samp_test(
         n_permutations=n_permutations, connectivity=connectivity,
         n_jobs=n_jobs, seed=seed, max_step=max_step, exclude=exclude,
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
-        check_disjoint=check_disjoint, buffer_size=buffer_size)
+        check_disjoint=check_disjoint, buffer_size=buffer_size,
+        min_size=min_size)
 
 
 @verbose
@@ -1475,7 +1476,8 @@ def spatio_temporal_cluster_test(
         n_permutations=n_permutations, connectivity=connectivity,
         n_jobs=n_jobs, seed=seed, max_step=max_step, exclude=exclude,
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
-        check_disjoint=check_disjoint, buffer_size=buffer_size)
+        check_disjoint=check_disjoint, buffer_size=buffer_size,
+        min_size=min_size)
 
 
 def _st_mask_from_s_inds(n_times, n_vertices, vertices, set_as=True):


### PR DESCRIPTION
Following up from issue #5279. Discussion with @agramfort about adding a cluster-size threshold.

This does not make the cluster test much faster, but it allows the user to not return clusters that are smaller than X-many time/spatial samples. For example, it can be used to remove clusters that are just 1 or 2 samples big -- i.e. unlikely to reflect a meaningful result.