### PR TITLE
MRG: Fewer warnings during install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
               conda update --yes --quiet conda;
               conda env create --quiet -f environment.yml;
               source activate mne;
+              conda install sphinx;
+              pip install sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master"
               pip uninstall --yes mne;
               echo "source activate mne" >> $BASH_ENV;
         - save_cache:

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -154,10 +154,14 @@ Off-screen rendering on Linux with MESA
 #######################################
 
 On remote systems, it might be possible to use MESA software rendering
-(``swr``) for 3D visualization with some tweaks. For example, on CentOS 7.5
-you might be able to use the environment variable to force MESA to use
-modern OpenGL by using this before executing ``spyder`` or ``python``:
+(such as ``llvmpipe`` or ``swr``) for 3D visualization with some tweaks.
+For example, on CentOS 7.5 you might be able to use the environment variable
+to force MESA to use modern OpenGL by using this before executing
+``spyder`` or ``python``:
 
 .. code-block:: console
 
     $ export MESA_GL_VERSION_OVERRIDE=3.3
+
+Also, it's possible that different software rending backends might perform
+better than others, such as using the ``llvmpipe`` backend rather than ``swr``.

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -143,9 +143,21 @@ using mayavi), you can try setting the ``ETS_TOOLKIT`` environment variable::
 
     >>> import os
     >>> os.environ['ETS_TOOLKIT'] = 'qt4'
-    >>> os.environ['QT_API'] = 'pyqt'
+    >>> os.environ['QT_API'] = 'pyqt5'
 
 This will tell Traits that we will use Qt with PyQt bindings.
 
 For more information, see
 http://docs.enthought.com/mayavi/mayavi/building_applications.html.
+
+Off-screen rendering on Linux with MESA
+#######################################
+
+On remote systems, it might be possible to use MESA software rendering
+(``swr``) for 3D visualization with some tweaks. For example, on CentOS 7.5
+you might be able to use the environment variable to force MESA to use
+modern OpenGL by using this before executing ``spyder`` or ``python``:
+
+.. code-block:: console
+
+    $ export MESA_GL_VERSION_OVERRIDE=3.3

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -121,8 +121,8 @@ follows the `NumPy docstring standard`_.
 
 Documentation is automatically built remotely during pull requests. If
 you want to also test documentation locally, you will need to install
-``sphinx sphinx-gallery sphinx_bootstrap_theme numpydoc``, and then within
-the ``mne/doc`` directory do:
+``sphinx sphinx-gallery sphinx_bootstrap_theme sphinx_fontawesome``, and then
+within the ``mne/doc`` directory do:
 
 .. code-block:: console
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -30,11 +30,11 @@ You can also chat with developers `on Gitter <https://gitter.im/mne-tools/mne-py
 I can't get Mayavi/3D plotting to work under Windows.
 -----------------------------------------------------
 If Mayavi plotting in Jupyter Notebooks doesn't work
-well, using the IPython magic ``%gui qt`` after importing MNE/Mayavi/PySurfer 
+well, using the IPython magic ``%gui qt`` after importing MNE/Mayavi/PySurfer
 should `help <https://github.com/ipython/ipython/issues/10384>`_.
-   
+
 .. code:: ipython
-   
+
    from mayavi import mlab
    %gui qt
 
@@ -73,30 +73,6 @@ Please report any problems you find while using MNE-Python to the
 Try :ref:`using the latest master version <installing_master>` to
 see if the problem persists before reporting the bug, as it may have
 been fixed since the latest release.
-
-It is helpful to include system information with bug reports, so it can be
-useful to include the output of the :func:`mne.sys_info` command when
-reporting a bug, which should look something like this::
-
-    >>> import mne
-    >>> mne.sys_info()  # doctest:+SKIP
-    Platform:      Linux-4.2.0-27-generic-x86_64-with-debian-jessie-sid
-    Python:        2.7.11 |Continuum Analytics, Inc.| (default, Dec  6 2015, 18:08:32)  [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]
-    Executable:    /home/larsoner/miniconda/bin/python
-
-    mne:           0.12.dev0
-    numpy:         1.10.2 {lapack=mkl_lapack95_lp64, blas=mkl_intel_lp64}
-    scipy:         0.16.1
-    matplotlib:    1.5.1
-
-    sklearn:       Not found
-    nibabel:       Not found
-    nitime:        Not found
-    mayavi:        Not found
-    pandas:        Not found
-    pycuda:        Not found
-    skcuda:        Not found
-
 
 Why is it dangerous to "pickle" my MNE-Python objects and data for later use?
 -----------------------------------------------------------------------------

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -36,7 +36,8 @@ From the command line, install the MNE dependencies to a dedicated ``mne`` Anaco
     $ conda env create -f environment.yml
     $ conda activate mne
 
-You can also use a web browser to `download the required environment file <https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml>`_ if you do not have ``curl``.
+You can also use a web browser to `download the required environment file <https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml>`_
+if you do not have ``curl``.
 
 .. admonition:: |apple| macOS
   :class: note
@@ -57,7 +58,7 @@ To make sure everything installed correctly, type the following command in a ter
 
     $ python
 
-This should open an interactive Python prompt, where you can type:
+This should open an interactive Python prompt, where you can type::
 
     >>> import mne
 
@@ -73,6 +74,29 @@ If you get a new prompt with no error messages, you should be good to go!
 
      In [1]: from mayavi import mlab
      In [2]: %gui qt
+
+The ``$ conda env create ...`` step sometimes emits warnings, but you can ensure
+all default dependencies are installed by listing their versions with::
+
+    >>> mne.sys_info()
+    Platform:      Linux-4.4.0-112-generic-x86_64-with-debian-jessie-sid
+    Python:        3.6.6 |Anaconda, Inc.| (default, Jun 28 2018, 17:14:51)  [GCC 7.2.0]
+    Executable:    /home/travis/miniconda/envs/test/bin/python
+    CPU:           x86_64: 48 cores
+    Memory:        62.7 GB
+
+    mne:           0.16.2
+    numpy:         1.15.0 {blas=mkl_rt, lapack=mkl_rt}
+    scipy:         1.1.0
+    matplotlib:    2.2.2 {backend=Qt5Agg}
+
+    sklearn:       0.19.1
+    nibabel:       2.3.0
+    mayavi:        4.6.1 {qt_api=pyqt5}
+    pycuda:        Not found
+    skcuda:        Not found
+    pandas:        0.23.4
+
 
 For advanced topics like how to get :ref:`CUDA` support or if you are experiencing other issues, check out :ref:`advanced_setup`.
 

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -78,7 +78,7 @@ If you get a new prompt with no error messages, you should be good to go!
 The ``$ conda env create ...`` step sometimes emits warnings, but you can ensure
 all default dependencies are installed by listing their versions with::
 
-    >>> mne.sys_info()
+    >>> mne.sys_info()  # doctest:+SKIP
     Platform:      Linux-4.4.0-112-generic-x86_64-with-debian-jessie-sid
     Python:        3.6.6 |Anaconda, Inc.| (default, Jun 28 2018, 17:14:51)  [GCC 7.2.0]
     Executable:    /home/travis/miniconda/envs/test/bin/python

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - numpy
 - scipy
 - matplotlib
+- cython
 - pyqt>=5.9
 - vtk>=8
 - pandas
@@ -18,7 +19,6 @@ dependencies:
 - jupyter
 - pytest
 - pytest-cov
-- sphinx
 - joblib
 - psutil
 - numpydoc
@@ -31,7 +31,7 @@ dependencies:
 - pip:
   - mne
   - mayavi
-  - "https://api.github.com/repos/nipy/PySurfer/zipball/master"
+  - PySurfer
   - nitime
   - nibabel
   - nilearn
@@ -39,7 +39,5 @@ dependencies:
   - pytest-sugar
   - pytest-faulthandler
   - pydocstyle
-  - sphinx_bootstrap_theme
-  - "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master"
+  - codespell
   - python-picard
-  - sphinx_fontawesome


### PR DESCRIPTION
1. Multiple users have complained about the Cython warnings. This should get rid of those.
2. I don't think we need to have the doc-building deps in there by default, since that's really a dev thing, and devs can easily install those deps. (Unit test stuff is still nice for users who submit bug reports.)
3. I think we can do PySurfer on standard `pip` instead of from `master` nowadays.
4. There were some tweaks and tips proposed in #5390 that are included here.
5. We have `Issue` templates on GitHub now, so no need to duplicate instructions in our own docs.

Closes #5390.