### PR TITLE
Added "FAQ" to the headline for SEO

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -4,9 +4,9 @@
 
 .. _faq:
 
-==========================
-Frequently Asked Questions
-==========================
+================================
+Frequently Asked Questions (FAQ)
+================================
 
 .. contents:: Contents
    :local:


### PR DESCRIPTION
The FAQ page was not found by the search engine when looking for "FAQ", because it did not contain this abbreviation.