### PR TITLE
MRG: Use cupy instead of pycuda+skcuda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,9 +92,8 @@ For full functionality, some functions require:
 - Picard >= 0.3
 
 To use `NVIDIA CUDA <https://developer.nvidia.com/cuda-zone>`_ for resampling
-and FFT FIR filtering, you will also need to install the NVIDIA CUDA SDK,
-pycuda, and scikit-cuda (see the `getting started page`_
-for more information).
+and FFT FIR filtering, you will also need to install the NVIDIA CUDA SDK
+and ``cupy`` (see the `getting started page`_ for more information).
 
 
 Contributing to MNE-Python

--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,7 @@ For full functionality, some functions require:
 - NiBabel >= 2.1.0
 - Pandas >= 0.13
 - Picard >= 0.3
-
-To use `NVIDIA CUDA <https://developer.nvidia.com/cuda-zone>`_ for resampling
-and FFT FIR filtering, you will also need to install the NVIDIA CUDA SDK
-and ``cupy`` (see the `getting started page`_ for more information).
+- CuPy >= 4.0 (for NVIDIA CUDA acceleration)
 
 
 Contributing to MNE-Python

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -68,7 +68,7 @@ on your operating system, and then do:
     $ MNE_USE_CUDA=true python -c "import mne; mne.cuda.init_cuda(verbose=True)"
     Enabling CUDA with 1.55 GB available memory
 
-If you receieve a message reporting the GPU's available memory, CuPy_
+If you receive a message reporting the GPU's available memory, CuPy_
 is woriking properly. To permanently enable CUDA in MNE, you can do::
 
     >>> mne.utils.set_config('MNE_USE_CUDA', 'true') # doctest: +SKIP

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -56,42 +56,34 @@ If you plan to contribute to MNE, please continue reading how to
 CUDA (NVIDIA GPU acceleration)
 ##############################
 
-We have developed specialized routines to make use of
-`NVIDIA CUDA GPU processing <http://www.nvidia.com/object/cuda_home_new.html>`_
-to speed up some operations (e.g. FIR filtering) by up to 10x.
-If you want to use NVIDIA CUDA, you should ensure that you are running the
-NVIDIA proprietary drivers, and then do the following (assuming you are using
-``conda`` as your Python environment):
-
-.. code-block: console
-
-    $ conda install cupy
-
-To initialize and test mne-python cuda support, after installing cupy_
-you can run the following, which should give you an INFO-level log
-message telling you your CUDA hardware's available memory:
+Some routines can utilize
+`NVIDIA CUDA GPU processing <https://developer.nvidia.com/cuda-zone>`_
+to speed up some operations (e.g. FIR filtering) by roughly an order of magnitude.
+To use CUDA, first  ensure that you are running the NVIDIA proprietary drivers
+on your operating system, and then do:
 
 .. code-block:: console
 
+    $ conda install cupy
     $ MNE_USE_CUDA=true python -c "import mne; mne.cuda.init_cuda(verbose=True)"
     Enabling CUDA with 1.55 GB available memory
 
-To have CUDA initialized automatically when necessary by MNE, you can do::
+If you receieve a message reporting the GPU's available memory, ``cupy``
+is woriking properly. To permanently enable CUDA in MNE, you can do::
 
     >>> mne.utils.set_config('MNE_USE_CUDA', 'true') # doctest: +SKIP
 
-You can test if MNE CUDA support is working by running the associated test:
+You can then test MNE CUDA support by running the associated test:
 
 .. code-block:: console
 
-    $ pytest mne/tests/test_filter.py
+    $ pytest mne/tests/test_filter.py -k cuda
 
-If ``MNE_USE_CUDA=true`` and all tests pass with none skipped due to missing
-CUDA, then MNE-Python CUDA support works.
-
-To use CUDA, look for functions and methods that state that tehy allow
-passing ``n_jobs='cuda'``, such as :meth:`mne.io.Raw.filter` and
-:meth:`mne.io.Raw.resample`.
+If the tests pass, then CUDA should work in MNE. You can use CUDA in methods
+that state that they allow passing ``n_jobs='cuda'``, such as
+:meth:`mne.io.Raw.filter` and :meth:`mne.io.Raw.resample`,
+and they should run faster than the CPU-based multithreading such as
+``n_jobs=8``.
 
 IPython / Jupyter notebooks
 ###########################

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -59,44 +59,24 @@ CUDA (NVIDIA GPU acceleration)
 We have developed specialized routines to make use of
 `NVIDIA CUDA GPU processing <http://www.nvidia.com/object/cuda_home_new.html>`_
 to speed up some operations (e.g. FIR filtering) by up to 10x.
-If you want to use NVIDIA CUDA, you should install:
+If you want to use NVIDIA CUDA, you should ensure that you are running the
+NVIDIA proprietary drivers, and then do the following (assuming you are using
+``conda`` as your Python environment):
 
-1. `the NVIDIA toolkit on your system <https://developer.nvidia.com/cuda-downloads>`_
-2. `PyCUDA <http://wiki.tiker.net/PyCuda/Installation/>`_
-3. `skcuda <https://github.com/lebedov/scikits.cuda>`_
+.. code-block: console
 
-For example, on Ubuntu 15.10, a combination of system packages and ``git``
-packages can be used to install the CUDA stack:
+    $ conda install cupy
 
-.. code-block:: console
-
-    # install system packages for CUDA
-    $ sudo apt-get install nvidia-cuda-dev nvidia-modprobe
-    # install PyCUDA
-    $ git clone http://git.tiker.net/trees/pycuda.git
-    $ cd pycuda
-    $ ./configure.py --cuda-enable-gl
-    $ git submodule update --init
-    $ make -j 4
-    $ python setup.py install
-    # install skcuda
-    $ cd ..
-    $ git clone https://github.com/lebedov/scikit-cuda.git
-    $ cd scikit-cuda
-    $ python setup.py install
-
-To initialize mne-python cuda support, after installing these dependencies
-and running their associated unit tests (to ensure your installation is correct)
-you can run:
+To initialize and test mne-python cuda support, after installing cupy_
+you can run the following, which should give you an INFO-level log
+message telling you your CUDA hardware's available memory:
 
 .. code-block:: console
 
-    $ MNE_USE_CUDA=true MNE_LOGGING_LEVEL=info python -c "import mne; mne.cuda.init_cuda()"
+    $ MNE_USE_CUDA=true python -c "import mne; mne.cuda.init_cuda(verbose=True)"
     Enabling CUDA with 1.55 GB available memory
 
-If you have everything installed correctly, you should see an INFO-level log
-message telling you your CUDA hardware's available memory. To have CUDA
-initialized on startup, you can do::
+To have CUDA initialized automatically when necessary by MNE, you can do::
 
     >>> mne.utils.set_config('MNE_USE_CUDA', 'true') # doctest: +SKIP
 
@@ -106,8 +86,12 @@ You can test if MNE CUDA support is working by running the associated test:
 
     $ pytest mne/tests/test_filter.py
 
-If ``MNE_USE_CUDA=true`` and all tests pass with none skipped, then
-MNE-Python CUDA support works.
+If ``MNE_USE_CUDA=true`` and all tests pass with none skipped due to missing
+CUDA, then MNE-Python CUDA support works.
+
+To use CUDA, look for functions and methods that state that tehy allow
+passing ``n_jobs='cuda'``, such as :meth:`mne.io.Raw.filter` and
+:meth:`mne.io.Raw.resample`.
 
 IPython / Jupyter notebooks
 ###########################

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -68,7 +68,7 @@ on your operating system, and then do:
     $ MNE_USE_CUDA=true python -c "import mne; mne.cuda.init_cuda(verbose=True)"
     Enabling CUDA with 1.55 GB available memory
 
-If you receieve a message reporting the GPU's available memory, ``cupy``
+If you receieve a message reporting the GPU's available memory, CuPy_
 is woriking properly. To permanently enable CUDA in MNE, you can do::
 
     >>> mne.utils.set_config('MNE_USE_CUDA', 'true') # doctest: +SKIP

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -93,8 +93,7 @@ all default dependencies are installed by listing their versions with::
     sklearn:       0.19.1
     nibabel:       2.3.0
     mayavi:        4.6.1 {qt_api=pyqt5}
-    pycuda:        Not found
-    skcuda:        Not found
+    cupy:          Not found
     pandas:        0.23.4
 
 

--- a/doc/known_projects.inc
+++ b/doc/known_projects.inc
@@ -59,5 +59,5 @@
 .. pymatreader
 .. _pymatreader: https://gitlab.com/obob/pymatreader
 
-.. cupy
-.. _cupy: https://cupy.chainer.org/
+.. CuPy
+.. _CuPy: https://cupy.chainer.org/

--- a/doc/known_projects.inc
+++ b/doc/known_projects.inc
@@ -58,3 +58,6 @@
 
 .. pymatreader
 .. _pymatreader: https://gitlab.com/obob/pymatreader
+
+.. cupy
+.. _cupy: https://cupy.chainer.org/

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1089,4 +1089,5 @@ Logging and Configuration
    :toctree: generated/
    :template: function.rst
 
+   get_cuda_memory
    init_cuda

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -105,7 +105,7 @@ API
 
 - Prepare transition to Python 3. This release will be the last release compatible with Python 2. The next version will be Python 3 only.
 
-- CUDA support now relies on cupy_ instead of ``PyCUDA`` and ``scikits-cuda``. It can be installed using ``conda install cupy``. By `Eric Larson`_
+- CUDA support now relies on CuPy_ instead of ``PyCUDA`` and ``scikits-cuda``. It can be installed using ``conda install cupy``. By `Eric Larson`_
 
 - Functions requiring a color cycle will now default to Matplotlib rcParams colors, by `Stefan Appelhoff`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -105,6 +105,8 @@ API
 
 - Prepare transition to Python 3. This release will be the last release compatible with Python 2. The next version will be Python 3 only.
 
+- CUDA support now relies on cupy_ instead of ``PyCUDA`` and ``scikits-cuda``. It can be installed using ``conda install cupy``. By `Eric Larson`_
+
 - Functions requiring a color cycle will now default to Matplotlib rcParams colors, by `Stefan Appelhoff`_
 
 - :meth:`mne.Evoked.plot_image` has gained the ability to ``show_names``, and if a selection is provided to ``group_by``, ``axes`` can now receive a `dict`, by `Jona Sassenhagen`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,7 +66,7 @@ Bug
 
 - Fix bug with IIR filtering axis in :func:`mne.filter.filter_data` by `Eric Larson`_
 
-- Fix bug with non-boxcar windows in :meth:`mne.Raw.resample` and :func:`mne.filter.resample` by `Eric Larson`_
+- Fix bug with non-boxcar windows in :meth:`mne.io.Raw.resample` and :func:`mne.filter.resample` by `Eric Larson`_
 
 - Fix bug in :func:`mne.minimum_norm.apply_inverse` where applying an MEG-only inverse would raise an error about needing an average EEG reference by `Eric Larson`_
 
@@ -88,7 +88,7 @@ Bug
 
 - Fix bug in :func:`mne.make_sphere_model` where EEG sphere model coefficients were not optimized properly by `Eric Larson`_
 
-- Fix bug in :func:`mne.io.ctf.read_raw_ctf` to read bad channels and segments from CTF ds files by `Luke Bloy`_
+- Fix bug in :func:`mne.io.read_raw_ctf` to read bad channels and segments from CTF ds files by `Luke Bloy`_
 
 - Fix problem with :meth:`mne.io.Raw.add_channels` where ``raw.info['bads']`` was replicated by `Eric Larson`_
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -529,8 +529,8 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
         free orientation, a vector beamformer is computed, combining the output
         for all source orientations.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly and CUDA is initialized.
+        Number of jobs to run in parallel.
+        Can be 'cuda' if ``cupy`` is installed properly.
     rank : None | int | dict
         Specified rank of the noise covariance matrix. If None, the rank is
         detected automatically. If int, the rank is specified for the MEG

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -8,7 +8,6 @@ from .utils import (sizeof_fmt, logger, get_config, warn, _explain_exception,
                     verbose)
 
 
-# Support CUDA for FFTs; requires scikits.cuda and pycuda
 _cuda_capable = False
 
 
@@ -62,7 +61,7 @@ def init_cuda(ignore_config=False, verbose=True):
         warn('module cupy not found, CUDA not enabled')
         return
     try:
-        # Initialize CUDA; happens with importing autoinit
+        # Initialize CUDA
         cupy.cuda.Device()
     except Exception:
         warn('so CUDA device could be initialized, likely a hardware error, '

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -12,20 +12,25 @@ from .utils import (sizeof_fmt, logger, get_config, warn, _explain_exception,
 _cuda_capable = False
 
 
-def get_cuda_memory():
+def get_cuda_memory(kind='available'):
     """Get the amount of free memory for CUDA operations.
+
+    Parameters
+    ----------
+    kind : str
+        Can be "available" or "total".
 
     Returns
     -------
     memory : str
-        The amount of available memory as a human-readable string.
+        The amount of available or total memory as a human-readable string.
     """
     if not _cuda_capable:
         warn('CUDA not enabled, returning zero for memory')
         mem = 0
     else:
         import cupy
-        mem = cupy.get_default_memory_pool().total_bytes()
+        mem = cupy.cuda.runtime.memGetInfo()[dict(available=0, total=1)[kind]]
     return sizeof_fmt(mem)
 
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -34,7 +34,7 @@ def get_cuda_memory(kind='available'):
 
 
 @verbose
-def init_cuda(ignore_config=False, verbose=True):
+def init_cuda(ignore_config=False, verbose=None):
     """Initialize CUDA functionality.
 
     This function attempts to load the necessary interfaces
@@ -45,6 +45,15 @@ def init_cuda(ignore_config=False, verbose=True):
     MNE_USE_CUDA == 'true', this function will be executed when
     the first CUDA setup is performed. If this variable is not
     set, this function can be manually executed.
+
+    Parameters
+    ----------
+    ignore_config : bool
+        If True, ignore the config value MNE_USE_CUDA and force init.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+        self.verbose.
     """
     global _cuda_capable
     if _cuda_capable:

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -3,26 +3,13 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from numpy.fft import rfft, irfft
 
-from .utils import sizeof_fmt, logger, get_config, warn, _explain_exception
+from .utils import (sizeof_fmt, logger, get_config, warn, _explain_exception,
+                    verbose)
 
 
 # Support CUDA for FFTs; requires scikits.cuda and pycuda
 _cuda_capable = False
-_multiply_inplace_c128 = _halve_c128 = _double_c128 = None
-
-
-def _get_cudafft():
-    """Deal with scikit-cuda namespace change."""
-    try:
-        from skcuda import fft
-    except ImportError:
-        try:
-            from scikits.cuda import fft
-        except ImportError:
-            fft = None
-    return fft
 
 
 def get_cuda_memory():
@@ -37,12 +24,13 @@ def get_cuda_memory():
         warn('CUDA not enabled, returning zero for memory')
         mem = 0
     else:
-        from pycuda.driver import mem_get_info
-        mem = mem_get_info()[0]
+        import cupy
+        mem = cupy.get_default_memory_pool().total_bytes()
     return sizeof_fmt(mem)
 
 
-def init_cuda(ignore_config=False):
+@verbose
+def init_cuda(ignore_config=False, verbose=True):
     """Initialize CUDA functionality.
 
     This function attempts to load the necessary interfaces
@@ -54,7 +42,7 @@ def init_cuda(ignore_config=False):
     the first CUDA setup is performed. If this variable is not
     set, this function can be manually executed.
     """
-    global _cuda_capable, _multiply_inplace_c128, _halve_c128, _double_c128
+    global _cuda_capable
     if _cuda_capable:
         return
     if not ignore_config and (get_config('MNE_USE_CUDA', 'false').lower() !=
@@ -64,40 +52,18 @@ def init_cuda(ignore_config=False):
     # Triage possible errors for informative messaging
     _cuda_capable = False
     try:
-        from pycuda import gpuarray, driver  # noqa: F401, analysis:ignore
-        from pycuda.elementwise import ElementwiseKernel
+        import cupy
     except ImportError:
-        warn('module pycuda not found, CUDA not enabled')
+        warn('module cupy not found, CUDA not enabled')
         return
     try:
         # Initialize CUDA; happens with importing autoinit
-        import pycuda.autoinit  # noqa: F401, analysis:ignore
-    except ImportError:
-        warn('pycuda.autoinit could not be imported, likely a hardware error, '
+        cupy.cuda.Device()
+    except Exception:
+        warn('so CUDA device could be initialized, likely a hardware error, '
              'CUDA not enabled%s' % _explain_exception())
         return
-    # Make sure scikit-cuda is installed
-    cudafft = _get_cudafft()
-    if cudafft is None:
-        warn('module scikit-cuda not found, CUDA not enabled')
-        return
 
-    # let's construct our own CUDA multiply in-place function
-    _multiply_inplace_c128 = ElementwiseKernel(
-        'pycuda::complex<double> *a, pycuda::complex<double> *b',
-        'b[i] *= a[i]', 'multiply_inplace')
-    _halve_c128 = ElementwiseKernel(
-        'pycuda::complex<double> *a', 'a[i] /= 2.0', 'halve_value')
-    _double_c128 = ElementwiseKernel(
-        'pycuda::complex<double> *a', 'a[i] *= 2.0', 'double_value')
-
-    # Make sure we can use 64-bit FFTs
-    try:
-        cudafft.Plan(16, np.float64, np.complex128)  # will get auto-GC'ed
-    except Exception:
-        warn('Device does not appear to support 64-bit FFTs, CUDA not '
-             'enabled%s' % _explain_exception())
-        return
     _cuda_capable = True
     # Figure out limit for CUDA FFT calculations
     logger.info('Enabling CUDA with %s available memory' % get_cuda_memory())
@@ -106,7 +72,7 @@ def init_cuda(ignore_config=False):
 ###############################################################################
 # Repeated FFT multiplication
 
-def setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
+def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
     """Set up repeated CUDA FFT multiplication with a given filter.
 
     Parameters
@@ -144,38 +110,31 @@ def setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
     -----
     This function is designed to be used with fft_multiply_repeated().
     """
-    cuda_dict = dict(use_cuda=False, fft_plan=None, ifft_plan=None,
-                     x_fft=None, x=None)
-    h_fft = rfft(h, n=n_fft)
+    cuda_dict = dict(n_fft=n_fft, rfft=np.fft.rfft, irfft=np.fft.irfft,
+                     h_fft=np.fft.rfft(h, n=n_fft))
     if n_jobs == 'cuda':
         n_jobs = 1
         init_cuda()
         if _cuda_capable:
-            from pycuda import gpuarray
-            cudafft = _get_cudafft()
-            # set up all arrays necessary for CUDA
-            # try setting up for float64
+            import cupy
             try:
                 # do the IFFT normalization now so we don't have to later
-                h_fft = gpuarray.to_gpu(h_fft.astype('complex_') / n_fft)
-                cuda_dict.update(
-                    use_cuda=True,
-                    fft_plan=cudafft.Plan(n_fft, np.float64, np.complex128),
-                    ifft_plan=cudafft.Plan(n_fft, np.complex128, np.float64),
-                    x_fft=gpuarray.empty(len(h_fft), np.complex128),
-                    x=gpuarray.empty(n_fft, np.float64))
+                h_fft = cupy.array(cuda_dict['h_fft'])
                 logger.info('Using CUDA for FFT FIR filtering')
             except Exception as exp:
                 logger.info('CUDA not used, could not instantiate memory '
                             '(arrays may be too large: "%s"), falling back to '
                             'n_jobs=1' % str(exp))
+            cuda_dict.update(h_fft=h_fft,
+                             rfft=_cuda_upload_rfft,
+                             irfft=_cuda_irfft_get)
         else:
             logger.info('CUDA not used, CUDA could not be initialized, '
                         'falling back to n_jobs=1')
-    return n_jobs, cuda_dict, h_fft
+    return n_jobs, cuda_dict
 
 
-def fft_multiply_repeated(h_fft, x, n_fft, cuda_dict):
+def _fft_multiply_repeated(x, cuda_dict):
     """Do FFT multiplication by a filter function (possibly using CUDA).
 
     Parameters
@@ -194,28 +153,17 @@ def fft_multiply_repeated(h_fft, x, n_fft, cuda_dict):
     x : 1-d array
         Filtered version of x.
     """
-    if not cuda_dict['use_cuda']:
-        # do the fourier-domain operations
-        x = irfft(h_fft * rfft(x, n=n_fft), n_fft)
-    else:
-        cudafft = _get_cudafft()
-        # do the fourier-domain operations, results in second param
-        cuda_dict['x'].set(x.astype(np.float64))
-        cudafft.fft(cuda_dict['x'], cuda_dict['x_fft'], cuda_dict['fft_plan'])
-        _multiply_inplace_c128(h_fft, cuda_dict['x_fft'])
-        # If we wanted to do it locally instead of using our own kernel:
-        # cuda_seg_fft.set(cuda_seg_fft.get() * h_fft)
-        cudafft.ifft(cuda_dict['x_fft'], cuda_dict['x'],
-                     cuda_dict['ifft_plan'], False)
-        x = np.array(cuda_dict['x'].get(), dtype=x.dtype, subok=True,
-                     copy=False)
+    # do the fourier-domain operations
+    x_fft = cuda_dict['rfft'](x, cuda_dict['n_fft'])
+    x_fft *= cuda_dict['h_fft']
+    x = cuda_dict['irfft'](x_fft, cuda_dict['n_fft'])
     return x
 
 
 ###############################################################################
 # FFT Resampling
 
-def setup_cuda_fft_resample(n_jobs, W, new_len):
+def _setup_cuda_fft_resample(n_jobs, W, new_len):
     """Set up CUDA FFT resampling.
 
     Parameters
@@ -249,20 +197,13 @@ def setup_cuda_fft_resample(n_jobs, W, new_len):
                 frequency-domain multiplication.
             x : instance of gpuarray
                 Empty allocated GPU space for the data to resample.
-    W : array | instance of gpuarray
-        This will either be a gpuarray (if CUDA enabled) or np.ndarray.
-        If CUDA is enabled, W will be modified appropriately for use
-        with filter.fft_multiply().
 
     Notes
     -----
     This function is designed to be used with fft_resample().
     """
-    cuda_dict = dict(use_cuda=False, fft_plan=None, ifft_plan=None,
-                     x_fft=None, x=None, y_fft=None, y=None)
-    n_fft_x, n_fft_y = len(W), new_len
-    rfft_len_x = n_fft_x // 2 + 1
-    rfft_len_y = n_fft_y // 2 + 1
+    cuda_dict = dict(use_cuda=False, rfft=np.fft.rfft, irfft=np.fft.irfft)
+    rfft_len_x = len(W) // 2 + 1
     # fold the window onto inself (should be symmetric) and truncate
     W = W.copy()
     W[1:rfft_len_x] = (W[1:rfft_len_x] + W[::-1][:rfft_len_x - 1]) / 2.
@@ -271,40 +212,46 @@ def setup_cuda_fft_resample(n_jobs, W, new_len):
         n_jobs = 1
         init_cuda()
         if _cuda_capable:
-            # try setting up for float64
-            from pycuda import gpuarray
-            cudafft = _get_cudafft()
             try:
+                import cupy
                 # do the IFFT normalization now so we don't have to later
-                W = gpuarray.to_gpu(W.astype('complex_') / n_fft_y)
-                cuda_dict.update(
-                    use_cuda=True,
-                    fft_plan=cudafft.Plan(n_fft_x, np.float64, np.complex128),
-                    ifft_plan=cudafft.Plan(n_fft_y, np.complex128, np.float64),
-                    x_fft=gpuarray.zeros(max(rfft_len_x,
-                                             rfft_len_y), np.complex128),
-                    x=gpuarray.empty(max(n_fft_x, n_fft_y), np.float64))
+                W = cupy.array(W)
                 logger.info('Using CUDA for FFT resampling')
             except Exception:
                 logger.info('CUDA not used, could not instantiate memory '
                             '(arrays may be too large), falling back to '
                             'n_jobs=1')
+            else:
+                cuda_dict.update(use_cuda=True,
+                                 rfft=_cuda_upload_rfft,
+                                 irfft=_cuda_irfft_get)
         else:
             logger.info('CUDA not used, CUDA could not be initialized, '
                         'falling back to n_jobs=1')
-    return n_jobs, cuda_dict, W
+    cuda_dict['W'] = W
+    return n_jobs, cuda_dict
 
 
-def fft_resample(x, W, new_len, npads, to_removes, cuda_dict=None,
-                 pad='reflect_limited'):
+def _cuda_upload_rfft(x, n):
+    """Upload and compute rfft."""
+    import cupy
+    return cupy.fft.rfft(cupy.array(x), n)
+
+
+def _cuda_irfft_get(x, n):
+    """Compute irfft and get."""
+    import cupy
+    return cupy.fft.irfft(x, n).get()
+
+
+def _fft_resample(x, new_len, npads, to_removes, cuda_dict=None,
+                  pad='reflect_limited'):
     """Do FFT resampling with a filter function (possibly using CUDA).
 
     Parameters
     ----------
     x : 1-d array
         The array to resample. Will be converted to float64 if necessary.
-    W : 1-d array or gpuarray
-        The filtering function to apply.
     new_len : int
         The size of the output array (before removing padding).
     npads : tuple of int
@@ -335,32 +282,12 @@ def fft_resample(x, W, new_len, npads, to_removes, cuda_dict=None,
     old_len = len(x)
     shorter = new_len < old_len
     use_len = new_len if shorter else old_len
-    if not cuda_dict['use_cuda']:
-        x_fft = rfft(x)
-        if use_len % 2 == 0:
-            nyq = use_len // 2
-            x_fft[nyq] *= 2 if shorter else 0.5
-        x_fft *= W
-        y = irfft(x_fft, n=new_len)
-    else:
-        cudafft = _get_cudafft()
-        cuda_dict['x'].set(np.concatenate((x, np.zeros(max(new_len - old_len,
-                                                           0), x.dtype))))
-        # do the fourier-domain operations, results put in second param
-        cudafft.fft(cuda_dict['x'], cuda_dict['x_fft'], cuda_dict['fft_plan'])
-        _multiply_inplace_c128(W, cuda_dict['x_fft'])
-        # This is not straightforward, but because x_fft and y_fft share
-        # the same data (and only one half of the full DFT is stored), we
-        # don't have to transfer the slice like we do in scipy. All we
-        # need to worry about is the Nyquist component, either halving it
-        # or taking just the real component...
-        func = _double_c128 if shorter else _halve_c128
-        if use_len % 2 == 0:
-            nyq = use_len // 2
-            func(cuda_dict['x_fft'], slice=slice(nyq, nyq + 1))
-        cudafft.ifft(cuda_dict['x_fft'], cuda_dict['x'],
-                     cuda_dict['ifft_plan'], scale=False)
-        y = cuda_dict['x'].get()[:new_len]
+    x_fft = cuda_dict['rfft'](x, None)
+    if use_len % 2 == 0:
+        nyq = use_len // 2
+        x_fft[nyq:nyq + 1] *= 2 if shorter else 0.5
+    x_fft *= cuda_dict['W']
+    y = cuda_dict['irfft'](x_fft, new_len)
 
     # now let's trim it back to the correct size (if there was padding)
     if (to_removes > 0).any():

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -455,10 +455,10 @@ class FilterEstimator(TransformerMixin):
     h_trans_bandwidth : float
         Width of the transition band at the high cut-off frequency in Hz.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly, CUDA is initialized, and method='fft'.
+        Number of jobs to run in parallel.
+        Can be 'cuda' if ``cupy`` is installed properly and method='fir'.
     method : str
-        'fft' will use overlap-add FIR filtering, 'iir' will use IIR
+        'fir' will use overlap-add FIR filtering, 'iir' will use IIR
         forward-backward filtering (via filtfilt).
     iir_params : dict | None
         Dictionary of parameters to use for IIR filtering.
@@ -484,7 +484,7 @@ class FilterEstimator(TransformerMixin):
 
     def __init__(self, info, l_freq, h_freq, picks=None, filter_length='auto',
                  l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
-                 method='fft', iir_params=None, fir_design='firwin',
+                 method='fir', iir_params=None, fir_design='firwin',
                  verbose=None):  # noqa: D102
         self.info = info
         self.l_freq = l_freq
@@ -749,8 +749,8 @@ class TemporalFilter(TransformerMixin):
 
         Only used for ``method='fir'``.
     n_jobs : int | str, defaults to 1
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly, CUDA is initialized, and method='fft'.
+        Number of jobs to run in parallel.
+        Can be 'cuda' if ``cupy`` is installed properly and method='fir'.
     method : str, defaults to 'fir'
         'fir' will use overlap-add FIR filtering, 'iir' will use IIR
         forward-backward filtering (via filtfilt).

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -146,8 +146,8 @@ def _overlap_add_filter(x, h, n_fft=None, phase='zero', picks=None,
         filtered. Only supported for 2D (n_channels, n_times) and 3D
         (n_epochs, n_channels, n_times) data.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly and CUDA is initialized.
+        Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+        is installed properly.
     copy : bool
         If True, a copy of x, filtered, is returned. Otherwise, it operates
         on x in place.
@@ -782,8 +782,8 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
 
         Only used for ``method='fir'``.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly, CUDA is initialized, and method='fir'.
+        Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+        is installed properly and method='fir'.
     method : str
         'fir' will use overlap-add FIR filtering, 'iir' will use IIR
         forward-backward filtering (via filtfilt).
@@ -1225,8 +1225,8 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
         filtered. Only supported for 2D (n_channels, n_times) and 3D
         (n_epochs, n_channels, n_times) data.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly, CUDA is initialized, and method='fir'.
+        Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+        is installed properly and method='fir'.
     copy : bool
         If True, a copy of x, filtered, is returned. Otherwise, it operates
         on x in place.
@@ -1489,8 +1489,8 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
     window : string or tuple
         See :func:`scipy.signal.resample` for description.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-        is installed properly and CUDA is initialized.
+        Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+        is installed properly.
     pad : str
         The type of padding to use. Supports all :func:`numpy.pad` ``mode``
         options. Can also be "reflect_limited" (default), which pads with a
@@ -1989,8 +1989,8 @@ class FilterMixin(object):
 
             Only used for ``method='fir'``.
         n_jobs : int | str
-            Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-            is installed properly, CUDA is initialized, and method='fir'.
+            Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+            is installed properly and method='fir'.
         method : str
             'fir' will use overlap-add FIR filtering, 'iir' will use IIR
             forward-backward filtering (via filtfilt).

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1162,8 +1162,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             Only used for ``method='fir'``.
         n_jobs : int | str
-            Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-            is installed properly, CUDA is initialized, and method='fir'.
+            Number of jobs to run in parallel.
+            Can be 'cuda' if ``cupy`` is installed properly and method='fir'.
         method : str
             'fir' will use overlap-add FIR filtering, 'iir' will use IIR
             forward-backward filtering (via filtfilt).
@@ -1256,7 +1256,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @verbose
     def notch_filter(self, freqs, picks=None, filter_length='auto',
                      notch_widths=None, trans_bandwidth=1.0, n_jobs=1,
-                     method='fft', iir_params=None, mt_bandwidth=None,
+                     method='fir', iir_params=None, mt_bandwidth=None,
                      p_value=0.05, phase='zero', fir_window='hamming',
                      fir_design='firwin', pad='reflect_limited', verbose=None):
         """Notch filter a subset of channels.
@@ -1302,8 +1302,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Width of the transition band in Hz.
             Only used for ``method='fir'``.
         n_jobs : int | str
-            Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-            is installed properly, CUDA is initialized, and method='fir'.
+            Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+            is installed properly and method='fir'.
         method : str
             'fir' will use overlap-add FIR filtering, 'iir' will use IIR
             forward-backward filtering (via filtfilt). 'spectrum_fit' will
@@ -1427,8 +1427,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             triggers. If None, stim channels are automatically chosen using
             :func:`mne.pick_types`.
         n_jobs : int | str
-            Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
-            is installed properly and CUDA is initialized.
+            Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+            is installed properly and method='fir'.
         events : 2D array, shape (n_events, 3) | None
             An optional event matrix. When specified, the onsets of the events
             are resampled jointly with the data. NB: The input events are not

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -147,7 +147,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                                                eeg=50e-6, eog=250e-6),
                      flat=None, bads=[], avg_ref=False,
                      no_proj=False, event_id=999, ecg_l_freq=5, ecg_h_freq=35,
-                     tstart=0., qrs_threshold='auto', filter_method='fft',
+                     tstart=0., qrs_threshold='auto', filter_method='fir',
                      iir_params=None, copy=True, return_drop_log=False,
                      verbose=None):
     """Compute SSP/PCA projections for ECG artifacts.
@@ -205,7 +205,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         automatically choose the threshold that generates a reasonable
         number of heartbeats (40-160 beats / min).
     filter_method : str
-        Method for filtering ('iir' or 'fft').
+        Method for filtering ('iir' or 'fir').
     iir_params : dict | None
         Dictionary of parameters to use for IIR filtering.
         See mne.filter.construct_iir_filter for details. If iir_params
@@ -256,7 +256,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      reject=dict(grad=2000e-13, mag=3000e-15, eeg=500e-6,
                                  eog=np.inf), flat=None, bads=[],
                      avg_ref=False, no_proj=False, event_id=998, eog_l_freq=1,
-                     eog_h_freq=10, tstart=0., filter_method='fft',
+                     eog_h_freq=10, tstart=0., filter_method='fir',
                      iir_params=None, ch_name=None, copy=True,
                      return_drop_log=False, verbose=None):
     """Compute SSP/PCA projections for EOG artifacts.
@@ -308,7 +308,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
     tstart : float
         Start artifact detection after tstart seconds.
     filter_method : str
-        Method for filtering ('iir' or 'fft').
+        Method for filtering ('iir' or 'fir').
     iir_params : dict | None
         Dictionary of parameters to use for IIR filtering.
         See mne.filter.construct_iir_filter for details. If iir_params

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -21,6 +21,7 @@ public_modules = [
     'mne.beamformer',
     'mne.chpi',
     'mne.connectivity',
+    'mne.cuda',
     'mne.datasets',
     'mne.datasets.brainstorm',
     'mne.datasets.hf_sef',
@@ -187,7 +188,6 @@ def test_tabs():
 
 
 documented_ignored_mods = (
-    'mne.cuda',
     'mne.fixes',
     'mne.io.write',
     'mne.utils',

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -255,7 +255,7 @@ def test_resample():
     assert_array_equal(resample([0, 0], 2, 1), [0., 0., 0., 0.])
 
 
-@requires_version('scipy', '0.13')  # 0.12 at least has a Nyquist bug
+@requires_version('scipy', '1.0')  # earlier versions have a Nyquist bug
 def test_resample_scipy():
     """Test resampling against SciPy."""
     n_jobs_test = (1, 'cuda')

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2597,8 +2597,7 @@ def sys_info(fid=None, show_paths=False):
         sklearn:       0.18.dev0
         nibabel:       2.1.0dev
         mayavi:        4.3.1
-        pycuda:        2015.1.3
-        skcuda:        0.5.2
+        cupy:          4.1.0
         pandas:        0.17.1+25.g547750a
 
     """  # noqa: E501
@@ -2636,9 +2635,8 @@ def sys_info(fid=None, show_paths=False):
                     lib = lib.split('[')[1].split("'")[1]
                 libs += ['%s=%s' % (key, lib)]
     libs = ', '.join(libs)
-    version_texts = dict(pycuda='VERSION_TEXT')
     for mod_name in ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
-                     'nibabel', 'mayavi', 'pycuda', 'skcuda', 'pandas'):
+                     'nibabel', 'mayavi', 'cupy', 'pandas'):
         if mod_name == '':
             out += '\n'
             continue
@@ -2651,7 +2649,6 @@ def sys_info(fid=None, show_paths=False):
         except Exception:
             out += 'Not found\n'
         else:
-            version = getattr(mod, version_texts.get(mod_name, '__version__'))
             extra = (' (%s)' % op.dirname(mod.__file__)) if show_paths else ''
             if mod_name == 'numpy':
                 extra = ' {%s}%s' % (libs, extra)
@@ -2663,7 +2660,7 @@ def sys_info(fid=None, show_paths=False):
                 except Exception:
                     qt_api = 'unknown'
                 extra = ' {qt_api=%s}%s' % (qt_api, extra)
-            out += '%s%s\n' % (version, extra)
+            out += '%s%s\n' % (mod.__version__, extra)
     print(out, end='', file=fid)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ filterwarnings =
     ignore::ImportWarning
     ignore:the matrix subclass:PendingDeprecationWarning
     ignore:numpy.dtype size changed:RuntimeWarning
-    ignore:module pycuda not found:RuntimeWarning
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:.*takes no parameters:DeprecationWarning
     ignore:joblib not installed:RuntimeWarning


### PR DESCRIPTION
It turns out using `cupy`:

1. Simplifies things: one module to install (cupy) instead of two (pycuda, skcuda)
2. NumPy-like operations requires less branching (see +/- of equivalent-output code of this PR: +69, -142)
3. Is slightly faster (10%) in filtering/resampling than old code
4. Is more future compatible (e.g., using for `ReceptiveField` should be easier)

So I think in this release we should probably support just `cupy`. I don't think the burden is so high on users, as it was very easy to install on my system (easier than `pycuda` for example). I don't think it's a great idea to support both for a release because it will be a lot more work and complications in our code base, but we can do it if absolutely necessary.

Todo:

- [x] Get @jona-sassenhagen on board
- [x] Update README
- [x] Update advanced install docs
- [x] Update `whats_new.rst`
- [x] Get @agramfort on board

Closes #5439.