### PR TITLE
MRG: Better Qt info

### DIFF
--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -46,7 +46,7 @@ if you do not have ``curl``.
 
   .. code-block:: console
 
-    $ pip install --upgrade pyqt5>=5.10
+    $ pip install --upgrade "pyqt5>=5.10"
 
 
 3. Check that everything works
@@ -92,7 +92,7 @@ all default dependencies are installed by listing their versions with::
 
     sklearn:       0.19.1
     nibabel:       2.3.0
-    mayavi:        4.6.1 {qt_api=pyqt5}
+    mayavi:        4.6.1 {qt_api=pyqt5, PyQt5=5.10.1}
     cupy:          Not found
     pandas:        0.23.4
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -2848,6 +2848,12 @@ def sys_info(fid=None, show_paths=False):
                     from pyface.qt import qt_api
                 except Exception:
                     qt_api = 'unknown'
+                if qt_api == 'pyqt5':
+                    try:
+                        from PyQt5.Qt import PYQT_VERSION_STR
+                        qt_api += ', PyQt5=%s' % (PYQT_VERSION_STR,)
+                    except Exception:
+                        pass
                 extra = ' {qt_api=%s}%s' % (qt_api, extra)
             out += '%s%s\n' % (mod.__version__, extra)
     print(out, end='', file=fid)


### PR DESCRIPTION
This PR

1. Fixes a minor bug with our OSX install instructions
2. Improves our `mne.sys_info()` to give the PyQt5 version, where relevant. This can help debug OSX problems.