### PR TITLE
Prevent overflow in concatenate epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -108,6 +108,8 @@ Bug
 
 - Fix the use of :func:`sklearn.model_selection.cross_val_predict` with :class:`mne.decoding.SlidingEstimator` by `Alex Gramfort`_
 
+- Fix event sample number increase when combining many Epochs objects with :func:`mne.concatenate_epochs` with  by `Jasper van den Bosch`_
+
 API
 ~~~
 
@@ -2858,3 +2860,5 @@ of commits):
 .. _Steven Gutstein: http://robust.cs.utep.edu/~gutstein
 
 .. _Peter Molfese: https://github.com/pmolfese
+
+.. _Jasper van den Bosch: https://github.com/ilogue

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2877,7 +2877,7 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True):
             evs[:, 0] += events_offset
         # Update offset for the next iteration.
         # offset is the last epoch + tmax + 10 second
-        events_offset += (np.max(evs[:, 0]) +
+        events_offset += (np.max(epochs.events[:, 0]) +
                           int((10 + tmax) * epochs.info['sfreq']))
         events.append(evs)
         selection = np.concatenate((selection, epochs.selection))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2158,6 +2158,12 @@ def test_concatenate_epochs():
         rel_pos = epochs_list[ii].events[:, 0] - evs[:, 0]
         assert (sum(rel_pos - rel_pos[0]) == 0)
 
+    # test large number of epochs
+    long_epochs_list = [epochs.copy() for ii in range(60)]
+    many_epochs_cat = concatenate_epochs(long_epochs_list)
+    max_expected_sample_index = 60 * 1.2 * np.max(epochs.events[:, 0])
+    assert np.max(many_epochs_cat.events[:, 0]) < max_expected_sample_index
+
 
 def test_add_channels():
     """Test epoch splitting / re-appending channel types."""


### PR DESCRIPTION

#### Reference issue
Fixes #5495.


#### What does this implement/fix?
In `mne.concatenate_epochs()`, when adding an offset to each iteration of epochs, don't update the offset with itself, as this leads to an overflow with large numbers of epochs.

