### PR TITLE
doc/install_mne_c.rst: Update setup setion and add some more detail

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,9 @@ ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 
+# make with no arguments will build the first target by default, i.e., build standalone HTML files
+first_target: html_dev-noplot
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html_stable      to make standalone HTML files (stable version)"

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -83,32 +83,48 @@ Installing from a Mac OSX disk image
 Setting up MNE-C environment
 ############################
 
-The system-dependent location of the MNE Software will be
-here referred to by the environment variable MNE_ROOT. There are
-two scripts for setting up user environment so that the software
-can be used conveniently:
+Your system-dependent path to the MNE Software will be referred to by the environment variable MNE_ROOT. 
+
+Your system-dependent path to MATLAB Software will be referred to by the environment variable MATLAB_ROOT.
+
+You can download a free runtime distribution of Matlab with the libraries necessary to run Matlab code from,
+https://www.mathworks.com/products/compiler/matlab-runtime.html
+
+If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined. Please note however that if Matlab
+is not available, the utilities mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
+
+To setup the MNE environment, a script must be sourced into your current shell.
+The result will be that additional environment varaibles like MNE_LIB_PATH will be set in your current shell 
+in order to run the MNE Software.
+
+A note about source-ing scripts with "source" and "." (dot). The hash bang at the top of a script tells 
+exec what shell to use by default to interpret the script. But the hash bang line is ignored when you 
+source a script via either the builtin "source" or "." directive.  So there needs to be a setup script
+compatible with your current shell, i.e., if you use csh you cannot source a bash script.  (BTW, the "." (dot)
+directive will search for the script in $PATH if there is no slash in the script argument while "source" 
+does not search $PATH).
+
+For Bourne or bash compatible shells, e.g., sh/bash/zsh, the script to source is:
 
 .. code-block:: console
 
-    $ . $MNE_ROOT/bin/mne_setup_sh
+    $ $MNE_ROOT/bin/mne_setup_sh
 
-and
+For C shells, e.g., csh/tcsh, the script to source is:
 
 .. code-block:: console
 
-    $ . $MNE_ROOT/bin/mne_setup
+    $ $MNE_ROOT/bin/mne_setup
 
-compatible with the POSIX and csh/tcsh shells, respectively. Since
-the scripts set environment variables they should be 'sourced' to
-the present shell. You can find which type of a shell you are using
-by saying
+The SHELL variable should already be set in your current shell by your login or profile init file. 
+You can echo $SHELL on the command line to see what type of shell you are using with:
 
 .. code-block:: console
 
     $ echo $SHELL
 
-If the output indicates a POSIX shell (``bash`` or ``sh``) you should issue
-the three commands:
+If the output indicates a POSIX shell ``bash`` or ``sh`` then you should export variables and 
+source the bash/sh setup file with three commands:
 
 .. code-block:: console
 
@@ -116,19 +132,29 @@ the three commands:
     $ export MATLAB_ROOT=<Matlab>
     $ . $MNE_ROOT/bin/mne_setup_sh
 
-with ``<MNE>`` replaced
-by the directory where you have installed the MNE software and ``<Matlab>`` is
-the directory where Matlab is installed. If you do not have Matlab,
-leave MATLAB_ROOT undefined. If Matlab is not available, the utilities
-mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
+where ``<MNE>`` is replaced by the absolute path to where you have installed the MNE software. This path
+will be the parent path to the ./bin and ./lib subdirecotries in the MNE distribution. Or the command 
+"ls $MNE_ROOT/bin/mne_setup_sh" should succeed if you have set MNE_ROOT correctly.
 
-For csh/tcsh the corresponding commands are:
+If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined. 
 
-.. code-block:: csh
+For the bash compatible ``zsh`` use the builtin emulate command to source the bash/sh setup script
+(after exporting variables):
+
+.. code-block:: console
+
+    $ export MNE_ROOT=<MNE>
+    $ export MATLAB_ROOT=<Matlab>
+    $ emulate sh -c 'source $MNE_ROOT/bin/mne_setup_sh'
+
+For ``csh`` or ``tcsh`` shell, the corresponding commands are:
+
+.. code-block:: console
 
     $ setenv MNE_ROOT <MNE>
     $ setenv MATLAB_ROOT <Matlab>
     $ source $MNE_ROOT/bin/mne_setup
+
 
 For BEM mesh generation using the watershed algorithm or
 on the basis of multi-echo FLASH MRI data (see :ref:`create_bem_model`) and

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -98,7 +98,7 @@ Please note however that if Matlab is not available, the utilities
 mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
 
 To setup the MNE environment, a script must be sourced into your current shell.
-The result will be that additional environment varaibles like MNE_LIB_PATH
+The result will be that additional environment variables like MNE_LIB_PATH
 will be set in your current shell in order to run the MNE Software.
 
 A note about source-ing scripts with "source" and "." (dot). The hash bang at

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -83,48 +83,49 @@ Installing from a Mac OSX disk image
 Setting up MNE-C environment
 ############################
 
-Your system-dependent path to the MNE Software will be referred to by the environment variable MNE_ROOT. 
+Your system-dependent path to the MNE Software will be referred to by
+the environment variable MNE_ROOT. 
 
-Your system-dependent path to MATLAB Software will be referred to by the environment variable MATLAB_ROOT.
+Your system-dependent path to MATLAB Software will be referred to by
+the environment variable MATLAB_ROOT.
 
-You can download a free runtime distribution of Matlab with the libraries necessary to run Matlab code from,
+You can download a free runtime distribution of Matlab with the libraries
+necessary to run Matlab code from,
 https://www.mathworks.com/products/compiler/matlab-runtime.html
 
-If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined. Please note however that if Matlab
-is not available, the utilities mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
+If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined.
+Please note however that if Matlab is not available, the utilities
+mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
 
 To setup the MNE environment, a script must be sourced into your current shell.
-The result will be that additional environment varaibles like MNE_LIB_PATH will be set in your current shell 
-in order to run the MNE Software.
+The result will be that additional environment varaibles like MNE_LIB_PATH
+will be set in your current shell in order to run the MNE Software.
 
-A note about source-ing scripts with "source" and "." (dot). The hash bang at the top of a script tells 
-exec what shell to use by default to interpret the script. But the hash bang line is ignored when you 
-source a script via either the builtin "source" or "." directive.  So there needs to be a setup script
-compatible with your current shell, i.e., if you use csh you cannot source a bash script.  (BTW, the "." (dot)
-directive will search for the script in $PATH if there is no slash in the script argument while "source" 
-does not search $PATH).
+A note about source-ing scripts with "source" and "." (dot). The hash bang at
+the top of a script tells exec what shell to use by default to interpret the
+script. But the hash bang line is ignored when you source a script via either
+the builtin "source" or "." directive.  So there needs to be a setup script
+compatible with your current shell, i.e., if you use csh you cannot source a
+bash script.  (BTW, the "." (dot) directive will search for the script in 
+$PATH if there is no slash in the script argument while "source" does not 
+search $PATH).
 
-For Bourne or bash compatible shells, e.g., sh/bash/zsh, the script to source is:
+For Bourne or bash compatible shells, e.g., sh/bash/zsh, the script to source
+is ``$MNE_ROOT/bin/mne_setup_sh``.
 
-.. code-block:: console
+For C shells, e.g., csh/tcsh, the script to source
+is ``$MNE_ROOT/bin/mne_setup``.
 
-    $ $MNE_ROOT/bin/mne_setup_sh
-
-For C shells, e.g., csh/tcsh, the script to source is:
-
-.. code-block:: console
-
-    $ $MNE_ROOT/bin/mne_setup
-
-The SHELL variable should already be set in your current shell by your login or profile init file. 
-You can echo $SHELL on the command line to see what type of shell you are using with:
+The SHELL variable should already be set in your current shell by your login or
+profile init file.  You can echo $SHELL on the command line to see what type of
+shell you are using with:
 
 .. code-block:: console
 
     $ echo $SHELL
 
-If the output indicates a POSIX shell ``bash`` or ``sh`` then you should export variables and 
-source the bash/sh setup file with three commands:
+If the output indicates a POSIX shell ``bash`` or ``sh`` then you should export
+variables and source the bash/sh setup file with three commands:
 
 .. code-block:: console
 
@@ -132,14 +133,16 @@ source the bash/sh setup file with three commands:
     $ export MATLAB_ROOT=<Matlab>
     $ . $MNE_ROOT/bin/mne_setup_sh
 
-where ``<MNE>`` is replaced by the absolute path to where you have installed the MNE software. This path
-will be the parent path to the ./bin and ./lib subdirecotries in the MNE distribution. Or the command 
-"ls $MNE_ROOT/bin/mne_setup_sh" should succeed if you have set MNE_ROOT correctly.
+where ``<MNE>`` is replaced by the absolute path to where you have installed
+the MNE software. This path will be the parent path to the ./bin and ./lib
+subdirecotries in the MNE distribution. Or the command
+"ls $MNE_ROOT/bin/mne_setup_sh" should succeed if you have set MNE_ROOT
+correctly.
 
-If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined. 
+If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined.
 
-For the bash compatible ``zsh`` use the builtin emulate command to source the bash/sh setup script
-(after exporting variables):
+For the bash compatible ``zsh`` use the builtin emulate command to source
+the bash/sh setup script (after exporting variables):
 
 .. code-block:: console
 


### PR DESCRIPTION
including setup for zsh and how to get free matlab runtime distribution

doc/Makefile: add "first_target:" as the first makefile target to build
target html_dev-noplot by default when typing "make" with no args.

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://martinos.org/mne/stable/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #1234.


#### What does this implement/fix?
Explain your changes.


#### Additional information
Any additional information you think is important.
