### PR TITLE
quick fix doc

### DIFF
--- a/tutorials/plot_info.py
+++ b/tutorials/plot_info.py
@@ -83,7 +83,7 @@ channel_indices = mne.pick_channels_regexp(info['ch_names'], 'MEG *')
 #
 # Get channel indices by type
 channel_indices = mne.pick_types(info, meg=True)  # MEG only
-channel_indices = mne.pick_types(info, eeg=True)  # EEG only
+channel_indices = mne.pick_types(info, meg=False, eeg=True)  # EEG only
 
 ###############################################################################
 # MEG gradiometers and EEG channels


### PR DESCRIPTION
This is just a quick fix of a single line in the documentation.

The point is that `mne.pick_types` has the default of `meg=True`, so we have to set `meg=False` to pick only EEG channels.