### PR TITLE
MRG: Remove pytest-sugar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
     global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
-            PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar" OPTION=""
+            PIP_DEPENDENCIES="codecov pytest-faulthandler" OPTION=""
             TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
@@ -19,7 +19,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx pytest pytest-cov"
-               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest pytest-sugar"
+               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest"
                OPTION="--doctest-ignore-import-errors"
 
         # Linux

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - nibabel
   - nilearn
   - neo
-  - pytest-sugar
   - pytest-faulthandler
   - pydocstyle
   - codespell

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ python-picard
 statsmodels
 pytest
 pytest-cov
-pytest-sugar
 joblib
 psutil
 dipy


### PR DESCRIPTION
Since pytest 3.10 came out, pytest-sugar is broken:

https://github.com/Frozenball/pytest-sugar/pull/160

For now let's not bother installing it. Once they fix the bug and cut a new version we can add it back. (Seems better than the alternative, namely to pin pytest < 3.10.)