### PR TITLE
[MRG] Add support for indexing/slicing Annotations objects

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add support for indexing and slicing :mne:`mne.Annotations` by `Joan Massich`_
+
 - Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
 
 - :func:`mne.io.read_raw_edf` now detects analog stim channels labeled ``'STATUS'`` and sets them as stim channel. :func:`mne.io.read_raw_edf` no longer synthesize TAL annotations into stim channel but stores them in ``raw.annotations`` when reading by `Joan Massich`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Add support for indexing and slicing :class:`mne.Annotations` by `Joan Massich`_
+- Add support for indexing, slicing, and iterating :class:`mne.Annotations` by `Joan Massich`_
 
 - :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Add support for indexing and slicing :mne:`mne.Annotations` by `Joan Massich`_
+- Add support for indexing and slicing :class:`mne.Annotations` by `Joan Massich`_
 
 - :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -217,18 +217,15 @@ class Annotations(object):
     def __iter__(self):
         """Iterate over the annotations."""
         for idx in range(len(self.onset)):
-            yield OrderedDict(zip(
-                ('onset', 'duration', 'description', 'orig_time'),
-                (self.onset[idx], self.duration[idx], self.description[idx],
-                 self.orig_time)))
+            yield self.__getitem__(idx)
 
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
         if isinstance(key, int):
-            return OrderedDict(zip(
-                ('onset', 'duration', 'description', 'orig_time'),
-                (self.onset[key], self.duration[key],
-                    self.description[key], self.orig_time)))
+            out_keys = ('onset', 'duration', 'description', 'orig_time')
+            out_vals = (self.onset[key], self.duration[key],
+                        self.description[key], self.orig_time)
+            return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
             return Annotations(onset=self.onset[key],

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -224,30 +224,17 @@ class Annotations(object):
 
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
-        try:
-            if isinstance(key, slice) or isinstance(key, list):
-                out = Annotations(onset=self.onset[key],
-                                  duration=self.duration[key],
-                                  description=self.description[key],
-                                  orig_time=self.orig_time)
-            elif isinstance(key, int):
-                out = OrderedDict(zip(
-                    ('onset', 'duration', 'description', 'orig_time'),
-                    (self.onset[key], self.duration[key],
-                     self.description[key], self.orig_time)))
-            else:
-                raise TypeError
-
-        except IndexError as idx_error:
-            if idx_error.args[0].startswith('only integers'):
-                # raise the error recommended by the standard
-                raise TypeError(idx_error.args[0])
-            else:
-                raise
-        except Exception:
-            raise
+        if isinstance(key, int):
+            return OrderedDict(zip(
+                ('onset', 'duration', 'description', 'orig_time'),
+                (self.onset[key], self.duration[key],
+                    self.description[key], self.orig_time)))
         else:
-            return out
+            key = list(key) if isinstance(key, tuple) else key
+            return Annotations(onset=self.onset[key],
+                                duration=self.duration[key],
+                                description=self.description[key],
+                                orig_time=self.orig_time)
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -228,10 +228,10 @@ class Annotations(object):
             return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
-            return Annotations(onset=self.onset[key],
-                                duration=self.duration[key],
-                                description=self.description[key],
-                                orig_time=self.orig_time)
+            return Annotations(onset=self.onset[key].copy(),
+                               duration=self.duration[key].copy(),
+                               description=self.description[key].copy(),
+                               orig_time=self.orig_time)
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -231,6 +231,11 @@ class Annotations(object):
         else:
             return out
 
+    def foo(self, key):
+        """Propagate indexing and slicing to the underlying numpy structure."""
+        foo = np.vstack((self.onset, self.duration, self.description))
+        return foo[:, key]
+
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -228,9 +228,9 @@ class Annotations(object):
             return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
-            return Annotations(onset=self.onset[key].copy(),
-                               duration=self.duration[key].copy(),
-                               description=self.description[key].copy(),
+            return Annotations(onset=self.onset[key],
+                               duration=self.duration[key],
+                               description=self.description[key],
                                orig_time=self.orig_time)
 
     def append(self, onset, duration, description):

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -229,10 +229,10 @@ class Annotations(object):
                                   orig_time=self.orig_time)
             elif isinstance(key, int):
                 print('__getitem__ with integer: {}'.format(key))
-                out = Annotations(onset=[self.onset[key]],
-                                  duration=[self.duration[key]],
-                                  description=[self.description[key]],
-                                  orig_time=self.orig_time)
+                out = {'onset': self.onset[key],
+                       'duration': self.duration[key],
+                       'description': self.description[key],
+                       'orig_time': self.orig_time}
             else:
                 raise TypeError
                 # out = (self.onset[key].copy(),

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -214,12 +214,31 @@ class Annotations(object):
                                                  other.orig_time))
         return self.append(other.onset, other.duration, other.description)
 
+    def __iter__(self):
+        for idx in range(len(self.onset)):
+            yield (self.onset[idx], self.duration[idx], self.description[idx])
+        return
+
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
         try:
-            out = (self.onset[key].copy(),
-                   self.duration[key].copy(),
-                   self.description[key].copy())
+            if isinstance(key, slice):
+                print('__getitem__ with slice: {}'.format(key))
+                out = Annotations(onset=self.onset[key],
+                                  duration=self.duration[key],
+                                  description=self.description[key],
+                                  orig_time=self.orig_time)
+            elif isinstance(key, int):
+                print('__getitem__ with integer: {}'.format(key))
+                out = Annotations(onset=[self.onset[key]],
+                                  duration=[self.duration[key]],
+                                  description=[self.description[key]],
+                                  orig_time=self.orig_time)
+            else:
+                pass
+                # out = (self.onset[key].copy(),
+                #        self.duration[key].copy(),
+                #        self.description[key].copy())
 
         except IndexError as idx_error:
             if idx_error.args[0].startswith('only integers'):

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -217,12 +217,11 @@ class Annotations(object):
     def __iter__(self):
         for idx in range(len(self.onset)):
             yield (self.onset[idx], self.duration[idx], self.description[idx])
-        return
 
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
         try:
-            if isinstance(key, slice):
+            if isinstance(key, slice) or isinstance(key, list):
                 print('__getitem__ with slice: {}'.format(key))
                 out = Annotations(onset=self.onset[key],
                                   duration=self.duration[key],
@@ -235,7 +234,7 @@ class Annotations(object):
                                   description=[self.description[key]],
                                   orig_time=self.orig_time)
             else:
-                pass
+                raise TypeError
                 # out = (self.onset[key].copy(),
                 #        self.duration[key].copy(),
                 #        self.description[key].copy())

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -214,6 +214,20 @@ class Annotations(object):
                                                  other.orig_time))
         return self.append(other.onset, other.duration, other.description)
 
+    def __getitem__(self, key):
+        """Propagate indexing and slicing to the underlying numpy structure."""
+        try:
+            out = (self.onset[key], self.duration[key], self.description[key])
+        except IndexError as idx_error:
+            if idx_error.args[0].startswith('only integers'):
+                raise TypeError(idx_error.args[0])
+            else:
+                raise
+        except:
+            raise
+        else: 
+            return out
+
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -222,25 +222,21 @@ class Annotations(object):
         """Propagate indexing and slicing to the underlying numpy structure."""
         try:
             if isinstance(key, slice) or isinstance(key, list):
-                print('__getitem__ with slice: {}'.format(key))
                 out = Annotations(onset=self.onset[key],
                                   duration=self.duration[key],
                                   description=self.description[key],
                                   orig_time=self.orig_time)
             elif isinstance(key, int):
-                print('__getitem__ with integer: {}'.format(key))
                 out = {'onset': self.onset[key],
                        'duration': self.duration[key],
                        'description': self.description[key],
                        'orig_time': self.orig_time}
             else:
                 raise TypeError
-                # out = (self.onset[key].copy(),
-                #        self.duration[key].copy(),
-                #        self.description[key].copy())
 
         except IndexError as idx_error:
             if idx_error.args[0].startswith('only integers'):
+                # raise the error recommended by the standard
                 raise TypeError(idx_error.args[0])
             else:
                 raise
@@ -248,11 +244,6 @@ class Annotations(object):
             raise
         else:
             return out
-
-    def foo(self, key):
-        """Propagate indexing and slicing to the underlying numpy structure."""
-        foo = np.vstack((self.onset, self.duration, self.description))
-        return foo[:, key]
 
     def append(self, onset, duration, description):
         """Add an annotated segment. Operates inplace.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -217,7 +217,10 @@ class Annotations(object):
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
         try:
-            out = (self.onset[key], self.duration[key], self.description[key])
+            out = (self.onset[key].copy(),
+                   self.duration[key].copy(),
+                   self.description[key].copy())
+
         except IndexError as idx_error:
             if idx_error.args[0].startswith('only integers'):
                 raise TypeError(idx_error.args[0])
@@ -225,7 +228,7 @@ class Annotations(object):
                 raise
         except:
             raise
-        else: 
+        else:
             return out
 
     def append(self, onset, duration, description):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -794,6 +794,120 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
+def test_annotations_foo():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for onset, duration, description in annot:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for ii, (onset, duration, description) in enumerate(annot):
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+        assert (onset, druation, description) == (ii, ii, str(ii))
+
+def test_dummy():
+    class Ob(object):
+        def __init__(self):
+            self.NUM = 5
+            self.a = [x for x in range(self.NUM)]
+            self.b = [x.__repr__() for x in range(self.NUM)]
+
+        def __iter__(self):
+            for ii in range(self.NUM):
+                yield (self.a[ii], self.b[ii])
+            return
+
+    xx = Ob()
+    for ii, elem in enumerate([(x, y) for x, y in xx]):
+        assert elem[0] == ii
+        assert elem[1] == str(ii)
+
+
+def test_annotations_xx():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 10
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    every_other = slice(0, None, 2)
+    for kk in [every_other, 1]:
+        xx = annot[kk]
+        print(type(xx))
+        print(len(xx))
+
+    bool_sequence = [bool(ii%2) for ii in range(len(annot))]
+    for onset, duration, description in annot[bool_sequence]:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+
+def test_annotations_bar():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for ii, (onset, duration, description) in enumerate(annot[:2]):
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+        assert (onset, druation, description) == (ii, ii, str(ii))
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for onset, duration, description in annot[:2]:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+
+
+def test_annotations_foo():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for onset, duration, description in annot:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert type(elem) == expected_type
+
+
 def test_annotations_slices():
     """Test indexing Annotations."""
     NUM_ANNOT = 5

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -854,5 +854,18 @@ def test_annotations_slices():
     with pytest.raises(TypeError):
         annot['foo']
 
+def test_annotations_slices_with_foo():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    for ii in EXPECTED_ONSETS:
+        assert annot.foo(ii) == (ii, ii, str(ii))
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -4,6 +4,7 @@
 
 from datetime import datetime
 from itertools import repeat
+from collections import OrderedDict
 
 import os.path as op
 
@@ -794,7 +795,6 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
-@pytest.mark.skip(reason='untuple no longer works')
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
@@ -807,31 +807,20 @@ def test_annotations_simple_iteration():
                         description=EXPECTED_DESCS,
                         orig_time=None)
 
-    for ii, (onset, duration, description) in enumerate(annot[:2]):
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+    for ii, elements in enumerate(annot[:2]):
+        assert isinstance(elements, OrderedDict)
+        expected_values = (ii, ii, str(ii))
+        for elem, expected_type, expected_value in zip(elements.values(),
+                                                       EXPECTED_ELEMENTS_TYPE,
+                                                       expected_values):
             assert np.isscalar(elem)
             assert type(elem) == expected_type
-        assert (onset, duration, description) == (ii, ii, str(ii))
+            assert elem == expected_value
 
-    bool_sequence = [bool(ii % 2) for ii in range(len(annot))]
-    for onset, duration, description in annot[bool_sequence]:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert type(elem) == expected_type
-
-    # Slicing with int is no longer the same iterator
+    # unpacking is not allowed
     with pytest.raises(ValueError, match='too many values'):
         for onset, duration, description in annot[0]:
             pass
-
-    annotations_with_single_element = annot[slice(0, None, None)]
-    for onset, duration, description in annotations_with_single_element:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert type(elem) == expected_type
 
 
 def test_annotations_slices():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -794,9 +794,10 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
-def test_annotations_foo():
+def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 
@@ -805,129 +806,27 @@ def test_annotations_foo():
                         description=EXPECTED_DESCS,
                         orig_time=None)
 
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
-    for onset, duration, description in annot:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert type(elem) == expected_type
-
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
-    for ii, (onset, duration, description) in enumerate(annot):
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert type(elem) == expected_type
-        assert (onset, druation, description) == (ii, ii, str(ii))
-
-def test_dummy():
-    class Ob(object):
-        def __init__(self):
-            self.NUM = 5
-            self.a = np.array([x for x in range(self.NUM)])
-            self.b = np.array([x.__repr__() for x in range(self.NUM)])
-
-        def __iter__(self):
-            for ii in range(self.NUM):
-                yield (self.a[ii], self.b[ii])
-
-    xx = Ob()
-    for ii, elem in enumerate([(x, y) for x, y in xx]):
-        assert elem[0] == ii
-        assert elem[1] == str(ii)
-
-def test_annotations_simple_iterator():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 10
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS.copy(),
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
-    for onset, duration, description in annot:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert isinstance(elem, expected_type)
-
-    my_new_annot = annot[slice(0, None, 2)]
-    assert isinstance(my_new_annot, Annotations)
-
-    bool_sequence = [bool(ii%2) for ii in range(len(annot))]
-    for onset, duration, description in annot[bool_sequence]:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert isinstance(elem, expected_type)
-
-def test_annotations_xx():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 10
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    every_other = slice(0, None, 2)
-    for kk in [every_other, 1]:
-        xx = annot[kk]
-        print(type(xx))
-        print(len(xx))
-
-    bool_sequence = [bool(ii%2) for ii in range(len(annot))]
-    for onset, duration, description in annot[bool_sequence]:
-        elements = (onset, duration, description)
-        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
-            assert np.isscalar(elem)
-            assert type(elem) == expected_type
-
-def test_annotations_bar():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 5
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
     for ii, (onset, duration, description) in enumerate(annot[:2]):
         elements = (onset, duration, description)
         for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
             assert np.isscalar(elem)
             assert type(elem) == expected_type
-        assert (onset, druation, description) == (ii, ii, str(ii))
+        assert (onset, duration, description) == (ii, ii, str(ii))
 
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
-    for onset, duration, description in annot[:2]:
+    bool_sequence = [bool(ii % 2) for ii in range(len(annot))]
+    for onset, duration, description in annot[bool_sequence]:
         elements = (onset, duration, description)
         for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
             assert np.isscalar(elem)
             assert type(elem) == expected_type
 
+    # Slicing with int is no longer the same iterator
+    with pytest.raises(ValueError, match='too many values'):
+        for onset, duration, description in annot[0]:
+            pass
 
-def test_annotations_foo():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 5
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
-    for onset, duration, description in annot:
+    annotations_with_single_element = annot[slice(0, None, None)]
+    for onset, duration, description in annotations_with_single_element:
         elements = (onset, duration, description)
         for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
             assert np.isscalar(elem)
@@ -940,52 +839,24 @@ def test_annotations_slices():
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
+    annot = Annotations(onset=EXPECTED_ONSETS.copy(),
+                        duration=EXPECTED_DURATIONS.copy(),
+                        description=EXPECTED_DESCS.copy(),
                         orig_time=None)
 
+    # Slicing with single element returns a dictionary
     for ii in EXPECTED_ONSETS:
-        assert annot[ii] == (ii, ii, str(ii))
+        assert annot[ii] == dict(zip(['onset', 'duration',
+                                      'description', 'orig_time'],
+                                     [ii, ii, str(ii), None]))
 
-    _onsets, _durations, _desc = annot[:]
-    _onsets[0], _durations[0], _desc[0] = (42, 42, 'foo')
-
-    _onsets, _durations, _desc = annot[:]
-    for actual, expected in [(_onsets, EXPECTED_ONSETS),
-                             (_durations, EXPECTED_DURATIONS),
-                             (_desc, EXPECTED_DESCS)]:
-        assert all(actual == expected)
-
-    _onsets, _durations, _desc = annot[2:]
-    for actual, expected in zip([_onsets, _durations, _desc],
-                                [np.array(EXPECTED_ONSETS)[2:],
-                                 np.array(EXPECTED_DURATIONS)[2:],
-                                 np.array(EXPECTED_DESCS)[2:]]):
-        assert all(actual == expected)
-
-    _onsets, _durations, _desc = annot[1::2]
-    for actual, expected in zip([_onsets, _durations, _desc],
-                                [np.array(EXPECTED_ONSETS)[1::2],
-                                 np.array(EXPECTED_DURATIONS)[1::2],
-                                 np.array(EXPECTED_DESCS)[1::2]]):
-        assert all(actual == expected)
-
-    every_other = slice(0, None, 2)
-    _onsets, _durations, _desc = annot[every_other]
-    for actual, expected in zip([_onsets, _durations, _desc],
-                                [np.array(EXPECTED_ONSETS)[every_other],
-                                 np.array(EXPECTED_DURATIONS)[every_other],
-                                 np.array(EXPECTED_DESCS)[every_other]]):
-        assert all(actual == expected)
-
-    valid_bool = [True, False, True, True, False]
-    _onsets, _durations, _desc = annot[valid_bool]
-    for actual, expected in zip([_onsets, _durations, _desc],
-                                [np.array(EXPECTED_ONSETS)[valid_bool],
-                                 np.array(EXPECTED_DURATIONS)[valid_bool],
-                                 np.array(EXPECTED_DESCS)[valid_bool]]):
-        assert all(actual == expected)
+    # Slices should give back Annotations
+    for current in (annot[slice(0, None, 2)],
+                    annot[[bool(ii % 2) for ii in range(len(annot))]],
+                    annot[:],
+                    annot[1::2],
+                    ):
+        assert isinstance(current, Annotations)
 
     for bad_ii in [len(EXPECTED_ONSETS), 42]:
         with pytest.raises(IndexError):
@@ -994,18 +865,5 @@ def test_annotations_slices():
     with pytest.raises(TypeError):
         annot['foo']
 
-def test_annotations_slices_with_foo():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 5
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    for ii in EXPECTED_ONSETS:
-        assert annot.foo(ii) == (ii, ii, str(ii))
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -834,6 +834,11 @@ def test_annotations_slices():
                         description=EXPECTED_DESCS.copy(),
                         orig_time=None)
 
+    # Indexing returns a copy. So this has no effect in annot
+    annot[0]['onset'] = 42
+    annot[0]['duration'] = 3.14
+    annot[0]['description'] = 'foobar'
+
     # Slicing with single element returns a dictionary
     for ii in EXPECTED_ONSETS:
         assert annot[ii] == dict(zip(['onset', 'duration',

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -829,9 +829,9 @@ def test_annotations_slices():
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 
-    annot = Annotations(onset=EXPECTED_ONSETS.copy(),
-                        duration=EXPECTED_DURATIONS.copy(),
-                        description=EXPECTED_DESCS.copy(),
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
                         orig_time=None)
 
     # Indexing returns a copy. So this has no effect in annot

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -794,6 +794,7 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
+@pytest.mark.skip(reason='untuple no longer works')
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
@@ -864,40 +865,5 @@ def test_annotations_slices():
 
     with pytest.raises(TypeError):
         annot['foo']
-
-
-def test_dummy():
-    from collections import OrderedDict
-
-    class Ob_tuple(object):
-        def __init__(self):
-            self.NUM = 5
-            self.a = np.array([x for x in range(self.NUM)])
-            self.b = np.array([x.__repr__() for x in range(self.NUM)])
-
-        def __iter__(self):
-            for ii in range(self.NUM):
-                yield (self.a[ii], self.b[ii])
-
-    for a, b in Ob_tuple():
-        print((a, b))
-
-    class Ob_dict(object):
-        def __init__(self):
-            self.NUM = 5
-            self.a = np.array([x for x in range(self.NUM)])
-            self.b = np.array([x.__repr__() for x in range(self.NUM)])
-
-        def __iter__(self):
-            for ii in range(self.NUM):
-                yield OrderedDict(zip(('a', 'b'), (self.a[ii], self.b[ii])))
-
-    # the dict elements are ok
-    for x in Ob_dict():
-        print(x)
-
-    # iterate over a dict gives you the keys not the values
-    for a, b in Ob_dict():
-        print((a, b))
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -797,8 +797,8 @@ def test_read_annotation_txt_orig_time(
 def test_annotations_slices():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [_ for _ in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [_.__repr__() for _ in range(NUM_ANNOT)]
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 
     annot = Annotations(onset=EXPECTED_ONSETS,
                         duration=EXPECTED_DURATIONS,
@@ -807,6 +807,9 @@ def test_annotations_slices():
 
     for ii in EXPECTED_ONSETS:
         assert annot[ii] == (ii, ii, str(ii))
+
+    _onsets, _durations, _desc = annot[:]
+    _onsets[0], _durations[0], _desc[0] = (42, 42, 'foo')
 
     _onsets, _durations, _desc = annot[:]
     for actual, expected in [(_onsets, EXPECTED_ONSETS),

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -866,4 +866,38 @@ def test_annotations_slices():
         annot['foo']
 
 
+def test_dummy():
+    from collections import OrderedDict
+
+    class Ob_tuple(object):
+        def __init__(self):
+            self.NUM = 5
+            self.a = np.array([x for x in range(self.NUM)])
+            self.b = np.array([x.__repr__() for x in range(self.NUM)])
+
+        def __iter__(self):
+            for ii in range(self.NUM):
+                yield (self.a[ii], self.b[ii])
+
+    for a, b in Ob_tuple():
+        print((a, b))
+
+    class Ob_dict(object):
+        def __init__(self):
+            self.NUM = 5
+            self.a = np.array([x for x in range(self.NUM)])
+            self.b = np.array([x.__repr__() for x in range(self.NUM)])
+
+        def __iter__(self):
+            for ii in range(self.NUM):
+                yield OrderedDict(zip(('a', 'b'), (self.a[ii], self.b[ii])))
+
+    # the dict elements are ok
+    for x in Ob_dict():
+        print(x)
+
+    # iterate over a dict gives you the keys not the values
+    for a, b in Ob_dict():
+        print((a, b))
+
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -839,6 +839,10 @@ def test_annotations_slices():
     annot[0]['duration'] = 3.14
     annot[0]['description'] = 'foobar'
 
+    annot[:1].onset[0] = 42
+    annot[:1].duration[0] = 3.14
+    annot[:1].description[0] = 'foobar'
+
     # Slicing with single element returns a dictionary
     for ii in EXPECTED_ONSETS:
         assert annot[ii] == dict(zip(['onset', 'duration',

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -794,4 +794,40 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
+def test_annotations_slices():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [_ for _ in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [_.__repr__() for _ in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    for ii in EXPECTED_ONSETS:
+        assert annot[ii] == (ii, ii, str(ii))
+
+    _onsets, _durations, _desc = annot[:]
+    for actual, expected in [(_onsets, EXPECTED_ONSETS),
+                             (_durations, EXPECTED_DURATIONS),
+                             (_desc, EXPECTED_DESCS)]:
+        assert all(actual == expected)
+
+    valid_bool = [True, False, True, True, False]
+    _onsets, _durations, _desc = annot[valid_bool]
+    for actual, expected in zip([_onsets, _durations, _desc],
+                                [np.array(EXPECTED_ONSETS)[valid_bool],
+                                 np.array(EXPECTED_DURATIONS)[valid_bool],
+                                 np.array(EXPECTED_DESCS)[valid_bool]]):
+        assert all(actual == expected)
+
+    for bad_ii in [len(EXPECTED_ONSETS), 42]:
+        with pytest.raises(IndexError):
+            annot[bad_ii]
+
+    with pytest.raises(TypeError):
+        annot['foo']
+
+
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -824,19 +824,45 @@ def test_dummy():
     class Ob(object):
         def __init__(self):
             self.NUM = 5
-            self.a = [x for x in range(self.NUM)]
-            self.b = [x.__repr__() for x in range(self.NUM)]
+            self.a = np.array([x for x in range(self.NUM)])
+            self.b = np.array([x.__repr__() for x in range(self.NUM)])
 
         def __iter__(self):
             for ii in range(self.NUM):
                 yield (self.a[ii], self.b[ii])
-            return
 
     xx = Ob()
     for ii, elem in enumerate([(x, y) for x, y in xx]):
         assert elem[0] == ii
         assert elem[1] == str(ii)
 
+def test_annotations_simple_iterator():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 10
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS.copy(),
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    for onset, duration, description in annot:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert isinstance(elem, expected_type)
+
+    my_new_annot = annot[slice(0, None, 2)]
+    assert isinstance(my_new_annot, Annotations)
+
+    bool_sequence = [bool(ii%2) for ii in range(len(annot))]
+    for onset, duration, description in annot[bool_sequence]:
+        elements = (onset, duration, description)
+        for elem, expected_type in zip(elements, EXPECTED_ELEMENTS_TYPE):
+            assert np.isscalar(elem)
+            assert isinstance(elem, expected_type)
 
 def test_annotations_xx():
     """Test indexing Annotations."""

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -823,6 +823,7 @@ def test_annotations_simple_iteration():
             pass
 
 
+@requires_version('numpy', '1.12')
 def test_annotations_slices():
     """Test indexing Annotations."""
     NUM_ANNOT = 5

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -850,34 +850,16 @@ def test_annotations_slices():
                     annot[[bool(ii % 2) for ii in range(len(annot))]],
                     annot[:1],
                     annot[[0, 2, 2]],
+                    annot[(0, 2, 2)],
+                    annot[np.array([0, 2, 2])],
                     annot[1::2],
                     ):
         assert isinstance(current, Annotations)
         assert len(current) != len(annot)
 
-    for bad_ii in [len(EXPECTED_ONSETS), 42]:
+    for bad_ii in [len(EXPECTED_ONSETS), 42, 'foo']:
         with pytest.raises(IndexError):
             annot[bad_ii]
 
-    with pytest.raises(TypeError):
-        annot['foo']
-
-
-def test_annotations_slices_breaking_():
-    """Test indexing Annotations."""
-    NUM_ANNOT = 5
-    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
-    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
-
-    annot = Annotations(onset=EXPECTED_ONSETS,
-                        duration=EXPECTED_DURATIONS,
-                        description=EXPECTED_DESCS,
-                        orig_time=None)
-
-    for current in (annot[(0, 2, 2)],
-                    annot[np.array([0, 2, 2])],
-                    ):
-        assert isinstance(current, Annotations)
-        assert len(current) != len(annot)
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -817,11 +817,6 @@ def test_annotations_simple_iteration():
             assert type(elem) == expected_type
             assert elem == expected_value
 
-    # unpacking as a tuple is not allowed since it returns a dict
-    with pytest.raises(ValueError, match='too many values'):
-        for onset, duration, description, orig_time in annot[0]:
-            pass
-
 
 @requires_version('numpy', '1.12')
 def test_annotations_slices():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -849,6 +849,7 @@ def test_annotations_slices():
     for current in (annot[slice(0, None, 2)],
                     annot[[bool(ii % 2) for ii in range(len(annot))]],
                     annot[:1],
+                    annot[[0, 2, 2]],
                     annot[1::2],
                     ):
         assert isinstance(current, Annotations)
@@ -860,5 +861,23 @@ def test_annotations_slices():
 
     with pytest.raises(TypeError):
         annot['foo']
+
+
+def test_annotations_slices_breaking_():
+    """Test indexing Annotations."""
+    NUM_ANNOT = 5
+    EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
+    EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
+
+    annot = Annotations(onset=EXPECTED_ONSETS,
+                        duration=EXPECTED_DURATIONS,
+                        description=EXPECTED_DESCS,
+                        orig_time=None)
+
+    for current in (annot[(0, 2, 2)],
+                    annot[np.array([0, 2, 2])],
+                    ):
+        assert isinstance(current, Annotations)
+        assert len(current) != len(annot)
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -848,10 +848,11 @@ def test_annotations_slices():
     # Slices should give back Annotations
     for current in (annot[slice(0, None, 2)],
                     annot[[bool(ii % 2) for ii in range(len(annot))]],
-                    annot[:],
+                    annot[:1],
                     annot[1::2],
                     ):
         assert isinstance(current, Annotations)
+        assert len(current) != len(annot)
 
     for bad_ii in [len(EXPECTED_ONSETS), 42]:
         with pytest.raises(IndexError):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -817,6 +817,28 @@ def test_annotations_slices():
                              (_desc, EXPECTED_DESCS)]:
         assert all(actual == expected)
 
+    _onsets, _durations, _desc = annot[2:]
+    for actual, expected in zip([_onsets, _durations, _desc],
+                                [np.array(EXPECTED_ONSETS)[2:],
+                                 np.array(EXPECTED_DURATIONS)[2:],
+                                 np.array(EXPECTED_DESCS)[2:]]):
+        assert all(actual == expected)
+
+    _onsets, _durations, _desc = annot[1::2]
+    for actual, expected in zip([_onsets, _durations, _desc],
+                                [np.array(EXPECTED_ONSETS)[1::2],
+                                 np.array(EXPECTED_DURATIONS)[1::2],
+                                 np.array(EXPECTED_DESCS)[1::2]]):
+        assert all(actual == expected)
+
+    every_other = slice(0, None, 2)
+    _onsets, _durations, _desc = annot[every_other]
+    for actual, expected in zip([_onsets, _durations, _desc],
+                                [np.array(EXPECTED_ONSETS)[every_other],
+                                 np.array(EXPECTED_DURATIONS)[every_other],
+                                 np.array(EXPECTED_DESCS)[every_other]]):
+        assert all(actual == expected)
+
     valid_bool = [True, False, True, True, False]
     _onsets, _durations, _desc = annot[valid_bool]
     for actual, expected in zip([_onsets, _durations, _desc],

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -817,9 +817,9 @@ def test_annotations_simple_iteration():
             assert type(elem) == expected_type
             assert elem == expected_value
 
-    # unpacking is not allowed
+    # unpacking as a tuple is not allowed since it returns a dict
     with pytest.raises(ValueError, match='too many values'):
-        for onset, duration, description in annot[0]:
+        for onset, duration, description, orig_time in annot[0]:
             pass
 
 

--- a/tutorials/plot_object_annotations.py
+++ b/tutorials/plot_object_annotations.py
@@ -188,7 +188,6 @@ print(annot)
 # with the sliced elements.
 #
 # See the following examples and usages:
-plt.close('all')
 print('type: {0} content: {1}'.format(type(annot[0]), annot[0]))
 
 print('type: {0} content: {1}'.format(type(annot[:]), annot[:]))

--- a/tutorials/plot_object_annotations.py
+++ b/tutorials/plot_object_annotations.py
@@ -1,5 +1,5 @@
 """
-The **:term:`<events>`** and :class:`~mne.Annotations` data structures
+The :term:`Events <events>` and :class:`~mne.Annotations` data structures
 =========================================================================
 
 :term:`Events <events>` and :term:`annotations` are quite similar.
@@ -190,19 +190,23 @@ print(annot)
 # See the following examples and usages:
 
 # difference between indexing and slicing a single element
-print(annot[0])
-print(annot[:1])
+print(annot[0])  # indexing
+print(annot[:1])  # slicing
 
 ###############################################################################
-#
+# How about iterations?
 
-for key, val in annot[0].items():
+for key, val in annot[0].items():  # iterate on one element which is dictionary
     print(key, val)
 
-for idx, my_annot in enumerate(annot):
+###############################################################################
+
+for idx, my_annot in enumerate(annot):  # iterate on the Annotations object
     print('annot #{0}: onset={1}'.format(idx, my_annot['onset']))
     print('annot #{0}: duration={1}'.format(idx, my_annot['duration']))
     print('annot #{0}: description={1}'.format(idx, my_annot['description']))
+
+###############################################################################
 
 for idx, my_annot in enumerate(annot[:1]):
     for key, val in my_annot.items():

--- a/tutorials/plot_object_annotations.py
+++ b/tutorials/plot_object_annotations.py
@@ -191,7 +191,7 @@ print(annot)
 
 # difference between indexing and slicing a single element
 print(annot[0])
-print(annot[slice(0, None, None)])
+print(annot[:1])
 
 ###############################################################################
 #

--- a/tutorials/plot_object_annotations.py
+++ b/tutorials/plot_object_annotations.py
@@ -183,38 +183,43 @@ print(annot)
 # Iterating, Indexing and Slicing :class:`mne.Annotations`
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# :class:`~mne.Annotations` supports the same indexing and slicing as
-# ``numpy.array``, and it returns a ``(onset, duration, description)`` tuple
-# with the sliced elements.
+# :class:`~mne.Annotations` supports iterating, indexing and slicing.
+# Iterating over :class:`~mne.Annotations` and indexing with an integer returns
+# a dictionary. While slicing returns a new :class:`~mne.Annotations` instance.
 #
 # See the following examples and usages:
-print('type: {0} content: {1}'.format(type(annot[0]), annot[0]))
 
-print('type: {0} content: {1}'.format(type(annot[:]), annot[:]))
+# difference between indexing and slicing a single element
+print(annot[0])
+print(annot[slice(0, None, None)])
 
-_MSG = 'annotation #{0}: onset={1} duration={2} desc={3}'
-for idx, (onset, duration, desc) in enumerate(annot):
-    print(_MSG.format(idx, onset, duration, desc))
+###############################################################################
+#
 
-start, stop, step = (0, None, 2)
-every_other_annotation = slice(start, stop, step)
-for onset, duration, desc in zip(*annot[every_other_annotation]):
-    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+for key, val in annot[0].items():
+    print(key, val)
 
-for onset, duration, desc in zip(*annot[1::2]):
-    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+for idx, my_annot in enumerate(annot):
+    print('annot #{0}: onset={1}'.format(idx, my_annot['onset']))
+    print('annot #{0}: duration={1}'.format(idx, my_annot['duration']))
+    print('annot #{0}: description={1}'.format(idx, my_annot['description']))
 
-# XXX: it works 'cos its 3
-desc_starts_with_foo = [desc.startswith('foo') for desc in annot.description]
-print(desc_starts_with_foo)
-for onset, duration, desc in annot[desc_starts_with_foo]:
-    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+for idx, my_annot in enumerate(annot[:1]):
+    for key, val in my_annot.items():
+        print('annot #{0}: {1} = {2}'.format(idx, key, val))
 
+###############################################################################
+# Iterating, indexing and slicing return a copy. This has implications like the
+# fact that changes are not kept.
 
-# desc_is_foo = [desc == 'foo' for desc in annot.description]
-# print(desc_is_foo)
-# for onset, duration, desc in annot[desc_is_foo]:
-#     print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+# this change is not kept
+annot[0]['onset'] = 42
+print(annot[0])
+
+# this change is kept
+annot.onset[0] = 42
+print(annot[0])
+
 
 ###############################################################################
 # Save

--- a/tutorials/plot_object_annotations.py
+++ b/tutorials/plot_object_annotations.py
@@ -1,26 +1,11 @@
 """
-The **events** and :class:`~mne.Annotations` data structures
+The **:term:`<events>`** and :class:`~mne.Annotations` data structures
 =========================================================================
 
-Events and :class:`~mne.Annotations` are quite similar.
+:term:`Events <events>` and :term:`annotations` are quite similar.
 This tutorial highlights their differences and similarities, and tries to shed
 some light on which one is preferred to use in different situations when using
 MNE.
-
-Here are the definitions from the :ref:`glossary`.
-
-    events
-        Events correspond to specific time points in raw data; e.g., triggers,
-        experimental condition events, etc. MNE represents events with integers
-        that are stored in numpy arrays of shape (n_events, 3). Such arrays are
-        classically obtained from a trigger channel, also referred to as stim
-        channel.
-
-    annotations
-        An annotation is defined by an onset, a duration, and a string
-        description. It can contain information about the experiment, but
-        also details on signals marked by a human: bad data segments,
-        sleep scores, sleep events (spindles, K-complex) etc.
 
 Both events and :class:`~mne.Annotations` can be seen as triplets
 where the first element answers to **when** something happens and the last
@@ -101,8 +86,8 @@ annotated_blink_raw.plot()
 
 
 ###############################################################################
-# Working with Annotations
-# ------------------------
+# Add :term:`annotations` to :term:`raw` objects
+# ----------------------------------------------
 #
 # An important element of :class:`~mne.Annotations` is
 # ``orig_time`` which is the time reference for the ``onset``.
@@ -179,6 +164,12 @@ print('annot_none.onset[0] is {}'.format(annot_none.onset[0]))
 print('raw_a.annotations.onset[0] is {}'.format(raw_a.annotations.onset[0]))
 
 ###############################################################################
+# Valid operations in :class:`mne.Annotations`
+# --------------------------------------------
+#
+# Concatenate
+# ~~~~~~~~~~~
+#
 # It is possible to concatenate two annotations with the + operator (just like
 # lists) if both share the same ``orig_time``
 
@@ -189,6 +180,47 @@ annot = annot_orig + annot  # concatenation
 print(annot)
 
 ###############################################################################
+# Iterating, Indexing and Slicing :class:`mne.Annotations`
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# :class:`~mne.Annotations` supports the same indexing and slicing as
+# ``numpy.array``, and it returns a ``(onset, duration, description)`` tuple
+# with the sliced elements.
+#
+# See the following examples and usages:
+plt.close('all')
+print('type: {0} content: {1}'.format(type(annot[0]), annot[0]))
+
+print('type: {0} content: {1}'.format(type(annot[:]), annot[:]))
+
+_MSG = 'annotation #{0}: onset={1} duration={2} desc={3}'
+for idx, (onset, duration, desc) in enumerate(annot):
+    print(_MSG.format(idx, onset, duration, desc))
+
+start, stop, step = (0, None, 2)
+every_other_annotation = slice(start, stop, step)
+for onset, duration, desc in zip(*annot[every_other_annotation]):
+    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+
+for onset, duration, desc in zip(*annot[1::2]):
+    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+
+# XXX: it works 'cos its 3
+desc_starts_with_foo = [desc.startswith('foo') for desc in annot.description]
+print(desc_starts_with_foo)
+for onset, duration, desc in annot[desc_starts_with_foo]:
+    print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+
+
+# desc_is_foo = [desc == 'foo' for desc in annot.description]
+# print(desc_is_foo)
+# for onset, duration, desc in annot[desc_is_foo]:
+#     print('onset={0} duration={1} desc={2}'.format(onset, duration, desc))
+
+###############################################################################
+# Save
+# ~~~~
+#
 # Note that you can also save annotations to disk in FIF format::
 #
 #     >>> annot.save('my-annot.fif')


### PR DESCRIPTION
Based on [python 3 doc](https://docs.python.org/3/reference/datamodel.html#object.__getitem__) indexing with
the wrong type should raise `TypeError` not `IndexError`. Then the entire function gets much more simpler:

``` python

def __getitem__(self, key):
    """Propagate indexing and slicing to the underlying numpy structure."""
    return (self.onset[key], self.duration[key], self.description[key])
```

About the current solution: 
* (pros) I like the idea that we are raising the right 
* (cons) the code has 5 branches