### PR TITLE
ENH: Use faulthandler in coreg gui

### DIFF
--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -92,6 +92,11 @@ def run():
     trans = options.trans
     if trans is not None:
         trans = op.expanduser(trans)
+    try:
+        import faulthandler
+        faulthandler.enable()
+    except ImportError:
+        pass  # old Python2
     with ETSContext():
         mne.gui.coregistration(
             options.tabbed, inst=options.inst, subject=options.subject,


### PR DESCRIPTION
On `gitter` people are experiencing what seem to be VTK-related errors. This should help us debug them in the future.