### PR TITLE
Add nanovolts to allowed units in brainvision files

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -341,6 +341,7 @@ _fmt_dtype_dict = dict(short='<i2', int='<i4', single='<f4')
 _unit_dict = {'V': 1.,  # V stands for Volt
               u'µV': 1e-6,
               'uV': 1e-6,
+              'nV': 1e-9,
               'C': 1,  # C stands for celsius
               u'µS': 1e-6,  # S stands for Siemens
               u'uS': 1e-6,
@@ -501,7 +502,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
         unit = unit.replace(u'\xc2', u'')  # Remove unwanted control characters
         cals[n] = float(resolution)
         ranges[n] = _unit_dict.get(unit, 1) * scale
-        if unit not in ('V', u'µV', 'uV'):
+        if unit not in ('V', 'nV', u'µV', 'uV'):
             misc_chs[name] = (FIFF.FIFF_UNIT_CEL if unit == 'C'
                               else FIFF.FIFF_UNIT_NONE)
     misc = list(misc_chs.keys()) if misc == 'auto' else misc

--- a/mne/io/brainvision/tests/data/test_nV.vhdr
+++ b/mne/io/brainvision/tests/data/test_nV.vhdr
@@ -1,0 +1,151 @@
+Brain Vision Data Exchange Header File Version 2.0
+; Data created from history path
+
+[Common Infos]
+Codepage=UTF-8
+DataFile=test.eeg
+MarkerFile=test.vmrk
+DataFormat=BINARY
+; Data orientation: VECTORIZED=ch1,pt1, ch1,pt2..., MULTIPLEXED=ch1,pt1, ch2,pt1 ...
+DataOrientation=MULTIPLEXED
+DataType=TIMEDOMAIN
+NumberOfChannels=32
+; Sampling interval in microseconds if time domain (convert to Hertz:
+; 1000000 / SamplingInterval) or in Hertz if frequency domain:
+SamplingInterval=1000
+
+[User Infos]
+; Each entry: Prop<Number>=<Type>,<Name>,<Value>,<Value2>,...,<ValueN>
+; Property number must be unique. Types can be int, single, string, bool, byte, double, uint
+; or arrays of those, indicated int-array etc
+; Array types have more than one value, number of values determines size of array.
+; Fields are delimited by commas, commas in strings are written \1
+
+[Binary Infos]
+BinaryFormat=INT_16
+
+[Channel Infos]
+; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,
+; <Resolution in "Unit">,<Unit>, Future extensions...
+; Fields are delimited by commas, some fields might be omitted (empty).
+; Commas in channel names are coded as "\1".
+Ch1=FP1,,500,nV
+Ch2=FP2,,0.5,µV
+Ch3=F3,,0.5,µV
+Ch4=F4,,0.5,µV
+Ch5=C3,,0.5,µV
+Ch6=C4,,0.5,µV
+Ch7=P3,,0.5,µV
+Ch8=P4,,0.5,µV
+Ch9=O1,,0.5,µV
+Ch10=O2,,0.5,µV
+Ch11=F7,,0.5,µV
+Ch12=F8,,0.5,µV
+Ch13=P7,,0.5,µV
+Ch14=P8,,0.5,µV
+Ch15=Fz,,0.5,µV
+Ch16=FCz,,0.5,µV
+Ch17=Cz,,0.5,µV
+Ch18=CPz,,0.5,µV
+Ch19=Pz,,0.5,µV
+Ch20=POz,,0.5,µV
+Ch21=FC1,,0.5,µV
+Ch22=FC2,,0.5,µV
+Ch23=CP1,,0.5,µV
+Ch24=CP2,,0.5,µV
+Ch25=FC5,,0.5,µV
+Ch26=FC6,,0.5,µV
+Ch27=CP5,,0.5,BS
+Ch28=CP6,,0.5,µS
+Ch29=HL,,0.5,ARU
+Ch30=HR,,0.5,uS
+Ch31=Vb,,0.5,S
+Ch32=ReRef,,0.5,C
+
+[Comment]
+
+A m p l i f i e r  S e t u p
+============================
+Number of channels: 32
+Sampling Rate [Hz]: 1000
+Sampling Interval [µS]: 1000
+
+Channels
+--------
+#     Name      Phys. Chn.    Resolution / Unit   Low Cutoff [s]   High Cutoff [Hz]   Notch [Hz]    Series Res. [kOhm] Gradient         Offset
+1     FP1         1                500 nV             DC              250              Off                0
+2     FP2         2                0.5 µV             DC              250              Off                0
+3     F3          3                0.5 µV             DC              250              Off                0
+4     F4          4                0.5 µV             DC              250              Off                0
+5     C3          5                0.5 µV             DC              250              Off                0
+6     C4          6                0.5 µV             DC              250              Off                0
+7     P3          7                0.5 µV             DC              250              Off                0
+8     P4          8                0.5 µV             DC              250              Off                0
+9     O1          9                0.5 µV             DC              250              Off                0
+10    O2          10               0.5 µV             DC              250              Off                0
+11    F7          11               0.5 µV             DC              250              Off                0
+12    F8          12               0.5 µV             DC              250              Off                0
+13    P7          13               0.5 µV             DC              250              Off                0
+14    P8          14               0.5 µV             DC              250              Off                0
+15    Fz          15               0.5 µV             DC              250              Off                0
+16    FCz         16               0.5 µV             DC              250              Off                0
+17    Cz          17               0.5 µV             DC              250              Off                0
+18    CPz         18               0.5 µV             DC              250              Off                0
+19    Pz          19               0.5 µV             DC              250              Off                0
+20    POz         20               0.5 µV             DC              250              Off                0
+21    FC1         21               0.5 µV             DC              250              Off                0
+22    FC2         22               0.5 µV             DC              250              Off                0
+23    CP1         23               0.5 µV             DC              250              Off                0
+24    CP2         24               0.5 µV             DC              250              Off                0
+25    FC5         25               0.5 µV             DC              250              Off                0
+26    FC6         26               0.5 µV             DC              250              Off                0
+27    CP5         27               0.5 BS             DC              250              Off                0
+28    CP6         28               0.5 µS             DC              250              Off                0
+29    HL          29               0.5 ARU            DC              250              Off                0
+30    HR          30               0.5 uS             DC              250              Off                0
+31    Vb          31               0.5 S              DC              250              Off                0
+32    ReRef       32               0.5 C              DC              250              Off                0
+
+S o f t w a r e  F i l t e r s
+==============================
+Disabled
+
+
+Data Electrodes Selected Impedance Measurement Range: 0 - 100 kOhm
+Ground Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Reference Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Impedance [kOhm] at 16:12:27 :
+FP1:        ???
+FP2:        ???
+F3:         ???
+F4:         ???
+C3:         ???
+C4:         ???
+P3:         ???
+P4:         ???
+O1:         ???
+O2:         ???
+F7:         ???
+F8:         ???
+P7:         ???
+P8:         ???
+Fz:         ???
+FCz:        ???
+Cz:         ???
+CPz:        ???
+Pz:         ???
+POz:        ???
+FC1:        ???
+FC2:        ???
+CP1:        ???
+CP2:        ???
+FC5:        ???
+FC6:        ???
+CP5:        ???
+CP6:        ???
+HL:         ???
+HR:         ???
+Vb:         ???
+ReRef:      ???
+Ref:          0
+Gnd:          4

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -50,6 +50,9 @@ vhdr_mixed_lowpass_path = op.join(data_dir, 'test_mixed_lowpass.vhdr')
 vhdr_lowpass_s_path = op.join(data_dir, 'test_lowpass_s.vhdr')
 vhdr_mixed_lowpass_s_path = op.join(data_dir, 'test_mixed_lowpass_s.vhdr')
 
+# Test for nanovolts as unit
+vhdr_nV_path = op.join(data_dir, 'test_nV.vhdr')
+
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
@@ -325,6 +328,15 @@ def test_brainvision_data():
     # test loading v2
     read_raw_brainvision(vhdr_v2_path, eog=eog, preload=True,
                          response_trig_shift=1000, verbose='error')
+    # For the nanovolt unit test we use the same data file with a different
+    # header file.
+    raw_nV = _test_raw_reader(
+        read_raw_brainvision, vhdr_fname=vhdr_nV_path, montage=montage,
+        eog=eog, misc='auto', event_id=event_id)
+    assert_equal(raw_nV.info['chs'][0]['ch_name'], 'FP1')
+    assert_equal(raw_nV.info['chs'][0]['kind'], FIFF.FIFFV_EEG_CH)
+    data_nanovolt, _ = raw_nV[0]
+    assert_array_almost_equal(data_py[0, :], data_nanovolt[0, :])
 
 
 def test_brainvision_vectorized_data():


### PR DESCRIPTION
The BrainVision export in Analyser exports EEG data in nanovolts.

Currently, these EEG channels get interpreted as MISC channels so the import fails. This PR adds nV as possible unit.