### PR TITLE
[MRG] Fix bf proj with bads

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,8 @@ Bug
 
 - Fixed a bug where :meth:`mne.time_frequency.AverageTFR.plot_joint` would mishandle bad channels, by `David Haslacher`_ and `Jona Sassenhagen`_
 
+- Fix issue with bad channels ignored in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` by `Alex Gramfort`_
+
 API
 ~~~
 

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -171,7 +171,7 @@ def _prepare_beamformer_input(info, forward, label, picks, pick_ori,
     ch_names = [info_ch_names[k] for k in picks]
     fwd_ch_names = forward['sol']['row_names']
     # Keep channels in forward present in info:
-    fwd_ch_names = [ch for ch in fwd_ch_names if ch in info_ch_names]
+    fwd_ch_names = [ch for ch in fwd_ch_names if ch in ch_names]
     forward = pick_channels_forward(forward, fwd_ch_names)
     picks_forward = [fwd_ch_names.index(ch) for ch in ch_names]
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -423,16 +423,17 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
             info, forward, label, picks, pick_ori)
 
     # Handle whitening
-    info = pick_info(
-        info, [info['ch_names'].index(k) for k in ch_names
-               if k in info['ch_names']])
+    picks = [info['ch_names'].index(k) for k in ch_names
+             if k in info['ch_names']]
+    info = pick_info(info, picks)
+    del picks  # everything should be picked now
 
     # XXX this could maybe use pca=True to avoid needing to use
     # _reg_pinv(..., rank=rank) later
     if noise_cov is not None:
         whitener_rank = None if rank == 'full' else rank
         whitener, _ = compute_whitener(
-            noise_cov, info, picks, rank=whitener_rank)
+            noise_cov, info, rank=whitener_rank)
 
         # whiten the leadfield
         G = np.dot(whitener, G)

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -67,6 +67,8 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     picks = mne.pick_types(raw.info, selection=left_temporal_channels)
     picks = picks[::2]  # decimate for speed
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
+    raw.info['bads'] = raw.ch_names[:10]  # add more bads
+
     del picks
     raw.info.normalize_proj()  # avoid projection warnings
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -66,10 +66,15 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
     left_temporal_channels = mne.read_selection('Left-temporal')
     picks = mne.pick_types(raw.info, selection=left_temporal_channels)
     picks = picks[::2]  # decimate for speed
+    # add a couple channels we will consider bad
+    bad_picks = [100, 101]
+    bads = [raw.ch_names[pick] for pick in bad_picks]
+    assert not any(pick in picks for pick in bad_picks)
+    picks = np.concatenate([picks, bad_picks])
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
-    raw.info['bads'] = raw.ch_names[:10]  # add more bads
-
     del picks
+
+    raw.info['bads'] = bads  # add more bads
     raw.info.normalize_proj()  # avoid projection warnings
 
     if epochs:


### PR DESCRIPTION
make_lcmv and make_dics were computing filters on full meg data even in the presence of bads which caused a crash when applied to data with bad channels as proj matrix was suddenly different.

cc @britta-wstnr @wmvanvliet 