### PR TITLE
MRG: Fix errors in master

### DIFF
--- a/mne/externals/pymatreader/utils.py
+++ b/mne/externals/pymatreader/utils.py
@@ -102,7 +102,8 @@ def _handle_hdf5_dataset(hdf5_object):
     if 'MATLAB_empty' in hdf5_object.attrs.keys():
         data = numpy.empty((0,))
     else:
-        data = hdf5_object.value
+        # this used to be just hdf5_object.value, but this is deprecated
+        data = hdf5_object[()]
 
     if isinstance(data, numpy.ndarray) and \
             data.dtype == numpy.dtype('object'):

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -291,6 +291,8 @@ def test_other_volume_source_spaces():
     pytest.raises(ValueError, read_source_spaces, temp_name)
 
 
+@pytest.mark.timeout(60)  # can be slow on OSX Travis
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_triangle_neighbors():
     """Test efficient vertex neighboring triangles for surfaces."""
@@ -647,6 +649,7 @@ def test_morph_source_spaces():
     _compare_source_spaces(src_morph, src_morph_py, mode='approx')
 
 
+@pytest.mark.timeout(60)  # can be slow on OSX Travis
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_morphed_source_space_return():


### PR DESCRIPTION
```
Results (1268.35s):
     926 passed
       3 failed
         - mne/io/eeglab/tests/test_eeglab.py:56 test_io_set_raw[fnames1]
         - mne/io/eeglab/tests/test_eeglab.py:259 test_eeglab_annotations[/home/travis/mne_data/MNE-testing-data/EEGLAB/test_raw_h5.set]
         - mne/io/eeglab/tests/test_eeglab.py:259 test_eeglab_annotations[/home/travis/mne_data/MNE-testing-data/EEGLAB/test_raw_onefile_h5.set]
      18 skipped
       2 deselected
The command "py.test -m "${CONDITION}" ${OPTION} ${USE_DIRS} --cov=mne;" exited with 1.
```