### PR TITLE
MRG+1: fix for set_bipolar_reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_. 
+
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,10 @@ Changelog
 Bug
 ~~~
 
+- Fix :func:`set_bipolar_reference` in the case of generating all bipolar combinations and also in the case of repeated channels in both lists (anode and cathode) by `Cristóbal Moënne-Loccoz`_
+
+- Fix missing code for computing the median when ``method='median'`` in :meth:`mne.Epochs.average` by `Cristóbal Moënne-Loccoz`_
+
 - Fix CTF helmet plotting in :func:`mne.viz.plot_evoked_field` by `Eric Larson`_
 
 - Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_
@@ -3098,3 +3102,5 @@ of commits):
 .. _jeythekey: https://github.com/jeythekey
 
 .. _Sara Sommariva: http://www.dima.unige.it/~sommariva/
+
+.. _Cristóbal Moënne-Loccoz: https://github.com/cmmoenne

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -431,7 +431,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         each bipolar channel) containing channel information to merge in,
         overwriting the default values. Defaults to None.
     drop_refs : bool
-        Whether to drop or not the anode/cathode channels from the instance.
+        Whether to drop the anode/cathode channels from the instance.
     copy : bool
         Whether to operate on a copy of the data (True) or modify it in-place
         (False). Defaults to True.

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -398,7 +398,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
 
 @verbose
 def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
-                          copy=True, verbose=None):
+                          drop_refs=True, copy=True, verbose=None):
     """Re-reference selected channels using a bipolar referencing scheme.
 
     A bipolar reference takes the difference between two channels (the anode
@@ -430,6 +430,8 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         This parameter can be used to supply a dictionary (or a dictionary for
         each bipolar channel) containing channel information to merge in,
         overwriting the default values. Defaults to None.
+    drop_refs : bool
+        Whether to drop or not the anode/cathode channels from the instance.
     copy : bool
         Whether to operate on a copy of the data (True) or modify it in-place
         (False). Defaults to True.
@@ -510,7 +512,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     for i, (an, ca, name, chs) in enumerate(
             zip(anode, cathode, ch_name, new_chs)):
-        if an in anode[i + 1:] or an in cathode[i + 1:]:
+        if an in anode[i + 1:] or an in cathode[i + 1:] or not drop_refs:
             # Make a copy of the channel if it's still needed later
             # otherwise it's modified inplace
             _copy_channel(inst, an, 'TMP')
@@ -523,7 +525,8 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info._update_redundant()
 
     # Drop remaining channels.
-    drop_channels = (set(anode) | set(cathode)) & set(inst.ch_names)
-    inst.drop_channels(drop_channels)
+    if drop_refs:
+        drop_channels = (set(anode) | set(cathode)) & set(inst.ch_names)
+        inst.drop_channels(drop_channels)
 
     return inst

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -508,11 +508,10 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     if copy:
         inst = inst.copy()
 
-    rem_ca = list(cathode)
     for i, (an, ca, name, chs) in enumerate(
             zip(anode, cathode, ch_name, new_chs)):
-        if an in anode[i + 1:]:
-            # Make a copy of anode if it's still needed later
+        if an in anode[i + 1:] or an in cathode[i + 1:]:
+            # Make a copy of the channel if it's still needed later
             # otherwise it's modified inplace
             _copy_channel(inst, an, 'TMP')
             an = 'TMP'
@@ -522,11 +521,11 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info['chs'][an_idx]['ch_name'] = name
         logger.info('Bipolar channel added as "%s".' % name)
         inst.info._update_redundant()
-        if an in rem_ca:
-            idx = rem_ca.index(an)
-            del rem_ca[idx]
 
-    # Drop remaining cathode channels
-    inst.drop_channels(rem_ca)
+    # Drop remaining channels.
+    inst.drop_channels([
+        ch_name for ch_name in set(list(anode) + list(cathode))
+        if ch_name in inst.ch_names
+    ])
 
     return inst

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -523,9 +523,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         inst.info._update_redundant()
 
     # Drop remaining channels.
-    inst.drop_channels([
-        ch_name for ch_name in set(list(anode) + list(cathode))
-        if ch_name in inst.ch_names
-    ])
+    drop_channels = (set(anode) | set(cathode)) & set(inst.ch_names)
+    inst.drop_channels(drop_channels)
 
     return inst

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -495,10 +495,8 @@ def test_bipolar_combinations():
 
     # test all combinations.
     a_channels, b_channels = zip(*itertools.combinations(channels, 2))
-    a_channels = list(a_channels)
-    b_channels = list(b_channels)
-    raw_test = mne.io.set_bipolar_reference(
-        raw, a_channels, b_channels, copy=True)
+    a_channels, b_channels = list(a_channels), list(b_channels)
+    raw_test = set_bipolar_reference(raw, a_channels, b_channels, copy=True)
     for ch_a, ch_b in zip(a_channels, b_channels):
         _check_bipolar(raw_test, ch_a, ch_b)
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -483,25 +483,23 @@ def test_bipolar_combinations():
     raw = RawArray(raw_data, info)
 
     def _check_bipolar(raw_test, ch_a, ch_b):
-        assert_array_equal(
-            raw_test.get_data(
-                picks=[raw_test.ch_names.index(ch_a + '-' + ch_b)])[0, :],
-            raw_data[channels.index(ch_a), :] -
-            raw_data[channels.index(ch_b), :])
+        picks = [raw_test.ch_names.index(ch_a + '-' + ch_b)]
+        get_data_res = raw_test.get_data(picks=picks)[0, :]
+        manual_a = raw_data[channels.index(ch_a), :]
+        manual_b = raw_data[channels.index(ch_b), :]
+        assert_array_equal(get_data_res, manual_a - manual_b)
 
     # test classic EOG/ECG bipolar reference (only two channels per pair).
     raw_test = set_bipolar_reference(raw, ['CH2'], ['CH1'], copy=True)
     _check_bipolar(raw_test, 'CH2', 'CH1')
 
     # test all combinations.
-    bipolars = list(itertools.combinations(channels, 2))
-    a_channels, b_channels = [], []
-    for ch_a, ch_b in bipolars:
-        a_channels.append(ch_a)
-        b_channels.append(ch_b)
-    raw_test = set_bipolar_reference(
+    a_channels, b_channels = zip(*itertools.combinations(channels, 2))
+    a_channels = list(a_channels)
+    b_channels = list(b_channels)
+    raw_test = mne.io.set_bipolar_reference(
         raw, a_channels, b_channels, copy=True)
-    for ch_a, ch_b in bipolars:
+    for ch_a, ch_b in zip(a_channels, b_channels):
         _check_bipolar(raw_test, ch_a, ch_b)
 
     # test bipolars with a channel in both list (anode & cathode).

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -499,6 +499,17 @@ def test_bipolar_combinations():
     raw_test = set_bipolar_reference(raw, a_channels, b_channels, copy=True)
     for ch_a, ch_b in zip(a_channels, b_channels):
         _check_bipolar(raw_test, ch_a, ch_b)
+    # check if reference channels have been dropped.
+    assert (len(raw_test.ch_names) == len(a_channels))
+
+    raw_test = set_bipolar_reference(
+        raw, a_channels, b_channels, drop_refs=False, copy=True)
+    # check if reference channels have been kept correctly.
+    assert (len(raw_test.ch_names) == len(a_channels) + len(channels))
+    for ch_label in channels:
+        picks = [raw_test.ch_names.index(ch_label)]
+        manual_ch = raw_data[channels.index(ch_label), :]
+        assert_array_equal(raw_test.get_data(picks=picks)[0, :], manual_ch)
 
     # test bipolars with a channel in both list (anode & cathode).
     raw_test = set_bipolar_reference(

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -476,17 +476,17 @@ def test_add_reference():
 
 def test_bipolar_combinations():
     """Test bipolar channel generation."""
-    channels = ['CH' + str(ni + 1) for ni in range(10)]
+    ch_names = ['CH' + str(ni + 1) for ni in range(10)]
     info = create_info(
-        ch_names=channels, sfreq=1000., ch_types=['eeg'] * len(channels))
-    raw_data = np.random.randn(len(channels), 1000)
+        ch_names=ch_names, sfreq=1000., ch_types=['eeg'] * len(ch_names))
+    raw_data = np.random.randn(len(ch_names), 1000)
     raw = RawArray(raw_data, info)
 
     def _check_bipolar(raw_test, ch_a, ch_b):
         picks = [raw_test.ch_names.index(ch_a + '-' + ch_b)]
         get_data_res = raw_test.get_data(picks=picks)[0, :]
-        manual_a = raw_data[channels.index(ch_a), :]
-        manual_b = raw_data[channels.index(ch_b), :]
+        manual_a = raw_data[ch_names.index(ch_a), :]
+        manual_b = raw_data[ch_names.index(ch_b), :]
         assert_array_equal(get_data_res, manual_a - manual_b)
 
     # test classic EOG/ECG bipolar reference (only two channels per pair).
@@ -494,7 +494,7 @@ def test_bipolar_combinations():
     _check_bipolar(raw_test, 'CH2', 'CH1')
 
     # test all combinations.
-    a_channels, b_channels = zip(*itertools.combinations(channels, 2))
+    a_channels, b_channels = zip(*itertools.combinations(ch_names, 2))
     a_channels, b_channels = list(a_channels), list(b_channels)
     raw_test = set_bipolar_reference(raw, a_channels, b_channels, copy=True)
     for ch_a, ch_b in zip(a_channels, b_channels):
@@ -505,11 +505,11 @@ def test_bipolar_combinations():
     raw_test = set_bipolar_reference(
         raw, a_channels, b_channels, drop_refs=False, copy=True)
     # check if reference channels have been kept correctly.
-    assert (len(raw_test.ch_names) == len(a_channels) + len(channels))
-    for ch_label in channels:
-        picks = [raw_test.ch_names.index(ch_label)]
-        manual_ch = raw_data[channels.index(ch_label), :]
-        assert_array_equal(raw_test.get_data(picks=picks)[0, :], manual_ch)
+    assert (len(raw_test.ch_names) == len(a_channels) + len(ch_names))
+    for idx, ch_label in enumerate(ch_names):
+        manual_ch = raw_data[idx, :]
+        assert_array_equal(
+            raw_test._data[raw_test.ch_names.index(ch_label), :], manual_ch)
 
     # test bipolars with a channel in both list (anode & cathode).
     raw_test = set_bipolar_reference(


### PR DESCRIPTION
I messed up the original pull request while trying to squash the commits (sorry!) :'(

Short description of the bug: `set_bipolar reference` try to remove a list of repeated channels when producing all the bipolar references of a dataset. Also, does not take into account channels of cathode list when performing in-place operations.

In this new pull, I added the requested changes, including a test, and also I updated whats new file.

Note that the current implementation of set_bipolar_reference fail in both, generating all the bipolar combinations and with repeated channels in the anode and cathode lists.

Closes #5780

Closes #5772