### PR TITLE
[MRG] [TST] MNT remove unused variables

### DIFF
--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -85,6 +85,7 @@ def test_vmrk_meas_date():
 def test_vhdr_codepage_ansi():
     """Test BV reading with ANSI codepage."""
     raw_init = read_raw_brainvision(vhdr_path, event_id=event_id)
+    data_expected, times_expected = raw_init[:]
     tempdir = _TempDir()
     ansi_vhdr_path = op.join(tempdir, op.split(vhdr_path)[-1])
     ansi_vmrk_path = op.join(tempdir, op.split(vmrk_path)[-1])
@@ -107,8 +108,13 @@ def test_vhdr_codepage_ansi():
                 if line.startswith(b'Codepage'):
                     line = b'Codepage=ANSI\n'
                 fout.write(line)
+
     raw = read_raw_brainvision(ansi_vhdr_path, event_id=event_id)
+    data_new, times_new = raw[:]
+
     assert_equal(raw_init.ch_names, raw.ch_names)
+    assert_allclose(data_new, data_expected, atol=1e-15)
+    assert_allclose(times_new, times_expected, atol=1e-15)
 
 
 def test_ascii():

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -34,11 +34,8 @@ vhdr_partially_disabled_hw_filter_path = op.join(data_dir,
 
 vhdr_old_path = op.join(data_dir,
                         'test_old_layout_latin1_software_filter.vhdr')
-vmrk_old_path = op.join(data_dir,
-                        'test_old_layout_latin1_software_filter.vmrk')
 
 vhdr_v2_path = op.join(data_dir, 'testv2.vhdr')
-vmrk_v2_path = op.join(data_dir, 'testv2.vmrk')
 
 vhdr_highpass_path = op.join(data_dir, 'test_highpass.vhdr')
 vhdr_mixed_highpass_path = op.join(data_dir, 'test_mixed_highpass.vhdr')
@@ -111,7 +108,6 @@ def test_vhdr_codepage_ansi():
                     line = b'Codepage=ANSI\n'
                 fout.write(line)
     raw = read_raw_brainvision(ansi_vhdr_path, event_id=event_id)
-    data_new, times_new = raw[:]
     assert_equal(raw_init.ch_names, raw.ch_names)
 
 


### PR DESCRIPTION
fixes #5571 

To @palday, @teonbrooks do you need the `xxxxx.vmrk`?
To @agramfort, I guess that testing `channels` was enough.
