### PR TITLE
[MRG+1] Improve support for divergent colormaps

### DIFF
--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -11,14 +11,13 @@ Freeview.
 #
 # License: BSD (3-clause)
 
+# sphinx_gallery_thumbnail_number = 3
+
 import mne
 from mne.datasets import sample
 from mne.beamformer import make_lcmv, apply_lcmv
 
 print(__doc__)
-
-# sphinx_gallery_thumbnail_number = 3
-
 
 ###############################################################################
 # Data preprocessing:

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1473,7 +1473,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
     @copy_function_doc_to_method_doc(plot_source_estimates)
     def plot(self, subject=None, surface='inflated', hemi='lh',
              colormap='auto', time_label='auto', smoothing_steps=10,
-             transparent=None, alpha=1.0, time_viewer=False, subjects_dir=None,
+             transparent=True, alpha=1.0, time_viewer=False, subjects_dir=None,
              figure=None, views='lat', colorbar=True, clim='auto',
              cortex="classic", size=800, background="black",
              foreground="white", initial_time=None, time_unit='s',
@@ -2027,7 +2027,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
 
     @copy_function_doc_to_method_doc(plot_vector_source_estimates)
     def plot(self, subject=None, hemi='lh', colormap='hot', time_label='auto',
-             smoothing_steps=10, transparent=None, brain_alpha=0.4,
+             smoothing_steps=10, transparent=True, brain_alpha=0.4,
              overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
              time_viewer=False, subjects_dir=None, figure=None, views='lat',
              colorbar=True, clim='auto', cortex='classic', size=800,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1290,7 +1290,7 @@ def _limits_to_control_points(clim, stc_data, colormap, transparent,
     clim_kind = clim.get('kind', 'percent')
     if clim_kind == 'percent':
         ctrl_pts = np.percentile(np.abs(stc_data), ctrl_pts)
-    elif clim_kind != 'value':
+    elif clim_kind not in ('value', 'values'):
         raise ValueError('clim["kind"] must be "value" or "percent", got %s'
                          % (clim['kind'],))
     if len(set(ctrl_pts)) != 3:

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1267,7 +1267,10 @@ def _limits_to_control_points(clim, stc_data, colormap, transparent,
     diverging_maps += ['mne', 'mne_analyze', ]
     if clim == 'auto':
         # this is merely a heuristic!
-        key = 'pos_lims' if colormap in diverging_maps else 'lims'
+        if allow_pos_lims and colormap in diverging_maps:
+            key = 'pos_lims'
+        else:
+            key = 'lims'
         clim = {'kind': 'percent', key: [96, 97.5, 99.95]}
     if not isinstance(clim, dict):
         raise ValueError('"clim" must be "auto" or dict, got %s' % (clim,))
@@ -1543,7 +1546,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
     colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
         Name of colormap to use or a custom look up table. If array, must
         be (n x 3) or (n x 4) array for with RGB or RGBA values between
-        0 and 255. Default is 'hot'.
+        0 and 255. The default ('auto') uses 'hot' for one-sided data and
+        'mne' for two-sided data.
     time_label : str | callable | None
         Format of the time label (a format string, a function that maps
         floating point time values to strings, or None for no label). The
@@ -1580,9 +1584,13 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                 Flag to specify type of limits.
             ``lims`` : list | np.ndarray | tuple of float, 3 elements
                 Left, middle, and right bound for colormap.
+            ``pos_lims`` : list | np.ndarray | tuple of float, 3 elements
+                Left, middle, and right bound for colormap. Positive values
+                will be mirrored directly across zero during colormap
+                construction to obtain negative control points.
 
-        Unlike :meth:`stc.plot <mne.SourceEstimate.plot>`, it cannot use
-        ``pos_lims``, as the surface plot must show the magnitude.
+        .. note:: Only sequential colormaps should be used with ``lims``, and
+                  only divergent colormaps should be used with ``pos_lims``.
     cortex : str or tuple
         Specifies how binarized curvature values are rendered.
         Either the name of a preset PySurfer cortex colorscheme (one of
@@ -1778,7 +1786,8 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
         Name of colormap to use or a custom look up table. If array, must
         be (n x 3) or (n x 4) array for with RGB or RGBA values between
-        0 and 255.
+        0 and 255. Default ('auto') uses 'hot' for one-sided data and 'mne'
+        for two-sided data.
     clim : str | dict
         Colorbar properties specification. If 'auto', set clim automatically
         based on data percentiles. If dict, should contain:

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -287,24 +287,21 @@ def test_limits_to_control_points():
     stc.plot(clim=dict(kind='value', lims=(10, 50, 90)), figure=99, **kwargs)
     pytest.raises(ValueError, stc.plot, clim='auto', figure=figs, **kwargs)
 
-    # Test both types of incorrect limits key (lims/pos_lims)
-    pytest.raises(KeyError, plot_source_estimates, stc, colormap='mne',
-                  clim=dict(kind='value', lims=(5, 10, 15)), **kwargs)
-    pytest.raises(KeyError, plot_source_estimates, stc, colormap='hot',
-                  clim=dict(kind='value', pos_lims=(5, 10, 15)), **kwargs)
-
     # Test for correct clim values
-    pytest.raises(ValueError, stc.plot,
-                  clim=dict(kind='value', pos_lims=[0, 1, 0]), **kwargs)
-    pytest.raises(ValueError, stc.plot, colormap='mne',
-                  clim=dict(pos_lims=(5, 10, 15, 20)), **kwargs)
-    pytest.raises(ValueError, stc.plot,
-                  clim=dict(pos_lims=(5, 10, 15), kind='foo'), **kwargs)
-    pytest.raises(ValueError, stc.plot, colormap='mne', clim='foo', **kwargs)
-    pytest.raises(ValueError, stc.plot, clim=(5, 10, 15), **kwargs)
-    pytest.raises(TypeError, plot_source_estimates, 'foo', clim='auto',
-                  **kwargs)
-    pytest.raises(ValueError, stc.plot, hemi='foo', clim='auto', **kwargs)
+    with pytest.raises(ValueError, match='monotonically'):
+        stc.plot(clim=dict(kind='value', pos_lims=[0, 1, 0]), **kwargs)
+    with pytest.raises(ValueError, match=r'.*must be \(3,\)'):
+        stc.plot(colormap='mne', clim=dict(pos_lims=(5, 10, 15, 20)), **kwargs)
+    with pytest.raises(ValueError, match='must be "value" or "percent"'):
+        stc.plot(clim=dict(pos_lims=(5, 10, 15), kind='foo'), **kwargs)
+    with pytest.raises(ValueError, match='must be "auto" or dict'):
+        stc.plot(colormap='mne', clim='foo', **kwargs)
+    with pytest.raises(TypeError, match='must be an instance of'):
+        plot_source_estimates('foo', clim='auto', **kwargs)
+    with pytest.raises(ValueError, match='hemi'):
+        stc.plot(hemi='foo', clim='auto', **kwargs)
+    with pytest.raises(ValueError, match='Exactly one'):
+        stc.plot(clim=dict(lims=[0, 1, 2], pos_lims=[0, 1, 2], kind='value'))
 
     # Test handling of degenerate data: thresholded maps
     stc._data.fill(0.)


### PR DESCRIPTION
This does the refactoring to make `_limits_to_control_points` handle one- and two-sided colormaps more gracefully. Should wait until #5329 is in, then some minor tweaks to the vol plotter will be necessary. But at least with this commit I can now do:
```
import os.path as op
import mne
data_path = mne.datasets.sample.data_path()
subjects_dir = data_path + '/subjects'
if not op.isfile('temp-lh.stc'):
    evoked = mne.read_evokeds(data_path + '/MEG/sample/sample_audvis-ave.fif',
                              'Left Auditory', baseline=(None, 0))
    inv = mne.minimum_norm.read_inverse_operator(
        data_path + '/MEG/sample/sample_audvis-meg-oct-6-meg-fixed-inv.fif')
    mne.minimum_norm.apply_inverse(evoked, inv).save('temp')
stc = mne.read_source_estimate('temp')
stc.plot('sample', subjects_dir=subjects_dir, colormap='coolwarm',
         initial_time=0.09)
```
![screenshot from 2018-09-13 15-58-46](https://user-images.githubusercontent.com/2365790/45512525-eb316000-b76d-11e8-96c5-582e4ea63d1d.png)
