### PR TITLE
[MRG] ENH: alternative layout of extra points in interpolation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,13 +21,15 @@ Changelog
 
 - :func:`mne.io.read_raw_edf` now detects analog stim channels labeled ``'STATUS'`` and sets them as stim channel. :func:`mne.io.read_raw_edf` no longer synthesize TAL annotations into stim channel but stores them in ``raw.annotations`` when reading by `Joan Massich`_
 
-- Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_. 
+- Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_.
 
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
 - Add Epoch selection and metadata functionality to :class:`mne.time_frequency.EpochsTFR` using new mixin class by `Keith Doelling`_
+
+- Add ``extrapolate`` argument to :func:`mne.viz.plot_topomap` for better control of extrapolation points placement by `Mikołaj Magnuski`_
 
 Bug
 ~~~

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -29,6 +29,9 @@ condition = 'Left Auditory'
 evoked = read_evokeds(fname, condition=condition, baseline=(None, 0))
 
 ###############################################################################
+# Basic `plot_topomap` options
+# ----------------------------
+#
 # We plot evoked topographies using :func:`mne.Evoked.plot_topomap`. The first
 # argument, ``times`` allows to specify time instants (in seconds!) for which
 # topographies will be shown. We select timepoints from 50 to 150 ms with a
@@ -51,6 +54,9 @@ evoked.plot_topomap(times, ch_type='mag', average=0.05, time_unit='s')
 evoked.plot_topomap(times, ch_type='grad', time_unit='s')
 
 ###############################################################################
+# Additional `plot_topomap` options
+# ---------------------------------
+#
 # We can also use a range of various :func:`mne.viz.plot_topomap` arguments
 # that control how the topography is drawn. For example:
 #
@@ -76,14 +82,20 @@ evoked.plot_topomap(0.1, ch_type='mag', size=2)
 evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate='head')
 
 ###############################################################################
+# More advanced usage
+# -------------------
+#
 # Now we plot magnetometer data as topomap at a single time point: 100 ms
-# post-stimulus and add channel labels and title
+# post-stimulus, add channel labels, title and adjust plot margins:
 evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
-                    size=3, res=128, title='Auditory response',
+                    size=6, res=128, title='Auditory response',
                     time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
 ###############################################################################
+# Animating the topomap
+# ---------------------
+#
 # Instead of using a still image we can plot magnetometer data as an animation
 # (animates only in matplotlib interactive mode)
 evoked.animate_topomap(ch_type='mag', times=times, frame_rate=10,

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -82,7 +82,7 @@ fig, axes = plt.subplots(figsize=(7.5, 2.5), ncols=3)
 
 for ax, extr in zip(axes, extrapolations):
     evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate=extr, axes=ax,
-                        show=False)
+                        show=False, colorbar=False)
     ax.set_title(extr, fontsize=14)
 
 ###############################################################################

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -12,6 +12,7 @@ additional options.
 #          Mikołaj Magnuski <mmagnuski@swps.edu.pl>
 #
 # License: BSD (3-clause)
+# sphinx_gallery_thumbnail_number = 5
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -40,7 +41,8 @@ times = np.arange(0.05, 0.151, 0.02)
 evoked.plot_topomap(times, ch_type='mag', time_unit='s')
 
 ###############################################################################
-# If times is set to None only 10 regularly spaced topographies will be shown:
+# If times is set to None at most 10 regularly spaced topographies will be
+# shown:
 evoked.plot_topomap(ch_type='mag', time_unit='s')
 
 ###############################################################################

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -53,6 +53,7 @@ evoked.plot_topomap(times, ch_type='grad', time_unit='s')
 ###############################################################################
 # We can also use a range of various :func:`mne.viz.plot_topomap` arguments
 # that control how the topography is drawn. For example:
+#
 # * ``cmap`` - to specify the color map
 # * ``res`` - to control the resolution of the topographies (lower resolution
 #   means faster plotting)
@@ -65,20 +66,20 @@ evoked.plot_topomap(times, ch_type='mag', cmap='Spectral_r', res=32,
 # If you look at the edges of the head circle of a single topomap you'll see
 # the effect of extrapolation. By default ``extrapolate='box'`` is used which
 # extrapolates to large box stretching beyond the head circle:
-evoked.plot_topomap(0.1, ch_type='mag')
+evoked.plot_topomap(0.1, ch_type='mag', size=2)
 
 ###############################################################################
 # Compare the image above with the one below, where we use
 # ``extrapolate='head'`` so that extrapolation would go to 0 at the head
 # circle (another option is to use ``extrapolate='local'`` in which case the
 # extrapolation is performed only within some distance from channels):
-evoked.plot_topomap(0.1, ch_type='mag', extrapolate='head')
+evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate='head')
 
 ###############################################################################
 # Now we plot magnetometer data as topomap at a single time point: 100 ms
 # post-stimulus and add channel labels and title
 evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
-                    size=6, res=128, title='Auditory response',
+                    size=3, res=128, title='Auditory response',
                     time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -73,15 +73,17 @@ evoked.plot_topomap(times, ch_type='mag', cmap='Spectral_r', res=32,
 ###############################################################################
 # If you look at the edges of the head circle of a single topomap you'll see
 # the effect of extrapolation. By default ``extrapolate='box'`` is used which
-# extrapolates to large box stretching beyond the head circle:
-evoked.plot_topomap(0.1, ch_type='mag', size=2)
+# extrapolates to a large box stretching beyond the head circle.
+# Compare this with ``extrapolate='head'`` (second topography below) where
+# extrapolation goes to 0 at the head circle and ``extrapolate='local'`` where
+# extrapolation is performed only within some distance from channels:
+extrapolations = ['box', 'head', 'local']
+fig, axes = plt.subplots(figsize=(7.5, 2.5), ncols=3)
 
-###############################################################################
-# Compare the image above with the one below, where we use
-# ``extrapolate='head'`` so that extrapolation would go to 0 at the head
-# circle (another option is to use ``extrapolate='local'`` in which case the
-# extrapolation is performed only within some distance from channels):
-evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate='head')
+for ax, extr in zip(axes, extrapolations):
+    evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate=extr, axes=ax,
+                        show=False)
+    ax.set_title(extr, fontsize=14)
 
 ###############################################################################
 # More advanced usage

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -3,11 +3,13 @@
 Plotting topographic maps of evoked data
 ========================================
 
-Load evoked data and plot topomaps for selected time points.
+Load evoked data and plot topomaps for selected time points using multiple
+additional options.
 """
 # Authors: Christian Brodbeck <christianbrodbeck@nyu.edu>
 #          Tal Linzen <linzen@nyu.edu>
 #          Denis A. Engeman <denis.engemann@gmail.com>
+#          Mikołaj Magnuski <mmagnuski@swps.edu.pl>
 #
 # License: BSD (3-clause)
 
@@ -21,30 +23,67 @@ print(__doc__)
 path = sample.data_path()
 fname = path + '/MEG/sample/sample_audvis-ave.fif'
 
-# load evoked and subtract baseline
+# load evoked corresponding to a specific condition
+# from the fif file and subtract baseline
 condition = 'Left Auditory'
 evoked = read_evokeds(fname, condition=condition, baseline=(None, 0))
 
-# set time instants in seconds (from 50 to 150ms in a step of 10ms)
-times = np.arange(0.05, 0.15, 0.01)
-# If times is set to None only 10 regularly spaced topographies will be shown
-
-# plot magnetometer data as topomaps
+###############################################################################
+# We plot evoked topographies using :func:`mne.Evoked.plot_topomap`. The first
+# argument, ``times`` allows to specify time instants (in seconds!) for which
+# topographies will be shown. We select timepoints from 50 to 150 ms with a
+# step of 20ms and plot magnetometer data:
+times = np.arange(0.05, 0.151, 0.02)
 evoked.plot_topomap(times, ch_type='mag', time_unit='s')
 
-# compute a 50 ms bin to stabilize topographies
+###############################################################################
+# If times is set to None only 10 regularly spaced topographies will be shown:
+evoked.plot_topomap(ch_type='mag', time_unit='s')
+
+###############################################################################
+# Instead of showing topographies at specific time points we can compute
+# averages of 50 ms bins centered on these time points to reduce the noise in
+# the topographies:
 evoked.plot_topomap(times, ch_type='mag', average=0.05, time_unit='s')
 
-# plot gradiometer data (plots the RMS for each pair of gradiometers)
+###############################################################################
+# We can plot gradiometer data (plots the RMS for each pair of gradiometers)
 evoked.plot_topomap(times, ch_type='grad', time_unit='s')
 
-# plot magnetometer data as an animation
-evoked.animate_topomap(ch_type='mag', times=times, frame_rate=10,
-                       time_unit='s')
+###############################################################################
+# We can also use a range of various :func:`mne.viz.plot_topomap` arguments
+# that control how the topography is drawn. For example:
+# * ``cmap`` - to specify the color map
+# * ``res`` - to control the resolution of the topographies (lower resolution
+#   means faster plotting)
+# * ``outlines='skirt'`` to see the topography stretched beyond the head circle
+# * ``contours`` to define how many contour lines should be plotted
+evoked.plot_topomap(times, ch_type='mag', cmap='Spectral_r', res=32,
+                    outlines='skirt', contours=4, time_unit='s')
 
-# plot magnetometer data as topomap at 1 time point : 100 ms
-# and add channel labels and title
+###############################################################################
+# If you look at the edges of the head circle of a single topomap you'll see
+# the effect of extrapolation. By default ``extrapolate='box'`` is used which
+# extrapolates to large box stretching beyond the head circle:
+evoked.plot_topomap(0.1, ch_type='mag')
+
+###############################################################################
+# Compare the image above with the one below, where we use
+# ``extrapolate='head'`` so that extrapolation would go to 0 at the head
+# circle (another option is to use ``extrapolate='local'`` in which case the
+# extrapolation is performed only within some distance from channels):
+evoked.plot_topomap(0.1, ch_type='mag', extrapolate='head')
+
+###############################################################################
+# Now we plot magnetometer data as topomap at a single time point: 100 ms
+# post-stimulus and add channel labels and title
 evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
                     size=6, res=128, title='Auditory response',
                     time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
+
+###############################################################################
+# Instead of using a still image we can plot magnetometer data as an animation
+# (animates only in matplotlib interactive mode)
+evoked.animate_topomap(ch_type='mag', times=times, frame_rate=10,
+                       time_unit='s')

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -346,7 +346,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None):
+                     head_pos=None, axes=None, extrapolate='local'):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -356,7 +356,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             show_names=show_names, title=title, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, average=average, head_pos=head_pos,
-            axes=axes)
+            axes=axes, extrapolate=extrapolate)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -346,7 +346,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None, extrapolate='local'):
+                     head_pos=None, axes=None, extrapolate='box'):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -892,6 +892,24 @@ def einsum(*args, **kwargs):
     return np.einsum(*args, **kwargs)
 
 
+# NumPy unique has axis kwarg only since 1.13.0. This is used only once in
+# topomap interpolation code to remove duplicates from 2d array along axis 0
+# can be removed once we require NumPy 1.13.0
+
+_has_unique_axis = (LooseVersion(np.__version__) >= '1.13.0')
+
+
+def remove_duplicates(arr):
+    if _has_unique_axis:
+        return np.unique(arr, axis=0)
+    else:
+        remove = np.zeros(arr.shape[0], dtype='bool')
+        for idx in range(arr.shape[0] - 1):
+            remove[idx + 1:] = ((arr[idx + 1:, :] == arr[[idx], :]).all(axis=1)
+                                | remove[idx + 1:])
+        return arr[~remove, :]
+
+
 ###############################################################################
 # From nilearn
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -899,7 +899,7 @@ def einsum(*args, **kwargs):
 _has_unique_axis = (LooseVersion(np.__version__) >= '1.13.0')
 
 
-def remove_duplicates(arr):
+def _remove_duplicate_rows(arr):
     if _has_unique_axis:
         return np.unique(arr, axis=0)
     else:

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -892,7 +892,7 @@ def einsum(*args, **kwargs):
     return np.einsum(*args, **kwargs)
 
 
-# NumPy unique has axis kwarg only since 1.13.0. This is used only once in
+# np.unique has axis kwarg only since 1.13.0. This is used only once in
 # topomap interpolation code to remove duplicates from 2d array along axis 0
 # can be removed once we require NumPy 1.13.0
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -172,7 +172,8 @@ def _plot_legend(pos, colors, axis, bads, outlines, loc, size=30):
     ax = inset_axes(axis, width=str(size / ratio) + '%',
                     height=str(size) + '%', loc=loc)
     ax.set_adjustable("box")
-    pos_x, pos_y = _prepare_topomap(pos, ax, check_nonzero=False)
+    pos_x, pos_y = pos.T
+    _prepare_topomap(pos, ax, check_nonzero=False)
     ax.scatter(pos_x, pos_y, color=colors, s=size * .8, marker='.', zorder=1)
     if bads:
         bads = np.array(bads)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -172,8 +172,8 @@ def _plot_legend(pos, colors, axis, bads, outlines, loc, size=30):
     ax = inset_axes(axis, width=str(size / ratio) + '%',
                     height=str(size) + '%', loc=loc)
     ax.set_adjustable("box")
-    pos_x, pos_y = pos.T
     _prepare_topomap(pos, ax, check_nonzero=False)
+    pos_x, pos_y = pos.T
     ax.scatter(pos_x, pos_y, color=colors, s=size * .8, marker='.', zorder=1)
     if bads:
         bads = np.array(bads)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -171,7 +171,7 @@ def test_plot_topomap():
 
     # extrapolation options when < 4 channels:
     temp_data = np.random.random(3)
-    info_sel = mne.pick_info(evoked.info, [0, 5, 6])
+    info_sel = pick_info(evoked.info, [0, 5, 6])
     plot_topomap(temp_data, info_sel, extrapolate='local', res=res)
     plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -157,6 +157,11 @@ def test_plot_topomap():
 
     evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
                         contours=[-100, 0, 100], time_unit='ms')
+
+    # extrapolation to edges of the head circle
+    evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
+                        contours=[-100, 0, 100], time_unit='ms',
+                        extrapolate='head')
     plt_topomap = partial(evoked.plot_topomap, **fast_test)
     plt_topomap(0.1, layout=layout, scalings=dict(mag=0.1))
     plt.close('all')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -171,7 +171,8 @@ def test_plot_topomap():
 
     # extrapolation options when < 4 channels:
     temp_data = np.random.random(3)
-    info_sel = pick_info(evoked.info, [0, 5, 6])
+    picks = channel_indices_by_type(evoked.info)['mag'][:3]
+    info_sel = pick_info(evoked.info, picks)
     plot_topomap(temp_data, info_sel, extrapolate='local', res=res)
     plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -158,7 +158,10 @@ def test_plot_topomap():
     evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
                         contours=[-100, 0, 100], time_unit='ms')
 
-    # extrapolation to edges of the head circle
+    # extrapolation to the edges of the convex hull or the head circle
+    evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
+                        contours=[-100, 0, 100], time_unit='ms',
+                        extrapolate='local')
     evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
                         contours=[-100, 0, 100], time_unit='ms',
                         extrapolate='head')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -165,6 +165,16 @@ def test_plot_topomap():
     evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
                         contours=[-100, 0, 100], time_unit='ms',
                         extrapolate='head')
+    evoked.plot_topomap([0.1], ch_type='eeg', scalings=1, res=res,
+                        contours=[-100, 0, 100], time_unit='ms',
+                        extrapolate='head', outlines='skirt')
+
+    # extrapolation options when < 4 channels:
+    temp_data = np.random.random(3)
+    info_sel = mne.pick_info(evoked.info, [0, 5, 6])
+    plot_topomap(temp_data, info_sel, extrapolate='local', res=res)
+    plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
+
     plt_topomap = partial(evoked.plot_topomap, **fast_test)
     plt_topomap(0.1, layout=layout, scalings=dict(mag=0.1))
     plt.close('all')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2240,8 +2240,8 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_grads):
     for frame in params['frames']:
         params['Zis'].append(interp.set_values(data[:, frame])(Xi, Yi))
     Zi = params['Zis'][0]
-    zi_min = np.min(params['Zis'])
-    zi_max = np.max(params['Zis'])
+    zi_min = np.nanmin(params['Zis'])
+    zi_max = np.nanmax(params['Zis'])
     cont_lims = np.linspace(zi_min, zi_max, 7, endpoint=False)[1:]
     pos = _autoshrink(outlines, pos, res)
     params.update({'vmin': vmin, 'vmax': vmax, 'Xi': Xi, 'Yi': Yi, 'Zi': Zi,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 
 from ..baseline import rescale
-from ..fixes import remove_duplicates
+from ..fixes import _remove_duplicate_rows
 from ..io.pick import (pick_types, _picks_by_type, channel_type, pick_info,
                        _pick_data_channels, pick_channels)
 from ..utils import _clean_names, _time_mask, verbose, logger, warn
@@ -557,7 +557,7 @@ def _get_extra_points(pos, method, head_radius):
                                steps).reshape((-1, 2)))
 
         # remove duplicates from hull_extended
-        hull_extended = remove_duplicates(hull_extended.reshape((-1, 2)))
+        hull_extended = _remove_duplicate_rows(hull_extended.reshape((-1, 2)))
         new_pos = np.concatenate([hull_extended] + add_points)
     else:
         # return points on the head circle

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -472,8 +472,7 @@ def _draw_outlines(ax, outlines):
 
 
 def _get_extra_points(pos, method, head_radius):
-    """
-    Get coordinates of additinal interpolation points.
+    """Get coordinates of additinal interpolation points.
 
     If head_radius is None, returns coordinates of convex hull of channel
     positions, expanded by the median inter-channel distance.

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -483,11 +483,12 @@ def _get_extra_points(pos, head_radius):
     diffs = np.diff(pos, axis=0)
     with np.errstate(divide='ignore'):
         slopes = diffs[:, 1] / diffs[:, 0]
-    colinear = (slopes == slopes[0]).all() or np.isinf(slopes).all()
+    colinear = ((slopes == slopes[0]).all() or np.isinf(slopes).all()
+                or pos.shape[0] < 4)
 
     # compute median inter-electrode distance
     if colinear:
-        dim = 1 if (diffs[:, 0] == 0).all() else 0
+        dim = 1 if diffs[:, 1].sum() > diffs[:, 0].sum() else 0
         sorting = np.argsort(pos[:, dim])
         pos_sorted = pos[sorting, :]
         diffs = np.diff(pos_sorted, axis=0)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -703,6 +703,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         nearby points (approximately to points closer than median
         inter-electrode distance).
 
+        .. versionadded:: 0.18
+
     Returns
     -------
     im : matplotlib.image.AxesImage
@@ -1415,7 +1417,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
                         show=True, show_names=False, title=None, mask=None,
                         mask_params=None, outlines='head', contours=6,
                         image_interp='bilinear', average=None, head_pos=None,
-                        axes=None):
+                        axes=None, extrapolate='local'):
     """Plot topographic maps of specific time points of evoked data.
 
     Parameters
@@ -1553,6 +1555,13 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         same length as ``times`` (unless ``times`` is None). If instance of
         Axes, ``times`` must be a float or a list of one float.
         Defaults to None.
+    extrapolate : str
+        If 'head' extrapolate to the edges of the head circle (does not work
+        when `outlines='skirt'`. If 'local' (default) extrapolate only to
+        nearby points (approximately to points closer than median
+        inter-electrode distance).
+
+        .. versionadded:: 0.18
 
     Returns
     -------
@@ -1707,7 +1716,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     kwargs = dict(vmin=vmin, vmax=vmax, sensors=sensors, res=res, names=names,
                   show_names=show_names, cmap=cmap[0], mask_params=mask_params,
                   outlines=outlines, contours=contours,
-                  image_interp=image_interp, show=False)
+                  image_interp=image_interp, show=False,
+                  extrapolate=extrapolate)
     for idx, time in enumerate(times):
         tp, cn, interp = _plot_topomap(
             data[:, idx], pos, axes=axes[idx],
@@ -2634,6 +2644,8 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
         when `outlines='skirt'`. If 'local' (default) extrapolate only to
         nearby points (approximately to points closer than median
         inter-electrode distance).
+
+        .. versionadded:: 0.18
 
     Returns
     -------

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1787,7 +1787,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
             images=images, contours_=contours_, pos=pos, time_idx=time_idx,
             res=res, plot_update_proj_callback=_plot_update_evoked_topomap,
             merge_grads=merge_grads, scale=scaling, axes=axes,
-            contours=contours, interp=interp)
+            contours=contours, interp=interp, extrapolate=extrapolate)
         _draw_proj_checkbox(None, params)
 
     plt_show(show)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -472,12 +472,14 @@ def _draw_outlines(ax, outlines):
 
 
 def _get_extra_points(pos, head_radius):
-    '''
+    """
+    Get coordinates of additinal interpolation points.
+
     If head_radius is None, returns coordinates of convex hull of channel
     positions, expanded by the median inter-channel distance.
     Otherwise gives positions of points on the head circle placed with a step
     of median inter-channel distance.
-    '''
+    """
     from scipy.spatial.qhull import Delaunay
 
     # check if positions are colinear:
@@ -2180,8 +2182,9 @@ def _onselect(eclick, erelease, tfr, pos, ch_type, itmin, itmax, ifmin, ifmax,
 
 def _prepare_topomap(pos, ax, check_nonzero=True):
     """
-    Prepare the topomap: hide axis frame and check that position information is
-    present.
+    Prepare the topomap axis and check positions.
+
+    Hides axis frame and check that position information is present.
     """
     _hide_frame(ax)
     if check_nonzero and not pos.any():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -9,6 +9,7 @@
 
 import math
 import copy
+import itertools
 from functools import partial
 from numbers import Integral
 import warnings
@@ -2266,7 +2267,7 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_grads):
     Xi, Yi = np.meshgrid(xi, yi)
     params['Zis'] = list()
 
-    interp = _GridData(pos)
+    interp = _GridData(pos, params['extrapolate'], 0.53)
     for frame in params['frames']:
         params['Zis'].append(interp.set_values(data[:, frame])(Xi, Yi))
     Zi = params['Zis'][0]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -10,7 +10,6 @@
 import math
 import copy
 from functools import partial
-import itertools
 from numbers import Integral
 import warnings
 
@@ -486,8 +485,8 @@ def _get_extra_points(pos, head_radius):
     diffs = np.diff(pos, axis=0)
     with np.errstate(divide='ignore'):
         slopes = diffs[:, 1] / diffs[:, 0]
-    colinear = ((slopes == slopes[0]).all() or np.isinf(slopes).all()
-                or pos.shape[0] < 4)
+    colinear = ((slopes == slopes[0]).all() or np.isinf(slopes).all() or
+                pos.shape[0] < 4)
 
     # compute median inter-electrode distance
     if colinear:
@@ -539,10 +538,10 @@ def _get_extra_points(pos, head_radius):
         n_times_dist = np.round(hull_distances / distance).astype('int')
         for n in range(2, n_times_dist.max() + 1):
             mask = n_times_dist == n
-            mult = np.arange(1/n, 1 - eps, 1/n)[:, np.newaxis, np.newaxis]
+            mult = np.arange(1 / n, 1 - eps, 1 / n)[:, np.newaxis, np.newaxis]
             steps = hull_diff[mask][np.newaxis, ...] * mult
-            add_points.append((hull_extended[mask, 0][np.newaxis, ...]
-                               + steps).reshape((-1, 2)))
+            add_points.append((hull_extended[mask, 0][np.newaxis, ...] +
+                               steps).reshape((-1, 2)))
 
         # remove duplicates from hull_extended
         hull_extended = remove_duplicates(hull_extended.reshape((-1, 2)))

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -715,9 +715,10 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
         times the range of the data in respective dimension. If 'head'
-        extrapolate to the edges of the head circle (does not work when
-        `outlines='skirt'`). If 'local' extrapolate only to nearby points
-        (approximately to points closer than median inter-electrode distance).
+        extrapolate to the edges of the head circle (or to the edges of the
+        skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
+        points (approximately to points closer than median inter-electrode
+        distance).
 
         .. versionadded:: 0.18
 
@@ -829,7 +830,8 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                   np.max(np.r_[ylim[1], mask_[:, 1]]))
 
     # interpolate data
-    head_radius = None if extrapolate == 'local' else 0.53
+    head_radius = (None if extrapolate == 'local' else
+                   outlines['clip_radius'][0] * 1.06)
     xi = np.linspace(xmin, xmax, res)
     yi = np.linspace(ymin, ymax, res)
     Xi, Yi = np.meshgrid(xi, yi)
@@ -1575,9 +1577,10 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
         times the range of the data in respective dimension. If 'head'
-        extrapolate to the edges of the head circle (does not work when
-        `outlines='skirt'`). If 'local' extrapolate only to nearby points
-        (approximately to points closer than median inter-electrode distance).
+        extrapolate to the edges of the head circle (or to the edges of the
+        skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
+        points (approximately to points closer than median inter-electrode
+        distance).
 
         .. versionadded:: 0.18
 
@@ -2661,9 +2664,10 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
         times the range of the data in respective dimension. If 'head'
-        extrapolate to the edges of the head circle (does not work when
-        `outlines='skirt'`). If 'local' extrapolate only to nearby points
-        (approximately to points closer than median inter-electrode distance).
+        extrapolate to the edges of the head circle (or to the edges of the
+        skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
+        points (approximately to points closer than median inter-electrode
+        distance).
 
         .. versionadded:: 0.18
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -695,6 +695,11 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         Handle for a function that is called when the user selects a set of
         channels by rectangle selection (matplotlib ``RectangleSelector``). If
         None interactive selection is disabled. Defaults to None.
+    extrapolate : str
+        If 'head' extrapolate to the edges of the head circle (does not work
+        when `outlines='skirt'`. If 'local' (default) extrapolate only to
+        nearby points (approximately to points closer than median
+        inter-electrode distance).
 
     Returns
     -------
@@ -2527,7 +2532,8 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
                   vmax=None, cmap=None, sensors=True, res=64, axes=None,
                   names=None, show_names=False, mask=None, mask_params=None,
                   outlines='head', contours=6, image_interp='bilinear',
-                  show=True, head_pos=None, onselect=None):
+                  show=True, head_pos=None, onselect=None,
+                  extrapolate='local'):
     """Plot arrow map.
 
     Compute arrowmaps, based upon the Hosaka-Cohen transformation [1]_,
@@ -2620,6 +2626,11 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
         Handle for a function that is called when the user selects a set of
         channels by rectangle selection (matplotlib ``RectangleSelector``). If
         None interactive selection is disabled. Defaults to None.
+    extrapolate : str
+        If 'head' extrapolate to the edges of the head circle (does not work
+        when `outlines='skirt'`. If 'local' (default) extrapolate only to
+        nearby points (approximately to points closer than median
+        inter-electrode distance).
 
     Returns
     -------
@@ -2680,7 +2691,7 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
                  sensors=sensors, res=res, names=names, show_names=show_names,
                  mask=mask, mask_params=mask_params, outlines=outlines,
                  contours=contours, image_interp=image_interp, show=show,
-                 head_pos=head_pos, onselect=onselect)
+                 head_pos=head_pos, onselect=onselect, extrapolate=extrapolate)
     x, y = tuple(pos.T)
     dx, dy = _trigradient(x, y, data)
     dxx = dy.data

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2267,7 +2267,7 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_grads):
     Xi, Yi = np.meshgrid(xi, yi)
     params['Zis'] = list()
 
-    interp = _GridData(pos, params['extrapolate'], 0.53)
+    interp = _GridData(pos, 'box', None)
     for frame in params['frames']:
         params['Zis'].append(interp.set_values(data[:, frame])(Xi, Yi))
     Zi = params['Zis'][0]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -713,7 +713,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     extrapolate : str
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
-        times the range of the data in respective dimension. If 'head'
+        times the range of the data in the respective dimension. If 'head'
         extrapolate to the edges of the head circle (or to the edges of the
         skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
         points (approximately to points closer than median inter-electrode
@@ -828,7 +828,8 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     ymin, ymax = (np.min(np.r_[ylim[0], mask_[:, 1]]),
                   np.max(np.r_[ylim[1], mask_[:, 1]]))
 
-    # interpolate data
+    # interpolate the data, we multiply clip radius by 1.06 so that pixelated edges
+    # of the interpolated image would appear under the mask
     head_radius = (None if extrapolate == 'local' else
                    outlines['clip_radius'][0] * 1.06)
     xi = np.linspace(xmin, xmax, res)
@@ -1575,7 +1576,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     extrapolate : str
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
-        times the range of the data in respective dimension. If 'head'
+        times the range of the data in the respective dimension. If 'head'
         extrapolate to the edges of the head circle (or to the edges of the
         skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
         points (approximately to points closer than median inter-electrode
@@ -2210,8 +2211,7 @@ def _onselect(eclick, erelease, tfr, pos, ch_type, itmin, itmax, ifmin, ifmax,
 
 
 def _prepare_topomap(pos, ax, check_nonzero=True):
-    """
-    Prepare the topomap axis and check positions.
+    """Prepare the topomap axis and check positions.
 
     Hides axis frame and check that position information is present.
     """
@@ -2662,7 +2662,7 @@ def plot_arrowmap(data, info_from, info_to=None, scale=1e-10, vmin=None,
     extrapolate : str
         If 'box' (default) extrapolate to four points placed to form a square
         encompassing all data points, where each side of the square is three
-        times the range of the data in respective dimension. If 'head'
+        times the range of the data in the respective dimension. If 'head'
         extrapolate to the edges of the head circle (or to the edges of the
         skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
         points (approximately to points closer than median inter-electrode

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -17,6 +17,7 @@ import warnings
 import numpy as np
 
 from ..baseline import rescale
+from ..fixes import remove_duplicates
 from ..io.pick import (pick_types, _picks_by_type, channel_type, pick_info,
                        _pick_data_channels, pick_channels)
 from ..utils import _clean_names, _time_mask, verbose, logger, warn
@@ -542,7 +543,7 @@ def _get_extra_points(pos, head_radius):
                                + steps).reshape((-1, 2)))
 
         # remove duplicates from hull_extended
-        hull_extended = np.unique(hull_extended.reshape((-1, 2)), axis=0)
+        hull_extended = remove_duplicates(hull_extended.reshape((-1, 2)))
         new_pos = np.concatenate([hull_extended] + add_points)
     else:
         # return points on the head circle

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -899,7 +899,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
 
 def _autoshrink(outlines, pos, res):
-    """Make an image mask."""
+    """Shrink channel positions until all are within the mask contour."""
     if outlines.get('autoshrink', False):
         mask_ = np.c_[outlines['mask_pos']]
         inside = _inside_contour(pos, mask_)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -828,8 +828,8 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     ymin, ymax = (np.min(np.r_[ylim[0], mask_[:, 1]]),
                   np.max(np.r_[ylim[1], mask_[:, 1]]))
 
-    # interpolate the data, we multiply clip radius by 1.06 so that pixelated edges
-    # of the interpolated image would appear under the mask
+    # interpolate the data, we multiply clip radius by 1.06 so that pixelated
+    # edges of the interpolated image would appear under the mask
     head_radius = (None if extrapolate == 'local' else
                    outlines['clip_radius'][0] * 1.06)
     xi = np.linspace(xmin, xmax, res)

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -76,7 +76,7 @@ evoked_r_aud.plot_topomap(times=times, ch_type='mag', time_unit='s')
 evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 
 ###############################################################################
-# See :ref:`sphx_glr_auto_examples_visualization_plot_evoked_topomap.py.py` for
+# See :ref:`sphx_glr_auto_examples_visualization_plot_evoked_topomap.py` for
 # more advanced topomap plotting options. You can also take a look at the
 # documentation of :func:`mne.Evoked.plot_topomap` or simply write
 # ``evoked_r_aud.plot_topomap?`` in your python console to see the different

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -101,8 +101,8 @@ plt.show()
 # ``colorbar=False``. That's what the warnings are trying to tell you. Also, we
 # used ``show=False`` for the three first function calls. This prevents the
 # showing of the figure prematurely. The behavior depends on the mode you are
-# using for your Python session. See https://matplotlib.org/users/shell.html for
-# more information.
+# using for your Python session. See https://matplotlib.org/users/shell.html
+# for more information.
 #
 # We can combine the two kinds of plots in one figure using the
 # :func:`mne.Evoked.plot_joint` method of Evoked objects. Called as-is

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -76,10 +76,9 @@ evoked_r_aud.plot_topomap(times=times, ch_type='mag', time_unit='s')
 evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 
 ###############################################################################
-# See :ref:`sphx_glr_auto_example_plot_evoked_topomap.py` for more advanced
-# topomap plotting options.
-# You can also take a look at the documentation of
-# :func:`mne.Evoked.plot_topomap` or simply write
+# See :ref:`sphx_glr_auto_examples_visualization_plot_evoked_topomap.py.py` for
+# more advanced topomap plotting options. You can also take a look at the
+# documentation of :func:`mne.Evoked.plot_topomap` or simply write
 # ``evoked_r_aud.plot_topomap?`` in your python console to see the different
 # parameters you can pass to this function. Most of the plotting functions also
 # accept ``axes`` parameter. With that, you can customise your plots even

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -76,13 +76,15 @@ evoked_r_aud.plot_topomap(times=times, ch_type='mag', time_unit='s')
 evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 
 ###############################################################################
-# You can take a look at the documentation of :func:`mne.Evoked.plot_topomap`
-# or simply write ``evoked_r_aud.plot_topomap?`` in your python console to
-# see the different parameters you can pass to this function. Most of the
-# plotting functions also accept ``axes`` parameter. With that, you can
-# customise your plots even further. First we create a set of matplotlib
-# axes in a single figure and plot all of our evoked categories next to each
-# other.
+# See :ref:`sphx_glr_auto_example_plot_evoked_topomap.py` for more advanced
+# topomap plotting options.
+# You can also take a look at the documentation of
+# :func:`mne.Evoked.plot_topomap` or simply write
+# ``evoked_r_aud.plot_topomap?`` in your python console to see the different
+# parameters you can pass to this function. Most of the plotting functions also
+# accept ``axes`` parameter. With that, you can customise your plots even
+# further. First we create a set of matplotlib axes in a single figure and plot
+# all of our evoked categories next to each other.
 fig, ax = plt.subplots(1, 5, figsize=(8, 2))
 kwargs = dict(times=0.1, show=False, vmin=-300, vmax=300, time_unit='s')
 evoked_l_aud.plot_topomap(axes=ax[0], colorbar=True, **kwargs)

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -79,7 +79,7 @@ evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 # See :ref:`sphx_glr_auto_examples_visualization_plot_evoked_topomap.py` for
 # more advanced topomap plotting options. You can also take a look at the
 # documentation of :func:`mne.Evoked.plot_topomap` or simply write
-# ``evoked_r_aud.plot_topomap?`` in your python console to see the different
+# ``evoked_r_aud.plot_topomap?`` in your Python console to see the different
 # parameters you can pass to this function. Most of the plotting functions also
 # accept ``axes`` parameter. With that, you can customise your plots even
 # further. First we create a set of matplotlib axes in a single figure and plot
@@ -101,8 +101,8 @@ plt.show()
 # ``colorbar=False``. That's what the warnings are trying to tell you. Also, we
 # used ``show=False`` for the three first function calls. This prevents the
 # showing of the figure prematurely. The behavior depends on the mode you are
-# using for your python session. See https://matplotlib.org/users/shell.html
-# for more information.
+# using for your Python session. See https://matplotlib.org/users/shell.html for
+# more information.
 #
 # We can combine the two kinds of plots in one figure using the
 # :func:`mne.Evoked.plot_joint` method of Evoked objects. Called as-is
@@ -110,7 +110,7 @@ plt.show()
 # of spatio-temporal dynamics.
 # You can directly style the time series part and the topomap part of the plot
 # using the ``topomap_args`` and ``ts_args`` parameters. You can pass key-value
-# pairs as a python dictionary. These are then passed as parameters to the
+# pairs as a Python dictionary. These are then passed as parameters to the
 # topomaps (:func:`mne.Evoked.plot_topomap`) and time series
 # (:func:`mne.Evoked.plot`) of the joint plot.
 # For an example of specific styling using these ``topomap_args`` and


### PR DESCRIPTION
Implements the extra points layout for topo interpolation discussed in #5315 
It may eliminate the issues raised in #5315 but it might be suboptimal in some standard cases. For example this is a frontal theta topography before this PR:
<img src="https://user-images.githubusercontent.com/8452354/49180525-37e00c80-f355-11e8-9013-ee5da9f386ab.png" width="300px">
and this is after:
<img src="https://user-images.githubusercontent.com/8452354/49180535-3f9fb100-f355-11e8-9b53-8aaa26e24a0b.png" width="300px">

I must say I prefer the "before" topo in this case (the "after" looks like a laughing cyclops in a party hat). Probably the extra points are too close to channels. I'll check that later. Also - masking using convex hull (but slightly less extended than here) might make it better.

### TODO:
- [x] rebase and add tests
- [x] add whats new
- [x] link topomap example to evoked plotting tutorial
- [x] enhance example to show the new extrapolation option
- [x] add back the old behavior (let's call it `'box'` bacause the additional points were added on a rectangular box)
- [x] resolve what to do when `outlines='skirt'`
- [x] add tests
- [x] special case for colinear points when `extrapolate='local'`
- [x] test extra points on the head circle
- [x] use median inter-channel distance
- [x] take convex hull from triangulation to use Delaunay only once