### PR TITLE
[MRG] Get multiple spaced events from single annotation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,9 +19,11 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
+
 - :func:`mne.io.read_raw_edf` now detects analog stim channels labeled ``'STATUS'`` and sets them as stim channel. :func:`mne.io.read_raw_edf` no longer synthesize TAL annotations into stim channel but stores them in ``raw.annotations`` when reading by `Joan Massich`_
 
-- Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_. 
+- Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_.
 
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -702,9 +702,9 @@ def _ensure_annotation_object(obj):
 
 
 def _select_annotations_based_on_description(descriptions, event_id=None,
-                                             regexp='.*', on_missing='ignore'):
+                                             regexp=None, on_missing='ignore'):
     """Get a collection of descriptions and returns index of selected."""
-    regexp_comp = re.compile(regexp)
+    regexp_comp = re.compile('.*' if regexp is None else regexp)
 
     if event_id is None:
         event_id = Counter()
@@ -733,7 +733,7 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
     event_sel = [ii for ii, kk in enumerate(descriptions)
                  if kk in event_id_]
 
-    if len(event_sel) == 0 and regexp is not '.*':
+    if len(event_sel) == 0 and regexp is not None:
         msg = 'Could not find any of the events you specified.'
         if on_missing == 'error':
             raise ValueError(msg)
@@ -748,7 +748,7 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
 
 
 @verbose
-def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
+def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
                             chunk_duration=None, on_missing='error',
                             verbose=None):
     """Get events and event_id from an Annotations object.
@@ -765,7 +765,7 @@ def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
         a string or that returns None for an event to ignore.
         If None, all descriptions of annotations are mapped
         and assigned arbitrary unique integer values.
-    regexp : str
+    regexp : str | None
         Regular expression used to filter the annotations whose
         descriptions is a match.
     use_rounding : boolean
@@ -799,9 +799,6 @@ def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
         return np.empty((0, 3), dtype=int), event_id
 
     annotations = raw.annotations
-
-    # regexp None support for 0.17 backward compat, not exposed to users
-    regexp = '.*' if regexp is None else regexp
 
     event_sel, event_id_ = _select_annotations_based_on_description(
         annotations.description, event_id=event_id, regexp=regexp,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -749,12 +749,6 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
     ----------
     raw : instance of Raw
         The raw data for which Annotations are defined.
-    chunk_duration: int | None
-        If chunk_duration parameter in events_from_annotations is None, events
-        correspond to the annotation onsets.
-        If not, :func:`mne.events_from_annotations` returns as many events as
-        they fit within the annotation duration spaced according to
-        `chunk_duration`, which is given in seconds.
     event_id : dict | Callable | None
         Dictionary of string keys and integer values as used in mne.Epochs
         to map annotation descriptions to integer event codes. Only the
@@ -769,6 +763,12 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
     use_rounding : boolean
         If True, use rounding (instead of truncation) when converting
         times to indices. This can help avoid non-unique indices.
+    chunk_duration: int | None
+        If chunk_duration parameter in events_from_annotations is None, events
+        correspond to the annotation onsets.
+        If not, :func:`mne.events_from_annotations` returns as many events as
+        they fit within the annotation duration spaced according to
+        `chunk_duration`, which is given in seconds.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see
         :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -701,8 +701,7 @@ def _ensure_annotation_object(obj):
                          'mne.Annotations. Got %s.' % obj)
 
 
-def _select_annotations_based_on_description(descriptions, event_id=None,
-                                             regexp=None, on_missing='ignore'):
+def _select_annotations_based_on_description(descriptions, event_id, regexp):
     """Get a collection of descriptions and returns index of selected."""
     regexp_comp = re.compile('.*' if regexp is None else regexp)
 
@@ -786,8 +785,7 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
     annotations = raw.annotations
 
     event_sel, event_id_ = _select_annotations_based_on_description(
-        annotations.description, event_id=event_id, regexp=regexp,
-        on_missing=on_missing)
+        annotations.description, event_id=event_id, regexp=regexp)
 
     if chunk_duration is None:
         inds = raw.time_as_index(annotations.onset, use_rounding=use_rounding,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -700,10 +700,10 @@ def _ensure_annotation_object(obj):
         raise ValueError('Annotations must be an instance of '
                          'mne.Annotations. Got %s.' % obj)
 
+
 def _select_annotations_based_on_description(descriptions, event_id=None,
                                              regexp=None):
-    """Gets a collection of descriptions and returns index of selected.
-    """
+    """Get a collection of descriptions and returns index of selected."""
     # Filter out the annotations that do not match regexp
     regexp_comp = re.compile('.*' if regexp is None else regexp)
 
@@ -751,9 +751,10 @@ def events_from_annotations(raw, chunk_duration=None, event_id=None,
         The raw data for which Annotations are defined.
     chunk_duration: int | None
         If chunk_duration parameter in events_from_annotations is None, events
-        correspond to the annotation onsets. If not, events_from_annotations
-        returns as many events as they fit within the annotation duration spaced
-        according to `chunk_duraiton`.
+        correspond to the annotation onsets.
+        If not, :func:`mne.events_from_annotations` returns as many events as
+        they fit within the annotation duration spaced according to
+        `chunk_duration`, which is given in seconds.
     event_id : dict | Callable | None
         Dictionary of string keys and integer values as used in mne.Epochs
         to map annotation descriptions to integer event codes. Only the
@@ -786,22 +787,22 @@ def events_from_annotations(raw, chunk_duration=None, event_id=None,
     annotations = raw.annotations
 
     event_sel, event_id_ = _select_annotations_based_on_description(
-                    annotations.description, event_id=event_id, regexp=regexp)
+        annotations.description, event_id=event_id, regexp=regexp)
 
     if chunk_duration is None:
         inds = raw.time_as_index(annotations.onset, use_rounding=use_rounding,
-                                origin=annotations.orig_time) + raw.first_samp
+                                 origin=annotations.orig_time) + raw.first_samp
 
         values = [event_id_[kk] for kk in annotations.description[event_sel]]
         inds = inds[event_sel]
     else:
         inds = values = np.array([]).astype(int)
         iterator = list(zip(annotations.onset[event_sel],
-                       annotations.duration[event_sel],
-                       annotations.description[event_sel]))
+                            annotations.duration[event_sel],
+                            annotations.description[event_sel]))
 
         for onset, duration, description in iterator:
-            _onsets = np.arange(start=onset, stop=onset+duration,
+            _onsets = np.arange(start=onset, stop=(onset + duration),
                                 step=chunk_duration)
             _inds = raw.time_as_index(_onsets,
                                       use_rounding=use_rounding,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -704,8 +704,8 @@ def _ensure_annotation_object(obj):
 def _select_annotations_based_on_description(descriptions, event_id=None,
                                              regexp=None):
     """Get a collection of descriptions and returns index of selected."""
-    # Filter out the annotations that do not match regexp
-    regexp_comp = re.compile('.*' if regexp is None else regexp)
+
+    regexp_comp = re.compile(regexp)
 
     if event_id is None:
         event_id = Counter()
@@ -741,7 +741,7 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
 
 
 @verbose
-def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
+def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
                             chunk_duration=None, verbose=None):
     """Get events and event_id from an Annotations object.
 
@@ -757,7 +757,7 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
         a string or that returns None for an event to ignore.
         If None, all descriptions of annotations are mapped
         and assigned arbitrary unique integer values.
-    regexp : str | None
+    regexp : str
         Regular expression used to filter the annotations whose
         descriptions is a match.
     use_rounding : boolean
@@ -785,6 +785,9 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
         return np.empty((0, 3), dtype=int), event_id
 
     annotations = raw.annotations
+
+    # regexp None support for 0.17 backward compat, not exposed to users
+    regexp = '.*' if regexp is None else regexp
 
     event_sel, event_id_ = _select_annotations_based_on_description(
         annotations.description, event_id=event_id, regexp=regexp)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -762,7 +762,7 @@ def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
     use_rounding : boolean
         If True, use rounding (instead of truncation) when converting
         times to indices. This can help avoid non-unique indices.
-    chunk_duration: int | None
+    chunk_duration: float | None
         If chunk_duration parameter in events_from_annotations is None, events
         correspond to the annotation onsets.
         If not, :func:`mne.events_from_annotations` returns as many events as

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -702,7 +702,7 @@ def _ensure_annotation_object(obj):
 
 
 def _select_annotations_based_on_description(descriptions, event_id=None,
-                                             regexp='.*'):
+                                             regexp='.*', on_missing='ignore'):
     """Get a collection of descriptions and returns index of selected."""
     regexp_comp = re.compile(regexp)
 
@@ -733,15 +733,24 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
     event_sel = [ii for ii, kk in enumerate(descriptions)
                  if kk in event_id_]
 
-    if len(event_sel) == 0 and regexp is not None:
-        raise ValueError('Could not find any of the events you specified.')
+    if len(event_sel) == 0 and regexp is not '.*':
+        msg = 'Could not find any of the events you specified.'
+        if on_missing == 'error':
+            raise ValueError(msg)
+        elif on_missing == 'warning':
+            warn(msg)
+        elif on_missing == 'log':
+            logger.info(msg)
+        else:  # on_missing == 'ignore':
+            pass
 
     return event_sel, event_id_
 
 
 @verbose
 def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
-                            chunk_duration=None, verbose=None):
+                            chunk_duration=None, on_missing='error',
+                            verbose=None):
     """Get events and event_id from an Annotations object.
 
     Parameters
@@ -768,6 +777,12 @@ def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
         If not, :func:`mne.events_from_annotations` returns as many events as
         they fit within the annotation duration spaced according to
         `chunk_duration`, which is given in seconds.
+    on_missing : str
+        What to do if no events are found based on `event_id` and `regexp`
+        parameters.
+        Valid keys are 'error' | 'warning' | 'log' | 'ignore'
+        Default is 'error'. If on_missing is 'warning' it will proceed but
+        warn, if 'ignore' it will proceed silently.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see
         :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -789,7 +804,8 @@ def events_from_annotations(raw, event_id=None, regexp='.*', use_rounding=True,
     regexp = '.*' if regexp is None else regexp
 
     event_sel, event_id_ = _select_annotations_based_on_description(
-        annotations.description, event_id=event_id, regexp=regexp)
+        annotations.description, event_id=event_id, regexp=regexp,
+        on_missing=on_missing)
 
     if chunk_duration is None:
         inds = raw.time_as_index(annotations.onset, use_rounding=use_rounding,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -810,7 +810,8 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
             _inds += raw.first_samp
             inds = np.append(inds, _inds)
             _values = np.full(shape=len(_inds),
-                              fill_value=event_id_[description])
+                              fill_value=event_id_[description],
+                              dtype=int)
             values = np.append(values, _values)
 
     events = np.c_[inds, np.zeros(len(inds)), values].astype(int)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -795,11 +795,11 @@ def events_from_annotations(raw, chunk_duration=None, event_id=None,
         values = [event_id_[kk] for kk in annotations.description[event_sel]]
         inds = inds[event_sel]
     else:
-        inds = []
-        values = []
-        iterator = zip(annotations.onset[event_sel],
+        inds = values = np.array([]).astype(int)
+        iterator = list(zip(annotations.onset[event_sel],
                        annotations.duration[event_sel],
-                       annotations.description[event_sel])
+                       annotations.description[event_sel]))
+
         for onset, duration, description in iterator:
             _onsets = np.arange(start=onset, stop=onset+duration,
                                 step=chunk_duration)
@@ -807,9 +807,10 @@ def events_from_annotations(raw, chunk_duration=None, event_id=None,
                                       use_rounding=use_rounding,
                                       origin=annotations.orig_time)
             _inds += raw.first_samp
-            inds.append(_inds)
-            values.append(np.full(shape=len(_inds),
-                                  fill_value=event_id_[description]))
+            inds = np.append(inds, _inds)
+            _values = np.full(shape=len(_inds),
+                              fill_value=event_id_[description])
+            values = np.append(values, _values)
 
     events = np.c_[inds, np.zeros(len(inds)), values].astype(int)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -702,9 +702,8 @@ def _ensure_annotation_object(obj):
 
 
 def _select_annotations_based_on_description(descriptions, event_id=None,
-                                             regexp=None):
+                                             regexp='.*'):
     """Get a collection of descriptions and returns index of selected."""
-
     regexp_comp = re.compile(regexp)
 
     if event_id is None:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -741,8 +741,8 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
 
 
 @verbose
-def events_from_annotations(raw, chunk_duration=None, event_id=None,
-                            regexp=None, use_rounding=True, verbose=None):
+def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
+                            chunk_duration=None, verbose=None):
     """Get events and event_id from an Annotations object.
 
     Parameters

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -734,23 +734,14 @@ def _select_annotations_based_on_description(descriptions, event_id=None,
                  if kk in event_id_]
 
     if len(event_sel) == 0 and regexp is not None:
-        msg = 'Could not find any of the events you specified.'
-        if on_missing == 'error':
-            raise ValueError(msg)
-        elif on_missing == 'warning':
-            warn(msg)
-        elif on_missing == 'log':
-            logger.info(msg)
-        else:  # on_missing == 'ignore':
-            pass
+        raise ValueError('Could not find any of the events you specified.')
 
     return event_sel, event_id_
 
 
 @verbose
 def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
-                            chunk_duration=None, on_missing='error',
-                            verbose=None):
+                            chunk_duration=None, verbose=None):
     """Get events and event_id from an Annotations object.
 
     Parameters
@@ -777,12 +768,6 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
         If not, :func:`mne.events_from_annotations` returns as many events as
         they fit within the annotation duration spaced according to
         `chunk_duration`, which is given in seconds.
-    on_missing : str
-        What to do if no events are found based on `event_id` and `regexp`
-        parameters.
-        Valid keys are 'error' | 'warning' | 'log' | 'ignore'
-        Default is 'error'. If on_missing is 'warning' it will proceed but
-        warn, if 'ignore' it will proceed silently.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see
         :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -195,14 +195,18 @@ def test_chunk_duration():
     """
     # create dummy raw
     raw = RawArray(data=np.empty([10, 10], dtype=np.float64),
-                   info=create_info(ch_names=10, sfreq=1000.),
+                   info=create_info(ch_names=10, sfreq=1.),
                    first_samp=0)
     raw.info['meas_date'] = 0
     raw.set_annotations(Annotations(description='foo', onset=[0],
                                     duration=[10], orig_time=None))
 
-    events = events_from_annotations(raw, chunk_duration=1)
-    assert_array_equal(events, np.arrange(10))
+    EXPECTED_EVENT_ONSETS = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7,
+                             8, 8, 9, 9]
+
+    events, events_id = events_from_annotations(raw, chunk_duration=.5,
+                                                use_rounding=False)
+    assert_array_equal(events[:,0], EXPECTED_EVENT_ONSETS)
 
 
 def test_crop_more():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -551,7 +551,7 @@ def test_events_from_annot_in_raw_objects():
     assert_array_equal(expected_events5, events5)
 
     with pytest.raises(ValueError, match='not find any of the events'):
-        events_from_annotations(raw, regexp='not_there', on_missing='error')
+        events_from_annotations(raw, regexp='not_there')
 
     raw.set_annotations(None)
     events7, _ = events_from_annotations(raw)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -185,6 +185,26 @@ def test_crop():
     assert len(raw_read.annotations.onset) == 0  # XXX to be fixed in #5416
 
 
+def test_chunk_duration():
+    """Test chunk_duration.
+
+    If chunk_duration parameter in events_from_annotations is None, events
+    correspond to the annotation onsets. If not, events_from_annotations
+    returns as many events as they fit within the annotation duration spaced
+    according to `chunk_duraiton`.
+    """
+    # create dummy raw
+    raw = RawArray(data=np.empty([10, 10], dtype=np.float64),
+                   info=create_info(ch_names=10, sfreq=1000.),
+                   first_samp=0)
+    raw.info['meas_date'] = 0
+    raw.set_annotations(Annotations(description='foo', onset=[0],
+                                    duration=[10], orig_time=None))
+
+    events = events_from_annotations(raw, chunk_duration=1)
+    assert_array_equal(events, np.arrange(10))
+
+
 def test_crop_more():
     """Test more cropping."""
     raw = mne.io.read_raw_fif(fif_fname).crop(0, 11).load_data()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -201,12 +201,15 @@ def test_chunk_duration():
     raw.set_annotations(Annotations(description='foo', onset=[0],
                                     duration=[10], orig_time=None))
 
-    EXPECTED_EVENT_ONSETS = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7,
-                             8, 8, 9, 9]
+    # expected_events = [[0, 0, 1], [0, 0, 1], [1, 0, 1], [1, 0, 1], ..
+    #                    [9, 0, 1], [9, 0, 1]]
+    expected_events = np.atleast_2d(np.repeat(range(10), repeats=2)).T
+    expected_events = np.insert(expected_events, 1, 0, axis=1)
+    expected_events = np.insert(expected_events, 2, 1, axis=1)
 
     events, events_id = events_from_annotations(raw, chunk_duration=.5,
                                                 use_rounding=False)
-    assert_array_equal(events[:,0], EXPECTED_EVENT_ONSETS)
+    assert_array_equal(events, expected_events)
 
 
 def test_crop_more():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -553,9 +553,6 @@ def test_events_from_annot_in_raw_objects():
     with pytest.raises(ValueError, match='not find any of the events'):
         events_from_annotations(raw, regexp='not_there', on_missing='error')
 
-    with pytest.warns(RuntimeWarning, match='not find any of the events'):
-        events_from_annotations(raw, regexp='not_there', on_missing='warning')
-
     raw.set_annotations(None)
     events7, _ = events_from_annotations(raw)
     assert_array_equal(events7, np.empty((0, 3), dtype=int))

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -551,7 +551,10 @@ def test_events_from_annot_in_raw_objects():
     assert_array_equal(expected_events5, events5)
 
     with pytest.raises(ValueError, match='not find any of the events'):
-        events_from_annotations(raw, regexp='not_there')
+        events_from_annotations(raw, regexp='not_there', on_missing='error')
+
+    with pytest.warns(RuntimeWarning, match='not find any of the events'):
+        events_from_annotations(raw, regexp='not_there', on_missing='warning')
 
     raw.set_annotations(None)
     events7, _ = events_from_annotations(raw)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -186,13 +186,7 @@ def test_crop():
 
 
 def test_chunk_duration():
-    """Test chunk_duration.
-
-    If chunk_duration parameter in events_from_annotations is None, events
-    correspond to the annotation onsets. If not, events_from_annotations
-    returns as many events as they fit within the annotation duration spaced
-    according to `chunk_duration` parameter in `events_from_annotations`.
-    """
+    """Test chunk_duration."""
     # create dummy raw
     raw = RawArray(data=np.empty([10, 10], dtype=np.float64),
                    info=create_info(ch_names=10, sfreq=1.),

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -191,7 +191,7 @@ def test_chunk_duration():
     If chunk_duration parameter in events_from_annotations is None, events
     correspond to the annotation onsets. If not, events_from_annotations
     returns as many events as they fit within the annotation duration spaced
-    according to `chunk_duraiton`.
+    according to `chunk_duration` parameter in `events_from_annotations`.
     """
     # create dummy raw
     raw = RawArray(data=np.empty([10, 10], dtype=np.float64),


### PR DESCRIPTION
This PR adds a parameter to `events_from_annotation` so that if this parameter
None, events correspond to the annotation onsets (as was happening until nos).
But if not, events_from_annotations returns as many events as they fit within
the annotation duration spaced according to this new parameter (right now is
called `chunk_duraiton` but we should discuss it before merging).

This PR needs to go in before #5718 

---
Things that are not in this PR (it will be done in subsequent PRs):
- allow slicing of Annotations
- update the documentation of events and annotations