### PR TITLE
[Hot fix] circle ci

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -281,7 +281,7 @@ class RawEDF(BaseRaw):
                     d_sidx = d_lims[ai][0]
                     d_eidx = d_lims[ai + n_read - 1][1]
                     if n_samps[ci] != buf_len:
-                        if ci in stim_channel:
+                        if stim_channel is not None and ci in stim_channel:
                             # Stim channel will be interpolated
                             old = np.linspace(0, 1, n_samps[ci] + 1, True)
                             new = np.linspace(0, 1, buf_len, False)


### PR DESCRIPTION
fixes #5864
A regression in plot_sleep.py due to #5841

in the original code, comparison with `None` was working
```diff
-                        if ci == stim_channel:
+                        if ci in stim_channel:
```

in the new code, if `stim_channel` is `None` the conditional breaks.
It should had been:

```diff
-                        if ci == stim_channel:
+                        if stim_channel is not None and ci in stim_channel:
```

I think we should not need a test for that. I checked all other comparions, 
and they would never run into a `None` `stim_channel`.

The tutorial works as expected

``` shell
In [1]: %run tutorials/plot_sleep.py
/home/sik/miniconda3/envs/mne/lib/python3.6/site-packages/sklearn/externals/joblib/externals/cloudpickle/cloudpickle.py:47: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
<Epochs  |   2650 events (good & bad), 0 - 29.99 sec, baseline off, ~18 kB, data not loaded,
 'Sleep stage 1': 58
 'Sleep stage 2': 250
 'Sleep stage 3/4': 220
 'Sleep stage R': 125
 'Sleep stage W': 1997>
<Epochs  |   2802 events (good & bad), 0 - 29.99 sec, baseline off, ~18 kB, data not loaded,
 'Sleep stage 1': 109
 'Sleep stage 2': 562
 'Sleep stage 3/4': 105
 'Sleep stage R': 170
 'Sleep stage W': 1856>

Accuracy score: 0.8618843683083511
[[1853    0    0    3    0]
 [  95    4    4    1    5]
 [  81   11  434   21   15]
 [   0    0    7   98    0]
 [  83   31   30    0   26]]
                 precision    recall  f1-score   support

  Sleep stage W       0.88      1.00      0.93      1856
  Sleep stage 1       0.09      0.04      0.05       109
  Sleep stage 2       0.91      0.77      0.84       562
Sleep stage 3/4       0.80      0.93      0.86       105
  Sleep stage R       0.57      0.15      0.24       170

      micro avg       0.86      0.86      0.86      2802
      macro avg       0.65      0.58      0.58      2802
   weighted avg       0.83      0.86      0.84      2802
```