### PR TITLE
[MRG] Allow overwriting figures in a report

### DIFF
--- a/doc/tutorials/report.rst
+++ b/doc/tutorials/report.rst
@@ -165,7 +165,7 @@ make this even easier, :class:`mne.Report` can be used as a context manager,
 allowing you to do this::
 
     >>> with open_report('report.h5') as report:  # Creates a new report if 'report.h5' doesn't exist # doctest: +SKIP
-    >>>    report.add_figs_to_section(fig, captions='Left Auditory', section='evoked') # doctest: +SKIP
+    >>>    report.add_figs_to_section(fig, captions='Left Auditory', section='evoked', replace=True) # doctest: +SKIP
     >>>    report.save('report.html', overwrite=True)  # Update the HTML page # doctest: +SKIP
     >>> # Updated report is automatically saved back to 'report.h5' upon leaving the block
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,8 @@ Changelog
 
 - Add support for Neuromag 122 system by `Alex Gramfort`_
 
+- Add :meth:`mne.Report.remove` method to remove existing figures from a report, by `Marijn van Vliet`_
+
 
 Bug
 ~~~

--- a/mne/report.py
+++ b/mne/report.py
@@ -949,21 +949,19 @@ class Report(object):
 
         return items, captions, comments
 
-    def remove(self, index=None, caption=None, section=None):
+    def remove(self, caption, section=None):
         """Remove a figure from the report.
 
-        The figures to remove can be either specified by integer index or
-        searched for by their caption. When searching by caption, the section
-        label can be specified as well to narrow down the search. If multiple
-        figures match the search criteria, the last one will be removed.
+        The figure to remove is searched for by its caption. When searching by
+        caption, the section label can be specified as well to narrow down the
+        search. If multiple figures match the search criteria, the last one
+        will be removed.
 
         Any empty sections will be removed as well.
 
         Parameters
         ----------
-        index : int | None
-            If set, specifies the figure to remove by integer index.
-        caption : str | None
+        caption : str
             If set, search for the figure by caption.
         section : str | None
             If set, limit the search to the section with the given label.
@@ -974,28 +972,23 @@ class Report(object):
             The integer index of the figure that was removed, or ``None`` if no
             figure matched the search criteria.
         """
-        if (index is None) == (caption is None):
-            raise ValueError('Specify either an index or caption '
-                             '(but not both).')
+        # Construct the search pattern
+        pattern = r'^%s-#-.*-#-custom$' % caption
 
-        if caption is not None:
-            # Construct the search pattern
-            pattern = r'^%s-#-.*-#-custom$' % caption
+        # Search for figures matching the search pattern, regardless of
+        # section
+        matches = [i for i, fname in enumerate(self.fnames)
+                   if re.match(pattern, fname)]
+        if section is not None:
+            # Narrow down the search to the given section
+            svar = self._sectionvars[section]
+            matches = [i for i in matches
+                       if self._sectionlabels[i] == svar]
+        if len(matches) == 0:
+            return None
 
-            # Search for figures matching the search pattern, regardless of
-            # section
-            matches = [i for i, fname in enumerate(self.fnames)
-                       if re.match(pattern, fname)]
-            if section is not None:
-                # Narrow down the search to the given section
-                svar = self._sectionvars[section]
-                matches = [i for i in matches
-                           if self._sectionlabels[i] == svar]
-            if len(matches) == 0:
-                return None
-
-            # Remove last occurrence
-            index = max(matches)
+        # Remove last occurrence
+        index = max(matches)
 
         # Remove the figure
         del self.fnames[index]

--- a/mne/report.py
+++ b/mne/report.py
@@ -977,8 +977,8 @@ class Report(object):
 
         # Search for figures matching the search pattern, regardless of
         # section
-        matches = [i for i, fname in enumerate(self.fnames)
-                   if re.match(pattern, fname)]
+        matches = [i for i, fname_ in enumerate(self.fnames)
+                   if re.match(pattern, fname_)]
         if section is not None:
             # Narrow down the search to the given section
             svar = self._sectionvars[section]

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -343,15 +343,6 @@ def test_remove():
     r.add_figs_to_section(fig2, 'figure1', 'mysection')
     r.add_figs_to_section(fig2, 'figure2', 'mysection')
 
-    # Test removal by index
-    r2 = copy.deepcopy(r)
-    removed_index = r2.remove(2)
-    assert removed_index == 2
-    assert len(r2.html) == 3
-    assert r2.html[0] == r.html[0]
-    assert r2.html[1] == r.html[1]
-    assert r2.html[2] == r.html[3]
-
     # Test removal by caption
     r2 = copy.deepcopy(r)
     removed_index = r2.remove(caption='figure1')
@@ -361,7 +352,7 @@ def test_remove():
     assert r2.html[1] == r.html[1]
     assert r2.html[2] == r.html[3]
 
-    # Test removal by caption, restrict to section
+    # Test restricting to section
     r2 = copy.deepcopy(r)
     removed_index = r2.remove(caption='figure1', section='othersection')
     assert removed_index == 1


### PR DESCRIPTION
This is the final piece to fully address #5501 

PR #5505 allows you to open a previously saved `Report` object and add new figures to it. The intended use case is to have different analysis script write figures to the same report and have one HTML file that collects them all.

This PR adds the ability to overwrite a figure if it already existed in the report. The idea is that, when you re-run a script, you don't want to end up with copies of the same figure in the report. So now, all functions that add a figure to a `Report` object have gotten a `replace` parameter (defaults to `False`). 

Internally, all figures are already given a unique `fname` property that is a combination of the caption and section of the figure (and filename, if the figure was generated from a file). So, when `replace=True`, we check whether a figure with the same `fname` already exists and replace it. If there are multiple figures with the same `fname`, we replace the last occurrence.

With this PR, everything is in place to sprinkle your analysis scripts with:

```python
with open_report('report.h5') as r:
    r.add_figs_to_section(ica.plot_components(), 'ICA components',
                          section='Preprocessing', replace=True)
```

to quickly dump some figures during the analysis. All figures are collected in a single `Report` object that can be rendered to HTML to have a nice visual overview of the data passing through your pipeline.