### PR TITLE
MRG: CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
         - run: pip uninstall --yes mayavi vtk
         - run: pip install vtk mayavi PyQt5 PyQt5-sip sip matplotlib
         - run: echo "export LD_PRELOAD=~/miniconda/envs/mne/lib/libgobject-2.0.so.0.5600.1" >> $BASH_ENV
+        - run: pip install --upgrade "https://api.github.com/repos/nipy/PySurfer/zipball/master"
         # Look at what we have and fail early if there is some library conflict
         - run: which python
         - run: python -c "import mne; mne.sys_info()"

--- a/examples/visualization/plot_parcellation.py
+++ b/examples/visualization/plot_parcellation.py
@@ -5,7 +5,7 @@ Plot a cortical parcellation
 ============================
 
 In this example, we download the HCP-MMP1.0 parcellation [1]_ and show it
-on fsaverage.
+on ``fsaverage``.
 
 .. note:: The HCP-MMP dataset has license terms restricting its use.
           Of particular relevance:


### PR DESCRIPTION
Should make CircleCI green on `master` again.

We should really release a new PySurfer. But in the meantime, this should work.