### PR TITLE
MRG: Rename buffer_size_sec

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,8 @@ Bug
 
 - Fix problem with :meth:`mne.io.Raw.add_channels` where ``raw.info['bads']`` was replicated by `Eric Larson`_
 
+- Rename ``raw.info['buffer_size_sec']`` to ``raw.buffer_size_sec`` as it is a writing parameter rather than a measurement parameter by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -64,8 +64,6 @@ class RawArray(BaseRaw):
                              'len(info["ch_names"]) (%s)'
                              % (len(data), len(info['ch_names'])))
         assert len(info['ch_names']) == info['nchan']
-        if info.get('buffer_size_sec', None) is None:
-            info['buffer_size_sec'] = 1.  # reasonable default
         info = info.copy()  # do not modify original info
         super(RawArray, self).__init__(info, data,
                                        first_samps=(int(first_samp),),

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -160,7 +160,7 @@ def _get_artemis123_info(fname, pos_fname=None):
     desc += 'Comments : {}'.format(header_info['comments'])
 
     info.update({'meas_date': meas_date,
-                 'description': desc, 'buffer_size_sec': 1.,
+                 'description': desc,
                  'subject_info': subject_info,
                  'proj_name': header_info['Project Name']})
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -461,7 +461,6 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
     path = op.dirname(vhdr_fname)
     data_filename = op.join(path, cfg.get('Common Infos', 'DataFile'))
     info['meas_date'] = int(time.time())
-    info['buffer_size_sec'] = 1.  # reasonable default
 
     # load channel labels
     nchan = cfg.getint('Common Infos', 'NumberOfChannels') + 1

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1156,7 +1156,6 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
         info['meas_date'] = None
         bti_info['processes'] = list()
 
-    info['buffer_size_sec'] = 1.  # reasonable default for writing
     # browse processing info for filter specs.
     hp, lp = ((0.0, info['sfreq'] * 0.4) if pdf_fname is not None else
               (None, None))

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -286,7 +286,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     cnt_info.update(baselines=np.array(baselines), n_samples=n_samples,
                     stim_channel=stim_channel, n_bytes=n_bytes)
     info.update(meas_date=meas_date,
-                description=str(session_label), buffer_size_sec=10., bads=bads,
+                description=str(session_label), bads=bads,
                 subject_info=subject_info, chs=chs)
     info._update_redundant()
     return info, cnt_info

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -138,8 +138,9 @@ class RawCTF(BaseRaw):
             if sample_info['n_samp'] == 0:
                 break
             if len(fnames) == 0:
-                info['buffer_size_sec'] = \
-                    sample_info['block_size'] / info['sfreq']
+                buffer_size_sec = sample_info['block_size'] / info['sfreq']
+            else:
+                buffer_size_sec = 1.
             fnames.append(meg4_name)
             last_samps.append(sample_info['n_samp'] - 1)
             raw_extras.append(sample_info)
@@ -147,7 +148,8 @@ class RawCTF(BaseRaw):
         super(RawCTF, self).__init__(
             info, preload, first_samps=first_samps,
             last_samps=last_samps, filenames=fnames,
-            raw_extras=raw_extras, orig_format='int', verbose=verbose)
+            raw_extras=raw_extras, orig_format='int',
+            buffer_size_sec=buffer_size_sec, verbose=verbose)
 
         if clean_names:
             self._clean_names()

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -126,8 +126,7 @@ def test_read_ctf():
             assert_equal(raw.info[key], raw_c.info[key], key)
         if op.basename(fname) not in single_trials:
             # We don't force buffer size to be smaller like MNE-C
-            assert_equal(raw.info['buffer_size_sec'],
-                         raw_c.info['buffer_size_sec'])
+            assert raw.buffer_size_sec == raw_c.buffer_size_sec
         assert_equal(len(raw.info['comps']), len(raw_c.info['comps']))
         for c1, c2 in zip(raw.info['comps'], raw_c.info['comps']):
             for key in ('colcals', 'rowcals'):
@@ -192,7 +191,7 @@ def test_read_ctf():
         # so let's check tricky cases based on sample boundaries
         rng = np.random.RandomState(0)
         pick_ch = rng.permutation(np.arange(len(raw.ch_names)))[:10]
-        bnd = int(round(raw.info['sfreq'] * raw.info['buffer_size_sec']))
+        bnd = int(round(raw.info['sfreq'] * raw.buffer_size_sec))
         assert_equal(bnd, raw._raw_extras[0]['block_size'])
         assert_equal(bnd, block_sizes[op.basename(fname)])
         slices = (slice(0, bnd), slice(bnd - 1, bnd), slice(3, bnd),

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -562,7 +562,6 @@ def _get_info(fname, stim_channel, annot, annotmap, eog, misc, exclude,
 
     # Some keys to be consistent with FIF measurement info
     info['description'] = None
-    info['buffer_size_sec'] = 1.
     edf_info['nsamples'] = int(edf_info['n_records'] * max_samp)
 
     # These are the conditions under which a stim channel will be interpolated

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -110,9 +110,6 @@ def _get_info(eeg, montage, eog=()):
             info, montage, path=path, update_ch_names=update_ch_names,
             raise_missing=False)
 
-    info['buffer_size_sec'] = 1.  # reasonable default
-    # update the info dict
-
     if eog == 'auto':
         eog = _find_channels(ch_names)
 

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -241,7 +241,6 @@ class RawEGI(BaseRaw):
             self.event_id = None
             self._new_trigger = None
         info = _empty_info(egi_info['samp_rate'])
-        info['buffer_size_sec'] = 1.  # reasonable default
         my_time = datetime.datetime(
             egi_info['year'], egi_info['month'], egi_info['day'],
             egi_info['hour'], egi_info['minute'], egi_info['second'])

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -340,7 +340,6 @@ class RawMff(BaseRaw):
             self.event_id = None
             event_codes = []
         info = _empty_info(egi_info['sfreq'])
-        info['buffer_size_sec'] = 1.  # reasonable default
         my_time = datetime.datetime(
             egi_info['year'], egi_info['month'], egi_info['day'],
             egi_info['hour'], egi_info['minute'], egi_info['second'])

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -76,7 +76,6 @@ class RawEximia(BaseRaw):
         ch_types += ['eeg'] * n_eeg
         assert len(ch_names) == n_chan
         info = create_info(ch_names, sfreq, ch_types)
-        info.update(buffer_size_sec=1.)
         n_bytes = _file_size(fname)
         n_samples, extra = divmod(n_bytes, (n_chan * 2))
         if extra != 0:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -397,13 +397,13 @@ def test_split_files():
     # Test a very close corner case
     raw_crop = raw_1.copy().crop(0, 1.)
 
-    assert_allclose(raw_1.info['buffer_size_sec'], 10., atol=1e-2)  # samp rate
+    assert_allclose(raw_1.buffer_size_sec, 10., atol=1e-2)  # samp rate
     split_fname = op.join(tempdir, 'split_raw.fif')
     raw_1.annotations = Annotations([2.], [5.5], 'test')
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
 
     raw_2 = read_raw_fif(split_fname)
-    assert_allclose(raw_2.info['buffer_size_sec'], 1., atol=1e-2)  # samp rate
+    assert_allclose(raw_2.buffer_size_sec, 1., atol=1e-2)  # samp rate
     assert_array_equal(raw_1.annotations.onset, raw_2.annotations.onset)
     assert_array_equal(raw_1.annotations.duration, raw_2.annotations.duration)
     assert_array_equal(raw_1.annotations.description,

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -741,8 +741,7 @@ def get_kit_info(rawfile, allow_unknown_format):
     # Create raw.info dict for raw fif object with SQD data
     info = _empty_info(float(sqd['sfreq']))
     info.update(meas_date=create_time, lowpass=sqd['lowpass'],
-                highpass=sqd['highpass'], buffer_size_sec=1.,
-                kit_system_id=sysid)
+                highpass=sqd['highpass'], kit_system_id=sysid)
 
     # Creates a list of dicts of meg channels for raw.info
     logger.info('Setting channel info structure...')

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -92,8 +92,6 @@ class Info(dict):
     bads : list of str
         List of bad (noisy/broken) channels, by name. These channels will by
         default be ignored by many processing steps.
-    buffer_size_sec : float | None
-        Buffer size (in seconds) when reading the raw data in chunks.
     ch_names : list of str
         The names of the channels.
     chs : list of dict
@@ -1695,7 +1693,7 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
             raise ValueError(msg)
 
     # other fields
-    other_fields = ['acq_pars', 'acq_stim', 'bads', 'buffer_size_sec',
+    other_fields = ['acq_pars', 'acq_stim', 'bads',
                     'comps', 'custom_ref_applied', 'description',
                     'experimenter', 'file_id', 'highpass',
                     'hpi_subsystem', 'events',
@@ -1808,7 +1806,7 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
 
 
 RAW_INFO_FIELDS = (
-    'acq_pars', 'acq_stim', 'bads', 'buffer_size_sec', 'ch_names', 'chs',
+    'acq_pars', 'acq_stim', 'bads', 'ch_names', 'chs',
     'comps', 'ctf_head_t', 'custom_ref_applied', 'description', 'dev_ctf_t',
     'dev_head_t', 'dig', 'experimenter', 'events',
     'file_id', 'highpass', 'hpi_meas', 'hpi_results',
@@ -1822,7 +1820,7 @@ def _empty_info(sfreq):
     """Create an empty info dictionary."""
     from ..transforms import Transform
     _none_keys = (
-        'acq_pars', 'acq_stim', 'buffer_size_sec', 'ctf_head_t', 'description',
+        'acq_pars', 'acq_stim', 'ctf_head_t', 'description',
         'dev_ctf_t', 'dig', 'experimenter',
         'file_id', 'highpass', 'hpi_subsystem', 'kit_system_id',
         'line_freq', 'lowpass', 'meas_date', 'meas_id', 'proj_id', 'proj_name',

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -104,8 +104,7 @@ def _get_nicolet_info(fname, ch_type, eog, ecg, emg, misc):
     date = datetime.datetime(int(date[0]), int(date[1]), int(date[2]),
                              int(time[0]), int(time[1]), int(sec), int(msec))
     info = _empty_info(header_info['sample_freq'])
-    info.update({'meas_date': calendar.timegm(date.utctimetuple()),
-                 'description': None, 'buffer_size_sec': 1.})
+    info['meas_date'] = calendar.timegm(date.utctimetuple())
 
     if ch_type == 'eeg':
         ch_coil = FIFF.FIFFV_COIL_EEG

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -339,8 +339,6 @@ def test_merge_info():
 
     info_0 = read_info(raw_fname)
     info_0['bads'] = ['MEG 2443', 'EEG 053']
-    # XXX eventually this should not be in meas, but a property of BaseRaw
-    info_0['buffer_size_sec'] = None
     assert len(info_0['chs']) == 376
     assert len(info_0['dig']) == 146
     info_1 = create_info(["STI XXX"], info_0['sfreq'], ['stim'])

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -39,7 +39,7 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
         buffer_fname = op.join(tempdir, 'buffer')
         picks = rng.permutation(np.arange(len(raw.ch_names) - 1))[:10]
         picks = np.append(picks, len(raw.ch_names) - 1)  # test trigger channel
-        bnd = min(int(round(raw.info['buffer_size_sec'] *
+        bnd = min(int(round(raw.buffer_size_sec *
                             raw.info['sfreq'])), raw.n_times)
         slices = [slice(0, bnd), slice(bnd - 1, bnd), slice(3, bnd),
                   slice(3, 300), slice(None), slice(1, bnd)]

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -68,7 +68,7 @@ def _get_data():
     raw.info.normalize_proj()
     ecg = RawArray(np.zeros((1, len(raw.times))),
                    create_info(['ECG 063'], raw.info['sfreq'], 'ecg'))
-    for key in ('dev_head_t', 'buffer_size_sec', 'highpass', 'lowpass', 'dig'):
+    for key in ('dev_head_t', 'highpass', 'lowpass', 'dig'):
         ecg.info[key] = raw.info[key]
     raw.add_channels([ecg])
 

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -404,7 +404,6 @@ def test_chpi_subtraction():
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
     with warnings.catch_warnings(record=True):  # uint cast suggestion
         raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
-    raw.info['buffer_size_sec'] = np.float64(2.)
     raw.info['lowpass'] = 200.
     del raw.info['maxshield']
     del raw.info['hpi_results'][0]['moments']

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1809,7 +1809,7 @@ def test_contains():
     # Add seeg channel
     seeg = RawArray(np.zeros((1, len(raw.times))),
                     create_info(['SEEG 001'], raw.info['sfreq'], 'seeg'))
-    for key in ('dev_head_t', 'buffer_size_sec', 'highpass', 'lowpass',
+    for key in ('dev_head_t', 'highpass', 'lowpass',
                 'dig', 'description', 'acq_pars', 'experimenter',
                 'proj_name'):
         seeg.info[key] = raw.info[key]

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -551,7 +551,6 @@ def test_time_as_index():
 def test_add_channels():
     """Test evoked splitting / re-appending channel types."""
     evoked = read_evokeds(fname, condition=0)
-    evoked.info['buffer_size_sec'] = None
     hpi_coils = [{'event_bits': []},
                  {'event_bits': np.array([256,   0, 256, 256])},
                  {'event_bits': np.array([512,   0, 512, 512])}]


### PR DESCRIPTION
This bugfix moves `info['buffer_size_sec']` to `raw.buffer_size_sec`:

1. It is not actually a property of meas info so it's a misnomer
2. There is no FIFF constant for it so our nice info<->FIFF relationship is broken
3. Cleans up our code
4. Should help prevent problems like #5287

I think this is a bigfix, and the hard rename should have limited impact on end-users -- I don't expect them to have used this.

Ready for review/merge from my end.