### PR TITLE
MRG: Improve OpenGL compat

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - testpath<0.4
 - pip:
   - mne
-  - mayavi
+  - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
   - PySurfer[save_movie]
   - dipy
   - nitime

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1841,12 +1841,16 @@ class CoregFrame(HasTraits):
     @on_trait_change('scene:activated')
     def _init_plot(self):
         _toggle_mlab_render(self, False)
+        self.scene.renderer.use_fxaa = True
 
         lpa_color = defaults['lpa_color']
         nasion_color = defaults['nasion_color']
         rpa_color = defaults['rpa_color']
 
         # MRI scalp
+        #
+        # Due to MESA rendering / z-order bugs, this should be added and
+        # rendered first (see gh-5375).
         color = defaults['head_color']
         self.mri_obj = SurfaceObject(
             points=np.empty((0, 3)), color=color, tris=np.empty((0, 3)),
@@ -1857,6 +1861,8 @@ class CoregFrame(HasTraits):
         )
         self.mri_obj.opacity = self._initial_kwargs['head_opacity']
         self.data_panel.fid_panel.hsp_obj = self.mri_obj
+        self._update_mri_obj()
+        self.mri_obj.plot()
         # Do not do sync_trait here, instead use notifiers elsewhere
 
         # MRI Fiducials
@@ -1952,9 +1958,7 @@ class CoregFrame(HasTraits):
 
         self.sync_trait('bgcolor', self.scene, 'background')
 
-        self._update_mri_obj()
         self._update_projections()
-        self.mri_obj.plot()
 
         _toggle_mlab_render(self, True)
         self.scene.render()

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1841,7 +1841,8 @@ class CoregFrame(HasTraits):
     @on_trait_change('scene:activated')
     def _init_plot(self):
         _toggle_mlab_render(self, False)
-        self.scene.renderer.use_fxaa = True
+        if hasattr(getattr(self.scene, 'renderer', None), 'use_fxaa'):
+            self.scene.renderer.use_fxaa = True
 
         lpa_color = defaults['lpa_color']
         nasion_color = defaults['nasion_color']

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -186,7 +186,8 @@ class Object(HasPrivateTraits):
 
     # This should be Tuple, but it is broken on Anaconda as of 2016/12/16
     color = RGBColor((1., 1., 1.))
-    opacity = Range(low=0., high=1., value=1.)
+    # Due to a MESA bug, we use 0.99 opacity to force alpha blending
+    opacity = Range(low=0., high=1., value=0.99)
     visible = Bool(True)
 
     def _update_points(self):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -352,6 +352,7 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
                                      np.tile([255., 0., 0., 255.], (127, 1))])
 
     fig = mlab.figure(bgcolor=(0.0, 0.0, 0.0), size=(600, 600))
+    fig.scene.renderer.use_fxaa = True
     _toggle_mlab_render(fig, False)
 
     for ii, this_map in enumerate(surf_maps):
@@ -1063,6 +1064,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
     # initialize figure
     if fig is None:
         fig = mlab.figure(bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
+    fig.scene.renderer.use_fxaa = True
     if interaction == 'terrain' and fig.scene is not None:
         fig.scene.interactor.interactor_style = \
             tvtk.InteractorStyleTerrain()
@@ -2381,6 +2383,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     color_converter = ColorConverter()
 
     f = mlab.figure(figure=fig_name, bgcolor=bgcolor, size=(600, 600))
+    f.scene.renderer.use_fxaa = True
     mlab.clf()
     _toggle_mlab_render(f, False)
     with warnings.catch_warnings(record=True):  # traits warnings

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1062,7 +1062,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
 
     # initialize figure
     if fig is None:
-        _mlab_figure(bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
+        fig = _mlab_figure(bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
     if interaction == 'terrain' and fig.scene is not None:
         fig.scene.interactor.interactor_style = \
             tvtk.InteractorStyleTerrain()

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -351,8 +351,7 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
                                      np.tile([0., 0., 0., 255.], (2, 1)),
                                      np.tile([255., 0., 0., 255.], (127, 1))])
 
-    fig = mlab.figure(bgcolor=(0.0, 0.0, 0.0), size=(600, 600))
-    fig.scene.renderer.use_fxaa = True
+    fig = _mlab_figure(bgcolor=(0.0, 0.0, 0.0), size=(600, 600))
     _toggle_mlab_render(fig, False)
 
     for ii, this_map in enumerate(surf_maps):
@@ -1042,7 +1041,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
             hpi_loc = np.array([d['r'] for d in info['dig']
                                 if d['kind'] == FIFF.FIFFV_POINT_HPI])
             ext_loc = np.array([d['r'] for d in info['dig']
-                               if d['kind'] == FIFF.FIFFV_POINT_EXTRA])
+                                if d['kind'] == FIFF.FIFFV_POINT_EXTRA])
         car_loc = _fiducial_coords(info['dig'])
         # Transform from head coords if necessary
         if coord_frame == 'meg':
@@ -1063,8 +1062,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
 
     # initialize figure
     if fig is None:
-        fig = mlab.figure(bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
-    fig.scene.renderer.use_fxaa = True
+        _mlab_figure(bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
     if interaction == 'terrain' and fig.scene is not None:
         fig.scene.interactor.interactor_style = \
             tvtk.InteractorStyleTerrain()
@@ -1978,7 +1976,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
             ax_z.clear()
             params.update({'img_idx': index_img(img, idx)})
             params.update({'title': 'Activation (t=%.3f s.)'
-                          % params['stc'].times[idx]})
+                           % params['stc'].times[idx]})
             plot_map_callback(
                 params['img_idx'], title='',
                 cut_coords=cut_coords)
@@ -2382,9 +2380,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
     color_converter = ColorConverter()
 
-    f = mlab.figure(figure=fig_name, bgcolor=bgcolor, size=(600, 600))
-    f.scene.renderer.use_fxaa = True
-    mlab.clf()
+    f = _mlab_figure(figure=fig_name, bgcolor=bgcolor, size=(600, 600))
     _toggle_mlab_render(f, False)
     with warnings.catch_warnings(record=True):  # traits warnings
         surface = mlab.triangular_mesh(points[:, 0], points[:, 1],
@@ -2449,6 +2445,16 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     surface.actor.property.shading = True
     _toggle_mlab_render(f, True)
     return surface
+
+
+def _mlab_figure(**kwargs):
+    """Create a Mayavi figure using our defaults."""
+    from mayavi import mlab
+    fig = mlab.figure(**kwargs)
+    # If using modern VTK/Mayavi, improve rendering with FXAA
+    if hasattr(getattr(fig.scene, 'renderer', None), 'use_fxaa'):
+        fig.scene.renderer.use_fxaa = True
+    return fig
 
 
 def _toggle_mlab_render(fig, render):


### PR DESCRIPTION
This PR:

- Adresses #5375 for graphics renderers (Intel, MESA, ...) that do not properly do Z-buffer based rendering (argh) by making it so the fiducials (and other items) are visible, even though they still aren't rendered perfectly.
- Improves Mayavi rendering by using full-screen anti-aliasing by default.

@bloyl can you see if it makes `mne coreg` usable for you with Intel/MESA rendering?
```
$ 
mne coreg -d ~/mne_data/MNE-sample-data/subjects -s sample --fif ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
```
After runinng this and clicking "Fit Fid." on `master` this is what I get with `llvmpipe` (MESA software) rendering:

![screenshot_2018-10-25_14-44-12](https://user-images.githubusercontent.com/2365790/47522806-838a2c80-d864-11e8-9a19-c3c5fe3b1823.png)

And on this PR:

![screenshot_2018-10-25_14-50-58](https://user-images.githubusercontent.com/2365790/47523177-6ace4680-d865-11e8-97a1-1f1b25029b47.png)

And on this PR (or `master`, approximately) with proper NVIDIA rendering:

![screenshot from 2018-10-25 14-41-53](https://user-images.githubusercontent.com/2365790/47522662-27270d00-d864-11e8-88ee-20244cb7ced6.png)

So it's not perfect -- points that should be occluded by the scalp are not --but it's better, and hopefully much more usable.

Closes #5375.