### PR TITLE
[MRG] ADD split_naming arg to save to make BIDS-compatible files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,8 @@ Changelog
 
 - :func:`mne.combine_evoked` and :func:`mne.grand_average` can now handle input with the same channels in different orders, if required, by `Jona Sassenhagen`_
 
+- Add `split_naming` parameter to the `Raw.save` method to allow for BIDS-compatible raw file name construction by `Teon Brooks`_
+
 Bug
 ~~~
 
@@ -2685,7 +2687,7 @@ of commits):
 
 .. _Simon Kornblith: http://simonster.com
 
-.. _Teon Brooks: http://sites.google.com/a/nyu.edu/teon/
+.. _Teon Brooks: https://teonbrooks.github.io
 
 .. _Mainak Jas: http://ltl.tkk.fi/wiki/Mainak_Jas
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1607,7 +1607,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @verbose
     def save(self, fname, picks=None, tmin=0, tmax=None, buffer_size_sec=None,
              drop_small_buffer=False, proj=False, fmt='single',
-             overwrite=False, split_size='2GB', verbose=None):
+             overwrite=False, split_size='2GB', split_naming='elekta',
+             verbose=None):
         """Save raw data to file.
 
         Parameters
@@ -1661,6 +1662,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             .. note:: Due to FIFF file limitations, the maximum split
                       size is 2GB.
 
+        split_naming : string ('elekta' | 'bids')
+            Add the filename partition with the appropriate naming schema.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -1734,9 +1737,18 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         buffer_size = self._get_buffer_size(buffer_size_sec)
 
         # write the raw file
-        _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
-                   start, stop, buffer_size, projector, drop_small_buffer,
-                   split_size, 0, None)
+        if split_naming == 'elekta':
+            _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
+                       start, stop, buffer_size, projector, drop_small_buffer,
+                       split_size, split_naming, 0, None)
+        elif split_naming == 'bids':
+            _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
+                       start, stop, buffer_size, projector, drop_small_buffer,
+                       split_size, split_naming, 1, None)
+        else:
+            err = ("split_naming must be either 'elekta' or 'bids instead of'"
+                   "'{}'".format(split_naming))
+            raise ValueError(err)
 
     @copy_function_doc_to_method_doc(plot_raw)
     def plot(self, events=None, duration=10.0, start=0.0, n_channels=20,
@@ -2161,7 +2173,7 @@ class _RawShell():
 # Writing
 def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                stop, buffer_size, projector, drop_small_buffer,
-               split_size, part_idx, prev_fname):
+               split_size, split_naming, part_idx, prev_fname):
     """Write raw file with splitting."""
     # we've done something wrong if we hit this
     n_times_max = len(raw.times)
@@ -2170,9 +2182,15 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                            '(max: %s) requested' % (start, stop, n_times_max))
 
     if part_idx > 0:
-        # insert index in filename
-        base, ext = op.splitext(fname)
-        use_fname = '%s-%d%s' % (base, part_idx, ext)
+        if split_naming == 'elekta':
+            # insert index in filename
+            base, ext = op.splitext(fname)
+            use_fname = '%s-%d%s' % (base, part_idx, ext)
+        else:
+            # insert index in filename
+            base, ext = op.splitext(fname)
+            use_fname = '%s_part-%02d_meg%s' % (base, part_idx, ext)
+
     else:
         use_fname = fname
     logger.info('Writing %s' % use_fname)
@@ -2186,14 +2204,25 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
 
     # previous file name and id
-    if part_idx > 0 and prev_fname is not None:
-        start_block(fid, FIFF.FIFFB_REF)
-        write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
-        write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
-        if info['meas_id'] is not None:
-            write_id(fid, FIFF.FIFF_REF_FILE_ID, info['meas_id'])
-        write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
-        end_block(fid, FIFF.FIFFB_REF)
+    if split_naming == 'elekta':
+        if part_idx > 0 and prev_fname is not None:
+            start_block(fid, FIFF.FIFFB_REF)
+            write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
+            write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
+            if info['meas_id'] is not None:
+                write_id(fid, FIFF.FIFF_REF_FILE_ID, info['meas_id'])
+            write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
+            end_block(fid, FIFF.FIFFB_REF)
+    else:
+        if part_idx > 1 and prev_fname is not None:
+            start_block(fid, FIFF.FIFFB_REF)
+            write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
+            write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
+            if info['meas_id'] is not None:
+                write_id(fid, FIFF.FIFF_REF_FILE_ID, info['meas_id'])
+            write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 2)
+            end_block(fid, FIFF.FIFFB_REF)
+
 
     pos_prev = fid.tell()
     if pos_prev > split_size:
@@ -2271,7 +2300,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             next_fname, next_idx = _write_raw(
                 fname, raw, info, picks, fmt,
                 data_type, reset_range, first + buffer_size, stop, buffer_size,
-                projector, drop_small_buffer, split_size,
+                projector, drop_small_buffer, split_size, split_naming,
                 part_idx + 1, use_fname)
 
             start_block(fid, FIFF.FIFFB_REF)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1742,8 +1742,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         elif split_naming == 'bids':
             part_idx = 1
         else:
-            err = ("split_naming must be either 'elekta' or 'bids instead of'"
-                   "'{}'".format(split_naming))
+            err = ("split_naming must be either 'elekta' or 'bids' instead "
+                   "of '{}'.".format(split_naming))
             raise ValueError(err)
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
                    start, stop, buffer_size, projector, drop_small_buffer,
@@ -2203,16 +2203,16 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
 
     # previous file name and id
     if split_naming == 'elekta':
-        data = part_idx - 1
+        part_idx_tag = part_idx - 1
     else:
-        data = part_idx - 2
+        part_idx_tag = part_idx - 2
     if part_idx > 0 and prev_fname is not None:
         start_block(fid, FIFF.FIFFB_REF)
         write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
         write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
         if info['meas_id'] is not None:
             write_id(fid, FIFF.FIFF_REF_FILE_ID, info['meas_id'])
-        write_int(fid, FIFF.FIFF_REF_FILE_NUM, data)
+        write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx_tag)
         end_block(fid, FIFF.FIFFB_REF)
 
     pos_prev = fid.tell()

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2223,7 +2223,6 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 2)
             end_block(fid, FIFF.FIFFB_REF)
 
-
     pos_prev = fid.tell()
     if pos_prev > split_size:
         fid.close()

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1607,7 +1607,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @verbose
     def save(self, fname, picks=None, tmin=0, tmax=None, buffer_size_sec=None,
              drop_small_buffer=False, proj=False, fmt='single',
-             overwrite=False, split_size='2GB', split_naming='elekta',
+             overwrite=False, split_size='2GB', split_naming='neuromag',
              verbose=None):
         """Save raw data to file.
 
@@ -1662,8 +1662,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             .. note:: Due to FIFF file limitations, the maximum split
                       size is 2GB.
 
-        split_naming : string ('elekta' | 'bids')
+        split_naming : string ('neuromag' | 'bids')
             Add the filename partition with the appropriate naming schema.
+
+            .. versionadded:: 0.17
+
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -1742,9 +1745,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         elif split_naming == 'bids':
             part_idx = 1
         else:
-            err = ("split_naming must be either 'elekta' or 'bids' instead "
-                   "of '{}'.".format(split_naming))
-            raise ValueError(err)
+            raise ValueError(
+            "split_naming must be either 'elekta' or 'bids' instead "
+            "of '{}'.".format(split_naming))
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
                    start, stop, buffer_size, projector, drop_small_buffer,
                    split_size, split_naming, part_idx, None)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1750,7 +1750,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 "of '{}'.".format(split_naming))
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
                    start, stop, buffer_size, projector, drop_small_buffer,
-                   split_size, split_naming, part_idx, None)
+                   split_size, split_naming, part_idx, None, overwrite)
 
     @copy_function_doc_to_method_doc(plot_raw)
     def plot(self, events=None, duration=10.0, start=0.0, n_channels=20,
@@ -2175,7 +2175,7 @@ class _RawShell():
 # Writing
 def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                stop, buffer_size, projector, drop_small_buffer,
-               split_size, split_naming, part_idx, prev_fname):
+               split_size, split_naming, part_idx, prev_fname, overwrite):
     """Write raw file with splitting."""
     # we've done something wrong if we hit this
     n_times_max = len(raw.times)
@@ -2191,6 +2191,8 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         else:
             # insert index in filename
             use_fname = '%s_part-%02d_meg%s' % (base, part_idx, ext)
+            # check for file existence
+            _check_fname(use_fname, overwrite)
 
     else:
         use_fname = fname
@@ -2295,7 +2297,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                 fname, raw, info, picks, fmt,
                 data_type, reset_range, first + buffer_size, stop, buffer_size,
                 projector, drop_small_buffer, split_size, split_naming,
-                part_idx + 1, use_fname)
+                part_idx + 1, use_fname, overwrite)
 
             start_block(fid, FIFF.FIFFB_REF)
             write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_NEXT_FILE)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1662,7 +1662,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             .. note:: Due to FIFF file limitations, the maximum split
                       size is 2GB.
 
-        split_naming : string ('neuromag' | 'bids')
+        split_naming : {'neuromag' | 'bids'}
             Add the filename partition with the appropriate naming schema.
 
             .. versionadded:: 0.17
@@ -1740,14 +1740,14 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         buffer_size = self._get_buffer_size(buffer_size_sec)
 
         # write the raw file
-        if split_naming == 'elekta':
+        if split_naming == 'neuromag':
             part_idx = 0
         elif split_naming == 'bids':
             part_idx = 1
         else:
             raise ValueError(
-            "split_naming must be either 'elekta' or 'bids' instead "
-            "of '{}'.".format(split_naming))
+                "split_naming must be either 'neuromag' or 'bids' instead "
+                "of '{}'.".format(split_naming))
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
                    start, stop, buffer_size, projector, drop_small_buffer,
                    split_size, split_naming, part_idx, None)
@@ -2185,7 +2185,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
 
     if part_idx > 0:
         base, ext = op.splitext(fname)
-        if split_naming == 'elekta':
+        if split_naming == 'neuromag':
             # insert index in filename
             use_fname = '%s-%d%s' % (base, part_idx, ext)
         else:
@@ -2205,7 +2205,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
 
     # previous file name and id
-    if split_naming == 'elekta':
+    if split_naming == 'neuromag':
         part_idx_tag = part_idx - 1
     else:
         part_idx_tag = part_idx - 2

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -427,6 +427,11 @@ def test_split_files():
     assert_array_equal(data_1, data_2)
     assert_array_equal(times_1, times_2)
 
+    raw_bids = read_raw_fif(split_fname_bids_part1)
+    data_bids, times_bids = raw_bids[:, :]
+    assert_array_equal(data_1, data_bids)
+    assert_array_equal(times_1, times_bids)
+
     # test the case where we only end up with one buffer to write
     # (GH#3210). These tests rely on writing meas info and annotations
     # taking up a certain number of bytes, so if we change those functions

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -409,7 +409,7 @@ def test_split_files():
     # check that the filenames match the intended pattern
     assert op.exists(split_fname_elekta_part2)
     # check that filenames are being formatted correctly for BIDS
-    with pytest.warns(None):
+    with pytest.warns(RuntimeWarning):
         raw_1.save(split_fname,
                    buffer_size_sec=1.0, split_size='10MB',
                    split_naming='bids',

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -409,10 +409,11 @@ def test_split_files():
     # check that the filenames match the intended pattern
     assert op.exists(split_fname_elekta_part2)
     # check that filenames are being formatted correctly for BIDS
-    raw_1.save(split_fname,
-               buffer_size_sec=1.0, split_size='10MB',
-               split_naming='bids',
-               overwrite=True)
+    with pytest.warns(None):
+        raw_1.save(split_fname,
+                   buffer_size_sec=1.0, split_size='10MB',
+                   split_naming='bids',
+                   overwrite=True)
     assert op.exists(split_fname_bids_part1)
     assert op.exists(split_fname_bids_part2)
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -409,11 +409,10 @@ def test_split_files():
     # check that the filenames match the intended pattern
     assert op.exists(split_fname_elekta_part2)
     # check that filenames are being formatted correctly for BIDS
-    with pytest.warns(RuntimeWarning):
-        raw_1.save(split_fname,
-                   buffer_size_sec=1.0, split_size='10MB',
-                   split_naming='bids',
-                   overwrite=True)
+    raw_1.save(split_fname,
+               buffer_size_sec=1.0, split_size='10MB',
+               split_naming='bids',
+               overwrite=True)
     assert op.exists(split_fname_bids_part1)
     assert op.exists(split_fname_bids_part2)
 
@@ -428,7 +427,8 @@ def test_split_files():
     assert_array_equal(data_1, data_2)
     assert_array_equal(times_1, times_2)
 
-    raw_bids = read_raw_fif(split_fname_bids_part1)
+    with pytest.warns(RuntimeWarning, match='does not conform to MNE'):
+        raw_bids = read_raw_fif(split_fname_bids_part1)
     data_bids, times_bids = raw_bids[:, :]
     assert_array_equal(data_1, data_bids)
     assert_array_equal(times_1, times_bids)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -399,8 +399,22 @@ def test_split_files():
 
     assert_allclose(raw_1.buffer_size_sec, 10., atol=1e-2)  # samp rate
     split_fname = op.join(tempdir, 'split_raw.fif')
+    # intended filenames
+    split_fname_elekta_part2 = op.join(tempdir, 'split_raw-1.fif')
+    split_fname_bids_part1 = op.join(tempdir, 'split_raw_part-01_meg.fif')
+    split_fname_bids_part2 = op.join(tempdir, 'split_raw_part-02_meg.fif')
     raw_1.set_annotations(Annotations([2.], [5.5], 'test'))
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
+
+    # check that the filenames match the intended pattern
+    assert op.exists(split_fname_elekta_part2)
+    # check that filenames are being formatted correctly for BIDS
+    raw_1.save(split_fname,
+               buffer_size_sec=1.0, split_size='10MB',
+               split_naming='bids',
+               overwrite=True)
+    assert op.exists(split_fname_bids_part1)
+    assert op.exists(split_fname_bids_part2)
 
     raw_2 = read_raw_fif(split_fname)
     assert_allclose(raw_2.buffer_size_sec, 1., atol=1e-2)  # samp rate


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-bids/issues/17

This adds `split_naming` arg to the save method to make BIDS-compatible files