### PR TITLE
MRG: Fix fwd with surf + discrete

### DIFF
--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -613,7 +613,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
 
     if surf_ori:
         if use_cps:
-            if fwd['src'][0].get('patch_inds') is not None:
+            if any(s.get('patch_inds') is not None for s in fwd['src']):
                 use_ave_nn = True
                 logger.info('    Average patch normals will be employed in '
                             'the rotation to the local surface coordinates..'
@@ -664,7 +664,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
             if s['type'] in ['surf', 'discrete']:
                 for p in range(s['nuse']):
                     #  Project out the surface normal and compute SVD
-                    if use_ave_nn is True:
+                    if use_ave_nn and s.get('patch_inds') is not None:
                         nn = s['nn'][s['pinfo'][s['patch_inds'][p]], :]
                         nn = np.sum(nn, axis=0)[:, np.newaxis]
                         nn /= linalg.norm(nn)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -14,7 +14,8 @@ from mne import (read_forward_solution, write_forward_solution,
                  make_forward_solution, convert_forward_solution,
                  setup_volume_source_space, read_source_spaces,
                  make_sphere_model, pick_types_forward, pick_info, pick_types,
-                 Transform, read_evokeds, read_cov, read_dipole)
+                 Transform, read_evokeds, read_cov, read_dipole,
+                 SourceSpaces)
 from mne.utils import (requires_mne, requires_nibabel, _TempDir,
                        run_tests_if_main, run_subprocess)
 from mne.forward._make_forward import _create_meg_coils, make_forward_dipole
@@ -219,6 +220,19 @@ def test_make_forward_solution():
     fwd = read_forward_solution(fname_meeg)
     assert (isinstance(fwd, Forward))
     _compare_forwards(fwd, fwd_py, 366, 1494, meg_rtol=1e-3)
+
+
+@testing.requires_testing_data
+def test_make_forward_solution_discrete():
+    # smoke test for depth weighting and discrete source spaces
+    src = read_source_spaces(fname_src)[0]
+    src = SourceSpaces([src] + setup_volume_source_space(
+        pos=dict(rr=src['rr'][src['vertno'][:3]].copy(),
+                 nn=src['nn'][src['vertno'][:3]].copy())))
+    sphere = make_sphere_model()
+    fwd = make_forward_solution(fname_raw, fname_trans, src, sphere,
+                                meg=True, eeg=False)
+    convert_forward_solution(fwd, surf_ori=True)
 
 
 @testing.requires_testing_data

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -224,6 +224,7 @@ def test_make_forward_solution():
 
 @testing.requires_testing_data
 def test_make_forward_solution_discrete():
+    """Test making and converting a forward solution with discrete src."""
     # smoke test for depth weighting and discrete source spaces
     src = read_source_spaces(fname_src)[0]
     src = SourceSpaces([src] + setup_volume_source_space(


### PR DESCRIPTION
Using surface source spaces plus a discrete source space and going to surface orientation didn't work before, now it does.