### PR TITLE
MRG: handle different time vecs in plot_evoked_topo()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -153,6 +153,7 @@ Changelog
 
 - Add parameter ``rank='full'`` to :func:`mne.beamformer.make_lcmv`, which can be set to ``None`` to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
 
+- Handle different time vectors in topography plots by `Jussi Nurminen`_
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -153,7 +153,7 @@ Changelog
 
 - Add parameter ``rank='full'`` to :func:`mne.beamformer.make_lcmv`, which can be set to ``None`` to auto-compute the rank of the covariance matrix before regularization by `Marijn van Vliet`_
 
-- Handle different time vectors in topography plots by `Jussi Nurminen`_
+- Handle different time vectors in topography plots using :func:`mne.viz.plot_evoked_topo` by `Jussi Nurminen`_
 
 Bug
 ~~~

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -1173,9 +1173,9 @@ def plot_raw_psd_topo(raw, tmin=0., tmax=None, fmin=0., fmax=100., proj=False,
     else:
         y_label = 'Power'
     show_func = partial(_plot_timeseries_unified, data=[psds], color=color,
-                        times=freqs)
+                        times=[freqs])
     click_func = partial(_plot_timeseries, data=[psds], color=color,
-                         times=freqs)
+                         times=[freqs])
     picks = _pick_data_channels(raw.info)
     info = pick_info(raw.info, picks)
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -153,7 +153,11 @@ def test_plot_topo():
 def test_plot_topo_single_ch():
     """Test single channel topoplot with time cursor."""
     evoked = _get_epochs().average()
-    fig = plot_evoked_topo(evoked, background_color='w')
+    evoked2 = evoked.copy()
+    # test plotting several evokeds on different time grids
+    evoked.crop(-.19, 0)
+    evoked2.crop(.05, .19)
+    fig = plot_evoked_topo([evoked, evoked2], background_color='w')
     # test status bar message
     ax = plt.gca()
     assert ('MEG 0113' in ax.format_coord(.065, .63))

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -446,7 +446,7 @@ def _plot_timeseries_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim, data,
     """Show multiple time series on topo using a single axes."""
     import matplotlib.pyplot as plt
     if not (ylim and not any(v is None for v in ylim)):
-        ylim = [min([np.min(d) for d in data]), max([np.max(d) for d in data])]
+        ylim = [min(np.min(d) for d in data), max(np.max(d) for d in data)]
     # Translation and scale parameters to take data->under_ax normalized coords
     _compute_scalings(bn, (tmin, tmax), ylim)
     pos = bn.pos

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -746,13 +746,14 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
 
     time_min = min([t[0] for t in times])
     time_max = max([t[-1] for t in times])
-    fig = _plot_topo(info=info, times=[time_min, time_max], show_func=show_func,
-                     click_func=click_func, layout=layout, colorbar=False,
-                     ylim=ylim_, cmap=None, layout_scale=layout_scale,
-                     border=border, fig_facecolor=fig_facecolor,
-                     font_color=font_color, axis_facecolor=axis_facecolor,
-                     title=title, x_label='Time (s)', y_label=y_label,
-                     unified=True, axes=axes)
+    fig = _plot_topo(info=info, times=[time_min, time_max],
+                     show_func=show_func, click_func=click_func, layout=layout,
+                     colorbar=False, ylim=ylim_, cmap=None,
+                     layout_scale=layout_scale, border=border,
+                     fig_facecolor=fig_facecolor, font_color=font_color,
+                     axis_facecolor=axis_facecolor, title=title,
+                     x_label='Time (s)', y_label=y_label, unified=True,
+                     axes=axes)
 
     add_background_image(fig, fig_background)
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -361,9 +361,8 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     def _format_coord(x, y, labels, ax):
         """Create status string based on cursor coordinates."""
-        """ see if we are close enough to a time range """
+        # find indices for datasets near cursor (if any)
         tdiffs = [np.abs(tvec - x).min() for tvec in times]
-        # find indices for datasets near cursor
         nearby = [k for k, tdiff in enumerate(tdiffs) if
                   tdiff < (tmax - tmin) / 100]
         timestr = '%6.3f s: ' % x
@@ -377,6 +376,7 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
         # try to estimate whether to truncate condition labels
         slen = 10 + sum([12 + len(unit) + len(label) for label in labels])
         bar_width = (ax.figure.get_size_inches() * ax.figure.dpi)[0] / 5.5
+        # show labels and y values for datasets near cursor
         trunc_labels = bar_width < slen
         s = timestr
         for data_, label, tvec in nearby_data:

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -361,17 +361,26 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     def _format_coord(x, y, labels, ax):
         """Create status string based on cursor coordinates."""
-        idx = np.abs(times - x).argmin()
+        """ see if we are close enough to a time range """
+        tdiffs = [np.abs(tvec - x).min() for tvec in times]
+        # find indices for datasets near cursor
+        nearby = [k for k, tdiff in enumerate(tdiffs) if
+                  tdiff < (tmax - tmin) / 100]
+        timestr = '%6.3f s: ' % x
+        if not nearby:
+            return '%s Nothing here' % timestr
+        nearby_data = [(data[n], labels[n], times[n]) for n in nearby]
         ylabel = ax.get_ylabel()
         unit = (ylabel[ylabel.find('(') + 1:ylabel.find(')')]
                 if '(' in ylabel and ')' in ylabel else '')
-        labels = [''] * len(data) if labels is None else labels
+        labels = [''] * len(nearby_data) if labels is None else labels
         # try to estimate whether to truncate condition labels
         slen = 10 + sum([12 + len(unit) + len(label) for label in labels])
         bar_width = (ax.figure.get_size_inches() * ax.figure.dpi)[0] / 5.5
         trunc_labels = bar_width < slen
-        s = '%6.3f s: ' % times[idx]
-        for data_, label in zip(data, labels):
+        s = timestr
+        for data_, label, tvec in nearby_data:
+            idx = np.abs(tvec - x).argmin()
             s += '%7.2f %s' % (data_[ch_idx, idx], unit)
             if trunc_labels:
                 label = (label if len(label) <= 10 else

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -717,11 +717,10 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
             y_label.append('Amplitude (%s)' % unit)
 
     if ylim is None:
-        def set_ylim(x):
-            return np.abs(x).max()
-        ylim_ = [set_ylim([e.data[t] for e in evoked]) for t in picks]
-        ymax = np.array(ylim_)
-        ylim_ = (-ymax, ymax)
+        # find maxima over all evoked data for each channel pick
+        ymaxes = np.array([max(np.abs(e.data[t]).max() for e in evoked)
+                          for t in picks])
+        ylim_ = (-ymaxes, ymaxes)
     elif isinstance(ylim, dict):
         ylim_ = _handle_default('ylim', ylim)
         ylim_ = [ylim_[kk] for kk in types_used]


### PR DESCRIPTION
Closes #5766 
Since matplotlib can already overlay data on different x grids, this should an easy fix. Or maybe I'm missing something... let's see.
