### PR TITLE
MRG: Simpler coil defs

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -43,7 +43,7 @@ from .io.pick import pick_types, pick_channels, pick_channels_regexp
 from .io.constants import FIFF
 from .io.ctf.trans import _make_ctf_coord_trans_set
 from .forward import (_magnetic_dipole_field_vec, _create_meg_coils,
-                      _concatenate_coils, _read_coil_defs)
+                      _concatenate_coils)
 from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
@@ -512,8 +512,7 @@ def _setup_hpi_struct(info, model_n_window,
                      % (len(msg), u' '.join(msg)))
 
     megchs = [ch for ci, ch in enumerate(info['chs']) if ci in meg_picks]
-    templates = _read_coil_defs(elekta_defs=True, verbose=False)
-    coils = _create_meg_coils(megchs, 'accurate', coilset=templates)
+    coils = _create_meg_coils(megchs, 'accurate')
     if method == 'forward':
         coils = _concatenate_coils(coils)
     else:  # == 'multipole'

--- a/mne/data/coil_def_Elekta.dat
+++ b/mne/data/coil_def_Elekta.dat
@@ -1,12 +1,12 @@
 #
 #	MEG coil definition file for Maxwell Filtering
-#	
+#
 #	These coil definitions make use of integration points according to the last
 #	formula in section 25.4.62 in the "Handbook of Mathematical Functions:
 #	With Formulas, Graphs, and Mathematical Tables" edited by Abramowitz and Stegun.
 #
 #	These coil definitions were used by Samu Taulu in the Spherical Space
-#	Separation work, which was subsequently used by Elekta in Maxfilter. The only 
+#	Separation work, which was subsequently used by Elekta in Maxfilter. The only
 #	difference is that the local z-coordinate was set to zero in Taulu's original
 #	formulation. Source of small z-coordinate offset (0.0003m) is due to manufacturing bug.
 #
@@ -39,10 +39,6 @@
 #
 1   2000    2   1  0.000e+00  0.000e+00	"Point magnetometer, z-normal"
   1.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  1.0000000000e+00
-1   2002    2   1  0.000e+00  0.000e+00	"Point magnetometer, x-normal"
-  1.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  1.0000000000e+00  0.0000000000e+00  0.0000000000e+00
-1   2003    2   1  0.000e+00  0.000e+00	"Point magnetometer, y-normal"
-  1.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00  1.0000000000e+00  0.0000000000e+00
 3   3012    2   8  2.639e-02  1.669e-02	"Vectorview planar gradiometer T1 size = 26.39  mm base = 16.69  mm"
 1.4979029359e+01  1.0800000000e-02  6.7100000000e-03  3.0000000000e-04  0.0000000000e+00  0.0000000000e+00  1.0000000000e+00
 1.4979029359e+01  5.8900000000e-03  6.7100000000e-03  3.0000000000e-04  0.0000000000e+00  0.0000000000e+00  1.0000000000e+00

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -37,17 +37,11 @@ _extra_coil_def_fname = None
 
 
 @verbose
-def _read_coil_defs(elekta_defs=False, verbose=None):
+def _read_coil_defs(verbose=None):
     """Read a coil definition file.
 
     Parameters
     ----------
-    elekta_defs : bool
-        If true, prepend Elekta's coil definitions for numerical
-        integration (from Abramowitz and Stegun section 25.4.62).
-        Note that this will likely cause duplicate coil definitions,
-        so the first matching coil should be selected for optimal
-        integration parameters.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -68,8 +62,6 @@ def _read_coil_defs(elekta_defs=False, verbose=None):
     """
     coil_dir = op.join(op.split(__file__)[0], '..', 'data')
     coils = list()
-    if elekta_defs:
-        coils += _read_coil_def_file(op.join(coil_dir, 'coil_def_Elekta.dat'))
     if _extra_coil_def_fname is not None:
         coils += _read_coil_def_file(_extra_coil_def_fname, use_registry=False)
     coils += _read_coil_def_file(op.join(coil_dir, 'coil_def.dat'))
@@ -269,8 +261,8 @@ def _setup_bem(bem, bem_extra, neeg, mri_head_t, allow_none=False,
 
 @verbose
 def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
-                       elekta_defs=False, head_frame=True, do_es=False,
-                       do_picking=True, verbose=None):
+                       head_frame=True, do_es=False, do_picking=True,
+                       verbose=None):
     """Prepare MEG coil definitions for forward calculation.
 
     Parameters
@@ -285,9 +277,6 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
         info['bads']
     ignore_ref : bool
         If true, ignore compensation coils
-    elekta_defs : bool
-        If True, use Elekta's coil definitions, which use different integration
-        point geometry. False by default.
     head_frame : bool
         If True (default), use head frame coords. Otherwise, use device frame.
     do_es : bool
@@ -351,7 +340,7 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
     picks = pick_types(info, meg=True, ref_meg=ref_meg, exclude=exclude)
 
     # Create coil descriptions with transformation to head or device frame
-    templates = _read_coil_defs(elekta_defs=elekta_defs)
+    templates = _read_coil_defs()
 
     if head_frame:
         _print_coord_trans(info['dev_head_t'])

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -788,8 +788,6 @@ FIFF.FIFFV_COIL_MCG_42             = 1000  # For testing the MCG software
 
 FIFF.FIFFV_COIL_POINT_MAGNETOMETER   = 2000  # Simple point magnetometer
 FIFF.FIFFV_COIL_AXIAL_GRAD_5CM       = 2001  # Generic axial gradiometer
-FIFF.FIFFV_COIL_POINT_MAGNETOMETER_X = 2002  # Simple point magnetometer, x-direction
-FIFF.FIFFV_COIL_POINT_MAGNETOMETER_Y = 2003  # Simple point magnetometer, y-direction
 
 FIFF.FIFFV_COIL_VV_PLANAR_W        = 3011  # VV prototype wirewound planar sensor
 FIFF.FIFFV_COIL_VV_PLANAR_T1       = 3012  # Vectorview SQ20483N planar gradiometer

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -23,11 +23,6 @@ _dir_ignore_names = ('clear', 'copy', 'fromkeys', 'get', 'items', 'keys',
                      'has_key', 'iteritems', 'iterkeys', 'itervalues',  # Py2
                      'viewitems', 'viewkeys', 'viewvalues',  # Py2
                      )
-# XXX These should all probably be added to the FIFF constants
-_missing_names = (
-    'FIFFV_COIL_POINT_MAGNETOMETER_X',
-    'FIFFV_COIL_POINT_MAGNETOMETER_Y',
-)
 # not in coil_def.dat but in DictionaryTypes:enum(coil)
 _missing_coil_def = (
     0,      # The location info contains no data
@@ -213,8 +208,7 @@ def test_constants(tmpdir):
 
     # Assert that all our constants are in the FIF def
     for name in sorted(dir(FIFF)):
-        if name.startswith('_') or name in _dir_ignore_names or \
-                name in _missing_names:
+        if name.startswith('_') or name in _dir_ignore_names:
             continue
         check = None
         val = getattr(FIFF, name)


### PR DESCRIPTION
This PR:

1. Removes the unnecessary `X` and `Y` point mag coil defs by using a simple rotation of the local coordinate system combined with the standard `Z` point mag def.
2. Simplifies the coil def machinery by making use of the new `use_coil_def`.
3. Makes it so that `maxwell_filter` uses the same coil defs as the rest of MNE. In some of the tests we still use `use_coil_def(elekta_def_fname)` just to cross-check high compat when using identical defs; in others, we don't bother (to check that processing is working properly with MNE defs). Some of the "check vs. MaxFilter" test tolerances thus needed to be lowered, but critically none of the shielding / data quality ones did, telling us that things are still working.

No need for `whats_new.rst` update as this should be transparent to users.