### PR TITLE
WIP: Improve ica docstring, the second

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -121,21 +121,22 @@ class ICA(ContainsMixin):
 
     This object can be used to estimate ICA components and then remove some
     from Raw, Epochs or Evoked for data exploration or artifact correction.
-    
+
     Prior to fitting and applying the ICA, data is whitened (de-correlated and
     scaled to unit variance, also called sphering transformation) by means of
-    a Principle Component Analysis (PCA). In addition to the whitening, this step
-    introduces the option to reduce the dimensionality of the data, both, prior to
-    fitting the ICA and prior to reverting to sensor space, controllable by the
-    two parameters `max_pca_components` and `n_pca_components`, respectively.
+    a Principle Component Analysis (PCA). In addition to the whitening, this
+    step introduces the option to reduce the dimensionality of the data, both,
+    prior to fitting the ICA and prior to reverting to sensor space,
+    controllable by the two parameters `max_pca_components` and
+    `n_pca_components`, respectively.
     .. note:: Commonly used for reasons of i) computational efficiency and
               ii) additional noise reduction, it is a matter of current debate
-              whether pre-ICA dimensionality reduction could decrease the reliability
-              and stability of the ICA, at least for EEG data and especially during
-              preprocessing [5].
-              On the other hand, for rank-deficient data such as EEG data after 
-              average reference, it is recommended to reduce the dimensionality by 1
-              for optimal ICA performance [6].
+              whether pre-ICA dimensionality reduction could decrease the
+              reliability and stability of the ICA, at least for EEG data and
+              especially during preprocessing [5].
+              On the other hand, for rank-deficient data such as EEG data after
+              average reference or interpolation, it is recommended to reduce
+              the dimensionality by 1 for optimal ICA performance [6].
 
 
     Caveat! If supplying a noise covariance, keep track of the projections
@@ -162,41 +163,45 @@ class ICA(ContainsMixin):
     n_components : int | float | None
         Controls the number of PCA components from the pre-ICA PCA entering the
         ICA decomposition in the `fit()` method.
-        If None (default), all PCA components will be used (== `max_pca_components`). 
+        If None (default), all PCA components will be used
+        (== `max_pca_components`).
         If int, must be <= `max_pca_components`.
         If float between 0 and 1, the number of components selected matches the
-        number of components with a cumulative explained variance below `n_components`
-        (<1> resulting in `max_pca_components`).
-        The actual number of components resulting from evaluating this parameter
-        in the `fit()` method is stored in the attribute `n_components_`.
-        (Note that the trailing ``_`` signifies attributes added to the object by
-        methods to store results from the actual calculations.)
+        number of components with a cumulative explained variance below
+        `n_components` (<1> resulting in `max_pca_components`).
+        The actual number of components resulting from evaluating this
+        parameter in the `fit()` method is stored in the attribute
+        `n_components_`.
+        (Note that the trailing ``_`` signifies attributes added to the object
+        by methods to store results from the actual calculations.)
     max_pca_components : int | None
-        The number of components returned by the PCA decomposition in the `fit()`
-        method. 
+        The number of components returned by the PCA decomposition in the
+        `fit()` method.
         If None (default), no dimensionality reduction will be applied and
         `max_pca_components` will equal the number of channels supplied for
-        decomposing the data. 
-        If > `n_components_`, the additional PCA-only-components can later be used
-        for re-projecting the data into sensor space, additinally controllable 
-        by the `n_pca_components` parameter. It potentially [TO CHECK] 
-        also influences the choice of the actual PCA-algorithm used. Refer to the
-        docstring of sklearn.PCA() for details.
+        decomposing the data.
+        If > `n_components_`, the additional PCA-only-components can later be
+        used for re-projecting the data into sensor space, additionally
+        controllable by the `n_pca_components` parameter. It potentially [TO
+        CHECK] also influences the choice of the actual PCA-algorithm used.
+        Refer to the docstring of sklearn.PCA() for details.
     n_pca_components : int | float
-        The number of PCA components used by the `apply()` method for re-projecting
-        the decomposed data into sensor space. Has to be >= `n_components(_)` and <= 
-        `max_pca_components`. If greater than `n_components_`, the next `n_pca_components`
-        minus `n_components` PCA components will be added before restoring the sensor 
+        The number of PCA components used by the `apply()` method for
+        re-projecting the decomposed data into sensor space. Has to be
+        >= `n_components(_)` and <= `max_pca_components`.
+        If greater than `n_components_`, the next `n_pca_components` minus
+        `n_components` PCA components will be added before restoring the sensor
         space data.
         If None (default), all PCA components will be used.
-        If float between 0 and 1, the number of components selected matches the number
-        of components with a cumulative explained variance below `n_pca_components`.
-        This attribute allows to balance noise reduction against potential loss of 
-        features due to dimensionality reduction, independently of the number of ICA
-        components.
+        If float between 0 and 1, the number of components selected matches the
+        number of components with a cumulative explained variance below
+        `n_pca_components`. This attribute allows to balance noise reduction
+        against potential loss of features due to dimensionality reduction,
+        independently of the number of ICA components.
     noise_cov : None | instance of mne.cov.Covariance
-        Noise covariance used for pre-whitening. If None (default), channels are
-        scaled to unit variance ("z-standardized") prior to the whitening by PCA.
+        Noise covariance used for pre-whitening. If None (default), channels
+        are scaled to unit variance ("z-standardized") prior to the whitening
+        by PCA.
     random_state : None | int | instance of np.random.RandomState
         Random state to initialize ICA estimation for reproducible results.
     method : {'fastica', 'infomax', 'extended-infomax', 'picard'}
@@ -229,11 +234,12 @@ class ICA(ContainsMixin):
     pca_explained_variance_ : ndarray, shape (`max_pca_components`,)
         If fit, the variance explained by each PCA component.
     mixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
-        If fit, the whitened mixing matrix to go back from ICA space to PCA space.
+        If fit, the whitened mixing matrix to go back from ICA space to PCA
+        space.
         It is, in combination with the `pca_components_`, used by the `apply()`
-        and the `get_components()` methods to re-mix/project (a subset of) the ICA 
-        components into the observed channel space. The former method also removes
-        the pre-whitening (z-scaling) and the de-meaning.
+        and the `get_components()` methods to re-mix/project (a subset of) the
+        ICA components into the observed channel space. The former method also
+        removes the pre-whitening (z-scaling) and the de-meaning.
     unmixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
         If fit, the whitened matrix to go from PCA space to ICA space.
         Used, in combination with the `pca_components_`, by the methods
@@ -241,8 +247,8 @@ class ICA(ContainsMixin):
     exclude : list
         List of sources indices to exclude when re-mixing the data in the
         `apply()` method, i.e. artifactual ICA components.
-        The components identified manually and by the various automatic artifact 
-        detection methods should be (manually) appended to this list
+        The components identified manually and by the various automatic
+        artifact detection methods should be (manually) appended to this list
         (e.g. ``ica.exclude.extend(eog_inds)``).
         (There is also an `exclude` parameter in the `apply()` method.)
         To scrap all marked components, set this attribute to an empty list.
@@ -280,14 +286,15 @@ class ICA(ContainsMixin):
     .. [4] Ablin, P., Cardoso, J.F., Gramfort, A., 2017. Faster Independent
            Component Analysis by preconditioning with Hessian approximations.
            arXiv:1706.08171
-           
-    .. [5] Artoni, F., Delorme, A., und Makeig, S, 2018. Applying Dimension Reduction
-           to EEG Data by Principal Component Analysis Reduces the Quality of 
-           Its Subsequent Independent Component Decomposition. NeuroImage 175,
-           pp.176–187. https://sccn.ucsd.edu/%7Earno/mypapers/Artoni2018.pdf
- 
+
+    .. [5] Artoni, F., Delorme, A., und Makeig, S, 2018. Applying Dimension
+           Reduction to EEG Data by Principal Component Analysis Reduces the
+           Quality of Its Subsequent Independent Component Decomposition.
+           NeuroImage 175, pp.176–187.
+           https://sccn.ucsd.edu/%7Earno/mypapers/Artoni2018.pdf
+
      .. [6] https://sccn.ucsd.edu/wiki/Chapter_09:_Decomposing_Data_Using_ICA#Issue:_ICA_returns_near-identical_components_with_opposite_polarities
- 
+
     """
 
     @verbose

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -124,18 +124,18 @@ class ICA(ContainsMixin):
     
     Prior to fitting and applying the ICA, data is whitened (de-correlated and
     scaled to unit variance, also called sphering transformation) by means of
-    a Principle Component Analysis (PCA). This step additionally introduces the
-    option to reduce the dimensionality of the data prior to fitting/reverting
-    the ICA,controllable by the two parameters `max_pca_components` (for 
-    decomposition) and `n_pca_components` (for re-composition).
+    a Principle Component Analysis (PCA). In addition to the whitening, this step
+    introduces the option to reduce the dimensionality of the data, both, prior to
+    fitting the ICA and prior to reverting to sensor space, controllable by the
+    two parameters `max_pca_components` and `n_pca_components`, respectively.
     .. note:: Commonly used for reasons of i) computational efficiency and
               ii) additional noise reduction, it is a matter of current debate
-              whether pre-ICA dimensionality reduction could decrease reliability/
-              stability of ICA, especially during preprocessing (see e.g. [5]).
+              whether pre-ICA dimensionality reduction could decrease the reliability
+              and stability of the ICA, at least for EEG data and especially during
+              preprocessing [5].
               On the other hand, for rank-deficient data such as EEG data after 
-              average reference, it is recommended to reduce dimensionality by 1
-              for the ICA to work optimally.
-              See here: https://sccn.ucsd.edu/wiki/Chapter_09:_Decomposing_Data_Using_ICA#Issue:_ICA_returns_near-identical_components_with_opposite_polarities
+              average reference, it is recommended to reduce the dimensionality by 1
+              for optimal ICA performance [6].
 
 
     Caveat! If supplying a noise covariance, keep track of the projections
@@ -160,17 +160,23 @@ class ICA(ContainsMixin):
     Parameters
     ----------
     n_components : int | float | None
-        The number of PCA components from the pre-ICA PCA entering the ICA 
-        decomposition in the `fit()` method.
-        If int, it must be <= `max_pca_components`. 
-        If None, all PCA components will be used. If float between 0 and 1, 
-        components will be selected by the cumulative percentage of their 
-        explained variance.
+        Controls the number of PCA components from the pre-ICA PCA entering the
+        ICA decomposition in the `fit()` method.
+        If None (default), all PCA components will be used (== `max_pca_components`). 
+        If int, must be <= `max_pca_components`.
+        If float between 0 and 1, the number of components selected matches the
+        number of components with a cumulative explained variance below `n_components`
+        (<1> resulting in `max_pca_components`).
+        The actual number of components resulting from evaluating this parameter
+        in the `fit()` method is stored in the attribute `n_components_`.
+        (Note that the trailing ``_`` signifies attributes added to the object by
+        methods to store results from the actual calculations.)
     max_pca_components : int | None
         The number of components returned by the PCA decomposition in the `fit()`
         method. 
-        If None, no dimensionality reduction will be applied and `max_pca_components`
-        will equal the number of channels supplied for decomposing the data. 
+        If None (default), no dimensionality reduction will be applied and
+        `max_pca_components` will equal the number of channels supplied for
+        decomposing the data. 
         If > `n_components_`, the additional PCA-only-components can later be used
         for re-projecting the data into sensor space, additinally controllable 
         by the `n_pca_components` parameter. It potentially [TO CHECK] 
@@ -183,14 +189,14 @@ class ICA(ContainsMixin):
         minus `n_components` PCA components will be added before restoring the sensor 
         space data.
         If None (default), all PCA components will be used.
-        If float, the number of components selected matches the number of components 
-        with a cumulative explained variance below `n_pca_components`.
+        If float between 0 and 1, the number of components selected matches the number
+        of components with a cumulative explained variance below `n_pca_components`.
         This attribute allows to balance noise reduction against potential loss of 
         features due to dimensionality reduction, independently of the number of ICA
         components.
     noise_cov : None | instance of mne.cov.Covariance
-        Noise covariance used for pre-whitening. If None, channels are scaled
-        to unit variance (z-standardized) prior to whitening (by the PCA).
+        Noise covariance used for pre-whitening. If None (default), channels are
+        scaled to unit variance ("z-standardized") prior to the whitening by PCA.
     random_state : None | int | instance of np.random.RandomState
         Random state to initialize ICA estimation for reproducible results.
     method : {'fastica', 'infomax', 'extended-infomax', 'picard'}
@@ -255,7 +261,7 @@ class ICA(ContainsMixin):
     Reducing the tolerance (set in `fit_params`) speeds up estimation at the
     cost of consistency of the obtained results. It is difficult to directly
     compare tolerance levels between Infomax and Picard, but for Picard and
-    FastICA a good rule of thumb is ``tol_fastica = tol_picard ** 2``.
+    FastICA a good rule of thumb is ``tol_fastica == tol_picard ** 2``.
 
     References
     ----------
@@ -280,6 +286,9 @@ class ICA(ContainsMixin):
            to EEG Data by Principal Component Analysis Reduces the Quality of 
            Its Subsequent Independent Component Decomposition. NeuroImage 175,
            pp.176–187. https://sccn.ucsd.edu/%7Earno/mypapers/Artoni2018.pdf
+ 
+     .. [6] https://sccn.ucsd.edu/wiki/Chapter_09:_Decomposing_Data_Using_ICA#Issue:_ICA_returns_near-identical_components_with_opposite_polarities
+ 
     """
 
     @verbose

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -120,7 +120,17 @@ class ICA(ContainsMixin):
     u"""M/EEG signal decomposition using Independent Component Analysis (ICA).
 
     This object can be used to estimate ICA components and then remove some
-    from Raw or Epochs for data exploration or artifact correction.
+    from Raw, Epochs or Evoked for data exploration or artifact correction.
+    
+    Prior to fitting and applying the ICA, data is whitened (de-correlated and
+    scaled to unit variance, also called sphering transformation) by means of
+    a Principle Component Analysis (PCA). This step additionally introduces the
+    option to reduce the dimensionality of the data prior to fitting the ICA,
+    controllable by the two parameters `max_pca_components` (for decomposition)
+    and `n_pca_components` (for re-composition).
+    Commonly used for reasons of computational efficiency and noise reduction,
+    it is a matter of current debate whether pre-ICA dimensionality reduction 
+    should be applied, especially during preprocessing (see e.g. [5]).
 
     Caveat! If supplying a noise covariance, keep track of the projections
     available in the cov or in the raw object. For example, if you are
@@ -144,23 +154,31 @@ class ICA(ContainsMixin):
     Parameters
     ----------
     n_components : int | float | None
-        The number of components used for ICA decomposition. If int, it must be
-        smaller than `max_pca_components`. If None, all PCA components will
-        be used. If float between 0 and 1, components will be selected by the
-        cumulative percentage of explained variance.
+        The number of PCA components from the pre-ICA PCA entering the ICA 
+        decomposition. If int, it must be <= `max_pca_components`. 
+        If None, all PCA components will be used. If float between 0 and 1, 
+        components will be selected by the cumulative percentage of their 
+        explained variance.
     max_pca_components : int | None
-        The number of components used for PCA decomposition. If None, no
+        The number of components returned by the PCA decomposition. If None, no
         dimensionality reduction will be applied and `max_pca_components` will
-        equal the number of channels supplied for decomposing data.
+        equal the number of channels supplied for decomposing the data. 
+        If > `n_components_`, the additional PCA-only-components can later be used
+        for re-projecting the data into sensor space, additinally controllable 
+        by the `n_pca_components` parameter. It potentially [I don't know this] 
+        also influences the choice of the actual PCA-algorithm used. Refer to the
+        docstring of sklearn.PCA() for details.
     n_pca_components : int | float
-        The number of PCA components used after ICA recomposition. The ensuing
-        attribute `n_components_` allows to balance noise reduction against
-        potential loss of information due to dimensionality reduction. If
-        greater than `n_components_`, the next `n_pca_components` minus
-        `n_components_` PCA components will be added before restoring the
-        sensor space data. If float, the number of components selected matches
-        the number of components with a cumulative explained variance below
-        `n_pca_components`.
+        The number of PCA components used by the `apply()` method for re-projecting
+        the decomposed data into sensor space. Has to be >= `n_components(_)` and <= 
+        `max_pca_components`. If greater than `n_components_`, the next `n_pca_components`
+        minus `n_components` PCA components will be added before restoring the sensor 
+        space data. If None (default), all PCA components will be used.
+        If float, the number of components selected matches the number of components 
+        with a cumulative explained variance below `n_pca_components`.
+        This attribute allows to balance noise reduction against potential loss of 
+        features due to dimensionality reduction, independently of the number of ICA
+        components.
     noise_cov : None | instance of mne.cov.Covariance
         Noise covariance used for pre-whitening. If None, channels are scaled
         to unit variance prior to whitening.
@@ -186,23 +204,34 @@ class ICA(ContainsMixin):
     ch_names : list-like
         Channel names resulting from initial picking.
     n_components_ : int
-        If fit, the actual number of components used for ICA decomposition.
+        If fit, the actual number of PCA components used for ICA decomposition.
     pre_whitener_ : ndarray, shape (n_channels, 1)
         If fit, array used to pre-whiten the data prior to PCA.
-    pca_components_ : ndarray, shape (`n_components_`, n_channels)
+    pca_components_ : ndarray, shape (`max_pca_components`, n_channels)
         If fit, the PCA components.
     pca_mean_ : ndarray, shape (n_channels,)
         If fit, the mean vector used to center the data before doing the PCA.
-    pca_explained_variance_ : ndarray, shape (`n_components_`,)
-        If fit, the variance explained by each PCA component
+    pca_explained_variance_ : ndarray, shape (`max_pca_components`,)
+        If fit, the variance explained by each PCA component.
     mixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
-        If fit, the mixing matrix to restore observed data.
+        If fit, the whitened mixing matrix to go back from ICA space to PCA space.
+        It is, in combination with the `pca_components_`, used by the `apply()`
+        and the `get_components()` methods to re-mix/project (a subset of) the ICA 
+        components into the observed channel space. The former method also takes
+        care of the whitening and re-scaling.
     unmixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
-        If fit, the matrix to unmix observed data.
+        If fit, the whitened matrix to go from PCA space to ICA space.
+        Used, in combination with the `pca_components_`, by the methods
+        `get_sources()` and `apply()` to unmix the observed data.
     exclude : list
-        List of sources indices to exclude, i.e. artifact components identified
-        throughout the ICA solution. To scrap all marked components, you can
-        set this attribute to an empty list.
+        List of sources indices to exclude when re-mixing the data in the
+        `apply()` method, i.e. artifactual ICA components.
+        The components identified manually and by the various automatic artifact 
+        detection methods should be (manually) appended to this list
+        (e.g. ica.exclude.extend(eog_inds)).
+        (There is also an `exclude` parameter in the `apply()` method, which
+        is also appended to this attribute.)
+        To scrap all marked components, set this attribute to an empty list.
     info : None | instance of Info
         The measurement info copied from the object fitted.
     n_samples_ : int
@@ -214,10 +243,10 @@ class ICA(ContainsMixin):
 
     Notes
     -----
-    Reducing the tolerance speeds up estimation at the cost of consistency of
-    the obtained results. It is difficult to directly compare tolerance levels
-    between Infomax and Picard, but for Picard and FastICA a good rule of thumb
-    is ``tol_fastica = tol_picard ** 2``.
+    Reducing the tolerance (set in `fit_params`) speeds up estimation at the
+    cost of consistency of the obtained results. It is difficult to directly
+    compare tolerance levels between Infomax and Picard, but for Picard and
+    FastICA a good rule of thumb is ``tol_fastica = tol_picard ** 2``.
 
     References
     ----------
@@ -237,6 +266,11 @@ class ICA(ContainsMixin):
     .. [4] Ablin, P., Cardoso, J.F., Gramfort, A., 2017. Faster Independent
            Component Analysis by preconditioning with Hessian approximations.
            arXiv:1706.08171
+           
+    .. [5] Artoni, F., Delorme, A., und Makeig, S, 2018. Applying Dimension Reduction
+           to EEG Data by Principal Component Analysis Reduces the Quality of 
+           Its Subsequent Independent Component Decomposition. NeuroImage 175,
+           pp.176–187. https://sccn.ucsd.edu/%7Earno/mypapers/Artoni2018.pdf
     """
 
     @verbose

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -243,9 +243,8 @@ class ICA(ContainsMixin):
         `apply()` method, i.e. artifactual ICA components.
         The components identified manually and by the various automatic artifact 
         detection methods should be (manually) appended to this list
-        (e.g. ica.exclude.extend(eog_inds)).
-        (There is also an `exclude` parameter in the `apply()` method, which
-        is also appended to this attribute.)
+        (e.g. ``ica.exclude.extend(eog_inds)``).
+        (There is also an `exclude` parameter in the `apply()` method.)
         To scrap all marked components, set this attribute to an empty list.
     info : None | instance of Info
         The measurement info copied from the object fitted.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -293,7 +293,7 @@ class ICA(ContainsMixin):
            NeuroImage 175, pp.176–187.
            https://sccn.ucsd.edu/%7Earno/mypapers/Artoni2018.pdf
 
-     .. [6] https://sccn.ucsd.edu/wiki/Chapter_09:_Decomposing_Data_Using_ICA#Issue:_ICA_returns_near-identical_components_with_opposite_polarities
+     .. [6] https://sccn.ucsd.edu/wiki/Chapter_09:_Decomposing_Data_Using_ICA#Issue:_ICA_returns_near-identical_components_with_opposite_polarities  # noqa
 
     """
 


### PR DESCRIPTION
One more attempt to make the docstring of ICA more explicit, especially as to the three different `*_components_*` parameters.

Also fixing wrong shape specifications of the attributes `pca_components_` and `pca_explained_variance_`.

#### Reference issue
Expanding on #5114, in reference to #4856.

#### What does this implement/fix?
V.s.; in detail:
* Adding a (first attempt of an) introduction about pre-ICA PCA, also referencing the warning about dimensionality reduction mentioned e.g. [here](https://github.com/mne-tools/mne-python/issues/4856#issuecomment-377194869).
!! The formulation about the whitening needs to be reviewed, I am not sure, if this is correct! See below.
* Referencing the most important methods which make use of the various attributes and parameters, especially thereby trying to be more explicit in which steps the various component-parameters are used.
* Some re-formulations.
* Mentioning Evoked as supported container.

#### OPEN QUESTIONS:

1. `max_pca_components`:
I am not sure if (with now explicitly specifying the sklearn.PCA svd_solver to 'full' as of sklearn 0.18.) max_pca_components has any influence on the actual PCA (e.g. by influencing the choice of the algorithm used; I am referring to this of the PCA docstring: "If ``n_components == 'mle'`` and ``svd_solver == 'full'``, Minka's MLE is used to guess the dimension.") 
If this would _not_ be the case, the only other use case I could think of for including 2 separate n-PCA-parameters for decomp and re-comp is that the user makes up his mind later, after fitting, about how many PCA-compos to include in the reconstruction. But would it then hurt (data size etc.) to always return and store simply all PCA-compos?
If the latter would also _not_ be the case, I think this parameter is completely redundant and should be merged with `n_pca_components` (which has to be >= `n_components_`), as it is probably the primary source of confusion to have two parameters related to the number of PCA components.
--> Could someone check this?


2. I am not sure about the whitening/sphering:
In `_fit()`, the variance-normalization is somehow applied to both the pca_components_ and the (un)mixing_matrix_ (once * and once /, though):
```python
    593: self.pca_components_ *= np.sqrt(exp_var[:, None])  # (or in pca.fit_transform())
    ...
    619: self.unmixing_matrix_ /= np.sqrt(exp_var[sel])[None, :]  # whitening
    620: self.mixing_matrix_ = linalg.pinv(self.unmixing_matrix_)
```
Then, later in _pick_sources, the two are combined:
```python
    unmixing = np.eye(_n_pca_comp)
    unmixing[:n_components, :n_components] = self.unmixing_matrix_
    unmixing = np.dot(unmixing, self.pca_components_[:_n_pca_comp])
```
So, I wonder, if it is correct to say that the `(un)mixing_` matrix is whitened? Or would you rather way it is "also whitening the data"?
And could I think of applying the normalization in this way is in the end cancelling itself out when pca-unmixing and and ica-unmixing are being combined (i.e. in the complete unmixing)?

This is actually my first commit/PR ever, so please bear with me ;)

