### PR TITLE
MRG [VIZ, MINOR] Histogram for epochs variance in ica_plot_properties

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -208,7 +208,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
 
     # epoch variance
     set_title_and_labels(var_ax, kind + ' variance', kind + ' (index)',
-                         'Arbitrary Units')
+                         'Arbitrary Units (AU)')
 
     hist_ax.set_ylabel("")
     hist_ax.set_yticks([])

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -132,6 +132,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                          kind):
     """Plot ICA properties (helper)."""
     from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
+    from scipy.stats import gaussian_kde
 
     topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
 
@@ -160,9 +161,20 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
                    facecolor=[0, 0, 0], lw=0)
     var_ax.set_yticks([])
-    hist_ax.hist(epoch_var, orientation="horizontal", color="grey")
-    hist_ax.set_ylabel("")
-    hist_ax.set_yticks([])
+
+    # histogram & histogram
+    _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
+                                color="k", alpha=.5)
+
+    # kde
+    kde = gaussian_kde(epoch_var)
+    ymin, ymax = hist_ax.get_ylim()
+    x = np.linspace(ymin, ymax, 50)
+    kde_ = kde(x)
+    kde_ /= kde_.max()
+    kde_ *= hist_ax.get_xlim()[-1] * .9
+    hist_ax.plot(kde_, x, color="k")
+    hist_ax.set_ylim(ymin, ymax)
 
     # aesthetics
     # ----------
@@ -197,6 +209,10 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
 
     # epoch variance
     set_title_and_labels(var_ax, kind + ' variance', kind + ' (index)', 'AU')
+
+    hist_ax.set_title("Variance KDE\nand histogram")
+    hist_ax.set_ylabel("")
+    hist_ax.set_yticks([])
 
     return fig
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -207,9 +207,9 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     image_ax.axhline(0, color='k', linewidth=.5)
 
     # epoch variance
-    set_title_and_labels(var_ax, kind + ' variance', kind + ' (index)', 'AU')
+    set_title_and_labels(var_ax, kind + ' variance', kind + ' (index)',
+                         'Arbitrary Units')
 
-    hist_ax.set_title("Variance KDE\nand histogram")
     hist_ax.set_ylabel("")
     hist_ax.set_yticks([])
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -212,6 +212,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
 
     hist_ax.set_ylabel("")
     hist_ax.set_yticks([])
+    set_title_and_labels(hist_ax, None, None, None)
 
     return fig
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -189,8 +189,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     # remove half of yticks if more than 5
     yt = erp_ax.get_yticks()
     if len(yt) > 5:
-        yt = yt[::2]
-        erp_ax.yaxis.set_ticks(yt)
+        erp_ax.yaxis.set_ticks(yt[::2])
 
     # remove xticks - erp plot shows xticks for both image and erp plot
     image_ax.xaxis.set_ticks([])

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -130,6 +130,8 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                          set_title_and_labels, plot_std, psd_ylabel,
                          spectrum_std, topomap_args, image_args, fig, axes):
     """Plot ICA properties (helper)."""
+    from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
+
     topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
 
     # plotting
@@ -152,8 +154,14 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                         color='k', alpha=0.2)
 
     # epoch variance
+    var_ax_divider= make_axes_locatable(var_ax)
+    hist_ax = var_ax_divider.append_axes("right", size="33%", pad="2.5%")
     var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
                    facecolor=[0, 0, 0], lw=0)
+    hist_ax.hist(epoch_var, orientation="horizontal", color="grey")
+    hist_ax.set_ylabel("")
+    hist_ax.set_yticklabels([])
+
 
     # aesthetics
     # ----------

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -128,7 +128,8 @@ def _create_properties_layout(figsize=None):
 def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                          epoch_var, plot_lowpass_edge, epochs_src,
                          set_title_and_labels, plot_std, psd_ylabel,
-                         spectrum_std, topomap_args, image_args, fig, axes):
+                         spectrum_std, topomap_args, image_args, fig, axes,
+                         kind):
     """Plot ICA properties (helper)."""
     from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 
@@ -154,20 +155,20 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                         color='k', alpha=0.2)
 
     # epoch variance
-    var_ax_divider= make_axes_locatable(var_ax)
+    var_ax_divider = make_axes_locatable(var_ax)
     hist_ax = var_ax_divider.append_axes("right", size="33%", pad="2.5%")
     var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
                    facecolor=[0, 0, 0], lw=0)
+    var_ax.set_yticks([])
     hist_ax.hist(epoch_var, orientation="horizontal", color="grey")
     hist_ax.set_ylabel("")
-    hist_ax.set_yticklabels([])
-
+    hist_ax.set_yticks([])
 
     # aesthetics
     # ----------
     topo_ax.set_title(ica._ica_names[pick])
 
-    set_title_and_labels(image_ax, 'Epochs image and ERP/ERF', [], 'Epochs')
+    set_title_and_labels(image_ax, kind + ' image and ERP/ERF', [], kind)
 
     # erp
     set_title_and_labels(erp_ax, [], 'Time (s)', 'AU\n')
@@ -195,7 +196,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     image_ax.axhline(0, color='k', linewidth=.5)
 
     # epoch variance
-    set_title_and_labels(var_ax, 'Epochs variance', 'Epoch (index)', 'AU')
+    set_title_and_labels(var_ax, kind + ' variance', kind + ' (index)', 'AU')
 
     return fig
 
@@ -317,6 +318,9 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         from ..epochs import _segment_raw
         inst = _segment_raw(inst, segment_length=2., verbose=False,
                             preload=True)
+        kind = "Segment"
+    else:
+        kind = "Epochs"
 
     epochs_src = ica.get_sources(inst)
     ica_data = np.swapaxes(epochs_src.get_data()[:, picks, :], 0, 1)
@@ -358,7 +362,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
             pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
             np.var(ica_data[idx], axis=1), plot_lowpass_edge,
             epochs_src, set_title_and_labels, plot_std, psd_ylabel,
-            spectrum_std, topomap_args, image_args, fig, axes)
+            spectrum_std, topomap_args, image_args, fig, axes, kind)
         all_fig.append(fig)
 
     plt_show(show)


### PR DESCRIPTION
This adds a histogram right next to the epochs variance plot. I think it makes it a bit more readable and perhaps easier to interpret for the inexperienced.

I also like that it breaks the false and confusing symmetry between the top right axes' x axis and the bottom right axes' x axis.
@mmagnuski 


<img width="491" alt="unknown-195" src="https://user-images.githubusercontent.com/4321826/49015443-61e1d500-f183-11e8-8742-7f013700b3ab.png">