### PR TITLE
MRG: Fix bleeding-edge library bugs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.txt
 include requirements.txt
 include mne/__init__.py
 
+include conftest.py
 recursive-include examples *.py
 recursive-include examples *.txt
 recursive-include tutorials *.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import pytest
+
+
+@pytest.fixture(scope='package')
+def matplotlib_config():
+    """Configure matplotlib for viz tests."""
+    import matplotlib
+    matplotlib.use('agg')  # don't pop up windows
+    import matplotlib.pyplot as plt
+    assert plt.get_backend() == 'agg'
+    # overwrite some params that can horribly slow down tests that
+    # users might have changed locally (but should not otherwise affect
+    # functionality)
+    plt.ioff()
+    plt.rcParams['figure.dpi'] = 100

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -7,12 +7,12 @@
 
 import copy
 import os.path as op
-import matplotlib
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
+import matplotlib.pyplot as plt
 
 from mne.channels import (make_eeg_layout, make_grid_layout, read_layout,
                           find_layout)
@@ -24,7 +24,6 @@ from mne.io import read_raw_kit, _empty_info, read_info
 from mne.io.constants import FIFF
 from mne.bem import fit_sphere_to_headshape
 from mne.utils import _TempDir
-matplotlib.use('Agg')  # for testing don't use X server
 
 io_dir = op.join(op.dirname(__file__), '..', '..', 'io')
 fif_fname = op.join(io_dir, 'tests', 'data', 'test_raw.fif')
@@ -185,7 +184,6 @@ def test_make_grid_layout():
 
 def test_find_layout():
     """Test finding layout."""
-    import matplotlib.pyplot as plt
     pytest.raises(ValueError, find_layout, _get_test_info(), ch_type='meep')
 
     sample_info = read_info(fif_fname)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -6,7 +6,6 @@ import glob
 
 import pytest
 from numpy.testing import assert_equal, assert_allclose
-import matplotlib
 
 from mne import concatenate_raws, read_bem_surfaces, read_surface
 from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
@@ -21,8 +20,6 @@ from mne.io import read_raw_fif
 from mne.utils import (run_tests_if_main, _TempDir, requires_mne,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
                        traits_test, ArgvSetter)
-
-matplotlib.use('Agg')
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1113,7 +1113,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
 
     if add_dist:
         logger.info("Recomputing distances, this might take a while")
-        dist_limit = np.asscalar(np.abs(sss[0]['dist_limit']))
+        dist_limit = float(np.abs(sss[0]['dist_limit']))
         add_source_space_distances(sss, dist_limit, n_jobs)
 
     write_source_spaces(dst, sss)

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -302,8 +302,7 @@ def _mixed_norm_solver_cd(M, G, alpha, lipschitz_constant, maxit=10000,
     clf = MultiTaskLasso(alpha=alpha / len(M), tol=tol / sum_squared(M),
                          normalize=False, fit_intercept=False, max_iter=maxit,
                          warm_start=True)
-    if init is not None:
-        clf.coef_ = init.T
+    clf.coef_ = init.T if init is not None else init
     clf.fit(G, M)
 
     X = clf.coef_.T

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -3,12 +3,12 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import matplotlib
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_allclose,
                            assert_equal)
 import pytest
+import matplotlib.pyplot as plt
 
 from mne import find_events, Epochs, pick_types, channels
 from mne.io import read_raw_fif
@@ -16,8 +16,6 @@ from mne.io.array import RawArray
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.meas_info import create_info, _kind_dict
 from mne.utils import requires_version, run_tests_if_main
-
-matplotlib.use('Agg')  # for testing don't use X server
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'tests', 'data')
 fif_fname = op.join(base_dir, 'test_raw.fif')
@@ -39,7 +37,6 @@ def test_long_names():
 @requires_version('scipy', '0.12')
 def test_array_raw():
     """Test creating raw from array."""
-    import matplotlib.pyplot as plt
     # creating
     raw = read_raw_fif(fif_fname).crop(2, 5)
     data, times = raw[:, :]

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -3,6 +3,7 @@
 #
 # License: BSD (3-clause)
 
+from itertools import product
 import os
 import os.path as op
 from unittest import SkipTest
@@ -12,7 +13,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 from scipy import stats
-from itertools import product
+import matplotlib.pyplot as plt
 
 from mne import (Epochs, read_events, pick_types, create_info, EpochsArray,
                  EvokedArray, Annotations)
@@ -28,10 +29,6 @@ from mne.utils import (catch_logging, _TempDir, requires_sklearn,
                        run_tests_if_main)
 from mne.datasets import testing
 from mne.event import make_fixed_length_events
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(data_dir, 'test_raw.fif')
@@ -317,7 +314,6 @@ def test_ica_additional(method):
     """Test additional ICA functionality."""
     _skip_check_picard(method)
 
-    import matplotlib.pyplot as plt
     tempdir = _TempDir()
     stop2 = 500
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()

--- a/mne/realtime/tests/test_fieldtrip_client.py
+++ b/mne/realtime/tests/test_fieldtrip_client.py
@@ -23,10 +23,6 @@ from mne.realtime import FieldTripClient, RtEpochs
 
 from mne.realtime.tests.test_mockclient import _call_base_epochs_public_api
 
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
-
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.realpath(op.join(base_dir, 'test_raw.fif'))
 
@@ -42,7 +38,7 @@ def free_tcp_port():
 def _run_buffer(kill_signal, server_port):
     """Start a FieldTrip Buffer from FIF file as a subprocess."""
     neuromag2ft_fname = op.realpath(op.join(os.environ['NEUROMAG2FT_ROOT'],
-                                    'neuromag2ft'))
+                                            'neuromag2ft'))
     # Works with neuromag2ft-3.0.2
     cmd = (neuromag2ft_fname, '--file', raw_fname, '--speed', '8.0',
            '--bufport', str(server_port))

--- a/mne/realtime/tests/test_mockclient.py
+++ b/mne/realtime/tests/test_mockclient.py
@@ -13,10 +13,6 @@ from mne.utils import run_tests_if_main
 from mne.realtime import MockRtClient, RtEpochs
 from mne.datasets import testing
 
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
-
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 event_name = op.join(base_dir, 'test-eve.fif')

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -10,6 +10,7 @@ from shutil import copy
 import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
+import matplotlib.pyplot as plt
 
 from mne import (make_bem_model, read_bem_surfaces, write_bem_surfaces,
                  make_bem_solution, read_bem_solution, write_bem_solution,
@@ -25,9 +26,6 @@ from mne.bem import (_ico_downsample, _get_ico_map, _order_surfaces,
                      _check_surface_size, _bem_find_surface, make_flash_bem)
 from mne.surface import read_surface
 from mne.io import read_info
-
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 fname_raw = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data',
                     'test_raw.fif')
@@ -343,7 +341,6 @@ def test_fit_sphere_to_headshape():
 @testing.requires_testing_data
 def test_make_flash_bem():
     """Test computing bem from flash images."""
-    import matplotlib.pyplot as plt
     tmp = _TempDir()
     bemdir = op.join(subjects_dir, 'sample', 'bem')
     flash_path = op.join(subjects_dir, 'sample', 'mri', 'flash')

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -2,6 +2,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+import matplotlib.pyplot as plt
 import pytest
 
 from mne import (read_dipole, read_forward_solution,
@@ -23,9 +24,6 @@ from mne.io.constants import FIFF
 from mne.surface import _compute_nearest
 from mne.bem import _bem_find_surface, read_bem_solution
 from mne.transforms import apply_trans, _get_trans
-
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_path = testing.data_path(download=False)
 meg_path = op.join(data_path, 'MEG', 'sample')
@@ -185,7 +183,6 @@ def test_dipole_fitting():
 @testing.requires_testing_data
 def test_dipole_fitting_fixed():
     """Test dipole fitting with a fixed position."""
-    import matplotlib.pyplot as plt
     tpeak = 0.073
     sphere = make_sphere_model(head_radius=0.1)
     evoked = read_evokeds(fname_evo, baseline=(None, 0))[0]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -14,7 +14,7 @@ import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_allclose, assert_equal)
 import numpy as np
-import matplotlib
+import matplotlib.pyplot as plt
 
 import mne
 from mne import (Epochs, Annotations, read_events, pick_events, read_epochs,
@@ -37,8 +37,6 @@ from mne.event import merge_events
 from mne.io.constants import FIFF
 from mne.datasets import testing
 from mne.tests.common import assert_meg_snr
-
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_path = testing.data_path(download=False)
 fname_raw_move = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
@@ -2034,7 +2032,6 @@ def test_add_channels_epochs():
 
 def test_array_epochs(tmpdir):
     """Test creating epochs from array."""
-    import matplotlib.pyplot as plt
     tempdir = str(tmpdir)
 
     # creating

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -1,10 +1,5 @@
-import os.path as op
 import sys
 from subprocess import Popen, PIPE
-
-import pytest
-
-from mne.utils import run_tests_if_main
 
 
 run_script = """
@@ -53,43 +48,3 @@ def test_module_nesting():
     stdout = stdout.decode('utf-8')
     stderr = stderr.decode('utf-8')
     assert not proc.returncode, stdout + stderr
-
-
-mpl_script = """
-import os
-import os.path as op
-import re
-import sys
-import mne
-
-reg = re.compile('test_.*.py')
-for dirpath, _, filenames in os.walk('{0}'):
-    if dirpath.endswith('tests'):
-        test_dir = op.join('{0}', dirpath)
-        sys.path.insert(0, test_dir)
-        for filename in filenames:
-            if reg.match(filename) is not None:
-                __import__(op.splitext(filename)[0])
-                for x in sys.modules.keys():
-                    if x.startswith('matplotlib.pyplot'):
-                        print('\\nFound un-nested pyplot import: ' +
-                              op.join(test_dir, filename))
-                        exit(1)
-        sys.path.pop(0)
-"""
-
-
-@pytest.mark.timeout(60)  # ~25 sec on AppVeyor
-@pytest.mark.slowtest
-def test_mpl_nesting():
-    """Test that matplotlib imports are properly nested in tests."""
-    mne_path = op.abspath(op.join(op.dirname(__file__), '..'))
-    proc = Popen([sys.executable, '-c', mpl_script.format(mne_path)],
-                 stdout=PIPE, stderr=PIPE)
-    stdout, stderr = proc.communicate()
-    stdout = stdout.decode('utf-8')
-    stderr = stderr.decode('utf-8')
-    assert not proc.returncode, stdout + stderr
-
-
-run_tests_if_main()

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -13,6 +13,7 @@ import shutil
 import numpy as np
 from numpy.testing import assert_equal
 import pytest
+from matplotlib import pyplot as plt
 
 from mne import Epochs, read_events, read_evokeds
 from mne.io import read_raw_fif
@@ -21,9 +22,6 @@ from mne.report import Report, open_report
 from mne.utils import (_TempDir, requires_mayavi, requires_nibabel,
                        run_tests_if_main, traits_test, requires_h5py)
 from mne.viz import plot_alignment
-
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_dir = testing.data_path(download=False)
 subjects_dir = op.join(data_dir, 'subjects')
@@ -45,7 +43,6 @@ evoked_fname = op.join(base_dir, 'test-ave.fif')
 
 def _get_example_figures():
     """Create two example figures."""
-    from matplotlib import pyplot as plt
     fig1 = plt.plot([1, 2], [1, 2])[0].figure
     fig2 = plt.plot([3, 4], [3, 4])[0].figure
     return [fig1, fig2]
@@ -179,7 +176,6 @@ def test_report_raw_psd_and_date():
 def test_render_add_sections():
     """Test adding figures/images to section."""
     tempdir = _TempDir()
-    import matplotlib.pyplot as plt
     report = Report(subjects_dir=subjects_dir)
     # Check add_figs_to_section functionality
     fig = plt.plot([1, 2], [1, 2])[0].figure
@@ -274,7 +270,6 @@ def test_add_htmls_to_section():
 def test_add_slider_to_section():
     """Test adding a slider with a series of images to mne report."""
     tempdir = _TempDir()
-    from matplotlib import pyplot as plt
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=subjects_dir)
     section = 'slider_section'

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1,9 +1,11 @@
-import numpy as np
+from itertools import product
 import os.path as op
 
+import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal)
 import pytest
+import matplotlib.pyplot as plt
 
 import mne
 from mne import Epochs, read_events, pick_types, create_info, EpochsArray
@@ -17,9 +19,6 @@ from mne.time_frequency.tfr import (morlet, tfr_morlet, _make_dpss,
 from mne.time_frequency import tfr_array_multitaper, tfr_array_morlet
 from mne.viz.utils import _fake_click
 from mne.tests.test_epochs import assert_metadata_equal
-from itertools import product
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(data_path, 'test_raw.fif')
@@ -442,8 +441,6 @@ def test_io():
 
 def test_plot():
     """Test TFR plotting."""
-    import matplotlib.pyplot as plt
-
     data = np.zeros((3, 2, 3))
     times = np.array([.1, .2, .3])
     freqs = np.array([.10, .20])
@@ -489,8 +486,6 @@ def test_plot():
 
 def test_plot_joint():
     """Test TFR joint plotting."""
-    import matplotlib.pyplot as plt
-
     raw = read_raw_fif(raw_fname)
     times = np.linspace(-0.1, 0.1, 200)
     n_freqs = 3

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -11,6 +11,7 @@ import os.path as op
 
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 from mne import (make_field_map, pick_channels_evoked, read_evokeds,
                  read_trans, read_dipole, SourceEstimate, VectorSourceEstimate,
@@ -31,10 +32,6 @@ from mne.datasets import testing
 from mne.source_space import read_source_spaces
 from mne.bem import read_bem_solution, read_bem_surfaces
 
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_dir = testing.data_path(download=False)
 subjects_dir = op.join(data_dir, 'subjects')
@@ -73,7 +70,6 @@ coil_3d = """# custom cube coil def
 
 def test_plot_head_positions():
     """Test plotting of head positions."""
-    import matplotlib.pyplot as plt
     info = read_info(evoked_fname)
     pos = np.random.RandomState(0).randn(4, 10)
     pos[:, 0] = np.arange(len(pos))
@@ -345,7 +341,6 @@ def test_limits_to_control_points():
 @requires_nibabel()
 def test_stc_mpl():
     """Test plotting source estimates with matplotlib."""
-    import matplotlib.pyplot as plt
     sample_src = read_source_spaces(src_fname)
 
     vertices = [s['vertno'] for s in sample_src]
@@ -379,7 +374,6 @@ def test_stc_mpl():
 @requires_nibabel()
 def test_plot_dipole_mri_orthoview():
     """Test mpl dipole plotting."""
-    import matplotlib.pyplot as plt
     dipoles = read_dipole(dip_fname)
     trans = read_trans(trans_fname)
     for coord_frame, idx, show_all in zip(['head', 'mri'],

--- a/mne/viz/tests/test_circle.py
+++ b/mne/viz/tests/test_circle.py
@@ -7,17 +7,13 @@
 
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 from mne.viz import plot_connectivity_circle, circular_layout
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 
 def test_plot_connectivity_circle():
     """Test plotting connectivity circle."""
-    import matplotlib.pyplot as plt
     node_order = ['frontalpole-lh', 'parsorbitalis-lh',
                   'lateralorbitofrontal-lh', 'rostralmiddlefrontal-lh',
                   'medialorbitofrontal-lh', 'parstriangularis-lh',

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -10,6 +10,7 @@ import os.path as op
 
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 from mne import read_events, Epochs, pick_types, read_cov
 from mne.channels import read_layout
@@ -17,11 +18,6 @@ from mne.io import read_raw_fif
 from mne.utils import run_tests_if_main, requires_version
 from mne.viz import plot_drop_log
 from mne.viz.utils import _fake_click
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
-
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 evoked_fname = op.join(base_dir, 'test-ave.fif')
@@ -50,7 +46,6 @@ def _get_epochs():
 
 def test_plot_epochs():
     """Test epoch plotting."""
-    import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.info['lowpass'] = 10.  # allow heavy decim during plotting
     epochs.plot(scalings=None, title='Epochs')
@@ -129,7 +124,6 @@ def test_plot_epochs():
 
 def test_plot_epochs_image():
     """Test plotting of epochs image."""
-    import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.plot_image(picks=[1, 2])
     overlay_times = [0.1]
@@ -169,7 +163,6 @@ def test_plot_epochs_image():
 
 def test_plot_drop_log():
     """Test plotting a drop log."""
-    import matplotlib.pyplot as plt
     epochs = _get_epochs()
     pytest.raises(ValueError, epochs.plot_drop_log)
     epochs.drop_bad()
@@ -183,7 +176,6 @@ def test_plot_drop_log():
 @requires_version('scipy', '0.12')
 def test_plot_psd_epochs():
     """Test plotting epochs psd (+topomap)."""
-    import matplotlib.pyplot as plt
     epochs = _get_epochs()
     epochs.plot_psd()
     pytest.raises(RuntimeError, epochs.plot_psd_topomap,

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -13,6 +13,7 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+import matplotlib.pyplot as plt
 
 import mne
 from mne import (read_events, Epochs, read_cov, compute_covariance,
@@ -23,10 +24,6 @@ from mne.viz.evoked import plot_compare_evokeds
 from mne.viz.utils import _fake_click
 from mne.stats import _parametric_ci
 from mne.datasets import testing
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 evoked_fname = op.join(base_dir, 'test-ave.fif')
@@ -68,8 +65,6 @@ def _get_epochs_delayed_ssp():
 
 def test_plot_evoked_cov():
     """Test plot_evoked with noise_cov."""
-    return
-    import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     cov = read_cov(cov_fname)
     cov['projs'] = []  # avoid warnings
@@ -91,7 +86,6 @@ def test_plot_evoked_cov():
 @pytest.mark.slowtest
 def test_plot_evoked():
     """Test evoked.plot."""
-    import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     fig = evoked.plot(proj=True, hline=[1], exclude=[], window_title='foo',
                       time_unit='s')
@@ -143,7 +137,6 @@ def test_plot_evoked():
 
 def test_plot_evoked_image():
     """Test plot_evoked_image."""
-    import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     evoked.plot_image(proj=True, time_unit='ms')
 
@@ -191,7 +184,6 @@ def test_plot_evoked_image():
 
 def test_plot_white():
     """Test plot_white."""
-    import matplotlib.pyplot as plt
     cov = read_cov(cov_fname)
     cov['method'] = 'empirical'
     cov['projs'] = []  # avoid warnings
@@ -222,7 +214,6 @@ def test_plot_white():
 
 def test_plot_compare_evokeds():
     """Test plot_compare_evokeds."""
-    import matplotlib.pyplot as plt
     rng = np.random.RandomState(0)
     evoked = _get_epochs().average()
     # plot_compare_evokeds: test condition contrast, CI, color assignment

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -7,6 +7,7 @@ import os.path as op
 
 from numpy.testing import assert_equal, assert_array_equal
 import pytest
+import matplotlib.pyplot as plt
 
 from mne import read_events, Epochs, read_cov, pick_types
 from mne.io import read_raw_fif
@@ -14,10 +15,6 @@ from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne.utils import run_tests_if_main, requires_sklearn
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
 from mne.viz.utils import _fake_click
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 evoked_fname = op.join(base_dir, 'test-ave.fif')
@@ -56,7 +53,6 @@ def _get_epochs():
 @requires_sklearn
 def test_plot_ica_components():
     """Test plotting of ICA solutions."""
-    import matplotlib.pyplot as plt
     res = 8
     fast_test = {"res": res, "contours": 0, "sensors": False}
     raw = _get_raw()
@@ -112,8 +108,6 @@ def test_plot_ica_components():
 @requires_sklearn
 def test_plot_ica_properties():
     """Test plotting of ICA properties."""
-    import matplotlib.pyplot as plt
-
     res = 8
     raw = _get_raw(preload=True)
     raw.add_proj([], remove_existing=True)
@@ -173,7 +167,6 @@ def test_plot_ica_properties():
 @requires_sklearn
 def test_plot_ica_sources():
     """Test plotting of ICA panel."""
-    import matplotlib.pyplot as plt
     raw = read_raw_fif(raw_fname).crop(0, 1).load_data()
     picks = _get_picks(raw)
     epochs = _get_epochs()
@@ -223,7 +216,6 @@ def test_plot_ica_sources():
 @requires_sklearn
 def test_plot_ica_overlay():
     """Test plotting of ICA cleaning."""
-    import matplotlib.pyplot as plt
     raw = _get_raw(preload=True)
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
@@ -259,7 +251,6 @@ def test_plot_ica_overlay():
 @requires_sklearn
 def test_plot_ica_scores():
     """Test plotting of ICA scores."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
@@ -285,7 +276,6 @@ def test_plot_ica_scores():
 @requires_sklearn
 def test_plot_instance_components():
     """Test plotting of components as instances of raw and epochs."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -11,6 +11,7 @@ import os.path as op
 
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
                  read_dipole, SourceEstimate)
@@ -22,10 +23,6 @@ from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
                      plot_snr_estimate, plot_filter, plot_csd)
 from mne.utils import requires_nibabel, run_tests_if_main, requires_version
 from mne.time_frequency import CrossSpectralDensity
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 data_path = testing.data_path(download=False)
 subjects_dir = op.join(data_path, 'subjects')
@@ -54,7 +51,6 @@ def _get_events():
 @requires_version('scipy', '0.16')
 def test_plot_filter():
     """Test filter plotting."""
-    import matplotlib.pyplot as plt
     l_freq, h_freq, sfreq = 2., 40., 1000.
     data = np.zeros(5000)
     freq = [0, 2, 40, 50, 500]
@@ -79,7 +75,6 @@ def test_plot_filter():
 
 def test_plot_cov():
     """Test plotting of covariances."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     cov = read_cov(cov_fname)
     with pytest.warns(RuntimeWarning, match='projection'):
@@ -106,7 +101,6 @@ def test_plot_bem():
 
 def test_plot_events():
     """Test plotting events."""
-    import matplotlib.pyplot as plt
     event_labels = {'aud_l': 1, 'aud_r': 2, 'vis_l': 3, 'vis_r': 4}
     color = {1: 'green', 2: 'yellow', 3: 'red', 4: 'c'}
     raw = _get_raw()
@@ -135,7 +129,6 @@ def test_plot_events():
 @testing.requires_testing_data
 def test_plot_source_spectrogram():
     """Test plotting of source spectrogram."""
-    import matplotlib.pyplot as plt
     sample_src = read_source_spaces(op.join(subjects_dir, 'sample',
                                             'bem', 'sample-oct-6-src.fif'))
 
@@ -158,7 +151,6 @@ def test_plot_source_spectrogram():
 @testing.requires_testing_data
 def test_plot_snr():
     """Test plotting SNR estimate."""
-    import matplotlib.pyplot as plt
     inv = read_inverse_operator(inv_fname)
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     plot_snr_estimate(evoked, inv)
@@ -168,7 +160,6 @@ def test_plot_snr():
 @testing.requires_testing_data
 def test_plot_dipole_amplitudes():
     """Test plotting dipole amplitudes."""
-    import matplotlib.pyplot as plt
     dipoles = read_dipole(dip_fname)
     dipoles.plot_amplitudes(show=False)
     plt.close('all')
@@ -176,7 +167,6 @@ def test_plot_dipole_amplitudes():
 
 def test_plot_csd():
     """Test plotting of CSD matrices."""
-    import matplotlib.pyplot as plt
     csd = CrossSpectralDensity([1, 2, 3], ['CH1', 'CH2'],
                                frequencies=[(10, 20)], n_fft=1,
                                tmin=0, tmax=1,)

--- a/mne/viz/tests/test_montage.py
+++ b/mne/viz/tests/test_montage.py
@@ -8,12 +8,9 @@
 import os.path as op
 
 import pytest
-import matplotlib
+import matplotlib.pyplot as plt
 
 from mne.channels import read_montage, read_dig_montage
-
-matplotlib.use('Agg')  # for testing don't use X server
-
 
 p_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'kit', 'tests', 'data')
 elp = op.join(p_dir, 'test_elp.txt')
@@ -26,7 +23,6 @@ fif_fname = op.join(io_dir, 'test_raw.fif')
 
 def test_plot_montage():
     """Test plotting montages."""
-    import matplotlib.pyplot as plt
     m = read_montage('easycap-M1')
     m.plot()
     plt.close('all')

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -9,6 +9,8 @@ from distutils.version import LooseVersion
 
 from numpy.testing import assert_allclose
 import pytest
+import matplotlib
+import matplotlib.pyplot as plt
 
 from mne import read_events, pick_types, Annotations
 from mne.datasets import testing
@@ -16,10 +18,6 @@ from mne.io import read_raw_fif, read_raw_ctf
 from mne.utils import run_tests_if_main
 from mne.viz.utils import _fake_click, _annotation_radio_clicked, _sync_onset
 from mne.viz import plot_raw, plot_sensors
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 ctf_dir = op.join(testing.data_path(download=False), 'CTF')
 ctf_fname_continuous = op.join(ctf_dir, 'testdata_ctf.ds')
@@ -48,7 +46,6 @@ def _get_events():
 
 def _annotation_helper(raw, events=False):
     """Test interactive annotations."""
-    import matplotlib.pyplot as plt
     # Some of our checks here require modern mpl to work properly
     mpl_good_enough = LooseVersion(matplotlib.__version__) >= '2.0'
     n_anns = len(raw.annotations)
@@ -153,7 +150,6 @@ def _annotation_helper(raw, events=False):
 
 def test_plot_raw():
     """Test plotting of raw data."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     raw.info['lowpass'] = 10.  # allow heavy decim during plotting
     events = _get_events()
@@ -250,7 +246,6 @@ def test_plot_raw():
 @testing.requires_testing_data
 def test_plot_raw_white():
     """Test plotting whitened raw data."""
-    import matplotlib.pyplot as plt
     raw = read_raw_fif(raw_fname).crop(0, 1).load_data()
     raw.plot(noise_cov=cov_fname)
     plt.close('all')
@@ -259,7 +254,6 @@ def test_plot_raw_white():
 @testing.requires_testing_data
 def test_plot_ref_meg():
     """Test plotting ref_meg."""
-    import matplotlib.pyplot as plt
     raw_ctf = read_raw_ctf(ctf_fname_continuous).crop(0, 1).load_data()
     raw_ctf.plot()
     plt.close('all')
@@ -294,7 +288,6 @@ def test_plot_raw_filtered():
 
 def test_plot_raw_psd():
     """Test plotting of raw psds."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     # normal mode
     raw.plot_psd(average=False)
@@ -348,7 +341,6 @@ def test_plot_raw_psd():
 
 def test_plot_sensors():
     """Test plotting of sensor array."""
-    import matplotlib.pyplot as plt
     raw = _get_raw()
     fig = raw.plot_sensors('3d')
     _fake_click(fig, fig.gca(), (-0.08, 0.67))

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -10,6 +10,8 @@ from collections import namedtuple
 
 import numpy as np
 import pytest
+import matplotlib
+import matplotlib.pyplot as plt
 
 from mne import read_events, Epochs, pick_channels_evoked, read_cov
 from mne.channels import read_layout
@@ -24,11 +26,6 @@ from mne.viz.utils import _fake_click
 
 from mne.viz.topo import (_plot_update_evoked_topo_proj, iter_topography,
                           _imshow_tfr)
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
-
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 evoked_fname = op.join(base_dir, 'test-ave.fif')
@@ -75,7 +72,6 @@ def _get_epochs_delayed_ssp():
 
 def test_plot_topo():
     """Test plotting of ERP topography."""
-    import matplotlib.pyplot as plt
     # Show topography
     evoked = _get_epochs().average()
     # should auto-find layout
@@ -156,7 +152,6 @@ def test_plot_topo():
 
 def test_plot_topo_single_ch():
     """Test single channel topoplot with time cursor."""
-    import matplotlib.pyplot as plt
     evoked = _get_epochs().average()
     fig = plot_evoked_topo(evoked, background_color='w')
     # test status bar message
@@ -176,7 +171,6 @@ def test_plot_topo_single_ch():
 
 def test_plot_topo_image_epochs():
     """Test plotting of epochs image topography."""
-    import matplotlib.pyplot as plt
     title = 'ERF images - MNE sample data'
     epochs = _get_epochs()
     epochs.load_data()
@@ -194,8 +188,6 @@ def test_plot_topo_image_epochs():
 
 def test_plot_tfr_topo():
     """Test plotting of TFR data."""
-    import matplotlib.pyplot as plt
-
     epochs = _get_epochs()
     n_freqs = 3
     nave = 1

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -11,6 +11,11 @@ from functools import partial
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
 import pytest
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.patches import Circle
 
 from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
                  compute_proj_evoked, find_layout)
@@ -31,10 +36,6 @@ from mne.viz.topomap import (_check_outlines, _onselect, plot_topomap,
 from mne.viz.utils import _find_peaks, _fake_click
 
 
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
-
 data_dir = testing.data_path(download=False)
 subjects_dir = op.join(data_dir, 'subjects')
 ecg_fname = op.join(data_dir, 'MEG', 'sample', 'sample_audvis_ecg-proj.fif')
@@ -50,9 +51,6 @@ layout = read_layout('Vectorview-all')
 
 def test_plot_topomap_interactive():
     """Test interactive topomap projection plotting."""
-    import matplotlib.pyplot as plt
-    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-    from matplotlib.figure import Figure
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     evoked.pick_types(meg='mag')
     evoked.info['projs'] = []
@@ -105,7 +103,6 @@ def test_plot_topomap_interactive():
 @testing.requires_testing_data
 def test_plot_projs_topomap():
     """Test plot_projs_topomap."""
-    import matplotlib.pyplot as plt
     projs = read_proj(ecg_fname)
     info = read_info(raw_fname)
     fast_test = {"res": 8, "contours": 0, "sensors": False}
@@ -129,8 +126,6 @@ def test_plot_projs_topomap():
 @testing.requires_testing_data
 def test_plot_topomap():
     """Test topomap plotting."""
-    import matplotlib.pyplot as plt
-    from matplotlib.patches import Circle
     # evoked
     res = 8
     fast_test = dict(res=res, contours=0, sensors=False, time_unit='s')
@@ -383,8 +378,6 @@ def test_plot_topomap():
 
 def test_plot_tfr_topomap():
     """Test plotting of TFR data."""
-    import matplotlib as mpl
-    import matplotlib.pyplot as plt
     raw = read_raw_fif(raw_fname)
     times = np.linspace(-0.1, 0.1, 200)
     res = 8
@@ -398,12 +391,12 @@ def test_plot_tfr_topomap():
     tfr.plot_topomap(ch_type='mag', tmin=0.05, tmax=0.150, fmin=0, fmax=10,
                      res=res, contours=0)
 
-    eclick = mpl.backend_bases.MouseEvent('button_press_event',
-                                          plt.gcf().canvas, 0, 0, 1)
+    eclick = matplotlib.backend_bases.MouseEvent(
+        'button_press_event', plt.gcf().canvas, 0, 0, 1)
     eclick.xdata = eclick.ydata = 0.1
     eclick.inaxes = plt.gca()
-    erelease = mpl.backend_bases.MouseEvent('button_release_event',
-                                            plt.gcf().canvas, 0.9, 0.9, 1)
+    erelease = matplotlib.backend_bases.MouseEvent(
+        'button_release_event', plt.gcf().canvas, 0.9, 0.9, 1)
     erelease.xdata = 0.3
     erelease.ydata = 0.2
     pos = [[0.11, 0.11], [0.25, 0.5], [0.0, 0.2], [0.2, 0.39]]
@@ -486,5 +479,6 @@ def test_plot_topomap_neuromag122():
     plot_projs_topomap([proj], info=evoked.info, **fast_test)
     plot_projs_topomap([proj], layout=layout, **fast_test)
     pytest.raises(RuntimeError, plot_projs_topomap, [proj], **fast_test)
+
 
 run_tests_if_main()

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -7,6 +7,8 @@ import os.path as op
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
 
 from mne.viz.utils import (compare_fiff, _fake_click, _compute_scalings,
                            _validate_if_list_of_axes, _get_color_list,
@@ -16,10 +18,6 @@ from mne.utils import run_tests_if_main
 from mne.io import read_raw_fif
 from mne.event import read_events
 from mne.epochs import Epochs
-
-# Set our plotters to test mode
-import matplotlib
-matplotlib.use('Agg')  # for testing don't use X server
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -51,7 +49,6 @@ def test_mne_analyze_colormap():
 
 def test_compare_fiff():
     """Test compare_fiff."""
-    import matplotlib.pyplot as plt
     compare_fiff(raw_fname, cov_fname, read_limit=0, show=False)
     plt.close('all')
 
@@ -59,7 +56,6 @@ def test_compare_fiff():
 def test_clickable_image():
     """Test the ClickableImage class."""
     # Gen data and create clickable image
-    import matplotlib.pyplot as plt
     im = np.random.RandomState(0).randn(100, 100)
     clk = ClickableImage(im)
     clicks = [(12, 8), (46, 48), (10, 24)]
@@ -81,7 +77,6 @@ def test_clickable_image():
 
 def test_add_background_image():
     """Test adding background image to a figure."""
-    import matplotlib.pyplot as plt
     rng = np.random.RandomState(0)
     for ii in range(2):
         f, axs = plt.subplots(1, 2)
@@ -142,7 +137,6 @@ def test_auto_scale():
 
 def test_validate_if_list_of_axes():
     """Test validation of axes."""
-    import matplotlib.pyplot as plt
     fig, ax = plt.subplots(2, 2)
     pytest.raises(ValueError, _validate_if_list_of_axes, ax)
     ax_flat = ax.ravel()
@@ -163,7 +157,6 @@ def test_validate_if_list_of_axes():
 
 def test_center_cmap():
     """Test centering of colormap."""
-    import matplotlib.cm as cm
     from matplotlib.colors import LinearSegmentedColormap
     from matplotlib.pyplot import Normalize
     cmap = center_cmap(cm.get_cmap("RdBu"), -5, 10)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ doc-files = doc
 
 [tool:pytest]
 addopts = --showlocals --durations=20 --doctest-modules -rs --cov-report= --doctest-ignore-import-errors
+usefixtures = matplotlib_config
 # Set this pretty low to ensure we do not by default add really long tests,
 # or make changes that make things a lot slower
 timeout = 30


### PR DESCRIPTION
Since SciPy 1.2.0 just came out and NumPy 1.16.0 is in RC status, I updated all my libs locally and hunted down errors. This PR thus (in three separate commits):

1. Fixes a bug with how we warm-started a `sklearn` var (we shouldn't ever set `clf.coefs_ = None`, sklearn can't handle this anymore). I also fixed PEP8 errors while in the file.
2. Works around an obscure `scipy.io.savemat` bug when subselecting fields from a structured array in `test_eeglab.py`. I also fixed PEP8 errors while in the file.
3. Unifies how we deal with `matplotlib` tests. I noticed mine had been horribly slow for some time. Turns out it's because I added `interactive=True` to my `matplotlibrc`. We now use a package-wide `pytest` fixture to set `matplotlib` params. This allows us to stop nesting our `plt` imports in tests, and no longer need `matploltlib.use` at the top of every test file that has viz tests. This makes our code more DRY and lowers maintenance *and* new-contributor burden! (I am really starting to appreciate all that `pytest` brings to the table.)