### PR TITLE
[MRG] More work on the beamformer code

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -89,6 +89,8 @@ Changelog
 
 - Add support for ``weight_norm='nai'`` to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
 
+- Add parameter ``rank=None`` to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
+
 Bug
 ~~~
 
@@ -179,7 +181,7 @@ Bug
 API
 ~~~
 
-- The parameter ``rank`` was added to :func:`mne.beamformer.make_dics` and :func:`mne.beamformer.make_lcmv`` with a default of ``'full'`` that will change to ``None`` in 0.18 to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
+- The parameter ``rank`` was added to :func:`mne.beamformer.make_lcmv`` with a default of ``'full'`` that will change to ``None`` in 0.18 to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -89,11 +89,6 @@ Changelog
 
 - Add support for ``weight_norm='nai'`` to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
 
-- Add ``rank`` parameter for specifying the rank of the covariance matrix to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
-
-- Add ``rank='auto'`` parameter for automatically determining the rank of the covariance matrix to :func:`mne.beamformer.lcmv` and :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
-
-
 Bug
 ~~~
 
@@ -181,9 +176,10 @@ Bug
 
 - Fix computation of max-power orientation in :func:`mne.beamformer.make_dics` when ``pick_ori='max-power', weight_norm='unit_noise_gain'`` by `Marijn van Vliet`_
 
-
 API
 ~~~
+
+- The parameter ``rank`` was added to :func:`mne.beamformer.make_dics` and :func:`mne.beamformer.make_lcmv`` with a default of ``'full'`` that will change to ``None`` in 0.18 to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -81,6 +81,18 @@ Changelog
 
 - Add :meth:`mne.Report.remove` method to remove existing figures from a report, by `Marijn van Vliet`_
 
+- Add sign to output of max-power orientation for :func:`mne.beamformer.make_dics` by `Eric Larson`_
+
+- Add support for ``pick_ori='max-power'`` when ``weight_norm=None`` in :func:`mne.beamformer.make_lcmv` by `Marijn van Vliet`_
+
+- Add support for ``weight_norm='nai'`` for all ``pick_ori`` options in :func:`mne.beamformer.make_lcmv` by `Marijn van Vliet`_
+
+- Add support for ``weight_norm='nai'`` to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
+
+- Add ``rank`` parameter for specifying the rank of the covariance matrix to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
+
+- Add ``rank='auto'`` parameter for automatically determining the rank of the covariance matrix to :func:`mne.beamformer.lcmv` and :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
+
 
 Bug
 ~~~
@@ -164,6 +176,10 @@ Bug
 - Fix symlinking to use relative paths in ``mne flash_bem` and ``mne watershed_bem`` by `Eric Larson`_
 
 - Fix error in mne coreg when saving with scaled MRI if fiducials haven't been saved by `Ezequiel Mikulan`_
+
+- Fix normalization error in :func:`mne.beamformer.make_lcmv` when ``pick_ori='normal', weight_norm='unit_noise_gain'`` by `Marijn van Vliet`_
+
+- Fix computation of max-power orientation in :func:`mne.beamformer.make_dics` when ``pick_ori='max-power', weight_norm='unit_noise_gain'`` by `Marijn van Vliet`_
 
 
 API

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -91,6 +91,9 @@ Changelog
 
 - Add parameter ``rank=None`` to :func:`mne.beamformer.make_dics` by `Marijn van Vliet`_
 
+- Add parameter ``rank='full'`` to :func:`mne.beamformer.make_lcmv``, which can be set to ``None`` to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
+
+
 Bug
 ~~~
 
@@ -180,8 +183,6 @@ Bug
 
 API
 ~~~
-
-- The parameter ``rank`` was added to :func:`mne.beamformer.make_lcmv`` with a default of ``'full'`` that will change to ``None`` in 0.18 to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -79,7 +79,7 @@ for pick_ori, name, desc, color in zip(pick_oris, names, descriptions, colors):
     # data (enabled by passing a noise covariance matrix)
     filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
                         noise_cov=noise_cov, pick_ori=pick_ori,
-                        weight_norm='unit-noise-gain')
+                        weight_norm='unit-noise-gain', rank=None)
     print(filters)
     # apply this spatial filter to source-reconstruct the evoked data
     stc = apply_lcmv(evoked, filters, max_ori_out='signed')

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -86,26 +86,22 @@ for pick_ori, name, desc, color in zip(pick_oris, names, descriptions, colors):
 
     # View activation time-series in maximum voxel at 100 ms:
     time_idx = stc.time_as_index(0.1)
-    max_idx = np.argmax(stc.data[:, time_idx])
+    max_idx = np.argmax(np.abs(stc.data[:, time_idx]))
     # we know these are all left hemi, so we can just use vertices[0]
     max_voxs.append(stc.vertices[0][max_idx])
     ax.plot(stc.times, stc.data[max_idx, :], color, label=desc % max_idx)
 
-ax.set(xlabel='Time (ms)', ylabel='LCMV value', ylim=(-0.8, 2.2),
+ax.set(xlabel='Time (ms)', ylabel='LCMV value',
        title='LCMV in maximum voxel')
-ax.legend()
+ax.legend(loc='lower right')
 mne.viz.utils.plt_show()
 
 ###############################################################################
 # We can also look at the spatial distribution
 
-# take absolute value for plotting
-np.abs(stc.data, out=stc.data)
-
 # Plot last stc in the brain in 3D with PySurfer if available
-brain = stc.plot(hemi='lh', subjects_dir=subjects_dir,
-                 initial_time=0.1, time_unit='s')
-brain.show_view('lateral')
+brain = stc.plot(hemi='lh', views='lat', subjects_dir=subjects_dir,
+                 initial_time=0.1, time_unit='s', smoothing_steps=5)
 for color, vertex in zip(colors, max_voxs):
     brain.add_foci([vertex], coords_as_verts=True, scale_factor=0.5,
                    hemi='lh', color=color)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -77,7 +77,7 @@ data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
 # of orientation selection and weight normalization are implemented yet.
 filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
                     noise_cov=noise_cov, pick_ori='max-power',
-                    weight_norm='nai')
+                    weight_norm='nai', rank=None)
 print(filters)
 
 # You can save these with:

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -1,7 +1,7 @@
 """
-===================================================================
-Compute LCMV inverse solution on evoked data in volume source space
-===================================================================
+====================================================
+Compute LCMV inverse solution in volume source space
+====================================================
 
 Compute LCMV inverse solution on an auditory evoked dataset in a volume source
 space.

--- a/examples/inverse/plot_tf_dics.py
+++ b/examples/inverse/plot_tf_dics.py
@@ -3,8 +3,7 @@
 Time-frequency beamforming using DICS
 =====================================
 
-Compute DICS source power [1]_ in a grid of time-frequency windows and
-display results.
+Compute DICS source power [1]_ in a grid of time-frequency windows.
 
 References
 ----------
@@ -114,8 +113,7 @@ for freq_bin, win_length, n_fft in zip(freq_bins, win_lengths, n_ffts):
 # space for faster computation, use label=None for full solution
 stcs = tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
                freq_bins=freq_bins, subtract_evoked=subtract_evoked,
-               n_ffts=n_ffts, reg=0.05, label=label, inversion='matrix',
-               rank=None)
+               n_ffts=n_ffts, reg=0.05, label=label, inversion='matrix')
 
 # Plotting source spectrogram for source with maximum activity
 # Note that tmin and tmax are set to display a time range that is smaller than

--- a/examples/inverse/plot_tf_dics.py
+++ b/examples/inverse/plot_tf_dics.py
@@ -114,7 +114,8 @@ for freq_bin, win_length, n_fft in zip(freq_bins, win_lengths, n_ffts):
 # space for faster computation, use label=None for full solution
 stcs = tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
                freq_bins=freq_bins, subtract_evoked=subtract_evoked,
-               n_ffts=n_ffts, reg=0.05, label=label, inversion='matrix')
+               n_ffts=n_ffts, reg=0.05, label=label, inversion='matrix',
+               rank=None)
 
 # Plotting source spectrogram for source with maximum activity
 # Note that tmin and tmax are set to display a time range that is smaller than

--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -134,7 +134,7 @@ for (l_freq, h_freq) in freq_bins:
 # space for faster computation, use label=None for full solution
 stcs = tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                freq_bins=freq_bins, subtract_evoked=subtract_evoked,
-               reg=data_reg, label=label)
+               reg=data_reg, label=label, rank=None)
 
 # Plotting source spectrogram for source with maximum activity.
 # Note that tmin and tmax are set to display a time range that is smaller than

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -29,11 +29,12 @@ from ..externals.six import string_types
 def _check_rank(rank):
     """Check rank parameter and deal with deprecation."""
     if isinstance(rank, string_types):
-        if rank == '':
-            warn('The rank parameter default in 0.17 of "full" will change '
-                 'to None in 0.18, set it explicitly to avoid this warning',
-                 DeprecationWarning)
-            rank = 'full'
+        # XXX we can use rank='' to deprecate to get to None eventually:
+        # if rank == '':
+        #     warn('The rank parameter default in 0.18 of "full" will change '
+        #          'to None in 0.19, set it explicitly to avoid this warning',
+        #          DeprecationWarning)
+        #     rank = 'full'
         if rank != 'full':
             raise ValueError('rank, if str, must be "full", got %s' % (rank,))
     elif rank is not None and not isinstance(rank, dict):

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -301,11 +301,14 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         The source orientation to compute the beamformer in.
     reduce_rank : bool
         Whether to reduce the rank by one during computation of the filter.
-    rank : None | False | int
-        The effective rank of the covariance matrix.
-        If None, the rank will be estimated before regularization is
-        applied. If False, the rank will be estimated after regularization
-        is applied. Defaults to ``None``.
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
     inversion : 'matrix' | 'single'
         The inversion scheme to compute the weights.
     nn : ndarray, shape (n_dipoles, 3)

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -67,11 +67,7 @@ def _compare_ch_names(names1, names2, bads):
 
 def _check_one_ch_type(info, picks, noise_cov, method):
     """Check number of sensor types and presence of noise covariance matrix."""
-    # XXX : ugly hack to avoid picking subset of info with applied comps
-    comps = info['comps']
-    info['comps'] = []
     info_pick = pick_info(info, sel=picks)
-    info['comps'] = comps
     ch_types =\
         [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
     if method == 'lcmv' and sum(ch_types) > 1 and noise_cov is None:

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -206,8 +206,8 @@ def _prepare_beamformer_input(info, forward, label, picks, pick_ori,
     return is_free_ori, ch_names, proj, vertno, G, nn
 
 
-def _shortcut(Wk, Gk, Cm_inv_sq, reduce_rank, nn):
-    """Shortcut to compute the normalized weights in max-power orientation.
+def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn):
+    """Compute the normalized weights in max-power orientation.
 
     Uses Eq. 4.47 from [1]_.
 
@@ -339,7 +339,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         if (inversion == 'matrix' and pick_ori == 'max-power' and
                 weight_norm in ['unit-noise-gain', 'nai']):
             # In this case, take a shortcut to compute the filter
-            Wk[:] = _shortcut(Wk, Gk, Cm_inv_sq, reduce_rank, nn[k])
+            Wk[:] = _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn[k])
         else:
             # Normalize the spatial filters
             if Wk.ndim == 2 and len(Wk) > 1:

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -31,7 +31,7 @@ def _check_rank(rank):
     if isinstance(rank, string_types):
         if rank == '':
             warn('The rank parameter default in 0.17 of "full" will change '
-                 'to None in 0.18, set it explicitly to aviod this warning',
+                 'to None in 0.18, set it explicitly to avoid this warning',
                  DeprecationWarning)
             rank = 'full'
         if rank != 'full':

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -24,7 +24,6 @@ from ..time_frequency.csd import CrossSpectralDensity
 from ..externals.h5io import read_hdf5, write_hdf5
 
 
-
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):
     """Return good channels common to forward model and covariance matrices."""
     # get a list of all channel names:
@@ -430,29 +429,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         W *= noise_norm_inv
         W = W.reshape(-1, W.shape[-1])
 
-        Parameters
-        ----------
-        fname : str
-            The filename to use to write the HDF5 data.
-            Should end in ``'-lcmv.h5'`` or ``'-dics.h5'``.
-        overwrite : bool
-            If True, overwrite the file (if it exists).
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
-        """
-        ending = '-%s.h5' % (self['kind'].lower(),)
-        check_fname(fname, self['kind'], (ending,))
-        csd_orig = None
-        try:
-            if 'csd' in self:
-                csd_orig = self['csd']
-                self['csd'] = self['csd'].__getstate__()
-            write_hdf5(fname, self, overwrite=overwrite, title='mnepython')
-        finally:
-            if csd_orig is not None:
-                self['csd'] = csd_orig
+    return W
 
 
 class Beamformer(dict):
@@ -496,6 +473,30 @@ class Beamformer(dict):
     @verbose
     def save(self, fname, overwrite=False, verbose=None):
         """Save the beamformer filter.
+
+        Parameters
+        ----------
+        fname : str
+            The filename to use to write the HDF5 data.
+            Should end in ``'-lcmv.h5'`` or ``'-dics.h5'``.
+        overwrite : bool
+            If True, overwrite the file (if it exists).
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more).
+        """
+        ending = '-%s.h5' % (self['kind'].lower(),)
+        check_fname(fname, self['kind'], (ending,))
+        csd_orig = None
+        try:
+            if 'csd' in self:
+                csd_orig = self['csd']
+                self['csd'] = self['csd'].__getstate__()
+            write_hdf5(fname, self, overwrite=overwrite, title='mnepython')
+        finally:
+            if csd_orig is not None:
+                self['csd'] = csd_orig
 
 
 def read_beamformer(fname):

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -7,6 +7,7 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
+import operator
 
 import numpy as np
 from scipy import linalg
@@ -22,6 +23,26 @@ from ..channels.channels import _contains_ch_type
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
+from ..externals.six import string_types
+
+
+def _check_rank(rank):
+    """Check rank parameter and deal with deprecation."""
+    if isinstance(rank, string_types):
+        if rank == '':
+            warn('The rank parameter default in 0.17 of "full" will change '
+                 'to None in 0.18, set it explicitly to aviod this warning',
+                 DeprecationWarning)
+            rank = 'full'
+        if rank != 'full':
+            raise ValueError('rank, if str, must be "full", got %s' % (rank,))
+    elif rank is not None and not isinstance(rank, dict):
+        try:
+            rank = int(operator.index(rank))
+        except TypeError:
+            raise TypeError('rank must be None, dict, "full", or int-like, '
+                            'got %s (type %s)' % (rank, type(rank)))
+    return rank
 
 
 def _setup_picks(info, forward, data_cov=None, noise_cov=None):

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -63,11 +63,15 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
                 filters are computer for the orientation that maximizes
                 spectral power.
 
-    rank : None | False | int
-        The effective rank of the covariance matrix.
-        If None, the rank will be estimated before regularization is
-        applied. If False, the rank will be estimated after regularization
-        is applied. Defaults to ``None``.
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
+        Defaults to 'full'.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -600,7 +604,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
             subtract_evoked=False, mode='fourier', freq_bins=None,
             frequencies=None, n_ffts=None, mt_bandwidths=None,
             mt_adaptive=False, mt_low_bias=True, cwt_n_cycles=7, decim=1,
-            reg=0.05, label=None, pick_ori=None, inversion='single',
+            reg=0.05, label=None, pick_ori=None, rank=None, inversion='single',
             weight_norm=None, normalize_fwd=True, real_filter=False,
             reduce_rank=False, verbose=None):
     """5D time-frequency beamforming based on DICS.
@@ -691,6 +695,18 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
                 spectral power.
 
         Defaults to ``None``.
+
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
+        Defaults to 'full'.
+        
+        .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
         This determines how the beamformer deals with source spaces in "free"
         orientation. Such source spaces define three orthogonal dipoles at each
@@ -867,7 +883,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
 
                 filters = make_dics(epochs.info, forward, csd, reg=reg,
                                     label=label, pick_ori=pick_ori,
-                                    inversion=inversion,
+                                    rank=rank, inversion=inversion,
                                     weight_norm=weight_norm,
                                     normalize_fwd=normalize_fwd,
                                     reduce_rank=reduce_rank,

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -17,13 +17,13 @@ from ._compute_beamformer import (_setup_picks,
                                   _pick_channels_spatial_filter,
                                   _check_proj_match, _prepare_beamformer_input,
                                   _compute_beamformer, _check_one_ch_type,
-                                  _check_src_type, Beamformer)
+                                  _check_src_type, Beamformer, _check_rank)
 from ..externals import six
 
 
 @verbose
 def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
-              rank=None, inversion='single', weight_norm=None,
+              rank='', inversion='single', weight_norm=None,
               normalize_fwd=True, real_filter=False, reduce_rank=False,
               verbose=None):
     """Compute a Dynamic Imaging of Coherent Sources (DICS) spatial filter.
@@ -71,7 +71,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to ``None``.
+        The default in 0.17 is 'full' and this will change to None in 0.18.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -186,6 +186,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
            https://doi.org/10.1101/245530
     """  # noqa: E501
     allowed_ori = [None, 'normal', 'max-power']
+    rank = _check_rank(rank)
     if pick_ori not in allowed_ori:
         raise ValueError('"pick_ori" should be one of %s.' % allowed_ori)
 
@@ -604,7 +605,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
             subtract_evoked=False, mode='fourier', freq_bins=None,
             frequencies=None, n_ffts=None, mt_bandwidths=None,
             mt_adaptive=False, mt_low_bias=True, cwt_n_cycles=7, decim=1,
-            reg=0.05, label=None, pick_ori=None, rank=None, inversion='single',
+            reg=0.05, label=None, pick_ori=None, rank='', inversion='single',
             weight_norm=None, normalize_fwd=True, real_filter=False,
             reduce_rank=False, verbose=None):
     """5D time-frequency beamforming based on DICS.
@@ -704,7 +705,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to ``None``.
+        The default in 0.17 is 'full' and this will change to None in 0.18.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -762,6 +763,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
            brain imaging (2008) Springer Science & Business Media
     """
     _check_reference(epochs)
+    rank = _check_rank(rank)
 
     if mode == 'cwt_morlet' and frequencies is None:
         raise ValueError('In "cwt_morlet" mode, the "frequencies" parameter '

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -8,12 +8,12 @@
 # License: BSD (3-clause)
 import numpy as np
 
-from ..utils import logger, verbose, warn
+from ..utils import logger, verbose, warn, reg_pinv
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
 from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
-from ._compute_beamformer import (_reg_pinv, _setup_picks,
+from ._compute_beamformer import (_setup_picks,
                                   _pick_channels_spatial_filter,
                                   _check_proj_match, _prepare_beamformer_input,
                                   _compute_beamformer, _check_one_ch_type,
@@ -23,8 +23,9 @@ from ..externals import six
 
 @verbose
 def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
-              inversion='single', weight_norm=None, normalize_fwd=True,
-              real_filter=False, reduce_rank=False, verbose=None):
+              rank='auto', inversion='single', weight_norm=None,
+              normalize_fwd=True, real_filter=False, reduce_rank=False,
+              verbose=None):
     """Compute a Dynamic Imaging of Coherent Sources (DICS) spatial filter.
 
     This is a beamformer filter that can be used to estimate the source power
@@ -62,6 +63,13 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
                 filters are computer for the orientation that maximizes
                 spectral power.
 
+    rank : int | 'auto' | None
+        The effective rank of the covariance matrix. If 'auto', the rank will
+        be estimated before regularization is applied. If ``None``, the rank
+        will be estimated after regularization is applied.
+        Defaults to 'auto'.
+
+        .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
         This determines how the beamformer deals with source spaces in "free"
         orientation. Such source spaces define three orthogonal dipoles at each
@@ -71,12 +79,12 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         three dipoles at a source vertex are considered as a group and the
         spatial filters are computed jointly using a matrix inversion. While
         ``inversion='single'`` is more stable, ``inversion='matrix'`` is more
-        precise. See section 5 of [4]_.  Defaults to 'single'.
-    weight_norm : None | 'unit-noise-gain'
-        How to normalize the beamformer weights. None means no normalization is
-        performed. If 'unit-noise-gain', the unit-noise gain minimum variance
-        beamformer will be computed (Borgiotti-Kaplan beamformer) [2]_.
-        Defaults to ``None``.
+        precise. See section 5 of [5]_.  Defaults to 'single'.
+    weight_norm : 'unit-noise-gain' | 'nai' | None
+        If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
+        will be computed (Borgiotti-Kaplan beamformer) [2]_,
+        If 'nai', the Neural Activity Index [4]_ will be computed.
+        Defaults to ``None``, in which case no normalization is performed.
     normalize_fwd : bool
         Whether to normalize the forward solution. Defaults to ``True``. Note
         that this normalization is not required when weight normalization
@@ -131,7 +139,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
 
     Notes
     -----
-    The original reference is [1]_. See [4]_ for a tutorial style paper on the
+    The original reference is [1]_. See [5]_ for a tutorial style paper on the
     topic.
 
     The DICS beamformer is very similar to the LCMV (:func:`make_lcmv`)
@@ -142,7 +150,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
     searching), and it remains to be seen how functionally interchangeable they
     could be.
 
-    The default setting reproduce the DICS beamformer as described in [4]_::
+    The default setting reproduce the DICS beamformer as described in [5]_::
 
         inversion='single', weight_norm=None, normalize_fwd=True
 
@@ -165,7 +173,10 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
            in Large-Scale Cortical Networks Predicts Perception.
            Neuron (2011) vol 69 pp. 387-396.
            https://doi.org/10.1016/j.neuron.2010.12.027
-    .. [4] van Vliet, et al. (2018) Analysis of functional connectivity and
+    .. [4] Van Veen et al. Localization of brain electrical activity via
+           linearly constrained minimum variance spatial filtering.
+           Biomedical Engineering (1997) vol. 44 (9) pp. 867--880
+    .. [5] van Vliet, et al. (2018) Analysis of functional connectivity and
            oscillatory power using DICS: from raw MEG data to group-level
            statistics in Python. bioRxiv, 245530.
            https://doi.org/10.1101/245530
@@ -229,9 +240,8 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         Cm = Cm[csd_picks, :][:, csd_picks]
 
         # compute spatial filter
-        W, _ = _compute_beamformer('dics', G, Cm, reg, n_orient, weight_norm,
-                                   pick_ori, reduce_rank, rank=None,
-                                   is_free_ori=None, inversion=inversion)
+        W = _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
+                                reduce_rank, rank=rank, inversion=inversion)
         Ws.append(W)
 
     Ws = np.array(Ws)
@@ -516,7 +526,7 @@ def _apply_old_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
     # Tikhonov regularization using reg parameter to control for
     # trade-off between spatial resolution and noise sensitivity
     # eq. 25 in Gross and Ioannides, 1999 Phys. Med. Biol. 44 2081
-    Cm_inv, _ = _reg_pinv(Cm, reg)
+    Cm_inv, _ = reg_pinv(Cm, reg, rank='auto')
     del Cm
 
     # Compute spatial filters

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -23,7 +23,7 @@ from ..externals import six
 
 @verbose
 def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
-              rank='', inversion='single', weight_norm=None,
+              rank=None, inversion='single', weight_norm=None,
               normalize_fwd=True, real_filter=False, reduce_rank=False,
               verbose=None):
     """Compute a Dynamic Imaging of Coherent Sources (DICS) spatial filter.
@@ -71,7 +71,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        The default in 0.17 is 'full' and this will change to None in 0.18.
+        The default is None.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -605,7 +605,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
             subtract_evoked=False, mode='fourier', freq_bins=None,
             frequencies=None, n_ffts=None, mt_bandwidths=None,
             mt_adaptive=False, mt_low_bias=True, cwt_n_cycles=7, decim=1,
-            reg=0.05, label=None, pick_ori=None, rank='', inversion='single',
+            reg=0.05, label=None, pick_ori=None, rank=None, inversion='single',
             weight_norm=None, normalize_fwd=True, real_filter=False,
             reduce_rank=False, verbose=None):
     """5D time-frequency beamforming based on DICS.
@@ -705,7 +705,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        The default in 0.17 is 'full' and this will change to None in 0.18.
+        The default is None.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -216,7 +216,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         fwd_norm = None  # No normalization
 
     picks = _setup_picks(info=info, forward=forward)
-    _, ch_names, proj, vertices, G = _prepare_beamformer_input(
+    _, ch_names, proj, vertices, G, nn = _prepare_beamformer_input(
         info, forward, label, picks=picks, pick_ori=pick_ori,
         fwd_norm=fwd_norm,
     )
@@ -241,7 +241,8 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
 
         # compute spatial filter
         W = _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
-                                reduce_rank, rank=rank, inversion=inversion)
+                                reduce_rank, rank=rank, inversion=inversion,
+                                nn=nn)
         Ws.append(W)
 
     Ws = np.array(Ws)
@@ -513,7 +514,7 @@ def _apply_old_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
         raise ValueError('CSD matrix object should only contain one '
                          'frequency.')
 
-    is_free_ori, _, proj, vertno, G =\
+    is_free_ori, _, proj, vertno, G, _ =\
         _prepare_beamformer_input(info, forward, label, picks, pick_ori)
 
     Cm = data_csd.get_data(index=0)

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -8,7 +8,7 @@
 # License: BSD (3-clause)
 import numpy as np
 
-from ..utils import logger, verbose, warn, reg_pinv
+from ..utils import logger, verbose, warn, _reg_pinv
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
@@ -23,7 +23,7 @@ from ..externals import six
 
 @verbose
 def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
-              rank='auto', inversion='single', weight_norm=None,
+              rank=None, inversion='single', weight_norm=None,
               normalize_fwd=True, real_filter=False, reduce_rank=False,
               verbose=None):
     """Compute a Dynamic Imaging of Coherent Sources (DICS) spatial filter.
@@ -63,11 +63,11 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
                 filters are computer for the orientation that maximizes
                 spectral power.
 
-    rank : int | 'auto' | None
-        The effective rank of the covariance matrix. If 'auto', the rank will
-        be estimated before regularization is applied. If ``None``, the rank
-        will be estimated after regularization is applied.
-        Defaults to 'auto'.
+    rank : None | False | int
+        The effective rank of the covariance matrix.
+        If None, the rank will be estimated before regularization is
+        applied. If False, the rank will be estimated after regularization
+        is applied. Defaults to ``None``.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -527,7 +527,7 @@ def _apply_old_dics(data, info, tmin, forward, noise_csd, data_csd, reg,
     # Tikhonov regularization using reg parameter to control for
     # trade-off between spatial resolution and noise sensitivity
     # eq. 25 in Gross and Ioannides, 1999 Phys. Med. Biol. 44 2081
-    Cm_inv, _ = reg_pinv(Cm, reg, rank='auto')
+    Cm_inv, _ = _reg_pinv(Cm, reg, rank=None)
     del Cm
 
     # Compute spatial filters

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -71,7 +71,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to 'full'.
+        Defaults to ``None``.
 
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
@@ -704,7 +704,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to 'full'.
+        Defaults to '``None``.
         
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -63,7 +63,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
                 filters are computer for the orientation that maximizes
                 spectral power.
 
-    rank : int | None | 'full'
+    rank : None | int | 'full'
         This controls the effective rank of the covariance matrix when
         computing the inverse. The rank can be set explicitly by specifying an
         integer value. If ``None``, the rank will be automatically estimated.
@@ -696,7 +696,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
 
         Defaults to ``None``.
 
-    rank : int | None | 'full'
+    rank : None | int | 'full'
         This controls the effective rank of the covariance matrix when
         computing the inverse. The rank can be set explicitly by specifying an
         integer value. If ``None``, the rank will be automatically estimated.
@@ -704,8 +704,8 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to '``None``.
-        
+        Defaults to ``None``.
+
         .. versionadded:: 0.17
     inversion : 'single' | 'matrix'
         This determines how the beamformer deals with source spaces in "free"

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -24,7 +24,7 @@ from ._compute_beamformer import (
 
 @verbose
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
-              pick_ori=None, rank=None, weight_norm='unit-noise-gain',
+              pick_ori=None, rank='full', weight_norm='unit-noise-gain',
               reduce_rank=False, verbose=None):
     """Compute LCMV spatial filter.
 
@@ -60,11 +60,15 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
             'vector'
                 Keeps the currents for each direction separate
 
-    rank : None | False | int
-        The effective rank of the covariance matrix.
-        If None, the rank will be estimated before regularization is
-        applied. If False, the rank will be estimated after regularization
-        is applied. Defaults to ``None``.
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
+        Defaults to 'full'.
     weight_norm : 'unit-noise-gain' | 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
@@ -486,7 +490,7 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
 @verbose
 def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
             freq_bins, subtract_evoked=False, reg=0.05, label=None,
-            pick_ori=None, n_jobs=1, rank=None,
+            pick_ori=None, n_jobs=1, rank='full',
             weight_norm='unit-noise-gain', raw=None, verbose=None):
     """5D time-frequency beamforming based on LCMV.
 
@@ -542,11 +546,15 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     n_jobs : int | str
         Number of jobs to run in parallel.
         Can be 'cuda' if ``cupy`` is installed properly.
-    rank : None | False | int
-        The effective rank of the covariance matrix.
-        If None, the rank will be estimated before regularization is
-        applied. If False, the rank will be estimated after regularization
-        is applied. Defaults to ``None``.
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
+        Defaults to 'full'.
     weight_norm : 'unit-noise-gain' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -127,7 +127,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     """
     picks = _setup_picks(info, forward, data_cov, noise_cov)
 
-    is_free_ori, ch_names, proj, vertno, G = \
+    is_free_ori, ch_names, proj, vertno, G, nn = \
         _prepare_beamformer_input(info, forward, label, picks, pick_ori)
 
     data_cov = pick_channels_cov(data_cov, include=ch_names)
@@ -172,7 +172,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     n_orient = 3 if is_free_ori else 1
     W = _compute_beamformer(G, Cm, reg, n_orient, weight_norm,
                             pick_ori, reduce_rank, rank,
-                            inversion='matrix')
+                            inversion='matrix', nn=nn)
 
     # get src type to store with filters for _make_stc
     src_type = _get_src_type(forward['src'], vertno)
@@ -414,7 +414,7 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
         picks = pick_types(info, meg=True, eeg=True, ref_meg=False,
                            exclude='bads')
 
-    is_free_ori, ch_names, proj, vertno, G =\
+    is_free_ori, ch_names, proj, vertno, G, _ =\
         _prepare_beamformer_input(
             info, forward, label, picks, pick_ori)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -19,12 +19,12 @@ from ..externals import six
 from ._compute_beamformer import (
     _setup_picks, _pick_channels_spatial_filter,
     _check_proj_match, _prepare_beamformer_input, _check_one_ch_type,
-    _compute_beamformer, _check_src_type, Beamformer)
+    _compute_beamformer, _check_src_type, Beamformer, _check_rank)
 
 
 @verbose
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
-              pick_ori=None, rank='full', weight_norm='unit-noise-gain',
+              pick_ori=None, rank='', weight_norm='unit-noise-gain',
               reduce_rank=False, verbose=None):
     """Compute LCMV spatial filter.
 
@@ -68,7 +68,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to 'full'.
+        The default in 0.17 is 'full' and this will change to None in 0.18.
     weight_norm : 'unit-noise-gain' | 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
@@ -129,6 +129,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     picks = _setup_picks(info, forward, data_cov, noise_cov)
+    rank = _check_rank(rank)
 
     is_free_ori, ch_names, proj, vertno, G, nn = \
         _prepare_beamformer_input(info, forward, label, picks, pick_ori)
@@ -493,7 +494,7 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
 @verbose
 def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
             freq_bins, subtract_evoked=False, reg=0.05, label=None,
-            pick_ori=None, n_jobs=1, rank='full',
+            pick_ori=None, n_jobs=1, rank='',
             weight_norm='unit-noise-gain', raw=None, verbose=None):
     """5D time-frequency beamforming based on LCMV.
 
@@ -557,7 +558,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        Defaults to 'full'.
+        The default in 0.17 is 'full' and this will change to None in 0.18.
     weight_norm : 'unit-noise-gain' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
@@ -585,6 +586,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
            brain imaging (2008) Springer Science & Business Media
     """
     _check_reference(epochs)
+    rank = _check_rank(rank)
 
     if pick_ori not in [None, 'normal']:
         raise ValueError('pick_ori must be one of "normal" and None, '

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -24,7 +24,7 @@ from ._compute_beamformer import (
 
 @verbose
 def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
-              pick_ori=None, rank='', weight_norm='unit-noise-gain',
+              pick_ori=None, rank='full', weight_norm='unit-noise-gain',
               reduce_rank=False, verbose=None):
     """Compute LCMV spatial filter.
 
@@ -68,7 +68,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        The default in 0.17 is 'full' and this will change to None in 0.18.
+        The default in ``'full'``.
     weight_norm : 'unit-noise-gain' | 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
@@ -494,7 +494,7 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
 @verbose
 def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
             freq_bins, subtract_evoked=False, reg=0.05, label=None,
-            pick_ori=None, n_jobs=1, rank='',
+            pick_ori=None, n_jobs=1, rank='full',
             weight_norm='unit-noise-gain', raw=None, verbose=None):
     """5D time-frequency beamforming based on LCMV.
 
@@ -558,7 +558,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
         full rank, the rank is estimated before regularization in this case. If
         'full', the rank will be estimated after regularization and hence
         will mean using the full rank, unless ``reg=0`` is used.
-        The default in 0.17 is 'full' and this will change to None in 0.18.
+        The default is ``'full'``.
     weight_norm : 'unit-noise-gain' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
         will be computed (Borgiotti-Kaplan beamformer) [2]_,

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -149,8 +149,9 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
 
     if noise_cov is not None:
         # Handle whitening + data covariance
-        whitener, _, rank = compute_whitener(noise_cov, info, picks, rank=rank,
-                                             return_rank=True)
+        whitener_rank = None if rank == 'full' else rank
+        whitener, _, rank = compute_whitener(
+            noise_cov, info, picks, rank=whitener_rank, return_rank=True)
         # whiten the leadfield
         G = np.dot(whitener, G)
         # whiten data covariance
@@ -429,7 +430,9 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
     # XXX this could maybe use pca=True to avoid needing to use
     # _reg_pinv(..., rank=rank) later
     if noise_cov is not None:
-        whitener, _ = compute_whitener(noise_cov, info, picks, rank=rank)
+        whitener_rank = None if rank == 'full' else rank
+        whitener, _ = compute_whitener(
+            noise_cov, info, picks, rank=whitener_rank)
 
         # whiten the leadfield
         G = np.dot(whitener, G)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -46,7 +46,7 @@ def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2,
         selected active dipoles and their estimated orientation.
         Computed only if return_explained_data is True.
     """
-    is_free_ori, ch_names, proj, vertno, G = _prepare_beamformer_input(
+    is_free_ori, ch_names, proj, vertno, G, _ = _prepare_beamformer_input(
         info, forward, label=None, picks=picks, pick_ori=None)
 
     gain = G.copy()

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -4,7 +4,6 @@
 # License: BSD 3 clause
 
 import copy as cp
-from functools import partial
 import os.path as op
 
 import pytest
@@ -34,12 +33,6 @@ fname_event = op.join(data_path, 'MEG', 'sample',
 subjects_dir = op.join(data_path, 'subjects')
 fname_label = op.join(subjects_dir, 'sample', 'label', 'aparc',
                       'rostralmiddlefrontal-lh.label')
-
-# deal with deprecation
-make_dics_orig = make_dics
-make_dics = partial(make_dics, rank=None)
-tf_dics_orig = tf_dics
-tf_dics = partial(tf_dics, rank=None)
 
 
 def _load_forward():
@@ -128,9 +121,9 @@ def test_make_dics(tmpdir):
     raises(ValueError, make_dics, epochs.info, fwd_fixed, csd,
            pick_ori="notexistent")
     with raises(ValueError, match='rank, if str'):
-        make_dics_orig(epochs.info, fwd_fixed, csd, rank='foo')
+        make_dics(epochs.info, fwd_fixed, csd, rank='foo')
     with raises(TypeError, match='rank must be'):
-        make_dics_orig(epochs.info, fwd_fixed, csd, rank=1.)
+        make_dics(epochs.info, fwd_fixed, csd, rank=1.)
 
     # Test if fixed forward operator is detected when picking normal
     # orientation

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -3,8 +3,9 @@
 #
 # License: BSD 3 clause
 
-import os.path as op
 import copy as cp
+from functools import partial
+import os.path as op
 
 import pytest
 from pytest import raises
@@ -33,6 +34,12 @@ fname_event = op.join(data_path, 'MEG', 'sample',
 subjects_dir = op.join(data_path, 'subjects')
 fname_label = op.join(subjects_dir, 'sample', 'label', 'aparc',
                       'rostralmiddlefrontal-lh.label')
+
+# deal with deprecation
+make_dics_orig = make_dics
+make_dics = partial(make_dics, rank=None)
+tf_dics_orig = tf_dics
+tf_dics = partial(tf_dics, rank=None)
 
 
 def _load_forward():
@@ -120,6 +127,10 @@ def test_make_dics(tmpdir):
 
     raises(ValueError, make_dics, epochs.info, fwd_fixed, csd,
            pick_ori="notexistent")
+    with raises(ValueError, match='rank, if str'):
+        make_dics_orig(epochs.info, fwd_fixed, csd, rank='foo')
+    with raises(TypeError, match='rank must be'):
+        make_dics_orig(epochs.info, fwd_fixed, csd, rank=1.)
 
     # Test if fixed forward operator is detected when picking normal
     # orientation

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -276,7 +276,7 @@ def test_make_lcmv(tmpdir):
                                            bem=sphere, eeg=False, meg=True)
 
     # Test that we get an error if not reducing rank
-    with pytest.raises(ValueError, match='Singular matrix'):
+    with pytest.raises(ValueError):  # Singular matrix or complex spectrum
         make_lcmv_orig(evoked.info, fwd_sphere, data_cov, reg=0.1,
                        noise_cov=noise_cov, weight_norm='unit-noise-gain',
                        pick_ori='max-power', reduce_rank=False, rank='full')

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -15,7 +15,6 @@ from mne.beamformer import (make_lcmv, apply_lcmv, apply_lcmv_epochs,
                             apply_lcmv_raw, tf_lcmv, Beamformer,
                             read_beamformer)
 from mne.beamformer._lcmv import _lcmv_source_power
-from mne.beamformer._compute_beamformer import _reg_pinv, _eig_inv
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.externals.six import advance_iterator
 from mne.simulation import simulate_evoked
@@ -104,15 +103,18 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
 def test_lcmv_vector():
     """Test vector LCMV solutions."""
     info = mne.io.read_raw_fif(fname_raw).info
+
     # For speed and for rank-deficiency calculation simplicity,
-    # just use grads:
+    # just use grads
     info = mne.pick_info(info, mne.pick_types(info, meg='grad', exclude=()))
     info.update(bads=[], projs=[])
+
     forward = mne.read_forward_solution(fname_fwd)
     forward = mne.pick_channels_forward(forward, info['ch_names'])
     vertices = [s['vertno'][::100] for s in forward['src']]
     n_vertices = sum(len(v) for v in vertices)
     assert 5 < n_vertices < 20
+
     amplitude = 100e-9
     stc = mne.SourceEstimate(amplitude * np.eye(n_vertices), vertices,
                              0, 1. / info['sfreq'])
@@ -124,17 +126,17 @@ def test_lcmv_vector():
     evoked = simulate_evoked(forward_sim, stc, info, noise_cov, nave=1)
     source_nn = forward_sim['source_nn']
     source_rr = forward_sim['source_rr']
+
     # Figure out our indices
     mask = np.concatenate([np.in1d(s['vertno'], v)
                            for s, v in zip(forward['src'], vertices)])
     mapping = np.where(mask)[0]
     assert_array_equal(source_rr, forward['source_rr'][mapping])
+
     # Don't check NN because we didn't rotate to surf ori
     del forward_sim
 
-    #
     # Let's do minimum norm as a sanity check (dipole_fit is slower)
-    #
     inv = make_inverse_operator(info, forward, noise_cov, loose=1.)
     stc_vector_mne = apply_inverse(evoked, inv, pick_ori='vector')
     mne_ori = stc_vector_mne.data[mapping, :, np.arange(n_vertices)]
@@ -142,12 +144,11 @@ def test_lcmv_vector():
     mne_angles = np.rad2deg(np.arccos(np.sum(mne_ori * source_nn, axis=-1)))
     assert np.mean(mne_angles) < 35
 
-    #
     # Now let's do LCMV
-    #
     data_cov = mne.make_ad_hoc_cov(info)  # just a stub for later
     with pytest.raises(ValueError, match='pick_ori must be one of'):
         make_lcmv(info, forward, data_cov, 0.05, noise_cov, pick_ori='bad')
+
     lcmv_ori = list()
     for ti in range(n_vertices):
         this_evoked = evoked.copy().crop(evoked.times[ti], evoked.times[ti])
@@ -155,14 +156,16 @@ def test_lcmv_vector():
                             noise_cov['data'])
         vals = linalg.svdvals(data_cov['data'])
         assert vals[0] / vals[-1] < 1e5  # not rank deficient
+
         filters = make_lcmv(info, forward, data_cov, 0.05, noise_cov)
         filters_vector = make_lcmv(info, forward, data_cov, 0.05, noise_cov,
                                    pick_ori='vector')
         stc = apply_lcmv(this_evoked, filters)
-        assert isinstance(stc, mne.SourceEstimate)
         stc_vector = apply_lcmv(this_evoked, filters_vector)
+        assert isinstance(stc, mne.SourceEstimate)
         assert isinstance(stc_vector, mne.VectorSourceEstimate)
         assert_allclose(stc.data, stc_vector.magnitude().data)
+
         # Check the orientation by pooling across some neighbors, as LCMV can
         # have some "holes" at the points of interest
         idx = np.where(cdist(forward['source_rr'], source_rr[[ti]]) < 0.02)[0]
@@ -196,7 +199,7 @@ def test_make_lcmv(tmpdir):
         assert 0.9 < np.max(max_stc) < 3., np.max(max_stc)
 
         if fwd is forward:
-            # Test picking normal orientation (surface source space only)
+            # Test picking normal orientation (surface source space only).
             filters = make_lcmv(evoked.info, forward_surf_ori, data_cov,
                                 reg=0.01, noise_cov=noise_cov,
                                 pick_ori='normal', weight_norm=None)
@@ -211,8 +214,9 @@ def test_make_lcmv(tmpdir):
             assert 0.04 < tmax < 0.13, tmax
             assert 3e-7 < np.max(max_stc) < 5e-7, np.max(max_stc)
 
-            # The amplitude of normal orientation results should always be
-            # smaller than free orientation results
+            # No weight normalization was applied, so the amplitude of normal
+            # orientation results should always be smaller than free
+            # orientation results.
             assert (np.abs(stc_normal.data) <= stc.data).all()
 
         # Test picking source orientation maximizing output source power
@@ -329,21 +333,6 @@ def test_make_lcmv(tmpdir):
     pytest.raises(ValueError, make_lcmv, evoked.info, forward_vol,
                   data_cov=data_cov, reg=0.01, noise_cov=None,
                   pick_ori='max-power')
-
-    # Test if not-yet-implemented orientation selections raise error with
-    # neural activity index
-    pytest.raises(NotImplementedError, make_lcmv, evoked.info,
-                  forward_surf_ori, data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori='normal', weight_norm='nai')
-    pytest.raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
-                  data_cov, reg=0.01, noise_cov=noise_cov, pick_ori=None,
-                  weight_norm='nai')
-
-    # Test if no weight-normalization and max-power source orientation throws
-    # an error
-    pytest.raises(NotImplementedError, make_lcmv, evoked.info, forward_vol,
-                  data_cov, reg=0.01, noise_cov=noise_cov,
-                  pick_ori='max-power', weight_norm=None)
 
     # Test if wrong channel selection is detected in application of filter
     evoked_ch = deepcopy(evoked)
@@ -629,29 +618,6 @@ def test_tf_lcmv():
                        label=label, raw=raw)
 
     assert_array_almost_equal(stcs[0].data, np.zeros_like(stcs[0].data))
-
-
-def test_reg_pinv():
-    """Test regularization and inversion of covariance matrix."""
-    # create rank-deficient array
-    a = np.array([[1., 0., 1.], [0., 1., 0.], [1., 0., 1.]])
-
-    # Test if rank-deficient matrix without regularization throws
-    # specific warning
-    with pytest.warns(RuntimeWarning, match='deficient'):
-        _reg_pinv(a, reg=0.)
-
-
-def test_eig_inv():
-    """Test matrix pseudoinversion with setting smallest eigenvalue to zero."""
-    # create rank-deficient array
-    a = np.array([[1., 0., 1.], [0., 1., 0.], [1., 0., 1.]])
-
-    # test inversion
-    a_inv = np.linalg.pinv(a)
-    a_inv_eig = _eig_inv(a, 2)
-
-    assert_almost_equal(a_inv, a_inv_eig)
 
 
 @testing.requires_testing_data

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from functools import partial
 import os.path as op
 
 import pytest
@@ -34,12 +33,6 @@ fname_event = op.join(data_path, 'MEG', 'sample',
 fname_label = op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-lh.label')
 
 reject = dict(grad=4000e-13, mag=4e-12)
-
-# deal with deprecation
-make_lcmv_orig = make_lcmv
-make_lcmv = partial(make_lcmv, rank=None)
-orig_tf_lcmv = tf_lcmv
-tf_lcmv = partial(tf_lcmv, rank=None)
 
 
 def _read_forward_solution_meg(*args, **kwargs):
@@ -277,9 +270,10 @@ def test_make_lcmv(tmpdir):
 
     # Test that we get an error if not reducing rank
     with pytest.raises(ValueError):  # Singular matrix or complex spectrum
-        make_lcmv_orig(evoked.info, fwd_sphere, data_cov, reg=0.1,
-                       noise_cov=noise_cov, weight_norm='unit-noise-gain',
-                       pick_ori='max-power', reduce_rank=False, rank='full')
+        make_lcmv(
+            evoked.info, fwd_sphere, data_cov, reg=0.1,
+            noise_cov=noise_cov, weight_norm='unit-noise-gain',
+            pick_ori='max-power', reduce_rank=False, rank='full')
 
     # Now let's reduce it
     filters = make_lcmv(evoked.info, fwd_sphere, data_cov, reg=0.1,

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -7,6 +7,7 @@
 from copy import deepcopy
 import itertools as itt
 from math import log
+import operator
 import os
 
 import numpy as np
@@ -1386,7 +1387,7 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
             for ch_type in out_idx_type:
                 ranks_type[ch_type] = rank.get(ch_type, None)
         else:
-            ranks_type['meg'] = int(rank)
+            ranks_type['meg'] = int(operator.index(rank))
 
     for ch_type, this_has in has_type.items():
         if not this_has:

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -934,5 +934,11 @@ def test_reg_pinv():
     assert_array_equal(a_inv_np, a_inv_mne)
     assert estimated_rank == 1
 
+    # Test inverting an all zero cov
+    a_inv, loading_factor, estimated_rank = reg_pinv(np.zeros((3, 3)), reg=2)
+    assert_array_equal(a_inv, 0)
+    assert loading_factor == 0
+    assert estimated_rank == 0
+
 
 run_tests_if_main()

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -19,7 +19,7 @@ from mne.parallel import parallel_func
 from mne.time_frequency import tfr_morlet
 from mne.utils import (set_log_level, set_log_file, _TempDir,
                        get_config, set_config, deprecated, _fetch_file,
-                       sum_squared, estimate_rank, reg_pinv,
+                       sum_squared, estimate_rank, _reg_pinv,
                        _url_to_local_path, sizeof_fmt, _check_subject,
                        _check_type_picks, object_hash, object_diff,
                        requires_good_network, run_tests_if_main, md5sum,
@@ -903,22 +903,22 @@ def test_reg_pinv():
     # Test if rank-deficient matrix without regularization throws
     # specific warning
     with pytest.warns(RuntimeWarning, match='deficient'):
-        reg_pinv(a, reg=0.)
+        _reg_pinv(a, reg=0.)
 
     # Test inversion with explicit rank
     a_inv_np = np.linalg.pinv(a)
-    a_inv_mne, loading_factor, rank = reg_pinv(a, rank=2)
+    a_inv_mne, loading_factor, rank = _reg_pinv(a, rank=2)
     assert loading_factor == 0
     assert rank == 2
     assert_array_equal(a_inv_np, a_inv_mne)
 
     # Test inversion with automatic rank detection
-    a_inv_mne, _, estimated_rank = reg_pinv(a, rank='auto')
+    a_inv_mne, _, estimated_rank = _reg_pinv(a, rank=None)
     assert_array_equal(a_inv_np, a_inv_mne)
     assert estimated_rank == 2
 
     # Test adding regularization
-    a_inv_mne, loading_factor, estimated_rank = reg_pinv(a, reg=2)
+    a_inv_mne, loading_factor, estimated_rank = _reg_pinv(a, reg=2)
     # Since A has a diagonal of all ones, loading_factor should equal the
     # regularization parameter
     assert loading_factor == 2
@@ -930,12 +930,12 @@ def test_reg_pinv():
 
     # Test setting rcond
     a_inv_np = np.linalg.pinv(a, rcond=0.5)
-    a_inv_mne, _, estimated_rank = reg_pinv(a, rcond=0.5)
+    a_inv_mne, _, estimated_rank = _reg_pinv(a, rcond=0.5)
     assert_array_equal(a_inv_np, a_inv_mne)
     assert estimated_rank == 1
 
     # Test inverting an all zero cov
-    a_inv, loading_factor, estimated_rank = reg_pinv(np.zeros((3, 3)), reg=2)
+    a_inv, loading_factor, estimated_rank = _reg_pinv(np.zeros((3, 3)), reg=2)
     assert_array_equal(a_inv, 0)
     assert loading_factor == 0
     assert estimated_rank == 0

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -646,11 +646,11 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     loading_factor : float
         Value added to the diagonal of the matrix during regularization.
     rank : int
-        If ``rank`` was set to an integer value, this value is returned.
-        If ``rank=None`` or ``rank=False``, the estimated rank of the matrix,
-        before regularization, is returned.
+        If ``rank`` was set to an integer value, this value is returned,
+        else the estimated rank of the matrix, before regularization, is
+        returned.
     """
-    if rank is not None and rank is not False:
+    if rank is not None and rank != 'full':
         rank = int(operator.index(rank))
     if x.ndim != 2 or x.shape[0] != x.shape[1]:
         raise ValueError('Input matrix must be square.')
@@ -674,7 +674,7 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
 
     # Warn the user if both all parameters were kept at their defaults and the
     # matrix is rank deficient.
-    if rank_after < len(x) and reg == 0 and rank is False and rcond == 1e-15:
+    if rank_after < len(x) and reg == 0 and rank == 'full' and rcond == 1e-15:
         warn('Covariance matrix is rank-deficient and no regularization is '
              'done.')
     elif isinstance(rank, int) and rank > len(x):
@@ -685,7 +685,7 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     # Pick the requested number of singular values
     if rank is None:
         sel_s = s[:rank_before]
-    elif rank is False:
+    elif rank == 'full':
         sel_s = s[:rank_after]
     else:
         sel_s = s[:rank]
@@ -699,7 +699,7 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     # Compute the pseudo inverse
     x_inv = np.dot(V.T, s_inv[:, np.newaxis] * U.T)
 
-    if rank is None or rank is False:
+    if rank is None or rank == 'full':
         return x_inv, loading_factor, rank_before
     else:
         return x_inv, loading_factor, rank

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -605,7 +605,7 @@ def _compute_row_norms(data):
     return norms
 
 
-def _reg_pinv(x, reg=0, rank=False, rcond=1e-15):
+def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     """Compute a regularized pseudoinverse of a square matrix.
 
     Regularization is performed by adding a constant value to each diagonal
@@ -624,14 +624,15 @@ def _reg_pinv(x, reg=0, rank=False, rcond=1e-15):
         Square matrix to invert.
     reg : float
         Regularization parameter. Defaults to 0.
-    rank : None | False | int
-        Estimated rank of the matrix. This determines the number of singular
-        values used to compute the pseudo-inverse. When set to None, the rank
-        is estimated on the non-regularized matrix using the ``rcond`` cutoff
-        for small singular values. When set to False, the behavior of
-        :func:`numpy.linalg.pinv` is mimicked: the rank is estimated on the
-        regularized matrix using the ``rcond`` cutoff for small singular
-        values. Defaults to False.
+    rank : int | None | 'full'
+        This controls the effective rank of the covariance matrix when
+        computing the inverse. The rank can be set explicitly by specifying an
+        integer value. If ``None``, the rank will be automatically estimated.
+        Since applying regularization will always make the covariance matrix
+        full rank, the rank is estimated before regularization in this case. If
+        'full', the rank will be estimated after regularization and hence
+        will mean using the full rank, unless ``reg=0`` is used.
+        Defaults to 'full'.
     rcond : float | 'auto'
         Cutoff for detecting small singular values when attempting to estimate
         the rank of the matrix (``rank='auto'``). Singular values smaller than

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -679,15 +679,21 @@ def reg_pinv(x, reg=0, rank=None, rcond=1e-15):
                          'the shape of the input matrix (%d x %d).' %
                          (rank, x.shape[0], x.shape[1]))
 
-    # Pseudo-inverse is computed by only using the requested number of singular
-    # values
-    s_inv = np.zeros(s.shape)
+    # Pick the requested number of singular values
     if rank == 'auto':
-        s_inv[:rank_before] = 1. / s[:rank_before]
+        sel_s = s[:rank_before]
     elif rank is None:
-        s_inv[:rank_after] = 1. / s[:rank_after]
+        sel_s = s[:rank_after]
     else:
-        s_inv[:rank] = 1. / s[:rank]
+        sel_s = s[:rank]
+
+    # Invert only non-zero singular values
+    s_inv = np.zeros(s.shape)
+    nonzero_inds = np.flatnonzero(sel_s != 0)
+    if len(nonzero_inds) > 0:
+        s_inv[nonzero_inds] = 1. / sel_s[nonzero_inds]
+
+    # Compute the pseudo inverse
     x_inv = np.dot(V.T, s_inv[:, np.newaxis] * U.T)
 
     if rank == 'auto' or rank is None:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -537,7 +537,7 @@ def estimate_rank(data, tol='auto', return_singular=False, norm=True):
     ----------
     data : array
         Data to estimate the rank of (should be 2-dimensional).
-    tol : float | str
+    tol : float | 'auto'
         Tolerance for singular values to consider non-zero in
         calculating the rank. The singular values are calculated
         in this method such that independent data are expected to
@@ -563,17 +563,39 @@ def estimate_rank(data, tol='auto', return_singular=False, norm=True):
         norms = _compute_row_norms(data)
         data /= norms[:, np.newaxis]
     s = linalg.svd(data, compute_uv=False, overwrite_a=True)
-    if isinstance(tol, string_types):
-        if tol != 'auto':
-            raise ValueError('tol must be "auto" or float')
-        eps = np.finfo(float).eps
-        tol = np.max(data.shape) * np.amax(s) * eps
-    tol = float(tol)
-    rank = np.sum(s > tol)
+    rank = _estimate_rank_from_s(s, tol)
     if return_singular is True:
         return rank, s
     else:
         return rank
+
+
+def _estimate_rank_from_s(s, tol='auto'):
+    """Estimate the rank of a matrix from its singular values.
+
+    Parameters
+    ----------
+    s : list of float
+        The singular values of the matrix.
+    tol : float | 'auto'
+        Tolerance for singular values to consider non-zero in calculating the
+        rank. Can be 'auto' to use the same thresholding as
+        ``scipy.linalg.orth``.
+
+    Returns
+    -------
+    rank : int
+        The estimated rank.
+    """
+    if isinstance(tol, string_types):
+        if tol != 'auto':
+            raise ValueError('tol must be "auto" or float')
+        eps = np.finfo(float).eps
+        tol = len(s) * np.amax(s) * eps
+
+    tol = float(tol)
+    rank = np.sum(s > tol)
+    return rank
 
 
 def _compute_row_norms(data):
@@ -581,6 +603,97 @@ def _compute_row_norms(data):
     norms = np.sqrt(np.sum(data ** 2, axis=1))
     norms[norms == 0] = 1.0
     return norms
+
+
+def reg_pinv(x, reg=0, rank=None, rcond=1e-15):
+    """Compute a regularized pseudoinverse of a square matrix.
+
+    Regularization is performed by adding a constant value to each diagonal
+    element of the matrix before inversion. This is known as "diagonal
+    loading". The loading factor is computed as ``reg * np.trace(x) / len(x)``.
+
+    The pseudo-inverse is computed through SVD decomposition and inverting the
+    singular values. When the matrix is rank deficient, some singular values
+    will be close to zero and will not be used during the inversion. The number
+    of singular values to use can either be manually specified or automatically
+    estimated.
+
+    Parameters
+    ----------
+    x : ndarray, shape (n, n)
+        Square matrix to invert.
+    reg : float
+        Regularization parameter. Defaults to 0.
+    rank : int | 'auto' | None
+        Estimated rank of the matrix. This determines the number of singular
+        values used to compute the pseudo-inverse. When set to 'auto', the rank
+        is estimated on the non-regularized matrix using the ``rcond`` cutoff
+        for small singular values. When set to ``None``, the behavior of
+        ``numpy.linalg.pinv`` is mimicked: the rank is estimated on the
+        regularized matrix using the ``rcond`` cutoff for small singular
+        values. Defaults to ``None``.
+    rcond : float | 'auto'
+        Cutoff for detecting small singular values when attempting to estimate
+        the rank of the matrix (``rank='auto'``). Singular values smaller than
+        the cutoff are set to zero. When set to 'auto', a cutoff based on
+        floating point precision will be used. Defaults to 1e-15.
+
+    Returns
+    -------
+    x_inv : ndarray, shape (n, n)
+        The inverted matrix.
+    loading_factor : float
+        Value added to the diagonal of the matrix during regularization.
+    rank : int
+        If ``rank`` was set to an integer value, this value is returned.
+        If ``rank='auto'`` or ``rank=None``, the estimated rank of the matrix,
+        before regularization, is returned.
+    """
+    if x.ndim != 2 or x.shape[0] != x.shape[1]:
+        raise ValueError('Input matrix must be square.')
+    if not np.allclose(x, x.conj().T):
+        raise ValueError('Input matrix must be Hermitian (symmetric)')
+
+    # Decompose the matrix
+    U, s, V = linalg.svd(x)
+
+    # Estimate the rank before regularization
+    tol = 'auto' if rcond == 'auto' else rcond * s.max()
+    rank_before = _estimate_rank_from_s(s, tol)
+
+    # Decompose the matrix again after regularization
+    loading_factor = reg * np.mean(s)
+    U, s, V = linalg.svd(x + loading_factor * np.eye(len(x)))
+
+    # Estimate the rank after regularization
+    tol = 'auto' if rcond == 'auto' else rcond * s.max()
+    rank_after = _estimate_rank_from_s(s, tol)
+
+    # Warn the user if both all parameters were kept at their defaults and the
+    # matrix is rank deficient.
+    if rank_after < len(x) and reg == 0 and rank is None and rcond == 1e-15:
+        warn('Covariance matrix is rank-deficient and no regularization is '
+             'done.')
+    elif _is_numeric(rank) and rank > len(x):
+        raise ValueError('Invalid value for the rank parameter (%d) given '
+                         'the shape of the input matrix (%d x %d).' %
+                         (rank, x.shape[0], x.shape[1]))
+
+    # Pseudo-inverse is computed by only using the requested number of singular
+    # values
+    s_inv = np.zeros(s.shape)
+    if rank == 'auto':
+        s_inv[:rank_before] = 1. / s[:rank_before]
+    elif rank is None:
+        s_inv[:rank_after] = 1. / s[:rank_after]
+    else:
+        s_inv[:rank] = 1. / s[:rank]
+    x_inv = np.dot(V.T, s_inv[:, np.newaxis] * U.T)
+
+    if rank == 'auto' or rank is None:
+        return x_inv, loading_factor, rank_before
+    else:
+        return x_inv, loading_factor, rank
 
 
 def _reject_data_segments(data, reject, flat, decim, info, tstep):

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -268,7 +268,7 @@ filters_approach1 = make_dics(
 print(filters_approach1)
 
 filters_approach2 = make_dics(
-    info, fwd, csd_signal, reg=0.05, pick_ori='max-power', normalize_fwd=False,
+    info, fwd, csd_signal, reg=0.1, pick_ori='max-power', normalize_fwd=False,
     inversion='matrix', weight_norm='unit-noise-gain')
 print(filters_approach2)
 

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -7,7 +7,7 @@ In this tutorial, we'll simulate two signals originating from two
 locations on the cortex. These signals will be sinusoids, so we'll be looking
 at oscillatory activity (as opposed to evoked activity).
 
-We'll be using dynamic imaging of coherent sources (DICS) [1]_ to map out
+We'll use dynamic imaging of coherent sources (DICS) [1]_ to map out
 spectral power along the cortex. Let's see if we can find our two simulated
 sources.
 """
@@ -264,12 +264,12 @@ csd_signal = csd_morlet(epochs['signal'], frequencies=[10])
 # Compute the spatial filters for each vertex, using two approaches.
 filters_approach1 = make_dics(
     info, fwd, csd_signal, reg=0.05, pick_ori='max-power', normalize_fwd=True,
-    inversion='single', weight_norm=None, rank=None)
+    inversion='single', weight_norm=None)
 print(filters_approach1)
 
 filters_approach2 = make_dics(
     info, fwd, csd_signal, reg=0.1, pick_ori='max-power', normalize_fwd=False,
-    inversion='matrix', weight_norm='unit-noise-gain', rank=None)
+    inversion='matrix', weight_norm='unit-noise-gain')
 print(filters_approach2)
 
 # You can save these to disk with:

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -3,8 +3,8 @@
 DICS for power mapping
 ======================
 
-In this tutorial, we're going to simulate two signals originating from two
-locations on the cortex. These signals will be sine waves, so we'll be looking
+In this tutorial, we'll simulate two signals originating from two
+locations on the cortex. These signals will be sinusoids, so we'll be looking
 at oscillatory activity (as opposed to evoked activity).
 
 We'll be using dynamic imaging of coherent sources (DICS) [1]_ to map out

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -264,12 +264,12 @@ csd_signal = csd_morlet(epochs['signal'], frequencies=[10])
 # Compute the spatial filters for each vertex, using two approaches.
 filters_approach1 = make_dics(
     info, fwd, csd_signal, reg=0.05, pick_ori='max-power', normalize_fwd=True,
-    inversion='single', weight_norm=None)
+    inversion='single', weight_norm=None, rank=None)
 print(filters_approach1)
 
 filters_approach2 = make_dics(
     info, fwd, csd_signal, reg=0.1, pick_ori='max-power', normalize_fwd=False,
-    inversion='matrix', weight_norm='unit-noise-gain')
+    inversion='matrix', weight_norm='unit-noise-gain', rank=None)
 print(filters_approach2)
 
 # You can save these to disk with:


### PR DESCRIPTION
This PR gives the `_create_beamformer` another refactoring pass to unify the LCMV and DICS flow. 

Bugs fixed:

 - LCMV beamformer when `pick_ori='normal', weight_norm='unit_noise_gain'`. The existing implementation has a bug where the weights were first normalized to have unit length *before* picking the normal direction. Instead, the weights should be normalized to unit length *after* picking the orientation, as is the case when `pick_ori='max-power'`.
 - DICS beamformer when `inversion='single', pick_ori='max-power', weight_norm='unit_noise_gain'`. The computation of the power (in order to pick the orientation with max power) was bugged.
 - DICS beamformer when `inversion='matrix', pick_ori='max-power', weight_norm='unit_noise_gain'`. In this case, a computational shortcut is performed, but it was performed incorrectly. See [this comment](https://github.com/mne-tools/mne-python/pull/5135/files#r200652209).

New features:

 - New fancy `reg_pinv` function, which now lives in `utils.py` and will even walk your dog.
 - No more branching between `method='lcmv'` and `method='dics'`.
 - The sign of the max power orientation is now always aligned with the sign of the surface normal (tnx @larsoner)

New features we got for free in the process:

 - `pick_ori='max-power'` now also supported when `weight_norm=None`
 - `weight_norm='nai'` now also supported when `pick_ori=None` and `pick_ori='normal'`
 - `weight_norm='nai'` now also supported for the DICS beamformer
 - `rank` parameter for the DICS beamformer to explicitly specify rank
 - `rank='auto'` setting to do rank-based inversion as in #5362 (DICS already did this)

In all other cases, the new version gives exactly the same output as the version in the current master branch:

### LCMV
pick_ori    | weight_norm       | new == old?
------------|-------------------|------------
None        | None              | True
None        | 'unit-noise-gain' | True
None        | 'nai'             | Not available in old
'normal'    | None              | True
'normal'    | 'unit-noise-gain' | True
'normal'    | 'nai'             | Not available in old
'max-power' | None              | Not available in old
'max-power' | 'unit-noise-gain' | True
'max-power' | 'nai'             | True

### DICS
pick_ori    | weight_norm       | inversion | new == old?
------------|-------------------|-----------|------------
None | None | 'single' | True
None | None | 'matrix' | True
None | 'unit-noise-gain' | 'single' | True
None | 'unit-noise-gain' | 'matrix' | True
None | 'nai' | 'single' | Not available in old
None | 'nai' | 'matrix' | Not available in old
'normal' | None | 'single' | True
'normal' | None | 'matrix' | True
'normal' | 'unit-noise-gain' | 'single' | True
'normal' | 'unit-noise-gain' | 'matrix' | True
'normal' | 'nai' | 'single' | Not available in old
'normal' | 'nai' | 'matrix' | Not available in old
'max-power' | None | 'single' | True
'max-power' | None | 'matrix' | True
'max-power' | 'unit-noise-gain' | 'single' | **False**
'max-power' | 'unit-noise-gain' | 'matrix' | **False**
'max-power' | 'nai' | 'single' | Not available in old
'max-power' | 'nai' | 'matrix' | Not available in old




