### PR TITLE
[MRG] Warn when removing channels needed to compensation matrices.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -159,6 +159,8 @@ Bug
 API
 ~~~
 
+- Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
+
 - Deprecation of ``annot`` and ``annotmap`` parameters in :meth:`mne.io.read_raw_edf` by `Joan Massich`_
 
 - :meth:`mne.Epochs.save` now has the parameter `fmt` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alex Gramfort`_

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -116,11 +116,7 @@ def _compare_ch_names(names1, names2, bads):
 
 def _check_one_ch_type(info, picks, noise_cov, method):
     """Check number of sensor types and presence of noise covariance matrix."""
-    # XXX : ugly hack to avoid picking subset of info with applied comps
-    comps = info['comps']
-    info['comps'] = []
     info_pick = pick_info(info, sel=picks)
-    info['comps'] = comps
     ch_types =\
         [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
     if method == 'lcmv' and sum(ch_types) > 1 and noise_cov is None:

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -173,6 +173,7 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
         Can be ``'auto'``, which means a head-digitization-based origin
         fit. Default is ``(0., 0., 0.04)``.
     verbose : bool, str, int, or None
+    verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
     """
@@ -193,9 +194,7 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
     # return without doing anything if there are no meg channels
     if len(picks_meg) == 0 or len(picks_bad) == 0:
         return
-    inst_info = inst.info.copy()
-    inst_info['comps'] = []
-    info_from = pick_info(inst_info, picks_good)
-    info_to = pick_info(inst_info, picks_bad)
-    mapping = _map_meg_channels(info_from, info_to, mode=mode, origin=origin)
+    info_from = pick_info(inst.info, picks_good)
+    info_to = pick_info(inst.info, picks_bad)
+    mapping = _map_meg_channels(info_from, info_to, mode=mode)
     _do_interp_dots(inst, mapping, picks_good, picks_bad)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -173,7 +173,6 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
         Can be ``'auto'``, which means a head-digitization-based origin
         fit. Default is ``(0., 0., 0.04)``.
     verbose : bool, str, int, or None
-    verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
     """

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -803,8 +803,6 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         data_mean = [1.0 / n_epoch * np.dot(mean, mean.T) for n_epoch, mean
                      in zip(n_epochs, data_mean)]
 
-    if info['comps']:
-        info['comps'] = []
     info = pick_info(info, picks_meeg)
     tslice = _get_tslice(epochs[0], tmin, tmax)
     epochs = [ee.get_data()[:, picks_meeg, tslice] for ee in epochs]
@@ -1329,7 +1327,6 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
         A copy of the covariance with the good channels subselected
         and parameters updated.
     """
-    info = info.copy()
     noise_cov_idx = [noise_cov.ch_names.index(c) for c in ch_names]
     n_chan = len(ch_names)
     if not noise_cov['diag']:
@@ -1390,11 +1387,6 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
                 ranks_type[ch_type] = rank.get(ch_type, None)
         else:
             ranks_type['meg'] = int(rank)
-
-    # XXX cov objects don't include compensation_grade
-    # so we can't check that the supplied cov matches info
-    if info['comps']:
-        info['comps'] = []
 
     for ch_type, this_has in has_type.items():
         if not this_has:

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -482,7 +482,6 @@ def _prepare_for_forward(src, mri_head_t, info, bem, mindist, n_jobs,
         raise RuntimeError('No MEG or EEG channels found.')
 
     # pick out final info
-    info['comps'] = []
     info = pick_info(info, pick_types(info, meg=meg, eeg=eeg, ref_meg=False,
                                       exclude=[]))
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -501,14 +501,6 @@ def read_forward_solution(fname, include=(), exclude=(), verbose=None):
         #
         fwd['info'] = _read_forward_meas_info(tree, fid)
 
-        # remove compensation matrcies.
-        if len(fwd['info'].get('comps', [])) > 0:
-            fwd['info']['comps'] = []
-            warn('Removing compensation matrices found in measurement info of '
-                 'forward operator. This should not affect application of the '
-                 'forward model but it will change the model if it\'s written '
-                 'back to disk', UserWarning)
-
         # MNE environment
         parent_env = dir_tree_find(tree, FIFF.FIFFB_MNE_ENV)
         if len(parent_env) > 0:

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -289,11 +289,12 @@ def test_saving_picked():
     raw_pick.save(out_fname)  # should work
     read_raw_fif(out_fname)
     read_raw_fif(out_fname, preload=True)
-    # If comp is applied, picking should error
+    # If comp is applied, picking should log a message
     raw.apply_gradient_compensation(1)
     assert raw.compensation_grade == get_current_comp(raw.info) == 1
-    with pytest.raises(RuntimeError, match='Compensation grade 1 has been'):
+    with catch_logging() as log:
         raw.copy().pick_types(**pick_kwargs)
+    assert 'Compensation grade 1 has been applied' in log.getvalue()
 
 
 run_tests_if_main()

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -280,21 +280,18 @@ def test_saving_picked():
     assert raw.compensation_grade == get_current_comp(raw.info) == 0
     assert len(raw.info['comps']) == 5
     pick_kwargs = dict(meg=True, ref_meg=False, verbose=True)
-    with catch_logging() as log:
-        raw_pick = raw.copy().pick_types(**pick_kwargs)
-    assert len(raw.info['comps']) == 5
-    assert len(raw_pick.info['comps']) == 0
-    log = log.getvalue()
-    assert 'Removing 5 compensators' in log
-    raw_pick.save(out_fname)  # should work
-    read_raw_fif(out_fname)
-    read_raw_fif(out_fname, preload=True)
-    # If comp is applied, picking should log a message
-    raw.apply_gradient_compensation(1)
-    assert raw.compensation_grade == get_current_comp(raw.info) == 1
-    with catch_logging() as log:
-        raw.copy().pick_types(**pick_kwargs)
-    assert 'Compensation grade 1 has been applied' in log.getvalue()
+    for comp_grade in [0, 1]:
+        if comp_grade != 0:
+            raw.apply_gradient_compensation(comp_grade)
+        with catch_logging() as log:
+            raw_pick = raw.copy().pick_types(**pick_kwargs)
+        assert len(raw.info['comps']) == 5
+        assert len(raw_pick.info['comps']) == 0
+        log = log.getvalue()
+        assert 'Removing 5 compensators' in log
+        raw_pick.save(out_fname, overwrite=True)  # should work
+        read_raw_fif(out_fname)
+        read_raw_fif(out_fname, preload=True)
 
 
 run_tests_if_main()

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -281,8 +281,7 @@ def test_saving_picked():
     assert len(raw.info['comps']) == 5
     pick_kwargs = dict(meg=True, ref_meg=False, verbose=True)
     for comp_grade in [0, 1]:
-        if comp_grade != 0:
-            raw.apply_gradient_compensation(comp_grade)
+        raw.apply_gradient_compensation(comp_grade)
         with catch_logging() as log:
             raw_pick = raw.copy().pick_types(**pick_kwargs)
         assert len(raw.info['comps']) == 5
@@ -290,8 +289,17 @@ def test_saving_picked():
         log = log.getvalue()
         assert 'Removing 5 compensators' in log
         raw_pick.save(out_fname, overwrite=True)  # should work
-        read_raw_fif(out_fname)
-        read_raw_fif(out_fname, preload=True)
+        raw2 = read_raw_fif(out_fname)
+        assert (raw_pick.ch_names == raw2.ch_names)
+        assert_array_equal(raw_pick.times, raw2.times)
+        assert_allclose(raw2[0:20][0], raw_pick[0:20][0], rtol=1e-6,
+                        atol=1e-20)  # atol is very small but > 0
+
+        raw2 = read_raw_fif(out_fname, preload=True)
+        assert (raw_pick.ch_names == raw2.ch_names)
+        assert_array_equal(raw_pick.times, raw2.times)
+        assert_allclose(raw2[0:20][0], raw_pick[0:20][0], rtol=1e-6,
+                        atol=1e-20)  # atol is very small but > 0
 
 
 run_tests_if_main()

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -490,11 +490,12 @@ class Info(dict):
                     self['ch_names'][ch_idx] = ch_name
                     self['chs'][ch_idx]['ch_name'] = ch_name
 
-        # make sure required the compensation channels are present
-        comps_bad, comps_missing = _bad_chans_comp(self, self['ch_names'])
-        if comps_bad:
-            msg = 'Compensation channel(s) %s do not exist in info'
-            raise RuntimeError(msg % (comps_missing,))
+        # Not sure if this should remain or not?
+        # # make sure required the compensation channels are present
+        # comps_bad, comps_missing = _bad_chans_comp(self, self['ch_names'])
+        # if comps_bad:
+        #     warn('Compensation channel(s) %s do not exist in info'
+        #          % comps_missing)
 
         if 'filename' in self:
             warn('the "filename" key is misleading\

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -490,13 +490,6 @@ class Info(dict):
                     self['ch_names'][ch_idx] = ch_name
                     self['chs'][ch_idx]['ch_name'] = ch_name
 
-        # Not sure if this should remain or not?
-        # # make sure required the compensation channels are present
-        # comps_bad, comps_missing = _bad_chans_comp(self, self['ch_names'])
-        # if comps_bad:
-        #     warn('Compensation channel(s) %s do not exist in info'
-        #          % comps_missing)
-
         if 'filename' in self:
             warn('the "filename" key is misleading\
                  and info should not have it')

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -406,7 +406,11 @@ def pick_info(info, sel=(), copy=True):
                             'not all compensation channels were picked: %s\n'
                             'This may complicate source analysis using this '
                             'data.' % (current_comp, comps_missing))
-
+            else:
+                logger.info('Removing %d compensators from info because '
+                            'not all compensation channels were picked'
+                            % (len(info['comps']),))
+                info['comps'] = []
     info['chs'] = [info['chs'][k] for k in sel]
     info._update_redundant()
     info['bads'] = [ch for ch in info['bads'] if ch in info['ch_names']]

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -10,7 +10,7 @@ import re
 import numpy as np
 
 from .constants import FIFF
-from ..utils import logger, verbose, _validate_type, warn
+from ..utils import logger, verbose, _validate_type
 from ..externals.six import string_types
 from .compensator import get_current_comp
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -402,10 +402,10 @@ def pick_info(info, sel=(), copy=True):
         current_comp = get_current_comp(info)
         if len(comps_missing) > 0:
             if current_comp != 0:
-                warn('Compensation grade %d has been applied, but '
-                     'not all compensation channels were picked: %s\n'
-                     'This may complicate source analysis using this data'
-                      % (current_comp, comps_missing))
+                logger.info('Compensation grade %d has been applied, but '
+                            'not all compensation channels were picked: %s\n'
+                            'This may complicate source analysis using this '
+                            'data.' % (current_comp, comps_missing))
 
     info['chs'] = [info['chs'][k] for k in sel]
     info._update_redundant()

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -366,7 +366,8 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     return sel
 
 
-def pick_info(info, sel=(), copy=True):
+@verbose
+def pick_info(info, sel=(), copy=True, verbose=None):
     """Restrict an info structure to a selection of channels.
 
     Parameters
@@ -378,6 +379,9 @@ def pick_info(info, sel=(), copy=True):
         are included.
     copy : bool
         If copy is False, info is modified inplace.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -12,7 +12,6 @@ import numpy as np
 from .constants import FIFF
 from ..utils import logger, verbose, _validate_type
 from ..externals.six import string_types
-from .compensator import get_current_comp
 
 
 def get_channel_types():
@@ -399,18 +398,11 @@ def pick_info(info, sel=(), copy=True):
     if len(info.get('comps', [])) > 0:
         ch_names = [info['ch_names'][idx] for idx in sel]
         _, comps_missing = _bad_chans_comp(info, ch_names)
-        current_comp = get_current_comp(info)
         if len(comps_missing) > 0:
-            if current_comp != 0:
-                logger.info('Compensation grade %d has been applied, but '
-                            'not all compensation channels were picked: %s\n'
-                            'This may complicate source analysis using this '
-                            'data.' % (current_comp, comps_missing))
-            else:
-                logger.info('Removing %d compensators from info because '
-                            'not all compensation channels were picked'
-                            % (len(info['comps']),))
-                info['comps'] = []
+            logger.info('Removing %d compensators from info because '
+                        'not all compensation channels were picked.'
+                        % (len(info['comps']),))
+            info['comps'] = []
     info['chs'] = [info['chs'][k] for k in sel]
     info._update_redundant()
     info['bads'] = [ch for ch in info['bads'] if ch in info['ch_names']]

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -10,7 +10,7 @@ import re
 import numpy as np
 
 from .constants import FIFF
-from ..utils import logger, verbose, _validate_type
+from ..utils import logger, verbose, _validate_type, warn
 from ..externals.six import string_types
 from .compensator import get_current_comp
 
@@ -402,16 +402,10 @@ def pick_info(info, sel=(), copy=True):
         current_comp = get_current_comp(info)
         if len(comps_missing) > 0:
             if current_comp != 0:
-                raise RuntimeError(
-                    'Compensation grade %d has been applied, but '
-                    'compensation channels are missing: %s\n'
-                    'Either remove compensation or pick compensation '
-                    'channels' % (current_comp, comps_missing))
-            else:
-                logger.info('Removing %d compensators from info because '
-                            'not all compensation channels were picked'
-                            % (len(info['comps']),))
-                info['comps'] = []
+                warn('Compensation grade %d has been applied, but '
+                     'not all compensation channels were picked: %s\n'
+                     'This may complicate source analysis using this data'
+                      % (current_comp, comps_missing))
 
     info['chs'] = [info['chs'][k] for k in sel]
     info._update_redundant()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -20,7 +20,7 @@ from mne.io.meas_info import (Info, create_info, _write_dig_points,
                               _force_update_info, RAW_INFO_FIELDS,
                               _bad_chans_comp)
 from mne.io import read_raw_ctf
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import _TempDir, run_tests_if_main, catch_logging
 from mne.channels.montage import read_montage, read_dig_montage
 
 base_dir = op.join(op.dirname(__file__), 'data')
@@ -541,10 +541,11 @@ def test_check_compensation_consistency():
         assert ret == expected_result
         assert len(missing) == 17
         if comp != 0:
-            with pytest.raises(RuntimeWarning,
-                               match='Compensation grade 1 has been applied'):
+            with catch_logging() as log:
                 Epochs(raw, events, None, -0.2, 0.2, preload=False,
                        picks=picks)
+            log = log.getvalue().splitlines()
+            assert(log[3].startswith('Compensation grade 1'))
         else:
             Epochs(raw, events, None, -0.2, 0.2, preload=False, picks=picks)
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -541,7 +541,7 @@ def test_check_compensation_consistency():
         assert ret == expected_result
         assert len(missing) == 17
         if comp != 0:
-            with pytest.raises(RuntimeError,
+            with pytest.raises(RuntimeWarning,
                                match='Compensation grade 1 has been applied'):
                 Epochs(raw, events, None, -0.2, 0.2, preload=False,
                        picks=picks)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -540,13 +540,10 @@ def test_check_compensation_consistency():
         ret, missing = _bad_chans_comp(raw.info, pick_ch_names)
         assert ret == expected_result
         assert len(missing) == 17
-        if comp != 0:
-            with catch_logging() as log:
-                Epochs(raw, events, None, -0.2, 0.2, preload=False,
-                       picks=picks)
-            assert('Removing 5 compensators' in log.getvalue())
-        else:
-            Epochs(raw, events, None, -0.2, 0.2, preload=False, picks=picks)
+        with catch_logging() as log:
+            Epochs(raw, events, None, -0.2, 0.2, preload=False,
+                   picks=picks, verbose=True)
+            assert'Removing 5 compensators' in log.getvalue()
 
 
 run_tests_if_main()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -544,8 +544,7 @@ def test_check_compensation_consistency():
             with catch_logging() as log:
                 Epochs(raw, events, None, -0.2, 0.2, preload=False,
                        picks=picks)
-            log = log.getvalue().splitlines()
-            assert(log[3].startswith('Compensation grade 1'))
+            assert('Compensation grade 1' in log.getvalue())
         else:
             Epochs(raw, events, None, -0.2, 0.2, preload=False, picks=picks)
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -544,7 +544,7 @@ def test_check_compensation_consistency():
             with catch_logging() as log:
                 Epochs(raw, events, None, -0.2, 0.2, preload=False,
                        picks=picks)
-            assert('Compensation grade 1' in log.getvalue())
+            assert('Removing 5 compensators' in log.getvalue())
         else:
             Epochs(raw, events, None, -0.2, 0.2, preload=False, picks=picks)
 

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -100,7 +100,6 @@ def test_pick_refs():
                 pick_info(info, pick)
             log = log.getvalue().splitlines()
             assert(log[0].startswith('Compensation grade'))
-            
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -15,7 +15,7 @@ from mne.io.pick import (channel_indices_by_type, channel_type,
                          pick_types_forward, _picks_by_type)
 from mne.io.constants import FIFF
 from mne.datasets import testing
-from mne.utils import run_tests_if_main
+from mne.utils import run_tests_if_main, catch_logging
 
 io_dir = op.join(op.dirname(inspect.getfile(inspect.currentframe())), '..')
 data_path = testing.data_path(download=False)
@@ -96,7 +96,10 @@ def test_pick_refs():
 
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
-            pytest.raises(RuntimeWarning, pick_info, info, pick)
+            with catch_logging() as log:
+                pick_info(info, pick)
+            assert(log.getvalue().startswith('Compensation grade'))
+
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -98,8 +98,9 @@ def test_pick_refs():
         if len(pick) > 0:
             with catch_logging() as log:
                 pick_info(info, pick)
-            assert(log.getvalue().startswith('Compensation grade'))
-
+            log = log.getvalue().splitlines()
+            assert(log[0].startswith('Compensation grade'))
+            
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -94,12 +94,12 @@ def test_pick_refs():
         if len(pick) > 0:
             pick_info(info, pick)
 
-    msg = 'Removing %d compensators' % len(info['comps'])
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
             with catch_logging() as log:
                 pick_info(info, pick, verbose=True)
-            assert msg in log.getvalue()
+            assert ('Removing {} compensators'.format(len(info['comps']))
+                    in log.getvalue())
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -94,11 +94,12 @@ def test_pick_refs():
         if len(pick) > 0:
             pick_info(info, pick)
 
+    msg = 'Removing %d compensators' % len(info['comps'])
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
             with catch_logging() as log:
                 pick_info(info, pick)
-            assert('Compensation grade 2' in log.getvalue())
+            assert msg in log.getvalue()
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -96,7 +96,7 @@ def test_pick_refs():
 
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
-            pytest.raises(RuntimeError, pick_info, info, pick)
+            pytest.raises(RuntimeWarning, pick_info, info, pick)
 
 
 def test_pick_channels_regexp():

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -98,7 +98,7 @@ def test_pick_refs():
     for pick in (picks_meg, picks_mag):
         if len(pick) > 0:
             with catch_logging() as log:
-                pick_info(info, pick)
+                pick_info(info, pick, verbose=True)
             assert msg in log.getvalue()
 
 

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -98,8 +98,7 @@ def test_pick_refs():
         if len(pick) > 0:
             with catch_logging() as log:
                 pick_info(info, pick)
-            log = log.getvalue().splitlines()
-            assert(log[0].startswith('Compensation grade'))
+            assert('Compensation grade 2' in log.getvalue())
 
 
 def test_pick_channels_regexp():

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1297,8 +1297,6 @@ def _xyz2lf(Lf_xyz, normals):
 def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
                      verbose=None):
     """Prepare forward solution for inverse solvers."""
-    info = info.copy()
-
     # fwd['sol']['row_names'] may be different order from fwd['info']['chs']
     fwd_sol_ch_names = forward['sol']['row_names']
     ch_names = [c['ch_name'] for c in info['chs']
@@ -1325,12 +1323,6 @@ def _prepare_forward(forward, info, noise_cov, pca=False, rank=None,
     gain = gain[fwd_idx]
     # Any function calling this helper will be using the returned fwd_info
     # dict, so fwd['sol']['row_names'] becomes obsolete and is NOT re-ordered
-
-    # remove comps if needed.
-    assert('comps' not in forward['info'] or
-           len(forward['info']['comps']) == 0)
-    if info['comps']:
-        info['comps'] = []
 
     info_idx = [info['ch_names'].index(name) for name in ch_names]
     fwd_info = pick_info(info, info_idx)

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -769,9 +769,7 @@ def _check_loose_forward(loose, forward):
 
 def _check_reference(inst, ch_names=None):
     """Check for EEG ref."""
-    info = inst.info.copy()  # make a copy as comps are now hacked:
-    # XXX : ugly hack to avoid picking subset of info with applied comps
-    info['comps'] = []
+    info = inst.info
     if ch_names is not None:
         picks = [ci for ci, ch_name in enumerate(info['ch_names'])
                  if ch_name in ch_names]

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -410,12 +410,16 @@ def test_plot_tfr_topomap():
 def test_ctf_plotting():
     """Test CTF topomap plotting."""
     raw = read_raw_fif(ctf_fname, preload=True)
+    assert raw.compensation_grade == 3
     events = make_fixed_length_events(raw, duration=0.01)
     assert len(events) > 10
     evoked = Epochs(raw, events, tmin=0, tmax=0.01, baseline=None).average()
     assert get_current_comp(evoked.info) == 3
     # smoke test that compensation does not matter
     evoked.plot_topomap(time_unit='s')
+    # better test that topomaps can still be used without plotting ref
+    evoked.pick_types(meg=True, ref_meg=False)
+    evoked.plot_topomap()
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
This is converts the RuntimeError that was raised when removing channels that were needed for applied compensation matrices to a Warning.

this is an initial PR in response to issue: #5342

If there are any other PRs that were made to skip this issue please add it to this list.

PRs to check
- [ ] #5125
- [x] #5133
- [ ] #5225
- [ ] #5270 
- [ ] #5295
- [x] #5388 
- [x] #5321
- [x] #5341

Closes #5384.