### PR TITLE
MRG: Speed up tests

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -10,7 +10,7 @@ from math import log
 import os
 
 import numpy as np
-from scipy import linalg
+from scipy import linalg, sparse
 
 from .io.write import start_file, end_file
 from .io.proj import (make_projector, _proj_equal, activate_proj,
@@ -1769,7 +1769,6 @@ def _read_cov(fid, node, cov_kind, limited=False, verbose=None):
                                 '%d) found.' % (dim, dim, cov_kind))
 
             else:
-                from scipy import sparse
                 if not sparse.issparse(tag.data):
                     #   Lower diagonal is stored
                     vals = tag.data

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -354,6 +354,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self.reject_tmax = reject_tmax
         self.detrend = detrend
         self._raw = raw
+        info._check_consistency()
         self.info = info
         del info
         self._metadata = None

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -219,8 +219,7 @@ def test_make_forward_solution_kit():
 def test_make_forward_solution():
     """Test making M-EEG forward solution from python."""
     fwd_py = make_forward_solution(fname_raw, fname_trans, fname_src,
-                                   fname_bem, mindist=5.0, eeg=True, meg=True,
-                                   n_jobs=-1)
+                                   fname_bem, mindist=5.0, eeg=True, meg=True)
     assert (isinstance(fwd_py, Forward))
     fwd = read_forward_solution(fname_meeg)
     assert (isinstance(fwd, Forward))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -492,8 +492,8 @@ class Info(dict):
                     self['chs'][ch_idx]['ch_name'] = ch_name
 
         if 'filename' in self:
-            warn('the "filename" key is misleading\
-                 and info should not have it')
+            warn('the "filename" key is misleading '
+                 'and info should not have it')
 
     def _check_ch_name_length(self):
         """Check that channel names are sufficiently short."""

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from gzip import GzipFile
 
 import numpy as np
+from scipy import sparse
 
 from .tag import read_tag_info, read_tag, read_big, Tag, _call_dict_names
 from .tree import make_dir_tree, dir_tree_find
@@ -66,8 +67,8 @@ def _get_next_fname(fid, fname, tree):
                 num_str = base[idx2 + 1:idx]
                 if not num_str.isdigit():
                     continue
-                next_fname = op.join(path, '%s-%d.%s' % (base[:idx2],
-                                     next_num, base[idx + 1:]))
+                next_fname = op.join(path, '%s-%d.%s'
+                                     % (base[:idx2], next_num, base[idx + 1:]))
         if next_fname is not None:
             break
     return next_fname
@@ -210,7 +211,6 @@ def _find_type(value, fmts=['FIFF_'], exclude=['FIFF_UNIT']):
 
 def _show_tree(fid, tree, indent, level, read_limit, max_str, tag_id):
     """Show FIFF tree."""
-    from scipy import sparse
     this_idt = indent * level
     next_idt = indent * (level + 1)
     # print block-level information

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -397,6 +397,10 @@ def pick_info(info, sel=(), copy=True, verbose=None):
         return info
     elif len(sel) == 0:
         raise ValueError('No channels match the selection.')
+    n_unique = len(np.unique(np.arange(len(info['ch_names']))[sel]))
+    if n_unique != len(sel):
+        raise ValueError('Found %d / %d unique names, sel is not unique'
+                         % (n_unique, len(sel)))
 
     # make sure required the compensation channels are present
     if len(info.get('comps', [])) > 0:
@@ -423,6 +427,7 @@ def pick_info(info, sel=(), copy=True, verbose=None):
             c['data']['row_names'] = row_names
             c['data']['data'] = c['data']['data'][row_idx]
         info['comps'] = comps
+    info._check_consistency()
     info._check_consistency()
     return info
 

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -9,6 +9,7 @@ import os
 import struct
 
 import numpy as np
+from scipy import sparse
 
 from .constants import FIFF
 from ..externals.six import text_type
@@ -280,7 +281,6 @@ def _read_matrix(fid, tag, shape, rlims, matrix_coding):
                             % matrix_type)
         data.shape = dims
     elif matrix_coding in (_matrix_coding_CCS, _matrix_coding_RCS):
-        from scipy import sparse
         # Find dimensions and return to the beginning of tag data
         pos = fid.tell()
         fid.seek(tag.size - 4, 1)

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -312,6 +312,8 @@ def test_clean_info_bads():
     info._check_consistency()
     info['bads'] += ['EEG 053']
     pytest.raises(RuntimeError, info._check_consistency)
+    with pytest.raises(ValueError, match='unique'):
+        pick_info(raw.info, [0, 0])
 
 
 run_tests_if_main()

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -162,29 +162,28 @@ def fast_cross_3d(x, y):
     Parameters
     ----------
     x : array
-        Input array 1.
+        Input array 1, shape (..., 3).
     y : array
-        Input array 2.
+        Input array 2, shape (..., 3).
 
     Returns
     -------
-    z : array
-        Cross product of x and y.
+    z : array, shape (..., 3)
+        Cross product of x and y along the last dimension.
 
     Notes
     -----
-    x and y must both be 2D row vectors. One must have length 1, or both
-    lengths must match.
+    x and y must broadcast against each other.
     """
-    assert x.ndim == 2
-    assert y.ndim == 2
-    assert x.shape[1] == 3
-    assert y.shape[1] == 3
-    assert (x.shape[0] == 1 or y.shape[0] == 1) or x.shape[0] == y.shape[0]
-    if max([x.shape[0], y.shape[0]]) >= 500:
-        return np.c_[x[:, 1] * y[:, 2] - x[:, 2] * y[:, 1],
-                     x[:, 2] * y[:, 0] - x[:, 0] * y[:, 2],
-                     x[:, 0] * y[:, 1] - x[:, 1] * y[:, 0]]
+    assert x.ndim >= 1
+    assert y.ndim >= 1
+    assert x.shape[-1] == 3
+    assert y.shape[-1] == 3
+    if max(x.size, y.size) >= 1500:
+        return np.stack([x[..., 1] * y[..., 2] - x[..., 2] * y[..., 1],
+                         x[..., 2] * y[..., 0] - x[..., 0] * y[..., 2],
+                         x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]],
+                        axis=-1)
     else:
         return np.cross(x, y)
 

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -180,10 +180,12 @@ def fast_cross_3d(x, y):
     assert x.shape[-1] == 3
     assert y.shape[-1] == 3
     if max(x.size, y.size) >= 1500:
-        return np.stack([x[..., 1] * y[..., 2] - x[..., 2] * y[..., 1],
-                         x[..., 2] * y[..., 0] - x[..., 0] * y[..., 2],
-                         x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]],
-                        axis=-1)
+        a = x[..., 1] * y[..., 2] - x[..., 2] * y[..., 1]
+        b = x[..., 2] * y[..., 0] - x[..., 0] * y[..., 2]
+        c = x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+        # Once we bump to NumPy 1.10, np.stack simplifies this
+        return np.concatenate([
+            a[..., np.newaxis], b[..., np.newaxis], c[..., np.newaxis]], -1)
     else:
         return np.cross(x, y)
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
 from scipy.fftpack import fft
+from scipy import sparse
 
 from mne.datasets import testing
 from mne import (stats, SourceEstimate, VectorSourceEstimate,
@@ -850,7 +851,6 @@ def test_epochs_vector_inverse():
 @testing.requires_testing_data
 def test_vol_connectivity():
     """Test volume connectivity."""
-    from scipy import sparse
     vol = read_source_spaces(fname_vsrc)
 
     pytest.raises(ValueError, spatial_src_connectivity, vol, dist=1.)

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -58,13 +58,16 @@ def test_head():
                   subjects_dir=subjects_dir)
 
 
-def test_huge_cross():
+def test_fast_cross_3d():
     """Test cross product with lots of elements."""
     x = rng.rand(100000, 3)
     y = rng.rand(1, 3)
     z = np.cross(x, y)
     zz = fast_cross_3d(x, y)
     assert_array_equal(z, zz)
+    # broadcasting and non-2D
+    zz = fast_cross_3d(x[:, np.newaxis], y[0])
+    assert_array_equal(z, zz[:, 0])
 
 
 def test_compute_nearest():

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -19,7 +19,7 @@ import warnings
 from functools import partial
 
 import numpy as np
-from scipy import linalg
+from scipy import linalg, sparse
 
 from ..defaults import DEFAULTS
 from ..externals.six import BytesIO, string_types, advance_iterator
@@ -1473,7 +1473,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
     from matplotlib import cm
     from matplotlib.widgets import Slider
     import nibabel as nib
-    from scipy import sparse, stats
+    from scipy import stats
     from ..morph import _get_subject_sphere_tris
     if hemi not in ['lh', 'rh']:
         raise ValueError("hemi must be 'lh' or 'rh' when using matplotlib. "

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -287,7 +287,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
         picks = [pick for pick in picks if pick not in exclude]
     picks = np.array(picks)
 
-    types = np.array([channel_type(info, idx) for idx in picks])
+    types = np.array([channel_type(info, idx) for idx in picks], np.unicode)
     ch_types_used = list()
     for this_type in _VALID_CHANNEL_TYPES:
         if this_type in types:

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -19,7 +19,9 @@ from mne.utils import run_tests_if_main
 
 from mne.viz import (plot_topo_image_epochs, _get_presser,
                      mne_analyze_colormap, plot_evoked_topo)
+from mne.viz.evoked import _line_plot_onselect
 from mne.viz.utils import _fake_click
+
 from mne.viz.topo import (_plot_update_evoked_topo_proj, iter_topography,
                           _imshow_tfr)
 
@@ -143,6 +145,12 @@ def test_plot_topo():
     cov = read_cov(cov_fname)
     cov['projs'] = []
     evoked.pick_types(meg=True).plot_topo(noise_cov=cov)
+    plt.close('all')
+
+    # test plot_topo
+    evoked.plot_topo()  # should auto-find layout
+    _line_plot_onselect(0, 200, ['mag', 'grad'], evoked.info, evoked.data,
+                        evoked.times)
     plt.close('all')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytest-cov
 pytest-sugar
 joblib
 psutil
+dipy
 numpydoc
 https://api.github.com/repos/nipy/PySurfer/zipball/master
 nitime


### PR DESCRIPTION
This should speed up our tests a bit. I noticed some were going over 40 minutes and thus flirting with the Travis test limit.

Big speed gains were realized by changing code used by `setup_source_space` to much more efficiently compute the neighboring triangles for each vertex.

Minor speed gains in forward computation came from different vectorization forms.