### PR TITLE
Aligns events to samples in multi epoch EGI recordings.

### DIFF
--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -73,11 +73,12 @@ def _read_mff_events(filename, sfreq, nsamples):
             event_start = _ns2py_time(event['beginTime'])
             start = (event_start - start_time).total_seconds()
             # adjust the start to account for epochs
-            epoch = [i[0] for i in enumerate(epoch_times)
-                     if (i[1][0] <= start and i[1][1] >= start)]
-            if len(epoch) == 0:
+            epoch_idx = [idx for idx, times in enumerate(epoch_times)
+                         if (times[0] <= start and times[1] >= start)]
+            if len(epoch_idx) == 0:
+                logger.warning('An event falls outside any recording epoch.')
                 continue
-            start = start - epoch_offsets[epoch[0]]
+            start = start - epoch_offsets[epoch_idx]
             if event['code'] not in code:
                 code.append(event['code'])
             marker = {'name': event['code'],


### PR DESCRIPTION
This provides a work around for #5373 and #4826 by properly aligning the event times to samples in MFF files with multiple epochs. This is not the right way to completely solve this problem, as there are still unmarked discontinuities in the data. A more involved solution probably involves modifying `egimff.py` to insert the appropriate `BAD_ACQ_SKIP` Annotations, but I'm not sure what the pattern for reading discontinuous data is.


