### PR TITLE
[MRG+1] Bring back the green line

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -445,7 +445,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     params['callback_key'] = callback_key
     # have to store this, or it could get garbage-collected
     params['opt_button'] = opt_button
-    params['plot_vertline'] = partial(_draw_vert_line, params=params)
+    params['update_vertline'] = partial(_draw_vert_line, params=params)
 
     # do initial plots
     callback_proj('none')
@@ -932,15 +932,14 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
     ax_vscroll.set_title('Ch.')
 
     vertline_color = (0., 0.75, 0.)
-    params['ax_vertline'] = ax.plot([0, 0], ax.get_ylim(),
-                                    color=vertline_color, zorder=4)[0]
+    params['ax_vertline'] = ax.axvline(0, color=vertline_color, zorder=4)
     params['ax_vertline'].ch_name = ''
     params['vertline_t'] = ax_hscroll.text(params['first_time'], 1.2, '',
                                            color=vertline_color, fontsize=10,
                                            va='bottom', ha='right')
-    params['ax_hscroll_vertline'] = ax_hscroll.plot([0, 0], [0, 1],
-                                                    color=vertline_color,
-                                                    zorder=2)[0]
+    params['ax_hscroll_vertline'] = ax_hscroll.axvline(0,
+                                                       color=vertline_color,
+                                                       zorder=2)
     # make shells for plotting traces
     _setup_browser_offsets(params, n_channels)
     ax.set_xlim(params['t_start'], params['t_start'] + params['duration'],

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -29,7 +29,7 @@ from .utils import (_toggle_options, _toggle_proj, tight_layout,
                     _radio_clicked, _set_radio_button, _handle_topomap_bads,
                     _change_channel_group, _plot_annotations, _setup_butterfly,
                     _handle_decim, _setup_plot_projector, _check_cov,
-                    _set_ax_label_style)
+                    _set_ax_label_style, _draw_vert_line)
 from .evoked import _plot_lines
 
 
@@ -445,6 +445,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     params['callback_key'] = callback_key
     # have to store this, or it could get garbage-collected
     params['opt_button'] = opt_button
+    params['plot_vertline'] = partial(_draw_vert_line, params=params)
 
     # do initial plots
     callback_proj('none')
@@ -934,8 +935,8 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
     params['ax_vertline'] = ax.plot([0, 0], ax.get_ylim(),
                                     color=vertline_color, zorder=4)[0]
     params['ax_vertline'].ch_name = ''
-    params['vertline_t'] = ax_hscroll.text(params['first_time'], 1, '',
-                                           color=vertline_color,
+    params['vertline_t'] = ax_hscroll.text(params['first_time'], 1.2, '',
+                                           color=vertline_color, fontsize=10,
                                            va='bottom', ha='right')
     params['ax_hscroll_vertline'] = ax_hscroll.plot([0, 0], [0, 1],
                                                     color=vertline_color,

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -910,7 +910,7 @@ def _mouse_click(event, params):
     if event.button == 3:  # right click
         if params['fig_annotation'] is not None:  # annotation mode
             raw = params['raw']
-            if np.any([c.contains(event)[0] for c in params['ax'].collections]):
+            if any(c.contains(event)[0] for c in params['ax'].collections):
                 xdata = event.xdata - params['first_time']
                 onset = _sync_onset(raw, raw.annotations.onset)
                 ends = onset + raw.annotations.duration

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -906,14 +906,9 @@ def _mouse_click(event, params):
     """Handle mouse clicks."""
     if event.button not in (1, 3):
         return
-    if event.button == 3:
-        if params['fig_annotation'] is None:
-            if not isinstance(event.xdata, tuple):
-                xdata = (event.xdata, event.xdata)
-            else:
-                xdata = event.xdata
-            params['plot_vertline'](xdata)
-        else:
+
+    if event.button == 3:  # right click
+        if params['fig_annotation'] is not None:  # annotation mode
             raw = params['raw']
             if np.any([c.contains(event)[0] for c in params['ax'].collections]):
                 xdata = event.xdata - params['first_time']
@@ -924,6 +919,8 @@ def _mouse_click(event, params):
             _remove_segment_line(params)
             _plot_annotations(raw, params)
             params['plot_fun']()
+        else:  # right click in browse mode does nothing
+            return
 
     if event.inaxes is None:  # check if channel label is clicked
         if params['n_channels'] > 100:
@@ -989,9 +986,9 @@ def _find_channel_idx(ch_name, params):
 
 def _draw_vert_line(xdata, params):
     """Draw vertical line."""
-    params['ax_vertline'].set_data(xdata[0], np.array(params['ax'].get_ylim()))
-    params['ax_hscroll_vertline'].set_data(xdata[0], np.array([0., 1.]))
-    params['vertline_t'].set_text('%0.2f' % xdata[0])
+    params['ax_vertline'].set_xdata(xdata)
+    params['ax_hscroll_vertline'].set_xdata(xdata)
+    params['vertline_t'].set_text('%0.2f  ' % xdata)
 
 
 def _select_bads(event, params, bads):
@@ -1032,7 +1029,7 @@ def _select_bads(event, params, bads):
                         params['ax_vscroll'].patches[idx].set_color(color)
                     break
     else:
-        _draw_vert_line(np.array([event.xdata] * 2), params)
+        _draw_vert_line(event.xdata, params)
 
     return bads
 
@@ -2018,9 +2015,6 @@ def _on_hover(event, params):
             line = params['segment_line'].line
             pe = [Stroke(linewidth=4, foreground=color, alpha=0.5), Normal()]
             line.set_path_effects(pe if line.contains(event)[0] else pe[1:])
-            params['vertline_t'].set_text('%.3f' % x)
-            params['ax_vertline'].set_data(0,
-                                           np.array(params['ax'].get_ylim()))
             params['ax'].selector.active = False
             params['fig'].canvas.draw()
             return
@@ -2033,7 +2027,6 @@ def _remove_segment_line(params):
         params['segment_line'].remove()
         params['segment_line'] = None
         params['ax'].selector.active = True
-        params['vertline_t'].set_text('')
 
 
 def _annotation_modify(old_x, new_x, params):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -908,18 +908,22 @@ def _mouse_click(event, params):
         return
     if event.button == 3:
         if params['fig_annotation'] is None:
-            return
-        raw = params['raw']
-        if np.any([c.contains(event)[0] for c in params['ax'].collections]):
-            xdata = event.xdata - params['first_time']
-            onset = _sync_onset(raw, raw.annotations.onset)
-            ends = onset + raw.annotations.duration
-            ann_idx = np.where((xdata > onset) & (xdata < ends))[0]
-            raw.annotations.delete(ann_idx)  # only first one deleted
-        _remove_segment_line(params)
-        _plot_annotations(raw, params)
-        params['plot_fun']()
-        return
+            if not isinstance(event.xdata, tuple):
+                xdata = (event.xdata, event.xdata)
+            else:
+                xdata = event.xdata
+            params['plot_vertline'](xdata)
+        else:
+            raw = params['raw']
+            if np.any([c.contains(event)[0] for c in params['ax'].collections]):
+                xdata = event.xdata - params['first_time']
+                onset = _sync_onset(raw, raw.annotations.onset)
+                ends = onset + raw.annotations.duration
+                ann_idx = np.where((xdata > onset) & (xdata < ends))[0]
+                raw.annotations.delete(ann_idx)  # only first one deleted
+            _remove_segment_line(params)
+            _plot_annotations(raw, params)
+            params['plot_fun']()
 
     if event.inaxes is None:  # check if channel label is clicked
         if params['n_channels'] > 100:
@@ -985,9 +989,9 @@ def _find_channel_idx(ch_name, params):
 
 def _draw_vert_line(xdata, params):
     """Draw vertical line."""
-    params['ax_vertline'].set_data(xdata, np.array(params['ax'].get_ylim()))
-    params['ax_hscroll_vertline'].set_data(xdata, np.array([0., 1.]))
-    params['vertline_t'].set_text('%0.3f' % xdata[0])
+    params['ax_vertline'].set_data(xdata[0], np.array(params['ax'].get_ylim()))
+    params['ax_hscroll_vertline'].set_data(xdata[0], np.array([0., 1.]))
+    params['vertline_t'].set_text('%0.2f' % xdata[0])
 
 
 def _select_bads(event, params, bads):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -996,7 +996,7 @@ def _select_bads(event, params, bads):
     # trade-off, avoid selecting more than one channel when drifts are present
     # however for clean data don't click on peaks but on flat segments
     if params['butterfly']:
-        _draw_vert_line(np.array([event.xdata] * 2), params)
+        _draw_vert_line(event.xdata, params)
         return bads
 
     def f(x, y):


### PR DESCRIPTION
Fixes #4771.

This (re)activates the vertical green line, which can be used to mark a specific position in time.

Current problems:
1. When right-clicking on a trace, both the green line is moved and the channel corresponding to the trace is marked as bad. Only the green line should be moved.
2. The green text indicating the current position of the line is too close to the x axis labels - is there any way to move the text more to the left?

@larsoner I think you are familiar with the plotting code, could you take a look? I'm not sure if what I did is OK or just an ugly hack - I'll ask specific question in code comments.