### PR TITLE
[MRG] FIX don't delete fname

### DIFF
--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -77,14 +77,13 @@ class Raw(BaseRaw):
     def __init__(self, fname, allow_maxshield=False, preload=False,
                  verbose=None):  # noqa: D102
         fnames = [op.realpath(fname)]
-        del fname
         split_fnames = []
 
         raws = []
-        for ii, fname in enumerate(fnames):
-            do_check_fname = fname not in split_fnames
+        for ii, this_fname in enumerate(fnames):
+            do_check_fname = this_fname not in split_fnames
             raw, next_fname, buffer_size_sec = \
-                self._read_raw_file(fname, allow_maxshield,
+                self._read_raw_file(this_fname, allow_maxshield,
                                     preload, do_check_fname)
             raws.append(raw)
             if next_fname is not None:


### PR DESCRIPTION
with @teonbrooks [we discovered](https://github.com/mne-tools/mne-bids/pull/137) that the `del fname` is causing `raw._init_kwargs` to store the `fname` variable incorrectly in the case of split filenames. It's a very specific case, so I think just fixing it here should be fine.