### PR TITLE
[MRG+1] Fix weight normalization for LCMV beamformer

### DIFF
--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -276,7 +276,7 @@ def _compute_beamformer(method, G, Cm, reg, n_orient, weight_norm,
             else:
                 rank_Cm = estimate_rank(Cm, tol='auto', norm=False,
                                         return_singular=False)
-            noise = noise[rank_Cm]
+            noise = noise[-rank_Cm]
 
             # use either noise floor or regularization parameter d
             noise = max(noise, d)

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -403,7 +403,7 @@ def _compute_beamformer(method, G, Cm, reg, n_orient, weight_norm,
 
                 elif weight_norm == 'unit-noise-gain':
                     noise_norm = np.sum(Wk ** 2, axis=1, keepdims=True)
-                    if is_free_ori and pick_ori in [None, 'vector']: 
+                    if is_free_ori and pick_ori in [None, 'vector']:
                         # Only do this when we don't select a single
                         # orientation later. We need to enforce:
                         # W @ I @ W.T == I

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -391,7 +391,8 @@ def _compute_beamformer(method, G, Cm, reg, n_orient, weight_norm,
                     Wk[:] = np.dot(linalg.pinv(Ck, 0.1), Wk)
                 else:
                     # Fixed source orientation
-                    Wk /= Ck
+                    if not np.all(Ck == 0.):
+                        Wk /= Ck
 
                 # handle noise normalization with free/normal source
                 # orientation:

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -276,10 +276,10 @@ def _compute_beamformer(method, G, Cm, reg, n_orient, weight_norm,
             else:
                 rank_Cm = estimate_rank(Cm, tol='auto', norm=False,
                                         return_singular=False)
-                noise = noise[len(noise) - rank_Cm]
+            noise = noise[rank_Cm]
 
-                # use either noise floor or regularization parameter d
-                noise = max(noise, d)
+            # use either noise floor or regularization parameter d
+            noise = max(noise, d)
 
     # compute spatial filter
     W = np.dot(G.T, Cm_inv)
@@ -402,11 +402,14 @@ def _compute_beamformer(method, G, Cm, reg, n_orient, weight_norm,
                                               'fixed orientation.')
 
                 elif weight_norm == 'unit-noise-gain':
-                    noise_norm = np.sum(Wk ** 2, axis=1)
-                    if is_free_ori:
+                    noise_norm = np.sum(Wk ** 2, axis=1, keepdims=True)
+                    if is_free_ori and pick_ori in [None, 'vector']: 
+                        # Only do this when we don't select a single
+                        # orientation later. We need to enforce:
+                        # W @ I @ W.T == I
                         noise_norm = np.sum(noise_norm)
                     noise_norm = np.sqrt(noise_norm)
-                    if noise_norm == 0.:
+                    if np.all(noise_norm == 0.):
                         noise_norm_inv = 0.  # avoid division by 0
                     else:
                         noise_norm_inv = 1. / noise_norm

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -405,8 +405,8 @@ def test_lcmv():
 
     assert_array_almost_equal(stcs_label[0].data, stcs[0].in_label(label).data)
 
-    # Test condition where the filters weights are zero. There should not be any
-    # divide-by-zero errors
+    # Test condition where the filters weights are zero. There should not be
+    # any divide-by-zero errors
     zero_cov = data_cov.copy()
     zero_cov['data'][:] = 0
     filters = make_lcmv(epochs.info, forward_fixed, zero_cov, reg=0.01,

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -197,7 +197,7 @@ def test_lcmv():
             # Test picking normal orientation (surface source space only)
             filters = make_lcmv(evoked.info, forward_surf_ori, data_cov,
                                 reg=0.01, noise_cov=noise_cov,
-                                pick_ori='normal')
+                                pick_ori='normal', weight_norm=None)
             stc_normal = apply_lcmv(evoked, filters, max_ori_out='signed')
             stc_normal.crop(0.02, None)
 
@@ -206,8 +206,8 @@ def test_lcmv():
             max_stc = stc_normal.data[idx]
             tmax = stc_normal.times[np.argmax(max_stc)]
 
-            assert 0.04 < tmax < 0.12, tmax
-            assert 0.4 < np.max(max_stc) < 2., np.max(max_stc)
+            assert 0.04 < tmax < 0.13, tmax
+            assert 3e-7 < np.max(max_stc) < 5e-7, np.max(max_stc)
 
             # The amplitude of normal orientation results should always be
             # smaller than free orientation results

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -405,6 +405,14 @@ def test_lcmv():
 
     assert_array_almost_equal(stcs_label[0].data, stcs[0].in_label(label).data)
 
+    # Test condition where the filters weights are zero. There should not be any
+    # divide-by-zero errors
+    zero_cov = data_cov.copy()
+    zero_cov['data'][:] = 0
+    filters = make_lcmv(epochs.info, forward_fixed, zero_cov, reg=0.01,
+                        noise_cov=noise_cov)
+    assert_array_equal(filters['weights'], 0)
+
 
 @testing.requires_testing_data
 def test_lcmv_raw():


### PR DESCRIPTION
This fixes a bug in the LCMV beamformer code:

Fix weight normalization when `pick_ori='normal', weight_norm='unit_noise_gain'`. The existing implementation has a bug where the weights were first normalized to have unit length *before* picking the normal direction. Instead, the weights should be normalized to unit length *after* picking the orientation.