### PR TITLE
[FIX] Repair scaling of data in _compute_covariance_auto

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,6 +107,8 @@ Changelog
 
 Bug
 ~~~
+- Fix: bug with scaling of data in func:`mne.cov._compute_covariance_auto` by `David Sabbagh `_ 
+
 - Fix :func:`mne.io.Raw.plot_projs_topomap` by `Joan Massich`_
 
 - Fix bug in :func:`mne.minimum_norm.compute_source_psd` where the ``stc.times`` output was scaled by 1000, by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,6 +107,7 @@ Changelog
 
 Bug
 ~~~
+
 - Fix: bug with scaling of data in func:`mne.cov._compute_covariance_auto` by `David Sabbagh `_ 
 
 - Fix :func:`mne.io.Raw.plot_projs_topomap` by `Joan Massich`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -2978,3 +2978,5 @@ of commits):
 .. _Rasmus Zetter: https://people.aalto.fi/rasmus.zetter
 
 .. _Marcin Koculak: https://github.com/mkoculak
+
+.. _David Sabbagh: https://github.com/DavidSabbagh

--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -36,7 +36,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import KFold, cross_val_predict
 
-# define parameters
+# Define parameters
 fname = data_path() + '/SubjectCMC.ds'
 raw = mne.io.read_raw_ctf(fname)
 raw.crop(50., 250.).load_data()  # crop for memory purposes
@@ -45,7 +45,7 @@ raw.crop(50., 250.).load_data()  # crop for memory purposes
 emg = raw.copy().pick_channels(['EMGlft'])
 emg.filter(20., None, fir_design='firwin')
 
-# Filter MEG data to focus on alpha band
+# Filter MEG data to focus on beta band
 raw.pick_types(meg=True, ref_meg=True, eeg=False, eog=False)
 raw.filter(15., 30., fir_design='firwin')
 
@@ -70,7 +70,7 @@ cv = KFold(n_splits=2, shuffle=False)
 # Run cross validaton
 y_preds = cross_val_predict(clf, X, y, cv=cv)
 
-# plot the True EMG power and the EMG power predicted from MEG data
+# Plot the True EMG power and the EMG power predicted from MEG data
 fig, ax = plt.subplots(1, 1, figsize=[10, 4])
 times = raw.times[meg_epochs.events[:, 0] - raw.first_samp]
 ax.plot(times, y_preds, color='b', label='Predicted EMG')

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -989,6 +989,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
         logliks = [None]
 
     # undo scaling
+    _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
     for c in estimator_cov_info:
         _undo_scaling_cov(c[1], picks_list, scalings)
 
@@ -997,8 +998,9 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     cov_methods = [c.__name__ if callable(c) else c for c in method]
     runtime_infos, covs = list(runtime_infos), list(covs)
     my_zip = zip(cov_methods, runtime_infos, logliks, covs, estimators)
-    for this_method, runtime_info, loglik, data, est in my_zip:
-        out[this_method] = {'loglik': loglik, 'data': data, 'estimator': est}
+    for this_method, runtime_info, loglik, cov_data, est in my_zip:
+        out[this_method] = {
+            'loglik': loglik, 'data': cov_data, 'estimator': est}
         if runtime_info is not None:
             out[this_method].update(runtime_info)
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -498,15 +498,6 @@ def test_cov_scaling():
     assert_allclose(data, evoked.data, atol=1e-20)
 
     # check that input data remain unchanged. gh-5698
-#     raw = read_raw_fif(raw_fname).crop(0, 5).load_data()
-#     events = find_events(raw, stim_channel='STI 014')
-#     raw.pick_channels(raw.ch_names[:5])
-#     raw.add_proj([], remove_existing=True)
-#     epochs = Epochs(raw, events, None, tmin=-0.2, tmax=0., preload=True)
-#     data = np.hstack(epochs.get_data())
-#     data_orig = data.copy()
-#     _regularized_covariance(data, info=epochs.info)
-#     assert_array_almost_equal(data, data_orig)
     _regularized_covariance(data)
     assert_array_almost_equal(data, evoked.data)
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -506,7 +506,7 @@ def test_cov_scaling():
     data = np.hstack(epochs.get_data())
     data_orig = data.copy()
     _ = _regularized_covariance(data, info=epochs.info)
-    assert_array_equal(data, data_orig)
+    assert_array_almost_equal(data, data_orig)
 
 
 @requires_version('sklearn', '0.15')

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -497,16 +497,18 @@ def test_cov_scaling():
     _undo_scaling_array(data, picks_list, scalings=scalings)
     assert_allclose(data, evoked.data, atol=1e-20)
 
-    # check that scaling is undone
-    raw = read_raw_fif(raw_fname).crop(0, 5).load_data()
-    events = find_events(raw, stim_channel='STI 014')
-    raw.pick_channels(raw.ch_names[:5])
-    raw.add_proj([], remove_existing=True)
-    epochs = Epochs(raw, events, None, tmin=-0.2, tmax=0., preload=True)
-    data = np.hstack(epochs.get_data())
-    data_orig = data.copy()
-    _ = _regularized_covariance(data, info=epochs.info)
-    assert_array_almost_equal(data, data_orig)
+    # check that input data remain unchanged. gh-5698
+#     raw = read_raw_fif(raw_fname).crop(0, 5).load_data()
+#     events = find_events(raw, stim_channel='STI 014')
+#     raw.pick_channels(raw.ch_names[:5])
+#     raw.add_proj([], remove_existing=True)
+#     epochs = Epochs(raw, events, None, tmin=-0.2, tmax=0., preload=True)
+#     data = np.hstack(epochs.get_data())
+#     data_orig = data.copy()
+#     _regularized_covariance(data, info=epochs.info)
+#     assert_array_almost_equal(data, data_orig)
+    _regularized_covariance(data)
+    assert_array_almost_equal(data, evoked.data)
 
 
 @requires_version('sklearn', '0.15')


### PR DESCRIPTION
This fixes a bug discovered in the SPoC MNE example: https://mne-tools.github.io/dev/auto_examples/decoding/plot_decoding_spoc_CMC.html
where the Predicted EMG is not in the same scale than True EMG.
After investigation, it was due to a missing rescaling of the data in _compute_covariance_auto.
This bug did not affect the usage of mne.compute_covariance because that function does a copy internally. 
This is the output of this example after bug correction:
![spoc_debugged](https://user-images.githubusercontent.com/33925146/48074098-77955780-e1e0-11e8-952e-f64aae8855a3.png)

cc @agramfort @dengemann @kingjr @alexandrebarachant 

It should be ready for review
 