### PR TITLE
fix pytest locally

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ release = egg_info -RDb ''
 doc-files = doc
 
 [tool:pytest]
-addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
+addopts = --showlocals --durations=20 --doctest-modules -rs --doctest-ignore-import-errors
 # Once SciPy updates not to have non-integer and non-tuple errors (1.2.0) we
 # should remove them from here.
 filterwarnings =


### PR DESCRIPTION
Pytest didn't work locally because this error kept being raised:

```pytest: error: unrecognized arguments: --cov-report=```

I see that in the `setup.cfg`, no arg is specified for `cov-report`. is `cov-report` for code coverage? if so, then this is not a proper fix to the pytest, and that would make sense why it didn't run locally bc i don't have support installed to test that.