### PR TITLE
[MRG] fix naming parsing for bids files

### DIFF
--- a/doc/manual/c_reference.rst
+++ b/doc/manual/c_reference.rst
@@ -1479,7 +1479,7 @@ anatomy only, not on the MEG/EEG data to be analyzed.
 		R_{13} & R_{13} & R_{13} & z_0 \\
 		0 & 0 & 0 & 1
 		\end{bmatrix}
-	     
+
 defined so that if the augmented location vectors in MRI
 head and MRI coordinate systems are denoted by :math:`r_{head}[x_{head}\ y_{head}\ z_{head}\ 1]` and :math:`r_{MRI}[x_{MRI}\ y_{MRI}\ z_{MRI}\ 1]`,
 respectively,
@@ -2030,7 +2030,7 @@ Times and baseline
     snapshots are produced as indicated by the ``--tmin`` , ``--tmax`` ,
     and ``--tstep`` options. This is useful, *e.g.*,
     for producing input for scripts merging the individual graphics
-    snapshots into a composite "filmstrip" reprensentation.
+    snapshots into a composite "filmstrip" representation.
     However, such scripts are not yet part of the MNE software.
 
 ``--bmin <*time/ms*>``

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -424,7 +424,7 @@ class RawArtemis123(BaseRaw):
                 hpi_result['dist_limit'] = dist_limit
                 hpi_result['good_limit'] = 0.98
 
-                # Warn for large discrepencies between digitized and fit
+                # Warn for large discrepancies between digitized and fit
                 # cHPI locations
                 if hpi_result['dist_limit'] > 0.005:
                     warn('Large difference between digitized geometry' +

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -14,6 +14,7 @@ import os.path as op
 import numpy as np
 
 from .constants import FIFF
+from .utils import _construct_bids_filename
 from .pick import pick_types, channel_type, pick_channels, pick_info
 from .pick import _pick_data_channels, _pick_data_or_ica
 from .meas_info import write_meas_info
@@ -2258,18 +2259,8 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         if split_naming == 'neuromag':
             # insert index in filename
             use_fname = '%s-%d%s' % (base, part_idx, ext)
-        else:
-            # insert index in filename
-            deconstructed_base = base.split('_')
-            bids_supported = ['meg', 'eeg', 'ieeg']
-            for mod in bids_supported:
-                if mod in deconstructed_base:
-                    idx = deconstructed_base.index(mod)
-                    modality = deconstructed_base.pop(idx)
-            base = '_'.join(deconstructed_base)
-            use_fname = '%s_part-%02d_%s%s' % (base, part_idx, modality, ext)
-            # check for file existence
-            _check_fname(use_fname, overwrite)
+        elif split_naming == 'bids':
+            use_fname = _construct_bids_filename(base, ext)
 
     else:
         use_fname = fname

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2260,7 +2260,14 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             use_fname = '%s-%d%s' % (base, part_idx, ext)
         else:
             # insert index in filename
-            use_fname = '%s_part-%02d_meg%s' % (base, part_idx, ext)
+            deconstructed_base = base.split('_')
+            bids_supported = ['meg', 'eeg', 'ieeg']
+            for mod in bids_supported:
+                if mod in deconstructed_base:
+                    idx = deconstructed_base.index(mod)
+                    modality = deconstructed_base.pop(idx)
+            base = '_'.join(deconstructed_base)
+            use_fname = '%s_part-%02d_%s%s' % (base, part_idx, modality, ext)
             # check for file existence
             _check_fname(use_fname, overwrite)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2260,7 +2260,9 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             # insert index in filename
             use_fname = '%s-%d%s' % (base, part_idx, ext)
         elif split_naming == 'bids':
-            use_fname = _construct_bids_filename(base, ext)
+            use_fname = _construct_bids_filename(base, ext, part_idx)
+            # check for file existence
+            _check_fname(use_fname, overwrite)
 
     else:
         use_fname = fname

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -398,24 +398,26 @@ def test_split_files():
     raw_crop = raw_1.copy().crop(0, 1.)
 
     assert_allclose(raw_1.buffer_size_sec, 10., atol=1e-2)  # samp rate
-    split_fname = op.join(tempdir, 'split_raw.fif')
+    split_fname = op.join(tempdir, 'split_raw_meg.fif')
     # intended filenames
-    split_fname_elekta_part2 = op.join(tempdir, 'split_raw-1.fif')
+    split_fname_elekta_part2 = op.join(tempdir, 'split_raw_meg-1.fif')
     split_fname_bids_part1 = op.join(tempdir, 'split_raw_part-01_meg.fif')
     split_fname_bids_part2 = op.join(tempdir, 'split_raw_part-02_meg.fif')
     raw_1.set_annotations(Annotations([2.], [5.5], 'test'))
-    raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
+    with pytest.warns(RuntimeWarning, match='does not conform to MNE'):
+        raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
 
     # check that the filenames match the intended pattern
     assert op.exists(split_fname_elekta_part2)
     # check that filenames are being formatted correctly for BIDS
-    raw_1.save(split_fname,
-               buffer_size_sec=1.0, split_size='10MB',
-               split_naming='bids',
-               overwrite=True)
+    with pytest.warns(RuntimeWarning, match='does not conform to MNE'):
+        raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB',
+                   split_naming='bids', overwrite=True)
     assert op.exists(split_fname_bids_part1)
     assert op.exists(split_fname_bids_part2)
 
+    split_fname = op.join(tempdir, 'split_raw.fif')
+    raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
     raw_2 = read_raw_fif(split_fname)
     assert_allclose(raw_2.buffer_size_sec, 1., atol=1e-2)  # samp rate
     assert_array_almost_equal(raw_1.annotations.onset, raw_2.annotations.onset)

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -250,7 +250,7 @@ def _synthesize_stim_channel(events, n_samples):
         stim_channel[onset:onset + duration] = trigger
     return stim_channel
 
-def _construct_bids_filename(base, ext):
+def _construct_bids_filename(base, ext, part_idx):
     """Helper function to construct a BIDS compatible filename."""
     # insert index in filename
     deconstructed_base = base.split('_')
@@ -261,7 +261,5 @@ def _construct_bids_filename(base, ext):
             modality = deconstructed_base.pop(idx)
     base = '_'.join(deconstructed_base)
     use_fname = '%s_part-%02d_%s%s' % (base, part_idx, modality, ext)
-    # check for file existence
-    _check_fname(use_fname, overwrite)
 
     return use_fname

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -249,3 +249,19 @@ def _synthesize_stim_channel(events, n_samples):
     for onset, duration, trigger in events:
         stim_channel[onset:onset + duration] = trigger
     return stim_channel
+
+def _construct_bids_filename(base, ext):
+    """Helper function to construct a BIDS compatible filename."""
+    # insert index in filename
+    deconstructed_base = base.split('_')
+    bids_supported = ['meg', 'eeg', 'ieeg']
+    for mod in bids_supported:
+        if mod in deconstructed_base:
+            idx = deconstructed_base.index(mod)
+            modality = deconstructed_base.pop(idx)
+    base = '_'.join(deconstructed_base)
+    use_fname = '%s_part-%02d_%s%s' % (base, part_idx, modality, ext)
+    # check for file existence
+    _check_fname(use_fname, overwrite)
+
+    return use_fname

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -252,7 +252,7 @@ def _synthesize_stim_channel(events, n_samples):
 
 
 def _construct_bids_filename(base, ext, part_idx):
-    """Helper function to construct a BIDS compatible filename."""
+    """Construct a BIDS compatible filename for split files."""
     # insert index in filename
     deconstructed_base = base.split('_')
     bids_supported = ['meg', 'eeg', 'ieeg']

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -250,6 +250,7 @@ def _synthesize_stim_channel(events, n_samples):
         stim_channel[onset:onset + duration] = trigger
     return stim_channel
 
+
 def _construct_bids_filename(base, ext, part_idx):
     """Helper function to construct a BIDS compatible filename."""
     # insert index in filename


### PR DESCRIPTION
this fixes the order of arguments in the filename construction for BIDS files. essentially, it looks to see if the filename string has the specific modality, it pops it off to infix the part argument then adds the modality as a suffix to the filename.