### PR TITLE
Fix import of Iterable

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -9,7 +9,7 @@
 #
 # License: Simplified BSD
 
-from collections import Iterable
+from collections.abc import Iterable
 import os
 import os.path as op
 

--- a/mne/utils.py
+++ b/mne/utils.py
@@ -5,7 +5,8 @@
 # License: BSD (3-clause)
 
 import atexit
-from collections import Iterable, OrderedDict
+from collections.abc import Iterable
+from collections import OrderedDict
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 from functools import wraps


### PR DESCRIPTION
In Python 3.7, `from collections import Iterable` is deprecated, it should be `from collections.abc import Iterable` from now on.