### PR TITLE
MRG: fix for bipolar_reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,10 @@ Changelog
 Bug
 ~~~
 
+- Fix :func:`set_bipolar_reference` in the case of generating all bipolar combinations and also in the case of repeated channels in both lists (anode and cathode) by `Cristóbal Moënne-Loccoz`_
+
+- Fix missing code for computing the median when ``method='median'`` in :meth:`mne.Epochs.average` by `Cristóbal Moënne-Loccoz`_
+
 - Fix CTF helmet plotting in :func:`mne.viz.plot_evoked_field` by `Eric Larson`_
 
 - Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_
@@ -3098,3 +3102,5 @@ of commits):
 .. _jeythekey: https://github.com/jeythekey
 
 .. _Sara Sommariva: http://www.dima.unige.it/~sommariva/
+
+.. _Cristóbal Moënne-Loccoz: https://github.com/cmmoenne

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -942,8 +942,10 @@ def _eigvec_subspace(eig, eigvec, mask):
 def _scaled_array(data, picks_list, scalings):
     """Scale, use, unscale array."""
     _apply_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
-    yield
-    _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
+    try:
+        yield
+    finally:
+        _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
 
 
 def _compute_covariance_auto(data, method, info, method_params, cv,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -912,6 +912,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             if mode == "mean":
                 def fun(data):
                     return np.mean(data, axis=0)
+            elif mode == "median":
+                def fun(data):
+                    return np.median(data, axis=0)
             elif mode == "std":
                 def fun(data):
                     return np.std(data, axis=0)

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -800,5 +800,7 @@ def use_coil_def(fname):
     """
     global _extra_coil_def_fname
     _extra_coil_def_fname = fname
-    yield
-    _extra_coil_def_fname = None
+    try:
+        yield
+    finally:
+        _extra_coil_def_fname = None

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -508,11 +508,10 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     if copy:
         inst = inst.copy()
 
-    rem_ca = list(cathode)
     for i, (an, ca, name, chs) in enumerate(
             zip(anode, cathode, ch_name, new_chs)):
-        if an in anode[i + 1:]:
-            # Make a copy of anode if it's still needed later
+        if an in anode[i + 1:] or an in cathode[i + 1:]:
+            # Make a copy of the channel if it's still needed later
             # otherwise it's modified inplace
             _copy_channel(inst, an, 'TMP')
             an = 'TMP'
@@ -522,11 +521,11 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info['chs'][an_idx]['ch_name'] = name
         logger.info('Bipolar channel added as "%s".' % name)
         inst.info._update_redundant()
-        if an in rem_ca:
-            idx = rem_ca.index(an)
-            del rem_ca[idx]
 
-    # Drop remaining cathode channels
-    inst.drop_channels(rem_ca)
+    # Drop remaining channels.
+    inst.drop_channels([
+        ch_name for ch_name in set(list(anode) + list(cathode))
+        if ch_name in inst.ch_names
+    ])
 
     return inst

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2488,6 +2488,27 @@ def test_readonly_times():
         epochs.times[:] = 0.
 
 
+def test_average_methods():
+    """Test average methods."""
+    n_epochs, n_channels, n_times = 5, 10, 20
+    sfreq = 1000.
+    data = rng.randn(n_epochs, n_channels, n_times)
+    events = np.array([np.arange(n_epochs), [0] * n_epochs, [1] * n_epochs]).T
+    info = create_info(n_channels, sfreq, 'eeg')
+    epochs = EpochsArray(data, info, events)
+
+    for method in ('mean', 'median'):
+        if method == "mean":
+            def fun(data):
+                return np.mean(data, axis=0)
+        elif method == "median":
+            def fun(data):
+                return np.median(data, axis=0)
+
+        evoked_data = epochs.average(method=method).data
+        assert_array_equal(evoked_data, fun(data))
+
+
 @pytest.mark.parametrize('relative', (True, False))
 def test_shift_time(relative):
     """Test the timeshift method."""

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1389,8 +1389,10 @@ def traits_test_context():
     from traits.api import push_exception_handler
 
     push_exception_handler(reraise_exceptions=True)
-    yield
-    push_exception_handler(reraise_exceptions=False)
+    try:
+        yield
+    finally:
+        push_exception_handler(reraise_exceptions=False)
 
 
 def traits_test(test_func):


### PR DESCRIPTION
If I want to make all bipolar references from a dataset I get a ValueError (for example):
```
Bipolar channel added as "CH17-CH18".
Bipolar channel added as "CH17-CH19".
Bipolar channel added as "CH17-CH20".
Bipolar channel added as "CH17-CH28".
Bipolar channel added as "CH17-CH29".
Bipolar channel added as "CH17-CH30".
Bipolar channel added as "CH17-CH31".
Bipolar channel added as "CH17-CH32".
Bipolar channel added as "CH18-CH19".
Bipolar channel added as "CH18-CH20".
Bipolar channel added as "CH18-CH28".
Bipolar channel added as "CH18-CH29".
Bipolar channel added as "CH18-CH30".
Bipolar channel added as "CH18-CH31".
Bipolar channel added as "CH18-CH32".
Bipolar channel added as "CH19-CH20".
Bipolar channel added as "CH19-CH28".
Bipolar channel added as "CH19-CH29".
Bipolar channel added as "CH19-CH30".
Bipolar channel added as "CH19-CH31".
Bipolar channel added as "CH19-CH32".
Bipolar channel added as "CH20-CH28".
Bipolar channel added as "CH20-CH29".
Bipolar channel added as "CH20-CH30".
Bipolar channel added as "CH20-CH31".
Bipolar channel added as "CH20-CH32".
Bipolar channel added as "CH28-CH29".
Bipolar channel added as "CH28-CH30".
Bipolar channel added as "CH28-CH31".
Bipolar channel added as "CH28-CH32".
Bipolar channel added as "CH29-CH30".
Bipolar channel added as "CH29-CH31".
Bipolar channel added as "CH29-CH32".
Bipolar channel added as "CH30-CH31".
Bipolar channel added as "CH30-CH32".
Bipolar channel added as "CH31-CH32".
Traceback (most recent call last):
  File "/home/cmmoenne/.local/share/virtualenvs/worksenv-d02f98b0/lib/python3.6/site-packages/mne/io/reference.py", line 530, in set_bipolar_reference
    inst.drop_channels(rem_ca)
  File "/home/cmmoenne/.local/share/virtualenvs/worksenv-d02f98b0/lib/python3.6/site-packages/mne/channels/channels.py", line 792, in drop_channels
    raise ValueError(msg.format(", ".join(missing)))
ValueError: Channel(s) CH19, CH20, CH28, CH29, CH30, CH31, CH20, CH28, CH29, CH30, CH31, CH28, CH29, CH30, CH31, CH29, CH30, CH31, CH30, CH31, CH31 not found, nothing dropped.
```
While checking the code of `set_bipolar_reference` I found some cases that are not considered:
- if `an` is in the cathode list when `an in anode[i + 1:]` is false, the operation is in-place and the cathode channel is lost.
- in the case of making all bipolar pairs, `drop_channels` fails by duplicates that remain in the `rem_ca` list.

So, instead of keep a list to track the channels to drop, now we drop anything that remains from the anode and cathode lists at the end of the function.