### PR TITLE
WIP: Fix topomap plotting for EEG

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1515,8 +1515,9 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
         ax.set(xticks=[], yticks=[], aspect='equal')
         fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
                             hspace=None)
+        head_dict = dict(center=(0, 0), scale=(0.25, 0.25))
         if to_sphere:
-            pos, outlines = _check_outlines(pos, 'head')
+            pos, outlines = _check_outlines(pos, 'head', head_dict)
         else:
             pos, outlines = _check_outlines(pos, np.array([0.5, 0.5]),
                                             {'center': (0, 0),


### PR DESCRIPTION
Closes #5190.

This is going to be a nightmare to ensure we don't break things. But at least so far #5190 is fixed.

Todo:
- [x] Make the `plot_sensors` be in physical coordinates
- [ ] make all code assume a 8cm head radius (or whatever we use in `Montage`)
- [ ] ensure our montages actually use the same head sizes
- [ ] check that #4880 is fixed
- [ ] check that #5190 is fixed 
- [ ] check `plot_topomap` examples
- [ ] check `plot_sensors` or `montage.plot` examples
- [ ] decide how to deal with `transform` in `montage`. I think that it should default to `True` -- we always want our data in some understandable coordinate system, so MEG device, head, or MRI. With `transform=False` default, the channels are in none of these (but can be converted using LPA/RPA/Nasion, assuming these have not been removed from the data). But maybe this should just wait for the `Digitization` PR...

cc @jona-sassenhagen @sappelhoff @cbrnr you might be interested in this plan.

After this, due to using physical units for the head, #5471 should be simpler.