### PR TITLE
Update pymatreader to version 0.0.18.1.

### DIFF
--- a/mne/externals/pymatreader/utils.py
+++ b/mne/externals/pymatreader/utils.py
@@ -111,7 +111,7 @@ def _handle_hdf5_dataset(hdf5_object):
         data = [hdf5_object.file[cur_data] for cur_data in data.flatten()]
         if len(data) == 1 and hdf5_object.attrs['MATLAB_class'] == b'cell':
             data = data[0]
-            data = data.value
+            data = data[()]
             return _assign_types(data)
 
         data = _hdf5todict(data)


### PR DESCRIPTION
Fixes possible warnings because of h5py deprecation of `object.value` access.

This is basically a follow up to #5809. Although it is already closed, one extra occurrence of the deprecated code was still in the codebase.

