### PR TITLE
MRG: Fix add_channels behavior

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -60,6 +60,7 @@ Bug
 
 - Fix error when interpolating MEG channels with compensation using reference channels (like for CTF data) by `Alex Gramfort`_
 
+- Fix problem with :meth:`mne.io.Raw.add_channels` where ``raw.info['bads']`` was replicated by `Eric Larson`_
 
 API
 ~~~

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1527,6 +1527,8 @@ def _merge_dict_values(dicts, key, verbose=None):
 
     Fork for {'dict', 'list', 'array', 'other'}
     and consider cases where one or all are of the same type.
+
+    Does special things for "projs", "bads", and "meas_date".
     """
     values = [d[key] for d in dicts]
     msg = ("Don't know how to merge '%s'. Make sure values are "
@@ -1545,8 +1547,12 @@ def _merge_dict_values(dicts, key, verbose=None):
     # list
     if _check_isinstance(values, list, all):
         lists = (d[key] for d in dicts)
-        return (_uniquify_projs(_flatten(lists)) if key == 'projs'
-                else _flatten(lists))
+        if key == 'projs':
+            return _uniquify_projs(_flatten(lists))
+        elif key == 'bads':
+            return sorted(set(_flatten(lists)))
+        else:
+            return _flatten(lists)
     elif _check_isinstance(values, list, any):
         idx = _where_isinstance(values, list)
         if len(idx) == 1:

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -337,6 +337,22 @@ def test_merge_info():
     info_d['hpi_meas'] = [{'f1': 3, 'f2': 5}]
     pytest.raises(ValueError, _merge_info, [info_a, info_d])
 
+    info_0 = read_info(raw_fname)
+    info_0['bads'] = ['MEG 2443', 'EEG 053']
+    # XXX eventually this should not be in meas, but a property of BaseRaw
+    info_0['buffer_size_sec'] = None
+    assert len(info_0['chs']) == 376
+    assert len(info_0['dig']) == 146
+    info_1 = create_info(["STI XXX"], info_0['sfreq'], ['stim'])
+    assert info_1['bads'] == []
+    info_out = _merge_info([info_0, info_1], force_update_to_first=True)
+    assert len(info_out['chs']) == 377
+    assert len(info_out['bads']) == 2
+    assert len(info_out['dig']) == 146
+    assert len(info_0['chs']) == 376
+    assert len(info_0['bads']) == 2
+    assert len(info_0['dig']) == 146
+
 
 def test_check_consistency():
     """Test consistency check of Info objects."""


### PR DESCRIPTION
Closes #5320.

@ckiefer0 can you see if this fixes your problem?

@agramfort in the long run we should get rid of `info['buffer_size_sec']`, it is really a property of the Raw instance and not stored in `FIFFB_MEAS_INFO` block anyway.