### PR TITLE
[MRG] Add open/save to HDF5 ability to mne.Report

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1047,15 +1047,17 @@ MNE-Report
 
 .. currentmodule:: mne
 
-.. automodule:: mne
-   :no-members:
-   :no-inherited-members:
-
 .. autosummary::
    :toctree: generated/
    :template: class.rst
 
    Report
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+    open_report
 
 
 Logging and Configuration

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,10 @@ Changelog
 
 - Add `split_naming` parameter to the `Raw.save` method to allow for BIDS-compatible raw file name construction by `Teon Brooks`_
 
+- Add capability to save a :class:`mne.Report` to an HDF5 file to :meth:`mne.Report.save` by `Marijn van Vliet`_
+
+- Add :func:`mne.open_report` to read back a :class:`mne.Report` object that was saved to an HDF5 file by `Marijn van Vliet`_
+
 Bug
 ~~~
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -87,7 +87,7 @@ from .proj import (read_proj, write_proj, compute_proj_epochs,
 from .selection import read_selection
 from .dipole import read_dipole, Dipole, DipoleFixed, fit_dipole
 from .channels import equalize_channels, rename_channels, find_layout
-from .report import Report
+from .report import Report, open_report
 
 from . import beamformer
 from . import channels


### PR DESCRIPTION
This allows you to save `mne.Report` objects in such a way that they can be read back later. This in turn allows you to incrementally add figures to a `Report` object across scripts.

The `mne.open_report` function either reads a `Report` if the file exists, or creates a new one if it doesn't. This mimics the behavior of the build-in Python `open` function. You can use it
like this:

    report = mne.open_report('report.h5')
    report.add_figures_to_section(...)
    report.save('report.html')  # by default, it saves the report back to 'report.h5'

You can also use it as a context manager:

    with mne.open_report('report.h5') as report:
    	report.add_figures_to_section(...)
    # report is saved upon exiting the context block

### TODO

 - [x] add ability to write/read HDF5
 - [x] add context manager
 - [x] ~add ability to overwrite existing figures~ will do this in a separate PR

closes #5501 