### PR TITLE
MRG: Speed up RF fitting with CuPy

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,8 @@ Changelog
 
 - Add :func:`mne.preprocessing.mark_flat` to automate marking of flat channels and segments of raw data by `Eric Larson`_
 
+- Add support for CUDA-based correlation computations and progress bars in :class:`mne.decoding.ReceptiveField` by `Eric Larson`_
+
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
 - Add option to SSP preprocessing functions (e.g., :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs`) to process MEG channels jointly with ``meg='combined'`` by `Eric Larson`_

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -82,7 +82,8 @@ def init_cuda(ignore_config=False, verbose=None):
 ###############################################################################
 # Repeated FFT multiplication
 
-def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
+def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft,
+                                      kind='FFT FIR filtering'):
     """Set up repeated CUDA FFT multiplication with a given filter.
 
     Parameters
@@ -94,6 +95,8 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
         The filtering function that will be used repeatedly.
     n_fft : int
         The number of points in the FFT.
+    kind : str
+        The kind to report to the user.
 
     Returns
     -------
@@ -130,7 +133,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft):
             try:
                 # do the IFFT normalization now so we don't have to later
                 h_fft = cupy.array(cuda_dict['h_fft'])
-                logger.info('Using CUDA for FFT FIR filtering')
+                logger.info('Using CUDA for %s' % kind)
             except Exception as exp:
                 logger.info('CUDA not used, could not instantiate memory '
                             '(arrays may be too large: "%s"), falling back to '
@@ -242,16 +245,16 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
     return n_jobs, cuda_dict
 
 
-def _cuda_upload_rfft(x, n):
+def _cuda_upload_rfft(x, n, axis=-1):
     """Upload and compute rfft."""
     import cupy
-    return cupy.fft.rfft(cupy.array(x), n)
+    return cupy.fft.rfft(cupy.array(x), n=n, axis=axis)
 
 
-def _cuda_irfft_get(x, n):
+def _cuda_irfft_get(x, n, axis=-1):
     """Compute irfft and get."""
     import cupy
-    return cupy.fft.irfft(x, n).get()
+    return cupy.fft.irfft(x, n=n, axis=axis).get()
 
 
 def _fft_resample(x, new_len, npads, to_removes, cuda_dict=None,

--- a/mne/utils/progressbar.py
+++ b/mne/utils/progressbar.py
@@ -228,8 +228,13 @@ class ProgressBar(object):
         self._mmap = None
         if op.isfile(self._mmap_fname):
             os.remove(self._mmap_fname)
+        self.done()
+
+    def done(self):
+        """Print a newline."""
         if self._do_print:
-            print('')
+            sys.stdout.write('\n')
+            sys.stdout.flush()
 
 
 class _PBSubsetUpdater(object):


### PR DESCRIPTION
Depends on #5452.

I can get some reasonable gains:
```
Running  2 in, -150 - 250 ms; 1.0 min epochs; 10000.0 Hz; 60 epochs
  n_out= 2 n_jobs=   1: 0.81 min
  n_out= 2 n_jobs=cuda: 0.69 min
  n_out=60 n_jobs=   1: 4.28 min
  n_out=60 n_jobs=cuda: 1.33 min
```
Using [this gist](https://gist.github.com/larsoner/c58127bc466e8e8b7ce38af9f6ab825f).

~~The remaining time seems to be consumed mostly by the special treatment that we need to give edge samples. One way to fix it is to add an arg `edge_treatment='correct' | 'trim'` that will just trim the invalid values of the FFT-based cross-correlation instead of correcting them. Basically this would mean if you pass 1.4 sec of data and estimate a -0.2 to 0.2 TRF, it will only use 1 sec of the data to do this. Essentially a wider crop / epoching of your signal can allow you to (potentially) greatly speed up RF fitting. Still need to ensure that's actually the case, though.~~