### PR TITLE
MRG+1: ENH: functionality for doing ICA on MEG reference channels

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
 - Add ``drop_refs=True`` parameter to :func:`set_bipolar_reference` to drop/keep anode and cathode channels after applying the reference by `Cristóbal Moënne-Loccoz`_.
 
+- Add processing of reference MEG channels to :class:`mne.preprocessing.ICA` by `Jeff Hanna`_
+
 - Add use of :func:`scipy.signal.windows.dpss` for faster multitaper window computations in PSD functions by `Eric Larson`_
 
 - Add :func:`mne.morph_labels` to facilitate morphing label sets obtained from parcellations, by `Eric Larson`_
@@ -3157,3 +3159,5 @@ of commits):
 .. _Larry Eisenman:  https://github.com/lneisenman
 
 .. _Stanislas Chambon: https://github.com/Slasnista
+
+.. _Jeff Hanna: https://github.com/jshanna100

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -98,7 +98,7 @@ def _get_ch_type(inst, ch_type):
     then grads, then ... to plot.
     """
     if ch_type is None:
-        for type_ in ['mag', 'grad', 'planar1', 'planar2', 'eeg']:
+        for type_ in ['mag', 'grad', 'planar1', 'planar2', 'eeg', 'ref_meg']:
             if isinstance(inst, Info):
                 if _contains_ch_type(inst, type_):
                     ch_type = type_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -91,14 +91,16 @@ def _contains_ch_type(info, ch_type):
     return ch_type in [channel_type(info, ii) for ii in range(info['nchan'])]
 
 
-def _get_ch_type(inst, ch_type):
+def _get_ch_type(inst, ch_type, allow_ref_meg=False):
     """Choose a single channel type (usually for plotting).
 
     Usually used in plotting to plot a single datatype, e.g. look for mags,
     then grads, then ... to plot.
     """
     if ch_type is None:
-        for type_ in ['mag', 'grad', 'planar1', 'planar2', 'eeg', 'ref_meg']:
+        allowed_types = ['mag', 'grad', 'planar1', 'planar2', 'eeg']
+        allowed_types += ['ref_meg'] if allow_ref_meg else []
+        for type_ in allowed_types:
             if isinstance(inst, Info):
                 if _contains_ch_type(inst, type_):
                     ch_type = type_

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -192,7 +192,7 @@ def _triage_fnirs_pick(ch, fnirs):
 def _check_meg_type(meg, allow_auto=False):
     """Ensure a valid meg type."""
     if isinstance(meg, str):
-        allowed_types = ['grad', 'mag', 'planar1', 'planar2']
+        allowed_types = ['grad', 'mag', 'planar1', 'planar2', 'ref_meg']
         allowed_types += ['auto'] if allow_auto else []
         if meg not in allowed_types:
             raise ValueError('meg value must be one of %s or bool, not %s'

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -192,7 +192,7 @@ def _triage_fnirs_pick(ch, fnirs):
 def _check_meg_type(meg, allow_auto=False):
     """Ensure a valid meg type."""
     if isinstance(meg, str):
-        allowed_types = ['grad', 'mag', 'planar1', 'planar2', 'ref_meg']
+        allowed_types = ['grad', 'mag', 'planar1', 'planar2']
         allowed_types += ['auto'] if allow_auto else []
         if meg not in allowed_types:
             raise ValueError('meg value must be one of %s or bool, not %s'

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1039,53 +1039,9 @@ class ICA(ContainsMixin):
     def _find_bads_ch(self, inst, chs, threshold=3.0, start=None,
                       stop=None, l_freq=None, h_freq=None,
                       reject_by_annotation=True, verbose=None, prefix="chs"):
-        """Help function for eog_find_bads_eog/ecg/ref.
+        """Compute ExG/ref components.
 
-        Detection is based on Pearson correlation between the MEG data
-        components and MEG reference components.
-        Thresholding is based on adaptive z-scoring. The above threshold
-        components will be masked and the z-score will be recomputed
-        until no supra-threshold component remains.
-
-        Parameters
-        ----------
-        inst : instance of Raw, Epochs or Evoked
-            Object to compute sources from. Should contain at least one channel
-            i.e. component derived from MEG reference channels.
-        chs: list of array-like | list of ch_names
-            Which data/channels to use as targets
-        threshold : int | float
-            The value above which a feature is classified as outlier.
-        start : int | float | None
-            First sample to include. If float, data will be interpreted as
-            time in seconds. If None, data will be used from the first sample.
-        stop : int | float | None
-            Last sample to not include. If float, data will be interpreted as
-            time in seconds. If None, data will be used to the last sample.
-        l_freq : float
-            Low pass frequency.
-        h_freq : float
-            High pass frequency.
-        reject_by_annotation : bool
-            If True, data annotated as bad will be omitted. Defaults to True.
-
-            .. versionadded:: 0.14.0
-
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
-
-        Returns
-        -------
-        ref_idx : list of int
-            The indices of channel related ICA components, sorted by score.
-        scores : np.ndarray of float, shape (``n_components_``) | list of array
-            The correlation scores.
-
-        See Also
-        --------
-        find_bads_ecg, find_bads_eog, _find_bads_ch
+        See find_bads_ecg, find_bads, eog, and find_bads_ref for details.
         """
         scores, idx = [], []
         labels = {}
@@ -1192,7 +1148,7 @@ class ICA(ContainsMixin):
 
         See Also
         --------
-        find_bads_eog
+        find_bads_eog, find_bads_ref
 
         References
         ----------
@@ -1262,12 +1218,6 @@ class ICA(ContainsMixin):
                       reject_by_annotation=True, verbose=None):
         """Detect MEG reference related components using correlation.
 
-        Detection is based on Pearson correlation between the MEG data
-        components and MEG reference components.
-        Thresholding is based on adaptive z-scoring. The above threshold
-        components will be masked and the z-score will be recomputed
-        until no supra-threshold component remains.
-
         Parameters
         ----------
         inst : instance of Raw, Epochs or Evoked
@@ -1290,9 +1240,6 @@ class ICA(ContainsMixin):
             High pass frequency.
         reject_by_annotation : bool
             If True, data annotated as bad will be omitted. Defaults to True.
-
-            .. versionadded:: 0.14.0
-
         verbose : bool, str, int, or None
             If not None, override default verbose level (see
             :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
@@ -1305,9 +1252,24 @@ class ICA(ContainsMixin):
         scores : np.ndarray of float, shape (``n_components_``) | list of array
             The correlation scores.
 
+        Notes
+        -----
+        Detection is based on Pearson correlation between the MEG data
+        components and MEG reference components.
+        Thresholding is based on adaptive z-scoring. The above threshold
+        components will be masked and the z-score will be recomputed
+        until no supra-threshold component remains.
+
+        Recommended procedure is to perform ICA separately on reference
+        channels, extract them using .get_sources(), and then append them to
+        the inst using .add_channels(), preferably with the prefix REF_ICA so
+        that they can be automatically detected.
+
+        .. versionadded:: 0.18
+
         See Also
         --------
-        find_bads_ecg, find_bads_eog, _find_bads_ch
+        find_bads_ecg, find_bads_eog
         """
         if verbose is None:
             verbose = self.verbose
@@ -1377,7 +1339,7 @@ class ICA(ContainsMixin):
 
         See Also
         --------
-        find_bads_ecg, find_bads_ref, _find_bads_ch
+        find_bads_ecg, find_bads_ref
         """
         if verbose is None:
             verbose = self.verbose

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2244,7 +2244,7 @@ def run_ica(raw, n_components, max_pca_components=100,
             ecg_score_func='pearsonr', ecg_criterion=0.1, eog_ch=None,
             eog_score_func='pearsonr', eog_criterion=0.1, skew_criterion=-1,
             kurt_criterion=-1, var_criterion=0, add_nodes=None,
-            allow_ref_meg=False, method='fastica', verbose=None):
+            method='fastica', allow_ref_meg=False, verbose=None):
     """Run ICA decomposition on raw data and identify artifact sources.
 
     This function implements an automated artifact removal work flow.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -54,7 +54,7 @@ from ..fixes import _get_args
 from ..filter import filter_data
 from .bads import find_outliers
 from .ctps_ import ctps
-from ..io.pick import channel_type, pick_channels
+from ..io.pick import channel_type, pick_channels_regexp
 
 
 __all__ = ('ICA', 'ica_find_ecg_events', 'ica_find_eog_events',
@@ -1168,10 +1168,11 @@ class ICA(ContainsMixin):
         Parameters
         ----------
         inst : instance of Raw, Epochs or Evoked
-            instance of components from MEG reference channels, i.e.
-            from ICA.get_sources
+            Object to compute sources from. Should contain at least one channel
+            i.e. component derived from MEG reference channels.
         picks: list of int
-            Which MEG reference components to use. If None, then all.
+            Which MEG reference components to use. If None, then all channels
+            that begin with REF_ICA
         threshold : int | float
             The value above which a feature is classified as outlier.
         start : int | float | None
@@ -1209,7 +1210,7 @@ class ICA(ContainsMixin):
             verbose = self.verbose
 
         if not picks:
-            inds = pick_channels(inst.ch_names,[])
+            inds = pick_channels_regexp(inst.ch_names,"REF_ICA*")
         else:
             inds = picks
         scores, ref_idx = [], []

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1217,8 +1217,7 @@ class ICA(ContainsMixin):
 
         # some magic we need inevitably ...
         # get targets before equalizing
-        targets = [self._check_target(k, inst, start, stop,
-                                      reject_by_annotation) for k in ref_chs]
+        targets = [self._check_target(k, inst, start, stop,reject_by_annotation) for k in ref_chs]
 
         for ii, (ref_ch, target) in enumerate(zip(ref_chs, targets)):
             scores += [self.score_sources(

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1313,7 +1313,7 @@ class ICA(ContainsMixin):
         start : int | float | None
             First sample to include. If float, data will be interpreted as
             time in seconds. If None, data will be used from the first sample.
-        stop : int |eog_chs = [inst.ch_names[k] for k in eog_inds] float | None
+        stop : int | float | None
             Last sample to not include. If float, data will be interpreted as
             time in seconds. If None, data will be used to the last sample.
         l_freq : float

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -97,7 +97,7 @@ def _check_for_unsupported_ica_channels(picks, info):
     """Check for channels in picks that are not considered valid channels.
 
     Accepted channels are the data channels
-    ('seeg','ecog','eeg', 'hbo', 'hbr', 'mag', and 'grad') and 'eog'.
+    ('seeg','ecog','eeg', 'hbo', 'hbr', 'mag', and 'grad'), 'eog' and 'ref_meg.'
     This prevents the program from crashing without
     feedback when a bad channel is provided to ICA whitening.
     """
@@ -105,7 +105,7 @@ def _check_for_unsupported_ica_channels(picks, info):
         return
     elif len(picks) == 0:
         raise ValueError('No channels provided to ICA')
-    types = _DATA_CH_TYPES_SPLIT + ['eog']
+    types = _DATA_CH_TYPES_SPLIT + ['eog', 'ref_meg']
     chs = list(set([channel_type(info, j) for j in picks]))
     check = all([ch in types for ch in chs])
     if not check:
@@ -573,7 +573,7 @@ class ICA(ContainsMixin):
             # Scale (z-score) the data by channel type
             info = pick_info(info, picks)
             pre_whitener = np.empty([len(data), 1])
-            for ch_type in _DATA_CH_TYPES_SPLIT + ['eog']:
+            for ch_type in _DATA_CH_TYPES_SPLIT + ['eog', "ref_meg"]:
                 if _contains_ch_type(info, ch_type):
                     if ch_type == 'seeg':
                         this_picks = pick_types(info, meg=False, seeg=True)
@@ -587,6 +587,8 @@ class ICA(ContainsMixin):
                         this_picks = pick_types(info, meg=False, eog=True)
                     elif ch_type in ('hbo', 'hbr'):
                         this_picks = pick_types(info, meg=False, fnirs=ch_type)
+                    elif ch_type == 'ref_meg':
+                        this_picks = pick_types(info, meg=False, ref_meg=True)
                     else:
                         raise RuntimeError('Should not be reached.'
                                            'Unsupported channel {0}'

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1093,7 +1093,18 @@ class ICA(ContainsMixin):
         # get targets before equalizing
         targets = [self._check_target(
             ch, inst, start, stop, reject_by_annotation) for ch in chs]
-        for ii, (ch, target) in enumerate(zip(chs, targets)):
+        # assign names, if targets are arrays instead of strings
+        target_names = []
+        for ch in chs:
+            if not isinstance(ch, str):
+                if prefix == "ecg":
+                    target_names.append('ECG-MAG')
+                else:
+                    target_names.append(prefix)
+            else:
+                target_names.append(ch)
+
+        for ii, (ch, target) in enumerate(zip(target_names, targets)):
             scores += [self.score_sources(
                 inst, target=target, score_func='pearsonr', start=start,
                 stop=stop, l_freq=l_freq, h_freq=h_freq, verbose=verbose,
@@ -1101,7 +1112,7 @@ class ICA(ContainsMixin):
             # pick last scores
             this_idx = find_outliers(scores[-1], threshold=threshold)
             idx += [this_idx]
-            labels[(prefix + '/%i/' % ii) + ch] = list(this_idx)
+            labels['%s/%i/' % (prefix, ii) + ch] = list(this_idx)
 
         # remove duplicates but keep order by score, even across multiple
         # ref channels

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -726,19 +726,23 @@ def test_bad_channels(method):
     epochs = EpochsArray(data, info)
 
     n_components = 0.9
-    for allow_ref_meg in [False,True]:
+    for allow_ref_meg in [False, True]:
         data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
-        if allow_ref_meg: data_chs.append('ref_meg')
+        if allow_ref_meg:
+            data_chs.append('ref_meg')
         chs_bad = list(set(chs) - set(data_chs))
-        ica = ICA(n_components=n_components, method=method, allow_ref_meg=allow_ref_meg)
+        ica = ICA(n_components=n_components, method=method,
+                  allow_ref_meg=allow_ref_meg)
         for inst in [raw, epochs]:
             for ch in chs_bad:
                 if allow_ref_meg:
                     # Test case for only bad channels
-                    picks_bad1 = pick_types(inst.info, meg=False, ref_meg=False,
+                    picks_bad1 = pick_types(inst.info, meg=False,
+                                            ref_meg=False,
                                             **{str(ch): True})
                     # Test case for good and bad channels
-                    picks_bad2 = pick_types(inst.info, meg=True, ref_meg=True,
+                    picks_bad2 = pick_types(inst.info, meg=True,
+                                            ref_meg=True,
                                             **{str(ch): True})
                 else:
                     # Test case for only bad channels

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -718,8 +718,6 @@ def test_bad_channels(method):
     """Test exception when unsupported channels are used."""
     _skip_check_picard(method)
     chs = [i for i in _kind_dict]
-    data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
-    chs_bad = list(set(chs) - set(data_chs))
     info = create_info(len(chs), 500, chs)
     rng = np.random.RandomState(0)
     data = rng.rand(len(chs), 50)
@@ -728,18 +726,31 @@ def test_bad_channels(method):
     epochs = EpochsArray(data, info)
 
     n_components = 0.9
-    ica = ICA(n_components=n_components, method=method)
-    for inst in [raw, epochs]:
-        for ch in chs_bad:
-            # Test case for only bad channels
-            picks_bad1 = pick_types(inst.info, meg=False,
-                                    **{str(ch): True})
-            # Test case for good and bad channels
-            picks_bad2 = pick_types(inst.info, meg=True,
-                                    **{str(ch): True})
-            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad1)
-            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad2)
-        pytest.raises(ValueError, ica.fit, inst, picks=[])
+    for allow_ref_meg in [False,True]:
+        data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
+        if allow_ref_meg: data_chs.append('ref_meg')
+        chs_bad = list(set(chs) - set(data_chs))
+        ica = ICA(n_components=n_components, method=method, allow_ref_meg=allow_ref_meg)
+        for inst in [raw, epochs]:
+            for ch in chs_bad:
+                if allow_ref_meg:
+                    # Test case for only bad channels
+                    picks_bad1 = pick_types(inst.info, meg=False, ref_meg=False,
+                                            **{str(ch): True})
+                    # Test case for good and bad channels
+                    picks_bad2 = pick_types(inst.info, meg=True, ref_meg=True,
+                                            **{str(ch): True})
+                else:
+                    # Test case for only bad channels
+                    picks_bad1 = pick_types(inst.info, meg=False,
+                                            **{str(ch): True})
+                    # Test case for good and bad channels
+                    picks_bad2 = pick_types(inst.info, meg=True,
+                                            **{str(ch): True})
+
+                pytest.raises(ValueError, ica.fit, inst, picks=picks_bad1)
+                pytest.raises(ValueError, ica.fit, inst, picks=picks_bad2)
+            pytest.raises(ValueError, ica.fit, inst, picks=[])
 
 
 @requires_sklearn

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -714,7 +714,8 @@ def test_fit_params(method):
 
 @requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
-def test_bad_channels(method):
+@pytest.mark.parametrize("allow_ref_meg", [True, False])
+def test_bad_channels(method, allow_ref_meg):
     """Test exception when unsupported channels are used."""
     _skip_check_picard(method)
     chs = [i for i in _kind_dict]
@@ -726,35 +727,34 @@ def test_bad_channels(method):
     epochs = EpochsArray(data, info)
 
     n_components = 0.9
-    for allow_ref_meg in [False, True]:
-        data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
-        if allow_ref_meg:
-            data_chs.append('ref_meg')
-        chs_bad = list(set(chs) - set(data_chs))
-        ica = ICA(n_components=n_components, method=method,
-                  allow_ref_meg=allow_ref_meg)
-        for inst in [raw, epochs]:
-            for ch in chs_bad:
-                if allow_ref_meg:
-                    # Test case for only bad channels
-                    picks_bad1 = pick_types(inst.info, meg=False,
-                                            ref_meg=False,
-                                            **{str(ch): True})
-                    # Test case for good and bad channels
-                    picks_bad2 = pick_types(inst.info, meg=True,
-                                            ref_meg=True,
-                                            **{str(ch): True})
-                else:
-                    # Test case for only bad channels
-                    picks_bad1 = pick_types(inst.info, meg=False,
-                                            **{str(ch): True})
-                    # Test case for good and bad channels
-                    picks_bad2 = pick_types(inst.info, meg=True,
-                                            **{str(ch): True})
+    data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
+    if allow_ref_meg:
+        data_chs.append('ref_meg')
+    chs_bad = list(set(chs) - set(data_chs))
+    ica = ICA(n_components=n_components, method=method,
+              allow_ref_meg=allow_ref_meg)
+    for inst in [raw, epochs]:
+        for ch in chs_bad:
+            if allow_ref_meg:
+                # Test case for only bad channels
+                picks_bad1 = pick_types(inst.info, meg=False,
+                                        ref_meg=False,
+                                        **{str(ch): True})
+                # Test case for good and bad channels
+                picks_bad2 = pick_types(inst.info, meg=True,
+                                        ref_meg=True,
+                                        **{str(ch): True})
+            else:
+                # Test case for only bad channels
+                picks_bad1 = pick_types(inst.info, meg=False,
+                                        **{str(ch): True})
+                # Test case for good and bad channels
+                picks_bad2 = pick_types(inst.info, meg=True,
+                                        **{str(ch): True})
 
-                pytest.raises(ValueError, ica.fit, inst, picks=picks_bad1)
-                pytest.raises(ValueError, ica.fit, inst, picks=picks_bad2)
-            pytest.raises(ValueError, ica.fit, inst, picks=[])
+            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad1)
+            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad2)
+        pytest.raises(ValueError, ica.fit, inst, picks=[])
 
 
 @requires_sklearn

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -63,9 +63,6 @@ def _prepare_topo_plot(inst, ch_type, layout):
         if ch_type == 'eeg':
             picks = pick_types(info, meg=False, eeg=True, ref_meg=False,
                                exclude='bads')
-        elif ch_type == 'ref_meg':
-            picks = pick_types(info, meg=False, ref_meg=True,
-                               exclude='bads')
         else:
             picks = pick_types(info, meg=ch_type, ref_meg=False,
                                exclude='bads')
@@ -966,7 +963,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', colorbar=False,
                       title=None, show=True, outlines='head', contours=6,
                       image_interp='bilinear', head_pos=None, axes=None,
-                      sensors=True):
+                      sensors=True, allow_ref_meg=False):
     """Plot single ica map to axes."""
     import matplotlib as mpl
     from ..channels import _get_ch_type
@@ -977,9 +974,9 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
     if not isinstance(axes, mpl.axes.Axes):
         raise ValueError('axis has to be an instance of matplotlib Axes, '
                          'got %s instead.' % type(axes))
-    ch_type = _get_ch_type(ica, ch_type)
+    ch_type = _get_ch_type(ica, ch_type, allow_ref_meg=ica.allow_ref_meg)
     if ch_type == "ref_meg":
-        print("Cannot produce topographies for MEG reference channels.")
+        logger.info("Cannot produce topographies for MEG reference channels.")
         return
 
     data = ica.get_components()[:, idx]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -978,6 +978,9 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
         raise ValueError('axis has to be an instance of matplotlib Axes, '
                          'got %s instead.' % type(axes))
     ch_type = _get_ch_type(ica, ch_type)
+    if ch_type == "ref_meg":
+        print("Cannot produce topographies for MEG reference channels.")
+        return
 
     data = ica.get_components()[:, idx]
     data_picks, pos, merge_grads, names, _ = _prepare_topo_plot(

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -63,6 +63,9 @@ def _prepare_topo_plot(inst, ch_type, layout):
         if ch_type == 'eeg':
             picks = pick_types(info, meg=False, eeg=True, ref_meg=False,
                                exclude='bads')
+        elif ch_type == 'ref_meg':
+            picks = pick_types(info, meg=False, ref_meg=True,
+                               exclude='bads')
         else:
             picks = pick_types(info, meg=ch_type, ref_meg=False,
                                exclude='bads')


### PR DESCRIPTION
I recently had some success removing a pattern of intermittent external noise using ICA decompositions of the reference channel array in a 4D MEG system. The procedure went as follows:

1) Use ICA to decompose the MEG reference channels into components. I used n_components=0.99, which generally yielded one or two components.
2) Decompose the MEG data channels into components.
3) Use preprocessing.ICA.scores_sources to get pearsonr for each individual reference component against the data channel components.
4) Eliminate data channel components that have a z-transformed pearsonr with reference component beyond a threshold.

MNE as it currently stands does not allow ICA decomposition of reference channels. The suggested changes are a first step in providing this functionality. They allow the decomposition itself, as well as permitting visualisation functions like e.g. preprocessing.ICA.plot_properties. The topographies are nonsense, but plotting functions at least now do not fail entirely, allowing inspection of other types of visualisations.

One possible substitute for the topographies might be quiver plots, where the arrows orientations are determined by the orientations of the reference channels, projected onto 2D space. I could also put together a proper component identifier function that carries out steps 3 and 4.