### PR TITLE
MRG: Add time series to example

### DIFF
--- a/examples/time_frequency/plot_time_frequency_simulated.py
+++ b/examples/time_frequency/plot_time_frequency_simulated.py
@@ -60,6 +60,8 @@ for k in range(n_epochs):
 epochs = EpochsArray(data=data, info=info, events=events, event_id=event_id,
                      reject=reject)
 
+epochs.average().plot()
+
 ###############################################################################
 # Calculate a time-frequency representation (TFR)
 # -----------------------------------------------


### PR DESCRIPTION
We should probably show the original simulated data time series before showing a bunch of TFRs.