### PR TITLE
[MRG] FIX: save-load split FIF round trip

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -149,6 +149,9 @@ Changelog
 
 Bug
 ~~~
+
+- Fix annotations in split fif files :func:`mne.io.read_raw_fif` by `Joan Massich`_
+
 - Fix :meth:`mne.Epochs.plot` with ``scalings='auto'`` to properly compute channel-wise scalings by `Stefan Repplinger`_
 
 - Fix :func:`mne.gui.coregistration` and :ref:`mne coreg <gen_mne_coreg>` crashing with segmentation fault when switching subjects by `Eric Larson`_

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -104,16 +104,7 @@ class Raw(BaseRaw):
             verbose=verbose)
 
         # combine annotations
-        self.set_annotations(raws[0].annotations, False)
-        if any([r.annotations for r in raws[1:]]):
-            n_samples = np.sum(self._last_samps - self._first_samps + 1)
-            for r in raws:
-                annotations = _combine_annotations(
-                    self.annotations, r.annotations,
-                    n_samples, self.first_samp, r.first_samp,
-                    r.info['sfreq'], self.info['meas_date'])
-                self.set_annotations(annotations, emit_warning=False)
-                n_samples += r.last_samp - r.first_samp + 1
+        self.set_annotations(raws[0].annotations, emit_warning=True)
 
         # Add annotations for in-data skips
         for extra in self._raw_extras:

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -104,7 +104,7 @@ class Raw(BaseRaw):
             verbose=verbose)
 
         # combine annotations
-        self.set_annotations(raws[0].annotations, emit_warning=True)
+        self.set_annotations(raws[0].annotations, emit_warning=False)
 
         # Add annotations for in-data skips
         for extra in self._raw_extras:

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -21,8 +21,7 @@ from ..base import (BaseRaw, _RawShell, _check_raw_compatibility,
                     _check_maxshield)
 from ..utils import _mult_cal_one
 
-from ...annotations import (Annotations, _combine_annotations,
-                            _read_annotations_fif)
+from ...annotations import Annotations, _read_annotations_fif
 
 from ...event import AcqParserFIF
 from ...utils import check_fname, logger, verbose, warn, fill_doc

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -388,7 +388,8 @@ def test_split_files(tmpdir):
     raw_2 = read_raw_fif(split_fname)
     assert_allclose(raw_2.buffer_size_sec, 1., atol=1e-2)  # samp rate
     assert_array_almost_equal(raw_1.annotations.onset, raw_2.annotations.onset)
-    assert_array_equal(raw_1.annotations.duration, raw_2.annotations.duration)
+    assert_array_almost_equal(raw_1.annotations.duration,
+                              raw_2.annotations.duration)
     assert_array_equal(raw_1.annotations.description,
                        raw_2.annotations.description)
     data_1, times_1 = raw_1[:, :]
@@ -401,6 +402,9 @@ def test_split_files(tmpdir):
     data_bids, times_bids = raw_bids[:, :]
     assert_array_equal(data_1, data_bids)
     assert_array_equal(times_1, times_bids)
+
+    # XXX: If I don't do this, the error message on saving changes :S
+    raw_1.set_annotations(Annotations([2.], [5.5], 'test'))
 
     # test the case where we only end up with one buffer to write
     # (GH#3210). These tests rely on writing meas info and annotations

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1536,9 +1536,14 @@ def test_file_like(kind, preload, split, tmpdir):
     assert file_fid.closed
 
 
-def test_foo(tmpdir):
+@pytest.mark.parametrize('delta_shift', [0, 1, 2])
+def test_foo(tmpdir, delta_shift):
     raw_1 = read_raw_fif(test_fif_fname, preload=False)
-    raw_1.set_annotations(Annotations(np.arange(25), np.zeros((25,)), 'test'),
+    delta = 1 / raw_1.info['sfreq']
+    shift = delta_shift * delta
+    raw_1.set_annotations(Annotations(np.arange(25) + shift,
+                                      np.zeros((25,)),
+                                      'test'),
                           emit_warning=False)
     split_fname = op.join(str(tmpdir), 'split_raw.fif')
     print(str(tmpdir))
@@ -1548,7 +1553,10 @@ def test_foo(tmpdir):
     print(raw_1.annotations)
     print(raw_2.annotations)
 
-    assert_array_almost_equal(raw_1.annotations.onset, raw_2.annotations.onset)
+    print(max(abs(raw_1.annotations.onset - raw_2.annotations.onset)))
+    assert_array_almost_equal(raw_1.annotations.onset,
+                              raw_2.annotations.onset,
+                              decimal=5)
 
 
 run_tests_if_main()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -382,6 +382,7 @@ def test_split_files(tmpdir):
     assert op.exists(split_fname_bids_part1)
     assert op.exists(split_fname_bids_part2)
 
+    raw_1.set_annotations(Annotations(np.arange(20), np.ones((20,)), 'test'))
     split_fname = op.join(tempdir, 'split_raw.fif')
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
     raw_2 = read_raw_fif(split_fname)
@@ -1533,6 +1534,21 @@ def test_file_like(kind, preload, split, tmpdir):
         assert not fid.closed
         assert not file_fid.closed
     assert file_fid.closed
+
+
+def test_foo(tmpdir):
+    raw_1 = read_raw_fif(test_fif_fname, preload=False)
+    raw_1.set_annotations(Annotations(np.arange(25), np.zeros((25,)), 'test'),
+                          emit_warning=False)
+    split_fname = op.join(str(tmpdir), 'split_raw.fif')
+    print(str(tmpdir))
+    raw_1.save(split_fname, buffer_size_sec=None, split_size='9MB')
+    raw_2 = read_raw_fif(split_fname)
+
+    print(raw_1.annotations)
+    print(raw_2.annotations)
+
+    assert_array_almost_equal(raw_1.annotations.onset, raw_2.annotations.onset)
 
 
 run_tests_if_main()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1541,24 +1541,4 @@ def test_file_like(kind, preload, split, tmpdir):
     assert file_fid.closed
 
 
-# @pytest.mark.parametrize('delta_shift', [0, 1, 2])
-@pytest.mark.parametrize('delta_shift', [1, 2])
-def test_split_files_more(tmpdir, delta_shift):
-    """Test writing and reading of split raw files."""
-    raw_1 = read_raw_fif(test_fif_fname, preload=False)
-    delta = 1 / raw_1.info['sfreq']
-    shift = delta_shift * delta
-    raw_1.set_annotations(Annotations(np.arange(25) + shift,
-                                      np.zeros((25,)),
-                                      'test'),
-                          emit_warning=False)
-    split_fname = op.join(str(tmpdir), 'split_raw.fif')
-    print(str(tmpdir))
-    raw_1.save(split_fname, buffer_size_sec=None, split_size='9MB')
-    raw_2 = read_raw_fif(split_fname)
-
-    assert_allclose(raw_1.annotations.onset, raw_2.annotations.onset)
-    assert_allclose(raw_1.annotations.duration, raw_2.annotations.duration)
-
-
 run_tests_if_main()


### PR DESCRIPTION
split save and reload a FIF file fails due to Annotations

Fixes #5856