### PR TITLE
MRG: Use relative paths for BEM surfaces

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1889,7 +1889,8 @@ def _check_bem_size(surfs):
 
 
 def _symlink(src, dest):
-    """Create a symlink."""
+    """Create a relative symlink."""
+    src = op.relpath(src, op.dirname(dest))
     try:
         os.symlink(src, dest)
     except OSError:


### PR DESCRIPTION
When symlinking BEM surfaces to watershed or flash results, relative paths should be used instead of absolute ones.

The way to test is try running `mne watershed_bem` on some subject and see that within the `bem` directory `*.surf` symlinks to `watershed/*` as opposed to `/whatever/annoying/full/path/subject/bem/watershed/*`.