### PR TITLE
FIX: Pytest 3.8 fixes

### DIFF
--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -498,7 +498,7 @@ def test_inverse_residual():
     fwd = read_forward_solution(fname_fwd)
     fwd = convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
     fwd = pick_channels_forward(fwd, evoked.ch_names)
-    matcher = re.compile('.* ([0-9]?[0-9]?[0-9]?\.[0-9])% variance.*')
+    matcher = re.compile(r'.* ([0-9]?[0-9]?[0-9]?\.[0-9])% variance.*')
     for method in ('MNE', 'dSPM', 'sLORETA'):
         with catch_logging() as log:
             stc, residual = apply_inverse(

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ filterwarnings =
     ignore:joblib not installed:RuntimeWarning
     ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
     ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
+    ignore:Importing from numpy.testing.decorators is deprecated, import from numpy.testing instead:DeprecationWarning
+    ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py


### PR DESCRIPTION
pytest 3.8 is more sensitive about warnings. This should fix them (the new ignores are due to imported / bundled libs).