### PR TITLE
FIX: Issue #5764.

### DIFF
--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1514,7 +1514,7 @@ class AverageTFR(_BaseTFR):
             data = tfr.data
 			
             if layout is None:
-			    layout = find_layout(tfr.info)
+                layout = find_layout(tfr.info)
             
             # only use position information for channels from layout 
             # whose names appear as a substring in info['ch_names']

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1512,8 +1512,13 @@ class AverageTFR(_BaseTFR):
             fmax = freq + freq_half_range
 
             data = tfr.data
-
-            pos = find_layout(tfr.info).pos if layout is None else layout.pos
+			
+            if layout is None:
+			    layout = find_layout(tfr.info)
+            
+            # only use position information for channels from layout 
+            # whose names appear as a substring in info['ch_names']
+            pos = np.array([p for p,n in zip(layout.pos,layout.names) if np.any([n in ni for ni in tfr.info['ch_names']])])
 
             # merging grads here before rescaling makes ERDs visible
             if ch_type == 'grad':

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1518,7 +1518,8 @@ class AverageTFR(_BaseTFR):
             
             # only use position information for channels from layout 
             # whose names appear as a substring in info['ch_names']
-            pos = np.array([p for p,n in zip(layout.pos,layout.names) if np.any([n in ni for ni in tfr.info['ch_names']])])
+            idx = [ii for ii, ch_name in enumerate(layout.names) if any([ch_name in ch_name_tfr for ch_name_tfr in tfr.ch_names])]
+            pos = layout.pos[idx]
 
             # merging grads here before rescaling makes ERDs visible
             if ch_type == 'grad':

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1518,7 +1518,7 @@ class AverageTFR(_BaseTFR):
             
             # only use position information for channels from layout 
             # whose names appear as a substring in info['ch_names']
-            idx = [ii for ii, ch_name in enumerate(layout.names) if any([ch_name in ch_name_tfr for ch_name_tfr in tfr.ch_names])]
+            idx = [ix for ix, ch_name in enumerate(layout.names) if any([ch_name in ch_name_tfr for ch_name_tfr in tfr.ch_names])]
             pos = layout.pos[idx]
 
             # merging grads here before rescaling makes ERDs visible


### PR DESCRIPTION
#### Reference issue
Fixes #5764.


#### What does this implement/fix?
In AverageTFR.plot_joint(), the position information is loaded from a layout, where only those channels in info['bads'] are excluded. Usually, info['ch_names'] is only a subset of the remaining channels, however. The position information is therefore too long, resulting in a ValueError, "Data and pos need to be of same length...". This fix subselects position information for channels actually in info['ch_names'].

@jona-sassenhagen 
