### PR TITLE
attempt to fix interpolation of bad MEG sensors with applied compensation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,8 @@ Bug
 
 - Fix error when saving stc as nifti image when using volume source space formed by more than one label by `Alex Gramfort`_
 
+- Fix error when interpolating MEG channels with compensation using reference channels (like for CTF data) by `Alex Gramfort`_
+
 
 API
 ~~~

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -172,9 +172,9 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
         and :ref:`Logging documentation <tut_logging>` for more).
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
-                           ref_meg=True, exclude=[])
+                           ref_meg=False, exclude=[])
     picks_good = pick_types(inst.info, meg=True, eeg=False,
-                            ref_meg=True, exclude='bads')
+                            ref_meg=False, exclude='bads')
     meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 
@@ -188,7 +188,9 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
     # return without doing anything if there are no meg channels
     if len(picks_meg) == 0 or len(picks_bad) == 0:
         return
-    info_from = pick_info(inst.info, picks_good)
-    info_to = pick_info(inst.info, picks_bad)
+    inst_info = inst.info.copy()
+    inst_info['comps'] = []
+    info_from = pick_info(inst_info, picks_good)
+    info_to = pick_info(inst_info, picks_bad)
     mapping = _map_meg_channels(info_from, info_to, mode=mode)
     _do_interp_dots(inst, mapping, picks_good, picks_bad)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -171,8 +171,10 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
     """
-    picks_meg = pick_types(inst.info, meg=True, eeg=False, exclude=[])
-    picks_good = pick_types(inst.info, meg=True, eeg=False, exclude='bads')
+    picks_meg = pick_types(inst.info, meg=True, eeg=False,
+                           ref_meg=True, exclude=[])
+    picks_good = pick_types(inst.info, meg=True, eeg=False,
+                            ref_meg=True, exclude='bads')
     meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -172,9 +172,9 @@ def _interpolate_bads_meg(inst, mode='accurate', verbose=None):
         and :ref:`Logging documentation <tut_logging>` for more).
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
-                           ref_meg=False, exclude=[])
+                           ref_meg=True, exclude=[])
     picks_good = pick_types(inst.info, meg=True, eeg=False,
-                            ref_meg=False, exclude='bads')
+                            ref_meg=True, exclude='bads')
     meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -161,8 +161,9 @@ def test_interpolation_ctf_comp():
     ctf_dir = op.join(testing.data_path(download=False), 'CTF')
     raw_fname = op.join(ctf_dir, 'somMDYO-18av.ds')
     raw = io.read_raw_ctf(raw_fname, preload=True)
-    raw.info['bads'] = [raw.ch_names[-5]]
-    raw.interpolate_bads()
+    raw.info['bads'] = [raw.ch_names[5], raw.ch_names[-5]]
+    raw.interpolate_bads(mode='fast')
+    assert raw.info['bads'] == []
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -8,6 +8,7 @@ from nose.tools import assert_raises, assert_equal, assert_true
 
 from mne import io, pick_types, pick_channels, read_events, Epochs
 from mne.channels.interpolation import _make_interpolation_matrix
+from mne.datasets import testing
 from mne.utils import run_tests_if_main
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -152,6 +153,16 @@ def test_interpolation():
     evoked.info.normalize_proj()
     data2 = evoked.interpolate_bads().data[pick]
     assert_true(np.corrcoef(data1, data2)[0, 1] > thresh)
+
+
+@testing.requires_testing_data
+def test_interpolation_ctf_comp():
+    """Test interpolation with compensated CTF data."""
+    ctf_dir = op.join(testing.data_path(download=False), 'CTF')
+    raw_fname = op.join(ctf_dir, 'somMDYO-18av.ds')
+    raw = io.read_raw_ctf(raw_fname, preload=True)
+    raw.info['bads'] = [raw.ch_names[-5]]
+    raw.interpolate_bads()
 
 
 run_tests_if_main()


### PR DESCRIPTION
attempt to closes #5292

@larsoner @bloyl I need you help here.

to replicate the error run:

`pytest mne/channels/tests/test_interpolation.py -k test_interpolation_ctf_comp`

basically what happens is that doing `info_to = pick_info(inst.info, picks_bad)` here https://github.com/mne-tools/mne-python/blob/master/mne/channels/interpolation.py#L190

breaks as it wants to pick the info for just one data channel without the compensation channels.

help very much welcome.

cc @Heneark 