### PR TITLE
avoid attriute error

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1484,7 +1484,7 @@ def _onpick_sensor(event, fig, ax, pos, ch_names, show_names):
 
 def _close_event(event, fig):
     """Listen for sensor plotter close event."""
-    if fig.lasso is not None:
+    if hasattr(fig, 'lasso') and fig.lasso is not None:
         fig.lasso.disconnect()
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1484,7 +1484,7 @@ def _onpick_sensor(event, fig, ax, pos, ch_names, show_names):
 
 def _close_event(event, fig):
     """Listen for sensor plotter close event."""
-    if hasattr(fig, 'lasso') and fig.lasso is not None:
+    if getattr(fig, 'lasso') is not None:
         fig.lasso.disconnect()
 
 


### PR DESCRIPTION
avoid a crash observed when running #5548

```
import os.path as op
import numpy as np
import mne

data_path = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
raw = mne.io.read_raw_fif(op.join(data_path, 'sample_audvis_raw.fif'),
preload=True)
raw.set_eeg_reference('average', projection=True) # set EEG average reference


raw.plot(butterfly=True, group_by='position')
raw.plot_sensors(kind='3d', ch_type='mag', ch_groups='position')
```