### PR TITLE
ENH: add aparc_sub parcellation

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -194,6 +194,7 @@ Datasets
    brainstorm.bst_resting.data_path
    brainstorm.bst_raw.data_path
    eegbci.load_data
+   fetch_aparc_sub_parcellation
    fetch_hcp_mmp_parcellation
    hf_sef.data_path
    kiloword.data_path

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
+
 Bug
 ~~~
 

--- a/examples/visualization/plot_parcellation.py
+++ b/examples/visualization/plot_parcellation.py
@@ -6,6 +6,7 @@ Plot a cortical parcellation
 
 In this example, we download the HCP-MMP1.0 parcellation [1]_ and show it
 on ``fsaverage``.
+We will also download the customized 448-label aparc parcellation from [2]_
 
 .. note:: The HCP-MMP dataset has license terms restricting its use.
           Of particular relevance:
@@ -18,8 +19,13 @@ References
 ----------
 .. [1] Glasser MF et al. (2016) A multi-modal parcellation of human
        cerebral cortex. Nature 536:171-178.
+.. [2] Khan S et al. (2018) Maturation trajectories of cortical
+       resting-state networks depend on the mediating frequency band.
+       Neuroimage 174 57-68.
+
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>
+#         Denis Engemann <denis.engemann@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -30,6 +36,10 @@ import mne
 subjects_dir = mne.datasets.sample.data_path() + '/subjects'
 mne.datasets.fetch_hcp_mmp_parcellation(subjects_dir=subjects_dir,
                                         verbose=True)
+
+mne.datasets.fetch_aparc_sub_parcellation(subjects_dir=subjects_dir,
+                                          verbose=True)
+
 labels = mne.read_labels_from_annot(
     'fsaverage', 'HCPMMP1', 'lh', subjects_dir=subjects_dir)
 
@@ -39,9 +49,18 @@ brain.add_annotation('HCPMMP1')
 aud_label = [label for label in labels if label.name == 'L_A1_ROI-lh'][0]
 brain.add_label(aud_label, borders=False)
 
-###############################################################################
+################################################################################
 # We can also plot a combined set of labels (23 per hemisphere).
 
 brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
               cortex='low_contrast', background='white', size=(800, 600))
 brain.add_annotation('HCPMMP1_combined')
+
+###############################################################################
+# We can add another custom parcellation
+
+brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
+              cortex='low_contrast', background='white', size=(800, 600))
+brain.add_annotation('aparc_sub')
+
+

--- a/examples/visualization/plot_parcellation.py
+++ b/examples/visualization/plot_parcellation.py
@@ -49,7 +49,7 @@ brain.add_annotation('HCPMMP1')
 aud_label = [label for label in labels if label.name == 'L_A1_ROI-lh'][0]
 brain.add_label(aud_label, borders=False)
 
-################################################################################
+###############################################################################
 # We can also plot a combined set of labels (23 per hemisphere).
 
 brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
@@ -62,5 +62,3 @@ brain.add_annotation('HCPMMP1_combined')
 brain = Brain('fsaverage', 'lh', 'inflated', subjects_dir=subjects_dir,
               cortex='low_contrast', background='white', size=(800, 600))
 brain.add_annotation('aparc_sub')
-
-

--- a/mne/datasets/__init__.py
+++ b/mne/datasets/__init__.py
@@ -20,4 +20,6 @@ from . import spm_face
 from . import testing
 from . import _fake
 from . import phantom_4dbti
-from .utils import _download_all_example_data, fetch_hcp_mmp_parcellation
+from .utils import (_download_all_example_data, fetch_hcp_mmp_parcellation,
+                    fetch_aparc_sub_parcellation)
+

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -1,8 +1,16 @@
 import os
 from os import path as op
+import shutil
+import sys
+
+import pytest
 
 from mne import datasets
+from mne.datasets import testing
 from mne.utils import _TempDir, run_tests_if_main, requires_good_network
+
+
+subjects_dir = op.join(testing.data_path(download=False), 'subjects')
 
 
 def test_datasets():
@@ -55,6 +63,34 @@ def test_downloads():
     path = datasets._fake.data_path(path=data_dir, update_path=False)
     assert op.isfile(op.join(path, 'bar'))
     assert datasets._fake.get_version() is None
+
+
+@pytest.mark.slowtest
+@testing.requires_testing_data
+@requires_good_network
+def test_fetch_parcellations(tmpdir):
+    """Test fetching parcellations."""
+    this_subjects_dir = str(tmpdir)
+    os.mkdir(op.join(this_subjects_dir, 'fsaverage'))
+    os.mkdir(op.join(this_subjects_dir, 'fsaverage', 'label'))
+    os.mkdir(op.join(this_subjects_dir, 'fsaverage', 'surf'))
+    for hemi in ('lh', 'rh'):
+        shutil.copyfile(
+            op.join(subjects_dir, 'fsaverage', 'surf', '%s.white' % hemi),
+            op.join(this_subjects_dir, 'fsaverage', 'surf', '%s.white' % hemi))
+    # speed up by prenteding we have one of them
+    with open(op.join(this_subjects_dir, 'fsaverage', 'label',
+                      'lh.aparc_sub.annot'), 'wb'):
+        pass
+    datasets.fetch_aparc_sub_parcellation(subjects_dir=this_subjects_dir)
+    try:
+        sys.argv.append('--accept-hcpmmp-license')
+        datasets.fetch_hcp_mmp_parcellation(subjects_dir=this_subjects_dir)
+    finally:
+        sys.argv.pop(-1)
+    for hemi in ('lh', 'rh'):
+        assert op.isfile(op.join(this_subjects_dir, 'fsaverage', 'label',
+                         '%s.aparc_sub.annot' % hemi))
 
 
 run_tests_if_main()

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -616,13 +616,14 @@ def fetch_aparc_sub_parcellation(subjects_dir=None, verbose=None):
     """  # noqa: E501
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     destination = op.join(subjects_dir, 'fsaverage', 'label')
-    fnames = [op.join(destination, '%s.aparc_sub.annot' % hemi)
-              for hemi in ('lh', 'rh')]
-    if not all(op.isfile(fname) for fname in fnames):
-        _fetch_file('https://osf.io/p92yb/download',
-                    fnames[0], hash_='9e4d8d6b90242b7e4b0145353436ef77')
-        _fetch_file('https://osf.io/4kxny/download',
-                    fnames[1], hash_='dd6464db8e7762d969fc1d8087cd211b')
+    urls = dict(lh='https://osf.io/p92yb/download',
+                rh='https://osf.io/4kxny/download')
+    hashes = dict(lh='9e4d8d6b90242b7e4b0145353436ef77',
+                  rh='dd6464db8e7762d969fc1d8087cd211b')
+    for hemi in ('lh', 'rh'):
+        fname = op.join(destination, '%s.aparc_sub.annot' % hemi)
+        if not op.isfile(fname):
+            _fetch_file(urls[hemi], fname, hash_=hashes[hemi])
 
 
 @verbose
@@ -661,6 +662,10 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
     destination = op.join(subjects_dir, 'fsaverage', 'label')
     fnames = [op.join(destination, '%s.HCPMMP1.annot' % hemi)
               for hemi in ('lh', 'rh')]
+    urls = dict(lh='https://ndownloader.figshare.com/files/5528816',
+                rh='https://ndownloader.figshare.com/files/5528819')
+    hashes = dict(lh='46a102b59b2fb1bb4bd62d51bf02e975',
+                  rh='75e96b331940227bbcb07c1c791c2463')
     if not all(op.isfile(fname) for fname in fnames):
         if '--accept-hcpmmp-license' in sys.argv:
             answer = 'y'
@@ -669,10 +674,9 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
         if answer.lower() != 'y':
             raise RuntimeError('You must agree to the license to use this '
                                'dataset')
-        _fetch_file('https://ndownloader.figshare.com/files/5528816',
-                    fnames[0], hash_='46a102b59b2fb1bb4bd62d51bf02e975')
-        _fetch_file('https://ndownloader.figshare.com/files/5528819',
-                    fnames[1], hash_='75e96b331940227bbcb07c1c791c2463')
+    for hemi, fname in zip(('lh', 'rh'), fnames):
+        if not op.isfile(fname):
+            _fetch_file(urls[hemi], fname, hash_=hashes[hemi])
     if combine:
         fnames = [op.join(destination, '%s.HCPMMP1_combined.annot' % hemi)
                   for hemi in ('lh', 'rh')]

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -594,6 +594,42 @@ def _download_all_example_data(verbose=True):
 
 
 @verbose
+def fetch_aparc_sub_parcellation(subjects_dir=None, combine=True, verbose=None):
+    """Fetch the modified subdivided aparc parcellation.
+
+    This will download and install the subdivided aparc parcellation [1]_ files for
+    FreeSurfer's fsaverage to the specified directory.
+
+    Parameters
+    ----------
+    subjects_dir : str | None
+        The subjects directory to use. The file will be placed in
+        ``subjects_dir + '/fsaverage/label'``.
+    combine : bool
+        If True, also produce the combined/reduced set of 23 labels per
+        hemisphere as ``aparc_sub.annot`` [3]_.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    References
+    ----------
+    .. [1] Khan S et al. (2018) Maturation trajectories of cortical
+           resting-state networks depend on the mediating frequency band.
+           Neuroimage 174 57-68.
+    """  # noqa: E501
+
+    subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+    destination = op.join(subjects_dir, 'fsaverage', 'label')
+    fnames = [op.join(destination, '%s.aparc_sub.annot' % hemi)
+              for hemi in ('lh', 'rh')]
+    if not all(op.isfile(fname) for fname in fnames):
+  
+        _fetch_file('https://osf.io/p92yb/download',
+                    fnames[0], hash_='9e4d8d6b90242b7e4b0145353436ef77')
+        _fetch_file('https://osf.io/4kxny/download',
+                    fnames[1], hash_='dd6464db8e7762d969fc1d8087cd211b')
+
+@verbose
 def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
     """Fetch the HCP-MMP parcellation.
 

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -594,7 +594,7 @@ def _download_all_example_data(verbose=True):
 
 
 @verbose
-def fetch_aparc_sub_parcellation(subjects_dir=None, combine=True, verbose=None):
+def fetch_aparc_sub_parcellation(subjects_dir=None, verbose=None):
     """Fetch the modified subdivided aparc parcellation.
 
     This will download and install the subdivided aparc parcellation [1]_ files for
@@ -605,9 +605,6 @@ def fetch_aparc_sub_parcellation(subjects_dir=None, combine=True, verbose=None):
     subjects_dir : str | None
         The subjects directory to use. The file will be placed in
         ``subjects_dir + '/fsaverage/label'``.
-    combine : bool
-        If True, also produce the combined/reduced set of 23 labels per
-        hemisphere as ``aparc_sub.annot`` [3]_.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -617,17 +614,16 @@ def fetch_aparc_sub_parcellation(subjects_dir=None, combine=True, verbose=None):
            resting-state networks depend on the mediating frequency band.
            Neuroimage 174 57-68.
     """  # noqa: E501
-
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     destination = op.join(subjects_dir, 'fsaverage', 'label')
     fnames = [op.join(destination, '%s.aparc_sub.annot' % hemi)
               for hemi in ('lh', 'rh')]
     if not all(op.isfile(fname) for fname in fnames):
-  
         _fetch_file('https://osf.io/p92yb/download',
                     fnames[0], hash_='9e4d8d6b90242b7e4b0145353436ef77')
         _fetch_file('https://osf.io/4kxny/download',
                     fnames[1], hash_='dd6464db8e7762d969fc1d8087cd211b')
+
 
 @verbose
 def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):


### PR DESCRIPTION
This adds the 448 aparc atlas from @SherazKhan 2018 NIMG paper.
Ready for review / input [tests are missing].

I've updated our plot parcellations example to also show this parcellation

<img width="795" alt="screenshot 2018-11-20 17 28 36" src="https://user-images.githubusercontent.com/1908618/48787915-011d4d00-ecea-11e8-905d-0041a0852d6a.png">

@larsoner @agramfort 
