### PR TITLE
MRG: Lower mem usage rfft

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Bug
 
 - Fix bug with IIR filtering axis in :func:`mne.filter.filter_data` by `Eric Larson`_
 
+- Fix bug with non-boxcar windows in :meth:`mne.Raw.resample` and :func:`mne.filter.resample` by `Eric Larson`_
+
 - Fix bug in :func:`mne.minimum_norm.apply_inverse` where applying an MEG-only inverse would raise an error about needing an average EEG reference by `Eric Larson`_
 
 - Fix bug in ``inst.apply_proj()`` where an average EEG reference was always added by `Eric Larson`_

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -116,6 +116,8 @@ def setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
         FFT multiplication.
     h : array
         The filtering function that will be used repeatedly.
+    n_fft : int
+        The number of points in the FFT.
 
     Returns
     -------
@@ -182,6 +184,8 @@ def fft_multiply_repeated(h_fft, x, n_fft, cuda_dict):
         The filtering array to apply.
     x : 1-d array
         The array to filter.
+    n_fft : int
+        The number of points in the FFT.
     cuda_dict : dict
         Dictionary constructed using setup_cuda_multiply_repeated().
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -157,7 +157,7 @@ def setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
             # try setting up for float64
             try:
                 # do the IFFT normalization now so we don't have to later
-                h_fft = gpuarray.to_gpu(h_fft.astype('complex_') / len(h_fft))
+                h_fft = gpuarray.to_gpu(h_fft.astype('complex_') / n_fft)
                 cuda_dict.update(
                     use_cuda=True,
                     fft_plan=cudafft.Plan(n_fft, np.float64, np.complex128),

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -255,7 +255,25 @@ def test_resample():
     assert_array_equal(resample([0, 0], 2, 1), [0., 0., 0., 0.])
 
 
-def test_resample_stim_channel():
+@pytest.mark.parametrize('n_jobs', (1, 'cuda'))
+def test_resample_scipy(n_jobs):
+    """Test resampling against SciPy."""
+    for window in ('boxcar', 'hann'):
+        for N in (100, 101, 102, 103):
+            x = np.arange(N).astype(float)
+            err_msg = '%s: %s' % (N, window)
+            x_2 = resample(x, 2, 1, 0, window=window, n_jobs=n_jobs)
+            assert x_2.shape == (2 * N,)
+            x_2_sp = sp_resample(x, 2 * N, window=window)
+            assert_allclose(x_2, x_2_sp, atol=1e-12, err_msg=err_msg)
+            x_p5 = resample(x, 1, 2, 0, window=window, n_jobs=n_jobs)
+            new_len = int(round(len(x) * (1. / 2.)))
+            assert x_p5.shape == (new_len,)
+            x_p5_sp = sp_resample(x, new_len, window=window)
+            assert_allclose(x_p5, x_p5_sp, atol=1e-12, err_msg=err_msg)
+
+
+def test_resamp_stim_channel():
     """Test resampling of stim channels."""
     # Downsampling
     assert_array_equal(

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -255,6 +255,7 @@ def test_resample():
     assert_array_equal(resample([0, 0], 2, 1), [0., 0., 0., 0.])
 
 
+@requires_version('scipy', '0.13')  # 0.12 at least has a Nyquist bug
 def test_resample_scipy():
     """Test resampling against SciPy."""
     n_jobs_test = (1, 'cuda')

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -255,22 +255,22 @@ def test_resample():
     assert_array_equal(resample([0, 0], 2, 1), [0., 0., 0., 0.])
 
 
-@pytest.mark.parametrize('n_jobs', (1, 'cuda'))
-def test_resample_scipy(n_jobs):
+def test_resample_scipy():
     """Test resampling against SciPy."""
+    n_jobs_test = (1, 'cuda')
     for window in ('boxcar', 'hann'):
         for N in (100, 101, 102, 103):
             x = np.arange(N).astype(float)
             err_msg = '%s: %s' % (N, window)
-            x_2 = resample(x, 2, 1, 0, window=window, n_jobs=n_jobs)
-            assert x_2.shape == (2 * N,)
             x_2_sp = sp_resample(x, 2 * N, window=window)
-            assert_allclose(x_2, x_2_sp, atol=1e-12, err_msg=err_msg)
-            x_p5 = resample(x, 1, 2, 0, window=window, n_jobs=n_jobs)
+            for n_jobs in n_jobs_test:
+                x_2 = resample(x, 2, 1, 0, window=window, n_jobs=n_jobs)
+                assert_allclose(x_2, x_2_sp, atol=1e-12, err_msg=err_msg)
             new_len = int(round(len(x) * (1. / 2.)))
-            assert x_p5.shape == (new_len,)
             x_p5_sp = sp_resample(x, new_len, window=window)
-            assert_allclose(x_p5, x_p5_sp, atol=1e-12, err_msg=err_msg)
+            for n_jobs in n_jobs_test:
+                x_p5 = resample(x, 1, 2, 0, window=window, n_jobs=n_jobs)
+                assert_allclose(x_p5, x_p5_sp, atol=1e-12, err_msg=err_msg)
 
 
 def test_resamp_stim_channel():


### PR DESCRIPTION
This PR, by using `np.fft.rfft` for filtering and resampling:

- Reduces memory slightly
- Should speed up filtering a little bit
- Fixes some minor bugs with `resample(..., window=<non-boxcar>)`

Only reason it's not MRG is that I am not on a CUDA machine currently so can't see if that passes (though it should). @jona-sassenhagen if you are on a CUDA machine can you run `pytest mne/tests/test_filter.py` and let me know if it passes for you?