### PR TITLE
Fixes #5284: converts 1-indexed BrainVision offsets into 0-indexed mne offsets

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,8 @@ Bug
 
 - Fix bug in :class:`mne.realtime.RtEpochs` where events during the buildup of the buffer were not correctly processed when incoming data buffers are smaller than the epochs by `Henrich Kolkhorst`_
 
+- Fix bug in :func:`mne.io.read_raw_brainvision` where 1-indexed BrainVision events were not being converted into 0-indexed mne events by `Steven Bethard`_
+
 API
 ~~~
 
@@ -2775,3 +2777,5 @@ of commits):
 .. _Joan Massich: https://github.com/massich
 
 .. _Henrich Kolkhorst: https://github.com/hekolk
+
+.. _Steven Bethard: https://github.com/bethard

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -276,7 +276,7 @@ def _read_vmrk_events(fname, event_id=None, response_trig_shift=0):
     events, dropped = list(), list()
     for info in items:
         mtype, mdesc, onset, duration = info.split(',')[:4]
-        onset = int(onset)
+        onset = int(onset) - 1  # BrainVision is 1-indexed, not 0-indexed
         duration = (int(duration) if duration.isdigit() else 1)
         if mdesc in event_id:
             trigger = event_id[mdesc]

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -371,22 +371,24 @@ def test_brainvision_vectorized_data():
 def test_events():
     """Test reading and modifying events."""
     tempdir = _TempDir()
+    # Note: BrainVision event offsets are 1-based, mne offsets are 0-based.
+    # So in all tests below, the "onset" is 1 less than what's in the file
 
     # check that events are read and stim channel is synthesized correctly
     raw = read_raw_brainvision(vhdr_path, eog=eog, event_id=event_id)
     events = raw._get_brainvision_events()
     events = events[events[:, 2] != event_id['Sync On']]
-    assert_array_equal(events, [[487, 0, 253],
-                                [497, 1, 255],
-                                [1770, 1, 254],
-                                [1780, 1, 255],
-                                [3253, 1, 254],
-                                [3263, 1, 255],
-                                [4936, 1, 253],
-                                [4946, 1, 255],
-                                [6000, 1, 255],
-                                [6620, 1, 254],
-                                [6630, 1, 255]])
+    assert_array_equal(events, [[486, 0, 253],
+                                [496, 1, 255],
+                                [1769, 1, 254],
+                                [1779, 1, 255],
+                                [3252, 1, 254],
+                                [3262, 1, 255],
+                                [4935, 1, 253],
+                                [4945, 1, 255],
+                                [5999, 1, 255],
+                                [6619, 1, 254],
+                                [6629, 1, 255]])
 
     # check that events are read and stim channel is synthesized correctly and
     # response triggers are shifted like they're supposed to be.
@@ -394,17 +396,17 @@ def test_events():
                                response_trig_shift=1000, event_id=event_id)
     events = raw._get_brainvision_events()
     events = events[events[:, 2] != event_id['Sync On']]
-    assert_array_equal(events, [[487, 0, 253],
-                                [497, 1, 255],
-                                [1770, 1, 254],
-                                [1780, 1, 255],
-                                [3253, 1, 254],
-                                [3263, 1, 255],
-                                [4936, 1, 253],
-                                [4946, 1, 255],
-                                [6000, 1, 1255],
-                                [6620, 1, 254],
-                                [6630, 1, 255]])
+    assert_array_equal(events, [[486, 0, 253],
+                                [496, 1, 255],
+                                [1769, 1, 254],
+                                [1779, 1, 255],
+                                [3252, 1, 254],
+                                [3262, 1, 255],
+                                [4935, 1, 253],
+                                [4945, 1, 255],
+                                [5999, 1, 1255],
+                                [6619, 1, 254],
+                                [6629, 1, 255]])
 
     # check that events are read and stim channel is synthesized correctly and
     # response triggers are ignored.
@@ -413,16 +415,16 @@ def test_events():
                                    response_trig_shift=None)
     events = raw._get_brainvision_events()
     events = events[events[:, 2] != event_id['Sync On']]
-    assert_array_equal(events, [[487, 0, 253],
-                                [497, 1, 255],
-                                [1770, 1, 254],
-                                [1780, 1, 255],
-                                [3253, 1, 254],
-                                [3263, 1, 255],
-                                [4936, 1, 253],
-                                [4946, 1, 255],
-                                [6620, 1, 254],
-                                [6630, 1, 255]])
+    assert_array_equal(events, [[486, 0, 253],
+                                [496, 1, 255],
+                                [1769, 1, 254],
+                                [1779, 1, 255],
+                                [3252, 1, 254],
+                                [3262, 1, 255],
+                                [4935, 1, 253],
+                                [4945, 1, 255],
+                                [6619, 1, 254],
+                                [6629, 1, 255]])
 
     # check that events are read properly when event_id is specified for
     # auxiliary events
@@ -431,17 +433,17 @@ def test_events():
                                    response_trig_shift=None,
                                    event_id=event_id)
     events = raw._get_brainvision_events()
-    assert_array_equal(events, [[487, 0, 253],
-                                [497, 1, 255],
-                                [1770, 1, 254],
-                                [1780, 1, 255],
-                                [3253, 1, 254],
-                                [3263, 1, 255],
-                                [4936, 1, 253],
-                                [4946, 1, 255],
-                                [6620, 1, 254],
-                                [6630, 1, 255],
-                                [7630, 1, 5]])
+    assert_array_equal(events, [[486, 0, 253],
+                                [496, 1, 255],
+                                [1769, 1, 254],
+                                [1779, 1, 255],
+                                [3252, 1, 254],
+                                [3262, 1, 255],
+                                [4935, 1, 253],
+                                [4945, 1, 255],
+                                [6619, 1, 254],
+                                [6629, 1, 255],
+                                [7629, 1, 5]])
 
     assert_raises(TypeError, read_raw_brainvision, vhdr_path, eog=eog,
                   preload=True, response_trig_shift=0.1)
@@ -449,17 +451,17 @@ def test_events():
                   preload=True, response_trig_shift=np.nan)
 
     # to handle the min duration = 1 of stim trig (re)construction ...
-    events = np.array([[487, 1, 253],
-                       [497, 1, 255],
-                       [1770, 1, 254],
-                       [1780, 1, 255],
-                       [3253, 1, 254],
-                       [3263, 1, 255],
-                       [4936, 1, 253],
-                       [4946, 1, 255],
-                       [6620, 1, 254],
-                       [6630, 1, 255],
-                       [7630, 1, 5]])
+    events = np.array([[486, 1, 253],
+                       [496, 1, 255],
+                       [1769, 1, 254],
+                       [1779, 1, 255],
+                       [3252, 1, 254],
+                       [3262, 1, 255],
+                       [4935, 1, 253],
+                       [4945, 1, 255],
+                       [6619, 1, 254],
+                       [6629, 1, 255],
+                       [7629, 1, 5]])
 
     # Test that both response_trig_shit and event_id can be set
     read_raw_brainvision(vhdr_path, eog=eog, preload=False,


### PR DESCRIPTION
closes #5284