### PR TITLE
MRG: Add raw PSD to parse_folder

### DIFF
--- a/doc/manual/cookbook.rst
+++ b/doc/manual/cookbook.rst
@@ -295,7 +295,7 @@ Using this model, the BEM solution can be computed using
 
 After the BEM is set up it is advisable to check that the
 BEM model meshes are correctly positioned using *e.g.*
-:func:`mne.viz.plot_alignment` or :class:`mne.report.Report`.
+:func:`mne.viz.plot_alignment` or :class:`mne.Report`.
 
 .. note:: Up to this point all processing stages depend on the
           anatomical (geometrical) information only and thus remain

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1043,11 +1043,11 @@ Realtime
 MNE-Report
 ==========
 
-:py:mod:`mne.report`:
+:py:mod:`mne`:
 
-.. currentmodule:: mne.report
+.. currentmodule:: mne
 
-.. automodule:: mne.report
+.. automodule:: mne
    :no-members:
    :no-inherited-members:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,8 @@ Changelog
 
 - Add support for reading MATLAB ``v7.3+`` files in :func:`mne.io.read_raw_eeglab` and :func:`mne.read_epochs_eeglab` via `pymatreader`_ by `Steven Gutstein`_, `Eric Larson`_, and `Thomas Hartmann`_
 
+- Add support for raw PSD plots in :meth:`mne.Report.parse_folder` via ``raw_psd`` argument of :class:`mne.Report` by `Eric Larson`_
+
 - Add `trig_shift_by_type` parameter in :func:`mne.io.read_raw_brainvision` to allow to specify offsets for arbitrary marker types by `Henrich Kolkhorst`_
 
 Bug
@@ -124,7 +126,7 @@ Changelog
 
 - Reduce memory consumption and do not require data to be loaded in :meth:`mne.Epochs.apply_baseline` by `Eric Larson`_
 
-- Add option ``render_bem`` to :meth:`mne.report.Report.parse_folder` by `Eric Larson`_
+- Add option ``render_bem`` to :meth:`mne.Report.parse_folder` by `Eric Larson`_
 
 - Add to :func:`mne.viz.plot_alignment` plotting of coordinate frame axes via ``show_axes`` and terrain-style interaction via ``interaction``, by `Eric Larson`_
 
@@ -136,7 +138,7 @@ Changelog
 
 - Add possibility to concatenate `mne.Annotations` objects with ``+`` or ``+=`` operators by `Clemens Brunner`_
 
-- Add support for MaxShield raw files in :class:`mne.report.Report` by `Eric Larson`_
+- Add support for MaxShield raw files in :class:`mne.Report` by `Eric Larson`_
 
 - Add ability to plot whitened data in :meth:`mne.io.Raw.plot`, :meth:`mne.Epochs.plot`, :meth:`mne.Evoked.plot`, and :meth:`mne.Evoked.plot_topo` by `Eric Larson`_
 
@@ -243,9 +245,9 @@ Bug
 
 - Fix bug in :class:`mne.Epochs` when passing events as list with ``event_id=None``  by `Alex Gramfort`_
 
-- Fix bug in :meth:`mne.report.Report.add_figs_to_section` when passing :class:`numpy.ndarray` by `Eric Larson`_
+- Fix bug in :meth:`mne.Report.add_figs_to_section` when passing :class:`numpy.ndarray` by `Eric Larson`_
 
-- Fix bug in CSS class setting in `mne.report.Report` BEM section by `Eric Larson`_
+- Fix bug in CSS class setting in `mne.Report` BEM section by `Eric Larson`_
 
 - Fix bug in :class:`Annotations` where annotations that extend to the end of a recording were not extended properly by `Eric Larson`_
 
@@ -429,7 +431,7 @@ Changelog
 
 - Add MGH 60- and 70-channel standard montages to :func:`mne.channels.read_montage` by `Eric Larson`_
 
-- Add option for embedding SVG instead of PNG in HTML for :class:`mne.report.Report` by `Eric Larson`_
+- Add option for embedding SVG instead of PNG in HTML for :class:`mne.Report` by `Eric Larson`_
 
 - Add confidence intervals, number of free parameters, and χ² to :func:`mne.fit_dipole` and :func:`mne.read_dipole` by `Eric Larson`_
 
@@ -1515,7 +1517,7 @@ Changelog
 
 - Add support for scaling and adjusting the number of channels/time per view by `Jaakko Leppakangas`_
 
-- Add support to toggle the show/hide state of all sections with a single keypress ('t') in :class:`mne.report.Report` by `Mainak Jas`_
+- Add support to toggle the show/hide state of all sections with a single keypress ('t') in :class:`mne.Report` by `Mainak Jas`_
 
 - Add support for BEM model creation :func:`mne.make_bem_model` by `Eric Larson`_
 
@@ -1573,7 +1575,7 @@ Changelog
 
 - New gfp parameter in :func:`mne.Evoked.plot` method to display Global Field Power (GFP) by `Eric Larson`_.
 
-- Add :meth:`mne.report.Report.add_slider_to_section` methods to :class:`mne.report.Report` by `Teon Brooks`_
+- Add :meth:`mne.Report.add_slider_to_section` methods to :class:`mne.Report` by `Teon Brooks`_
 
 BUG
 ~~~
@@ -1734,7 +1736,7 @@ Changelog
 
 - Add ``evoked.as_type`` to  allow remapping data in MEG channels to virtual magnetometer or gradiometer channels by `Mainak Jas`_
 
-- Add :meth:`mne.report.Report.add_bem_to_section`, :meth:`mne.report.Report.add_htmls_to_section` methods to :class:`mne.report.Report` by `Teon Brooks`_
+- Add :meth:`mne.Report.add_bem_to_section`, :meth:`mne.Report.add_htmls_to_section` methods to :class:`mne.Report` by `Teon Brooks`_
 
 - Add support for KIT epochs files with ``read_epochs_kit`` by `Teon Brooks`_
 

--- a/examples/visualization/make_report.py
+++ b/examples/visualization/make_report.py
@@ -26,7 +26,7 @@ evoked_fname = meg_path + '/sample_audvis-ave.fif'
 # Do standard folder parsing (this can take a couple of minutes):
 
 report = Report(image_format='png', subjects_dir=subjects_dir,
-                info_fname=evoked_fname, subject='sample')
+                info_fname=evoked_fname, subject='sample', raw_psd=True)
 report.parse_folder(meg_path)
 
 ###############################################################################

--- a/mne/report.py
+++ b/mne/report.py
@@ -86,8 +86,10 @@ def _fig_to_img(fig, image_format='png', scale=None, **kwargs):
         _scale_mpl_figure(fig, scale)
     logger.debug('Saving figure %s with dpi %s'
                  % (fig.get_size_inches(), fig.get_dpi()))
-    fig.savefig(output, format=image_format, dpi=fig.get_dpi(),
-                bbox_to_inches='tight')
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore')  # incompatible axes
+        fig.savefig(output, format=image_format, dpi=fig.get_dpi(),
+                    bbox_to_inches='tight')
     plt.close(fig)
     output = output.getvalue()
     return (output.decode('utf-8') if image_format == 'svg' else

--- a/mne/report.py
+++ b/mne/report.py
@@ -333,11 +333,11 @@ def _build_image_png(data, cmap='gray'):
     if figsize[0] == 1:
         figsize = tuple(figsize[1:])
         data = data[:, :, 0]
-    fig = _figure_agg(figsize=figsize, dpi=92, frameon=False)
+    fig = _figure_agg(figsize=figsize, dpi=1.0, frameon=False)
     cmap = getattr(plt.cm, cmap, plt.cm.gray)
     fig.figimage(data, cmap=cmap)
     output = BytesIO()
-    fig.savefig(output, dpi=92, format='png')
+    fig.savefig(output, dpi=fig.get_dpi(), format='png')
     return base64.b64encode(output.getvalue()).decode('ascii')
 
 
@@ -1303,8 +1303,16 @@ class Report(object):
             info = read_info(self.info_fname, verbose=False)
             sfreq = info['sfreq']
         else:
-            warn('`info_fname` not provided. Cannot render -cov.fif(.gz) and '
-                 '-trans.fif(.gz) files.')
+            # only warn if relevant
+            if any(fname.endswith(('-cov.fif', '-cov.fif.gz'))
+                   for fname in fnames):
+                warn('`info_fname` not provided. Cannot render '
+                     '-cov.fif(.gz) files.')
+            if any(fname.endswith(('-trans.fif', '-trans.fif.gz'))
+                   for fname in fnames):
+                warn('`info_fname` not provided. Cannot render '
+                     '-trans.fif(.gz) files.')
+                raise RuntimeError
             info, sfreq = None, None
 
         cov = None

--- a/mne/report.py
+++ b/mne/report.py
@@ -851,11 +851,10 @@ class Report(object):
         # boolean to specify if sections should be ordered in natural
         # order of processing (raw -> events ... -> inverse)
         self._sort_sections = False
-        raw_psd = {} if raw_psd is True else raw_psd
-        if raw_psd is not False and not isinstance(raw_psd, dict):
+        if not isinstance(raw_psd, bool) and not isinstance(raw_psd, dict):
             raise TypeError('raw_psd must be bool or dict, got %s'
                             % (type(raw_psd),))
-        self._raw_psd = raw_psd
+        self.raw_psd = raw_psd
         self._init_render()  # Initialize the renderer
 
     def __repr__(self):
@@ -1314,7 +1313,6 @@ class Report(object):
                    for fname in fnames):
                 warn('`info_fname` not provided. Cannot render '
                      '-trans.fif(.gz) files.')
-                raise RuntimeError
             info, sfreq = None, None
 
         cov = None
@@ -1612,14 +1610,15 @@ class Report(object):
             meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad, n_mag=n_mag,
             eog=eog, ecg=ecg, tmin=tmin, tmax=tmax)
 
-        if isinstance(self._raw_psd, dict):
+        raw_psd = {} if self.raw_psd is True else self.raw_psd
+        if isinstance(raw_psd, dict):
             from matplotlib.backends.backend_agg import FigureCanvasAgg
             n_ax = sum(kind in raw for kind in _data_types)
             fig, axes = plt.subplots(n_ax, 1, figsize=(6, 1 + 1.5 * n_ax),
                                      dpi=92)
             FigureCanvasAgg(fig)
             img = _fig_to_img(raw.plot_psd, self.image_format,
-                              ax=axes, **self._raw_psd)
+                              ax=axes, **raw_psd)
             new_html = image_template.substitute(
                 img=img, div_klass='raw', img_klass='raw',
                 caption='PSD', show=True, image_format=self.image_format)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -136,6 +136,18 @@ def test_render_report():
     # ndarray support smoke test
     report.add_figs_to_section(np.zeros((2, 3, 3)), 'caption', 'section')
 
+    # PSD functionality
+    with pytest.raises(TypeError, match='dict'):
+        Report(raw_psd='foo')
+
+    tempdir = _TempDir()
+    raw_fname_new = op.join(tempdir, 'temp_raw.fif')
+    shutil.copyfile(raw_fname, raw_fname_new)
+    report = Report(raw_psd=dict(tmax=2.))
+    report.parse_folder(data_path=tempdir, on_error='raise')
+    assert isinstance(report.html, list)
+    assert 'PSD' in ''.join(report.html)
+
 
 @testing.requires_testing_data
 @requires_mayavi

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -148,10 +148,8 @@ def test_report_raw_psd_and_date():
     raw_fname_new = op.join(tempdir, 'temp_raw.fif')
     raw.save(raw_fname_new)
     report = Report(raw_psd=True)
-    with warnings.catch_warnings(record=True) as w:
-        report.parse_folder(data_path=tempdir, render_bem=False,
-                            on_error='raise')
-    assert len(w) == 0
+    report.parse_folder(data_path=tempdir, render_bem=False,
+                        on_error='raise')
     assert isinstance(report.html, list)
     assert 'PSD' in ''.join(report.html)
     assert 'GMT' in ''.join(report.html)
@@ -226,9 +224,8 @@ def test_render_mri():
         shutil.copyfile(a, b)
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=subjects_dir)
-    with pytest.warns(None):  # contours
-        report.parse_folder(data_path=tempdir, mri_decim=30, pattern='*',
-                            n_jobs=2)
+    report.parse_folder(data_path=tempdir, mri_decim=30, pattern='*',
+                        n_jobs=2)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
     assert repr(report)
 
@@ -243,8 +240,7 @@ def test_render_mri_without_bem():
     shutil.copyfile(mri_fname, op.join(tempdir, 'sample', 'mri', 'T1.mgz'))
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=tempdir)
-    with pytest.warns(RuntimeWarning, match='bem directory .* does not exist'):
-        report.parse_folder(tempdir)
+    report.parse_folder(tempdir, render_bem=False)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -536,6 +536,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
         # and then plot the contours on top
         for surf in surfs:
             with warnings.catch_warnings(record=True):  # no contours
+                warnings.simplefilter('ignore')
                 ax.tricontour(surf['rr'][:, inds[0]], surf['rr'][:, inds[1]],
                               surf['tris'], surf['rr'][:, inds[2]],
                               levels=[sl], colors='yellow', linewidths=2.0)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -538,6 +538,9 @@ def _label_clicked(pos, params):
     _plot_update_raw_proj(params, None)
 
 
+_data_types = ('mag', 'grad', 'eeg', 'seeg', 'ecog')
+
+
 def _set_psd_plot_params(info, proj, picks, ax, area_mode):
     """Set PSD plot params."""
     import matplotlib.pyplot as plt
@@ -545,11 +548,11 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
         raise ValueError('"area_mode" must be "std", "range", or None')
 
     # XXX this could be refactored more with e.g., plot_evoked
+    # XXX when it's refactored, Report._render_raw will need to be updated
     megs = ['mag', 'grad', False, False, False]
     eegs = [False, False, True, False, False]
     seegs = [False, False, False, True, False]
     ecogs = [False, False, False, False, True]
-    names = ['mag', 'grad', 'eeg', 'seeg', 'ecog']
     titles = _handle_default('titles', None)
     units = _handle_default('units', None)
     scalings = _handle_default('scalings', None)
@@ -557,7 +560,8 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
     titles_list = list()
     units_list = list()
     scalings_list = list()
-    for meg, eeg, seeg, ecog, name in zip(megs, eegs, seegs, ecogs, names):
+    for meg, eeg, seeg, ecog, name in zip(megs, eegs, seegs, ecogs,
+                                          _data_types):
         these_picks = pick_types(info, meg=meg, eeg=eeg, seeg=seeg, ecog=ecog,
                                  ref_meg=False)
         if picks is not None:
@@ -579,7 +583,6 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
         ax_list = ax
     del picks
 
-    make_label = False
     fig = None
     if ax is None:
         fig = plt.figure()
@@ -594,6 +597,7 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
         make_label = True
     else:
         fig = ax_list[0].get_figure()
+        make_label = len(ax_list) == len(fig.axes)
 
     return (fig, picks_list, titles_list, units_list, scalings_list,
             ax_list, make_label)


### PR DESCRIPTION
Closes #5237.

Also shifts our docs from `mne.report` namespace to the root namespace as `mne.Report` already lives there.

Copying the truncated testing raw file to desktop and doing:
```
import mne
report = mne.Report(raw_psd=True)
report.parse_folder('/Users/larsoner/Desktop')
report.save('/Users/larsoner/Desktop/report.html')
```
I get:

<img width="917" alt="screen shot 2018-08-04 at 17 52 48" src="https://user-images.githubusercontent.com/2365790/43681086-3d96ce80-980f-11e8-839f-92372af252fb.png">

@jona-sassenhagen happy?