### PR TITLE
MINOR, WIP remove warning for custom solvers in rERP

### DIFF
--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -253,11 +253,7 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
                 return linalg.solve(a, X.T * y, sym_pos=True,
                                     overwrite_a=True, overwrite_b=True).T
     elif callable(solver):
-        warn("When using a custom solver, note that since MNE 0.15, this "
-             "function will pass the transposed data (n_channels, n_times) "
-             "to the solver. If you are using a solver that expects a "
-             "different format, it will give wrong results and might in "
-             "extreme cases crash your session.")
+        pass
     else:
         raise TypeError("The solver must be a str or a callable.")
 

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -140,13 +140,13 @@ def test_continuous_regression_with_overlap():
     from sklearn.linear_model.ridge import ridge_regression
 
     def solver(X, y):
-        return ridge_regression(X, y, alpha=0.)
+        return ridge_regression(X, y, alpha=0., solver="cholesky")
     assert_allclose(effect, linear_regression_raw(
         raw, events, tmin=0, solver=solver)['1'].data.flatten())
 
     # test bad solvers
     def solT(X, y):
-        return ridge_regression(X, y, alpha=0.).T
+        return ridge_regression(X, y, alpha=0., solver="cholesky").T
     pytest.raises(ValueError, linear_regression_raw, raw, events,
                   solver=solT)
     pytest.raises(ValueError, linear_regression_raw, raw, events, solver='err')

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -141,17 +141,14 @@ def test_continuous_regression_with_overlap():
 
     def solver(X, y):
         return ridge_regression(X, y, alpha=0.)
-
-    with pytest.warns(RuntimeWarning, match='transposed'):
-        assert_allclose(effect, linear_regression_raw(
-            raw, events, tmin=0, solver=solver)['1'].data.flatten())
+    assert_allclose(effect, linear_regression_raw(
+        raw, events, tmin=0, solver=solver)['1'].data.flatten())
 
     # test bad solvers
     def solT(X, y):
         return ridge_regression(X, y, alpha=0.).T
-    with pytest.warns(RuntimeWarning, match='transposed'):
-        pytest.raises(ValueError, linear_regression_raw, raw, events,
-                      solver=solT)
+    pytest.raises(ValueError, linear_regression_raw, raw, events,
+                  solver=solT)
     pytest.raises(ValueError, linear_regression_raw, raw, events, solver='err')
     pytest.raises(TypeError, linear_regression_raw, raw, events, solver=0)
 


### PR DESCRIPTION
Since .15, linear_regression_raw warns if a custom solver is passed. This can probably be removed for .17.