### PR TITLE
MRG: added missing median keyword for method parameter in epochs average

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,8 @@ Changelog
 Bug
 ~~~
 
+- Fix missing code for computing the median when ``method='median'`` in :meth:`mne.Epochs.average` by `Cristóbal Moënne-Loccoz`_
+
 - Fix CTF helmet plotting in :func:`mne.viz.plot_evoked_field` by `Eric Larson`_
 
 - Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3100,3 +3100,5 @@ of commits):
 .. _jeythekey: https://github.com/jeythekey
 
 .. _Sara Sommariva: http://www.dima.unige.it/~sommariva/
+
+.. _Cristóbal Moënne-Loccoz: https://github.com/cmmoenne

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -912,6 +912,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             if mode == "mean":
                 def fun(data):
                     return np.mean(data, axis=0)
+            elif mode == "median":
+                def fun(data):
+                    return np.median(data, axis=0)
             elif mode == "std":
                 def fun(data):
                     return np.std(data, axis=0)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2487,6 +2487,26 @@ def test_readonly_times():
     with pytest.raises(ValueError, match='read-only'):
         epochs.times[:] = 0.
 
+def test_average_methods():
+    """Test average methods."""
+    n_epochs, n_channels, n_times = 5, 10, 20
+    sfreq = 1000.
+    data = rng.randn(n_epochs, n_channels, n_times)
+    events = np.array([np.arange(n_epochs), [0] * n_epochs, [1] * n_epochs]).T
+    info = create_info(n_channels, sfreq, 'eeg')
+    epochs = EpochsArray(data, info, events)
+
+    for method in ('mean', 'median'):
+        if method == "mean":
+            def fun(data):
+                return np.mean(data, axis=0)
+        elif method == "median":
+            def fun(data):
+                return np.median(data, axis=0)
+
+        evoked_data = epochs.copy().average(method=method).data
+        assert_array_equal(evoked_data, fun(data.copy()))
+
 
 @pytest.mark.parametrize('relative', (True, False))
 def test_shift_time(relative):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2487,6 +2487,7 @@ def test_readonly_times():
     with pytest.raises(ValueError, match='read-only'):
         epochs.times[:] = 0.
 
+
 def test_average_methods():
     """Test average methods."""
     n_epochs, n_channels, n_times = 5, 10, 20
@@ -2504,8 +2505,8 @@ def test_average_methods():
             def fun(data):
                 return np.median(data, axis=0)
 
-        evoked_data = epochs.copy().average(method=method).data
-        assert_array_equal(evoked_data, fun(data.copy()))
+        evoked_data = epochs.average(method=method).data
+        assert_array_equal(evoked_data, fun(data))
 
 
 @pytest.mark.parametrize('relative', (True, False))


### PR DESCRIPTION
It seems that something is missing. This is my guess to fix the following error:

```python
evoked = epochs.average(method='median')
  File "/home/cmmoenne/.local/share/virtualenvs/worksenv-d02f98b0/lib/python3.6/site-packages/mne/epochs.py", line 875, in average
    return self._compute_aggregate(picks=picks, mode=method)
  File "/home/cmmoenne/.local/share/virtualenvs/worksenv-d02f98b0/lib/python3.6/site-packages/mne/epochs.py", line 922, in _compute_aggregate
    ", got %s (type %s)." % (mode, type(mode)))
ValueError: mode must be mean, median, std, or callable, got median (type <class 'str'>).
```

...but, I do not know. Perhaps is something different.