### PR TITLE
Added link to gist to save/export EDF files

### DIFF
--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -339,6 +339,9 @@ annotation  data can be converted to a trigger channel (STI 014) using an
 annotation map file which associates an annotation label with a number on
 the trigger channel.
 
+Saving EDF files is not supported natively (mne 0.18) yet. 
+This (gist)[https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be] can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
+
 Biosemi data format (.bdf)
 ==========================
 

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -340,7 +340,7 @@ annotation map file which associates an annotation label with a number on
 the trigger channel.
 
 Saving EDF files is not supported natively (mne 0.18) yet. 
-This (gist)[https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be] can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
+This `gist <[https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be>`_ can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
 
 Biosemi data format (.bdf)
 ==========================

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -340,7 +340,8 @@ annotation map file which associates an annotation label with a number on
 the trigger channel.
 
 Saving EDF files is not supported natively (mne 0.18) yet. 
-This `gist <[https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be>`_ can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
+This `gist <https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be>`__
+can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
 
 Biosemi data format (.bdf)
 ==========================


### PR DESCRIPTION
I created a small (gist)[https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be] for exporting EDF or BDF files as suggested in #5755 and integrated it into the IO documentation. 