### PR TITLE
ENH: Bump maint Travis to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: trusty
+dist: xenial
 sudo: false
 cache:
   apt: true
@@ -33,8 +33,9 @@ matrix:
         # PIP + non-default stim channel
         - os: linux
           env: MNE_STIM_CHANNEL=STI101
+               PYTHON_VERSION=3.7
           language: python
-          python: "3.6"
+          python: "3.7"
 
         # 2.7 Old dependencies
         - os: linux
@@ -54,7 +55,7 @@ before_install:
     - if [ -z "$CONDA_ENVIRONMENT" ] && [ -z "$CONDA_DEPENDENCIES" ]; then
         pip uninstall -y numpy;
         pip install numpy scipy vtk;
-        pip install -r requirements.txt;
+        pip install --upgrade -r requirements.txt;
       else
         git clone https://github.com/astropy/ci-helpers.git;
         source ci-helpers/travis/setup_conda.sh;

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.txt
 include requirements.txt
 include mne/__init__.py
 
+exclude conftest.py
 recursive-include examples *.py
 recursive-include examples *.txt
 recursive-include tutorials *.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import pytest
+import warnings
+# For some unknown reason, on Travis-xenial there are segfaults caused on
+# the line pytest -> pdb.Pdb.__init__ -> "import readline". Forcing an
+# import here seems to prevent them (!?). This suggests a potential problem
+# with some other library stepping on memory where it shouldn't. It only
+# seems to happen on the Linux runs that install Mayavi. Anectodally,
+# @larsoner has had problems a couple of years ago where a mayavi import
+# seemed to corrupt SciPy linalg function results (!), likely due to the
+# associated VTK import, so this could be another manifestation of that.
+import readline  # noqa
+
+
+@pytest.fixture(scope='session')
+def matplotlib_config():
+    """Configure matplotlib for viz tests."""
+    import matplotlib
+    matplotlib.use('agg')  # don't pop up windows
+    import matplotlib.pyplot as plt
+    assert plt.get_backend() == 'agg'
+    # overwrite some params that can horribly slow down tests that
+    # users might have changed locally (but should not otherwise affect
+    # functionality)
+    plt.ioff()
+    plt.rcParams['figure.dpi'] = 100
+    try:
+        with warnings.catch_warnings(record=True):  # traits
+            from mayavi import mlab
+    except Exception:
+        pass
+    else:
+        mlab.options.backend = 'test'

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -137,9 +137,10 @@ def test_docstring_parameters():
                 continue
             with pytest.warns(None) as w:
                 cdoc = docscrape.ClassDoc(cls)
-            if len(w):
-                raise RuntimeError('Error for __init__ of %s in %s:\n%s'
-                                   % (cls, name, w[0]))
+            for ww in w:
+                if 'Using or importing the ABCs' not in str(ww.message):
+                    raise RuntimeError('Error for __init__ of %s in %s:\n%s'
+                                       % (cls, name, ww))
             if hasattr(cls, '__init__'):
                 incorrect += check_parameters_match(cls.__init__, cdoc)
             for method_name in cdoc.methods:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ filterwarnings =
     ignore:The oldnumeric module will be dropped:DeprecationWarning
     ignore:Importing from numpy.testing.decorators:DeprecationWarning
     ignore:Using or importing the ABCs:DeprecationWarning
+    ignore:invalid escape sequence:
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ filterwarnings =
     ignore:Importing from numpy.testing.decorators:DeprecationWarning
     ignore:Using or importing the ABCs:DeprecationWarning
     ignore:invalid escape sequence:
+    ignore:`formatargspec` is deprecated:DeprecationWarning
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning
 


### PR DESCRIPTION
Let's see if things pass on `maint/0.17`, too.