### PR TITLE
FIX kit2fiff-GUI:  allow converting files with unknown format

### DIFF
--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -416,7 +416,8 @@ class Kit2FiffModel(HasPrivateTraits):
                     stim_code, self.stim_threshold)
         raw = RawKIT(self.sqd_file, preload=preload, stim=self.stim_chs_array,
                      slope=self.stim_slope, stim_code=stim_code,
-                     stimthresh=self.stim_threshold)
+                     stimthresh=self.stim_threshold,
+                     allow_unknown_format=self.allow_unknown_format)
 
         if np.any(self.fid):
             raw.info['dig'] = _make_dig_points(self.fid[0], self.fid[1],


### PR DESCRIPTION
Fixes #4634 for the GUI. I was trying to help someone convert old data today and found what the issue was (the raw file is read twice, and the `allow_unkown_format` parameter was omitted the second time). Bad timing. Can this go into a minor release or should I ask them to install the dev version?
