### PR TITLE
MRG: Fix maxwell_filter with data skips

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -135,6 +135,8 @@ Bug
 
 - Fix missing initialization of ``self._current`` in :class:`mne.Epochs` by `Henrich Kolkhorst`_
 
+- Fix processing of data with bad segments and acquisition skips with new ``skip_by_annotation`` paremeter in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
+
 - Fix symlinking to use relative paths in ``mne flash_bem` and ``mne watershed_bem`` by `Eric Larson`_
 
 - Fix error in mne coreg when saving with scaled MRI if fiducials haven't been saved by `Ezequiel Mikulan`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -135,7 +135,7 @@ Bug
 
 - Fix missing initialization of ``self._current`` in :class:`mne.Epochs` by `Henrich Kolkhorst`_
 
-- Fix processing of data with bad segments and acquisition skips with new ``skip_by_annotation`` paremeter in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
+- Fix processing of data with bad segments and acquisition skips with new ``skip_by_annotation`` parameter in :func:`mne.preprocessing.maxwell_filter` by `Eric Larson`_
 
 - Fix symlinking to use relative paths in ``mne flash_bem` and ``mne watershed_bem`` by `Eric Larson`_
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -442,7 +442,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
                         % ((n_last_buf - st_duration) / info['sfreq'],))
                 else:
                     logger.info(
-                        '    Contiguous data segement of duration %0.2f '
+                        '    Contiguous data segment of duration %0.2f '
                         'seconds is too short to be processed with tSSS '
                         'using duration %0.2f'
                         % (n_last_buf / info['sfreq'],

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -997,6 +997,7 @@ def test_MGH_cross_talk():
     assert (len(py_ctc) > 0)
 
 
+@testing.requires_testing_data
 def test_mf_skips():
     """Test processing of data with skips."""
     raw = read_raw_fif(skip_fname, preload=True)


### PR DESCRIPTION
Currently `maxwell_filter` (and tSSS in particular) does not deal nicely with acquisition skips. This makes it process them properly.