### PR TITLE
MRG: Do regularization in PCA space

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,8 @@ Changelog
 
 - Add :func:`mne.io.read_raw_fieldtrip`, :func:`mne.read_epochs_fieldtrip` and :func:`mne.read_evoked_fieldtrip` to import FieldTrip data. By `Thomas Hartmann`_ and `Dirk Gütlin`_.
 
+- Add ``rank`` parameter to :func:`mne.compute_covariance`, :func:`mne.cov.regularize` and related functions to preserve data rank during regularization by `Eric Larson`_ and `Denis Engemann`_
+
 - Add new function :func:`mne.read_annotations` that can read annotations in EEGLAB, BrainVision, EDF and Brainstorm formats by `Joan Massich`_ and `Alex Gramfort`_.
 
 - :func:`mne.io.read_raw_eeglab` no longer warns when the stim channel is populated with an array of zeros by `Joan Massich`_
@@ -114,6 +116,8 @@ Bug
 - Fix :func:`mne.io.Raw.plot_projs_topomap` by `Joan Massich`_
 
 - Fix bug in :func:`mne.minimum_norm.compute_source_psd` where the ``stc.times`` output was scaled by 1000, by `Eric Larson`_
+
+- Fix default values for ``'diagonal_fixed'`` estimation method of :func:`mne.compute_covariance` to be ``0.1`` for all channel types, as in :func:`mne.cov.regularize` by `Eric Larson`_
 
 - Fix reading edf file annotations by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,7 +25,7 @@ Changelog
 
 - Add :func:`mne.io.read_raw_fieldtrip`, :func:`mne.read_epochs_fieldtrip` and :func:`mne.read_evoked_fieldtrip` to import FieldTrip data. By `Thomas Hartmann`_ and `Dirk Gütlin`_.
 
-- Add ``rank`` parameter to :func:`mne.compute_covariance`, :func:`mne.cov.regularize` and related functions to preserve data rank during regularization by `Eric Larson`_ and `Denis Engemann`_
+- Add ``rank`` parameter to :func:`mne.compute_covariance`, :func:`mne.cov.regularize` and related functions to preserve data rank and speed up computation using low-rank computations during regularization by `Eric Larson`_ and `Denis Engemann`_
 
 - Add new function :func:`mne.read_annotations` that can read annotations in EEGLAB, BrainVision, EDF and Brainstorm formats by `Joan Massich`_ and `Alex Gramfort`_.
 

--- a/examples/inverse/plot_covariance_whitening_dspm.py
+++ b/examples/inverse/plot_covariance_whitening_dspm.py
@@ -104,7 +104,7 @@ for n_train in samples_epochs:
     # with verbose='error'
     noise_covs = compute_covariance(
         epochs_train, method=method, tmin=None, tmax=0,  # baseline only
-        return_estimators=True, verbose='error')  # returns list
+        return_estimators=True, rank=None, verbose='error')  # returns list
     # prepare contrast
     evokeds = [epochs_train[k].average() for k in conditions]
     del epochs_train, events_

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -58,9 +58,10 @@ forward = mne.read_forward_solution(fname_fwd)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
 # Compute regularized noise and data covariances
-noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk')
+noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk',
+                                   rank=None)
 data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
-                                  method='shrunk')
+                                  method='shrunk', rank=None)
 evoked.plot(time_unit='s')
 
 ###############################################################################

--- a/examples/visualization/plot_evoked_whitening.py
+++ b/examples/visualization/plot_evoked_whitening.py
@@ -54,9 +54,11 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
 
 ###############################################################################
 # Compute covariance using automated regularization
+method_params = dict(diagonal_fixed=dict(mag=0.01, grad=0.01, eeg=0.01))
 noise_covs = compute_covariance(epochs, tmin=None, tmax=0, method='auto',
                                 return_estimators=True, verbose=True, n_jobs=1,
-                                projs=None)
+                                projs=None, rank=None,
+                                method_params=method_params)
 
 # With "return_estimator=True" all estimated covariances sorted
 # by log-likelihood are returned.

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -89,7 +89,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     noise_cov = mne.read_cov(fname_cov)
     noise_cov['projs'] = []  # avoid warning
     noise_cov = mne.cov.regularize(noise_cov, info, mag=0.05, grad=0.05,
-                                   eeg=0.1, proj=True)
+                                   eeg=0.1, proj=True, rank=None)
     if data_cov:
         data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.145)
     else:
@@ -539,7 +539,7 @@ def test_tf_lcmv():
             epochs_band, tmin=tmin, tmax=tmin + win_length)
         noise_cov = mne.cov.regularize(
             noise_cov, epochs_band.info, mag=reg, grad=reg, eeg=reg,
-            proj=True)
+            proj=True, rank=None)
         noise_covs.append(noise_cov)
         del raw_band  # to save memory
 

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -38,7 +38,7 @@ def _get_data(ch_decim=1):
 
     noise_cov = mne.read_cov(fname_cov)
     noise_cov['projs'] = []
-    noise_cov = regularize(noise_cov, evoked.info)
+    noise_cov = regularize(noise_cov, evoked.info, rank=None)
     return evoked, noise_cov
 
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -573,8 +573,8 @@ def _check_rank(rank, methods, was_auto=False):
             methods.pop(methods.index('factor_analysis'))
         for method in methods:
             if method in ('pca', 'factor_analysis'):
-                raise ValueError('%s can only be used with rank="full", '
-                                 'got rank=%r' % (method, rank))
+                raise ValueError('%s can so far only be used with rank="full",'
+                                 ' got rank=%r' % (method, rank))
         rank = dict() if rank is None else rank
         orig_rank = rank
         try:

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1075,8 +1075,6 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     if len(method) > 1:
         logger.info('Using cross-validation to select the best estimator.')
 
-    # undo scaling
-    _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
     out = dict()
     for ei, (estimator, cov, runtime_info) in enumerate(estimator_cov_info):
         if len(method) > 1:
@@ -1092,6 +1090,9 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
         this_method = method_.__name__ if callable(method_) else method_
         out[this_method] = dict(loglik=loglik, data=cov, estimator=estimator)
         out[this_method].update(runtime_info)
+    # undo scaling if we need to, as we might have been operating inplace
+    if eigvec is None:
+        _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
 
     return out
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -964,7 +964,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     ok_sklearn = check_version('sklearn', '0.15')
     if not ok_sklearn and (len(method) != 1 or method[0] != 'empirical'):
         raise ValueError('scikit-learn is not installed, `method` must be '
-                         '`empirical`')
+                         '`empirical`, got %s' % (method,))
 
     for this_method in method:
         data_ = data.copy()
@@ -1038,7 +1038,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
             del shrinkage, sc
 
         elif this_method == 'pca':
-            # XXX Disallow unless rank='full'?
+            assert rank == 'full'  # guaranteed above
             pca, _info = _auto_low_rank_model(
                 data_, this_method, n_jobs=n_jobs, method_params=mp, cv=cv,
                 stop_early=stop_early)
@@ -1047,7 +1047,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
             del pca
 
         elif this_method == 'factor_analysis':
-            # XXX Disallow unless rank='full'?
+            assert rank == 'full'
             fa, _info = _auto_low_rank_model(
                 data_, this_method, n_jobs=n_jobs, method_params=mp, cv=cv,
                 stop_early=stop_early)
@@ -1176,8 +1176,8 @@ def _auto_low_rank_model(data, mode, n_jobs, method_params, cv,
 class _RegCovariance(BaseEstimator):
     """Aux class."""
 
-    def __init__(self, info, grad=0.01, mag=0.01, eeg=0., seeg=0., ecog=0.,
-                 hbo=0., hbr=0., store_precision=False,
+    def __init__(self, info, grad=0.1, mag=0.1, eeg=0.1, seeg=0.1, ecog=0.1,
+                 hbo=0.1, hbr=0.1, store_precision=False,
                  assume_centered=False):
         self.info = info
         # For sklearn compat, these cannot (easily?) be combined into
@@ -1209,7 +1209,7 @@ class _RegCovariance(BaseEstimator):
             cov_, self.info, proj=False, exclude='bads',
             grad=self.grad, mag=self.mag, eeg=self.eeg,
             ecog=self.ecog, seeg=self.seeg,
-            hbo=self.hbo, hbr=self.hbr, rank='full')  # ~proj == important!!
+            hbo=self.hbo, hbr=self.hbr, rank='full')
         self.estimator_.covariance_ = self.covariance_ = cov_.data
         return self
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -60,6 +60,10 @@ class CSP(TransformerMixin, BaseEstimator):
         Parameters to pass to :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.16
+    rank : None | int | dict | 'full'
+        See :func:`mne.compute_covariance`.
+
+        .. versionadded:: 0.17
 
     Attributes
     ----------
@@ -92,12 +96,13 @@ class CSP(TransformerMixin, BaseEstimator):
 
     def __init__(self, n_components=4, reg=None, log=None, cov_est="concat",
                  transform_into='average_power', norm_trace=False,
-                 cov_method_params=None):
+                 cov_method_params=None, rank=''):
         """Init of CSP."""
         # Init default CSP
         if not isinstance(n_components, int):
             raise ValueError('n_components must be an integer.')
         self.n_components = n_components
+        self.rank = rank
 
         self.reg = reg
 
@@ -169,7 +174,8 @@ class CSP(TransformerMixin, BaseEstimator):
                 class_ = np.transpose(X[y == this_class], [1, 0, 2])
                 class_ = class_.reshape(n_channels, -1)
                 cov = _regularized_covariance(
-                    class_, reg=self.reg, method_params=self.cov_method_params)
+                    class_, reg=self.reg, method_params=self.cov_method_params,
+                    rank=self.rank)
                 weight = sum(y == this_class)
             elif self.cov_est == "epoch":
                 class_ = X[y == this_class]
@@ -177,7 +183,8 @@ class CSP(TransformerMixin, BaseEstimator):
                 for this_X in class_:
                     cov += _regularized_covariance(
                         this_X, reg=self.reg,
-                        method_params=self.cov_method_params)
+                        method_params=self.cov_method_params,
+                        rank=self.rank)
                 cov /= len(class_)
                 weight = len(class_)
 

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -187,7 +187,8 @@ def test_regularized_csp():
     n_components = 3
     reg_cov = [None, 0.05, 'ledoit_wolf', 'oas']
     for reg in reg_cov:
-        csp = CSP(n_components=n_components, reg=reg, norm_trace=False)
+        csp = CSP(n_components=n_components, reg=reg, norm_trace=False,
+                  rank=None)
         csp.fit(epochs_data, epochs.events[:, -1])
         y = epochs.events[:, -1]
         X = csp.fit_transform(epochs_data, y)

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -63,7 +63,7 @@ def test_gamma_map():
     evoked.crop(tmin=0.1, tmax=0.14)  # crop to window around peak
 
     cov = read_cov(fname_cov)
-    cov = regularize(cov, evoked.info)
+    cov = regularize(cov, evoked.info, rank=None)
 
     alpha = 0.5
     stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
@@ -98,7 +98,7 @@ def test_gamma_map_vol_sphere():
     evoked.crop(tmin=0.1, tmax=0.16)  # crop to window around peak
 
     cov = read_cov(fname_cov)
-    cov = regularize(cov, evoked.info)
+    cov = regularize(cov, evoked.info, rank=None)
 
     info = evoked.info
     sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.080)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -663,6 +663,14 @@ def pick_channels_cov(orig, include=[], exclude='bads'):
     return res
 
 
+def _mag_grad_dependent(info):
+    """Determine of mag and grad should be dealt with jointly."""
+    # right now just uses SSS, could be computed / checked from cov
+    # but probably overkill
+    return any(ph.get('max_info', {}).get('sss_info', {}).get('in_order', 0)
+               for ph in info.get('proc_history', []))
+
+
 def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     """Get data channel indices as separate list of tuples.
 
@@ -672,6 +680,7 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
         The info.
     meg_combined : bool
         Whether to return combined picks for grad and mag.
+        Can be 'auto' to choose based on Maxwell filtering status.
     ref_meg : bool
         If True include CTF / 4D reference channels
     exclude : list of string | str
@@ -684,6 +693,8 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
         The list of tuples of picks and the type string.
     """
     from ..channels.channels import _contains_ch_type
+    if meg_combined == 'auto':
+        meg_combined = _mag_grad_dependent(info)
     picks_list = []
     has = [_contains_ch_type(info, k) for k in _DATA_CH_TYPES_SPLIT]
     has = dict(zip(_DATA_CH_TYPES_SPLIT, has))

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 #          Martin Luessi <mluessi@nmr.mgh.harvard.edu>
@@ -678,7 +679,7 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     ----------
     info : instance of mne.measuerment_info.Info
         The info.
-    meg_combined : bool | 'auto'
+    meg_combined : bool | 'auto'
         Whether to return combined picks for grad and mag.
         Can be 'auto' to choose based on Maxwell filtering status.
     ref_meg : bool

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -678,7 +678,7 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     ----------
     info : instance of mne.measuerment_info.Info
         The info.
-    meg_combined : bool
+    meg_combined : bool | 'auto'
         Whether to return combined picks for grad and mag.
         Can be 'auto' to choose based on Maxwell filtering status.
     ref_meg : bool

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -147,10 +147,15 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
 
     classes = np.unique(y)
 
+    # XXX Eventually this could be made to deal with rank deficiency properly
+    # by exposing this "rank" parameter, but this will require refactoring
+    # the linalg.eigh call to operate in the lower-dimension
+    # subspace, then project back out.
+
     # Retrieve or compute whitening covariance
     if signal_cov is None:
         signal_cov = _regularized_covariance(
-            np.hstack(epochs_data), reg, method_params, info)
+            np.hstack(epochs_data), reg, method_params, info, rank='full')
     elif isinstance(signal_cov, Covariance):
         signal_cov = signal_cov.data
     if not isinstance(signal_cov, np.ndarray) or (
@@ -175,7 +180,8 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
     for evo, toeplitz in zip(evokeds, toeplitzs):
         # Estimate covariance matrix of the prototype response
         evo = np.dot(evo, toeplitz)
-        evo_cov = _regularized_covariance(evo, reg, method_params, info)
+        evo_cov = _regularized_covariance(evo, reg, method_params, info,
+                                          rank='full')
 
         # Fit spatial filters
         try:

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -40,7 +40,8 @@ def test_simulate_evoked():
     evoked_template = read_evokeds(ave_fname, condition=0, baseline=None)
     evoked_template.pick_types(meg=True, eeg=True, exclude=raw.info['bads'])
 
-    cov = regularize(cov, evoked_template.info)
+    with pytest.deprecated_call(match='full'):  # this won't depend on rank
+        cov = regularize(cov, evoked_template.info)
     nave = evoked_template.nave
 
     tmin = -0.1

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -734,9 +734,9 @@ def test_low_rank():
     with pytest.deprecated_call(match='rank'):
         compute_covariance(epochs, method='oas')
     # degenerate
-    with pytest.raises(ValueError, match='can only be used with rank="full"'):
+    with pytest.raises(ValueError, match='can.*only be used with rank="full"'):
         compute_covariance(epochs, rank=None, method='pca')
-    with pytest.raises(ValueError, match='can only be used with rank="full"'):
+    with pytest.raises(ValueError, match='can.*only be used with rank="full"'):
         compute_covariance(epochs, rank=None, method='factor_analysis')
 
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -350,7 +350,6 @@ def test_arithmetic_cov():
 
 def test_regularize_cov():
     """Test cov regularization."""
-    # XXX this needs to be fixed to properly support SSS / rank
     raw = read_raw_fif(raw_fname)
     raw.info['bads'].append(raw.ch_names[0])  # test with bad channels
     noise_cov = read_cov(cov_fname)

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -658,7 +658,7 @@ def test_low_rank():
     bounds = {
         'None': dict(empirical=(-6000, -5000),
                      diagonal_fixed=(-1500, -500),
-                     oas=(-800, -700)),
+                     oas=(-700, -600)),
         'full': dict(empirical=(-9000, -8000),
                      diagonal_fixed=(-2000, -1600),
                      oas=(-1600, -1000)),

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -21,16 +21,18 @@ from mne.cov import (regularize, whiten_evoked, _estimate_rank_meeg_cov,
 from mne import (read_cov, write_cov, Epochs, merge_events,
                  find_events, compute_raw_covariance,
                  compute_covariance, read_evokeds, compute_proj_raw,
-                 pick_channels_cov, pick_types, pick_info, make_ad_hoc_cov)
-from mne.fixes import _get_args
-from mne.io import read_raw_fif, RawArray, read_info, read_raw_ctf
-from mne.tests.common import assert_snr
-from mne.utils import _TempDir, requires_version, run_tests_if_main
-from mne.io.proc_history import _get_sss_rank
-from mne.io.pick import channel_type, _picks_by_type, _DATA_CH_TYPES_SPLIT
-from mne.io.proj import _has_eeg_average_ref_proj
+                 pick_channels_cov, pick_types, pick_info, make_ad_hoc_cov,
+                 make_fixed_length_events)
 from mne.datasets import testing
-from mne.event import make_fixed_length_events
+from mne.fixes import _get_args
+from mne.io import read_raw_fif, RawArray, read_raw_ctf
+from mne.io.pick import channel_type, _picks_by_type, _DATA_CH_TYPES_SPLIT
+from mne.io.proc_history import _get_sss_rank
+from mne.io.proj import _has_eeg_average_ref_proj
+from mne.preprocessing import maxwell_filter
+from mne.tests.common import assert_snr
+from mne.utils import (_TempDir, requires_version, run_tests_if_main,
+                       catch_logging)
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 cov_fname = op.join(base_dir, 'test-cov.fif')
@@ -74,7 +76,9 @@ def test_cov_mismatch():
 
 def test_cov_order():
     """Test covariance ordering."""
-    info = read_info(raw_fname)
+    raw = read_raw_fif(raw_fname)
+    raw.set_eeg_reference(projection=True)
+    info = raw.info
     # add MEG channel with low enough index number to affect EEG if
     # order is incorrect
     info['bads'] += ['MEG 0113']
@@ -92,8 +96,14 @@ def test_cov_order():
     _assert_reorder(cov_reorder, cov, order)
     # Now check some functions that should get the same result for both
     # regularize
-    cov_reg = regularize(cov, info)
-    cov_reg_reorder = regularize(cov_reorder, info)
+    with pytest.raises(ValueError, match='rank, if str'):
+        regularize(cov, info, rank='foo')
+    with pytest.raises(ValueError, match='or "full"'):
+        regularize(cov, info, rank=False)
+    with pytest.raises(ValueError, match='or "full"'):
+        regularize(cov, info, rank=1.)
+    cov_reg = regularize(cov, info, rank='full')
+    cov_reg_reorder = regularize(cov_reorder, info, rank='full')
     _assert_reorder(cov_reg_reorder, cov_reg, order)
     # prepare_noise_cov
     cov_prep = prepare_noise_cov(cov, info, ch_names)
@@ -250,7 +260,8 @@ def _assert_cov(cov, cov_desired, tol=0.005, nfree=True):
 
 
 @pytest.mark.slowtest
-def test_cov_estimation_with_triggers():
+@pytest.mark.parametrize('rank', ('full', None))
+def test_cov_estimation_with_triggers(rank):
     """Test estimation from raw with triggers."""
     tempdir = _TempDir()
     raw = read_raw_fif(raw_fname)
@@ -291,7 +302,7 @@ def test_cov_estimation_with_triggers():
     pytest.raises(ValueError, compute_covariance, epochs,
                   keep_sample_mean=False, method_params=method_params)
     pytest.raises(ValueError, compute_covariance, epochs,
-                  keep_sample_mean=False, method='factor_analysis')
+                  keep_sample_mean=False, method='shrunk', rank=rank)
 
     # test IO when computation done in Python
     cov.save(op.join(tempdir, 'test-cov.fif'))  # test saving
@@ -339,13 +350,14 @@ def test_arithmetic_cov():
 
 def test_regularize_cov():
     """Test cov regularization."""
+    # XXX this needs to be fixed to properly support SSS / rank
     raw = read_raw_fif(raw_fname)
     raw.info['bads'].append(raw.ch_names[0])  # test with bad channels
     noise_cov = read_cov(cov_fname)
     # Regularize noise cov
     reg_noise_cov = regularize(noise_cov, raw.info,
                                mag=0.1, grad=0.1, eeg=0.1, proj=True,
-                               exclude='bads')
+                               exclude='bads', rank='full')
     assert noise_cov['dim'] == reg_noise_cov['dim']
     assert noise_cov['data'].shape == reg_noise_cov['data'].shape
     assert np.mean(noise_cov['data'] < reg_noise_cov['data']) < 0.08
@@ -365,7 +377,7 @@ def test_whiten_evoked():
                        exclude='bads')
 
     noise_cov = regularize(cov, evoked.info, grad=0.1, mag=0.1, eeg=0.1,
-                           exclude='bads')
+                           exclude='bads', rank='full')
 
     evoked_white = whiten_evoked(evoked, noise_cov, picks, diag=True)
     whiten_baseline_data = evoked_white.data[picks][:, evoked.times < 0]
@@ -541,14 +553,11 @@ def test_auto_low_rank():
         _auto_low_rank_model(X, mode=mode, n_jobs=n_jobs,
                              method_params=method_params, cv=cv)
 
-    method_params = {'iter_n_components': [n_features + 5]}
-    pytest.raises(ValueError, _auto_low_rank_model, X, mode='foo',
-                  n_jobs=n_jobs, method_params=method_params, cv=cv)
-
 
 @pytest.mark.slowtest
+@pytest.mark.parametrize('rank', ('full', None))
 @requires_version('sklearn', '0.15')
-def test_compute_covariance_auto_reg():
+def test_compute_covariance_auto_reg(rank):
     """Test automated regularization."""
     raw = read_raw_fif(raw_fname, preload=True)
     raw.resample(100, npad='auto')  # much faster estimation
@@ -565,21 +574,21 @@ def test_compute_covariance_auto_reg():
     epochs = Epochs(
         raw, events_merged, 1234, tmin=-0.2, tmax=0,
         baseline=(-0.2, -0.1), proj=True, reject=reject, preload=True)
-    epochs = epochs.crop(None, 0)[:10]
+    epochs = epochs.crop(None, 0)[:5]
 
     method_params = dict(factor_analysis=dict(iter_n_components=[3]),
                          pca=dict(iter_n_components=[3]))
 
     covs = compute_covariance(epochs, method='auto',
                               method_params=method_params,
-                              return_estimators=True)
+                              return_estimators=True, rank=rank)
     # make sure regularization produces structured differencess
     diag_mask = np.eye(len(epochs.ch_names)).astype(bool)
     off_diag_mask = np.invert(diag_mask)
     for cov_a, cov_b in itt.combinations(covs, 2):
         if (cov_a['method'] == 'diagonal_fixed' and
                 # here we have diagnoal or no regularization.
-                cov_b['method'] == 'empirical'):
+                cov_b['method'] == 'empirical' and rank == 'full'):
 
             assert not np.any(cov_a['data'][diag_mask] ==
                               cov_b['data'][diag_mask])
@@ -599,26 +608,29 @@ def test_compute_covariance_auto_reg():
     logliks = [c['loglik'] for c in covs]
     assert np.diff(logliks).max() <= 0  # descending order
 
-    methods = ['empirical', 'factor_analysis', 'ledoit_wolf', 'oas', 'pca',
-               'shrunk', 'shrinkage']
+    methods = ['empirical', 'ledoit_wolf', 'oas', 'shrunk', 'shrinkage']
+    if rank == 'full':
+        methods.extend(['factor_analysis', 'pca'])
     cov3 = compute_covariance(epochs, method=methods,
                               method_params=method_params, projs=None,
-                              return_estimators=True)
+                              return_estimators=True, rank=rank)
     method_names = [cov['method'] for cov in cov3]
-    for method in ['factor_analysis', 'ledoit_wolf', 'oas', 'pca',
-                   'shrinkage']:
+    best_bounds = [-45, -35]
+    bounds = [-55, -45] if rank == 'full' else best_bounds
+    for method in set(methods) - set(['empirical', 'shrunk']):
         this_lik = cov3[method_names.index(method)]['loglik']
-        assert -55 < this_lik < -45
-    this_lik = cov3[method_names.index('empirical')]['loglik']
-    assert -110 < this_lik < -100
+        assert bounds[0] < this_lik < bounds[1]
     this_lik = cov3[method_names.index('shrunk')]['loglik']
-    assert -45 < this_lik < -35
+    assert best_bounds[0] < this_lik < best_bounds[1]
+    this_lik = cov3[method_names.index('empirical')]['loglik']
+    bounds = [-110, -100] if rank == 'full' else best_bounds
+    assert bounds[0] < this_lik < bounds[1]
 
     assert_equal(set([c['method'] for c in cov3]), set(methods))
 
     cov4 = compute_covariance(epochs, method=methods,
                               method_params=method_params, projs=None,
-                              return_estimators=False)
+                              return_estimators=False, rank=rank)
     assert cov3[0]['method'] == cov4['method']  # ordering
 
     # invalid prespecified method
@@ -627,6 +639,89 @@ def test_compute_covariance_auto_reg():
     # invalid scalings
     pytest.raises(ValueError, compute_covariance, epochs, method='shrunk',
                   scalings=dict(misc=123))
+
+
+def _cov_rank(cov, info):
+    return compute_whitener(cov, info, return_rank=True)[2]
+
+
+@requires_version('sklearn', '0.15')
+def test_low_rank():
+    """Test low-rank covariance matrix estimation."""
+    raw = read_raw_fif(raw_fname).set_eeg_reference(projection=True).crop(0, 3)
+    raw = maxwell_filter(raw, regularize=None)  # heavily reduce the rank
+    sss_proj_rank = 139  # 80 MEG + 60 EEG - 1 proj
+    n_ch = 366
+    proj_rank = 365  # one EEG proj
+    events = make_fixed_length_events(raw)
+    methods = ('empirical', 'diagonal_fixed', 'oas')
+    epochs = Epochs(raw, events, tmin=-0.2, tmax=0, preload=True)
+    bounds = {
+        'None': dict(empirical=(-6000, -5000),
+                     diagonal_fixed=(-1500, -500),
+                     oas=(-700, -600)),
+        'full': dict(empirical=(-9000, -8000),
+                     diagonal_fixed=(-2000, -1600),
+                     oas=(-1600, -1000)),
+    }
+    for rank in ('full', None):
+        covs = compute_covariance(
+            epochs, method=methods, return_estimators=True,
+            verbose='error', rank=rank)
+        for cov in covs:
+            method = cov['method']
+            these_bounds = bounds[str(rank)][method]
+            this_rank = _cov_rank(cov, epochs.info)
+            if rank is None or method == 'empirical':
+                assert this_rank == sss_proj_rank
+            else:
+                assert this_rank == proj_rank
+            assert these_bounds[0] < cov['loglik'] < these_bounds[1], \
+                (rank, method)
+            if method == 'empirical':
+                emp_cov = cov  # save for later, rank param does not matter
+
+    # Test equivalence with mne.cov.regularize subspace
+    with pytest.raises(ValueError, match='are dependent.*must equal'):
+        regularize(emp_cov, epochs.info, rank=None, mag=0.1, grad=0.2)
+    assert _cov_rank(emp_cov, epochs.info) == sss_proj_rank
+    reg_cov = regularize(emp_cov, epochs.info, proj=True, rank='full')
+    assert _cov_rank(reg_cov, epochs.info) == proj_rank
+    del reg_cov
+    with catch_logging() as log:
+        reg_r_cov = regularize(emp_cov, epochs.info, proj=True, rank=None,
+                               verbose=True)
+    log = log.getvalue()
+    assert 'jointly' in log
+    assert _cov_rank(reg_r_cov, epochs.info) == sss_proj_rank
+    reg_r_only_cov = regularize(emp_cov, epochs.info, proj=False, rank=None)
+    assert _cov_rank(reg_r_only_cov, epochs.info) == sss_proj_rank
+    assert_allclose(reg_r_only_cov['data'], reg_r_cov['data'])
+    del reg_r_only_cov, reg_r_cov
+
+    # Work with just EEG data to simplify projection / rank reduction
+    raw.pick_types(meg=False, eeg=True)
+    n_proj = 2
+    raw.add_proj(compute_proj_raw(raw, n_eeg=n_proj))
+    n_ch = len(raw.ch_names)
+    rank = n_ch - n_proj - 1  # plus avg proj
+    assert len(raw.info['projs']) == 3
+    epochs = Epochs(raw, events, tmin=-0.2, tmax=0, preload=True)
+    assert len(raw.ch_names) == n_ch
+    emp_cov = compute_covariance(epochs, rank='full', verbose='error')
+    assert _cov_rank(emp_cov, epochs.info) == rank
+    reg_cov = regularize(emp_cov, epochs.info, proj=True, rank='full')
+    assert _cov_rank(reg_cov, epochs.info) == rank
+    reg_r_cov = regularize(emp_cov, epochs.info, proj=False, rank=None)
+    assert _cov_rank(reg_r_cov, epochs.info) == rank
+    dia_cov = compute_covariance(epochs, rank=None, method='diagonal_fixed',
+                                 verbose='error')
+    assert _cov_rank(dia_cov, epochs.info) == rank
+    assert_allclose(dia_cov['data'], reg_cov['data'])
+    # test our deprecation: can simply remove later
+    epochs.pick_channels(epochs.ch_names[:103])
+    with pytest.deprecated_call(match='rank'):
+        compute_covariance(epochs, method='oas')
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -722,6 +722,11 @@ def test_low_rank():
     epochs.pick_channels(epochs.ch_names[:103])
     with pytest.deprecated_call(match='rank'):
         compute_covariance(epochs, method='oas')
+    # degenerate
+    with pytest.raises(ValueError, match='can only be used with rank="full"'):
+        compute_covariance(epochs, rank=None, method='pca')
+    with pytest.raises(ValueError, match='can only be used with rank="full"'):
+        compute_covariance(epochs, rank=None, method='factor_analysis')
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -70,6 +70,7 @@ def test_bad_proj():
     #     applying projector with 101/306 of the original channels available
     #     may be dangerous.
     raw = read_raw_fif(raw_fname).crop(0, 1)
+    raw.set_eeg_reference(projection=True)
     raw.info['bads'] = ['MEG 0111']
     meg_picks = mne.pick_types(raw.info, meg=True, exclude=())
     ch_names = [raw.ch_names[pick] for pick in meg_picks]
@@ -79,7 +80,7 @@ def test_bad_proj():
         data[:, idx] = p['data']['data']
         p['data'].update(ncol=len(meg_picks), col_names=ch_names, data=data)
     mne.cov.regularize(mne.compute_raw_covariance(raw, verbose='error'),
-                       raw.info)
+                       raw.info, rank=None)
 
 
 def _check_warnings(raw, events, picks=None, count=3):

--- a/tutorials/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/plot_brainstorm_phantom_elekta.py
@@ -98,7 +98,9 @@ mne.viz.plot_alignment(raw.info, subject='sample',
 # then do the fits for each event_id taking the time instant that maximizes
 # the global field power.
 
-cov = mne.compute_covariance(epochs, tmax=0)
+cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', rank=None)
+mne.viz.plot_evoked_white(epochs['1'].average(), cov)
+
 data = []
 for ii in event_id:
     evoked = epochs[str(ii)].average()
@@ -132,19 +134,19 @@ actual_amp = 100.  # nAm
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, figsize=(6, 7))
 
 diffs = 1000 * np.sqrt(np.sum((dip.pos - actual_pos) ** 2, axis=-1))
-print('mean(position error) = %s' % (np.mean(diffs),))
+print('mean(position error) = %0.1f mm' % (np.mean(diffs),))
 ax1.bar(event_id, diffs)
 ax1.set_xlabel('Dipole index')
 ax1.set_ylabel('Loc. error (mm)')
 
-angles = np.arccos(np.abs(np.sum(dip.ori * actual_ori, axis=1)))
-print('mean(angle error) = %s' % (np.mean(angles),))
+angles = np.rad2deg(np.arccos(np.abs(np.sum(dip.ori * actual_ori, axis=1))))
+print(u'mean(angle error) = %0.1f°' % (np.mean(angles),))
 ax2.bar(event_id, angles)
 ax2.set_xlabel('Dipole index')
-ax2.set_ylabel('Angle error (rad)')
+ax2.set_ylabel(u'Angle error (°)')
 
 amps = actual_amp - dip.amplitude / 1e-9
-print('mean(abs amplitude error) = %s' % (np.mean(np.abs(amps)),))
+print('mean(abs amplitude error) = %0.1f nAm' % (np.mean(np.abs(amps)),))
 ax3.bar(event_id, amps)
 ax3.set_xlabel('Dipole index')
 ax3.set_ylabel('Amplitude error (nAm)')

--- a/tutorials/plot_compute_covariance.py
+++ b/tutorials/plot_compute_covariance.py
@@ -102,7 +102,8 @@ noise_cov_baseline.plot(epochs.info, proj=True)
 # described in [1]_. For this the 'auto' option can be used. With this
 # option cross-validation will be used to learn the optimal regularization:
 
-noise_cov_reg = mne.compute_covariance(epochs, tmax=0., method='auto')
+noise_cov_reg = mne.compute_covariance(epochs, tmax=0., method='auto',
+                                       rank=None)
 
 ###############################################################################
 # This procedure evaluates the noise covariance quantitatively by how well it
@@ -145,7 +146,8 @@ evoked.plot_white(noise_cov_reg, time_unit='s')
 # :ref:`sphx_glr_auto_examples_inverse_plot_covariance_whitening_dspm.py`):
 
 noise_covs = mne.compute_covariance(
-    epochs, tmax=0., method=('empirical', 'shrunk'), return_estimators=True)
+    epochs, tmax=0., method=('empirical', 'shrunk'), return_estimators=True,
+    rank=None)
 evoked.plot_white(noise_covs, time_unit='s')
 
 

--- a/tutorials/plot_whitened.py
+++ b/tutorials/plot_whitened.py
@@ -32,7 +32,7 @@ reject = dict(grad=4000e-13, mag=4e-12, eog=150e-6)
 epochs = mne.Epochs(raw, events, event_id=event_id, reject=reject)
 
 # baseline noise cov, not a lot of samples
-noise_cov = mne.compute_covariance(epochs, tmax=0., method='shrunk',
+noise_cov = mne.compute_covariance(epochs, tmax=0., method='shrunk', rank=None,
                                    verbose='error')
 
 # butterfly mode shows the differences most clearly


### PR DESCRIPTION
We currently do covariance regularization on the full rank data. Thus rank-deficient covariance matrices become full rank. This PR changes it so that regularization is done in the lower-dimensional space, then projected back out, which should preserve the original rank.

This probably has some small impact on full-rank MEG data (e.g., 306 channels with a handful of projs) but the impact is magnified by Maxwell filtering due to the larger rank reduction.

- [x] ~~Something is fishy with~~ the `loglik` values are pretty uniformly `-39` in the previous tests across all methods, because they all provide the same quality estimates when using low-rank computation. This score was the best score before, so it's reasonable they all achieve it now (assuming the differences before were driven by how well the low-rank-ness was captured by each method).
- [x] Need to check examples
- [x] Try on SSS'ed data
- [x] Add check that `mne.cov.regularize(..., proj=True)` gives same result as `diagonal_fixed` now
- [x] Fix `mne.cov.regularize` to respect rank with new `rank` argument
- [x] Fix defaults for `diagonal_fixed` method to match those of `mne.cov.regularize`
- [x] ~~Fix some missing FIFF constants, and fix check for missing ones~~ #5691
- [x] ~~Fix `job` output in info for `maxwell_filtering` to reflect what we actually do~~ #5691
- [x] Make CIs happy
- [x] Check diagonal_fixed result -- amplitude decreases in plot_white example?
- [x] Merge #5691 and rebase this
- [x] Update API to reflect beamformer changes

Updated examples (930bee9):

- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_examples/inverse/plot_covariance_whitening_dspm.html) - [master](http://mne-tools.github.io/dev/auto_examples/inverse/plot_covariance_whitening_dspm.html)
- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_examples/inverse/plot_lcmv_beamformer.html) - [master](http://mne-tools.github.io/dev/auto_examples/inverse/plot_lcmv_beamformer.html)
- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_examples/visualization/plot_evoked_whitening.html) - [master](http://mne-tools.github.io/dev/auto_examples/visualization/plot_evoked_whitening.html)
- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_tutorials/plot_brainstorm_phantom_elekta.html) - [master](http://mne-tools.github.io/dev/auto_tutorials/plot_brainstorm_phantom_elekta.html)
- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_tutorials/plot_compute_covariance.html) - [master](http://mne-tools.github.io/dev/auto_tutorials/plot_compute_covariance.html)
- [PR](https://10142-1301584-gh.circle-artifacts.com/0/html/auto_tutorials/plot_whitened.html) - [master](http://mne-tools.github.io/dev/auto_tutorials/plot_whitened.html)

It looks like most did not change. I did change `bst_phantom_elekta` to use `method='shrunk'`, which no longer increases the cov rank to 306 (hooray!).