### PR TITLE
MRG: Initialize self._current in Epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -112,6 +112,8 @@ Bug
 
 - Fix title of custom slider images to :class:`mne.Report` by `Marijn van Vliet`_
 
+- Fix missing initialization of ``self._current`` in :class:`mne.Epochs` by `Henrich Kolkhorst`_
+
 API
 ~~~
 
@@ -135,6 +137,8 @@ API
 - `src.kind` now equals to `'mixed'` (and not `'combined'`) for a mixed source space (made of surfaces and volume grids) by `Alex Gramfort`_
 
 - Deprecation of :meth:`mne.io.BaseRaw.annotations` property in favor of :meth:`mne.io.BaseRaw.set_annotations` by `Joan Massich`_
+
+- The default value of ``stop_receive_thread`` in :meth:`mne.realtime.RtEpochs.stop` has been changed to ``True`` by `Henrich Kolkhorst`_
 
 .. _changes_0_16:
 

--- a/examples/realtime/ftclient_rt_average.py
+++ b/examples/realtime/ftclient_rt_average.py
@@ -90,4 +90,5 @@ with FieldTripClient(host='localhost', port=1972,
         plt.pause(0.05)
         plt.draw()
 
+    rt_epochs.stop()
     plt.close()

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -341,6 +341,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         del info
         self._metadata = None
         self.metadata = metadata
+        self._current = 0
 
         if picks is None:
             picks = list(range(len(self.info['ch_names'])))
@@ -720,6 +721,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         The Evoked objects yielded will each contain a single epoch (i.e., no
         averaging is performed).
+
+        This method resets the object iteration state to the first epoch.
         """
         self._current = 0
 
@@ -1304,6 +1307,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     def __iter__(self):
         """Facilitate iteration over epochs.
+
+        This method resets the object iteration state to the first epoch.
 
         Notes
         -----
@@ -2007,6 +2012,10 @@ class Epochs(BaseEpochs):
 
     For indexing and slicing using ``epochs[...]``, see
     :meth:`mne.Epochs.__getitem__`.
+
+    All methods for iteration over objects (using :meth:`mne.Epochs.__iter__`,
+    :meth:`mne.Epochs.iter_evoked` or :meth:`mne.Epochs.next`) use the same
+    internal state.
     """
 
     @verbose

--- a/mne/realtime/client.py
+++ b/mne/realtime/client.py
@@ -292,7 +292,6 @@ class RtClient(object):
             Also stop the measurement.
         """
         if self._recv_thread is not None:
-            self._recv_thread.stop()
             self._recv_thread = None
 
         if stop_measurement:
@@ -364,7 +363,8 @@ class RtClient(object):
         raw_buffer : generator
             Generator for iteration over raw buffers.
         """
-        while True:
+        # stops the loop if stop_receive_thread has been called
+        while self._recv_thread == threading.current_thread():
             raw_buffer = self.read_raw_buffer(nchan)
             if raw_buffer is not None:
                 yield raw_buffer

--- a/mne/realtime/client.py
+++ b/mne/realtime/client.py
@@ -291,8 +291,7 @@ class RtClient(object):
         stop_measurement : bool
             Also stop the measurement.
         """
-        if self._recv_thread is not None:
-            self._recv_thread = None
+        self._recv_thread = None
 
         if stop_measurement:
             self.stop_measurement()

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -311,13 +311,18 @@ class RtEpochs(BaseEpochs):
         if stop_receive_thread or stop_measurement:
             self._client.stop_receive_thread(stop_measurement=stop_measurement)
 
-    def next(self, return_event_id=False):
+    @verbose
+    def next(self, return_event_id=False, verbose=None):
         """Make iteration over epochs easy.
 
         Parameters
         ----------
         return_event_id : bool
             If True, return both an epoch and and event_id.
+        verbose: bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more). Defaults to self.verbose.
 
         Returns
         -------

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -290,7 +290,7 @@ class RtEpochs(BaseEpochs):
             self._started = True
             self._last_time = np.inf  # init delay counter. Will stop iters
 
-    def stop(self, stop_receive_thread=False, stop_measurement=False):
+    def stop(self, stop_receive_thread=True, stop_measurement=False):
         """Stop receiving epochs.
 
         Parameters

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -333,10 +333,9 @@ class FieldTripClient(object):
         Parameters
         ----------
         stop_measurement : bool
-            Also stop the measurement.
+            unused, for compatibility.
         """
-        if self._recv_thread is not None:
-            self._recv_thread = None
+        self._recv_thread = None
 
     def iter_raw_buffers(self):
         """Return an iterator over raw buffers.

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -336,7 +336,6 @@ class FieldTripClient(object):
             Also stop the measurement.
         """
         if self._recv_thread is not None:
-            self._recv_thread.stop()
             self._recv_thread = None
 
     def iter_raw_buffers(self):
@@ -366,3 +365,7 @@ class FieldTripClient(object):
             raw_buffer = self.ft_client.getData([start, stop - 1]).transpose()
 
             yield raw_buffer
+
+            if self._recv_thread != threading.current_thread():
+                # stop_receive_thread has been called
+                break

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -116,7 +116,7 @@ def test_fieldtrip_rtepochs(free_tcp_port, tmpdir):
                                                   int(ev.comment))
 
                 _call_base_epochs_public_api(epochs_rt, tmpdir)
-                epochs_rt.stop()
+                epochs_rt.stop(stop_receive_thread=True)
 
         assert_array_equal(events_ids_rt, epochs_rt.events[:, 2])
         assert_array_equal(data_rt, epochs_rt.get_data())

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -175,7 +175,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events, verbose='WARNING')
+                         find_events=find_events)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     # make sure next() works even if no iter-method has been called before
@@ -191,7 +191,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events, verbose='WARNING')
+                         find_events=find_events)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 6]
@@ -204,7 +204,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events, verbose='WARNING')
+                         find_events=find_events)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5]
@@ -217,7 +217,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events, verbose='WARNING')
+                         find_events=find_events)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 0, 6, 0]
@@ -238,7 +238,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events, verbose='WARNING')
+                         find_events=find_events)
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5]
@@ -258,7 +258,7 @@ def test_find_events():
         rt_client = MockRtClient(raw)
         rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                              stim_channel='STI 014', isi_max=0.5,
-                             find_events=find_events, verbose='WARNING')
+                             find_events=find_events)
         rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10,
                             buffer_size=1000)
         rt_epochs.start()

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -26,6 +26,7 @@ events = read_events(event_name)
 
 def _call_base_epochs_public_api(epochs, tmpdir):
     """Call all public API methods of an (non-empty) epochs object."""
+    # make sure saving and loading returns the same data
     orig_data = epochs.get_data()
     export_file = tmpdir.join('test_rt-epo.fif')
     epochs.save(str(export_file))
@@ -174,9 +175,12 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, verbose='WARNING')
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
+    # make sure next() works even if no iter-method has been called before
+    rt_epochs.next()
+
     events = [5, 6]
     for ii, ev in enumerate(rt_epochs.iter_evoked()):
         assert ev.comment == str(events[ii])
@@ -187,7 +191,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, verbose='WARNING')
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 6]
@@ -200,7 +204,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, verbose='WARNING')
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5]
@@ -213,7 +217,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, verbose='WARNING')
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5, 6, 5, 0, 6, 0]
@@ -234,7 +238,7 @@ def test_find_events():
     rt_client = MockRtClient(raw)
     rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                          stim_channel='STI 014', isi_max=0.5,
-                         find_events=find_events)
+                         find_events=find_events, verbose='WARNING')
     rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10, buffer_size=1000)
     rt_epochs.start()
     events = [5]
@@ -254,7 +258,7 @@ def test_find_events():
         rt_client = MockRtClient(raw)
         rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, picks=picks,
                              stim_channel='STI 014', isi_max=0.5,
-                             find_events=find_events)
+                             find_events=find_events, verbose='WARNING')
         rt_client.send_data(rt_epochs, picks, tmin=0, tmax=10,
                             buffer_size=1000)
         rt_epochs.start()


### PR DESCRIPTION
#### Reference issue
Fixes #5449 and fixes #5450.


#### What does this implement/fix?
* Initializes ``self._current`` in ``Epochs``. I also added some notes that the iteration state for an ``Epochs`` object is shared between the different methods (something I stumbled over a while ago).
* remove call no non-existing ``stop`` method of ``Thread`` (there do not seem to be tests or examples that use ``RtClient``!?)
* while at it, I added a verbose decorator to ``RtEpochs.next()`` to be able to turn off the "Waiting for epoch i" messages
