### PR TITLE
MRG+1: Use read_mat for eeglab

### DIFF
--- a/doc/known_projects.inc
+++ b/doc/known_projects.inc
@@ -55,3 +55,6 @@
 
 .. Flake8
 .. _Flake8: http://flake8.pycqa.org/
+
+.. pymatreader
+.. _pymatreader: https://gitlab.com/obob/pymatreader

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,8 @@ Changelog
 
 - Add helmet for Artemis123 for :func:`mne.viz.plot_alignment` by `Eric Larson`_
 
+- Add support for reading MATLAB ``v7.3+`` files in :func:`mne.io.read_raw_eeglab` and :func:`mne.read_epochs_eeglab` via `pymatreader`_ by `Steven Gutstein`_, `Eric Larson`_, and `Thomas Hartmann`_
+
 Bug
 ~~~
 
@@ -2806,3 +2808,7 @@ of commits):
 .. _Henrich Kolkhorst: https://github.com/hekolk
 
 .. _Steven Bethard: https://github.com/bethard
+
+.. _Thomas Hartmann: https://github.com/thht
+
+.. _Steven Gutstein: http://robust.cs.utep.edu/~gutstein

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -76,7 +76,9 @@ class Annotations(object):
 
         onset = np.array(onset, dtype=float)
         if onset.ndim != 1:
-            raise ValueError('Onset must be a one dimensional array.')
+            raise ValueError('Onset must be a one dimensional array, got %s '
+                             '(shape %s).'
+                             % (onset.ndim, onset.shape))
         duration = np.array(duration, dtype=float)
         if isinstance(description, string_types):
             description = np.repeat(description, len(onset))

--- a/mne/externals/pymatreader/pymatreader.py
+++ b/mne/externals/pymatreader/pymatreader.py
@@ -26,11 +26,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-# XXX we have modified this from upstream because nesting imports was rejected
-# as a change upstream, and we need it for a soft dependency on h5py.
-# We can't simply use try/except when reading because `pymatreader` modifies
-# the scipy.io.loadmat output.
-
 import sys
 if sys.version_info <= (2, 7):
     chr = unichr # This is needed for python 2 and 3 compatibility
@@ -121,7 +116,9 @@ def _hdf5todict(hdf5_object, variable_names=None, ignore_fields=None):
     dict
         Python dictionary
     """
+
     h5py = _import_h5py()
+
     if isinstance(hdf5_object, h5py.Group):
         all_keys = set(hdf5_object.keys())
         if ignore_fields:

--- a/mne/externals/pymatreader/pymatreader.py
+++ b/mne/externals/pymatreader/pymatreader.py
@@ -76,9 +76,10 @@ def read_mat(filename, variable_names=None, ignore_fields=None, uint16_codec=Non
     if ignore_fields is None:
         ignore_fields = []
     try:
-        hdf5_file = scipy.io.loadmat(filename, struct_as_record=False,
-                                     squeeze_me=True,
-                                     variable_names=variable_names, uint16_codec=uint16_codec)
+        with open(filename, 'rb') as fid:  # avoid open file warnings on error
+            hdf5_file = scipy.io.loadmat(fid, struct_as_record=False,
+                                         squeeze_me=True,
+                                         variable_names=variable_names, uint16_codec=uint16_codec)
         data = _check_for_scipy_mat_struct(hdf5_file)
         print("finished loading .mat file <v7.3")
     except NotImplementedError:
@@ -199,7 +200,7 @@ def _check_for_scipy_mat_struct(data):
 
 
 def _todict(matobj):
-    """private function to enhance scipy.io.loadmat. 
+    """private function to enhance scipy.io.loadmat.
     A recursive function which constructs from matobjects nested dictionaries. Idea taken from:
     <stackoverflow.com/questions/7008608/scipy-io-loadmat-nested-structures-i-e-dictionaries>"""
 

--- a/mne/externals/pymatreader/pymatreader.py
+++ b/mne/externals/pymatreader/pymatreader.py
@@ -81,12 +81,10 @@ def read_mat(filename, variable_names=None, ignore_fields=None, uint16_codec=Non
                                          squeeze_me=True,
                                          variable_names=variable_names, uint16_codec=uint16_codec)
         data = _check_for_scipy_mat_struct(hdf5_file)
-        print("finished loading .mat file <v7.3")
     except NotImplementedError:
         ignore_fields.append('#refs#')
         with h5py.File(filename, 'r') as hdf5_file:
             data = _hdf5todict(hdf5_file, variable_names=variable_names, ignore_fields=ignore_fields)
-        print("finished loading .mat file v7.3")
     return data
 
 

--- a/mne/externals/pymatreader/pymatreader.py
+++ b/mne/externals/pymatreader/pymatreader.py
@@ -30,7 +30,6 @@ import sys
 if sys.version_info <= (2, 7):
     chr = unichr # This is needed for python 2 and 3 compatibility
 
-import h5py
 import numpy
 import scipy.io
 import types
@@ -83,6 +82,7 @@ def read_mat(filename, variable_names=None, ignore_fields=None, uint16_codec=Non
         data = _check_for_scipy_mat_struct(hdf5_file)
     except NotImplementedError:
         ignore_fields.append('#refs#')
+        import h5py
         with h5py.File(filename, 'r') as hdf5_file:
             data = _hdf5todict(hdf5_file, variable_names=variable_names, ignore_fields=ignore_fields)
     return data
@@ -107,6 +107,7 @@ def _hdf5todict(hdf5_object, variable_names=None, ignore_fields=None):
     dict
         Python dictionary
     """
+    import h5py
     if isinstance(hdf5_object, h5py.Group):
         all_keys = set(hdf5_object.keys())
         if ignore_fields:

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -55,6 +55,7 @@ def _check_h5(fname):
             raise SkipTest('h5py module required')
 
 
+@requires_h5py
 @testing.requires_testing_data
 @pytest.mark.parametrize('fnames', [raw_mat_fnames, raw_h5_fnames])
 def test_io_set_raw(fnames, tmpdir):
@@ -252,6 +253,7 @@ def test_io_set_raw(fnames, tmpdir):
                            np.array([np.nan, np.nan, np.nan]))
 
 
+@requires_h5py
 @testing.requires_testing_data
 @pytest.mark.parametrize('fnames', [epochs_mat_fnames, epochs_h5_fnames])
 def test_io_set_epochs(fnames, tmpdir):

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -99,8 +99,8 @@ def test_io_set(fnames):
                            event_id=event_id, preload=False,
                            uint16_codec='ascii')
 
-    # test old EEGLAB version event import
-    eeg = io.loadmat(raw_fname, struct_as_record=False,
+    # test old EEGLAB version event import (read old version)
+    eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
     for event in eeg.event:  # old version allows integer events
         event.type = 1
@@ -133,8 +133,8 @@ def test_io_set(fnames):
     pytest.raises(ValueError, read_epochs_eeglab, epochs_fname,
                   epochs.events, None)
 
-    # test reading file with one event
-    eeg = io.loadmat(raw_fname, struct_as_record=False,
+    # test reading file with one event (read old version)
+    eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
     one_event_fname = op.join(temp_dir, 'test_one_event.set')
     io.savemat(one_event_fname, {'EEG':
@@ -290,7 +290,7 @@ def test_degenerate():
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': eeg.data,
                 'epoch': eeg.epoch, 'event': eeg.event,
-                'chanlocs': eeg.chanlocs}}, appendmat=False)
+                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}}, appendmat=False)
     shutil.copyfile(op.join(base_dir, 'test_epochs.fdt'),
                     op.join(temp_dir, 'test_epochs.dat'))
     with warnings.catch_warnings(record=True) as w:

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -22,7 +22,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.eeglab.eeglab import read_events_eeglab
 from mne.io.eeglab import read_annotations_eeglab
 from mne.datasets import testing
-from mne.utils import run_tests_if_main
+from mne.utils import run_tests_if_main, requires_h5py
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -60,6 +60,7 @@ def _check_h5(fname):
 @pytest.mark.parametrize('fnames', [raw_mat_fnames, raw_h5_fnames])
 def test_io_set_raw(fnames, tmpdir):
     """Test importing EEGLAB .set files."""
+    tmpdir = str(tmpdir)
     raw_fname, raw_fname_onefile = fnames
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
@@ -256,7 +257,7 @@ def test_io_set_raw(fnames, tmpdir):
 @requires_h5py
 @testing.requires_testing_data
 @pytest.mark.parametrize('fnames', [epochs_mat_fnames, epochs_h5_fnames])
-def test_io_set_epochs(fnames, tmpdir):
+def test_io_set_epochs(fnames):
     """Test importing EEGLAB .set epochs files."""
     epochs_fname, epochs_fname_onefile = fnames
     with warnings.catch_warnings(record=True) as w:
@@ -272,6 +273,7 @@ def test_io_set_epochs(fnames, tmpdir):
 @testing.requires_testing_data
 def test_io_set_epochs_events(tmpdir):
     """Test different combinations of events and event_ids."""
+    tmpdir = str(tmpdir)
     out_fname = op.join(tmpdir, 'test-eve.fif')
     events = np.array([[4, 0, 1], [12, 0, 2], [20, 0, 3], [26, 0,  3]])
     write_events(out_fname, events)
@@ -292,6 +294,7 @@ def test_io_set_epochs_events(tmpdir):
 def test_degenerate(tmpdir):
     """Test some degenerate conditions."""
     # test if .dat file raises an error
+    tmpdir = str(tmpdir)
     eeg = io.loadmat(epochs_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
     eeg.data = 'epochs_fname.dat'

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -22,7 +22,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.eeglab.eeglab import read_events_eeglab
 from mne.io.eeglab import read_annotations_eeglab
 from mne.datasets import testing
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import run_tests_if_main
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
 
@@ -30,15 +30,15 @@ raw_fname_mat = op.join(base_dir, 'test_raw.set')
 raw_fname_onefile_mat = op.join(base_dir, 'test_raw_onefile.set')
 epochs_fname_mat = op.join(base_dir, 'test_epochs.set')
 epochs_fname_onefile_mat = op.join(base_dir, 'test_epochs_onefile.set')
-mat_fnames = [raw_fname_mat, raw_fname_onefile_mat,
-              epochs_fname_mat, epochs_fname_onefile_mat]
+raw_mat_fnames = [raw_fname_mat, raw_fname_onefile_mat]
+epochs_mat_fnames = [epochs_fname_mat, epochs_fname_onefile_mat]
 
 raw_fname_h5 = op.join(base_dir, 'test_raw_h5.set')
 raw_fname_onefile_h5 = op.join(base_dir, 'test_raw_onefile_h5.set')
 epochs_fname_h5 = op.join(base_dir, 'test_epochs_h5.set')
 epochs_fname_onefile_h5 = op.join(base_dir, 'test_epochs_onefile_h5.set')
-h5_fnames = [raw_fname_h5, raw_fname_onefile_h5,
-             epochs_fname_h5, epochs_fname_onefile_h5]
+raw_h5_fnames = [raw_fname_h5, raw_fname_onefile_h5]
+epochs_h5_fnames = [epochs_fname_h5, epochs_fname_onefile_h5]
 
 raw_fnames = [raw_fname_mat, raw_fname_onefile_mat,
               raw_fname_h5, raw_fname_onefile_h5]
@@ -56,10 +56,10 @@ def _check_h5(fname):
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('fnames', [mat_fnames, h5_fnames])
-def test_io_set(fnames):
+@pytest.mark.parametrize('fnames', [raw_mat_fnames, raw_h5_fnames])
+def test_io_set_raw(fnames, tmpdir):
     """Test importing EEGLAB .set files."""
-    raw_fname, raw_fname_onefile, epochs_fname, epochs_fname_onefile = fnames
+    raw_fname, raw_fname_onefile = fnames
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         # main tests, and test missing event_id
@@ -108,35 +108,10 @@ def test_io_set(fnames):
     eeg.event = eeg.event[0]  # single event
     assert_equal(read_events_eeglab(eeg)[-1, -1], 1)
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        epochs = read_epochs_eeglab(epochs_fname)
-        epochs2 = read_epochs_eeglab(epochs_fname_onefile)
-    # one warning for each read_epochs_eeglab because both files have epochs
-    # associated with multiple events
-    assert_equal(len(w), 2)
-    assert_array_equal(epochs.get_data(), epochs2.get_data())
-
-    # test different combinations of events and event_ids
-    temp_dir = _TempDir()
-    out_fname = op.join(temp_dir, 'test-eve.fif')
-    write_events(out_fname, epochs.events)
-    event_id = {'S255/S8': 1, 'S8': 2, 'S255/S9': 3}
-
-    epochs = read_epochs_eeglab(epochs_fname, epochs.events, event_id)
-    assert_equal(len(epochs.events), 4)
-    assert (epochs.preload)
-    assert (epochs._bad_dropped)
-    epochs = read_epochs_eeglab(epochs_fname, out_fname, event_id)
-    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname,
-                  None, event_id)
-    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname,
-                  epochs.events, None)
-
     # test reading file with one event (read old version)
     eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
-    one_event_fname = op.join(temp_dir, 'test_one_event.set')
+    one_event_fname = op.join(tmpdir, 'test_one_event.set')
     io.savemat(one_event_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
@@ -153,7 +128,7 @@ def test_io_set(fnames):
     assert find_events(test_raw)[0, 0] == round(eeg.event[0].latency) - 1
 
     # test negative event latencies
-    negative_latency_fname = op.join(temp_dir, 'test_negative_latency.set')
+    negative_latency_fname = op.join(tmpdir, 'test_negative_latency.set')
     evnts = deepcopy(eeg.event[0])
     evnts.latency = 0
     io.savemat(negative_latency_fname, {'EEG':
@@ -168,7 +143,7 @@ def test_io_set(fnames):
                   event_id=event_id, input_fname=negative_latency_fname)
 
     # test overlapping events
-    overlap_fname = op.join(temp_dir, 'test_overlap_event.set')
+    overlap_fname = op.join(tmpdir, 'test_overlap_event.set')
     io.savemat(overlap_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': 'test_overlap_event.fdt',
@@ -190,7 +165,7 @@ def test_io_set(fnames):
     assert (len(events_read_events_eeglab) == 2)
 
     # test reading file with one channel
-    one_chan_fname = op.join(temp_dir, 'test_one_channel.set')
+    one_chan_fname = op.join(tmpdir, 'test_one_channel.set')
     io.savemat(one_chan_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': 1, 'data': np.random.random((1, 3)),
@@ -220,7 +195,7 @@ def test_io_set(fnames):
         raise SkipTest('Need to fix bug in NumPy 1.14.0!')
 
     # save set file
-    one_chanpos_fname = op.join(temp_dir, 'test_chanpos.set')
+    one_chanpos_fname = op.join(tmpdir, 'test_chanpos.set')
     io.savemat(one_chanpos_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': 3, 'data': np.random.random((3, 3)),
@@ -260,7 +235,7 @@ def test_io_set(fnames):
     # test reading channel names but not positions when there is no X (only Z)
     # field in the EEG.chanlocs structure
     nopos_chanlocs = chanlocs[['labels', 'Z']]
-    nopos_fname = op.join(temp_dir, 'test_no_chanpos.set')
+    nopos_fname = op.join(tmpdir, 'test_no_chanpos.set')
     io.savemat(nopos_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate, 'nbchan': 3,
                 'data': np.random.random((3, 2)), 'epoch': eeg.epoch,
@@ -278,21 +253,54 @@ def test_io_set(fnames):
 
 
 @testing.requires_testing_data
-def test_degenerate():
+@pytest.mark.parametrize('fnames', [epochs_mat_fnames, epochs_h5_fnames])
+def test_io_set_epochs(fnames, tmpdir):
+    """Test importing EEGLAB .set epochs files."""
+    epochs_fname, epochs_fname_onefile = fnames
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        epochs = read_epochs_eeglab(epochs_fname)
+        epochs2 = read_epochs_eeglab(epochs_fname_onefile)
+    # one warning for each read_epochs_eeglab because both files have epochs
+    # associated with multiple events
+    assert_equal(len(w), 2)
+    assert_array_equal(epochs.get_data(), epochs2.get_data())
+
+
+@testing.requires_testing_data
+def test_io_set_epochs_events(tmpdir):
+    """Test different combinations of events and event_ids."""
+    out_fname = op.join(tmpdir, 'test-eve.fif')
+    events = np.array([[4, 0, 1], [12, 0, 2], [20, 0, 3], [26, 0,  3]])
+    write_events(out_fname, events)
+    event_id = {'S255/S8': 1, 'S8': 2, 'S255/S9': 3}
+    out_fname = op.join(tmpdir, 'test-eve.fif')
+    epochs = read_epochs_eeglab(epochs_fname_mat, events, event_id)
+    assert_equal(len(epochs.events), 4)
+    assert epochs.preload
+    assert epochs._bad_dropped
+    epochs = read_epochs_eeglab(epochs_fname_mat, out_fname, event_id)
+    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname_mat,
+                  None, event_id)
+    pytest.raises(ValueError, read_epochs_eeglab, epochs_fname_mat,
+                  epochs.events, None)
+
+
+@testing.requires_testing_data
+def test_degenerate(tmpdir):
     """Test some degenerate conditions."""
     # test if .dat file raises an error
-    temp_dir = _TempDir()
     eeg = io.loadmat(epochs_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
     eeg.data = 'epochs_fname.dat'
-    bad_epochs_fname = op.join(temp_dir, 'test_epochs.set')
+    bad_epochs_fname = op.join(tmpdir, 'test_epochs.set')
     io.savemat(bad_epochs_fname, {'EEG':
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': eeg.data,
                 'epoch': eeg.epoch, 'event': eeg.event,
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}}, appendmat=False)
     shutil.copyfile(op.join(base_dir, 'test_epochs.fdt'),
-                    op.join(temp_dir, 'test_epochs.dat'))
+                    op.join(tmpdir, 'test_epochs.dat'))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         pytest.raises(NotImplementedError, read_epochs_eeglab,


### PR DESCRIPTION
I have changed the code to use `read_mat`. So far I noticed that I needed `uint16_codec` to be exposed to `read_mat`, which I added. Now all the `.mat` reading versions work. However, there are failures in the `.h5` versions of the files, indicating a likely problem with `read_mat`'s conversion.

@thht since the problems are with the `h5`-to-dict conversion, do you have time to take a quick look? It wasn't obvious from the traceback or `pymatreader` code what changes would be necessary to make it work.