### PR TITLE
[MRG] Log number of rejected samples in raw.get_data

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -933,8 +933,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # set the data
         self._data[sel, start:stop] = value
 
+    @verbose
     def get_data(self, picks=None, start=0, stop=None,
-                 reject_by_annotation=None, return_times=False):
+                 reject_by_annotation=None, return_times=False, verbose=None):
         """Get data in the given range.
 
         Parameters
@@ -953,6 +954,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             'bad' are omitted. If 'NaN', the bad samples are filled with NaNs.
         return_times : bool
             Whether to return times as well. Defaults to False.
+        verbose : bool, str, int, or None
+            If not None, override default verbose level (see
+            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
+            for more). Defaults to self.verbose.
 
         Returns
         -------

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1003,10 +1003,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         n_rejected = n_samples - n_kept  # rejected samples
         if n_rejected > 0:
             if reject_by_annotation == 'omit':
-                logger.info(f"Omitting {n_rejected} of {n_samples} "
-                            f"({n_rejected / n_samples:.2%}) samples, "
-                            f"retaining {n_kept} ({n_kept / n_samples:.2%}) "
-                            "samples.")
+                msg = ("Omitting {} of {} ({:.2%}) samples, retaining {}"
+                       " ({:.2%}) samples.")
+                logger.info(msg.format(n_rejected, n_samples,
+                                       n_rejected / n_samples,
+                                       n_kept, n_kept / n_samples))
                 data = np.zeros((len(picks), n_kept))
                 times = np.zeros(data.shape[1])
                 idx = 0
@@ -1017,10 +1018,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                     data[:, idx:end], times[idx:end] = self[picks, start:stop]
                     idx = end
             else:
-                logger.info(f"Setting {n_rejected} of {n_samples} "
-                            f"({n_rejected / n_samples:.2%}) samples to NaN, "
-                            f"retaining {n_kept} ({n_kept / n_samples:.2%}) "
-                            "samples.")
+                msg = ("Setting {} of {} ({:.2%}) samples to NaN, retaining {}"
+                       " ({:.2%}) samples.")
+                logger.info(msg.format(n_rejected, n_samples,
+                                       n_rejected / n_samples,
+                                       n_kept, n_kept / n_samples))
                 data, times = self[picks, start:stop]
                 data[:, ~used[1:-1]] = np.nan
         else:

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -269,15 +269,15 @@ def test_get_data_reject():
                                     description="bad"))
 
     with catch_logging() as log:
-        data = raw.get_data(reject_by_annotation="omit")
+        data = raw.get_data(reject_by_annotation="omit", verbose=True)
         msg = ('Omitting 1024 of 2560 (40.00%) samples, retaining 1536' +
                ' (60.00%) samples.')
         assert log.getvalue().strip() == msg
-        assert data.shape == (len(ch_names), 1536)
+    assert data.shape == (len(ch_names), 1536)
     with catch_logging() as log:
-        data = raw.get_data(reject_by_annotation="nan")
+        data = raw.get_data(reject_by_annotation="nan", verbose=True)
         msg = ('Setting 1024 of 2560 (40.00%) samples to NaN, retaining 1536' +
                ' (60.00%) samples.')
         assert log.getvalue().strip() == msg
-        assert data.shape == (len(ch_names), 2560)  # shape doesn't change
-        assert np.isnan(data).sum() == 3072  # but NaNs are introduced instead
+    assert data.shape == (len(ch_names), 2560)  # shape doesn't change
+    assert np.isnan(data).sum() == 3072  # but NaNs are introduced instead

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -17,7 +17,7 @@ from mne import concatenate_raws, create_info, Annotations
 from mne.annotations import _handle_meas_date
 from mne.datasets import testing
 from mne.io import read_raw_fif, RawArray, BaseRaw
-from mne.utils import _TempDir
+from mne.utils import _TempDir, catch_logging
 from mne.io.meas_info import _get_valid_units
 
 
@@ -257,3 +257,27 @@ def test_meas_date_orig_time():
     assert raw.annotations.orig_time is None
     assert raw.annotations.onset[0] == 0.5
     assert raw.annotations.duration[0] == 0.2
+
+
+def test_get_data_reject():
+    """Test if reject_by_annotation is working correctly."""
+    fs = 256
+    ch_names = ["C3", "Cz", "C4"]
+    info = create_info(ch_names, sfreq=fs)
+    raw = RawArray(np.zeros((len(ch_names), 10 * fs)), info)
+    raw.set_annotations(Annotations(onset=[2, 4], duration=[3, 2],
+                                    description="bad"))
+
+    with catch_logging() as log:
+        data = raw.get_data(reject_by_annotation="omit")
+        msg = ('Omitting 1024 of 2560 (40.00%) samples, retaining 1536' +
+               ' (60.00%) samples.')
+        assert log.getvalue().strip() == msg
+        assert data.shape == (len(ch_names), 1536)
+    with catch_logging() as log:
+        data = raw.get_data(reject_by_annotation="nan")
+        msg = ('Setting 1024 of 2560 (40.00%) samples to NaN, retaining 1536' +
+               ' (60.00%) samples.')
+        assert log.getvalue().strip() == msg
+        assert data.shape == (len(ch_names), 2560)  # shape doesn't change
+        assert np.isnan(data).sum() == 3072  # but NaNs are introduced instead


### PR DESCRIPTION
I think it would be useful if `get_data` mentioned the number of rejected samples (if `reject_by_annotation` is "omit" or `"nan"`. Here's a sample message when getting data from a signal with 120000 samples with 1100 samples marked by bad annotations with `reject_by_annotation` is "omit"`:

```
Omitting 1100 of 120000 (0.92%) samples, retaining 118900 (99.08%) samples.
```

And here is the message when `reject_by_annotation` is "nan":

```
Setting 1100 of 120000 (0.92%) samples to NaN, retaining 118900 (99.08%) samples.
```

I'd like to add a test - where should I put it (I didn't find a test for `raw.get_data` at all)?