### PR TITLE
MRG: Add timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
     - if [ -z "$CONDA_ENVIRONMENT" ] && [ -z "$CONDA_DEPENDENCIES" ]; then
         pip uninstall -y numpy;
         pip install numpy scipy vtk;
-        pip install -r requirements.txt;
+        pip install --upgrade -r requirements.txt;
       else
         git clone https://github.com/astropy/ci-helpers.git;
         source ci-helpers/travis/setup_conda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
     global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
-            PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar" OPTION=""
+            PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout" OPTION=""
             TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
@@ -19,7 +19,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx pytest pytest-cov"
-               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest"
+               PIP_DEPENDENCIES="flake8 numpydoc codespell git+git://github.com/PyCQA/pydocstyle.git codecov check-manifest pytest-faulthandler pytest-sugar pytest-timeout"
                OPTION="--doctest-ignore-import-errors"
 
         # Linux
@@ -44,7 +44,7 @@ matrix:
         # Minimal
         - os: linux
           env: DEPS=minimial
-               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest pytest-cov"
+               CONDA_DEPENDENCIES="numpy scipy matplotlib pytest pytest-cov pytest-faulthandler pytest-timeout"
 
 # Setup anaconda
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       CONDA_ENVIRONMENT: "environment.yml"
-      PIP_DEPENDENCIES: "codecov pytest-faulthandler"
+      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -34,7 +34,7 @@ command_rst = """
 .. _gen_%s:
 
 %s
-----------------------------------------------------------
+%s
 
 .. raw:: html
 
@@ -72,7 +72,9 @@ def generate_commands_rst(app):
             output, _ = run_subprocess([sys.executable, run_name, '--help'],
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE, verbose=False)
-            f.write(command_rst % (cmd_name, cmd_name.replace('mne_', 'mne '),
+            f.write(command_rst % (cmd_name,
+                                   cmd_name.replace('mne_', 'mne '),
+                                   '-' * len(cmd_name),
                                    output))
     print('[Done]')
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,8 @@ Bug
 
 - Fix CTF helmet plotting in :func:`mne.viz.plot_evoked_field` by `Eric Larson`_
 
+- Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -67,6 +67,11 @@ def run():
     parser.add_option("-v", "--view", dest="show", action="store_true",
                       help="Show BEM model in 3D for visual inspection",
                       default=False)
+    parser.add_option("-p", "--flash-path", dest="flash_path",
+                      default=None,
+                      help="The directory containing flash05.mgz and "
+                      "flash30.mgz files (defaults to "
+                      "$SUBJECTS_DIR/$SUBJECT/mri/flash/parameter_maps")
 
     options, args = parser.parse_args()
 
@@ -77,6 +82,7 @@ def run():
     unwarp = options.unwarp
     overwrite = options.overwrite
     show = options.show
+    flash_path = options.flash_path
 
     if options.subject is None:
         parser.print_help()
@@ -85,7 +91,7 @@ def run():
     convert_flash_mris(subject=subject, subjects_dir=subjects_dir,
                        flash30=flash30, convert=convert, unwarp=unwarp)
     make_flash_bem(subject=subject, subjects_dir=subjects_dir,
-                   overwrite=overwrite, show=show, flash_path='.')
+                   overwrite=overwrite, show=show, flash_path=flash_path)
 
 
 is_main = (__name__ == '__main__')

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -119,6 +119,7 @@ def test_kit2fiff():
     check_usage(mne_kit2fiff, force_help=True)
 
 
+@pytest.mark.timeout(60)  # can take > 60 sec on Travis OSX
 @requires_tvtk
 @testing.requires_testing_data
 def test_make_scalp_surfaces():

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.testing import assert_equal, assert_allclose
 import matplotlib
 
-from mne import concatenate_raws, read_bem_surfaces
+from mne import concatenate_raws, read_bem_surfaces, read_surface
 from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_compute_proj_ecg, mne_compute_proj_eog,
                           mne_coreg, mne_kit2fiff,
@@ -202,6 +202,7 @@ def test_surf2bem():
     check_usage(mne_surf2bem)
 
 
+@pytest.mark.timeout(600)  # took ~400 sec on a local test
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
 @requires_freesurfer
@@ -212,21 +213,29 @@ def test_watershed_bem():
     # Copy necessary files to tempdir
     tempdir = _TempDir()
     mridata_path = op.join(subjects_dir, 'sample', 'mri')
-    mridata_path_new = op.join(tempdir, 'sample', 'mri')
+    subject_path_new = op.join(tempdir, 'sample')
+    mridata_path_new = op.join(subject_path_new, 'mri')
     os.mkdir(op.join(tempdir, 'sample'))
     os.mkdir(mridata_path_new)
     if op.exists(op.join(mridata_path, 'T1')):
         shutil.copytree(op.join(mridata_path, 'T1'), op.join(mridata_path_new,
-                        'T1'))
+                                                             'T1'))
     if op.exists(op.join(mridata_path, 'T1.mgz')):
         shutil.copyfile(op.join(mridata_path, 'T1.mgz'),
                         op.join(mridata_path_new, 'T1.mgz'))
-
+    out_fnames = list()
+    for kind in ('outer_skin', 'outer_skull', 'inner_skull'):
+        out_fnames.append(op.join(subject_path_new, 'bem', 'inner_skull.surf'))
+    assert not any(op.isfile(out_fname) for out_fname in out_fnames)
     with ArgvSetter(('-d', tempdir, '-s', 'sample', '-o'),
                     disable_stdout=False, disable_stderr=False):
         mne_watershed_bem.run()
+    for out_fname in out_fnames:
+        _, tris = read_surface(out_fname)
+        assert len(tris) == 20480
 
 
+@pytest.mark.timeout(300)  # took 200 sec locally
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
 @requires_freesurfer
@@ -239,25 +248,32 @@ def test_flash_bem():
     # Copy necessary files to tempdir
     tempdir = _TempDir()
     mridata_path = op.join(subjects_dir, 'sample', 'mri')
-    mridata_path_new = op.join(tempdir, 'sample', 'mri')
+    subject_path_new = op.join(tempdir, 'sample')
+    mridata_path_new = op.join(subject_path_new, 'mri')
     os.makedirs(op.join(mridata_path_new, 'flash'))
-    os.makedirs(op.join(tempdir, 'sample', 'bem'))
+    os.makedirs(op.join(subject_path_new, 'bem'))
     shutil.copyfile(op.join(mridata_path, 'T1.mgz'),
                     op.join(mridata_path_new, 'T1.mgz'))
     shutil.copyfile(op.join(mridata_path, 'brain.mgz'),
                     op.join(mridata_path_new, 'brain.mgz'))
     # Copy the available mri/flash/mef*.mgz files from the dataset
-    files = glob.glob(op.join(mridata_path, 'flash', 'mef*.mgz'))
-    for infile in files:
-        shutil.copyfile(infile, op.join(mridata_path_new, 'flash',
-                                        op.basename(infile)))
+    flash_path = op.join(mridata_path_new, 'flash')
+    for kind in (5, 30):
+        in_fname = op.join(mridata_path, 'flash', 'mef%02d.mgz' % kind)
+        shutil.copyfile(in_fname, op.join(flash_path, op.basename(in_fname)))
     # Test mne flash_bem with --noconvert option
     # (since there are no DICOM Flash images in dataset)
-    currdir = os.getcwd()
+    out_fnames = list()
+    for kind in ('outer_skin', 'outer_skull', 'inner_skull'):
+        out_fnames.append(op.join(subject_path_new, 'bem', 'outer_skin.surf'))
+    assert not any(op.isfile(out_fname) for out_fname in out_fnames)
     with ArgvSetter(('-d', tempdir, '-s', 'sample', '-n'),
                     disable_stdout=False, disable_stderr=False):
         mne_flash_bem.run()
-    os.chdir(currdir)
+    # do they exist and are expected size
+    for out_fname in out_fnames:
+        _, tris = read_surface(out_fname)
+        assert len(tris) == 5120
 
 
 def test_show_info():

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -41,6 +41,7 @@ def _check_stcs(stc1, stc2):
     assert_allclose(stc1.tstep, stc2.tstep)
 
 
+@pytest.mark.timeout(60)  # ~30 sec on AppVeyor and Travis Linux
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_mxne_inverse():

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -155,6 +155,7 @@ def test_norm_epsilon():
                     stft_norm2(Y.reshape(-1, n_freqs[0], n_steps[0])))
 
 
+@pytest.mark.timeout(60)  # ~30 sec on Travis OSX and Linux OpenBLAS
 def test_dgapl21l1():
     """Test duality gap for L21 + L1 regularization."""
     n_orient = 2

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -42,6 +42,7 @@ def _assert_trans(actual, desired, dist_tol=0.003, angle_tol=5.):
     assert angle <= angle_tol, '%0.3f > %0.3f deg' % (angle, angle_tol)
 
 
+@pytest.mark.timeout(60)  # ~25 sec on Travis Linux OpenBLAS
 @testing.requires_testing_data
 def test_data():
     """Test reading raw Artemis123 files."""

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -198,6 +198,7 @@ def test_io_set_raw(fnames, tmpdir):
                            np.array([np.nan, np.nan, np.nan]))
 
 
+@pytest.mark.timeout(60)  # ~60 sec on Travis OSX
 @requires_h5py
 @testing.requires_testing_data
 @pytest.mark.parametrize('fnames', [epochs_mat_fnames, epochs_h5_fnames])

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -128,6 +128,7 @@ def test_scale_mri():
         assert ssrc[0]['dist'] is not None
 
 
+@pytest.mark.timeout(60)  # ~29 sec on OSX Travis
 @testing.requires_testing_data
 @requires_nibabel()
 def test_scale_mri_xfm():

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -46,6 +46,7 @@ def test_coregister_fiducials():
     assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
+@pytest.mark.timeout(60)  # can take longer than 30 sec on Travis
 @testing.requires_testing_data
 def test_scale_mri():
     """Test creating fsaverage and scaling it."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -667,6 +667,7 @@ def test_read_epochs_bad_events():
     assert evoked
 
 
+@pytest.mark.timeout(60)  # can take > 30 s on Travis
 @pytest.mark.slowtest
 def test_read_write_epochs(tmpdir):
     """Test epochs from raw files with IO as fif file."""

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -2,6 +2,8 @@ import os.path as op
 import sys
 from subprocess import Popen, PIPE
 
+import pytest
+
 from mne.utils import run_tests_if_main
 
 
@@ -77,6 +79,8 @@ for dirpath, _, filenames in os.walk('{0}'):
 """
 
 
+@pytest.mark.timeout(60)  # ~25 sec on AppVeyor
+@pytest.mark.slowtest
 def test_mpl_nesting():
     """Test that matplotlib imports are properly nested in tests."""
     mne_path = op.abspath(op.join(op.dirname(__file__), '..'))

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -531,6 +531,8 @@ def test_source_space_from_label():
     _compare_source_spaces(src, src_from_file, mode='approx')
 
 
+@pytest.mark.timeout(60)  # ~24 sec on Travis
+@pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_freesurfer
 @requires_nibabel()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ python-picard
 statsmodels
 pytest
 pytest-cov
+pytest-sugar
+pytest-timeout
 joblib
 psutil
 dipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,10 @@ release = egg_info -RDb ''
 doc-files = doc
 
 [tool:pytest]
-addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
+addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors --fulltrace
+# Set this pretty low to ensure we do not by default add really long tests,
+# or make changes that make things a lot slower
+timeout = 30
 # Once SciPy updates not to have non-integer and non-tuple errors (1.2.0) we
 # should remove them from here.
 # This list should also be considered alongside reset_warnings in doc/conf.py


### PR DESCRIPTION
Based on the suggestion of @massich I:

1. added `pytest-timeout`.
2. set the default a bit stringent to 30 to make sure we don't slow our test suite too much accidentally (new tests, bad changes). If it ends up giving too many false positives we can relax it later, but from what I've seen the CIs are pretty reliable in terms of timing.
3. added exceptions for tests that the Travis and Appveyor logs suggested needed them
4. split up the `interpolation` tests for MEG and EEG (nicer factorization, also less likely to time out)
5. ran the `ultraslowtest` tests locally, added reasonable timeout exceptions for them
6. fixed some bigs with `make_flash_bem`, and also converted them to using full paths instead of `os.chdir` and the like (which is less clean)

Small coverage hit likely due to changes to `make_*_bem` command tests. They pass locally but are not run on CIs.