### PR TITLE
[MRG+1] Unify read annotations

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -57,7 +57,6 @@ Reading raw data
   anonymize_info
   find_edf_events
   read_events_eeglab
-  read_annotations_eeglab
   read_raw_artemis123
   read_raw_bti
   read_raw_cnt
@@ -67,7 +66,6 @@ Reading raw data
   read_raw_nicolet
   read_raw_eeglab
   read_raw_brainvision
-  read_annotations_brainvision
   read_raw_egi
   read_raw_fif
   read_raw_eximia

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -203,6 +203,10 @@ Bug
 
 API
 ~~~
+- Remove :func:`mne.io.read_annotations_brainvision`, :func:`mne.io.read_annotations_eeglab`,
+:func:`mne.io.edf.edf.read_annotations_edf` and :func:`mne.annotations.read_brainstorm_annotations` to unify their behavior under :func:`mne.read_annotations` by `Joan Massich`_
+
+- Deprecate :func:`mne.io.read_annotations_eeglab` by `Joan Massich`_
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Changelog
 
 - Add :func:`mne.io.read_raw_fieldtrip`, :func:`mne.read_epochs_fieldtrip` and :func:`mne.read_evoked_fieldtrip` to import FieldTrip data. By `Thomas Hartmann`_ and `Dirk Gütlin`_.
 
-- Default parameters in :func:`mne.io.read_annotations_eeglab` no longer filter out annotations by `Joan Massich`_ and `Alex Gramfort`_
+- Default parameters in ``mne.io.read_annotations_eeglab`` no longer filter out annotations by `Joan Massich`_ and `Alex Gramfort`_
 
 - :func:`mne.io.read_raw_eeglab` no longer warns when the stim channel is populated with an array of zeros by `Joan Massich`_
 
@@ -88,7 +88,7 @@ Changelog
 
 - Add support for Neuromag 122 system by `Alex Gramfort`_
 
-- Add function :func:`mne.io.read_annotations_brainvision` for reading directly Brainvision marker files by `Alex Gramfort`_
+- Add function ``mne.io.read_annotations_brainvision`` for reading directly Brainvision marker files by `Alex Gramfort`_
 
 - Add :meth:`mne.Report.remove` method to remove existing figures from a report, by `Marijn van Vliet`_
 
@@ -203,10 +203,10 @@ Bug
 
 API
 ~~~
-- Remove :func:`mne.io.read_annotations_brainvision`, :func:`mne.io.read_annotations_eeglab`,
-:func:`mne.io.edf.edf.read_annotations_edf` and :func:`mne.annotations.read_brainstorm_annotations` to unify their behavior under :func:`mne.read_annotations` by `Joan Massich`_
 
-- Deprecate :func:`mne.io.read_annotations_eeglab` by `Joan Massich`_
+- Remove ``mne.io.read_annotations_brainvision``, ``mne.io.read_annotations_eeglab``, ``mne.io.edf.edf.read_annotations_edf`` and ``mne.annotations.read_brainstorm_annotations`` to unify their behavior under :func:`mne.read_annotations` by `Joan Massich`_
+
+- Deprecate ``mne.io.read_annotations_eeglab`` by `Joan Massich`_
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 
@@ -300,7 +300,7 @@ Changelog
 
 - Add support for any data type like sEEG or ECoG in covariance related functions (estimation, whitening and plotting) by `Alex Gramfort`_ and `Eric Larson`_
 
-- Add function :func:`mne.io.read_annotations_eeglab` to allow loading annotations from EEGLAB files, by `Alex Gramfort`_
+- Add function ``mne.io.read_annotations_eeglab`` to allow loading annotations from EEGLAB files, by `Alex Gramfort`_
 
 - :meth:`mne.io.Raw.set_montage` now accepts a string as its ``montage`` argument; this will set a builtin montage, by `Clemens Brunner`_
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -430,21 +430,35 @@ def _write_annotations(fid, annotations):
     end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
 
 
-def read_annotations(fname):
+def read_annotations(fname, sfreq='auto'):
     """Read annotations from a file.
+
+    This function reads a .fif, .fif.gz, .vrmk file and makes an
+    :class:`mne.Annotations` object.
 
     Parameters
     ----------
     fname : str
         The filename.
 
+    sfreq : float | 'auto'
+        The sampling frequency in the file. This parameter is necessary for
+        vmrk files as Annotations are expressed in seconds and vmrk files are
+        in samples. If set to 'auto' then the sfreq is taken from the .vhdr
+        file that has the same name (without file extension). So data.vrmk
+        looks for sfreq in data.vhdr.
+
     Returns
     -------
     annot : instance of Annotations | None
         The annotations.
     """
+    # XXX: I've issues with circular imports
+    from mne.io.brainvision.brainvision import _read_annotations_brainvision_xx
     if fname.endswith(('fif', 'fif.gz')):
         annotations = _read_annotations_fif_xx(fname)
+    elif fname.endswith('vmrk'):
+        annotations = _read_annotations_brainvision_xx(fname, sfreq=sfreq)
     else:
         raise IOError('Unknown annotation file format "%s"' % fname)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -431,7 +431,7 @@ def _write_annotations(fid, annotations):
 
 
 def read_annotations(fname):
-    """Read annotations from a FIF file.
+    """Read annotations from a file.
 
     Parameters
     ----------
@@ -443,11 +443,21 @@ def read_annotations(fname):
     annot : instance of Annotations | None
         The annotations.
     """
-    ff, tree, _ = fiff_open(fname, preload=False)
-    with ff as fid:
-        annotations = _read_annotations(fid, tree)
+    if fname.endswith(('fif', 'fif.gz')):
+        annotations = _read_annotations_fif_xx(fname)
+    else:
+        raise IOError('Unknown annotation file format "%s"' % fname)
+
+
     if annotations is None:
         raise IOError('No annotation data found in file "%s"' % fname)
+    return annotations
+
+
+def _read_annotations_fif_xx(fname):
+    ff, tree, _ = fiff_open(fname, preload=False)
+    with ff as fid:
+        annotations = _read_annotations_fif(fid, tree)
     return annotations
 
 
@@ -491,7 +501,7 @@ def read_brainstorm_annotations(fname, orig_time=None):
                        orig_time=orig_time)
 
 
-def _read_annotations(fid, tree):
+def _read_annotations_fif(fid, tree):
     """Read annotations."""
     annot_data = dir_tree_find(tree, FIFF.FIFFB_MNE_ANNOTATIONS)
     if len(annot_data) == 0:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -463,10 +463,9 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     annot : instance of Annotations | None
         The annotations.
     """
-    # XXX: I've issues with circular imports
-    from mne.io.brainvision.brainvision import _read_annotations_brainvision
-    from mne.io.eeglab.eeglab import _read_annotations_eeglab
-    from mne.io.edf.edf import _read_annotations_edf
+    from .io.brainvision.brainvision import _read_annotations_brainvision
+    from .io.eeglab.eeglab import _read_annotations_eeglab
+    from .io.edf.edf import _read_annotations_edf
 
     name = op.basename(fname)
     if name.endswith(('fif', 'fif.gz')):

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -432,7 +432,7 @@ def _write_annotations(fid, annotations):
 
 
 def read_annotations(fname, sfreq='auto', uint16_codec=None):
-    """Read annotations from a file.
+    r"""Read annotations from a file.
 
     This function reads a .fif, .fif.gz, .vrmk, .edf or .set file and makes an
     :class:`mne.Annotations` object.
@@ -444,12 +444,14 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
 
     sfreq : float | 'auto'
         The sampling frequency in the file. This parameter is necessary for
-        vmrk files as Annotations are expressed in seconds and vmrk files are
-        in samples. If set to 'auto' then the sfreq is taken from the .vhdr
+        \*.vmrk files as Annotations are expressed in seconds and \*.vmrk files
+        are in samples. For any other file format, ``sfreq`` is omitted.
+        If set to 'auto' then the ``sfreq`` is taken from the \*.vhdr
         file that has the same name (without file extension). So data.vrmk
         looks for sfreq in data.vhdr.
 
     uint16_codec : str | None
+        This parameter is only used in EEGLAB (\*.set) and omitted otherwise.
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is
         too small". ``uint16_codec`` allows to specify what codec (for example:
@@ -485,14 +487,13 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
         onset = np.array(onset, dtype=float)
         duration = np.array(duration, dtype=float)
         annotations = Annotations(onset=onset, duration=duration,
-                                description=description,
-                                orig_time=None)
+                                  description=description,
+                                  orig_time=None)
 
     elif name.startswith('events_') and fname.endswith('mat'):
         annotations = _read_brainstorm_annotations(fname)
     else:
         raise IOError('Unknown annotation file format "%s"' % fname)
-
 
     if annotations is None:
         raise IOError('No annotation data found in file "%s"' % fname)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -430,7 +430,7 @@ def _write_annotations(fid, annotations):
     end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
 
 
-def read_annotations(fname, sfreq='auto', uint16_codec=None, orig_time=None):
+def read_annotations(fname, sfreq='auto', uint16_codec=None):
     """Read annotations from a file.
 
     This function reads a .fif, .fif.gz, .vrmk, .edf or .set file and makes an
@@ -455,15 +455,6 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None, orig_time=None):
         'latin1' or 'utf-8') should be used when reading character arrays and
         can therefore help you solve this problem.
 
-    orig_time : float | int | instance of datetime | array of int | None
-        A POSIX Timestamp, datetime or an array containing the timestamp as the
-        first element and microseconds as the second element. Determines the
-        starting time of annotation acquisition. If None (default),
-        starting time is determined from beginning of raw data acquisition.
-        In general, ``raw.info['meas_date']`` (or None) can be used for syncing
-        the annotations with raw data if their acquisiton is started at the
-        same time.
-
     Returns
     -------
     annot : instance of Annotations | None
@@ -484,7 +475,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None, orig_time=None):
     elif fname.endswith('edf'):
         annotations = _read_annotations_edf_caller(fname)
     elif fname.startswith('events_') and fname.endswith('mat'):
-        annotations = _read_brainstorm_annotations(fname, orig_time=orig_time)
+        annotations = _read_brainstorm_annotations(fname)
     else:
         raise IOError('Unknown annotation file format "%s"' % fname)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -470,19 +470,19 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None, orig_time=None):
         The annotations.
     """
     # XXX: I've issues with circular imports
-    from mne.io.brainvision.brainvision import _read_annotations_brainvision_xx
-    from mne.io.eeglab.eeglab import _read_annotations_eeglab_xx
-    from mne.io.edf.edf import _read_annotations_edf_xx
+    from mne.io.brainvision.brainvision import _read_annotations_brainvision
+    from mne.io.eeglab.eeglab import _read_annotations_eeglab_caller
+    from mne.io.edf.edf import _read_annotations_edf_caller
 
     if fname.endswith(('fif', 'fif.gz')):
-        annotations = _read_annotations_fif_xx(fname)
+        annotations = _read_annotations_fif_caller(fname)
     elif fname.endswith('vmrk'):
-        annotations = _read_annotations_brainvision_xx(fname, sfreq=sfreq)
+        annotations = _read_annotations_brainvision(fname, sfreq=sfreq)
     elif fname.endswith('set'):
-        annotations = _read_annotations_eeglab_xx(fname,
+        annotations = _read_annotations_eeglab_caller(fname,
                                                   uint16_codec=uint16_codec)
     elif fname.endswith('edf'):
-        annotations = _read_annotations_edf_xx(fname)
+        annotations = _read_annotations_edf_caller(fname)
     elif fname.startswith('events_') and fname.endswith('mat'):
         annotations = _read_brainstorm_annotations(fname, orig_time=orig_time)
     else:
@@ -494,7 +494,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None, orig_time=None):
     return annotations
 
 
-def _read_annotations_fif_xx(fname):
+def _read_annotations_fif_caller(fname):
     ff, tree, _ = fiff_open(fname, preload=False)
     with ff as fid:
         annotations = _read_annotations_fif(fid, tree)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -4,6 +4,7 @@
 
 from datetime import datetime
 import time
+import os.path as op
 import re
 from copy import deepcopy
 
@@ -465,16 +466,21 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     from mne.io.eeglab.eeglab import _read_annotations_eeglab_caller
     from mne.io.edf.edf import _read_annotations_edf_caller
 
-    if fname.endswith(('fif', 'fif.gz')):
         annotations = _read_annotations_fif_caller(fname)
-    elif fname.endswith('vmrk'):
+    name = op.basename(fname)
+    if name.endswith(('fif', 'fif.gz')):
+
+    elif name.endswith('vmrk'):
         annotations = _read_annotations_brainvision(fname, sfreq=sfreq)
-    elif fname.endswith('set'):
+
+    elif name.endswith('set'):
         annotations = _read_annotations_eeglab_caller(fname,
                                                   uint16_codec=uint16_codec)
-    elif fname.endswith('edf'):
+
+    elif name.endswith('edf'):
         annotations = _read_annotations_edf_caller(fname)
-    elif fname.startswith('events_') and fname.endswith('mat'):
+
+    elif name.startswith('events_') and fname.endswith('mat'):
         annotations = _read_brainstorm_annotations(fname)
     else:
         raise IOError('Unknown annotation file format "%s"' % fname)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -430,10 +430,10 @@ def _write_annotations(fid, annotations):
     end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
 
 
-def read_annotations(fname, sfreq='auto'):
+def read_annotations(fname, sfreq='auto', uint16_codec=None):
     """Read annotations from a file.
 
-    This function reads a .fif, .fif.gz, .vrmk file and makes an
+    This function reads a .fif, .fif.gz, .vrmk or .set file and makes an
     :class:`mne.Annotations` object.
 
     Parameters
@@ -448,6 +448,13 @@ def read_annotations(fname, sfreq='auto'):
         file that has the same name (without file extension). So data.vrmk
         looks for sfreq in data.vhdr.
 
+    uint16_codec : str | None
+        If your \*.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
+
     Returns
     -------
     annot : instance of Annotations | None
@@ -455,10 +462,15 @@ def read_annotations(fname, sfreq='auto'):
     """
     # XXX: I've issues with circular imports
     from mne.io.brainvision.brainvision import _read_annotations_brainvision_xx
+    from mne.io.eeglab.eeglab import _read_annotations_eeglab_xx
+
     if fname.endswith(('fif', 'fif.gz')):
         annotations = _read_annotations_fif_xx(fname)
     elif fname.endswith('vmrk'):
         annotations = _read_annotations_brainvision_xx(fname, sfreq=sfreq)
+    elif fname.endswith('set'):
+        annotations = _read_annotations_eeglab_xx(fname,
+                                                  uint16_codec=uint16_codec)
     else:
         raise IOError('Unknown annotation file format "%s"' % fname)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -441,7 +441,6 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     ----------
     fname : str
         The filename.
-
     sfreq : float | 'auto'
         The sampling frequency in the file. This parameter is necessary for
         \*.vmrk files as Annotations are expressed in seconds and \*.vmrk files
@@ -449,7 +448,6 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
         If set to 'auto' then the ``sfreq`` is taken from the \*.vhdr
         file that has the same name (without file extension). So data.vrmk
         looks for sfreq in data.vhdr.
-
     uint16_codec : str | None
         This parameter is only used in EEGLAB (\*.set) and omitted otherwise.
         If your \*.set file contains non-ascii characters, sometimes reading

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -41,6 +41,7 @@ from .fiff import read_raw_fif
 from .nicolet import read_raw_nicolet
 from .artemis123 import read_raw_artemis123
 from .eeglab import read_raw_eeglab, read_epochs_eeglab, read_events_eeglab
+from .eeglab.eeglab import read_annotations_eeglab
 from .eximia import read_raw_eximia
 from .fieldtrip import (read_raw_fieldtrip, read_epochs_fieldtrip,
                         read_evoked_fieldtrip)

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -41,7 +41,6 @@ from .fiff import read_raw_fif
 from .nicolet import read_raw_nicolet
 from .artemis123 import read_raw_artemis123
 from .eeglab import read_raw_eeglab, read_epochs_eeglab, read_events_eeglab
-from .eeglab import read_annotations_eeglab
 from .eximia import read_raw_eximia
 from .fieldtrip import (read_raw_fieldtrip, read_epochs_fieldtrip,
                         read_evoked_fieldtrip)

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -30,7 +30,7 @@ from . import eeglab
 from . import pick
 
 from .array import RawArray
-from .brainvision import read_raw_brainvision, read_annotations_brainvision
+from .brainvision import read_raw_brainvision
 from .bti import read_raw_bti
 from .cnt import read_raw_cnt
 from .ctf import read_raw_ctf

--- a/mne/io/brainvision/__init__.py
+++ b/mne/io/brainvision/__init__.py
@@ -4,4 +4,4 @@
 #
 # License: BSD (3-clause)
 
-from .brainvision import read_raw_brainvision, read_annotations_brainvision
+from .brainvision import read_raw_brainvision

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -335,6 +335,47 @@ def _read_vmrk(fname):
     return np.array(onset), np.array(duration), np.array(description), date_str
 
 
+def _read_annotations_brainvision(fname, sfreq='auto'):
+    """Create Annotations from BrainVision vrmk.
+
+    This function reads a .vrmk file and makes an
+    :class:`mne.Annotations` object.
+
+    Parameters
+    ----------
+    fname : str | object
+        The path to the .vmrk file.
+    sfreq : float | 'auto'
+        The sampling frequency in the file. It's necessary
+        as Annotations are expressed in seconds and vmrk
+        files are in samples. If set to 'auto' then
+        the sfreq is taken from the .vhdr file that
+        has the same name (without file extension). So
+        data.vrmk looks for sfreq in data.vhdr.
+
+    Returns
+    -------
+    annotations : instance of Annotations
+        The annotations present in the file.
+    """
+    onset, duration, description, date_str = _read_vmrk(fname)
+    orig_time = _str_to_meas_date(date_str)
+
+    if sfreq == 'auto':
+        vhdr_fname = op.splitext(fname)[0] + '.vhdr'
+        logger.info("Finding 'sfreq' from header file: %s" % vhdr_fname)
+        _, _, _, info = _aux_vhdr_info(vhdr_fname)
+        sfreq = info['sfreq']
+
+    onset = np.array(onset, dtype=float) / sfreq
+    duration = np.array(duration, dtype=float) / sfreq
+    annotations = Annotations(onset=onset, duration=duration,
+                              description=description,
+                              orig_time=orig_time)
+
+    return annotations
+
+
 def _event_id_func(desc, event_id, trig_shift_by_type, dropped_desc):
     """Get integers from string description.
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -26,9 +26,8 @@ from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
 from ..utils import (_read_segments_file, _synthesize_stim_channel,
                      _mult_cal_one)
-from ...annotations import Annotations, events_from_annotations, read_annotations
-# from mne import read_annotations
-
+from ...annotations import (Annotations, events_from_annotations,
+                            read_annotations)
 from ...externals.six import StringIO, string_types
 from ...externals.six.moves import configparser
 

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -17,10 +17,9 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 import pytest
 
 from mne.utils import _TempDir, run_tests_if_main
-from mne import pick_types, find_events
+from mne import pick_types, find_events, read_annotations
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
-from mne.io.brainvision import read_annotations_brainvision
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
 
@@ -622,7 +621,7 @@ def test_brainvision_neuroone_export():
 def test_read_vmrk_annotations():
     """Test load brainvision annotations."""
     sfreq = 1000.0
-    annotations = read_annotations_brainvision(vmrk_path, sfreq=sfreq)
+    annotations = read_annotations(vmrk_path, sfreq=sfreq)
     assert annotations.orig_time == 1384359243.794231
     expected = np.array([0, 486., 496., 1769., 1779., 3252., 3262., 4935.,
                          4945., 5999., 6619., 6629., 7629., 7699.]) / sfreq
@@ -637,7 +636,7 @@ def test_read_vmrk_annotations():
     assert_array_equal(annotations.description, description)
 
     # Test automatic detection of sfreq from header file
-    annotations_auto = read_annotations_brainvision(vmrk_path)
+    annotations_auto = read_annotations(vmrk_path)
     assert_array_equal(annotations.onset, annotations_auto.onset)
 
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1124,7 +1124,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
     return edf_info
 
 
-def read_annotations_edf(fname):
+def _read_annotations_edf_xx(fname):
     """Create Annotations from EDF (and EDF+) files.
 
     This function reads a .edf file and makes an

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1124,32 +1124,6 @@ def _read_gdf_header(fname, stim_channel, exclude):
     return edf_info
 
 
-def _read_annotations_edf_caller(fname):
-    """Create Annotations from EDF (and EDF+) files.
-
-    This function reads a .edf file and makes an
-    :class:`mne.Annotations` object.
-
-    Parameters
-    ----------
-    fname : str | object
-        The path to the .edf file.
-
-    Returns
-    -------
-    annotations : instance of Annotations
-        The annotations present in the file.
-    """
-    onset, duration, description = _read_annotations_edf(fname)
-    onset = np.array(onset, dtype=float)
-    duration = np.array(duration, dtype=float)
-    annotations = Annotations(onset=onset, duration=duration,
-                              description=description,
-                              orig_time=None)
-
-    return annotations
-
-
 def _read_annot(annot, annotmap, sfreq, data_length):
     """Annotation File Reader.
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1133,7 +1133,7 @@ def read_annotations_edf(fname):
     Parameters
     ----------
     fname : str | object
-        The path to the .vmrk file.
+        The path to the .edf file.
 
     Returns
     -------

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1124,7 +1124,7 @@ def _read_gdf_header(fname, stim_channel, exclude):
     return edf_info
 
 
-def _read_annotations_edf_xx(fname):
+def _read_annotations_edf_caller(fname):
     """Create Annotations from EDF (and EDF+) files.
 
     This function reads a .edf file and makes an

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -27,10 +27,10 @@ from mne.io.meas_info import _empty_info
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.pick import channel_type
 from mne.io.edf.edf import find_edf_events, _read_annot, _read_annotations_edf
-from mne.io.edf.edf import read_annotations_edf, _get_edf_default_event_id
+from mne.io.edf.edf import _get_edf_default_event_id
 from mne.io.edf.edf import _read_edf_header
 from mne.event import find_events
-from mne.annotations import events_from_annotations
+from mne.annotations import events_from_annotations, read_annotations
 
 FILE = inspect.getfile(inspect.currentframe())
 data_dir = op.join(op.dirname(op.abspath(FILE)), 'data')
@@ -402,7 +402,7 @@ def test_find_events_and_events_from_annot_are_the_same():
     events_from_find_events = find_events(raw)
     assert_array_equal(events_from_find_events, EXPECTED_EVENTS)
 
-    annot = read_annotations_edf(edf_path)
+    annot = read_annotations(edf_path)
     raw_shell.set_annotations(annot)
     event_id = _get_edf_default_event_id(annot.description)
     event_id.pop('start')

--- a/mne/io/eeglab/__init__.py
+++ b/mne/io/eeglab/__init__.py
@@ -3,4 +3,3 @@
 # Author: Mainak Jas <mainak.jas@telecom-paristech.fr>
 
 from .eeglab import read_raw_eeglab, read_epochs_eeglab, read_events_eeglab
-from .eeglab import read_annotations_eeglab

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -583,8 +583,6 @@ class EpochsEEGLAB(BaseEpochs):
                 warn('At least one epoch has multiple events. Only the latency'
                      ' of the first event will be retained.')
 
-
-
             # now fill up the event array
             events = np.zeros((eeg.trials, 3), dtype=int)
             for idx in range(0, eeg.trials):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -789,7 +789,7 @@ def _bunchify(items):
 
 
 def _read_annotations_eeglab(eeg, uint16_codec=None):
-    """Create Annotations from EEGLAB file.
+    r"""Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB
     structure and makes an :class:`mne.Annotations` object.
@@ -842,8 +842,8 @@ def _dol_to_lod(dol):
             for ii in range(len(dol[list(dol.keys())[0]]))]
 
 
-@deprecated('read_annotations_eeglab is deprecated from 0.17 and will be removed'
-            ' in 0.18. Please use mne.read_annotations')
+@deprecated('read_annotations_eeglab is deprecated from 0.17 and will be'
+            ' removed in 0.18. Please use mne.read_annotations')
 def read_annotations_eeglab(fname, uint16_codec=None):
     r"""Create Annotations from EEGLAB file.
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -811,7 +811,7 @@ def _read_annotations_eeglab(eeg, uint16_codec=None):
     annotations : instance of Annotations
         The annotations present in the file.
     """
-    if isinstance(eeg, str):
+    if isinstance(eeg, string_types):
         eeg = _check_load_mat(eeg, uint16_codec=uint16_codec)
 
     if not hasattr(eeg, 'event'):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -788,7 +788,7 @@ def _bunchify(items):
     return items
 
 
-def _read_annotations_eeglab(eeg):
+def _read_annotations_eeglab(eeg, uint16_codec=None):
     """Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB
@@ -796,14 +796,24 @@ def _read_annotations_eeglab(eeg):
 
     Parameters
     ----------
-    eeg : object
-        'EEG' struct
+    eeg : object | str
+        'EEG' struct or the path to the (EEGLAB) .set file.
+
+    uint16_codec : str | None
+        If your \*.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
 
     Returns
     -------
     annotations : instance of Annotations
         The annotations present in the file.
     """
+    if isinstance(eeg, str):
+        eeg = _check_load_mat(eeg, uint16_codec=uint16_codec)
+
     if not hasattr(eeg, 'event'):
         events = []
     elif isinstance(eeg.event, dict) and \
@@ -835,31 +845,6 @@ def _dol_to_lod(dol):
 @deprecated('read_annotations_eeglab is deprecated from 0.17 and will be removed'
             ' in 0.18. Please use mne.read_annotations')
 def read_annotations_eeglab(fname, uint16_codec=None):
-    r"""Create Annotations from EEGLAB file.
-
-    This function reads the event attribute from the EEGLAB
-    structure and makes an :class:`mne.Annotations` object.
-
-    Parameters
-    ----------
-    fname : str | object
-        The path to the (EEGLAB) .set file.
-    uint16_codec : str | None
-        If your \*.set file contains non-ascii characters, sometimes reading
-        it may fail and give rise to error message stating that "buffer is
-        too small". ``uint16_codec`` allows to specify what codec (for example:
-        'latin1' or 'utf-8') should be used when reading character arrays and
-        can therefore help you solve this problem.
-
-    Returns
-    -------
-    annotations : instance of Annotations
-        The annotations present in the file.
-    """
-    return _read_annotations_eeglab_caller(fname, uint16_codec=uint16_codec)
-
-
-def _read_annotations_eeglab_caller(fname, uint16_codec=None):
     r"""Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -582,6 +582,8 @@ class EpochsEEGLAB(BaseEpochs):
                 warn('At least one epoch has multiple events. Only the latency'
                      ' of the first event will be retained.')
 
+
+
             # now fill up the event array
             events = np.zeros((eeg.trials, 3), dtype=int)
             for idx in range(0, eeg.trials):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -834,7 +834,34 @@ def _dol_to_lod(dol):
             for ii in range(len(dol[list(dol.keys())[0]]))]
 
 
-def _read_annotations_eeglab(fname, uint16_codec=None):
+@deprecated('read_annotations_eeglab is deprecated from 0.17 and will be removed'
+            ' in 0.18. Please use mne.read_annotations')
+def read_annotations_eeglab(fname, uint16_codec=None):
+    r"""Create Annotations from EEGLAB file.
+
+    This function reads the event attribute from the EEGLAB
+    structure and makes an :class:`mne.Annotations` object.
+
+    Parameters
+    ----------
+    fname : str | object
+        The path to the (EEGLAB) .set file.
+    uint16_codec : str | None
+        If your \*.set file contains non-ascii characters, sometimes reading
+        it may fail and give rise to error message stating that "buffer is
+        too small". ``uint16_codec`` allows to specify what codec (for example:
+        'latin1' or 'utf-8') should be used when reading character arrays and
+        can therefore help you solve this problem.
+
+    Returns
+    -------
+    annotations : instance of Annotations
+        The annotations present in the file.
+    """
+    return _read_annotations_eeglab_caller(fname, uint16_codec=uint16_codec)
+
+
+def _read_annotations_eeglab_caller(fname, uint16_codec=None):
     r"""Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -834,7 +834,7 @@ def _dol_to_lod(dol):
             for ii in range(len(dol[list(dol.keys())[0]]))]
 
 
-def _read_annotations_eeglab_xx(fname, uint16_codec=None):
+def _read_annotations_eeglab(fname, uint16_codec=None):
     r"""Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -20,7 +20,8 @@ from ...channels.montage import Montage
 from ...epochs import BaseEpochs
 from ...event import read_events
 from ...externals.six import string_types
-from ...annotations import Annotations, events_from_annotations
+from ...annotations import (Annotations, events_from_annotations,
+                            read_annotations)
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6
@@ -391,7 +392,7 @@ class RawEEGLAB(BaseRaw):
                 orig_format='double', verbose=verbose)
 
         # create event_ch from annotations
-        annot = read_annotations_eeglab(input_fname)
+        annot = read_annotations(input_fname)
         self.set_annotations(annot)
 
         _check_boundary(annot, event_id)
@@ -658,8 +659,8 @@ def _check_latencies(latencies):
 
 
 @deprecated('read_events_eeglab is deprecated from 0.17 and will be removed'
-            ' in 0.18. Please use read_annotations_eeglab and create events'
-            ' using events_from_annotations.')
+            ' in 0.18. Please use read_annotations and create events using'
+            ' events_from_annotations.')
 def read_events_eeglab(eeg, event_id=None, event_id_func='strip_to_integer',
                        uint16_codec=None):
     r"""Create events array from EEGLAB structure.
@@ -833,7 +834,7 @@ def _dol_to_lod(dol):
             for ii in range(len(dol[list(dol.keys())[0]]))]
 
 
-def read_annotations_eeglab(fname, uint16_codec=None):
+def _read_annotations_eeglab_xx(fname, uint16_codec=None):
     r"""Create Annotations from EEGLAB file.
 
     This function reads the event attribute from the EEGLAB

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -798,7 +798,6 @@ def _read_annotations_eeglab(eeg, uint16_codec=None):
     ----------
     eeg : object | str
         'EEG' struct or the path to the (EEGLAB) .set file.
-
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -19,10 +19,10 @@ from scipy import io
 from mne import write_events, read_epochs_eeglab, Epochs, find_events
 from mne.io import read_raw_eeglab
 from mne.io.tests.test_raw import _test_raw_reader
-from mne.io.eeglab import read_annotations_eeglab, read_events_eeglab
+from mne.io.eeglab import read_events_eeglab
 from mne.datasets import testing
 from mne.utils import run_tests_if_main, requires_h5py, filter_out_warnings
-from mne.annotations import events_from_annotations
+from mne.annotations import events_from_annotations, read_annotations 
 
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
@@ -336,16 +336,16 @@ def test_degenerate(tmpdir):
 def test_eeglab_annotations(fname):
     """Test reading annotations in EEGLAB files."""
     _check_h5(fname)
-    annotations = read_annotations_eeglab(fname)
+    annotations = read_annotations(fname)
     assert len(annotations) == 154
     assert set(annotations.description) == set(['rt', 'square'])
     assert np.all(annotations.duration == 0.)
 
 
 @testing.requires_testing_data
-def test_read_annotations_eeglab():
+def test_eeglab_read_annotations():
     """Test annotations onsets are timestamps (+ validate some)."""
-    annotations = read_annotations_eeglab(raw_fname_mat)
+    annotations = read_annotations(raw_fname_mat)
     validation_samples = [0, 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
     expected_onset = np.array([1.00, 1.69, 2.08, 4.70, 7.71, 11.30, 17.18,
                                20.20, 26.12, 29.14, 35.25, 44.30, 47.15])
@@ -367,7 +367,7 @@ def test_eeglab_event_from_annot(recwarn):
 
     events_a = find_events(raw1)
     events_b = read_events_eeglab(raw_fname, event_id=event_id)
-    annotations = read_annotations_eeglab(raw_fname)
+    annotations = read_annotations(raw_fname)
     assert len(raw1.annotations) == 154
     raw1.set_annotations(annotations)
     events_c, _ = events_from_annotations(raw1, event_id=event_id)

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -359,7 +359,7 @@ def test_read_annotations_eeglab_is_deprecated():
     """Test read_annotations_eeglab is deprecated."""
     from mne.io import read_annotations_eeglab
     with pytest.deprecated_call():
-        annotations = read_annotations_eeglab(raw_fname_mat)
+        read_annotations_eeglab(raw_fname_mat)
 
 
 @testing.requires_testing_data

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -22,7 +22,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.eeglab import read_events_eeglab
 from mne.datasets import testing
 from mne.utils import run_tests_if_main, requires_h5py, filter_out_warnings
-from mne.annotations import events_from_annotations, read_annotations 
+from mne.annotations import events_from_annotations, read_annotations
 
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
@@ -352,6 +352,14 @@ def test_eeglab_read_annotations():
     assert annotations.orig_time is None
     assert_array_almost_equal(annotations.onset[validation_samples],
                               expected_onset, decimal=2)
+
+
+@testing.requires_testing_data
+def test_read_annotations_eeglab_is_deprecated():
+    """Test read_annotations_eeglab is deprecated."""
+    from mne.io import read_annotations_eeglab
+    with pytest.deprecated_call():
+        annotations = read_annotations_eeglab(raw_fname_mat)
 
 
 @testing.requires_testing_data

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -22,7 +22,7 @@ from ..base import (BaseRaw, _RawShell, _check_raw_compatibility,
 from ..utils import _mult_cal_one
 
 from ...annotations import (Annotations, _combine_annotations,
-                            _read_annotations)
+                            _read_annotations_fif)
 
 from ...event import AcqParserFIF
 from ...utils import check_fname, logger, verbose, warn
@@ -153,7 +153,7 @@ class Raw(BaseRaw):
             #   Read the measurement info
 
             info, meas = read_meas_info(fid, tree, clean_bads=True)
-            annotations = _read_annotations(fid, tree)
+            annotations = _read_annotations_fif(fid, tree)
 
             #   Locate the data of interest
             raw_node = dir_tree_find(meas, FIFF.FIFFB_RAW_DATA)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -21,7 +21,6 @@ from mne.utils import run_tests_if_main, _TempDir
 from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.io.tests.test_raw import _raw_annot
 from mne.annotations import _sync_onset, _handle_meas_date
-from mne.annotations import read_brainstorm_annotations
 from mne.datasets import testing
 
 
@@ -225,14 +224,14 @@ def test_crop_more():
 def test_read_brainstorm_annotations():
     """Test reading for Brainstorm events file."""
     fname = op.join(data_dir, 'events_sample_audvis_raw_bst.mat')
-    annot = read_brainstorm_annotations(fname)
+    annot = read_annotations(fname)
     assert len(annot) == 238
     assert annot.onset.min() > 40  # takes into account first_samp
     assert np.unique(annot.description).size == 5
 
     # Now test with orig_time
     orig_time = np.array([1038942070, 720100], dtype=np.int32)
-    annot = read_brainstorm_annotations(fname, orig_time=orig_time)
+    annot = read_annotations(fname, orig_time=orig_time)
     orig_time_as_scalar = orig_time[0] + orig_time[1] / 1000000.
     assert annot.orig_time == orig_time_as_scalar
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -229,12 +229,6 @@ def test_read_brainstorm_annotations():
     assert annot.onset.min() > 40  # takes into account first_samp
     assert np.unique(annot.description).size == 5
 
-    # Now test with orig_time
-    orig_time = np.array([1038942070, 720100], dtype=np.int32)
-    annot = read_annotations(fname, orig_time=orig_time)
-    orig_time_as_scalar = orig_time[0] + orig_time[1] / 1000000.
-    assert annot.orig_time == orig_time_as_scalar
-
 
 def test_raw_reject():
     """Test raw data getter with annotation reject."""


### PR DESCRIPTION
Fixes #5670 

Things to do:
- [x] migrate the calls of:
  - [x] brainstorm
  - [x] brainvision
  - [x] EDF
  - [x] fif
  - [x] eeglab
- [x] Depreacate read_annotations_eeglab since it was in 0.16
```rst - Add function :func:`mne.io.read_annotations_eeglab` to allow loading annotations from EEGLAB files, by `Alex Gramfort`_` ```
