### PR TITLE
MRG: Add check for comps in inv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -206,6 +206,8 @@ API
 
 - :attr:`mne.io.Raw.annotations` when missing is set to an empty :class:`mne.Annotations` rather than ``None`` by `Joan Massich`_ and `Alex Gramfort`_
 
+- Mismatches in CTF compensation grade are now checked in inverse computation by `Eric Larson`_
+
 .. _changes_0_16:
 
 Version 0.16


### PR DESCRIPTION
This PR adds checking that compensation grade of data matches that of forward. If it's not the case, it's probably a (fairly easily correctable) error on the part of the user.

@bloyl do you agree?