### PR TITLE
[MRG+2] Added threshold option for find_eog_events() and create_eog_epochs()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add ability to pass threshold for EOG to :func:`mne.preprocessing.find_eog_events` and :func:`mne.preprocessing.create_eog_epochs` by `Peter Molfese_`
+
 - Add possibility to save :class:`mne.VolSourceEstimate` and :class:`mne.MixedSourceEstimate` to HDF5 format (file extension .h5) with :meth:`mne.VolSourceEstimate.save` and :meth:`mne.MixedSourceEstimate.save` by `Alex Gramfort`_
 
 - Add `replace` parameter to :meth:`mne.io.Raw.add_events` to allow adding events while removing the old ones on the stim channel by `Alex Gramfort`_
@@ -2842,3 +2844,5 @@ of commits):
 .. _Thomas Hartmann: https://github.com/thht
 
 .. _Steven Gutstein: http://robust.cs.utep.edu/~gutstein
+
+.. _Peter Molfese: https://github.com/pmolfese

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -17,7 +17,7 @@ from ..externals.six import string_types
 @verbose
 def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                     filter_length='10s', ch_name=None, tstart=0,
-                    reject_by_annotation=False, verbose=None):
+                    reject_by_annotation=False, thresh=None, verbose=None):
     """Locate EOG artifacts.
 
     Parameters
@@ -38,6 +38,8 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
         Start detection after tstart seconds.
     reject_by_annotation : bool
         Whether to omit data that is annotated as bad.
+    thresh : float
+    	Threshold to trigger EOG event.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -68,7 +70,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                                   sampling_rate=raw.info['sfreq'],
                                   first_samp=raw.first_samp,
                                   filter_length=filter_length,
-                                  tstart=tstart)
+                                  tstart=tstart, thresh=thresh)
     # Map times to corresponding samples.
     eog_events[:, 0] = np.round(times[eog_events[:, 0] -
                                       raw.first_samp]).astype(int)
@@ -76,7 +78,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
 
 
 def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
-                     filter_length='10s', tstart=0.):
+                     filter_length='10s', tstart=0., thresh=None):
     """Find EOG events."""
     logger.info('Filtering the data to remove DC offset to help '
                 'distinguish blinks from saccades')
@@ -104,9 +106,9 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     temp = filteog - np.mean(filteog)
     n_samples_start = int(sampling_rate * tstart)
     if np.abs(np.max(temp)) > np.abs(np.min(temp)):
-        eog_events, _ = peak_finder(filteog[n_samples_start:], extrema=1)
+        eog_events, _ = peak_finder(filteog[n_samples_start:], thresh, extrema=1)
     else:
-        eog_events, _ = peak_finder(filteog[n_samples_start:], extrema=-1)
+        eog_events, _ = peak_finder(filteog[n_samples_start:], thresh, extrema=-1)
 
     eog_events += n_samples_start
     n_events = len(eog_events)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -39,7 +39,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
     reject_by_annotation : bool
         Whether to omit data that is annotated as bad.
     thresh : float
-    	Threshold to trigger EOG event.
+        Threshold to trigger EOG event.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -106,9 +106,11 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     temp = filteog - np.mean(filteog)
     n_samples_start = int(sampling_rate * tstart)
     if np.abs(np.max(temp)) > np.abs(np.min(temp)):
-        eog_events, _ = peak_finder(filteog[n_samples_start:], thresh, extrema=1)
+        eog_events, _ = peak_finder(filteog[n_samples_start:],
+                                    thresh, extrema=1)
     else:
-        eog_events, _ = peak_finder(filteog[n_samples_start:], thresh, extrema=-1)
+        eog_events, _ = peak_finder(filteog[n_samples_start:],
+                                    thresh, extrema=-1)
 
     eog_events += n_samples_start
     n_events = len(eog_events)
@@ -158,8 +160,8 @@ def _get_eog_channel_index(ch_name, inst):
 @verbose
 def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
                       tmax=0.5, l_freq=1, h_freq=10, reject=None, flat=None,
-                      baseline=None, preload=True, reject_by_annotation=True, thresh=None,
-                      verbose=None):
+                      baseline=None, preload=True, reject_by_annotation=True,
+                      thresh=None, verbose=None):
     """Conveniently generate epochs around EOG artifact events.
 
     Parameters
@@ -215,9 +217,8 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
         rejection based on annotations is performed.
 
         .. versionadded:: 0.14.0
-        
     thresh : float
-    	Threshold to trigger EOG event.
+        Threshold to trigger EOG event.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -240,7 +241,8 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
     """
     events = find_eog_events(raw, ch_name=ch_name, event_id=event_id,
                              l_freq=l_freq, h_freq=h_freq,
-                             reject_by_annotation=reject_by_annotation, thresh=thresh)
+                             reject_by_annotation=reject_by_annotation,
+                             thresh=thresh)
 
     # create epochs around EOG events
     eog_epochs = Epochs(raw, events=events, event_id=event_id, tmin=tmin,

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -158,7 +158,7 @@ def _get_eog_channel_index(ch_name, inst):
 @verbose
 def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
                       tmax=0.5, l_freq=1, h_freq=10, reject=None, flat=None,
-                      baseline=None, preload=True, reject_by_annotation=True,
+                      baseline=None, preload=True, reject_by_annotation=True, thresh=None,
                       verbose=None):
     """Conveniently generate epochs around EOG artifact events.
 
@@ -215,7 +215,9 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
         rejection based on annotations is performed.
 
         .. versionadded:: 0.14.0
-
+        
+    thresh : float
+    	Threshold to trigger EOG event.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -238,7 +240,7 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
     """
     events = find_eog_events(raw, ch_name=ch_name, event_id=event_id,
                              l_freq=l_freq, h_freq=h_freq,
-                             reject_by_annotation=reject_by_annotation)
+                             reject_by_annotation=reject_by_annotation, thresh=thresh)
 
     # create epochs around EOG events
     eog_epochs = Epochs(raw, events=events, event_id=event_id, tmin=tmin,

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -20,3 +20,7 @@ def test_find_eog():
 
     events = find_eog_events(raw, reject_by_annotation=True)
     assert all(events[:, 0] < 29000)
+
+	#threshold option 
+	events_thr = find_eog_events(raw, thresh=100e-6)
+	assert len(events) == 5

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -21,6 +21,6 @@ def test_find_eog():
     events = find_eog_events(raw, reject_by_annotation=True)
     assert all(events[:, 0] < 29000)
 
-	#threshold option 
-	events_thr = find_eog_events(raw, thresh=100e-6)
-	assert len(events) == 5
+    # threshold option
+    events_thr = find_eog_events(raw, thresh=100e-6)
+    assert len(events_thr) == 5


### PR DESCRIPTION
#### What does this implement/fix?
Found that find_eog_events() and thus create_eog_epochs() weren't detecting many EOG events, despite seeing them in data.  The function used on the backend - peak_finder() - can take a threshold as argument, added option for user to pass a threshold to the function.  Initial testing found better detection of blinks.  


#### Additional information
Perhaps more necessary in EEG recordings.  
