### PR TITLE
WIP: Make morphed source spaces easier

### DIFF
--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -648,7 +648,8 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs):
     # simplify the result to make things easier later
     src = dict(rr=src['rr'][src['vertno']], nn=src['nn'][src['vertno']],
                nuse=src['nuse'], coord_frame=src['coord_frame'],
-               vertno=np.arange(src['nuse']))
+               vertno=np.arange(src['nuse']), inuse=np.ones(src['nuse'], bool),
+               np=src['nuse'])
     return SourceSpaces([src])
 
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -826,7 +826,7 @@ def _read_one_source_space(fid, this, verbose=None):
         tag = find_tag(fid, this, FIFF.FIFF_MNE_SOURCE_SPACE_VERTICES)
         if tag is not None:
             # vertno_ord is an order of the vertices in the source space,
-            # which satifies some desirable goal, e.g., corresponding vertices
+            # which satisfies some desirable goal, e.g., corresponding vertices
             # across the subjects being close to each other on the cortical
             # surface.
             res['vertno_ord'] = tag.data.astype(np.int)


### PR DESCRIPTION
Need to:

- [x] Get updated morphed source space from MNE-C into `mne-testing-data`, ~~but still keep old one for testing~~
- [x] Mimic old `src` versions in tests by removing newly added fields
- [ ] Set `SourceEstimate.vertices` using `vertno_ord`
- [ ] Ensure we don't require `SourceEstimate.vertices` to be sorted for anything
- [ ] Write note in `to_original_src` that it's only needed for old source spaces
- [ ] Add check in `to_original_src` that it does just sanity checks if new source spaces are used (or otherwise fix it)
- [ ] Add tests for modern morphed source spaces in `test_morphed_source_space_return`
- [ ] Update `sample` data
- [ ] Update source-space morphing example not to use `to_original_src`