### PR TITLE
[wip] investigate merge_info

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1596,6 +1596,7 @@ def _merge_info_values(infos, key, verbose=None):
         if is_qual:
             return values[0]
         elif key == 'meas_date':
+            1/0
             logger.info('Found multiple entries for %s. '
                         'Setting value to `None`' % key)
             return None


### PR DESCRIPTION
I sneaked in `1/0` inside `meas_info.py` but nothing in `test_meas_info` breaks:

```
(mne) ❯ pytest ./mne/io/tests/test_meas_info.py
Test session starts (platform: linux, Python 3.6.6, pytest 3.6.3, pytest-sugar 0.9.1)
rootdir: /home/sik/code/mne-python, inifile: setup.cfg
plugins: smother-0.2, sugar-0.9.1, pudb-0.6, ipdb-0.1, faulthandler-1.5.0, cov-2.5.1

 mne/io/tests/test_meas_info.py ✓✓✓✓✓✓✓✓✓✓✓✓✓                         100% ██████████
============================= slowest 20 test durations =============================
0.21s call     mne/io/tests/test_meas_info.py::test_anonymize
0.16s call     mne/io/tests/test_meas_info.py::test_check_compensation_consistency
0.15s call     mne/io/tests/test_meas_info.py::test_read_write_info
0.13s call     mne/io/tests/test_meas_info.py::test_csr_csc
0.12s call     mne/io/tests/test_meas_info.py::test_info
0.03s call     mne/io/tests/test_meas_info.py::test_merge_info
0.01s call     mne/io/tests/test_meas_info.py::test_make_info
0.01s call     mne/io/tests/test_meas_info.py::test_io_dig_points
0.00s call     mne/io/tests/test_meas_info.py::test_make_dig_points
0.00s call     mne/io/tests/test_meas_info.py::test_check_consistency
0.00s call     mne/io/tests/test_meas_info.py::test_fiducials_io
0.00s call     mne/io/tests/test_meas_info.py::test_redundant
0.00s call     mne/io/tests/test_meas_info.py::test_coil_trans
0.00s setup    mne/io/tests/test_meas_info.py::test_coil_trans
0.00s teardown mne/io/tests/test_meas_info.py::test_make_info
0.00s setup    mne/io/tests/test_meas_info.py::test_check_compensation_consistency
0.00s teardown mne/io/tests/test_meas_info.py::test_merge_info
0.00s setup    mne/io/tests/test_meas_info.py::test_fiducials_io
0.00s teardown mne/io/tests/test_meas_info.py::test_info
0.00s setup    mne/io/tests/test_meas_info.py::test_make_info

Results (0.99s):
      13 passed
```

And the fact that is covered somewhere else ('cos it is covered, see image) it is not helpful because it might be a trivial case.

![image](https://user-images.githubusercontent.com/7044835/45487827-bdddb580-b75f-11e8-9e3e-7e35549c1cb6.png)

I guess that this illustrate my case against using integration tests instead of unit tests. I'll open an RFC issue to disucuss it at some point.
