### PR TITLE
MRG+1: Save hilbert transformed epochs containing complex numbers

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,7 +18,8 @@ Current
 
 Changelog
 ~~~~~~~~~
-- Add capability to read and save Epochs containing complex data (e.g. after Hilbert-transform) using :meth:`mne.Epochs.save` and :func:`mne.read_epochs`, by `Stefan Repplinger`_, `Eric Larson`_ and `Alexandre Gramfort`_
+
+- Add capability to read and save Epochs containing complex data (e.g. after Hilbert-transform) using :meth:`mne.Epochs.save` and :func:`mne.read_epochs`, by `Stefan Repplinger`_, `Eric Larson`_ and `Alex Gramfort`_
 
 - Add optically pumped magnetometer dataset and example by `Rasmus Zetter`_ and `Eric Larson`_
 
@@ -143,7 +144,8 @@ Bug
 
 API
 ~~~
-- :meth:`mne.Epochs.save` now has the parameter `fmt` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alexandre Gramfort`_
+
+- :meth:`mne.Epochs.save` now has the parameter `fmt` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alex Gramfort`_
 
 - Deprecated ``mne.SourceEstimate.morph_precomputed``, ``mne.SourceEstimate.morph``, ``mne.compute_morph_matrix``, ``mne.morph_data_precomputed`` and ``mne.morph_data`` in favor of :func:`mne.compute_source_morph`, by `Tommy Clausner`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,7 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Add capability to read and save Epochs containing complex data (e.g. after Hilbert-transform) using :meth:`mne.Epochs.save` and :func:`mne.read_epochs`, by `Stefan Repplinger`_, `Eric Larson`_ and `Alexandre Gramfort`_
 
 - Add optically pumped magnetometer dataset and example by `Rasmus Zetter`_ and `Eric Larson`_
 
@@ -142,6 +143,7 @@ Bug
 
 API
 ~~~
+- :meth:`mne.Epochs.save` now has the parameter `fmt` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alexandre Gramfort`_
 
 - Deprecated ``mne.SourceEstimate.morph_precomputed``, ``mne.SourceEstimate.morph``, ``mne.compute_morph_matrix``, ``mne.morph_data_precomputed`` and ``mne.morph_data`` in favor of :func:`mne.compute_source_morph`, by `Tommy Clausner`_
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -89,26 +89,19 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
     # write events out after getting data to ensure bad events are dropped
     data = epochs.get_data()
 
-    if fmt not in ['short', 'int', 'single', 'double']:
-        raise ValueError('fmt must be "short", "single", or "double"')
+    if fmt not in ['single', 'double']:
+        raise ValueError('fmt must be "single" or "double". Got (%s)' % fmt)
 
-    if np.isrealobj(data):
-        if fmt == 'short':
-            write_function = write_dau_pack16
-        elif fmt == 'int':
-            write_function = write_int_matrix
-        elif fmt == 'single':
-            write_function = write_float_matrix
-        elif fmt == 'double':
-            write_function = write_double_matrix
-    elif np.iscomplexobj(data):
+    if np.iscomplexobj(data):
         if fmt == 'single':
             write_function = write_complex_float_matrix
         elif fmt == 'double':
             write_function = write_complex_double_matrix
-        else:
-            raise ValueError('only "single" and "double" supported for '
-                             'writing complex data')
+    else:
+        if fmt == 'single':
+            write_function = write_float_matrix
+        elif fmt == 'double':
+            write_function = write_double_matrix
 
     start_block(fid, FIFF.FIFFB_MNE_EVENTS)
     write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, epochs.events.T)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1698,7 +1698,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Format to save data. Valid options are 'double' or
             'single' for 64- or 32-bit float, or for 128- or
             64-bit complex numbers respectively. Note: Data are processed with
-            double-precision. Choosing single-precision, the saved data
+            double precision. Choosing single-precision, the saved data
             will slightly differ due to the reduction in precision.
 
             .. versionadded:: 0.17
@@ -2579,16 +2579,12 @@ def _read_one_epoch_file(f, tree, preload):
         # on read double-precision is always used
         if data_tag.type == FIFF.FIFFT_FLOAT:
             datatype = np.dtype('>f8')
-            warn('Saved data only available as %s but read as %s'
-                 % (np.dtype('>f4').name, datatype.name))
             size_actual = data_tag.size // 4 - 4
         elif data_tag.type == FIFF.FIFFT_DOUBLE:
             datatype = np.dtype('>f8')
             size_actual = data_tag.size // 8 - 2
         elif data_tag.type == FIFF.FIFFT_COMPLEX_FLOAT:
             datatype = np.dtype('>c16')
-            warn('Saved data only available as %s but read as %s'
-                 % (np.dtype('>c8').name, datatype.name))
             size_actual = data_tag.size // 8 - 2
         elif data_tag.type == FIFF.FIFFT_COMPLEX_DOUBLE:
             datatype = np.dtype('>c16')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -85,7 +85,7 @@ def _save_split(epochs, fname, part_idx, n_parts):
 
     # write events out after getting data to ensure bad events are dropped
     data = epochs.get_data()
-    assert data.dtype == 'float64'
+    assert data.dtype in ['float64', 'complex64']
     start_block(fid, FIFF.FIFFB_MNE_EVENTS)
     write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, epochs.events.T)
     mapping_ = ';'.join([k + ':' + str(v) for k, v in

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1695,9 +1695,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             .. versionadded:: 0.10.0
         fmt : str
-            Format to use to save data. Valid options are 'double' or
+            Format to save data. Valid options are 'double' or
             'single' for 64- or 32-bit float, or for 128- or
-            64-bit complex numbers respectively.
+            64-bit complex numbers respectively. Note: Data are processed with
+            double-precision. Choosing single-precision, the saved data
+            will slightly differ due to the reduction in precision.
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2579,7 +2579,7 @@ def _read_one_epoch_file(f, tree, preload):
         # on read double-precision is always used
         if data_tag.type == FIFF.FIFFT_FLOAT:
             datatype = np.dtype('>f8')
-            warn('Data only available as %s but read as %s'
+            warn('Saved data only available as %s but read as %s'
                  % (np.dtype('>f4').name, datatype.name))
             size_actual = data_tag.size // 4 - 4
         elif data_tag.type == FIFF.FIFFT_DOUBLE:
@@ -2587,7 +2587,7 @@ def _read_one_epoch_file(f, tree, preload):
             size_actual = data_tag.size // 8 - 2
         elif data_tag.type == FIFF.FIFFT_COMPLEX_FLOAT:
             datatype = np.dtype('>c16')
-            warn('Data only available as %s but read as %s'
+            warn('Saved data only available as %s but read as %s'
                  % (np.dtype('>c8').name, datatype.name))
             size_actual = data_tag.size // 8 - 2
         elif data_tag.type == FIFF.FIFFT_COMPLEX_DOUBLE:
@@ -2601,7 +2601,7 @@ def _read_one_epoch_file(f, tree, preload):
         # Calibration factors
         cals = np.array([[info['chs'][k]['cal'] *
                           info['chs'][k].get('scale', 1.0)]
-                         for k in range(info['nchan'])], datatype)
+                         for k in range(info['nchan'])], np.float64)
 
         # Read the data
         if preload:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2596,7 +2596,7 @@ def _read_one_epoch_file(f, tree, preload):
             size_actual = data_tag.size // 4 - 1
         elif data_tag.type == FIFF.FIFFT_INT:
             datatype = np.int32
-            size_actual = data_tag.size // 4 - 2
+            size_actual = data_tag.size // 4 - 3
         elif data_tag.type == FIFF.FIFFT_FLOAT:
             datatype = np.float32
             size_actual = data_tag.size // 4 - 4

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2545,8 +2545,10 @@ def _read_one_epoch_file(f, tree, preload):
         epoch_shape = (len(info['ch_names']), n_samp)
         expected = len(events) * np.prod(epoch_shape)
         if data_tag.size // 4 - 4 == expected:  # 32-bit floats stored
+            datatype = np.float64
             pass
         elif data_tag.size // 16 - 1 == expected:  # 128-bit complex stored
+            datatype = np.complex128
             pass
         else:
             raise (ValueError('Incorrect number of samples (%d instead of %d)'+
@@ -2559,11 +2561,11 @@ def _read_one_epoch_file(f, tree, preload):
         # Calibration factors
         cals = np.array([[info['chs'][k]['cal'] *
                           info['chs'][k].get('scale', 1.0)]
-                         for k in range(info['nchan'])], np.float64)
+                         for k in range(info['nchan'])], datatype)
 
         # Read the data
         if preload:
-            data = read_tag(fid, data_tag.pos).data.astype(np.complex128)
+            data = read_tag(fid, data_tag.pos).data.astype(datatype)
             data *= cals[np.newaxis, :, :]
 
         # Put it all together

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2545,18 +2545,16 @@ def _read_one_epoch_file(f, tree, preload):
         epoch_shape = (len(info['ch_names']), n_samp)
         expected = len(events) * np.prod(epoch_shape)
         if data_tag.size // 4 - 4 == expected:  # 32-bit floats stored
-            datatype = np.float64
-            pass
-        elif data_tag.size // 16 - 1 == expected:  # 128-bit complex stored
-            datatype = np.complex128
-            pass
+            datatype = np.float32
+        elif data_tag.size // 8 - 2 == expected:  # 64-bit complex stored
+            datatype = np.complex64
         else:
             raise (ValueError('Incorrect number of samples (%d instead of %d)'+
                               'for 32-bit floats'
                  % (data_tag.size // 4, expected)),
                    ValueError('Incorrect number of samples (%d instead of %d)'+
-                              'for 128-bit complex'
-                 % (data_tag.size // 16, expected)))
+                              'for 64-bit complex'
+                 % (data_tag.size // 8, expected)))
 
         # Calibration factors
         cals = np.array([[info['chs'][k]['cal'] *

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -21,8 +21,7 @@ import numpy as np
 import scipy
 
 from .io.write import (start_file, start_block, end_file, end_block,
-                       write_int, write_dau_pack16, write_float,
-                       write_float_matrix, write_int_matrix,
+                       write_int, write_float, write_float_matrix,
                        write_double_matrix, write_complex_float_matrix,
                        write_complex_double_matrix, write_id, write_string,
                        _get_split_size)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1769,7 +1769,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                          int=FIFF.FIFFT_INT,
                          single=FIFF.FIFFT_FLOAT,
                          double=FIFF.FIFFT_DOUBLE)
-        if fmt not in type_dict.keys():
+        if fmt not in type_dict:
             raise ValueError('fmt must be "short", "int", "single", '
                              'or "double"')
         reset_dict = dict(short=False, int=False, single=True, double=True)

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -194,18 +194,38 @@ def write_int_matrix(fid, kind, mat):
     check_fiff_length(fid)
 
 
-def write_complex_matrix(fid, kind, mat):
+def write_complex_float_matrix(fid, kind, mat):
     """Write complex 64 matrix tag."""
     FIFFT_MATRIX = 1 << 30
-    FIFFT_MATRIX_FLOAT = FIFF.FIFFT_FLOAT | FIFFT_MATRIX
+    FIFFT_MATRIX_COMPLEX_FLOAT = FIFF.FIFFT_COMPLEX_FLOAT  | FIFFT_MATRIX
 
-    data_size = 8 * mat.size + 4 * (mat.ndim + 1)
+    data_size = 4 * 2 * mat.size + 4 * (mat.ndim + 1)
 
     fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_FLOAT, dtype='>i4').tostring())
+    fid.write(np.array(FIFFT_MATRIX_COMPLEX_FLOAT, dtype='>i4').tostring())
     fid.write(np.array(data_size, dtype='>i4').tostring())
     fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
     fid.write(np.array(mat, dtype='>c8').tostring())
+
+    dims = np.empty(mat.ndim + 1, dtype=np.int32)
+    dims[:mat.ndim] = mat.shape[::-1]
+    dims[-1] = mat.ndim
+    fid.write(np.array(dims, dtype='>i4').tostring())
+    check_fiff_length(fid)
+
+
+def write_complex_double_matrix(fid, kind, mat):
+    """Write complex 128 matrix tag."""
+    FIFFT_MATRIX = 1 << 30
+    FIFFT_MATRIX_COMPLEX_DOUBLE = FIFF.FIFFT_COMPLEX_DOUBLE  | FIFFT_MATRIX
+
+    data_size = 8 * 2 * mat.size + 4 * (mat.ndim + 1)
+
+    fid.write(np.array(kind, dtype='>i4').tostring())
+    fid.write(np.array(FIFFT_MATRIX_COMPLEX_DOUBLE, dtype='>i4').tostring())
+    fid.write(np.array(data_size, dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
+    fid.write(np.array(mat, dtype='>c16').tostring())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -195,17 +195,17 @@ def write_int_matrix(fid, kind, mat):
 
 
 def write_complex_matrix(fid, kind, mat):
-    """Write a single-precision floating-point matrix tag."""
+    """Write complex 64 matrix tag."""
     FIFFT_MATRIX = 1 << 30
     FIFFT_MATRIX_FLOAT = FIFF.FIFFT_FLOAT | FIFFT_MATRIX
 
-    data_size = 16 * mat.size + 4 * (mat.ndim + 1)
+    data_size = 8 * mat.size + 4 * (mat.ndim + 1)
 
     fid.write(np.array(kind, dtype='>i4').tostring())
     fid.write(np.array(FIFFT_MATRIX_FLOAT, dtype='>i4').tostring())
     fid.write(np.array(data_size, dtype='>i4').tostring())
     fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>c16').tostring())
+    fid.write(np.array(mat, dtype='>c8').tostring())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -197,7 +197,7 @@ def write_int_matrix(fid, kind, mat):
 def write_complex_float_matrix(fid, kind, mat):
     """Write complex 64 matrix tag."""
     FIFFT_MATRIX = 1 << 30
-    FIFFT_MATRIX_COMPLEX_FLOAT = FIFF.FIFFT_COMPLEX_FLOAT  | FIFFT_MATRIX
+    FIFFT_MATRIX_COMPLEX_FLOAT = FIFF.FIFFT_COMPLEX_FLOAT | FIFFT_MATRIX
 
     data_size = 4 * 2 * mat.size + 4 * (mat.ndim + 1)
 
@@ -217,7 +217,7 @@ def write_complex_float_matrix(fid, kind, mat):
 def write_complex_double_matrix(fid, kind, mat):
     """Write complex 128 matrix tag."""
     FIFFT_MATRIX = 1 << 30
-    FIFFT_MATRIX_COMPLEX_DOUBLE = FIFF.FIFFT_COMPLEX_DOUBLE  | FIFFT_MATRIX
+    FIFFT_MATRIX_COMPLEX_DOUBLE = FIFF.FIFFT_COMPLEX_DOUBLE | FIFFT_MATRIX
 
     data_size = 8 * 2 * mat.size + 4 * (mat.ndim + 1)
 

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -194,6 +194,26 @@ def write_int_matrix(fid, kind, mat):
     check_fiff_length(fid)
 
 
+def write_complex_matrix(fid, kind, mat):
+    """Write a single-precision floating-point matrix tag."""
+    FIFFT_MATRIX = 1 << 30
+    FIFFT_MATRIX_FLOAT = FIFF.FIFFT_FLOAT | FIFFT_MATRIX
+
+    data_size = 16 * mat.size + 4 * (mat.ndim + 1)
+
+    fid.write(np.array(kind, dtype='>i4').tostring())
+    fid.write(np.array(FIFFT_MATRIX_FLOAT, dtype='>i4').tostring())
+    fid.write(np.array(data_size, dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
+    fid.write(np.array(mat, dtype='>c16').tostring())
+
+    dims = np.empty(mat.ndim + 1, dtype=np.int32)
+    dims[:mat.ndim] = mat.shape[::-1]
+    dims[-1] = mat.ndim
+    fid.write(np.array(dims, dtype='>i4').tostring())
+    check_fiff_length(fid)
+
+
 def get_machid():
     """Get (mostly) unique machine ID.
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2434,7 +2434,7 @@ def test_events_list():
 def test_save_complex_data():
     """Test whether epochs of hilbert-transformed data can be saved."""
     for is_complex in [False, True]:
-        for fmt in ['single', 'double']:
+        for fmt, rtol in [('single', 1e-6), ('double', 1e-7)]:
             raw, events = _get_data()[:2]
             raw.load_data()
             if is_complex:
@@ -2444,7 +2444,6 @@ def test_save_complex_data():
             temp_fname = op.join(tempdir, 'test-epo.fif')
             epochs.save(temp_fname, fmt=fmt)
             epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-            rtol = 1e-6 if fmt == "single" else 1e-7
             assert_allclose(epochs_read.get_data(),
                             epochs.get_data(), rtol=rtol)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2433,16 +2433,17 @@ def test_events_list():
 
 def test_save_complex_data():
     """Test whether epochs of hilbert-transformed data can be saved."""
-    raw, events = _get_data()[:2]
-    raw.load_data().apply_hilbert(envelope=False, n_fft=None)
-    epochs = Epochs(raw, events, preload=True)[0]
-
-    tempdir = _TempDir()
-    temp_fname = op.join(tempdir, 'test-epo.fif')
-    epochs.save(temp_fname)
-    epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-#    assert_array_equal(epochs_read.get_data(), epochs.get_data())
-    assert_allclose(epochs_read.get_data(), epochs.get_data())
+    for complex in [False, True]:
+        raw, events = _get_data()[:2]
+        raw.load_data()
+        if complex == True:
+            raw.apply_hilbert(envelope=False, n_fft=None)
+        epochs = Epochs(raw, events, preload=True)[0]
+        tempdir = _TempDir()
+        temp_fname = op.join(tempdir, 'test-epo.fif')
+        epochs.save(temp_fname, fmt='double')
+        epochs_read = read_epochs(temp_fname, proj=False, preload=True)
+        assert_allclose(epochs_read.get_data(), epochs.get_data())
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2433,18 +2433,20 @@ def test_events_list():
 
 def test_save_complex_data():
     """Test whether epochs of hilbert-transformed data can be saved."""
-    for complex in [False, True]:
-        for fmt in ['short', 'int', 'single', 'double']:
+    for is_complex in [False, True]:
+        for fmt in ['single', 'double']:
             raw, events = _get_data()[:2]
             raw.load_data()
-            if complex == True:
+            if is_complex:
                 raw.apply_hilbert(envelope=False, n_fft=None)
-            epochs = Epochs(raw, events, preload=True)[0]
+            epochs = Epochs(raw, events[:1], preload=True)[0]
             tempdir = _TempDir()
             temp_fname = op.join(tempdir, 'test-epo.fif')
-            epochs.save(temp_fname, fmt='double')
+            epochs.save(temp_fname, fmt=fmt)
             epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-            assert_allclose(epochs_read.get_data(), epochs.get_data())
+            rtol = 1e-6 if fmt == "single" else 1e-7
+            assert_allclose(epochs_read.get_data(),
+                            epochs.get_data(), rtol=rtol)
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2431,4 +2431,17 @@ def test_events_list():
     assert_array_equal(epochs.events, np.array(events))
 
 
+def test_epochs_save_complex():
+    """Test whether epochs of hilbert-transformed data can be saved."""
+    raw, events = _get_data()[:2]
+    raw.load_data().apply_hilbert(envelope=False, n_fft=None)
+    epochs = Epochs(raw, events, preload=True)
+
+    tempdir = _TempDir()
+    temp_fname = op.join(tempdir, 'test-epo.fif')
+    epochs.save(temp_fname)
+    epochs_read = read_epochs(temp_fname, proj=False, preload=True)
+    assert((epochs.get_data()==epochs_read.get_data()).all())
+
+
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2431,7 +2431,7 @@ def test_events_list():
     assert_array_equal(epochs.events, np.array(events))
 
 
-def test_epochs_save_complex():
+def test_save_complex_data():
     """Test whether epochs of hilbert-transformed data can be saved."""
     raw, events = _get_data()[:2]
     raw.load_data().apply_hilbert(envelope=False, n_fft=None)
@@ -2441,7 +2441,8 @@ def test_epochs_save_complex():
     temp_fname = op.join(tempdir, 'test-epo.fif')
     epochs.save(temp_fname)
     epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-    assert_array_equal(epochs.get_data(), epochs_read.get_data())
+#    assert_array_equal(epochs_read.get_data(), epochs.get_data())
+    assert_allclose(epochs_read.get_data(), epochs.get_data())
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2434,16 +2434,17 @@ def test_events_list():
 def test_save_complex_data():
     """Test whether epochs of hilbert-transformed data can be saved."""
     for complex in [False, True]:
-        raw, events = _get_data()[:2]
-        raw.load_data()
-        if complex == True:
-            raw.apply_hilbert(envelope=False, n_fft=None)
-        epochs = Epochs(raw, events, preload=True)[0]
-        tempdir = _TempDir()
-        temp_fname = op.join(tempdir, 'test-epo.fif')
-        epochs.save(temp_fname, fmt='double')
-        epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-        assert_allclose(epochs_read.get_data(), epochs.get_data())
+        for fmt in ['short', 'int', 'single', 'double']:
+            raw, events = _get_data()[:2]
+            raw.load_data()
+            if complex == True:
+                raw.apply_hilbert(envelope=False, n_fft=None)
+            epochs = Epochs(raw, events, preload=True)[0]
+            tempdir = _TempDir()
+            temp_fname = op.join(tempdir, 'test-epo.fif')
+            epochs.save(temp_fname, fmt='double')
+            epochs_read = read_epochs(temp_fname, proj=False, preload=True)
+            assert_allclose(epochs_read.get_data(), epochs.get_data())
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2435,13 +2435,13 @@ def test_epochs_save_complex():
     """Test whether epochs of hilbert-transformed data can be saved."""
     raw, events = _get_data()[:2]
     raw.load_data().apply_hilbert(envelope=False, n_fft=None)
-    epochs = Epochs(raw, events, preload=True)
+    epochs = Epochs(raw, events, preload=True)[0]
 
     tempdir = _TempDir()
     temp_fname = op.join(tempdir, 'test-epo.fif')
     epochs.save(temp_fname)
     epochs_read = read_epochs(temp_fname, proj=False, preload=True)
-    assert((epochs.get_data()==epochs_read.get_data()).all())
+    assert_array_equal(epochs.get_data(), epochs_read.get_data())
 
 
 run_tests_if_main()


### PR DESCRIPTION
Enables saving hilbert transformed data which has datatype `complex64` not `float64`.