### PR TITLE
[MINOR] Add evoked GFP to tutorials

### DIFF
--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -65,9 +65,13 @@ print(data[10])
 
 ###############################################################################
 # In the same vein, we can quickly extract (and, e.g., plot) the GFP as the
-# standard deviation across channels.
-gfp = evoked.copy().pick_types(eeg=True, meg=False).data.std(0)
-plt.plot(evoked.times, gfp)
+# standard deviation across channels, here shown just for EEG.
+
+gfp = evoked.copy().pick_types(eeg=True, meg=False).data.std(axis=0)
+fig, ax = plt.subplots(1)
+ax.plot(evoked.times, gfp)
+ax.set(xlabel='Time (sec)', ylabel='GFP (uV)')
+fig.tight_layout()
 
 ###############################################################################
 # If you want to import evoked data from some other system and you have it in a

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -12,6 +12,7 @@ averaging epochs data with :func:`mne.Epochs.average`.
 import os.path as op
 
 import mne
+import matplotlib.pyplot as plt
 
 ###############################################################################
 # Here for convenience we read the evoked dataset from a file.

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -12,8 +12,8 @@ averaging epochs data with :func:`mne.Epochs.average`.
 
 import os.path as op
 
-import mne
 import matplotlib.pyplot as plt
+import mne
 
 ###############################################################################
 # Here for convenience we read the evoked dataset from a file.

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -8,6 +8,7 @@ The :class:`Evoked <mne.Evoked>` data structure is mainly used for storing
 averaged data over trials. In MNE the evoked objects are usually created by
 averaging epochs data with :func:`mne.Epochs.average`.
 """
+# sphinx_gallery_thumbnail_number = 2
 
 import os.path as op
 

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -64,6 +64,12 @@ print('Data from channel {0}:'.format(evoked.ch_names[10]))
 print(data[10])
 
 ###############################################################################
+# In the same vein, we can quickly extract (and, e.g., plot) the GFP as the
+# standard deviation across channels.
+gfp = evoked.copy().pick_types(eeg=True, meg=False).data.std(0)
+plt.plot(evoked.times, gfp)
+
+###############################################################################
 # If you want to import evoked data from some other system and you have it in a
 # numpy array you can use :class:`mne.EvokedArray` for that. All you need is
 # the data and some info about the evoked data. For more information, see

--- a/tutorials/plot_object_evoked.py
+++ b/tutorials/plot_object_evoked.py
@@ -71,7 +71,7 @@ print(data[10])
 
 gfp = evoked.copy().pick_types(eeg=True, meg=False).data.std(axis=0)
 fig, ax = plt.subplots(1)
-ax.plot(evoked.times, gfp)
+ax.plot(evoked.times, gfp / 1e6)  # scale to uV
 ax.set(xlabel='Time (sec)', ylabel='GFP (uV)')
 fig.tight_layout()
 


### PR DESCRIPTION
This adds a few lines to the evoked object tutorial to show how to extract and plot the SD across channels, as discussed in #4002 

I'm trying to close old issues :)

Closes #4002