### PR TITLE
read meas_date from BrainVision vmrk

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug with reading measurement dates from BrainVision files by `Stefan Appelhoff`_
+
 - Fix bug with ``mne flash_bem`` when ``flash30`` is not used by `Eric Larson`_
 
 - Fix bug with channel names in ``mgh70`` montage in :func:`mne.channels.read_montage` by `Eric Larson`_

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -471,7 +471,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
         lines = tmp_mrk_f.readlines()
 
     for line in lines:
-        match = re.findall(regexp, line)
+        match = re.findall(regexp, line.strip())
 
         # Always take first measurement date we find
         if match:

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -466,7 +466,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
 
     # Try to get measurement date from marker file
     # Usually saved with a marker "New Segment", see BrainVision documentation
-    regexp = r'^Mk\d*=New Segment,[.*,]\d*.\d*,\d*,(\d{20})$'
+    regexp = r'^Mk\d+=New Segment,.*,\d+,\d+,\d+,(\d{20})$'
     with open(mrk_fname, 'r') as tmp_mrk_f:
         lines = tmp_mrk_f.readlines()
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -480,7 +480,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             # We need list of unix time in milliseconds and as second entry
             # the additional amount of microseconds
             epoch = datetime.utcfromtimestamp(0)
-            unix_time_millis = (meas_date - epoch).total_seconds() * 1000.
+            unix_time_millis = (meas_date - epoch).total_seconds()
             info['meas_date'] = [int(t) for t in
                                  str(unix_time_millis).split('.')]
             break

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -485,8 +485,8 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
                                  str(unix_time_millis).split('.')]
             break
 
-    if not match:
-        info['meas_date'] = DATE_NONE
+        else:
+            info['meas_date'] = DATE_NONE
 
     # load channel labels
     nchan = cfg.getint('Common Infos', 'NumberOfChannels') + 1

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -15,6 +15,7 @@ import os
 import os.path as op
 import re
 from datetime import datetime
+from math import modf
 
 import numpy as np
 
@@ -480,9 +481,10 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             # We need list of unix time in milliseconds and as second entry
             # the additional amount of microseconds
             epoch = datetime.utcfromtimestamp(0)
-            unix_time_millis = (meas_date - epoch).total_seconds()
-            info['meas_date'] = [int(t) for t in
-                                 str(unix_time_millis).split('.')]
+            unix_time = (meas_date - epoch).total_seconds()
+            unix_secs = int(modf(unix_time)[1])
+            microsecs = int(modf(unix_time)[0] * 1e6)
+            info['meas_date'] = [unix_secs, microsecs]
             break
 
     else:

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -485,8 +485,8 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
                                  str(unix_time_millis).split('.')]
             break
 
-        else:
-            info['meas_date'] = DATE_NONE
+    else:
+        info['meas_date'] = DATE_NONE
 
     # load channel labels
     nchan = cfg.getint('Common Infos', 'NumberOfChannels') + 1

--- a/mne/io/brainvision/tests/data/test_old_layout_latin1_software_filter.vmrk
+++ b/mne/io/brainvision/tests/data/test_old_layout_latin1_software_filter.vmrk
@@ -12,3 +12,4 @@ DataFile=test_old_layout_latin1_software_filter.eeg
 ; Fields are delimited by commas, some fields might be omitted (empty).
 ; Commas in type or description text are coded as "".
 Mk1=New Segment,,1,1,0,20070716122240937454
+Mk2=New Segment,,2,1,0,20070716122240937455

--- a/mne/io/brainvision/tests/data/testv2.vmrk
+++ b/mne/io/brainvision/tests/data/testv2.vmrk
@@ -11,7 +11,7 @@ DataFile=test.eeg
 ; <Size in data points>, <Channel number (0 = marker is related to all channels)>
 ; Fields are delimited by commas, some fields might be omitted (empty).
 ; Commas in type or description text are coded as "\1".
-Mk1=New Segment,,1,1,0,20131113161403794232
+Mk1=New Segment,,1,1,0
 Mk2=Stimulus,S253,487,1,0
 Mk3=Stimulus,S255,497,1,0
 Mk4=Stimulus,S254,1770,1,0

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -78,6 +78,7 @@ def test_vmrk_meas_date():
     # Test files with no date, we should get DATE_NONE from mne.io.write
     raw = read_raw_brainvision(vhdr_v2_path)
     assert_allclose(raw.info['meas_date'], DATE_NONE)
+    assert 'unspecified' in repr(raw.info)
 
 
 def test_vhdr_codepage_ansi():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -67,15 +67,18 @@ def test_vmrk_meas_date():
     """Test successful extraction of measurement date."""
     # Test file that does have a specific date
     raw = read_raw_brainvision(vhdr_path)
-    assert_allclose(raw.info['meas_date'], [1384359243794, 232])
+    assert_allclose(raw.info['meas_date'], [1384359243, 794232])
+    assert '2013-11-13 16:14:03 GMT' in repr(raw.info)
 
-    # Test file with multiple dates ... we should take the first
+    # Test file with multiple dates ... we should only take the first
     raw = read_raw_brainvision(vhdr_old_path)
-    assert_allclose(raw.info['meas_date'], [1184588560937, 454])
+    assert_allclose(raw.info['meas_date'], [1184588560, 937454])
+    assert '2007-07-16 12:22:40 GMT' in repr(raw.info)
 
-    # Test files with no date
+    # Test files with no date, we should take DATE_NONE from mne.io.write
     raw = read_raw_brainvision(vhdr_v2_path)
     assert_allclose(raw.info['meas_date'], DATE_NONE)
+    assert '1970-01-01 00:35:47' in repr(raw.info)
 
 
 def test_vhdr_codepage_ansi():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 # Author: Teon Brooks <teon.brooks@gmail.com>
+#         Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 
@@ -59,6 +60,21 @@ eog = ['HL', 'HR', 'Vb']
 event_id = {'Sync On': 5}
 
 warnings.simplefilter('always')
+
+
+def test_vmrk_meas_date():
+    """Test successful extraction of measurement date."""
+    # Test file that does have a specific date
+    raw = read_raw_brainvision(vhdr_path)
+    assert raw.info['meas_date'] == [1384355643.0, 1384355643000000.0]
+
+    # Test file with multiple dates ... we should take the first
+    raw = read_raw_brainvision(vhdr_old_path)
+    assert raw.info['meas_date'] == [1184581360.0, 1184581360000000.0]
+
+    # Test files with no date
+    raw = read_raw_brainvision(vhdr_v2_path)
+    assert raw.info['meas_date'] == []
 
 
 def test_vhdr_codepage_ansi():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -67,18 +67,17 @@ def test_vmrk_meas_date():
     """Test successful extraction of measurement date."""
     # Test file that does have a specific date
     raw = read_raw_brainvision(vhdr_path)
-    assert_allclose(raw.info['meas_date'], [1384359243, 794232])
+    assert_allclose(raw.info['meas_date'], [1384359243, 794231])
     assert '2013-11-13 16:14:03 GMT' in repr(raw.info)
 
     # Test file with multiple dates ... we should only take the first
     raw = read_raw_brainvision(vhdr_old_path)
-    assert_allclose(raw.info['meas_date'], [1184588560, 937454])
+    assert_allclose(raw.info['meas_date'], [1184588560, 937453])
     assert '2007-07-16 12:22:40 GMT' in repr(raw.info)
 
-    # Test files with no date, we should take DATE_NONE from mne.io.write
+    # Test files with no date, we should get DATE_NONE from mne.io.write
     raw = read_raw_brainvision(vhdr_v2_path)
     assert_allclose(raw.info['meas_date'], DATE_NONE)
-    assert '1970-01-01 00:35:47' in repr(raw.info)
 
 
 def test_vhdr_codepage_ansi():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -21,6 +21,7 @@ from mne import pick_types, find_events
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
 from mne.io.tests.test_raw import _test_raw_reader
+from mne.io.write import DATE_NONE
 
 FILE = inspect.getfile(inspect.currentframe())
 data_dir = op.join(op.dirname(op.abspath(FILE)), 'data')
@@ -66,15 +67,15 @@ def test_vmrk_meas_date():
     """Test successful extraction of measurement date."""
     # Test file that does have a specific date
     raw = read_raw_brainvision(vhdr_path)
-    assert raw.info['meas_date'] == [1384355643.0, 1384355643000000.0]
+    assert_allclose(raw.info['meas_date'], [1384359243794, 232])
 
     # Test file with multiple dates ... we should take the first
     raw = read_raw_brainvision(vhdr_old_path)
-    assert raw.info['meas_date'] == [1184581360.0, 1184581360000000.0]
+    assert_allclose(raw.info['meas_date'], [1184588560937, 454])
 
     # Test files with no date
     raw = read_raw_brainvision(vhdr_v2_path)
-    assert raw.info['meas_date'] == []
+    assert_allclose(raw.info['meas_date'], DATE_NONE)
 
 
 def test_vhdr_codepage_ansi():

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -147,9 +147,9 @@ class Info(dict):
     lowpass : float | None
         Lowpass corner frequency in Hertz.
     meas_date : list of int
-        The first element of this list is a POSIX timestamp (milliseconds since
+        The first element of this list is a UNIX timestamp (seconds since
         1970-01-01 00:00:00) denoting the date and time at which the
-        measurement was taken. The second element is the number of
+        measurement was taken. The second element is the additional number of
         microseconds.
     meas_id : dict | None
         The ID assigned to this measurement by the acquisition system or

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -410,8 +410,12 @@ class Info(dict):
                 if len(entr) >= 56:
                     entr = _summarize_str(entr)
             elif k == 'meas_date' and np.iterable(v):
-                # first entry in meas_date is meaningful
-                entr = _stamp_to_dt(v).strftime('%Y-%m-%d %H:%M:%S') + ' GMT'
+                if np.array_equal(v, DATE_NONE):
+                    entr = 'unspecified'
+                else:
+                    # first entry in meas_date is meaningful
+                    entr = (_stamp_to_dt(v).strftime('%Y-%m-%d %H:%M:%S') +
+                            ' GMT')
             elif k == 'kit_system_id' and v is not None:
                 from .kit.constants import KIT_SYSNAMES
                 entr = '%i (%s)' % (v, KIT_SYSNAMES.get(v, 'unknown'))


### PR DESCRIPTION
fixes #5357 

Note that I made some convenient changes to the test files that do not influence the other tests but allow us to test this new function without having to clutter more additional test files into `/tests/data`