### PR TITLE
FIX: fix save fiducials in mne coreg with scaled MRI (#5491)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -110,6 +110,8 @@ Bug
 
 - Fix event sample number increase when combining many Epochs objects with :func:`mne.concatenate_epochs` with  by `Jasper van den Bosch`_
 
+- Fix error in mne coreg when saving with scaled MRI if fiducials haven't been saved by `Ezequiel Mikulan`_
+  
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -111,7 +111,7 @@ Bug
 - Fix event sample number increase when combining many Epochs objects with :func:`mne.concatenate_epochs` with  by `Jasper van den Bosch`_
 
 - Fix error in mne coreg when saving with scaled MRI if fiducials haven't been saved by `Ezequiel Mikulan`_
-  
+
 API
 ~~~
 
@@ -2864,3 +2864,5 @@ of commits):
 .. _Peter Molfese: https://github.com/pmolfese
 
 .. _Jasper van den Bosch: https://github.com/ilogue
+
+.. _Ezequiel Mikulan: https://github.com/ezemikulan

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -923,8 +923,7 @@ class CoregPanelHandler(Handler):
                    "Select No to proceed scaling the MRI without fiducials.".
                    format(src=subject_from))
             title = "Save Fiducials for %s?" % subject_from
-            rc = confirm(None, msg, title, cancel=True, default=CANCEL,
-                         parent=self.info.ui.control)
+            rc = confirm(self.info.ui.control, msg, title, cancel=True, default=CANCEL)
             if rc == CANCEL:
                 return
             elif rc == YES:

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -923,7 +923,8 @@ class CoregPanelHandler(Handler):
                    "Select No to proceed scaling the MRI without fiducials.".
                    format(src=subject_from))
             title = "Save Fiducials for %s?" % subject_from
-            rc = confirm(self.info.ui.control, msg, title, cancel=True, default=CANCEL)
+            rc = confirm(self.info.ui.control, msg, title, cancel=True,
+                         default=CANCEL)
             if rc == CANCEL:
                 return
             elif rc == YES:


### PR DESCRIPTION
#### Reference issue
Fixes #5491 

#### What does this implement/fix?
The dialog box asking to save the fiducials file didn't open when trying to save a -trans file with a scaled MRI, which caused the saving procedure to fail. This fixes the problem. 
