### PR TITLE
FIX: Use pip for vtk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # https://github.com/xianyi/OpenBLAS/issues/731
     global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
             PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout nitime"
-            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
+            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.5.12"
             OPENBLAS_NUM_THREADS=1
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # https://github.com/xianyi/OpenBLAS/issues/731
     global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
             PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout nitime"
-            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.5.12"
+            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       CONDA_ENVIRONMENT: "environment.yml"
-      CONDA_VERSION: ">=4.5.12"
+      CONDA_VERSION: "=4.5.12"
       PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
   matrix:
       - PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,12 @@
 # Use an old image with an incompatible compiler (pip wants MSVC 2015 / 14.0)
-image: Visual Studio 2017
+image: Visual Studio 2013
 environment:
   global:
       PYTHON: "C:\\conda"
-      CONDA_ENVIRONMENT: "environment.yml"
-      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
+      # CONDA_ENVIRONMENT: "environment.yml"
+      # PIP_DEPENDENCIES: "pip install codecov pytest-faulthandler pytest-sugar pytest-timeout"
+      CONDA_DEPENDENCIES: ""
+      PIP_DEPENDENCIES: ""
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
@@ -13,8 +15,15 @@ install:
   - "git clone git://github.com/astropy/ci-helpers.git"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # From https://github.com/conda-forge/gdal-feedstock/issues/241
+  - "cd %PYTHON%\\envs\\test\\Library\\bin"
+  - "copy tiff.dll libtiff.dll"
+  - "cd C:\\projects\\mne-python"
+  - "conda env remove -yn test"
+  - "conda env create -yn test -f environment.yml"
   - "activate test"
   - "pip uninstall -yq mne"
+  - "pip install -yq codecov pytest-faulthandler pytest-sugar pytest-timeout"
   - "python setup.py develop"
   - "python -c \"import mne; print(mne.sys_info())\""
   - "SET MNE_FORCE_SERIAL=true"  # otherwise joblib will bomb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 # Use an old image with an incompatible compiler (pip wants MSVC 2015 / 14.0)
-image: Visual Studio 2013
+image: Visual Studio 2017
 environment:
   global:
       PYTHON: "C:\\conda"
       CONDA_ENVIRONMENT: "environment.yml"
-      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout vtk"
+      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,8 @@ environment:
   global:
       PYTHON: "C:\\conda"
       # CONDA_ENVIRONMENT: "environment.yml"
-      # PIP_DEPENDENCIES: "pip install codecov pytest-faulthandler pytest-sugar pytest-timeout"
-      CONDA_DEPENDENCIES: ""
-      PIP_DEPENDENCIES: ""
+      CONDA_DEPENDENCIES: "python>=3.6 pip mkl numpy scipy matplotlib cython pyqt>=5.9 pandas xlrd scikit-learn h5py pillow statsmodels jupyter pytest pytest-cov joblib psutil numpydoc flake8 spyder numexpr traits>=4.6.0 pyface>=6 traitsui>=6 testpath<0.4"
+      PIP_DEPENDENCIES: "pip install codecov pytest-sugar pytest-timeout vtk https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12 PySurfer[save_movie] dipy --only-binary dipy nibabel nilearn neo pytest-faulthandler pytest-mock pydocstyle codespell python-picard"
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
@@ -15,15 +14,8 @@ install:
   - "git clone git://github.com/astropy/ci-helpers.git"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  # From https://github.com/conda-forge/gdal-feedstock/issues/241
-  - "cd %PYTHON%\\envs\\test\\Library\\bin"
-  - "copy tiff.dll libtiff.dll"
-  - "cd C:\\projects\\mne-python"
-  - "conda env remove -yn test"
-  - "conda env create -yn test -f environment.yml"
   - "activate test"
-  - "pip uninstall -yq mne"
-  - "pip install -yq codecov pytest-faulthandler pytest-sugar pytest-timeout"
+  # "pip uninstall -yq mne"
   - "python setup.py develop"
   - "python -c \"import mne; print(mne.sys_info())\""
   - "SET MNE_FORCE_SERIAL=true"  # otherwise joblib will bomb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       CONDA_ENVIRONMENT: "environment.yml"
-      CONDA_VERSION: "=4.5.12"
-      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
+      PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout vtk"
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
       PYTHON: "C:\\conda"
       # CONDA_ENVIRONMENT: "environment.yml"
       CONDA_DEPENDENCIES: "python>=3.6 pip mkl numpy scipy matplotlib cython pyqt>=5.9 pandas xlrd scikit-learn h5py pillow statsmodels jupyter pytest pytest-cov joblib psutil numpydoc flake8 spyder numexpr traits>=4.6.0 pyface>=6 traitsui>=6 testpath<0.4"
-      PIP_DEPENDENCIES: "pip install codecov pytest-sugar pytest-timeout vtk https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12 PySurfer[save_movie] dipy --only-binary dipy nibabel nilearn neo pytest-faulthandler pytest-mock pydocstyle codespell python-picard"
+      PIP_DEPENDENCIES: "codecov pytest-sugar pytest-timeout vtk https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12 PySurfer[save_movie] dipy --only-binary dipy nibabel nilearn neo pytest-faulthandler pytest-mock pydocstyle codespell python-picard"
   matrix:
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       CONDA_ENVIRONMENT: "environment.yml"
+      CONDA_VERSION: ">=4.5.12"
       PIP_DEPENDENCIES: "codecov pytest-faulthandler pytest-sugar pytest-timeout"
   matrix:
       - PYTHON_VERSION: "3.6"

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,8 @@ dependencies:
 - jupyter
 - pytest
 - pytest-cov
+- pytest-mock
+- pytest-timeout
 - joblib
 - psutil
 - numpydoc
@@ -39,7 +41,6 @@ dependencies:
   - nilearn
   - neo
   - pytest-faulthandler
-  - pytest-mock
   - pydocstyle
   - codespell
   - python-picard


### PR DESCRIPTION
CircleCI linkcheck had an error

https://circleci.com/gh/mne-tools/mne-python/10878

And AppVeyor has been failing. Let's see if VTK from `pip` makes AppVeyor happy.