### PR TITLE
[MRG+2] BrainVision warning message should refer to parameter

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -68,8 +68,9 @@ class RawBrainVision(BaseRaw):
     event_id : dict | None
         Special events to consider in addition to those that follow the normal
         BrainVision trigger format ('###' with an optional single character
-        prefix). If dict, the keys will be mapped to trigger values on the
-        stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+        prefix, e.g., "111", "S  1", "R128", "S 21"). If dict, the keys will be
+        mapped to trigger values on the stimulus channel.
+        Example: {'SyncStatus': 1, 'Pulse Artifact': 3}.
         If None or an empty dict (default), only BrainVision format events are
         added to the stimulus channel. Keys are case sensitive. "New Segment"
         markers are always dropped.
@@ -160,9 +161,10 @@ class RawBrainVision(BaseRaw):
         events, _ = events_from_annotations(self, event_id)
         if len(dropped_desc) > 0:
             dropped = list(set(dropped_desc))
-            warn("{0} annotation(s) will be dropped, such as {1}. "
-                 "Consider using ``regexp`` to ignore annotations that "
-                 "do not follow a specific pattern."
+            warn("{0} event(s) will be dropped, such as {1}. "
+                 "Consider using the event_id parameter to parse events "
+                 "that do not follow the BrainVision format. For more "
+                 "information, see the docstring of read_raw_brainvision."
                  .format(len(dropped), dropped[:5]))
         self._create_event_ch(events, n_samples)
 
@@ -1000,7 +1002,7 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         Special events to consider in addition to those that follow the normal
         BrainVision trigger format ('###' with an optional single character
         prefix). If dict, the keys will be mapped to trigger values on the
-        stimulus channel. Example: {'SyncStatus': 1; 'Pulse Artifact': 3}.
+        stimulus channel. Example: {'SyncStatus': 1, 'Pulse Artifact': 3}.
         If None or an empty dict (default), only BrainVision format events are
         added to the stimulus channel. Keys are case sensitive. "New Segment"
         markers are always dropped.

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -628,11 +628,14 @@ def test_read_vmrk_annotations():
 
 def test_read_raw_brainvision_warn_on_marker_drop():
     """Test that loading test.vhdr warns a summary of each dropped type."""
-    EXPECTED_WARN_MSG = \
-        r"1 annotation\(s\) will be dropped, such as \['SyncStatus/Sync On'\]"
+    EXPECTED_WARN_MSG = (r"1 event\(s\) will be dropped, such as "
+                         r"\[\'SyncStatus\/Sync On\'\]. Consider using the "
+                         r"event\_id parameter to parse events that do not "
+                         r"follow the BrainVision format. For more "
+                         r"information, see the docstring of "
+                         r"read_raw_brainvision.")
     with pytest.warns(RuntimeWarning, match=EXPECTED_WARN_MSG) as recwarn:
         read_raw_brainvision(vhdr_path, verbose=True)
     assert len(recwarn) == 1
-
 
 run_tests_if_main()


### PR DESCRIPTION
fixes #5669 

If we want to read the testing data like `raw=mne.io.read_raw_brainvision('Analyzer_nV_Export.vhdr')`,
we get this output and warning message:

> Extracting parameters from Analyzer_nV_Export.vhdr...
Setting channel info structure...
Used Annotations descriptions: []
<ipython-input-11-cddac3454f0f>:1: RuntimeWarning: 1 annotation(s) will be dropped, such as ['Trigger/Trigger#2']. Consider using ``regexp`` to ignore annotations that do not follow a specific pattern.
  raw=mne.io.read_raw_brainvision('Analyzer_nV_Export.vhdr')

This is not helpful, because `mne.io.read_raw_brainvision` does not have a `regexp` parameter (was this inserted through/because of `mne.annotation.events_from_annotations`?).

I changed it so that the warning message now refers the user to the `event_id` parameter (see changes). The test file can be properly read using:

```python
event_id = {"Trigger#2": 1}
raw=mne.io.read_raw_brainvision('Analyzer_nV_Export.vhdr', event_id=event_id)
```

Which then gives:

> Extracting parameters from Analyzer_nV_Export.vhdr...
Setting channel info structure...
Used Annotations descriptions: ['Trigger/Trigger#2']