### PR TITLE
MRG: Fix backend warning

### DIFF
--- a/mne/gui/_backend.py
+++ b/mne/gui/_backend.py
@@ -4,6 +4,7 @@
 # License: BSD (3-clause)
 
 import os
+from ..utils import warn
 
 
 def _check_backend():
@@ -11,7 +12,8 @@ def _check_backend():
     try:
         from pyface.api import warning
     except ImportError:
-        warning = None
+        def warning(a, msg, title):
+            warn(msg)
 
     backend, status = _check_pyface_backend()
     if status == 0:


### PR DESCRIPTION
This fixes the case where no backend is imported by `pyface`. Currently it later tries to call `warning(...)` when `warning is None`. There is no good way to test for this in the test suite that I can think of.