### PR TITLE
MRG: No warning in example

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,6 +339,8 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(
         'always', '.*converting a masked element to nan.*')  # matplotlib?
     # allow these warnings, but don't show them
+    warnings.filterwarnings(
+        'ignore', '.*OpenSSL\\.rand is deprecated.*')
     warnings.filterwarnings('ignore', '.*is currently using agg.*')
     warnings.filterwarnings(  # SciPy-related warning (maybe 1.2.0 will fix it)
         'ignore', '.*the matrix subclass is not the recommended.*')

--- a/doc/tutorials/philosophy.rst
+++ b/doc/tutorials/philosophy.rst
@@ -9,16 +9,16 @@ One of the first things you might be wondering about is how to get your
 data into mne. Assuming that you have unprocessed data, you will probably
 be happy with at least one of these readers:
 
-* :func:`read_raw_fif <mne.io.read_raw_fif>`
-* :func:`read_raw_kit <mne.io.read_raw_kit>`
-* :func:`read_raw_bti <mne.io.read_raw_bti>`
-* :func:`read_raw_ctf <mne.io.read_raw_ctf>`
-* :func:`read_raw_brainvision <mne.io.read_raw_brainvision>`
-* :func:`read_raw_cnt <mne.io.read_raw_cnt>`
-* :func:`read_raw_edf <mne.io.read_raw_edf>`
-* :func:`read_raw_eeglab <mne.io.read_raw_eeglab>`
-* :func:`read_raw_egi <mne.io.read_raw_egi>`
-* :func:`read_raw_nicolet <mne.io.read_raw_nicolet>`
+* :func:`~mne.io.read_raw_fif`
+* :func:`~mne.io.read_raw_kit`
+* :func:`~mne.io.read_raw_bti`
+* :func:`~mne.io.read_raw_ctf`
+* :func:`~mne.io.read_raw_brainvision`
+* :func:`~mne.io.read_raw_cnt`
+* :func:`~mne.io.read_raw_edf`
+* :func:`~mne.io.read_raw_eeglab`
+* :func:`~mne.io.read_raw_egi`
+* :func:`~mne.io.read_raw_nicolet`
 
 They all have in common to return an :class:`mne.io.Raw`-like object.
 See :ref:`ch_convert`.
@@ -87,7 +87,7 @@ Besides ``.ch_names`` another important attribute is ``.info``. It contains
 the channel information and some details about the processing history.
 This is especially relevant if your data cannot be read using the io
 functions listed above. You then need to learn how to create an info.
-See :ref:`tut_info_objects`.
+See :ref:`sphx_glr_auto_tutorials_plot_info.py`.
 
 4. MNE is modular
 -----------------

--- a/tutorials/plot_creating_data_structures.py
+++ b/tutorials/plot_creating_data_structures.py
@@ -14,11 +14,11 @@ import numpy as np
 
 ###############################################################################
 # ------------------------------------------------------
-# Creating :class:`Info <mne.Info>` objects
+# Creating :class:`~mne.Info` objects
 # ------------------------------------------------------
 #
-# .. note:: for full documentation on the `Info` object, see
-#           :ref:`tut_info_objects`. See also
+# .. note:: for full documentation on the :class:`~mne.Info` object, see
+#           :ref:`sphx_glr_auto_tutorials_plot_info.py`. See also
 #           :ref:`sphx_glr_auto_examples_io_plot_objects_from_arrays.py`.
 #
 # Normally, :class:`mne.Info` objects are created by the various
@@ -73,9 +73,9 @@ print(info)
 #           - The `ch_names` field should be consistent with the `name` field
 #             of the channel information contained in `chs`.
 #
-# ---------------------------------------------
-# Creating :class:`Raw <mne.io.Raw>` objects
-# ---------------------------------------------
+# -------------------------------------
+# Creating :class:`~mne.io.Raw` objects
+# -------------------------------------
 #
 # To create a :class:`mne.io.Raw` object from scratch, you can use the
 # :class:`mne.io.RawArray` class, which implements raw data that is backed by a
@@ -105,9 +105,9 @@ custom_raw = mne.io.RawArray(data, info)
 print(custom_raw)
 
 ###############################################################################
-# ---------------------------------------------
-# Creating :class:`Epochs <mne.Epochs>` objects
-# ---------------------------------------------
+# -------------------------------------
+# Creating :class:`~mne.Epochs` objects
+# -------------------------------------
 #
 # To create an :class:`mne.Epochs` object from scratch, you can use the
 # :class:`mne.EpochsArray` class, which uses a numpy array directly without
@@ -168,9 +168,9 @@ print(custom_epochs)
 _ = custom_epochs['smiling'].average().plot(time_unit='s')
 
 ###############################################################################
-# ---------------------------------------------
-# Creating :class:`Evoked <mne.Evoked>` Objects
-# ---------------------------------------------
+# -------------------------------------
+# Creating :class:`~mne.Evoked` Objects
+# -------------------------------------
 # If you already have data that is collapsed across trials, you may also
 # directly create an evoked array.  Its constructor accepts an array of
 # `shape(n_chans, n_times)` in addition to some bookkeeping parameters.

--- a/tutorials/plot_epoching_and_averaging.py
+++ b/tutorials/plot_epoching_and_averaging.py
@@ -12,7 +12,8 @@ import mne
 ###############################################################################
 # In MNE, `epochs` refers to a collection of `single trials` or short segments
 # of time locked raw data. If you haven't already, you might want to check out
-# :ref:`tut_epochs_objects`. In this tutorial we take a deeper look into
+# :ref:`sphx_glr_auto_tutorials_plot_object_epochs.py`.
+# In this tutorial we take a deeper look into
 # construction of epochs and averaging the epoch data to evoked instances.
 # First let's read in the raw sample data.
 data_path = mne.datasets.sample.data_path()
@@ -139,7 +140,7 @@ epochs.plot_drop_log()
 # you might ask. They're different because ``picks`` is simply a list of
 # channel indices and as the epochs were constructed, also a new info structure
 # is created where the channel indices run from 0 to ``epochs.info['nchan']``.
-# See :ref:`tut_info_objects` for more information.
+# See :ref:`sphx_glr_auto_tutorials_plot_info.py` for more information.
 picks = mne.pick_types(epochs.info, meg=True, eog=True)
 evoked_left = epochs['Auditory/Left'].average(picks=picks)
 evoked_right = epochs['Auditory/Right'].average(picks=picks)

--- a/tutorials/plot_info.py
+++ b/tutorials/plot_info.py
@@ -1,10 +1,8 @@
 """
-.. _tut_info_objects:
+The :class:`~mne.Info` data structure
+=====================================
 
-The :class:`Info <mne.Info>` data structure
-===========================================
-
-The :class:`Info <mne.Info>` data object is typically created
+The :class:`~mne.Info` data object is typically created
 when data is imported into MNE-Python and contains details such as:
 
 - date, subject information, and other recording details

--- a/tutorials/plot_object_raw.py
+++ b/tutorials/plot_object_raw.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-.. _tut_raw_objects:
+The :class:`~mne.io.Raw` data structure: continuous data
+========================================================
 
-The :class:`Raw <mne.io.Raw>` data structure: continuous data
-=============================================================
-
-Continuous data is stored in objects of type :class:`Raw <mne.io.Raw>`.
+Continuous data is stored in objects of type :class:`~mne.io.Raw`.
 The core data structure is simply a 2D numpy array (channels × samples)
 (in memory or loaded on demand) combined with an
-:class:`Info <mne.Info>` object (`.info` attribute)
-(see :ref:`tut_info_objects`).
+:class:`~mne.Info` object (`.info` attribute)
+(see :ref:`sphx_glr_auto_tutorials_plot_info.py`).
 
 The most common way to load continuous data is from a .fif file. For more
 information on :ref:`loading data from other formats <ch_convert>`, or
@@ -43,20 +41,20 @@ print('%s channels x %s samples' % (len(raw), len(raw.times)))
 #           variable directly but rely on indexing syntax detailed just below.
 
 ###############################################################################
-# Information about the channels contained in the :class:`Raw <mne.io.Raw>`
-# object is contained in the :class:`Info <mne.Info>` attribute.
+# Information about the channels contained in the :class:`~mne.io.Raw`
+# object is contained in the :class:`~mne.Info` attribute.
 # This is essentially a dictionary with a number of relevant fields (see
-# :ref:`tut_info_objects`).
+# :ref:`sphx_glr_auto_tutorials_plot_info.py`).
 
 
 ###############################################################################
 # Indexing data
 # -------------
 #
-# To access the data stored within :class:`Raw <mne.io.Raw>` objects,
-# it is possible to index the :class:`Raw <mne.io.Raw>` object.
+# To access the data stored within :class:`~mne.io.Raw` objects,
+# it is possible to index the :class:`~mne.io.Raw` object.
 #
-# Indexing a :class:`Raw <mne.io.Raw>` object will return two arrays: an array
+# Indexing a :class:`~mne.io.Raw` object will return two arrays: an array
 # of times, as well as the data representing those timepoints. This works
 # even if the data is not preloaded, in which case the data will be read from
 # disk when indexing. The syntax is as follows:
@@ -113,16 +111,16 @@ raw = raw.drop_channels(['MEG 0241', 'EEG 001'])
 print('Number of channels reduced from', nchan, 'to', raw.info['nchan'])
 
 ###############################################################################
-# --------------------------------------------------
-# Concatenating :class:`Raw <mne.io.Raw>` objects
-# --------------------------------------------------
+# ------------------------------------------
+# Concatenating :class:`~mne.io.Raw` objects
+# ------------------------------------------
 #
-# :class:`Raw <mne.io.Raw>` objects can be concatenated in time by using the
-# :func:`append <mne.io.Raw.append>` function. For this to work, they must
-# have the same number of channels and their :class:`Info
-# <mne.Info>` structures should be compatible.
+# :class:`~mne.io.Raw` objects can be concatenated in time by using the
+# :func:`~mne.io.Raw.append` function. For this to work, they must
+# have the same number of channels and their :class:`~mne.Info`
+# structures should be compatible.
 
-# Create multiple :class:`Raw <mne.io.RawFIF>` objects
+# Create multiple :class:`~mne.io.Raw` objects
 raw1 = raw.copy().crop(0, 10)
 raw2 = raw.copy().crop(10, 20)
 raw3 = raw.copy().crop(20, 40)

--- a/tutorials/plot_point_spread.py
+++ b/tutorials/plot_point_spread.py
@@ -1,6 +1,4 @@
 """
-.. _point_spread:
-
 Corrupt known signal with point spread
 ======================================
 
@@ -58,8 +56,9 @@ fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
 fwd['info']['bads'] = []
 inv_op = read_inverse_operator(fname_inv)
 
-raw = mne.io.RawFIF(op.join(data_path, 'MEG', 'sample',
-                            'sample_audvis_raw.fif'))
+raw = mne.io.read_raw_fif(op.join(data_path, 'MEG', 'sample',
+                                  'sample_audvis_raw.fif'))
+raw.set_eeg_reference(projection=True)
 events = mne.find_events(raw)
 event_id = {'Auditory/Left': 1, 'Auditory/Right': 2}
 epochs = mne.Epochs(raw, events, event_id, baseline=(None, 0), preload=True)


### PR DESCRIPTION
Gets rid of a missing EEG ref warning, plus a ref to `RawFIF` that should be `Raw` (the former is an alias for the latter). I also modernized some linking methods while I was in there.