### PR TITLE
MRG: Add helper functions for label data

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -689,6 +689,8 @@ Source Space Data
    grade_to_vertices
    grow_labels
    label_sign_flip
+   labels_to_stc
+   morph_labels
    random_parcellation
    read_labels_from_annot
    read_dipole

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,11 @@ Changelog
 
 - Add use of :func:`scipy.signal.windows.dpss` for faster multitaper window computations in PSD functions by `Eric Larson`_
 
+- Add :func:`mne.morph_labels` to facilitate morphing label sets obtained from parcellations, by `Eric Larson`_
+
+- Add :func:`mne.labels_to_stc` to facilitate working with label data, by `Eric Larson`_
+
+- Add ``overlap`` argument to :func:`mne.make_fixed_length_events` by `Eric Larson`_
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -75,7 +75,8 @@ from .epochs import (BaseEpochs, Epochs, EpochsArray, read_epochs,
 from .evoked import Evoked, EvokedArray, read_evokeds, write_evokeds, combine_evoked
 from .label import (read_label, label_sign_flip,
                     write_label, stc_to_label, grow_labels, Label, split_label,
-                    BiHemiLabel, read_labels_from_annot, write_labels_to_annot, random_parcellation)
+                    BiHemiLabel, read_labels_from_annot, write_labels_to_annot,
+                    random_parcellation, morph_labels, labels_to_stc)
 from .misc import parse_config, read_reject_parameters
 from .coreg import (create_default_subject, scale_bem, scale_mri, scale_labels,
                     scale_source_space)

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1068,12 +1068,23 @@ def _remove_duplicate_rows(arr):
 ###############################################################################
 # csr_matrix.argmax from SciPy 0.19+
 
+def _find_missing_index(ind, n):
+    for k, a in enumerate(ind):
+        if k != a:
+            return k
+
+    k += 1
+    if k < n:
+        return k
+    else:
+        return -1
+
+
 def _sparse_argmax(mat, axis):
     import scipy
     if LooseVersion(scipy.__version__) >= '0.19':
         return mat.argmax(axis)
     else:
-        from scipy.sparse.data import _find_missing_index
         op = np.argmax
         compare = np.greater
         self = mat

--- a/mne/label.py
+++ b/mne/label.py
@@ -6,13 +6,14 @@
 
 from collections import defaultdict
 from colorsys import hsv_to_rgb, rgb_to_hsv
+from distutils.version import LooseVersion
 from os import path as op
 import os
 import copy as cp
 import re
 
 import numpy as np
-from scipy import linalg, sparse
+from scipy import linalg, sparse, __version__ as sp_version
 
 from .parallel import parallel_func, check_n_jobs
 from .source_estimate import (SourceEstimate, _center_of_mass,
@@ -2095,6 +2096,9 @@ def morph_labels(labels, subject_to, subject_from=None, subjects_dir=None,
 
     .. versionadded:: 0.18
     """
+    if not LooseVersion(sp_version) >= LooseVersion('0.19'):
+        raise ImportError('SciPy 0.19+ required to use this function, got %s'
+                          % (sp_version,))
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     subject_from = _check_labels_subject(labels, subject_from, 'subject_from')
     mmaps = read_morph_map(subject_from, subject_to, subjects_dir)

--- a/mne/label.py
+++ b/mne/label.py
@@ -2042,7 +2042,7 @@ def _check_labels_subject(labels, subject, name):
         _validate_type(label, Label, 'each entry in labels')
         if subject is None:
             subject = label.subject
-        if subject is not None:
+        if subject is not None:  # label.subject can be None, depending on init
             if subject != label.subject:
                 raise ValueError('Got multiple values of %s: %s and %s'
                                  % (name, subject, label.subject))

--- a/mne/label.py
+++ b/mne/label.py
@@ -2119,6 +2119,9 @@ def morph_labels(labels, subject_to, subject_from=None, subjects_dir=None,
 def labels_to_stc(labels, values, tmin=0, tstep=1, subject=None, verbose=None):
     """Convert a set of labels and values to a STC.
 
+    This function is meant to work like the opposite of
+    `extract_label_time_course`.
+
     Parameters
     ----------
     labels : list of Label
@@ -2139,6 +2142,10 @@ def labels_to_stc(labels, values, tmin=0, tstep=1, subject=None, verbose=None):
     -------
     stc : instance of SourceEstimate
         The values-in-labels converted to a STC.
+
+    See Also
+    --------
+    extract_label_time_course
 
     Notes
     -----

--- a/mne/label.py
+++ b/mne/label.py
@@ -14,15 +14,15 @@ import re
 import numpy as np
 from scipy import linalg, sparse
 
-from .utils import get_subjects_dir, _check_subject, logger, verbose, warn,\
-    check_random_state
+from .parallel import parallel_func, check_n_jobs
 from .source_estimate import (SourceEstimate, _center_of_mass,
                               spatial_src_connectivity)
-from .source_space import add_source_space_distances
-from .surface import read_surface, fast_cross_3d, mesh_edges, mesh_dist
-from .source_space import SourceSpaces
-from .parallel import parallel_func, check_n_jobs
+from .source_space import add_source_space_distances, SourceSpaces
 from .stats.cluster_level import _find_clusters, _get_components
+from .surface import (read_surface, fast_cross_3d, mesh_edges, mesh_dist,
+                      read_morph_map)
+from .utils import (get_subjects_dir, _check_subject, logger, verbose, warn,
+                    check_random_state, _validate_type)
 
 
 def _blend_colors(color_1, color_2):
@@ -550,6 +550,10 @@ class Label(object):
         -------
         label : instance of Label
             The morphed label.
+
+        See Also
+        --------
+        mne.morph_labels : morph a set of labels
 
         Notes
         -----
@@ -1925,6 +1929,20 @@ def _get_annot_fname(annot_fname, subject, hemi, parc, subjects_dir):
     return annot_fname, hemis
 
 
+def _load_vert_pos(subject, subjects_dir, surf_name, hemi, n_expected,
+                   extra=''):
+    fname_surf = op.join(subjects_dir, subject, 'surf',
+                         '%s.%s' % (hemi, surf_name))
+    vert_pos, _ = read_surface(fname_surf)
+    vert_pos /= 1e3  # the positions in labels are in meters
+    if len(vert_pos) != n_expected:
+        raise RuntimeError('Number of surface vertices (%s) for subject %s'
+                           ' does not match the expected number of vertices'
+                           '(%s)%s'
+                           % (len(vert_pos), subject, n_expected, extra))
+    return vert_pos
+
+
 @verbose
 def read_labels_from_annot(subject, parc='aparc', hemi='both',
                            surf_name='white', annot_fname=None, regexp=None,
@@ -1936,11 +1954,11 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     Parameters
     ----------
     subject : str
-        The subject for which to read the parcellation for.
+        The subject for which to read the parcellation.
     parc : str
         The parcellation to use, e.g., 'aparc' or 'aparc.a2009s'.
     hemi : str
-        The hemisphere to read the parcellation for, can be 'lh', 'rh',
+        The hemisphere from which to read the parcellation, can be 'lh', 'rh',
         or 'both'.
     surf_name : str
         Surface used to obtain vertex locations, e.g., 'white', 'pial'
@@ -1973,7 +1991,7 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     if regexp is not None:
         # allow for convenient substring match
         r_ = (re.compile('.*%s.*' % regexp if regexp.replace('_', '').isalnum()
-              else regexp))
+                         else regexp))
 
     # now we are ready to create the labels
     n_read = 0
@@ -1981,14 +1999,13 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     for fname, hemi in zip(annot_fname, hemis):
         # read annotation
         annot, ctab, label_names = _read_annot(fname)
-        label_rgbas = ctab[:, :4]
+        label_rgbas = ctab[:, :4] / 255.
         label_ids = ctab[:, -1]
 
         # load the vertex positions from surface
-        fname_surf = op.join(subjects_dir, subject, 'surf',
-                             '%s.%s' % (hemi, surf_name))
-        vert_pos, _ = read_surface(fname_surf)
-        vert_pos /= 1e3  # the positions in labels are in meters
+        vert_pos = _load_vert_pos(
+            subject, subjects_dir, surf_name, hemi, len(annot),
+            extra='for annotation file %s' % fname)
         for label_id, label_name, label_rgba in\
                 zip(label_ids, label_names, label_rgbas):
             vertices = np.where(annot == label_id)[0]
@@ -1999,10 +2016,8 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
             if (regexp is not None) and not r_.match(name):
                 continue
             pos = vert_pos[vertices, :]
-            values = np.ones(len(vertices))
-            label_rgba = tuple(label_rgba / 255.)
-            label = Label(vertices, pos, values, hemi, name=name,
-                          subject=subject, color=label_rgba)
+            label = Label(vertices, pos, hemi=hemi, name=name,
+                          subject=subject, color=tuple(label_rgba))
             labels.append(label)
 
         n_read = len(labels) - n_read
@@ -2018,6 +2033,147 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
         raise RuntimeError(msg)
 
     return labels
+
+
+def _check_labels_subject(labels, subject, name):
+    _validate_type(labels, (list, tuple), 'labels')
+    for label in labels:
+        _validate_type(label, Label, 'each entry in labels')
+        if subject is None:
+            subject = label.subject
+        if subject is not None:
+            if subject != label.subject:
+                raise ValueError('Got multiple values of %s: %s and %s'
+                                 % (name, subject, label.subject))
+    if subject is None:
+        raise ValueError('if label.subject is None for all labels, '
+                         '%s must be provided' % name)
+    return subject
+
+
+@verbose
+def morph_labels(labels, subject_to, subject_from=None, subjects_dir=None,
+                 surf_name='white', verbose=None):
+    """Morph a set of labels.
+
+    This is useful when morphing a set of non-overlapping labels (such as those
+    obtained with :func:`read_labels_from_annot`) from one subject to
+    another.
+
+    Parameters
+    ----------
+    labels : list
+        The labels to morph.
+    subject_to : str
+        The subject to morph labels to.
+    subject_from : str | None
+        The subject to morph labels from. Can be None if the labels
+        have the ``.subject`` property defined.
+    subjects_dir : string, or None
+        Path to SUBJECTS_DIR if it is not set in the environment.
+    surf_name : str
+        Surface used to obtain vertex locations, e.g., 'white', 'pial'
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    labels : list
+        The morphed labels.
+
+    See Also
+    --------
+    read_labels_from_annot
+    mne.Label.morph
+
+    Notes
+    -----
+    This does not use the same algorithm as Freesurfer, so the results
+    morphing (e.g., from ``'fsaverage'`` to your subject) might not match
+    what Freesurfer produces during ``recon-all``.
+
+    .. versionadded:: 0.18
+    """
+    subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+    subject_from = _check_labels_subject(labels, subject_from, 'subject_from')
+    mmaps = read_morph_map(subject_from, subject_to, subjects_dir)
+    mmaps = dict((hemi, mmap) for hemi, mmap in zip(('lh', 'rh'), mmaps))
+    vert_poss = dict((hemi, _load_vert_pos(
+        subject_to, subjects_dir, surf_name, hemi, mmap.shape[0]))
+        for hemi, mmap in mmaps.items())
+    mmaps = dict((hemi, mmap.argmax(-1)) for hemi, mmap in mmaps.items())
+    out_labels = list()
+    values = filename = None
+    for label in labels:
+        vertices = np.where(np.in1d(mmaps[label.hemi], label.vertices))[0]
+        pos = vert_poss[label.hemi][vertices]
+        out_labels.append(
+            Label(vertices, pos, values, label.hemi, label.comment, label.name,
+                  filename, subject_to, label.color, label.verbose))
+    return out_labels
+
+
+@verbose
+def labels_to_stc(labels, values, tmin=0, tstep=1, subject=None, verbose=None):
+    """Convert a set of labels and values to a STC.
+
+    Parameters
+    ----------
+    labels : list of Label
+        The labels. Must not overlap.
+    values : ndarray, shape (len(labels), ...)
+        The values in each label. Can be 1D or 2D.
+    tmin : float
+        The tmin to use for the STC.
+    tstep : float
+        The tstep to use for the STC.
+    subject : str | None
+        The subject for which to create the STC.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+
+    Returns
+    -------
+    stc : instance of SourceEstimate
+        The values-in-labels converted to a STC.
+
+    Notes
+    -----
+    Vertices that appear in more than one label will be averaged.
+
+    .. versionadded:: 0.18
+    """
+    subject = _check_labels_subject(labels, subject, 'subject')
+    values = np.array(values, float)
+    if values.ndim == 1:
+        values = values[:, np.newaxis]
+    if values.ndim != 2:
+        raise ValueError('values must have 1 or 2 dimensions, got %s'
+                         % (values.ndim,))
+    if len(labels) != len(values):
+        raise ValueError('values.shape[0] (%s) must match len(labels) (%s)'
+                         % (values.shape[0], len(labels)))
+    vertices = dict(lh=[], rh=[])
+    data = dict(lh=[], rh=[])
+    for li, label in enumerate(labels):
+        data[label.hemi].append(
+            np.repeat(values[li][np.newaxis], len(label.vertices), axis=0))
+        vertices[label.hemi].append(label.vertices)
+    hemis = ('lh', 'rh')
+    for hemi in hemis:
+        vertices[hemi] = np.concatenate(vertices[hemi], axis=0)
+        data[hemi] = np.concatenate(data[hemi], axis=0).astype(float)
+        cols = np.arange(len(vertices[hemi]))
+        vertices[hemi], rows = np.unique(vertices[hemi], return_inverse=True)
+        mat = sparse.coo_matrix((np.ones(len(rows)), (rows, cols))).tocsr()
+        mat = mat * sparse.diags(1. / np.asarray(mat.sum(axis=-1))[:, 0])
+        data[hemi] = mat.dot(data[hemi])
+    vertices = [vertices[hemi] for hemi in hemis]
+    data = np.concatenate([data[hemi] for hemi in hemis], axis=0)
+    stc = SourceEstimate(data, vertices, tmin, tstep, subject, verbose)
+    return stc
 
 
 def _write_annot(fname, annot, ctab, names):
@@ -2081,7 +2237,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
     labels : list with instances of mne.Label
         The labels to create a parcellation from.
     subject : str | None
-        The subject for which to write the parcellation for.
+        The subject for which to write the parcellation.
     parc : str | None
         The parcellation name to use.
     overwrite : bool

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2519,33 +2519,13 @@ def _pca_flip(flip, data):
     return sign * scale * V[0]
 
 
-def _pca_flip_mean(flip, data):
-    v = _pca_flip(flip, data)
-    # XXX corrcoef probably incorrect choice because of mean subtraction
-    flip = np.sign(np.corrcoef(v, data))[1:, 0]
-    return np.mean(flip[:, np.newaxis] * data, axis=0)
-
-
-def _pca_flip_truncated(flip, data, n_comps=0.9):
-    # XXX the "scale" here is probably wrong
-    U, s, V = linalg.svd(data, full_matrices=False)
-    if isinstance(n_comps, float):
-        s *= s
-        s = s.cumsum()
-        n_comps = np.sum(s / s[-1] <= n_comps) + 1
-    n_comps = int(operator.index(n_comps))
-    return np.mean(
-        flip * np.dot(U[:, :n_comps] * s[:n_comps], V[:n_comps]), axis=0)
-
-
 _label_funcs = {
     'mean': lambda flip, data: np.mean(data, axis=0),
     'mean_flip': lambda flip, data: np.mean(flip * data, axis=0),
     'max': lambda flip, data: np.max(np.abs(data, axis=0)),
     'pca_flip': _pca_flip,
-    'pca_flip_mean': _pca_flip_mean,
-    'pca_flip_truncated': _pca_flip_truncated,
 }
+
 
 @verbose
 def _gen_extract_label_time_course(stcs, labels, src, mode='mean',

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -8,7 +8,6 @@
 import copy
 import os.path as op
 import numpy as np
-import operator
 from scipy import linalg, sparse
 from scipy.sparse import coo_matrix, block_diag as sparse_block_diag
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -8,6 +8,7 @@
 import copy
 import os.path as op
 import numpy as np
+import operator
 from scipy import linalg, sparse
 from scipy.sparse import coo_matrix, block_diag as sparse_block_diag
 
@@ -2509,6 +2510,43 @@ def _get_label_flip(labels, label_vertidx, src):
     return label_flip
 
 
+def _pca_flip(flip, data):
+    U, s, V = linalg.svd(data, full_matrices=False)
+    # determine sign-flip
+    sign = np.sign(np.dot(U[:, 0], flip))
+    # use average power in label for scaling
+    scale = linalg.norm(s) / np.sqrt(len(data))
+    return sign * scale * V[0]
+
+
+def _pca_flip_mean(flip, data):
+    v = _pca_flip(flip, data)
+    # XXX corrcoef probably incorrect choice because of mean subtraction
+    flip = np.sign(np.corrcoef(v, data))[1:, 0]
+    return np.mean(flip[:, np.newaxis] * data, axis=0)
+
+
+def _pca_flip_truncated(flip, data, n_comps=0.9):
+    # XXX the "scale" here is probably wrong
+    U, s, V = linalg.svd(data, full_matrices=False)
+    if isinstance(n_comps, float):
+        s *= s
+        s = s.cumsum()
+        n_comps = np.sum(s / s[-1] <= n_comps) + 1
+    n_comps = int(operator.index(n_comps))
+    return np.mean(
+        flip * np.dot(U[:, :n_comps] * s[:n_comps], V[:n_comps]), axis=0)
+
+
+_label_funcs = {
+    'mean': lambda flip, data: np.mean(data, axis=0),
+    'mean_flip': lambda flip, data: np.mean(flip * data, axis=0),
+    'max': lambda flip, data: np.max(np.abs(data, axis=0)),
+    'pca_flip': _pca_flip,
+    'pca_flip_mean': _pca_flip_mean,
+    'pca_flip_truncated': _pca_flip_truncated,
+}
+
 @verbose
 def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
                                    allow_empty=False, verbose=None):
@@ -2517,6 +2555,10 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
     # the other ones are vol type. For mixed source space n_labels will be the
     # given by the number of ROIs of the cortical parcellation plus the number
     # of vol src space
+
+    if mode not in _label_funcs:
+        raise ValueError('%s is an invalid mode' % mode)
+    func = _label_funcs[mode]
 
     if len(src) > 2:
         if src[0]['type'] != 'surf' or src[1]['type'] != 'surf':
@@ -2568,18 +2610,11 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
         label_vertidx.append(this_vertidx)
 
     # mode-dependent initialization
-    if mode == 'mean':
-        pass  # we have this here to catch invalid values for mode
-    elif mode == 'mean_flip':
+    if mode not in ('mean', 'max'):
         # get the sign-flip vector for every label
-        label_flip = _get_label_flip(labels, label_vertidx, src[:2])
-    elif mode == 'pca_flip':
-        # get the sign-flip vector for every label
-        label_flip = _get_label_flip(labels, label_vertidx, src[:2])
-    elif mode == 'max':
-        pass  # we calculate the maximum value later
+        src_flip = _get_label_flip(labels, label_vertidx, src[:2])
     else:
-        raise ValueError('%s is an invalid mode' % mode)
+        src_flip = [None] * len(labels)
 
     # loop through source estimates and extract time series
     for stc in stcs:
@@ -2605,34 +2640,9 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
         # do the extraction
         label_tc = np.zeros((n_labels, stc.data.shape[1]),
                             dtype=stc.data.dtype)
-        if mode == 'mean':
-            for i, vertidx in enumerate(label_vertidx):
-                if vertidx is not None:
-                    label_tc[i] = np.mean(stc.data[vertidx, :], axis=0)
-        elif mode == 'mean_flip':
-            for i, (vertidx, flip) in enumerate(zip(label_vertidx,
-                                                    label_flip)):
-                if vertidx is not None:
-                    label_tc[i] = np.mean(flip * stc.data[vertidx, :], axis=0)
-        elif mode == 'pca_flip':
-            for i, (vertidx, flip) in enumerate(zip(label_vertidx,
-                                                    label_flip)):
-                if vertidx is not None:
-                    U, s, V = linalg.svd(stc.data[vertidx, :],
-                                         full_matrices=False)
-                    # determine sign-flip
-                    sign = np.sign(np.dot(U[:, 0], flip))
-
-                    # use average power in label for scaling
-                    scale = linalg.norm(s) / np.sqrt(len(vertidx))
-
-                    label_tc[i] = sign * scale * V[0]
-        elif mode == 'max':
-            for i, vertidx in enumerate(label_vertidx):
-                if vertidx is not None:
-                    label_tc[i] = np.max(np.abs(stc.data[vertidx, :]), axis=0)
-        else:
-            raise ValueError('%s is an invalid mode' % mode)
+        for i, (vertidx, flip) in enumerate(zip(label_vertidx, src_flip)):
+            if vertidx is not None:
+                label_tc[i] = func(flip, stc.data[vertidx, :])
 
         # extract label time series for the vol src space
         if len(src) > 2:

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2521,7 +2521,7 @@ def _pca_flip(flip, data):
 _label_funcs = {
     'mean': lambda flip, data: np.mean(data, axis=0),
     'mean_flip': lambda flip, data: np.mean(flip * data, axis=0),
-    'max': lambda flip, data: np.max(np.abs(data, axis=0)),
+    'max': lambda flip, data: np.max(np.abs(data), axis=0),
     'pca_flip': _pca_flip,
 }
 

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -425,6 +425,17 @@ def test_make_fixed_length_events():
     expected = np.cov(data[:, :21216])
     np.testing.assert_allclose(cov['data'], expected, atol=1e-12)
 
+    # overlaps
+    events = make_fixed_length_events(raw, 1, duration=1)
+    assert len(events) == 136
+    events_ol = make_fixed_length_events(raw, 1, duration=1, overlap=0.5)
+    assert len(events_ol) == 271
+    events_ol_2 = make_fixed_length_events(raw, 1, duration=1, overlap=0.9)
+    assert len(events_ol_2) == 1355
+    assert_array_equal(events_ol_2[:, 0], np.unique(events_ol_2[:, 0]))
+    with pytest.raises(ValueError, match='overlap must be'):
+        make_fixed_length_events(raw, 1, duration=1, overlap=1.1)
+
 
 def test_define_events():
     """Test defining response events."""

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -19,7 +19,7 @@ from mne import (read_label, stc_to_label, read_source_estimate,
                  labels_to_stc)
 from mne.label import Label, _blend_colors, label_sign_flip, _load_vert_pos
 from mne.utils import (_TempDir, requires_sklearn, get_subjects_dir,
-                       run_tests_if_main, requires_version)
+                       run_tests_if_main)
 from mne.fixes import assert_is, assert_is_not
 from mne.label import _n_colors
 from mne.source_space import SourceSpaces
@@ -377,7 +377,6 @@ def test_annot_io():
         assert_labels_equal(l1, l)
 
 
-@requires_version('scipy', '0.19')
 @testing.requires_testing_data
 def test_morph_labels():
     """Test morph_labels."""

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -379,6 +379,7 @@ def test_annot_io():
         assert_labels_equal(l1, l)
 
 
+@requires_version('scipy', '0.19')
 @testing.requires_testing_data
 def test_morph_labels():
     """Test morph_labels."""
@@ -725,7 +726,6 @@ def test_stc_to_label():
 
 
 @pytest.mark.slowtest
-@requires_version('scipy', '0.13')  # 0.12 has a sparse matrix bug
 @testing.requires_testing_data
 def test_morph():
     """Test inter-subject label morphing."""

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -15,7 +15,8 @@ from mne.datasets import testing
 from mne import (read_label, stc_to_label, read_source_estimate,
                  read_source_spaces, grow_labels, read_labels_from_annot,
                  write_labels_to_annot, split_label, spatial_tris_connectivity,
-                 read_surface, random_parcellation)
+                 read_surface, random_parcellation, morph_labels,
+                 labels_to_stc)
 from mne.label import Label, _blend_colors, label_sign_flip
 from mne.utils import (_TempDir, requires_sklearn, get_subjects_dir,
                        run_tests_if_main, requires_version)
@@ -376,6 +377,47 @@ def test_annot_io():
     parc_lh = [l for l in parc if l.name.endswith('lh')]
     for l1, l in zip(parc1, parc_lh):
         assert_labels_equal(l1, l)
+
+
+@testing.requires_testing_data
+def test_morph_labels():
+    """Test morph_labels."""
+    # Just process the first 5 labels for speed
+    parc_fsaverage = read_labels_from_annot(
+        'fsaverage', 'aparc', subjects_dir=subjects_dir)[:5]
+    parc_sample = read_labels_from_annot(
+        'sample', 'aparc', subjects_dir=subjects_dir)[:5]
+    parc_fssamp = morph_labels(
+        parc_fsaverage, 'sample', subjects_dir=subjects_dir)
+    for lf, ls, lfs in zip(parc_fsaverage, parc_sample, parc_fssamp):
+        assert lf.hemi == ls.hemi == lfs.hemi
+        assert lf.name == ls.name == lfs.name
+        perc_1 = np.in1d(lfs.vertices, ls.vertices).mean() * 100
+        perc_2 = np.in1d(ls.vertices, lfs.vertices).mean() * 100
+        # Ideally this would be 100%, but we do not use the same algorithm
+        # as FreeSurfer ...
+        assert perc_1 > 92
+        assert perc_2 > 88
+    with pytest.raises(ValueError, match='wrong and fsaverage'):
+        morph_labels(parc_fsaverage, 'sample', subjects_dir=subjects_dir,
+                     subject_from='wrong')
+
+
+@testing.requires_testing_data
+def test_labels_to_stc():
+    """Test labels_to_stc."""
+    labels = read_labels_from_annot(
+        'sample', 'aparc', subjects_dir=subjects_dir)
+    values = np.random.RandomState(0).randn(len(labels))
+    with pytest.raises(ValueError, match='1 or 2 dim'):
+        labels_to_stc(labels, values[:, np.newaxis, np.newaxis])
+    with pytest.raises(ValueError, match=r'values\.shape'):
+        labels_to_stc(labels, values[np.newaxis])
+    stc = labels_to_stc(labels, values)
+    for value, label in zip(values, labels):
+        stc_label = stc.in_label(label)
+        assert (stc_label.data == value).all()
+    stc = read_source_estimate(stc_fname, 'sample')
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
These are a set of three changes that make it easier to work with label data, eventually for #5389.

1. Add `overlap` option to `make_fixed_length_events`.
2. Add `labels_to_stc` that allows you to map one-value-per-label back to a STC. This is useful when chaining `apply_inverse_epochs` and `extract_label_time_courses`, and pumping the result into some function.
3. Add `morph_labels` to morph a set of non-overlapping labels from one subject to another. This is useful when dealing with the parcellations that we have only for `fsaverage`, such as `HCPMMP1` and now `aparc_sub`. It should be better than doing `labels = [label.morph(...) for label in labels]` because the latter will create labels that overlap at the edges. I just used the nearest-neighbor from the morph-maps to do the morphing. It does not create a perfect match of vertex numbers with the parcellations that Freesurfer morphs, so they must use a different method.

The only change I can think we might want to make is to maybe change the algorithm to whatever Freesurfer uses. But we could always do that in another PR, with a `method` kwarg.

No examples of usage yet because those will come in #5389.