### PR TITLE
[MRG] fix _read_annot + dreprecate it

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,7 +75,7 @@ Changelog
 Bug
 ~~~
 
-- Fix reading edf file annotations by `Joan Massich`_ (`#5580 <https://github.com/mne-tools/mne-python/pull/5580>`_)
+- Fix reading edf file annotations by `Joan Massich`_
 
 - Fix bug with reading events from BrainVision files by `Stefan Appelhoff`_
 
@@ -157,7 +157,7 @@ Bug
 API
 ~~~
 
-- Deprecation of ``annot`` and ``annotmap`` parameters in :meth:`mne.io.edf.RawEDF` by `Joan Massich`_ (`#5580 <https://github.com/mne-tools/mne-python/pull/5580>`_)
+- Deprecation of ``annot`` and ``annotmap`` parameters in :meth:`mne.io.edf.RawEDF` by `Joan Massich`_
 
 - Deprecated ``mne.SourceEstimate.morph_precomputed``, ``mne.SourceEstimate.morph``, ``mne.compute_morph_matrix``, ``mne.morph_data_precomputed`` and ``mne.morph_data`` in favor of :func:`mne.compute_source_morph`, by `Tommy Clausner`_
 
@@ -1345,7 +1345,7 @@ BUG
 
 - Time-cropping functions (e.g., :func:`mne.Epochs.crop`, :func:`mne.Evoked.crop`, :func:`mne.io.Raw.crop`, :func:`mne.SourceEstimate.crop`) made consistent with behavior of ``tmin`` and ``tmax`` of :class:`mne.Epochs`, where nearest sample is kept. For example, for MGH data acquired with ``sfreq=600.614990234``, constructing ``Epochs(..., tmin=-1, tmax=1)`` has bounds ``+/-1.00064103``, and now ``epochs.crop(-1, 1)`` will also have these bounds (previously they would have been ``+/-0.99897607``). Time cropping functions also no longer use relative tolerances when determining the boundaries. These changes have minor effects on functions that use cropping under the hood, such as :func:`mne.compute_covariance` and :func:`mne.connectivity.spectral_connectivity`. Changes by `Jaakko Leppakangas`_ and `Eric Larson`_
 
-- Fix EEG spherical spline interpolation code to account for average reference by `Mainak Jas`_ (`#2758 <https://github.com/mne-tools/mne-python/pull/2758>`_)
+- Fix EEG spherical spline interpolation code to account for average reference by `Mainak Jas`_
 
 - MEG projectors are removed after Maxwell filtering by `Eric Larson`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,8 @@ Changelog
 Bug
 ~~~
 
+- Fix reading edf file annotations by `Joan Massich`_ (`#5580 <https://github.com/mne-tools/mne-python/pull/5580>`_)
+
 - Fix bug with reading events from BrainVision files by `Stefan Appelhoff`_
 
 - Don't use 2nd column of events in BrainVision to store duration but rather raw.annotations by `Alex Gramfort`_
@@ -154,6 +156,8 @@ Bug
 
 API
 ~~~
+
+- Deprecation of ``annot`` and ``annotmap`` parameters in :meth:`mne.io.edf.RawEDF` by `Joan Massich`_ (`#5580 <https://github.com/mne-tools/mne-python/pull/5580>`_)
 
 - Deprecated ``mne.SourceEstimate.morph_precomputed``, ``mne.SourceEstimate.morph``, ``mne.compute_morph_matrix``, ``mne.morph_data_precomputed`` and ``mne.morph_data`` in favor of :func:`mne.compute_source_morph`, by `Tommy Clausner`_
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -10,7 +10,6 @@ import calendar
 import datetime
 import os
 import re
-from io import open  # python 2 backward compatible open
 
 import numpy as np
 
@@ -1117,6 +1116,7 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     stim_channel : ndarray
         An array containing stimulus trigger events.
     """
+    from io import open  # python 2 backward compatible open
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
     with open(annot, encoding='latin-1') as annot_file:
         triggers = re.findall(pat, annot_file.read())

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -12,6 +12,7 @@ import os
 import re
 
 import numpy as np
+from io import open as io_open  # python 2 backward compatible open
 
 from ...utils import verbose, logger, warn
 from ..utils import _blk_read_lims
@@ -1116,9 +1117,8 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     stim_channel : ndarray
         An array containing stimulus trigger events.
     """
-    from io import open  # python 2 backward compatible open
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
-    with open(annot, encoding='latin-1') as annot_file:
+    with io_open(annot, encoding='latin-1') as annot_file:
         triggers = re.findall(pat, annot_file.read())
 
     events = []
@@ -1133,7 +1133,7 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     times = [float(time) * sfreq for time in times]
 
     pat = r'([\w\s]+):(\d+)'
-    with open(annotmap) as annotmap_file:
+    with io_open(annotmap) as annotmap_file:
         mappings = re.findall(pat, annotmap_file.read())
     maps = {}
     for mapping in mappings:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -163,7 +163,7 @@ class RawEDF(BaseRaw):
             warn("Stimulus channel will not be annotated. Both 'annot' and "
                  "'annotmap' must be specified.")
 
-        if bool(annot) or bool(annotmap):
+        if annot or annotmap:
             warn("'annot' and 'annotmap' parameters are deprecated and will be"
                  " removed in 0.18", DeprecationWarning)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -295,8 +295,8 @@ class RawEDF(BaseRaw):
         if stim_channel is not None and len(stim_channel_idx) > 0:
             if annot and annotmap:
                 evts = _read_annot(annot, annotmap, sfreq,
-                                   self._last_samps[fi])
-                data[stim_channel_idx, :] = evts[start:stop + 1]
+                                   self._last_samps[fi] + 1)
+                data[stim_channel_idx, :] = evts[start:stop]
             elif len(tal_sel) > 0:
                 tal_channel_idx = np.in1d(orig_sel[idx], tal_sel)
                 evts = _parse_tal_channel(np.atleast_2d(data[tal_channel_idx]))

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -10,7 +10,7 @@ import calendar
 import datetime
 import os
 import re
-import sys  # XXX I would like to import only PY2 from six
+from io import open  # python 2 backward compatible open
 
 import numpy as np
 
@@ -22,9 +22,6 @@ from ..constants import FIFF
 from ...filter import resample
 from ...externals.six.moves import zip
 from ...utils import copy_function_doc_to_method_doc
-
-
-PY2 = sys.version_info[0] == 2
 
 
 def find_edf_events(raw):
@@ -1120,10 +1117,6 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     stim_channel : ndarray
         An array containing stimulus trigger events.
     """
-    if PY2:
-        # backward compatibility `open(..., encoding=..)`
-        from io import open
-
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
     with open(annot, encoding='latin-1') as annot_file:
         triggers = re.findall(pat, annot_file.read())

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -388,9 +388,9 @@ def _parse_tal_channel(tal_channel_data):
     for ev in tal_list:
         onset = float(ev[0])
         duration = float(ev[2]) if ev[2] else 0
-        for annotation in ev[3].split('\x14')[1:]:
-            if annotation:
-                events.append([onset, duration, annotation])
+        for description in ev[3].split('\x14')[1:]:
+            if description:
+                events.append([onset, duration, description])
 
     return events
 
@@ -1125,9 +1125,9 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     for ev in triggers:
         onset = float(ev[0])
         duration = float(ev[2]) if ev[2] else 0
-        for annotation in ev[3].split('\x14')[1:]:
-            if annotation:
-                events.append([onset, duration, annotation])
+        for description in ev[3].split('\x14')[1:]:
+            if description:
+                events.append([onset, duration, description])
 
     times, durations, descriptions = zip(*events)
     times = [float(time) * sfreq for time in times]

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -10,6 +10,7 @@ import calendar
 import datetime
 import os
 import re
+import sys  # XXX I would like to import only PY2 from six
 
 import numpy as np
 
@@ -21,6 +22,9 @@ from ..constants import FIFF
 from ...filter import resample
 from ...externals.six.moves import zip
 from ...utils import copy_function_doc_to_method_doc
+
+
+PY2 = sys.version_info[0] == 2
 
 
 def find_edf_events(raw):
@@ -1116,6 +1120,10 @@ def _read_annot(annot, annotmap, sfreq, data_length):
     stim_channel : ndarray
         An array containing stimulus trigger events.
     """
+    if PY2:
+        # backward compatibility `open(..., encoding=..)`
+        from io import open
+
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
     with open(annot, encoding='latin-1') as annot_file:
         triggers = re.findall(pat, annot_file.read())

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -163,6 +163,10 @@ class RawEDF(BaseRaw):
             warn("Stimulus channel will not be annotated. Both 'annot' and "
                  "'annotmap' must be specified.")
 
+        if bool(annot) or bool(annotmap):
+            warn("'annot' and 'annotmap' parameters are deprecated and will be"
+                 " removed in 0.18", DeprecationWarning)
+
         # Raw attributes
         last_samps = [edf_info['nsamples'] - 1]
         super(RawEDF, self).__init__(

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -300,6 +300,8 @@ def test_read_annot(tmpdir):
     EXPECTED_ANNOTATIONS = [[180.0, 0, 'Lights off'], [180.0, 0, 'Close door'],
                             [180.0, 0, 'Lights off'], [180.0, 0, 'Close door'],
                             [3.14, 4.2, 'nothing'], [1800.2, 25.5, 'Apnea']]
+    SFREQ = 100
+    DATA_LENGTH = int(EXPECTED_ANNOTATIONS[-1][0] * SFREQ) + 1
     annot = (b'+180\x14Lights off\x14Close door\x14\x00\x00\x00\x00\x00'
              b'+180\x14Lights off\x14\x00\x00\x00\x00\x00\x00\x00\x00'
              b'+180\x14Close door\x14\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -309,11 +311,13 @@ def test_read_annot(tmpdir):
     annot_file = tmpdir.join('annotations.txt')
     annot_file.write(annot)
     annotmap_file = tmpdir.join('annotations_map.txt')
-    annotmap_file.write('Lights off:0\nnothing:1\nApnea:2\nClose door:3')
+    annotmap_file.write('Lights off:1,nothing:2,Apnea:3,Close door:4')
 
     stim_ch = _read_annot(annot=annot_file, annotmap=annotmap_file,
-                          sfreq=100, data_length=None)
-    assert stim_ch
+                          sfreq=SFREQ, data_length=DATA_LENGTH)
+
+    assert stim_ch.shape == (DATA_LENGTH,)
+    assert_array_equal(np.bincount(stim_ch), [180018, 0, 1, 1, 1])
 
 
 run_tests_if_main()

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -331,7 +331,7 @@ def test_read_raw_edf_deprecation_of_annot_annotmap(tmpdir):
     annotmap_file = tmpdir.join('annotations_map.txt')
     annotmap_file.write('two:2,three:3')
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="annot.*annotmap.*"):
         read_raw_edf(input_fname=edf_path, annot=str(annot_file),
                      annotmap=str(annotmap_file), preload=True)
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -322,10 +322,6 @@ def test_read_annot(tmpdir):
 
 def test_read_raw_edf_deprecation_of_annot_annotmap(tmpdir):
     """Test deprecation of annot and annotmap."""
-    EXPECTED_ANNOTATIONS = [[0.1344, 0.2560, 2],
-                            [0.3904, 1.0000, 2],
-                            [2.0000, 0.0000, 3],
-                            [2.5000, 2.5000, 2]]
     annot = (b'+0.1344\x150.2560\x14two\x14\x00\x00\x00\x00'
              b'+0.3904\x151.0\x14two\x14\x00\x00\x00\x00'
              b'+2.0\x14three\x14\x00\x00\x00\x00\x00\x00\x00\x00'

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -313,7 +313,7 @@ def test_read_annot(tmpdir):
     annotmap_file = tmpdir.join('annotations_map.txt')
     annotmap_file.write('Lights off:1,nothing:2,Apnea:3,Close door:4')
 
-    stim_ch = _read_annot(annot=annot_file, annotmap=annotmap_file,
+    stim_ch = _read_annot(annot=str(annot_file), annotmap=str(annotmap_file),
                           sfreq=SFREQ, data_length=DATA_LENGTH)
 
     assert stim_ch.shape == (DATA_LENGTH,)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -320,4 +320,23 @@ def test_read_annot(tmpdir):
     assert_array_equal(np.bincount(stim_ch), [180018, 0, 1, 1, 1])
 
 
+def test_read_raw_edf_deprecation_of_annot_annotmap(tmpdir):
+    """Test deprecation of annot and annotmap."""
+    EXPECTED_ANNOTATIONS = [[0.1344, 0.2560, 2],
+                            [0.3904, 1.0000, 2],
+                            [2.0000, 0.0000, 3],
+                            [2.5000, 2.5000, 2]]
+    annot = (b'+0.1344\x150.2560\x14two\x14\x00\x00\x00\x00'
+             b'+0.3904\x151.0\x14two\x14\x00\x00\x00\x00'
+             b'+2.0\x14three\x14\x00\x00\x00\x00\x00\x00\x00\x00'
+             b'+2.5\x152.5\x14two\x14\x00\x00\x00\x00')
+    annot_file = tmpdir.join('annotations.txt')
+    annot_file.write(annot)
+    annotmap_file = tmpdir.join('annotations_map.txt')
+    annotmap_file.write('two:2,three:3')
+
+    with pytest.warns(DeprecationWarning):
+        read_raw_edf(input_fname=edf_path, annot=str(annot_file),
+                     annotmap=str(annotmap_file), preload=True)
+
 run_tests_if_main()


### PR DESCRIPTION
I'm working on creating events from annotations for EDF files in #5574.

I'm trying to read annotations, and I had troubles with different things. Anyway, covering `_read_annot` might help. 

Can anyone see what am I doing wrong on this test? Sure the problem is that the regex does not pick up anything. But what I'm not sure is if the problem is the code or the test.

Thx.

ping (based on blame): @teonbrooks, @larsoner, @agramfort