### PR TITLE
MRG: Do not allow projection of all components

### DIFF
--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -70,7 +70,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     # Set up pick list: MEG - bad channels
     left_temporal_channels = mne.read_selection('Left-temporal')
     picks = mne.pick_types(raw.info, selection=left_temporal_channels)
-    picks = picks[::4]  # decimate for speed
+    picks = picks[::2]  # decimate for speed
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
     del picks
     raw.info.normalize_proj()  # avoid projection warnings
@@ -496,7 +496,7 @@ def test_tf_lcmv():
     # Set up pick list: MEG - bad channels
     left_temporal_channels = mne.read_selection('Left-temporal')
     picks = mne.pick_types(raw.info, selection=left_temporal_channels)
-    picks = picks[::4]  # decimate for speed
+    picks = picks[::2]  # decimate for speed
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
     raw.info.normalize_proj()  # avoid projection warnings
     del picks

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -644,6 +644,9 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
 
     # Here is the celebrated result
     proj = np.eye(nchan, nchan) - np.dot(U, U.T)
+    if nproj >= nchan:  # e.g., 3 channels and 3 projectors
+        raise RuntimeError('Application of %d projectors for %d channels '
+                           'will yield no components.' % (nproj, nchan))
 
     return proj, nproj, U
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -45,7 +45,7 @@ def test_bad_proj():
     events = read_events(event_fname)
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
-    picks = picks[2:9:3]
+    picks = picks[2:18:3]
     _check_warnings(raw, events, picks)
     # still bad
     raw.pick_channels([raw.ch_names[ii] for ii in picks])

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -33,7 +33,7 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 cov_fname = op.join(base_dir, 'test-cov.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
 event_id, tmin, tmax = 1, -0.1, 1.0
-n_chan = 15
+n_chan = 20
 layout = read_layout('Vectorview-all')
 
 
@@ -68,14 +68,12 @@ def test_plot_epochs():
         epochs.plot(noise_cov=cov)
     plt.close('all')
     # add a channel to the epochs.info['bads']
-    assert 'MEG 0242' in epochs.ch_names
-    epochs.info['bads'] = ['MEG 0242']
+    epochs.info['bads'] = [epochs.ch_names[0]]
     with warnings.catch_warnings(record=True):  # projectors
         epochs.plot(noise_cov=cov)
     plt.close('all')
     # add a channel to cov['bads']
-    assert 'MEG 0431' in epochs.ch_names
-    cov['bads'] = ['MEG 0431']
+    cov['bads'] = [epochs.ch_names[1]]
     with warnings.catch_warnings(record=True):  # projectors
         epochs.plot(noise_cov=cov)
     plt.close('all')


### PR DESCRIPTION
While working on #5409 I realized `test_lcmv.py` had a bug where it was projecting out three components from data with three channels. This seems like errant behavior that we should catch.