### PR TITLE
MRG: Fix coreg rendering bugs on modern graphics cards

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,8 @@ Changelog
 
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
+- Add option to improve rendering in :ref:`gen_mne_coreg` for modern graphics cards by `Eric Larson`_
+
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
 - Add Epoch selection and metadata functionality to :class:`mne.time_frequency.EpochsTFR` using new mixin class by `Keith Doelling`_

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -72,6 +72,9 @@ def run():
                       help='Scale factor for the scene.')
     parser.add_option('--verbose', action='store_true', dest='verbose',
                       help='Turn on verbose mode.')
+    parser.add_option('--simple-rendering', action='store_false',
+                      dest='advanced_rendering',
+                      help='Use simplified OpenGL rendering')
 
     options, args = parser.parse_args()
 
@@ -107,7 +110,9 @@ def run():
             orient_to_surface=options.orient_to_surface,
             scale_by_distance=options.scale_by_distance,
             mark_inside=options.mark_inside, interaction=options.interaction,
-            scale=options.scale, verbose=options.verbose)
+            scale=options.scale,
+            advanced_rendering=options.advanced_rendering,
+            verbose=options.verbose)
     if is_main:
         sys.exit(0)
 

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -26,7 +26,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
                    trans=None, scrollable=True, project_eeg=None,
                    orient_to_surface=None, scale_by_distance=None,
                    mark_inside=None, interaction=None, scale=None,
-                   verbose=None):
+                   advanced_rendering=None, verbose=None):
     """Coregister an MRI with a subject's head shape.
 
     The recommended way to use the GUI is through bash with:
@@ -104,7 +104,13 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
     scale : float | None
         The scaling for the scene.
 
-        ..versionadded:: 0.16
+        .. versionadded:: 0.16
+    advanced_rendering : bool
+        Use advanced OpenGL rendering techniques (default True).
+        For some renderers (such as MESA software) this can cause rendering
+        bugs.
+
+        .. versionadded:: 0.18
     verbose : bool, str, int, or None
         If not None, override default verbose level (see :func:`mne.verbose`
         and :ref:`Logging documentation <tut_logging>` for more).
@@ -127,6 +133,9 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
             'MNE_COREG_GUESS_MRI_SUBJECT', 'true') == 'true'
     if head_high_res is None:
         head_high_res = config.get('MNE_COREG_HEAD_HIGH_RES', 'true') == 'true'
+    if advanced_rendering is None:
+        advanced_rendering = \
+            config.get('MNE_COREG_ADVANCED_RENDERING', 'true') == 'true'
     if head_opacity is None:
         head_opacity = config.get('MNE_COREG_HEAD_OPACITY', 1.)
     if width is None:
@@ -167,7 +176,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
                        orient_to_surface=orient_to_surface,
                        scale_by_distance=scale_by_distance,
                        mark_inside=mark_inside, interaction=interaction,
-                       scale=scale)
+                       scale=scale, advanced_rendering=advanced_rendering)
     return _initialize_gui(frame, view)
 
 

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -1632,6 +1632,10 @@ class ViewOptionsPanel(HasTraits):
     bgcolor = RGBColor()
     coord_frame = Enum('mri', 'head', label='Display coordinate frame')
     head_high_res = Bool(True, label='Show high-resolution head')
+    advanced_rendering = Bool(True, label='Use advanced OpenGL',
+                              desc='Enable advanced OpenGL methods that do '
+                              'not work with all renderers (e.g., depth '
+                              'peeling)')
 
     view = View(
         VGroup(
@@ -1643,9 +1647,9 @@ class ViewOptionsPanel(HasTraits):
                        editor=EnumEditor(values={'mri': '1:MRI',
                                                  'head': '2:Head'}, cols=2,
                                          format_func=_pass)),
-                  Spring(),
-                  Item('head_high_res'),
-                  Spring(), columns=2, show_labels=True),
+                  Item('head_high_res'), Spring(),
+                  Item('advanced_rendering'),
+                  Spring(), Spring(), columns=3, show_labels=True),
             Item('hsp_cf_obj', style='custom', label='Head axes'),
             Item('mri_cf_obj', style='custom', label='MRI axes'),
             HGroup(Item('bgcolor', label='Background'), Spring()),
@@ -1727,6 +1731,7 @@ class CoregFrame(HasTraits):
 
     scene = Instance(MlabSceneModel, ())
     head_high_res = Bool(True)
+    advanced_rendering = Bool(True)
 
     data_panel = Instance(DataPanel)
     coreg_panel = Instance(CoregPanel)  # right panel
@@ -1788,10 +1793,12 @@ class CoregFrame(HasTraits):
                  head_high_res=True, trans=None, config=None,
                  project_eeg=False, orient_to_surface=False,
                  scale_by_distance=False, mark_inside=False,
-                 interaction='trackball', scale=0.16):  # noqa: D102
+                 interaction='trackball', scale=0.16,
+                 advanced_rendering=True):  # noqa: D102
         self._config = config or {}
         super(CoregFrame, self).__init__(guess_mri_subject=guess_mri_subject,
-                                         head_high_res=head_high_res)
+                                         head_high_res=head_high_res,
+                                         advanced_rendering=advanced_rendering)
         self._initial_kwargs = dict(project_eeg=project_eeg,
                                     orient_to_surface=orient_to_surface,
                                     scale_by_distance=scale_by_distance,
@@ -1841,8 +1848,7 @@ class CoregFrame(HasTraits):
     @on_trait_change('scene:activated')
     def _init_plot(self):
         _toggle_mlab_render(self, False)
-        if hasattr(getattr(self.scene, 'renderer', None), 'use_fxaa'):
-            self.scene.renderer.use_fxaa = True
+        self._on_advanced_rendering_change()
 
         lpa_color = defaults['lpa_color']
         nasion_color = defaults['nasion_color']
@@ -1969,7 +1975,7 @@ class CoregFrame(HasTraits):
             eeg_obj=self.eeg_obj, hpi_obj=self.hpi_obj,
             hsp_cf_obj=self.hsp_cf_obj, mri_cf_obj=self.mri_cf_obj,
             head_high_res=self.head_high_res,
-            bgcolor=self.bgcolor)
+            bgcolor=self.bgcolor, advanced_rendering=self.advanced_rendering)
         self.data_panel.headview.scale = self._initial_kwargs['scale']
         self.data_panel.headview.interaction = \
             self._initial_kwargs['interaction']
@@ -1977,7 +1983,28 @@ class CoregFrame(HasTraits):
         self.data_panel.view_options_panel.sync_trait(
             'coord_frame', self.model)
         self.data_panel.view_options_panel.sync_trait('head_high_res', self)
+        self.data_panel.view_options_panel.sync_trait('advanced_rendering',
+                                                      self)
         self.data_panel.view_options_panel.sync_trait('bgcolor', self)
+
+    @on_trait_change('advanced_rendering')
+    def _on_advanced_rendering_change(self):
+        renderer = getattr(self.scene, 'renderer', None)
+        if renderer is None:
+            return
+        if self.advanced_rendering:
+            renderer.use_depth_peeling = 1
+            renderer.occlusion_ratio = 0.1
+            renderer.maximum_number_of_peels = 100
+            renderer.vtk_window.multi_samples = 0
+            renderer.vtk_window.alpha_bit_planes = 1
+        else:
+            renderer.use_depth_peeling = 0
+            renderer.vtk_window.multi_samples = 8
+            renderer.vtk_window.alpha_bit_planes = 0
+            if hasattr(renderer, 'use_fxaa'):
+                self.scene.renderer.use_fxaa = True
+        self.scene.render()
 
     @on_trait_change('lock_fiducials')
     def _on_lock_change(self):
@@ -2049,6 +2076,7 @@ class CoregFrame(HasTraits):
 
         s_c('MNE_COREG_GUESS_MRI_SUBJECT', self.model.guess_mri_subject)
         s_c('MNE_COREG_HEAD_HIGH_RES', self.head_high_res)
+        s_c('MNE_COREG_ADVANCED_RENDERING', self.advanced_rendering)
         if self.lock_fiducials:
             opacity = self.mri_obj.opacity
         else:

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1721,6 +1721,7 @@ def set_memmap_min_size(memmap_min_size):
 known_config_types = (
     'MNE_BROWSE_RAW_SIZE',
     'MNE_CACHE_DIR',
+    'MNE_COREG_ADVANCED_RENDERING',
     'MNE_COREG_COPY_ANNOT',
     'MNE_COREG_GUESS_MRI_SUBJECT',
     'MNE_COREG_HEAD_HIGH_RES',


### PR DESCRIPTION
#5666 was a step forward for people with bad graphics cards but a step back for ones with good graphics cards. This adds an option to properly render points for people whose OpenGL support is good enough (i.e., not using software rendering). On `master` you see points in the back can appear at the front:

![screenshot from 2018-12-05 12-06-28](https://user-images.githubusercontent.com/2365790/49530805-f7b5e800-f886-11e8-89b7-261f6171f397.png)

On this PR, depth peeling fixes it:

![screenshot from 2018-12-05 12-06-34](https://user-images.githubusercontent.com/2365790/49530812-fdabc900-f886-11e8-9578-a86f9cba8c1d.png)
