### PR TITLE
[MRG] improve ignore deprecation warnings

### DIFF
--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -106,8 +106,8 @@ def test_io_set_raw(fnames, tmpdir):
     # test that using uint16_codec does not break stuff
     with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
         raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
-                            event_id=event_id, preload=False,
-                            uint16_codec='ascii')
+                               event_id=event_id, preload=False,
+                               uint16_codec='ascii')
 
     # test old EEGLAB version event import (read old version)
     eeg = io.loadmat(raw_fname_mat, struct_as_record=False,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -21,7 +21,7 @@ from mne.io import read_raw_eeglab
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.eeglab import read_annotations_eeglab, read_events_eeglab
 from mne.datasets import testing
-from mne.utils import run_tests_if_main, requires_h5py
+from mne.utils import run_tests_if_main, requires_h5py, filter_out_warnings
 from mne.annotations import events_from_annotations
 
 
@@ -56,7 +56,6 @@ def _check_h5(fname):
 
 @requires_h5py
 @testing.requires_testing_data
-@pytest.mark.filterwarnings('ignore:Function read_events_eeglab is deprecated')
 @pytest.mark.parametrize('fnames', [raw_mat_fnames, raw_h5_fnames])
 def test_io_set_raw(fnames, tmpdir):
     """Test importing EEGLAB .set files."""
@@ -84,8 +83,6 @@ def test_io_set_raw(fnames, tmpdir):
                                event_id=event_id)
         raw4 = read_raw_eeglab(input_fname=raw_fname, montage=montage)
 
-        [w.pop(DeprecationWarning) for _ in range(5)]  # read_events_eeglab
-
         assert raw0.filenames[0].endswith('.fdt')  # .set with additional .fdt
         assert raw2.filenames[0].endswith('.set')  # standalone .set
 
@@ -101,11 +98,9 @@ def test_io_set_raw(fnames, tmpdir):
         raw0.filter(1, None, l_trans_bandwidth='auto', filter_length='auto',
                     phase='zero')  # test that preloading works
 
-        while 'FutureWarning' in [xx._category_name for xx in w]:
-            w.pop(FutureWarning)
-        while 'ImportWarning' in [xx._category_name for xx in w]:
-            w.pop(ImportWarning)
-
+    filter_out_warnings(w, category=DeprecationWarning)
+    filter_out_warnings(w, category=FutureWarning)
+    filter_out_warnings(w, category=ImportWarning)
     assert len(w) == 4  # check `preload=False` raises RuntimeWarning
 
     # test that using uint16_codec does not break stuff

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -104,19 +104,22 @@ def test_io_set_raw(fnames, tmpdir):
     assert len(w) == 4  # check `preload=False` raises RuntimeWarning
 
     # test that using uint16_codec does not break stuff
-    raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
-                           event_id=event_id, preload=False,
-                           uint16_codec='ascii')
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        raw0 = read_raw_eeglab(input_fname=raw_fname, montage=montage,
+                            event_id=event_id, preload=False,
+                            uint16_codec='ascii')
 
     # test old EEGLAB version event import (read old version)
     eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
     for event in eeg.event:  # old version allows integer events
         event.type = 1
-    assert_equal(read_events_eeglab(eeg)[-1, -1], 1)
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        assert read_events_eeglab(eeg)[-1, -1] == 1
     eeg.event = eeg.event[0]  # single event
     eeg.event.latency = float(eeg.event.latency) - .1  # test rounding
-    assert_equal(read_events_eeglab(eeg)[-1, -1], 1)
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        assert read_events_eeglab(eeg)[-1, -1] == 1
 
     # test reading file with one event (read old version)
     eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
@@ -131,8 +134,10 @@ def test_io_set_raw(fnames, tmpdir):
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     one_event_fname.replace('.set', '.fdt'))
     event_id = {eeg.event[0].type: 1}
-    test_raw = read_raw_eeglab(input_fname=one_event_fname, montage=montage,
-                               event_id=event_id, preload=True)
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        test_raw = read_raw_eeglab(input_fname=one_event_fname,
+                                   montage=montage, event_id=event_id,
+                                   preload=True)
 
     # test that sample indices are read python-wise (zero-based)
     assert find_events(test_raw)[0, 0] == round(eeg.event[0].latency) - 1
@@ -170,7 +175,8 @@ def test_io_set_raw(fnames, tmpdir):
                               montage=montage, event_id=event_id,
                               preload=True)
     events_stimchan = find_events(raw)
-    events_read_events_eeglab = read_events_eeglab(overlap_fname, event_id)
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        events_read_events_eeglab = read_events_eeglab(overlap_fname, event_id)
     assert (len(events_stimchan) == 1)
     assert (len(events_read_events_eeglab) == 2)
 
@@ -248,7 +254,8 @@ def test_io_set_raw(fnames, tmpdir):
                 'times': eeg.times[:2], 'pnts': 2}},
                appendmat=False, oned_as='row')
     # load the file
-    raw = read_raw_eeglab(input_fname=nopos_fname, preload=True)
+    with pytest.warns(DeprecationWarning, match="read_events_eeglab"):
+        raw = read_raw_eeglab(input_fname=nopos_fname, preload=True)
     # test that channel names have been loaded but not channel positions
     for i in range(3):
         assert_equal(raw.info['chs'][i]['ch_name'], ch_names[i])

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -31,7 +31,7 @@ from mne.utils import (set_log_level, set_log_file, _TempDir,
                        check_fname, get_config_path,
                        object_size, buggy_mkl_svd, _get_inst_data,
                        copy_doc, copy_function_doc_to_method_doc, ProgressBar,
-                       linkcode_resolve, array_split_idx)
+                       linkcode_resolve, array_split_idx, filter_out_warnings)
 
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
@@ -479,14 +479,13 @@ def test_deprecated():
     pytest.deprecated_call(deprecated_class)
 
 
-# @pytest.mark.warnings("ignore:*:UserWarning")
-from sklearn.utils.testing import ignore_warnings
 def test_how_to_deal_with_warnnings():
-    with pytest.warns(UserWarning, match='bb') as w, \
-         ignore_warnings(category=RuntimeWarning):
-
-        warnings.warn("aa warning", RuntimeWarning)
+    with pytest.warns(UserWarning, match='bb') as w:
+        warnings.warn("aa warning", UserWarning)
         warnings.warn("bb warning", UserWarning)
+        warnings.warn("bb warning", RuntimeWarning)
+    filter_out_warnings(w, category=UserWarning, match='aa')
+    filter_out_warnings(w, category=RuntimeWarning)
     assert len(w) == 1
 
 

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -5,6 +5,7 @@ import sys
 import webbrowser
 
 import numpy as np
+import warnings
 import pytest
 from scipy import sparse
 from numpy.testing import assert_equal, assert_array_equal, assert_allclose
@@ -476,6 +477,14 @@ def test_deprecated():
     """Test deprecated function."""
     pytest.deprecated_call(deprecated_func)
     pytest.deprecated_call(deprecated_class)
+
+
+@pytest.mark.filterwarnings("ignore:aa")
+def test_how_to_deal_with_warnnings():
+    with pytest.warns(UserWarning, match='bb') as w:
+        warnings.warn("aa warning", UserWarning)
+        warnings.warn("bb warning", UserWarning)
+    assert len(w) == 1
 
 
 def _test_fetch(url):

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -484,6 +484,7 @@ def test_how_to_deal_with_warnnings():
         warnings.warn("aa warning", UserWarning)
         warnings.warn("bb warning", UserWarning)
         warnings.warn("bb warning", RuntimeWarning)
+        warnings.warn("aa warning", UserWarning)
     filter_out_warnings(w, category=UserWarning, match='aa')
     filter_out_warnings(w, category=RuntimeWarning)
     assert len(w) == 1

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -479,10 +479,13 @@ def test_deprecated():
     pytest.deprecated_call(deprecated_class)
 
 
-@pytest.mark.warnings("ignore:*:UserWarning")
+# @pytest.mark.warnings("ignore:*:UserWarning")
+from sklearn.utils.testing import ignore_warnings
 def test_how_to_deal_with_warnnings():
-    with pytest.warns(UserWarning, match='bb') as w:
-        warnings.warn("aa warning", UserWarning)
+    with pytest.warns(UserWarning, match='bb') as w, \
+         ignore_warnings(category=RuntimeWarning):
+
+        warnings.warn("aa warning", RuntimeWarning)
         warnings.warn("bb warning", UserWarning)
     assert len(w) == 1
 

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -479,7 +479,7 @@ def test_deprecated():
     pytest.deprecated_call(deprecated_class)
 
 
-@pytest.mark.filterwarnings("ignore:aa")
+@pytest.mark.warnings("ignore:*:UserWarning")
 def test_how_to_deal_with_warnnings():
     with pytest.warns(UserWarning, match='bb') as w:
         warnings.warn("aa warning", UserWarning)

--- a/mne/tests/test_utils.py
+++ b/mne/tests/test_utils.py
@@ -480,6 +480,7 @@ def test_deprecated():
 
 
 def test_how_to_deal_with_warnnings():
+    """Test filter some messages out of warning records."""
     with pytest.warns(UserWarning, match='bb') as w:
         warnings.warn("aa warning", UserWarning)
         warnings.warn("bb warning", UserWarning)

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -397,6 +397,10 @@ def warn(message, category=RuntimeWarning):
     logger.warning(message)
 
 
+def filter_out_warnings(warns, category=None, match=None):
+    pass
+
+
 def check_fname(fname, filetype, endings, endings_err=()):
     """Enforce MNE filename conventions.
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -404,22 +404,6 @@ def filter_out_warnings(warn_record, category=None, match=None):
     This helper takes a list of :class:`warnings.WarningMessage` objects,
     and remove those matching category and/or text.
 
-        >>> with pytest.warns(None) as recwarn:
-        ...     warnings.warn("value must be 0 or None", UserWarning)
-        ... filter_out_warnings(recwarn, match='0 or None')
-        ... assert len(recwarn.list) == 0
-
-        >>> with warns(UserWarning, match=r'must be \d+$'):
-        >>> with pytest.warns(None) as recwarn:
-        ...     warnings.warn("value must be 42", UserWarning)
-        ... filter_out_warnings(recwarn, match=r'must be \d+$'):
-        ... assert len(recwarn.list) == 0
-
-        >>> with warns(UserWarning, match=r'must be \d+$'):
-        ...     warnings.warn("this is not here", UserWarning)
-        ... filter_out_warnings(recwarn, match=r'must be \d+$'):
-        ... assert len(recwarn.list) == 1
-
     Parameters
     ----------
     category: WarningMessage type | None
@@ -427,6 +411,28 @@ def filter_out_warnings(warn_record, category=None, match=None):
 
     match : str | None
         text or regex that matches the error message to filter out
+
+    Examples
+    --------
+    This can be used as::
+
+        >>> import pytest
+        >>> import warnings
+        >>> from mne.utils import filter_out_warnings
+        >>> with pytest.warns(None) as recwarn:
+        ...     warnings.warn("value must be 0 or None", UserWarning)
+        >>> filter_out_warnings(recwarn, match=".* 0 or None")
+        >>> assert len(recwarn.list) == 0
+
+        >>> with pytest.warns(None) as recwarn:
+        ...     warnings.warn("value must be 42", UserWarning)
+        >>> filter_out_warnings(recwarn, match=r'.* must be \d+$')
+        >>> assert len(recwarn.list) == 0
+
+        >>> with pytest.warns(None) as recwarn:
+        ...     warnings.warn("this is not here", UserWarning)
+        >>> filter_out_warnings(recwarn, match=r'.* must be \d+$')
+        >>> assert len(recwarn.list) == 1
     """
     regexp = re.compile('.*' if match is None else match)
     is_category = [w.category == category if category is not None else True

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -33,6 +33,7 @@ import traceback
 from unittest import SkipTest
 import warnings
 import webbrowser
+import re
 
 import numpy as np
 from scipy import linalg, sparse
@@ -397,8 +398,46 @@ def warn(message, category=RuntimeWarning):
     logger.warning(message)
 
 
-def filter_out_warnings(warns, category=None, match=None):
-    pass
+def filter_out_warnings(warn_record, category=None, match=None):
+    r"""Remove particular records from ``warn_record``
+
+    This helper takes a list of :class:`warnings.WarningMessage` objects,
+    and remove those matching category and/or text.
+
+        >>> with pytest.warns(None) as recwarn:
+        ...     warnings.warn("value must be 0 or None", UserWarning)
+        ... filter_out_warnings(recwarn, match='0 or None')
+        ... assert len(recwarn.list) == 0
+
+        >>> with warns(UserWarning, match=r'must be \d+$'):
+        >>> with pytest.warns(None) as recwarn:
+        ...     warnings.warn("value must be 42", UserWarning)
+        ... filter_out_warnings(recwarn, match=r'must be \d+$'):
+        ... assert len(recwarn.list) == 0
+
+        >>> with warns(UserWarning, match=r'must be \d+$'):
+        ...     warnings.warn("this is not here", UserWarning)
+        ... filter_out_warnings(recwarn, match=r'must be \d+$'):
+        ... assert len(recwarn.list) == 1
+
+    Parameters
+    ----------
+    category: WarningMessage type | None
+       class of the message to filter out
+
+    match : str | None
+        text or regex that matches the error message to filter out
+    """
+    regexp = re.compile('.*' if match is None else match)
+    is_category = [w.category == category if category is not None else True
+                   for w in warn_record._list]
+    is_match = [regexp.match(w.message.args[0]) is not None
+                for w in warn_record._list]
+    ind = [ind for ind, (c, m) in enumerate(zip(is_category, is_match))
+           if c and m]
+
+    for i in reversed(ind):
+        warn_record._list.pop(i)
 
 
 def check_fname(fname, filetype, endings, endings_err=()):

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -399,7 +399,7 @@ def warn(message, category=RuntimeWarning):
 
 
 def filter_out_warnings(warn_record, category=None, match=None):
-    r"""Remove particular records from ``warn_record``
+    r"""Remove particular records from ``warn_record``.
 
     This helper takes a list of :class:`warnings.WarningMessage` objects,
     and remove those matching category and/or text.


### PR DESCRIPTION
#### What does this implement/fix?
This PR adds `mne.utils.filter_out_warnings` to remove warnings from a warning record, when using `pytest.warns`.

The main problem is that by construction, `@pytest.mark.filterwarnings` and `pytest.warns` cannot be used together since `pytest.warns` overwrites all the filters to not miss any potential warning. (see https://github.com/pytest-dev/pytest/issues/4011)

#### Additional information
This PR would allow to simplify #4936 in the following manner:

```diff
 @requires_h5py
 @testing.requires_testing_data
-@pytest.mark.filterwarnings('ignore:Function read_events_eeglab is deprecated')
 @pytest.mark.parametrize('fnames', [raw_mat_fnames, raw_h5_fnames])
 def test_io_set_raw(fnames, tmpdir):
     """Test importing EEGLAB .set files."""
@@ -84,8 +83,6 @@ def test_io_set_raw(fnames, tmpdir):
                                event_id=event_id)
         raw4 = read_raw_eeglab(input_fname=raw_fname, montage=montage)
 
-        [w.pop(DeprecationWarning) for _ in range(5)]  # read_events_eeglab
-
         assert raw0.filenames[0].endswith('.fdt')  # .set with additional .fdt
         assert raw2.filenames[0].endswith('.set')  # standalone .set
 
@@ -101,11 +98,9 @@ def test_io_set_raw(fnames, tmpdir):
         raw0.filter(1, None, l_trans_bandwidth='auto', filter_length='auto',
                     phase='zero')  # test that preloading works
 
-        while 'FutureWarning' in [xx._category_name for xx in w]:
-            w.pop(FutureWarning)
-        while 'ImportWarning' in [xx._category_name for xx in w]:
-            w.pop(ImportWarning)
-
+    filter_out_warnings(w, category=DeprecationWarning)
+    filter_out_warnings(w, category=FutureWarning)
+    filter_out_warnings(w, category=ImportWarning)
     assert len(w) == 4  # check `preload=False` raises RuntimeWarning
```