### PR TITLE
ENH: Give EpochsTFR __getitem__ and __len__ functionality

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -48,7 +48,7 @@ from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
 from .utils import (check_fname, logger, verbose, _check_type_picks,
                     _time_mask, check_random_state, warn, _pl, _ensure_int,
                     sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc,
-                    _check_pandas_installed, _check_preload)
+                    _check_pandas_installed, _check_preload, _hid_match)
 
 
 def _save_split(epochs, fname, part_idx, n_parts, fmt):
@@ -1891,35 +1891,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         first = int(tshift * sfreq) + offset
         last = first + len(times) - 1
         self._set_times(np.arange(first, last + 1, dtype=np.float) / sfreq)
-
-
-def _hid_match(event_id, keys):
-    """Match event IDs using HID selection.
-
-    Parameters
-    ----------
-    event_id : dict
-        The event ID dictionary.
-    keys : list | str
-        The event ID or subset (for HID), or list of such items.
-
-    Returns
-    -------
-    use_keys : list
-        The full keys that fit the selection criteria.
-    """
-    # form the hierarchical event ID mapping
-    use_keys = []
-    for key in keys:
-        if not isinstance(key, str):
-            raise KeyError('keys must be strings, got %s (%s)'
-                           % (type(key), key))
-        use_keys.extend(k for k in event_id.keys()
-                        if set(key.split('/')).issubset(k.split('/')))
-    if len(use_keys) == 0:
-        raise KeyError('Event "%s" is not in Epochs.' % key)
-    use_keys = list(set(use_keys))  # deduplicate if necessary
-    return use_keys
 
 
 def _check_baseline(baseline, tmin, tmax, sfreq):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1952,6 +1952,11 @@ class EpochsTFR(_BaseTFR):
         The time values in seconds.
     freqs : ndarray, shape (n_freqs,)
         The frequencies in Hz.
+    events : ndarray, shape (n_events, 3)
+        The events as stored in the Epochs class
+    event_id : dict
+        Example: dict(auditory=1, visual=3). They keys can be used to access
+        associated events.
     comment : str | None, defaults to None
         Comment on the data, e.g., the experimental condition.
     method : str | None, defaults to None
@@ -1977,6 +1982,12 @@ class EpochsTFR(_BaseTFR):
     freqs : ndarray, shape (n_freqs,)
         The frequencies in Hz.
 
+    events : ndarray, shape (n_events, 3)
+        Array containing sample information as event_id
+
+    event_id : dict
+        Names of conditions correspond to event_ids
+        
     comment : string
         Comment on dataset. Can be the condition.
 
@@ -2045,14 +2056,46 @@ class EpochsTFR(_BaseTFR):
             raise KeyError(msg)
 
     def __getitem__(self, item):
-        """
-        Text for later
+        """Return an EpochsTFR object with a copied subset of epochs.
+
+        Parameters
+        ----------
+        item : slice, array-like, str, or list
+
+        Returns
+        -------
+        epochs : instance of Epochs
+
+        Notes
+        -----
+        See BaseEpochs.__getitem__ for use cases.
+        The use of metadata in EpochsTFR is not yet functional.
         """
         return self._getitem(item)
 
-    def _getitem(self, item, reason='IGNORED', copy=True, drop_event_id=True,
-                 select_data=True, return_indices=False):
+    def _getitem(self, item, copy=True, drop_event_id=True,
+                 return_indices=False):
+        """
+        Select epochs from current object.
 
+        Parameters
+        ----------
+        item: slice, array-like, str, or list
+            see `__getitem__` for details.
+        copy: bool
+            return a copy of the current object
+        drop_event_id: bool
+            remove non-existing event-ids after selection
+        return_indices: bool
+            return the indices of selected epochs from the original object)
+            in addition to the new `Epochs` objects
+        Returns
+        -------
+        `Epochs` or tuple(Epochs, np.ndarray) if `return_indices` is True
+
+        object with subset of epochs (and optionally array with kept
+        epoch indices)
+        """
         epochsTF = self.copy() if copy else self
 
         if isinstance(item, str):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2028,6 +2028,10 @@ class EpochsTFR(_BaseTFR):
                          events=self.events.copy(), event_id=self.event_id.copy(),
                          method=self.method, comment=self.comment)
 
+    def __len__(self):
+        """Get the number of epochs."""
+        return len(self.events)
+
     def _keys_to_idx(self, keys):
         """Find entries in event dict."""
         keys = [keys] if not isinstance(keys, (list, tuple)) else keys

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2026,6 +2026,38 @@ class EpochsTFR(_BaseTFR):
                          times=self.times.copy(), freqs=self.freqs.copy(),
                          method=self.method, comment=self.comment)
 
+    def __getitem__(self, item):
+        """
+        Text for later
+        """
+        return self._getitem(item)
+
+    def _getitem(self, item, reason='IGNORED', copy=True,
+                 select_data=True, return_indices=False):
+
+        epochsTF = self.copy() if copy else self
+
+        if isinstance(item, str):
+            item = [item]
+
+        # Start with slices. Get to string index later.
+        if isinstance(item, (list, tuple)) and len(item) > 0 and \
+                isinstance(item[0], str):
+            raise TypeError('String indexing not yet supported.')
+        elif isinstance(item, slice):
+            select = item
+        else:
+            select = np.atleast_1d(item)
+            if len(select) == 0:
+                select = np.array([], int)
+
+        epochsTF.data = np.require(epochsTF.data[select], requirements=['O'])
+
+        if return_indices:
+            return epochsTF, select
+        else:
+            return epochsTF
+
     def copy(self):
         """Give a copy of the EpochsTFR.
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -3172,3 +3172,32 @@ def _check_if_nan(data, msg=" to be plotted"):
     """Raise if any of the values are NaN."""
     if not np.isfinite(data).all():
         raise ValueError("Some of the values {} are NaN.".format(msg))
+
+
+def _hid_match(event_id, keys):
+    """Match event IDs using HID selection.
+
+    Parameters
+    ----------
+    event_id : dict
+        The event ID dictionary.
+    keys : list | str
+        The event ID or subset (for HID), or list of such items.
+
+    Returns
+    -------
+    use_keys : list
+        The full keys that fit the selection criteria.
+    """
+    # form the hierarchical event ID mapping
+    use_keys = []
+    for key in keys:
+        if not isinstance(key, str):
+            raise KeyError('keys must be strings, got %s (%s)'
+                           % (type(key), key))
+        use_keys.extend(k for k in event_id.keys()
+                        if set(key.split('/')).issubset(k.split('/')))
+    if len(use_keys) == 0:
+        raise KeyError('Event "%s" is not in Epochs.' % key)
+    use_keys = list(set(use_keys))  # deduplicate if necessary
+    return use_keys


### PR DESCRIPTION
#### Reference issue
Addresses some of the points brought up in #5711 


#### What does this implement/fix?
This allows for the selection of a subset of epochs either using slice, indexing or event_id. 


#### Additional information
I had to move `_hid_match` function, which helps with extracting epochs based on event_id, from epochs.py to utils.py in order to call it from tfr.py and avoid rewriting the function there. 

I didn't have time to implement metadata functionality for EpochsTFR. Perhaps I can get to that over the next week. Thought it would be good to start the pull request with this though. 