### PR TITLE
[MRG] VIZ: change n_chanels default if there are less chanels

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- :meth:`mne.io.Raw.plot` now adapts default parameter ``n_channels=20`` in the ``raw`` object has less than 20 channels `Joan Massich`_
+
 - Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
 
 - :func:`mne.io.read_raw_edf` now detects analog stim channels labeled ``'STATUS'`` and sets them as stim channel. :func:`mne.io.read_raw_edf` no longer synthesize TAL annotations into stim channel but stores them in ``raw.annotations`` when reading by `Joan Massich`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Current
 Changelog
 ~~~~~~~~~
 
-- :meth:`mne.io.Raw.plot` now adapts default parameter ``n_channels=20`` in the ``raw`` object has less than 20 channels `Joan Massich`_
+- :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_
 
 - Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1846,6 +1846,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
              highpass=None, lowpass=None, filtorder=4, clipping=None,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None):
+        n_channels = min(len(self.info['chs']), n_channels)
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1846,7 +1846,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
              highpass=None, lowpass=None, filtorder=4, clipping=None,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None):
-        n_channels = min(len(self.info['chs']), n_channels)
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -120,9 +120,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         show_first_samp is True, then it is taken relative to
         ``raw.first_samp``.
     n_channels : int
-        Number of channels to plot at once. Defaults to 20 unless the ``raw``
-        has less than 20 channels. Then it defaults to the number of channels
-        in ``raw``.
+        Number of channels to plot at once. Defaults to 20. The lesser of
+        ``n_channels`` and ``len(raw.ch_names)`` will be shown.
         Has no effect if ``order`` is 'position', 'selection' or 'butterfly'.
     bgcolor : color object
         Color of the background.

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -14,7 +14,7 @@ from ..annotations import _annotations_starts_stops
 from ..io.pick import (pick_types, _pick_data_channels, pick_info,
                        _PICK_TYPES_KEYS, pick_channels, channel_type)
 from ..io.meas_info import create_info
-from ..utils import verbose, get_config, _ensure_int
+from ..utils import verbose, get_config, _ensure_int, _validate_type
 from ..time_frequency import psd_welch
 from ..defaults import _handle_default
 from .topo import _plot_topo, _plot_timeseries, _plot_timeseries_unified
@@ -260,10 +260,12 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     import matplotlib.pyplot as plt
     import matplotlib as mpl
     from scipy.signal import butter
+    from ..io.base import BaseRaw
     color = _handle_default('color', color)
     scalings = _compute_scalings(scalings, raw)
     scalings = _handle_default('scalings_plot_raw', scalings)
-    n_channels = min(len(self.info['chs']), n_channels)
+    _validate_type(raw, BaseRaw, 'raw', 'Raw')
+    n_channels = min(len(raw.info['chs']), n_channels)
 
     if clipping is not None and clipping not in ('clamp', 'transparent'):
         raise ValueError('clipping must be None, "clamp", or "transparent", '

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -120,8 +120,10 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         show_first_samp is True, then it is taken relative to
         ``raw.first_samp``.
     n_channels : int
-        Number of channels to plot at once. Defaults to 20. Has no effect if
-        ``order`` is 'position', 'selection' or 'butterfly'.
+        Number of channels to plot at once. Defaults to 20 unless the ``raw``
+        has less than 20 channels. Then it defaults to the number of channels
+        in ``raw``.
+        Has no effect if ``order`` is 'position', 'selection' or 'butterfly'.
     bgcolor : color object
         Color of the background.
     color : dict | color object | None
@@ -262,6 +264,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     color = _handle_default('color', color)
     scalings = _compute_scalings(scalings, raw)
     scalings = _handle_default('scalings_plot_raw', scalings)
+    n_channels = min(len(self.info['chs']), n_channels)
 
     if clipping is not None and clipping not in ('clamp', 'transparent'):
         raise ValueError('clipping must be None, "clamp", or "transparent", '

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -784,7 +784,7 @@ def _plot_raw_onkey(event, params):
         params['scale_factor'] /= 1.1
         params['plot_fun']()
     elif event.key == 'pageup' and 'fig_selection' not in params:
-        n_channels = params['n_channels'] + 1
+        n_channels = min(params['n_channels'] + 1, len(params['info']['chs']))
         _setup_browser_offsets(params, n_channels)
         _channels_changed(params, len(params['inds']))
     elif event.key == 'pagedown' and 'fig_selection' not in params:


### PR DESCRIPTION
When plotting a `raw** file that has less channels than  20 channels
the visualization does not look proper.
![image](https://user-images.githubusercontent.com/7044835/50288921-9e91ab00-0467-11e9-9cfb-c7eba290b942.png)


This PR fixes it to get this:

![image](https://user-images.githubusercontent.com/7044835/50288911-99346080-0467-11e9-94b7-fe3dc9b0cdd0.png)
