### PR TITLE
[MRG+1] Be more precise about warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ sample_data:
 testing_data:
 	@python -c "import mne; mne.datasets.testing.data_path(verbose=True);"
 
+pytest: test
+
 test: in
 	rm -f .coverage
 	$(PYTESTS) -m 'not ultraslowtest' mne

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -3,7 +3,6 @@
 #
 # License: BSD 3 clause
 
-import warnings
 import os.path as op
 import copy as cp
 
@@ -20,10 +19,6 @@ from mne.time_frequency import csd_morlet
 from mne.utils import run_tests_if_main
 from mne.externals.six import advance_iterator
 from mne.proj import compute_proj_evoked, make_projector
-
-# Note that if this is the first test file, this will apply to all subsequent
-# tests in a full test:
-warnings.simplefilter('always')  # ensure we can verify expected warnings
 
 data_path = testing.data_path(download=False)
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
@@ -278,9 +273,9 @@ def test_apply_dics_csd():
                              real_filter=True)
     # Also test here that no warings are thrown - implemented to check whether
     # src should not be None warning occurs:
-    with warnings.catch_warnings(record=True) as wrn:
+    with pytest.warns(None) as w:
         power, f = apply_dics_csd(csd, filters_real)
-    assert len(wrn) == 0
+    assert len(w) == 0
 
     assert f == [10, 20]
     assert np.argmax(power.data[:, 1]) == source_ind
@@ -340,7 +335,7 @@ def test_apply_dics_timeseries():
     # Sanity checks on the resulting STC after applying DICS on epochs.
     # Also test here that no warnings are thrown - implemented to check whether
     # src should not be None warning occurs
-    with warnings.catch_warnings(record=True) as wrn:
+    with pytest.warns(None) as wrn:
         stcs = apply_dics_epochs(epochs, filters)
     assert len(wrn) == 0
 
@@ -496,7 +491,7 @@ def test_tf_dics():
 
     # Test if subtracting evoked responses yields NaN's, since we only have one
     # epoch. Suppress division warnings.
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='invalid value'):
         stcs = tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep, win_lengths,
                        mode='cwt_morlet', frequencies=frequencies,
                        subtract_evoked=True, reg=reg, label=label, decim=20)

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -491,7 +491,7 @@ def test_tf_dics():
 
     # Test if subtracting evoked responses yields NaN's, since we only have one
     # epoch. Suppress division warnings.
-    with pytest.warns(RuntimeWarning, match='invalid value'):
+    with pytest.warns(RuntimeWarning, match='[invalid|empty]'):
         stcs = tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep, win_lengths,
                        mode='cwt_morlet', frequencies=frequencies,
                        subtract_evoked=True, reg=reg, label=label, decim=20)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -91,8 +91,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     noise_cov = mne.cov.regularize(noise_cov, info, mag=0.05, grad=0.05,
                                    eeg=0.1, proj=True)
     if data_cov:
-        with pytest.warns(RuntimeWarning, match='samples'):
-            data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.145)
+        data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.145)
     else:
         data_cov = None
 
@@ -516,9 +515,8 @@ def test_tf_lcmv():
         epochs_band = mne.Epochs(
             raw_band, epochs.events, epochs.event_id, tmin=tmin, tmax=tmax,
             baseline=None, proj=True)
-        with pytest.warns(RuntimeWarning, match='samples'):
-            noise_cov = mne.compute_covariance(
-                epochs_band, tmin=tmin, tmax=tmin + win_length)
+        noise_cov = mne.compute_covariance(
+            epochs_band, tmin=tmin, tmax=tmin + win_length)
         noise_cov = mne.cov.regularize(
             noise_cov, epochs_band.info, mag=reg, grad=reg, eeg=reg,
             proj=True)
@@ -529,13 +527,11 @@ def test_tf_lcmv():
         # time windows to compare to tf_lcmv results and test overlapping
         if (l_freq, h_freq) == freq_bins[0]:
             for time_window in time_windows:
-                with pytest.warns(RuntimeWarning, match='samples'):
-                    data_cov = mne.compute_covariance(
-                        epochs_band, tmin=time_window[0], tmax=time_window[1])
-                with pytest.warns(RuntimeWarning, match='projection'):
-                    stc_source_power = _lcmv_source_power(
-                        epochs.info, forward, noise_cov, data_cov,
-                        reg=reg, label=label, weight_norm='unit-noise-gain')
+                data_cov = mne.compute_covariance(
+                    epochs_band, tmin=time_window[0], tmax=time_window[1])
+                stc_source_power = _lcmv_source_power(
+                    epochs.info, forward, noise_cov, data_cov,
+                    reg=reg, label=label, weight_norm='unit-noise-gain')
                 source_power.append(stc_source_power.data)
 
     pytest.raises(ValueError, tf_lcmv, epochs, forward, noise_covs, tmin, tmax,
@@ -592,13 +588,12 @@ def test_tf_lcmv():
     epochs_preloaded = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                                   baseline=(None, 0), preload=True)
     epochs_preloaded._raw = None
-    with pytest.warns(RuntimeWarning, match='samples'):
-        pytest.raises(ValueError, tf_lcmv, epochs_preloaded, forward,
-                      noise_covs, tmin, tmax, tstep, win_lengths, freq_bins)
+    pytest.raises(ValueError, tf_lcmv, epochs_preloaded, forward,
+                  noise_covs, tmin, tmax, tstep, win_lengths, freq_bins)
 
+    # Pass only one epoch to test if subtracting evoked
+    # responses yields zeros
     with pytest.warns(RuntimeWarning, match='samples'):
-        # Pass only one epoch to test if subtracting evoked
-        # responses yields zeros
         stcs = tf_lcmv(epochs[0], forward, noise_covs, tmin, tmax, tstep,
                        win_lengths, freq_bins, subtract_evoked=True, reg=reg,
                        label=label, raw=raw)

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -7,7 +7,6 @@ import os.path as op
 import numpy as np
 from scipy import linalg
 
-import warnings
 from numpy.testing import assert_array_equal, assert_equal
 
 import mne
@@ -22,8 +21,6 @@ fname_ave = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
 fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
 def _get_data(ch_decim=1):

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -7,8 +7,6 @@
 
 import copy
 import os.path as op
-import warnings
-# Set our plotters to test mode
 import matplotlib
 
 import numpy as np
@@ -27,8 +25,6 @@ from mne.io.constants import FIFF
 from mne.bem import fit_sphere_to_headshape
 from mne.utils import _TempDir
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')
 
 io_dir = op.join(op.dirname(__file__), '..', '..', 'io')
 fif_fname = op.join(io_dir, 'tests', 'data', 'test_raw.fif')

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -379,7 +379,7 @@ def test_read_dig_montage():
     # test unit parameter and .mat support
     tempdir = _TempDir()
     mat_hsp = op.join(tempdir, 'test.mat')
-    savemat(mat_hsp, dict(Points=(1000 * hsp_points).T))
+    savemat(mat_hsp, dict(Points=(1000 * hsp_points).T), oned_as='row')
     montage_cm = read_dig_montage(mat_hsp, hpi, elp, names, unit='cm')
     assert_allclose(montage_cm.hsp, montage.hsp * 10.)
     assert_allclose(montage_cm.elp, montage.elp * 10.)

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
@@ -10,8 +8,6 @@ from mne.connectivity.spectral import _CohEst, _get_n_epochs
 from mne import SourceEstimate
 from mne.utils import run_tests_if_main
 from mne.filter import filter_data
-
-warnings.simplefilter('always')
 
 
 def _stc_gen(data, sfreq, tmin, combo=False):

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -1,7 +1,6 @@
 # Authors: Chris Holdgraf <choldgraf@gmail.com>
 #
 # License: BSD (3-clause)
-import warnings
 import os.path as op
 
 import pytest
@@ -11,7 +10,7 @@ from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
 from mne import io, pick_types
 from mne.fixes import einsum
-from mne.utils import requires_version, run_tests_if_main, check_version
+from mne.utils import requires_version, run_tests_if_main
 from mne.decoding import ReceptiveField, TimeDelayingRidge
 from mne.decoding.receptive_field import (_delay_time_series, _SCORERS,
                                           _times_to_delays, _delays_to_slice)
@@ -27,8 +26,6 @@ rng = np.random.RandomState(1337)
 
 tmin, tmax = -0.1, 0.5
 event_id = dict(aud_l=1, vis_l=3)
-
-warnings.simplefilter('always')
 
 # Loading raw data
 raw = io.read_raw_fif(raw_fname, preload=True)
@@ -517,14 +514,9 @@ def test_inverse_coef():
     X, y = make_data(n_feats, n_targets, n_samples, tmin, tmax)
     for estimator in (0., Ridge(alpha=0.)):
         rf = ReceptiveField(tmin, tmax, 1., estimator=estimator, patterns=True)
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(RuntimeWarning,
+                          match='[singular|scipy.linalg.solve]'):
             rf.fit(y, X)
-            # For some reason there is no warning
-            if estimator and not check_version('numpy', '1.13'):
-                continue
-            assert_equal(len(w), 1)
-            assert any(x in str(w[0].message).lower()
-                       for x in ('singular', 'scipy.linalg.solve'))
 
 
 run_tests_if_main()

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -514,7 +514,7 @@ def test_inverse_coef():
     X, y = make_data(n_feats, n_targets, n_samples, tmin, tmax)
     for estimator in (0., Ridge(alpha=0.)):
         rf = ReceptiveField(tmin, tmax, 1., estimator=estimator, patterns=True)
-        with pytest.warns(RuntimeWarning,
+        with pytest.warns((RuntimeWarning, UserWarning),
                           match='[Singular|scipy.linalg.solve]'):
             rf.fit(y, X)
 

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -515,7 +515,7 @@ def test_inverse_coef():
     for estimator in (0., Ridge(alpha=0.)):
         rf = ReceptiveField(tmin, tmax, 1., estimator=estimator, patterns=True)
         with pytest.warns(RuntimeWarning,
-                          match='[singular|scipy.linalg.solve]'):
+                          match='[Singular|scipy.linalg.solve]'):
             rf.fit(y, X)
 
 

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -29,7 +29,8 @@ def test_search_light():
     from sklearn.linear_model import Ridge, LogisticRegression
     from sklearn.pipeline import make_pipeline
     from sklearn.metrics import roc_auc_score, make_scorer
-    from sklearn.ensemble import BaggingClassifier
+    with pytest.warns(None):  # NumPy module import
+        from sklearn.ensemble import BaggingClassifier
     from sklearn.base import is_classifier
 
     X, y = make_data()

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -5,13 +5,12 @@
 #
 # License: BSD (3-clause)
 
-import warnings
-
 import numpy as np
 from scipy import linalg
 
 from .base import BaseEstimator
 from ..filter import next_fast_len
+from ..utils import warn
 from ..externals.six import string_types
 
 
@@ -199,8 +198,8 @@ def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
         #       is raised
         w = linalg.solve(mat, x_y, sym_pos=True, overwrite_a=False)
     except np.linalg.LinAlgError:
-        warnings.warn('Singular matrix in solving dual problem. Using '
-                      'least-squares solution instead.')
+        warn('Singular matrix in solving dual problem. Using '
+             'least-squares solution instead.')
         w = linalg.lstsq(mat, x_y, lapack_driver='gelsy')[0]
     w = w.T.reshape([n_ch_out, n_ch_in, n_delays])
     return w

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -1,7 +1,6 @@
 from itertools import product
 import os
 import os.path as op
-import warnings
 
 import pytest
 import numpy as np
@@ -172,7 +171,7 @@ def test_make_forward_solution_kit():
     fwd = _do_forward_solution('sample', fname_bti_raw, src=fname_src_small,
                                bem=fname_bem_meg, mri=trans_path,
                                eeg=False, meg=True, subjects_dir=subjects_dir)
-    with warnings.catch_warnings(record=True):  # weight tables
+    with pytest.warns(RuntimeWarning, match='tables'):
         raw_py = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
     fwd_py = make_forward_solution(raw_py.info, src=src, eeg=False, meg=True,
                                    bem=fname_bem_meg, trans=trans_path)
@@ -194,7 +193,7 @@ def test_make_forward_solution_kit():
 
     fwd_py = make_forward_solution(ctf_raw.info, fname_trans, src,
                                    fname_bem_meg, eeg=False, meg=True)
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='samples'):
         fwd = _do_forward_solution('sample', ctf_raw, mri=fname_trans,
                                    src=fname_src_small, bem=fname_bem_meg,
                                    eeg=False, meg=True,
@@ -353,10 +352,9 @@ def test_make_forward_dipole():
     sphere = make_sphere_model(head_radius=0.1)
 
     # Warning emitted due to uneven sampling in time
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='unevenly spaced'):
         fwd, stc = make_forward_dipole(dip_test, sphere, info,
                                        trans=fname_trans)
-        assert (issubclass(w[-1].category, RuntimeWarning))
 
     # stc is list of VolSourceEstimate's
     assert isinstance(stc, list)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -171,8 +171,7 @@ def test_make_forward_solution_kit():
     fwd = _do_forward_solution('sample', fname_bti_raw, src=fname_src_small,
                                bem=fname_bem_meg, mri=trans_path,
                                eeg=False, meg=True, subjects_dir=subjects_dir)
-    with pytest.warns(RuntimeWarning, match='tables'):
-        raw_py = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
+    raw_py = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
     fwd_py = make_forward_solution(raw_py.info, src=src, eeg=False, meg=True,
                                    bem=fname_bem_meg, trans=trans_path)
     _compare_forwards(fwd, fwd_py, 248, n_src)
@@ -193,11 +192,10 @@ def test_make_forward_solution_kit():
 
     fwd_py = make_forward_solution(ctf_raw.info, fname_trans, src,
                                    fname_bem_meg, eeg=False, meg=True)
-    with pytest.warns(RuntimeWarning, match='samples'):
-        fwd = _do_forward_solution('sample', ctf_raw, mri=fname_trans,
-                                   src=fname_src_small, bem=fname_bem_meg,
-                                   eeg=False, meg=True,
-                                   subjects_dir=subjects_dir)
+    fwd = _do_forward_solution('sample', ctf_raw, mri=fname_trans,
+                               src=fname_src_small, bem=fname_bem_meg,
+                               eeg=False, meg=True,
+                               subjects_dir=subjects_dir)
     _compare_forwards(fwd, fwd_py, 274, n_src)
 
     temp_dir = _TempDir()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import sys
 from unittest import SkipTest
-import warnings
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
@@ -37,7 +36,6 @@ fname_trans = op.join(data_path, 'MEG', 'sample',
                       'sample_audvis_trunc-trans.fif')
 kit_raw_path = op.join(kit_data_dir, 'test_bin_raw.fif')
 subjects_dir = op.join(data_path, 'subjects')
-warnings.simplefilter('always')
 
 
 @testing.requires_testing_data
@@ -56,10 +54,9 @@ def test_coreg_model_decimation():
         os.remove(op.join(subject_dir, 'bem', fname))
 
     model = CoregModel(guess_mri_subject=False)
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='No low-resolution'):
         model.mri.subjects_dir = tempdir
     assert model.mri.subject == 'sample'  # already set by setting subjects_dir
-    assert any('No low-resolution' in str(ww.message) for ww in w)
     assert model.mri.bem_low_res.file == ''
     assert len(model.mri.bem_low_res.surf.rr) == 2562
     assert len(model.mri.bem_high_res.surf.rr) == 2562  # because we moved it
@@ -325,8 +322,7 @@ def test_coreg_model_with_fsaverage():
 
     # test switching raw disables point omission
     assert_equal(model.hsp.n_omitted, 1)
-    with warnings.catch_warnings(record=True):
-        model.hsp.file = kit_raw_path
+    model.hsp.file = kit_raw_path
     assert_equal(model.hsp.n_omitted, 0)
 
 

--- a/mne/gui/tests/test_kit2fiff_gui.py
+++ b/mne/gui/tests/test_kit2fiff_gui.py
@@ -4,7 +4,6 @@
 
 import os
 import sys
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -22,8 +21,6 @@ sqd_path = os.path.join(kit_data_dir, 'test.sqd')
 hsp_path = os.path.join(kit_data_dir, 'test_hsp.txt')
 fid_path = os.path.join(kit_data_dir, 'test_elp.txt')
 fif_path = os.path.join(kit_data_dir, 'test_bin_raw.fif')
-
-warnings.simplefilter('always')
 
 
 def _check_ci():

--- a/mne/gui/tests/test_marker_gui.py
+++ b/mne/gui/tests/test_marker_gui.py
@@ -5,7 +5,6 @@
 import os
 import sys
 from unittest import SkipTest
-import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -18,8 +17,6 @@ from mne.utils import (_TempDir, requires_mayavi, run_tests_if_main,
 mrk_pre_path = os.path.join(kit_data_dir, 'test_mrk_pre.sqd')
 mrk_post_path = os.path.join(kit_data_dir, 'test_mrk_post.sqd')
 mrk_avg_path = os.path.join(kit_data_dir, 'test_mrk.sqd')
-
-warnings.simplefilter('always')
 
 
 def _check_ci():
@@ -83,9 +80,7 @@ def test_combine_markers_model():
     _check_ci()
     os.environ['_MNE_GUI_TESTING_MODE'] = 'true'
     try:
-        with warnings.catch_warnings(record=True):  # traits warnings
-            warnings.simplefilter('always')
-            CombineMarkersPanel()
+        CombineMarkersPanel()
     finally:
         del os.environ['_MNE_GUI_TESTING_MODE']
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -98,26 +98,29 @@ def test_mxne_inverse():
     assert stc_cd.vertices[1][0] in label.vertices
     assert stc_bcd.vertices[1][0] in label.vertices
 
-    dips = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
-                      depth=depth, maxit=300, tol=1e-8, active_set_size=10,
-                      weights=stc_dspm, weights_min=weights_min,
-                      solver='cd', return_as_dipoles=True)
+    with pytest.warns(None):  # CD
+        dips = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
+                          depth=depth, maxit=300, tol=1e-8, active_set_size=10,
+                          weights=stc_dspm, weights_min=weights_min,
+                          solver='cd', return_as_dipoles=True)
     stc_dip = make_stc_from_dipoles(dips, forward['src'])
     assert isinstance(dips[0], Dipole)
     _check_stcs(stc_cd, stc_dip)
 
-    stc, _ = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
-                        depth=depth, maxit=300, tol=1e-8,
-                        active_set_size=10, return_residual=True,
-                        solver='cd')
+    with pytest.warns(None):  # CD
+        stc, _ = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
+                            depth=depth, maxit=300, tol=1e-8,
+                            active_set_size=10, return_residual=True,
+                            solver='cd')
     assert_array_almost_equal(stc.times, evoked_l21.times, 5)
     assert stc.vertices[1][0] in label.vertices
 
     # irMxNE tests
-    stc = mixed_norm(evoked_l21, forward, cov, alpha,
-                     n_mxne_iter=5, loose=loose, depth=depth,
-                     maxit=300, tol=1e-8, active_set_size=10,
-                     solver='cd')
+    with pytest.warns(None):  # CD
+        stc = mixed_norm(evoked_l21, forward, cov, alpha,
+                         n_mxne_iter=5, loose=loose, depth=depth,
+                         maxit=300, tol=1e-8, active_set_size=10,
+                         solver='cd')
     assert_array_almost_equal(stc.times, evoked_l21.times, 5)
     assert stc.vertices[1][0] in label.vertices
     assert stc.vertices == [[63152], [79017]]

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -79,10 +79,11 @@ def test_mxne_inverse():
                           depth=depth, maxit=300, tol=1e-8,
                           active_set_size=10, weights=stc_dspm,
                           weights_min=weights_min, solver='prox')
-    stc_cd = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
-                        depth=depth, maxit=300, tol=1e-8, active_set_size=10,
-                        weights=stc_dspm, weights_min=weights_min,
-                        solver='cd')
+    with pytest.warns(None):  # CD
+        stc_cd = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
+                            depth=depth, maxit=300, tol=1e-8,
+                            active_set_size=10, weights=stc_dspm,
+                            weights_min=weights_min, solver='cd')
     stc_bcd = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
                          depth=depth, maxit=300, tol=1e-8, active_set_size=10,
                          weights=stc_dspm, weights_min=weights_min,

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -45,41 +45,49 @@ def test_l21_mxne():
     M = np.dot(G, X)
 
     args = (M, G, alpha, 1000, 1e-8)
-    X_hat_prox, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=None,
-        debias=True, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=None,
+            debias=True, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_cd, active_set, _, gap_cd = mixed_norm_solver(
-        *args, active_set_size=None,
-        debias=True, solver='cd', return_gap=True)
+    with pytest.warns(None):  # CD
+        X_hat_cd, active_set, _, gap_cd = mixed_norm_solver(
+            *args, active_set_size=None,
+            debias=True, solver='cd', return_gap=True)
     assert_array_less(gap_cd, 1e-8)
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_bcd, active_set, E, gap_bcd = mixed_norm_solver(
-        M, G, alpha, maxit=1000, tol=1e-8, active_set_size=None,
-        debias=True, solver='bcd', return_gap=True)
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, E, gap_bcd = mixed_norm_solver(
+            M, G, alpha, maxit=1000, tol=1e-8, active_set_size=None,
+            debias=True, solver='bcd', return_gap=True)
     assert_array_less(gap_bcd, 9.6e-9)
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_allclose(X_hat_prox, X_hat_cd, rtol=1e-2)
     assert_allclose(X_hat_prox, X_hat_bcd, rtol=1e-2)
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
 
-    X_hat_prox, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_cd, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, solver='cd')
+    with pytest.warns(None):  # CD
+        X_hat_cd, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, solver='cd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_bcd, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
     assert_allclose(X_hat_bcd, X_hat_prox, rtol=1e-2)
 
-    X_hat_prox, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, n_orient=2, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, n_orient=2, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
-    X_hat_bcd, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, n_orient=2, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, n_orient=2, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
 
     # suppress a coordinate-descent warning here
@@ -90,11 +98,13 @@ def test_l21_mxne():
     assert_allclose(X_hat_bcd, X_hat_prox, rtol=1e-2)
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
 
-    X_hat_bcd, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, n_orient=5, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, n_orient=5, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
-    X_hat_prox, active_set, _ = mixed_norm_solver(
-        *args, active_set_size=2, debias=True, n_orient=5, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = mixed_norm_solver(
+            *args, active_set_size=2, debias=True, n_orient=5, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
     with pytest.warns(RuntimeWarning, match='descent'):
         X_hat_cd, active_set, _ = mixed_norm_solver(
@@ -112,9 +122,10 @@ def test_tf_mxne():
 
     M, G, active_set = _generate_tf_data()
 
-    X_hat_tf, active_set_hat_tf, E, gap_tfmxne = tf_mixed_norm_solver(
-        M, G, alpha_space, alpha_time, maxit=200, tol=1e-8, verbose=True,
-        n_orient=1, tstep=4, wsize=32, return_gap=True)
+    with pytest.warns(None):  # CD
+        X_hat_tf, active_set_hat_tf, E, gap_tfmxne = tf_mixed_norm_solver(
+            M, G, alpha_space, alpha_time, maxit=200, tol=1e-8, verbose=True,
+            n_orient=1, tstep=4, wsize=32, return_gap=True)
     assert_array_less(gap_tfmxne, 1e-8)
     assert_array_equal(np.where(active_set_hat_tf)[0], active_set)
 
@@ -218,36 +229,43 @@ def test_iterative_reweighted_mxne():
     X[4] = -2
     M = np.dot(G, X)
 
-    X_hat_l21, _, _ = mixed_norm_solver(
-        M, G, alpha, maxit=1000, tol=1e-8, verbose=False, n_orient=1,
-        active_set_size=None, debias=False, solver='bcd')
-    X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 1, maxit=1000, tol=1e-8, active_set_size=None,
-        debias=False, solver='bcd')
-    X_hat_prox, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 1, maxit=1000, tol=1e-8, active_set_size=None,
-        debias=False, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_l21, _, _ = mixed_norm_solver(
+            M, G, alpha, maxit=1000, tol=1e-8, verbose=False, n_orient=1,
+            active_set_size=None, debias=False, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 1, maxit=1000, tol=1e-8, active_set_size=None,
+            debias=False, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 1, maxit=1000, tol=1e-8, active_set_size=None,
+            debias=False, solver='prox')
     assert_allclose(X_hat_bcd, X_hat_l21, rtol=1e-3)
     assert_allclose(X_hat_prox, X_hat_l21, rtol=1e-3)
 
-    X_hat_prox, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=None,
-        debias=True, solver='prox')
+    with pytest.warns(None):  # CD
+        X_hat_prox, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=None,
+            debias=True, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
-        debias=True, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
+            debias=True, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    X_hat_cd, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=None,
-        debias=True, solver='cd')
+    with pytest.warns(None):  # CD
+        X_hat_cd, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=None,
+            debias=True, solver='cd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_array_almost_equal(X_hat_prox, X_hat_cd, 5)
     assert_array_almost_equal(X_hat_bcd, X_hat_cd, 5)
 
-    X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
-        M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
-        debias=True, n_orient=2, solver='bcd')
+    with pytest.warns(None):  # CD
+        X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
+            M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
+            debias=True, n_orient=2, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
     # suppress a coordinate-descent warning here
     with pytest.warns(RuntimeWarning, match='descent'):

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -3,8 +3,8 @@
 #
 # License: Simplified BSD
 
+import pytest
 import numpy as np
-import warnings
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_allclose, assert_array_less)
 
@@ -14,8 +14,6 @@ from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            norm_epsilon_inf, norm_epsilon,
                                            _Phi, _PhiT, dgap_l21l1)
 from mne.time_frequency.stft import stft_norm2
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 
 def _generate_tf_data():
@@ -85,7 +83,7 @@ def test_l21_mxne():
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
 
     # suppress a coordinate-descent warning here
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='descent'):
         X_hat_cd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, n_orient=2, solver='cd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
@@ -98,7 +96,7 @@ def test_l21_mxne():
     X_hat_prox, active_set, _ = mixed_norm_solver(
         *args, active_set_size=2, debias=True, n_orient=5, solver='prox')
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
-    with warnings.catch_warnings(record=True):  # coordinate-ascent warning
+    with pytest.warns(RuntimeWarning, match='descent'):
         X_hat_cd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, n_orient=5, solver='cd')
 
@@ -252,7 +250,7 @@ def test_iterative_reweighted_mxne():
         debias=True, n_orient=2, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
     # suppress a coordinate-descent warning here
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='descent'):
         X_hat_cd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
             debias=True, n_orient=2, solver='cd')
@@ -263,7 +261,7 @@ def test_iterative_reweighted_mxne():
         M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2, debias=True,
         n_orient=5)
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
-    with warnings.catch_warnings(record=True):  # coordinate-ascent warning
+    with pytest.warns(RuntimeWarning, match='descent'):
         X_hat_cd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
             debias=True, n_orient=5, solver='cd')

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
 import matplotlib
 
 import numpy as np
@@ -19,8 +18,6 @@ from mne.io.meas_info import create_info, _kind_dict
 from mne.utils import requires_version, run_tests_if_main
 
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')  # enable b/c these tests might throw warnings
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'tests', 'data')
 fif_fname = op.join(base_dir, 'test_raw.fif')

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -4,10 +4,10 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+import pytest
 
 from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_artemis123
@@ -72,7 +72,7 @@ def test_data():
     assert_equal(raw.info['sfreq'], 5000.0)
 
     # test with head loc and digitization
-    with warnings.catch_warnings(record=True):  # bad dig
+    with pytest.warns(RuntimeWarning, match='Large difference'):
         raw = read_raw_artemis123(short_HPI_dip_fname,  add_head_trans=True,
                                   pos_fname=dig_fname)
     _assert_trans(raw.info['dev_head_t']['trans'], dev_head_t_1)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -11,7 +11,6 @@ import copy
 from copy import deepcopy
 import os
 import os.path as op
-import warnings
 
 import numpy as np
 
@@ -667,10 +666,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @annotations.setter
     def annotations(self, annotations, emit_warning=True):
-        warnings.warn('setting the annotations attribute by assignation is'
-                      ' deprecated since 0.17, and would be removed in 0.19.'
-                      ' Please use raw.set_annotations() instead.',
-                      category=DeprecationWarning)
+        warn('setting the annotations attribute by assignment is'
+             ' deprecated since 0.17, and will be removed in 0.18.'
+             ' Please use raw.set_annotations() instead.',
+             category=DeprecationWarning)
         self.set_annotations(annotations, emit_warning=emit_warning)
 
     def set_annotations(self, annotations, emit_warning=True):

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -13,7 +13,6 @@
 import os
 import os.path as op
 import re
-import warnings
 from datetime import datetime
 from math import modf
 
@@ -96,9 +95,9 @@ class RawBrainVision(BaseRaw):
                  event_id=None, verbose=None,
                  trig_shift_by_type=None):  # noqa: D107
         if response_trig_shift != 0:
-            warnings.warn(
+            warn(
                 "'response_trig_shift' was deprecated in version "
-                "0.17 and will be removed in 0.19. Use "
+                "0.17 and will be removed in 0.18. Use "
                 "trig_shift_by_type={{'response': {} }} instead".format(
                     response_trig_shift), DeprecationWarning)
             if trig_shift_by_type and 'response' in (

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import os
 import os.path as op
 from functools import reduce, partial
-import warnings
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -26,8 +25,6 @@ from mne import pick_types
 from mne.utils import run_tests_if_main
 from mne.transforms import Transform, combine_transforms, invert_transform
 from mne.externals import six
-
-warnings.simplefilter('always')
 
 base_dir = op.join(op.abspath(op.dirname(__file__)), 'data')
 

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -4,15 +4,13 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
+import pytest
 
 from mne import pick_types
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
-
-warnings.simplefilter('always')
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
@@ -21,11 +19,9 @@ fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
 @testing.requires_testing_data
 def test_data():
     """Test reading raw cnt files."""
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='number of bytes'):
         raw = _test_raw_reader(read_raw_cnt, montage=None, input_fname=fname,
                                eog='auto', misc=['NA1', 'LEFT_EAR'])
-    assert all('meas date' in str(ww.message) or
-               'number of bytes' in str(ww.message) for ww in w)
     eog_chs = pick_types(raw.info, eog=True, exclude=[])
     assert len(eog_chs) == 2  # test eog='auto'
     assert raw.info['bads'] == ['LEFT_EAR', 'VEOGR']  # test bads

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -197,7 +197,7 @@ def test_read_ctf():
             assert_allclose(raw_read[pick_ch, sl_time][0],
                             raw_c[pick_ch, sl_time][0])
         # all data / preload
-        with pytest.warns(RuntimeWarning, match='MISC channel'):
+        with pytest.warns(None):  # sometimes MISC
             raw = read_raw_ctf(fname, preload=True)
         assert_allclose(raw[:][0], raw_c[:][0], atol=1e-15)
         # test bad segment annotations

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -113,7 +113,7 @@ def test_io_set_raw(fnames, tmpdir):
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': eeg.event[0],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
-               appendmat=False)
+               appendmat=False, oned_as='row')
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     one_event_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
@@ -131,7 +131,8 @@ def test_io_set_raw(fnames, tmpdir):
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': 'test_one_event.fdt',
                 'epoch': eeg.epoch, 'event': evnts,
-                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}}, appendmat=False)
+                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
+               appendmat=False, oned_as='row')
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     negative_latency_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
@@ -145,7 +146,7 @@ def test_io_set_raw(fnames, tmpdir):
                 'nbchan': eeg.nbchan, 'data': 'test_overlap_event.fdt',
                 'epoch': eeg.epoch, 'event': [eeg.event[0], eeg.event[0]],
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
-               appendmat=False)
+               appendmat=False, oned_as='row')
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     overlap_fname.replace('.set', '.fdt'))
     event_id = {'rt': 1, 'square': 2}
@@ -166,7 +167,8 @@ def test_io_set_raw(fnames, tmpdir):
                 'epoch': eeg.epoch, 'event': eeg.epoch,
                 'chanlocs': {'labels': 'E1', 'Y': -6.6069,
                              'X': 6.3023, 'Z': -2.9423},
-                'times': eeg.times[:3], 'pnts': 3}}, appendmat=False)
+                'times': eeg.times[:3], 'pnts': 3}},
+               appendmat=False, oned_as='row')
     with pytest.warns(None) as w:
         read_raw_eeglab(input_fname=one_chan_fname, preload=True)
     # no warning for 'no events found'
@@ -194,7 +196,7 @@ def test_io_set_raw(fnames, tmpdir):
                 'nbchan': 3, 'data': np.random.random((3, 3)),
                 'epoch': eeg.epoch, 'event': eeg.epoch,
                 'chanlocs': chanlocs, 'times': eeg.times[:3], 'pnts': 3}},
-               appendmat=False)
+               appendmat=False, oned_as='row')
     # load it
     with pytest.warns(RuntimeWarning, match='did not have a position'):
         raw = read_raw_eeglab(input_fname=one_chanpos_fname, preload=True)
@@ -227,7 +229,8 @@ def test_io_set_raw(fnames, tmpdir):
                {'trials': eeg.trials, 'srate': eeg.srate, 'nbchan': 3,
                 'data': np.random.random((3, 2)), 'epoch': eeg.epoch,
                 'event': eeg.epoch, 'chanlocs': nopos_chanlocs,
-                'times': eeg.times[:2], 'pnts': 2}}, appendmat=False)
+                'times': eeg.times[:2], 'pnts': 2}},
+               appendmat=False, oned_as='row')
     # load the file
     raw = read_raw_eeglab(input_fname=nopos_fname, preload=True)
     # test that channel names have been loaded but not channel positions
@@ -285,7 +288,8 @@ def test_degenerate(tmpdir):
                {'trials': eeg.trials, 'srate': eeg.srate,
                 'nbchan': eeg.nbchan, 'data': eeg.data,
                 'epoch': eeg.epoch, 'event': eeg.event,
-                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}}, appendmat=False)
+                'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
+               appendmat=False, oned_as='row')
     shutil.copyfile(op.join(base_dir, 'test_epochs.fdt'),
                     op.join(tmpdir, 'test_epochs.dat'))
     with pytest.warns(RuntimeWarning, match='multiple events'):

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -9,7 +9,6 @@ import os.path as op
 import shutil
 from unittest import SkipTest
 
-import warnings
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_equal)
@@ -44,8 +43,6 @@ raw_fnames = [raw_fname_mat, raw_fname_onefile_mat,
               raw_fname_h5, raw_fname_onefile_h5]
 montage = op.join(base_dir, 'test_chans.locs')
 
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
-
 
 def _check_h5(fname):
     if fname.endswith('_h5.set'):
@@ -62,9 +59,7 @@ def test_io_set_raw(fnames, tmpdir):
     """Test importing EEGLAB .set files."""
     tmpdir = str(tmpdir)
     raw_fname, raw_fname_onefile = fnames
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        # main tests, and test missing event_id
+    with pytest.warns(RuntimeWarning) as w:
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname,
                          montage=montage)
         _test_raw_reader(read_raw_eeglab, input_fname=raw_fname_onefile,
@@ -72,8 +67,7 @@ def test_io_set_raw(fnames, tmpdir):
     for want in ('Events like', 'consist entirely', 'could not be mapped',
                  'string preload is not supported'):
         assert (any(want in str(ww.message) for ww in w))
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning) as w:
         # test finding events in continuous data
         event_id = {'rt': 1, 'square': 2}
         raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
@@ -155,12 +149,10 @@ def test_io_set_raw(fnames, tmpdir):
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     overlap_fname.replace('.set', '.fdt'))
     event_id = {'rt': 1, 'square': 2}
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning, match='will be dropped'):
         raw = read_raw_eeglab(input_fname=overlap_fname,
                               montage=montage, event_id=event_id,
                               preload=True)
-    assert_equal(len(w), 1)  # one warning for the dropped event
     events_stimchan = find_events(raw)
     events_read_events_eeglab = read_events_eeglab(overlap_fname, event_id)
     assert (len(events_stimchan) == 1)
@@ -175,11 +167,10 @@ def test_io_set_raw(fnames, tmpdir):
                 'chanlocs': {'labels': 'E1', 'Y': -6.6069,
                              'X': 6.3023, 'Z': -2.9423},
                 'times': eeg.times[:3], 'pnts': 3}}, appendmat=False)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(None) as w:
         read_raw_eeglab(input_fname=one_chan_fname, preload=True)
     # no warning for 'no events found'
-    assert_equal(len(w), 0)
+    assert len(w) == 0
 
     # test reading file with 3 channels - one without position information
     # first, create chanlocs structured array
@@ -205,11 +196,8 @@ def test_io_set_raw(fnames, tmpdir):
                 'chanlocs': chanlocs, 'times': eeg.times[:3], 'pnts': 3}},
                appendmat=False)
     # load it
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning, match='did not have a position'):
         raw = read_raw_eeglab(input_fname=one_chanpos_fname, preload=True)
-    # one warning because some channels are not found in Montage
-    assert_equal(len(w), 1)
     # position should be present for first two channels
     for i in range(2):
         assert_array_equal(raw.info['chs'][i]['loc'][:3],
@@ -220,12 +208,9 @@ def test_io_set_raw(fnames, tmpdir):
     assert_array_equal(raw.info['chs'][-1]['loc'][:3], [np.nan] * 3)
 
     # test reading channel names from set and positions from montage
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning, match='did not have a position'):
         raw = read_raw_eeglab(input_fname=one_chanpos_fname, preload=True,
                               montage=montage)
-    # one warning because some channels are not found in Montage
-    assert_equal(len(w), 1)
 
     # when montage was passed - channel positions should be taken from there
     correct_pos = [[-0.56705965, 0.67706631, 0.46906776], [np.nan] * 3,
@@ -244,9 +229,7 @@ def test_io_set_raw(fnames, tmpdir):
                 'event': eeg.epoch, 'chanlocs': nopos_chanlocs,
                 'times': eeg.times[:2], 'pnts': 2}}, appendmat=False)
     # load the file
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        raw = read_raw_eeglab(input_fname=nopos_fname, preload=True)
+    raw = read_raw_eeglab(input_fname=nopos_fname, preload=True)
     # test that channel names have been loaded but not channel positions
     for i in range(3):
         assert_equal(raw.info['chs'][i]['ch_name'], ch_names[i])
@@ -260,13 +243,12 @@ def test_io_set_raw(fnames, tmpdir):
 def test_io_set_epochs(fnames):
     """Test importing EEGLAB .set epochs files."""
     epochs_fname, epochs_fname_onefile = fnames
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning, match='multiple events'):
         epochs = read_epochs_eeglab(epochs_fname)
+    with pytest.warns(RuntimeWarning, match='multiple events'):
         epochs2 = read_epochs_eeglab(epochs_fname_onefile)
     # one warning for each read_epochs_eeglab because both files have epochs
     # associated with multiple events
-    assert_equal(len(w), 2)
     assert_array_equal(epochs.get_data(), epochs2.get_data())
 
 
@@ -306,11 +288,9 @@ def test_degenerate(tmpdir):
                 'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}}, appendmat=False)
     shutil.copyfile(op.join(base_dir, 'test_epochs.fdt'),
                     op.join(tmpdir, 'test_epochs.dat'))
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(RuntimeWarning, match='multiple events'):
         pytest.raises(NotImplementedError, read_epochs_eeglab,
                       bad_epochs_fname)
-    assert_equal(len(w), 1)
 
 
 @pytest.mark.parametrize("fname", raw_fnames)

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -4,7 +4,6 @@
 
 import inspect
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -237,9 +236,8 @@ def test_decimate():
     np.savetxt(sphere_hsp_path, hsp_mm)
 
     # read in raw data using spherical hsp, and extract new hsp
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='more than'):
         raw = read_raw_kit(sqd_path, mrk_path, elp_txt_path, sphere_hsp_path)
-    assert any('more than' in str(ww.message) for ww in w)
     # collect headshape from raw (should now be in m)
     hsp_dec = np.array([dig['r'] for dig in raw.info['dig']])[8:]
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import hashlib
 import os.path as op
-import warnings
 
 import pytest
 import numpy as np
@@ -23,8 +22,6 @@ from mne.io.meas_info import (Info, create_info, _write_dig_points,
 from mne.io import read_raw_ctf
 from mne.utils import _TempDir, run_tests_if_main
 from mne.channels.montage import read_montage, read_dig_montage
-
-warnings.simplefilter("always")  # ensure we can verify expected warnings
 
 base_dir = op.join(op.dirname(__file__), 'data')
 fiducials_fname = op.join(base_dir, 'fsaverage-fiducials.fif')
@@ -387,10 +384,8 @@ def test_check_consistency():
 
     info2 = info.copy()
     info2['filename'] = 'foo'
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='filename'):
         info2._check_consistency()
-    assert len(w) == 1
-    assert (all('filename' in str(ww.message) for ww in w))
 
     # Silent type conversion to float
     info2 = info.copy()
@@ -408,10 +403,8 @@ def test_check_consistency():
     pytest.raises(RuntimeError, info2._check_consistency)
 
     # Duplicates appended with running numbers
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='Channel names are not'):
         info3 = create_info(ch_names=['a', 'b', 'b', 'c', 'b'], sfreq=1000.)
-    assert len(w) == 1
-    assert (all('Channel names are not' in '%s' % ww.message for ww in w))
     assert_array_equal(info3['ch_names'], ['a', 'b-0', 'b-1', 'c', 'b-2'])
 
 

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -1,6 +1,5 @@
 import inspect
 import os.path as op
-import warnings
 
 from numpy.testing import assert_array_equal, assert_equal
 import pytest
@@ -41,8 +40,7 @@ def test_pick_refs():
     bti_pdf = op.join(bti_dir, 'test_pdf_linux')
     bti_config = op.join(bti_dir, 'test_config_linux')
     bti_hs = op.join(bti_dir, 'test_hs_linux')
-    with warnings.catch_warnings(record=True):  # weight tables
-        raw_bti = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
+    raw_bti = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
     infos.append(raw_bti.info)
     # CTF
     fname_ctf_raw = op.join(io_dir, 'tests', 'data', 'test_ctf_comp_raw.fif')

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -151,5 +151,5 @@ def test_annotation_property_deprecation_warning():
     with pytest.warns(None) as record:
         raw = RawArray(np.random.rand(1, 1), create_info(1, 1))
     assert len(record) is 0
-    with pytest.warns(DeprecationWarning, match='assignation is deprecated'):
+    with pytest.warns(DeprecationWarning, match='by assignment is deprecated'):
         raw.annotations = None

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -4,7 +4,6 @@
 #
 # License: BSD (3-clause)
 
-import warnings
 import os.path as op
 import numpy as np
 
@@ -21,8 +20,6 @@ from mne.io.proj import _has_eeg_average_ref_proj, Projection
 from mne.io.reference import _apply_reference
 from mne.datasets import testing
 from mne.utils import run_tests_if_main
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
 fif_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
@@ -155,9 +152,9 @@ def test_set_eeg_reference():
                     [ch for ch in eeg_chans if ch not in raw.info['bads']])
 
     # Test setting an average reference when one was already present
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='untouched'):
         reref, ref_data = set_eeg_reference(raw, copy=False, projection=True)
-    assert (ref_data is None)
+    assert ref_data is None
 
     # Test setting an average reference on non-preloaded data
     raw_nopreload = read_raw_fif(fif_fname, preload=False)
@@ -418,7 +415,7 @@ def test_add_reference():
     # create epochs in delayed mode, allowing removal of CAR when re-reffing
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True, proj='delayed')
-    with warnings.catch_warnings(record=True):  # multiple set zero
+    with pytest.warns(RuntimeWarning, match='ignored'):
         epochs_ref = add_reference_channels(epochs, ['M1', 'M2'], copy=True)
     assert_equal(epochs_ref._data.shape[1], epochs._data.shape[1] + 2)
     _check_channel_names(epochs_ref, ['M1', 'M2'])
@@ -458,7 +455,7 @@ def test_add_reference():
     epochs = Epochs(raw, events=events, event_id=1, tmin=-0.2, tmax=0.5,
                     picks=picks_eeg, preload=True, proj='delayed')
     evoked = epochs.average()
-    with warnings.catch_warnings(record=True):  # multiple set zero
+    with pytest.warns(RuntimeWarning, match='ignored'):
         evoked_ref = add_reference_channels(evoked, ['M1', 'M2'], copy=True)
     assert_equal(evoked_ref.data.shape[0], evoked.data.shape[0] + 2)
     _check_channel_names(evoked_ref, ['M1', 'M2'])

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -7,7 +7,6 @@ from scipy import sparse
 
 import pytest
 import copy
-import warnings
 
 import mne
 from mne.datasets import testing
@@ -27,7 +26,6 @@ from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       write_inverse_operator,
                                       compute_rank_inverse,
                                       prepare_inverse_operator)
-from mne.tests.common import assert_naming
 from mne.utils import _TempDir, run_tests_if_main
 from mne.externals import six
 
@@ -211,9 +209,8 @@ def test_warn_inverse_operator():
                                       surf_ori=True, copy=False)
     noise_cov = read_cov(fname_cov)
     noise_cov['projs'].pop(-1)  # get rid of avg EEG ref proj
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='reference'):
         make_inverse_operator(bad_info, fwd_op, noise_cov)
-    assert_equal(len(w), 1)
 
 
 @pytest.mark.slowtest
@@ -671,12 +668,11 @@ def test_io_inverse_operator():
     _compare_io(inverse_operator, '.gz')
 
     # test warnings on bad filenames
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        inv_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    inv_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    with pytest.warns(RuntimeWarning, match='-inv.fif'):
         write_inverse_operator(inv_badname, inverse_operator)
+    with pytest.warns(RuntimeWarning, match='-inv.fif'):
         read_inverse_operator(inv_badname)
-    assert_naming(w, 'test_inverse.py', 2)
 
     # make sure we can write and read
     inv_fname = op.join(tempdir, 'test-inv.fif')

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -402,7 +402,7 @@ def test_apply_inverse_sphere():
     write_inverse_operator(temp_fname, inv)
     inv = read_inverse_operator(temp_fname)
     stc = apply_inverse(evoked, inv, method='eLORETA',
-                        method_params=dict(eps=1e-3))
+                        method_params=dict(eps=1e-2))
     # assert zero localization bias
     assert_array_equal(np.argmax(stc.data, axis=0),
                        np.repeat(np.arange(101), 3))

--- a/mne/minimum_norm/tests/test_time_frequency.py
+++ b/mne/minimum_norm/tests/test_time_frequency.py
@@ -3,7 +3,6 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
 import pytest
-import warnings
 
 from mne.datasets import testing
 from mne import find_events, Epochs, pick_types
@@ -28,7 +27,6 @@ fname_inv = op.join(data_path, 'MEG', 'sample',
 fname_data = op.join(data_path, 'MEG', 'sample',
                      'sample_audvis_trunc_raw.fif')
 fname_label = op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-lh.label')
-warnings.simplefilter('always')
 
 
 @testing.requires_testing_data

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -162,7 +162,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
         tmin = epochs.times[0]
         tstep = float(decim) / Fs
         stc = _make_stc(power, vertices=vertno, tmin=tmin, tstep=tstep,
-                        subject=subject)
+                        subject=subject, src_type=inverse_operator['src'].kind)
         stcs[name] = stc
 
         logger.info('[done]')
@@ -515,7 +515,8 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
 
     subject = _subject_from_inverse(inverse_operator)
     stc = _make_stc(psd, vertices=vertno, tmin=fmin * 1e-3,
-                    tstep=fstep * 1e-3, subject=subject)
+                    tstep=fstep * 1e-3, subject=subject,
+                    src_type=inverse_operator['src'].kind)
     return stc
 
 
@@ -611,7 +612,7 @@ def _compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
             psd *= noise_norm ** 2
 
         stc = _make_stc(psd, tmin=fmin, tstep=fstep, vertices=vertno,
-                        subject=subject)
+                        subject=subject, src_type=inverse_operator['src'].kind)
 
         # we return a generator object for "stream processing"
         yield stc

--- a/mne/preprocessing/tests/test_ctps.py
+++ b/mne/preprocessing/tests/test_ctps.py
@@ -1,7 +1,6 @@
 # Authors: Denis A. Engemann <denis.engemann@gmail.com>
 #
 # License: BSD 3 clause
-import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -35,8 +34,7 @@ def get_data(n_trials, j_extent):
     ground_truth = np.tile(single_trial,  n_trials)
     my_shape = n_trials, 1, 600
     random_data = rng.random_sample(my_shape)
-    with warnings.catch_warnings(record=True):  # weight tables
-        rand_ints = rng.random_integers(-j_extent, j_extent, n_trials)
+    rand_ints = rng.randint(-j_extent, j_extent, n_trials)
     jittered_data = np.array([np.roll(single_trial, i) for i in rand_ints])
     data = np.concatenate([ground_truth.reshape(my_shape),
                            jittered_data.reshape(my_shape),

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -3,14 +3,11 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
 
 from mne.datasets import testing
 from mne.preprocessing._fine_cal import (read_fine_calibration,
                                          write_fine_calibration)
 from mne.utils import _TempDir, object_hash, run_tests_if_main
-
-warnings.simplefilter('always')  # Always throw warnings
 
 # Define fine calibration filepaths
 data_path = testing.data_path(download=False)

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -1,7 +1,7 @@
 import os.path as op
-import warnings
 
-from numpy.testing import assert_array_almost_equal, assert_equal
+import pytest
+from numpy.testing import assert_array_almost_equal
 import numpy as np
 
 from mne.io import read_raw_fif, read_raw_ctf
@@ -10,8 +10,6 @@ from mne.preprocessing.ssp import compute_proj_ecg, compute_proj_eog
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne import pick_types
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 data_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(data_path, 'test_raw.fif')
@@ -51,13 +49,11 @@ def test_compute_proj_ecg():
         # XXX: better tests
 
         # without setting a bad channel, this should throw a warning
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with pytest.warns(RuntimeWarning, match='No good epochs found'):
             projs, events, drop_log = compute_proj_ecg(
                 raw, n_mag=2, n_grad=2, n_eeg=2, ch_name='MEG 1531', bads=[],
                 average=average, avg_ref=True, no_proj=True, l_freq=None,
                 h_freq=None, tmax=dur_use, return_drop_log=True)
-        assert len(w) >= 1
         assert projs is None
         assert len(events) == len(drop_log)
 
@@ -90,16 +86,13 @@ def test_compute_proj_eog():
                 assert (proj['explained_var'] > thresh_eeg)
         # XXX: better tests
 
-        # This will throw a warning b/c simplefilter('always')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with pytest.warns(RuntimeWarning, match='longer'):
             projs, events = compute_proj_eog(raw, n_mag=2, n_grad=2, n_eeg=2,
                                              average=average, bads=[],
                                              avg_ref=True, no_proj=False,
                                              l_freq=None, h_freq=None,
                                              tmax=dur_use)
-        assert (len(w) >= 1)
-        assert_equal(projs, None)
+        assert projs is None
 
 
 def test_compute_proj_parallel():

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -90,8 +90,10 @@ def test_fieldtrip_rtepochs(free_tcp_port, tmpdir):
     try:
         data_rt = None
         events_ids_rt = None
-        with FieldTripClient(host='localhost', port=free_tcp_port,
-                             tmax=raw_tmax, wait_max=2) as rt_client:
+        with pytest.warns(RuntimeWarning, match='Trying to guess it'):
+            rt_client = FieldTripClient(host='localhost', port=free_tcp_port,
+                                        tmax=raw_tmax, wait_max=2)
+        with rt_client:
             # get measurement info guessed by MNE-Python
             raw_info = rt_client.get_measurement_info()
             assert ([ch['ch_name'] for ch in raw_info['chs']] ==

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -38,6 +38,7 @@ def _call_base_epochs_public_api(epochs, tmpdir):
     epochs_copy = epochs.copy()
     epochs_copy.decimate(1)
     assert epochs_copy.get_data().shape == orig_data.shape
+    epochs_copy.info['lowpass'] = 10  # avoid warning
     epochs_copy.decimate(10)
     assert np.abs(10.0 - orig_data.shape[2] /
                   epochs_copy.get_data().shape[2]) <= 1

--- a/mne/report.py
+++ b/mne/report.py
@@ -6,6 +6,7 @@
 #
 # License: BSD (3-clause)
 
+import base64
 import os
 import os.path as op
 import fnmatch
@@ -13,7 +14,7 @@ import re
 import codecs
 import time
 from glob import glob
-import base64
+import warnings
 
 import numpy as np
 
@@ -445,12 +446,14 @@ def _build_html_slider(slices_range, slides_klass, slider_id,
     """Build an html slider for a given slices range and a slices klass."""
     if start_value is None:
         start_value = slices_range[len(slices_range) // 2]
-    return slider_template.substitute(slider_id=slider_id,
-                                      klass=slides_klass,
-                                      step=slices_range[1] - slices_range[0],
-                                      minvalue=slices_range[0],
-                                      maxvalue=slices_range[-1],
-                                      startvalue=start_value)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore')
+        out = slider_template.substitute(
+            slider_id=slider_id, klass=slides_klass,
+            step=slices_range[1] - slices_range[0],
+            minvalue=slices_range[0], maxvalue=slices_range[-1],
+            startvalue=start_value)
+    return out
 
 
 ###############################################################################
@@ -1353,8 +1356,10 @@ class Report(object):
 
         self._render_toc()
 
-        html = footer_template.substitute(date=time.strftime("%B %d, %Y"),
-                                          current_year=time.strftime("%Y"))
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+            html = footer_template.substitute(date=time.strftime("%B %d, %Y"),
+                                              current_year=time.strftime("%Y"))
         self.html.append(html)
 
         if not overwrite and op.isfile(fname):

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal)
 import pytest
-import warnings
 
 from mne import (read_cov, read_forward_solution, convert_forward_solution,
                  pick_types_forward, read_evokeds)
@@ -17,8 +16,6 @@ from mne.simulation import simulate_sparse_stc, simulate_evoked
 from mne.io import read_raw_fif
 from mne.cov import regularize
 from mne.utils import run_tests_if_main
-
-warnings.simplefilter('always')
 
 data_path = testing.data_path(download=False)
 fwd_fname = op.join(data_path, 'MEG', 'sample',

--- a/mne/simulation/tests/test_metrics.py
+++ b/mne/simulation/tests/test_metrics.py
@@ -9,14 +9,11 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
-import warnings
 
 from mne import read_source_spaces
 from mne.datasets import testing
 from mne.simulation import simulate_sparse_stc, source_estimate_quantification
 from mne.utils import run_tests_if_main
-
-warnings.simplefilter('always')
 
 data_path = testing.data_path(download=False)
 src_fname = op.join(data_path, 'subjects', 'sample', 'bem',

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -27,8 +26,6 @@ from mne.io import read_raw_fif, RawArray
 from mne.time_frequency import psd_welch
 from mne.utils import _TempDir, run_tests_if_main
 
-
-warnings.simplefilter('always')
 
 data_path = testing.data_path(download=False)
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')

--- a/mne/tests/common.py
+++ b/mne/tests/common.py
@@ -104,23 +104,3 @@ def assert_dig_allclose(info_py, info_bin, limit=None):
         assert_allclose(r_py, r_bin, atol=1e-6)
         assert_allclose(o_dev_py, o_dev_bin, rtol=1e-5, atol=1e-6)
         assert_allclose(o_head_py, o_head_bin, rtol=1e-5, atol=1e-6)
-
-
-def assert_naming(warns, fname, n_warn):
-    """Assert a non-standard naming scheme was used while saving or loading.
-
-    Parameters
-    ----------
-    warns : list
-        List of warnings from ``warnings.catch_warnings(record=True)``.
-    fname : str
-        Filename that should appear in the warning message.
-    n_warn : int
-        Number of warnings that should have naming convention errors.
-    """
-    assert sum('naming conventions' in str(ww.message)
-               for ww in warns) == n_warn
-    # check proper stacklevel reporting
-    for ww in warns:
-        if 'naming conventions' in str(ww.message):
-            assert fname in ww.filename

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -4,7 +4,6 @@
 
 from datetime import datetime
 import os.path as op
-import warnings
 
 import pytest
 from numpy.testing import (assert_equal, assert_array_equal,
@@ -233,7 +232,7 @@ def test_raw_reject():
     sfreq = 100.
     info = create_info(['a', 'b', 'c', 'd', 'e'], sfreq, ch_types='eeg')
     raw = RawArray(np.ones((5, 15000)), info)
-    with warnings.catch_warnings(record=True):  # one outside range
+    with pytest.warns(RuntimeWarning, match='outside the data range'):
         raw.set_annotations(Annotations([2, 100, 105, 148],
                                         [2, 8, 5, 8], 'BAD'))
     data, times = raw.get_data([0, 1, 3, 4], 100, 11200,  # 1-112 sec

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -46,8 +45,6 @@ art_fname = op.join(data_path, 'ARTEMIS123', 'Artemis_Data_2017-04-04' +
                     '-15h-44m-22s_Motion_Translation-z.bin')
 art_mc_fname = op.join(data_path, 'ARTEMIS123', 'Artemis_Data_2017-04-04' +
                        '-15h-44m-22s_Motion_Translation-z_mc.pos')
-
-warnings.simplefilter('always')
 
 
 @testing.requires_testing_data
@@ -213,7 +210,7 @@ def test_calculate_chpi_positions():
     picks = np.concatenate([np.arange(306, len(raw_bad.ch_names)),
                             pick_types(raw_bad.info, meg=True)[::16]])
     raw_bad.pick_channels([raw_bad.ch_names[pick] for pick in picks])
-    with warnings.catch_warnings(record=True):  # bad pos
+    with pytest.warns(RuntimeWarning, match='Discrepancy'):
         with catch_logging() as log_file:
             _calculate_chpi_positions(raw_bad, t_step_min=1., verbose=True)
     # ignore HPI info header and [done] footer
@@ -402,8 +399,7 @@ def test_chpi_subtraction():
     #           -o test_move_anon_ds2_raw.fif
     # it can strip out some values of info, which we emulate here:
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
-    with warnings.catch_warnings(record=True):  # uint cast suggestion
-        raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
+    raw = raw.crop(0, 1).load_data().resample(600., npad='auto')
     raw.info['lowpass'] = 200.
     del raw.info['maxshield']
     del raw.info['hpi_results'][0]['moments']

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -92,8 +92,9 @@ def test_scale_mri():
     # scale fsaverage
     for scale in (.9, [1, .2, .8]):
         os.environ['_MNE_FEW_SURFACES'] = 'true'
-        scale_mri('fsaverage', 'flachkopf', scale, True, subjects_dir=tempdir,
-                  verbose='debug')
+        with pytest.warns(None):  # sometimes missing nibabel
+            scale_mri('fsaverage', 'flachkopf', scale, True,
+                      subjects_dir=tempdir, verbose='debug')
         del os.environ['_MNE_FEW_SURFACES']
         assert _is_mri_subject('flachkopf', tempdir), "Scaling failed"
         spath = op.join(tempdir, 'flachkopf', 'bem', 'flachkopf-%s-src.fif')

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -135,7 +135,7 @@ def test_dipole_fitting():
 
     # Run mne-python version
     sphere = make_sphere_model(head_radius=0.1)
-    with pytest.warns(RuntimeWarning, match='foo'):
+    with pytest.warns(RuntimeWarning, match='projection'):
         dip, residuals = fit_dipole(evoked, cov, sphere, fname_fwd)
 
     # Sanity check: do our residuals have less power than orig data?

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
 
 import inspect
+from inspect import getsource
 import os.path as op
+from pkgutil import walk_packages
 import re
 import sys
 from unittest import SkipTest
-import warnings
 
-from pkgutil import walk_packages
-from inspect import getsource
+import pytest
 
 import mne
 from mne.utils import (run_tests_if_main, _doc_special_members,
@@ -85,7 +85,7 @@ def check_parameters_match(func, doc=None):
         args = args[1:]
 
     if doc is None:
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             try:
                 doc = docscrape.FunctionDoc(func)
             except Exception as exp:
@@ -126,7 +126,7 @@ def test_docstring_parameters():
 
     incorrect = []
     for name in public_modules_:
-        with warnings.catch_warnings(record=True):  # traits warnings
+        with pytest.warns(None):  # traits warnings
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)
@@ -134,7 +134,7 @@ def test_docstring_parameters():
         for cname, cls in classes:
             if cname.startswith('_') and cname not in _doc_special_members:
                 continue
-            with warnings.catch_warnings(record=True) as w:
+            with pytest.warns(None) as w:
                 cdoc = docscrape.ClassDoc(cls)
             if len(w):
                 raise RuntimeError('Error for __init__ of %s in %s:\n%s'
@@ -172,7 +172,7 @@ def test_tabs():
         if not ispkg and modname not in ignore:
             # mod = importlib.import_module(modname)  # not py26 compatible!
             try:
-                with warnings.catch_warnings(record=True):  # traits
+                with pytest.warns(None):
                     __import__(modname)
             except Exception:  # can't import properly
                 continue
@@ -279,7 +279,7 @@ def test_documented():
 
     missing = []
     for name in public_modules_:
-        with warnings.catch_warnings(record=True):  # traits warnings
+        with pytest.warns(None):  # traits warnings
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -1,5 +1,4 @@
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
@@ -19,7 +18,6 @@ from mne.utils import (sum_squared, run_tests_if_main,
                        catch_logging, requires_version, _TempDir,
                        requires_mne, run_subprocess)
 
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 rng = np.random.RandomState(0)
 
 
@@ -225,7 +223,7 @@ def test_notch_filters():
     tols = [2, 1, 1, 1]
     for meth, lf, fl, tol in zip(methods, line_freqs, filter_lengths, tols):
         with catch_logging() as log_file:
-            with warnings.catch_warnings(record=True):
+            with pytest.warns(None):
                 b = notch_filter(a, sfreq, lf, fl, method=meth,
                                  fir_design='firwin', verbose=True)
         if lf is None:
@@ -417,7 +415,7 @@ def test_filters():
 
     # check for n-dimensional case
     a = rng.randn(2, 2, 2, 2)
-    with warnings.catch_warnings(record=True):  # filter too long
+    with pytest.warns(RuntimeWarning, match='longer'):
         pytest.raises(ValueError, filter_data, a, sfreq, 4, 8,
                       np.array([0, 1]), 100, 1.0, 1.0)
 

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -6,7 +6,6 @@ from unittest import SkipTest
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
-import warnings
 
 from mne.datasets import testing
 from mne import (read_source_spaces, vertex_to_mni, write_source_spaces,
@@ -25,10 +24,7 @@ from mne.externals.six.moves import zip
 from mne.source_space import (get_volume_labels_from_aseg, SourceSpaces,
                               get_volume_labels_from_src,
                               _compare_source_spaces)
-from mne.tests.common import assert_naming
 from mne.io.constants import FIFF
-
-warnings.simplefilter('always')
 
 data_path = testing.data_path(download=False)
 subjects_dir = op.join(data_path, 'subjects')
@@ -361,8 +357,7 @@ def test_setup_source_space():
 
     # ico 5 (fsaverage) - write to temp file
     src = read_source_spaces(fname_ico)
-    with warnings.catch_warnings(record=True):  # sklearn equiv neighbors
-        warnings.simplefilter('always')
+    with pytest.warns(None):  # sklearn equiv neighbors
         src_new = setup_source_space('fsaverage', spacing='ico5',
                                      subjects_dir=subjects_dir, add_dist=False)
     _compare_source_spaces(src, src_new, mode='approx')
@@ -374,8 +369,7 @@ def test_setup_source_space():
     # oct-6 (sample) - auto filename + IO
     src = read_source_spaces(fname)
     temp_name = op.join(tempdir, 'temp-src.fif')
-    with warnings.catch_warnings(record=True):  # sklearn equiv neighbors
-        warnings.simplefilter('always')
+    with pytest.warns(None):  # sklearn equiv neighbors
         src_new = setup_source_space('sample', spacing='oct6',
                                      subjects_dir=subjects_dir, add_dist=False)
         write_source_spaces(temp_name, src_new, overwrite=True)
@@ -429,12 +423,11 @@ def test_write_source_space():
     _compare_source_spaces(src0, src1)
 
     # test warnings on bad filenames
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        src_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    src_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    with pytest.warns(RuntimeWarning, match='-src.fif'):
         write_source_spaces(src_badname, src0)
+    with pytest.warns(RuntimeWarning, match='-src.fif'):
         read_source_spaces(src_badname)
-    assert_naming(w, 'test_source_space.py', 2)
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 import os
 import os.path as op
-import numpy as np
-import warnings
 from shutil import copyfile
+
+import numpy as np
 from scipy import sparse
 
 import pytest
@@ -24,7 +24,6 @@ subjects_dir = op.join(data_path, 'subjects')
 fname = op.join(subjects_dir, 'sample', 'bem',
                 'sample-1280-1280-1280-bem-sol.fif')
 
-warnings.simplefilter('always')
 rng = np.random.RandomState(0)
 
 
@@ -111,7 +110,7 @@ def test_make_morph_maps():
             ('fsaverage_ds', 'sample_ds', False),
             ('fsaverage_ds', 'fsaverage_ds', True)):
         # trigger the creation of morph-maps dir and create the map
-        with warnings.catch_warnings(record=True):
+        with pytest.warns(None):
             mmap = read_morph_map(subject_from, subject_to, tempdir,
                                   xhemi=xhemi)
         mmap2 = read_morph_map(subject_from, subject_to, subjects_dir,
@@ -123,7 +122,7 @@ def test_make_morph_maps():
             assert_allclose(diff, np.zeros_like(diff), atol=1e-3, rtol=0)
 
     # This will also trigger creation, but it's trivial
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(None):
         mmap = read_morph_map('sample', 'sample', subjects_dir=tempdir)
     for mm in mmap:
         assert (mm - sparse.eye(mm.shape[0], mm.shape[0])).sum() == 0
@@ -138,11 +137,10 @@ def test_io_surface():
     fname_tri = op.join(data_path, 'subjects', 'fsaverage', 'surf',
                         'lh.inflated')
     for fname in (fname_quad, fname_tri):
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None):  # no volume info
             pts, tri, vol_info = read_surface(fname, read_metadata=True)
-        assert all('No volume info' in str(ww.message) for ww in w)
         write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info)
-        with warnings.catch_warnings(record=True) as w:  # No vol info
+        with pytest.warns(None):  # no volume info
             c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
                                                     read_metadata=True)
         assert_array_equal(pts, c_pts)

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -1,6 +1,5 @@
 import os
 import os.path as op
-import warnings
 
 import pytest
 import numpy as np
@@ -10,7 +9,6 @@ from mne.datasets import testing
 from mne import read_trans, write_trans
 from mne.io import read_info
 from mne.utils import _TempDir, run_tests_if_main
-from mne.tests.common import assert_naming
 from mne.transforms import (invert_transform, _get_trans,
                             rotation, rotation3d, rotation_angles, _find_trans,
                             combine_transforms, apply_trans, translation,
@@ -21,8 +19,6 @@ from mne.transforms import (invert_transform, _get_trans,
                             _SphericalSurfaceWarp as SphericalSurfaceWarp,
                             rotation3d_align_z_axis, _read_fs_xfm,
                             _write_fs_xfm)
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-trans.fif')
@@ -84,10 +80,9 @@ def test_io_trans():
     pytest.raises(IOError, read_trans, fname_eve)
 
     # check warning on bad filenames
-    with warnings.catch_warnings(record=True) as w:
-        fname2 = op.join(tempdir, 'trans-test-bad-name.fif')
+    fname2 = op.join(tempdir, 'trans-test-bad-name.fif')
+    with pytest.warns(RuntimeWarning, match='-trans.fif'):
         write_trans(fname2, trans0)
-    assert_naming(w, 'test_transforms.py', 1)
 
 
 def test_get_ras_to_neuromag_trans():

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -3,7 +3,6 @@ import pytest
 from pytest import raises
 from numpy.testing import assert_array_equal, assert_allclose
 from os import path as op
-import warnings
 import pickle
 from itertools import product
 
@@ -534,11 +533,10 @@ def test_csd_morlet():
     assert_allclose(csd._data[[0, 3, 5]] * sfreq, power)
 
     # Test baselining warning
+    epochs_nobase = epochs.copy()
+    epochs_nobase.baseline = None
+    epochs_nobase.info['highpass'] = 0
     with pytest.warns(RuntimeWarning, match='baseline'):
-        warnings.simplefilter('always')
-        epochs_nobase = epochs.copy()
-        epochs_nobase.baseline = None
-        epochs_nobase.info['highpass'] = 0
         csd = csd_morlet(epochs_nobase, frequencies=[10], decim=20)
 
 

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -20,7 +20,7 @@ def test_dpss_windows():
     Kmax = int(2 * half_nbw)
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, low_bias=False)
-    with warnings.catch_warnings(record=True):  # conversions
+    with pytest.warns(None):  # conversions
         dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
 
     assert_array_almost_equal(dpss, dpss_ni)
@@ -28,7 +28,7 @@ def test_dpss_windows():
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, interp_from=200,
                               low_bias=False)
-    with warnings.catch_warnings(record=True):  # conversions
+    with pytest.warns(None):  # conversions
         dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax,
                                                       interp_from=200)
 

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -1,5 +1,4 @@
 from distutils.version import LooseVersion
-import warnings
 
 import numpy as np
 import pytest
@@ -55,7 +54,7 @@ def test_multitaper_psd():
             psd, freqs = psd_multitaper(raw, adaptive=adaptive,
                                         n_jobs=n_jobs,
                                         normalization=norm)
-            with warnings.catch_warnings(record=True):  # nitime integers
+            with pytest.warns(None):  # nitime integers
                 freqs_ni, psd_ni, _ = ni.algorithms.spectral.multi_taper_psd(
                     data, sfreq, adaptive=adaptive, jackknife=False)
             assert_array_almost_equal(psd, psd_ni, decimal=4)

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -4,8 +4,8 @@
 # License : BSD 3-clause
 
 import os.path as op
-import warnings
 
+import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_allclose,
                            assert_equal)
@@ -43,7 +43,7 @@ def test_stockwell_check_input():
 
     for last_dim in (127, 128):
         data = np.zeros((2, 10, last_dim))
-        with warnings.catch_warnings(record=True):  # 127 < n_fft
+        with pytest.warns(RuntimeWarning, match='n_fft'):
             x_in, n_fft, zero_pad = _check_input_st(data, None)
 
         assert_equal(x_in.shape, (2, 10, 128))
@@ -112,12 +112,12 @@ def test_stockwell_api():
     epochs = Epochs(raw, events,  # XXX pick 2 has epochs of zeros.
                     event_id, tmin, tmax, picks=[0, 1, 3])
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:
-        with warnings.catch_warnings(record=True):  # zero papdding
+        with pytest.warns(RuntimeWarning, match='padding'):
             power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
                                        return_itc=True)
         if fmax is not None:
             assert (power.freqs.max() <= fmax)
-        with warnings.catch_warnings(record=True):  # padding
+        with pytest.warns(RuntimeWarning, match='padding'):
             power_evoked = tfr_stockwell(epochs.average(), fmin=fmin,
                                          fmax=fmax, return_itc=False)
         # for multitaper these don't necessarily match, but they seem to

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -43,7 +43,7 @@ def test_stockwell_check_input():
 
     for last_dim in (127, 128):
         data = np.zeros((2, 10, last_dim))
-        with pytest.warns(RuntimeWarning, match='n_fft'):
+        with pytest.warns(None):  # n_fft sometimes
             x_in, n_fft, zero_pad = _check_input_st(data, None)
 
         assert_equal(x_in.shape, (2, 10, 128))

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -332,6 +332,7 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
         # and then plot the contours on top
         for surf, color in surfs:
             with warnings.catch_warnings(record=True):  # ignore contour warn
+                warnings.simplefilter('ignore')
                 ax.tricontour(surf['rr'][:, x], surf['rr'][:, y],
                               surf['tris'], surf['rr'][:, z],
                               levels=[sl], colors=color, linewidths=1.0,

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -732,6 +732,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
                 this_H = freqz(section[:3], section[3:], omega)[1]
                 H *= this_H
                 with warnings.catch_warnings(record=True):  # singular GD
+                    warnings.simplefilter('ignore')
                     gd += group_delay((section[:3], section[3:]), omega)[1]
             n = estimate_ringing_samples(h)
             delta = np.zeros(n)
@@ -744,12 +745,14 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
             delta[0] = 1
             H = freqz(h['b'], h['a'], omega)[1]
             with warnings.catch_warnings(record=True):  # singular GD
+                warnings.simplefilter('ignore')
                 gd = group_delay((h['b'], h['a']), omega)[1]
             h = lfilter(h['b'], h['a'], delta)
         title = 'SOS (IIR) filter' if title is None else title
     else:
         H = freqz(h, worN=omega)[1]
         with warnings.catch_warnings(record=True):  # singular GD
+            warnings.simplefilter('ignore')
             gd = group_delay((h, [1.]), omega)[1]
         title = 'FIR filter' if title is None else title
     gd /= sfreq

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -73,7 +73,8 @@ def test_plot_head_positions():
         pytest.raises(ValueError, plot_head_positions, pos[:, :9])
     pytest.raises(ValueError, plot_head_positions, pos, 'foo')
     with pytest.raises(ValueError, match='shape'):
-        plot_head_positions(pos, axes=1.)
+        with pytest.warns(None):  # old mpl no viridis warning
+            plot_head_positions(pos, axes=1.)
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -9,7 +9,6 @@
 import os.path as op
 
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
 
 from mne import read_events, Epochs, pick_types, read_cov

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -9,7 +9,6 @@
 # License: Simplified BSD
 
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -29,8 +28,6 @@ from mne.datasets import testing
 # Set our plotters to test mode
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 evoked_fname = op.join(base_dir, 'test-ave.fif')
@@ -91,10 +88,9 @@ def test_plot_evoked_cov():
     epochs = Epochs(raw, events)
     cov = compute_covariance(epochs)
     evoked_sss = epochs.average()
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='relative scaling'):
         evoked_sss.plot(noise_cov=cov, time_unit='s')
     plt.close('all')
-    assert any('relative scal' in str(ww.message) for ww in w)
 
 
 @pytest.mark.slowtest
@@ -148,10 +144,9 @@ def test_plot_evoked():
                       mask=np.ones(evoked.data.shape).astype(bool),
                       time_unit='s')
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning, match='not adding contour'):
         evoked.plot_image(picks=[1, 2], mask=None, mask_style="both",
                           time_unit='s')
-    assert len(w) == 2
     pytest.raises(ValueError, evoked.plot_image, mask=evoked.data[1:, 1:] > 0,
                   time_unit='s')
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -135,8 +135,9 @@ def test_plot_evoked():
     evoked_nan = evoked.copy()
     evoked_nan.data[:, 0] = np.nan
     pytest.raises(ValueError, evoked_nan.plot)
-    pytest.raises(ValueError, evoked_nan.plot_image)
-    pytest.raises(ValueError, evoked_nan.plot_joint)
+    with np.errstate(invalid='ignore'):
+        pytest.raises(ValueError, evoked_nan.plot_image)
+        pytest.raises(ValueError, evoked_nan.plot_joint)
 
     # test mask
     evoked.plot_image(picks=[1, 2], mask=evoked.data > 0, time_unit='s')

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -157,8 +157,8 @@ def test_plot_source_spectrogram():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_plot_snr():
-    import matplotlib.pyplot as plt
     """Test plotting SNR estimate."""
+    import matplotlib.pyplot as plt
     inv = read_inverse_operator(inv_fname)
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     plot_snr_estimate(evoked, inv)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -72,7 +72,8 @@ def _annotation_helper(raw, events=False):
     ann_fig = plt.gcf()
     for key in ' test':
         ann_fig.canvas.key_press_event(key)
-    ann_fig.canvas.key_press_event('enter')
+    with pytest.warns(None):  # old mpl
+        ann_fig.canvas.key_press_event('enter')
 
     ann_fig = plt.gcf()
     # XXX: _fake_click raises an error on Agg backend
@@ -135,13 +136,17 @@ def _annotation_helper(raw, events=False):
         assert_allclose(raw.annotations.duration[n_anns], 5.0)
     assert len(fig.axes[0].texts) == n_anns + 1 + n_events
     # Delete
-    _fake_click(fig, data_ax, [1.5, 1.], xform='data', button=3, kind='press')
-    fig.canvas.key_press_event('a')  # exit annotation mode
+    with pytest.warns(None):  # old mpl
+        _fake_click(fig, data_ax, [1.5, 1.], xform='data', button=3,
+                    kind='press')
+        fig.canvas.key_press_event('a')  # exit annotation mode
     assert len(raw.annotations.onset) == n_anns
     assert len(fig.axes[0].texts) == n_anns + n_events
-    fig.canvas.key_press_event('shift+right')
+    with pytest.warns(None):  # old mpl
+        fig.canvas.key_press_event('shift+right')
     assert len(fig.axes[0].texts) == 0
-    fig.canvas.key_press_event('shift+left')
+    with pytest.warns(None):  # old mpl
+        fig.canvas.key_press_event('shift+left')
     assert len(fig.axes[0].texts) == n_anns + n_events
     plt.close('all')
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 import os.path as op
-import warnings
 import itertools
 from distutils.version import LooseVersion
 
@@ -14,15 +13,13 @@ import pytest
 from mne import read_events, pick_types, Annotations
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf
-from mne.utils import requires_version, run_tests_if_main
+from mne.utils import run_tests_if_main
 from mne.viz.utils import _fake_click, _annotation_radio_clicked, _sync_onset
 from mne.viz import plot_raw, plot_sensors
 
 # Set our plotters to test mode
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 ctf_dir = op.join(testing.data_path(download=False), 'CTF')
 ctf_fname_continuous = op.join(ctf_dir, 'testdata_ctf.ds')
@@ -37,7 +34,7 @@ def _get_raw():
     """Get raw data."""
     raw = read_raw_fif(raw_fname, preload=True)
     # Throws a warning about a changed unit.
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(RuntimeWarning, match='unit'):
         raw.set_channel_types({raw.ch_names[0]: 'ias'})
     raw.pick_channels(raw.ch_names[:9])
     raw.info.normalize_proj()  # Fix projectors after subselection
@@ -155,91 +152,94 @@ def test_plot_raw():
     raw.info['lowpass'] = 10.  # allow heavy decim during plotting
     events = _get_events()
     plt.close('all')  # ensure all are closed
-    with warnings.catch_warnings(record=True):
-        fig = raw.plot(events=events, show_options=True, order=[1, 7, 3],
-                       group_by='original')
-        # test mouse clicks
-        x = fig.get_axes()[0].lines[1].get_xdata().mean()
-        y = fig.get_axes()[0].lines[1].get_ydata().mean()
-        data_ax = fig.axes[0]
+    fig = raw.plot(events=events, show_options=True, order=[1, 7, 3],
+                   group_by='original')
+    # test mouse clicks
+    x = fig.get_axes()[0].lines[1].get_xdata().mean()
+    y = fig.get_axes()[0].lines[1].get_ydata().mean()
+    data_ax = fig.axes[0]
 
-        _fake_click(fig, data_ax, [x, y], xform='data')  # mark a bad channel
-        _fake_click(fig, data_ax, [x, y], xform='data')  # unmark a bad channel
-        _fake_click(fig, data_ax, [0.5, 0.999])  # click elsewhere in 1st axes
-        _fake_click(fig, data_ax, [-0.1, 0.9])  # click on y-label
-        _fake_click(fig, fig.get_axes()[1], [0.5, 0.5])  # change time
-        _fake_click(fig, fig.get_axes()[2], [0.5, 0.5])  # change channels
-        _fake_click(fig, fig.get_axes()[3], [0.5, 0.5])  # open SSP window
-        fig.canvas.button_press_event(1, 1, 1)  # outside any axes
-        fig.canvas.scroll_event(0.5, 0.5, -0.5)  # scroll down
-        fig.canvas.scroll_event(0.5, 0.5, 0.5)  # scroll up
-        # sadly these fail when no renderer is used (i.e., when using Agg):
-        # ssp_fig = set(plt.get_fignums()) - set([fig.number])
-        # assert_equal(len(ssp_fig), 1)
-        # ssp_fig = plt.figure(list(ssp_fig)[0])
-        # ax = ssp_fig.get_axes()[0]  # only one axis is used
-        # t = [c for c in ax.get_children() if isinstance(c,
-        #      matplotlib.text.Text)]
-        # pos = np.array(t[0].get_position()) + 0.01
-        # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # off
-        # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # on
-        #  test keypresses
-        for key in ['down', 'up', 'right', 'left', 'o', '-', '+', '=',
-                    'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'escape']:
-            fig.canvas.key_press_event(key)
-        fig = plot_raw(raw, events=events, group_by='selection')
-        for key in ['b', 'down', 'up', 'right', 'left', 'o', '-', '+', '=',
-                    'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'b',
-                    'escape']:
-            fig.canvas.key_press_event(key)
-        # Color setting
-        pytest.raises(KeyError, raw.plot, event_color={0: 'r'})
-        pytest.raises(TypeError, raw.plot, event_color={'foo': 'r'})
-        annot = Annotations([10, 10 + raw.first_samp / raw.info['sfreq']],
-                            [10, 10], ['test', 'test'], raw.info['meas_date'])
+    _fake_click(fig, data_ax, [x, y], xform='data')  # mark a bad channel
+    _fake_click(fig, data_ax, [x, y], xform='data')  # unmark a bad channel
+    _fake_click(fig, data_ax, [0.5, 0.999])  # click elsewhere in 1st axes
+    _fake_click(fig, data_ax, [-0.1, 0.9])  # click on y-label
+    _fake_click(fig, fig.get_axes()[1], [0.5, 0.5])  # change time
+    _fake_click(fig, fig.get_axes()[2], [0.5, 0.5])  # change channels
+    _fake_click(fig, fig.get_axes()[3], [0.5, 0.5])  # open SSP window
+    fig.canvas.button_press_event(1, 1, 1)  # outside any axes
+    fig.canvas.scroll_event(0.5, 0.5, -0.5)  # scroll down
+    fig.canvas.scroll_event(0.5, 0.5, 0.5)  # scroll up
+    # sadly these fail when no renderer is used (i.e., when using Agg):
+    # ssp_fig = set(plt.get_fignums()) - set([fig.number])
+    # assert_equal(len(ssp_fig), 1)
+    # ssp_fig = plt.figure(list(ssp_fig)[0])
+    # ax = ssp_fig.get_axes()[0]  # only one axis is used
+    # t = [c for c in ax.get_children() if isinstance(c,
+    #      matplotlib.text.Text)]
+    # pos = np.array(t[0].get_position()) + 0.01
+    # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # off
+    # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # on
+    #  test keypresses
+    for key in ['down', 'up', 'right', 'left', 'o', '-', '+', '=',
+                'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'escape']:
+        fig.canvas.key_press_event(key)
+    fig = plot_raw(raw, events=events, group_by='selection')
+    for key in ['b', 'down', 'up', 'right', 'left', 'o', '-', '+', '=',
+                'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'b',
+                'escape']:
+        fig.canvas.key_press_event(key)
+    # Color setting
+    pytest.raises(KeyError, raw.plot, event_color={0: 'r'})
+    pytest.raises(TypeError, raw.plot, event_color={'foo': 'r'})
+    annot = Annotations([10, 10 + raw.first_samp / raw.info['sfreq']],
+                        [10, 10], ['test', 'test'], raw.info['meas_date'])
+    with pytest.warns(RuntimeWarning, match='outside data range'):
         raw.set_annotations(annot)
-        fig = plot_raw(raw, events=events, event_color={-1: 'r', 998: 'b'})
-        plt.close('all')
-        for group_by, order in zip(['position', 'selection'],
-                                   [np.arange(len(raw.ch_names))[::-3],
-                                    [1, 2, 4, 6]]):
+    fig = plot_raw(raw, events=events, event_color={-1: 'r', 998: 'b'})
+    plt.close('all')
+    for group_by, order in zip(['position', 'selection'],
+                               [np.arange(len(raw.ch_names))[::-3],
+                                [1, 2, 4, 6]]):
+        with pytest.warns(None):  # sometimes projection
             fig = raw.plot(group_by=group_by, order=order)
-            x = fig.get_axes()[0].lines[1].get_xdata()[10]
-            y = fig.get_axes()[0].lines[1].get_ydata()[10]
-            _fake_click(fig, data_ax, [x, y], xform='data')  # mark bad
-            fig.canvas.key_press_event('down')  # change selection
-            _fake_click(fig, fig.get_axes()[2], [0.5, 0.5])  # change channels
-            sel_fig = plt.figure(1)
-            topo_ax = sel_fig.axes[1]
-            _fake_click(sel_fig, topo_ax, [-0.425, 0.20223853],
-                        xform='data')
-            fig.canvas.key_press_event('down')
-            fig.canvas.key_press_event('up')
-            fig.canvas.scroll_event(0.5, 0.5, -1)  # scroll down
-            fig.canvas.scroll_event(0.5, 0.5, 1)  # scroll up
-            _fake_click(sel_fig, topo_ax, [-0.5, 0.], xform='data')
-            _fake_click(sel_fig, topo_ax, [0.5, 0.], xform='data',
-                        kind='motion')
-            _fake_click(sel_fig, topo_ax, [0.5, 0.5], xform='data',
-                        kind='motion')
-            _fake_click(sel_fig, topo_ax, [-0.5, 0.5], xform='data',
-                        kind='release')
+        x = fig.get_axes()[0].lines[1].get_xdata()[10]
+        y = fig.get_axes()[0].lines[1].get_ydata()[10]
+        _fake_click(fig, data_ax, [x, y], xform='data')  # mark bad
+        fig.canvas.key_press_event('down')  # change selection
+        _fake_click(fig, fig.get_axes()[2], [0.5, 0.5])  # change channels
+        sel_fig = plt.figure(1)
+        topo_ax = sel_fig.axes[1]
+        _fake_click(sel_fig, topo_ax, [-0.425, 0.20223853],
+                    xform='data')
+        fig.canvas.key_press_event('down')
+        fig.canvas.key_press_event('up')
+        fig.canvas.scroll_event(0.5, 0.5, -1)  # scroll down
+        fig.canvas.scroll_event(0.5, 0.5, 1)  # scroll up
+        _fake_click(sel_fig, topo_ax, [-0.5, 0.], xform='data')
+        _fake_click(sel_fig, topo_ax, [0.5, 0.], xform='data',
+                    kind='motion')
+        _fake_click(sel_fig, topo_ax, [0.5, 0.5], xform='data',
+                    kind='motion')
+        _fake_click(sel_fig, topo_ax, [-0.5, 0.5], xform='data',
+                    kind='release')
 
-            plt.close('all')
-        # test if meas_date has only one element
-        raw.info['meas_date'] = np.array([raw.info['meas_date'][0]],
-                                         dtype=np.int32)
-        annot = Annotations([1 + raw.first_samp / raw.info['sfreq']],
-                            [5], ['bad'])
-        raw.set_annotations(annot)
-        raw.plot(group_by='position', order=np.arange(8))
-        for fig_num in plt.get_fignums():
-            fig = plt.figure(fig_num)
-            if hasattr(fig, 'radio'):  # Get access to selection fig.
-                break
-        for key in ['down', 'up', 'escape']:
-            fig.canvas.key_press_event(key)
         plt.close('all')
+    # test if meas_date has only one element
+    raw.info['meas_date'] = np.array([raw.info['meas_date'][0]],
+                                     dtype=np.int32)
+    annot = Annotations([1 + raw.first_samp / raw.info['sfreq']],
+                        [5], ['bad'])
+    with pytest.warns(RuntimeWarning, match='outside data range'):
+        raw.set_annotations(annot)
+    with pytest.warns(RuntimeWarning, match='projection'):
+        raw.plot(group_by='position', order=np.arange(8))
+    for fig_num in plt.get_fignums():
+        fig = plt.figure(fig_num)
+        if hasattr(fig, 'radio'):  # Get access to selection fig.
+            break
+    for key in ['down', 'up', 'escape']:
+        fig.canvas.key_press_event(key)
+    plt.close('all')
 
 
 @testing.requires_testing_data
@@ -268,13 +268,12 @@ def test_plot_annotations():
     _annotation_helper(raw)
     _annotation_helper(raw, events=True)
 
-    with warnings.catch_warnings(record=True):  # cut off
+    with pytest.warns(RuntimeWarning, match='units'):
         annot = Annotations([42], [1], 'test', raw.info['meas_date'])
         raw.set_annotations(annot)
     _annotation_helper(raw)
 
 
-@requires_version('scipy', '0.10')
 def test_plot_raw_filtered():
     """Test filtering of raw plots."""
     raw = _get_raw()
@@ -288,7 +287,6 @@ def test_plot_raw_filtered():
     raw.plot(highpass=1, lowpass=2, butterfly=True)
 
 
-@requires_version('scipy', '0.12')
 def test_plot_raw_psd():
     """Test plotting of raw psds."""
     import matplotlib.pyplot as plt
@@ -321,15 +319,14 @@ def test_plot_raw_psd():
     # with channel information not available
     for idx in range(len(raw.info['chs'])):
         raw.info['chs'][idx]['loc'] = np.zeros(12)
-    with warnings.catch_warnings(record=True):  # missing channel locations
+    with pytest.warns(RuntimeWarning, match='locations not available'):
         raw.plot_psd(spatial_colors=True, average=False)
     # with a flat channel
     raw[5, :] = 0
-    with warnings.catch_warnings(record=True) as w:
-        for dB, estimate in itertools.product((True, False),
-                                              ('power', 'amplitude')):
+    for dB, estimate in itertools.product((True, False),
+                                          ('power', 'amplitude')):
+        with pytest.warns(UserWarning, match='[Infinite|Zero]'):
             raw.plot_psd(average=True, dB=dB, estimate=estimate)
-    assert len(w) == 4
     # test reject_by_annotation
     raw = _get_raw()
     raw.set_annotations(Annotations([1, 5], [3, 3], ['test', 'test']))

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -268,8 +268,8 @@ def test_plot_annotations():
     _annotation_helper(raw)
     _annotation_helper(raw, events=True)
 
-    with pytest.warns(RuntimeWarning, match='units'):
-        annot = Annotations([42], [1], 'test', raw.info['meas_date'])
+    annot = Annotations([42], [1], 'test', raw.info['meas_date'])
+    with pytest.warns(RuntimeWarning, match='expanding outside'):
         raw.set_annotations(annot)
     _annotation_helper(raw)
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -64,7 +64,8 @@ def _annotation_helper(raw, events=False):
     fig = raw.plot(events=events)
     assert len(plt.get_fignums()) == 1
     data_ax = fig.axes[0]
-    fig.canvas.key_press_event('a')  # annotation mode
+    with pytest.warns(None):  # on old mpl we warns about no modifications
+        fig.canvas.key_press_event('a')  # annotation mode
     assert len(plt.get_fignums()) == 2
     assert len(fig.axes[0].texts) == n_anns + n_events
     # modify description
@@ -231,7 +232,7 @@ def test_plot_raw():
                         [5], ['bad'])
     with pytest.warns(RuntimeWarning, match='outside data range'):
         raw.set_annotations(annot)
-    with pytest.warns(RuntimeWarning, match='projection'):
+    with pytest.warns(None):  # sometimes projection
         raw.plot(group_by='position', order=np.arange(8))
     for fig_num in plt.get_fignums():
         fig = plt.figure(fig_num)

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -201,7 +201,8 @@ def test_plot_tfr_topo():
     # test opening tfr by clicking
     num_figures_before = len(plt.get_fignums())
     # could use np.reshape(fig.axes[-1].images[0].get_extent(), (2, 2)).mean(1)
-    _fake_click(fig, fig.axes[0], (0.08, 0.65))
+    with pytest.warns(None):  # on old mpl there is a warning
+        _fake_click(fig, fig.axes[0], (0.08, 0.65))
     assert num_figures_before + 1 == len(plt.get_fignums())
     plt.close('all')
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -6,7 +6,6 @@
 # License: Simplified BSD
 
 import os.path as op
-import warnings
 from functools import partial
 
 import numpy as np
@@ -34,9 +33,6 @@ from mne.viz.utils import _find_peaks, _fake_click
 # Set our plotters to test mode
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
-
 
 data_dir = testing.data_path(download=False)
 subjects_dir = op.join(data_dir, 'subjects')
@@ -109,9 +105,7 @@ def test_plot_topomap_interactive():
 def test_plot_projs_topomap():
     """Test plot_projs_topomap."""
     import matplotlib.pyplot as plt
-    with warnings.catch_warnings(record=True):  # file conventions
-        warnings.simplefilter('always')
-        projs = read_proj(ecg_fname)
+    projs = read_proj(ecg_fname)
     info = read_info(raw_fname)
     fast_test = {"res": 8, "contours": 0, "sensors": False}
     plot_projs_topomap(projs, info=info, colorbar=True, **fast_test)
@@ -137,7 +131,6 @@ def test_plot_topomap():
     import matplotlib.pyplot as plt
     from matplotlib.patches import Circle
     # evoked
-    warnings.simplefilter('always')
     res = 8
     fast_test = dict(res=res, contours=0, sensors=False, time_unit='s')
     fast_test_noscale = dict(res=res, contours=0, sensors=False)
@@ -227,9 +220,7 @@ def test_plot_topomap():
     plt.close('all')
 
     # delaunay triangulation warning
-    with warnings.catch_warnings(record=True):  # can't show
-        warnings.simplefilter('always')
-        plt_topomap(times, ch_type='mag', layout=None)
+    plt_topomap(times, ch_type='mag', layout=None)
     # projs have already been applied
     pytest.raises(RuntimeError, plot_evoked_topomap, evoked, 0.1, 'mag',
                   proj='interactive', time_unit='s')
@@ -237,11 +228,9 @@ def test_plot_topomap():
     # change to no-proj mode
     evoked = read_evokeds(evoked_fname, 'Left Auditory',
                           baseline=(None, 0), proj=False)
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter('always')
-        fig1 = evoked.plot_topomap('interactive', 'mag', proj='interactive',
-                                   **fast_test)
-        _fake_click(fig1, fig1.axes[1], (0.5, 0.5))  # click slider
+    fig1 = evoked.plot_topomap('interactive', 'mag', proj='interactive',
+                               **fast_test)
+    _fake_click(fig1, fig1.axes[1], (0.5, 0.5))  # click slider
     data_max = np.max(fig1.axes[0].images[0]._A)
     fig2 = plt.gcf()
     _fake_click(fig2, fig2.axes[0], (0.075, 0.775))  # toggle projector
@@ -353,8 +342,7 @@ def test_plot_topomap():
 
     # Test peak finder
     axes = [plt.subplot(131), plt.subplot(132)]
-    with warnings.catch_warnings(record=True):  # rightmost column
-        evoked.plot_topomap(times='peaks', axes=axes, **fast_test)
+    evoked.plot_topomap(times='peaks', axes=axes, **fast_test)
     plt.close('all')
     evoked.data = np.zeros(evoked.data.shape)
     evoked.data[50][1] = 1

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -3,7 +3,6 @@
 # License: Simplified BSD
 
 import os.path as op
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -20,8 +19,6 @@ from mne.epochs import Epochs
 # Set our plotters to test mode
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-warnings.simplefilter('always')  # enable b/c these tests throw warnings
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -13,6 +13,7 @@ import copy
 from functools import partial
 import itertools
 from numbers import Integral
+import warnings
 
 import numpy as np
 
@@ -709,8 +710,10 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     if (Zi == Zi[0, 0]).all():
         cont = None  # can't make contours for constant-valued functions
     else:
-        cont = ax.contour(Xi, Yi, Zi, contours, colors='k',
-                          linewidths=linewidth / 2.)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+            cont = ax.contour(Xi, Yi, Zi, contours, colors='k',
+                              linewidths=linewidth / 2.)
     if no_contours and cont is not None:
         for col in cont.collections:
             col.set_visible(False)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -818,7 +818,7 @@ def _setup_annotation_fig(params):
     if params['fig_annotation'] is not None:
         params['fig_annotation'].canvas.close_event()
     if params['raw'].annotations is None:
-        params['raw'].annotations = Annotations(list(), list(), list())
+        params['raw'].set_annotations(Annotations(list(), list(), list()))
     annotations = params['raw'].annotations
     labels = list(set(annotations.description))
     labels = np.union1d(labels, params['added_label'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ filterwarnings =
     ignore:numpy.dtype size changed:RuntimeWarning
     ignore:module pycuda not found:RuntimeWarning
     ignore:.*HasTraits.trait_.*:DeprecationWarning
+    ignore:.*takes no parameters:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning
-    ignore:takes no parameters:
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
     ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ filterwarnings =
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
+    error::
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,16 +16,18 @@ doc-files = doc
 
 [tool:pytest]
 addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
+# Once SciPy updates not to have non-integer and non-tuple errors (1.2.0) we
+# should remove them from here.
 filterwarnings =
     error::
     ignore::ImportWarning
-    ignore:Importing from numpy.testing.decorators is deprecated:DeprecationWarning
     ignore:the matrix subclass:PendingDeprecationWarning
     ignore:numpy.dtype size changed:RuntimeWarning
     ignore:module pycuda not found:RuntimeWarning
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
+    ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,14 +17,14 @@ doc-files = doc
 [tool:pytest]
 addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
 filterwarnings =
+    error::
     ignore::ImportWarning
     ignore:the matrix subclass:PendingDeprecationWarning
-    ignore:numpy.dtype size changed
-    ignore:module pycuda not found
+    ignore:numpy.dtype size changed:RuntimeWarning
+    ignore:module pycuda not found:RuntimeWarning
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
-    error::
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ filterwarnings =
     ignore:module pycuda not found:RuntimeWarning
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning
+    ignore:takes no parameters:
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
     ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doct
 filterwarnings =
     error::
     ignore::ImportWarning
+    ignore:Importing from numpy.testing.decorators is deprecated:DeprecationWarning
     ignore:the matrix subclass:PendingDeprecationWarning
     ignore:numpy.dtype size changed:RuntimeWarning
     ignore:module pycuda not found:RuntimeWarning


### PR DESCRIPTION
We end up with a lot of warnings creeping up in our testing code as people make changes. `pytest` has nice fixtures that allow us not to have this problem, making our use of warnings more precise. 

Basically we should use `with pytest.warns` instead of `with warnings.catch_warnings` in our code. This is WIP because I need to replace a bunch of `with warnings.catch_warnings` in our code with `with pytest.warns`.