### PR TITLE
MRG Evoked plots should error nicely on NaN input

### DIFF
--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2751,7 +2751,7 @@ def _validate_type(item, types=None, item_name=None, type_name=None):
 
 
 def linkcode_resolve(domain, info):
-    """Determine the URL corresponding to Python object.
+    """Determine the URL corresponding to a Python object.
 
     Parameters
     ----------

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2825,5 +2825,5 @@ def linkcode_resolve(domain, info):
 
 def _check_if_nan(data, msg=" to be plotted"):
     """Raise if any of the values are NaN."""
-    if (data != data).any():
+    if not np.isfinite(data).all():
         raise ValueError("Some of the values {} are NaN.".format(msg))

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2821,3 +2821,9 @@ def linkcode_resolve(domain, info):
         kind = 'maint/%s' % ('.'.join(mne.__version__.split('.')[:2]))
     return "http://github.com/mne-tools/mne-python/blob/%s/mne/%s%s" % (  # noqa
        kind, fn, linespec)
+
+
+def _check_if_nan(data, msg=" to be plotted"):
+    """Raise if any of the values are NaN."""
+    if (data != data).any():
+        raise ValueError("Some of the values {} are NaN.".format(msg))

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -31,7 +31,8 @@ from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
                     _setup_plot_projector, _prepare_joint_axes,
                     _set_title_multiple_electrodes, _check_time_unit,
                     _plot_masked_image)
-from ..utils import logger, _clean_names, warn, _pl, verbose, _validate_type
+from ..utils import (logger, _clean_names, warn, _pl, verbose, _validate_type,
+                     _check_if_nan)
 
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
@@ -409,8 +410,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
         if len(idx) > 0:
             # Set amplitude scaling
             D = this_scaling * data[idx, :]
-            if (D != D).any():
-                raise ValueError("Some of the values to be plotted are NaN.")
+            _check_if_nan(D)
             gfp_only = (isinstance(gfp, string_types) and gfp == 'only')
             if not gfp_only:
                 chs = [info['chs'][i] for i in idx]
@@ -579,8 +579,7 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
     else:
         vmin, vmax = ylim[this_type]
 
-    if (data != data).any():
-        raise ValueError("Some of the values to be plotted are NaN.")
+    _check_if_nan(data)
 
     im, t_end = _plot_masked_image(
         ax, data, times, mask, picks=None, yvals=None, cmap=cmap[0],
@@ -1995,8 +1994,7 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
             ci_dict[cond] = _ci_fun(data)
         # average across conditions:
         data_dict[cond] = data = np.mean(data, axis=0)
-        if (data != data).any():
-            raise ValueError("Some of the values to be plotted are NaN.")
+        _check_if_nan(data)
 
     del evokeds
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -409,6 +409,8 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
         if len(idx) > 0:
             # Set amplitude scaling
             D = this_scaling * data[idx, :]
+            if (D != D).any():
+                raise ValueError("Some of the values to be plotted are NaN.")
             gfp_only = (isinstance(gfp, string_types) and gfp == 'only')
             if not gfp_only:
                 chs = [info['chs'][i] for i in idx]
@@ -576,6 +578,9 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         vmin = -vmax
     else:
         vmin, vmax = ylim[this_type]
+
+    if (data != data).any():
+        raise ValueError("Some of the values to be plotted are NaN.")
 
     im, t_end = _plot_masked_image(
         ax, data, times, mask, picks=None, yvals=None, cmap=cmap[0],
@@ -1989,7 +1994,9 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
         if _ci_fun is not None:  # compute CI if requested:
             ci_dict[cond] = _ci_fun(data)
         # average across conditions:
-        data_dict[cond] = np.mean(data, axis=0)
+        data_dict[cond] = data = np.mean(data, axis=0)
+        if (data != data).any():
+            raise ValueError("Some of the values to be plotted are NaN.")
 
     del evokeds
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -135,6 +135,13 @@ def test_plot_evoked():
 
     evoked.plot_image(proj=True, time_unit='ms')
 
+    # fail nicely on NaN
+    evoked_nan = evoked.copy()
+    evoked_nan.data[:, 0] = np.nan
+    pytest.raises(ValueError, evoked_nan.plot)
+    pytest.raises(ValueError, evoked_nan.plot_image)
+    pytest.raises(ValueError, evoked_nan.plot_joint)
+
     # test mask
     evoked.plot_image(picks=[1, 2], mask=evoked.data > 0, time_unit='s')
     evoked.plot_image(picks=[1, 2], mask_cmap=None, colorbar=False,


### PR DESCRIPTION
Trying to plot data with NaNs included can result in some pretty weird output. This raises a `ValueError` at a hopefully sufficiently early time point.