### PR TITLE
Fix title of sliders added to Report

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -110,6 +110,8 @@ Bug
 
 - Fix event sample number increase when combining many Epochs objects with :func:`mne.concatenate_epochs` with  by `Jasper van den Bosch`_
 
+- Fix title of custom slider images to :class:`mne.Report` by `Marijn van Vliet`_
+
 API
 ~~~
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1184,7 +1184,7 @@ class Report(object):
                                             slider_id=slider_id, html=html,
                                             image_html=image_html))
 
-        self.fnames.append('%s-#-%s-#-custom' % (section, sectionvar))
+        self.fnames.append('%s-#-%s-#-custom' % (title, sectionvar))
 
     ###########################################################################
     # HTML rendering


### PR DESCRIPTION
When adding custom figures with `mne.Report.add_slider_to_section`, the `section` parameter is erroneously used in the sidebar to refer to the image. This should be the `title` parameter.

![fig](https://user-images.githubusercontent.com/428273/45301034-b082ba00-b518-11e8-8659-4a16a7fb6a39.png)
