### PR TITLE
Fix event parsing brainvision

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug with reading events from BrainVision files by `Stefan Appelhoff`_
+
 - Fix bug of not showing ERD's in baseline rescaled tfr topomaps if grads are combined by `Erkka Heinila`_
 
 - Fix bug with reading measurement dates from BrainVision files by `Stefan Appelhoff`_

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -321,7 +321,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             trigger = event_id[mdesc]
         else:
             try:
-                trigger = int(re.findall(r'[A-Za-z]*\s*?(\d+)', mdesc)[0])
+                trigger = int(re.findall(r'[SR]([\s\d]{2}\d{1})', mdesc)[0])
             except IndexError:
                 trigger = None
             if mtype.lower() in trig_shift_by_type:

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -70,7 +70,8 @@ class RawBrainVision(BaseRaw):
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive.
+        to the stimulus channel. Keys are case sensitive. "New Segment" markers
+        are always dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -235,7 +236,8 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive.
+        to the stimulus channel. Keys are case sensitive. "New Segment" markers
+        are always dropped.
     response_trig_shift : int | None
         Integer to shift response triggers by. None ignores response triggers.
 
@@ -870,7 +872,8 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive.
+        to the stimulus channel. Keys are case sensitive. "New Segment" markers
+        are always dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -331,19 +331,24 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             if cur_shift is not None:
                 trigger += cur_shift
             else:
+                # The trigger has been deliberately shifted to None. Do not
+                # add this to "dropped" so we do not warn about something
+                # that was done deliberately. Just continue with next item.
                 trigger = None
+                continue
         # FIXME: ideally, we would not use the middle column of the events
         # array to store the duration. A better solution would be using
         # annotations.
         if trigger:
             events.append((onset, duration, trigger))
         else:
+            # Markers with no description are not regarded as dropped but
+            # instead are simply ignored. For example, the "New Segment"
+            # markers are ignored, because they usually look like:
+            # Mk1=New Segment,,1,1,0
             if len(mdesc) > 0:
                 dropped.append(mdesc)
 
-    # Drop all markers with no description from the dropped markers
-    # For example, the "New Segment" markers will be dropped from the list
-    # of dropped markers because they usually look like: Mk1=New Segment,,1,1,0
     if len(dropped) > 0:
         dropped = list(set(dropped))
         examples = ", ".join(dropped[:5])

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -66,11 +66,11 @@ class RawBrainVision(BaseRaw):
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal Brainvision trigger format ('S###' or 'R###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus events are added to the
-        stimulus channel. Keys are case sensitive.
+        or an empty dict (default), only stimulus and response events are added
+        to the stimulus channel. Keys are case sensitive.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -231,11 +231,11 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         vmrk file to be read.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal Brainvision trigger format ('S###' or 'R###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus events are added to the
-        stimulus channel. Keys are case sensitive.
+        or an empty dict (default), only stimulus and response events are added
+        to the stimulus channel. Keys are case sensitive.
     response_trig_shift : int | None
         Integer to shift response triggers by. None ignores response triggers.
 
@@ -349,7 +349,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             examples += ", ..."
         warn("Currently, {0} trigger(s) will be dropped, such as [{1}]. "
              "Consider using ``event_id`` to parse triggers that "
-             "do not follow the 'S###' pattern.".format(
+             "do not follow the 'S###' or 'R###' pattern.".format(
                  len(dropped), examples))
 
     events = np.array(events).reshape(-1, 3)
@@ -866,11 +866,11 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal Brainvision trigger format ('S###' or 'R###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus events are added to the
-        stimulus channel. Keys are case sensitive.
+        or an empty dict (default), only stimulus and response events are added
+        to the stimulus channel. Keys are case sensitive.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -60,7 +60,7 @@ class RawBrainVision(BaseRaw):
     response_trig_shift : int | None
         An integer that will be added to all response triggers when reading
         events (stimulus triggers will be unaffected). This parameter was
-        deprecated in version 0.17 and will be removed in 0.19. Use
+        deprecated in version 0.17 and will be removed in 0.18. Use
         ``trig_shift_by_type={'response': ...}`` instead. If None, response
         triggers will be ignored. Default is 0 for backwards compatibility,
         but typically another value or None will be necessary.

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -324,12 +324,12 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
                 trigger = int(re.findall(r'[SR]([\s\d]{2}\d{1})', mdesc)[0])
             except IndexError:
                 trigger = None
-            if mtype.lower() in trig_shift_by_type:
-                cur_shift = trig_shift_by_type[mtype.lower()]
-                if cur_shift is not None:
-                    trigger += cur_shift
-                else:
-                    trigger = None
+        if mtype.lower() in trig_shift_by_type:
+            cur_shift = trig_shift_by_type[mtype.lower()]
+            if cur_shift is not None:
+                trigger += cur_shift
+            else:
+                trigger = None
         # FIXME: ideally, we would not use the middle column of the events
         # array to store the duration. A better solution would be using
         # annotations.

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -66,7 +66,7 @@ class RawBrainVision(BaseRaw):
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###' or 'R###').
+        follow the normal Brainvision trigger format ('S###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
@@ -232,7 +232,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         vmrk file to be read.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###' or 'R###').
+        follow the normal Brainvision trigger format ('S###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
@@ -323,7 +323,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             trigger = event_id[mdesc]
         else:
             try:
-                trigger = int(re.findall(r'[SR]([\s\d]{2}\d{1})', mdesc)[0])
+                trigger = int(re.findall(r'S([\s\d]{2}\d{1})', mdesc)[0])
             except IndexError:
                 trigger = None
         if mtype.lower() in trig_shift_by_type:
@@ -356,7 +356,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             examples += ", ..."
         warn("Currently, {0} trigger(s) will be dropped, such as [{1}]. "
              "Consider using ``event_id`` to parse triggers that "
-             "do not follow the 'S###' or 'R###' pattern.".format(
+             "do not follow the 'S###' pattern.".format(
                  len(dropped), examples))
 
     events = np.array(events).reshape(-1, 3)
@@ -873,7 +873,7 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###' or 'R###').
+        follow the normal Brainvision trigger format ('S###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -62,7 +62,7 @@ vhdr_nV_path = op.join(data_dir, 'test_nV.vhdr')
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
-event_id = {'Sync On': 5}
+event_id = {'Sync On': 5, 'O  1': 6}
 
 
 def test_vmrk_meas_date():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -62,7 +62,7 @@ vhdr_nV_path = op.join(data_dir, 'test_nV.vhdr')
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
-event_id = {'Sync On': 5, 'O  1': 6}
+event_id = {'Sync On': 5, 'O  1': 1}
 
 
 def test_vmrk_meas_date():
@@ -469,7 +469,7 @@ def test_events():
     # check that events are read and stim channel is synthesized correctly and
     # response triggers are ignored.
     with pytest.warns(RuntimeWarning, match='to parse triggers'):
-        raw = read_raw_brainvision(vhdr_path, eog=eog,
+        raw = read_raw_brainvision(vhdr_path, eog=eog, event_id=event_id,
                                    trig_shift_by_type={'response': None})
     events = raw._get_brainvision_events()
     events = events[events[:, 2] != event_id['Sync On']]

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -466,11 +466,13 @@ def test_events():
                                 [7629, 1, 5],
                                 [7699, 1, 2001]])
 
+    # Check that we warn if a trigger is dropped
+    with pytest.warns(RuntimeWarning, match='to parse triggers'):
+        raw = read_raw_brainvision(vhdr_path)
     # check that events are read and stim channel is synthesized correctly and
     # response triggers are ignored.
-    with pytest.warns(RuntimeWarning, match='to parse triggers'):
-        raw = read_raw_brainvision(vhdr_path, eog=eog, event_id=event_id,
-                                   trig_shift_by_type={'response': None})
+    raw = read_raw_brainvision(vhdr_path, eog=eog, event_id=event_id,
+                               trig_shift_by_type={'response': None})
     events = raw._get_brainvision_events()
     events = events[events[:, 2] != event_id['Sync On']]
     assert_array_equal(events, [[486, 0, 253],
@@ -518,10 +520,9 @@ def test_events():
 
     # check that events are read properly when event_id is specified for
     # auxiliary events
-    with pytest.warns(RuntimeWarning, match='dropped'):
-        raw = read_raw_brainvision(vhdr_path, eog=eog, preload=True,
-                                   trig_shift_by_type={'response': None},
-                                   event_id=event_id)
+    raw = read_raw_brainvision(vhdr_path, eog=eog, preload=True,
+                               trig_shift_by_type={'response': None},
+                               event_id=event_id)
     events = raw._get_brainvision_events()
     assert_array_equal(events, [[486, 0, 253],
                                 [496, 1, 255],

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -62,7 +62,7 @@ vhdr_nV_path = op.join(data_dir, 'test_nV.vhdr')
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
-event_id = {'Sync On': 5, 'O  1': 1}
+event_id = {'Sync On': 5, 'O  1': 1, 'R255': 255}
 
 
 def test_vmrk_meas_date():
@@ -349,6 +349,7 @@ def test_brainvision_data():
 
     # test loading v2
     read_raw_brainvision(vhdr_v2_path, eog=eog, preload=True,
+                         event_id=event_id,
                          trig_shift_by_type={'response': 1000},
                          verbose='error')
     # For the nanovolt unit test we use the same data file with a different
@@ -508,7 +509,7 @@ def test_events():
     with pytest.warns(RuntimeWarning, match='channel types to misc'):
         raw = read_raw_brainvision(vhdr_v2_path)
     events = raw._get_brainvision_events()
-    assert events.shape == (11, 3)  # shape of events without the comment
+    assert events.shape == (10, 3)  # shape of events without comment/response
 
     # with event_id specified, get that comment and assert it's there
     tmp_event_id = {'comment using [square] brackets': 999}
@@ -516,7 +517,7 @@ def test_events():
         raw = read_raw_brainvision(vhdr_v2_path, event_id=tmp_event_id)
     events = raw._get_brainvision_events()
     assert 999 in events[:, -1]
-    assert events.shape == (12, 3)
+    assert events.shape == (11, 3)  # shape of events without response
 
     # check that events are read properly when event_id is specified for
     # auxiliary events


### PR DESCRIPTION
fixes #5420 

TL;DR: We now by default parse events that are stimuli `S###` or responses `R###`, covering the bulk of events in BrainVision files. All other events have to be specified using `event_id`.

-----------------------
The changes to the tests were much more minimal than I expected. Basically I:
1. added `'0  1': 1` to the `event_id` so that the *optic event* in our test files gets parsed (before this bugfix it was wrongly parsed by default)
2. added the `event_id` argument to a `read_raw_brainvision` call where previously the `event_id` was apparently forgotten.

Next to that, I noticed yet another bug that we did not know of before, look at this code:

https://github.com/mne-tools/mne-python/blob/62ecf9e482bf84a7f58c5fefff766336068f8bce/mne/io/brainvision/brainvision.py#L316-L332

The `trig_shift_by_type` is only applied if an `mdesc` was not found in `event_id`. However of course we want to apply the `trig_shift_by_type` also when we have an automatically parsed event type (such as S### and R### from now on). I fixed that by removing one level of indentation.