### PR TITLE
MRG: Fix GDF

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -99,7 +99,7 @@ Bug
 
 - Fix bug with channel names in ``mgh70`` montage in :func:`mne.channels.read_montage` by `Eric Larson`_
 
-- Fix bug in :func:`mne.io.read_raw_edf` where GDF files had ``info['highpass']`` and ``info['lowpass']`` set to NaN by `Eric Larson`_
+- Fix bug in :func:`mne.io.read_raw_edf` where GDF files had ``info['highpass']`` and ``info['lowpass']`` set to NaN and ``info['meas_date']`` set incorrectly, by `Eric Larson`_
 
 - Fix bug in :func:`mne.preprocessing.ICA.apply` to handle arrays as `exclude` property by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -99,6 +99,8 @@ Bug
 
 - Fix bug with channel names in ``mgh70`` montage in :func:`mne.channels.read_montage` by `Eric Larson`_
 
+- Fix bug in :func:`mne.io.read_raw_edf` where GDF files had ``info['highpass']`` and ``info['lowpass']`` set to NaN by `Eric Larson`_
+
 - Fix bug in :func:`mne.preprocessing.ICA.apply` to handle arrays as `exclude` property by `Joan Massich`_
 
 - Fix bug in ``method='eLORETA'`` for :func:`mne.minimum_norm.apply_inverse` when using a sphere model and saved ``inv`` by `Eric Larson`_

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -467,6 +467,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         #  Initialize the data and calibration vector
         n_sel_channels = self.info['nchan'] if sel is None else len(sel)
+        assert n_sel_channels <= self.info['nchan']
         # convert sel to a slice if possible for efficiency
         if sel is not None and len(sel) > 1 and np.all(np.diff(sel) == 1):
             sel = slice(sel[0], sel[-1] + 1)
@@ -831,6 +832,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 stop += nchan
                 if stop < 0:
                     raise ValueError('stop must be >= -%s' % nchan)
+            stop = min(stop, nchan)  # slices can legally exceed max
             step = item[0].step if item[0].step is not None else 1
             sel = list(range(start, stop, step))
         else:

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -13,6 +13,8 @@ import pytest
 
 from mne.datasets import testing
 from mne.io import read_raw_edf
+from mne.io.meas_info import DATE_NONE
+from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import run_tests_if_main
 from mne import pick_types, find_events
 
@@ -48,6 +50,12 @@ def test_gdf_data():
     evs = raw.find_edf_events()
     assert (all([event in evs[1] for event in events[:, 0]]))
 
+    # gh-5604
+    assert raw.info['meas_date'] == DATE_NONE
+    with pytest.warns(RuntimeWarning, match='Overlapping events'):
+        _test_raw_reader(read_raw_edf, input_fname=gdf1_path + '.gdf',
+                         eog=None, misc=None, stim_channel='auto')
+
 
 @testing.requires_testing_data
 def test_gdf2_data():
@@ -79,6 +87,11 @@ def test_gdf2_data():
         raw = read_raw_edf(gdf2_path + '.gdf', stim_channel='auto')
     assert_equal(nchan, raw.info['nchan'])  # stim channel not constructed
     assert_array_equal(ch_names[1:], raw.ch_names[1:])
+
+    # gh-5604
+    assert raw.info['meas_date'] == DATE_NONE
+    _test_raw_reader(read_raw_edf, input_fname=gdf2_path + '.gdf',
+                     eog=None, misc=None, stim_channel='STATUS')
 
 
 run_tests_if_main()

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -127,7 +127,7 @@ class Info(dict):
         Name of the person that ran the experiment.
     file_id : dict | None
         The FIF globally unique ID. See Notes for more information.
-    highpass : float | None
+    highpass : float
         Highpass corner frequency in Hertz. Zero indicates a DC recording.
     hpi_meas : list of dict
         HPI measurements that were taken at the start of the recording
@@ -145,7 +145,7 @@ class Info(dict):
         Frequency of the power line in Hertz.
     gantry_angle : float | None
         Tilt angle of the gantry in degrees.
-    lowpass : float | None
+    lowpass : float
         Lowpass corner frequency in Hertz.
     meas_date : tuple of int
         The first element of this list is a UNIX timestamp (seconds since

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -8,6 +8,7 @@ from numpy.testing import (assert_allclose, assert_array_almost_equal,
                            assert_equal, assert_array_equal)
 
 from mne import concatenate_raws, create_info, Annotations
+from mne.annotations import _handle_meas_date
 from mne.datasets import testing
 from mne.io import read_raw_fif, RawArray
 from mne.utils import _TempDir
@@ -61,6 +62,9 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
     full_data = raw._data
     assert raw.__class__.__name__ in repr(raw)  # to test repr
     assert raw.info.__class__.__name__ in repr(raw.info)
+
+    # gh-5604
+    assert _handle_meas_date(raw.info['meas_date']) >= 0
 
     # Test saving and reading
     out_fname = op.join(tempdir, 'test_raw.fif')


### PR DESCRIPTION
Closes #5604.

Also fixes a bug where our slicing logic in `base.py` was not safe for when `raw[:n_ch + 1]` was done. It was exposed by adding `_test_raw_reader` to `test_gdf.py`, where there were only 17 channels but `_test_raw_reader` looked at `raw[:20]`. Now it works like Python slicing where this still gives all 17 channels, but does not throw an error.