### PR TITLE
MRG: Fix linkcode

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,7 @@ import sphinx_bootstrap_theme
 from numpydoc import numpydoc, docscrape  # noqa
 import sphinx_fontawesome
 import mne
+from mne.utils import linkcode_resolve  # noqa, analysis:ignore
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -322,60 +323,3 @@ sphinx_gallery_conf = {
 }
 
 numpydoc_class_members_toctree = False
-
-
-# -----------------------------------------------------------------------------
-# Source code links (adapted from SciPy (doc/source/conf.py))
-# -----------------------------------------------------------------------------
-
-def linkcode_resolve(domain, info):
-    """
-    Determine the URL corresponding to Python object
-    """
-    if domain != 'py':
-        return None
-
-    modname = info['module']
-    fullname = info['fullname']
-
-    submod = sys.modules.get(modname)
-    if submod is None:
-        return None
-
-    obj = submod
-    for part in fullname.split('.'):
-        try:
-            obj = getattr(obj, part)
-        except:
-            return None
-
-    try:
-        fn = inspect.getsourcefile(obj)
-    except:
-        fn = None
-    if not fn:
-        try:
-            fn = inspect.getsourcefile(sys.modules[obj.__module__])
-        except:
-            fn = None
-    if not fn:
-        return None
-
-    try:
-        source, lineno = inspect.getsourcelines(obj)
-    except:
-        lineno = None
-
-    if lineno:
-        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
-    else:
-        linespec = ""
-
-    fn = relpath(fn, start=dirname(mne.__file__))
-
-    if 'dev' in mne.__version__:
-        kind = 'master'
-    else:
-        kind = 'maint/%s' % ('.'.join(mne.__version__.split('.')[:2]))
-    return "http://github.com/mne-tools/mne-python/blob/%s/mne/%s%s" % (  # noqa
-       kind, fn, linespec)

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import os.path as op
 import os
+import sys
 import warnings
 import webbrowser
 
@@ -806,17 +807,18 @@ def test_open_docs():
 
 def test_linkcode_resolve():
     """Test linkcode resolving."""
+    ex = '' if sys.version[0] == '2' else '#L'
     url = linkcode_resolve('py', dict(module='mne', fullname='Epochs'))
-    assert '/mne/epochs.py#L' in url
+    assert '/mne/epochs.py' + ex in url
     url = linkcode_resolve('py', dict(module='mne',
                                       fullname='compute_covariance'))
-    assert '/mne/cov.py#L' in url
+    assert '/mne/cov.py' + ex in url
     url = linkcode_resolve('py', dict(module='mne',
                                       fullname='convert_forward_solution'))
-    assert '/mne/forward/forward.py#L' in url
+    assert '/mne/forward/forward.py' + ex in url
     url = linkcode_resolve('py', dict(module='mne',
                                       fullname='datasets.sample.data_path'))
-    assert '/mne/datasets/sample/sample.py#L' in url
+    assert '/mne/datasets/sample/sample.py' + ex in url
 
 
 run_tests_if_main()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -814,6 +814,9 @@ def test_linkcode_resolve():
     url = linkcode_resolve('py', dict(module='mne',
                                       fullname='convert_forward_solution'))
     assert '/mne/forward/forward.py#L' in url
+    url = linkcode_resolve('py', dict(module='mne',
+                                      fullname='datasets.sample.data_path'))
+    assert '/mne/datasets/sample/sample.py#L' in url
 
 
 run_tests_if_main()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -28,7 +28,8 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        _get_call_line, compute_corr, sys_info, verbose,
                        check_fname, get_config_path,
                        object_size, buggy_mkl_svd, _get_inst_data,
-                       copy_doc, copy_function_doc_to_method_doc, ProgressBar)
+                       copy_doc, copy_function_doc_to_method_doc, ProgressBar,
+                       linkcode_resolve)
 
 
 warnings.simplefilter('always')  # enable b/c these tests throw warnings
@@ -801,6 +802,18 @@ def test_open_docs():
         pytest.raises(ValueError, open_docs, 'api', 'foo')
     finally:
         webbrowser.open_new_tab = old_tab
+
+
+def test_linkcode_resolve():
+    """Test linkcode resolving."""
+    url = linkcode_resolve('py', dict(module='mne', fullname='Epochs'))
+    assert '/mne/epochs.py#L' in url
+    url = linkcode_resolve('py', dict(module='mne',
+                                      fullname='compute_covariance'))
+    assert '/mne/cov.py#L' in url
+    url = linkcode_resolve('py', dict(module='mne',
+                                      fullname='convert_forward_solution'))
+    assert '/mne/forward/forward.py#L' in url
 
 
 run_tests_if_main()

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2803,6 +2803,7 @@ def linkcode_resolve(domain, info):
     if fn == '<string>':  # verbose decorator
         fn = inspect.getmodule(obj).__file__
     fn = op.relpath(fn, start=op.dirname(mne.__file__))
+    fn = '/'.join(op.normpath(fn).split(os.sep))  # in case on Windows
 
     try:
         source, lineno = inspect.getsourcelines(obj)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2801,8 +2801,9 @@ def linkcode_resolve(domain, info):
     if not fn:
         return None
     if fn == '<string>':  # verbose decorator
-        fn = '/'.join(op.split(inspect.getmodule(obj).__file__))
-        fn = 'mne/' + fn.split('/mne/')[-1]
+        fn = inspect.getmodule(obj).__file__
+    # rejoin with '/' for Windows
+    fn = '/'.join(op.split(op.relpath(fn, start=op.dirname(mne.__file__))))
 
     try:
         source, lineno = inspect.getsourcelines(obj)
@@ -2813,10 +2814,6 @@ def linkcode_resolve(domain, info):
         linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
     else:
         linespec = ""
-    if '<string>' in fn:
-        raise RuntimeError
-
-    fn = op.relpath(fn, start=op.dirname(mne.__file__))
 
     if 'dev' in mne.__version__:
         kind = 'master'

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2802,8 +2802,7 @@ def linkcode_resolve(domain, info):
         return None
     if fn == '<string>':  # verbose decorator
         fn = inspect.getmodule(obj).__file__
-    # rejoin with '/' for Windows
-    fn = '/'.join(op.split(op.relpath(fn, start=op.dirname(mne.__file__))))
+    fn = op.relpath(fn, start=op.dirname(mne.__file__))
 
     try:
         source, lineno = inspect.getsourcelines(obj)

--- a/tutorials/plot_background_filtering.py
+++ b/tutorials/plot_background_filtering.py
@@ -929,7 +929,7 @@ baseline_plot(x)
 # ``h_freq + transition_bandwidth/2.``.
 #
 # Filter length (order) and transition bandwidth (roll-off)
-# --------------------------------------------------------
+# ---------------------------------------------------------
 # In the :ref:`tut_filtering_in_python` section, we have already talked about
 # the default filter lengths and transition bandwidths that are used when no
 # custom values are specified using the respective filter function's arguments.


### PR DESCRIPTION
Fixes doc links when `verbose` decorator is used.

Closes #5290.