### PR TITLE
[MRG+1] BUG: projection vectors

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -89,7 +89,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :func:`mne.io.BaseRaw.plot_proj_topomap` by `Joan Massich`_
+- Fix :func:`mne.io.Raw.plot_proj_topomap` by `Joan Massich`_
 
 - Fix reading edf file annotations by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -89,6 +89,7 @@ Changelog
 
 Bug
 ~~~
+- Fix :func:`mne.io.BaseRaw.plot_proj_topomap` by `Joan Massich`_
 
 - Fix reading edf file annotations by `Joan Massich`_
 

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -1,0 +1,36 @@
+"""
+==============================================
+Read and visualize SSP (and other) projections
+==============================================
+
+This example shows how to read and visualize SSP vector correcting for ECG.
+"""
+# Author: Joan Massich <mailsik@gmail.com>
+#
+# License: BSD (3-clause)
+
+
+from mne import read_proj 
+
+from mne.datasets import sample
+
+print(__doc__)
+
+data_path = sample.data_path()
+
+subjects_dir = data_path + '/subjects'
+fname = data_path + '/MEG/sample/sample_audvis.fif'
+ecg_fname = data_path + '/MEG/sample/sample_audvis_ecg-proj.fif'
+
+ssp_projs = read_proj(ecg_fname)
+
+###############################################################################
+# Show a single projection
+ssp_projs[0].plot_topomap()
+
+
+###############################################################################
+# Show all projections within a raw file
+
+
+

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -4,8 +4,10 @@
 Read and visualize projections (SSP and other)
 ==============================================
 
-This example shows how to read and visualize SSP vector
+This example shows how to read and visualize Signal Subspace Projectors (SSP)
+vector. Such projections are sometimes referred to as PCA projections.
 """
+
 # Author: Joan Massich <mailsik@gmail.com>
 #
 # License: BSD (3-clause)
@@ -27,14 +29,16 @@ fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
 ecg_fname = data_path + '/MEG/sample/sample_audvis_ecg-proj.fif'
 
 ###############################################################################
-# Load the FIF file and display the recorded projections within the file from
-# the empty room recording.
+# Load the FIF file and display the projections present in the file. Here the
+# projections are added to the file during the acquisition and are obtained
+# from empty room recordings.
 raw = read_raw_fif(fname)
 empty_room_proj = raw.info['projs']
 
 # Display the projections stored in `info['projs']` from the raw object
 raw.plot_projs_topomap()
 
+###############################################################################
 # Display the projections one by one
 fig, axes = plt.subplots(1, len(empty_room_proj))
 for proj, ax in zip(empty_room_proj, axes):
@@ -45,9 +49,9 @@ assert isinstance(empty_room_proj, list)
 mne.viz.plot_projs_topomap(empty_room_proj)
 
 ###############################################################################
-# As shown in the tutorial on how to 
-# :ref:`<sphx_glr_download_auto_tutorials_plot_visualize_raw.py>`
-# the ECG projections can be loaded from a file and added to the raw object 
+# As shown in the tutorial on how to
+# :ref:`<sphx_glr_auto_tutorials_plot_visualize_raw.py>`
+# the ECG projections can be loaded from a file and added to the raw object
 
 # read the projections
 ecg_projs = read_proj(ecg_fname)
@@ -60,11 +64,11 @@ raw.plot_projs_topomap()
 # Displaying the projections from a raw object requires no extra information
 # since all the layout information is present in `raw.info`.
 # MNE is able to automatically determine the layout for some magnetometer and
-# gradiomiter configurations but not the layout of EEG electrodes.
+# gradiometer configurations but not the layout of EEG electrodes.
 #
 # Here we display the `ecg_projs` individually and we provide extra parameters
-# for EEG. (Notice that planar projection refers to the gradiomiters and axial
-# refers to magnetomiters.)
+# for EEG. (Notice that planar projection refers to the gradiometers and axial
+# refers to magnetometers.)
 fig, axes = plt.subplots(1, len(ecg_projs))
 for proj, ax in zip(ecg_projs, axes):
     if proj['desc'].startswith('ECG-eeg'):
@@ -72,6 +76,7 @@ for proj, ax in zip(ecg_projs, axes):
     else:
         proj.plot_topomap(axes=ax)
 
+###############################################################################
 # To display it in one go we can provide always info and avoid the guesswork
 mne.viz.plot_projs_topomap(ecg_projs, info=raw.info)
 

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -44,13 +44,14 @@ fig, axes = plt.subplots(1, len(empty_room_proj))
 for proj, ax in zip(empty_room_proj, axes):
     proj.plot_topomap(axes=ax)
 
+###############################################################################
 # Use the function in `mne.viz` to display a list of projections
 assert isinstance(empty_room_proj, list)
 mne.viz.plot_projs_topomap(empty_room_proj)
 
 ###############################################################################
 # As shown in the tutorial on how to
-# :ref:`<sphx_glr_auto_tutorials_plot_visualize_raw.py>`
+# :ref:`sphx_glr_auto_tutorials_plot_visualize_raw.py`
 # the ECG projections can be loaded from a file and added to the raw object
 
 # read the projections

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -70,16 +70,16 @@ raw.plot_projs_topomap()
 # Here we display the `ecg_projs` individually and we provide extra parameters
 # for EEG. (Notice that planar projection refers to the gradiometers and axial
 # refers to magnetometers.)
+#
+# Notice that the conditional is just for illustration purposes. We could
+# `raw.info` in all cases to avoid the guesswork in `plot_topomap` and ensure
+# that the right layout is always found
 fig, axes = plt.subplots(1, len(ecg_projs))
 for proj, ax in zip(ecg_projs, axes):
     if proj['desc'].startswith('ECG-eeg'):
         proj.plot_topomap(axes=ax, info=raw.info)
     else:
         proj.plot_topomap(axes=ax)
-
-###############################################################################
-# To display it in one go we can provide always info and avoid the guesswork
-mne.viz.plot_projs_topomap(ecg_projs, info=raw.info)
 
 ###############################################################################
 # The correct layout or a list of layouts from where to choose can also be

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -9,7 +9,8 @@ from numpy.testing import assert_allclose
 import pytest
 
 from mne.viz.utils import (compare_fiff, _fake_click, _compute_scalings,
-                           _validate_if_list_of_axes, _get_color_list)
+                           _validate_if_list_of_axes, _get_color_list,
+                           _setup_vmin_vmax)
 from mne.viz import ClickableImage, add_background_image, mne_analyze_colormap
 from mne.utils import run_tests_if_main
 from mne.io import read_raw_fif
@@ -24,6 +25,12 @@ base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 cov_fname = op.join(base_dir, 'test-cov.fif')
 ev_fname = op.join(base_dir, 'test_raw-eve.fif')
+
+
+def test_setup_vmin_vmax_warns():
+    expected_msg = '\(min=0.0, max=1\) range.*minimum of data is -1'
+    with pytest.warns(UserWarning, match=expected_msg):
+        _setup_vmin_vmax(data=[-1, 0], vmin=None, vmax=None, norm=True)
 
 
 def test_get_color_list():

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -28,7 +28,8 @@ ev_fname = op.join(base_dir, 'test_raw-eve.fif')
 
 
 def test_setup_vmin_vmax_warns():
-    expected_msg = '\(min=0.0, max=1\) range.*minimum of data is -1'
+    """Test that _setup_vmin_vmax warns properly."""
+    expected_msg = r'\(min=0.0, max=1\) range.*minimum of data is -1'
     with pytest.warns(UserWarning, match=expected_msg):
         _setup_vmin_vmax(data=[-1, 0], vmin=None, vmax=None, norm=True)
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -675,8 +675,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         raise ValueError("Data and pos need to be of same length. Got data of "
                          "length %s, pos of length %s" % (len(data), len(pos)))
 
-    norm = min(data) >= 0
-    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
+    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm=False)
     if cmap is None:
         cmap = 'Reds' if norm else 'RdBu_r'
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -159,6 +159,7 @@ def _remove_zeros(proj):
     meg_regex = '^MEG.*1$'
 
     proj = copy.deepcopy(proj)
+    proj['data']['data'] = np.atleast_2d(proj['data']['data'])
 
     for regex in (grad_regex, meg_regex):
         names = proj['data']['col_names']

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -153,7 +153,7 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
 
 
 def _remove_zeros(proj):
-    """Remove grad or mag data if only contains 0s (gh 5641). """
+    """Remove grad or mag data if only contains 0s (gh 5641)."""
     import re
     grad_regex = '^MEG.*[23]$'
     meg_regex = '^MEG.*1$'
@@ -166,8 +166,9 @@ def _remove_zeros(proj):
 
         # if all 0, remove the 0s an their labels
         if not proj['data']['data'][0][idx].any():
-            proj['data']['col_names'] = np.delete(np.array(names), idx).tolist()
+            new_col_names = np.delete(np.array(names), idx).tolist()
             new_data = np.delete(np.array(proj['data']['data'][0]), idx)
+            proj['data']['col_names'] = new_col_names
             proj['data']['data'] = np.array([new_data])
 
     proj['data']['ncol'] = len(proj['data']['col_names'])

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -256,8 +256,8 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                                    Layout, _merge_grad_data)
     from ..channels import _get_ch_type
 
-    is_layout_parameter_none = layout == None
-    is_info_parameter_none = info == None
+    is_layout_parameter_none = layout is None
+    is_info_parameter_none = info is None
 
     if info is not None:
         if not isinstance(info, Info):
@@ -357,9 +357,9 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                     raise RuntimeError(msg)
                 else:
                     raise RuntimeError('Cannot find a proper layout for '
-                                    'projection %s, consider explicitly '
-                                    'passing a Layout or Info as the layout '
-                                    'parameter.' % proj['desc'])
+                                       'projection %s, consider explicitly '
+                                       'passing a Layout or Info as the layout'
+                                       ' parameter.' % proj['desc'])
 
         im = plot_topomap(data, pos[:, :2], vmax=None, cmap=cmap,
                           sensors=sensors, res=res, axes=axes[proj_idx],

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -154,16 +154,15 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
 
 def _eliminate_zeros(proj):
     """Remove grad or mag data if only contains 0s (gh 5641)."""
-    import re
-    grad_regex = '^MEG.*[23]$'
-    meg_regex = '^MEG.*1$'
+    GRAD_ENDING = ('2', '3')
+    MAG_ENDING = '1'
 
     proj = copy.deepcopy(proj)
     proj['data']['data'] = np.atleast_2d(proj['data']['data'])
 
-    for regex in (grad_regex, meg_regex):
+    for ending in (GRAD_ENDING, MAG_ENDING):
         names = proj['data']['col_names']
-        idx = [i for i, name in enumerate(names) if re.search(regex, name)]
+        idx = [i for i, name in enumerate(names) if name.endswith(ending)]
 
         # if all 0, remove the 0s an their labels
         if not proj['data']['data'][0][idx].any():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -255,6 +255,10 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                                    _pair_grad_sensors_ch_names_neuromag122,
                                    Layout, _merge_grad_data)
     from ..channels import _get_ch_type
+
+    is_layout_parameter_none = layout == None
+    is_info_parameter_none = info == None
+
     if info is not None:
         if not isinstance(info, Info):
             raise TypeError('info must be an instance of Info, got %s'
@@ -334,10 +338,28 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                     data = _merge_grad_data(data[grad_pairs]).ravel()
                 break
             if len(idx) == 0:
-                raise RuntimeError('Cannot find a proper layout for '
-                                   'projection %s, consider explicitly '
-                                   'passing a Layout or Info as the layout '
-                                   'parameter.' % proj['desc'])
+                if ch_names[0].startswith('EEG'):
+                    msg = ('Cannot find a proper layout for projection {0}.'
+                           ' The proper layout of an EEG topomap cannot be'
+                           ' inferred from the data. '.format(proj['desc']))
+                    if is_layout_parameter_none and is_info_parameter_none:
+                        msg += (' For EEG data, valid `layout` or `info` is'
+                                ' reauired. None was provided, please consider'
+                                ' passing one of them.')
+                    elif not is_layout_parameter_none:
+                        msg += (' A `layout` was provided but could not be'
+                                ' used for display. Please review the `layout`'
+                                ' parameter.')
+                    else:  # layout is none, but we have info
+                        msg += (' The `info` parameter was provided but could'
+                                ' not be for display. Please review the `info`'
+                                ' parameter.')
+                    raise RuntimeError(msg)
+                else:
+                    raise RuntimeError('Cannot find a proper layout for '
+                                    'projection %s, consider explicitly '
+                                    'passing a Layout or Info as the layout '
+                                    'parameter.' % proj['desc'])
 
         im = plot_topomap(data, pos[:, :2], vmax=None, cmap=cmap,
                           sensors=sensors, res=res, axes=axes[proj_idx],

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -344,7 +344,7 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                            ' inferred from the data. '.format(proj['desc']))
                     if is_layout_parameter_none and is_info_parameter_none:
                         msg += (' For EEG data, valid `layout` or `info` is'
-                                ' reauired. None was provided, please consider'
+                                ' required. None was provided, please consider'
                                 ' passing one of them.')
                     elif not is_layout_parameter_none:
                         msg += (' A `layout` was provided but could not be'

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -145,7 +145,7 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
     divider = make_axes_locatable(ax)
     cax = divider.append_axes(side, size=size, pad=pad)
     cbar = plt.colorbar(im, cax=cax, cmap=cmap, format=format)
-    if cmap[1]:
+    if cmap is not None and cmap[1]:
         ax.CB = DraggableColorbar(cbar, im)
     if title is not None:
         cax.set_title(title, y=1.05, fontsize=10)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -152,7 +152,7 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
     return cbar, cax
 
 
-def _remove_zeros(proj):
+def _eliminate_zeros(proj):
     """Remove grad or mag data if only contains 0s (gh 5641)."""
     import re
     grad_regex = '^MEG.*[23]$'
@@ -296,7 +296,7 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
         title = proj['desc']
         title = '\n'.join(title[ii:ii + 22] for ii in range(0, len(title), 22))
         axes[proj_idx].set_title(title, fontsize=10)
-        proj = _remove_zeros(proj)  # gh 5641
+        proj = _eliminate_zeros(proj)  # gh 5641
         ch_names = _clean_names(proj['data']['col_names'],
                                 remove_whitespace=True)
         data = proj['data']['data'].ravel()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -276,7 +276,6 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
     nrows = math.floor(math.sqrt(n_projs))
     ncols = math.ceil(n_projs / nrows)
 
-    cmap = _setup_cmap(cmap)
     if axes is None:
         plt.figure()
         axes = list()
@@ -338,7 +337,7 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                                    'passing a Layout or Info as the layout '
                                    'parameter.' % proj['desc'])
 
-        im = plot_topomap(data, pos[:, :2], vmax=None, cmap=cmap[0],
+        im = plot_topomap(data, pos[:, :2], vmax=None, cmap=cmap,
                           sensors=sensors, res=res, axes=axes[proj_idx],
                           outlines=outlines, contours=contours,
                           image_interp=image_interp, show=False)[0]
@@ -675,7 +674,8 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         raise ValueError("Data and pos need to be of same length. Got data of "
                          "length %s, pos of length %s" % (len(data), len(pos)))
 
-    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm=False)
+    norm = min(data) >= 0
+    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
     if cmap is None:
         cmap = 'Reds' if norm else 'RdBu_r'
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -152,6 +152,30 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
     return cbar, cax
 
 
+def _fix_proj_for_backward_compatibility(proj):
+    """Fix proj to pass 5641.
+
+    Things that I don't like:
+    - Extra copy vs inplace modification
+    - no idea of colateral effects
+    """
+    import re
+    grad_regex = '^MEG.*[23]$'
+    meg_regex = '^MEG.*1$'
+
+    for regex in (grad_regex, meg_regex):
+        names = proj['data']['col_names']
+        idx = [i for i, item in enumerate(names) if re.search(regex, item)]
+        if not proj['data']['data'][0][idx].reshape(-1).any():
+            proj['data']['col_names'] = np.delete(np.array(names), idx).tolist()
+            new_data = np.delete(np.array(proj['data']['data'][0]), idx)
+            proj['data']['data'] = np.array([new_data])
+
+    # np.array(xx)[np.where((proj['data']['data']==0).flatten())]
+    proj['data']['ncol'] = len(proj['data']['col_names'])
+    return proj
+
+
 def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                        colorbar=False, res=64, size=1, show=True,
                        outlines='head', contours=6, image_interp='bilinear',
@@ -269,6 +293,7 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
         title = proj['desc']
         title = '\n'.join(title[ii:ii + 22] for ii in range(0, len(title), 22))
         axes[proj_idx].set_title(title, fontsize=10)
+        proj = _fix_proj_for_backward_compatibility(proj)
         ch_names = _clean_names(proj['data']['col_names'],
                                 remove_whitespace=True)
         data = proj['data']['data'].ravel()

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -46,25 +46,37 @@ _channel_type_prettyprint = {'eeg': "EEG channel", 'grad': "Gradiometer",
 
 
 def _setup_vmin_vmax(data, vmin, vmax, norm=False):
-    """Handle vmin and vmax parameters."""
+    """Handle vmin and vmax parameters for visualizing topomaps.
+
+    For the normal use-case (when `vmin` and `vmax` are None), the parameter
+    `norm` drives the computation. When norm=False, data is supposed to come
+    from a mag and the output tuple (vmin, vmax) is symmetric range
+    (-x, x) where x is the max(abs(data)). When norm=False (aka data is the L2
+    norm of a gradiometer pair) the output tuple corresponds to (0, x).
+
+    Otherwise, vmin and vmax are callables that drive the operation.
+    """
     if vmax is None and vmin is None:
         vmax = np.abs(data).max()
-        if norm:
-            vmin = 0.
-        else:
-            vmin = -vmax
+        vmin = 0. if norm else -vmax
+
     else:
         if callable(vmin):
             vmin = vmin(data)
         elif vmin is None:
-            if norm:
-                vmin = 0.
-            else:
-                vmin = np.min(data)
+            vmin = 0. if norm else np.min(data)
+
         if callable(vmax):
             vmax = vmax(data)
         elif vmax is None:
             vmax = np.max(data)
+
+    if vmin == 0 and np.min(data) < 0:
+        warn_msg = ("_setup_vmin_vmax output a (min={vmin}, max={vmax})"
+                    " range whereas the minimum of data is {data_min}")
+        warn_val = {'vmin': vmin, 'vmax': vmax, 'data_min': np.min(data)}
+        warn(warn_msg.format(**warn_val), UserWarning)
+
     return vmin, vmax
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -56,22 +56,27 @@ def _setup_vmin_vmax(data, vmin, vmax, norm=False):
 
     Otherwise, vmin and vmax are callables that drive the operation.
     """
+    should_warn = False
     if vmax is None and vmin is None:
         vmax = np.abs(data).max()
         vmin = 0. if norm else -vmax
+        if vmin == 0 and np.min(data) < 0:
+            should_warn = True
 
     else:
         if callable(vmin):
             vmin = vmin(data)
         elif vmin is None:
             vmin = 0. if norm else np.min(data)
+            if vmin == 0 and np.min(data) < 0:
+                should_warn = True
 
         if callable(vmax):
             vmax = vmax(data)
         elif vmax is None:
             vmax = np.max(data)
 
-    if vmin == 0 and np.min(data) < 0:
+    if should_warn:
         warn_msg = ("_setup_vmin_vmax output a (min={vmin}, max={vmax})"
                     " range whereas the minimum of data is {data_min}")
         warn_val = {'vmin': vmin, 'vmax': vmax, 'data_min': np.min(data)}

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -5,7 +5,7 @@ Artifact Correction with SSP
 This tutorial explains how to estimate Signal Subspace Projectors (SSP)
 for correction of ECG and EOG artifacts.
 
-See :ref:`<sphx_glr_auto_examples_io_plot_read_proj.py>` for how to read
+See :ref:`sphx_glr_auto_examples_io_plot_read_proj.py` for how to read
 and visualize already present SSP projection vectors.
 
 """

--- a/tutorials/plot_artifacts_correction_ssp.py
+++ b/tutorials/plot_artifacts_correction_ssp.py
@@ -2,6 +2,12 @@
 Artifact Correction with SSP
 ============================
 
+This tutorial explains how to estimate Signal Subspace Projectors (SSP)
+for correction of ECG and EOG artifacts.
+
+See :ref:`<sphx_glr_auto_examples_io_plot_read_proj.py>` for how to read
+and visualize already present SSP projection vectors.
+
 """
 import numpy as np
 

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -106,6 +106,15 @@ raw.add_proj(projs)
 raw.plot_projs_topomap()
 
 ###############################################################################
+# Note that the SSP projections (and any other projections in
+# ``raw.info['projs']``) can be visualized using ``raw.plot_projs_topomap`` or
+# by calling :func:`proj.plot_topomap <mne.io.proj.Projection.plot_topomap>`
+#
+# more examples can be found in
+# :ref:`sphx_glr_auto_examples_io_plot_read_proj.py`
+projs[0].plot_topomap()
+
+###############################################################################
 # The first three projectors that we see are the SSP vectors from empty room
 # measurements to compensate for the noise. The fourth one is the average EEG
 # reference. These are already applied to the data and can no longer be

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -106,9 +106,9 @@ raw.add_proj(projs)
 raw.plot_projs_topomap()
 
 ###############################################################################
-# Note that the SSP projections (and any other projections in
-# ``raw.info['projs']``) can be visualized using ``raw.plot_projs_topomap`` or
-# by calling :func:`proj.plot_topomap <mne.io.proj.Projection.plot_topomap>`
+# Note that the projections in ``raw.info['projs']`` can be visualized using
+# ``raw.plot_projs_topomap`` or calling
+# :func:`proj.plot_topomap <mne.io.proj.Projection.plot_topomap>`
 #
 # more examples can be found in
 # :ref:`sphx_glr_auto_examples_io_plot_read_proj.py`

--- a/tutorials/plot_visualize_raw.py
+++ b/tutorials/plot_visualize_raw.py
@@ -107,8 +107,8 @@ raw.plot_projs_topomap()
 
 ###############################################################################
 # Note that the projections in ``raw.info['projs']`` can be visualized using
-# ``raw.plot_projs_topomap`` or calling
-# :func:`proj.plot_topomap <mne.io.proj.Projection.plot_topomap>`
+# :meth:`raw.plot_projs_topomap <mne.io.Raw.plot_projs_topomap>` or calling
+# :func:`proj.plot_topomap <mne.Projection.plot_topomap>`
 #
 # more examples can be found in
 # :ref:`sphx_glr_auto_examples_io_plot_read_proj.py`


### PR DESCRIPTION
Some projections do not plot properly. When executing the following lines, the data of the first projection gets substituted by a vector of zeros (see figure)

```py
import mne
import matplotlib.pyplot as plt

FNAME= '/home/sik/Dropbox/mne-python/issues-pr-data/5641_proj_vectors/passive_raw.fif'

# getting some data ready
data_path = mne.datasets.sample.data_path()
raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'

# def test_xx():
raw = mne.io.read_raw_fif(FNAME, preload=True)
p1 = raw.info['projs'][0]
p1.plot_topomap()

raw_2 = mne.io.read_raw_fif(raw_fname, preload=True)
p2 = raw_2.info['projs'][0]
p2.plot_topomap()
```

![image](https://user-images.githubusercontent.com/7044835/47297855-9a3b4400-d616-11e8-881d-b427b34b2a52.png)


Please find the data in [this dropbox folder](https://www.dropbox.com/sh/8e07r7a22rzwv34/AAC5pVEPfl7Q-9ccJPW6oUKZa?dl=0)
