### PR TITLE
MRG: Fix SNR estimation and plotting

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -52,6 +52,8 @@ Bug
 
 - Fix bug in :func:`mne.io.read_raw_brainvision` where 1-indexed BrainVision events were not being converted into 0-indexed mne events by `Steven Bethard`_
 
+- Fix bug in :func:`mne.viz.plot_snr_estimate` and :func:`mne.minimum_norm.estimate_snr` where the inverse rank was not properly utilized (especially affecting SSS'ed MEG data) by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/minimum_norm/tests/test_snr.py
+++ b/mne/minimum_norm/tests/test_snr.py
@@ -38,5 +38,6 @@ def test_snr():
         pass  # this returns 1 for some reason
     finally:
         os.chdir(orig_dir)
-    snr_c = np.loadtxt(op.join(tempdir, 'SNR'))[:, 1]
+    times, snr_c, _ = np.loadtxt(op.join(tempdir, 'SNR')).T
+    assert_allclose(times / 1000., evoked.times, atol=1e-2)
     assert_allclose(snr, snr_c, atol=1e-2, rtol=1e-2)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1220,7 +1220,8 @@ def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True,
     return fig
 
 
-def plot_snr_estimate(evoked, inv, show=True):
+@verbose
+def plot_snr_estimate(evoked, inv, show=True, verbose=None):
     """Plot a data SNR estimate.
 
     Parameters
@@ -1239,23 +1240,26 @@ def plot_snr_estimate(evoked, inv, show=True):
 
     Notes
     -----
+    The bluish green line is the SNR determined by the GFP of the whitened
+    evoked data. The orange line is the SNR estimated based on the mismatch
+    between the data and the data re-estimated from the regularized inverse.
+
     .. versionadded:: 0.9.0
     """
     import matplotlib.pyplot as plt
     from ..minimum_norm import estimate_snr
-    snr, snr_est = estimate_snr(evoked, inv, verbose=True)
+    snr, snr_est = estimate_snr(evoked, inv)
     fig, ax = plt.subplots(1, 1)
     lims = np.concatenate([evoked.times[[0, -1]], [-1, snr_est.max()]])
-    ax.plot([0, 0], lims[2:], 'k:')
-    ax.plot(lims[:2], [0, 0], 'k:')
+    ax.axvline(0, color='k', ls=':', lw=1)
+    ax.axhline(0, color='k', ls=':', lw=1)
     # Colors are "bluish green" and "vermilion" taken from:
     #  http://bconnelly.net/2013/10/creating-colorblind-friendly-figures/
     ax.plot(evoked.times, snr_est, color=[0.0, 0.6, 0.5])
-    ax.plot(evoked.times, snr, color=[0.8, 0.4, 0.0])
+    ax.plot(evoked.times, snr - 1, color=[0.8, 0.4, 0.0])
     ax.set(xlim=lims[:2], ylim=lims[2:], ylabel='SNR', xlabel='Time (s)')
     if evoked.comment is not None:
         ax.set_title(evoked.comment)
-    plt.draw()
     plt_show(show)
     return fig
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1232,6 +1232,9 @@ def plot_snr_estimate(evoked, inv, show=True, verbose=None):
         The minimum-norm inverse operator.
     show : bool
         Show figure if True.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------


### PR DESCRIPTION
Fixes two bugs:

1. `mne.minimum_norm.estimate_snr` was not properly utilizing the effective number of channels, which made the inverse-based SNR estimates bad for data processed with SSS.
2. `mne.viz.plot_snr_estimate` was not subtracting one from the GFP, doing so makes it match MNE-C's output. I imagine this is done to make it relate more readily to the SNR estimated from the data, but maybe we should add one to it instead?

On `master` this is what sample and some random SSS'ed data I have look like:

![sample_master](https://user-images.githubusercontent.com/2365790/41745704-da25218c-7575-11e8-9943-bd7ddda5171c.png)

![sss_master](https://user-images.githubusercontent.com/2365790/41745707-dc3df156-7575-11e8-86a8-38bd7b0f4cb6.png)

And on this PR:

![sample_pr](https://user-images.githubusercontent.com/2365790/41745713-e2adb18e-7575-11e8-9211-c9c3373ad12b.png)

![sss_pr](https://user-images.githubusercontent.com/2365790/41745715-e54657c0-7575-11e8-8c90-d852ef936adb.png)

And in MNE-C:

![sample_c](https://user-images.githubusercontent.com/2365790/41745773-1cf5b742-7576-11e8-9e39-3750bb6b5e8d.png)

![sss_c](https://user-images.githubusercontent.com/2365790/41745781-224d0240-7576-11e8-93af-a09fba6a76cc.png)
