### PR TITLE
[MRG][Fix] Concatenate raw objects with annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,8 @@ Changelog
 Bug
 ~~~
 
+- Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
+
 - Fix :func:`mne.io.read_raw_edf` reading duplicate channel names by `Larry Eisenman`_
 
 - Fix :func:`set_bipolar_reference` in the case of generating all bipolar combinations and also in the case of repeated channels in both lists (anode and cathode) by `Cristóbal Moënne-Loccoz`_

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2127,8 +2127,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         edge_samps = list()
         for ri, r in enumerate(raws):
             n_samples = self.last_samp - self.first_samp + 1
+            r_annot = Annotations(onset=r.annotations.onset - r._first_time,
+                                  duration=r.annotations.duration,
+                                  description=r.annotations.description,
+                                  orig_time=None)
             annotations = _combine_annotations(
-                annotations, r.annotations, n_samples,
+                annotations, r_annot, n_samples,
                 self.first_samp, r.first_samp,
                 self.info['sfreq'], self.info['meas_date'])
             edge_samps.append(sum(self._last_samps) -

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -112,7 +112,7 @@ class Raw(BaseRaw):
                     self.annotations, r.annotations,
                     n_samples, self.first_samp, r.first_samp,
                     r.info['sfreq'], self.info['meas_date'])
-                self.set_annotations(annotations, False)
+                self.set_annotations(annotations, emit_warning=True)
                 n_samples += r.last_samp - r.first_samp + 1
 
         # Add annotations for in-data skips

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -112,7 +112,7 @@ class Raw(BaseRaw):
                     self.annotations, r.annotations,
                     n_samples, self.first_samp, r.first_samp,
                     r.info['sfreq'], self.info['meas_date'])
-                self.set_annotations(annotations, emit_warning=True)
+                self.set_annotations(annotations, emit_warning=False)
                 n_samples += r.last_samp - r.first_samp + 1
 
         # Add annotations for in-data skips


### PR DESCRIPTION
Fix #5839, #5555 

This PR fixes the fact that `raw_A.append(raw_B)` ignores `meas_date` and
supposes that the buffers of `raw_A` and `raw_B` where captured one right
after the other.