### PR TITLE
MRG: Fix OSX test

### DIFF
--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -119,7 +119,7 @@ def test_kit2fiff():
     check_usage(mne_kit2fiff, force_help=True)
 
 
-@pytest.mark.timeout(60)  # can take > 60 sec on Travis OSX
+@pytest.mark.slowtest  # slow on Travis OSX
 @requires_tvtk
 @testing.requires_testing_data
 def test_make_scalp_surfaces():

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -129,7 +129,8 @@ def test_scale_mri():
         assert ssrc[0]['dist'] is not None
 
 
-@pytest.mark.timeout(90)  # ~29 sec on OSX Travis
+@pytest.mark.slowtest
+@pytest.mark.timeout(60)  # >30 sec on Travis
 @testing.requires_testing_data
 @requires_nibabel()
 def test_scale_mri_xfm():

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -331,7 +331,8 @@ def test_limits_to_control_points():
     with pytest.raises(ValueError, match='hemi'):
         stc.plot(hemi='foo', clim='auto', **kwargs)
     with pytest.raises(ValueError, match='Exactly one'):
-        stc.plot(clim=dict(lims=[0, 1, 2], pos_lims=[0, 1, 2], kind='value'))
+        stc.plot(clim=dict(lims=[0, 1, 2], pos_lims=[0, 1, 2], kind='value'),
+                 **kwargs)
 
     # Test handling of degenerate data: thresholded maps
     stc._data.fill(0.)


### PR DESCRIPTION
For some reason `test_scale_mri_xfm` is very slow on OSX. By marking it slow, it will be skipped there. I left the timeout as 60 because IIRC it was a bit slow on Linux, too.

Feel free to merge if CIs come back happy so that PRs can be green again