### PR TITLE
[MRG] fix brainvision markers

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -65,13 +65,13 @@ class RawBrainVision(BaseRaw):
         triggers will be ignored. Default is 0 for backwards compatibility,
         but typically another value or None will be necessary.
     event_id : dict | None
-        The id of special events to consider in addition to those that
-        follow the normal BrainVision trigger format ('S###' or '###').
-        If dict, the keys will be mapped to trigger values on the stimulus
-        channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive. "New Segment" markers
-        are always dropped.
+        Special events to consider in addition to those that follow the normal
+        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
+        'O'). If dict, the keys will be mapped to trigger values on the
+        stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+        If None or an empty dict (default), only BrainVision format events are
+        added to the stimulus channel. Keys are case sensitive. "New Segment"
+        markers are always dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -231,13 +231,13 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
     fname : str
         vmrk file to be read.
     event_id : dict | None
-        The id of special events to consider in addition to those that
-        follow the normal BrainVision trigger format ('S###' or '###').
-        If dict, the keys will be mapped to trigger values on the stimulus
-        channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive. "New Segment" markers
-        are always dropped.
+        Special events to consider in addition to those that follow the normal
+        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
+        'O'). If dict, the keys will be mapped to trigger values on the
+        stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+        If None or an empty dict (default), only BrainVision format events are
+        added to the stimulus channel. Keys are case sensitive. "New Segment"
+        markers are always dropped.
     response_trig_shift : int | None
         Integer to shift response triggers by. None ignores response triggers.
 
@@ -323,8 +323,11 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             trigger = event_id[mdesc]
         else:
             try:
-                # Match S### (BrainVision Recorder) or ### (PyCorder) format
-                marker_regexp = r'^S{0,1}([\s\d]{2}\d{1})$'
+                # Match any three digit marker value (padded with whitespace)
+                # In BrainVision Recorder, these sometimes have a prefix
+                # depending on the type, e.g., Stimulus=S, Response=R,
+                # Optical=O, ...
+                marker_regexp = r'^[SRO]{0,1}([\s\d]{2}\d{1})$'
                 trigger = int(re.findall(marker_regexp, mdesc)[0])
             except IndexError:
                 trigger = None
@@ -355,8 +358,8 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         dropped = list(set(dropped))
         warn("Currently, {0} trigger(s) will be dropped, such as {1}. "
              "Consider using ``event_id`` to parse triggers that "
-             "do not follow the 'S###' or '###' pattern.".format(
-                 len(dropped), dropped[:5]))
+             "do not follow the '###' pattern with possible prefixes: "
+             "'S', 'R', or 'O'.".format(len(dropped), dropped[:5]))
 
     events = np.array(events).reshape(-1, 3)
     return events
@@ -871,13 +874,13 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         triggers will be ignored. Default is 0 for backwards compatibility,
         but typically another value or None will be necessary.
     event_id : dict | None
-        The id of special events to consider in addition to those that
-        follow the normal BrainVision trigger format ('S###' or '###').
-        If dict, the keys will be mapped to trigger values on the stimulus
-        channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
-        or an empty dict (default), only stimulus and response events are added
-        to the stimulus channel. Keys are case sensitive. "New Segment" markers
-        are always dropped.
+        Special events to consider in addition to those that follow the normal
+        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
+        'O'). If dict, the keys will be mapped to trigger values on the
+        stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+        If None or an empty dict (default), only BrainVision format events are
+        added to the stimulus channel. Keys are case sensitive. "New Segment"
+        markers are always dropped.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -66,7 +66,7 @@ class RawBrainVision(BaseRaw):
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal BrainVision trigger format ('S###' or '###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
@@ -232,7 +232,7 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         vmrk file to be read.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal BrainVision trigger format ('S###' or '###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added
@@ -323,7 +323,9 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             trigger = event_id[mdesc]
         else:
             try:
-                trigger = int(re.findall(r'S([\s\d]{2}\d{1})', mdesc)[0])
+                # Match S### (BrainVision Recorder) or ### (PyCorder) format
+                marker_regexp = r'^S{0,1}([\s\d]{2}\d{1})$'
+                trigger = int(re.findall(marker_regexp, mdesc)[0])
             except IndexError:
                 trigger = None
         if mtype.lower() in trig_shift_by_type:
@@ -351,13 +353,10 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
 
     if len(dropped) > 0:
         dropped = list(set(dropped))
-        examples = ", ".join(dropped[:5])
-        if len(dropped) > 5:
-            examples += ", ..."
-        warn("Currently, {0} trigger(s) will be dropped, such as [{1}]. "
+        warn("Currently, {0} trigger(s) will be dropped, such as {1}. "
              "Consider using ``event_id`` to parse triggers that "
-             "do not follow the 'S###' pattern.".format(
-                 len(dropped), examples))
+             "do not follow the 'S###' or '###' pattern.".format(
+                 len(dropped), dropped[:5]))
 
     events = np.array(events).reshape(-1, 3)
     return events
@@ -873,7 +872,7 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         but typically another value or None will be necessary.
     event_id : dict | None
         The id of special events to consider in addition to those that
-        follow the normal Brainvision trigger format ('S###').
+        follow the normal BrainVision trigger format ('S###' or '###').
         If dict, the keys will be mapped to trigger values on the stimulus
         channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}. If None
         or an empty dict (default), only stimulus and response events are added

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -66,8 +66,8 @@ class RawBrainVision(BaseRaw):
         but typically another value or None will be necessary.
     event_id : dict | None
         Special events to consider in addition to those that follow the normal
-        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
-        'O'). If dict, the keys will be mapped to trigger values on the
+        BrainVision trigger format ('###' with an optional single character
+        prefix). If dict, the keys will be mapped to trigger values on the
         stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
         If None or an empty dict (default), only BrainVision format events are
         added to the stimulus channel. Keys are case sensitive. "New Segment"
@@ -232,8 +232,8 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         vmrk file to be read.
     event_id : dict | None
         Special events to consider in addition to those that follow the normal
-        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
-        'O'). If dict, the keys will be mapped to trigger values on the
+        BrainVision trigger format ('###' with an optional single character
+        prefix). If dict, the keys will be mapped to trigger values on the
         stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
         If None or an empty dict (default), only BrainVision format events are
         added to the stimulus channel. Keys are case sensitive. "New Segment"
@@ -323,11 +323,13 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
             trigger = event_id[mdesc]
         else:
             try:
-                # Match any three digit marker value (padded with whitespace)
-                # In BrainVision Recorder, these sometimes have a prefix
+                # Match any three digit marker value (padded with whitespace).
+                # In BrainVision Recorder, the markers sometimes have a prefix
                 # depending on the type, e.g., Stimulus=S, Response=R,
-                # Optical=O, ...
-                marker_regexp = r'^[SRO]{0,1}([\s\d]{2}\d{1})$'
+                # Optical=O, ... Note that any arbitrary stimulus type can be
+                # defined. So we match any single character that is not
+                # forbidden by BrainVision Recorder: [^a-z$%\-@/\\|;,:.\s]
+                marker_regexp = r'^[^a-z$%\-@/\\|;,:.\s]{0,1}([\s\d]{2}\d{1})$'
                 trigger = int(re.findall(marker_regexp, mdesc)[0])
             except IndexError:
                 trigger = None
@@ -358,8 +360,8 @@ def _read_vmrk_events(fname, event_id=None, trig_shift_by_type=None):
         dropped = list(set(dropped))
         warn("Currently, {0} trigger(s) will be dropped, such as {1}. "
              "Consider using ``event_id`` to parse triggers that "
-             "do not follow the '###' pattern with possible prefixes: "
-             "'S', 'R', or 'O'.".format(len(dropped), dropped[:5]))
+             "do not follow the '###' pattern with an optional single "
+             "character prefix.".format(len(dropped), dropped[:5]))
 
     events = np.array(events).reshape(-1, 3)
     return events
@@ -875,8 +877,8 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         but typically another value or None will be necessary.
     event_id : dict | None
         Special events to consider in addition to those that follow the normal
-        BrainVision trigger format ('###' with possible prefixes: 'S', 'R', or
-        'O'). If dict, the keys will be mapped to trigger values on the
+        BrainVision trigger format ('###' with an optional single character
+        prefix). If dict, the keys will be mapped to trigger values on the
         stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
         If None or an empty dict (default), only BrainVision format events are
         added to the stimulus channel. Keys are case sensitive. "New Segment"

--- a/mne/io/brainvision/tests/data/testv2.vmrk
+++ b/mne/io/brainvision/tests/data/testv2.vmrk
@@ -22,8 +22,19 @@ Mk8=Stimulus,S255,3263,1,0
 Mk9=Stimulus,S253,4936,1,0
 Mk10=Stimulus,S255,4946,1,0
 Mk11=Response,R255,6000,1,0
-Mk12=Stimulus,S254,6620,1,0
-Mk13=Stimulus,S255,6630,1,0
+
+;Removing the prefix makes the marker "PyCorder" style
+;The removal of the prefix should not change the parsing
+Mk12=Stimulus,254,6620,1,0
+Mk13=Stimulus,255,6630,1,0
+
+;Do not parse by default if not in shape '###' + optional single char prefix
+Mk14=Comment,This will not be parsed by default 13,8010,1,0
+Mk15=Comment,Not parsed by default either S456 ms,8020,1,0
+
+;Certain prefixes are blacklisted by BrainVision recorder: [^a-z$%\-@/\\|;,:.\s]
+;Will not be parsed by default
+Mk16=$User_Spec,$ 18,8030,1,0
 
 [Marker User Infos]
 ; Each entry: Prop<Number>=Mk<Marker number>,<Type>,<Name>,<Value>,<Value2>,...,<ValueN>

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -62,7 +62,7 @@ vhdr_nV_path = op.join(data_dir, 'test_nV.vhdr')
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
-event_id = {'Sync On': 5, 'O  1': 1, 'R255': 255}
+event_id = {'Sync On': 5}
 
 
 def test_vmrk_meas_date():
@@ -509,7 +509,7 @@ def test_events():
     with pytest.warns(RuntimeWarning, match='channel types to misc'):
         raw = read_raw_brainvision(vhdr_v2_path)
     events = raw._get_brainvision_events()
-    assert events.shape == (10, 3)  # shape of events without comment/response
+    assert events.shape == (11, 3)  # shape of events without comment
 
     # with event_id specified, get that comment and assert it's there
     tmp_event_id = {'comment using [square] brackets': 999}
@@ -517,7 +517,7 @@ def test_events():
         raw = read_raw_brainvision(vhdr_v2_path, event_id=tmp_event_id)
     events = raw._get_brainvision_events()
     assert 999 in events[:, -1]
-    assert events.shape == (11, 3)  # shape of events without response
+    assert events.shape == (12, 3)  # shape of events with comment
 
     # check that events are read properly when event_id is specified for
     # auxiliary events


### PR DESCRIPTION
fixes #5441 

- Now reading 'S###' as the format of BrainVision Recorder and '###' as the format of PyCorder.
- Adjusted docstrings and warning message
- In the warning message, the dropped markers are now printed as they are (i.e., no potentially crucial whitespace is being dropped)

To Do:
- [x] adding some tests asserting that we do read PyCorder style events
- [x] adding some tests asserting that we do NOT read events (e.g., comment events) ending with integers or similiar (just come up with some weird things that should be rejected)
- [x] discussion whether to include 'R###' as an automatically parsed event. Right now, it needs to be specified in `event_id` ... @hekolk seems to have an opinion about this?