### PR TITLE
[RCF] raw.times does not change after changing sfreq

### DIFF
--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -219,6 +219,17 @@ def test_time_as_index_ref(offset, origin):
     assert_array_equal(inds, np.arange(raw.n_times))
 
 
+def test_time_as_index_update():
+    MEAS_DATE = 1
+    info = create_info(ch_names=1, sfreq=10.)
+    raw = RawArray(data=np.empty((1, 10)), info=info, first_samp=10)
+    raw.info['meas_date'] = MEAS_DATE
+
+    original_times = raw.times
+    raw.info['sfreq'] = 1
+    assert raw.times != original_times
+
+
 def _raw_annot(meas_date, orig_time):
     info = create_info(ch_names=10, sfreq=10.)
     raw = RawArray(data=np.empty((10, 10)), info=info, first_samp=10)


### PR DESCRIPTION
`raw.times` does not change after changing `raw.info['sfreq']`. 

See: 

```py
MEAS_DATE = 1
info = create_info(ch_names=1, sfreq=10.)
raw = RawArray(data=np.empty((1, 10)), info=info, first_samp=10)
raw.info['meas_date'] = MEAS_DATE

print(raw.times)
raw.info['sfreq'] = 1
print(raw.times)
```

```
[0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
[0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
```

The question is: 
Does it make sense to change `'sfreq'`? 
If yes, we should fix the test in this PR.

If not, shall we forbid to change `'sfreq'` once the raw object is created?