### PR TITLE
Removed redundant command in git guide.

### DIFF
--- a/doc/configure_git.rst
+++ b/doc/configure_git.rst
@@ -117,7 +117,6 @@ These steps can be broken out to be more explicit as:
 
    .. code-block:: console
 
-      $ cd mne-python
       $ git remote add upstream git://github.com/mne-tools/mne-python.git
 
    ``upstream`` here is just the arbitrary name we're using to refer to the


### PR DESCRIPTION
The command "cd mne-python" is listed twice but can only be executed once.