### PR TITLE
Don't italicize Hz in PSD y-label

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -640,7 +640,7 @@ def _convert_psds(psds, dB, estimate, scaling, unit, ch_names):
         ylabel = r'$\mathrm{%s / \sqrt{Hz}}$' % unit
     else:
         psds *= scaling * scaling
-        ylabel = r'$\mathrm{%s^2}/Hz}$' % unit
+        ylabel = r'$\mathrm{%s^2/Hz}$' % unit
 
     if dB:
         np.log10(np.maximum(psds, np.finfo(float).tiny), out=psds)


### PR DESCRIPTION
This wasn't even valid LaTeX code.

Before:
![before](https://user-images.githubusercontent.com/4377312/49149910-aac49580-f30b-11e8-9ac1-5621e5f7b46e.png)

After:
![after](https://user-images.githubusercontent.com/4377312/49149914-adbf8600-f30b-11e8-8707-ee01aba0d410.png)

