### PR TITLE
MRG: Add shift_time method to Epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,8 @@ Current
 
 Changelog
 ~~~~~~~~~
+- Add :meth:`mne.Epochs.shift_time` that shifts the time axis of :class:`mne.Epochs` by `Thomas Hartmann`_
+
 - Add :func:`mne.viz.plot_arrowmap` computes arrowmaps using Hosaka-Cohen transformation from magnetometer or gradiometer data, these arrows represents an estimation of the current flow underneath the MEG sensors by `Sheraz Khan`_
 
 - Add :func:`mne.io.read_raw_fieldtrip`, :func:`mne.read_epochs_fieldtrip` and :func:`mne.read_evoked_fieldtrip` to import FieldTrip data. By `Thomas Hartmann`_ and `Dirk Gütlin`_.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1864,6 +1864,26 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # actually remove the indices
         return self, indices
 
+    def shift_time(self, tshift, relative=True):
+        """Shift time scale in epoched data.
+
+        Parameters
+        ----------
+        tshift : float
+            The amount of time shift to be applied if relative is True
+            else the first time point. When relative is True, positive value
+            of tshift moves the data forward while negative tshift moves it
+            backward.
+        relative : bool
+            If true, move the time backwards or forwards by specified amount.
+            Else, set the starting time point to the value of tshift.
+
+        Notes
+        -----
+        Maximum accuracy of time shift is 1 / evoked.info['sfreq']
+        """
+        pass
+
 
 def _hid_match(event_id, keys):
     """Match event IDs using HID selection.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1885,8 +1885,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         _check_preload(self, 'shift_time')
         times = self.times
         sfreq = self.info['sfreq']
+        old_first = int(self.tmin * sfreq)
 
-        offset = self.tmin if relative else 0
+        offset = old_first if relative else 0
 
         first = int(tshift * sfreq) + offset
         last = first + len(times) - 1

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1882,7 +1882,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         -----
         Maximum accuracy of time shift is 1 / evoked.info['sfreq']
         """
-        pass
+        _check_preload(self, 'shift_time')
 
 
 def _hid_match(event_id, keys):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1883,6 +1883,14 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         Maximum accuracy of time shift is 1 / epochs.info['sfreq']
         """
         _check_preload(self, 'shift_time')
+        times = self.times
+        sfreq = self.info['sfreq']
+
+        offset = self.tmin if relative else 0
+
+        first = int(tshift * sfreq) + offset
+        last = first + len(times) - 1
+        self._set_times(np.arange(first, last + 1, dtype=np.float) / sfreq)
 
 
 def _hid_match(event_id, keys):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1880,7 +1880,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         Notes
         -----
-        Maximum accuracy of time shift is 1 / evoked.info['sfreq']
+        Maximum accuracy of time shift is 1 / epochs.info['sfreq']
         """
         _check_preload(self, 'shift_time')
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2501,7 +2501,7 @@ def test_timeshift(relative):
     assert_array_equal(avg.times, avg2.times)
     assert_equal(avg.first, avg2.first)
     assert_equal(avg.last, avg2.last)
-    assert_allclose(avg.data, avg2.data, atol=1e-16, rtol=1e-3)
+    assert_array_equal(avg.data, avg2.data)
 
 
 @pytest.mark.parametrize('preload', (True, False))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2488,4 +2488,19 @@ def test_readonly_times():
         epochs.times[:] = 0.
 
 
+def test_timeshift():
+    """Test the timeshift method."""
+    timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
+    raw, events = _get_data()[:2]
+    epochs = Epochs(raw, events[:1], preload=True, baseline=None)
+    avg = epochs.average()
+    avg.shift_time(timeshift, relative=True)
+    epochs.shift_time(timeshift, relative=True)
+    avg2 = epochs.average()
+    assert_array_equal(avg.times, avg2.times)
+    assert_equal(avg.tmin, avg2.tmin)
+    assert_equal(avg.tmax, avg2.tmax)
+    assert_allclose(avg.data, avg2.data, atol=1e-16, rtol=1e-3)
+
+
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2489,7 +2489,7 @@ def test_readonly_times():
 
 
 @pytest.mark.parametrize('relative', (True, False))
-def test_timeshift(relative):
+def test_shift_time(relative):
     """Test the timeshift method."""
     timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
     raw, events = _get_data()[:2]
@@ -2505,7 +2505,7 @@ def test_timeshift(relative):
 
 
 @pytest.mark.parametrize('preload', (True, False))
-def test_timeshift_raises_when_not_loaded(preload):
+def test_shift_time_raises_when_not_loaded(preload):
     """Test whether shift_time throws an exception when data is not loaded."""
     timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
     raw, events = _get_data()[:2]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2499,8 +2499,8 @@ def test_timeshift(relative):
     epochs.shift_time(timeshift, relative=relative)
     avg2 = epochs.average()
     assert_array_equal(avg.times, avg2.times)
-    assert_equal(avg.tmin, avg2.tmin)
-    assert_equal(avg.tmax, avg2.tmax)
+    assert_equal(avg.first, avg2.first)
+    assert_equal(avg.last, avg2.last)
     assert_allclose(avg.data, avg2.data, atol=1e-16, rtol=1e-3)
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2504,4 +2504,16 @@ def test_timeshift(relative):
     assert_allclose(avg.data, avg2.data, atol=1e-16, rtol=1e-3)
 
 
+@pytest.mark.parametrize('preload', (True, False))
+def test_timeshift_raises_when_not_loaded(preload):
+    """Test whether shift_time throws an exception when data is not loaded."""
+    timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
+    raw, events = _get_data()[:2]
+    epochs = Epochs(raw, events[:1], preload=preload, baseline=None)
+    if not preload:
+        pytest.raises(RuntimeError, epochs.shift_time, timeshift)
+    else:
+        epochs.shift_time(timeshift)
+
+
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2488,14 +2488,15 @@ def test_readonly_times():
         epochs.times[:] = 0.
 
 
-def test_timeshift():
+@pytest.mark.parametrize('relative', (True, False))
+def test_timeshift(relative):
     """Test the timeshift method."""
     timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events[:1], preload=True, baseline=None)
     avg = epochs.average()
-    avg.shift_time(timeshift, relative=True)
-    epochs.shift_time(timeshift, relative=True)
+    avg.shift_time(timeshift, relative=relative)
+    epochs.shift_time(timeshift, relative=relative)
     avg2 = epochs.average()
     assert_array_equal(avg.times, avg2.times)
     assert_equal(avg.tmin, avg2.tmin)


### PR DESCRIPTION
This adds the shift_time method to the Epochs class as discussed in #5642.

Relevant unit tests were added, flake8 and pydocstyle are happy.

Please review.