### PR TITLE
fix nans in bti dev head t when presen

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -245,15 +245,16 @@ def _points_to_dig(points, n_idx_points, use_hpi):
     return dig
 
 
+def _check_nan_dev_head_t(dev_ctf_t):
+    """Make sure we deal with nans."""
+    has_nan = np.isnan(dev_ctf_t['trans'])
+    if np.any(has_nan):
+        dev_ctf_t['trans'] = np.identity(4)
+
+
 def _convert_coil_trans(coil_trans, dev_ctf_t, bti_dev_t):
     """Convert the coil trans."""
-
-    dev_ctf_t_ = dev_ctf_t.copy()
-    has_nan = np.isnan(dev_ctf_t_['trans'])
-    if np.any(has_nan):
-        dev_ctf_t_['trans'] = np.identity(4)
-
-    t = combine_transforms(invert_transform(dev_ctf_t_), bti_dev_t,
+    t = combine_transforms(invert_transform(dev_ctf_t), bti_dev_t,
                            'ctf_head', 'meg')
     t = np.dot(t['trans'], coil_trans)
     return t
@@ -1138,6 +1139,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
     dev_ctf_t = Transform('ctf_meg', 'ctf_head',
                           _correct_trans(bti_info['bti_transform'][0]))
 
+    _check_nan_dev_head_t(dev_ctf_t)
     # for old backward compatibility and external processing
     rotation_x = 0. if rotation_x is None else rotation_x
     bti_dev_t = _get_bti_dev_t(rotation_x, translation) if convert else None

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -247,7 +247,13 @@ def _points_to_dig(points, n_idx_points, use_hpi):
 
 def _convert_coil_trans(coil_trans, dev_ctf_t, bti_dev_t):
     """Convert the coil trans."""
-    t = combine_transforms(invert_transform(dev_ctf_t), bti_dev_t,
+
+    dev_ctf_t_ = dev_ctf_t.copy()
+    has_nan = np.isnan(dev_ctf_t_['trans'])
+    if np.any(has_nan):
+        dev_ctf_t_['trans'] = np.identity(4)
+
+    t = combine_transforms(invert_transform(dev_ctf_t_), bti_dev_t,
                            'ctf_head', 'meg')
     t = np.dot(t['trans'], coil_trans)
     return t

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -249,6 +249,8 @@ def _check_nan_dev_head_t(dev_ctf_t):
     """Make sure we deal with nans."""
     has_nan = np.isnan(dev_ctf_t['trans'])
     if np.any(has_nan):
+        logger.info('Missing values BTI dev->head transform. '
+                    'Replacing with identity matrix.')
         dev_ctf_t['trans'] = np.identity(4)
 
 

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -16,7 +16,10 @@ from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_bti
 from mne.io.bti.bti import (_read_config, _process_bti_headshape,
                             _read_bti_header, _get_bti_dev_t,
-                            _correct_trans, _get_bti_info)
+                            _correct_trans, _get_bti_info,
+                            _loc_to_coil_trans,
+                            _convert_coil_trans,
+                            _rename_channels)
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.tests.common import assert_dig_allclose
 from mne.io.pick import pick_info
@@ -296,5 +299,45 @@ def test_setup_headshape():
                            [d.keys() for d in dig]))
         assert (not expected - found)
 
+
+def test_nan_trans():
+    """Test unlikely case that the device to head transform is empty."""
+    for ii, pdf_fname in enumerate(pdf_fnames):
+        bti_info = _read_bti_header(
+            pdf_fname, config_fnames[ii], sort_by_ch_name=True)
+
+        dev_ctf_t = Transform('ctf_meg', 'ctf_head',
+                              _correct_trans(bti_info['bti_transform'][0]))
+
+        # reading params
+        convert = True
+        rotation_x = 0.
+        translation = (0.0, 0.02, 0.11)
+        bti_dev_t = _get_bti_dev_t(rotation_x, translation)
+        bti_dev_t = Transform('ctf_meg', 'meg', bti_dev_t)
+        ecg_ch = 'E31'
+        eog_ch = ('E63', 'E64')
+
+        # read parts of info to get trans
+        bti_ch_names = list()
+        for ch in bti_info['chs']:
+            ch_name = ch['name']
+            if not ch_name.startswith('A'):
+                ch_name = ch.get('chan_label', ch_name)
+            bti_ch_names.append(ch_name)
+
+        neuromag_ch_names = _rename_channels(
+            bti_ch_names, ecg_ch=ecg_ch, eog_ch=eog_ch)
+        ch_mapping = zip(bti_ch_names, neuromag_ch_names)
+
+        # add some nan in some locations!
+        dev_ctf_t['trans'][:, 3] = np.nan
+
+        for idx, (chan_4d, chan_neuromag) in enumerate(ch_mapping):
+            loc = bti_info['chs'][idx]['loc']
+            if loc is not None:
+                if convert:
+                    t = _loc_to_coil_trans(bti_info['chs'][idx]['loc'])
+                    t = _convert_coil_trans(t, dev_ctf_t, bti_dev_t)
 
 run_tests_if_main()

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -17,9 +17,8 @@ from mne.io import read_raw_fif, read_raw_bti
 from mne.io.bti.bti import (_read_config, _process_bti_headshape,
                             _read_bti_header, _get_bti_dev_t,
                             _correct_trans, _get_bti_info,
-                            _loc_to_coil_trans,
-                            _convert_coil_trans,
-                            _rename_channels)
+                            _loc_to_coil_trans, _convert_coil_trans,
+                            _check_nan_dev_head_t, _rename_channels)
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.tests.common import assert_dig_allclose
 from mne.io.pick import pick_info
@@ -332,7 +331,7 @@ def test_nan_trans():
 
         # add some nan in some locations!
         dev_ctf_t['trans'][:, 3] = np.nan
-
+        _check_nan_dev_head_t(dev_ctf_t)
         for idx, (chan_4d, chan_neuromag) in enumerate(ch_mapping):
             loc = bti_info['chs'][idx]['loc']
             if loc is not None:


### PR DESCRIPTION
This is to fix the issue reported by Joshua Bear that occurs when nans are found in the device to head transform. The patch enables reading the files that Joshua shared with us.

cc @agramfort