### PR TITLE
MRG: Make the times property of Epochs read only

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -385,7 +385,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         start_idx = int(round(tmin * sfreq))
         self._raw_times = np.arange(start_idx,
                                     int(round(tmax * sfreq)) + 1) / sfreq
-        self.times = self._raw_times.copy()
+        self._times = self._raw_times.copy()
         self._decim = 1
         self.decimate(decim)
 
@@ -1419,6 +1419,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             return epoch, self.events[self._current - 1][-1]
 
         return epoch if not return_event_id else epoch, self.event_id
+
+    @property
+    def times(self):
+        """Time vector in seconds."""
+        return self._times.copy()
 
     @property
     def tmin(self):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1423,7 +1423,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @property
     def times(self):
         """Time vector in seconds."""
-        return self._times.copy()
+        self._times.flags['WRITEABLE'] = False
+        return self._times
 
     @property
     def tmin(self):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -561,10 +561,10 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 self._data = np.ascontiguousarray(self._data)
             self._decim_slice = slice(None)
             self._decim = 1
-            self.times = self._raw_times
+            self._times = self._raw_times
         else:
             self._decim_slice = decim_slice
-            self.times = self._raw_times[self._decim_slice]
+            self._times = self._raw_times[self._decim_slice]
         return self
 
     @verbose
@@ -1667,7 +1667,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             tmax = self.tmax
 
         tmask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'])
-        self.times = self.times[tmask]
+        self._times = self._times[tmask]
         self._raw_times = self._raw_times[tmask]
         self._data = self._data[:, :, tmask]
         return self

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2100,7 +2100,7 @@ class FilterMixin(object):
                               n_jobs=n_jobs, pad=pad)
         self.info['sfreq'] = float(sfreq)
         new_times = (np.arange(self._data.shape[-1], dtype=np.float) /
-                      sfreq + self.times[0])
+                     sfreq + self.times[0])
         # adjust indirectly affected variables
         if isinstance(self, BaseEpochs):
             self._times = new_times

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2099,8 +2099,8 @@ class FilterMixin(object):
         self._data = resample(self._data, sfreq, o_sfreq, npad, window=window,
                               n_jobs=n_jobs, pad=pad)
         self.info['sfreq'] = float(sfreq)
-        self.times = (np.arange(self._data.shape[-1], dtype=np.float) /
-                      sfreq + self.times[0])
+        self._times = (np.arange(self._data.shape[-1], dtype=np.float) /
+                      sfreq + self._times[0])
         # adjust indirectly affected variables
         if isinstance(self, BaseEpochs):
             self._raw_times = self.times

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2099,12 +2099,14 @@ class FilterMixin(object):
         self._data = resample(self._data, sfreq, o_sfreq, npad, window=window,
                               n_jobs=n_jobs, pad=pad)
         self.info['sfreq'] = float(sfreq)
-        self._times = (np.arange(self._data.shape[-1], dtype=np.float) /
-                      sfreq + self._times[0])
+        new_times = (np.arange(self._data.shape[-1], dtype=np.float) /
+                      sfreq + self.times[0])
         # adjust indirectly affected variables
         if isinstance(self, BaseEpochs):
+            self._times = new_times
             self._raw_times = self.times
         else:
+            self.times = new_times
             self.first = int(self.times[0] * self.info['sfreq'])
             self.last = len(self.times) + self.first - 1
         return self

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2471,4 +2471,12 @@ def test_save_complex_data(tmpdir):
     assert len(epochs) == 0  # all dropped
 
 
+def test_readonly_times():
+    """Test that the times property is read only."""
+    raw, events = _get_data()[:2]
+    epochs = Epochs(raw, events[:1], preload=True)
+    with pytest.raises(AttributeError):
+        epochs.times += 1
+
+
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2007,12 +2007,12 @@ def test_add_channels_epochs():
     pytest.raises(ValueError, add_channels_epochs, [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
-    epochs_meg2.times += 0.4
+    epochs_meg2._times += 0.4
     pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()
-    epochs_meg2.times += 0.5
+    epochs_meg2._times += 0.5
     pytest.raises(NotImplementedError, add_channels_epochs,
                   [epochs_meg2, epochs_eeg])
 
@@ -2138,7 +2138,7 @@ def test_concatenate_epochs():
         ValueError, concatenate_epochs,
         [epochs, epochs2.copy().drop_channels(epochs2.ch_names[:1])])
 
-    epochs2.times = np.delete(epochs2.times, 1)
+    epochs2._times = np.delete(epochs2._times, 1)
     pytest.raises(
         ValueError,
         concatenate_epochs, [epochs, epochs2])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2478,5 +2478,8 @@ def test_readonly_times():
     with pytest.raises(AttributeError):
         epochs.times += 1
 
+    with pytest.raises(ValueError):
+        epochs.times[:] = np.random.rand(*epochs.times.shape)
+
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2475,7 +2475,7 @@ def test_readonly_times():
     """Test that the times property is read only."""
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events[:1], preload=True)
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         epochs.times += 1
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
#### Reference issue
Fixes #5642.


#### What does this implement/fix?
Make the times property of Epochs read only as discussed in the referenced issue.
A unit test for this is included.
I did my best to modify the other unit tests and low level functions accordingly.


#### Additional information
WIP to see if CIs are happy
