### PR TITLE
MRG: Modernize testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         # No data + style testing
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
-               CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx nose pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx pytest pytest-cov"
                PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest pytest-sugar"
                OPTION="--doctest-ignore-import-errors"
 
@@ -45,21 +45,21 @@ matrix:
         # 2.7 Old dependencies
         - os: linux
           env: PYTHON_VERSION=2.7
-               CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.13 scikit-learn=0.15 nose pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.13 scikit-learn=0.15 pytest pytest-cov"
                SPLIT=0
         - os: linux
           env: PYTHON_VERSION=2.7
-               CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.13 scikit-learn=0.15 nose pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy=1.8 scipy=0.12 matplotlib=1.3 pandas=0.13 scikit-learn=0.15 pytest pytest-cov"
                SPLIT=1
 
         # Minimal
         - os: linux
           env: DEPS=minimial
-               CONDA_DEPENDENCIES="numpy scipy matplotlib nose pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest pytest-cov"
                SPLIT=0
         - os: linux
           env: DEPS=minimial
-               CONDA_DEPENDENCIES="numpy scipy matplotlib nose pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest pytest-cov"
                SPLIT=1
 
 # Setup anaconda

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ codespell-error:  # running on travis
 
 pydocstyle:
 	@echo "Running pydocstyle"
-	@pydocstyle
+	@pydocstyle mne
 
 docstring:
 	@echo "Running docstring tests"
@@ -134,5 +134,4 @@ build-doc-stable:
 	cd doc; make clean
 	cd doc; DISPLAY=:1.0 xvfb-run -n 1 -s "-screen 0 1280x1024x24 -noreset -ac +extension GLX +render" make html_stable
 
-docstyle:
-	@pydocstyle
+docstyle: pydocstyle

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- nose
 - pytest
 - pytest-cov
 - sphinx

--- a/environment2.yml
+++ b/environment2.yml
@@ -15,7 +15,6 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- nose
 - pytest
 - pytest-cov
 - sphinx

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -2,7 +2,7 @@
 #          Britta Westner
 #
 # License: BSD 3 clause
-from __future__ import print_function
+
 import warnings
 import os.path as op
 import copy as cp
@@ -22,7 +22,7 @@ from mne.externals.six import advance_iterator
 from mne.proj import compute_proj_evoked, make_projector
 
 # Note that if this is the first test file, this will apply to all subsequent
-# tests in a full nosetest:
+# tests in a full test:
 warnings.simplefilter('always')  # ensure we can verify expected warnings
 
 data_path = testing.data_path(download=False)
@@ -40,7 +40,7 @@ fname_label = op.join(subjects_dir, 'sample', 'label', 'aparc',
 
 
 def _load_forward():
-    """Load forward models"""
+    """Load forward models."""
     fwd_free = mne.read_forward_solution(fname_fwd)
     fwd_free = mne.pick_types_forward(fwd_free, meg=True, eeg=False)
     fwd_free = mne.convert_forward_solution(fwd_free, surf_ori=False)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 import os.path as op
 
 import pytest
-from nose.tools import assert_true, assert_raises
 import numpy as np
 from scipy import linalg
 from scipy.spatial.distance import cdist
@@ -196,8 +195,8 @@ def test_lcmv():
         max_stc = stc.data[idx]
         tmax = stc.times[np.argmax(max_stc)]
 
-        assert_true(0.09 < tmax < 0.105, tmax)
-        assert_true(0.9 < np.max(max_stc) < 3., np.max(max_stc))
+        assert 0.09 < tmax < 0.105, tmax
+        assert 0.9 < np.max(max_stc) < 3., np.max(max_stc)
 
         if fwd is forward:
             # Test picking normal orientation (surface source space only)
@@ -212,12 +211,12 @@ def test_lcmv():
             max_stc = stc_normal.data[idx]
             tmax = stc_normal.times[np.argmax(max_stc)]
 
-            assert_true(0.04 < tmax < 0.11, tmax)
-            assert_true(0.4 < np.max(max_stc) < 2., np.max(max_stc))
+            assert 0.04 < tmax < 0.11, tmax
+            assert 0.4 < np.max(max_stc) < 2., np.max(max_stc)
 
             # The amplitude of normal orientation results should always be
             # smaller than free orientation results
-            assert_true((np.abs(stc_normal.data) <= stc.data).all())
+            assert (np.abs(stc_normal.data) <= stc.data).all()
 
         # Test picking source orientation maximizing output source power
         filters = make_lcmv(evoked.info, fwd, data_cov, reg=0.01,
@@ -229,8 +228,8 @@ def test_lcmv():
         max_stc = np.abs(stc_max_power.data[idx])
         tmax = stc.times[np.argmax(max_stc)]
 
-        assert_true(0.08 < tmax < 0.11, tmax)
-        assert_true(0.8 < np.max(max_stc) < 3., np.max(max_stc))
+        assert 0.08 < tmax < 0.11, tmax
+        assert 0.8 < np.max(max_stc) < 3., np.max(max_stc)
 
         stc_max_power.data[:, :] = np.abs(stc_max_power.data)
 
@@ -244,7 +243,7 @@ def test_lcmv():
             mean_stc_max_pow = \
                 stc_max_power.extract_label_time_course(label, fwd['src'],
                                                         mode='mean')
-            assert_true((np.abs(mean_stc - mean_stc_max_pow) < 0.5).all())
+            assert ((np.abs(mean_stc - mean_stc_max_pow) < 0.5).all())
 
         # Test NAI weight normalization:
         filters = make_lcmv(evoked.info, fwd, data_cov, reg=0.01,
@@ -269,7 +268,7 @@ def test_lcmv():
                                            bem=sphere, eeg=False, meg=True)
 
     # Test that we get an error if not reducing rank
-    assert_raises(ValueError, make_lcmv, evoked.info, fwd_sphere, data_cov,
+    pytest.raises(ValueError, make_lcmv, evoked.info, fwd_sphere, data_cov,
                   reg=0.1, noise_cov=noise_cov, weight_norm='unit-noise-gain',
                   pick_ori='max-power', reduce_rank=False)
 
@@ -286,44 +285,44 @@ def test_lcmv():
     max_stc = stc_sphere.data[idx]
     tmax = stc_sphere.times[np.argmax(max_stc)]
 
-    assert_true(0.08 < tmax < 0.11, tmax)
-    assert_true(0.4 < np.max(max_stc) < 2., np.max(max_stc))
+    assert 0.08 < tmax < 0.11, tmax
+    assert 0.4 < np.max(max_stc) < 2., np.max(max_stc)
 
     # Test if fixed forward operator is detected when picking normal or
     # max-power orientation
-    assert_raises(ValueError, make_lcmv, evoked.info, forward_fixed, data_cov,
+    pytest.raises(ValueError, make_lcmv, evoked.info, forward_fixed, data_cov,
                   reg=0.01, noise_cov=noise_cov, pick_ori='normal')
-    assert_raises(ValueError, make_lcmv, evoked.info, forward_fixed, data_cov,
+    pytest.raises(ValueError, make_lcmv, evoked.info, forward_fixed, data_cov,
                   reg=0.01, noise_cov=noise_cov, pick_ori='max-power')
 
     # Test if non-surface oriented forward operator is detected when picking
     # normal orientation
-    assert_raises(ValueError, make_lcmv, evoked.info, forward, data_cov,
+    pytest.raises(ValueError, make_lcmv, evoked.info, forward, data_cov,
                   reg=0.01, noise_cov=noise_cov, pick_ori='normal')
 
     # Test if volume forward operator is detected when picking normal
     # orientation
-    assert_raises(ValueError, make_lcmv, evoked.info, forward_vol, data_cov,
+    pytest.raises(ValueError, make_lcmv, evoked.info, forward_vol, data_cov,
                   reg=0.01, noise_cov=noise_cov, pick_ori='normal')
 
     # Test if missing of noise covariance matrix is detected when more than
     # one channel type is present in the data
-    assert_raises(ValueError, make_lcmv, evoked.info, forward_vol,
+    pytest.raises(ValueError, make_lcmv, evoked.info, forward_vol,
                   data_cov=data_cov, reg=0.01, noise_cov=None,
                   pick_ori='max-power')
 
     # Test if not-yet-implemented orientation selections raise error with
     # neural activity index
-    assert_raises(NotImplementedError, make_lcmv, evoked.info,
+    pytest.raises(NotImplementedError, make_lcmv, evoked.info,
                   forward_surf_ori, data_cov, reg=0.01, noise_cov=noise_cov,
                   pick_ori='normal', weight_norm='nai')
-    assert_raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
+    pytest.raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
                   data_cov, reg=0.01, noise_cov=noise_cov, pick_ori=None,
                   weight_norm='nai')
 
     # Test if no weight-normalization and max-power source orientation throws
     # an error
-    assert_raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
+    pytest.raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
                   data_cov, reg=0.01, noise_cov=noise_cov,
                   pick_ori='max-power', weight_norm=None)
 
@@ -332,7 +331,7 @@ def test_lcmv():
     evoked_ch.pick_channels(evoked_ch.ch_names[1:])
     filters = make_lcmv(evoked.info, forward_vol, data_cov, reg=0.01,
                         noise_cov=noise_cov)
-    assert_raises(ValueError, apply_lcmv, evoked_ch, filters,
+    pytest.raises(ValueError, apply_lcmv, evoked_ch, filters,
                   max_ori_out='signed')
 
     # Test if discrepancies in channel selection of data and fwd model are
@@ -351,15 +350,15 @@ def test_lcmv():
     # Test if non-matching SSP projection is detected in application of filter
     raw_proj = deepcopy(raw)
     raw_proj.del_proj()
-    assert_raises(ValueError, apply_lcmv_raw, raw_proj, filters,
+    pytest.raises(ValueError, apply_lcmv_raw, raw_proj, filters,
                   max_ori_out='signed')
 
     # Test if setting reduce_rank to True returns a NotImplementedError
     # when no orientation selection is done or pick_ori='normal'
-    assert_raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
+    pytest.raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
                   data_cov, noise_cov=noise_cov, pick_ori=None,
                   weight_norm='nai', reduce_rank=True)
-    assert_raises(NotImplementedError, make_lcmv, evoked.info,
+    pytest.raises(NotImplementedError, make_lcmv, evoked.info,
                   forward_surf_ori, data_cov, noise_cov=noise_cov,
                   pick_ori='normal', weight_norm='nai', reduce_rank=True)
 
@@ -373,7 +372,7 @@ def test_lcmv():
     assert_array_equal(stcs[0].data, advance_iterator(stcs_).data)
 
     epochs.drop_bad()
-    assert_true(len(epochs.events) == len(stcs))
+    assert (len(epochs.events) == len(stcs))
 
     # average the single trial estimates
     stc_avg = np.zeros_like(stcs[0].data)
@@ -418,9 +417,9 @@ def test_lcmv_raw():
 
     # make sure we get an stc with vertices only in the lh
     vertno = [forward['src'][0]['vertno'], forward['src'][1]['vertno']]
-    assert_true(len(stc.vertices[0]) == len(np.intersect1d(vertno[0],
-                                                           label.vertices)))
-    assert_true(len(stc.vertices[1]) == 0)
+    assert len(stc.vertices[0]) == len(np.intersect1d(vertno[0],
+                                                      label.vertices))
+    assert len(stc.vertices[1]) == 0
 
 
 @testing.requires_testing_data
@@ -436,8 +435,8 @@ def test_lcmv_source_power():
     max_source_idx = np.argmax(stc_source_power.data)
     max_source_power = np.max(stc_source_power.data)
 
-    assert_true(max_source_idx == 0, max_source_idx)
-    assert_true(0.4 < max_source_power < 2.4, max_source_power)
+    assert max_source_idx == 0, max_source_idx
+    assert 0.4 < max_source_power < 2.4, max_source_power
 
     # Test picking normal orientation and using a list of CSD matrices
     stc_normal = _lcmv_source_power(
@@ -446,22 +445,21 @@ def test_lcmv_source_power():
 
     # The normal orientation results should always be smaller than free
     # orientation results
-    assert_true((np.abs(stc_normal.data[:, 0]) <=
-                 stc_source_power.data[:, 0]).all())
+    assert (np.abs(stc_normal.data[:, 0]) <= stc_source_power.data[:, 0]).all()
 
     # Test if fixed forward operator is detected when picking normal
     # orientation
-    assert_raises(ValueError, _lcmv_source_power, raw.info, forward_fixed,
+    pytest.raises(ValueError, _lcmv_source_power, raw.info, forward_fixed,
                   noise_cov, data_cov, pick_ori="normal")
 
     # Test if non-surface oriented forward operator is detected when picking
     # normal orientation
-    assert_raises(ValueError, _lcmv_source_power, raw.info, forward, noise_cov,
+    pytest.raises(ValueError, _lcmv_source_power, raw.info, forward, noise_cov,
                   data_cov, pick_ori="normal")
 
     # Test if volume forward operator is detected when picking normal
     # orientation
-    assert_raises(ValueError, _lcmv_source_power, epochs.info, forward_vol,
+    pytest.raises(ValueError, _lcmv_source_power, epochs.info, forward_vol,
                   noise_cov, data_cov, pick_ori="normal")
 
 
@@ -530,13 +528,13 @@ def test_tf_lcmv():
                         reg=reg, label=label, weight_norm='unit-noise-gain')
                 source_power.append(stc_source_power.data)
 
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
                   tstep, win_lengths, freq_bins, reg=reg, label=label)
     stcs = tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep,
                    win_lengths, freq_bins, reg=reg, label=label, raw=raw)
 
-    assert_true(len(stcs) == len(freq_bins))
-    assert_true(stcs[0].shape[1] == 4)
+    assert (len(stcs) == len(freq_bins))
+    assert (stcs[0].shape[1] == 4)
 
     # Averaging all time windows that overlap the time period 0 to 100 ms
     source_power = np.mean(source_power, axis=0)
@@ -548,31 +546,31 @@ def test_tf_lcmv():
     assert_array_almost_equal(stc.data[:, 2], source_power[:, 0])
 
     # Test if using unsupported max-power orientation is detected
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
                   tstep, win_lengths, freq_bins=freq_bins,
                   pick_ori='max-power')
 
     # Test if incorrect number of noise CSDs is detected
     # Test if incorrect number of noise covariances is detected
-    assert_raises(ValueError, tf_lcmv, epochs, forward, [noise_covs[0]], tmin,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, [noise_covs[0]], tmin,
                   tmax, tstep, win_lengths, freq_bins)
 
     # Test if freq_bins and win_lengths incompatibility is detected
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
                   tstep, win_lengths=[0, 1, 2], freq_bins=freq_bins)
 
     # Test if time step exceeding window lengths is detected
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
                   tstep=0.15, win_lengths=[0.2, 0.1], freq_bins=freq_bins)
 
     # Test if missing of noise covariance matrix is detected when more than
     # one channel type is present in the data
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs=None,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs=None,
                   tmin=tmin, tmax=tmax, tstep=tstep, win_lengths=win_lengths,
                   freq_bins=freq_bins)
 
     # Test if unsupported weight normalization specification is detected
-    assert_raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
+    pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
                   tstep, win_lengths, freq_bins, weight_norm='nai')
 
     # Test unsupported pick_ori (vector not supported here)
@@ -585,7 +583,7 @@ def test_tf_lcmv():
                                   baseline=(None, 0), preload=True)
     epochs_preloaded._raw = None
     with warnings.catch_warnings(record=True):  # not enough samples
-        assert_raises(ValueError, tf_lcmv, epochs_preloaded, forward,
+        pytest.raises(ValueError, tf_lcmv, epochs_preloaded, forward,
                       noise_covs, tmin, tmax, tstep, win_lengths, freq_bins)
 
     with warnings.catch_warnings(record=True):  # not enough samples
@@ -607,7 +605,7 @@ def test_reg_pinv():
     # specific warning
     with warnings.catch_warnings(record=True) as w:
         _reg_pinv(a, reg=0.)
-    assert_true(any('deficient' in str(ww.message) for ww in w))
+    assert (any('deficient' in str(ww.message) for ww in w))
 
 
 def test_eig_inv():

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -8,8 +8,7 @@ import numpy as np
 from scipy import linalg
 
 import warnings
-from nose.tools import assert_true, assert_equal
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 import mne
 from mne.datasets import testing
@@ -90,8 +89,8 @@ def _check_dipoles(dipoles, fwd, stc, evoked, residual=None):
                             len(src[0]['vertno'])]
 
     # Check the position of the two dipoles
-    assert_true(dipoles[0].pos[0] in np.array([pos1, pos2]))
-    assert_true(dipoles[1].pos[0] in np.array([pos1, pos2]))
+    assert (dipoles[0].pos[0] in np.array([pos1, pos2]))
+    assert (dipoles[1].pos[0] in np.array([pos1, pos2]))
 
     ori1 = fwd['source_nn'][np.where(src[0]['vertno'] ==
                                      stc.vertices[0])[0]][0]
@@ -100,20 +99,19 @@ def _check_dipoles(dipoles, fwd, stc, evoked, residual=None):
                             len(src[0]['vertno'])][0]
 
     # Check the orientation of the dipoles
-    assert_true(np.max(np.abs(np.dot(dipoles[0].ori[0],
-                                     np.array([ori1, ori2]).T))) > 0.99)
+    assert (np.max(np.abs(np.dot(dipoles[0].ori[0],
+                                 np.array([ori1, ori2]).T))) > 0.99)
 
-    assert_true(np.max(np.abs(np.dot(dipoles[1].ori[0],
-                                     np.array([ori1, ori2]).T))) > 0.99)
+    assert (np.max(np.abs(np.dot(dipoles[1].ori[0],
+                                 np.array([ori1, ori2]).T))) > 0.99)
 
     if residual is not None:
         picks_grad = mne.pick_types(residual.info, meg='grad')
         picks_mag = mne.pick_types(residual.info, meg='mag')
         rel_tol = 0.02
         for picks in [picks_grad, picks_mag]:
-            assert_true(linalg.norm(residual.data[picks], ord='fro') <
-                        rel_tol *
-                        linalg.norm(evoked.data[picks], ord='fro'))
+            assert (linalg.norm(residual.data[picks], ord='fro') <
+                    rel_tol * linalg.norm(evoked.data[picks], ord='fro'))
 
 
 @testing.requires_testing_data
@@ -133,8 +131,8 @@ def test_rap_music_simulated():
     dipoles = rap_music(sim_evoked, forward_fixed, noise_cov,
                         n_dipoles=n_dipoles)
     _check_dipoles(dipoles, forward_fixed, stc, sim_evoked)
-    assert_true(0.98 < dipoles[0].gof.max() < 1.)
-    assert_true(dipoles[0].gof.min() >= 0.)
+    assert (0.98 < dipoles[0].gof.max() < 1.)
+    assert (dipoles[0].gof.min() >= 0.)
     assert_array_equal(dipoles[0].gof, dipoles[1].gof)
 
     nave = 100000  # add a tiny amount of noise to the simulated evokeds
@@ -173,11 +171,11 @@ def test_rap_music_sphere():
     assert_equal((pos[:, 0] < 0).sum(), 1)
     assert_equal((pos[:, 0] > 0).sum(), 1)
     # Check the amplitude scale
-    assert_true(1e-10 < dipoles[0].amplitude[0] < 1e-7)
+    assert (1e-10 < dipoles[0].amplitude[0] < 1e-7)
     # Check the orientation
     dip_fit = mne.fit_dipole(evoked, noise_cov, sphere)[0]
-    assert_true(np.max(np.abs(np.dot(dip_fit.ori, dipoles[0].ori[0]))) > 0.99)
-    assert_true(np.max(np.abs(np.dot(dip_fit.ori, dipoles[1].ori[0]))) > 0.99)
+    assert (np.max(np.abs(np.dot(dip_fit.ori, dipoles[0].ori[0]))) > 0.99)
+    assert (np.max(np.abs(np.dot(dip_fit.ori, dipoles[1].ori[0]))) > 0.99)
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -12,8 +12,7 @@ import warnings
 import pytest
 import numpy as np
 from scipy.io import savemat
-from numpy.testing import assert_array_equal
-from nose.tools import assert_raises, assert_true, assert_equal, assert_false
+from numpy.testing import assert_array_equal, assert_equal
 
 from mne.channels import (rename_channels, read_ch_connectivity,
                           find_ch_connectivity, make_1020_channel_selections)
@@ -45,25 +44,25 @@ def test_reorder_channels():
 
 
 def test_rename_channels():
-    """Test rename channels"""
+    """Test rename channels."""
     info = read_info(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, rename_channels, info, mapping)
+    pytest.raises(ValueError, rename_channels, info, mapping)
     # Test improper mapping configuration
     mapping = {'MEG 2641': 1.0}
-    assert_raises(TypeError, rename_channels, info, mapping)
+    pytest.raises(TypeError, rename_channels, info, mapping)
     # Test non-unique mapping configuration
     mapping = {'MEG 2641': 'MEG 2642'}
-    assert_raises(ValueError, rename_channels, info, mapping)
+    pytest.raises(ValueError, rename_channels, info, mapping)
     # Test bad input
-    assert_raises(ValueError, rename_channels, info, 1.)
-    assert_raises(ValueError, rename_channels, info, 1.)
+    pytest.raises(ValueError, rename_channels, info, 1.)
+    pytest.raises(ValueError, rename_channels, info, 1.)
     # Test name too long (channel names must be less than 15 characters)
     A16 = 'A' * 16
     mapping = {'MEG 2641': A16}
-    assert_raises(ValueError, rename_channels, info, mapping)
+    pytest.raises(ValueError, rename_channels, info, mapping)
 
     # Test successful changes
     # Test ch_name and ch_names are changed
@@ -71,14 +70,14 @@ def test_rename_channels():
     info2['bads'] = ['EEG 060', 'EOG 061']
     mapping = {'EEG 060': 'EEG060', 'EOG 061': 'EOG061'}
     rename_channels(info2, mapping)
-    assert_true(info2['chs'][374]['ch_name'] == 'EEG060')
-    assert_true(info2['ch_names'][374] == 'EEG060')
-    assert_true(info2['chs'][375]['ch_name'] == 'EOG061')
-    assert_true(info2['ch_names'][375] == 'EOG061')
+    assert info2['chs'][374]['ch_name'] == 'EEG060'
+    assert info2['ch_names'][374] == 'EEG060'
+    assert info2['chs'][375]['ch_name'] == 'EOG061'
+    assert info2['ch_names'][375] == 'EOG061'
     assert_array_equal(['EEG060', 'EOG061'], info2['bads'])
     info2 = deepcopy(info)
     rename_channels(info2, lambda x: x.replace(' ', ''))
-    assert_true(info2['chs'][373]['ch_name'] == 'EEG059')
+    assert info2['chs'][373]['ch_name'] == 'EEG059'
     info2 = deepcopy(info)
     info2['bads'] = ['EEG 060', 'EEG 060']
     rename_channels(info2, mapping)
@@ -86,65 +85,65 @@ def test_rename_channels():
 
 
 def test_set_channel_types():
-    """Test set_channel_types"""
+    """Test set_channel_types."""
     raw = read_raw_fif(raw_fname)
     # Error Tests
     # Test channel name exists in ch_names
     mapping = {'EEG 160': 'EEG060'}
-    assert_raises(ValueError, raw.set_channel_types, mapping)
+    pytest.raises(ValueError, raw.set_channel_types, mapping)
     # Test change to illegal channel type
     mapping = {'EOG 061': 'xxx'}
-    assert_raises(ValueError, raw.set_channel_types, mapping)
+    pytest.raises(ValueError, raw.set_channel_types, mapping)
     # Test changing type if in proj (avg eeg ref here)
     mapping = {'EEG 058': 'ecog', 'EEG 059': 'ecg', 'EEG 060': 'eog',
                'EOG 061': 'seeg', 'MEG 2441': 'eeg', 'MEG 2443': 'eeg',
                'MEG 2442': 'hbo'}
-    assert_raises(RuntimeError, raw.set_channel_types, mapping)
+    pytest.raises(RuntimeError, raw.set_channel_types, mapping)
     # Test type change
     raw2 = read_raw_fif(raw_fname)
     raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     with warnings.catch_warnings(record=True):  # MEG channel change
-        assert_raises(RuntimeError, raw2.set_channel_types, mapping)  # has prj
+        pytest.raises(RuntimeError, raw2.set_channel_types, mapping)  # has prj
     raw2.add_proj([], remove_existing=True)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         raw2.set_channel_types(mapping)
-    assert_true(len(w) >= 1, msg=[str(ww.message) for ww in w])
-    assert_true(all('The unit for channel' in str(ww.message) for ww in w))
+    assert len(w) >= 1, [str(ww.message) for ww in w]
+    assert all('The unit for channel' in str(ww.message) for ww in w)
     info = raw2.info
-    assert_true(info['chs'][372]['ch_name'] == 'EEG 058')
-    assert_true(info['chs'][372]['kind'] == FIFF.FIFFV_ECOG_CH)
-    assert_true(info['chs'][372]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info['chs'][372]['coil_type'] == FIFF.FIFFV_COIL_EEG)
-    assert_true(info['chs'][373]['ch_name'] == 'EEG 059')
-    assert_true(info['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH)
-    assert_true(info['chs'][373]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info['chs'][373]['coil_type'] == FIFF.FIFFV_COIL_NONE)
-    assert_true(info['chs'][374]['ch_name'] == 'EEG 060')
-    assert_true(info['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH)
-    assert_true(info['chs'][374]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info['chs'][374]['coil_type'] == FIFF.FIFFV_COIL_NONE)
-    assert_true(info['chs'][375]['ch_name'] == 'EOG 061')
-    assert_true(info['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH)
-    assert_true(info['chs'][375]['unit'] == FIFF.FIFF_UNIT_V)
-    assert_true(info['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG)
+    assert info['chs'][372]['ch_name'] == 'EEG 058'
+    assert info['chs'][372]['kind'] == FIFF.FIFFV_ECOG_CH
+    assert info['chs'][372]['unit'] == FIFF.FIFF_UNIT_V
+    assert info['chs'][372]['coil_type'] == FIFF.FIFFV_COIL_EEG
+    assert info['chs'][373]['ch_name'] == 'EEG 059'
+    assert info['chs'][373]['kind'] == FIFF.FIFFV_ECG_CH
+    assert info['chs'][373]['unit'] == FIFF.FIFF_UNIT_V
+    assert info['chs'][373]['coil_type'] == FIFF.FIFFV_COIL_NONE
+    assert info['chs'][374]['ch_name'] == 'EEG 060'
+    assert info['chs'][374]['kind'] == FIFF.FIFFV_EOG_CH
+    assert info['chs'][374]['unit'] == FIFF.FIFF_UNIT_V
+    assert info['chs'][374]['coil_type'] == FIFF.FIFFV_COIL_NONE
+    assert info['chs'][375]['ch_name'] == 'EOG 061'
+    assert info['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH
+    assert info['chs'][375]['unit'] == FIFF.FIFF_UNIT_V
+    assert info['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG
     for idx in pick_channels(raw.ch_names, ['MEG 2441', 'MEG 2443']):
-        assert_true(info['chs'][idx]['kind'] == FIFF.FIFFV_EEG_CH)
-        assert_true(info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_V)
-        assert_true(info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_EEG)
+        assert info['chs'][idx]['kind'] == FIFF.FIFFV_EEG_CH
+        assert info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_V
+        assert info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_EEG
     idx = pick_channels(raw.ch_names, ['MEG 2442'])[0]
-    assert_true(info['chs'][idx]['kind'] == FIFF.FIFFV_FNIRS_CH)
-    assert_true(info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_MOL)
-    assert_true(info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO)
+    assert info['chs'][idx]['kind'] == FIFF.FIFFV_FNIRS_CH
+    assert info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_MOL
+    assert info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO
 
     # Test meaningful error when setting channel type with unknown unit
     raw.info['chs'][0]['unit'] = 0.
     ch_types = {raw.ch_names[0]: 'misc'}
-    assert_raises(ValueError, raw.set_channel_types, ch_types)
+    pytest.raises(ValueError, raw.set_channel_types, ch_types)
 
 
 def test_read_ch_connectivity():
-    """Test reading channel connectivity templates"""
+    """Test reading channel connectivity templates."""
     tempdir = _TempDir()
     a = partial(np.array, dtype='<U7')
     # no pep8
@@ -164,24 +163,24 @@ def test_read_ch_connectivity():
     assert_equal(x.shape, (3, 3))
     assert_equal(x[0, 1], False)
     assert_equal(x[0, 2], True)
-    assert_true(np.all(x.diagonal()))
-    assert_raises(ValueError, read_ch_connectivity, mat_fname, [0, 3])
+    assert np.all(x.diagonal())
+    pytest.raises(ValueError, read_ch_connectivity, mat_fname, [0, 3])
     ch_connectivity, ch_names = read_ch_connectivity(mat_fname, picks=[0, 2])
     assert_equal(ch_connectivity.shape[0], 2)
     assert_equal(len(ch_names), 2)
 
     ch_names = ['EEG01', 'EEG02', 'EEG03']
     neighbors = [['EEG02'], ['EEG04'], ['EEG02']]
-    assert_raises(ValueError, _ch_neighbor_connectivity, ch_names, neighbors)
+    pytest.raises(ValueError, _ch_neighbor_connectivity, ch_names, neighbors)
     neighbors = [['EEG02'], ['EEG01', 'EEG03'], ['EEG 02']]
-    assert_raises(ValueError, _ch_neighbor_connectivity, ch_names[:2],
+    pytest.raises(ValueError, _ch_neighbor_connectivity, ch_names[:2],
                   neighbors)
     neighbors = [['EEG02'], 'EEG01', ['EEG 02']]
-    assert_raises(ValueError, _ch_neighbor_connectivity, ch_names, neighbors)
+    pytest.raises(ValueError, _ch_neighbor_connectivity, ch_names, neighbors)
     connectivity, ch_names = read_ch_connectivity('neuromag306mag')
     assert_equal(connectivity.shape, (102, 102))
     assert_equal(len(ch_names), 102)
-    assert_raises(ValueError, read_ch_connectivity, 'bananas!')
+    pytest.raises(ValueError, read_ch_connectivity, 'bananas!')
 
     # In EGI 256, E31 sensor has no neighbour
     a = partial(np.array)
@@ -200,9 +199,9 @@ def test_read_ch_connectivity():
     x = ch_connectivity.todense()
     assert_equal(x.shape[0], len(ch_names))
     assert_equal(x.shape, (4, 4))
-    assert_true(np.all(x.diagonal()))
-    assert_false(np.any(x[0, 1:]))
-    assert_false(np.any(x[1:, 0]))
+    assert np.all(x.diagonal())
+    assert not np.any(x[0, 1:])
+    assert not np.any(x[1:, 0])
 
     # Check for neighbours consistency. If a sensor is marked as a neighbour,
     # then it should also have its neighbours defined.
@@ -218,11 +217,11 @@ def test_read_ch_connectivity():
     mat = dict(neighbours=nbh)
     mat_fname = op.join(tempdir, 'test_error_mat.mat')
     savemat(mat_fname, mat, oned_as='row')
-    assert_raises(ValueError, read_ch_connectivity, mat_fname)
+    pytest.raises(ValueError, read_ch_connectivity, mat_fname)
 
 
 def test_get_set_sensor_positions():
-    """Test get/set functions for sensor positions"""
+    """Test get/set functions for sensor positions."""
     raw1 = read_raw_fif(raw_fname)
     picks = pick_types(raw1.info, meg=False, eeg=True)
     pos = np.array([ch['loc'][:3] for ch in raw1.info['chs']])[picks]
@@ -230,7 +229,7 @@ def test_get_set_sensor_positions():
     assert_array_equal(raw_pos, pos)
 
     ch_name = raw1.info['ch_names'][13]
-    assert_raises(ValueError, raw1._set_channel_positions, [1, 2], ['name'])
+    pytest.raises(ValueError, raw1._set_channel_positions, [1, 2], ['name'])
     raw2 = read_raw_fif(raw_fname)
     raw2.info['chs'][13]['loc'][:3] = np.array([1, 2, 3])
     raw1._set_channel_positions([[1, 2, 3]], [ch_name])
@@ -240,14 +239,14 @@ def test_get_set_sensor_positions():
 
 @testing.requires_testing_data
 def test_1020_selection():
-    """Test making a 10/20 selection dict"""
+    """Test making a 10/20 selection dict."""
     base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
     raw_fname = op.join(base_dir, 'test_raw.set')
     loc_fname = op.join(base_dir, 'test_chans.locs')
     raw = read_raw_eeglab(raw_fname, montage=loc_fname)
 
     for input in ("a_string", 100, raw, [1, 2]):
-        assert_raises(TypeError, make_1020_channel_selections, input)
+        pytest.raises(TypeError, make_1020_channel_selections, input)
 
     sels = make_1020_channel_selections(raw.info)
     # are all frontal channels placed before all occipital channels?
@@ -256,12 +255,12 @@ def test_1020_selection():
                   if raw.ch_names[pick].startswith("F")])
         ps = max([ii for ii, pick in enumerate(picks)
                   if raw.ch_names[pick].startswith("O")])
-        assert_true(fs > ps)
+        assert fs > ps
 
     # are channels in the correct selection?
     fz_c3_c4 = [raw.ch_names.index(ch) for ch in ("Fz", "C3", "C4")]
     for channel, roi in zip(fz_c3_c4, ("Midline", "Left", "Right")):
-        assert_true(channel in sels[roi])
+        assert channel in sels[roi]
 
 
 @testing.requires_testing_data
@@ -277,7 +276,7 @@ def test_find_ch_connectivity():
         # Silly test for checking the number of neighbors.
         assert_equal(conn.getnnz(), sizes[ch_type])
         assert_equal(len(ch_names), nchans[ch_type])
-    assert_raises(ValueError, find_ch_connectivity, raw.info, None)
+    pytest.raises(ValueError, find_ch_connectivity, raw.info, None)
 
     # Test computing the conn matrix with gradiometers.
     conn, ch_names = _compute_ch_connectivity(raw.info, 'grad')
@@ -291,14 +290,14 @@ def test_find_ch_connectivity():
     bti_config_name = op.join(data_path, 'BTi', 'erm_HFH', 'config')
     raw = read_raw_bti(bti_fname, bti_config_name, None)
     _, ch_names = find_ch_connectivity(raw.info, 'mag')
-    assert_true('A1' in ch_names)
+    assert 'A1' in ch_names
 
     ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf_short.ds')
     raw = read_raw_ctf(ctf_fname)
     _, ch_names = find_ch_connectivity(raw.info, 'mag')
-    assert_true('MLC11' in ch_names)
+    assert 'MLC11' in ch_names
 
-    assert_raises(ValueError, find_ch_connectivity, raw.info, 'eog')
+    pytest.raises(ValueError, find_ch_connectivity, raw.info, 'eog')
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -6,14 +6,14 @@ import os
 import os.path as op
 import warnings
 
-from nose.tools import assert_equal, assert_true, assert_raises
+import pytest
 
 import numpy as np
 from scipy.io import savemat
 
 from numpy.testing import (assert_array_equal, assert_almost_equal,
                            assert_allclose, assert_array_almost_equal,
-                           assert_array_less)
+                           assert_array_less, assert_equal)
 from mne.tests.common import assert_dig_allclose
 from mne.channels.montage import (read_montage, _set_montage, read_dig_montage,
                                   get_builtin_montages)
@@ -81,15 +81,15 @@ def test_documented():
         elif start is not None and li > start and line.startswith('===='):
             stop = li
             break
-    assert_true(start is not None)
-    assert_true(stop is not None)
+    assert (start is not None)
+    assert (stop is not None)
     kinds = [line.split(' ')[0] for line in lines[start:stop]]
     kinds = [kind for kind in kinds if kind != '']
     montages = os.listdir(op.join(op.dirname(_mne_file), 'channels', 'data',
                                   'montages'))
     montages = sorted(op.splitext(m)[0] for m in montages)
     assert_equal(len(set(montages)), len(montages))
-    assert_equal(len(set(kinds)), len(kinds), msg=sorted(kinds))
+    assert_equal(len(set(kinds)), len(kinds), err_msg=str(sorted(kinds)))
     assert_equal(set(montages), set(kinds))
 
 
@@ -193,7 +193,7 @@ def test_montage():
             fid.write(text)
         montage = read_montage(fname)
         if kind in ('sfp', 'txt'):
-            assert_true('very_very_very_long_name' in montage.ch_names)
+            assert ('very_very_very_long_name' in montage.ch_names)
         assert_equal(len(montage.ch_names), 4)
         assert_equal(len(montage.ch_names), len(montage.pos))
         assert_equal(montage.pos.shape, (4, 3))
@@ -282,7 +282,7 @@ def test_montage():
             data=np.zeros((len(montage.ch_names), 1)), info=info, tmin=0)
 
         # test return type as well as set montage
-        assert_true(isinstance(evoked.set_montage(montage), type(evoked)))
+        assert (isinstance(evoked.set_montage(montage), type(evoked)))
 
         pos3 = np.array([c['loc'][:3] for c in evoked.info['chs']])
         assert_array_equal(pos3, montage.pos)
@@ -293,28 +293,28 @@ def test_montage():
             info = create_info(montage.ch_names + ['foo', 'bar'], 1e3,
                                ['eeg'] * (len(montage.ch_names) + 2))
             _set_montage(info, montage)
-            assert_true(len(w) == 1)
+            assert (len(w) == 1)
 
     # Channel names can be treated case insensitive
     with warnings.catch_warnings(record=True) as w:
         info = create_info(['FP1', 'af7', 'AF3'], 1e3, ['eeg'] * 3)
         _set_montage(info, montage)
-        assert_true(len(w) == 0)
+        assert (len(w) == 0)
 
     # Unless there is a collision in names
     with warnings.catch_warnings(record=True) as w:
         info = create_info(['FP1', 'Fp1', 'AF3'], 1e3, ['eeg'] * 3)
-        assert_true(info['dig'] is None)
+        assert (info['dig'] is None)
         _set_montage(info, montage)
         assert_equal(len(info['dig']), 5)  # 2 EEG w/pos, 3 fiducials
-        assert_true(len(w) == 1)
+        assert (len(w) == 1)
     with warnings.catch_warnings(record=True) as w:
         montage.ch_names = ['FP1', 'Fp1', 'AF3']
         info = create_info(['fp1', 'AF3'], 1e3, ['eeg', 'eeg'])
-        assert_true(info['dig'] is None)
+        assert (info['dig'] is None)
         _set_montage(info, montage, set_dig=False)
-        assert_true(info['dig'] is None)
-        assert_true(len(w) == 1)
+        assert (info['dig'] is None)
+        assert (len(w) == 1)
 
     # test get_pos2d method
     montage = read_montage("standard_1020")
@@ -323,19 +323,19 @@ def test_montage():
     fz = montage.get_pos2d()[montage.ch_names.index("Fz")]
     oz = montage.get_pos2d()[montage.ch_names.index("Oz")]
     f1 = montage.get_pos2d()[montage.ch_names.index("F1")]
-    assert_true(c3[0] < 0)  # left hemisphere
-    assert_true(c4[0] > 0)  # right hemisphere
-    assert_true(fz[1] > 0)  # frontal
-    assert_true(oz[1] < 0)  # occipital
+    assert (c3[0] < 0)  # left hemisphere
+    assert (c4[0] > 0)  # right hemisphere
+    assert (fz[1] > 0)  # frontal
+    assert (oz[1] < 0)  # occipital
     assert_allclose(fz[0], 0, atol=1e-2)  # midline
     assert_allclose(oz[0], 0, atol=1e-2)  # midline
-    assert_true(f1[0] < 0 and f1[1] > 0)  # left frontal
+    assert (f1[0] < 0 and f1[1] > 0)  # left frontal
 
     # test get_builtin_montages function
     montages = get_builtin_montages()
-    assert_true(len(montages) > 0)  # MNE should always ship with montages
-    assert_true("standard_1020" in montages)  # 10/20 montage
-    assert_true("standard_1005" in montages)  # 10/05 montage
+    assert (len(montages) > 0)  # MNE should always ship with montages
+    assert ("standard_1020" in montages)  # 10/20 montage
+    assert ("standard_1005" in montages)  # 10/05 montage
 
 
 @testing.requires_testing_data
@@ -350,7 +350,7 @@ def test_read_locs():
 
 
 def test_read_dig_montage():
-    """Test read_dig_montage"""
+    """Test read_dig_montage."""
     names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']
     montage = read_dig_montage(hsp, hpi, elp, names, transform=False)
     elp_points = _read_dig_points(elp)
@@ -360,7 +360,7 @@ def test_read_dig_montage():
     assert_array_equal(montage.elp, elp_points)
     assert_array_equal(montage.hsp, hsp_points)
     assert_array_equal(montage.hpi, hpi_points)
-    assert_true(montage.dev_head_t is None)
+    assert (montage.dev_head_t is None)
     montage = read_dig_montage(hsp, hpi, elp, names,
                                transform=True, dev_head_t=True)
     # check coordinate transformation
@@ -390,7 +390,7 @@ def test_read_dig_montage():
     assert_allclose(montage_cm.hsp, montage.hsp * 10.)
     assert_allclose(montage_cm.elp, montage.elp * 10.)
     assert_array_equal(montage_cm.hpi, montage.hpi)
-    assert_raises(ValueError, read_dig_montage, hsp, hpi, elp, names,
+    pytest.raises(ValueError, read_dig_montage, hsp, hpi, elp, names,
                   unit='km')
     # extra columns
     extra_hsp = op.join(tempdir, 'test.txt')
@@ -404,7 +404,7 @@ def test_read_dig_montage():
                     fout.write(line.rstrip() + b' 0.0 0.0 0.0\n')
     with warnings.catch_warnings(record=True) as w:
         montage_extra = read_dig_montage(extra_hsp, hpi, elp, names)
-    assert_true(len(w) == 1 and all('columns' in str(ww.message) for ww in w))
+    assert (len(w) == 1 and all('columns' in str(ww.message) for ww in w))
     assert_allclose(montage_extra.hsp, montage.hsp)
     assert_allclose(montage_extra.elp, montage.elp)
 
@@ -432,7 +432,7 @@ def test_set_dig_montage():
         info = create_info(['Test Ch'], 1e3, ['eeg'])
         with warnings.catch_warnings(record=True) as w:  # test ch pos not set
             _set_montage(info, use_mon)
-        assert_true(all('not set' in str(ww.message) for ww in w))
+        assert (all('not set' in str(ww.message) for ww in w))
         hs = np.array([p['r'] for i, p in enumerate(info['dig'])
                        if p['kind'] == FIFF.FIFFV_POINT_EXTRA])
         nasion_dig = np.array([p['r'] for p in info['dig']
@@ -467,7 +467,7 @@ def test_fif_dig_montage():
     # Make a BrainVision file like the one the user would have had
     with warnings.catch_warnings(record=True) as w:
         raw_bv = read_raw_brainvision(bv_fname, preload=True)
-    assert_true(any('will be dropped' in str(ww.message) for ww in w))
+    assert (any('will be dropped' in str(ww.message) for ww in w))
     raw_bv_2 = raw_bv.copy()
     mapping = dict()
     for ii, ch_name in enumerate(raw_bv.ch_names[:-1]):
@@ -504,7 +504,7 @@ def test_fif_dig_montage():
     # Roundtrip of non-FIF start
     names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']
     montage = read_dig_montage(hsp, hpi, elp, names, transform=False)
-    assert_raises(RuntimeError, montage.save, fname_temp)  # must be head coord
+    pytest.raises(RuntimeError, montage.save, fname_temp)  # must be head coord
     montage = read_dig_montage(hsp, hpi, elp, names)
     _check_roundtrip(montage, fname_temp)
 
@@ -550,7 +550,7 @@ def test_set_montage():
     raw.set_montage('mgh60')  # test loading with string argument
     new_pos = np.array([ch['loc'][:3] for ch in raw.info['chs']
                         if ch['ch_name'].startswith('EEG')])
-    assert_true((orig_pos != new_pos).all())
+    assert ((orig_pos != new_pos).all())
     r0 = _fit_sphere(new_pos)[1]
     assert_allclose(r0, [0., -0.016, 0.], atol=1e-3)
     # mgh70 has no 61/62/63/64 (these are EOG/ECG)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -4,8 +4,8 @@ from os import path as op
 import shutil
 import glob
 import warnings
+
 import pytest
-from nose.tools import assert_true, assert_raises
 from numpy.testing import assert_equal, assert_allclose
 
 from mne import concatenate_raws, read_bem_surfaces
@@ -32,14 +32,14 @@ warnings.simplefilter('always')
 
 
 def check_usage(module, force_help=False):
-    """Helper to ensure we print usage"""
+    """Ensure we print usage."""
     args = ('--help',) if force_help else ()
     with ArgvSetter(args) as out:
         try:
             module.run()
         except SystemExit:
             pass
-        assert_true('Usage: ' in out.stdout.getvalue())
+        assert 'Usage: ' in out.stdout.getvalue()
 
 
 @pytest.mark.slowtest
@@ -82,9 +82,9 @@ def test_clean_eog_ecg():
     with ArgvSetter(('-i', use_fname, '--quiet')):
         mne_clean_eog_ecg.run()
     fnames = glob.glob(op.join(tempdir, '*proj.fif'))
-    assert_true(len(fnames) == 2)  # two projs
+    assert len(fnames) == 2  # two projs
     fnames = glob.glob(op.join(tempdir, '*-eve.fif'))
-    assert_true(len(fnames) == 3)  # raw plus two projs
+    assert len(fnames) == 3  # raw plus two projs
 
 
 @pytest.mark.slowtest
@@ -103,14 +103,14 @@ def test_compute_proj_ecg_eog():
             with warnings.catch_warnings(record=True):  # too few samples
                 fun.run()
         fnames = glob.glob(op.join(tempdir, '*proj.fif'))
-        assert_true(len(fnames) == 1)
+        assert len(fnames) == 1
         fnames = glob.glob(op.join(tempdir, '*-eve.fif'))
-        assert_true(len(fnames) == 1)
+        assert len(fnames) == 1
 
 
 def test_coreg():
     """Test mne coreg."""
-    assert_true(hasattr(mne_coreg, 'run'))
+    assert hasattr(mne_coreg, 'run')
 
 
 def test_kit2fiff():
@@ -143,12 +143,12 @@ def test_make_scalp_surfaces():
     medium_fname = op.join(subj_dir, 'sample-head-medium.fif')
     try:
         with ArgvSetter(cmd, disable_stdout=False, disable_stderr=False):
-            assert_raises(RuntimeError, mne_make_scalp_surfaces.run)
+            pytest.raises(RuntimeError, mne_make_scalp_surfaces.run)
             os.environ['FREESURFER_HOME'] = tempdir  # don't actually use it
             mne_make_scalp_surfaces.run()
-            assert_true(op.isfile(dense_fname))
-            assert_true(op.isfile(medium_fname))
-            assert_raises(IOError, mne_make_scalp_surfaces.run)  # no overwrite
+            assert op.isfile(dense_fname)
+            assert op.isfile(medium_fname)
+            pytest.raises(IOError, mne_make_scalp_surfaces.run)  # no overwrite
     finally:
         if orig_fs is not None:
             os.environ['FREESURFER_HOME'] = orig_fs
@@ -176,9 +176,9 @@ def test_maxfilter():
                 mne_maxfilter.run()
             finally:
                 del os.environ['_MNE_MAXFILTER_TEST']
-        assert_true(len(w) == 1)
+        assert len(w) == 1
         for check in ('maxfilter', '-trans', '-movecomp'):
-            assert_true(check in out.stdout.getvalue(), check)
+            assert check in out.stdout.getvalue(), check
 
 
 @pytest.mark.slowtest
@@ -195,7 +195,7 @@ def test_report():
                      '-s', 'sample', '--no-browser', '-m', '30')):
         mne_report.run()
     fnames = glob.glob(op.join(tempdir, '*.html'))
-    assert_true(len(fnames) == 1)
+    assert len(fnames) == 1
 
 
 def test_surf2bem():

--- a/mne/connectivity/tests/test_effective.py
+++ b/mne/connectivity/tests/test_effective.py
@@ -1,12 +1,11 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true
 
 from mne.connectivity import phase_slope_index
 
 
 def test_psi():
-    """Test Phase Slope Index (PSI) estimation"""
+    """Test Phase Slope Index (PSI) estimation."""
     sfreq = 50.
     n_signals = 3
     n_epochs = 10
@@ -21,8 +20,8 @@ def test_psi():
 
     psi, freqs, times, n_epochs, n_tapers = phase_slope_index(
         data, mode='fourier', sfreq=sfreq)
-    assert_true(psi[1, 0, 0] < 0)
-    assert_true(psi[2, 0, 0] > 0)
+    assert psi[1, 0, 0] < 0
+    assert psi[2, 0, 0] > 0
 
     indices = (np.array([0]), np.array([1]))
     psi_2, freqs, times, n_epochs, n_tapers = phase_slope_index(
@@ -36,5 +35,5 @@ def test_psi():
         data, mode='cwt_morlet', sfreq=sfreq, cwt_freqs=cwt_freqs,
         indices=indices)
 
-    assert_true(np.all(psi_cwt > 0))
-    assert_true(psi_cwt.shape[-1] == n_times)
+    assert np.all(psi_cwt > 0)
+    assert psi_cwt.shape[-1] == n_times

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
-from nose.tools import assert_true, assert_raises
 
 from mne.connectivity import spectral_connectivity
 from mne.connectivity.spectral import _CohEst, _get_n_epochs
@@ -16,7 +15,7 @@ warnings.simplefilter('always')
 
 
 def _stc_gen(data, sfreq, tmin, combo=False):
-    """Simulate a SourceEstimate generator"""
+    """Simulate a SourceEstimate generator."""
     vertices = [np.arange(data.shape[1]), np.empty(0)]
     for d in data:
         if not combo:
@@ -33,9 +32,9 @@ def _stc_gen(data, sfreq, tmin, combo=False):
 
 @pytest.mark.slowtest
 def test_spectral_connectivity():
-    """Test frequency-domain connectivity methods"""
+    """Test frequency-domain connectivity methods."""
     # Use a case known to have no spurious correlations (it would bad if
-    # nosetests could randomly fail):
+    # tests could randomly fail):
     rng = np.random.RandomState(0)
     trans_bandwidth = 2.
 
@@ -60,17 +59,17 @@ def test_spectral_connectivity():
     data = np.transpose(data, [1, 0, 2])
 
     # First we test some invalid parameters:
-    assert_raises(ValueError, spectral_connectivity, data, method='notamethod')
-    assert_raises(ValueError, spectral_connectivity, data,
+    pytest.raises(ValueError, spectral_connectivity, data, method='notamethod')
+    pytest.raises(ValueError, spectral_connectivity, data,
                   mode='notamode')
 
     # test invalid fmin fmax settings
-    assert_raises(ValueError, spectral_connectivity, data, fmin=10,
+    pytest.raises(ValueError, spectral_connectivity, data, fmin=10,
                   fmax=10 + 0.5 * (sfreq / float(n_times)))
-    assert_raises(ValueError, spectral_connectivity, data, fmin=10, fmax=5)
-    assert_raises(ValueError, spectral_connectivity, data, fmin=(0, 11),
+    pytest.raises(ValueError, spectral_connectivity, data, fmin=10, fmax=5)
+    pytest.raises(ValueError, spectral_connectivity, data, fmin=(0, 11),
                   fmax=(5, 10))
-    assert_raises(ValueError, spectral_connectivity, data, fmin=(11,),
+    pytest.raises(ValueError, spectral_connectivity, data, fmin=(11,),
                   fmax=(12, 15))
 
     methods = ['coh', 'cohy', 'imcoh', ['plv', 'ppc', 'pli', 'pli2_unbiased',
@@ -108,7 +107,7 @@ def test_spectral_connectivity():
                     mt_bandwidth=mt_bandwidth, cwt_freqs=cwt_freqs,
                     cwt_n_cycles=cwt_n_cycles)
 
-                assert_true(n == n_epochs)
+                assert (n == n_epochs)
                 assert_array_almost_equal(times_data, times)
 
                 if mode == 'multitaper':
@@ -125,29 +124,26 @@ def test_spectral_connectivity():
                                        (fstart - trans_bandwidth * 2,
                                         fend + trans_bandwidth * 2))
                 if method == 'coh':
-                    assert_true(np.all(con[1, 0, gidx[0]:gidx[1]] > upper_t),
-                                con[1, 0, gidx[0]:gidx[1]].min())
+                    assert np.all(con[1, 0, gidx[0]:gidx[1]] > upper_t), \
+                        con[1, 0, gidx[0]:gidx[1]].min()
                     # we see something for zero-lag
-                    assert_true(np.all(con[1, 0, :bidx[0]] < lower_t))
-                    assert_true(np.all(con[1, 0, bidx[1]:] < lower_t),
-                                con[1, 0, bidx[1:]].max())
+                    assert (np.all(con[1, 0, :bidx[0]] < lower_t))
+                    assert np.all(con[1, 0, bidx[1]:] < lower_t), \
+                        con[1, 0, bidx[1:]].max()
                 elif method == 'cohy':
                     # imaginary coh will be zero
                     check = np.imag(con[1, 0, gidx[0]:gidx[1]])
-                    assert_true(np.all(check < lower_t), check.max())
+                    assert np.all(check < lower_t), check.max()
                     # we see something for zero-lag
-                    assert_true(np.all(np.abs(con[1, 0, gidx[0]:gidx[1]]) >
-                                upper_t))
-                    assert_true(np.all(np.abs(con[1, 0, :bidx[0]]) <
-                                lower_t))
-                    assert_true(np.all(np.abs(con[1, 0, bidx[1]:]) <
-                                lower_t))
+                    assert np.all(np.abs(con[1, 0, gidx[0]:gidx[1]]) > upper_t)
+                    assert np.all(np.abs(con[1, 0, :bidx[0]]) < lower_t)
+                    assert np.all(np.abs(con[1, 0, bidx[1]:]) < lower_t)
                 elif method == 'imcoh':
                     # imaginary coh will be zero
-                    assert_true(np.all(con[1, 0, gidx[0]:gidx[1]] < lower_t))
-                    assert_true(np.all(con[1, 0, :bidx[0]] < lower_t))
-                    assert_true(np.all(con[1, 0, bidx[1]:] < lower_t),
-                                con[1, 0, bidx[1]:].max())
+                    assert np.all(con[1, 0, gidx[0]:gidx[1]] < lower_t)
+                    assert np.all(con[1, 0, :bidx[0]] < lower_t)
+                    assert np.all(con[1, 0, bidx[1]:] < lower_t), \
+                        con[1, 0, bidx[1]:].max()
 
                 # compute same connections using indices and 2 jobs
                 indices = np.tril_indices(n_signals, -1)
@@ -165,8 +161,8 @@ def test_spectral_connectivity():
                     cwt_freqs=cwt_freqs,
                     cwt_n_cycles=cwt_n_cycles, n_jobs=2)
 
-                assert_true(isinstance(con2, list))
-                assert_true(len(con2) == len(test_methods))
+                assert (isinstance(con2, list))
+                assert (len(con2) == len(test_methods))
 
                 if method == 'coh':
                     assert_array_almost_equal(con2[0], con2[1])
@@ -177,15 +173,15 @@ def test_spectral_connectivity():
                     # we get the same result for the probed connections
                     assert_array_almost_equal(freqs, freqs2)
                     assert_array_almost_equal(con[indices], con2)
-                    assert_true(n == n2)
+                    assert (n == n2)
                     assert_array_almost_equal(times_data, times2)
                 else:
                     # we get the same result for the probed connections
-                    assert_true(len(con) == len(con2))
+                    assert (len(con) == len(con2))
                     for c, c2 in zip(con, con2):
                         assert_array_almost_equal(freqs, freqs2)
                         assert_array_almost_equal(c[indices], c2)
-                        assert_true(n == n2)
+                        assert (n == n2)
                         assert_array_almost_equal(times_data, times2)
 
                 # compute same connections for two bands, fskip=1, and f. avg.
@@ -198,11 +194,11 @@ def test_spectral_connectivity():
                     mt_bandwidth=mt_bandwidth, cwt_freqs=cwt_freqs,
                     cwt_n_cycles=cwt_n_cycles)
 
-                assert_true(isinstance(freqs3, list))
-                assert_true(len(freqs3) == len(fmin))
+                assert (isinstance(freqs3, list))
+                assert (len(freqs3) == len(fmin))
                 for i in range(len(freqs3)):
-                    assert_true(np.all((freqs3[i] >= fmin[i]) &
-                                       (freqs3[i] <= fmax[i])))
+                    assert np.all((freqs3[i] >= fmin[i]) &
+                                  (freqs3[i] <= fmax[i]))
 
                 # average con2 "manually" and we get the same result
                 if not isinstance(method, list):
@@ -219,9 +215,10 @@ def test_spectral_connectivity():
     # test _get_n_epochs
     full_list = list(range(10))
     out_lens = np.array([len(x) for x in _get_n_epochs(full_list, 4)])
-    assert_true((out_lens == np.array([4, 4, 2])).all())
+    assert ((out_lens == np.array([4, 4, 2])).all())
     out_lens = np.array([len(x) for x in _get_n_epochs(full_list, 11)])
-    assert_true(len(out_lens) > 0)
-    assert_true(out_lens[0] == 10)
+    assert (len(out_lens) > 0)
+    assert (out_lens[0] == 10)
+
 
 run_tests_if_main()

--- a/mne/connectivity/tests/test_utils.py
+++ b/mne/connectivity/tests/test_utils.py
@@ -1,11 +1,10 @@
 import numpy as np
-from nose.tools import assert_true
 
 from mne.connectivity import seed_target_indices
 
 
 def test_indices():
-    """Test connectivity indexing methods"""
+    """Test connectivity indexing methods."""
     n_seeds_test = [1, 3, 4]
     n_targets_test = [2, 3, 200]
     rng = np.random.RandomState(42)
@@ -15,10 +14,10 @@ def test_indices():
             seeds = idx[:n_seeds]
             targets = idx[n_seeds:]
             indices = seed_target_indices(seeds, targets)
-            assert_true(len(indices) == 2)
-            assert_true(len(indices[0]) == len(indices[1]))
-            assert_true(len(indices[0]) == n_seeds * n_targets)
+            assert len(indices) == 2
+            assert len(indices[0]) == len(indices[1])
+            assert len(indices[0]) == n_seeds * n_targets
             for seed in seeds:
-                assert_true(np.sum(indices[0] == seed) == n_targets)
+                assert np.sum(indices[0] == seed) == n_targets
             for target in targets:
-                assert_true(np.sum(indices[1] == target) == n_seeds)
+                assert np.sum(indices[1] == target) == n_seeds

--- a/mne/datasets/sample/sample.py
+++ b/mne/datasets/sample/sample.py
@@ -5,8 +5,6 @@
 
 from functools import partial
 
-import numpy as np
-
 from ...utils import verbose, get_config
 from ..utils import (has_dataset, _data_path, _data_path_doc,
                      _get_version, _version_doc)
@@ -22,12 +20,14 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
                       update_path=update_path, name='sample',
                       download=download)
 
+
 data_path.__doc__ = _data_path_doc.format(name='sample',
                                           conf='MNE_DATASETS_SAMPLE_PATH')
 
 
 def get_version():  # noqa: D103
     return _get_version('sample')
+
 
 get_version.__doc__ = _version_doc.format(name='sample')
 
@@ -39,5 +39,9 @@ def _skip_sample_data():
     skip = skip_testing or not has_sample_data()
     return skip
 
-requires_sample_data = np.testing.dec.skipif(_skip_sample_data,
-                                             'Requires sample dataset')
+
+def requires_sample_data(func):
+    """Skip testing data test."""
+    import pytest
+    return pytest.mark.skipif(_skip_sample_data(),
+                              reason='Requires sample dataset')(func)

--- a/mne/datasets/spm_face/spm_data.py
+++ b/mne/datasets/spm_face/spm_data.py
@@ -4,8 +4,6 @@
 
 from functools import partial
 
-import numpy as np
-
 from ...utils import verbose, get_config
 from ..utils import (has_dataset, _data_path, _data_path_doc,
                      _get_version, _version_doc)
@@ -21,12 +19,14 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
                       update_path=update_path, name='spm',
                       download=download)
 
+
 data_path.__doc__ = _data_path_doc.format(name='spm',
                                           conf='MNE_DATASETS_SPM_DATA_PATH')
 
 
 def get_version():  # noqa: D103
     return _get_version('spm')
+
 
 get_version.__doc__ = _version_doc.format(name='spm')
 
@@ -37,5 +37,9 @@ def _skip_spm_data():
     skip = skip_testing or not has_spm_data()
     return skip
 
-requires_spm_data = np.testing.dec.skipif(_skip_spm_data,
-                                          'Requires spm dataset')
+
+def requires_spm_data(func):
+    """Skip testing data test."""
+    import pytest
+    return pytest.mark.skipif(_skip_spm_data(),
+                              reason='Requires spm dataset')(func)

--- a/mne/datasets/testing/_testing.py
+++ b/mne/datasets/testing/_testing.py
@@ -5,8 +5,6 @@
 
 from functools import partial
 
-import numpy as np
-
 from ...utils import verbose, get_config
 from ..utils import (has_dataset, _data_path, _data_path_doc,
                      _get_version, _version_doc)
@@ -26,12 +24,14 @@ def data_path(path=None, force_update=False, update_path=True,
                       update_path=update_path, name='testing',
                       download=download)
 
+
 data_path.__doc__ = _data_path_doc.format(name='testing',
                                           conf='MNE_DATASETS_TESTING_PATH')
 
 
 def get_version():  # noqa: D103
     return _get_version('testing')
+
 
 get_version.__doc__ = _version_doc.format(name='testing')
 
@@ -44,5 +44,9 @@ def _skip_testing_data():
     skip = skip_testing or not has_testing_data()
     return skip
 
-requires_testing_data = np.testing.dec.skipif(_skip_testing_data,
-                                              'Requires testing dataset')
+
+def requires_testing_data(func):
+    """Skip testing data test."""
+    import pytest
+    return pytest.mark.skipif(_skip_testing_data(),
+                              reason='Requires testing dataset')(func)

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -1,6 +1,5 @@
 import os
 from os import path as op
-from nose.tools import assert_true, assert_equal
 
 from mne import datasets
 from mne.externals.six import string_types
@@ -17,16 +16,16 @@ def test_datasets():
         else:
             dataset = getattr(datasets, dname)
     if dataset.data_path(download=False) != '':
-        assert_true(isinstance(dataset.get_version(), string_types))
+        assert isinstance(dataset.get_version(), string_types)
     else:
-        assert_true(dataset.get_version() is None)
+        assert dataset.get_version() is None
     tempdir = _TempDir()
     # don't let it read from the config file to get the directory,
     # force it to look for the default
     os.environ['_MNE_FAKE_HOME_DIR'] = tempdir
     try:
-        assert_equal(datasets.utils._get_path(None, 'foo', 'bar'),
-                     op.join(tempdir, 'mne_data'))
+        assert (datasets.utils._get_path(None, 'foo', 'bar') ==
+                op.join(tempdir, 'mne_data'))
     finally:
         del os.environ['_MNE_FAKE_HOME_DIR']
 
@@ -37,8 +36,8 @@ def test_megsim():
     data_dir = _TempDir()
     paths = datasets.megsim.load_data(
         'index', 'text', 'text', path=data_dir, update_path=False)
-    assert_equal(len(paths), 1)
-    assert_true(paths[0].endswith('index.html'))
+    assert len(paths) == 1
+    assert paths[0].endswith('index.html')
 
 
 @requires_good_network
@@ -47,8 +46,8 @@ def test_downloads():
     # Try actually downloading a dataset
     data_dir = _TempDir()
     path = datasets._fake.data_path(path=data_dir, update_path=False)
-    assert_true(op.isfile(op.join(path, 'bar')))
-    assert_true(datasets._fake.get_version() is None)
+    assert op.isfile(op.join(path, 'bar'))
+    assert datasets._fake.get_version() is None
 
 
 run_tests_if_main()

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -4,8 +4,10 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import assert_true, assert_equal, assert_raises
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_equal)
+import pytest
+
 from mne.fixes import is_regressor, is_classifier
 from mne.utils import requires_version
 from mne.decoding.base import (_get_inverse_funcs, LinearModel, get_coef,
@@ -36,7 +38,6 @@ def _make_data(n_samples=1000, n_features=5, n_targets=3):
         The forward model, mapping the latent variables (=Y) to the measured
         data (=X).
     """
-
     # Define Y latent factors
     np.random.seed(0)
     cov_Y = np.eye(n_targets) * 10 + np.random.rand(n_targets, n_targets)
@@ -63,10 +64,10 @@ def test_get_coef():
     from sklearn.linear_model import Ridge, LinearRegression
 
     lm = LinearModel()
-    assert_true(is_classifier(lm))
+    assert (is_classifier(lm))
 
     lm = LinearModel(Ridge())
-    assert_true(is_regressor(lm))
+    assert (is_regressor(lm))
 
     # Define a classifier, an invertible transformer and an non-invertible one.
 
@@ -99,7 +100,7 @@ def test_get_coef():
 
     for expected_n, est in good_estimators:
         est.fit(X, y)
-        assert_true(expected_n == len(_get_inverse_funcs(est)))
+        assert (expected_n == len(_get_inverse_funcs(est)))
 
     bad_estimators = [
         Clf(),  # no preprocessing
@@ -124,15 +125,15 @@ def test_get_coef():
             coefs = clf.model.coef_
         assert_array_equal(filters, coefs[0])
         patterns = get_coef(clf, 'patterns_', False)
-        assert_true(filters[0] != patterns[0])
+        assert (filters[0] != patterns[0])
         n_chans = X.shape[1]
         assert_array_equal(filters.shape, patterns.shape, [n_chans, n_chans])
 
     # Inverse transform linear model
     filters_inv = get_coef(clf, 'filters_', True)
-    assert_true(filters[0] != filters_inv[0])
+    assert (filters[0] != filters_inv[0])
     patterns_inv = get_coef(clf, 'patterns_', True)
-    assert_true(patterns[0] != patterns_inv[0])
+    assert (patterns[0] != patterns_inv[0])
 
     # Check with search_light and combination of preprocessing ending with sl:
     slider = SlidingEstimator(make_pipeline(StandardScaler(), lm))
@@ -178,7 +179,7 @@ def test_linearmodel():
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features,))
     assert_equal(clf.patterns_.shape, (n_features,))
-    assert_raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
+    pytest.raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
 
     # check multi-target fit
     n_targets = 5
@@ -187,7 +188,7 @@ def test_linearmodel():
     clf.fit(X, Y)
     assert_equal(clf.filters_.shape, (n_targets, n_features))
     assert_equal(clf.patterns_.shape, (n_targets, n_features))
-    assert_raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
+    pytest.raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
 
 
 @requires_version('sklearn', '0.18')
@@ -222,7 +223,7 @@ def test_cross_val_multiscore():
     # raise an error if scoring is defined at cross-val-score level and
     # search light, because search light does not return a 1-dimensional
     # prediction.
-    assert_raises(ValueError, cross_val_multiscore, clf, X, y, cv=cv,
+    pytest.raises(ValueError, cross_val_multiscore, clf, X, y, cv=cv,
                   scoring='roc_auc')
     clf = SlidingEstimator(LogisticRegression(), scoring='roc_auc')
     scores_auc = cross_val_multiscore(clf, X, y, cv=cv, n_jobs=1)
@@ -243,7 +244,7 @@ def test_cross_val_multiscore():
         manual = cross_val(clf, X, y, cv=StratifiedKFold(2))
         auto = cross_val(clf, X, y, cv=2)
         assert_array_equal(manual, auto)
-        assert_raises(ValueError, cross_val, clf, X, y, cv=KFold(2))
+        pytest.raises(ValueError, cross_val, clf, X, y, cv=KFold(2))
 
         manual = cross_val(reg, X, y, cv=KFold(2))
         auto = cross_val(reg, X, y, cv=2)

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -4,8 +4,8 @@
 
 import os.path as op
 import numpy as np
-from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_equal, assert_raises
+from numpy.testing import assert_array_almost_equal, assert_equal
+import pytest
 
 from mne import io, Epochs, read_events, pick_types
 from mne.utils import requires_version, check_version, run_tests_if_main
@@ -34,10 +34,10 @@ def test_ems():
     picks = picks[1:13:3]
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
-    assert_raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
+    pytest.raises(ValueError, compute_ems, epochs, ['aud_l', 'vis_l'])
     epochs.equalize_event_counts(epochs.event_id)
 
-    assert_raises(KeyError, compute_ems, epochs, ['blah', 'hahah'])
+    pytest.raises(KeyError, compute_ems, epochs, ['blah', 'hahah'])
     surrogates, filters, conditions = compute_ems(epochs)
     assert_equal(list(set(conditions)), [1, 3])
 
@@ -49,7 +49,7 @@ def test_ems():
 
     n_expected = sum([len(epochs[k]) for k in ['aud_l', 'vis_l']])
 
-    assert_raises(ValueError, compute_ems, epochs)
+    pytest.raises(ValueError, compute_ems, epochs)
     surrogates, filters, conditions = compute_ems(epochs, ['aud_r', 'vis_l'])
     assert_equal(n_expected, len(surrogates))
     assert_equal(n_expected, len(conditions))
@@ -66,8 +66,8 @@ def test_ems():
         cv = StratifiedKFold(epochs.events[:, 2])
     compute_ems(epochs, cv=cv)
     compute_ems(epochs, cv=2)
-    assert_raises(ValueError, compute_ems, epochs, cv='foo')
-    assert_raises(ValueError, compute_ems, epochs, cv=len(epochs) + 1)
+    pytest.raises(ValueError, compute_ems, epochs, cv='foo')
+    pytest.raises(ValueError, compute_ems, epochs, cv=len(epochs) + 1)
     raw.close()
 
     # EMS transformer, check that identical to compute_ems

--- a/mne/decoding/tests/test_time_frequency.py
+++ b/mne/decoding/tests/test_time_frequency.py
@@ -5,20 +5,22 @@
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from nose.tools import assert_raises
+import pytest
+
 from mne.utils import requires_sklearn
 from mne.decoding.time_frequency import TimeFrequency
 
 
 @requires_sklearn
 def test_timefrequency():
+    """Test TimeFrequency."""
     from sklearn.base import clone
     # Init
     n_freqs = 3
     freqs = np.linspace(20, 30, n_freqs)
     tf = TimeFrequency(freqs, sfreq=100)
     for output in ['avg_power', 'foo', None]:
-        assert_raises(ValueError, TimeFrequency, freqs, output=output)
+        pytest.raises(ValueError, TimeFrequency, freqs, output=output)
     tf = clone(tf)
 
     # Fit

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -16,7 +16,6 @@ from __future__ import division
 
 import inspect
 from distutils.version import LooseVersion
-import re
 import warnings
 
 import numpy as np
@@ -936,83 +935,6 @@ def assert_is(expr1, expr2, msg=None):
 def assert_is_not(expr1, expr2, msg=None):
     """Fake assert_is_not without message"""
     assert_true(expr1 is not expr2, msg)
-
-
-assert_raises_regex_impl = None
-
-
-# from numpy 1.9.1
-def assert_raises_regex(exception_class, expected_regexp,
-                        callable_obj=None, *args, **kwargs):
-    """
-    Fail unless an exception of class exception_class and with message that
-    matches expected_regexp is thrown by callable when invoked with arguments
-    args and keyword arguments kwargs.
-    Name of this function adheres to Python 3.2+ reference, but should work in
-    all versions down to 2.6.
-    """
-    __tracebackhide__ = True  # Hide traceback for py.test
-    import nose
-
-    global assert_raises_regex_impl
-    if assert_raises_regex_impl is None:
-        try:
-            # Python 3.2+
-            assert_raises_regex_impl = nose.tools.assert_raises_regex
-        except AttributeError:
-            try:
-                # 2.7+
-                assert_raises_regex_impl = nose.tools.assert_raises_regexp
-            except AttributeError:
-                # 2.6
-
-                # This class is copied from Python2.7 stdlib almost verbatim
-                class _AssertRaisesContext(object):
-
-                    def __init__(self, expected, expected_regexp=None):
-                        self.expected = expected
-                        self.expected_regexp = expected_regexp
-
-                    def failureException(self, msg):
-                        return AssertionError(msg)
-
-                    def __enter__(self):
-                        return self
-
-                    def __exit__(self, exc_type, exc_value, tb):
-                        if exc_type is None:
-                            try:
-                                exc_name = self.expected.__name__
-                            except AttributeError:
-                                exc_name = str(self.expected)
-                            raise self.failureException(
-                                "{0} not raised".format(exc_name))
-                        if not issubclass(exc_type, self.expected):
-                            # let unexpected exceptions pass through
-                            return False
-                        self.exception = exc_value  # store for later retrieval
-                        if self.expected_regexp is None:
-                            return True
-
-                        expected_regexp = self.expected_regexp
-                        if isinstance(expected_regexp, basestring):
-                            expected_regexp = re.compile(expected_regexp)
-                        if not expected_regexp.search(str(exc_value)):
-                            raise self.failureException(
-                                '"%s" does not match "%s"' %
-                                (expected_regexp.pattern, str(exc_value)))
-                        return True
-
-                def impl(cls, regex, callable_obj, *a, **kw):
-                    mgr = _AssertRaisesContext(cls, regex)
-                    if callable_obj is None:
-                        return mgr
-                    with mgr:
-                        callable_obj(*a, **kw)
-                assert_raises_regex_impl = impl
-
-    return assert_raises_regex_impl(exception_class, expected_regexp,
-                                    callable_obj, *args, **kwargs)
 
 
 def _read_volume_info(fobj):

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -3,7 +3,6 @@ import os.path as op
 import warnings
 import gc
 
-from nose.tools import assert_true, assert_raises
 import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_equal,
@@ -39,38 +38,37 @@ fname_src = op.join(subjects_dir, 'sample', 'bem', 'sample-oct-4-src.fif')
 
 
 def compare_forwards(f1, f2):
-    """Helper to compare two potentially converted forward solutions"""
+    """Compare two potentially converted forward solutions."""
     assert_allclose(f1['sol']['data'], f2['sol']['data'])
     assert_equal(f1['sol']['ncol'], f2['sol']['ncol'])
     assert_equal(f1['sol']['ncol'], f1['sol']['data'].shape[1])
     assert_allclose(f1['source_nn'], f2['source_nn'])
     if f1['sol_grad'] is not None:
-        assert_true(f2['sol_grad'] is not None)
+        assert (f2['sol_grad'] is not None)
         assert_allclose(f1['sol_grad']['data'], f2['sol_grad']['data'])
         assert_equal(f1['sol_grad']['ncol'], f2['sol_grad']['ncol'])
         assert_equal(f1['sol_grad']['ncol'], f1['sol_grad']['data'].shape[1])
     else:
-        assert_true(f2['sol_grad'] is None)
+        assert (f2['sol_grad'] is None)
     assert_equal(f1['source_ori'], f2['source_ori'])
     assert_equal(f1['surf_ori'], f2['surf_ori'])
 
 
 @testing.requires_testing_data
 def test_convert_forward():
-    """Test converting forward solution between different representations
-    """
+    """Test converting forward solution between different representations."""
     fwd = read_forward_solution(fname_meeg_grad)
     fwd_repr = repr(fwd)
-    assert_true('306' in fwd_repr)
-    assert_true('60' in fwd_repr)
-    assert_true(fwd_repr)
-    assert_true(isinstance(fwd, Forward))
+    assert ('306' in fwd_repr)
+    assert ('60' in fwd_repr)
+    assert (fwd_repr)
+    assert (isinstance(fwd, Forward))
     # look at surface orientation
     fwd_surf = convert_forward_solution(fwd, surf_ori=True)
     # go back
     fwd_new = convert_forward_solution(fwd_surf, surf_ori=False)
-    assert_true(repr(fwd_new))
-    assert_true(isinstance(fwd_new, Forward))
+    assert (repr(fwd_new))
+    assert (isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
     del fwd_new
     gc.collect()
@@ -80,14 +78,14 @@ def test_convert_forward():
                                          force_fixed=True, use_cps=False)
     del fwd_surf
     gc.collect()
-    assert_true(repr(fwd_fixed))
-    assert_true(isinstance(fwd_fixed, Forward))
-    assert_true(is_fixed_orient(fwd_fixed))
+    assert (repr(fwd_fixed))
+    assert (isinstance(fwd_fixed, Forward))
+    assert (is_fixed_orient(fwd_fixed))
     # now go back to cartesian (original condition)
     fwd_new = convert_forward_solution(fwd_fixed, surf_ori=False,
                                        force_fixed=False)
-    assert_true(repr(fwd_new))
-    assert_true(isinstance(fwd_new, Forward))
+    assert (repr(fwd_new))
+    assert (isinstance(fwd_new, Forward))
     compare_forwards(fwd, fwd_new)
     del fwd, fwd_new, fwd_fixed
     gc.collect()
@@ -96,13 +94,12 @@ def test_convert_forward():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_io_forward():
-    """Test IO for forward solutions
-    """
+    """Test IO for forward solutions."""
     temp_dir = _TempDir()
     # do extensive tests with MEEG + grad
     n_channels, n_src = 366, 108
     fwd = read_forward_solution(fname_meeg_grad)
-    assert_true(isinstance(fwd, Forward))
+    assert (isinstance(fwd, Forward))
     fwd = read_forward_solution(fname_meeg_grad)
     fwd = convert_forward_solution(fwd, surf_ori=True)
     leadfield = fwd['sol']['data']
@@ -121,8 +118,8 @@ def test_io_forward():
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd_read['sol']['row_names']), n_channels)
     assert_equal(len(fwd_read['info']['chs']), n_channels)
-    assert_true('dev_head_t' in fwd_read['info'])
-    assert_true('mri_head_t' in fwd_read)
+    assert ('dev_head_t' in fwd_read['info'])
+    assert ('mri_head_t' in fwd_read)
     assert_array_almost_equal(fwd['sol']['data'], fwd_read['sol']['data'])
 
     fwd = read_forward_solution(fname_meeg)
@@ -134,9 +131,9 @@ def test_io_forward():
     fwd_read = read_forward_solution(fname_temp)
     fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
                                         force_fixed=True, use_cps=False)
-    assert_true(repr(fwd_read))
-    assert_true(isinstance(fwd_read, Forward))
-    assert_true(is_fixed_orient(fwd_read))
+    assert (repr(fwd_read))
+    assert (isinstance(fwd_read, Forward))
+    assert (is_fixed_orient(fwd_read))
     compare_forwards(fwd, fwd_read)
 
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
@@ -145,18 +142,18 @@ def test_io_forward():
     assert_equal(leadfield.shape, (n_channels, 1494 / 3))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
     assert_equal(len(fwd['info']['chs']), n_channels)
-    assert_true('dev_head_t' in fwd['info'])
-    assert_true('mri_head_t' in fwd)
-    assert_true(fwd['surf_ori'])
+    assert ('dev_head_t' in fwd['info'])
+    assert ('mri_head_t' in fwd)
+    assert (fwd['surf_ori'])
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         write_forward_solution(fname_temp, fwd, overwrite=True)
     fwd_read = read_forward_solution(fname_temp)
     fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
                                         force_fixed=True, use_cps=True)
-    assert_true(repr(fwd_read))
-    assert_true(isinstance(fwd_read, Forward))
-    assert_true(is_fixed_orient(fwd_read))
+    assert (repr(fwd_read))
+    assert (isinstance(fwd_read, Forward))
+    assert (is_fixed_orient(fwd_read))
     compare_forwards(fwd, fwd_read)
 
     fwd = read_forward_solution(fname_meeg_grad)
@@ -166,18 +163,18 @@ def test_io_forward():
     assert_equal(leadfield.shape, (n_channels, n_src / 3))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
     assert_equal(len(fwd['info']['chs']), n_channels)
-    assert_true('dev_head_t' in fwd['info'])
-    assert_true('mri_head_t' in fwd)
-    assert_true(fwd['surf_ori'])
+    assert ('dev_head_t' in fwd['info'])
+    assert ('mri_head_t' in fwd)
+    assert (fwd['surf_ori'])
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         write_forward_solution(fname_temp, fwd, overwrite=True)
     fwd_read = read_forward_solution(fname_temp)
     fwd_read = convert_forward_solution(fwd_read, surf_ori=True,
                                         force_fixed=True, use_cps=True)
-    assert_true(repr(fwd_read))
-    assert_true(isinstance(fwd_read, Forward))
-    assert_true(is_fixed_orient(fwd_read))
+    assert (repr(fwd_read))
+    assert (isinstance(fwd_read, Forward))
+    assert (is_fixed_orient(fwd_read))
     compare_forwards(fwd, fwd_read)
 
     # test warnings on bad filenames
@@ -197,8 +194,7 @@ def test_io_forward():
 
 @testing.requires_testing_data
 def test_apply_forward():
-    """Test projection of source space data to sensor space
-    """
+    """Test projection of source space data to sensor space."""
     start = 0
     stop = 5
     n_times = stop - start - 1
@@ -209,7 +205,7 @@ def test_apply_forward():
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=True)
     fwd = pick_types_forward(fwd, meg=True)
-    assert_true(isinstance(fwd, Forward))
+    assert isinstance(fwd, Forward)
 
     vertno = [fwd['src'][0]['vertno'], fwd['src'][1]['vertno']]
     stc_data = np.ones((len(vertno[0]) + len(vertno[1]), n_times))
@@ -248,8 +244,7 @@ def test_apply_forward():
 
 @testing.requires_testing_data
 def test_restrict_forward_to_stc():
-    """Test restriction of source space to source SourceEstimate
-    """
+    """Test restriction of source space to source SourceEstimate."""
     start = 0
     stop = 5
     n_times = stop - start - 1
@@ -266,7 +261,7 @@ def test_restrict_forward_to_stc():
     stc = SourceEstimate(stc_data, vertno, tmin=t_start, tstep=1.0 / sfreq)
 
     fwd_out = restrict_forward_to_stc(fwd, stc)
-    assert_true(isinstance(fwd_out, Forward))
+    assert (isinstance(fwd_out, Forward))
 
     assert_equal(fwd_out['sol']['ncol'], 20)
     assert_equal(fwd_out['src'][0]['nuse'], 15)
@@ -305,8 +300,7 @@ def test_restrict_forward_to_stc():
 
 @testing.requires_testing_data
 def test_restrict_forward_to_label():
-    """Test restriction of source space to label
-    """
+    """Test restriction of source space to label."""
     fwd = read_forward_solution(fname_meeg)
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
                                    use_cps=True)
@@ -374,26 +368,25 @@ def test_restrict_forward_to_label():
 @testing.requires_testing_data
 @requires_mne
 def test_average_forward_solution():
-    """Test averaging forward solutions
-    """
+    """Test averaging forward solutions."""
     temp_dir = _TempDir()
     fwd = read_forward_solution(fname_meeg)
     # input not a list
-    assert_raises(TypeError, average_forward_solutions, 1)
+    pytest.raises(TypeError, average_forward_solutions, 1)
     # list is too short
-    assert_raises(ValueError, average_forward_solutions, [])
+    pytest.raises(ValueError, average_forward_solutions, [])
     # negative weights
-    assert_raises(ValueError, average_forward_solutions, [fwd, fwd], [-1, 0])
+    pytest.raises(ValueError, average_forward_solutions, [fwd, fwd], [-1, 0])
     # all zero weights
-    assert_raises(ValueError, average_forward_solutions, [fwd, fwd], [0, 0])
+    pytest.raises(ValueError, average_forward_solutions, [fwd, fwd], [0, 0])
     # weights not same length
-    assert_raises(ValueError, average_forward_solutions, [fwd, fwd], [0, 0, 0])
+    pytest.raises(ValueError, average_forward_solutions, [fwd, fwd], [0, 0, 0])
     # list does not only have all dict()
-    assert_raises(TypeError, average_forward_solutions, [1, fwd])
+    pytest.raises(TypeError, average_forward_solutions, [1, fwd])
 
     # try an easy case
     fwd_copy = average_forward_solutions([fwd])
-    assert_true(isinstance(fwd_copy, Forward))
+    assert (isinstance(fwd_copy, Forward))
     assert_array_equal(fwd['sol']['data'], fwd_copy['sol']['data'])
 
     # modify a fwd solution, save it, use MNE to average with old one
@@ -414,5 +407,6 @@ def test_average_forward_solution():
     fwd = read_forward_solution(fname_meeg_grad)
     fwd_ave = average_forward_solutions([fwd, fwd])
     compare_forwards(fwd, fwd_ave)
+
 
 run_tests_if_main()

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -1,11 +1,8 @@
-from __future__ import print_function
-
 from itertools import product
 import os
 import os.path as op
 import warnings
 
-from nose.tools import assert_raises, assert_true
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, assert_array_equal
@@ -146,18 +143,18 @@ def test_make_forward_solution_kit():
     fwd = _do_forward_solution('sample', fname_kit_raw, src=fname_src_small,
                                bem=fname_bem_meg, mri=trans_path,
                                eeg=False, meg=True, subjects_dir=subjects_dir)
-    assert_true(isinstance(fwd, Forward))
+    assert (isinstance(fwd, Forward))
 
     # now let's use python with the same raw file
     fwd_py = make_forward_solution(fname_kit_raw, trans_path, src,
                                    fname_bem_meg, eeg=False, meg=True)
     _compare_forwards(fwd, fwd_py, 157, n_src)
-    assert_true(isinstance(fwd_py, Forward))
+    assert (isinstance(fwd_py, Forward))
 
     # now let's use mne-python all the way
     raw_py = read_raw_kit(sqd_path, mrk_path, elp_path, hsp_path)
     # without ignore_ref=True, this should throw an error:
-    assert_raises(NotImplementedError, make_forward_solution, raw_py.info,
+    pytest.raises(NotImplementedError, make_forward_solution, raw_py.info,
                   src=src, eeg=False, meg=True,
                   bem=fname_bem_meg, trans=trans_path)
 
@@ -218,9 +215,9 @@ def test_make_forward_solution():
     fwd_py = make_forward_solution(fname_raw, fname_trans, fname_src,
                                    fname_bem, mindist=5.0, eeg=True, meg=True,
                                    n_jobs=-1)
-    assert_true(isinstance(fwd_py, Forward))
+    assert (isinstance(fwd_py, Forward))
     fwd = read_forward_solution(fname_meeg)
-    assert_true(isinstance(fwd, Forward))
+    assert (isinstance(fwd, Forward))
     _compare_forwards(fwd, fwd_py, 366, 1494, meg_rtol=1e-3)
 
 
@@ -289,7 +286,7 @@ def test_forward_mixed_source_space():
 
     # calculate forward solution
     fwd = make_forward_solution(fname_raw, fname_trans, src, fname_bem, None)
-    assert_true(repr(fwd))
+    assert (repr(fwd))
 
     # extract source spaces
     src_from_fwd = fwd['src']
@@ -298,18 +295,18 @@ def test_forward_mixed_source_space():
     coord_frames = np.array([s['coord_frame'] for s in src_from_fwd])
 
     # assert that all source spaces are in head coordinates
-    assert_true((coord_frames == FIFF.FIFFV_COORD_HEAD).all())
+    assert ((coord_frames == FIFF.FIFFV_COORD_HEAD).all())
 
     # run tests for SourceSpaces.export_volume
     fname_img = op.join(temp_dir, 'temp-image.mgz')
 
     # head coordinates and mri_resolution, but trans file
-    assert_raises(ValueError, src_from_fwd.export_volume, fname_img,
+    pytest.raises(ValueError, src_from_fwd.export_volume, fname_img,
                   mri_resolution=True, trans=None)
 
     # head coordinates and mri_resolution, but wrong trans file
     vox_mri_t = vol1[0]['vox_mri_t']
-    assert_raises(ValueError, src_from_fwd.export_volume, fname_img,
+    pytest.raises(ValueError, src_from_fwd.export_volume, fname_img,
                   mri_resolution=True, trans=vox_mri_t)
 
 
@@ -344,7 +341,7 @@ def test_make_forward_dipole():
     with warnings.catch_warnings(record=True) as w:
         fwd, stc = make_forward_dipole(dip_test, sphere, info,
                                        trans=fname_trans)
-        assert_true(issubclass(w[-1].category, RuntimeWarning))
+        assert (issubclass(w[-1].category, RuntimeWarning))
 
     # stc is list of VolSourceEstimate's
     assert isinstance(stc, list)
@@ -382,10 +379,10 @@ def test_make_forward_dipole():
     # NB tolerance should be set relative to snr of simulated evoked!
     assert_allclose(dip_fit.pos, dip_test.pos, rtol=0, atol=1e-2,
                     err_msg='position mismatch')
-    assert_true(dist < 1e-2, 'dist: %s' % dist)  # within 1 cm
-    assert_true(corr > 1 - 1e-2, 'corr: %s' % corr)
-    assert_true(gc_dist < 20, 'gc_dist: %s' % gc_dist)  # less than 20 degrees
-    assert_true(amp_err < 10e-9, 'amp_err: %s' % amp_err)  # within 10 nAm
+    assert dist < 1e-2  # within 1 cm
+    assert corr > 1 - 1e-2
+    assert gc_dist < 20  # less than 20 degrees
+    assert amp_err < 10e-9  # within 10 nAm
 
     # Make sure rejection works with BEM: one dipole at z=1m
     # NB _make_forward.py:_prepare_for_forward will raise a RuntimeError
@@ -394,7 +391,7 @@ def test_make_forward_dipole():
                          pos=[[0., 0., 1.0], [0., 0., 0.040]],
                          amplitude=[100e-9, 100e-9],
                          ori=[[1., 0., 0.], [1., 0., 0.]], gof=1)
-    assert_raises(ValueError, make_forward_dipole, dip_outside, fname_bem,
+    pytest.raises(ValueError, make_forward_dipole, dip_outside, fname_bem,
                   info, fname_trans)
     # if we get this far, can safely assume the code works with BEMs too
     # -> use sphere again below for speed
@@ -412,7 +409,8 @@ def test_make_forward_dipole():
 
     fwd, stc = make_forward_dipole(dip_even_samp, sphere, info,
                                    trans=fname_trans)
-    assert_true(isinstance, VolSourceEstimate)
+    assert isinstance(stc, VolSourceEstimate)
     assert_allclose(stc.times, np.arange(0., 0.003, 0.001))
+
 
 run_tests_if_main()

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -294,7 +294,8 @@ class MarkerPointDest(MarkerPoints):  # noqa: D401
             return pts
 
         # Transform method
-        idx = np.intersect1d(self.src1.use, self.src2.use, assume_unique=True)
+        idx = np.intersect1d(np.array(self.src1.use),
+                             np.array(self.src2.use), assume_unique=True)
         if len(idx) < 3:
             error(None, "Need at least three shared points for trans"
                   "formation.", "Marker Interpolation Error")

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -11,9 +11,9 @@ from unittest import SkipTest
 import warnings
 
 import numpy as np
-from numpy.testing import assert_allclose
-from nose.tools import (assert_equal, assert_almost_equal, assert_false,
-                        assert_raises, assert_true)
+from numpy.testing import (assert_allclose, assert_equal,
+                           assert_array_almost_equal)
+import pytest
 
 import mne
 from mne.datasets import testing
@@ -75,16 +75,16 @@ def test_coreg_model():
     trans_dst = op.join(tempdir, 'test-trans.fif')
 
     model = CoregModel()
-    assert_raises(RuntimeError, model.save_trans, 'blah.fif')
+    pytest.raises(RuntimeError, model.save_trans, 'blah.fif')
 
     model.mri.subjects_dir = subjects_dir
     model.mri.subject = 'sample'
 
-    assert_false(model.mri.fid_ok)
+    assert not model.mri.fid_ok
     model.mri.lpa = [[-0.06, 0, 0]]
     model.mri.nasion = [[0, 0.05, 0]]
     model.mri.rpa = [[0.08, 0, 0]]
-    assert_true(model.mri.fid_ok)
+    assert (model.mri.fid_ok)
 
     model.hsp.file = raw_path
     assert_allclose(model.hsp.lpa, [[-7.137e-2, 0, 5.122e-9]], 1e-4)
@@ -132,21 +132,21 @@ def test_coreg_model():
                         "rot_z"])
     assert_equal(model.trans_x, 0)
     model.set_trans(trans)
-    assert_almost_equal(model.trans_x, x)
-    assert_almost_equal(model.trans_y, y)
-    assert_almost_equal(model.trans_z, z)
-    assert_almost_equal(model.rot_x, rot_x)
-    assert_almost_equal(model.rot_y, rot_y)
-    assert_almost_equal(model.rot_z, rot_z)
+    assert_array_almost_equal(model.trans_x, x)
+    assert_array_almost_equal(model.trans_y, y)
+    assert_array_almost_equal(model.trans_z, z)
+    assert_array_almost_equal(model.rot_x, rot_x)
+    assert_array_almost_equal(model.rot_y, rot_y)
+    assert_array_almost_equal(model.rot_z, rot_z)
 
     # info
-    assert_true(isinstance(model.fid_eval_str, string_types))
-    assert_true(isinstance(model.points_eval_str, string_types))
+    assert (isinstance(model.fid_eval_str, string_types))
+    assert (isinstance(model.points_eval_str, string_types))
 
     # scaling job
-    assert_false(model.can_prepare_bem_model)
+    assert not model.can_prepare_bem_model
     model.n_scale_params = 1
-    assert_true(model.can_prepare_bem_model)
+    assert (model.can_prepare_bem_model)
     model.prepare_bem_model = True
     sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
         model.get_scaling_job('sample2', False)
@@ -166,7 +166,7 @@ def test_coreg_model():
     sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
         model.get_scaling_job('sample2', True)
     assert_equal(bemsol, [])
-    assert_true(skip_fiducials)
+    assert (skip_fiducials)
 
     model.load_trans(fname_trans)
     model.save_trans(trans_dst)
@@ -192,7 +192,7 @@ def test_coreg_gui():
     os.environ['_MNE_GUI_TESTING_MODE'] = 'true'
     os.environ['_MNE_FAKE_HOME_DIR'] = home_dir
     try:
-        assert_raises(ValueError, mne.gui.coregistration, subject='Elvis',
+        pytest.raises(ValueError, mne.gui.coregistration, subject='Elvis',
                       subjects_dir=subjects_dir)
 
         from pyface.api import GUI
@@ -206,11 +206,11 @@ def test_coreg_gui():
         frame.model.mri.subjects_dir = subjects_dir
         frame.model.mri.subject = 'sample'
 
-        assert_false(frame.model.mri.fid_ok)
+        assert not frame.model.mri.fid_ok
         frame.model.mri.lpa = [[-0.06, 0, 0]]
         frame.model.mri.nasion = [[0, 0.05, 0]]
         frame.model.mri.rpa = [[0.08, 0, 0]]
-        assert_true(frame.model.mri.fid_ok)
+        assert (frame.model.mri.fid_ok)
         frame.data_panel.raw_src.file = raw_path
         assert isinstance(frame.eeg_obj.glyph.glyph.glyph_source.glyph_source,
                           tvtk.SphereSource)
@@ -236,14 +236,14 @@ def test_coreg_gui():
         assert not frame.data_panel.view_options_panel.head_high_res
 
         # configuration persistence
-        assert_true(frame.model.prepare_bem_model)
+        assert (frame.model.prepare_bem_model)
         frame.model.prepare_bem_model = False
         frame.save_config(home_dir)
         ui.dispose()
         gui.process_events()
 
         ui, frame = mne.gui.coregistration(subjects_dir=subjects_dir)
-        assert_false(frame.model.prepare_bem_model)
+        assert not frame.model.prepare_bem_model
         assert not frame.data_panel.view_options_panel.head_high_res
         ui.dispose()
         gui.process_events()
@@ -266,7 +266,7 @@ def test_coreg_model_with_fsaverage():
     model = CoregModel()
     model.mri.subjects_dir = tempdir
     model.mri.subject = 'fsaverage'
-    assert_true(model.mri.fid_ok)
+    assert (model.mri.fid_ok)
 
     model.hsp.file = raw_path
     lpa_distance = model.lpa_distance
@@ -299,11 +299,11 @@ def test_coreg_model_with_fsaverage():
     old_x = lpa_distance ** 2 + rpa_distance ** 2 + nasion_distance ** 2
     new_x = (model.lpa_distance ** 2 + model.rpa_distance ** 2 +
              model.nasion_distance ** 2)
-    assert_true(new_x < old_x)
+    assert (new_x < old_x)
 
     model.fit_icp(1)
     avg_point_distance_1param = np.mean(model.point_distance)
-    assert_true(avg_point_distance_1param < avg_point_distance)
+    assert (avg_point_distance_1param < avg_point_distance)
 
     # scaling job
     sdir, sfrom, sto, scale, skip_fiducials, labels, annot, bemsol = \
@@ -321,7 +321,7 @@ def test_coreg_model_with_fsaverage():
     # scale with 3 parameters
     model.n_scale_params = 3
     model.fit_icp(3)
-    assert_true(np.mean(model.point_distance) < avg_point_distance_1param)
+    assert (np.mean(model.point_distance) < avg_point_distance_1param)
 
     # test switching raw disables point omission
     assert_equal(model.hsp.n_omitted, 1)

--- a/mne/gui/tests/test_fiducials_gui.py
+++ b/mne/gui/tests/test_fiducials_gui.py
@@ -17,7 +17,7 @@ subjects_dir = os.path.join(sample_path, 'subjects')
 @requires_mayavi
 @traits_test
 def test_mri_model():
-    """Test MRIHeadWithFiducialsModel Traits Model"""
+    """Test MRIHeadWithFiducialsModel Traits Model."""
     from mne.gui._fiducials_gui import MRIHeadWithFiducialsModel
     tempdir = _TempDir()
     tgt_fname = os.path.join(tempdir, 'test-fiducials.fif')

--- a/mne/gui/tests/test_marker_gui.py
+++ b/mne/gui/tests/test_marker_gui.py
@@ -31,7 +31,7 @@ def _check_ci():
 @requires_mayavi
 @traits_test
 def test_combine_markers_model():
-    """Test CombineMarkersModel Traits Model"""
+    """Test CombineMarkersModel Traits Model."""
     from mne.gui._marker_gui import CombineMarkersModel, CombineMarkersPanel
     tempdir = _TempDir()
     tgt_fname = os.path.join(tempdir, 'test.txt')

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -4,7 +4,6 @@
 
 import os.path as op
 
-from nose.tools import assert_true, assert_raises
 import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_equal,
@@ -31,18 +30,18 @@ subjects_dir = op.join(data_path, 'subjects')
 
 
 def _check_stc(stc, evoked, idx, ratio=50.):
-    """Helper to check correctness"""
+    """Check correctness."""
     assert_array_almost_equal(stc.times, evoked.times, 5)
     amps = np.sum(stc.data ** 2, axis=1)
     order = np.argsort(amps)[::-1]
     amps = amps[order]
     verts = np.concatenate(stc.vertices)[order]
     assert_equal(idx, verts[0], err_msg=str(list(verts)))
-    assert_true(amps[0] > ratio * amps[1], msg=str(amps[0] / amps[1]))
+    assert amps[0] > ratio * amps[1]
 
 
 def _check_stcs(stc1, stc2):
-    """Helper to check correctness"""
+    """Check correctness."""
     assert_allclose(stc1.times, stc2.times)
     assert_allclose(stc1.data, stc2.data)
     assert_allclose(stc1.vertices[0], stc2.vertices[0])
@@ -54,7 +53,7 @@ def _check_stcs(stc1, stc2):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_gamma_map():
-    """Test Gamma MAP inverse"""
+    """Test Gamma MAP inverse."""
     forward = read_forward_solution(fname_fwd)
     forward = convert_forward_solution(forward, surf_ori=True)
 
@@ -79,7 +78,7 @@ def test_gamma_map():
     dips = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                      xyz_same_gamma=False, update_mode=1,
                      return_as_dipoles=True)
-    assert_true(isinstance(dips[0], Dipole))
+    assert (isinstance(dips[0], Dipole))
     stc_dip = make_stc_from_dipoles(dips, forward['src'])
     _check_stcs(stc, stc_dip)
 
@@ -93,7 +92,7 @@ def test_gamma_map():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_gamma_map_vol_sphere():
-    """Gamma MAP with a sphere forward and volumic source space"""
+    """Gamma MAP with a sphere forward and volumic source space."""
     evoked = read_evokeds(fname_evoked, condition=0, baseline=(None, 0),
                           proj=False)
     evoked.resample(50, npad=100)
@@ -112,10 +111,10 @@ def test_gamma_map_vol_sphere():
                                     eeg=False, meg=True)
 
     alpha = 0.5
-    assert_raises(ValueError, gamma_map, evoked, fwd, cov, alpha,
+    pytest.raises(ValueError, gamma_map, evoked, fwd, cov, alpha,
                   loose=0, return_residual=False)
 
-    assert_raises(ValueError, gamma_map, evoked, fwd, cov, alpha,
+    pytest.raises(ValueError, gamma_map, evoked, fwd, cov, alpha,
                   loose=0.2, return_residual=False)
 
     stc = gamma_map(evoked, fwd, cov, alpha, tol=1e-4,
@@ -137,9 +136,10 @@ def test_gamma_map_vol_sphere():
 
     amp_max = [np.max(d.amplitude) for d in dip_gmap]
     dip_gmap = dip_gmap[np.argmax(amp_max)]
-    assert_true(dip_gmap[0].pos[0] in src[0]['rr'][stc.vertices])
+    assert (dip_gmap[0].pos[0] in src[0]['rr'][stc.vertices])
 
     dip_fit = mne.fit_dipole(evoked_dip, cov, sphere)[0]
-    assert_true(np.abs(np.dot(dip_fit.ori[0], dip_gmap.ori[0])) > 0.99)
+    assert (np.abs(np.dot(dip_fit.ori[0], dip_gmap.ori[0])) > 0.99)
+
 
 run_tests_if_main()

--- a/mne/inverse_sparse/tests/test_mxne_debiasing.py
+++ b/mne/inverse_sparse/tests/test_mxne_debiasing.py
@@ -10,7 +10,7 @@ from mne.inverse_sparse.mxne_debiasing import compute_bias
 
 
 def test_compute_debiasing():
-    """Test source amplitude debiasing"""
+    """Test source amplitude debiasing."""
     rng = np.random.RandomState(42)
     G = rng.randn(10, 4)
     X = rng.randn(4, 20)

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -32,7 +32,7 @@ fname_label = op.join(data_path, 'MEG', 'sample', 'labels', '%s.label' % label)
 
 
 def _check_stcs(stc1, stc2):
-    """Helper to check correctness"""
+    """Check STC correctness."""
     assert_allclose(stc1.times, stc2.times)
     assert_allclose(stc1.data, stc2.data)
     assert_allclose(stc1.vertices[0], stc2.vertices[0])
@@ -44,7 +44,7 @@ def _check_stcs(stc1, stc2):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mxne_inverse():
-    """Test (TF-)MxNE inverse computation"""
+    """Test (TF-)MxNE inverse computation."""
     # Read noise covariance matrix
     cov = read_cov(fname_cov)
 
@@ -142,7 +142,7 @@ def test_mxne_inverse():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mxne_vol_sphere():
-    """(TF-)MxNE with a sphere forward and volumic source space"""
+    """Test (TF-)MxNE with a sphere forward and volumic source space."""
     evoked = read_evokeds(fname_data, condition=0, baseline=(None, 0))
     evoked.crop(tmin=-0.05, tmax=0.2)
     cov = read_cov(fname_cov)

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -7,8 +7,8 @@ import warnings
 import matplotlib
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_allclose
-from nose.tools import assert_equal, assert_raises, assert_true
+from numpy.testing import (assert_array_almost_equal, assert_allclose,
+                           assert_equal)
 import pytest
 
 from mne import find_events, Epochs, pick_types, channels
@@ -57,10 +57,10 @@ def test_array_raw():
     types.extend(['stim'] * 9)
     types.extend(['eeg'] * 60)
     # wrong length
-    assert_raises(ValueError, create_info, ch_names, sfreq, types)
+    pytest.raises(ValueError, create_info, ch_names, sfreq, types)
     # bad entry
     types.append('foo')
-    assert_raises(KeyError, create_info, ch_names, sfreq, types)
+    pytest.raises(KeyError, create_info, ch_names, sfreq, types)
     types[-1] = 'eog'
     # default type
     info = create_info(ch_names, sfreq)
@@ -72,8 +72,8 @@ def test_array_raw():
     data2, times2 = raw2[:, :]
     assert_allclose(data, data2)
     assert_allclose(times, times2)
-    assert_true('RawArray' in repr(raw2))
-    assert_raises(TypeError, RawArray, info, data)
+    assert ('RawArray' in repr(raw2))
+    pytest.raises(TypeError, RawArray, info, data)
 
     # filtering
     picks = pick_types(raw2.info, misc=True, exclude='bads')[:4]
@@ -106,7 +106,7 @@ def test_array_raw():
     # epoching
     events = find_events(raw2, stim_channel='STI 014')
     events[:, 2] = 1
-    assert_true(len(events) > 2)
+    assert (len(events) > 2)
     epochs = Epochs(raw2, events, 1, -0.2, 0.4, preload=True)
     epochs.plot_drop_log()
     epochs.plot()

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -8,7 +8,6 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from nose.tools import assert_true
 
 from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_artemis123
@@ -38,9 +37,9 @@ def _assert_trans(actual, desired, dist_tol=0.003, angle_tol=5.):
 
     angle = 180 * _angle_between_quats(quat_est, quat) / np.pi
     dist = np.sqrt(np.sum((trans - trans_est) ** 2))
-    assert_true(dist <= dist_tol, '%0.3f > %0.3f mm' % (1000 * dist,
-                                                        1000 * dist_tol))
-    assert_true(angle <= angle_tol, '%0.3f > %0.3f deg' % (angle, angle_tol))
+    assert dist <= dist_tol, '%0.3f > %0.3f mm' % (1000 * dist,
+                                                   1000 * dist_tol)
+    assert angle <= angle_tol, '%0.3f > %0.3f deg' % (angle, angle_tol)
 
 
 @testing.requires_testing_data

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -10,10 +10,10 @@ import os.path as op
 import shutil
 import warnings
 
-from nose.tools import assert_equal, assert_raises, assert_true
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_allclose)
+                           assert_allclose, assert_equal)
+import pytest
 
 from mne.utils import _TempDir, run_tests_if_main
 from mne import pick_types, find_events
@@ -135,7 +135,7 @@ def test_brainvision_data_highpass_filters():
         raw = _test_raw_reader(
             read_raw_brainvision, vhdr_fname=vhdr_highpass_path,
             montage=montage, eog=eog)
-    assert_true(all('parse triggers that' in str(ww.message) for ww in w))
+    assert (all('parse triggers that' in str(ww.message) for ww in w))
 
     assert_equal(raw.info['highpass'], 1. / (2 * np.pi * 10))
     assert_equal(raw.info['lowpass'], 250.)
@@ -153,7 +153,7 @@ def test_brainvision_data_highpass_filters():
 
     expected_warnings = zip(lowpass_warning, highpass_warning)
 
-    assert_true(all(any([lp, hp]) for lp, hp in expected_warnings))
+    assert (all(any([lp, hp]) for lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 1. / (2 * np.pi * 10))
     assert_equal(raw.info['lowpass'], 250.)
@@ -182,7 +182,7 @@ def test_brainvision_data_highpass_filters():
 
     expected_warnings = zip(trigger_warning, lowpass_warning, highpass_warning)
 
-    assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
+    assert (all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 5.)
     assert_equal(raw.info['lowpass'], 250.)
@@ -211,7 +211,7 @@ def test_brainvision_data_lowpass_filters():
 
     expected_warnings = zip(lowpass_warning, highpass_warning)
 
-    assert_true(all(any([lp, hp]) for lp, hp in expected_warnings))
+    assert (all(any([lp, hp]) for lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 1. / (2 * np.pi * 10))
     assert_equal(raw.info['lowpass'], 250.)
@@ -237,7 +237,7 @@ def test_brainvision_data_lowpass_filters():
 
     expected_warnings = zip(lowpass_warning, highpass_warning)
 
-    assert_true(all(any([lp, hp]) for lp, hp in expected_warnings))
+    assert (all(any([lp, hp]) for lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 1. / (2 * np.pi * 10))
     assert_equal(raw.info['lowpass'], 1. / (2 * np.pi * 0.004))
@@ -260,7 +260,7 @@ def test_brainvision_data_partially_disabled_hw_filters():
 
     expected_warnings = zip(trigger_warning, lowpass_warning, highpass_warning)
 
-    assert_true(all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
+    assert (all(any([trg, lp, hp]) for trg, lp, hp in expected_warnings))
 
     assert_equal(raw.info['highpass'], 0.)
     assert_equal(raw.info['lowpass'], 500.)
@@ -272,7 +272,7 @@ def test_brainvision_data_software_filters_latin1_global_units():
         raw = _test_raw_reader(
             read_raw_brainvision, vhdr_fname=vhdr_old_path,
             eog=("VEOGo", "VEOGu", "HEOGli", "HEOGre"), misc=("A2",))
-    assert_true(all('software filter detected' in str(ww.message) for ww in w))
+    assert (all('software filter detected' in str(ww.message) for ww in w))
 
     assert_equal(raw.info['highpass'], 1. / (2 * np.pi * 0.9))
     assert_equal(raw.info['lowpass'], 50.)
@@ -280,15 +280,15 @@ def test_brainvision_data_software_filters_latin1_global_units():
 
 def test_brainvision_data():
     """Test reading raw Brain Vision files."""
-    assert_raises(IOError, read_raw_brainvision, vmrk_path)
-    assert_raises(ValueError, read_raw_brainvision, vhdr_path, montage,
+    pytest.raises(IOError, read_raw_brainvision, vmrk_path)
+    pytest.raises(ValueError, read_raw_brainvision, vhdr_path, montage,
                   preload=True, scale="foo")
 
     raw_py = _test_raw_reader(
         read_raw_brainvision, vhdr_fname=vhdr_path, montage=montage,
         eog=eog, misc='auto', event_id=event_id)
 
-    assert_true('RawBrainVision' in repr(raw_py))
+    assert ('RawBrainVision' in repr(raw_py))
 
     assert_equal(raw_py.info['highpass'], 0.)
     assert_equal(raw_py.info['lowpass'], 250.)
@@ -445,9 +445,9 @@ def test_events():
                                 [6629, 1, 255],
                                 [7629, 1, 5]])
 
-    assert_raises(TypeError, read_raw_brainvision, vhdr_path, eog=eog,
+    pytest.raises(TypeError, read_raw_brainvision, vhdr_path, eog=eog,
                   preload=True, response_trig_shift=0.1)
-    assert_raises(TypeError, read_raw_brainvision, vhdr_path, eog=eog,
+    pytest.raises(TypeError, read_raw_brainvision, vhdr_path, eog=eog,
                   preload=True, response_trig_shift=np.nan)
 
     # to handle the min duration = 1 of stim trig (re)construction ...

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -10,8 +10,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_allclose)
-from nose.tools import assert_true, assert_raises, assert_equal
+                           assert_allclose, assert_equal)
 import pytest
 
 from mne.datasets import testing
@@ -58,8 +57,8 @@ def test_read_config():
     # for config in config_fname, config_solaris_fname:
     for config in config_fnames:
         cfg = _read_config(config)
-        assert_true(all('unknown' not in block.lower() and block != ''
-                        for block in cfg['user_blocks']))
+        assert all('unknown' not in block.lower() and block != ''
+                   for block in cfg['user_blocks'])
 
 
 def test_crop_append():
@@ -72,8 +71,8 @@ def test_crop_append():
     mask = (t0 <= t) * (t <= t1)
     raw_ = raw.copy().crop(t0, t1)
     y_, _ = raw_[:]
-    assert_true(y_.shape[1] == mask.sum())
-    assert_true(y_.shape[0] == y.shape[0])
+    assert (y_.shape[1] == mask.sum())
+    assert (y_.shape[0] == y.shape[0])
 
 
 def test_transforms():
@@ -104,14 +103,14 @@ def test_raw():
     for pdf, config, hs, exported in zip(pdf_fnames, config_fnames, hs_fnames,
                                          exported_fnames):
         # rx = 2 if 'linux' in pdf else 0
-        assert_raises(ValueError, read_raw_bti, pdf, 'eggs', preload=False)
-        assert_raises(ValueError, read_raw_bti, pdf, config, 'spam',
+        pytest.raises(ValueError, read_raw_bti, pdf, 'eggs', preload=False)
+        pytest.raises(ValueError, read_raw_bti, pdf, config, 'spam',
                       preload=False)
         if op.exists(tmp_raw_fname):
             os.remove(tmp_raw_fname)
         ex = read_raw_fif(exported, preload=True)
         ra = read_raw_bti(pdf, config, hs, preload=False)
-        assert_true('RawBTi' in repr(ra))
+        assert ('RawBTi' in repr(ra))
         assert_equal(ex.ch_names[:NCH], ra.ch_names[:NCH])
         assert_array_almost_equal(ex.info['dev_head_t']['trans'],
                                   ra.info['dev_head_t']['trans'], 7)
@@ -138,7 +137,7 @@ def test_raw():
             if ex.info[key] is None:
                 pass
             else:
-                assert_true(ra.info[key] is not None)
+                assert (ra.info[key] is not None)
                 for ent in ('to', 'from', 'trans'):
                     assert_allclose(ex.info[key][ent],
                                     ra.info[key][ent])
@@ -147,11 +146,11 @@ def test_raw():
         re = read_raw_fif(tmp_raw_fname)
         print(re)
         for key in ('dev_head_t', 'dev_ctf_t', 'ctf_head_t'):
-            assert_true(isinstance(re.info[key], dict))
+            assert (isinstance(re.info[key], dict))
             this_t = re.info[key]['trans']
             assert_equal(this_t.shape, (4, 4))
             # check that matrix by is not identity
-            assert_true(not np.allclose(this_t, np.eye(4)))
+            assert (not np.allclose(this_t, np.eye(4)))
         os.remove(tmp_raw_fname)
 
 
@@ -181,10 +180,10 @@ def test_info_no_rename_no_reorder_no_pdf():
         info2 = pick_info(info2, pick_types(info2, meg=True, stim=True,
                                             resp=True))
 
-        assert_true(info['sfreq'] is not None)
-        assert_true(info['lowpass'] is not None)
-        assert_true(info['highpass'] is not None)
-        assert_true(info['meas_date'] is not None)
+        assert (info['sfreq'] is not None)
+        assert (info['lowpass'] is not None)
+        assert (info['highpass'] is not None)
+        assert (info['meas_date'] is not None)
 
         assert_equal(info2['sfreq'], None)
         assert_equal(info2['lowpass'], None)
@@ -247,7 +246,7 @@ def test_no_conversion():
                 dig, raw_info['dig'], raw_info_con['dig'])):
             assert_equal(old['ident'], new['ident'])
             assert_array_equal(old['r'], new['r'])
-            assert_true(not np.allclose(old['r'], con['r']))
+            assert (not np.allclose(old['r'], con['r']))
 
             if ii > 10:
                 break
@@ -262,7 +261,7 @@ def test_no_conversion():
             t2 = raw_info['chs'][ii]['loc']
             t3 = raw_info_con['chs'][ii]['loc']
             assert_allclose(t1, t2, atol=1e-15)
-            assert_true(not np.allclose(t1, t3))
+            assert (not np.allclose(t1, t3))
             idx_a = raw_info_con['ch_names'].index('MEG 001')
             idx_b = raw_info['ch_names'].index('A22')
             assert_equal(
@@ -297,6 +296,7 @@ def test_setup_headshape():
         expected = set(['kind', 'ident', 'r'])
         found = set(reduce(lambda x, y: list(x) + list(y),
                            [d.keys() for d in dig]))
-        assert_true(not expected - found)
+        assert (not expected - found)
+
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -6,8 +6,6 @@
 import os.path as op
 import warnings
 
-from nose.tools import assert_equal, assert_true
-
 from mne import pick_types
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
@@ -26,10 +24,11 @@ def test_data():
     with warnings.catch_warnings(record=True) as w:
         raw = _test_raw_reader(read_raw_cnt, montage=None, input_fname=fname,
                                eog='auto', misc=['NA1', 'LEFT_EAR'])
-    assert_true(all('meas date' in str(ww.message) or
-                    'number of bytes' in str(ww.message) for ww in w))
+    assert all('meas date' in str(ww.message) or
+               'number of bytes' in str(ww.message) for ww in w)
     eog_chs = pick_types(raw.info, eog=True, exclude=[])
-    assert_equal(len(eog_chs), 2)  # test eog='auto'
-    assert_equal(raw.info['bads'], ['LEFT_EAR', 'VEOGR'])  # test bads
+    assert len(eog_chs) == 2  # test eog='auto'
+    assert raw.info['bads'] == ['LEFT_EAR', 'VEOGR']  # test bads
+
 
 run_tests_if_main()

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -50,7 +50,7 @@ ctf_fnames = tuple(sorted(block_sizes.keys()))
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_read_ctf():
-    """Test CTF reader"""
+    """Test CTF reader."""
     temp_dir = _TempDir()
     out_fname = op.join(temp_dir, 'test_py_raw.fif')
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -1,6 +1,3 @@
-"""Data Equivalence Tests"""
-from __future__ import print_function
-
 # Authors: Teon Brooks <teon.brooks@gmail.com>
 #          Martin Billinger <martin.billinger@tugraz.at>
 #          Alan Leggitt <alan.leggitt@ucsf.edu>
@@ -12,9 +9,10 @@ import os.path as op
 import inspect
 import warnings
 
-from nose.tools import assert_equal, assert_true
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_raises)
+                           assert_equal)
+import pytest
+
 from scipy import io
 import numpy as np
 
@@ -59,7 +57,7 @@ def test_bdf_data():
     raw_py = _test_raw_reader(read_raw_edf, input_fname=bdf_path,
                               montage=montage_path, eog=eog, misc=misc,
                               exclude=['M2', 'IEOG'], stim_channel=-1)
-    assert_true('RawEDF' in repr(raw_py))
+    assert ('RawEDF' in repr(raw_py))
     picks = pick_types(raw_py.info, meg=False, eeg=True, exclude='bads')
     data_py, _ = raw_py[picks]
 
@@ -71,9 +69,9 @@ def test_bdf_data():
     assert_array_almost_equal(data_py, data_eeglab, 8)
 
     # Manually checking that float coordinates are imported
-    assert_true((raw_py.info['chs'][0]['loc']).any())
-    assert_true((raw_py.info['chs'][25]['loc']).any())
-    assert_true((raw_py.info['chs'][63]['loc']).any())
+    assert ((raw_py.info['chs'][0]['loc']).any())
+    assert ((raw_py.info['chs'][25]['loc']).any())
+    assert ((raw_py.info['chs'][63]['loc']).any())
 
 
 @testing.requires_testing_data
@@ -81,7 +79,7 @@ def test_bdf_stim_channel():
     """Test BDF stim channel."""
     # test if last channel is detected as STIM by default
     raw_py = _test_raw_reader(read_raw_edf, input_fname=bdf_path)
-    assert_true(channel_type(raw_py.info, raw_py.info["nchan"] - 1) == 'stim')
+    assert (channel_type(raw_py.info, raw_py.info["nchan"] - 1) == 'stim')
 
     # test BDF file with wrong scaling info in header - this should be ignored
     # for BDF stim channels
@@ -190,7 +188,7 @@ def test_stim_channel():
 
     assert_array_almost_equal(data_py, data_eeglab, 10)
     events = find_edf_events(raw_py)
-    assert_true(len(events) - 1 == len(find_events(raw_py)))  # start not found
+    assert (len(events) - 1 == len(find_events(raw_py)))  # start not found
 
     # Test uneven sampling
     raw_py = read_raw_edf(edf_uneven_path, stim_channel=None)
@@ -205,22 +203,22 @@ def test_stim_channel():
     data_py = np.repeat(data_py, repeats=upsample)
     assert_array_equal(data_py, data_eeglab)
 
-    assert_raises(RuntimeError, read_raw_edf, edf_path, preload=False,
+    pytest.raises(RuntimeError, read_raw_edf, edf_path, preload=False,
                   stim_channel=-1)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         raw = read_raw_edf(edf_stim_resamp_path, verbose=True, stim_channel=-1)
     assert_equal(len(w), 2)
-    assert_true(any('Events may jitter' in str(ww.message) for ww in w))
-    assert_true(any('truncated' in str(ww.message) for ww in w))
+    assert (any('Events may jitter' in str(ww.message) for ww in w))
+    assert (any('truncated' in str(ww.message) for ww in w))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         raw[:]
     assert_equal(len(w), 0)
 
     events = raw_py.find_edf_events()
-    assert_true(len(events) == 0)
+    assert (len(events) == 0)
 
 
 def test_parse_annotation():
@@ -274,7 +272,7 @@ def test_edf_stim_channel():
     """Test stim channel for edf file."""
     # test if stim channel is automatically detected
     raw = read_raw_edf(edf_path, preload=True)
-    assert_true(channel_type(raw.info, raw.info["nchan"] - 1) == 'stim')
+    assert (channel_type(raw.info, raw.info["nchan"] - 1) == 'stim')
 
     raw = read_raw_edf(edf_stim_channel_path, preload=True,
                        stim_channel=-1)
@@ -299,10 +297,10 @@ def test_to_data_frame():
                            verbose='error')
         _, times = raw[0, :10]
         df = raw.to_data_frame()
-        assert_true((df.columns == raw.ch_names).all())
+        assert ((df.columns == raw.ch_names).all())
         assert_array_equal(np.round(times * 1e3), df.index.values[:10])
         df = raw.to_data_frame(index=None, scalings={'eeg': 1e13})
-        assert_true('time' in df.index.names)
+        assert ('time' in df.index.names)
         assert_array_equal(df.values[:, 0], raw._data[0] * 1e13)
 
 

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -1,6 +1,3 @@
-"""Data Equivalence Tests"""
-from __future__ import print_function
-
 # Authors: Alexandre Barachant <alexandre.barachant@gmail.com>
 #          Nicolas Barascud <nicolas.barascud@ens.fr>
 #
@@ -9,7 +6,6 @@ from __future__ import print_function
 import os.path as op
 import warnings
 
-from nose.tools import assert_true
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal)
 import numpy as np
@@ -52,7 +48,7 @@ def test_gdf_data():
     # Test events are encoded to stim channel.
     events = find_events(raw)
     evs = raw.find_edf_events()
-    assert_true(all([event in evs[1] for event in events[:, 0]]))
+    assert (all([event in evs[1] for event in events[:, 0]]))
 
 
 @testing.requires_testing_data
@@ -84,7 +80,7 @@ def test_gdf2_data():
         # header contains no events
         raw = read_raw_edf(gdf2_path + '.gdf', stim_channel='auto')
         assert_equal(len(w), 1)
-        assert_true(str(w[0].message).startswith('No events found.'))
+        assert (str(w[0].message).startswith('No events found.'))
     assert_equal(nchan, raw.info['nchan'])  # stim channel not constructed
     assert_array_equal(ch_names[1:], raw.ch_names[1:])
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -10,9 +10,10 @@ import shutil
 from unittest import SkipTest
 
 import warnings
-from nose.tools import assert_raises, assert_equal, assert_true
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_equal)
+import pytest
 from scipy import io
 
 from mne import write_events, read_epochs_eeglab, Epochs, find_events
@@ -46,7 +47,7 @@ def test_io_set():
                          montage=montage)
     for want in ('Events like', 'consist entirely', 'could not be mapped',
                  'string preload is not supported'):
-        assert_true(any(want in str(ww.message) for ww in w))
+        assert (any(want in str(ww.message) for ww in w))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         # test finding events in continuous data
@@ -102,12 +103,12 @@ def test_io_set():
 
     epochs = read_epochs_eeglab(epochs_fname, epochs.events, event_id)
     assert_equal(len(epochs.events), 4)
-    assert_true(epochs.preload)
-    assert_true(epochs._bad_dropped)
+    assert (epochs.preload)
+    assert (epochs._bad_dropped)
     epochs = read_epochs_eeglab(epochs_fname, out_fname, event_id)
-    assert_raises(ValueError, read_epochs_eeglab, epochs_fname,
+    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname,
                   None, event_id)
-    assert_raises(ValueError, read_epochs_eeglab, epochs_fname,
+    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname,
                   epochs.events, None)
 
     # test reading file with one event
@@ -140,7 +141,7 @@ def test_io_set():
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     negative_latency_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
-    assert_raises(ValueError, read_raw_eeglab, montage=montage, preload=True,
+    pytest.raises(ValueError, read_raw_eeglab, montage=montage, preload=True,
                   event_id=event_id, input_fname=negative_latency_fname)
 
     # test overlapping events
@@ -161,8 +162,8 @@ def test_io_set():
     assert_equal(len(w), 1)  # one warning for the dropped event
     events_stimchan = find_events(raw)
     events_read_events_eeglab = read_events_eeglab(overlap_fname, event_id)
-    assert_true(len(events_stimchan) == 1)
-    assert_true(len(events_read_events_eeglab) == 2)
+    assert (len(events_stimchan) == 1)
+    assert (len(events_read_events_eeglab) == 2)
 
     # test reading file with one channel
     one_chan_fname = op.join(temp_dir, 'test_one_channel.set')
@@ -269,18 +270,19 @@ def test_degenerate():
                     op.join(temp_dir, 'test_epochs.dat'))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        assert_raises(NotImplementedError, read_epochs_eeglab,
+        pytest.raises(NotImplementedError, read_epochs_eeglab,
                       bad_epochs_fname)
     assert_equal(len(w), 1)
 
 
 @testing.requires_testing_data
 def test_eeglab_annotations():
-    """Test reading annotations in EEGLAB files"""
+    """Test reading annotations in EEGLAB files."""
     for fname in [raw_fname_onefile, raw_fname]:
         annotations = read_annotations_eeglab(fname)
         assert len(annotations) == 154
         assert set(annotations.description) == set(['rt', 'square'])
         assert np.all(annotations.duration == 0.)
+
 
 run_tests_if_main()

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -8,8 +8,8 @@ import warnings
 import inspect
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
-from nose.tools import assert_true, assert_raises, assert_equal
+from numpy.testing import assert_array_equal, assert_allclose, assert_equal
+import pytest
 from scipy import io as sio
 
 
@@ -30,10 +30,10 @@ egi_txt_fname = op.join(base_dir, 'test_egi.txt')
 
 @requires_testing_data
 def test_io_egi_mff():
-    """Test importing EGI MFF simple binary files"""
+    """Test importing EGI MFF simple binary files."""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi.mff')
     raw = read_raw_egi(egi_fname_mff, include=None)
-    assert_true('RawMff' in repr(raw))
+    assert ('RawMff' in repr(raw))
     include = ['DIN1', 'DIN2', 'DIN3', 'DIN4', 'DIN5', 'DIN7']
     raw = _test_raw_reader(read_raw_egi, input_fname=egi_fname_mff,
                            include=include, channel_naming='EEG %03d')
@@ -48,16 +48,16 @@ def test_io_egi_mff():
     events = find_events(raw, stim_channel='STI 014')
     assert_equal(len(events), 8)
     assert_equal(np.unique(events[:, 1])[0], 0)
-    assert_true(np.unique(events[:, 0])[0] != 0)
-    assert_true(np.unique(events[:, 2])[0] != 0)
+    assert (np.unique(events[:, 0])[0] != 0)
+    assert (np.unique(events[:, 2])[0] != 0)
 
-    assert_raises(ValueError, read_raw_egi, egi_fname_mff, include=['Foo'],
+    pytest.raises(ValueError, read_raw_egi, egi_fname_mff, include=['Foo'],
                   preload=False)
-    assert_raises(ValueError, read_raw_egi, egi_fname_mff, exclude=['Bar'],
+    pytest.raises(ValueError, read_raw_egi, egi_fname_mff, exclude=['Bar'],
                   preload=False)
     for ii, k in enumerate(include, 1):
-        assert_true(k in raw.event_id)
-        assert_true(raw.event_id[k] == ii)
+        assert (k in raw.event_id)
+        assert (raw.event_id[k] == ii)
 
 
 def test_io_egi():
@@ -72,11 +72,11 @@ def test_io_egi():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         raw = read_raw_egi(egi_fname, include=None)
-        assert_true('RawEGI' in repr(raw))
+        assert ('RawEGI' in repr(raw))
         assert_equal(len(w), 1)
-        assert_true(w[0].category == RuntimeWarning)
+        assert (w[0].category == RuntimeWarning)
         msg = 'Did not find any event code with more than one event.'
-        assert_true(msg in '%s' % w[0].message)
+        assert (msg in '%s' % w[0].message)
     data_read, t_read = raw[:256]
     assert_allclose(t_read, t)
     assert_allclose(data_read, data, atol=1e-10)
@@ -97,8 +97,8 @@ def test_io_egi():
     events = find_events(raw, stim_channel='STI 014')
     assert_equal(len(events), 2)  # ground truth
     assert_equal(np.unique(events[:, 1])[0], 0)
-    assert_true(np.unique(events[:, 0])[0] != 0)
-    assert_true(np.unique(events[:, 2])[0] != 0)
+    assert (np.unique(events[:, 0])[0] != 0)
+    assert (np.unique(events[:, 2])[0] != 0)
     triggers = np.array([[0, 1, 1, 0], [0, 0, 1, 0]])
 
     # test trigger functionality
@@ -107,22 +107,22 @@ def test_io_egi():
     new_trigger = _combine_triggers(triggers, events_ids)
     assert_array_equal(np.unique(new_trigger), np.unique([0, 12, 24]))
 
-    assert_raises(ValueError, read_raw_egi, egi_fname, include=['Foo'],
+    pytest.raises(ValueError, read_raw_egi, egi_fname, include=['Foo'],
                   preload=False)
-    assert_raises(ValueError, read_raw_egi, egi_fname, exclude=['Bar'],
+    pytest.raises(ValueError, read_raw_egi, egi_fname, exclude=['Bar'],
                   preload=False)
     for ii, k in enumerate(include, 1):
-        assert_true(k in raw.event_id)
-        assert_true(raw.event_id[k] == ii)
+        assert (k in raw.event_id)
+        assert (raw.event_id[k] == ii)
 
 
 @requires_testing_data
 def test_io_egi_pns_mff():
-    """Test importing EGI MFF with PNS data"""
+    """Test importing EGI MFF with PNS data."""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns.mff')
     raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
                        verbose='error')
-    assert_true('RawMff' in repr(raw))
+    assert ('RawMff' in repr(raw))
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)
     assert_equal(len(pns_chans), 7)
     names = [raw.ch_names[x] for x in pns_chans]
@@ -159,7 +159,7 @@ def test_io_egi_pns_mff():
 
 @requires_testing_data
 def test_io_egi_pns_mff_bug():
-    """Test importing EGI MFF with PNS data (BUG)"""
+    """Test importing EGI MFF with PNS data (BUG)."""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
     with warnings.catch_warnings(record=True) as w:
         raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
@@ -193,5 +193,6 @@ def test_io_egi_pns_mff_bug():
         mat_data[:, -1] = 0  # The MFF has one less sample, the last one
         raw_data = raw[ch_idx][0]
         assert_array_equal(mat_data, raw_data)
+
 
 run_tests_if_main()

--- a/mne/io/eximia/tests/test_eximia.py
+++ b/mne/io/eximia/tests/test_eximia.py
@@ -4,7 +4,6 @@
 import os.path as op
 
 from numpy.testing import assert_array_equal
-from nose.tools import assert_equal, assert_true
 from scipy import io as sio
 
 from mne.io import read_raw_eximia
@@ -15,22 +14,22 @@ from mne.datasets.testing import data_path, requires_testing_data
 
 @requires_testing_data
 def test_eximia_nxe():
-    """Test reading Eximia NXE files"""
+    """Test reading Eximia NXE files."""
     fname = op.join(data_path(), 'eximia', 'test_eximia.nxe')
     raw = read_raw_eximia(fname, preload=True)
-    assert_true('RawEximia' in repr(raw))
+    assert 'RawEximia' in repr(raw)
     _test_raw_reader(read_raw_eximia, fname=fname)
     fname_mat = op.join(data_path(), 'eximia', 'test_eximia.mat')
     mc = sio.loadmat(fname_mat)
     m_data = mc['data']
     m_header = mc['header']
-    assert_equal(raw._data.shape, m_data.shape)
-    assert_equal(m_header['Fs'][0, 0][0, 0], raw.info['sfreq'])
+    assert raw._data.shape == m_data.shape
+    assert m_header['Fs'][0, 0][0, 0] == raw.info['sfreq']
     m_names = [x[0][0] for x in m_header['label'][0, 0]]
     m_names = list(
         map(lambda x: x.replace('GATE', 'GateIn').replace('TRIG', 'Trig'),
             m_names))
-    assert_equal(raw.ch_names, m_names)
+    assert raw.ch_names == m_names
     m_ch_types = [x[0][0] for x in m_header['chantype'][0, 0]]
     m_ch_types = list(
         map(lambda x: x.replace('unknown', 'stim').replace('trigger', 'stim'),
@@ -38,8 +37,9 @@ def test_eximia_nxe():
     types_dict = {2: 'eeg', 3: 'stim', 202: 'eog'}
     ch_types = [types_dict[raw.info['chs'][x]['kind']]
                 for x in range(len(raw.ch_names))]
-    assert_equal(ch_types, m_ch_types)
+    assert ch_types == m_ch_types
 
     assert_array_equal(m_data, raw._data)
+
 
 run_tests_if_main()

--- a/mne/io/kit/tests/test_coreg.py
+++ b/mne/io/kit/tests/test_coreg.py
@@ -4,9 +4,9 @@
 
 import inspect
 import os
-from ....externals.six.moves import cPickle as pickle
+from mne.externals.six.moves import cPickle as pickle
 
-from nose.tools import assert_raises
+import pytest
 from numpy.testing import assert_array_equal
 
 from mne.io.kit import read_mrk
@@ -21,7 +21,7 @@ mrk_fname = os.path.join(data_dir, 'test_mrk.sqd')
 
 
 def test_io_mrk():
-    """Test IO for mrk files"""
+    """Test IO for mrk files."""
     tempdir = _TempDir()
     pts = read_mrk(mrk_fname)
 
@@ -39,7 +39,7 @@ def test_io_mrk():
     assert_array_equal(pts_2, pts, "pickle mrk")
     with open(fname, 'wb') as fid:
         pickle.dump(dict(), fid)
-    assert_raises(ValueError, read_mrk, fname)
+    pytest.raises(ValueError, read_mrk, fname)
 
     # unsupported extension
-    assert_raises(ValueError, read_mrk, "file.ext")
+    pytest.raises(ValueError, read_mrk, "file.ext")

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -1,6 +1,3 @@
-"""Data and Channel Location Equivalence Tests"""
-from __future__ import print_function
-
 # Author: Teon Brooks <teon.brooks@gmail.com>
 #
 # License: BSD (3-clause)
@@ -10,9 +7,9 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import (assert_equal, assert_almost_equal, assert_raises,
-                        assert_true)
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
+import pytest
 from scipy import linalg
 import scipy.io
 
@@ -51,12 +48,12 @@ sqd_as_path = op.join(data_path, 'KIT', 'test_as-raw.con')
 @requires_testing_data
 def test_data():
     """Test reading raw kit files."""
-    assert_raises(TypeError, read_raw_kit, epochs_path)
-    assert_raises(TypeError, read_epochs_kit, sqd_path)
-    assert_raises(ValueError, read_raw_kit, sqd_path, mrk_path, elp_txt_path)
-    assert_raises(ValueError, read_raw_kit, sqd_path, None, None, None,
+    pytest.raises(TypeError, read_raw_kit, epochs_path)
+    pytest.raises(TypeError, read_epochs_kit, sqd_path)
+    pytest.raises(ValueError, read_raw_kit, sqd_path, mrk_path, elp_txt_path)
+    pytest.raises(ValueError, read_raw_kit, sqd_path, None, None, None,
                   list(range(200, 190, -1)))
-    assert_raises(ValueError, read_raw_kit, sqd_path, None, None, None,
+    pytest.raises(ValueError, read_raw_kit, sqd_path, None, None, None,
                   list(range(167, 159, -1)), '*', 1, True)
     # check functionality
     raw_mrk = read_raw_kit(sqd_path, [mrk2_path, mrk3_path], elp_txt_path,
@@ -65,7 +62,7 @@ def test_data():
                               elp=elp_txt_path, hsp=hsp_txt_path,
                               stim=list(range(167, 159, -1)), slope='+',
                               stimthresh=1)
-    assert_true('RawKIT' in repr(raw_py))
+    assert 'RawKIT' in repr(raw_py)
     assert_equal(raw_mrk.info['kit_system_id'], KIT.SYSTEM_NYU_2010)
 
     # check number/kind of channels
@@ -242,20 +239,21 @@ def test_decimate():
     # read in raw data using spherical hsp, and extract new hsp
     with warnings.catch_warnings(record=True) as w:
         raw = read_raw_kit(sqd_path, mrk_path, elp_txt_path, sphere_hsp_path)
-    assert_true(any('more than' in str(ww.message) for ww in w))
+    assert any('more than' in str(ww.message) for ww in w)
     # collect headshape from raw (should now be in m)
     hsp_dec = np.array([dig['r'] for dig in raw.info['dig']])[8:]
 
     # with 10242 points and _decimate_points set to resolution of 5 mm, hsp_dec
     # should be a bit over 5000 points. If not, something is wrong or
     # decimation resolution has been purposefully changed
-    assert_true(len(hsp_dec) > 5000)
+    assert len(hsp_dec) > 5000
 
     # should have similar size, distance from center
     dist = np.sqrt(np.sum((hsp_m - np.mean(hsp_m, axis=0))**2, axis=1))
     dist_dec = np.sqrt(np.sum((hsp_dec - np.mean(hsp_dec, axis=0))**2, axis=1))
     hsp_rad = np.mean(dist)
     hsp_dec_rad = np.mean(dist_dec)
-    assert_almost_equal(hsp_rad, hsp_dec_rad, places=3)
+    assert_array_almost_equal(hsp_rad, hsp_dec_rad, decimal=3)
+
 
 run_tests_if_main()

--- a/mne/io/tests/test_apply_function.py
+++ b/mne/io/tests/test_apply_function.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from nose.tools import assert_equal, assert_raises, assert_true
 import pytest
 
 from mne import create_info
@@ -12,40 +11,42 @@ from mne.utils import logger, catch_logging, run_tests_if_main
 
 
 def bad_1(x):
+    """Fail."""
     return  # bad return type
 
 
 def bad_2(x):
+    """Fail."""
     return x[:-1]  # bad shape
 
 
 def printer(x):
+    """Print."""
     logger.info('exec')
     return x
 
 
 @pytest.mark.slowtest
 def test_apply_function_verbose():
-    """Test apply function verbosity
-    """
+    """Test apply function verbosity."""
     n_chan = 2
     n_times = 3
     ch_names = [str(ii) for ii in range(n_chan)]
     raw = RawArray(np.zeros((n_chan, n_times)),
                    create_info(ch_names, 1., 'mag'))
     # test return types in both code paths (parallel / 1 job)
-    assert_raises(TypeError, raw.apply_function, bad_1)
-    assert_raises(ValueError, raw.apply_function, bad_2)
-    assert_raises(TypeError, raw.apply_function, bad_1, n_jobs=2)
-    assert_raises(ValueError, raw.apply_function, bad_2, n_jobs=2)
+    pytest.raises(TypeError, raw.apply_function, bad_1)
+    pytest.raises(ValueError, raw.apply_function, bad_2)
+    pytest.raises(TypeError, raw.apply_function, bad_1, n_jobs=2)
+    pytest.raises(ValueError, raw.apply_function, bad_2, n_jobs=2)
 
     # check our arguments
     with catch_logging() as sio:
         out = raw.apply_function(printer, verbose=False)
-        assert_equal(len(sio.getvalue()), 0)
-        assert_true(out is raw)
+        assert len(sio.getvalue()) == 0
+        assert out is raw
         raw.apply_function(printer, verbose=True)
-        assert_equal(sio.getvalue().count('\n'), n_chan)
+        assert sio.getvalue().count('\n') == n_chan
 
 
 run_tests_if_main()

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import os.path as op
-from nose.tools import assert_true
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
@@ -22,9 +21,9 @@ def test_compensation():
     raw = read_raw_fif(ctf_comp_fname)
     assert_equal(get_current_comp(raw.info), 3)
     comp1 = make_compensator(raw.info, 3, 1, exclude_comp_chs=False)
-    assert_true(comp1.shape == (340, 340))
+    assert comp1.shape == (340, 340)
     comp2 = make_compensator(raw.info, 3, 1, exclude_comp_chs=True)
-    assert_true(comp2.shape == (311, 340))
+    assert comp2.shape == (311, 340)
 
     # round-trip
     desired = np.eye(340)
@@ -54,7 +53,7 @@ def test_compensation():
     # channels have norm ~1e-12
     assert_allclose(data, data2, rtol=1e-9, atol=1e-18)
     for ch1, ch2 in zip(raw.info['chs'], raw2.info['chs']):
-        assert_true(ch1['coil_type'] == ch2['coil_type'])
+        assert ch1['coil_type'] == ch2['coil_type']
 
 
 @requires_mne
@@ -95,5 +94,6 @@ def test_compensation_mne():
         chs_c = [evoked_c.info['chs'][ii] for ii in picks_c]
         for ch_py, ch_c in zip(chs_py, chs_c):
             assert_equal(ch_py['coil_type'], ch_c['coil_type'])
+
 
 run_tests_if_main()

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -2,8 +2,8 @@ import inspect
 import os.path as op
 import warnings
 
-from nose.tools import assert_equal, assert_raises, assert_true
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
+import pytest
 import numpy as np
 
 from mne import (pick_channels_regexp, pick_types, Epochs,
@@ -50,8 +50,8 @@ def test_pick_refs():
     raw_ctf.apply_gradient_compensation(2)
     for info in infos:
         info['bads'] = []
-        assert_raises(ValueError, pick_types, info, meg='foo')
-        assert_raises(ValueError, pick_types, info, ref_meg='foo')
+        pytest.raises(ValueError, pick_types, info, meg='foo')
+        pytest.raises(ValueError, pick_types, info, ref_meg='foo')
         picks_meg_ref = pick_types(info, meg=True, ref_meg=True)
         picks_meg = pick_types(info, meg=True, ref_meg=False)
         picks_ref = pick_types(info, meg=False, ref_meg=True)
@@ -98,7 +98,7 @@ def test_pick_refs():
 
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
-            assert_raises(RuntimeError, pick_info, info, pick)
+            pytest.raises(RuntimeError, pick_info, info, pick)
 
 
 def test_pick_channels_regexp():
@@ -141,9 +141,9 @@ def test_pick_chpi():
     info = read_info(op.join(io_dir, 'tests', 'data', 'test_chpi_raw_sss.fif'))
     channel_types = set([channel_type(info, idx)
                          for idx in range(info['nchan'])])
-    assert_true('chpi' in channel_types)
-    assert_true('seeg' not in channel_types)
-    assert_true('ecog' not in channel_types)
+    assert 'chpi' in channel_types
+    assert 'seeg' not in channel_types
+    assert 'ecog' not in channel_types
 
 
 def test_pick_bio():
@@ -189,8 +189,8 @@ def test_pick_forward_seeg_ecog():
     fwd_ = pick_types_forward(fwd, meg=False, eeg=True)
     _check_fwd_n_chan_consistent(fwd_, counts['eeg'])
     # should raise exception related to emptiness
-    assert_raises(ValueError, pick_types_forward, fwd, meg=False, seeg=True)
-    assert_raises(ValueError, pick_types_forward, fwd, meg=False, ecog=True)
+    pytest.raises(ValueError, pick_types_forward, fwd, meg=False, seeg=True)
+    pytest.raises(ValueError, pick_types_forward, fwd, meg=False, ecog=True)
     # change last chan from EEG to sEEG, second-to-last to ECoG
     ecog_name = 'E1'
     seeg_name = 'OTp1'
@@ -256,8 +256,8 @@ def test_picks_by_channels():
                        [0, 1])
 
     # Make sure checks for list input work.
-    assert_raises(ValueError, pick_channels, ch_names, 'MEG 001')
-    assert_raises(ValueError, pick_channels, ch_names, ['MEG 001'], 'hi')
+    pytest.raises(ValueError, pick_channels, ch_names, 'MEG 001')
+    pytest.raises(ValueError, pick_channels, ch_names, ['MEG 001'], 'hi')
 
     pick_list = _picks_by_type(raw.info)
     assert_equal(len(pick_list), 1)
@@ -267,7 +267,7 @@ def test_picks_by_channels():
     assert_equal(pick_list2[0][0], 'mag')
 
     # pick_types type check
-    assert_raises(ValueError, raw.pick_types, eeg='string')
+    pytest.raises(ValueError, raw.pick_types, eeg='string')
 
     # duplicate check
     names = ['MEG 002', 'MEG 002']
@@ -277,7 +277,6 @@ def test_picks_by_channels():
 
 def test_clean_info_bads():
     """Test cleaning info['bads'] when bad_channels are excluded."""
-
     raw_file = op.join(op.dirname(_root_init_fname), 'io', 'tests', 'data',
                        'test_raw.fif')
     raw = read_raw_fif(raw_file)
@@ -311,6 +310,7 @@ def test_clean_info_bads():
     info = pick_info(raw.info, picks_meg)
     info._check_consistency()
     info['bads'] += ['EEG 053']
-    assert_raises(RuntimeError, info._check_consistency)
+    pytest.raises(RuntimeError, info._check_consistency)
+
 
 run_tests_if_main()

--- a/mne/io/tests/test_proc_history.py
+++ b/mne/io/tests/test_proc_history.py
@@ -2,12 +2,14 @@
 #          Eric Larson <larson.eric.d@gmail.com>
 # License: Simplified BSD
 
-import numpy as np
 import os.path as op
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
 from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
 from mne.io.proc_history import _get_rank_sss
-from nose.tools import assert_true, assert_equal
 
 base_dir = op.join(op.dirname(__file__), 'data')
 raw_fname = op.join(base_dir, 'test_chpi_raw_sss.fif')
@@ -18,24 +20,23 @@ def test_maxfilter_io():
     info = read_info(raw_fname)
     mf = info['proc_history'][1]['max_info']
 
-    assert_true(mf['sss_info']['frame'], FIFF.FIFFV_COORD_HEAD)
+    assert mf['sss_info']['frame'] == FIFF.FIFFV_COORD_HEAD
     # based on manual 2.0, rev. 5.0 page 23
-    assert_true(5 <= mf['sss_info']['in_order'] <= 11)
-    assert_true(mf['sss_info']['out_order'] <= 5)
-    assert_true(mf['sss_info']['nchan'] > len(mf['sss_info']['components']))
+    assert 5 <= mf['sss_info']['in_order'] <= 11
+    assert mf['sss_info']['out_order'] <= 5
+    assert mf['sss_info']['nchan'] > len(mf['sss_info']['components'])
 
-    assert_equal(info['ch_names'][:mf['sss_info']['nchan']],
-                 mf['sss_ctc']['proj_items_chs'])
-    assert_equal(mf['sss_ctc']['decoupler'].shape,
-                 (mf['sss_info']['nchan'], mf['sss_info']['nchan']))
-    assert_equal(np.unique(np.diag(mf['sss_ctc']['decoupler'].toarray())),
-                 np.array([1.], dtype=np.float32))
-
-    assert_equal(mf['sss_cal']['cal_corrs'].shape, (306, 14))
-    assert_equal(mf['sss_cal']['cal_chans'].shape, (306, 2))
+    assert (info['ch_names'][:mf['sss_info']['nchan']] ==
+            mf['sss_ctc']['proj_items_chs'])
+    assert (mf['sss_ctc']['decoupler'].shape ==
+            (mf['sss_info']['nchan'], mf['sss_info']['nchan']))
+    assert_array_equal(
+        np.unique(np.diag(mf['sss_ctc']['decoupler'].toarray())),
+        np.array([1.], dtype=np.float32))
+    assert mf['sss_cal']['cal_corrs'].shape == (306, 14)
+    assert mf['sss_cal']['cal_chans'].shape == (306, 2)
     vv_coils = [v for k, v in FIFF.items() if 'FIFFV_COIL_VV' in k]
-    assert_true(all(k in vv_coils
-                    for k in set(mf['sss_cal']['cal_chans'][:, 1])))
+    assert all(k in vv_coils for k in set(mf['sss_cal']['cal_chans'][:, 1]))
 
 
 def test_maxfilter_get_rank():
@@ -44,4 +45,4 @@ def test_maxfilter_get_rank():
     mf = raw.info['proc_history'][0]['max_info']
     rank1 = mf['sss_info']['nfree']
     rank2 = _get_rank_sss(raw)
-    assert_equal(rank1, rank2)
+    assert rank1 == rank2

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -1,10 +1,10 @@
 # Generic tests that all raw classes should run
 from os import path as op
 import math
-import numpy as np
-from numpy.testing import assert_allclose, assert_array_almost_equal
 
-from nose.tools import assert_equal, assert_true
+import numpy as np
+from numpy.testing import (assert_allclose, assert_array_almost_equal,
+                           assert_equal)
 
 from mne import concatenate_raws
 from mne.datasets import testing
@@ -58,25 +58,25 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
         raw = reader(**kwargs)
 
     full_data = raw._data
-    assert_true(raw.__class__.__name__, repr(raw))  # to test repr
-    assert_true(raw.info.__class__.__name__, repr(raw.info))
+    assert raw.__class__.__name__ in repr(raw)  # to test repr
+    assert raw.info.__class__.__name__ in repr(raw.info)
 
     # Test saving and reading
     out_fname = op.join(tempdir, 'test_raw.fif')
     raw = concatenate_raws([raw])
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
     raw3 = read_raw_fif(out_fname)
-    assert_equal(set(raw.info.keys()), set(raw3.info.keys()))
+    assert set(raw.info.keys()) == set(raw3.info.keys())
     assert_allclose(raw3[0:20][0], full_data[0:20], rtol=1e-6,
                     atol=1e-20)  # atol is very small but > 0
     assert_array_almost_equal(raw.times, raw3.times)
 
-    assert_true(not math.isnan(raw3.info['highpass']))
-    assert_true(not math.isnan(raw3.info['lowpass']))
-    assert_true(not math.isnan(raw.info['highpass']))
-    assert_true(not math.isnan(raw.info['lowpass']))
+    assert not math.isnan(raw3.info['highpass'])
+    assert not math.isnan(raw3.info['lowpass'])
+    assert not math.isnan(raw.info['highpass'])
+    assert not math.isnan(raw.info['lowpass'])
 
-    assert_equal(raw3.info['kit_system_id'], raw.info['kit_system_id'])
+    assert raw3.info['kit_system_id'] == raw.info['kit_system_id']
 
     # Make sure concatenation works
     first_samp = raw.first_samp

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -8,8 +8,8 @@ import warnings
 import os.path as op
 import numpy as np
 
-from nose.tools import assert_true, assert_equal, assert_raises
-from numpy.testing import assert_array_equal, assert_allclose
+from numpy.testing import assert_array_equal, assert_allclose, assert_equal
+import pytest
 
 from mne import (pick_channels, pick_types, Epochs, read_events,
                  set_eeg_reference, set_bipolar_reference,
@@ -76,15 +76,15 @@ def test_apply_reference():
     # Rereference raw data by creating a copy of original data
     reref, ref_data = _apply_reference(
         raw.copy(), ref_from=['EEG 001', 'EEG 002'])
-    assert_true(reref.info['custom_ref_applied'])
+    assert (reref.info['custom_ref_applied'])
     _test_reference(raw, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # The CAR reference projection should have been removed by the function
-    assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
+    assert (not _has_eeg_average_ref_proj(reref.info['projs']))
 
     # Test that data is modified in place when copy=False
     reref, ref_data = _apply_reference(raw, ['EEG 001', 'EEG 002'])
-    assert_true(raw is reref)
+    assert (raw is reref)
 
     # Test that disabling the reference does not change anything
     reref, ref_data = _apply_reference(raw.copy(), [])
@@ -98,19 +98,19 @@ def test_apply_reference():
                     picks=picks_eeg, preload=True)
     reref, ref_data = _apply_reference(
         epochs.copy(), ref_from=['EEG 001', 'EEG 002'])
-    assert_true(reref.info['custom_ref_applied'])
+    assert (reref.info['custom_ref_applied'])
     _test_reference(epochs, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # Test re-referencing Evoked object
     evoked = epochs.average()
     reref, ref_data = _apply_reference(
         evoked.copy(), ref_from=['EEG 001', 'EEG 002'])
-    assert_true(reref.info['custom_ref_applied'])
+    assert (reref.info['custom_ref_applied'])
     _test_reference(evoked, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # Referencing needs data to be preloaded
     raw_np = read_raw_fif(fif_fname, preload=False)
-    assert_raises(RuntimeError, _apply_reference, raw_np, ['EEG 001'])
+    pytest.raises(RuntimeError, _apply_reference, raw_np, ['EEG 001'])
 
     # Test having inactive SSP projections that deal with channels involved
     # during re-referencing
@@ -130,7 +130,7 @@ def test_apply_reference():
         )
     )
     # Projection concerns channels mentioned in projector
-    assert_raises(RuntimeError, _apply_reference, raw, ['EEG 001'])
+    pytest.raises(RuntimeError, _apply_reference, raw, ['EEG 001'])
 
     # Projection does not concern channels mentioned in projector, no error
     _apply_reference(raw, ['EEG 003'], ['EEG 004'])
@@ -143,11 +143,11 @@ def test_set_eeg_reference():
     raw.info['projs'] = []
 
     # Test setting an average reference projection
-    assert_true(not _has_eeg_average_ref_proj(raw.info['projs']))
+    assert (not _has_eeg_average_ref_proj(raw.info['projs']))
     reref, ref_data = set_eeg_reference(raw, projection=True)
-    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
-    assert_true(not reref.info['projs'][0]['active'])
-    assert_true(ref_data is None)
+    assert (_has_eeg_average_ref_proj(reref.info['projs']))
+    assert (not reref.info['projs'][0]['active'])
+    assert (ref_data is None)
     reref.apply_proj()
     eeg_chans = [raw.ch_names[ch]
                  for ch in pick_types(raw.info, meg=False, eeg=True)]
@@ -157,29 +157,29 @@ def test_set_eeg_reference():
     # Test setting an average reference when one was already present
     with warnings.catch_warnings(record=True):
         reref, ref_data = set_eeg_reference(raw, copy=False, projection=True)
-    assert_true(ref_data is None)
+    assert (ref_data is None)
 
     # Test setting an average reference on non-preloaded data
     raw_nopreload = read_raw_fif(fif_fname, preload=False)
     raw_nopreload.info['projs'] = []
     reref, ref_data = set_eeg_reference(raw_nopreload, projection=True)
-    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
-    assert_true(not reref.info['projs'][0]['active'])
+    assert (_has_eeg_average_ref_proj(reref.info['projs']))
+    assert (not reref.info['projs'][0]['active'])
 
     # Rereference raw data by creating a copy of original data
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'], copy=True)
-    assert_true(reref.info['custom_ref_applied'])
+    assert (reref.info['custom_ref_applied'])
     _test_reference(raw, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # Test that data is modified in place when copy=False
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'],
                                         copy=False)
-    assert_true(raw is reref)
+    assert (raw is reref)
 
     # Test moving from custom to average reference
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
     reref, _ = set_eeg_reference(reref, projection=True)
-    assert_true(_has_eeg_average_ref_proj(reref.info['projs']))
+    assert (_has_eeg_average_ref_proj(reref.info['projs']))
     assert_equal(reref.info['custom_ref_applied'], False)
 
     # When creating an average reference fails, make sure the
@@ -187,8 +187,8 @@ def test_set_eeg_reference():
     reref = raw.copy()
     reref.info['custom_ref_applied'] = True
     reref.pick_types(eeg=False)  # Cause making average ref fail
-    assert_raises(ValueError, set_eeg_reference, reref, projection=True)
-    assert_true(reref.info['custom_ref_applied'])
+    pytest.raises(ValueError, set_eeg_reference, reref, projection=True)
+    assert (reref.info['custom_ref_applied'])
 
     # Test moving from average to custom reference
     reref, ref_data = set_eeg_reference(raw, projection=True)
@@ -206,7 +206,7 @@ def test_set_eeg_reference():
     # make sure ref_channels=[] removes average reference projectors
     assert _has_eeg_average_ref_proj(raw.info['projs'])
     reref, _ = set_eeg_reference(raw, [])
-    assert_true(not _has_eeg_average_ref_proj(reref.info['projs']))
+    assert (not _has_eeg_average_ref_proj(reref.info['projs']))
 
     # Test that average reference gives identical results when calculated
     # via SSP projection (projection=True) or directly (projection=False)
@@ -222,8 +222,8 @@ def test_set_eeg_reference():
     _test_reference(raw, reref, ref_data, eeg_chans)
 
     # projection=True only works for ref_channels='average'
-    assert_raises(ValueError, set_eeg_reference, raw, [], True, True)
-    assert_raises(ValueError, set_eeg_reference, raw, ['EEG 001'], True, True)
+    pytest.raises(ValueError, set_eeg_reference, raw, [], True, True)
+    pytest.raises(ValueError, set_eeg_reference, raw, ['EEG 001'], True, True)
 
 
 @testing.requires_testing_data
@@ -235,7 +235,7 @@ def test_set_bipolar_reference():
     reref = set_bipolar_reference(raw, 'EEG 001', 'EEG 002', 'bipolar',
                                   {'kind': FIFF.FIFFV_EOG_CH,
                                    'extra': 'some extra value'})
-    assert_true(reref.info['custom_ref_applied'])
+    assert (reref.info['custom_ref_applied'])
 
     # Compare result to a manual calculation
     a = raw.copy().pick_channels(['EEG 001', 'EEG 002'])
@@ -244,9 +244,9 @@ def test_set_bipolar_reference():
     assert_allclose(a, b)
 
     # Original channels should be replaced by a virtual one
-    assert_true('EEG 001' not in reref.ch_names)
-    assert_true('EEG 002' not in reref.ch_names)
-    assert_true('bipolar' in reref.ch_names)
+    assert ('EEG 001' not in reref.ch_names)
+    assert ('EEG 002' not in reref.ch_names)
+    assert ('bipolar' in reref.ch_names)
 
     # Check channel information
     bp_info = reref.info['chs'][reref.ch_names.index('bipolar')]
@@ -264,14 +264,14 @@ def test_set_bipolar_reference():
 
     # Minimalist call
     reref = set_bipolar_reference(raw, 'EEG 001', 'EEG 002')
-    assert_true('EEG 001-EEG 002' in reref.ch_names)
+    assert ('EEG 001-EEG 002' in reref.ch_names)
 
     # Minimalist call with twice the same anode
     reref = set_bipolar_reference(raw,
                                   ['EEG 001', 'EEG 001', 'EEG 002'],
                                   ['EEG 002', 'EEG 003', 'EEG 003'])
-    assert_true('EEG 001-EEG 002' in reref.ch_names)
-    assert_true('EEG 001-EEG 003' in reref.ch_names)
+    assert ('EEG 001-EEG 002' in reref.ch_names)
+    assert ('EEG 001-EEG 003' in reref.ch_names)
 
     # Set multiple references at once
     reref = set_bipolar_reference(
@@ -293,20 +293,20 @@ def test_set_bipolar_reference():
     reref = set_bipolar_reference(raw, 'MEG 0111', 'MEG 0112',
                                   ch_info={'kind': FIFF.FIFFV_MEG_CH},
                                   verbose='error')
-    assert_true(not reref.info['custom_ref_applied'])
-    assert_true('MEG 0111-MEG 0112'[:15] in reref.ch_names)
+    assert (not reref.info['custom_ref_applied'])
+    assert ('MEG 0111-MEG 0112'[:15] in reref.ch_names)
 
     # Test a battery of invalid inputs
-    assert_raises(ValueError, set_bipolar_reference, raw,
+    pytest.raises(ValueError, set_bipolar_reference, raw,
                   'EEG 001', ['EEG 002', 'EEG 003'], 'bipolar')
-    assert_raises(ValueError, set_bipolar_reference, raw,
+    pytest.raises(ValueError, set_bipolar_reference, raw,
                   ['EEG 001', 'EEG 002'], 'EEG 003', 'bipolar')
-    assert_raises(ValueError, set_bipolar_reference, raw,
+    pytest.raises(ValueError, set_bipolar_reference, raw,
                   'EEG 001', 'EEG 002', ['bipolar1', 'bipolar2'])
-    assert_raises(ValueError, set_bipolar_reference, raw,
+    pytest.raises(ValueError, set_bipolar_reference, raw,
                   'EEG 001', 'EEG 002', 'bipolar',
                   ch_info=[{'foo': 'bar'}, {'foo': 'bar'}])
-    assert_raises(ValueError, set_bipolar_reference, raw,
+    pytest.raises(ValueError, set_bipolar_reference, raw,
                   'EEG 001', 'EEG 002', ch_name='EEG 003')
 
 
@@ -317,7 +317,7 @@ def _check_channel_names(inst, ref_names):
 
     # Test that the names of the reference channels are present in `ch_names`
     ref_idx = pick_channels(inst.info['ch_names'], ref_names)
-    assert_true(len(ref_idx), len(ref_names))
+    assert len(ref_idx) == len(ref_names)
 
     # Test that the names of the reference channels are present in the `chs`
     # list
@@ -330,7 +330,7 @@ def test_add_reference():
     raw = read_raw_fif(fif_fname, preload=True)
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
     # check if channel already exists
-    assert_raises(ValueError, add_reference_channels,
+    pytest.raises(ValueError, add_reference_channels,
                   raw, raw.info['ch_names'][0])
     # add reference channel to Raw
     raw_ref = add_reference_channels(raw, 'Ref', copy=True)
@@ -371,7 +371,7 @@ def test_add_reference():
     _check_channel_names(raw, 'Ref')
 
     # Test adding an existing channel as reference channel
-    assert_raises(ValueError, add_reference_channels, raw,
+    pytest.raises(ValueError, add_reference_channels, raw,
                   raw.info['ch_names'][0])
 
     # add two reference channels to Raw
@@ -395,7 +395,7 @@ def test_add_reference():
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True)
     # default: proj=True, after which adding a Ref channel is prohibited
-    assert_raises(RuntimeError, add_reference_channels, epochs, 'Ref')
+    pytest.raises(RuntimeError, add_reference_channels, epochs, 'Ref')
 
     # create epochs in delayed mode, allowing removal of CAR when re-reffing
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
@@ -472,8 +472,8 @@ def test_add_reference():
 
     # Test invalid inputs
     raw_np = read_raw_fif(fif_fname, preload=False)
-    assert_raises(RuntimeError, add_reference_channels, raw_np, ['Ref'])
-    assert_raises(ValueError, add_reference_channels, raw, 1)
+    pytest.raises(RuntimeError, add_reference_channels, raw_np, ['Ref'])
+    pytest.raises(ValueError, add_reference_channels, raw, 1)
 
 
 run_tests_if_main()

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_allclose, assert_array_equal)
 from scipy import sparse
-from nose.tools import assert_true, assert_raises
+
 import pytest
 import copy
 import warnings
@@ -96,7 +96,7 @@ def _compare(a, b):
                   'command_line', 'working_dir', 'mri_file', 'mri_id']
     try:
         if isinstance(a, (dict, Info)):
-            assert_true(isinstance(b, (dict, Info)))
+            assert (isinstance(b, (dict, Info)))
             for k, v in six.iteritems(a):
                 if k not in b and k not in skip_types:
                     raise ValueError('First one had one second one didn\'t:\n'
@@ -110,7 +110,7 @@ def _compare(a, b):
                     raise ValueError('Second one had one first one didn\'t:\n'
                                      '%s not in %s' % (k, a.keys()))
         elif isinstance(a, list):
-            assert_true(len(a) == len(b))
+            assert (len(a) == len(b))
             for i, j in zip(a, b):
                 _compare(i, j)
         elif isinstance(a, sparse.csr.csr_matrix):
@@ -135,13 +135,13 @@ def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,
         assert_allclose(inv_1['depth_prior']['data'],
                         inv_2['depth_prior']['data'], atol=depth_atol)
     else:
-        assert_true(inv_2['depth_prior'] is None)
+        assert (inv_2['depth_prior'] is None)
     # orient prior
     if inv_1['orient_prior'] is not None:
         assert_allclose(inv_1['orient_prior']['data'],
                         inv_2['orient_prior']['data'], atol=1e-7)
     else:
-        assert_true(inv_2['orient_prior'] is None)
+        assert (inv_2['orient_prior'] is None)
     # source cov
     assert_allclose(inv_1['source_cov']['data'], inv_2['source_cov']['data'],
                     atol=1e-7)
@@ -179,7 +179,7 @@ def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,
         stc_1 /= norms
         stc_2 /= norms
         corr = np.corrcoef(stc_1.ravel(), stc_2.ravel())[0, 1]
-        assert_true(corr > ctol, msg='%s < %s' % (corr, ctol))
+        assert corr > ctol
         assert_allclose(stc_1, stc_2, rtol=rtol, atol=atol,
                         err_msg='%s: %s' % (method, corr))
 
@@ -238,8 +238,8 @@ def test_make_inverse_operator():
     _compare_io(my_inv_op)
     _compare_inverses_approx(my_inv_op, inverse_operator, evoked,
                              rtol=1e-3, atol=1e-5)
-    assert_true('dev_head_t' in my_inv_op['info'])
-    assert_true('mri_head_t' in my_inv_op)
+    assert ('dev_head_t' in my_inv_op['info'])
+    assert ('mri_head_t' in my_inv_op)
 
 
 @pytest.mark.slowtest
@@ -288,7 +288,7 @@ def test_inverse_operator_channel_ordering():
     assert_equal(stc_1.subject, stc_2.subject)
     assert_array_equal(stc_1.times, stc_2.times)
     assert_allclose(stc_1.data, stc_2.data, rtol=1e-5, atol=1e-5)
-    assert_true(inv_orig['units'] == inv_reorder['units'])
+    assert (inv_orig['units'] == inv_reorder['units'])
 
     # Reload with original ordering & apply reordered inverse
     evoked = _get_evoked()
@@ -419,10 +419,10 @@ def test_apply_inverse_operator():
     evoked = _get_evoked()
 
     # Inverse has 306 channels - 4 proj = 302
-    assert_true(compute_rank_inverse(inverse_operator) == 302)
+    assert (compute_rank_inverse(inverse_operator) == 302)
 
     # Inverse has 306 channels - 4 proj = 302
-    assert_true(compute_rank_inverse(inverse_operator) == 302)
+    assert (compute_rank_inverse(inverse_operator) == 302)
 
     stc = apply_inverse(evoked, inverse_operator, lambda2, "MNE")
     assert stc.subject == 'sample'
@@ -477,10 +477,10 @@ def test_apply_inverse_operator():
 
     # Test we get errors when using custom ref or no average proj is present
     evoked.info['custom_ref_applied'] = True
-    assert_raises(ValueError, apply_inverse, evoked, inv_op, lambda2, "MNE")
+    pytest.raises(ValueError, apply_inverse, evoked, inv_op, lambda2, "MNE")
     evoked.info['custom_ref_applied'] = False
     evoked.info['projs'] = []  # remove EEG proj
-    assert_raises(ValueError, apply_inverse, evoked, inv_op, lambda2, "MNE")
+    pytest.raises(ValueError, apply_inverse, evoked, inv_op, lambda2, "MNE")
 
 
 @testing.requires_testing_data
@@ -493,7 +493,7 @@ def test_make_inverse_operator_fixed():
     # can't make fixed inv with depth weighting without free ori fwd
     fwd_fixed = convert_forward_solution(fwd, force_fixed=True,
                                          use_cps=True)
-    assert_raises(ValueError, make_inverse_operator, evoked.info, fwd_fixed,
+    pytest.raises(ValueError, make_inverse_operator, evoked.info, fwd_fixed,
                   noise_cov, depth=0.8, fixed=True)
 
     # now compare to C solution
@@ -511,7 +511,7 @@ def test_make_inverse_operator_fixed():
     _compare_inverses_approx(inverse_operator_nodepth, inv_op, evoked,
                              rtol=1e-5, atol=1e-4)
     # Inverse has 306 channels - 6 proj = 302
-    assert_true(compute_rank_inverse(inverse_operator_nodepth) == 302)
+    assert (compute_rank_inverse(inverse_operator_nodepth) == 302)
     # Now with depth
     fwd_surf = convert_forward_solution(fwd, surf_ori=True)  # not fixed
     for kwargs, use_fwd in zip([dict(fixed=True), dict(loose=0.)],
@@ -538,7 +538,7 @@ def test_make_inverse_operator_free():
     noise_cov = read_cov(fname_cov)
 
     # can't make free inv with fixed fwd
-    assert_raises(ValueError, make_inverse_operator, evoked.info, fwd_fixed,
+    pytest.raises(ValueError, make_inverse_operator, evoked.info, fwd_fixed,
                   noise_cov, depth=None)
 
     # for depth=None, surf_ori of the fwd should not matter
@@ -578,7 +578,7 @@ def test_make_inverse_operator_vector():
             assert_allclose(stc.data, stc_vec.magnitude().data)
 
     # Vector estimates don't work when using fixed orientations
-    assert_raises(RuntimeError, apply_inverse, evoked, inv_3,
+    pytest.raises(RuntimeError, apply_inverse, evoked, inv_3,
                   pick_ori='vector')
 
     # When computing with vector fields, computing the difference between two
@@ -614,59 +614,56 @@ def test_make_inverse_operator_diag():
     _compare_inverses_approx(inverse_operator_diag, inv_op, evoked,
                              rtol=1e-1, atol=1e-1, ctol=0.99, check_K=False)
     # Inverse has 366 channels - 6 proj = 360
-    assert_true(compute_rank_inverse(inverse_operator_diag) == 360)
+    assert (compute_rank_inverse(inverse_operator_diag) == 360)
 
 
 @testing.requires_testing_data
 def test_inverse_operator_noise_cov_rank():
-    """Test MNE inverse operator with a specified noise cov rank
-    """
+    """Test MNE inverse operator with a specified noise cov rank."""
     fwd_op = read_forward_solution_meg(fname_fwd, surf_ori=True)
     evoked = _get_evoked()
     noise_cov = read_cov(fname_cov)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov, rank=64)
-    assert_true(compute_rank_inverse(inv) == 64)
+    assert (compute_rank_inverse(inv) == 64)
 
     fwd_op = read_forward_solution_eeg(fname_fwd, surf_ori=True)
     inv = make_inverse_operator(evoked.info, fwd_op, noise_cov,
                                 rank=dict(eeg=20))
-    assert_true(compute_rank_inverse(inv) == 20)
+    assert (compute_rank_inverse(inv) == 20)
 
 
 @testing.requires_testing_data
 def test_inverse_operator_volume():
-    """Test MNE inverse computation on volume source space
-    """
+    """Test MNE inverse computation on volume source space."""
     tempdir = _TempDir()
     evoked = _get_evoked()
     inv_vol = read_inverse_operator(fname_vol_inv)
-    assert_true(repr(inv_vol))
+    assert (repr(inv_vol))
     stc = apply_inverse(evoked, inv_vol, lambda2, 'dSPM')
-    assert_true(isinstance(stc, VolSourceEstimate))
+    assert (isinstance(stc, VolSourceEstimate))
     # volume inverses don't have associated subject IDs
-    assert_true(stc.subject is None)
+    assert (stc.subject is None)
     stc.save(op.join(tempdir, 'tmp-vl.stc'))
     stc2 = read_source_estimate(op.join(tempdir, 'tmp-vl.stc'))
-    assert_true(np.all(stc.data > 0))
-    assert_true(np.all(stc.data < 35))
+    assert (np.all(stc.data > 0))
+    assert (np.all(stc.data < 35))
     assert_array_almost_equal(stc.data, stc2.data)
     assert_array_almost_equal(stc.times, stc2.times)
     # vector source estimate
     stc_vec = apply_inverse(evoked, inv_vol, lambda2, 'dSPM', 'vector')
-    assert_true(repr(stc_vec))
+    assert (repr(stc_vec))
     assert_allclose(np.linalg.norm(stc_vec.data, axis=1), stc.data)
 
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_io_inverse_operator():
-    """Test IO of inverse_operator
-    """
+    """Test IO of inverse_operator."""
     tempdir = _TempDir()
     inverse_operator = read_inverse_operator(fname_inv)
     x = repr(inverse_operator)
-    assert_true(x)
-    assert_true(isinstance(inverse_operator['noise_cov'], Covariance))
+    assert (x)
+    assert (isinstance(inverse_operator['noise_cov'], Covariance))
     # just do one example for .gz, as it should generalize
     _compare_io(inverse_operator, '.gz')
 
@@ -714,11 +711,11 @@ def test_apply_mne_inverse_raw():
                                  buffer_size=3, prepared=True)
 
         if pick_ori is None:
-            assert_true(np.all(stc.data > 0))
-            assert_true(np.all(stc2.data > 0))
+            assert (np.all(stc.data > 0))
+            assert (np.all(stc2.data > 0))
 
-        assert_true(stc.subject == 'sample')
-        assert_true(stc2.subject == 'sample')
+        assert (stc.subject == 'sample')
+        assert (stc2.subject == 'sample')
         assert_array_almost_equal(stc.times, times)
         assert_array_almost_equal(stc2.times, times)
         assert_array_almost_equal(stc.data, stc2.data)
@@ -737,7 +734,7 @@ def test_apply_mne_inverse_fixed_raw():
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=False,
                                     surf_ori=True)
     noise_cov = read_cov(fname_cov)
-    assert_raises(ValueError, make_inverse_operator,
+    pytest.raises(ValueError, make_inverse_operator,
                   raw.info, fwd, noise_cov, loose=1., fixed=True)
     inv_op = make_inverse_operator(raw.info, fwd, noise_cov,
                                    fixed=True, use_cps=True)
@@ -756,8 +753,8 @@ def test_apply_mne_inverse_fixed_raw():
                              label=label_lh, start=start, stop=stop, nave=1,
                              pick_ori=None, buffer_size=None)
 
-    assert_true(stc.subject == 'sample')
-    assert_true(stc2.subject == 'sample')
+    assert (stc.subject == 'sample')
+    assert (stc2.subject == 'sample')
     assert_array_almost_equal(stc.times, times)
     assert_array_almost_equal(stc2.times, times)
     assert_array_almost_equal(stc3.times, times)
@@ -797,9 +794,9 @@ def test_apply_mne_inverse_epochs():
         assert_array_almost_equal(stcs[0].data, stcs2[0].data)
         assert_array_almost_equal(stcs[0].times, stcs2[0].times)
 
-        assert_true(len(stcs) == 2)
-        assert_true(3 < stcs[0].data.max() < 10)
-        assert_true(stcs[0].subject == 'sample')
+        assert (len(stcs) == 2)
+        assert (3 < stcs[0].data.max() < 10)
+        assert (stcs[0].subject == 'sample')
     inverse_operator = read_inverse_operator(fname_full)
 
     stcs = apply_inverse_epochs(epochs, inverse_operator, lambda2, "dSPM",
@@ -810,7 +807,7 @@ def test_apply_mne_inverse_epochs():
     label_mean = np.mean(data, axis=0)
     label_mean_flip = np.mean(flip[:, np.newaxis] * data, axis=0)
 
-    assert_true(label_mean.max() < label_mean_flip.max())
+    assert (label_mean.max() < label_mean_flip.max())
 
     # test extracting a BiHemiLabel
     inverse_operator = prepare_inverse_operator(inverse_operator, nave=1,
@@ -831,9 +828,9 @@ def test_apply_mne_inverse_epochs():
     # test without using a label (so delayed computation is used)
     stcs = apply_inverse_epochs(epochs, inverse_operator, lambda2, "dSPM",
                                 pick_ori="normal", prepared=True)
-    assert_true(stcs[0].subject == 'sample')
+    assert (stcs[0].subject == 'sample')
     label_stc = stcs[0].in_label(label_rh)
-    assert_true(label_stc.subject == 'sample')
+    assert (label_stc.subject == 'sample')
     assert_array_almost_equal(stcs_rh[0].data, label_stc.data)
 
 
@@ -851,8 +848,8 @@ def test_make_inverse_operator_bads():
     union_bads = set(noise_cov['bads']) & set(evoked.info['bads'])
     evoked.info['bads'].append(bad)
 
-    assert_true(len(set(inv_['info']['ch_names']) - union_good) == 0)
-    assert_true(len(set(inv_['info']['bads']) - union_bads) == 0)
+    assert (len(set(inv_['info']['ch_names']) - union_good) == 0)
+    assert (len(set(inv_['info']['bads']) - union_bads) == 0)
 
 
 run_tests_if_main()

--- a/mne/minimum_norm/tests/test_psf_ctf.py
+++ b/mne/minimum_norm/tests/test_psf_ctf.py
@@ -8,8 +8,6 @@ from mne.minimum_norm import (read_inverse_operator,
                               point_spread_function, cross_talk_function)
 from mne.utils import run_tests_if_main
 
-from nose.tools import assert_true
-
 data_path = op.join(testing.data_path(download=False), 'MEG', 'sample')
 
 fname_inv_meg = op.join(data_path,
@@ -28,8 +26,7 @@ lambda2 = 1.0 / snr ** 2
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_psf_ctf():
-    """Test computation of PSFs and CTFs for linear estimators
-    """
+    """Test computation of PSFs and CTFs for linear estimators."""
     forward = read_forward_solution(fname_fwd)
     labels = [mne.read_label(ss) for ss in fname_label]
 
@@ -54,11 +51,11 @@ def test_psf_ctf():
             else:
                 should_n_samples = len(labels) + 1
 
-            assert_true(n_vert == should_n_vert)
-            assert_true(n_samples == should_n_samples)
+            assert (n_vert == should_n_vert)
+            assert (n_samples == should_n_samples)
 
             n_chan, n_samples = psf_ev.data.shape
-            assert_true(n_chan == forward['nchan'])
+            assert (n_chan == forward['nchan'])
 
         # Test CTFs
         for mode in ('sum', 'svd'):
@@ -75,8 +72,8 @@ def test_psf_ctf():
             else:
                 should_n_samples = len(labels) + 1
 
-            assert_true(n_vert == should_n_vert)
-            assert_true(n_samples == should_n_samples)
+            assert (n_vert == should_n_vert)
+            assert (n_samples == should_n_samples)
 
 
 run_tests_if_main()

--- a/mne/minimum_norm/tests/test_snr.py
+++ b/mne/minimum_norm/tests/test_snr.py
@@ -23,7 +23,7 @@ fname_evoked = op.join(s_path, 'sample_audvis-ave.fif')
 @testing.requires_testing_data
 @requires_mne
 def test_snr():
-    """Test SNR calculation"""
+    """Test SNR calculation."""
     tempdir = _TempDir()
     inv = read_inverse_operator(fname_inv)
     evoked = read_evokeds(fname_evoked, baseline=(None, 0))[0]

--- a/mne/preprocessing/tests/test_ctps.py
+++ b/mne/preprocessing/tests/test_ctps.py
@@ -3,9 +3,9 @@
 # License: BSD 3 clause
 import warnings
 
-from nose.tools import assert_true, assert_raises
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 from mne.time_frequency import morlet
 from mne.preprocessing.ctps_ import (ctps, _prob_kuiper,
@@ -31,7 +31,7 @@ rng = np.random.RandomState(42)
 
 
 def get_data(n_trials, j_extent):
-    """Generate ground truth and testing data"""
+    """Generate ground truth and testing data."""
     ground_truth = np.tile(single_trial,  n_trials)
     my_shape = n_trials, 1, 600
     random_data = rng.random_sample(my_shape)
@@ -42,8 +42,9 @@ def get_data(n_trials, j_extent):
                            jittered_data.reshape(my_shape),
                            random_data.reshape(my_shape)], 1)
 
-    assert_true(data.shape == (n_trials, 3, 600))
+    assert data.shape == (n_trials, 3, 600)
     return data
+
 
 # vary extent of jittering --> creates phaselocks at the borders if
 # 2 * extent != n_samples
@@ -51,8 +52,7 @@ iter_test_ctps = enumerate(zip([400, 400], [150, 300], [0.6, 0.2]))
 
 
 def test_ctps():
-    """ Test basic ctps functionality
-    """
+    """Test basic ctps functionality."""
     for ii, (n_trials, j_extent, pk_max) in iter_test_ctps:
         data = get_data(n_trials, j_extent)
         ks_dyn, pk_dyn, phase_trial = ctps(data)
@@ -61,27 +61,26 @@ def test_ctps():
         for a, b in zip([ks_dyn, pk_dyn, phase_trial],
                         [ks_dyn2, pk_dyn2, data2]):
             assert_array_equal(a, b)
-            assert_true(a.min() >= 0)
-            assert_true(a.max() <= 1)
-            assert_true(b.min() >= 0)
-            assert_true(b.max() <= 1)
+            assert (a.min() >= 0)
+            assert (a.max() <= 1)
+            assert (b.min() >= 0)
+            assert (b.max() <= 1)
 
         # test for normalization
-        assert_true((pk_dyn.min() > 0.0) or (pk_dyn.max() < 1.0))
+        assert ((pk_dyn.min() > 0.0) or (pk_dyn.max() < 1.0))
         # test shapes
-        assert_true(phase_trial.shape == data.shape)
-        assert_true(pk_dyn.shape == data.shape[1:])
+        assert (phase_trial.shape == data.shape)
+        assert (pk_dyn.shape == data.shape[1:])
         # tets ground_truth + random + jittered case
-        assert_true(pk_dyn[0].max() == 1.0)
-        assert_true(len(np.unique(pk_dyn[0])) == 1.0)
-        assert_true(pk_dyn[1].max() < pk_max)
-        assert_true(pk_dyn[2].max() > 0.3)
+        assert (pk_dyn[0].max() == 1.0)
+        assert (len(np.unique(pk_dyn[0])) == 1.0)
+        assert (pk_dyn[1].max() < pk_max)
+        assert (pk_dyn[2].max() > 0.3)
         if ii < 1:
-            assert_raises(ValueError, ctps,
-                          data[:, :, :, None])
+            pytest.raises(ValueError, ctps, data[:, :, :, None])
 
-    assert_true(_prob_kuiper(1.0, 400) == 1.0)
+    assert (_prob_kuiper(1.0, 400) == 1.0)
     # test vecrosization
     assert_array_equal(_prob_kuiper(np.array([1.0, 1.0]), 400),
                        _prob_kuiper(np.array([1.0, 1.0]), 400))
-    assert_true(_prob_kuiper(0.1, 400) < 0.1)
+    assert (_prob_kuiper(0.1, 400) < 0.1)

--- a/mne/preprocessing/tests/test_eeglab_infomax.py
+++ b/mne/preprocessing/tests/test_eeglab_infomax.py
@@ -18,7 +18,6 @@ base_dir = op.join(op.dirname(__file__), 'data')
 
 def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
     """Generate data."""
-
     data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
     raw_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 
@@ -62,7 +61,7 @@ def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mne_python_vs_eeglab():
-    """ Test eeglab vs mne_python infomax code."""
+    """Test eeglab vs mne_python infomax code."""
     random_state = 42
 
     methods = ['infomax', 'extended_infomax']
@@ -176,5 +175,6 @@ def test_mne_python_vs_eeglab():
                                                unmixing_eeglab))
 
             assert_almost_equal(maximum_difference, 1e-12, decimal=10)
+
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -1,5 +1,4 @@
 import os.path as op
-from nose.tools import assert_true
 
 from mne import Annotations
 from mne.io import read_raw_fif
@@ -16,8 +15,8 @@ def test_find_eog():
     raw = read_raw_fif(raw_fname)
     raw.annotations = Annotations([14, 21], [1, 1], 'BAD_blink')
     events = find_eog_events(raw)
-    assert_true(len(events) == 4)
-    assert_true(not all(events[:, 0] < 29000))
+    assert len(events) == 4
+    assert not all(events[:, 0] < 29000)
 
     events = find_eog_events(raw, reject_by_annotation=True)
-    assert_true(all(events[:, 0] < 29000))
+    assert all(events[:, 0] < 29000)

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -9,7 +9,6 @@ from mne.datasets import testing
 from mne.preprocessing._fine_cal import (read_fine_calibration,
                                          write_fine_calibration)
 from mne.utils import _TempDir, object_hash, run_tests_if_main
-from nose.tools import assert_equal
 
 warnings.simplefilter('always')  # Always throw warnings
 
@@ -21,7 +20,7 @@ fine_cal_fname_3d = op.join(data_path, 'SSS', 'sss_cal_3053_3d.dat')
 
 @testing.requires_testing_data
 def test_read_write_fine_cal():
-    """Test round trip reading/writing of fine calibration .dat file"""
+    """Test round trip reading/writing of fine calibration .dat file."""
     temp_dir = _TempDir()
     temp_fname = op.join(temp_dir, 'fine_cal_temp.dat')
 
@@ -34,7 +33,8 @@ def test_read_write_fine_cal():
         fine_cal_dict_reload = read_fine_calibration(temp_fname)
 
         # Load temp version of fine calibration file and compare hashes
-        assert_equal(object_hash(fine_cal_dict),
-                     object_hash(fine_cal_dict_reload))
+        assert (object_hash(fine_cal_dict) ==
+                object_hash(fine_cal_dict_reload))
+
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_infomax.py
+++ b/mne/preprocessing/tests/test_infomax.py
@@ -2,10 +2,7 @@
 #
 # License: BSD (3-clause)
 
-"""
-Test the infomax algorithm.
-Parts of this code are taken from scikit-learn
-"""
+# Parts of this code are taken from scikit-learn
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -18,10 +15,10 @@ from mne.utils import requires_sklearn, run_tests_if_main, check_version
 
 
 def center_and_norm(x, axis=-1):
-    """Centers and norms x **in place**.
+    """Center and norm x in place.
 
     Parameters
-    -----------
+    ----------
     x: ndarray
         Array with an axis of observations (statistical units) measured on
         random variables.
@@ -36,7 +33,6 @@ def center_and_norm(x, axis=-1):
 @requires_sklearn
 def test_infomax_blowup():
     """Test the infomax algorithm blowup condition."""
-
     # scipy.stats uses the global RNG:
     np.random.seed(0)
     n_samples = 100

--- a/mne/preprocessing/tests/test_peak_finder.py
+++ b/mne/preprocessing/tests/test_peak_finder.py
@@ -1,12 +1,13 @@
-from numpy.testing import assert_array_equal, assert_raises, assert_equal
+from numpy.testing import assert_array_equal, assert_equal
+import pytest
 import numpy as np
+
 from mne.utils import run_tests_if_main
 from mne.preprocessing.peak_finder import peak_finder
 
 
 def test_peak_finder():
-    """Test the peak detection method"""
-
+    """Test the peak detection method."""
     # check for random data
     rng = np.random.RandomState(42)
     peak_inds, peak_mags = peak_finder(rng.randn(20))
@@ -15,11 +16,11 @@ def test_peak_finder():
     assert_equal(peak_mags.dtype, np.dtype('float64'))
 
     # check for empty array as created in the #5025
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         peak_finder(np.arange(2, 1, 0.05))
 
     # check for empty array
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         peak_finder([])
 
     # check for monotonic function
@@ -37,5 +38,6 @@ def test_peak_finder():
     # check values
     peak_inds, peak_mags = peak_finder([0, 2, 5, 0, 6, -1])
     assert_array_equal(peak_inds, [2, 4])
+
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -1,8 +1,7 @@
 import os.path as op
 import warnings
 
-from nose.tools import assert_true, assert_equal
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_equal
 import numpy as np
 
 from mne.io import read_raw_fif, read_raw_ctf
@@ -36,8 +35,8 @@ def test_compute_proj_ecg():
             qrs_threshold=0.5, filter_length=6000)
         assert len(projs) == 7
         # heart rate at least 0.5 Hz, but less than 3 Hz
-        assert_true(events.shape[0] > 0.5 * dur_use and
-                    events.shape[0] < 3 * dur_use)
+        assert (events.shape[0] > 0.5 * dur_use and
+                events.shape[0] < 3 * dur_use)
         ssp_ecg = [proj for proj in projs if proj['desc'].startswith('ECG')]
         # check that the first principal component have a certain minimum
         ssp_ecg = [proj for proj in ssp_ecg if 'PCA-01' in proj['desc']]
@@ -75,20 +74,20 @@ def test_compute_proj_eog():
                                          l_freq=None, h_freq=None,
                                          reject=None, tmax=dur_use,
                                          filter_length=6000)
-        assert_true(len(projs) == (7 + n_projs_init))
-        assert_true(np.abs(events.shape[0] -
-                    np.sum(np.less(eog_times, dur_use))) <= 1)
+        assert (len(projs) == (7 + n_projs_init))
+        assert (np.abs(events.shape[0] -
+                np.sum(np.less(eog_times, dur_use))) <= 1)
         ssp_eog = [proj for proj in projs if proj['desc'].startswith('EOG')]
         # check that the first principal component have a certain minimum
         ssp_eog = [proj for proj in ssp_eog if 'PCA-01' in proj['desc']]
         thresh_eeg, thresh_axial, thresh_planar = .9, .3, .1
         for proj in ssp_eog:
             if 'planar' in proj['desc']:
-                assert_true(proj['explained_var'] > thresh_planar)
+                assert (proj['explained_var'] > thresh_planar)
             elif 'axial' in proj['desc']:
-                assert_true(proj['explained_var'] > thresh_axial)
+                assert (proj['explained_var'] > thresh_axial)
             elif 'eeg' in proj['desc']:
-                assert_true(proj['explained_var'] > thresh_eeg)
+                assert (proj['explained_var'] > thresh_eeg)
         # XXX: better tests
 
         # This will throw a warning b/c simplefilter('always')
@@ -99,7 +98,7 @@ def test_compute_proj_eog():
                                              avg_ref=True, no_proj=False,
                                              l_freq=None, h_freq=None,
                                              tmax=dur_use)
-        assert_true(len(w) >= 1)
+        assert (len(w) >= 1)
         assert_equal(projs, None)
 
 

--- a/mne/preprocessing/tests/test_stim.py
+++ b/mne/preprocessing/tests/test_stim.py
@@ -6,7 +6,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true, assert_raises
+import pytest
 
 from mne.io import read_raw_fif
 from mne.io.pick import pick_types
@@ -24,7 +24,7 @@ def test_fix_stim_artifact():
     events = read_events(event_fname)
 
     raw = read_raw_fif(raw_fname)
-    assert_raises(RuntimeError, fix_stim_artifact, raw)
+    pytest.raises(RuntimeError, fix_stim_artifact, raw)
 
     raw = read_raw_fif(raw_fname, preload=True)
 
@@ -47,7 +47,8 @@ def test_fix_stim_artifact():
 
     epochs = fix_stim_artifact(epochs, tmin=tmin, tmax=tmax, mode='window')
     data_from_epochs_fix = epochs.get_data()[:, :, tmin_samp:tmax_samp]
-    assert_true(np.all(data_from_epochs_fix) == 0.)
+    # XXX This is a very wierd check...
+    assert np.all(data_from_epochs_fix) == 0.
 
     # use window before stimulus in raw
     event_idx = np.where(events[:, 2] == 1)[0][0]
@@ -56,7 +57,7 @@ def test_fix_stim_artifact():
     tmax_samp = int(-0.015 * raw.info['sfreq'])
     tidx = int(events[event_idx, 0] - raw.first_samp)
 
-    assert_raises(ValueError, fix_stim_artifact, raw, events=np.array([]))
+    pytest.raises(ValueError, fix_stim_artifact, raw, events=np.array([]))
     raw = fix_stim_artifact(raw, events=None, event_id=1, tmin=tmin,
                             tmax=tmax, mode='linear', stim_channel='STI 014')
     data, times = raw[:, (tidx + tmin_samp):(tidx + tmax_samp)]
@@ -67,7 +68,7 @@ def test_fix_stim_artifact():
     raw = fix_stim_artifact(raw, events, event_id=1, tmin=tmin,
                             tmax=tmax, mode='window')
     data, times = raw[:, (tidx + tmin_samp):(tidx + tmax_samp)]
-    assert_true(np.all(data) == 0.)
+    assert np.all(data) == 0.
 
     # get epochs from raw with fixed data
     tmin, tmax, event_id = -0.2, 0.5, 1
@@ -77,7 +78,7 @@ def test_fix_stim_artifact():
     tmin_samp = int(-0.035 * epochs.info['sfreq']) - e_start
     tmax_samp = int(-0.015 * epochs.info['sfreq']) - e_start
     data_from_raw_fix = epochs.get_data()[:, :, tmin_samp:tmax_samp]
-    assert_true(np.all(data_from_raw_fix) == 0.)
+    assert np.all(data_from_raw_fix) == 0.
 
     # use window after stimulus
     evoked = epochs.average()
@@ -93,4 +94,4 @@ def test_fix_stim_artifact():
 
     evoked = fix_stim_artifact(evoked, tmin=tmin, tmax=tmax, mode='window')
     data = evoked.data[:, tmin_samp:tmax_samp]
-    assert_true(np.all(data) == 0.)
+    assert np.all(data) == 0.

--- a/mne/preprocessing/tests/test_stim.py
+++ b/mne/preprocessing/tests/test_stim.py
@@ -47,7 +47,7 @@ def test_fix_stim_artifact():
 
     epochs = fix_stim_artifact(epochs, tmin=tmin, tmax=tmax, mode='window')
     data_from_epochs_fix = epochs.get_data()[:, :, tmin_samp:tmax_samp]
-    # XXX This is a very wierd check...
+    # XXX This is a very weird check...
     assert np.all(data_from_epochs_fix) == 0.
 
     # use window before stimulus in raw

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -36,7 +36,7 @@ warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 @pytest.fixture
 def free_tcp_port():
-    """Returns a free TCP port"""
+    """Get a free TCP port."""
     with contextlib.closing(socket.socket()) as free_socket:
         free_socket.bind(('127.0.0.1', 0))
         return free_socket.getsockname()[1]
@@ -75,6 +75,7 @@ def _start_buffer_thread(buffer_port):
 @pytest.mark.slowtest
 @requires_neuromag2ft
 def test_fieldtrip_rtepochs(free_tcp_port, tmpdir):
+    """Test FieldTrip RtEpochs."""
     raw_tmax = 7
     raw = read_raw_fif(raw_fname, preload=True)
     raw.crop(tmin=0, tmax=raw_tmax)
@@ -130,8 +131,7 @@ def test_fieldtrip_rtepochs(free_tcp_port, tmpdir):
 
 @requires_neuromag2ft
 def test_fieldtrip_client(free_tcp_port):
-    """Test fieldtrip_client"""
-
+    """Test fieldtrip_client."""
     kill_signal = _start_buffer_thread(free_tcp_port)
 
     time.sleep(0.5)

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -78,7 +78,6 @@ def _call_base_epochs_public_api(epochs, tmpdir):
 
 def test_mockclient(tmpdir):
     """Test the RtMockClient."""
-
     raw = read_raw_fif(raw_fname, preload=True, verbose=False)
     picks = pick_types(raw.info, meg='grad', eeg=False, eog=True,
                        stim=True, exclude=raw.info['bads'])
@@ -125,7 +124,6 @@ def test_mockclient(tmpdir):
 
 def test_get_event_data():
     """Test emulation of realtime data stream."""
-
     raw = read_raw_fif(raw_fname, preload=True, verbose=False)
     picks = pick_types(raw.info, meg='grad', eeg=False, eog=True,
                        stim=True, exclude=raw.info['bads'])
@@ -147,7 +145,6 @@ def test_get_event_data():
 
 def test_find_events():
     """Test find_events in rt_epochs."""
-
     raw = read_raw_fif(raw_fname, preload=True, verbose=False)
     picks = pick_types(raw.info, meg='grad', eeg=False, eog=True,
                        stim=True, exclude=raw.info['bads'])
@@ -268,6 +265,7 @@ def test_find_events():
 
 @pytest.mark.parametrize("buffer_size", [420, 1000, 6000])
 def test_rejection(buffer_size):
+    """Test rejection."""
     event_id, tmin, tmax = 1, 0.0, 0.5
     sfreq = 1000
     ch_names = ['Fz', 'Cz', 'Pz', 'STI 014']
@@ -324,7 +322,7 @@ def test_rejection(buffer_size):
 
 @sample.requires_sample_data
 def test_events_sampledata():
-    """ based on examples/realtime/plot_compute_rt_decoder.py"""
+    """Test events."""
     data_path = sample.data_path()
     raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
     raw = read_raw_fif(raw_fname, preload=True)

--- a/mne/realtime/tests/test_stim_client_server.py
+++ b/mne/realtime/tests/test_stim_client_server.py
@@ -1,7 +1,7 @@
 import threading
 import time
-from nose.tools import assert_equal, assert_raises, assert_true
 
+import pytest
 from mne.realtime import StimServer, StimClient
 from mne.externals.six.moves import queue
 from mne.utils import requires_good_network, run_tests_if_main
@@ -14,8 +14,7 @@ _max_wait = 10.
 
 @requires_good_network
 def test_connection():
-    """Test TCP/IP connection for StimServer <-> StimClient.
-    """
+    """Test TCP/IP connection for StimServer <-> StimClient."""
     global _server, _have_put_in_trigger
 
     # have to start a thread to simulate the effect of two
@@ -48,25 +47,24 @@ def test_connection():
         # Hence communication between threads is necessary
         trig1 = trig_queue1.get(timeout=_max_wait)
         trig2 = trig_queue2.get(timeout=_max_wait)
-        assert_equal(trig1, 20)
+        assert trig1 == 20
 
         # test if both clients receive the same trigger
-        assert_equal(trig1, trig2)
+        assert trig1 == trig2
 
     # test timeout for stim_server
     with StimServer(port=4218) as stim_server:
-        assert_raises(StopIteration, stim_server.start, 0.1)
+        pytest.raises(StopIteration, stim_server.start, 0.1)
 
 
 def _connect_client(trig_queue):
-    """Helper method that instantiates the StimClient.
-    """
+    """Instantiate the StimClient."""
     # just wait till the main thread reaches stim_server.start()
     t0 = time.time()
     while (time.time() - t0 < _max_wait and
            (_server is None or not _server._running)):
         time.sleep(0.01)
-    assert_true(_server is not None and _server._running)
+    assert _server is not None and _server._running
 
     # instantiate StimClient
     stim_client = StimClient('localhost', port=4218)
@@ -75,7 +73,7 @@ def _connect_client(trig_queue):
     t0 = time.time()
     while (time.time() - t0 < _max_wait and not _have_put_in_trigger):
         time.sleep(0.01)
-    assert_true(_have_put_in_trigger)
+    assert _have_put_in_trigger
 
     trig_queue.put(stim_client.get_trigger())
     stim_client.close()

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -7,7 +7,7 @@ import os.path as op
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal)
-from nose.tools import assert_true, assert_raises
+import pytest
 import warnings
 
 from mne import (read_cov, read_forward_solution, convert_forward_solution,
@@ -34,7 +34,6 @@ cov_fname = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
 @testing.requires_testing_data
 def test_simulate_evoked():
     """Test simulation of evoked data."""
-
     raw = read_raw_fif(raw_fname)
     fwd = read_forward_solution(fwd_fname)
     fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=False)
@@ -62,7 +61,7 @@ def test_simulate_evoked():
     evoked = simulate_evoked(fwd, stc, evoked_template.info, cov,
                              iir_filter=iir_filter, nave=nave)
     assert_array_almost_equal(evoked.times, stc.times)
-    assert_true(len(evoked.data) == len(fwd['sol']['data']))
+    assert len(evoked.data) == len(fwd['sol']['data'])
     assert_equal(evoked.nave, nave)
 
     # make a vertex that doesn't exist in fwd, should throw error
@@ -70,7 +69,7 @@ def test_simulate_evoked():
     mv = np.max(fwd['src'][0]['vertno'][fwd['src'][0]['inuse']])
     stc_bad.vertices[0][0] = mv + 1
 
-    assert_raises(RuntimeError, simulate_evoked, fwd, stc_bad,
+    pytest.raises(RuntimeError, simulate_evoked, fwd, stc_bad,
                   evoked_template.info, cov)
     evoked_1 = simulate_evoked(fwd, stc, evoked_template.info, cov,
                                nave=np.inf)
@@ -79,7 +78,7 @@ def test_simulate_evoked():
     assert_array_equal(evoked_1.data, evoked_2.data)
 
     cov['names'] = cov.ch_names[:-2]  # Error channels are different.
-    assert_raises(ValueError, simulate_evoked, fwd, stc, evoked_template.info,
+    pytest.raises(ValueError, simulate_evoked, fwd, stc, evoked_template.info,
                   cov, nave=nave, iir_filter=None)
 
 

--- a/mne/simulation/tests/test_metrics.py
+++ b/mne/simulation/tests/test_metrics.py
@@ -8,7 +8,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from nose.tools import assert_true, assert_raises
+import pytest
 import warnings
 
 from mne import read_source_spaces
@@ -25,7 +25,7 @@ src_fname = op.join(data_path, 'subjects', 'sample', 'bem',
 
 @testing.requires_testing_data
 def test_metrics():
-    """Test simulation metrics"""
+    """Test simulation metrics."""
     src = read_source_spaces(src_fname)
     times = np.arange(600) / 1000.
     rng = np.random.RandomState(42)
@@ -37,16 +37,17 @@ def test_metrics():
     E2_cos = source_estimate_quantification(stc2, stc2, metric='cosine')
 
     # ### Tests to add
-    assert_true(E1_rms == 0.)
-    assert_true(E2_rms == 0.)
+    assert (E1_rms == 0.)
+    assert (E2_rms == 0.)
     assert_almost_equal(E1_cos, 0.)
     assert_almost_equal(E2_cos, 0.)
     stc_bad = stc2.copy().crop(0, 0.5)
-    assert_raises(ValueError, source_estimate_quantification, stc1, stc_bad)
+    pytest.raises(ValueError, source_estimate_quantification, stc1, stc_bad)
     stc_bad = stc2.copy()
     stc_bad.tmin -= 0.1
-    assert_raises(ValueError, source_estimate_quantification, stc1, stc_bad)
-    assert_raises(ValueError, source_estimate_quantification, stc1, stc2,
+    pytest.raises(ValueError, source_estimate_quantification, stc1, stc_bad)
+    pytest.raises(ValueError, source_estimate_quantification, stc1, stc2,
                   metric='foo')
+
 
 run_tests_if_main()

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -47,7 +47,7 @@ pos_fname = op.join(data_path, 'SSS', 'test_move_anon_raw_subsampled.pos')
 
 
 def _make_stc(raw, src):
-    """Helper to make a STC."""
+    """Make a STC."""
     seed = 42
     sfreq = raw.info['sfreq']  # Hz
     tstep = 1. / sfreq
@@ -58,7 +58,7 @@ def _make_stc(raw, src):
 
 
 def _get_data():
-    """Helper to get some starting data."""
+    """Get some starting data."""
     # raw with ECG channel
     raw = read_raw_fif(raw_fname).crop(0., 5.0).load_data()
     data_picks = pick_types(raw.info, meg=True, eeg=True)

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -1,8 +1,9 @@
 import os.path as op
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import assert_true, assert_raises, assert_equal
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
+import pytest
 
 from mne.datasets import testing
 from mne import (read_label, read_forward_solution, pick_types_forward,
@@ -22,6 +23,7 @@ subjects_dir = op.join(data_path, 'subjects')
 
 
 def read_forward_solution_meg(*args, **kwargs):
+    """Read forward MEG."""
     fwd = read_forward_solution(*args)
     fwd = convert_forward_solution(fwd, **kwargs)
     fwd = pick_types_forward(fwd, meg=True, eeg=False)
@@ -30,7 +32,7 @@ def read_forward_solution_meg(*args, **kwargs):
 
 @testing.requires_testing_data
 def test_simulate_stc():
-    """ Test generation of source estimate """
+    """Test generation of source estimate."""
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
@@ -63,8 +65,8 @@ def test_simulate_stc():
         if hemi_idx == 1:
             idx += len(stc.vertices[0])
 
-        assert_true(np.all(stc.data[idx] == 1.0))
-        assert_true(stc.data[idx].shape[1] == n_times)
+        assert (np.all(stc.data[idx] == 1.0))
+        assert (stc.data[idx].shape[1] == n_times)
 
     # test with function
     def fun(x):
@@ -92,15 +94,15 @@ def test_simulate_stc():
     label_subset = mylabels[:2]
     data_subset = stc_data[:2]
     stc = simulate_stc(fwd['src'], label_subset, data_subset, tmin, tstep, fun)
-    assert_raises(ValueError, simulate_stc, fwd['src'],
+    pytest.raises(ValueError, simulate_stc, fwd['src'],
                   label_subset, data_subset[:-1], tmin, tstep, fun)
-    assert_raises(RuntimeError, simulate_stc, fwd['src'], label_subset * 2,
+    pytest.raises(RuntimeError, simulate_stc, fwd['src'], label_subset * 2,
                   np.concatenate([data_subset] * 2, axis=0), tmin, tstep, fun)
 
 
 @testing.requires_testing_data
 def test_simulate_sparse_stc():
-    """ Test generation of sparse source estimate """
+    """Test generation of sparse source estimate."""
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels = [read_label(op.join(data_path, 'MEG', 'sample', 'labels',
                          '%s.label' % label)) for label in label_names]
@@ -110,7 +112,7 @@ def test_simulate_sparse_stc():
     tstep = 1e-3
     times = np.arange(n_times, dtype=np.float) * tstep + tmin
 
-    assert_raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
+    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='center', subject='sample',
                   subjects_dir=subjects_dir)  # no non-zero values
     for label in labels:
@@ -123,8 +125,8 @@ def test_simulate_sparse_stc():
                                     subjects_dir=subjects_dir)
         assert_equal(stc_1.subject, 'sample')
 
-        assert_true(stc_1.data.shape[0] == len(labels))
-        assert_true(stc_1.data.shape[1] == n_times)
+        assert (stc_1.data.shape[0] == len(labels))
+        assert (stc_1.data.shape[1] == n_times)
 
         # make sure we get the same result when using the same seed
         stc_2 = simulate_sparse_stc(fwd['src'], len(labels), times,
@@ -135,20 +137,20 @@ def test_simulate_sparse_stc():
         assert_array_equal(stc_1.lh_vertno, stc_2.lh_vertno)
         assert_array_equal(stc_1.rh_vertno, stc_2.rh_vertno)
     # Degenerate cases
-    assert_raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
+    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='center', subject='foo',
                   subjects_dir=subjects_dir)  # wrong subject
     del fwd['src'][0]['subject_his_id']
-    assert_raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
+    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='center',
                   subjects_dir=subjects_dir)  # no subject
-    assert_raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
+    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='foo')  # bad location
 
 
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():
-    """ Test generation of source estimate, single hemi """
+    """Test generation of source estimate, single hemi."""
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     labels_single_hemi = [read_label(op.join(data_path, 'MEG', 'sample',
                                              'labels', '%s.label' % label))
@@ -181,8 +183,8 @@ def test_generate_stc_single_hemi():
         if hemi_idx == 1:
             idx += len(stc.vertices[0])
 
-        assert_true(np.all(stc.data[idx] == 1.0))
-        assert_true(stc.data[idx].shape[1] == n_times)
+        assert (np.all(stc.data[idx] == 1.0))
+        assert (stc.data[idx].shape[1] == n_times)
 
     # test with function
     def fun(x):
@@ -209,7 +211,7 @@ def test_generate_stc_single_hemi():
 
 @testing.requires_testing_data
 def test_simulate_sparse_stc_single_hemi():
-    """ Test generation of sparse source estimate """
+    """Test generation of sparse source estimate."""
     fwd = read_forward_solution_meg(fname_fwd, force_fixed=True, use_cps=True)
     n_times = 10
     tmin = 0
@@ -223,8 +225,8 @@ def test_simulate_sparse_stc_single_hemi():
     stc_1 = simulate_sparse_stc(fwd['src'], len(labels_single_hemi), times,
                                 labels=labels_single_hemi, random_state=0)
 
-    assert_true(stc_1.data.shape[0] == len(labels_single_hemi))
-    assert_true(stc_1.data.shape[1] == n_times)
+    assert (stc_1.data.shape[0] == len(labels_single_hemi))
+    assert (stc_1.data.shape[1] == n_times)
 
     # make sure we get the same result when using the same seed
     stc_2 = simulate_sparse_stc(fwd['src'], len(labels_single_hemi), times,
@@ -232,5 +234,6 @@ def test_simulate_sparse_stc_single_hemi():
 
     assert_array_equal(stc_1.lh_vertno, stc_2.lh_vertno)
     assert_array_equal(stc_1.rh_vertno, stc_2.rh_vertno)
+
 
 run_tests_if_main()

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2723,8 +2723,8 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
 
     Note: this function is also used by forward/tests/test_make_forward.py
     """
-    from nose.tools import assert_equal, assert_true
-    from numpy.testing import assert_allclose, assert_array_equal
+    from numpy.testing import (assert_allclose, assert_array_equal,
+                               assert_equal, assert_)
     from scipy.spatial.distance import cdist
     if mode != 'exact' and 'approx' not in mode:  # 'nointerp' can be appended
         raise RuntimeError('unknown mode %s' % mode)
@@ -2743,10 +2743,10 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
                 diffs = (s0['interpolator'] - s1['interpolator']).data
                 if len(diffs) > 0 and 'nointerp' not in mode:
                     # 5%
-                    assert_true(np.sqrt(np.mean(diffs ** 2)) < 0.10, name)
+                    assert_(np.sqrt(np.mean(diffs ** 2)) < 0.10, name)
         for name in ['nn', 'rr', 'nuse_tri', 'coord_frame', 'tris']:
             if s0[name] is None:
-                assert_true(s1[name] is None, name)
+                assert_(s1[name] is None, name)
             else:
                 if mode == 'exact':
                     assert_array_equal(s0[name], s1[name], name)
@@ -2761,25 +2761,25 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
         if nearest:
             for name in ['nearest', 'nearest_dist', 'patch_inds']:
                 if s0[name] is None:
-                    assert_true(s1[name] is None, name)
+                    assert_(s1[name] is None, name)
                 else:
                     assert_array_equal(s0[name], s1[name])
             for name in ['pinfo']:
                 if s0[name] is None:
-                    assert_true(s1[name] is None, name)
+                    assert_(s1[name] is None, name)
                 else:
-                    assert_true(len(s0[name]) == len(s1[name]), name)
+                    assert_(len(s0[name]) == len(s1[name]), name)
                     for p1, p2 in zip(s0[name], s1[name]):
-                        assert_true(all(p1 == p2), name)
+                        assert_(all(p1 == p2), name)
         if mode == 'exact':
             for name in ['inuse', 'vertno', 'use_tris']:
                 assert_array_equal(s0[name], s1[name], err_msg=name)
             for name in ['dist_limit']:
-                assert_true(s0[name] == s1[name], name)
+                assert_(s0[name] == s1[name], name)
             for name in ['dist']:
                 if s0[name] is not None:
                     assert_equal(s1[name].shape, s0[name].shape)
-                    assert_true(len((s0['dist'] - s1['dist']).data) == 0)
+                    assert_(len((s0['dist'] - s1['dist']).data) == 0)
         else:  # 'approx' in mode:
             # deal with vertno, inuse, and use_tris carefully
             for ii, s in enumerate((s0, s1)):
@@ -2789,7 +2789,7 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
                                    % (ii, si, ii, si))
             assert_equal(len(s0['vertno']), len(s1['vertno']))
             agreement = np.mean(s0['inuse'] == s1['inuse'])
-            assert_true(agreement >= 0.99, "%s < 0.99" % agreement)
+            assert_(agreement >= 0.99, "%s < 0.99" % agreement)
             if agreement < 1.0:
                 # make sure mismatched vertno are within 1.5mm
                 v0 = np.setdiff1d(s0['vertno'], s1['vertno'])
@@ -2800,8 +2800,8 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
             if s0['use_tris'] is not None:  # for "spacing"
                 assert_array_equal(s0['use_tris'].shape, s1['use_tris'].shape)
             else:
-                assert_true(s1['use_tris'] is None)
-            assert_true(np.mean(s0['use_tris'] == s1['use_tris']) > 0.99)
+                assert_(s1['use_tris'] is None)
+            assert_(np.mean(s0['use_tris'] == s1['use_tris']) > 0.99)
     # The above "if s0[name] is not None" can be removed once the sample
     # dataset is updated to have a source space with distance info
     for name in ['working_dir', 'command_line']:
@@ -2809,7 +2809,6 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
             assert_equal(src0.info[name], src1.info[name])
         else:  # 'approx' in mode:
             if name in src0.info:
-                assert_true(name in src1.info, '"%s" missing' % name)
+                assert_(name in src1.info, '"%s" missing' % name)
             else:
-                assert_true(name not in src1.info,
-                            '"%s" should not exist' % name)
+                assert_(name not in src1.info, '"%s" should not exist' % name)

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import sparse, linalg, stats
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_array_almost_equal)
-from nose.tools import assert_true, assert_raises
+import pytest
 
 from mne.parallel import _force_serial
 from mne.stats.cluster_level import (permutation_cluster_test,
@@ -67,12 +67,12 @@ def test_cache_dir():
                 seed=0, stat_fun=ttest_1samp_no_p, verbose=False)
             # ensure that non-independence yields warning
             stat_fun = partial(ttest_1samp_no_p, sigma=1e-3)
-            assert_true('independently' not in log_file.getvalue())
+            assert 'independently' not in log_file.getvalue()
             with warnings.catch_warnings(record=True):  # independently
                 permutation_cluster_1samp_test(
                     X, buffer_size=10, n_jobs=2, n_permutations=1,
                     seed=0, stat_fun=stat_fun, verbose=False)
-            assert_true('independently' in log_file.getvalue())
+            assert 'independently' in log_file.getvalue()
     finally:
         if orig_dir is not None:
             os.environ['MNE_CACHE_DIR'] = orig_dir
@@ -125,7 +125,7 @@ def test_permutation_step_down_p():
         permutation_cluster_1samp_test(X, threshold=thresh,
                                        step_down_p=0.05)
     assert_equal(np.sum(p_new < 0.05), 2)  # time one rescued
-    assert_true(np.all(p_old >= p_new))
+    assert np.all(p_old >= p_new)
 
 
 def test_cluster_permutation_test():
@@ -241,7 +241,7 @@ def test_cluster_permutation_with_connectivity():
         assert_array_equal(out[0], out_connectivity[0])
         for a, b in zip(out_connectivity[1], out[1]):
             assert_array_equal(out[0][a], out[0][b])
-            assert_true(np.all(a[b]))
+            assert np.all(a[b])
 
         # test spatio-temporal w/o time connectivity (repeat spatial pattern)
         connectivity_2 = sparse.coo_matrix(
@@ -261,13 +261,13 @@ def test_cluster_permutation_with_connectivity():
 
         # make sure we really got 2x the number of original clusters
         n_clust_orig = len(out[1])
-        assert_true(len(out_connectivity_2[1]) == 2 * n_clust_orig)
+        assert len(out_connectivity_2[1]) == 2 * n_clust_orig
 
         # Make sure that we got the old ones back
         data_1 = set([np.sum(out[0][b[:n_pts]]) for b in out[1]])
         data_2 = set([np.sum(out_connectivity_2[0][a]) for a in
                      out_connectivity_2[1][:]])
-        assert_true(len(data_1.intersection(data_2)) == len(data_1))
+        assert len(data_1.intersection(data_2)) == len(data_1)
 
         # now use the other algorithm
         if isinstance(X1d, list):
@@ -285,13 +285,13 @@ def test_cluster_permutation_with_connectivity():
         assert_array_equal(out[0], out_connectivity_3[0][1])
 
         # make sure we really got 2x the number of original clusters
-        assert_true(len(out_connectivity_3[1]) == 2 * n_clust_orig)
+        assert len(out_connectivity_3[1]) == 2 * n_clust_orig
 
         # Make sure that we got the old ones back
         data_1 = set([np.sum(out[0][b[:n_pts]]) for b in out[1]])
         data_2 = set([np.sum(out_connectivity_3[0][a[0], a[1]]) for a in
                      out_connectivity_3[1]])
-        assert_true(len(data_1.intersection(data_2)) == len(data_1))
+        assert len(data_1.intersection(data_2)) == len(data_1)
 
         # test new versus old method
         out_connectivity_4 = spatio_temporal_func(X1d_3, n_permutations=50,
@@ -311,12 +311,12 @@ def test_cluster_permutation_with_connectivity():
         assert_array_almost_equal(sums_4, sums_5)
 
         if not _force_serial:
-            assert_raises(ValueError, spatio_temporal_func, X1d_3,
+            pytest.raises(ValueError, spatio_temporal_func, X1d_3,
                           n_permutations=1, connectivity=connectivity,
                           max_step=1, threshold=1.67, n_jobs=-1000)
 
         # not enough TFCE params
-        assert_raises(KeyError, spatio_temporal_func, X1d_3,
+        pytest.raises(KeyError, spatio_temporal_func, X1d_3,
                       connectivity=connectivity, threshold=dict(me='hello'))
 
         # too extreme a start threshold
@@ -324,27 +324,27 @@ def test_cluster_permutation_with_connectivity():
             spatio_temporal_func(X1d_3, connectivity=connectivity,
                                  threshold=dict(start=10, step=1))
         if not did_warn:
-            assert_true(len(w) == 1)
+            assert len(w) == 1
             did_warn = True
 
         # too extreme a start threshold
-        assert_raises(ValueError, spatio_temporal_func, X1d_3,
+        pytest.raises(ValueError, spatio_temporal_func, X1d_3,
                       connectivity=connectivity, tail=-1,
                       threshold=dict(start=1, step=-1))
-        assert_raises(ValueError, spatio_temporal_func, X1d_3,
+        pytest.raises(ValueError, spatio_temporal_func, X1d_3,
                       connectivity=connectivity, tail=-1,
                       threshold=dict(start=-1, step=1))
         # Make sure connectivity has to be sparse
-        assert_raises(ValueError, spatio_temporal_func, X1d_3,
+        pytest.raises(ValueError, spatio_temporal_func, X1d_3,
                       n_permutations=50, connectivity=connectivity.todense(),
                       max_step=1, threshold=1.67)
 
         # wrong type for threshold
-        assert_raises(TypeError, spatio_temporal_func, X1d_3,
+        pytest.raises(TypeError, spatio_temporal_func, X1d_3,
                       connectivity=connectivity, threshold=[])
 
         # wrong value for tail
-        assert_raises(ValueError, spatio_temporal_func, X1d_3,
+        pytest.raises(ValueError, spatio_temporal_func, X1d_3,
                       connectivity=connectivity, tail=2)
 
         # make sure it actually found a significant point
@@ -353,7 +353,7 @@ def test_cluster_permutation_with_connectivity():
                                                   max_step=1,
                                                   threshold=dict(start=1,
                                                                  step=1))
-        assert_true(np.min(out_connectivity_6[2]) < 0.05)
+        assert np.min(out_connectivity_6[2]) < 0.05
 
 
 def test_permutation_connectivity_equiv():
@@ -395,8 +395,8 @@ def test_permutation_connectivity_equiv():
                 X, threshold=thresh, connectivity=conn, n_jobs=2,
                 max_step=max_step, stat_fun=stat_fun)
         # make sure our output datatype is correct
-        assert_true(isinstance(clusters[0], np.ndarray))
-        assert_true(clusters[0].dtype == bool)
+        assert isinstance(clusters[0], np.ndarray)
+        assert clusters[0].dtype == bool
         assert_array_equal(clusters[0].shape, X.shape[1:])
 
         # make sure all comparisons were done; for TFCE, no perm
@@ -405,7 +405,7 @@ def test_permutation_connectivity_equiv():
         assert_equal(len(inds), count)
         if isinstance(thresh, dict):
             assert_equal(len(clusters), n_time * n_space)
-            assert_true(np.all(H0 != 0))
+            assert np.all(H0 != 0)
             continue
         this_cs = [clusters[ii] for ii in inds]
         this_ps = p[inds]
@@ -425,7 +425,7 @@ def test_permutation_connectivity_equiv():
         if stat_map is None:
             stat_map = this_stat_map
         assert_array_equal(ps, this_ps)
-        assert_true(len(cs) == len(this_cs))
+        assert len(cs) == len(this_cs)
         for c1, c2 in zip(cs, this_cs):
             assert_array_equal(c1, c2)
         assert_array_equal(stat_map, this_stat_map)
@@ -474,11 +474,11 @@ def test_spatio_temporal_cluster_connectivity():
                                      threshold=threshold, n_jobs=2,
                                      buffer_size=None)
     assert_array_equal(p_values_no_conn, p_values2)
-    assert_raises(ValueError, spatio_temporal_cluster_test,
+    pytest.raises(ValueError, spatio_temporal_cluster_test,
                   [data1_2d, data2_2d], tail=1, threshold=-2.)
-    assert_raises(ValueError, spatio_temporal_cluster_test,
+    pytest.raises(ValueError, spatio_temporal_cluster_test,
                   [data1_2d, data2_2d], tail=-1, threshold=2.)
-    assert_raises(ValueError, spatio_temporal_cluster_test,
+    pytest.raises(ValueError, spatio_temporal_cluster_test,
                   [data1_2d, data2_2d], tail=0, threshold=-1)
 
 
@@ -494,9 +494,9 @@ def test_summarize_clusters():
            np.array([0.02, 0.1]),
            np.array([12, -14, 30]))
     stc_sum = summarize_clusters_stc(clu)
-    assert_true(stc_sum.data.shape[1] == 2)
+    assert stc_sum.data.shape[1] == 2
     clu[2][0] = 0.3
-    assert_raises(RuntimeError, summarize_clusters_stc, clu)
+    pytest.raises(RuntimeError, summarize_clusters_stc, clu)
 
 
 def test_permutation_test_H0():
@@ -507,37 +507,38 @@ def test_permutation_test_H0():
         t, clust, p, h0 = spatio_temporal_cluster_1samp_test(
             data, threshold=100, n_permutations=1024, seed=rng)
     assert_equal(len(w), 1)
-    assert_true('No clusters found' in str(w[0].message))
+    assert 'No clusters found' in str(w[0].message)
     assert_equal(len(h0), 0)
 
     for n_permutations in (1024, 65, 64, 63):
         t, clust, p, h0 = spatio_temporal_cluster_1samp_test(
             data, threshold=0.1, n_permutations=n_permutations, seed=rng)
         assert_equal(len(h0), min(n_permutations, 64))
-        assert_true(isinstance(clust[0], tuple))  # sets of indices
+        assert isinstance(clust[0], tuple)  # sets of indices
     for tail, thresh in zip((-1, 0, 1), (-0.1, 0.1, 0.1)):
         with warnings.catch_warnings(record=True) as w:
             t, clust, p, h0 = spatio_temporal_cluster_1samp_test(
                 data, threshold=thresh, seed=rng, tail=tail, out_type='mask')
         assert_equal(len(w), 0)
-        assert_true(isinstance(clust[0], np.ndarray))  # bool mask
+        assert isinstance(clust[0], np.ndarray)  # bool mask
         # same as "128 if tail else 64"
         assert_equal(len(h0), 2 ** (7 - (tail == 0)))  # exact test
 
 
 def test_tfce_thresholds():
+    """Test TFCE thresholds."""
     rng = np.random.RandomState(0)
     data = rng.randn(7, 10, 1) - 0.5
 
     # if tail==-1, step must also be negative
-    assert_raises(ValueError, permutation_cluster_1samp_test, data, tail=-1,
+    pytest.raises(ValueError, permutation_cluster_1samp_test, data, tail=-1,
                   threshold=dict(start=0, step=0.1))
     # this works (smoke test)
     permutation_cluster_1samp_test(data, tail=-1,
                                    threshold=dict(start=0, step=-0.1))
 
     # thresholds must be monotonically increasing
-    assert_raises(ValueError, permutation_cluster_1samp_test, data, tail=1,
+    pytest.raises(ValueError, permutation_cluster_1samp_test, data, tail=1,
                   threshold=dict(start=1, step=-0.5))
 
 

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -1,15 +1,14 @@
 import numpy as np
-from numpy.testing import (
-    assert_almost_equal, assert_allclose, assert_raises, assert_array_equal)
-from nose.tools import assert_true
+from numpy.testing import (assert_almost_equal, assert_allclose,
+                           assert_array_equal)
 from scipy import stats
+import pytest
 
 from mne.stats import fdr_correction, bonferroni_correction
 
 
 def test_multi_pval_correction():
-    """Test pval correction for multi comparison (FDR and Bonferroni)
-    """
+    """Test pval correction for multi comparison (FDR and Bonferroni)."""
     rng = np.random.RandomState(0)
     X = rng.randn(10, 1000, 10)
     X[:, :50, 0] += 4.0  # 50 significant tests
@@ -23,8 +22,8 @@ def test_multi_pval_correction():
 
     reject_bonferroni, pval_bonferroni = bonferroni_correction(pval, alpha)
     thresh_bonferroni = stats.t.ppf(1.0 - alpha / n_tests, n_samples - 1)
-    assert_true(pval_bonferroni.ndim == 2)
-    assert_true(reject_bonferroni.ndim == 2)
+    assert pval_bonferroni.ndim == 2
+    assert reject_bonferroni.ndim == 2
     assert_allclose(pval_bonferroni / 10000, pval)
     reject_expected = pval_bonferroni < alpha
     assert_array_equal(reject_bonferroni, reject_expected)
@@ -33,15 +32,15 @@ def test_multi_pval_correction():
     assert_almost_equal(fwer, alpha, 1)
 
     reject_fdr, pval_fdr = fdr_correction(pval, alpha=alpha, method='indep')
-    assert_true(pval_fdr.ndim == 2)
-    assert_true(reject_fdr.ndim == 2)
+    assert pval_fdr.ndim == 2
+    assert reject_fdr.ndim == 2
     thresh_fdr = np.min(np.abs(T)[reject_fdr])
-    assert_true(0 <= (reject_fdr.sum() - 50) <= 50 * 1.05)
-    assert_true(thresh_uncorrected <= thresh_fdr <= thresh_bonferroni)
-    assert_raises(ValueError, fdr_correction, pval, alpha, method='blah')
-    assert_true(np.all(fdr_correction(pval, alpha=0)[0] == 0))
+    assert 0 <= (reject_fdr.sum() - 50) <= 50 * 1.05
+    assert thresh_uncorrected <= thresh_fdr <= thresh_bonferroni
+    pytest.raises(ValueError, fdr_correction, pval, alpha, method='blah')
+    assert np.all(fdr_correction(pval, alpha=0)[0] == 0)
 
     reject_fdr, pval_fdr = fdr_correction(pval, alpha=alpha, method='negcorr')
     thresh_fdr = np.min(np.abs(T)[reject_fdr])
-    assert_true(0 <= (reject_fdr.sum() - 50) <= 50 * 1.05)
-    assert_true(thresh_uncorrected <= thresh_fdr <= thresh_bonferroni)
+    assert 0 <= (reject_fdr.sum() - 50) <= 50 * 1.05
+    assert thresh_uncorrected <= thresh_fdr <= thresh_bonferroni

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -63,6 +63,7 @@ def test_permutation_t_test():
 
 
 def test_ci():
+    """Test confidence intervals."""
     # isolated test of CI functions
     arr = np.linspace(0, 1, 1000)[..., np.newaxis]
     assert_allclose(_ci(arr, method="parametric"),

--- a/mne/tests/common.py
+++ b/mne/tests/common.py
@@ -14,7 +14,7 @@ from ..bem import fit_sphere_to_headshape
 
 
 def _get_data(x, ch_idx):
-    """Helper to get the (n_ch, n_times) data array"""
+    """Get the (n_ch, n_times) data array."""
     if isinstance(x, BaseRaw):
         return x[ch_idx][0]
     elif isinstance(x, Evoked):
@@ -22,8 +22,7 @@ def _get_data(x, ch_idx):
 
 
 def _check_snr(actual, desired, picks, min_tol, med_tol, msg, kind='MEG'):
-    """Helper to check the SNR of a set of channels"""
-    from nose.tools import assert_true
+    """Check the SNR of a set of channels."""
     actual_data = _get_data(actual, picks)
     desired_data = _get_data(desired, picks)
     bench_rms = np.sqrt(np.mean(desired_data * desired_data, axis=1))
@@ -35,17 +34,18 @@ def _check_snr(actual, desired, picks, min_tol, med_tol, msg, kind='MEG'):
     snr = snrs.min()
     bad_count = (snrs < min_tol).sum()
     msg = ' (%s)' % msg if msg != '' else msg
-    assert_true(bad_count == 0, 'SNR (worst %0.2f) < %0.2f for %s/%s '
-                'channels%s' % (snr, min_tol, bad_count, len(picks), msg))
+    assert bad_count == 0, ('SNR (worst %0.2f) < %0.2f for %s/%s '
+                            'channels%s' % (snr, min_tol, bad_count,
+                                            len(picks), msg))
     # median tol
     snr = np.median(snrs)
-    assert_true(snr >= med_tol, '%s SNR median %0.2f < %0.2f%s'
-                % (kind, snr, med_tol, msg))
+    assert snr >= med_tol, ('%s SNR median %0.2f < %0.2f%s'
+                            % (kind, snr, med_tol, msg))
 
 
 def assert_meg_snr(actual, desired, min_tol, med_tol=500., chpi_med_tol=500.,
                    msg=None):
-    """Helper to assert channel SNR of a certain level
+    """Assert channel SNR of a certain level.
 
     Mostly useful for operations like Maxwell filtering that modify
     MEG channels while leaving EEG and others intact.
@@ -73,19 +73,19 @@ def assert_meg_snr(actual, desired, min_tol, med_tol=500., chpi_med_tol=500.,
 
 
 def assert_snr(actual, desired, tol):
-    """Assert actual and desired arrays are within some SNR tolerance"""
-    from nose.tools import assert_true
+    """Assert actual and desired arrays are within some SNR tolerance."""
     snr = (linalg.norm(desired, ord='fro') /
            linalg.norm(desired - actual, ord='fro'))
-    assert_true(snr >= tol, msg='%f < %f' % (snr, tol))
+    assert snr >= tol, '%f < %f' % (snr, tol)
 
 
 def _dig_sort_key(dig):
-    """Helper for sorting"""
-    return 10000 * dig['kind'] + dig['ident']
+    """Sort dig keys."""
+    return (dig['kind'], dig['ident'])
 
 
 def assert_dig_allclose(info_py, info_bin):
+    """Assert dig allclose."""
     # test dig positions
     dig_py = sorted(info_py['dig'], key=_dig_sort_key)
     dig_bin = sorted(info_bin['dig'], key=_dig_sort_key)
@@ -107,7 +107,7 @@ def assert_dig_allclose(info_py, info_bin):
 
 
 def assert_naming(warns, fname, n_warn):
-    """Assert a non-standard naming scheme was used while saving or loading
+    """Assert a non-standard naming scheme was used while saving or loading.
 
     Parameters
     ----------
@@ -118,11 +118,9 @@ def assert_naming(warns, fname, n_warn):
     n_warn : int
         Number of warnings that should have naming convention errors.
     """
-    from nose.tools import assert_true
-    assert_true(sum('naming conventions' in str(ww.message)
-                    for ww in warns) == n_warn)
+    assert sum('naming conventions' in str(ww.message)
+               for ww in warns) == n_warn
     # check proper stacklevel reporting
     for ww in warns:
         if 'naming conventions' in str(ww.message):
-            assert_true(fname in ww.filename,
-                        msg='"%s" not in "%s"' % (fname, ww.filename))
+            assert fname in ww.filename

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -212,7 +212,7 @@ def test_crop_more():
 
 @testing.requires_testing_data
 def test_read_brainstorm_annotations():
-    """Test reading for Brainstorm events file"""
+    """Test reading for Brainstorm events file."""
     fname = op.join(data_dir, 'events_sample_audvis_raw_bst.mat')
     annot = read_brainstorm_annotations(fname)
     assert len(annot) == 238

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -9,7 +9,6 @@ from shutil import copy
 import warnings
 
 import numpy as np
-from nose.tools import assert_raises, assert_true
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
@@ -47,7 +46,7 @@ fname_bem_sol_1 = op.join(subjects_dir, 'sample', 'bem',
 
 
 def _compare_bem_surfaces(surfs_1, surfs_2):
-    """Helper to compare BEM surfaces"""
+    """Compare BEM surfaces."""
     names = ['id', 'nn', 'rr', 'coord_frame', 'tris', 'sigma', 'ntri', 'np']
     ignores = ['tri_cent', 'tri_nn', 'tri_area', 'neighbor_tri']
     for s0, s1 in zip(surfs_1, surfs_2):
@@ -59,7 +58,7 @@ def _compare_bem_surfaces(surfs_1, surfs_2):
 
 
 def _compare_bem_solutions(sol_a, sol_b):
-    """Helper to compare BEM solutions"""
+    """Compare BEM solutions."""
     # compare the surfaces we used
     _compare_bem_surfaces(sol_a['surfs'], sol_b['surfs'])
     # compare the actual solutions
@@ -74,53 +73,53 @@ def _compare_bem_solutions(sol_a, sol_b):
 
 @testing.requires_testing_data
 def test_io_bem():
-    """Test reading and writing of bem surfaces and solutions"""
+    """Test reading and writing of bem surfaces and solutions."""
     tempdir = _TempDir()
     temp_bem = op.join(tempdir, 'temp-bem.fif')
-    assert_raises(ValueError, read_bem_surfaces, fname_raw)
-    assert_raises(ValueError, read_bem_surfaces, fname_bem_3, s_id=10)
+    pytest.raises(ValueError, read_bem_surfaces, fname_raw)
+    pytest.raises(ValueError, read_bem_surfaces, fname_bem_3, s_id=10)
     surf = read_bem_surfaces(fname_bem_3, patch_stats=True)
     surf = read_bem_surfaces(fname_bem_3, patch_stats=False)
     write_bem_surfaces(temp_bem, surf[0])
     surf_read = read_bem_surfaces(temp_bem, patch_stats=False)
     _compare_bem_surfaces(surf, surf_read)
 
-    assert_raises(RuntimeError, read_bem_solution, fname_bem_3)
+    pytest.raises(RuntimeError, read_bem_solution, fname_bem_3)
     temp_sol = op.join(tempdir, 'temp-sol.fif')
     sol = read_bem_solution(fname_bem_sol_3)
-    assert_true('BEM' in repr(sol))
+    assert 'BEM' in repr(sol)
     write_bem_solution(temp_sol, sol)
     sol_read = read_bem_solution(temp_sol)
     _compare_bem_solutions(sol, sol_read)
     sol = read_bem_solution(fname_bem_sol_1)
-    assert_raises(RuntimeError, _bem_find_surface, sol, 3)
+    pytest.raises(RuntimeError, _bem_find_surface, sol, 3)
 
 
 def test_make_sphere_model():
-    """Test making a sphere model"""
+    """Test making a sphere model."""
     info = read_info(fname_raw)
-    assert_raises(ValueError, make_sphere_model, 'foo', 'auto', info)
-    assert_raises(ValueError, make_sphere_model, 'auto', 'auto', None)
-    assert_raises(ValueError, make_sphere_model, 'auto', 'auto', info,
+    pytest.raises(ValueError, make_sphere_model, 'foo', 'auto', info)
+    pytest.raises(ValueError, make_sphere_model, 'auto', 'auto', None)
+    pytest.raises(ValueError, make_sphere_model, 'auto', 'auto', info,
                   relative_radii=(), sigmas=())
-    assert_raises(ValueError, make_sphere_model, 'auto', 'auto', info,
+    pytest.raises(ValueError, make_sphere_model, 'auto', 'auto', info,
                   relative_radii=(1,))  # wrong number of radii
     # here we just make sure it works -- the functionality is actually
     # tested more extensively e.g. in the forward and dipole code
     bem = make_sphere_model('auto', 'auto', info)
-    assert_true('3 layers' in repr(bem))
-    assert_true('Sphere ' in repr(bem))
-    assert_true(' mm' in repr(bem))
+    assert '3 layers' in repr(bem)
+    assert 'Sphere ' in repr(bem)
+    assert ' mm' in repr(bem)
     bem = make_sphere_model('auto', None, info)
-    assert_true('no layers' in repr(bem))
-    assert_true('Sphere ' in repr(bem))
-    assert_raises(ValueError, make_sphere_model, sigmas=(0.33,),
+    assert 'no layers' in repr(bem)
+    assert 'Sphere ' in repr(bem)
+    pytest.raises(ValueError, make_sphere_model, sigmas=(0.33,),
                   relative_radii=(1.0,))
 
 
 @testing.requires_testing_data
 def test_bem_model():
-    """Test BEM model creation from Python with I/O"""
+    """Test BEM model creation from Python with I/O."""
     tempdir = _TempDir()
     fname_temp = op.join(tempdir, 'temp-bem.fif')
     for kwargs, fname in zip((dict(), dict(conductivity=[0.3])),
@@ -133,35 +132,35 @@ def test_bem_model():
         model_read = read_bem_surfaces(fname_temp)
         _compare_bem_surfaces(model, model_c)
         _compare_bem_surfaces(model_read, model_c)
-    assert_raises(ValueError, make_bem_model, 'sample',  # bad conductivity
+    pytest.raises(ValueError, make_bem_model, 'sample',  # bad conductivity
                   conductivity=[0.3, 0.006], subjects_dir=subjects_dir)
 
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_bem_solution():
-    """Test making a BEM solution from Python with I/O"""
+    """Test making a BEM solution from Python with I/O."""
     # test degenerate conditions
     surf = read_bem_surfaces(fname_bem_1)[0]
-    assert_raises(RuntimeError, _ico_downsample, surf, 10)  # bad dec grade
+    pytest.raises(RuntimeError, _ico_downsample, surf, 10)  # bad dec grade
     s_bad = dict(tris=surf['tris'][1:], ntri=surf['ntri'] - 1, rr=surf['rr'])
-    assert_raises(RuntimeError, _ico_downsample, s_bad, 1)  # not isomorphic
+    pytest.raises(RuntimeError, _ico_downsample, s_bad, 1)  # not isomorphic
     s_bad = dict(tris=surf['tris'].copy(), ntri=surf['ntri'],
                  rr=surf['rr'])  # bad triangulation
     s_bad['tris'][0] = [0, 0, 0]
-    assert_raises(RuntimeError, _ico_downsample, s_bad, 1)
+    pytest.raises(RuntimeError, _ico_downsample, s_bad, 1)
     s_bad['id'] = 1
-    assert_raises(RuntimeError, _assert_complete_surface, s_bad)
+    pytest.raises(RuntimeError, _assert_complete_surface, s_bad)
     s_bad = dict(tris=surf['tris'], ntri=surf['ntri'], rr=surf['rr'].copy())
     s_bad['rr'][0] = 0.
-    assert_raises(RuntimeError, _get_ico_map, surf, s_bad)
+    pytest.raises(RuntimeError, _get_ico_map, surf, s_bad)
 
     surfs = read_bem_surfaces(fname_bem_3)
-    assert_raises(RuntimeError, _assert_inside, surfs[0], surfs[1])  # outside
+    pytest.raises(RuntimeError, _assert_inside, surfs[0], surfs[1])  # outside
     surfs[0]['id'] = 100  # bad surfs
-    assert_raises(RuntimeError, _order_surfaces, surfs)
+    pytest.raises(RuntimeError, _order_surfaces, surfs)
     surfs[1]['rr'] /= 1000.
-    assert_raises(RuntimeError, _check_surface_size, surfs[1])
+    pytest.raises(RuntimeError, _check_surface_size, surfs[1])
 
     # actually test functionality
     tempdir = _TempDir()
@@ -186,7 +185,7 @@ def test_bem_solution():
 
 
 def test_fit_sphere_to_headshape():
-    """Test fitting a sphere to digitization points"""
+    """Test fitting a sphere to digitization points."""
     # Create points of various kinds
     rad = 0.09
     big_rad = 0.12
@@ -246,12 +245,12 @@ def test_fit_sphere_to_headshape():
     info = Info(dig=dig, dev_head_t=dev_head_t)
 
     # Degenerate conditions
-    assert_raises(ValueError, fit_sphere_to_headshape, info,
+    pytest.raises(ValueError, fit_sphere_to_headshape, info,
                   dig_kinds=(FIFF.FIFFV_POINT_HPI,))
-    assert_raises(ValueError, fit_sphere_to_headshape, info,
+    pytest.raises(ValueError, fit_sphere_to_headshape, info,
                   dig_kinds='foo', units='m')
     info['dig'][0]['coord_frame'] = FIFF.FIFFV_COORD_DEVICE
-    assert_raises(RuntimeError, fit_sphere_to_headshape, info, units='m')
+    pytest.raises(RuntimeError, fit_sphere_to_headshape, info, units='m')
     info['dig'][0]['coord_frame'] = FIFF.FIFFV_COORD_HEAD
 
     #  # Test with 4 points that match a perfect sphere
@@ -297,7 +296,7 @@ def test_fit_sphere_to_headshape():
                                                 verbose='warning', units='mm')
     log_file = log_file.getvalue().strip()
     assert_equal(len(log_file.split('\n')), 2)
-    assert_true('Estimated head size' in log_file)
+    assert 'Estimated head size' in log_file
     assert_allclose(oh, center * 1000, atol=1e-3)
     assert_allclose(r, big_rad * 1000, atol=1e-3)
     del info_big
@@ -315,7 +314,7 @@ def test_fit_sphere_to_headshape():
                 info_shift, dig_kinds=dig_kinds, verbose='warning', units='m')
     log_file = log_file.getvalue().strip()
     assert_equal(len(log_file.split('\n')), 2)
-    assert_true('from head frame origin' in log_file)
+    assert 'from head frame origin' in log_file
     assert_allclose(oh, shift_center, atol=1e-6)
     assert_allclose(r, rad, atol=1e-6)
 
@@ -338,8 +337,8 @@ def test_fit_sphere_to_headshape():
         r, oh, od = fit_sphere_to_headshape(info, units='m')
     # this one should fail, 1 EXTRA point and 3 EEG (but the fit is terrible)
     info = Info(dig=dig[:6], dev_head_t=dev_head_t)
-    assert_raises(ValueError, fit_sphere_to_headshape, info, units='m')
-    assert_raises(TypeError, fit_sphere_to_headshape, 1, units='m')
+    pytest.raises(ValueError, fit_sphere_to_headshape, info, units='m')
+    pytest.raises(TypeError, fit_sphere_to_headshape, 1, units='m')
 
 
 @requires_nibabel()

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
-from nose.tools import assert_raises, assert_equal, assert_true
+from scipy.interpolate import interp1d
 import pytest
 
 from mne import (pick_types, Dipole, make_sphere_model, make_forward_dipole,
@@ -19,7 +19,6 @@ from mne.chpi import (_calculate_chpi_positions, _calculate_chpi_coil_locs,
                       _calculate_head_pos_ctf, head_pos_to_trans_rot_t,
                       read_head_pos, write_head_pos, filter_chpi,
                       _get_hpi_info, _get_hpi_initial_fit)
-from mne.fixes import assert_raises_regex
 from mne.transforms import rot_to_quat, _angle_between_quats
 from mne.simulation import simulate_raw
 from mne.utils import run_tests_if_main, _TempDir, catch_logging
@@ -74,7 +73,7 @@ def test_chpi_adjust():
            ]
 
     log = log.getvalue().splitlines()
-    assert_true(set(log) == set(msg), '\n' + '\n'.join(set(msg) - set(log)))
+    assert set(log) == set(msg), '\n' + '\n'.join(set(msg) - set(log))
 
     # Then took the raw file, did this:
     raw.info['dig'][5]['r'][2] += 1.
@@ -87,7 +86,7 @@ def test_chpi_adjust():
         _get_hpi_initial_fit(raw.info, adjust=True, verbose='debug')
         _get_hpi_info(raw.info, verbose='debug')
     log = log.getvalue().splitlines()
-    assert_true(set(log) == set(msg), '\n' + '\n'.join(set(msg) - set(log)))
+    assert set(log) == set(msg), '\n' + '\n'.join(set(msg) - set(log))
 
 
 @testing.requires_testing_data
@@ -104,11 +103,11 @@ def test_read_write_head_pos():
         head_pos = read_head_pos(temp_name)
         assert_allclose(head_pos_orig, head_pos, atol=1e-3)
     # Degenerate cases
-    assert_raises(TypeError, write_head_pos, 0, head_pos_read)  # not filename
-    assert_raises(ValueError, write_head_pos, temp_name, 'foo')  # not array
-    assert_raises(ValueError, write_head_pos, temp_name, head_pos_read[:, :9])
-    assert_raises(TypeError, read_head_pos, 0)
-    assert_raises(IOError, read_head_pos, temp_name + 'foo')
+    pytest.raises(TypeError, write_head_pos, 0, head_pos_read)  # not filename
+    pytest.raises(ValueError, write_head_pos, temp_name, 'foo')  # not array
+    pytest.raises(ValueError, write_head_pos, temp_name, head_pos_read[:, :9])
+    pytest.raises(TypeError, read_head_pos, 0)
+    pytest.raises(IOError, read_head_pos, temp_name + 'foo')
 
 
 @testing.requires_testing_data
@@ -118,16 +117,14 @@ def test_hpi_info():
     temp_name = op.join(tempdir, 'temp_raw.fif')
     for fname in (chpi_fif_fname, sss_fif_fname):
         raw = read_raw_fif(fname, allow_maxshield='yes').crop(0, 0.1)
-        assert_true(len(raw.info['hpi_subsystem']) > 0)
+        assert len(raw.info['hpi_subsystem']) > 0
         raw.save(temp_name, overwrite=True)
         info = read_info(temp_name)
-        assert_equal(len(info['hpi_subsystem']),
-                     len(raw.info['hpi_subsystem']))
+        assert len(info['hpi_subsystem']) == len(raw.info['hpi_subsystem'])
 
 
 def _assert_quats(actual, desired, dist_tol=0.003, angle_tol=5.):
     """Compare estimated cHPI positions."""
-    from scipy.interpolate import interp1d
     trans_est, rot_est, t_est = head_pos_to_trans_rot_t(actual)
     trans, rot, t = head_pos_to_trans_rot_t(desired)
     quats_est = rot_to_quat(rot_est)
@@ -151,18 +148,18 @@ def _assert_quats(actual, desired, dist_tol=0.003, angle_tol=5.):
     trans_est_interp = interp1d(t_est, trans_est, axis=0)(t)
     distances = np.sqrt(np.sum((trans - trans_est_interp) ** 2, axis=1))
     arg_worst = np.argmax(distances)
-    assert_true(distances[arg_worst] <= dist_tol,
-                '@ %0.3f seconds: %0.3f > %0.3f mm'
-                % (t[arg_worst], 1000 * distances[arg_worst], 1000 * dist_tol))
+    assert distances[arg_worst] <= dist_tol, (
+        '@ %0.3f seconds: %0.3f > %0.3f mm'
+        % (t[arg_worst], 1000 * distances[arg_worst], 1000 * dist_tol))
 
     # limit rotation difference between MF and our estimation
     # (note that the interpolation will make this slightly worse)
     quats_est_interp = interp1d(t_est, quats_est, axis=0)(t)
     angles = 180 * _angle_between_quats(quats_est_interp, quats) / np.pi
     arg_worst = np.argmax(angles)
-    assert_true(angles[arg_worst] <= angle_tol,
-                '@ %0.3f seconds: %0.3f > %0.3f deg'
-                % (t[arg_worst], angles[arg_worst], angle_tol))
+    assert angles[arg_worst] <= angle_tol, (
+        '@ %0.3f seconds: %0.3f > %0.3f deg'
+        % (t[arg_worst], angles[arg_worst], angle_tol))
 
 
 def _decimate_chpi(raw, decim=4):
@@ -193,21 +190,21 @@ def test_calculate_chpi_positions():
     with catch_logging() as log:
         py_quats = _calculate_chpi_positions(raw_dec, t_step_max=1.,
                                              verbose='debug')
-    assert_true(log.getvalue().startswith('HPIFIT'))
+    assert log.getvalue().startswith('HPIFIT')
     _assert_quats(py_quats, mf_quats, dist_tol=0.004, angle_tol=2.5)
 
     # degenerate conditions
     raw_no_chpi = read_raw_fif(test_fif_fname)
-    assert_raises(RuntimeError, _calculate_chpi_positions, raw_no_chpi)
+    pytest.raises(RuntimeError, _calculate_chpi_positions, raw_no_chpi)
     raw_bad = raw.copy()
     del raw_bad.info['hpi_meas'][0]['hpi_coils'][0]['coil_freq']
-    assert_raises(RuntimeError, _calculate_chpi_positions, raw_bad)
+    pytest.raises(RuntimeError, _calculate_chpi_positions, raw_bad)
     raw_bad = raw.copy()
     for d in raw_bad.info['dig']:
         if d['kind'] == FIFF.FIFFV_POINT_HPI:
             d['coord_frame'] = FIFF.FIFFV_COORD_UNKNOWN
             break
-    assert_raises(RuntimeError, _calculate_chpi_positions, raw_bad)
+    pytest.raises(RuntimeError, _calculate_chpi_positions, raw_bad)
     for d in raw_bad.info['dig']:
         if d['kind'] == FIFF.FIFFV_POINT_HPI:
             d['coord_frame'] = FIFF.FIFFV_COORD_HEAD
@@ -220,12 +217,12 @@ def test_calculate_chpi_positions():
         with catch_logging() as log_file:
             _calculate_chpi_positions(raw_bad, t_step_min=1., verbose=True)
     # ignore HPI info header and [done] footer
-    assert_true('0/5 good' in log_file.getvalue().strip().split('\n')[-2])
+    assert '0/5 good' in log_file.getvalue().strip().split('\n')[-2]
 
     # half the rate cuts off cHPI coils
     raw.info['lowpass'] /= 2.
-    assert_raises_regex(RuntimeError, 'above the',
-                        _calculate_chpi_positions, raw)
+    with pytest.raises(RuntimeError, match='above the'):
+        _calculate_chpi_positions(raw)
 
     # test on 5k artemis data
     raw = read_raw_artemis123(art_fname, preload=True)
@@ -386,8 +383,8 @@ def test_chpi_subtraction():
     raw.del_proj()
     with catch_logging() as log:
         filter_chpi(raw, include_line=False, verbose=True)
-    assert_true('No average EEG' not in log.getvalue())
-    assert_true('5 cHPI' in log.getvalue())
+    assert 'No average EEG' not in log.getvalue()
+    assert '5 cHPI' in log.getvalue()
     # MaxFilter doesn't do quite as well as our algorithm with the last bit
     raw.crop(0, 16)
     # remove cHPI status chans
@@ -398,7 +395,7 @@ def test_chpi_subtraction():
 
     # Degenerate cases
     raw_nohpi = read_raw_fif(test_fif_fname, preload=True)
-    assert_raises(RuntimeError, filter_chpi, raw_nohpi)
+    pytest.raises(RuntimeError, filter_chpi, raw_nohpi)
 
     # When MaxFliter downsamples, like::
     #     $ maxfilter -nosss -ds 2 -f test_move_anon_raw.fif \
@@ -414,8 +411,8 @@ def test_chpi_subtraction():
     del raw.info['hpi_subsystem']['event_channel']
     with catch_logging() as log:
         filter_chpi(raw, verbose=True)
-    assert_raises(ValueError, filter_chpi, raw, t_window=-1)
-    assert_true('2 cHPI' in log.getvalue())
+    pytest.raises(ValueError, filter_chpi, raw, t_window=-1)
+    assert '2 cHPI' in log.getvalue()
 
 
 @testing.requires_testing_data
@@ -427,7 +424,7 @@ def test_calculate_head_pos_ctf():
     _assert_quats(quats, mc_quats, dist_tol=0.004, angle_tol=2.5)
 
     raw = read_raw_fif(ctf_fname)
-    assert_raises(RuntimeError, _calculate_head_pos_ctf, raw)
+    pytest.raises(RuntimeError, _calculate_head_pos_ctf, raw)
 
 
 run_tests_if_main()

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -22,7 +22,7 @@ from mne.source_space import write_source_spaces
 
 
 def test_coregister_fiducials():
-    """Test coreg.coregister_fiducials()"""
+    """Test coreg.coregister_fiducials()."""
     # prepare head and MRI fiducials
     trans = Transform('head', 'mri',
                       rotation(.4, .1, 0).dot(translation(.1, -.1, .1)))
@@ -192,7 +192,7 @@ def test_scale_mri_xfm():
 
 
 def test_fit_matched_points():
-    """Test fit_matched_points: fitting two matching sets of points"""
+    """Test fit_matched_points: fitting two matching sets of points."""
     tgt_pts = np.random.RandomState(42).uniform(size=(6, 3))
 
     # rotation only

--- a/mne/tests/test_defaults.py
+++ b/mne/tests/test_defaults.py
@@ -1,22 +1,20 @@
-from nose.tools import assert_equal, assert_true
 from copy import deepcopy
 
 from mne.defaults import _handle_default
 
 
 def test_handle_default():
-    """Test mutable default
-    """
+    """Test mutable default."""
     x = deepcopy(_handle_default('scalings'))
     y = _handle_default('scalings')
     z = _handle_default('scalings', dict(mag=1, grad=2))
     w = _handle_default('scalings', {})
-    assert_equal(set(x.keys()), set(y.keys()))
-    assert_equal(set(x.keys()), set(z.keys()))
+    assert set(x.keys()) == set(y.keys())
+    assert set(x.keys()) == set(z.keys())
     for key in x.keys():
-        assert_equal(x[key], y[key])
-        assert_equal(x[key], w[key])
+        assert x[key] == y[key]
+        assert x[key] == w[key]
         if key in ('mag', 'grad'):
-            assert_true(x[key] != z[key])
+            assert x[key] != z[key]
         else:
-            assert_equal(x[key], z[key])
+            assert x[key] == z[key]

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -47,6 +47,7 @@ public_modules = [
 
 
 def get_name(func):
+    """Get the name."""
     parts = []
     module = inspect.getmodule(func)
     if module:
@@ -69,7 +70,7 @@ _tab_ignores = [
 
 
 def check_parameters_match(func, doc=None):
-    """Helper to check docstring, returns list of incorrect results"""
+    """Check docstring, return list of incorrect results."""
     from numpydoc import docscrape
     incorrect = []
     name_ = get_name(func)
@@ -155,7 +156,7 @@ def test_docstring_parameters():
 
 
 def test_tabs():
-    """Test that there are no tabs in our source files"""
+    """Test that there are no tabs in our source files."""
     # avoid importing modules that require mayavi if mayavi is not installed
     ignore = _tab_ignores[:]
     try:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -62,6 +62,7 @@ def get_name(func):
 _docstring_ignores = [
     'mne.io.Info',  # Parameters
     'mne.io.write',  # always ignore these
+    'mne.datasets.sample.sample.requires_sample_data',
     # Deprecations
 ]
 
@@ -240,6 +241,7 @@ plot_source_spectrogram
 prepare_inverse_operator
 read_fiducials
 read_tag
+requires_sample_data
 rescale
 simulate_noise_evoked
 source_estimate_quantification
@@ -255,9 +257,10 @@ def test_documented():
     public_modules_ = public_modules[:]
     try:
         import mayavi  # noqa: F401, analysis:ignore
-        public_modules_.append('mne.gui')
     except ImportError:
         pass
+    else:
+        public_modules_.append('mne.gui')
 
     doc_file = op.abspath(op.join(op.dirname(__file__), '..', '..', 'doc',
                                   'python_reference.rst'))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -10,10 +10,8 @@ from distutils.version import LooseVersion
 from functools import partial
 
 import pytest
-from nose.tools import (assert_true, assert_equal, assert_raises,
-                        assert_not_equal)
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_allclose)
+                           assert_allclose, assert_equal)
 import numpy as np
 import copy as cp
 import warnings
@@ -131,7 +129,7 @@ def test_average_movements():
                      np.array([0.]))
 
     # SSS-based
-    assert_raises(TypeError, average_movements, epochs, None)
+    pytest.raises(TypeError, average_movements, epochs, None)
     evoked_move_non = average_movements(epochs, head_pos=head_pos,
                                         weight_all=False, origin=origin)
     evoked_move_all = average_movements(epochs, head_pos=head_pos,
@@ -145,7 +143,7 @@ def test_average_movements():
     # substantial changes to MEG data
     for ev in (evoked_move_non, evoked_stat_all):
         assert_meg_snr(ev, evoked_std, 0., 0.1)
-        assert_raises(AssertionError, assert_meg_snr,
+        pytest.raises(AssertionError, assert_meg_snr,
                       ev, evoked_std, 1., 1.)
     meg_picks = pick_types(evoked_std.info, meg=True, exclude=())
     assert_allclose(evoked_move_non.data[meg_picks],
@@ -162,7 +160,7 @@ def test_average_movements():
     evoked_sss = epochs_sss.average()
     assert_equal(evoked_std.nave, evoked_sss.nave)
     # this should break the non-MEG channels
-    assert_raises(AssertionError, assert_meg_snr,
+    pytest.raises(AssertionError, assert_meg_snr,
                   evoked_sss, evoked_move_all, 0., 0.)
     assert_meg_snr(evoked_sss, evoked_move_non, 0.02, 2.6)
     assert_meg_snr(evoked_sss, evoked_stat_all, 0.05, 3.2)
@@ -174,7 +172,7 @@ def test_average_movements():
     x = head_pos_to_trans_rot_t(head_pos[1])
     epochs.info['dev_head_t']['trans'][:3, :3] = x[1]
     epochs.info['dev_head_t']['trans'][:3, 3] = x[0]
-    assert_raises(AssertionError, assert_allclose,
+    pytest.raises(AssertionError, assert_allclose,
                   epochs.info['dev_head_t']['trans'],
                   destination['trans'])
     evoked_miss = average_movements(epochs, head_pos=head_pos[2:],
@@ -186,10 +184,10 @@ def test_average_movements():
 
     # degenerate cases
     destination['to'] = destination['from']  # bad dest
-    assert_raises(RuntimeError, average_movements, epochs, head_pos,
+    pytest.raises(RuntimeError, average_movements, epochs, head_pos,
                   origin=origin, destination=destination)
-    assert_raises(TypeError, average_movements, 'foo', head_pos=head_pos)
-    assert_raises(RuntimeError, average_movements, epochs_proj,
+    pytest.raises(TypeError, average_movements, 'foo', head_pos=head_pos)
+    pytest.raises(RuntimeError, average_movements, epochs_proj,
                   head_pos=head_pos)  # prj
 
 
@@ -200,21 +198,21 @@ def test_reject():
     events = events[events[:, 2] == event_id, :]
     selection = np.arange(3)
     drop_log = [[]] * 3 + [['MEG 2443']] * 4
-    assert_raises(TypeError, pick_types, raw)
+    pytest.raises(TypeError, pick_types, raw)
     picks_meg = pick_types(raw.info, meg=True, eeg=False)
-    assert_raises(TypeError, Epochs, raw, events, event_id, tmin, tmax,
+    pytest.raises(TypeError, Epochs, raw, events, event_id, tmin, tmax,
                   picks=picks, preload=False, reject='foo')
-    assert_raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
                   picks=picks_meg, preload=False, reject=dict(eeg=1.))
     # this one is okay because it's not actually requesting rejection
     Epochs(raw, events, event_id, tmin, tmax, picks=picks_meg,
            preload=False, reject=dict(eeg=np.inf))
     for val in (None, -1):  # protect against older MNE-C types
         for kwarg in ('reject', 'flat'):
-            assert_raises(ValueError, Epochs, raw, events, event_id,
+            pytest.raises(ValueError, Epochs, raw, events, event_id,
                           tmin, tmax, picks=picks_meg, preload=False,
                           **{kwarg: dict(grad=val)})
-    assert_raises(KeyError, Epochs, raw, events, event_id, tmin, tmax,
+    pytest.raises(KeyError, Epochs, raw, events, event_id, tmin, tmax,
                   picks=picks, preload=False, reject=dict(foo=1.))
 
     data_7 = dict()
@@ -224,7 +222,7 @@ def test_reject():
             # no rejection
             epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                             preload=preload)
-            assert_raises(ValueError, epochs.drop_bad, reject='foo')
+            pytest.raises(ValueError, epochs.drop_bad, reject='foo')
             epochs.drop_bad()
             assert_equal(len(epochs), len(events))
             assert_array_equal(epochs.selection, np.arange(len(events)))
@@ -268,12 +266,12 @@ def test_reject():
             assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
 
             # ensure that thresholds must become more stringent, not less
-            assert_raises(ValueError, epochs.drop_bad, reject_part)
+            pytest.raises(ValueError, epochs.drop_bad, reject_part)
             assert_equal(len(epochs), len(events) - 4)
             assert_array_equal(epochs.get_data(), data_7[proj][keep_idx])
             epochs.drop_bad(flat=dict(mag=1.))
             assert_equal(len(epochs), 0)
-            assert_raises(ValueError, epochs.drop_bad,
+            pytest.raises(ValueError, epochs.drop_bad,
                           flat=dict(mag=0.))
 
             # rejection of subset of trials (ensure array ownership)
@@ -334,9 +332,9 @@ def test_decim():
     del picks
     sfreq_new = raw.info['sfreq'] / decim
     raw.info['lowpass'] = sfreq_new / 12.  # suppress aliasing warnings
-    assert_raises(ValueError, epochs.decimate, -1)
-    assert_raises(ValueError, epochs.decimate, 2, offset=-1)
-    assert_raises(ValueError, epochs.decimate, 2, offset=2)
+    pytest.raises(ValueError, epochs.decimate, -1)
+    pytest.raises(ValueError, epochs.decimate, 2, offset=-1)
+    pytest.raises(ValueError, epochs.decimate, 2, offset=2)
     for this_offset in range(decim):
         epochs = Epochs(raw, events, event_id,
                         tmin=-this_offset / raw.info['sfreq'], tmax=tmax)
@@ -345,9 +343,9 @@ def test_decim():
             expected_times = epochs.times[idx_offset::decim]
             expected_data = epochs.get_data()[:, :, idx_offset::decim]
             must_have = offset / float(epochs.info['sfreq'])
-            assert_true(np.isclose(must_have, expected_times).any())
+            assert (np.isclose(must_have, expected_times).any())
             ep_decim = epochs.copy().decimate(decim, offset)
-            assert_true(np.isclose(must_have, ep_decim.times).any())
+            assert (np.isclose(must_have, ep_decim.times).any())
             assert_allclose(ep_decim.times, expected_times)
             assert_allclose(ep_decim.get_data(), expected_data)
             assert_equal(ep_decim.info['sfreq'], sfreq_new)
@@ -420,11 +418,11 @@ def test_base_epochs():
     raw = _get_data()[0]
     epochs = BaseEpochs(raw.info, None, np.ones((1, 3), int),
                         event_id, tmin, tmax)
-    assert_raises(NotImplementedError, epochs.get_data)
+    pytest.raises(NotImplementedError, epochs.get_data)
     # events with non integers
-    assert_raises(ValueError, BaseEpochs, raw.info, None,
+    pytest.raises(ValueError, BaseEpochs, raw.info, None,
                   np.ones((1, 3), float), event_id, tmin, tmax)
-    assert_raises(ValueError, BaseEpochs, raw.info, None,
+    pytest.raises(ValueError, BaseEpochs, raw.info, None,
                   np.ones((1, 3, 2), int), event_id, tmin, tmax)
 
 
@@ -434,7 +432,7 @@ def test_savgol_filter():
     h_freq = 20.
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events, event_id, tmin, tmax)
-    assert_raises(RuntimeError, epochs.savgol_filter, 10.)
+    pytest.raises(RuntimeError, epochs.savgol_filter, 10.)
     epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
     epochs.pick_types(meg='grad')
     freqs = np.fft.rfftfreq(len(epochs.times), 1. / epochs.info['sfreq'])
@@ -448,8 +446,8 @@ def test_savgol_filter():
                     np.mean(data_filt[:, :, pass_mask], 0),
                     rtol=1e-2, atol=1e-18)
     # suppression in stop-band
-    assert_true(np.mean(data[:, :, stop_mask]) >
-                np.mean(data_filt[:, :, stop_mask]) * 5)
+    assert (np.mean(data[:, :, stop_mask]) >
+            np.mean(data_filt[:, :, stop_mask]) * 5)
 
 
 def test_filter():
@@ -458,7 +456,7 @@ def test_filter():
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events, event_id, tmin, tmax)
     assert round(epochs.info['lowpass']) == 172
-    assert_raises(RuntimeError, epochs.savgol_filter, 10.)
+    pytest.raises(RuntimeError, epochs.savgol_filter, 10.)
     epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
     epochs.pick_types(meg='grad')
     freqs = np.fft.rfftfreq(len(epochs.times), 1. / epochs.info['sfreq'])
@@ -473,24 +471,24 @@ def test_filter():
                     np.mean(data[:, :, pass_mask], 0),
                     rtol=5e-2, atol=1e-16)
     # suppression in stop-band
-    assert_true(np.mean(data[:, :, stop_mask]) >
-                np.mean(data_filt[:, :, stop_mask]) * 10)
+    assert (np.mean(data[:, :, stop_mask]) >
+            np.mean(data_filt[:, :, stop_mask]) * 10)
 
 
 def test_epochs_hash():
     """Test epoch hashing."""
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events, event_id, tmin, tmax)
-    assert_raises(RuntimeError, epochs.__hash__)
+    pytest.raises(RuntimeError, epochs.__hash__)
     epochs = Epochs(raw, events, event_id, tmin, tmax, preload=True)
     assert_equal(hash(epochs), hash(epochs))
     epochs_2 = Epochs(raw, events, event_id, tmin, tmax, preload=True)
     assert_equal(hash(epochs), hash(epochs_2))
     # do NOT use assert_equal here, failing output is terrible
-    assert_true(pickle.dumps(epochs) == pickle.dumps(epochs_2))
+    assert (pickle.dumps(epochs) == pickle.dumps(epochs_2))
 
     epochs_2._data[0, 0, 0] -= 1
-    assert_not_equal(hash(epochs), hash(epochs_2))
+    assert hash(epochs) != hash(epochs_2)
 
 
 def test_event_ordering():
@@ -504,11 +502,11 @@ def test_event_ordering():
             Epochs(raw, eve, event_id, tmin, tmax, reject=reject, flat=flat)
             assert_equal(len(w), ii)
             if ii > 0:
-                assert_true('chronologically' in '%s' % w[-1].message)
+                assert ('chronologically' in '%s' % w[-1].message)
     # Duplicate events should be an error...
     events2 = events[[0, 0]]
     events2[:, 2] = [1, 2]
-    assert_raises(RuntimeError, Epochs, raw, events2, event_id=None)
+    pytest.raises(RuntimeError, Epochs, raw, events2, event_id=None)
     # But only if duplicates are actually used by event_id
     assert_equal(len(Epochs(raw, events2, event_id=dict(a=1), preload=True)),
                  1)
@@ -562,21 +560,21 @@ def test_epochs_baseline():
 def test_epochs_bad_baseline():
     """Test Epochs initialization with bad baseline parameters."""
     raw, events = _get_data()[:2]
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (-0.2, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0, 0.4))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0.1, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, 0.1, 0.3, (None, 0))
-    assert_raises(ValueError, Epochs, raw, events, None, -0.3, -0.1, (0, None))
+    pytest.raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (-0.2, 0))
+    pytest.raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0, 0.4))
+    pytest.raises(ValueError, Epochs, raw, events, None, -0.1, 0.3, (0.1, 0))
+    pytest.raises(ValueError, Epochs, raw, events, None, 0.1, 0.3, (None, 0))
+    pytest.raises(ValueError, Epochs, raw, events, None, -0.3, -0.1, (0, None))
     epochs = Epochs(raw, events, None, 0.1, 0.3, baseline=None)
     epochs.load_data()
-    assert_raises(ValueError, epochs.apply_baseline, (None, 0))
-    assert_raises(ValueError, epochs.apply_baseline, (0, None))
+    pytest.raises(ValueError, epochs.apply_baseline, (None, 0))
+    pytest.raises(ValueError, epochs.apply_baseline, (0, None))
     # put some rescale options here, too
     data = np.arange(100, dtype=float)
-    assert_raises(ValueError, rescale, data, times=data, baseline=(-2, -1))
+    pytest.raises(ValueError, rescale, data, times=data, baseline=(-2, -1))
     rescale(data.copy(), times=data, baseline=(2, 2))  # ok
-    assert_raises(ValueError, rescale, data, times=data, baseline=(2, 1))
-    assert_raises(ValueError, rescale, data, times=data, baseline=(100, 101))
+    pytest.raises(ValueError, rescale, data, times=data, baseline=(2, 1))
+    pytest.raises(ValueError, rescale, data, times=data, baseline=(100, 101))
 
 
 def test_epoch_combine_ids():
@@ -618,9 +616,9 @@ def test_read_epochs_bad_events():
 
     epochs = Epochs(raw, np.array([[raw.first_samp, 0, event_id]]),
                     event_id, tmin, tmax, picks=picks)
-    assert_true(repr(epochs))  # test repr
+    assert (repr(epochs))  # test repr
     epochs.drop_bad()
-    assert_true(repr(epochs))
+    assert (repr(epochs))
     with warnings.catch_warnings(record=True):
         evoked = epochs.average()
 
@@ -647,12 +645,12 @@ def test_read_write_epochs():
     epochs_orig = epochs.copy()
     epochs_no_bl = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                           baseline=None, preload=True)
-    assert_true(epochs_no_bl.baseline is None)
+    assert (epochs_no_bl.baseline is None)
     evoked = epochs.average()
     data = epochs.get_data()
 
     # Bad tmin/tmax parameters
-    assert_raises(ValueError, Epochs, raw, events, event_id, tmax, tmin,
+    pytest.raises(ValueError, Epochs, raw, events, event_id, tmax, tmin,
                   baseline=None)
 
     epochs_no_id = Epochs(raw, pick_events(events, include=event_id),
@@ -663,10 +661,10 @@ def test_read_write_epochs():
                            eog=True, exclude='bads')
     eog_ch_names = [raw.ch_names[k] for k in eog_picks]
     epochs.drop_channels(eog_ch_names)
-    assert_true(len(epochs.info['chs']) == len(epochs.ch_names) ==
-                epochs.get_data().shape[1])
+    assert (len(epochs.info['chs']) == len(epochs.ch_names) ==
+            epochs.get_data().shape[1])
     data_no_eog = epochs.get_data()
-    assert_true(data.shape[1] == (data_no_eog.shape[1] + len(eog_picks)))
+    assert (data.shape[1] == (data_no_eog.shape[1] + len(eog_picks)))
 
     # test decim kwarg
     with warnings.catch_warnings(record=True) as w:
@@ -692,8 +690,8 @@ def test_read_write_epochs():
     n = evoked.data.shape[1]
     n_dec = evoked_dec.data.shape[1]
     n_dec_min = n // 4
-    assert_true(n_dec_min <= n_dec <= n_dec_min + 1)
-    assert_true(evoked_dec.info['sfreq'] == evoked.info['sfreq'] / 4)
+    assert (n_dec_min <= n_dec <= n_dec_min + 1)
+    assert (evoked_dec.info['sfreq'] == evoked.info['sfreq'] / 4)
 
     # Test event access on non-preloaded data (#2345)
 
@@ -740,12 +738,12 @@ def test_read_write_epochs():
         epochs_no_bl.save(temp_fname_no_bl)
         epochs_read = read_epochs(temp_fname)
         epochs_no_bl_read = read_epochs(temp_fname_no_bl)
-        assert_raises(ValueError, epochs.apply_baseline, baseline=[1, 2, 3])
+        pytest.raises(ValueError, epochs.apply_baseline, baseline=[1, 2, 3])
         epochs_with_bl = epochs_no_bl_read.copy().apply_baseline(baseline)
-        assert_true(isinstance(epochs_with_bl, BaseEpochs))
-        assert_true(epochs_with_bl.baseline == baseline)
-        assert_true(epochs_no_bl_read.baseline != baseline)
-        assert_true(str(epochs_read).startswith('<Epochs'))
+        assert (isinstance(epochs_with_bl, BaseEpochs))
+        assert (epochs_with_bl.baseline == baseline)
+        assert (epochs_no_bl_read.baseline != baseline)
+        assert (str(epochs_read).startswith('<Epochs'))
 
         epochs_no_bl_read.apply_baseline(baseline)
         assert_array_equal(epochs_no_bl_read.times, epochs.times)
@@ -782,7 +780,7 @@ def test_read_write_epochs():
         epochs_read3 = read_epochs(temp_fname, preload=preload)
         assert_array_equal(epochs_read3.events, epochs.events)
         data = epochs.get_data()
-        assert_true(epochs_read3.events.shape[0] == data.shape[0])
+        assert (epochs_read3.events.shape[0] == data.shape[0])
 
         # test copying loaded one (raw property)
         epochs_read4 = epochs_read3.copy()
@@ -867,9 +865,9 @@ def test_epochs_proj():
                             eog=True, exclude=exclude)
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
-    assert_true(all(p['active'] is True for p in epochs.info['projs']))
+    assert (all(p['active'] is True for p in epochs.info['projs']))
     evoked = epochs.average()
-    assert_true(all(p['active'] is True for p in evoked.info['projs']))
+    assert (all(p['active'] is True for p in evoked.info['projs']))
     data = epochs.get_data()
 
     raw_proj = read_raw_fif(raw_fname).apply_proj()
@@ -877,10 +875,10 @@ def test_epochs_proj():
                             picks=this_picks, proj=False)
 
     data_no_proj = epochs_no_proj.get_data()
-    assert_true(all(p['active'] is True for p in epochs_no_proj.info['projs']))
+    assert (all(p['active'] is True for p in epochs_no_proj.info['projs']))
     evoked_no_proj = epochs_no_proj.average()
-    assert_true(all(p['active'] is True for p in evoked_no_proj.info['projs']))
-    assert_true(epochs_no_proj.proj is True)  # as projs are active from Raw
+    assert (all(p['active'] is True for p in evoked_no_proj.info['projs']))
+    assert (epochs_no_proj.proj is True)  # as projs are active from Raw
 
     assert_array_almost_equal(data, data_no_proj, decimal=8)
 
@@ -890,16 +888,16 @@ def test_epochs_proj():
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
     epochs.set_eeg_reference(projection=True).apply_proj()
-    assert_true(_has_eeg_average_ref_proj(epochs.info['projs']))
+    assert (_has_eeg_average_ref_proj(epochs.info['projs']))
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
-    assert_true(not _has_eeg_average_ref_proj(epochs.info['projs']))
+    assert (not _has_eeg_average_ref_proj(epochs.info['projs']))
 
     # make sure we don't add avg ref when a custom ref has been applied
     raw.info['custom_ref_applied'] = True
     epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=this_picks,
                     proj=True)
-    assert_true(not _has_eeg_average_ref_proj(epochs.info['projs']))
+    assert (not _has_eeg_average_ref_proj(epochs.info['projs']))
 
     # From GH#2200:
     # This has no problem
@@ -935,7 +933,7 @@ def test_epochs_proj():
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
         epochs = read_epochs(temp_fname, proj=False, preload=preload)
         epochs.set_eeg_reference(projection=True)
-        assert_raises(AssertionError, assert_allclose,
+        pytest.raises(AssertionError, assert_allclose,
                       epochs.get_data().mean(axis=1), 0., atol=1e-15)
         epochs.apply_proj()
         assert_allclose(epochs.get_data().mean(axis=1), 0, atol=1e-15)
@@ -967,7 +965,7 @@ def test_evoked_io_from_epochs():
         warnings.simplefilter('always')
         epochs = Epochs(raw, events[:4], event_id, tmin + 0.011, tmax,
                         picks=picks, decim=5)
-    assert_true(len(w) == 1)
+    assert (len(w) == 1)
     evoked = epochs.average()
     evoked.info['proj_name'] = ''  # Test that empty string shortcuts to None.
     evoked.save(op.join(tempdir, 'evoked-ave.fif'))
@@ -1011,12 +1009,12 @@ def test_evoked_standard_error():
                read_evokeds(op.join(tempdir, 'evoked-ave.fif'), '1',
                             kind='standard_error')]
     for evoked_new in [evoked2, evoked3]:
-        assert_true(evoked_new[0]._aspect_kind ==
-                    FIFF.FIFFV_ASPECT_AVERAGE)
-        assert_true(evoked_new[0].kind == 'average')
-        assert_true(evoked_new[1]._aspect_kind ==
-                    FIFF.FIFFV_ASPECT_STD_ERR)
-        assert_true(evoked_new[1].kind == 'standard_error')
+        assert (evoked_new[0]._aspect_kind ==
+                FIFF.FIFFV_ASPECT_AVERAGE)
+        assert (evoked_new[0].kind == 'average')
+        assert (evoked_new[1]._aspect_kind ==
+                FIFF.FIFFV_ASPECT_STD_ERR)
+        assert (evoked_new[1].kind == 'standard_error')
         for ave, ave2 in zip(evoked, evoked_new):
             assert_array_almost_equal(ave.data, ave2.data)
             assert_array_almost_equal(ave.times, ave2.times)
@@ -1033,16 +1031,16 @@ def test_reject_epochs():
     events1 = events[events[:, 2] == event_id]
     epochs = Epochs(raw, events1, event_id, tmin, tmax,
                     reject=reject, flat=flat)
-    assert_raises(RuntimeError, len, epochs)
+    pytest.raises(RuntimeError, len, epochs)
     n_events = len(epochs.events)
     data = epochs.get_data()
     n_clean_epochs = len(data)
     # Should match
     # mne_process_raw --raw test_raw.fif --projoff \
     #   --saveavetag -ave --ave test.ave --filteroff
-    assert_true(n_events > n_clean_epochs)
-    assert_true(n_clean_epochs == 3)
-    assert_true(epochs.drop_log == [[], [], [], ['MEG 2443'], ['MEG 2443'],
+    assert (n_events > n_clean_epochs)
+    assert (n_clean_epochs == 3)
+    assert (epochs.drop_log == [[], [], [], ['MEG 2443'], ['MEG 2443'],
                                     ['MEG 2443'], ['MEG 2443']])
 
     # Ensure epochs are not dropped based on a bad channel
@@ -1053,25 +1051,25 @@ def test_reject_epochs():
                     reject=reject_crazy, flat=flat)
     epochs.drop_bad()
 
-    assert_true(all('MEG 2442' in e for e in epochs.drop_log))
-    assert_true(all('MEG 2443' not in e for e in epochs.drop_log))
+    assert (all('MEG 2442' in e for e in epochs.drop_log))
+    assert (all('MEG 2443' not in e for e in epochs.drop_log))
 
     # Invalid reject_tmin/reject_tmax/detrend
-    assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
                   reject_tmin=1., reject_tmax=0)
-    assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
                   reject_tmin=tmin - 1, reject_tmax=1.)
-    assert_raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events1, event_id, tmin, tmax,
                   reject_tmin=0., reject_tmax=tmax + 1)
 
     epochs = Epochs(raw, events1, event_id, tmin, tmax, picks=picks,
                     reject=reject, flat=flat, reject_tmin=0., reject_tmax=.1)
     data = epochs.get_data()
     n_clean_epochs = len(data)
-    assert_true(n_clean_epochs == 7)
-    assert_true(len(epochs) == 7)
-    assert_true(epochs.times[epochs._reject_time][0] >= 0.)
-    assert_true(epochs.times[epochs._reject_time][-1] <= 0.1)
+    assert (n_clean_epochs == 7)
+    assert (len(epochs) == 7)
+    assert (epochs.times[epochs._reject_time][0] >= 0.)
+    assert (epochs.times[epochs._reject_time][-1] <= 0.1)
 
     # Invalid data for _is_good_epoch function
     epochs = Epochs(raw, events1, event_id, tmin, tmax)
@@ -1164,7 +1162,7 @@ def test_comparision_with_c():
     evoked_data = evoked.data
     c_evoked_data = c_evoked.data[sel]
 
-    assert_true(evoked.nave == c_evoked.nave)
+    assert (evoked.nave == c_evoked.nave)
     assert_array_almost_equal(evoked_data, c_evoked_data, 10)
     assert_array_almost_equal(evoked.times, c_evoked.times, 12)
 
@@ -1174,21 +1172,21 @@ def test_crop():
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     preload=False, reject=reject, flat=flat)
-    assert_raises(RuntimeError, epochs.crop, None, 0.2)  # not preloaded
+    pytest.raises(RuntimeError, epochs.crop, None, 0.2)  # not preloaded
     data_normal = epochs.get_data()
 
     epochs2 = Epochs(raw, events[:5], event_id, tmin, tmax,
                      picks=picks, preload=True, reject=reject, flat=flat)
     with warnings.catch_warnings(record=True) as w:
         epochs2.crop(-20, 200)
-    assert_true(len(w) == 2)
+    assert (len(w) == 2)
 
     # indices for slicing
     tmin_window = tmin + 0.1
     tmax_window = tmax - 0.1
     tmask = (epochs.times >= tmin_window) & (epochs.times <= tmax_window)
-    assert_true(tmin_window > tmin)
-    assert_true(tmax_window < tmax)
+    assert (tmin_window > tmin)
+    assert (tmax_window < tmax)
     epochs3 = epochs2.copy().crop(tmin_window, tmax_window)
     data3 = epochs3.get_data()
     epochs2.crop(tmin_window, tmax_window)
@@ -1219,8 +1217,8 @@ def test_crop():
     assert_allclose(epochs.times, epochs_crop.times, rtol=1e-12)
     # Ensure we don't allow silly crops
     with warnings.catch_warnings(record=True):  # tmin/tmax out of bounds
-        assert_raises(ValueError, epochs.crop, 1000, 2000)
-        assert_raises(ValueError, epochs.crop, 0.1, 0)
+        pytest.raises(ValueError, epochs.crop, 1000, 2000)
+        pytest.raises(ValueError, epochs.crop, 0.1, 0)
 
 
 def test_resample():
@@ -1228,7 +1226,7 @@ def test_resample():
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
                     preload=False, reject=reject, flat=flat)
-    assert_raises(RuntimeError, epochs.resample, 100)
+    pytest.raises(RuntimeError, epochs.resample, 100)
 
     epochs_o = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks,
                       preload=True, reject=reject, flat=flat)
@@ -1248,25 +1246,25 @@ def test_resample():
     data_new = cp.deepcopy(epochs.get_data())
     times_new = cp.deepcopy(epochs.times)
     sfreq_new = epochs.info['sfreq']
-    assert_true(data_up.shape[2] == 2 * data_normal.shape[2])
-    assert_true(sfreq_up == 2 * sfreq_normal)
-    assert_true(sfreq_new == sfreq_normal)
-    assert_true(len(times_up) == 2 * len(times_normal))
+    assert (data_up.shape[2] == 2 * data_normal.shape[2])
+    assert (sfreq_up == 2 * sfreq_normal)
+    assert (sfreq_new == sfreq_normal)
+    assert (len(times_up) == 2 * len(times_normal))
     assert_array_almost_equal(times_new, times_normal, 10)
-    assert_true(data_up.shape[2] == 2 * data_normal.shape[2])
+    assert (data_up.shape[2] == 2 * data_normal.shape[2])
     assert_array_almost_equal(data_new, data_normal, 5)
 
     # use parallel
     epochs = epochs_o.copy()
     epochs.resample(sfreq_normal * 2, n_jobs=2, npad=0)
-    assert_true(np.allclose(data_up, epochs._data, rtol=1e-8, atol=1e-16))
+    assert (np.allclose(data_up, epochs._data, rtol=1e-8, atol=1e-16))
 
     # test copy flag
     epochs = epochs_o.copy()
     epochs_resampled = epochs.copy().resample(sfreq_normal * 2, npad=0)
-    assert_true(epochs_resampled is not epochs)
+    assert (epochs_resampled is not epochs)
     epochs_resampled = epochs.resample(sfreq_normal * 2, npad=0)
-    assert_true(epochs_resampled is epochs)
+    assert (epochs_resampled is epochs)
 
     # test proper setting of times (#2645)
     n_trial, n_chan, n_time, sfreq = 1, 1, 10, 1000.
@@ -1313,8 +1311,7 @@ def test_detrend():
     evoked_2 = epochs_2.average()
     evoked_2.detrend(1)
     # Due to roundoff these won't be exactly equal, but they should be close
-    assert_true(np.allclose(evoked_1.data, evoked_2.data,
-                            rtol=1e-8, atol=1e-20))
+    assert_allclose(evoked_1.data, evoked_2.data, rtol=1e-8, atol=1e-20)
 
     # test zeroth-order case
     for preload in [True, False]:
@@ -1325,13 +1322,13 @@ def test_detrend():
         a = epochs_1.get_data()
         b = epochs_2.get_data()
         # All data channels should be almost equal
-        assert_true(np.allclose(a[:, data_picks, :], b[:, data_picks, :],
-                                rtol=1e-16, atol=1e-20))
+        assert_allclose(a[:, data_picks, :], b[:, data_picks, :],
+                        rtol=1e-16, atol=1e-20)
         # There are non-M/EEG channels that should not be equal:
-        assert_true(not np.allclose(a, b))
+        assert not np.allclose(a, b)
 
     for value in ['foo', 2, False, True]:
-        assert_raises(ValueError, Epochs, raw, events[:4], event_id,
+        pytest.raises(ValueError, Epochs, raw, events[:4], event_id,
                       tmin, tmax, detrend=value)
 
 
@@ -1341,8 +1338,8 @@ def test_bootstrap():
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     preload=True, reject=reject, flat=flat)
     epochs2 = bootstrap(epochs, random_state=0)
-    assert_true(len(epochs2.events) == len(epochs.events))
-    assert_true(epochs._data.shape == epochs2._data.shape)
+    assert (len(epochs2.events) == len(epochs.events))
+    assert (epochs._data.shape == epochs2._data.shape)
 
 
 def test_epochs_copy():
@@ -1378,7 +1375,7 @@ def test_subtract_evoked():
     epochs = Epochs(raw, events[:10], event_id, tmin, tmax, picks=picks)
 
     # make sure subtraction fails if data channels are missing
-    assert_raises(ValueError, epochs.subtract_evoked,
+    pytest.raises(ValueError, epochs.subtract_evoked,
                   epochs.average(picks[:5]))
 
     # do the subtraction using the default argument
@@ -1418,7 +1415,7 @@ def test_epoch_eq():
     assert_equal(drop_log1, drop_log2)
     assert_equal(len([l for l in epochs_1.drop_log if not l]),
                  len(epochs_1.events))
-    assert_true(epochs_1.events.shape[0] != epochs_2.events.shape[0])
+    assert (epochs_1.events.shape[0] != epochs_2.events.shape[0])
     equalize_epoch_counts([epochs_1, epochs_2], method='mintime')
     assert_equal(epochs_1.events.shape[0], epochs_2.events.shape[0])
     epochs_3 = Epochs(raw, events, event_id, tmin, tmax, picks=picks)
@@ -1453,7 +1450,7 @@ def test_epoch_eq():
     new_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     assert_equal(new_shapes[0] + new_shapes[1], new_shapes[2])
     assert_equal(new_shapes[3], old_shapes[3])
-    assert_raises(KeyError, epochs.equalize_event_counts, [1, 'a'])
+    pytest.raises(KeyError, epochs.equalize_event_counts, [1, 'a'])
 
     # now let's combine conditions
     old_shapes = new_shapes
@@ -1461,7 +1458,7 @@ def test_epoch_eq():
     new_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     assert_equal(old_shapes[0] + old_shapes[1], new_shapes[0] + new_shapes[1])
     assert_equal(new_shapes[0] + new_shapes[1], new_shapes[2] + new_shapes[3])
-    assert_raises(ValueError, combine_event_ids, epochs, ['a', 'b'], {'ab': 1})
+    pytest.raises(ValueError, combine_event_ids, epochs, ['a', 'b'], {'ab': 1})
 
     combine_event_ids(epochs, ['a', 'b'], {'ab': np.int32(12)}, copy=False)
     caught = 0
@@ -1471,11 +1468,11 @@ def test_epoch_eq():
         except KeyError:
             caught += 1
     assert_equal(caught, 2)
-    assert_true(not np.any(epochs.events[:, 2] == 1))
-    assert_true(not np.any(epochs.events[:, 2] == 2))
+    assert (not np.any(epochs.events[:, 2] == 1))
+    assert (not np.any(epochs.events[:, 2] == 2))
     epochs = combine_event_ids(epochs, ['c', 'd'], {'cd': 34})
-    assert_true(np.all(np.logical_or(epochs.events[:, 2] == 12,
-                                     epochs.events[:, 2] == 34)))
+    assert np.all(np.logical_or(epochs.events[:, 2] == 12,
+                  epochs.events[:, 2] == 34))
     assert_equal(epochs['ab'].events.shape[0], old_shapes[0] + old_shapes[1])
     assert_equal(epochs['ab'].events.shape[0], epochs['cd'].events.shape[0])
 
@@ -1488,13 +1485,13 @@ def test_epoch_eq():
     assert_array_equal(es[0].events[:, 0], es[1].events[:, 0])
     cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
     for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
-        assert_raises(ValueError, epochs.equalize_event_counts, c)
-    assert_raises(KeyError, epochs.equalize_event_counts,
+        pytest.raises(ValueError, epochs.equalize_event_counts, c)
+    pytest.raises(KeyError, epochs.equalize_event_counts,
                   ["a/no_match", "b"])
     # test equalization with no events of one type
     epochs.drop(np.arange(10))
     assert_equal(len(epochs['a/x']), 0)
-    assert_true(len(epochs['a/y']) > 0)
+    assert (len(epochs['a/y']) > 0)
     epochs.equalize_event_counts(['a/x', 'a/y'])
     assert_equal(len(epochs['a/x']), 0)
     assert_equal(len(epochs['a/y']), 0)
@@ -1506,29 +1503,29 @@ def test_access_by_name():
     raw, events, picks = _get_data()
 
     # Test various invalid inputs
-    assert_raises(TypeError, Epochs, raw, events, {1: 42, 2: 42}, tmin,
+    pytest.raises(TypeError, Epochs, raw, events, {1: 42, 2: 42}, tmin,
                   tmax, picks=picks)
-    assert_raises(TypeError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
+    pytest.raises(TypeError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
                   tmin, tmax, picks=picks)
-    assert_raises(TypeError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
+    pytest.raises(TypeError, Epochs, raw, events, {'a': 'spam', 2: 'eggs'},
                   tmin, tmax, picks=picks)
-    assert_raises(TypeError, Epochs, raw, events, 'foo', tmin, tmax,
+    pytest.raises(TypeError, Epochs, raw, events, 'foo', tmin, tmax,
                   picks=picks)
-    assert_raises(TypeError, Epochs, raw, events, ['foo'], tmin, tmax,
+    pytest.raises(TypeError, Epochs, raw, events, ['foo'], tmin, tmax,
                   picks=picks)
 
     # Test accessing non-existent events (assumes 12345678 does not exist)
     event_id_illegal = dict(aud_l=1, does_not_exist=12345678)
-    assert_raises(ValueError, Epochs, raw, events, event_id_illegal,
+    pytest.raises(ValueError, Epochs, raw, events, event_id_illegal,
                   tmin, tmax)
     # Test on_missing
-    assert_raises(ValueError, Epochs, raw, events, 1, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events, 1, tmin, tmax,
                   on_missing='foo')
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='warning')
         nw = len(w)
-        assert_true(1 <= nw <= 2)
+        assert (1 <= nw <= 2)
         Epochs(raw, events, event_id_illegal, tmin, tmax, on_missing='ignore')
         assert_equal(len(w), nw)
 
@@ -1538,15 +1535,15 @@ def test_access_by_name():
         assert_equal(int(k), v)
 
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
-    assert_raises(KeyError, epochs.__getitem__, 'bar')
+    pytest.raises(KeyError, epochs.__getitem__, 'bar')
 
     data = epochs['a'].get_data()
     event_a = events[events[:, 2] == 1]
-    assert_true(len(data) == len(event_a))
+    assert (len(data) == len(event_a))
 
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks,
                     preload=True)
-    assert_raises(KeyError, epochs.__getitem__, 'bar')
+    pytest.raises(KeyError, epochs.__getitem__, 'bar')
     temp_fname = op.join(tempdir, 'test-epo.fif')
     epochs.save(temp_fname)
     epochs2 = read_epochs(temp_fname)
@@ -1554,7 +1551,7 @@ def test_access_by_name():
     for ep in [epochs, epochs2]:
         data = ep['a'].get_data()
         event_a = events[events[:, 2] == 1]
-        assert_true(len(data) == len(event_a))
+        assert (len(data) == len(event_a))
 
     assert_array_equal(epochs2['a'].events, epochs['a'].events)
 
@@ -1568,8 +1565,8 @@ def test_access_by_name():
     # 20 is our tolerance because epochs are written out as floats
     assert_array_almost_equal(epochs4.get_data(), epochs5.get_data(), 20)
     epochs6 = epochs3[['a', 'b']]
-    assert_true(all(np.logical_or(epochs6.events[:, 2] == 1,
-                                  epochs6.events[:, 2] == 2)))
+    assert all(np.logical_or(epochs6.events[:, 2] == 1,
+                             epochs6.events[:, 2] == 2))
     assert_array_equal(epochs.events, epochs6.events)
     assert_array_almost_equal(epochs.get_data(), epochs6.get_data(), 20)
 
@@ -1583,9 +1580,9 @@ def test_to_data_frame():
     """Test epochs Pandas exporter."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
-    assert_raises(ValueError, epochs.to_data_frame, index=['foo', 'bar'])
-    assert_raises(ValueError, epochs.to_data_frame, index='qux')
-    assert_raises(ValueError, epochs.to_data_frame, np.arange(400))
+    pytest.raises(ValueError, epochs.to_data_frame, index=['foo', 'bar'])
+    pytest.raises(ValueError, epochs.to_data_frame, index='qux')
+    pytest.raises(ValueError, epochs.to_data_frame, np.arange(400))
 
     df = epochs.to_data_frame(index=['condition', 'epoch', 'time'],
                               picks=list(range(epochs.info['nchan'])))
@@ -1596,12 +1593,12 @@ def test_to_data_frame():
     assert_array_equal(df.columns.values, epochs.ch_names)
 
     data = np.hstack(epochs.get_data())
-    assert_true((df.columns == epochs.ch_names).all())
+    assert ((df.columns == epochs.ch_names).all())
     assert_array_equal(df.values[:, 0], data[0] * 1e13)
     assert_array_equal(df.values[:, 2], data[2] * 1e15)
     for ind in ['time', ['condition', 'time'], ['condition', 'time', 'epoch']]:
         df = epochs.to_data_frame(picks=[11, 12, 14], index=ind)
-        assert_true(df.index.names == ind if isinstance(ind, list) else [ind])
+        assert (df.index.names == ind if isinstance(ind, list) else [ind])
         # test that non-indexed data were present as categorial variables
         assert_array_equal(sorted(df.reset_index().columns[:3]),
                            sorted(['time', 'condition', 'epoch']))
@@ -1614,30 +1611,30 @@ def test_epochs_proj_mixin():
         epochs = Epochs(raw, events[:4], event_id, tmin, tmax, picks=picks,
                         proj=proj)
 
-        assert_true(all(p['active'] == proj for p in epochs.info['projs']))
+        assert (all(p['active'] == proj for p in epochs.info['projs']))
 
         # test adding / deleting proj
         if proj:
             epochs.get_data()
-            assert_true(all(p['active'] == proj for p in epochs.info['projs']))
-            assert_raises(ValueError, epochs.add_proj, epochs.info['projs'][0],
+            assert (all(p['active'] == proj for p in epochs.info['projs']))
+            pytest.raises(ValueError, epochs.add_proj, epochs.info['projs'][0],
                           {'remove_existing': True})
-            assert_raises(ValueError, epochs.add_proj, 'spam')
-            assert_raises(ValueError, epochs.del_proj, 0)
+            pytest.raises(ValueError, epochs.add_proj, 'spam')
+            pytest.raises(ValueError, epochs.del_proj, 0)
         else:
             projs = deepcopy(epochs.info['projs'])
             n_proj = len(epochs.info['projs'])
             epochs.del_proj(0)
-            assert_true(len(epochs.info['projs']) == n_proj - 1)
+            assert (len(epochs.info['projs']) == n_proj - 1)
             # Test that already existing projections are not added.
             epochs.add_proj(projs, remove_existing=False)
-            assert_true(len(epochs.info['projs']) == n_proj)
+            assert (len(epochs.info['projs']) == n_proj)
             epochs.add_proj(projs[:-1], remove_existing=True)
-            assert_true(len(epochs.info['projs']) == n_proj - 1)
+            assert (len(epochs.info['projs']) == n_proj - 1)
 
     # catch no-gos.
     # wrong proj argument
-    assert_raises(ValueError, Epochs, raw, events[:4], event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events[:4], event_id, tmin, tmax,
                   picks=picks, proj='crazy')
 
     for preload in [True, False]:
@@ -1724,18 +1721,18 @@ def test_delayed_epochs():
                                              proj=proj)
                         epochs.info['sfreq'] /= decim
                         assert_equal(len(epochs), n_epochs)
-                    assert_true(raw.proj is False)
-                    assert_true(epochs.proj is
-                                (True if proj is True else False))
+                    assert (raw.proj is False)
+                    assert (epochs.proj is
+                            (True if proj is True else False))
                     if ii == 1:
                         epochs.load_data()
                     picks_data = pick_types(epochs.info, meg=True, eeg=True)
                     evoked = epochs.average(picks=picks_data)
-                    assert_equal(evoked.nave, n_epochs, epochs.drop_log)
+                    assert_equal(evoked.nave, n_epochs, str(epochs.drop_log))
                     if proj is True:
                         evoked.apply_proj()
                     else:
-                        assert_true(evoked.proj is False)
+                        assert (evoked.proj is False)
                     assert_array_equal(evoked.ch_names,
                                        np.array(epochs.ch_names)[picks_data])
                     assert_allclose(evoked.times, epochs.times)
@@ -1753,15 +1750,15 @@ def test_drop_epochs():
     events1 = events[events[:, 2] == event_id]
 
     # Bound checks
-    assert_raises(IndexError, epochs.drop, [len(epochs.events)])
-    assert_raises(IndexError, epochs.drop, [-len(epochs.events) - 1])
-    assert_raises(ValueError, epochs.drop, [[1, 2], [3, 4]])
+    pytest.raises(IndexError, epochs.drop, [len(epochs.events)])
+    pytest.raises(IndexError, epochs.drop, [-len(epochs.events) - 1])
+    pytest.raises(ValueError, epochs.drop, [[1, 2], [3, 4]])
 
     # Test selection attribute
     assert_array_equal(epochs.selection,
                        np.where(events[:, 2] == event_id)[0])
     assert_equal(len(epochs.drop_log), len(events))
-    assert_true(all(epochs.drop_log[k] == ['IGNORED']
+    assert (all(epochs.drop_log[k] == ['IGNORED']
                 for k in set(range(len(events))) - set(epochs.selection)))
 
     selection = epochs.selection.copy()
@@ -1792,11 +1789,11 @@ def test_drop_epochs_mult():
             assert_equal(len(epochs1.drop_log), len(epochs2.drop_log))
             for d1, d2 in zip(epochs1.drop_log, epochs2.drop_log):
                 if d1 == ['IGNORED']:
-                    assert_true(d2 == ['IGNORED'])
+                    assert (d2 == ['IGNORED'])
                 if d1 != ['IGNORED'] and d1 != []:
-                    assert_true((d2 == d1) or (d2 == ['IGNORED']))
+                    assert ((d2 == d1) or (d2 == ['IGNORED']))
                 if d1 == []:
-                    assert_true(d2 == [])
+                    assert (d2 == [])
             assert_array_equal(epochs1.events, epochs2.events)
             assert_array_equal(epochs1.selection, epochs2.selection)
         else:
@@ -1832,11 +1829,11 @@ def test_contains():
             test = 'seeg'
         else:
             test = meg
-        assert_true(test in epochs)
-        assert_true(not any(o in epochs for o in others))
+        assert (test in epochs)
+        assert (not any(o in epochs for o in others))
 
-    assert_raises(ValueError, epochs.__contains__, 'foo')
-    assert_raises(TypeError, epochs.__contains__, 1)
+    pytest.raises(ValueError, epochs.__contains__, 'foo')
+    pytest.raises(TypeError, epochs.__contains__, 1)
 
 
 def test_drop_channels_mixin():
@@ -1865,7 +1862,7 @@ def test_pick_channels_mixin():
                     preload=True)
     ch_names = epochs.ch_names[:3]
     epochs.preload = False
-    assert_raises(RuntimeError, epochs.drop_channels, [ch_names[0]])
+    pytest.raises(RuntimeError, epochs.drop_channels, [ch_names[0]])
     epochs.preload = True
     ch_names_orig = epochs.ch_names
     dummy = epochs.copy().pick_channels(ch_names)
@@ -1878,7 +1875,7 @@ def test_pick_channels_mixin():
     assert_equal(len(ch_names), epochs.get_data().shape[1])
 
     # Invalid picks
-    assert_raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
+    pytest.raises(ValueError, Epochs, raw, events, event_id, tmin, tmax,
                   picks=[])
 
 
@@ -1902,12 +1899,12 @@ def test_illegal_event_id():
     raw, events, picks = _get_data()
     event_id_illegal = dict(aud_l=1, does_not_exist=12345678)
 
-    assert_raises(ValueError, Epochs, raw, events, event_id_illegal, tmin,
+    pytest.raises(ValueError, Epochs, raw, events, event_id_illegal, tmin,
                   tmax, picks=picks, proj=False)
 
 
 def test_add_channels_epochs():
-    """Test adding channels"""
+    """Test adding channels."""
     raw, events, picks = _get_data()
 
     def make_epochs(picks, proj):
@@ -1950,64 +1947,64 @@ def test_add_channels_epochs():
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.events[3, 2] -= 1
-    assert_raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
-    assert_raises(ValueError, add_channels_epochs,
+    pytest.raises(ValueError, add_channels_epochs,
                   [epochs_meg, epochs_eeg[:2]])
 
     epochs_meg.info['chs'].pop(0)
     epochs_meg.info._update_redundant()
-    assert_raises(RuntimeError, add_channels_epochs, [epochs_meg, epochs_eeg])
+    pytest.raises(RuntimeError, add_channels_epochs, [epochs_meg, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['sfreq'] = None
-    assert_raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['sfreq'] += 10
-    assert_raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['chs'][1]['ch_name'] = epochs_meg2.info['ch_names'][0]
     epochs_meg2.info._update_redundant()
     with warnings.catch_warnings(record=True):  # duplicate names
-        assert_raises(RuntimeError, add_channels_epochs,
+        pytest.raises(RuntimeError, add_channels_epochs,
                       [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['dev_head_t']['to'] += 1
-    assert_raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['dev_head_t']['to'] += 1
-    assert_raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.info['expimenter'] = 'foo'
-    assert_raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(RuntimeError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.preload = False
-    assert_raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
+    pytest.raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.times += 0.4
-    assert_raises(NotImplementedError, add_channels_epochs,
+    pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.times += 0.5
-    assert_raises(NotImplementedError, add_channels_epochs,
+    pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.baseline = None
-    assert_raises(NotImplementedError, add_channels_epochs,
+    pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
     epochs_meg2.event_id['b'] = 2
-    assert_raises(NotImplementedError, add_channels_epochs,
+    pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
 
@@ -2027,13 +2024,13 @@ def test_array_epochs():
                    [1, 2] * 5]
     event_id = {'a': 1, 'b': 2}
     epochs = EpochsArray(data, info, events, tmin, event_id)
-    assert_true(str(epochs).startswith('<EpochsArray'))
+    assert (str(epochs).startswith('<EpochsArray'))
     # From GH#1963
-    assert_raises(ValueError, EpochsArray, data[:-1], info, events, tmin,
+    pytest.raises(ValueError, EpochsArray, data[:-1], info, events, tmin,
                   event_id)
-    assert_raises(ValueError, EpochsArray, data, info, events, tmin,
+    pytest.raises(ValueError, EpochsArray, data, info, events, tmin,
                   dict(a=1))
-    assert_raises(ValueError, EpochsArray, data, info, events, tmin,
+    pytest.raises(ValueError, EpochsArray, data, info, events, tmin,
                   selection=[1])
     # should be fine
     EpochsArray(data, info, events, tmin, selection=np.arange(len(events)) + 5)
@@ -2118,12 +2115,12 @@ def test_concatenate_epochs():
     epochs2 = epochs.copy()
     epochs2._data = epochs2.get_data()
     epochs2.preload = True
-    assert_raises(
+    pytest.raises(
         ValueError, concatenate_epochs,
         [epochs, epochs2.copy().drop_channels(epochs2.ch_names[:1])])
 
     epochs2.times = np.delete(epochs2.times, 1)
-    assert_raises(
+    pytest.raises(
         ValueError,
         concatenate_epochs, [epochs, epochs2])
 
@@ -2131,17 +2128,17 @@ def test_concatenate_epochs():
 
     # check if baseline is same for all epochs
     epochs2.baseline = (-0.1, None)
-    assert_raises(ValueError, concatenate_epochs, [epochs, epochs2])
+    pytest.raises(ValueError, concatenate_epochs, [epochs, epochs2])
 
     # check if dev_head_t is same
     epochs2 = epochs.copy()
     concatenate_epochs([epochs, epochs2])  # should work
     epochs2.info['dev_head_t']['trans'][:3, 3] += 0.0001
-    assert_raises(ValueError, concatenate_epochs, [epochs, epochs2])
-    assert_raises(TypeError, concatenate_epochs, 'foo')
-    assert_raises(TypeError, concatenate_epochs, [epochs, 'foo'])
+    pytest.raises(ValueError, concatenate_epochs, [epochs, epochs2])
+    pytest.raises(TypeError, concatenate_epochs, 'foo')
+    pytest.raises(TypeError, concatenate_epochs, [epochs, 'foo'])
     epochs2.info['dev_head_t'] = None
-    assert_raises(ValueError, concatenate_epochs, [epochs, epochs2])
+    pytest.raises(ValueError, concatenate_epochs, [epochs, epochs2])
     epochs.info['dev_head_t'] = None
     concatenate_epochs([epochs, epochs2])  # should work
 
@@ -2150,7 +2147,7 @@ def test_concatenate_epochs():
     epochs2 = epochs.copy()
     epochs1.event_id = dict(a=1)
     epochs2.event_id = dict(a=2)
-    assert_raises(ValueError, concatenate_epochs, [epochs1, epochs2])
+    pytest.raises(ValueError, concatenate_epochs, [epochs1, epochs2])
 
     # check events are shifted, but relative position are equal
     epochs_list = [epochs.copy() for ii in range(3)]
@@ -2158,7 +2155,7 @@ def test_concatenate_epochs():
     for ii in range(3):
         evs = epochs_cat.events[ii * len(epochs):(ii + 1) * len(epochs)]
         rel_pos = epochs_list[ii].events[:, 0] - evs[:, 0]
-        assert_true(sum(rel_pos - rel_pos[0]) == 0)
+        assert (sum(rel_pos - rel_pos[0]) == 0)
 
 
 def test_add_channels():
@@ -2175,14 +2172,14 @@ def test_add_channels():
     epoch_stim = epoch.copy().pick_types(meg=False, stim=True)
     epoch_eeg_meg = epoch.copy().pick_types(meg=True, eeg=True)
     epoch_new = epoch_meg.copy().add_channels([epoch_eeg, epoch_stim])
-    assert_true(all(ch in epoch_new.ch_names
-                    for ch in epoch_stim.ch_names + epoch_meg.ch_names))
+    assert all(ch in epoch_new.ch_names
+               for ch in epoch_stim.ch_names + epoch_meg.ch_names)
     epoch_new = epoch_meg.copy().add_channels([epoch_eeg])
 
-    assert_true(ch in epoch_new.ch_names for ch in epoch.ch_names)
+    assert (ch in epoch_new.ch_names for ch in epoch.ch_names)
     assert_array_equal(epoch_new._data, epoch_eeg_meg._data)
-    assert_true(all(ch not in epoch_new.ch_names
-                    for ch in epoch_stim.ch_names))
+    assert all(ch not in epoch_new.ch_names
+               for ch in epoch_stim.ch_names)
 
     # Now test errors
     epoch_badsf = epoch_eeg.copy()
@@ -2190,11 +2187,11 @@ def test_add_channels():
     epoch_eeg = epoch_eeg.crop(-.1, .1)
 
     epoch_meg.load_data()
-    assert_raises(RuntimeError, epoch_meg.add_channels, [epoch_nopre])
-    assert_raises(RuntimeError, epoch_meg.add_channels, [epoch_badsf])
-    assert_raises(AssertionError, epoch_meg.add_channels, [epoch_eeg])
-    assert_raises(ValueError, epoch_meg.add_channels, [epoch_meg])
-    assert_raises(TypeError, epoch_meg.add_channels, epoch_badsf)
+    pytest.raises(RuntimeError, epoch_meg.add_channels, [epoch_nopre])
+    pytest.raises(RuntimeError, epoch_meg.add_channels, [epoch_badsf])
+    pytest.raises(AssertionError, epoch_meg.add_channels, [epoch_eeg])
+    pytest.raises(ValueError, epoch_meg.add_channels, [epoch_meg])
+    pytest.raises(TypeError, epoch_meg.add_channels, epoch_badsf)
 
 
 def test_seeg_ecog():
@@ -2213,15 +2210,15 @@ def test_seeg_ecog():
 
 
 def test_default_values():
-    """Test default event_id, tmax tmin values are working correctly"""
+    """Test default event_id, tmax tmin values are working correctly."""
     raw, events = _get_data()[:2]
     epoch_1 = Epochs(raw, events[:1], preload=True)
     epoch_2 = Epochs(raw, events[:1], tmin=-0.2, tmax=0.5, preload=True)
     assert_equal(hash(epoch_1), hash(epoch_2))
 
 
-class FakeNoPandas(object):
-    def __enter__(self):
+class FakeNoPandas(object):  # noqa: D101
+    def __enter__(self):  # noqa: D105
 
         def _check(strict=True):
             if strict:
@@ -2416,5 +2413,6 @@ def test_events_list():
                                         mne.create_info(10, 1000.)),
                         events=events)
     assert_array_equal(epochs.events, np.array(events))
+
 
 run_tests_if_main()

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -259,7 +259,6 @@ def test_resample():
 
 def test_resample_stim_channel():
     """Test resampling of stim channels."""
-
     # Downsampling
     assert_array_equal(
         _resample_stim_channels([1, 0, 0, 0, 2, 0, 0, 0], 1, 2),
@@ -421,7 +420,7 @@ def test_filters():
 
 
 def test_filter_auto():
-    """Test filter auto parameters"""
+    """Test filter auto parameters."""
     # test that our overlap-add filtering doesn't introduce strange
     # artifacts (from mne_analyze mailing list 2015/06/25)
     N = 300
@@ -459,7 +458,7 @@ def test_filter_auto():
 
 
 def test_cuda():
-    """Test CUDA-based filtering"""
+    """Test CUDA-based filtering."""
     # NOTE: don't make test_cuda() the last test, or pycuda might spew
     # some warnings about clean-up failing
     # Also, using `n_jobs='cuda'` on a non-CUDA system should be fine,

--- a/mne/tests/test_fixes.py
+++ b/mne/tests/test_fixes.py
@@ -15,7 +15,7 @@ from mne.fixes import _sosfiltfilt as mne_sosfiltfilt, _sph_harm
 
 
 def test_filtfilt():
-    """Test SOS filtfilt replacement"""
+    """Test SOS filtfilt replacement."""
     x = np.r_[1, np.zeros(100)]
     # Filter with an impulse
     y = filtfilt([1, 0], [1, 0], x, padlen=0)
@@ -35,5 +35,6 @@ def test_spherical_harmonics():
             sph = _sph_harm(order, degree, az, pol)
             sph_scipy = sph_harm(order, degree, az, pol)
             assert_allclose(sph, sph_scipy, atol=1e-7)
+
 
 run_tests_if_main()

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -25,7 +25,7 @@ if len(bad) > 0:
     out.append('scipy submodules: %s' % list(bad))
 
 # check sklearn and others
-_sklearn = _pandas = _nose = _mayavi = _matplotlib = False
+_sklearn = _pandas = _mayavi = _matplotlib = False
 for x in sys.modules.keys():
     if x.startswith('sklearn') and not _sklearn:
         out.append('sklearn')
@@ -33,9 +33,6 @@ for x in sys.modules.keys():
     if x.startswith('pandas') and not _pandas:
         out.append('pandas')
         _pandas = True
-    if x.startswith('nose') and not _nose:
-        out.append('nose')
-        _nose = True
     if x.startswith('mayavi') and not _mayavi:
         out.append('mayavi')
         _mayavi = True

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -7,8 +7,8 @@ import warnings
 import numpy as np
 from scipy import sparse
 
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import assert_equal, assert_true, assert_false, assert_raises
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_equal)
 import pytest
 
 from mne.datasets import testing
@@ -150,6 +150,7 @@ def _stc_to_label(stc, src, smooth, subjects_dir=None):
 
 
 def assert_labels_equal(l0, l1, decimal=5, comment=True, color=True):
+    """Assert two labels are equal."""
     if comment:
         assert_equal(l0.comment, l1.comment)
     if color:
@@ -178,10 +179,10 @@ def test_label_subject():
     """Test label subject name extraction."""
     label = read_label(label_fname)
     assert_is(label.subject, None)
-    assert_true('unknown' in repr(label))
+    assert ('unknown' in repr(label))
     label = read_label(label_fname, subject='fsaverage')
-    assert_true(label.subject == 'fsaverage')
-    assert_true('fsaverage' in repr(label))
+    assert (label.subject == 'fsaverage')
+    assert ('fsaverage' in repr(label))
 
 
 def test_label_addition():
@@ -201,10 +202,10 @@ def test_label_addition():
     l_good.subject = 'sample'
     l_bad = l1.copy()
     l_bad.subject = 'foo'
-    assert_raises(ValueError, l_good.__add__, l_bad)
-    assert_raises(TypeError, l_good.__add__, 'foo')
-    assert_raises(ValueError, l_good.__sub__, l_bad)
-    assert_raises(TypeError, l_good.__sub__, 'foo')
+    pytest.raises(ValueError, l_good.__add__, l_bad)
+    pytest.raises(TypeError, l_good.__add__, 'foo')
+    pytest.raises(ValueError, l_good.__sub__, l_bad)
+    pytest.raises(TypeError, l_good.__sub__, 'foo')
 
     # adding non-overlapping labels
     l01 = l0 + l1
@@ -231,7 +232,7 @@ def test_label_addition():
     assert_equal(bhl.hemi, 'both')
     assert_equal(len(bhl), len(l0) + len(l2))
     assert_equal(bhl.color, l02.color)
-    assert_true('BiHemiLabel' in repr(bhl))
+    assert ('BiHemiLabel' in repr(bhl))
     # subtraction
     assert_labels_equal(bhl - l0, l2)
     assert_labels_equal(bhl - l2, l0)
@@ -241,7 +242,7 @@ def test_label_addition():
     assert_equal(bhl2.color, _blend_colors(l1.color, bhl.color))
     assert_array_equal((l2 + bhl).rh.vertices, bhl.rh.vertices)  # rh label
     assert_array_equal((bhl + bhl).lh.vertices, bhl.lh.vertices)
-    assert_raises(TypeError, bhl.__add__, 5)
+    pytest.raises(TypeError, bhl.__add__, 5)
 
     # subtraction
     bhl_ = bhl2 - l1
@@ -280,7 +281,7 @@ def test_label_in_src():
 
     # test exception
     vertices = np.append([-1], vert_in_src)
-    assert_raises(ValueError, Label(vertices, hemi='lh').fill, src)
+    pytest.raises(ValueError, Label(vertices, hemi='lh').fill, src)
 
     # test filling empty label
     label = Label([], hemi='lh')
@@ -295,8 +296,8 @@ def test_label_io_and_time_course_estimates():
     label = read_label(real_label_fname)
     stc_label = stc.in_label(label)
 
-    assert_true(len(stc_label.times) == stc_label.data.shape[1])
-    assert_true(len(stc_label.vertices[0]) == stc_label.data.shape[0])
+    assert (len(stc_label.times) == stc_label.data.shape[1])
+    assert (len(stc_label.vertices[0]) == stc_label.data.shape[0])
 
 
 @testing.requires_testing_data
@@ -325,11 +326,11 @@ def test_label_io():
 
 
 def _assert_labels_equal(labels_a, labels_b, ignore_pos=False):
-    """Make sure two sets of labels are equal"""
+    """Ensure two sets of labels are equal."""
     for label_a, label_b in zip(labels_a, labels_b):
         assert_array_equal(label_a.vertices, label_b.vertices)
-        assert_true(label_a.name == label_b.name)
-        assert_true(label_a.hemi == label_b.hemi)
+        assert (label_a.name == label_b.name)
+        assert (label_a.hemi == label_b.hemi)
         if not ignore_pos:
             assert_array_equal(label_a.pos, label_b.pos)
 
@@ -352,7 +353,7 @@ def test_annot_io():
     shutil.copy(os.path.join(surf_src, 'rh.white'), surf_dir)
 
     # read original labels
-    assert_raises(IOError, read_labels_from_annot, subject, 'PALS_B12_Lobesey',
+    pytest.raises(IOError, read_labels_from_annot, subject, 'PALS_B12_Lobesey',
                   subjects_dir=tempdir)
     labels = read_labels_from_annot(subject, 'PALS_B12_Lobes',
                                     subjects_dir=tempdir)
@@ -371,8 +372,8 @@ def test_annot_io():
     write_labels_to_annot(parc, subject, 'myparc2', hemi='lh',
                           subjects_dir=tempdir)
     annot_fname = os.path.join(tempdir, subject, 'label', '%sh.myparc2.annot')
-    assert_true(os.path.isfile(annot_fname % 'l'))
-    assert_false(os.path.isfile(annot_fname % 'r'))
+    assert os.path.isfile(annot_fname % 'l')
+    assert not os.path.isfile(annot_fname % 'r')
     parc1 = read_labels_from_annot(subject, 'myparc2',
                                    annot_fname=annot_fname % 'l',
                                    subjects_dir=tempdir)
@@ -385,17 +386,17 @@ def test_annot_io():
 def test_read_labels_from_annot():
     """Test reading labels from FreeSurfer parcellation."""
     # test some invalid inputs
-    assert_raises(ValueError, read_labels_from_annot, 'sample', hemi='bla',
+    pytest.raises(ValueError, read_labels_from_annot, 'sample', hemi='bla',
                   subjects_dir=subjects_dir)
-    assert_raises(ValueError, read_labels_from_annot, 'sample',
+    pytest.raises(ValueError, read_labels_from_annot, 'sample',
                   annot_fname='bla.annot', subjects_dir=subjects_dir)
 
     # read labels using hemi specification
     labels_lh = read_labels_from_annot('sample', hemi='lh',
                                        subjects_dir=subjects_dir)
     for label in labels_lh:
-        assert_true(label.name.endswith('-lh'))
-        assert_true(label.hemi == 'lh')
+        assert (label.name.endswith('-lh'))
+        assert (label.hemi == 'lh')
         assert_is_not(label.color, None)
 
     # read labels using annot_fname
@@ -403,8 +404,8 @@ def test_read_labels_from_annot():
     labels_rh = read_labels_from_annot('sample', annot_fname=annot_fname,
                                        subjects_dir=subjects_dir)
     for label in labels_rh:
-        assert_true(label.name.endswith('-rh'))
-        assert_true(label.hemi == 'rh')
+        assert (label.name.endswith('-rh'))
+        assert (label.hemi == 'rh')
         assert_is_not(label.color, None)
 
     # combine the lh, rh, labels and sort them
@@ -422,18 +423,18 @@ def test_read_labels_from_annot():
     _assert_labels_equal(labels_lhrh, labels_both)
 
     # aparc has 68 cortical labels
-    assert_true(len(labels_both) == 68)
+    assert (len(labels_both) == 68)
 
     # test regexp
     label = read_labels_from_annot('sample', parc='aparc.a2009s',
                                    regexp='Angu', subjects_dir=subjects_dir)[0]
-    assert_true(label.name == 'G_pariet_inf-Angular-lh')
+    assert (label.name == 'G_pariet_inf-Angular-lh')
     # silly, but real regexp:
     label = read_labels_from_annot('sample', 'aparc.a2009s',
                                    regexp='.*-.{4,}_.{3,3}-L',
                                    subjects_dir=subjects_dir)[0]
-    assert_true(label.name == 'G_oc-temp_med-Lingual-lh')
-    assert_raises(RuntimeError, read_labels_from_annot, 'sample', parc='aparc',
+    assert (label.name == 'G_oc-temp_med-Lingual-lh')
+    pytest.raises(RuntimeError, read_labels_from_annot, 'sample', parc='aparc',
                   annot_fname=annot_fname, regexp='JackTheRipper',
                   subjects_dir=subjects_dir)
 
@@ -468,24 +469,24 @@ def test_write_labels_to_annot():
     # test automatic filenames
     dst = op.join(tempdir, 'sample', 'label', '%s.%s.annot')
     write_labels_to_annot(labels, 'sample', 'test1', subjects_dir=tempdir)
-    assert_true(op.exists(dst % ('lh', 'test1')))
-    assert_true(op.exists(dst % ('rh', 'test1')))
+    assert (op.exists(dst % ('lh', 'test1')))
+    assert (op.exists(dst % ('rh', 'test1')))
     # lh only
     for label in labels:
         if label.hemi == 'lh':
             break
     write_labels_to_annot([label], 'sample', 'test2', subjects_dir=tempdir)
-    assert_true(op.exists(dst % ('lh', 'test2')))
-    assert_true(op.exists(dst % ('rh', 'test2')))
+    assert (op.exists(dst % ('lh', 'test2')))
+    assert (op.exists(dst % ('rh', 'test2')))
     # rh only
     for label in labels:
         if label.hemi == 'rh':
             break
     write_labels_to_annot([label], 'sample', 'test3', subjects_dir=tempdir)
-    assert_true(op.exists(dst % ('lh', 'test3')))
-    assert_true(op.exists(dst % ('rh', 'test3')))
+    assert (op.exists(dst % ('lh', 'test3')))
+    assert (op.exists(dst % ('rh', 'test3')))
     # label alone
-    assert_raises(TypeError, write_labels_to_annot, labels[0], 'sample',
+    pytest.raises(TypeError, write_labels_to_annot, labels[0], 'sample',
                   'test4', subjects_dir=tempdir)
 
     # write left and right hemi labels with filenames:
@@ -522,7 +523,7 @@ def test_write_labels_to_annot():
         assert_labels_equal(label, labels3[idx])
 
     # make sure we can't overwrite things
-    assert_raises(ValueError, write_labels_to_annot, labels, 'sample',
+    pytest.raises(ValueError, write_labels_to_annot, labels, 'sample',
                   annot_fname=fnames[0], subjects_dir=subjects_dir)
 
     # however, this works
@@ -538,13 +539,13 @@ def test_write_labels_to_annot():
 
     # duplicate color
     labels_[0].color = labels_[2].color
-    assert_raises(ValueError, write_labels_to_annot, labels_, 'sample',
+    pytest.raises(ValueError, write_labels_to_annot, labels_, 'sample',
                   annot_fname=fnames[0], overwrite=True,
                   subjects_dir=subjects_dir)
 
     # invalid color inputs
     labels_[0].color = (1.1, 1., 1., 1.)
-    assert_raises(ValueError, write_labels_to_annot, labels_, 'sample',
+    pytest.raises(ValueError, write_labels_to_annot, labels_, 'sample',
                   annot_fname=fnames[0], overwrite=True,
                   subjects_dir=subjects_dir)
 
@@ -553,7 +554,7 @@ def test_write_labels_to_annot():
     cuneus_lh = labels[6]
     precuneus_lh = labels[50]
     labels_.append(precuneus_lh + cuneus_lh)
-    assert_raises(ValueError, write_labels_to_annot, labels_, 'sample',
+    pytest.raises(ValueError, write_labels_to_annot, labels_, 'sample',
                   annot_fname=fnames[0], overwrite=True,
                   subjects_dir=subjects_dir)
 
@@ -567,12 +568,12 @@ def test_write_labels_to_annot():
     label0 = labels_lh[0]
     label1 = labels_reloaded[-1]
     assert_equal(label1.name, "unknown-lh")
-    assert_true(np.all(np.in1d(label0.vertices, label1.vertices)))
+    assert (np.all(np.in1d(label0.vertices, label1.vertices)))
 
     # unnamed labels
     labels4 = labels[:]
     labels4[0].name = None
-    assert_raises(ValueError, write_labels_to_annot, labels4,
+    pytest.raises(ValueError, write_labels_to_annot, labels4,
                   annot_fname=fnames[0])
 
 
@@ -585,7 +586,7 @@ def test_split_label():
     lingual = aparc[0]
 
     # Test input error
-    assert_raises(ValueError, lingual.split, 'bad_input_string')
+    pytest.raises(ValueError, lingual.split, 'bad_input_string')
 
     # split with names
     parts = ('lingual_post', 'lingual_ant')
@@ -651,35 +652,35 @@ def test_stc_to_label():
         labels_lh, labels_rh = stc_to_label(stc, src=src, smooth=True,
                                             connected=True)
 
-    assert_true(len(w) > 0)
-    assert_raises(ValueError, stc_to_label, stc, 'sample', smooth=True,
+    assert (len(w) > 0)
+    pytest.raises(ValueError, stc_to_label, stc, 'sample', smooth=True,
                   connected=True)
-    assert_raises(RuntimeError, stc_to_label, stc, smooth=True, src=src_bad,
+    pytest.raises(RuntimeError, stc_to_label, stc, smooth=True, src=src_bad,
                   connected=True)
     assert_equal(len(labels_lh), 1)
     assert_equal(len(labels_rh), 1)
 
     # test getting tris
     tris = labels_lh[0].get_tris(src[0]['use_tris'], vertices=stc.vertices[0])
-    assert_raises(ValueError, spatial_tris_connectivity, tris,
+    pytest.raises(ValueError, spatial_tris_connectivity, tris,
                   remap_vertices=False)
     connectivity = spatial_tris_connectivity(tris, remap_vertices=True)
-    assert_true(connectivity.shape[0] == len(stc.vertices[0]))
+    assert (connectivity.shape[0] == len(stc.vertices[0]))
 
     # "src" as a subject name
-    assert_raises(TypeError, stc_to_label, stc, src=1, smooth=False,
+    pytest.raises(TypeError, stc_to_label, stc, src=1, smooth=False,
                   connected=False, subjects_dir=subjects_dir)
-    assert_raises(ValueError, stc_to_label, stc, src=SourceSpaces([src[0]]),
+    pytest.raises(ValueError, stc_to_label, stc, src=SourceSpaces([src[0]]),
                   smooth=False, connected=False, subjects_dir=subjects_dir)
-    assert_raises(ValueError, stc_to_label, stc, src='sample', smooth=False,
+    pytest.raises(ValueError, stc_to_label, stc, src='sample', smooth=False,
                   connected=True, subjects_dir=subjects_dir)
-    assert_raises(ValueError, stc_to_label, stc, src='sample', smooth=True,
+    pytest.raises(ValueError, stc_to_label, stc, src='sample', smooth=True,
                   connected=False, subjects_dir=subjects_dir)
     labels_lh, labels_rh = stc_to_label(stc, src='sample', smooth=False,
                                         connected=False,
                                         subjects_dir=subjects_dir)
-    assert_true(len(labels_lh) > 1)
-    assert_true(len(labels_rh) > 1)
+    assert (len(labels_lh) > 1)
+    assert (len(labels_rh) > 1)
 
     # with smooth='patch'
     with warnings.catch_warnings(record=True) as w:  # connectedness warning
@@ -703,12 +704,12 @@ def test_morph():
     for grade in [5, [np.arange(10242), np.arange(10242)], np.arange(10242)]:
         label = label_orig.copy()
         # this should throw an error because the label has all zero values
-        assert_raises(ValueError, label.morph, 'sample', 'fsaverage')
+        pytest.raises(ValueError, label.morph, 'sample', 'fsaverage')
         label.values.fill(1)
         label = label.morph(None, 'fsaverage', 5, grade, subjects_dir, 1)
         label = label.morph('fsaverage', 'sample', 5, None, subjects_dir, 2)
-        assert_true(np.in1d(label_orig.vertices, label.vertices).all())
-        assert_true(len(label.vertices) < 3 * len(label_orig.vertices))
+        assert (np.in1d(label_orig.vertices, label.vertices).all())
+        assert (len(label.vertices) < 3 * len(label_orig.vertices))
         vals.append(label.vertices)
     assert_array_equal(vals[0], vals[1])
     # make sure label smoothing can run
@@ -718,9 +719,9 @@ def test_morph():
         label.hemi = hemi
         with warnings.catch_warnings(record=True):  # morph map maybe missing
             label.morph(None, 'fsaverage', 5, verts, subjects_dir, 2)
-    assert_raises(TypeError, label.morph, None, 1, 5, verts,
+    pytest.raises(TypeError, label.morph, None, 1, 5, verts,
                   subjects_dir, 2)
-    assert_raises(TypeError, label.morph, None, 'fsaverage', 5.5, verts,
+    pytest.raises(TypeError, label.morph, None, 'fsaverage', 5.5, verts,
                   subjects_dir, 2)
     with warnings.catch_warnings(record=True):  # morph map could be missing
         label.smooth(subjects_dir=subjects_dir)  # make sure this runs
@@ -740,8 +741,8 @@ def test_grow_labels():
     tgt_hemis = ['lh', 'rh']
     for label, seed, hemi, sh, name in zip(labels, seeds, tgt_hemis,
                                            should_be_in, tgt_names):
-        assert_true(np.any(label.vertices == seed))
-        assert_true(np.all(np.in1d(sh, label.vertices)))
+        assert (np.any(label.vertices == seed))
+        assert (np.all(np.in1d(sh, label.vertices)))
         assert_equal(label.hemi, hemi)
         assert_equal(label.name, name)
 
@@ -791,7 +792,7 @@ def test_random_parcellation():
         for label in labels:
             if label.hemi == hemi:
                 # test that labels are not empty
-                assert_true(len(label.vertices) > 0)
+                assert (len(label.vertices) > 0)
 
                 # vertices of hemi covered by labels
                 vertices_total = np.append(vertices_total, label.vertices)
@@ -853,10 +854,10 @@ def test_label_center_of_mass():
     for label, expected in zip([labels[2], labels[3], labels[-5]],
                                [141162, 145221, 55979]):
         label.values[:] = -1
-        assert_raises(ValueError, label.center_of_mass,
+        pytest.raises(ValueError, label.center_of_mass,
                       subjects_dir=subjects_dir)
         label.values[:] = 0
-        assert_raises(ValueError, label.center_of_mass,
+        pytest.raises(ValueError, label.center_of_mass,
                       subjects_dir=subjects_dir)
         label.values[:] = 1
         assert_equal(label.center_of_mass(subjects_dir=subjects_dir), expected)
@@ -880,11 +881,11 @@ def test_label_center_of_mass():
                                           restrict_vertices=src),
                      src_expected)
     # degenerate cases
-    assert_raises(ValueError, label.center_of_mass, subjects_dir=subjects_dir,
+    pytest.raises(ValueError, label.center_of_mass, subjects_dir=subjects_dir,
                   restrict_vertices='foo')
-    assert_raises(TypeError, label.center_of_mass, subjects_dir=subjects_dir,
+    pytest.raises(TypeError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf=1)
-    assert_raises(IOError, label.center_of_mass, subjects_dir=subjects_dir,
+    pytest.raises(IOError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf='foo')
 
 

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -4,10 +4,11 @@
 # License: BSD (3-clause)
 
 import os
-from nose.tools import assert_raises
 from unittest import SkipTest
 from os import path as op
 import sys
+
+import pytest
 
 from mne.utils import run_tests_if_main, _TempDir, _get_root_dir
 
@@ -27,7 +28,7 @@ skip_files = (
 
 
 def _assert_line_endings(dir_):
-    """Check line endings for a directory"""
+    """Check line endings for a directory."""
     if sys.platform == 'win32':
         raise SkipTest('Skipping line endings check on Windows')
     report = list()
@@ -56,17 +57,17 @@ def _assert_line_endings(dir_):
 
 
 def test_line_endings():
-    """Test line endings of mne-python"""
+    """Test line endings of mne-python."""
     tempdir = _TempDir()
     with open(op.join(tempdir, 'foo'), 'wb') as fid:
         fid.write('bad\r\ngood\n'.encode('ascii'))
     _assert_line_endings(tempdir)
     with open(op.join(tempdir, 'bad.py'), 'wb') as fid:
         fid.write(b'\x97')
-    assert_raises(AssertionError, _assert_line_endings, tempdir)
+    pytest.raises(AssertionError, _assert_line_endings, tempdir)
     with open(op.join(tempdir, 'bad.py'), 'wb') as fid:
         fid.write('bad\r\ngood\n'.encode('ascii'))
-    assert_raises(AssertionError, _assert_line_endings, tempdir)
+    pytest.raises(AssertionError, _assert_line_endings, tempdir)
     # now check mne
     _assert_line_endings(_get_root_dir())
 

--- a/mne/tests/test_misc.py
+++ b/mne/tests/test_misc.py
@@ -1,5 +1,4 @@
 import os.path as op
-from nose.tools import assert_true
 
 from mne.misc import parse_config
 
@@ -8,7 +7,6 @@ ave_fname = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data',
 
 
 def test_parse_ave():
-    """Test parsing of .ave file
-    """
+    """Test parsing of .ave file."""
     conditions = parse_config(ave_fname)
-    assert_true(len(conditions) == 4)
+    assert len(conditions) == 4

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -89,7 +89,7 @@ def test_bad_proj():
 
 
 def _check_warnings(raw, events, picks=None, count=3):
-    """Helper to count warnings."""
+    """Count warnings."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         Epochs(raw, events, dict(aud_l=1, vis_l=3),
@@ -228,7 +228,7 @@ def test_compute_proj_epochs():
 
 @pytest.mark.slowtest
 def test_compute_proj_raw():
-    """Test SSP computation on raw"""
+    """Test SSP computation on raw."""
     tempdir = _TempDir()
     # Test that the raw projectors work
     raw_time = 2.5  # Do shorter amount for speed
@@ -323,7 +323,7 @@ def test_make_eeg_average_ref_proj():
 
 
 def test_has_eeg_average_ref_proj():
-    """Test checking whether an EEG average reference exists"""
+    """Test checking whether an EEG average reference exists."""
     assert not _has_eeg_average_ref_proj([])
 
     raw = read_raw_fif(raw_fname)
@@ -332,7 +332,7 @@ def test_has_eeg_average_ref_proj():
 
 
 def test_needs_eeg_average_ref_proj():
-    """Test checking whether a recording needs an EEG average reference"""
+    """Test checking whether a recording needs an EEG average reference."""
     raw = read_raw_fif(raw_fname)
     assert _needs_eeg_average_ref_proj(raw.info)
 

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -11,7 +11,7 @@ import shutil
 import warnings
 
 import numpy as np
-from nose.tools import assert_true, assert_equal, assert_raises
+from numpy.testing import assert_equal
 import pytest
 
 from mne import Epochs, read_events, read_evokeds
@@ -83,15 +83,15 @@ def test_render_report():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         report.parse_folder(data_path=tempdir, on_error='raise')
-    assert_true(len(w) >= 1)
-    assert_true(repr(report))
+    assert (len(w) >= 1)
+    assert (repr(report))
 
     # Check correct paths and filenames
     fnames = glob.glob(op.join(tempdir, '*.fif'))
     for fname in fnames:
-        assert_true(op.basename(fname) in
-                    [op.basename(x) for x in report.fnames])
-        assert_true(''.join(report.html).find(op.basename(fname)) != -1)
+        assert (op.basename(fname) in
+                [op.basename(x) for x in report.fnames])
+        assert (''.join(report.html).find(op.basename(fname)) != -1)
 
     assert_equal(len(report.fnames), len(fnames))
     assert_equal(len(report.html), len(report.fnames))
@@ -101,7 +101,7 @@ def test_render_report():
     report.data_path = tempdir
     fname = op.join(tempdir, 'report.html')
     report.save(fname=fname, open_browser=False)
-    assert_true(op.isfile(fname))
+    assert (op.isfile(fname))
     with open(fname, 'rb') as fid:
         html = fid.read().decode('utf-8')
     assert '(MaxShield on)' in html
@@ -111,30 +111,30 @@ def test_render_report():
 
     # Check saving same report to new filename
     report.save(fname=op.join(tempdir, 'report2.html'), open_browser=False)
-    assert_true(op.isfile(op.join(tempdir, 'report2.html')))
+    assert (op.isfile(op.join(tempdir, 'report2.html')))
 
     # Check overwriting file
     report.save(fname=op.join(tempdir, 'report.html'), open_browser=False,
                 overwrite=True)
-    assert_true(op.isfile(op.join(tempdir, 'report.html')))
+    assert (op.isfile(op.join(tempdir, 'report.html')))
 
     # Check pattern matching with multiple patterns
     pattern = ['*raw.fif', '*eve.fif']
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         report.parse_folder(data_path=tempdir, pattern=pattern)
-    assert_true(len(w) >= 1)
-    assert_true(repr(report))
+    assert (len(w) >= 1)
+    assert (repr(report))
 
     fnames = glob.glob(op.join(tempdir, '*.raw')) + \
         glob.glob(op.join(tempdir, '*.raw'))
     for fname in fnames:
-        assert_true(op.basename(fname) in
-                    [op.basename(x) for x in report.fnames])
-        assert_true(''.join(report.html).find(op.basename(fname)) != -1)
+        assert (op.basename(fname) in
+                [op.basename(x) for x in report.fnames])
+        assert (''.join(report.html).find(op.basename(fname)) != -1)
 
-    assert_raises(ValueError, Report, image_format='foo')
-    assert_raises(ValueError, Report, image_format=None)
+    pytest.raises(ValueError, Report, image_format='foo')
+    pytest.raises(ValueError, Report, image_format=None)
 
     # SVG rendering
     report = Report(info_fname=raw_fname_new, subjects_dir=subjects_dir,
@@ -160,11 +160,11 @@ def test_render_add_sections():
     report.add_figs_to_section(figs=fig,  # test non-list input
                                captions=['evoked response'], scale=1.2,
                                image_format='svg')
-    assert_raises(ValueError, report.add_figs_to_section, figs=[fig, fig],
+    pytest.raises(ValueError, report.add_figs_to_section, figs=[fig, fig],
                   captions='H')
-    assert_raises(ValueError, report.add_figs_to_section, figs=fig,
+    pytest.raises(ValueError, report.add_figs_to_section, figs=fig,
                   captions=['foo'], scale=0, image_format='svg')
-    assert_raises(ValueError, report.add_figs_to_section, figs=fig,
+    pytest.raises(ValueError, report.add_figs_to_section, figs=fig,
                   captions=['foo'], scale=1e-10, image_format='svg')
     # need to recreate because calls above change size
     fig = plt.plot([1, 2], [1, 2])[0].figure
@@ -178,10 +178,10 @@ def test_render_add_sections():
     report.add_images_to_section(fnames=[img_fname],
                                  captions=['evoked response'])
 
-    assert_raises(ValueError, report.add_images_to_section,
+    pytest.raises(ValueError, report.add_images_to_section,
                   fnames=[img_fname, img_fname], captions='H')
 
-    assert_raises(ValueError, report.add_images_to_section,
+    pytest.raises(ValueError, report.add_images_to_section,
                   fnames=['foobar.xxx'], captions='H')
 
     evoked = read_evokeds(evoked_fname, condition='Left Auditory',
@@ -191,7 +191,7 @@ def test_render_add_sections():
 
     report.add_figs_to_section(figs=fig,  # test non-list input
                                captions='random image', scale=1.2)
-    assert_true(repr(report))
+    assert (repr(report))
 
 
 @pytest.mark.slowtest
@@ -212,7 +212,7 @@ def test_render_mri():
         report.parse_folder(data_path=tempdir, mri_decim=30, pattern='*',
                             n_jobs=2)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
-    assert_true(repr(report))
+    assert (repr(report))
 
 
 @testing.requires_testing_data
@@ -228,7 +228,7 @@ def test_render_mri_without_bem():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         report.parse_folder(tempdir)
-    assert_true(len(w) >= 1)
+    assert (len(w) >= 1)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
 
@@ -243,8 +243,8 @@ def test_add_htmls_to_section():
     report.add_htmls_to_section(html, caption, section)
     idx = report._sectionlabels.index('report_' + section)
     html_compare = report.html[idx]
-    assert_true(html in html_compare)
-    assert_true(repr(report))
+    assert (html in html_compare)
+    assert (repr(report))
 
 
 def test_add_slider_to_section():
@@ -264,12 +264,12 @@ def test_add_slider_to_section():
     report.add_slider_to_section(figs, section=section)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
-    assert_raises(NotImplementedError, report.add_slider_to_section,
+    pytest.raises(NotImplementedError, report.add_slider_to_section,
                   [figs, figs])
-    assert_raises(ValueError, report.add_slider_to_section, figs, ['wug'])
-    assert_raises(TypeError, report.add_slider_to_section, figs, 'wug')
+    pytest.raises(ValueError, report.add_slider_to_section, figs, ['wug'])
+    pytest.raises(TypeError, report.add_slider_to_section, figs, 'wug')
     # need at least 2
-    assert_raises(ValueError, report.add_slider_to_section, figs[:1], 'wug')
+    pytest.raises(ValueError, report.add_slider_to_section, figs[:1], 'wug')
 
     # Smoke test that SVG w/unicode can be added
     report = Report()
@@ -287,9 +287,9 @@ def test_validate_input():
     comments = ['First letter of the alphabet.',
                 'Second letter of the alphabet',
                 'Third letter of the alphabet']
-    assert_raises(ValueError, report._validate_input, items, captions[:-1],
+    pytest.raises(ValueError, report._validate_input, items, captions[:-1],
                   section, comments=None)
-    assert_raises(ValueError, report._validate_input, items, captions, section,
+    pytest.raises(ValueError, report._validate_input, items, captions, section,
                   comments=comments[:-1])
     values = report._validate_input(items, captions, section, comments=None)
     items_new, captions_new, comments_new = values

--- a/mne/tests/test_selection.py
+++ b/mne/tests/test_selection.py
@@ -1,6 +1,6 @@
 import os.path as op
 
-from nose.tools import assert_true, assert_equal, assert_raises
+import pytest
 
 from mne import read_selection
 from mne.io import read_raw_fif
@@ -23,28 +23,29 @@ def test_read_selection():
     raw = read_raw_fif(raw_fname)
     for i, name in enumerate(sel_names):
         sel = read_selection(name)
-        assert_true(ch_names[i] in sel)
+        assert ch_names[i] in sel
         sel_info = read_selection(name, info=raw.info)
-        assert_equal(sel, sel_info)
+        assert sel == sel_info
 
     # test some combinations
     all_ch = read_selection(['L', 'R'])
     left = read_selection('L')
     right = read_selection('R')
 
-    assert_true(len(all_ch) == len(left) + len(right))
-    assert_true(len(set(left).intersection(set(right))) == 0)
+    assert len(all_ch) == len(left) + len(right)
+    assert len(set(left).intersection(set(right))) == 0
 
     frontal = read_selection('frontal')
     occipital = read_selection('Right-occipital')
-    assert_true(len(set(frontal).intersection(set(occipital))) == 0)
+    assert len(set(frontal).intersection(set(occipital))) == 0
 
     ch_names_new = [ch.replace(' ', '') for ch in ch_names]
     raw_new = read_raw_fif(raw_new_fname)
     for i, name in enumerate(sel_names):
         sel = read_selection(name, info=raw_new.info)
-        assert_true(ch_names_new[i] in sel)
+        assert ch_names_new[i] in sel
 
-    assert_raises(TypeError, read_selection, name, info='foo')
+    pytest.raises(TypeError, read_selection, name, info='foo')
+
 
 run_tests_if_main()

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
 import os.path as op
-from nose.tools import assert_true, assert_raises
 import warnings
 from copy import deepcopy
 
@@ -71,7 +69,7 @@ def test_spatial_inter_hemi_connectivity():
     conn = spatial_inter_hemi_connectivity(src, 10e-3)
     conn = conn.tocsr()
     n_src = conn.shape[0]
-    assert_true(n_src * 0.02 < conn.data.size < n_src * 0.10)
+    assert (n_src * 0.02 < conn.data.size < n_src * 0.10)
     assert_equal(conn[:src[0]['nuse'], :src[0]['nuse']].data.size, 0)
     assert_equal(conn[-src[1]['nuse']:, -src[1]['nuse']:].data.size, 0)
     c = (conn.T + conn) / 2. - conn
@@ -89,7 +87,7 @@ def test_spatial_inter_hemi_connectivity():
                                         subjects_dir=subjects_dir)
         use_labels = [l.name[:-3] for l in labels
                       if np.in1d(l.vertices, has_neighbors).any()]
-        assert_true(set(use_labels) - set(good_labels) == set())
+        assert (set(use_labels) - set(good_labels) == set())
 
 
 @pytest.mark.slowtest
@@ -111,23 +109,23 @@ def test_volume_stc():
         for _ in range(2):
             stc_new.save(fname_temp)
             stc_new = read_source_estimate(fname_temp)
-            assert_true(isinstance(stc_new, VolSourceEstimate))
+            assert (isinstance(stc_new, VolSourceEstimate))
             assert_array_equal(vertno_read, stc_new.vertices)
             assert_array_almost_equal(stc.data, stc_new.data)
 
     # now let's actually read a MNE-C processed file
     stc = read_source_estimate(fname_vol, 'sample')
-    assert_true(isinstance(stc, VolSourceEstimate))
+    assert (isinstance(stc, VolSourceEstimate))
 
-    assert_true('sample' in repr(stc))
+    assert ('sample' in repr(stc))
     stc_new = stc
-    assert_raises(ValueError, stc.save, fname_vol, ftype='whatever')
+    pytest.raises(ValueError, stc.save, fname_vol, ftype='whatever')
     for ftype in ['w', 'h5']:
         for _ in range(2):
             fname_temp = op.join(tempdir, 'temp-vol.%s' % ftype)
             stc_new.save(fname_temp, ftype=ftype)
             stc_new = read_source_estimate(fname_temp)
-            assert_true(isinstance(stc_new, VolSourceEstimate))
+            assert (isinstance(stc_new, VolSourceEstimate))
             assert_array_equal(stc.vertices, stc_new.vertices)
             assert_array_almost_equal(stc.data, stc_new.data)
 
@@ -145,13 +143,13 @@ def test_save_vol_stc_as_nifti():
 
     # now let's actually read a MNE-C processed file
     stc = read_source_estimate(fname_vol, 'sample')
-    assert_true(isinstance(stc, VolSourceEstimate))
+    assert (isinstance(stc, VolSourceEstimate))
 
     stc.save_as_volume(vol_fname, src,
                        dest='surf', mri_resolution=False)
     with warnings.catch_warnings(record=True):  # nib<->numpy
         img = nib.load(vol_fname)
-    assert_true(img.shape == src[0]['shape'] + (len(stc.times),))
+    assert (img.shape == src[0]['shape'] + (len(stc.times),))
 
     with warnings.catch_warnings(record=True):  # nib<->numpy
         t1_img = nib.load(fname_t1)
@@ -159,12 +157,12 @@ def test_save_vol_stc_as_nifti():
                        dest='mri', mri_resolution=True)
     with warnings.catch_warnings(record=True):  # nib<->numpy
         img = nib.load(vol_fname)
-    assert_true(img.shape == t1_img.shape + (len(stc.times),))
+    assert (img.shape == t1_img.shape + (len(stc.times),))
     assert_allclose(img.affine, t1_img.affine, atol=1e-5)
 
     # export without saving
     img = stc.as_volume(src, dest='mri', mri_resolution=True)
-    assert_true(img.shape == t1_img.shape + (len(stc.times),))
+    assert (img.shape == t1_img.shape + (len(stc.times),))
     assert_allclose(img.affine, t1_img.affine, atol=1e-5)
 
     src = SourceSpaces([src[0], src[0]])
@@ -172,7 +170,7 @@ def test_save_vol_stc_as_nifti():
                             [stc.vertices, stc.vertices],
                             tmin=stc.tmin, tstep=stc.tstep)
     img = stc.as_volume(src, dest='mri', mri_resolution=False)
-    assert_true(img.shape == src[0]['shape'] + (len(stc.times),))
+    assert (img.shape == src[0]['shape'] + (len(stc.times),))
 
 
 @testing.requires_testing_data
@@ -185,7 +183,7 @@ def test_expand():
                                     stc_.subject)
 
     for stc in [stc_, vec_stc_]:
-        assert_true('sample' in repr(stc))
+        assert ('sample' in repr(stc))
         labels_lh = read_labels_from_annot('sample', 'aparc', 'lh',
                                            subjects_dir=subjects_dir)
         new_label = labels_lh[0] + labels_lh[1]
@@ -194,10 +192,10 @@ def test_expand():
         stc_new.data.fill(0)
         for label in labels_lh[:2]:
             stc_new += stc.in_label(label).expand(stc_limited.vertices)
-        assert_raises(TypeError, stc_new.expand, stc_limited.vertices[0])
-        assert_raises(ValueError, stc_new.expand, [stc_limited.vertices[0]])
+        pytest.raises(TypeError, stc_new.expand, stc_limited.vertices[0])
+        pytest.raises(ValueError, stc_new.expand, [stc_limited.vertices[0]])
         # make sure we can't add unless vertno agree
-        assert_raises(ValueError, stc.__add__, stc.in_label(labels_lh[0]))
+        pytest.raises(ValueError, stc.__add__, stc.in_label(labels_lh[0]))
 
 
 def _fake_stc(n_time=10):
@@ -240,23 +238,23 @@ def test_stc_attributes():
         setattr(stc, attr, val)
 
     # .times is read-only
-    assert_raises(ValueError, attempt_times_mutation, stc)
-    assert_raises(ValueError, attempt_assignment, stc, 'times', [1])
+    pytest.raises(ValueError, attempt_times_mutation, stc)
+    pytest.raises(ValueError, attempt_assignment, stc, 'times', [1])
 
     # Changing .tmin or .tstep re-computes .times
     stc.tmin = 1
-    assert_true(type(stc.tmin) == float)
+    assert (type(stc.tmin) == float)
     assert_array_almost_equal(
         stc.times, [1., 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9])
 
     stc.tstep = 1
-    assert_true(type(stc.tstep) == float)
+    assert (type(stc.tstep) == float)
     assert_array_almost_equal(
         stc.times, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.])
 
     # tstep <= 0 is not allowed
-    assert_raises(ValueError, attempt_assignment, stc, 'tstep', 0)
-    assert_raises(ValueError, attempt_assignment, stc, 'tstep', -1)
+    pytest.raises(ValueError, attempt_assignment, stc, 'tstep', 0)
+    pytest.raises(ValueError, attempt_assignment, stc, 'tstep', -1)
 
     # Changing .data re-computes .times
     stc.data = np.random.rand(100, 5)
@@ -264,14 +262,14 @@ def test_stc_attributes():
         stc.times, [1., 2., 3., 4., 5.])
 
     # .data must match the number of vertices
-    assert_raises(ValueError, attempt_assignment, stc, 'data', [[1]])
-    assert_raises(ValueError, attempt_assignment, stc, 'data', None)
+    pytest.raises(ValueError, attempt_assignment, stc, 'data', [[1]])
+    pytest.raises(ValueError, attempt_assignment, stc, 'data', None)
 
     # .data much match number of dimensions
-    assert_raises(ValueError, attempt_assignment, stc, 'data', np.arange(100))
-    assert_raises(ValueError, attempt_assignment, vec_stc, 'data',
+    pytest.raises(ValueError, attempt_assignment, stc, 'data', np.arange(100))
+    pytest.raises(ValueError, attempt_assignment, vec_stc, 'data',
                   [np.arange(100)])
-    assert_raises(ValueError, attempt_assignment, vec_stc, 'data',
+    pytest.raises(ValueError, attempt_assignment, vec_stc, 'data',
                   [[[np.arange(100)]]])
 
     # .shape attribute must also work when ._data is None
@@ -301,7 +299,7 @@ def test_io_stc_h5():
     """Test IO for STC files using HDF5."""
     for stc in [_fake_stc(), _fake_vec_stc()]:
         tempdir = _TempDir()
-        assert_raises(ValueError, stc.save, op.join(tempdir, 'tmp'),
+        pytest.raises(ValueError, stc.save, op.join(tempdir, 'tmp'),
                       ftype='foo')
         out_name = op.join(tempdir, 'tmp')
         stc.save(out_name, ftype='h5')
@@ -309,7 +307,7 @@ def test_io_stc_h5():
         stc3 = read_source_estimate(out_name)
         stc4 = read_source_estimate(out_name + '-stc')
         stc5 = read_source_estimate(out_name + '-stc.h5')
-        assert_raises(RuntimeError, read_source_estimate, out_name,
+        pytest.raises(RuntimeError, read_source_estimate, out_name,
                       subject='bar')
         for stc_new in stc3, stc4, stc5:
             assert_equal(stc_new.subject, stc.subject)
@@ -412,7 +410,7 @@ def test_stc_methods():
                                           subjects_dir=subjects_dir)[0]
         label_both = label_lh + label_rh
         for label in (label_lh, label_rh, label_both):
-            assert_true(isinstance(stc.shape, tuple) and len(stc.shape) == 2)
+            assert (isinstance(stc.shape, tuple) and len(stc.shape) == 2)
             stc_label = stc.in_label(label)
             if label.hemi != 'both':
                 if label.hemi == 'lh':
@@ -422,19 +420,19 @@ def test_stc_methods():
                 n_vertices_used = len(label.get_vertices_used(verts))
                 assert_equal(len(stc_label.data), n_vertices_used)
         stc_lh = stc.in_label(label_lh)
-        assert_raises(ValueError, stc_lh.in_label, label_rh)
+        pytest.raises(ValueError, stc_lh.in_label, label_rh)
         label_lh.subject = 'foo'
-        assert_raises(RuntimeError, stc.in_label, label_lh)
+        pytest.raises(RuntimeError, stc.in_label, label_lh)
 
         stc_new = deepcopy(stc)
         o_sfreq = 1.0 / stc.tstep
         # note that using no padding for this STC reduces edge ringing...
         stc_new.resample(2 * o_sfreq, npad=0, n_jobs=2)
-        assert_true(stc_new.data.shape[1] == 2 * stc.data.shape[1])
-        assert_true(stc_new.tstep == stc.tstep / 2)
+        assert (stc_new.data.shape[1] == 2 * stc.data.shape[1])
+        assert (stc_new.tstep == stc.tstep / 2)
         stc_new.resample(o_sfreq, npad=0)
-        assert_true(stc_new.data.shape[1] == stc.data.shape[1])
-        assert_true(stc_new.tstep == stc.tstep)
+        assert (stc_new.data.shape[1] == stc.data.shape[1])
+        assert (stc_new.tstep == stc.tstep)
         assert_array_almost_equal(stc_new.data, stc.data, 5)
 
 
@@ -442,10 +440,10 @@ def test_stc_methods():
 def test_center_of_mass():
     """Test computing the center of mass on an stc."""
     stc = read_source_estimate(fname_stc)
-    assert_raises(ValueError, stc.center_of_mass, 'sample')
+    pytest.raises(ValueError, stc.center_of_mass, 'sample')
     stc.lh_data[:] = 0
     vertex, hemi, t = stc.center_of_mass('sample', subjects_dir=subjects_dir)
-    assert_true(hemi == 1)
+    assert (hemi == 1)
     # XXX Should design a fool-proof test case, but here were the
     # results:
     assert_equal(vertex, 124791)
@@ -499,13 +497,13 @@ def test_extract_label_time_course():
         stcs.append(this_stc)
 
     # test some invalid inputs
-    assert_raises(ValueError, extract_label_time_course, stcs, labels,
+    pytest.raises(ValueError, extract_label_time_course, stcs, labels,
                   src, mode='notamode')
 
     # have an empty label
     empty_label = labels[0].copy()
     empty_label.vertices += 1000000
-    assert_raises(ValueError, extract_label_time_course, stcs, empty_label,
+    pytest.raises(ValueError, extract_label_time_course, stcs, empty_label,
                   src, mode='mean')
 
     # but this works:
@@ -513,7 +511,7 @@ def test_extract_label_time_course():
         tc = extract_label_time_course(stcs, empty_label, src, mode='mean',
                                        allow_empty=True)
     for arr in tc:
-        assert_true(arr.shape == (1, n_times))
+        assert (arr.shape == (1, n_times))
         assert_array_equal(arr, np.zeros((1, n_times)))
 
     # test the different modes
@@ -523,12 +521,12 @@ def test_extract_label_time_course():
         label_tc = extract_label_time_course(stcs, labels, src, mode=mode)
         label_tc_method = [stc.extract_label_time_course(labels, src,
                            mode=mode) for stc in stcs]
-        assert_true(len(label_tc) == n_stcs)
-        assert_true(len(label_tc_method) == n_stcs)
+        assert (len(label_tc) == n_stcs)
+        assert (len(label_tc_method) == n_stcs)
         for tc1, tc2 in zip(label_tc, label_tc_method):
-            assert_true(tc1.shape == (n_labels, n_times))
-            assert_true(tc2.shape == (n_labels, n_times))
-            assert_true(np.allclose(tc1, tc2, rtol=1e-8, atol=1e-16))
+            assert (tc1.shape == (n_labels, n_times))
+            assert (tc2.shape == (n_labels, n_times))
+            assert (np.allclose(tc1, tc2, rtol=1e-8, atol=1e-16))
             if mode == 'mean':
                 assert_array_almost_equal(tc1, label_means)
             if mode == 'mean_flip':
@@ -539,10 +537,10 @@ def test_extract_label_time_course():
     # test label with very few vertices (check SVD conditionals)
     label = Label(vertices=src[0]['vertno'][:2], hemi='lh')
     x = label_sign_flip(label, src)
-    assert_true(len(x) == 2)
+    assert (len(x) == 2)
     label = Label(vertices=[], hemi='lh')
     x = label_sign_flip(label, src)
-    assert_true(x.size == 0)
+    assert (x.size == 0)
 
 
 @pytest.mark.slowtest
@@ -559,7 +557,7 @@ def test_morph_data():
     stc_to.crop(0.09, 0.1)  # for faster computation
     assert_array_equal(stc_to.time_as_index([0.09, 0.1], use_rounding=True),
                        [0, len(stc_to.times) - 1])
-    assert_raises(ValueError, stc_from.morph, subject_to, grade=3, smooth=-1,
+    pytest.raises(ValueError, stc_from.morph, subject_to, grade=3, smooth=-1,
                   subjects_dir=subjects_dir)
     stc_to1 = stc_from.morph(subject_to, grade=3, smooth=12, buffer_size=1000,
                              subjects_dir=subjects_dir)
@@ -567,7 +565,7 @@ def test_morph_data():
     # Morphing to a density that is too high should raise an informative error
     # (here we need to push to grade=6, but for some subjects even grade=5
     # will break)
-    assert_raises(ValueError, stc_to1.morph, subject_from, grade=6,
+    pytest.raises(ValueError, stc_to1.morph, subject_from, grade=6,
                   subjects_dir=subjects_dir)
     # make sure we can specify vertices
     vertices_to = grade_to_vertices(subject_to, grade=3,
@@ -585,7 +583,7 @@ def test_morph_data():
         morph_data(subject_from, subject_to, stc_from,
                    grade=vertices_to, smooth=1, buffer_size=3,
                    subjects_dir=subjects_dir)
-    assert_equal(len(w), 2)
+    assert sum('consider increasing' in str(ww.message) for ww in w) == 2
 
     assert_array_almost_equal(stc_to.data, stc_to1.data, 5)
     assert_array_almost_equal(stc_to1.data, stc_to2.data)
@@ -596,13 +594,13 @@ def test_morph_data():
                                      smooth=12, subjects_dir=subjects_dir)
     stc_to3 = stc_from.morph_precomputed(subject_to, vertices_to, morph_mat)
     assert_array_almost_equal(stc_to1.data, stc_to3.data)
-    assert_raises(ValueError, stc_from.morph_precomputed,
+    pytest.raises(ValueError, stc_from.morph_precomputed,
                   subject_to, vertices_to, 'foo')
-    assert_raises(ValueError, stc_from.morph_precomputed,
+    pytest.raises(ValueError, stc_from.morph_precomputed,
                   subject_to, [vertices_to[0]], morph_mat)
-    assert_raises(ValueError, stc_from.morph_precomputed,
+    pytest.raises(ValueError, stc_from.morph_precomputed,
                   subject_to, [vertices_to[0][:-1], vertices_to[1]], morph_mat)
-    assert_raises(ValueError, stc_from.morph_precomputed, subject_to,
+    pytest.raises(ValueError, stc_from.morph_precomputed, subject_to,
                   vertices_to, morph_mat, subject_from='foo')
 
     # steps warning
@@ -615,12 +613,12 @@ def test_morph_data():
 
     mean_from = stc_from.data.mean(axis=0)
     mean_to = stc_to1.data.mean(axis=0)
-    assert_true(np.corrcoef(mean_to, mean_from).min() > 0.999)
+    assert (np.corrcoef(mean_to, mean_from).min() > 0.999)
 
     # make sure we can fill by morphing
     stc_to5 = morph_data(subject_from, subject_to, stc_from, grade=None,
                          smooth=12, buffer_size=3, subjects_dir=subjects_dir)
-    assert_true(stc_to5.data.shape[0] == 163842 + 163842)
+    assert (stc_to5.data.shape[0] == 163842 + 163842)
 
     # Morph sparse data
     # Make a sparse stc
@@ -628,7 +626,7 @@ def test_morph_data():
     stc_from.vertices[1] = stc_from.vertices[1][[200]]
     stc_from._data = stc_from._data[:3]
 
-    assert_raises(RuntimeError, stc_from.morph, subject_to, sparse=True,
+    pytest.raises(RuntimeError, stc_from.morph, subject_to, sparse=True,
                   grade=5, subjects_dir=subjects_dir)
 
     stc_to_sparse = stc_from.morph(subject_to, grade=None, sparse=True,
@@ -711,7 +709,7 @@ def test_transform():
 
     # data_t.ndim > 2 & copy is True
     stcs_t = stc.transform(_my_trans, copy=True)
-    assert_true(isinstance(stcs_t, list))
+    assert (isinstance(stcs_t, list))
     assert_array_equal(stc.times, stcs_t[0].times)
     assert_equal(stc.vertices, stcs_t[0].vertices)
 
@@ -721,12 +719,12 @@ def test_transform():
     assert_array_equal(data, data_t)  # check against stc.transform_data()
 
     # data_t.ndim > 2 & copy is False
-    assert_raises(ValueError, stc.transform, _my_trans, copy=False)
+    pytest.raises(ValueError, stc.transform, _my_trans, copy=False)
 
     # data_t.ndim = 2 & copy is True
     tmp = deepcopy(stc)
     stc_t = stc.transform(np.abs, copy=True)
-    assert_true(isinstance(stc_t, SourceEstimate))
+    assert (isinstance(stc_t, SourceEstimate))
     assert_array_equal(stc.data, tmp.data)  # xfrm doesn't modify original?
 
     # data_t.ndim = 2 & copy is False
@@ -739,7 +737,7 @@ def test_transform():
     data_t = stc.transform_data(np.abs, idx=verts, tmin_idx=tmin_idx,
                                 tmax_idx=tmax_idx)
     stc.transform(np.abs, idx=verts, tmin=-50, tmax=500, copy=False)
-    assert_true(isinstance(stc, SourceEstimate))
+    assert (isinstance(stc, SourceEstimate))
     assert_equal(stc.tmin, 0.)
     assert_equal(stc.times[-1], 0.5)
     assert_equal(len(stc.vertices[0]), 0)
@@ -767,7 +765,7 @@ def test_spatio_temporal_tris_connectivity():
     new_fmt = np.array(old_fmt)
     new_fmt = [np.nonzero(new_fmt == v)[0]
                for v in np.unique(new_fmt[new_fmt >= 0])]
-    assert_true(len(new_fmt), len(components))
+    assert len(new_fmt) == len(components)
     for c, n in zip(components, new_fmt):
         assert_array_equal(c, n)
 
@@ -804,7 +802,7 @@ def test_spatio_temporal_src_connectivity():
     assert_equal(len(w), 1)
     a = connectivity.shape[0] / 2
     b = sum([s['nuse'] for s in inverse_operator['src']])
-    assert_true(a == b)
+    assert (a == b)
 
     assert_equal(grade_to_tris(5).shape, [40960, 3])
 
@@ -820,15 +818,15 @@ def test_to_data_frame():
     stc_vol = VolSourceEstimate(data, vertices=vertices[0], tmin=0, tstep=1,
                                 subject='sample')
     for stc in [stc_surf, stc_vol]:
-        assert_raises(ValueError, stc.to_data_frame, index=['foo', 'bar'])
+        pytest.raises(ValueError, stc.to_data_frame, index=['foo', 'bar'])
         for ncat, ind in zip([1, 0], ['time', ['subject', 'time']]):
             df = stc.to_data_frame(index=ind)
-            assert_true(df.index.names == ind
-                        if isinstance(ind, list) else [ind])
+            assert (df.index.names == ind
+                    if isinstance(ind, list) else [ind])
             assert_array_equal(df.values.T[ncat:], stc.data)
             # test that non-indexed data were present as categorial variables
-            assert_true(all([c in ['time', 'subject'] for c in
-                             df.reset_index().columns][:2]))
+            assert all([c in ['time', 'subject'] for c in
+                        df.reset_index().columns][:2])
 
 
 def test_get_peak():
@@ -848,14 +846,14 @@ def test_get_peak():
                                   tstep=1, subject='sample')
 
     for ii, stc in enumerate([stc_surf, stc_vol, stc_surf_1, stc_vol_1]):
-        assert_raises(ValueError, stc.get_peak, tmin=-100)
-        assert_raises(ValueError, stc.get_peak, tmax=90)
-        assert_raises(ValueError, stc.get_peak, tmin=0.002, tmax=0.001)
+        pytest.raises(ValueError, stc.get_peak, tmin=-100)
+        pytest.raises(ValueError, stc.get_peak, tmax=90)
+        pytest.raises(ValueError, stc.get_peak, tmin=0.002, tmax=0.001)
 
         vert_idx, time_idx = stc.get_peak()
         vertno = np.concatenate(stc.vertices) if ii in [0, 2] else stc.vertices
-        assert_true(vert_idx in vertno)
-        assert_true(time_idx in stc.times)
+        assert (vert_idx in vertno)
+        assert (time_idx in stc.times)
 
         data_idx, time_idx = stc.get_peak(vert_as_index=True,
                                           time_as_index=True)
@@ -874,7 +872,7 @@ def test_mixed_stc():
     vertno = S * [np.arange(N // S)]
 
     # make sure error is raised if vertices are not a list of length >= 2
-    assert_raises(ValueError, MixedSourceEstimate, data=data,
+    pytest.raises(ValueError, MixedSourceEstimate, data=data,
                   vertices=[np.arange(N)])
 
     stc = MixedSourceEstimate(data, vertno, 0, 1)
@@ -882,7 +880,7 @@ def test_mixed_stc():
     vol = read_source_spaces(fname_vsrc)
 
     # make sure error is raised for plotting surface with volume source
-    assert_raises(ValueError, stc.plot_surface, src=vol)
+    pytest.raises(ValueError, stc.plot_surface, src=vol)
 
     tempdir = _TempDir()
     fname = op.join(tempdir, 'mixed-stc.h5')
@@ -924,8 +922,7 @@ def test_vec_stc():
 
 @testing.requires_testing_data
 def test_epochs_vector_inverse():
-    """Test vector inverse consistency between evoked and epochs"""
-
+    """Test vector inverse consistency between evoked and epochs."""
     raw = read_raw_fif(fname_raw)
     events = find_events(raw, stim_channel='STI 014')[:2]
     reject = dict(grad=2000e-13, mag=4e-12, eog=150e-6)
@@ -960,17 +957,17 @@ def test_vol_connectivity():
     from scipy import sparse
     vol = read_source_spaces(fname_vsrc)
 
-    assert_raises(ValueError, spatial_src_connectivity, vol, dist=1.)
+    pytest.raises(ValueError, spatial_src_connectivity, vol, dist=1.)
 
     connectivity = spatial_src_connectivity(vol)
     n_vertices = vol[0]['inuse'].sum()
     assert_equal(connectivity.shape, (n_vertices, n_vertices))
-    assert_true(np.all(connectivity.data == 1))
-    assert_true(isinstance(connectivity, sparse.coo_matrix))
+    assert (np.all(connectivity.data == 1))
+    assert (isinstance(connectivity, sparse.coo_matrix))
 
     connectivity2 = spatio_temporal_src_connectivity(vol, n_times=2)
     assert_equal(connectivity2.shape, (2 * n_vertices, 2 * n_vertices))
-    assert_true(np.all(connectivity2.data == 1))
+    assert (np.all(connectivity2.data == 1))
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -5,7 +5,7 @@ import numpy as np
 import warnings
 from shutil import copyfile
 from scipy import sparse
-from nose.tools import assert_true, assert_raises
+
 import pytest
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
@@ -51,8 +51,8 @@ def test_head():
     """Test loading the head surface."""
     surf_1 = get_head_surf('sample', subjects_dir=subjects_dir)
     surf_2 = get_head_surf('sample', 'head', subjects_dir=subjects_dir)
-    assert_true(len(surf_1['rr']) < len(surf_2['rr']))  # BEM vs dense head
-    assert_raises(TypeError, get_head_surf, subject=None,
+    assert len(surf_1['rr']) < len(surf_2['rr'])  # BEM vs dense head
+    pytest.raises(TypeError, get_head_surf, subject=None,
                   subjects_dir=subjects_dir)
 
 
@@ -126,7 +126,7 @@ def test_make_morph_maps():
     with warnings.catch_warnings(record=True):
         mmap = read_morph_map('sample', 'sample', subjects_dir=tempdir)
     for mm in mmap:
-        assert_true((mm - sparse.eye(mm.shape[0], mm.shape[0])).sum() == 0)
+        assert (mm - sparse.eye(mm.shape[0], mm.shape[0])).sum() == 0
 
 
 @testing.requires_testing_data
@@ -140,7 +140,7 @@ def test_io_surface():
     for fname in (fname_quad, fname_tri):
         with warnings.catch_warnings(record=True) as w:
             pts, tri, vol_info = read_surface(fname, read_metadata=True)
-        assert_true(all('No volume info' in str(ww.message) for ww in w))
+        assert all('No volume info' in str(ww.message) for ww in w)
         write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info)
         with warnings.catch_warnings(record=True) as w:  # No vol info
             c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
@@ -158,8 +158,8 @@ def test_read_curv():
                          'lh.inflated')
     bin_curv = read_curvature(fname_curv)
     rr = read_surface(fname_surf)[0]
-    assert_true(len(bin_curv) == len(rr))
-    assert_true(np.logical_or(bin_curv == 0, bin_curv == 1).all())
+    assert len(bin_curv) == len(rr)
+    assert np.logical_or(bin_curv == 0, bin_curv == 1).all()
 
 
 @requires_tvtk
@@ -174,10 +174,10 @@ def test_decimate_surface():
     tris = np.array([[0, 1, 2], [1, 2, 3], [0, 3, 1], [1, 2, 0]])
     for n_tri in [4, 3, 2]:  # quadric decimation creates even numbered output.
         _, this_tris = decimate_surface(points, tris, n_tri)
-        assert_true(len(this_tris) == n_tri if not n_tri % 2 else 2)
+        assert len(this_tris) == n_tri if not n_tri % 2 else 2
     nirvana = 5
     tris = np.array([[0, 1, 2], [1, 2, 3], [0, 3, 1], [1, 2, nirvana]])
-    assert_raises(ValueError, decimate_surface, points, tris, n_tri)
+    pytest.raises(ValueError, decimate_surface, points, tris, n_tri)
 
 
 run_tests_if_main()

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -58,7 +58,7 @@ def test_tps():
 
 @testing.requires_testing_data
 def test_get_trans():
-    """Test converting '-trans.txt' to '-trans.fif'"""
+    """Test converting '-trans.txt' to '-trans.fif'."""
     trans = read_trans(fname)
     trans = invert_transform(trans)  # starts out as head->MRI, so invert
     trans_2 = _get_trans(fname_trans)[0]
@@ -161,14 +161,14 @@ def test_sph_to_cart():
 
 
 def _polar_to_cartesian(theta, r):
-    """Transform polar coordinates to cartesian"""
+    """Transform polar coordinates to cartesian."""
     x = r * np.cos(theta)
     y = r * np.sin(theta)
     return x, y
 
 
 def test_polar_to_cartesian():
-    """Test helper transform function from polar to cartesian"""
+    """Test helper transform function from polar to cartesian."""
     r = 1
     theta = np.pi
     # expected values are (-1, 0)
@@ -259,8 +259,7 @@ def test_rotation3d_align_z_axis():
 
 @testing.requires_testing_data
 def test_combine():
-    """Test combining transforms
-    """
+    """Test combining transforms."""
     trans = read_trans(fname)
     inv = invert_transform(trans)
     combine_transforms(trans, inv, trans['from'], trans['from'])

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -1,13 +1,13 @@
-from numpy.testing import assert_equal, assert_array_equal, assert_allclose
-from nose.tools import (assert_true, assert_raises, assert_not_equal,
-                        assert_not_in)
 from copy import deepcopy
 import os.path as op
-import numpy as np
-from scipy import sparse
 import os
 import warnings
 import webbrowser
+
+import numpy as np
+import pytest
+from scipy import sparse
+from numpy.testing import assert_equal, assert_array_equal, assert_allclose
 
 from mne import read_evokeds, open_docs
 from mne.datasets import testing
@@ -45,7 +45,7 @@ fname_fsaverage_trans = op.join(data_path, 'subjects', 'fsaverage', 'bem',
 
 
 def clean_lines(lines=[]):
-    # Function to scrub filenames for checking logging output (in test_logging)
+    """Scrub filenames for checking logging output (in test_logging)."""
     return [l if 'Reading ' not in l else 'Reading test file' for l in lines]
 
 
@@ -57,13 +57,13 @@ def test_buggy_mkl():
     def foo(a, b):
         raise np.linalg.LinAlgError('SVD did not converge')
     with warnings.catch_warnings(record=True) as w:
-        assert_raises(SkipTest, foo, 1, 2)
-    assert_true(all('convergence error' in str(ww.message) for ww in w))
+        pytest.raises(SkipTest, foo, 1, 2)
+    assert (all('convergence error' in str(ww.message) for ww in w))
 
     @buggy_mkl_svd
     def bar(c, d, e):
         raise RuntimeError('SVD did not converge')
-    assert_raises(RuntimeError, bar, 1, 2, 3)
+    pytest.raises(RuntimeError, bar, 1, 2, 3)
 
 
 def test_sys_info():
@@ -71,7 +71,7 @@ def test_sys_info():
     out = StringIO()
     sys_info(fid=out)
     out = out.getvalue()
-    assert_true('numpy:' in out)
+    assert ('numpy:' in out)
 
 
 def test_get_call_line():
@@ -93,8 +93,8 @@ def test_get_call_line():
 
 def test_object_size():
     """Test object size estimation."""
-    assert_true(object_size(np.ones(10, np.float32)) <
-                object_size(np.ones(10, np.float64)))
+    assert (object_size(np.ones(10, np.float32)) <
+            object_size(np.ones(10, np.float64)))
     for lower, upper, obj in ((0, 60, ''),
                               (0, 30, 1),
                               (0, 30, 1.),
@@ -107,8 +107,8 @@ def test_object_size():
                               (200, 900, sparse.eye(20, format='csc')),
                               (200, 900, sparse.eye(20, format='csr'))):
         size = object_size(obj)
-        assert_true(lower < size < upper,
-                    msg='%s < %s < %s:\n%s' % (lower, size, upper, obj))
+        assert lower < size < upper, \
+            '%s < %s < %s:\n%s' % (lower, size, upper, obj)
 
 
 def test_get_inst_data():
@@ -131,7 +131,7 @@ def test_get_inst_data():
     tfr = tfr_morlet(evoked, freqs, n_cycles, return_itc=False, picks=picks)
     assert_equal(_get_inst_data(tfr), tfr.data)
 
-    assert_raises(TypeError, _get_inst_data, 'foo')
+    pytest.raises(TypeError, _get_inst_data, 'foo')
 
 
 def test_misc():
@@ -139,26 +139,26 @@ def test_misc():
     assert_equal(_memory_usage(-1)[0], -1)
     assert_equal(_memory_usage((clean_lines, [], {}))[0], -1)
     assert_equal(_memory_usage(clean_lines)[0], -1)
-    assert_raises(ValueError, check_random_state, 'foo')
-    assert_raises(ValueError, set_memmap_min_size, 1)
-    assert_raises(ValueError, set_memmap_min_size, 'foo')
-    assert_raises(TypeError, get_config, 1)
-    assert_raises(TypeError, set_config, 1)
-    assert_raises(TypeError, set_config, 'foo', 1)
-    assert_raises(TypeError, _get_stim_channel, 1, None)
-    assert_raises(TypeError, _get_stim_channel, [1], None)
-    assert_raises(TypeError, _check_fname, 1)
-    assert_raises(IOError, check_fname, 'foo', 'tets-dip.x', (), ('.fif',))
-    assert_raises(ValueError, _check_subject, None, None)
-    assert_raises(TypeError, _check_subject, None, 1)
-    assert_raises(TypeError, _check_subject, 1, None)
+    pytest.raises(ValueError, check_random_state, 'foo')
+    pytest.raises(ValueError, set_memmap_min_size, 1)
+    pytest.raises(ValueError, set_memmap_min_size, 'foo')
+    pytest.raises(TypeError, get_config, 1)
+    pytest.raises(TypeError, set_config, 1)
+    pytest.raises(TypeError, set_config, 'foo', 1)
+    pytest.raises(TypeError, _get_stim_channel, 1, None)
+    pytest.raises(TypeError, _get_stim_channel, [1], None)
+    pytest.raises(TypeError, _check_fname, 1)
+    pytest.raises(IOError, check_fname, 'foo', 'tets-dip.x', (), ('.fif',))
+    pytest.raises(ValueError, _check_subject, None, None)
+    pytest.raises(TypeError, _check_subject, None, 1)
+    pytest.raises(TypeError, _check_subject, 1, None)
 
 
 @requires_mayavi
 @traits_test
 def test_check_mayavi():
     """Test mayavi version check."""
-    assert_raises(RuntimeError, _check_mayavi_version, '100.0.0')
+    pytest.raises(RuntimeError, _check_mayavi_version, '100.0.0')
 
 
 def test_run_tests_if_main():
@@ -168,7 +168,7 @@ def test_run_tests_if_main():
     def test_a():
         x.append(True)
 
-    @np.testing.dec.skipif(True)
+    @pytest.mark.skipif(True)
     def test_b():
         return
 
@@ -188,8 +188,8 @@ def test_run_tests_if_main():
             raise RuntimeError('Error not raised')
     finally:
         del __name__
-    assert_true(len(x) == 2)
-    assert_true(x[0] and x[1])
+    assert (len(x) == 2)
+    assert (x[0] and x[1])
 
 
 def test_hash():
@@ -202,76 +202,76 @@ def test_hash():
     d0[2.] = b'123'
 
     d1 = deepcopy(d0)
-    assert_true(len(object_diff(d0, d1)) == 0)
-    assert_true(len(object_diff(d1, d0)) == 0)
+    assert (len(object_diff(d0, d1)) == 0)
+    assert (len(object_diff(d1, d0)) == 0)
     assert_equal(object_hash(d0), object_hash(d1))
 
     # change values slightly
     d1['data'] = np.ones(3, int)
     d1['d'][0] = 0
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert object_hash(d0) != object_hash(d1)
 
     d1 = deepcopy(d0)
     assert_equal(object_hash(d0), object_hash(d1))
     d1['a']['a'] = 0.11
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
+    assert object_hash(d0) != object_hash(d1)
 
     d1 = deepcopy(d0)
     assert_equal(object_hash(d0), object_hash(d1))
     d1['a']['d'] = 0  # non-existent key
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
+    assert object_hash(d0) != object_hash(d1)
 
     d1 = deepcopy(d0)
     assert_equal(object_hash(d0), object_hash(d1))
     d1['b'].append(0)  # different-length lists
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
+    assert object_hash(d0) != object_hash(d1)
 
     d1 = deepcopy(d0)
     assert_equal(object_hash(d0), object_hash(d1))
     d1['e'] = 'foo'  # non-None
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
+    assert object_hash(d0) != object_hash(d1)
 
     d1 = deepcopy(d0)
     d2 = deepcopy(d0)
     d1['e'] = StringIO()
     d2['e'] = StringIO()
     d2['e'].write('foo')
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
 
     d1 = deepcopy(d0)
     d1[1] = 2
-    assert_true(len(object_diff(d0, d1)) > 0)
-    assert_true(len(object_diff(d1, d0)) > 0)
-    assert_not_equal(object_hash(d0), object_hash(d1))
+    assert (len(object_diff(d0, d1)) > 0)
+    assert (len(object_diff(d1, d0)) > 0)
+    assert object_hash(d0) != object_hash(d1)
 
     # generators (and other types) not supported
     d1 = deepcopy(d0)
     d2 = deepcopy(d0)
     d1[1] = (x for x in d0)
     d2[1] = (x for x in d0)
-    assert_raises(RuntimeError, object_diff, d1, d2)
-    assert_raises(RuntimeError, object_hash, d1)
+    pytest.raises(RuntimeError, object_diff, d1, d2)
+    pytest.raises(RuntimeError, object_hash, d1)
 
     x = sparse.eye(2, 2, format='csc')
     y = sparse.eye(2, 2, format='csr')
-    assert_true('type mismatch' in object_diff(x, y))
+    assert ('type mismatch' in object_diff(x, y))
     y = sparse.eye(2, 2, format='csc')
     assert_equal(len(object_diff(x, y)), 0)
     y[1, 1] = 2
-    assert_true('elements' in object_diff(x, y))
+    assert ('elements' in object_diff(x, y))
     y = sparse.eye(3, 3, format='csc')
-    assert_true('shape' in object_diff(x, y))
+    assert ('shape' in object_diff(x, y))
     y = 0
-    assert_true('type mismatch' in object_diff(x, y))
+    assert ('type mismatch' in object_diff(x, y))
 
     # smoke test for gh-4796
     assert object_hash(np.int64(1)) != 0
@@ -289,16 +289,16 @@ def test_md5sum():
         fid.write(b'efgh')
     assert_equal(md5sum(fname1), md5sum(fname1, 1))
     assert_equal(md5sum(fname2), md5sum(fname2, 1024))
-    assert_true(md5sum(fname1) != md5sum(fname2))
+    assert (md5sum(fname1) != md5sum(fname2))
 
 
 def test_tempdir():
     """Test TempDir."""
     tempdir2 = _TempDir()
-    assert_true(op.isdir(tempdir2))
+    assert (op.isdir(tempdir2))
     x = str(tempdir2)
     del tempdir2
-    assert_true(not op.isdir(x))
+    assert (not op.isdir(x))
 
 
 def test_estimate_rank():
@@ -308,12 +308,12 @@ def test_estimate_rank():
                        np.ones(10))
     data[0, 0] = 0
     assert_equal(estimate_rank(data), 9)
-    assert_raises(ValueError, estimate_rank, data, 'foo')
+    pytest.raises(ValueError, estimate_rank, data, 'foo')
 
 
 def test_logging():
     """Test logging (to file)."""
-    assert_raises(ValueError, set_log_level, 'foo')
+    pytest.raises(ValueError, set_log_level, 'foo')
     tempdir = _TempDir()
     test_name = op.join(tempdir, 'test.log')
     with open(fname_log, 'r') as old_log_file:
@@ -333,15 +333,15 @@ def test_logging():
     # should NOT print
     evoked = read_evokeds(fname_evoked, condition=1)
     with open(test_name) as fid:
-        assert_true(fid.readlines() == [])
+        assert (fid.readlines() == [])
     # should NOT print
     evoked = read_evokeds(fname_evoked, condition=1, verbose=False)
     with open(test_name) as fid:
-        assert_true(fid.readlines() == [])
+        assert (fid.readlines() == [])
     # should NOT print
     evoked = read_evokeds(fname_evoked, condition=1, verbose='WARNING')
     with open(test_name) as fid:
-        assert_true(fid.readlines() == [])
+        assert (fid.readlines() == [])
     # SHOULD print
     evoked = read_evokeds(fname_evoked, condition=1, verbose=True)
     with open(test_name, 'r') as new_log_file:
@@ -356,11 +356,11 @@ def test_logging():
     # should NOT print
     evoked = read_evokeds(fname_evoked, condition=1, verbose='WARNING')
     with open(test_name) as fid:
-        assert_true(fid.readlines() == [])
+        assert (fid.readlines() == [])
     # should NOT print
     evoked = read_evokeds(fname_evoked, condition=1, verbose=False)
     with open(test_name) as fid:
-        assert_true(fid.readlines() == [])
+        assert (fid.readlines() == [])
     # SHOULD print
     evoked = read_evokeds(fname_evoked, condition=1)
     with open(test_name, 'r') as new_log_file:
@@ -373,7 +373,7 @@ def test_logging():
         assert_equal(len(w), 0)
         set_log_file(test_name)
     assert_equal(len(w), 1)
-    assert_true('test_utils.py' in w[0].filename)
+    assert ('test_utils.py' in w[0].filename)
     evoked = read_evokeds(fname_evoked, condition=1)
     with open(test_name, 'r') as new_log_file:
         new_lines = clean_lines(new_log_file.readlines())
@@ -406,31 +406,31 @@ def test_config():
     value2 = '123'
     old_val = os.getenv(key, None)
     os.environ[key] = value
-    assert_true(get_config(key) == value)
+    assert (get_config(key) == value)
     del os.environ[key]
     # catch the warning about it being a non-standard config key
-    assert_true(len(set_config(None, None)) > 10)  # tuple of valid keys
+    assert (len(set_config(None, None)) > 10)  # tuple of valid keys
     with warnings.catch_warnings(record=True) as w:  # non-standard key
         warnings.simplefilter('always')
         set_config(key, None, home_dir=tempdir, set_env=False)
-    assert_true(len(w) == 1)
-    assert_true(get_config(key, home_dir=tempdir) is None)
-    assert_raises(KeyError, get_config, key, raise_error=True)
+    assert (len(w) == 1)
+    assert (get_config(key, home_dir=tempdir) is None)
+    pytest.raises(KeyError, get_config, key, raise_error=True)
     with warnings.catch_warnings(record=True):  # non-standard key
         warnings.simplefilter('always')
-        assert_true(key not in os.environ)
+        assert (key not in os.environ)
         set_config(key, value, home_dir=tempdir, set_env=True)
-        assert_true(key in os.environ)
-        assert_true(get_config(key, home_dir=tempdir) == value)
+        assert (key in os.environ)
+        assert (get_config(key, home_dir=tempdir) == value)
         set_config(key, None, home_dir=tempdir, set_env=True)
-        assert_true(key not in os.environ)
+        assert (key not in os.environ)
         set_config(key, None, home_dir=tempdir, set_env=True)
-        assert_true(key not in os.environ)
+        assert (key not in os.environ)
     if old_val is not None:
         os.environ[key] = old_val
     # Check if get_config with key=None returns all config
     key = 'MNE_PYTHON_TESTING_KEY'
-    assert_not_in(key, get_config(home_dir=tempdir))
+    assert key not in get_config(home_dir=tempdir)
     with warnings.catch_warnings(record=True):  # non-standard key
         warnings.simplefilter('always')
         set_config(key, value, home_dir=tempdir)
@@ -449,10 +449,10 @@ def test_config():
     with open(json_fname, 'w') as fid:
         fid.write('foo{}')
     with warnings.catch_warnings(record=True) as w:
-        assert_not_in(key, get_config(home_dir=tempdir))
-    assert_true(any('not a valid JSON' in str(ww.message) for ww in w))
+        assert key not in get_config(home_dir=tempdir)
+    assert (any('not a valid JSON' in str(ww.message) for ww in w))
     with warnings.catch_warnings(record=True):  # non-standard key
-        assert_raises(RuntimeError, set_config, key, 'true', home_dir=tempdir)
+        pytest.raises(RuntimeError, set_config, key, 'true', home_dir=tempdir)
 
 
 @testing.requires_testing_data
@@ -463,9 +463,9 @@ def test_show_fiff():
     keys = ['FIFF_EPOCH', 'FIFFB_HPI_COIL', 'FIFFB_PROJ_ITEM',
             'FIFFB_PROCESSED_DATA', 'FIFFB_EVOKED', 'FIFF_NAVE',
             'FIFF_EPOCH']
-    assert_true(all(key in info for key in keys))
+    assert (all(key in info for key in keys))
     info = show_fiff(fname_raw, read_limit=1024)
-    assert_true('COORD_TRANS' in show_fiff(fname_fsaverage_trans))
+    assert ('COORD_TRANS' in show_fiff(fname_fsaverage_trans))
 
 
 @deprecated('message')
@@ -485,21 +485,21 @@ def test_deprecated():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         deprecated_func()
-    assert_true(len(w) == 1)
+    assert (len(w) == 1)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         deprecated_class()
-    assert_true(len(w) == 1)
+    assert (len(w) == 1)
 
 
 def _test_fetch(url):
-    """Helper to test URL retrieval."""
+    """Test URL retrieval."""
     tempdir = _TempDir()
     with ArgvSetter(disable_stderr=False):  # to capture stdout
         archive_name = op.join(tempdir, "download_test")
         _fetch_file(url, archive_name, timeout=30., verbose=False,
                     resume=False)
-        assert_raises(Exception, _fetch_file, 'NOT_AN_ADDRESS',
+        pytest.raises(Exception, _fetch_file, 'NOT_AN_ADDRESS',
                       op.join(tempdir, 'test'), verbose=False)
         resume_name = op.join(tempdir, "download_resume")
         # touch file
@@ -507,9 +507,9 @@ def _test_fetch(url):
             os.utime(resume_name + '.part', None)
         _fetch_file(url, resume_name, resume=True, timeout=30.,
                     verbose=False)
-        assert_raises(ValueError, _fetch_file, url, archive_name,
+        pytest.raises(ValueError, _fetch_file, url, archive_name,
                       hash_='a', verbose=False)
-        assert_raises(RuntimeError, _fetch_file, url, archive_name,
+        pytest.raises(RuntimeError, _fetch_file, url, archive_name,
                       hash_='a' * 32, verbose=False)
 
 
@@ -554,9 +554,9 @@ def test_check_type_picks():
     picks = None
     assert_array_equal(None, _check_type_picks(picks))
     picks = ['a', 'b']
-    assert_raises(TypeError, _check_type_picks, picks)
+    pytest.raises(TypeError, _check_type_picks, picks)
     picks = 'b'
-    assert_raises(TypeError, _check_type_picks, picks)
+    pytest.raises(TypeError, _check_type_picks, picks)
 
 
 def test_compute_corr():
@@ -576,42 +576,42 @@ def test_compute_corr():
     r2 = np.array([np.corrcoef(x, y[i])[0, 1]
                    for i in range(len(y))])
     assert_allclose(r, r2)
-    assert_raises(ValueError, compute_corr, [1, 2], [])
+    pytest.raises(ValueError, compute_corr, [1, 2], [])
 
 
 def test_create_slices():
     """Test checking the create of time create_slices."""
     # Test that create_slices default provide an empty list
-    assert_true(create_slices(0, 0) == [])
+    assert (create_slices(0, 0) == [])
     # Test that create_slice return correct number of slices
-    assert_true(len(create_slices(0, 100)) == 100)
+    assert (len(create_slices(0, 100)) == 100)
     # Test with non-zero start parameters
-    assert_true(len(create_slices(50, 100)) == 50)
+    assert (len(create_slices(50, 100)) == 50)
     # Test slices' length with non-zero start and window_width=2
-    assert_true(len(create_slices(0, 100, length=2)) == 50)
+    assert (len(create_slices(0, 100, length=2)) == 50)
     # Test slices' length with manual slice separation
-    assert_true(len(create_slices(0, 100, step=10)) == 10)
+    assert (len(create_slices(0, 100, step=10)) == 10)
     # Test slices' within length for non-consecutive samples
-    assert_true(len(create_slices(0, 500, length=50, step=10)) == 46)
+    assert (len(create_slices(0, 500, length=50, step=10)) == 46)
     # Test that slices elements start, stop and step correctly
     slices = create_slices(0, 10)
-    assert_true(slices[0].start == 0)
-    assert_true(slices[0].step == 1)
-    assert_true(slices[0].stop == 1)
-    assert_true(slices[-1].stop == 10)
+    assert (slices[0].start == 0)
+    assert (slices[0].step == 1)
+    assert (slices[0].stop == 1)
+    assert (slices[-1].stop == 10)
     # Same with larger window width
     slices = create_slices(0, 9, length=3)
-    assert_true(slices[0].start == 0)
-    assert_true(slices[0].step == 1)
-    assert_true(slices[0].stop == 3)
-    assert_true(slices[-1].stop == 9)
+    assert (slices[0].start == 0)
+    assert (slices[0].step == 1)
+    assert (slices[0].stop == 3)
+    assert (slices[-1].stop == 9)
     # Same with manual slices' separation
     slices = create_slices(0, 9, length=3, step=1)
-    assert_true(len(slices) == 7)
-    assert_true(slices[0].step == 1)
-    assert_true(slices[0].stop == 3)
-    assert_true(slices[-1].start == 6)
-    assert_true(slices[-1].stop == 9)
+    assert (len(slices) == 7)
+    assert (slices[0].step == 1)
+    assert (slices[0].stop == 3)
+    assert (slices[-1].start == 6)
+    assert (slices[-1].stop == 9)
 
 
 def test_time_mask():
@@ -637,8 +637,8 @@ def test_time_mask():
     assert_equal(_time_mask(x, tmin=4.4999, sfreq=1).sum(), 2)
     assert_equal(_time_mask(x, tmin=4, sfreq=1).sum(), 2)
     # degenerate cases
-    assert_raises(ValueError, _time_mask, x[:1], tmin=11, tmax=12)
-    assert_raises(ValueError, _time_mask, x[:1], tmin=10, sfreq=1)
+    pytest.raises(ValueError, _time_mask, x[:1], tmin=11, tmax=12)
+    pytest.raises(ValueError, _time_mask, x[:1], tmin=10, sfreq=1)
 
 
 def test_random_permutation():
@@ -657,7 +657,7 @@ def test_copy_doc():
     """Test decorator for copying docstrings."""
     class A:
         def m1():
-            """Docstring for m1"""
+            """Docstring for m1."""
             pass
 
     class B:
@@ -669,14 +669,14 @@ def test_copy_doc():
         def m1():
             pass
 
-    assert_equal(C.m1.__doc__, 'Docstring for m1')
-    assert_raises(ValueError, copy_doc(B.m1), C.m1)
+    assert_equal(C.m1.__doc__, 'Docstring for m1.')
+    pytest.raises(ValueError, copy_doc(B.m1), C.m1)
 
 
 def test_copy_function_doc_to_method_doc():
     """Test decorator for re-using function docstring as method docstrings."""
     def f1(object, a, b, c):
-        """Docstring for f1
+        """Docstring for f1.
 
         Parameters
         ----------
@@ -692,7 +692,7 @@ def test_copy_function_doc_to_method_doc():
         pass
 
     def f2(object):
-        """Docstring for f2
+        """Docstring for f2.
 
         Parameters
         ----------
@@ -706,7 +706,7 @@ def test_copy_function_doc_to_method_doc():
         pass
 
     def f3(object):
-        """Docstring for f3
+        """Docstring for f3.
 
         Parameters
         ----------
@@ -716,11 +716,11 @@ def test_copy_function_doc_to_method_doc():
         pass
 
     def f4(object):
-        """Docstring for f4"""
+        """Docstring for f4."""
         pass
 
-    def f5(object):
-        """Docstring for f5
+    def f5(object):  # noqa: D410, D411, D414
+        """Docstring for f5.
 
         Parameters
         ----------
@@ -746,7 +746,7 @@ def test_copy_function_doc_to_method_doc():
 
     assert_equal(
         A.method_f1.__doc__,
-        """Docstring for f1
+        """Docstring for f1.
 
         Parameters
         ----------
@@ -759,7 +759,7 @@ def test_copy_function_doc_to_method_doc():
 
     assert_equal(
         A.method_f2.__doc__,
-        """Docstring for f2
+        """Docstring for f2.
 
         Returns
         -------
@@ -767,12 +767,13 @@ def test_copy_function_doc_to_method_doc():
         method_f3 own docstring"""
     )
 
-    assert_equal(A.method_f3.__doc__, 'Docstring for f3\n\n        ')
-    assert_raises(ValueError, copy_function_doc_to_method_doc(f4), A.method_f1)
-    assert_raises(ValueError, copy_function_doc_to_method_doc(f5), A.method_f1)
+    assert_equal(A.method_f3.__doc__, 'Docstring for f3.\n\n        ')
+    pytest.raises(ValueError, copy_function_doc_to_method_doc(f4), A.method_f1)
+    pytest.raises(ValueError, copy_function_doc_to_method_doc(f5), A.method_f1)
 
 
 def test_progressbar():
+    """Test progressbar class."""
     a = np.arange(10)
     pbar = ProgressBar(a)
     assert_equal(a, pbar.iterable)
@@ -780,13 +781,18 @@ def test_progressbar():
 
     pbar = ProgressBar(10)
     assert_equal(10, pbar.max_value)
-    assert_true(pbar.iterable is None)
+    assert (pbar.iterable is None)
 
     # Make sure that non-iterable input raises an error
     def iter_func(a):
         for ii in a:
             pass
-    assert_raises(ValueError, iter_func, ProgressBar(20))
+    pytest.raises(ValueError, iter_func, ProgressBar(20))
+
+
+def myfun(x):
+    """Check url."""
+    assert 'martinos' in x
 
 
 def test_open_docs():
@@ -794,13 +800,14 @@ def test_open_docs():
     old_tab = webbrowser.open_new_tab
     try:
         # monkey patch temporarily to prevent tabs from actually spawning
-        webbrowser.open_new_tab = lambda x: assert_true('martinos' in x)
+        webbrowser.open_new_tab = myfun
         open_docs()
         open_docs('tutorials', 'dev')
         open_docs('examples', 'stable')
-        assert_raises(ValueError, open_docs, 'foo')
-        assert_raises(ValueError, open_docs, 'api', 'foo')
+        pytest.raises(ValueError, open_docs, 'foo')
+        pytest.raises(ValueError, open_docs, 'api', 'foo')
     finally:
         webbrowser.open_new_tab = old_tab
+
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_ar.py
+++ b/mne/time_frequency/tests/test_ar.py
@@ -2,7 +2,6 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_allclose
-from nose.tools import assert_equal
 from scipy.signal import lfilter
 
 from mne import io
@@ -33,7 +32,7 @@ def test_ar_raw():
     # pick MEG gradiometers
     for order in (2, 5, 10):
         coeffs = fit_iir_model_raw(raw, order)[1][1:]
-        assert_equal(coeffs.shape, (order,))
+        assert coeffs.shape == (order,)
         assert_allclose(-coeffs[0], 1., atol=0.5)
     # let's make sure we're doing something reasonable: first, white noise
     rng = np.random.RandomState(0)
@@ -48,5 +47,6 @@ def test_ar_raw():
     for order in (2, 5, 10):
         coeffs = fit_iir_model_raw(raw, order)[1]
         assert_allclose(coeffs, iir + [0.] * (order - 2), atol=5e-2)
+
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -15,7 +15,6 @@ from mne import create_info
 @requires_nitime
 def test_dpss_windows():
     """Test computation of DPSS windows."""
-
     import nitime as ni
     N = 1000
     half_nbw = 4

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -1,8 +1,6 @@
 import numpy as np
 import os.path as op
-from numpy.testing import (assert_array_almost_equal, assert_raises,
-                           assert_allclose)
-from nose.tools import assert_true, assert_equal
+from numpy.testing import assert_array_almost_equal, assert_allclose
 import pytest
 
 from mne import pick_types, Epochs, read_events
@@ -65,37 +63,37 @@ def test_psd():
         psds, freqs = func(raw, proj=False, **kws)
         psds_proj, freqs_proj = func(raw, proj=True, **kws)
 
-        assert_equal(psds.shape, (len(kws['picks']), len(freqs)))
-        assert_equal(np.sum(freqs < 0), 0)
-        assert_equal(np.sum(psds < 0), 0)
+        assert psds.shape == (len(kws['picks']), len(freqs))
+        assert np.sum(freqs < 0) == 0
+        assert np.sum(psds < 0) == 0
 
         # Is power found where it should be
         ixs_max = np.argmax(psds, axis=1)
         for ixmax, ifreq in zip(ixs_max, freqs_sig):
             # Find nearest frequency to the "true" freq
             ixtrue = np.argmin(np.abs(ifreq - freqs))
-            assert_true(np.abs(ixmax - ixtrue) < 2)
+            assert (np.abs(ixmax - ixtrue) < 2)
 
         # Make sure the projection doesn't change channels it shouldn't
         assert_array_almost_equal(psds, psds_proj)
         # Array input shouldn't work
-        assert_raises(ValueError, func, raw[:3, :20][0])
+        pytest.raises(ValueError, func, raw[:3, :20][0])
 
     # test n_per_seg in psd_welch (and padding)
     psds1, freqs1 = psd_welch(raw, proj=False, n_fft=128, n_per_seg=128,
                               **kws_psd)
     psds2, freqs2 = psd_welch(raw, proj=False, n_fft=256, n_per_seg=128,
                               **kws_psd)
-    assert_true(len(freqs1) == np.floor(len(freqs2) / 2.))
-    assert_true(psds1.shape[-1] == np.floor(psds2.shape[-1] / 2.))
+    assert (len(freqs1) == np.floor(len(freqs2) / 2.))
+    assert (psds1.shape[-1] == np.floor(psds2.shape[-1] / 2.))
 
     # tests ValueError when n_per_seg=None and n_fft > signal length
     kws_psd.update(dict(n_fft=tmax * 1.1 * raw.info['sfreq']))
-    assert_raises(ValueError, psd_welch, raw, proj=False, n_per_seg=None,
+    pytest.raises(ValueError, psd_welch, raw, proj=False, n_per_seg=None,
                   **kws_psd)
     # ValueError when n_overlap > n_per_seg
     kws_psd.update(dict(n_fft=128, n_per_seg=64, n_overlap=90))
-    assert_raises(ValueError, psd_welch, raw, proj=False, **kws_psd)
+    pytest.raises(ValueError, psd_welch, raw, proj=False, **kws_psd)
 
     # -- Epochs/Evoked --
     events = read_events(event_fname)
@@ -135,13 +133,13 @@ def test_psd():
         for ixmax, ifreq in zip(ixs_max, freqs_sig):
             # Find nearest frequency to the "true" freq
             ixtrue = np.argmin(np.abs(ifreq - freqs))
-            assert_true(np.abs(ixmax - ixtrue) < 2)
-        assert_true(psds.shape == (1, len(kws['picks']), len(freqs)))
-        assert_true(np.sum(freqs < 0) == 0)
-        assert_true(np.sum(psds < 0) == 0)
+            assert (np.abs(ixmax - ixtrue) < 2)
+        assert (psds.shape == (1, len(kws['picks']), len(freqs)))
+        assert (np.sum(freqs < 0) == 0)
+        assert (np.sum(psds < 0) == 0)
 
         # Array input shouldn't work
-        assert_raises(ValueError, func, epochs.get_data())
+        pytest.raises(ValueError, func, epochs.get_data())
 
         # Testing evoked (doesn't work w/ compute_epochs_psd)
         psds_ev, freqs_ev = func(
@@ -154,11 +152,11 @@ def test_psd():
         for ixmax, ifreq in zip(ixs_max, freqs_sig):
             # Find nearest frequency to the "true" freq
             ixtrue = np.argmin(np.abs(ifreq - freqs_ev))
-            assert_true(np.abs(ixmax - ixtrue) < 2)
+            assert (np.abs(ixmax - ixtrue) < 2)
 
         # Make sure the projection doesn't change channels it shouldn't
         assert_array_almost_equal(psds_ev, psds_ev_proj, 27)
-        assert_true(psds_ev.shape == (len(kws['picks']), len(freqs)))
+        assert (psds_ev.shape == (len(kws['picks']), len(freqs)))
 
 
 @pytest.mark.slowtest
@@ -196,13 +194,13 @@ def test_compares_psd():
     assert_array_almost_equal(psds_welch, psds_mpl)
     assert_array_almost_equal(freqs_welch, freqs_mpl)
 
-    assert_true(psds_welch.shape == (len(picks), len(freqs_welch)))
-    assert_true(psds_mpl.shape == (len(picks), len(freqs_mpl)))
+    assert (psds_welch.shape == (len(picks), len(freqs_welch)))
+    assert (psds_mpl.shape == (len(picks), len(freqs_mpl)))
 
-    assert_true(np.sum(freqs_welch < 0) == 0)
-    assert_true(np.sum(freqs_mpl < 0) == 0)
+    assert (np.sum(freqs_welch < 0) == 0)
+    assert (np.sum(freqs_mpl < 0) == 0)
 
-    assert_true(np.sum(psds_welch < 0) == 0)
-    assert_true(np.sum(psds_mpl < 0) == 0)
+    assert (np.sum(psds_welch < 0) == 0)
+    assert (np.sum(psds_mpl < 0) == 0)
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_stft.py
+++ b/mne/time_frequency/tests/test_stft.py
@@ -6,7 +6,7 @@ from mne.time_frequency.stft import stft, istft, stftfreq, stft_norm2
 
 
 def test_stft():
-    "Test stft and istft tight frame property"
+    """Test stft and istft tight frame property."""
     sfreq = 1000.  # Hz
     f = 7.  # Hz
     for T in [127, 128]:  # try with even and odd numbers

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -6,9 +6,9 @@
 import os.path as op
 import warnings
 
-from nose.tools import assert_true, assert_equal
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_allclose
+from numpy.testing import (assert_array_almost_equal, assert_allclose,
+                           assert_equal)
 
 from scipy import fftpack
 
@@ -38,7 +38,7 @@ def test_stockwell_ctf():
 
 
 def test_stockwell_check_input():
-    """Test input checker for stockwell"""
+    """Test input checker for stockwell."""
     # check for data size equal and unequal to a power of 2
 
     for last_dim in (127, 128):
@@ -52,7 +52,7 @@ def test_stockwell_check_input():
 
 
 def test_stockwell_st_no_zero_pad():
-    """Test stockwell power itc"""
+    """Test stockwell power itc."""
     data = np.zeros((20, 128))
     start_f = 1
     stop_f = 10
@@ -87,7 +87,7 @@ def test_stockwell_core():
     assert_equal(st_pulse.shape[-1], len(pulse))
     st_max_freq = freqs[st_pulse.max(axis=1).argmax(axis=0)]  # max freq
     assert_allclose(st_max_freq, pulse_freq, atol=1.0)
-    assert_true(onset < t[st_pulse.max(axis=0).argmax(axis=0)] < offset)
+    assert (onset < t[st_pulse.max(axis=0).argmax(axis=0)] < offset)
 
     # test inversion to FFT, by averaging local spectra, see eq. 5 in
     # Moukadem, A., Bouguila, Z., Ould Abdeslam, D. and Alain Dieterlen.
@@ -116,7 +116,7 @@ def test_stockwell_api():
             power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
                                        return_itc=True)
         if fmax is not None:
-            assert_true(power.freqs.max() <= fmax)
+            assert (power.freqs.max() <= fmax)
         with warnings.catch_warnings(record=True):  # padding
             power_evoked = tfr_stockwell(epochs.average(), fmin=fmin,
                                          fmax=fmax, return_itc=False)
@@ -124,12 +124,13 @@ def test_stockwell_api():
         # for stockwell... if this fails, this maybe could be changed
         # just to check the shape
         assert_array_almost_equal(power_evoked.data, power.data)
-    assert_true(isinstance(power, AverageTFR))
-    assert_true(isinstance(itc, AverageTFR))
+    assert (isinstance(power, AverageTFR))
+    assert (isinstance(itc, AverageTFR))
     assert_equal(power.data.shape, itc.data.shape)
-    assert_true(itc.data.min() >= 0.0)
-    assert_true(itc.data.max() <= 1.0)
-    assert_true(np.log(power.data.max()) * 20 <= 0.0)
-    assert_true(np.log(power.data.max()) * 20 <= 0.0)
+    assert (itc.data.min() >= 0.0)
+    assert (itc.data.max() <= 1.0)
+    assert (np.log(power.data.max()) * 20 <= 0.0)
+    assert (np.log(power.data.max()) * 20 <= 0.0)
+
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -2,8 +2,8 @@ import numpy as np
 import os.path as op
 import warnings
 
-from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import assert_true, assert_false, assert_equal, assert_raises
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
 import pytest
 
 import mne
@@ -41,8 +41,8 @@ def test_morlet():
     Wz = morlet(1000, [10], 2., zero_mean=True)
     W = morlet(1000, [10], 2., zero_mean=False)
 
-    assert_true(np.abs(np.mean(np.real(Wz[0]))) < 1e-5)
-    assert_true(np.abs(np.mean(np.real(W[0]))) > 1e-3)
+    assert (np.abs(np.mean(np.real(Wz[0]))) < 1e-5)
+    assert (np.abs(np.mean(np.real(W[0]))) > 1e-3)
 
 
 def test_time_frequency():
@@ -81,13 +81,13 @@ def test_time_frequency():
     evoked = epochs.average()
     power_evoked = tfr_morlet(evoked, freqs, n_cycles, use_fft=True,
                               return_itc=False)
-    assert_raises(ValueError, tfr_morlet, evoked, freqs, 1., return_itc=True)
+    pytest.raises(ValueError, tfr_morlet, evoked, freqs, 1., return_itc=True)
     power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles,
                             use_fft=True, return_itc=True)
     power_, itc_ = tfr_morlet(epochs, freqs=freqs, n_cycles=n_cycles,
                               use_fft=True, return_itc=True, decim=slice(0, 2))
     # Test picks argument and average parameter
-    assert_raises(ValueError, tfr_morlet, epochs, freqs=freqs,
+    pytest.raises(ValueError, tfr_morlet, epochs, freqs=freqs,
                   n_cycles=n_cycles, return_itc=True, average=False)
 
     power_picks, itc_picks = \
@@ -106,9 +106,9 @@ def test_time_frequency():
     assert_array_almost_equal(itc.data, itc_picks.data)
     assert_array_almost_equal(power.data, power_evoked.data)
     # complex output
-    assert_raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
+    pytest.raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
                   return_itc=False, average=True, output="complex")
-    assert_raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
+    pytest.raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
                   output="complex", average=False, return_itc=True)
     epochs_power_complex = tfr_morlet(epochs, freqs, n_cycles,
                                       output="complex", average=False,
@@ -127,19 +127,19 @@ def test_time_frequency():
 
     power = power.apply_baseline(baseline=(-0.1, 0), mode='logratio')
 
-    assert_true('meg' in power)
-    assert_true('grad' in power)
-    assert_false('mag' in power)
-    assert_false('eeg' in power)
+    assert 'meg' in power
+    assert 'grad' in power
+    assert 'mag' not in power
+    assert 'eeg' not in power
 
     assert_equal(power.nave, nave)
     assert_equal(itc.nave, nave)
-    assert_true(power.data.shape == (len(picks), len(freqs), len(times)))
-    assert_true(power.data.shape == itc.data.shape)
-    assert_true(power_.data.shape == (len(picks), len(freqs), 2))
-    assert_true(power_.data.shape == itc_.data.shape)
-    assert_true(np.sum(itc.data >= 1) == 0)
-    assert_true(np.sum(itc.data <= 0) == 0)
+    assert (power.data.shape == (len(picks), len(freqs), len(times)))
+    assert (power.data.shape == itc.data.shape)
+    assert (power_.data.shape == (len(picks), len(freqs), 2))
+    assert (power_.data.shape == itc_.data.shape)
+    assert (np.sum(itc.data >= 1) == 0)
+    assert (np.sum(itc.data <= 0) == 0)
 
     # grand average
     itc2 = itc.copy()
@@ -165,18 +165,18 @@ def test_time_frequency():
     power, itc = tfr_morlet(epochs, freqs=freqs, n_cycles=2, use_fft=False,
                             return_itc=True)
 
-    assert_true(power.data.shape == (len(picks), len(freqs), len(times)))
-    assert_true(power.data.shape == itc.data.shape)
-    assert_true(np.sum(itc.data >= 1) == 0)
-    assert_true(np.sum(itc.data <= 0) == 0)
+    assert (power.data.shape == (len(picks), len(freqs), len(times)))
+    assert (power.data.shape == itc.data.shape)
+    assert (np.sum(itc.data >= 1) == 0)
+    assert (np.sum(itc.data <= 0) == 0)
 
     tfr = tfr_morlet(epochs[0], freqs, use_fft=True, n_cycles=2, average=False,
                      return_itc=False).data[0]
-    assert_true(tfr.shape == (len(picks), len(freqs), len(times)))
+    assert (tfr.shape == (len(picks), len(freqs), len(times)))
     tfr2 = tfr_morlet(epochs[0], freqs, use_fft=True, n_cycles=2,
                       decim=slice(0, 2), average=False,
                       return_itc=False).data[0]
-    assert_true(tfr2.shape == (len(picks), len(freqs), 2))
+    assert (tfr2.shape == (len(picks), len(freqs), 2))
 
     single_power = tfr_morlet(epochs, freqs, 2, average=False,
                               return_itc=False).data
@@ -227,18 +227,18 @@ def test_time_frequency():
 
     # Test cwt modes
     Ws = morlet(512, [10, 20], n_cycles=2)
-    assert_raises(ValueError, cwt, data[0, :, :], Ws, mode='foo')
+    pytest.raises(ValueError, cwt, data[0, :, :], Ws, mode='foo')
     for use_fft in [True, False]:
         for mode in ['same', 'valid', 'full']:
             cwt(data[0], Ws, use_fft=use_fft, mode=mode)
 
     # Test decim parameter checks
-    assert_raises(TypeError, tfr_morlet, epochs, freqs=freqs,
+    pytest.raises(TypeError, tfr_morlet, epochs, freqs=freqs,
                   n_cycles=n_cycles, use_fft=True, return_itc=True,
                   decim='decim')
 
     # When convolving in time, wavelets must not be longer than the data
-    assert_raises(ValueError, cwt, data[0, :, :Ws[0].size - 1], Ws,
+    pytest.raises(ValueError, cwt, data[0, :, :Ws[0].size - 1], Ws,
                   use_fft=False)
     with warnings.catch_warnings(record=True) as w:
         cwt(data[0, :, :Ws[0].size - 1], Ws, use_fft=True)
@@ -256,12 +256,12 @@ def test_dpsswavelet():
     Ws = _make_dpss(1000, freqs=freqs, n_cycles=freqs / 2., time_bandwidth=4.0,
                     zero_mean=True)
 
-    assert_true(len(Ws) == 3)  # 3 tapers expected
+    assert (len(Ws) == 3)  # 3 tapers expected
 
     # Check that zero mean is true
-    assert_true(np.abs(np.mean(np.real(Ws[0][0]))) < 1e-5)
+    assert (np.abs(np.mean(np.real(Ws[0][0]))) < 1e-5)
 
-    assert_true(len(Ws[0]) == len(freqs))  # As many wavelets as asked for
+    assert (len(Ws[0]) == len(freqs))  # As many wavelets as asked for
 
 
 @pytest.mark.slowtest
@@ -319,7 +319,7 @@ def test_tfr_multitaper():
     assert_equal(power_epochs_picked.data.shape, (3, 1, 7, 200))
     assert_equal(power_epochs_picked.ch_names, ['SIM0001'])
 
-    assert_raises(ValueError, tfr_multitaper, epochs,
+    pytest.raises(ValueError, tfr_multitaper, epochs,
                   freqs=freqs, n_cycles=freqs / 2.,
                   return_itc=True, average=False)
 
@@ -335,22 +335,22 @@ def test_tfr_multitaper():
     # the other is average of the squared magnitudes (epochs PSD)
     # so values shouldn't match, but shapes should
     assert_array_equal(power.data.shape, power_evoked.data.shape)
-    assert_raises(AssertionError, assert_array_almost_equal,
+    pytest.raises(AssertionError, assert_array_almost_equal,
                   power.data, power_evoked.data)
 
     tmax = t[np.argmax(itc.data[0, freqs == 50, :])]
     fmax = freqs[np.argmax(power.data[1, :, t == 0.5])]
-    assert_true(tmax > 0.3 and tmax < 0.7)
-    assert_false(np.any(itc.data < 0.))
-    assert_true(fmax > 40 and fmax < 60)
-    assert_true(power2.data.shape == (len(picks), len(freqs), 2))
-    assert_true(power2.data.shape == itc2.data.shape)
+    assert (tmax > 0.3 and tmax < 0.7)
+    assert not np.any(itc.data < 0.)
+    assert (fmax > 40 and fmax < 60)
+    assert (power2.data.shape == (len(picks), len(freqs), 2))
+    assert (power2.data.shape == itc2.data.shape)
 
     # Test decim parameter checks and compatibility between wavelets length
     # and instance length in the time dimension.
-    assert_raises(TypeError, tfr_multitaper, epochs, freqs=freqs,
+    pytest.raises(TypeError, tfr_multitaper, epochs, freqs=freqs,
                   n_cycles=freqs / 2., time_bandwidth=4.0, decim=(1,))
-    assert_raises(ValueError, tfr_multitaper, epochs, freqs=freqs,
+    pytest.raises(ValueError, tfr_multitaper, epochs, freqs=freqs,
                   n_cycles=1000, time_bandwidth=4.0)
 
 
@@ -371,7 +371,6 @@ def test_crop():
 @requires_h5py
 def test_io():
     """Test TFR IO capacities."""
-
     tempdir = _TempDir()
     fname = op.join(tempdir, 'test-tfr.h5')
     data = np.zeros((3, 2, 3))
@@ -391,7 +390,7 @@ def test_io():
     assert_equal(tfr.comment, tfr2.comment)
     assert_equal(tfr.nave, tfr2.nave)
 
-    assert_raises(IOError, tfr.save, fname)
+    pytest.raises(IOError, tfr.save, fname)
 
     tfr.comment = None
     tfr.save(fname, overwrite=True)
@@ -404,14 +403,14 @@ def test_io():
     tfr3 = read_tfrs(fname, condition='test-A')
     assert_equal(tfr.comment, tfr3.comment)
 
-    assert_true(isinstance(tfr.info, mne.Info))
+    assert (isinstance(tfr.info, mne.Info))
 
     tfrs = read_tfrs(fname, condition=None)
     assert_equal(len(tfrs), 2)
     tfr4 = tfrs[1]
     assert_equal(tfr2.comment, tfr4.comment)
 
-    assert_raises(ValueError, read_tfrs, fname, condition='nonono')
+    pytest.raises(ValueError, read_tfrs, fname, condition='nonono')
 
     # Test save of EpochsTFR.
     data = np.zeros((5, 3, 2, 3))
@@ -500,7 +499,7 @@ def test_plot_joint():
     timefreqs = ([(-100, 1)], tfr.times[1], [1],
                  [(tfr.times[1], tfr.freqs[1], tfr.freqs[1])])
     for these_timefreqs in timefreqs:
-        assert_raises(ValueError, tfr.plot_joint, these_timefreqs)
+        pytest.raises(ValueError, tfr.plot_joint, these_timefreqs)
 
     # test that the object is not internally modified
     tfr_orig = tfr.copy()
@@ -508,8 +507,8 @@ def test_plot_joint():
                    topomap_args=topomap_args)
     plt.close('all')
     assert_array_equal(tfr.data, tfr_orig.data)
-    assert_true(set(tfr.ch_names) == set(tfr_orig.ch_names))
-    assert_true(set(tfr.times) == set(tfr_orig.times))
+    assert (set(tfr.ch_names) == set(tfr_orig.ch_names))
+    assert (set(tfr.times) == set(tfr_orig.times))
 
 
 def test_add_channels():
@@ -527,24 +526,24 @@ def test_add_channels():
     tfr_stim = tfr.copy().pick_types(meg=False, stim=True)
     tfr_eeg_meg = tfr.copy().pick_types(meg=True, eeg=True)
     tfr_new = tfr_meg.copy().add_channels([tfr_eeg, tfr_stim])
-    assert_true(all(ch in tfr_new.ch_names
-                    for ch in tfr_stim.ch_names + tfr_meg.ch_names))
+    assert all(ch in tfr_new.ch_names
+               for ch in tfr_stim.ch_names + tfr_meg.ch_names)
     tfr_new = tfr_meg.copy().add_channels([tfr_eeg])
 
-    assert_true(ch in tfr_new.ch_names for ch in tfr.ch_names)
+    assert all(ch in tfr_new.ch_names
+               for ch in tfr.ch_names if ch != 'STIM 001')
     assert_array_equal(tfr_new.data, tfr_eeg_meg.data)
-    assert_true(all(ch not in tfr_new.ch_names
-                    for ch in tfr_stim.ch_names))
+    assert all(ch not in tfr_new.ch_names for ch in tfr_stim.ch_names)
 
     # Now test errors
     tfr_badsf = tfr_eeg.copy()
     tfr_badsf.info['sfreq'] = 3.1415927
     tfr_eeg = tfr_eeg.crop(-.1, .1)
 
-    assert_raises(RuntimeError, tfr_meg.add_channels, [tfr_badsf])
-    assert_raises(AssertionError, tfr_meg.add_channels, [tfr_eeg])
-    assert_raises(ValueError, tfr_meg.add_channels, [tfr_meg])
-    assert_raises(TypeError, tfr_meg.add_channels, tfr_badsf)
+    pytest.raises(RuntimeError, tfr_meg.add_channels, [tfr_badsf])
+    pytest.raises(AssertionError, tfr_meg.add_channels, [tfr_eeg])
+    pytest.raises(ValueError, tfr_meg.add_channels, [tfr_meg])
+    pytest.raises(TypeError, tfr_meg.add_channels, tfr_badsf)
 
 
 def test_compute_tfr():
@@ -577,7 +576,7 @@ def test_compute_tfr():
          'avg_power_itc', 'avg_power', 'itc')):
         # Check exception
         if (func == tfr_array_multitaper) and (output == 'phase'):
-            assert_raises(NotImplementedError, func, data, sfreq=sfreq,
+            pytest.raises(NotImplementedError, func, data, sfreq=sfreq,
                           freqs=freqs, output=output)
             continue
 
@@ -596,32 +595,32 @@ def test_compute_tfr():
             assert_equal(np.complex, out.dtype)
         else:
             assert_equal(np.float, out.dtype)
-        assert_true(np.all(np.isfinite(out)))
+        assert (np.all(np.isfinite(out)))
 
     # Check errors params
     for _data in (None, 'foo', data[0]):
-        assert_raises(ValueError, _compute_tfr, _data, freqs, sfreq)
+        pytest.raises(ValueError, _compute_tfr, _data, freqs, sfreq)
     for _freqs in (None, 'foo', [[0]]):
-        assert_raises(ValueError, _compute_tfr, data, _freqs, sfreq)
+        pytest.raises(ValueError, _compute_tfr, data, _freqs, sfreq)
     for _sfreq in (None, 'foo'):
-        assert_raises(ValueError, _compute_tfr, data, freqs, _sfreq)
+        pytest.raises(ValueError, _compute_tfr, data, freqs, _sfreq)
     for key in ('output', 'method', 'use_fft', 'decim', 'n_jobs'):
         for value in (None, 'foo'):
             kwargs = {key: value}  # FIXME pep8
-            assert_raises(ValueError, _compute_tfr, data, freqs, sfreq,
+            pytest.raises(ValueError, _compute_tfr, data, freqs, sfreq,
                           **kwargs)
 
     # No time_bandwidth param in morlet
-    assert_raises(ValueError, _compute_tfr, data, freqs, sfreq,
+    pytest.raises(ValueError, _compute_tfr, data, freqs, sfreq,
                   method='morlet', time_bandwidth=1)
     # No phase in multitaper XXX Check ?
-    assert_raises(NotImplementedError, _compute_tfr, data, freqs, sfreq,
+    pytest.raises(NotImplementedError, _compute_tfr, data, freqs, sfreq,
                   method='multitaper', output='phase')
 
     # Inter-trial coherence tests
     out = _compute_tfr(data, freqs, sfreq, output='itc', n_cycles=2.)
-    assert_true(np.sum(out >= 1) == 0)
-    assert_true(np.sum(out <= 0) == 0)
+    assert (np.sum(out >= 1) == 0)
+    assert (np.sum(out <= 0) == 0)
 
     # Check decim shapes
     # 2: multiple of len(times) even
@@ -641,5 +640,6 @@ def test_compute_tfr():
             out = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
                                output='avg_power', n_cycles=2.)
             assert_array_equal(shape[1:], out.shape)
+
 
 run_tests_if_main()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -10,9 +10,7 @@
 import os.path as op
 import warnings
 
-from nose.tools import assert_true
 import numpy as np
-from numpy.testing import assert_raises
 import pytest
 
 from mne import (make_field_map, pick_channels_evoked, read_evokeds,
@@ -70,12 +68,12 @@ def test_plot_head_positions():
             plot_head_positions(pos, mode='field', info=info,
                                 destination=destination)
         else:
-            assert_raises(RuntimeError, plot_head_positions, pos, mode='field',
+            pytest.raises(RuntimeError, plot_head_positions, pos, mode='field',
                           info=info, destination=destination)
         plot_head_positions([pos, pos])  # list support
-        assert_raises(ValueError, plot_head_positions, ['pos'])
-        assert_raises(ValueError, plot_head_positions, pos[:, :9])
-    assert_raises(ValueError, plot_head_positions, pos, 'foo')
+        pytest.raises(ValueError, plot_head_positions, ['pos'])
+        pytest.raises(ValueError, plot_head_positions, pos[:, :9])
+    pytest.raises(ValueError, plot_head_positions, pos, 'foo')
     with pytest.raises(ValueError, match='shape'):
         plot_head_positions(pos, axes=1.)
     plt.close('all')
@@ -105,7 +103,7 @@ def test_plot_sparse_source_estimates():
                           background=(1, 1, 0),
                           subjects_dir=subjects_dir, colorbar=True,
                           clim='auto')
-    assert_raises(TypeError, plot_source_estimates, stc, 'sample',
+    pytest.raises(TypeError, plot_source_estimates, stc, 'sample',
                   figure='foo', hemi='both', clim='auto',
                   subjects_dir=subjects_dir)
 
@@ -175,11 +173,11 @@ def test_plot_alignment():
     # KIT ref sensor coil def is defined
     mlab.close(all=True)
     info = infos['Neuromag']
-    assert_raises(TypeError, plot_alignment, 'foo', trans_fname,
+    pytest.raises(TypeError, plot_alignment, 'foo', trans_fname,
                   subject='sample', subjects_dir=subjects_dir)
-    assert_raises(TypeError, plot_alignment, info, trans_fname,
+    pytest.raises(TypeError, plot_alignment, info, trans_fname,
                   subject='sample', subjects_dir=subjects_dir, src='foo')
-    assert_raises(ValueError, plot_alignment, info, trans_fname,
+    pytest.raises(ValueError, plot_alignment, info, trans_fname,
                   subject='fsaverage', subjects_dir=subjects_dir,
                   src=sample_src)
     sample_src.plot(subjects_dir=subjects_dir, head=True, skull=True,
@@ -188,7 +186,7 @@ def test_plot_alignment():
     # no-head version
     mlab.close(all=True)
     # all coord frames
-    assert_raises(ValueError, plot_alignment, info)
+    pytest.raises(ValueError, plot_alignment, info)
     plot_alignment(info, surfaces=[])
     for coord_frame in ('meg', 'head', 'mri'):
         plot_alignment(info, meg=['helmet', 'sensors'], dig=True,
@@ -208,7 +206,7 @@ def test_plot_alignment():
                        meg=['helmet', 'sensors'],
                        eeg=['original', 'projected'], ecog=True, seeg=True)
     mlab.close(all=True)
-    assert_true(['Cannot plot MEG' in str(ww.message) for ww in w])
+    assert any('Cannot plot MEG' in str(ww.message) for ww in w)
 
     sphere = make_sphere_model(info=evoked.info, r0='auto', head_radius='auto')
     bem_sol = read_bem_solution(op.join(subjects_dir, 'sample', 'bem',
@@ -240,23 +238,23 @@ def test_plot_alignment():
                    surfaces=['brain'], bem=sphere, show_axes=True)
 
     # one layer bem with skull surfaces:
-    assert_raises(ValueError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(ValueError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir,
                   surfaces=['brain', 'head', 'inner_skull'], bem=sphere)
     # wrong eeg value:
-    assert_raises(ValueError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(ValueError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir, eeg='foo')
     # wrong meg value:
-    assert_raises(ValueError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(ValueError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir, meg='bar')
     # multiple brain surfaces:
-    assert_raises(ValueError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(ValueError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir,
                   surfaces=['white', 'pial'])
-    assert_raises(TypeError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(TypeError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir,
                   surfaces=[1])
-    assert_raises(ValueError, plot_alignment, info=info, trans=trans_fname,
+    pytest.raises(ValueError, plot_alignment, info=info, trans=trans_fname,
                   subject='sample', subjects_dir=subjects_dir,
                   surfaces=['foo'])
     mlab.close(all=True)
@@ -286,26 +284,26 @@ def test_limits_to_control_points():
     stc.plot(colormap='mne', clim='auto', **kwargs)
     figs = [mlab.figure(), mlab.figure()]
     stc.plot(clim=dict(kind='value', lims=(10, 50, 90)), figure=99, **kwargs)
-    assert_raises(ValueError, stc.plot, clim='auto', figure=figs, **kwargs)
+    pytest.raises(ValueError, stc.plot, clim='auto', figure=figs, **kwargs)
 
     # Test both types of incorrect limits key (lims/pos_lims)
-    assert_raises(KeyError, plot_source_estimates, stc, colormap='mne',
+    pytest.raises(KeyError, plot_source_estimates, stc, colormap='mne',
                   clim=dict(kind='value', lims=(5, 10, 15)), **kwargs)
-    assert_raises(KeyError, plot_source_estimates, stc, colormap='hot',
+    pytest.raises(KeyError, plot_source_estimates, stc, colormap='hot',
                   clim=dict(kind='value', pos_lims=(5, 10, 15)), **kwargs)
 
     # Test for correct clim values
-    assert_raises(ValueError, stc.plot,
+    pytest.raises(ValueError, stc.plot,
                   clim=dict(kind='value', pos_lims=[0, 1, 0]), **kwargs)
-    assert_raises(ValueError, stc.plot, colormap='mne',
+    pytest.raises(ValueError, stc.plot, colormap='mne',
                   clim=dict(pos_lims=(5, 10, 15, 20)), **kwargs)
-    assert_raises(ValueError, stc.plot,
+    pytest.raises(ValueError, stc.plot,
                   clim=dict(pos_lims=(5, 10, 15), kind='foo'), **kwargs)
-    assert_raises(ValueError, stc.plot, colormap='mne', clim='foo', **kwargs)
-    assert_raises(ValueError, stc.plot, clim=(5, 10, 15), **kwargs)
-    assert_raises(TypeError, plot_source_estimates, 'foo', clim='auto',
+    pytest.raises(ValueError, stc.plot, colormap='mne', clim='foo', **kwargs)
+    pytest.raises(ValueError, stc.plot, clim=(5, 10, 15), **kwargs)
+    pytest.raises(TypeError, plot_source_estimates, 'foo', clim='auto',
                   **kwargs)
-    assert_raises(ValueError, stc.plot, hemi='foo', clim='auto', **kwargs)
+    pytest.raises(ValueError, stc.plot, hemi='foo', clim='auto', **kwargs)
 
     # Test handling of degenerate data
     with warnings.catch_warnings(record=True) as w:
@@ -343,9 +341,9 @@ def test_stc_mpl():
         _fake_click(time_viewer, time_viewer.axes[0], (0.5, 0.5))  # change t
         time_viewer.canvas.key_press_event('ctrl+right')
         time_viewer.canvas.key_press_event('left')
-    assert_raises(ValueError, stc.plot, subjects_dir=subjects_dir,
+    pytest.raises(ValueError, stc.plot, subjects_dir=subjects_dir,
                   hemi='both', subject='sample', backend='matplotlib')
-    assert_raises(ValueError, stc.plot, subjects_dir=subjects_dir,
+    pytest.raises(ValueError, stc.plot, subjects_dir=subjects_dir,
                   time_unit='ss', subject='sample', backend='matplotlib')
     plt.close('all')
 
@@ -368,7 +366,7 @@ def test_plot_dipole_mri_orthoview():
         fig.canvas.key_press_event('down')
         fig.canvas.key_press_event('a')  # some other key
     ax = plt.subplot(111)
-    assert_raises(TypeError, dipoles.plot_locations, trans, 'sample',
+    pytest.raises(TypeError, dipoles.plot_locations, trans, 'sample',
                   subjects_dir, ax=ax)
     plt.close('all')
 
@@ -388,13 +386,13 @@ def test_snapshot_brain_montage():
     xyz_dict[info['chs'][0]['ch_name']] = [1, 2]  # Set one ch to only 2 vals
 
     # Make sure wrong types are checked
-    assert_raises(TypeError, snapshot_brain_montage, fig, xyz)
+    pytest.raises(TypeError, snapshot_brain_montage, fig, xyz)
 
     # All chs must have 3 position values
-    assert_raises(ValueError, snapshot_brain_montage, fig, xyz_dict)
+    pytest.raises(ValueError, snapshot_brain_montage, fig, xyz_dict)
 
     # Make sure we raise error if the figure has no scene
-    assert_raises(TypeError, snapshot_brain_montage, fig, info)
+    pytest.raises(TypeError, snapshot_brain_montage, fig, info)
 
 
 @testing.requires_testing_data

--- a/mne/viz/tests/test_circle.py
+++ b/mne/viz/tests/test_circle.py
@@ -6,7 +6,7 @@
 
 
 import numpy as np
-from numpy.testing import assert_raises
+import pytest
 
 from mne.viz import plot_connectivity_circle, circular_layout
 
@@ -16,8 +16,7 @@ matplotlib.use('Agg')  # for testing don't use X server
 
 
 def test_plot_connectivity_circle():
-    """Test plotting connectivity circle
-    """
+    """Test plotting connectivity circle."""
     import matplotlib.pyplot as plt
     node_order = ['frontalpole-lh', 'parsorbitalis-lh',
                   'lateralorbitofrontal-lh', 'rostralmiddlefrontal-lh',
@@ -87,8 +86,8 @@ def test_plot_connectivity_circle():
                              node_angles=node_angles, title='test',
                              )
 
-    assert_raises(ValueError, circular_layout, label_names, node_order,
+    pytest.raises(ValueError, circular_layout, label_names, node_order,
                   group_boundaries=[-1])
-    assert_raises(ValueError, circular_layout, label_names, node_order,
+    pytest.raises(ValueError, circular_layout, label_names, node_order,
                   group_boundaries=[20, 0])
     plt.close('all')

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -8,7 +8,6 @@
 
 import os.path as op
 import warnings
-from nose.tools import assert_raises
 
 import numpy as np
 from numpy.testing import assert_equal
@@ -112,7 +111,7 @@ def test_plot_epochs():
     fig.canvas.resize_event()
     fig.canvas.close_event()  # closing and epoch dropping
     plt.close('all')
-    assert_raises(RuntimeError, epochs.plot, picks=[])
+    pytest.raises(RuntimeError, epochs.plot, picks=[])
     plt.close('all')
     with warnings.catch_warnings(record=True):
         fig = epochs.plot(events=epochs.events)
@@ -146,17 +145,17 @@ def test_plot_epochs_image():
                       )
     epochs.plot_image(picks=[1], overlay_times=overlay_times, vmin=-0.001,
                       vmax=0.001)
-    assert_raises(ValueError, epochs.plot_image,
+    pytest.raises(ValueError, epochs.plot_image,
                   picks=[1], overlay_times=[0.1, 0.2])
-    assert_raises(ValueError, epochs.plot_image,
+    pytest.raises(ValueError, epochs.plot_image,
                   picks=[1], order=[0, 1])
-    assert_raises(ValueError, epochs.plot_image, axes=dict(), group_by=list(),
+    pytest.raises(ValueError, epochs.plot_image, axes=dict(), group_by=list(),
                   combine='mean')
-    assert_raises(ValueError, epochs.plot_image, axes=list(), group_by=dict(),
+    pytest.raises(ValueError, epochs.plot_image, axes=list(), group_by=dict(),
                   combine='mean')
-    assert_raises(ValueError, epochs.plot_image, group_by='error',
+    pytest.raises(ValueError, epochs.plot_image, group_by='error',
                   picks=[1, 2])
-    assert_raises(ValueError, epochs.plot_image, units={"hi": 1},
+    pytest.raises(ValueError, epochs.plot_image, units={"hi": 1},
                   scalings={"ho": 1})
     epochs.load_data().pick_types(meg='mag')
     epochs.info.normalize_proj()
@@ -164,11 +163,11 @@ def test_plot_epochs_image():
         epochs.plot_image(group_by='type', combine='mean')
         epochs.plot_image(group_by={"1": [1, 2], "2": [1, 2]}, combine='mean')
         epochs.plot_image(vmin=lambda x: x.min())
-        assert_raises(ValueError, epochs.plot_image, axes=1, fig=2)
+        pytest.raises(ValueError, epochs.plot_image, axes=1, fig=2)
     ts_args = dict(show_sensors=False)
     with warnings.catch_warnings(record=True) as w:
         epochs.plot_image(overlay_times=[1.1], combine="gfp", ts_args=ts_args)
-        assert_raises(ValueError, epochs.plot_image, combine='error',
+        pytest.raises(ValueError, epochs.plot_image, combine='error',
                       ts_args=ts_args)
         warnings.simplefilter('always')
     assert_equal(len(w), 1)
@@ -182,7 +181,7 @@ def test_plot_drop_log():
     """Test plotting a drop log."""
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
-    assert_raises(ValueError, epochs.plot_drop_log)
+    pytest.raises(ValueError, epochs.plot_drop_log)
     epochs.drop_bad()
 
     warnings.simplefilter('always', UserWarning)
@@ -201,7 +200,7 @@ def test_plot_psd_epochs():
     import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.plot_psd()
-    assert_raises(RuntimeError, epochs.plot_psd_topomap,
+    pytest.raises(RuntimeError, epochs.plot_psd_topomap,
                   bands=[(0, 0.01, 'foo')])  # no freqs in range
     epochs.plot_psd_topomap()
     plt.close('all')

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -12,8 +12,7 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_raises, assert_allclose
-from nose.tools import assert_true
+from numpy.testing import assert_allclose
 import pytest
 
 import mne
@@ -121,18 +120,18 @@ def test_plot_evoked():
     evoked_delayed_ssp = _get_epochs_delayed_ssp().average()
     evoked_delayed_ssp.plot(proj='interactive', time_unit='s')
     evoked_delayed_ssp.apply_proj()
-    assert_raises(RuntimeError, evoked_delayed_ssp.plot,
+    pytest.raises(RuntimeError, evoked_delayed_ssp.plot,
                   proj='interactive', time_unit='s')
     evoked_delayed_ssp.info['projs'] = []
-    assert_raises(RuntimeError, evoked_delayed_ssp.plot,
+    pytest.raises(RuntimeError, evoked_delayed_ssp.plot,
                   proj='interactive', time_unit='s')
-    assert_raises(RuntimeError, evoked_delayed_ssp.plot,
+    pytest.raises(RuntimeError, evoked_delayed_ssp.plot,
                   proj='interactive', axes='foo', time_unit='s')
     plt.close('all')
 
     # test GFP only
     evoked.plot(gfp='only', time_unit='s')
-    assert_raises(ValueError, evoked.plot, gfp='foo', time_unit='s')
+    pytest.raises(ValueError, evoked.plot, gfp='foo', time_unit='s')
 
     evoked.plot_image(proj=True, time_unit='ms')
 
@@ -146,7 +145,7 @@ def test_plot_evoked():
         evoked.plot_image(picks=[1, 2], mask=None, mask_style="both",
                           time_unit='s')
     assert len(w) == 2
-    assert_raises(ValueError, evoked.plot_image, mask=evoked.data[1:, 1:] > 0,
+    pytest.raises(ValueError, evoked.plot_image, mask=evoked.data[1:, 1:] > 0,
                   time_unit='s')
 
     # plot with bad channels excluded
@@ -154,7 +153,7 @@ def test_plot_evoked():
     evoked.plot_image(exclude=evoked.info['bads'], time_unit='s')  # same thing
     plt.close('all')
 
-    assert_raises(ValueError, evoked.plot_image, picks=[0, 0],
+    pytest.raises(ValueError, evoked.plot_image, picks=[0, 0],
                   time_unit='s')  # duplicates
 
     ch_names = ["MEG 1131", "MEG 0111"]
@@ -162,14 +161,14 @@ def test_plot_evoked():
     evoked.plot_image(show_names="all", time_unit='s', picks=picks)
     yticklabels = plt.gca().get_yticklabels()
     for tick_target, tick_observed in zip(ch_names, yticklabels):
-        assert_true(tick_target in str(tick_observed))
+        assert tick_target in str(tick_observed)
     evoked.plot_image(show_names=True, time_unit='s')
 
     # test groupby
     evoked.plot_image(group_by=dict(sel=[0, 7]), axes=dict(sel=plt.axes()))
     plt.close('all')
     for group_by, axes in (("something", dict()), (dict(), "something")):
-        assert_raises(ValueError, evoked.plot_image, group_by=group_by,
+        pytest.raises(ValueError, evoked.plot_image, group_by=group_by,
                       axes=axes)
 
     # test plot_topo
@@ -185,10 +184,10 @@ def test_plot_evoked():
     evoked.plot_white(cov, rank={'mag': 101, 'grad': 201}, time_unit='s')
     evoked.plot_white(cov, rank={'mag': 101}, time_unit='s')  # test rank param
     evoked.plot_white(cov, rank={'grad': 201}, time_unit='s')
-    assert_raises(
+    pytest.raises(
         ValueError, evoked.plot_white, cov,
         rank={'mag': 101, 'grad': 201, 'meg': 306}, time_unit='s')
-    assert_raises(
+    pytest.raises(
         ValueError, evoked.plot_white, cov, rank={'meg': 306}, time_unit='s')
 
     evoked.plot_white([cov, cov], time_unit='s')
@@ -251,14 +250,14 @@ def test_plot_evoked():
               dict(picks=3, show_sensors="a"),
               dict(colors=dict(red=10., blue=-2))]
     for param in params:
-        assert_raises(ValueError, plot_compare_evokeds, evoked, **param)
-    assert_raises(TypeError, plot_compare_evokeds, evoked, picks='str')
-    assert_raises(TypeError, plot_compare_evokeds, evoked, vlines='x')
+        pytest.raises(ValueError, plot_compare_evokeds, evoked, **param)
+    pytest.raises(TypeError, plot_compare_evokeds, evoked, picks='str')
+    pytest.raises(TypeError, plot_compare_evokeds, evoked, vlines='x')
     plt.close('all')
     # `evoked` must contain Evokeds
-    assert_raises(TypeError, plot_compare_evokeds, [[1, 2], [3, 4]])
+    pytest.raises(TypeError, plot_compare_evokeds, [[1, 2], [3, 4]])
     # `ci` must be float or None
-    assert_raises(TypeError, plot_compare_evokeds, contrast, ci='err')
+    pytest.raises(TypeError, plot_compare_evokeds, contrast, ci='err')
     # test all-positive ylim
     contrast["red/stim"], contrast["blue/stim"] = red, blue
     plot_compare_evokeds(contrast, picks=[0], colors=['r', 'b'],
@@ -290,8 +289,8 @@ def test_plot_evoked():
     plot_compare_evokeds([red, blue], picks=[0], cmap="summer", ci=None,
                          split_legend=None)
     plot_compare_evokeds([red, blue], cmap=None, split_legend=True)
-    assert_raises(ValueError, plot_compare_evokeds, [red] * 20)
-    assert_raises(ValueError, plot_compare_evokeds, contrasts,
+    pytest.raises(ValueError, plot_compare_evokeds, [red] * 20)
+    pytest.raises(ValueError, plot_compare_evokeds, contrasts,
                   cmap='summer')
 
     plt.close('all')
@@ -301,7 +300,7 @@ def test_plot_evoked():
     sss = dict(sss_info=dict(in_order=80, components=np.arange(80)))
     evoked_sss.info['proc_history'] = [dict(max_info=sss)]
     evoked_sss.plot_white(cov, rank={'meg': 64}, time_unit='s')
-    assert_raises(
+    pytest.raises(
         ValueError, evoked_sss.plot_white, cov, rank={'grad': 201},
         time_unit='s')
     evoked_sss.plot_white(cov, time_unit='s')
@@ -312,7 +311,7 @@ def test_plot_evoked():
                 zorder='std', time_unit='s')
     evoked.plot(exclude=[], spatial_colors=True, zorder='unsorted',
                 time_unit='s')
-    assert_raises(TypeError, evoked.plot, zorder='asdf', time_unit='s')
+    pytest.raises(TypeError, evoked.plot, zorder='asdf', time_unit='s')
     plt.close('all')
 
     evoked.plot_sensors()  # Test plot_sensors
@@ -321,7 +320,7 @@ def test_plot_evoked():
     evoked.pick_channels(evoked.ch_names[:4])
     with catch_logging() as log_file:
         evoked.plot(verbose=True, time_unit='s')
-    assert_true('Need more than one' in log_file.getvalue())
+    assert 'Need more than one' in log_file.getvalue()
 
 
 @testing.requires_testing_data
@@ -341,5 +340,6 @@ def test_plot_ctf():
     evoked = epochs.average()
     evoked.plot_joint(times=[0.1])
     mne.viz.plot_compare_evokeds([evoked, evoked])
+
 
 run_tests_if_main()

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -6,8 +6,8 @@
 import os.path as op
 import warnings
 
-from numpy.testing import assert_raises, assert_equal, assert_array_equal
-from nose.tools import assert_true
+from numpy.testing import assert_equal, assert_array_equal
+import pytest
 
 from mne import read_events, Epochs, read_cov, pick_types
 from mne.io import read_raw_fif
@@ -101,15 +101,15 @@ def test_plot_ica_components():
         labels = [ax.get_label() for ax in c_fig.axes]
 
         for l in ['topomap', 'image', 'erp', 'spectrum', 'variance']:
-            assert_true(l in labels)
+            assert (l in labels)
 
         topomap_ax = c_fig.axes[labels.index('topomap')]
         title = topomap_ax.get_title()
-        assert_true(lbl == title)
+        assert (lbl == title)
 
     ica.info = None
-    assert_raises(ValueError, ica.plot_components, 1)
-    assert_raises(RuntimeError, ica.plot_components, 1, ch_type='mag')
+    pytest.raises(ValueError, ica.plot_components, 1)
+    pytest.raises(RuntimeError, ica.plot_components, 1, ch_type='mag')
     plt.close('all')
 
 
@@ -148,22 +148,22 @@ def test_plot_ica_properties():
                         figsize=[4.5, 4.5])
     plt.close('all')
 
-    assert_raises(TypeError, ica.plot_properties, epochs, dB=list('abc'))
-    assert_raises(TypeError, ica.plot_properties, ica)
-    assert_raises(TypeError, ica.plot_properties, [0.2])
-    assert_raises(TypeError, plot_ica_properties, epochs, epochs)
-    assert_raises(TypeError, ica.plot_properties, epochs,
+    pytest.raises(TypeError, ica.plot_properties, epochs, dB=list('abc'))
+    pytest.raises(TypeError, ica.plot_properties, ica)
+    pytest.raises(TypeError, ica.plot_properties, [0.2])
+    pytest.raises(TypeError, plot_ica_properties, epochs, epochs)
+    pytest.raises(TypeError, ica.plot_properties, epochs,
                   psd_args='not dict')
-    assert_raises(ValueError, ica.plot_properties, epochs, plot_std=[])
+    pytest.raises(ValueError, ica.plot_properties, epochs, plot_std=[])
 
     fig, ax = plt.subplots(2, 3)
     ax = ax.ravel()[:-1]
     ica.plot_properties(epochs, picks=1, axes=ax, **topoargs)
     fig = ica.plot_properties(raw, picks=[0, 1], **topoargs)
     assert_equal(len(fig), 2)
-    assert_raises(TypeError, plot_ica_properties, epochs, ica, picks=[0, 1],
+    pytest.raises(TypeError, plot_ica_properties, epochs, ica, picks=[0, 1],
                   axes=ax)
-    assert_raises(ValueError, ica.plot_properties, epochs, axes='not axes')
+    pytest.raises(ValueError, ica.plot_properties, epochs, axes='not axes')
     plt.close('all')
 
     # Test merging grads.
@@ -199,10 +199,10 @@ def test_plot_ica_sources():
     _fake_click(fig, data_ax, [-0.1, 0.9])  # click on y-label
 
     raw.info['bads'] = ['MEG 0113']
-    assert_raises(RuntimeError, ica.plot_sources, inst=raw)
+    pytest.raises(RuntimeError, ica.plot_sources, inst=raw)
     ica.plot_sources(epochs)
     epochs.info['bads'] = ['MEG 0113']
-    assert_raises(RuntimeError, ica.plot_sources, inst=epochs)
+    pytest.raises(RuntimeError, ica.plot_sources, inst=epochs)
     epochs.info['bads'] = []
     with warnings.catch_warnings(record=True):  # no labeled objects mpl
         ica.plot_sources(epochs.average())
@@ -222,7 +222,7 @@ def test_plot_ica_sources():
         ica.labels_ = dict(eog=[0])
         ica.labels_['eog/0/crazy-channel'] = [0]
         ica.plot_sources(evoked)  # now with labels
-    assert_raises(ValueError, ica.plot_sources, 'meeow')
+    pytest.raises(ValueError, ica.plot_sources, 'meeow')
     plt.close('all')
 
 
@@ -245,7 +245,7 @@ def test_plot_ica_overlay():
     with warnings.catch_warnings(record=True):  # bad proj
         eog_epochs = create_eog_epochs(raw, picks=picks)
     ica.plot_overlay(eog_epochs.average())
-    assert_raises(TypeError, ica.plot_overlay, raw[:2, :3][0])
+    pytest.raises(TypeError, ica.plot_overlay, raw[:2, :3][0])
     ica.plot_overlay(raw)
     plt.close('all')
 
@@ -278,11 +278,11 @@ def test_plot_ica_scores():
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='foo')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='eog')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
-    assert_raises(
+    pytest.raises(
         ValueError,
         ica.plot_scores,
         [0.3, 0.2], axhline=[0.1, -0.1], labels=['one', 'one-too-many'])
-    assert_raises(ValueError, ica.plot_scores, [0.2])
+    pytest.raises(ValueError, ica.plot_scores, [0.2])
     plt.close('all')
 
 

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -11,7 +11,6 @@ import os.path as op
 import warnings
 
 import numpy as np
-from numpy.testing import assert_raises
 import pytest
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
@@ -95,9 +94,9 @@ def test_plot_cov():
 @requires_nibabel()
 def test_plot_bem():
     """Test plotting of BEM contours."""
-    assert_raises(IOError, plot_bem, subject='bad-subject',
+    pytest.raises(IOError, plot_bem, subject='bad-subject',
                   subjects_dir=subjects_dir)
-    assert_raises(ValueError, plot_bem, subject='sample',
+    pytest.raises(ValueError, plot_bem, subject='sample',
                   subjects_dir=subjects_dir, orientation='bad-ori')
     plot_bem(subject='sample', subjects_dir=subjects_dir,
              orientation='sagittal', slices=[25, 50])
@@ -126,9 +125,9 @@ def test_plot_events():
                     color=color)
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     event_id=event_labels, color=color)
-        assert_raises(ValueError, plot_events, events, raw.info['sfreq'],
+        pytest.raises(ValueError, plot_events, events, raw.info['sfreq'],
                       raw.first_samp, event_id={'aud_l': 1}, color=color)
-        assert_raises(ValueError, plot_events, events, raw.info['sfreq'],
+        pytest.raises(ValueError, plot_events, events, raw.info['sfreq'],
                       raw.first_samp, event_id={'aud_l': 111}, color=color)
     plt.close('all')
 
@@ -146,10 +145,10 @@ def test_plot_source_spectrogram():
     stc_data = np.ones((n_verts, n_times))
     stc = SourceEstimate(stc_data, vertices, 1, 1)
     plot_source_spectrogram([stc, stc], [[1, 2], [3, 4]])
-    assert_raises(ValueError, plot_source_spectrogram, [], [])
-    assert_raises(ValueError, plot_source_spectrogram, [stc, stc],
+    pytest.raises(ValueError, plot_source_spectrogram, [], [])
+    pytest.raises(ValueError, plot_source_spectrogram, [stc, stc],
                   [[1, 2], [3, 4]], tmin=0)
-    assert_raises(ValueError, plot_source_spectrogram, [stc, stc],
+    pytest.raises(ValueError, plot_source_spectrogram, [stc, stc],
                   [[1, 2], [3, 4]], tmax=7)
     plt.close('all')
 

--- a/mne/viz/tests/test_montage.py
+++ b/mne/viz/tests/test_montage.py
@@ -22,8 +22,7 @@ point_names = ['nasion', 'lpa', 'rpa', '1', '2', '3', '4', '5']
 
 
 def test_plot_montage():
-    """Test plotting montages.
-    """
+    """Test plotting montages."""
     import matplotlib.pyplot as plt
     m = read_montage('easycap-M1')
     m.plot()
@@ -46,8 +45,7 @@ def test_plot_montage():
 
 
 def test_plot_defect_montage():
-    """Test plotting defect montages (i.e. with duplicate labels).
-    """
+    """Test plotting defect montages (i.e. with duplicate labels)."""
     # montage name and number of unique labels
     montages = [('standard_1005', 342), ('standard_postfixed', 85),
                 ('standard_primed', 85), ('standard_1020', 93)]

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -8,7 +8,8 @@ import warnings
 import itertools
 from distutils.version import LooseVersion
 
-from numpy.testing import assert_raises, assert_allclose
+from numpy.testing import assert_allclose
+import pytest
 
 from mne import read_events, pick_types, Annotations
 from mne.datasets import testing
@@ -49,7 +50,7 @@ def _get_events():
 
 
 def _annotation_helper(raw, events=False):
-    """Helper for testing interactive annotations."""
+    """Test interactive annotations."""
     import matplotlib.pyplot as plt
     # Some of our checks here require modern mpl to work properly
     mpl_good_enough = LooseVersion(matplotlib.__version__) >= '2.0'
@@ -192,8 +193,8 @@ def test_plot_raw():
                     'escape']:
             fig.canvas.key_press_event(key)
         # Color setting
-        assert_raises(KeyError, raw.plot, event_color={0: 'r'})
-        assert_raises(TypeError, raw.plot, event_color={'foo': 'r'})
+        pytest.raises(KeyError, raw.plot, event_color={0: 'r'})
+        pytest.raises(TypeError, raw.plot, event_color={'foo': 'r'})
         annot = Annotations([10, 10 + raw.first_samp / raw.info['sfreq']],
                             [10, 10], ['test', 'test'], raw.info['meas_date'])
         raw.annotations = annot
@@ -256,7 +257,7 @@ def test_plot_ref_meg():
     raw_ctf = read_raw_ctf(ctf_fname_continuous).crop(0, 1).load_data()
     raw_ctf.plot()
     plt.close('all')
-    assert_raises(ValueError, raw_ctf.plot, group_by='selection')
+    pytest.raises(ValueError, raw_ctf.plot, group_by='selection')
 
 
 def test_plot_annotations():
@@ -275,11 +276,11 @@ def test_plot_annotations():
 def test_plot_raw_filtered():
     """Test filtering of raw plots."""
     raw = _get_raw()
-    assert_raises(ValueError, raw.plot, lowpass=raw.info['sfreq'] / 2.)
-    assert_raises(ValueError, raw.plot, highpass=0)
-    assert_raises(ValueError, raw.plot, lowpass=1, highpass=1)
-    assert_raises(ValueError, raw.plot, lowpass=1, filtorder=0)
-    assert_raises(ValueError, raw.plot, clipping='foo')
+    pytest.raises(ValueError, raw.plot, lowpass=raw.info['sfreq'] / 2.)
+    pytest.raises(ValueError, raw.plot, highpass=0)
+    pytest.raises(ValueError, raw.plot, lowpass=1, highpass=1)
+    pytest.raises(ValueError, raw.plot, lowpass=1, filtorder=0)
+    pytest.raises(ValueError, raw.plot, clipping='foo')
     raw.plot(lowpass=1, clipping='transparent')
     raw.plot(highpass=1, clipping='clamp')
     raw.plot(highpass=1, lowpass=2, butterfly=True)
@@ -301,12 +302,12 @@ def test_plot_raw_psd():
     plt.close('all')
     ax = plt.axes()
     # if ax is supplied:
-    assert_raises(ValueError, raw.plot_psd, ax=ax, average=True)
-    assert_raises(ValueError, raw.plot_psd, average=True, spatial_colors=True)
+    pytest.raises(ValueError, raw.plot_psd, ax=ax, average=True)
+    pytest.raises(ValueError, raw.plot_psd, average=True, spatial_colors=True)
     raw.plot_psd(tmax=np.inf, picks=picks, ax=ax, average=True)
     plt.close('all')
     ax = plt.axes()
-    assert_raises(ValueError, raw.plot_psd, ax=ax, average=True)
+    pytest.raises(ValueError, raw.plot_psd, ax=ax, average=True)
     plt.close('all')
     ax = plt.subplots(2)[1]
     raw.plot_psd(tmax=np.inf, ax=ax, average=True)
@@ -354,9 +355,9 @@ def test_plot_sensors():
     raw.plot_sensors(ch_groups='position', axes=ax)
     raw.plot_sensors(ch_groups='selection', to_sphere=False)
     raw.plot_sensors(ch_groups=[[0, 1, 2], [3, 4]])
-    assert_raises(ValueError, raw.plot_sensors, ch_groups='asd')
-    assert_raises(TypeError, plot_sensors, raw)  # needs to be info
-    assert_raises(ValueError, plot_sensors, raw.info, kind='sasaasd')
+    pytest.raises(ValueError, raw.plot_sensors, ch_groups='asd')
+    pytest.raises(TypeError, plot_sensors, raw)  # needs to be info
+    pytest.raises(ValueError, plot_sensors, raw.info, kind='sasaasd')
     plt.close('all')
     fig, sels = raw.plot_sensors('select', show_names=True)
     ax = fig.axes[0]

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -10,8 +10,7 @@ import warnings
 from collections import namedtuple
 
 import numpy as np
-from numpy.testing import assert_raises, assert_equal
-from nose.tools import assert_true
+import pytest
 
 from mne import read_events, Epochs, pick_channels_evoked, read_cov
 from mne.channels import read_layout
@@ -91,7 +90,7 @@ def test_plot_topo():
                                                       time_unit='ms'),
                       ts_args=dict(spatial_colors=True, zorder=return_inds,
                                    time_unit='s'))
-    assert_raises(ValueError, evoked.plot_joint, ts_args=dict(axes=True,
+    pytest.raises(ValueError, evoked.plot_joint, ts_args=dict(axes=True,
                                                               time_unit='s'))
 
     warnings.simplefilter('always', UserWarning)
@@ -105,7 +104,7 @@ def test_plot_topo():
             plot_evoked_topo([picked_evoked] * 2, layout, ylim=ylim)
 
         for evo in [evoked, [evoked, picked_evoked]]:
-            assert_raises(ValueError, plot_evoked_topo, evo, layout,
+            pytest.raises(ValueError, plot_evoked_topo, evo, layout,
                           color=['y', 'b'])
 
         evoked_delayed_ssp = _get_epochs_delayed_ssp().average()
@@ -134,7 +133,7 @@ def test_plot_topo():
     for ax, idx in iter_topography(evoked.info):
         ax.plot(evoked.data[idx], color='red')
         # test status bar message
-        assert_true(evoked.ch_names[idx] in ax.format_coord(.5, .5))
+        assert (evoked.ch_names[idx] in ax.format_coord(.5, .5))
     plt.close('all')
     cov = read_cov(cov_fname)
     cov['projs'] = []
@@ -143,22 +142,22 @@ def test_plot_topo():
 
 
 def test_plot_topo_single_ch():
-    """Test single channel topoplot with time cursor"""
+    """Test single channel topoplot with time cursor."""
     import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     fig = plot_evoked_topo(evoked, background_color='w')
     # test status bar message
     ax = plt.gca()
-    assert_true('MEG 0113' in ax.format_coord(.065, .63))
+    assert ('MEG 0113' in ax.format_coord(.065, .63))
     num_figures_before = len(plt.get_fignums())
     _fake_click(fig, fig.axes[0], (0.08, 0.65))
-    assert_equal(num_figures_before + 1, len(plt.get_fignums()))
+    assert num_figures_before + 1 == len(plt.get_fignums())
     fig = plt.gcf()
     ax = plt.gca()
     _fake_click(fig, ax, (.5, .5), kind='motion')  # cursor should appear
-    assert_true(isinstance(ax._cursorline, matplotlib.lines.Line2D))
+    assert (isinstance(ax._cursorline, matplotlib.lines.Line2D))
     _fake_click(fig, ax, (1.5, 1.5), kind='motion')  # cursor should disappear
-    assert_equal(ax._cursorline, None)
+    assert ax._cursorline is None
     plt.close('all')
 
 
@@ -173,10 +172,10 @@ def test_plot_topo_image_epochs():
     plt.close('all')
     fig = plot_topo_image_epochs(epochs, sigma=0.5, vmin=-200, vmax=200,
                                  colorbar=True, title=title, cmap=cmap)
-    assert_equal(epochs._data.min(), data_min)
+    assert epochs._data.min() == data_min
     num_figures_before = len(plt.get_fignums())
     _fake_click(fig, fig.axes[0], (0.08, 0.64))
-    assert_equal(num_figures_before + 1, len(plt.get_fignums()))
+    assert num_figures_before + 1 == len(plt.get_fignums())
     plt.close('all')
 
 
@@ -198,17 +197,17 @@ def test_plot_tfr_topo():
     num_figures_before = len(plt.get_fignums())
     # could use np.reshape(fig.axes[-1].images[0].get_extent(), (2, 2)).mean(1)
     _fake_click(fig, fig.axes[0], (0.08, 0.65))
-    assert_equal(num_figures_before + 1, len(plt.get_fignums()))
+    assert num_figures_before + 1 == len(plt.get_fignums())
     plt.close('all')
 
     tfr.plot([4], baseline=(None, 0), mode='ratio', show=False, title='foo')
-    assert_raises(ValueError, tfr.plot, [4], yscale='lin', show=False)
+    pytest.raises(ValueError, tfr.plot, [4], yscale='lin', show=False)
 
     # nonuniform freqs
     freqs = np.logspace(*np.log10([3, 10]), num=3)
     tfr = AverageTFR(epochs.info, data, epochs.times, freqs, nave)
     fig = tfr.plot([4], baseline=(None, 0), mode='mean', vmax=14., show=False)
-    assert_equal(fig.axes[0].get_yaxis().get_scale(), 'log')
+    assert fig.axes[0].get_yaxis().get_scale() == 'log'
 
     # one timesample
     tfr = AverageTFR(epochs.info, data[:, :, [0]], epochs.times[[1]],
@@ -224,12 +223,12 @@ def test_plot_tfr_topo():
                 freq=freqs[[-1]], x_label=None, y_label=None,
                 colorbar=False, cmap=('RdBu_r', True), yscale='log')
     fig = plt.gcf()
-    assert_equal(fig.axes[0].get_yaxis().get_scale(), 'linear')
+    assert fig.axes[0].get_yaxis().get_scale() == 'linear'
 
     # ValueError when freq[0] == 0 and yscale == 'log'
     these_freqs = freqs[:3].copy()
     these_freqs[0] = 0
-    assert_raises(ValueError, _imshow_tfr, ax, 3, tmin, tmax, vmin, vmax,
+    pytest.raises(ValueError, _imshow_tfr, ax, 3, tmin, tmax, vmin, vmax,
                   None, tfr=data[:, :3, :], freq=these_freqs, x_label=None,
                   y_label=None, colorbar=False, cmap=('RdBu_r', True),
                   yscale='log')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -199,8 +199,9 @@ def test_plot_topomap():
 
     p = plt_topomap(times, ch_type='grad', image_interp='bilinear',
                     show_names=lambda x: x.replace('MEG', ''))
-    subplot = [x for x in p.get_children() if
-               isinstance(x, matplotlib.axes.Subplot)][0]
+    subplot = [x for x in p.get_children() if 'Subplot' in str(type(x))]
+    assert len(subplot) >= 1, [type(x) for x in p.get_children()]
+    subplot = subplot[0]
     assert (all('MEG' not in x.get_text()
                 for x in subplot.get_children()
                 if isinstance(x, matplotlib.text.Text)))

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -10,9 +10,7 @@ import warnings
 from functools import partial
 
 import numpy as np
-from numpy.testing import assert_raises, assert_array_equal
-
-from nose.tools import assert_true, assert_equal
+from numpy.testing import assert_array_equal, assert_equal
 import pytest
 
 from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
@@ -127,7 +125,7 @@ def test_plot_projs_topomap():
     plot_projs_topomap(read_info(triux_fname)['projs'][:1], ** fast_test)
     plt.close('all')
     eeg_avg = make_eeg_average_ref_proj(info)
-    assert_raises(RuntimeError, eeg_avg.plot_topomap)  # no layout
+    pytest.raises(RuntimeError, eeg_avg.plot_topomap)  # no layout
     eeg_avg.plot_topomap(info=info, **fast_test)
     plt.close('all')
 
@@ -156,12 +154,12 @@ def test_plot_topomap():
     ev_bad.pick_channels(ev_bad.ch_names[:2])
     plt_topomap = partial(ev_bad.plot_topomap, **fast_test)
     plt_topomap(times=ev_bad.times[:2] - 1e-6)  # auto, plots EEG
-    assert_raises(ValueError, plt_topomap, ch_type='mag')
-    assert_raises(TypeError, plt_topomap, head_pos='foo')
-    assert_raises(KeyError, plt_topomap, head_pos=dict(foo='bar'))
-    assert_raises(ValueError, plt_topomap, head_pos=dict(center=0))
-    assert_raises(ValueError, plt_topomap, times=[-100])  # bad time
-    assert_raises(ValueError, plt_topomap, times=[[0]])  # bad time
+    pytest.raises(ValueError, plt_topomap, ch_type='mag')
+    pytest.raises(TypeError, plt_topomap, head_pos='foo')
+    pytest.raises(KeyError, plt_topomap, head_pos=dict(foo='bar'))
+    pytest.raises(ValueError, plt_topomap, head_pos=dict(center=0))
+    pytest.raises(ValueError, plt_topomap, times=[-100])  # bad time
+    pytest.raises(ValueError, plt_topomap, times=[[0]])  # bad time
 
     evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
                         contours=[-100, 0, 100], time_unit='ms')
@@ -196,23 +194,23 @@ def test_plot_topomap():
     plt_topomap(times, ch_type='grad', mask=mask, show_names=True,
                 mask_params={'marker': 'x'})
     plt.close('all')
-    assert_raises(ValueError, plt_topomap, times, ch_type='eeg', average=-1e3)
-    assert_raises(ValueError, plt_topomap, times, ch_type='eeg', average='x')
+    pytest.raises(ValueError, plt_topomap, times, ch_type='eeg', average=-1e3)
+    pytest.raises(ValueError, plt_topomap, times, ch_type='eeg', average='x')
 
     p = plt_topomap(times, ch_type='grad', image_interp='bilinear',
                     show_names=lambda x: x.replace('MEG', ''))
     subplot = [x for x in p.get_children() if
                isinstance(x, matplotlib.axes.Subplot)][0]
-    assert_true(all('MEG' not in x.get_text()
-                    for x in subplot.get_children()
-                    if isinstance(x, matplotlib.text.Text)))
+    assert (all('MEG' not in x.get_text()
+                for x in subplot.get_children()
+                if isinstance(x, matplotlib.text.Text)))
 
     # Plot array
     for ch_type in ('mag', 'grad'):
         evoked_ = evoked.copy().pick_types(eeg=False, meg=ch_type)
         plot_topomap(evoked_.data[:, 0], evoked_.info, **fast_test_noscale)
     # fail with multiple channel types
-    assert_raises(ValueError, plot_topomap, evoked.data[0, :], evoked.info)
+    pytest.raises(ValueError, plot_topomap, evoked.data[0, :], evoked.info)
 
     # Test title
     def get_texts(p):
@@ -232,7 +230,7 @@ def test_plot_topomap():
         warnings.simplefilter('always')
         plt_topomap(times, ch_type='mag', layout=None)
     # projs have already been applied
-    assert_raises(RuntimeError, plot_evoked_topomap, evoked, 0.1, 'mag',
+    pytest.raises(RuntimeError, plot_evoked_topomap, evoked, 0.1, 'mag',
                   proj='interactive', time_unit='s')
 
     # change to no-proj mode
@@ -247,11 +245,11 @@ def test_plot_topomap():
     fig2 = plt.gcf()
     _fake_click(fig2, fig2.axes[0], (0.075, 0.775))  # toggle projector
     # make sure projector gets toggled
-    assert_true(np.max(fig1.axes[0].images[0]._A) != data_max)
+    assert (np.max(fig1.axes[0].images[0]._A) != data_max)
 
-    assert_raises(RuntimeError, plot_evoked_topomap, evoked,
+    pytest.raises(RuntimeError, plot_evoked_topomap, evoked,
                   np.repeat(.1, 50), time_unit='s')
-    assert_raises(ValueError, plot_evoked_topomap, evoked, [-3e12, 15e6],
+    pytest.raises(ValueError, plot_evoked_topomap, evoked, [-3e12, 15e6],
                   time_unit='s')
 
     for ch in evoked.info['chs']:
@@ -264,23 +262,23 @@ def test_plot_topomap():
 
     pos = make_eeg_layout(evoked.info).pos[:, :2]
     pos, outlines = _check_outlines(pos, 'head')
-    assert_true('head' in outlines.keys())
-    assert_true('nose' in outlines.keys())
-    assert_true('ear_left' in outlines.keys())
-    assert_true('ear_right' in outlines.keys())
-    assert_true('autoshrink' in outlines.keys())
-    assert_true(outlines['autoshrink'])
-    assert_true('clip_radius' in outlines.keys())
+    assert ('head' in outlines.keys())
+    assert ('nose' in outlines.keys())
+    assert ('ear_left' in outlines.keys())
+    assert ('ear_right' in outlines.keys())
+    assert ('autoshrink' in outlines.keys())
+    assert (outlines['autoshrink'])
+    assert ('clip_radius' in outlines.keys())
     assert_array_equal(outlines['clip_radius'], 0.5)
 
     pos, outlines = _check_outlines(pos, 'skirt')
-    assert_true('head' in outlines.keys())
-    assert_true('nose' in outlines.keys())
-    assert_true('ear_left' in outlines.keys())
-    assert_true('ear_right' in outlines.keys())
-    assert_true('autoshrink' in outlines.keys())
-    assert_true(not outlines['autoshrink'])
-    assert_true('clip_radius' in outlines.keys())
+    assert ('head' in outlines.keys())
+    assert ('nose' in outlines.keys())
+    assert ('ear_left' in outlines.keys())
+    assert ('ear_right' in outlines.keys())
+    assert ('autoshrink' in outlines.keys())
+    assert (not outlines['autoshrink'])
+    assert ('clip_radius' in outlines.keys())
     assert_array_equal(outlines['clip_radius'], 0.625)
 
     pos, outlines = _check_outlines(pos, 'skirt',
@@ -325,26 +323,26 @@ def test_plot_topomap():
 
     # Remove digitization points. Now topomap should fail
     evoked.info['dig'] = None
-    assert_raises(RuntimeError, plot_evoked_topomap, evoked,
+    pytest.raises(RuntimeError, plot_evoked_topomap, evoked,
                   times, ch_type='eeg', time_unit='s')
     plt.close('all')
 
     # Error for missing names
     n_channels = len(pos)
     data = np.ones(n_channels)
-    assert_raises(ValueError, plot_topomap, data, pos, show_names=True)
+    pytest.raises(ValueError, plot_topomap, data, pos, show_names=True)
 
     # Test error messages for invalid pos parameter
     pos_1d = np.zeros(n_channels)
     pos_3d = np.zeros((n_channels, 2, 2))
-    assert_raises(ValueError, plot_topomap, data, pos_1d)
-    assert_raises(ValueError, plot_topomap, data, pos_3d)
-    assert_raises(ValueError, plot_topomap, data, pos[:3, :])
+    pytest.raises(ValueError, plot_topomap, data, pos_1d)
+    pytest.raises(ValueError, plot_topomap, data, pos_3d)
+    pytest.raises(ValueError, plot_topomap, data, pos[:3, :])
 
     pos_x = pos[:, :1]
     pos_xyz = np.c_[pos, np.zeros(n_channels)[:, np.newaxis]]
-    assert_raises(ValueError, plot_topomap, data, pos_x)
-    assert_raises(ValueError, plot_topomap, data, pos_xyz)
+    pytest.raises(ValueError, plot_topomap, data, pos_x)
+    pytest.raises(ValueError, plot_topomap, data, pos_xyz)
 
     # An #channels x 4 matrix should work though. In this case (x, y, width,
     # height) is assumed.

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -4,9 +4,10 @@
 
 import os.path as op
 import warnings
+
 import numpy as np
-from nose.tools import assert_true, assert_raises
 from numpy.testing import assert_allclose
+import pytest
 
 from mne.viz.utils import (compare_fiff, _fake_click, _compute_scalings,
                            _validate_if_list_of_axes)
@@ -30,12 +31,13 @@ ev_fname = op.join(base_dir, 'test_raw-eve.fif')
 
 def test_mne_analyze_colormap():
     """Test mne_analyze_colormap."""
-    assert_raises(ValueError, mne_analyze_colormap, [0])
-    assert_raises(ValueError, mne_analyze_colormap, [-1, 1, 2])
-    assert_raises(ValueError, mne_analyze_colormap, [0, 2, 1])
+    pytest.raises(ValueError, mne_analyze_colormap, [0])
+    pytest.raises(ValueError, mne_analyze_colormap, [-1, 1, 2])
+    pytest.raises(ValueError, mne_analyze_colormap, [0, 2, 1])
 
 
 def test_compare_fiff():
+    """Test compare_fiff."""
     import matplotlib.pyplot as plt
     compare_fiff(raw_fname, cov_fname, read_limit=0, show=False)
     plt.close('all')
@@ -53,11 +55,11 @@ def test_clickable_image():
     for click in clicks:
         _fake_click(clk.fig, clk.ax, click, xform='data')
     assert_allclose(np.array(clicks), np.array(clk.coords))
-    assert_true(len(clicks) == len(clk.coords))
+    assert (len(clicks) == len(clk.coords))
 
     # Exporting to layout
     lt = clk.to_layout()
-    assert_true(lt.pos.shape[0] == len(clicks))
+    assert (lt.pos.shape[0] == len(clicks))
     assert_allclose(lt.pos[1, 0] / lt.pos[2, 0],
                     clicks[1][0] / float(clicks[2][0]))
     clk.plot_clicks()
@@ -81,20 +83,20 @@ def test_add_background_image():
         if ii == 0:
             ax_im = add_background_image(f, im)
             return
-            assert_true(ax_im.get_aspect() == 'auto')
+            assert (ax_im.get_aspect() == 'auto')
             for ax in axs:
-                assert_true(ax.get_aspect() == 1)
+                assert (ax.get_aspect() == 1)
         else:
             # Background with changing aspect
             ax_im_asp = add_background_image(f, im, set_ratios='auto')
-            assert_true(ax_im_asp.get_aspect() == 'auto')
+            assert (ax_im_asp.get_aspect() == 'auto')
             for ax in axs:
-                assert_true(ax.get_aspect() == 'auto')
+                assert (ax.get_aspect() == 'auto')
         plt.close('all')
 
     # Make sure passing None as image returns None
     f, axs = plt.subplots(1, 2)
-    assert_true(add_background_image(f, None) is None)
+    assert (add_background_image(f, None) is None)
     plt.close('all')
 
 
@@ -110,18 +112,18 @@ def test_auto_scale():
                              ('stim', 'auto')])
 
         # Test for wrong inputs
-        assert_raises(ValueError, inst.plot, scalings='foo')
-        assert_raises(ValueError, _compute_scalings, 'foo', inst)
+        pytest.raises(ValueError, inst.plot, scalings='foo')
+        pytest.raises(ValueError, _compute_scalings, 'foo', inst)
 
         # Make sure compute_scalings doesn't change anything not auto
         scalings_new = _compute_scalings(scalings_def, inst)
-        assert_true(scale_grad == scalings_new['grad'])
-        assert_true(scalings_new['eeg'] != 'auto')
+        assert (scale_grad == scalings_new['grad'])
+        assert (scalings_new['eeg'] != 'auto')
 
-    assert_raises(ValueError, _compute_scalings, scalings_def, rand_data)
+    pytest.raises(ValueError, _compute_scalings, scalings_def, rand_data)
     epochs = epochs[0].load_data()
     epochs.pick_types(eeg=True, meg=False)
-    assert_raises(ValueError, _compute_scalings,
+    pytest.raises(ValueError, _compute_scalings,
                   dict(grad='auto'), epochs)
 
 
@@ -129,19 +131,19 @@ def test_validate_if_list_of_axes():
     """Test validation of axes."""
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots(2, 2)
-    assert_raises(ValueError, _validate_if_list_of_axes, ax)
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax)
     ax_flat = ax.ravel()
     ax = ax.ravel().tolist()
     _validate_if_list_of_axes(ax_flat)
     _validate_if_list_of_axes(ax_flat, 4)
-    assert_raises(ValueError, _validate_if_list_of_axes, ax_flat, 5)
-    assert_raises(ValueError, _validate_if_list_of_axes, ax, 3)
-    assert_raises(ValueError, _validate_if_list_of_axes, 'error')
-    assert_raises(ValueError, _validate_if_list_of_axes, ['error'] * 2)
-    assert_raises(ValueError, _validate_if_list_of_axes, ax[0])
-    assert_raises(ValueError, _validate_if_list_of_axes, ax, 3)
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax_flat, 5)
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax, 3)
+    pytest.raises(ValueError, _validate_if_list_of_axes, 'error')
+    pytest.raises(ValueError, _validate_if_list_of_axes, ['error'] * 2)
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax[0])
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax, 3)
     ax_flat[2] = 23
-    assert_raises(ValueError, _validate_if_list_of_axes, ax_flat)
+    pytest.raises(ValueError, _validate_if_list_of_axes, ax_flat)
     _validate_if_list_of_axes(ax, 4)
     plt.close('all')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ doc-files = doc
 addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
 filterwarnings =
     ignore::ImportWarning
+    ignore:the matrix subclass:PendingDeprecationWarning
     ignore:numpy.dtype size changed
     ignore:module pycuda not found
     ignore:.*HasTraits.trait_.*:DeprecationWarning
@@ -33,8 +34,8 @@ ignore = E241,E305,W504
 
 [pydocstyle]
 convention = pep257
-match_dir = ^(?!\.|externals|doc|tutorials|examples|logo|tests).*$
-match = (?!test_|fixes).*\.py
-add-ignore = D100,D107,D413
+match_dir = ^(?!\.|externals|doc|tutorials|examples|logo).*$
+match = (?!tests/__init__\.py|fixes).*\.py
+add-ignore = D100,D104,D107,D413
 add-select = D214,D215,D404,D405,D406,D407,D408,D409,D410,D411
 ignore-decorators = ^(copy_.*_doc_to_|on_trait_change|cached_property|deprecated|property|.*setter).*


### PR DESCRIPTION
This PR:

1. Gets rid of `nose`
2. Fixes our `tests` docstrings
3. Fixes a number of small "misses" that were in tests because of improper use of `nose` functions
4. Fixes two small problems with `gui` and `test_topomap.py` I was having from running `dev` versions of libs.

Mostly it substitutes `assert ` for `assert_true` and `pytest.raises` for `assert_raises`.

This PR should help make our tests more robust and readable in the future, and promote modern testing practices.