### PR TITLE
[MRG] fix glossary path

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -75,7 +75,7 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
     manual/cookbook.rst
     whats_new.rst
     python_reference.rst
-    glossary.rst
+    doc/glossary.rst
     auto_examples/index.rst
     generated/commands.rst
     auto_tutorials/plot_configuration.rst


### PR DESCRIPTION
glossary is not reachable through search
![image](https://user-images.githubusercontent.com/7044835/44453081-819fb500-a5f8-11e8-8f4f-aed3e3efc3c8.png)

nor through index
![image](https://user-images.githubusercontent.com/7044835/44453140-a7c55500-a5f8-11e8-8cb5-171815f2d48b.png)
