### PR TITLE
[MRG+2] adding events dtype to Epochs error message

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -265,8 +265,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if events is not None:  # RtEpochs can have events=None
             if events.dtype.kind not in ['i', 'u']:
-                raise ValueError('events must be an array of type int, got type'
-                                 '%s' % (events.dtype.kind))
+                raise ValueError('events must be an array of type int, got '
+                                 'type %s' % (events.dtype))
             events = events.astype(int)
             if events.ndim != 2 or events.shape[1] != 3:
                 raise ValueError('events must be 2D with 3 columns')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -265,7 +265,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         if events is not None:  # RtEpochs can have events=None
             if events.dtype.kind not in ['i', 'u']:
-                raise ValueError('events must be an array of type int')
+                raise ValueError('events must be an array of type int, got type'
+                                 '%s' % (events.dtype.kind))
             events = events.astype(int)
             if events.ndim != 2 or events.shape[1] != 3:
                 raise ValueError('events must be 2D with 3 columns')

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -531,6 +531,15 @@ def test_event_ordering():
                  1)
 
 
+def test_events_type():
+    """Test type of events"""
+    raw, events = _get_data()[:2]
+    events_id = {'A': 1, 'B': 2}
+    events = (events, events_id)
+    with pytest.raises(ValueError, match='got type'):
+        Epochs(raw, events, event_id, tmin, tmax)
+
+
 def test_rescale():
     """Test rescale."""
     data = np.array([2, 3, 4, 5], float)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -532,7 +532,7 @@ def test_event_ordering():
 
 
 def test_events_type():
-    """Test type of events"""
+    """Test type of events."""
     raw, events = _get_data()[:2]
     events_id = {'A': 1, 'B': 2}
     events = (events, events_id)


### PR DESCRIPTION
This PR adds the dtype of the `events` array to the error message in `Epochs`. This is meant to make the error message a bit clearer when `events` is not actually an array. See #4936 for the case where `events` is an array when using `mne.find_events`, but becomes a tuple if `mne.find_events` is blindly replaced by `mne.annotations.events_from_annotations`.



