### PR TITLE
MRG: Fix contextmanager use

### DIFF
--- a/mne/cov.py
+++ b/mne/cov.py
@@ -942,8 +942,10 @@ def _eigvec_subspace(eig, eigvec, mask):
 def _scaled_array(data, picks_list, scalings):
     """Scale, use, unscale array."""
     _apply_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
-    yield
-    _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
+    try:
+        yield
+    finally:
+        _undo_scaling_array(data.T, picks_list=picks_list, scalings=scalings)
 
 
 def _compute_covariance_auto(data, method, info, method_params, cv,

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -800,5 +800,7 @@ def use_coil_def(fname):
     """
     global _extra_coil_def_fname
     _extra_coil_def_fname = fname
-    yield
-    _extra_coil_def_fname = None
+    try:
+        yield
+    finally:
+        _extra_coil_def_fname = None

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -1389,8 +1389,10 @@ def traits_test_context():
     from traits.api import push_exception_handler
 
     push_exception_handler(reraise_exceptions=True)
-    yield
-    push_exception_handler(reraise_exceptions=False)
+    try:
+        yield
+    finally:
+        push_exception_handler(reraise_exceptions=False)
 
 
 def traits_test(test_func):


### PR DESCRIPTION
Turns out that `contextlib.contextmanager` will raise any errors at the `yield` point, so things need to be wrapped in a `try/finally` if they are always supposed to be executed.