### PR TITLE
Removed "=True" in command line options

### DIFF
--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -64,7 +64,8 @@ def run():
                       help="Enable trace clipping mode, either 'clip' or "
                       "'transparent'", default=None)
     parser.add_option("--filterchpi", dest="filterchpi",
-                      help="Enable filtering cHPI signals.", default=None)
+                      help="Enable filtering cHPI signals.", default=None,
+                      action="store_true")
 
     options, args = parser.parse_args()
 


### PR DESCRIPTION
#### Reference issue
Example: Fixes #5656 (@agramfort suggestion)

#### What does this implement/fix?
Done the same as before but for filterchpi
