### PR TITLE
MRG: --only-binary dipy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
         # Get latest Anaconda running
         - run:
             command: |
-              wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+              wget -q http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
               chmod +x ~/miniconda.sh;
               ~/miniconda.sh -b -p ~/miniconda;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
     global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
-            PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout" OPTION=""
+            PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout nitime" OPTION=""
             TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+# Use an old image with a hopefully incompatible compiler
+image: Visual Studio 2013
 environment:
   global:
       PYTHON: "C:\\conda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# Use an old image with a hopefully incompatible compiler
+# Use an old image with an incompatible compiler (pip wants MSVC 2015 / 14.0)
 image: Visual Studio 2013
 environment:
   global:

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
   - PySurfer[save_movie]
-  - dipy --only-binary dipy
+  - "dipy --only-binary dipy"
   - nibabel
   - nilearn
   - neo

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
   - PySurfer[save_movie]
-  - "dipy --only-binary dipy"
+  - dipy --only-binary dipy
   - nibabel
   - nilearn
   - neo

--- a/environment.yml
+++ b/environment.yml
@@ -33,8 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
   - PySurfer[save_movie]
-  - dipy
-  - nitime
+  - dipy --only-binary dipy
   - nibabel
   - nilearn
   - neo

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ psutil
 dipy
 numpydoc
 https://api.github.com/repos/nipy/PySurfer/zipball/master
-nitime
 nilearn
 neo
 pydocstyle


### PR DESCRIPTION
Closes #5779.

First commit just to see if we can replicate #5779. After that, fix it.

Replicated: https://ci.appveyor.com/project/mne-tools/mne-python/builds/20931971