### PR TITLE
ENH: Add spatial pattern plot to SPoC example

### DIFF
--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -31,6 +31,7 @@ import mne
 from mne import Epochs
 from mne.decoding import SPoC
 from mne.datasets.fieldtrip_cmc import data_path
+from mne.channels import read_layout
 
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import Ridge
@@ -62,9 +63,8 @@ X = meg_epochs.get_data()
 y = emg_epochs.get_data().var(axis=2)[:, 0]  # target is EMG power
 
 # Classification pipeline with SPoC spatial filtering and Ridge Regression
-clf = make_pipeline(SPoC(n_components=2, log=True, reg='oas',
-                         rank='full'), Ridge())
-
+spoc = SPoC(n_components=2, log=True, reg='oas', rank='full')
+clf = make_pipeline(spoc, Ridge())
 # Define a two fold cross-validation
 cv = KFold(n_splits=2, shuffle=False)
 
@@ -82,3 +82,8 @@ ax.set_title('SPoC MEG Predictions')
 plt.legend()
 mne.viz.tight_layout()
 plt.show()
+
+# Plot the contributions to the detected components (i.e., the forward model)
+layout = read_layout('CTF151.lay')
+spoc.fit_transform(X, y)
+spoc.plot_patterns(meg_epochs.info, ch_type='mag', layout=layout)


### PR DESCRIPTION
Addresses #5782

Based on a brief discussion on gitter this weekend, this PR uses CSP's `plot_patterns` to generate a topomap of the spatial patterns that contributed to the predicted data. The changes are minor, basically breaking the original `make_pipline` line into two, so that spoc can be called later to use the bound methods `fit_transform` and `plot_patterns`.

The results look a little different from what I'd expect based on the Fieldtrip results at http://www.fieldtriptoolbox.org/tutorial/coherence , especially Appendix 1, but then I'm not terribly familiar with CTF data.
