### PR TITLE
MRG: Fix report BEM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,12 @@ docstring:
 check-manifest:
 	check-manifest --ignore .circleci*,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store
 
+nesting:
+	@echo "Running import nesting tests"
+	@$(PYTESTS) mne/tests/test_import_nesting.py
+
 pep:
-	@$(MAKE) -k flake pydocstyle docstring codespell-error check-manifest
+	@$(MAKE) -k flake pydocstyle docstring codespell-error check-manifest nesting
 
 manpages:
 	@echo "I: generating manpages"

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -21,7 +21,7 @@ from mne.utils import run_tests_if_main
 from mne.realtime import FieldTripClient, RtEpochs
 from mne.externals.six.moves import queue
 
-from .test_mockclient import _call_base_epochs_public_api
+from mne.realtime.tests.test_mockclient import _call_base_epochs_public_api
 
 # Set our plotters to test mode
 import matplotlib

--- a/mne/report.py
+++ b/mne/report.py
@@ -29,8 +29,7 @@ from .parallel import parallel_func, check_n_jobs
 from .viz.raw import _data_types
 
 from .externals.tempita import HTMLTemplate, Template
-from .externals.six import BytesIO
-from .externals.six import moves
+from .externals.six import BytesIO, moves, string_types
 from .externals.h5io import read_hdf5, write_hdf5
 
 VALID_EXTENSIONS = ['raw.fif', 'raw.fif.gz', 'sss.fif', 'sss.fif.gz',
@@ -1021,6 +1020,7 @@ class Report(object):
             Existing figures are only replaced if this is set to ``True``.
             Defaults to ``False``.
         """
+        assert isinstance(html, string_types)  # otherwise later will break
         if replace and fname in self.fnames:
             # Find last occurrence of the figure
             ind = max([i for i, existing in enumerate(self.fnames)
@@ -1220,6 +1220,9 @@ class Report(object):
                                 caption=caption)
         html, caption, _ = self._validate_input(html, caption, section)
         sectionvar = self._sectionvars[section]
+        # convert list->str
+        assert isinstance(html, list)
+        html = u''.join(html)
         self._add_or_replace('%s-#-%s-#-custom' % (caption[0], sectionvar),
                              sectionvar, html)
 

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -23,7 +23,6 @@ from mne.utils import (_TempDir, requires_mayavi, requires_nibabel,
 from mne.viz import plot_alignment
 
 import matplotlib
-from matplotlib import pyplot as plt
 matplotlib.use('Agg')  # for testing don't use X server
 
 data_dir = testing.data_path(download=False)
@@ -43,9 +42,13 @@ base_dir = op.realpath(op.join(op.dirname(__file__), '..', 'io', 'tests',
                                'data'))
 evoked_fname = op.join(base_dir, 'test-ave.fif')
 
-# Two example figures
-fig1 = plt.plot([1, 2], [1, 2])[0].figure
-fig2 = plt.plot([3, 4], [3, 4])[0].figure
+
+def _get_example_figures():
+    """Create two example figures."""
+    from matplotlib import pyplot as plt
+    fig1 = plt.plot([1, 2], [1, 2])[0].figure
+    fig2 = plt.plot([3, 4], [3, 4])[0].figure
+    return [fig1, fig2]
 
 
 @pytest.mark.slowtest
@@ -233,6 +236,10 @@ def test_render_mri():
     report.parse_folder(data_path=tempdir, mri_decim=30, pattern='*')
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
     assert repr(report)
+    report.add_bem_to_section('sample', caption='extra', section='foo',
+                              subjects_dir=subjects_dir, decim=30)
+    report.save(op.join(tempdir, 'report.html'), open_browser=False,
+                overwrite=True)
 
 
 @testing.requires_testing_data
@@ -271,7 +278,7 @@ def test_add_slider_to_section():
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=subjects_dir)
     section = 'slider_section'
-    figs = [fig1, fig2]
+    figs = _get_example_figures()
     report.add_slider_to_section(figs, section=section)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
@@ -314,6 +321,7 @@ def test_open_report():
     hdf5 = op.join(tempdir, 'report.h5')
 
     # Test creating a new report through the open_report function
+    fig1 = _get_example_figures()[0]
     with open_report(hdf5, subjects_dir=subjects_dir) as report:
         assert report.subjects_dir == subjects_dir
         assert report._fname == hdf5
@@ -338,6 +346,7 @@ def test_open_report():
 def test_remove():
     """Test removing figures from a report."""
     r = Report()
+    fig1, fig2 = _get_example_figures()
     r.add_figs_to_section(fig1, 'figure1', 'mysection')
     r.add_figs_to_section(fig1, 'figure1', 'othersection')
     r.add_figs_to_section(fig2, 'figure1', 'mysection')
@@ -371,6 +380,7 @@ def test_remove():
 def test_add_or_replace():
     """Test replacing existing figures in a report."""
     r = Report()
+    fig1, fig2 = _get_example_figures()
     r.add_figs_to_section(fig1, 'duplicate', 'mysection')
     r.add_figs_to_section(fig1, 'duplicate', 'mysection')
     r.add_figs_to_section(fig1, 'duplicate', 'othersection')


### PR DESCRIPTION
Fixes a regression caused by #5531 because `add_bem_to_section` was not covered by any test. It was added back in 0.9 so maybe our standards were more lax then :)

Also adds a test that `pyplot` imports are properly nested in tests.