### PR TITLE
MRG+1: ENH: refactor beamformer channel picks with utils

### DIFF
--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -60,25 +60,6 @@ def _check_one_ch_type(info, picks, noise_cov, method):
              'not heavily tested yet.')
 
 
-def _pick_channels_spatial_filter(ch_names, filters):
-    """Return data channel indices to be used with spatial filter.
-
-    Unlike ``pick_channels``, this respects the order of ch_names.
-    """
-    sel = []
-    # first check for channel discrepancies between filter and data:
-    for ch_name in filters['ch_names']:
-        if ch_name not in ch_names:
-            raise ValueError('The spatial filter was computed with channel %s '
-                             'which is not present in the data. You should '
-                             'compute a new spatial filter restricted to the '
-                             'good data channels.' % ch_name)
-    # then compare list of channels and get selection based on data:
-    sel = [ii for ii, ch_name in enumerate(ch_names)
-           if ch_name in filters['ch_names']]
-    return sel
-
-
 def _check_proj_match(info, filters):
     """Check whether SSP projections in data and spatial filter match."""
     proj_data, _, _ = make_projector(info['projs'],

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -108,9 +108,11 @@ def _prepare_beamformer_input(info, forward, label, picks, pick_ori,
                          'forward operator with a surface-based source space '
                          'is used.')
     # Check whether data and forward model have same compensation applied
-    if not get_current_comp(info) == get_current_comp(forward['info']):
-        raise ValueError('Data and forward model do not have same '
-                         'compensation applied.')
+    data_comp = get_current_comp(info)
+    fwd_comp = get_current_comp(forward['info'])
+    if data_comp != fwd_comp:
+        raise ValueError('Data (%s) and forward model (%s) do not have same '
+                         'compensation applied.' % (data_comp, fwd_comp))
 
     # Restrict forward solution to selected channels
     info_ch_names = [ch['ch_name'] for ch in info['chs']]

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -8,13 +8,12 @@
 # License: BSD (3-clause)
 import numpy as np
 
-from ..utils import logger, verbose, warn, _reg_pinv
+from ..utils import logger, verbose, warn, _reg_pinv, _check_info_inv
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
 from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
-from ._compute_beamformer import (_setup_picks,
-                                  _pick_channels_spatial_filter,
+from ._compute_beamformer import (_pick_channels_spatial_filter,
                                   _check_proj_match, _prepare_beamformer_input,
                                   _compute_beamformer, _check_one_ch_type,
                                   _check_src_type, Beamformer, _check_rank)
@@ -216,7 +215,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
     else:
         fwd_norm = None  # No normalization
 
-    picks = _setup_picks(info=info, forward=forward)
+    picks = _check_info_inv(info=info, forward=forward)
     _, ch_names, proj, vertices, G, nn = _prepare_beamformer_input(
         info, forward, label, picks=picks, pick_ori=pick_ori,
         fwd_norm=fwd_norm,

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -8,13 +8,13 @@
 # License: BSD (3-clause)
 import numpy as np
 
-from ..utils import logger, verbose, warn, _reg_pinv, _check_info_inv
+from ..utils import (logger, verbose, warn, _reg_pinv, _check_info_inv,
+                     _check_channels_spatial_filter)
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
 from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
-from ._compute_beamformer import (_pick_channels_spatial_filter,
-                                  _check_proj_match, _prepare_beamformer_input,
+from ._compute_beamformer import (_check_proj_match, _prepare_beamformer_input,
                                   _compute_beamformer, _check_one_ch_type,
                                   _check_src_type, Beamformer, _check_rank)
 
@@ -349,7 +349,7 @@ def apply_dics(evoked, filters, verbose=None):
     data = evoked.data
     tmin = evoked.times[0]
 
-    sel = _pick_channels_spatial_filter(evoked.ch_names, filters)
+    sel = _check_channels_spatial_filter(evoked.ch_names, filters)
     data = data[sel]
 
     stc = _apply_dics(data=data, filters=filters, info=info, tmin=tmin)
@@ -409,7 +409,7 @@ def apply_dics_epochs(epochs, filters, return_generator=False, verbose=None):
     info = epochs.info
     tmin = epochs.times[0]
 
-    sel = _pick_channels_spatial_filter(epochs.ch_names, filters)
+    sel = _check_channels_spatial_filter(epochs.ch_names, filters)
     data = epochs.get_data()[:, sel, :]
 
     stcs = _apply_dics(data=data, filters=filters, info=info, tmin=tmin)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -14,7 +14,7 @@ from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..cov import compute_whitener, compute_covariance
 from ..source_estimate import _make_stc, SourceEstimate, _get_src_type
 from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
-                     _check_info_inv)
+                     _check_info_inv, _check_channels_spatial_filter)
 from .. import Epochs
 from ._compute_beamformer import (
     _check_proj_match, _prepare_beamformer_input, _check_one_ch_type,
@@ -290,7 +290,7 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
     data = evoked.data
     tmin = evoked.times[0]
 
-    sel = _pick_channels_spatial_filter(evoked.ch_names, filters)
+    sel = _check_channels_spatial_filter(evoked.ch_names, filters)
     data = data[sel]
 
     stc = _apply_lcmv(data=data, filters=filters, info=info,
@@ -336,7 +336,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='signed',
     info = epochs.info
     tmin = epochs.times[0]
 
-    sel = _pick_channels_spatial_filter(epochs.ch_names, filters)
+    sel = _check_channels_spatial_filter(epochs.ch_names, filters)
     data = epochs.get_data()[:, sel, :]
     stcs = _apply_lcmv(data=data, filters=filters, info=info,
                        tmin=tmin, max_ori_out=max_ori_out)
@@ -386,7 +386,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
 
     info = raw.info
 
-    sel = _pick_channels_spatial_filter(raw.ch_names, filters)
+    sel = _check_channels_spatial_filter(raw.ch_names, filters)
     data, times = raw[sel, start:stop]
     tmin = times[0]
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -13,10 +13,10 @@ from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..cov import compute_whitener, compute_covariance
 from ..source_estimate import _make_stc, SourceEstimate, _get_src_type
-from ..utils import logger, verbose, warn, _validate_type, _reg_pinv
+from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
+                     _check_info_inv)
 from .. import Epochs
 from ._compute_beamformer import (
-    _setup_picks, _pick_channels_spatial_filter,
     _check_proj_match, _prepare_beamformer_input, _check_one_ch_type,
     _compute_beamformer, _check_src_type, Beamformer, _check_rank)
 
@@ -125,7 +125,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     .. [2] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    picks = _setup_picks(info, forward, data_cov, noise_cov)
+    picks = _check_info_inv(info, forward, data_cov, noise_cov)
     rank = _check_rank(rank)
 
     is_free_ori, ch_names, proj, vertno, G, nn = \
@@ -599,10 +599,10 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                          'underlying raw instance to this function')
 
     if noise_covs is None:
-        picks = _setup_picks(epochs.info, forward, data_cov=None)
+        picks = _check_info_inv(epochs.info, forward, data_cov=None)
     else:
-        picks = _setup_picks(epochs.info, forward, data_cov=None,
-                             noise_cov=noise_covs[0])
+        picks = _check_info_inv(epochs.info, forward, data_cov=None,
+                                noise_cov=noise_covs[0])
     ch_names = [epochs.ch_names[k] for k in picks]
 
     # check number of sensor types present in the data

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -10,9 +10,9 @@ from scipy import linalg
 
 from ..io.pick import pick_channels_evoked, _picks_to_idx
 from ..cov import compute_whitener
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _check_info_inv
 from ..dipole import Dipole
-from ._compute_beamformer import _prepare_beamformer_input, _setup_picks
+from ._compute_beamformer import _prepare_beamformer_input
 
 
 def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2,
@@ -242,7 +242,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
     data = evoked.data
     times = evoked.times
 
-    picks = _setup_picks(info, forward, data_cov=None, noise_cov=noise_cov)
+    picks = check_info_inv(info, forward, data_cov=None, noise_cov=noise_cov)
 
     data = data[picks]
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -242,7 +242,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
     data = evoked.data
     times = evoked.times
 
-    picks = check_info_inv(info, forward, data_cov=None, noise_cov=noise_cov)
+    picks = _check_info_inv(info, forward, data_cov=None, noise_cov=noise_cov)
 
     data = data[picks]
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -15,6 +15,7 @@ from mne.beamformer import (make_lcmv, apply_lcmv, apply_lcmv_epochs,
                             apply_lcmv_raw, tf_lcmv, Beamformer,
                             read_beamformer)
 from mne.beamformer._lcmv import _lcmv_source_power
+from mne.io.compensator import set_current_comp
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.simulation import simulate_evoked
 from mne.utils import run_tests_if_main, object_diff, requires_h5py
@@ -648,5 +649,9 @@ def test_lcmv_ctf_comp():
     filters = make_lcmv(evoked.info, fwd, data_cov)
     assert 'weights' in filters
 
+    # test whether different compensations throw error
+    info_comp = evoked.info.copy()
+    set_current_comp(info_comp, 1)
+    pytest.raises(ValueError, make_lcmv, info_comp, fwd, data_cov)
 
 run_tests_if_main()

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -652,6 +652,8 @@ def test_lcmv_ctf_comp():
     # test whether different compensations throw error
     info_comp = evoked.info.copy()
     set_current_comp(info_comp, 1)
-    pytest.raises(ValueError, make_lcmv, info_comp, fwd, data_cov)
+    with pytest.raises(ValueError,
+                       match='do not have same compensation applied'):
+        make_lcmv(info_comp, fwd, data_cov)
 
 run_tests_if_main()

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -10,7 +10,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_pandas_index_arguments, _check_mayavi_version,
                     _check_event_id, _check_ch_locs, _check_compensation_grade,
                     _check_if_nan, _is_numeric, _ensure_int, _check_preload,
-                    _validate_type, _check_pyface_backend)
+                    _validate_type, _check_pyface_backend, _check_type_picks,
+                    _check_info_inv)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -9,9 +9,9 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_fname, _check_subject, _check_pandas_installed,
                     _check_pandas_index_arguments, _check_mayavi_version,
                     _check_event_id, _check_ch_locs, _check_compensation_grade,
-                    _check_if_nan, _is_numeric, _ensure_int, _check_preload,
-                    _validate_type, _check_pyface_backend, _check_type_picks,
-                    _check_info_inv)
+                    _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
+                    _validate_type, _check_pyface_backend, _check_info_inv,
+                    _check_channels_spatial_filter)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -1,6 +1,6 @@
 # # # WARNING # # #
-# This list must also be updated in doc/_templates/class.rst if it is
-# changed here!
+# This list must also be updated in doc/_templates/autosummary/class.rst if it
+# is changed here!
 _doc_special_members = ('__contains__', '__getitem__', '__iter__', '__len__',
                         '__add__', '__sub__', '__mul__', '__div__',
                         '__neg__', '__hash__')

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -323,3 +323,49 @@ def _check_if_nan(data, msg=" to be plotted"):
     """Raise if any of the values are NaN."""
     if not np.isfinite(data).all():
         raise ValueError("Some of the values {} are NaN.".format(msg))
+
+
+def _check_info_inv(info, forward, data_cov=None, noise_cov=None):
+    """Return good channels common to forward model and covariance matrices."""
+    # get a list of all channel names:
+    fwd_ch_names = forward['info']['ch_names']
+
+    # handle channels from forward model and info:
+    ch_names = _compare_ch_names(info['ch_names'], fwd_ch_names, info['bads'])
+
+    # make sure that no reference channels are left:
+    ref_chs = pick_types(info, meg=False, ref_meg=True)
+    ref_chs = [info['ch_names'][ch] for ch in ref_chs]
+    ch_names = [ch for ch in ch_names if ch not in ref_chs]
+
+    # inform about excluding channels:
+    if (data_cov is not None and set(info['bads']) != set(data_cov['bads']) and
+            (len(set(ch_names).intersection(data_cov['bads'])) > 0)):
+        logger.info('info["bads"] and data_cov["bads"] do not match, '
+                    'excluding bad channels from both.')
+    if (noise_cov is not None and
+            set(info['bads']) != set(noise_cov['bads']) and
+            (len(set(ch_names).intersection(noise_cov['bads'])) > 0)):
+        logger.info('info["bads"] and noise_cov["bads"] do not match, '
+                    'excluding bad channels from both.')
+
+    # handle channels from data cov if data cov is not None
+    # Note: data cov is supposed to be None in tf_lcmv
+    if data_cov is not None:
+        ch_names = _compare_ch_names(ch_names, data_cov.ch_names,
+                                     data_cov['bads'])
+
+    # handle channels from noise cov if noise cov available:
+    if noise_cov is not None:
+        ch_names = _compare_ch_names(ch_names, noise_cov.ch_names,
+                                     noise_cov['bads'])
+
+    picks = [info['ch_names'].index(k) for k in ch_names if k in
+             info['ch_names']]
+    return picks
+
+
+def _compare_ch_names(names1, names2, bads):
+    """Return channel names of common and good channels."""
+    ch_names = [ch for ch in names1 if ch not in bads and ch in names2]
+    return ch_names

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -327,6 +327,7 @@ def _check_if_nan(data, msg=" to be plotted"):
 
 def _check_info_inv(info, forward, data_cov=None, noise_cov=None):
     """Return good channels common to forward model and covariance matrices."""
+    from .. import pick_types
     # get a list of all channel names:
     fwd_ch_names = forward['info']['ch_names']
 
@@ -369,3 +370,22 @@ def _compare_ch_names(names1, names2, bads):
     """Return channel names of common and good channels."""
     ch_names = [ch for ch in names1 if ch not in bads and ch in names2]
     return ch_names
+
+
+def _check_channels_spatial_filter(ch_names, filters):
+    """Return data channel indices to be used with spatial filter.
+
+    Unlike ``pick_channels``, this respects the order of ch_names.
+    """
+    sel = []
+    # first check for channel discrepancies between filter and data:
+    for ch_name in filters['ch_names']:
+        if ch_name not in ch_names:
+            raise ValueError('The spatial filter was computed with channel %s '
+                             'which is not present in the data. You should '
+                             'compute a new spatial filter restricted to the '
+                             'good data channels.' % ch_name)
+    # then compare list of channels and get selection based on data:
+    sel = [ii for ii, ch_name in enumerate(ch_names)
+           if ch_name in filters['ch_names']]
+    return sel

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -11,7 +11,7 @@ import os.path as op
 
 import numpy as np
 
-from ._logging import warn
+from ._logging import warn, logger
 
 
 def _ensure_int(x, name='unknown', must_be='an int'):
@@ -157,7 +157,6 @@ def _check_event_id(event_id, events):
 def _check_fname(fname, overwrite=False, must_exist=False):
     """Check for file existence."""
     _validate_type(fname, 'str', 'fname')
-    from mne.utils import logger
     if must_exist and not op.isfile(fname):
         raise IOError('File "%s" does not exist' % fname)
     if op.isfile(fname):
@@ -328,7 +327,6 @@ def _check_if_nan(data, msg=" to be plotted"):
 def _check_info_inv(info, forward, data_cov=None, noise_cov=None):
     """Return good channels common to forward model and covariance matrices."""
     from .. import pick_types
-    from mne.utils import logger
     # get a list of all channel names:
     fwd_ch_names = forward['info']['ch_names']
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -328,6 +328,7 @@ def _check_if_nan(data, msg=" to be plotted"):
 def _check_info_inv(info, forward, data_cov=None, noise_cov=None):
     """Return good channels common to forward model and covariance matrices."""
     from .. import pick_types
+    from mne.utils import logger
     # get a list of all channel names:
     fwd_ch_names = forward['info']['ch_names']
 

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import os.path as op
 import pytest
 
@@ -73,23 +72,23 @@ def test_check_info_inv():
 
     # check whether bad channels get excluded from the channel selection
     # info
-    info_bads = deepcopy(epochs.info)
+    info_bads = epochs.info.copy()
     info_bads['bads'] = info_bads['ch_names'][1:3]  # include two bad channels
     picks = _check_info_inv(info_bads, forward, noise_cov=noise_cov)
     assert [1, 2] not in picks
     # covariance matrix
-    data_cov_bads = deepcopy(data_cov)
+    data_cov_bads = data_cov.copy()
     data_cov_bads['bads'] = data_cov_bads.ch_names[0]
     picks = _check_info_inv(epochs.info, forward, data_cov=data_cov_bads)
     assert 0 not in picks
     # noise covariance matrix
-    noise_cov_bads = deepcopy(noise_cov)
+    noise_cov_bads = noise_cov.copy()
     noise_cov_bads['bads'] = noise_cov_bads.ch_names[1]
     picks = _check_info_inv(epochs.info, forward, noise_cov=noise_cov_bads)
     assert 1 not in picks
 
     # test whether reference channels get deleted
-    info_ref = deepcopy(epochs.info)
+    info_ref = epochs.info.copy()
     info_ref['chs'][0]['kind'] = 301  # pretend to have a ref channel
     picks = _check_info_inv(info_ref, forward, noise_cov=noise_cov)
     assert 0 not in picks

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -64,7 +64,7 @@ def _get_data():
 
 @testing.requires_testing_data
 def test_check_info_inv():
-    """Test checks for common channels acros fwd model and cov matrices."""
+    """Test checks for common channels across fwd model and cov matrices."""
     epochs, data_cov, noise_cov, forward = _get_data()
 
     # make sure same channel lists exist in data to make testing life easier

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -4,16 +4,16 @@ import pytest
 
 import mne
 from mne.datasets import testing
+from mne.io.pick import pick_channels_cov
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
-                       _check_mayavi_version)
+                       _check_mayavi_version, _check_info_inv)
 
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
 fname_event = op.join(base_dir, 'sample_audvis_trunc_raw-eve.fif')
 fname_fwd = op.join(base_dir, 'sample_audvis_trunc-meg-vol-7-fwd.fif')
-fname_cov = op.join(base_dir, 'sample_audvis_trunc-cov.fif')
 reject = dict(grad=4000e-13, mag=4e-12)
 
 
@@ -55,9 +55,51 @@ def _get_data():
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
                         baseline=(None, 0.), preload=True, reject=reject)
 
-    noise_cov = mne.read_cov(fname_cov)
-    noise_cov['projs'] = []
+    noise_cov = mne.compute_covariance(epochs, tmin=None, tmax=0.)
 
     data_cov = mne.compute_covariance(epochs, tmin=0.01, tmax=0.15)
 
     return epochs, data_cov, noise_cov, forward
+
+
+@testing.requires_testing_data
+def test_check_info_inv():
+    """Test checks for common channels acros fwd model and cov matrices."""
+    epochs, data_cov, noise_cov, forward = _get_data()
+
+    # make sure same channel lists exist in data to make testing life easier
+    assert epochs.info['ch_names'] == data_cov.ch_names
+    assert epochs.info['ch_names'] == noise_cov.ch_names
+
+    # check whether bad channels get excluded from the channel selection
+    # info
+    info_bads = deepcopy(epochs.info)
+    info_bads['bads'] = info_bads['ch_names'][1:3]  # include two bad channels
+    picks = _check_info_inv(info_bads, forward, noise_cov=noise_cov)
+    assert [1, 2] not in picks
+    # covariance matrix
+    data_cov_bads = deepcopy(data_cov)
+    data_cov_bads['bads'] = data_cov_bads.ch_names[0]
+    picks = _check_info_inv(epochs.info, forward, data_cov=data_cov_bads)
+    assert 0 not in picks
+    # noise covariance matrix
+    noise_cov_bads = deepcopy(noise_cov)
+    noise_cov_bads['bads'] = noise_cov_bads.ch_names[1]
+    picks = _check_info_inv(epochs.info, forward, noise_cov=noise_cov_bads)
+    assert 1 not in picks
+
+    # test whether reference channels get deleted
+    info_ref = deepcopy(epochs.info)
+    info_ref['chs'][0]['kind'] = 301  # pretend to have a ref channel
+    picks = _check_info_inv(info_ref, forward, noise_cov=noise_cov)
+    assert 0 not in picks
+
+    # pick channels in all inputs and make sure common set is returned
+    epochs.pick_channels([epochs.ch_names[ii] for ii in range(10)])
+    data_cov = pick_channels_cov(data_cov, include=[data_cov.ch_names[ii]
+                                                    for ii in range(5, 20)])
+    noise_cov = pick_channels_cov(noise_cov, include=[noise_cov.ch_names[ii]
+                                                      for ii in range(7, 12)])
+    picks = _check_info_inv(epochs.info, forward, noise_cov=noise_cov,
+                            data_cov=data_cov)
+    assert list(range(7, 10)) == picks

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -13,7 +13,7 @@ base_dir = op.join(data_path, 'MEG', 'sample')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
 fname_event = op.join(base_dir, 'sample_audvis_trunc_raw-eve.fif')
 fname_fwd = op.join(base_dir, 'sample_audvis_trunc-meg-vol-7-fwd.fif')
-fname_cov = op.join(base_dir, 'sample_audivis_trunc_cov.fif')
+fname_cov = op.join(base_dir, 'sample_audvis_trunc-cov.fif')
 reject = dict(grad=4000e-13, mag=4e-12)
 
 
@@ -58,16 +58,6 @@ def _get_data():
     noise_cov = mne.read_cov(fname_cov)
     noise_cov['projs'] = []
 
-    data_cov = mne.compute_covariance(epochs, tin=0.01, tmax=0.15)
+    data_cov = mne.compute_covariance(epochs, tmin=0.01, tmax=0.15)
 
     return epochs, data_cov, noise_cov, forward
-
-
-@testing.requires_testing_data
-def test_check_info_inv():
-    """Test checks for common channels acros fwd model and cov matrices."""
-    epochs, data_cov, noise_cov, forward = _get_data()
-
-    # test whether reference channels get deleted
-    info_ref = deepcopy(epochs.info)
-    info_ref['chs']

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -1,8 +1,20 @@
+from copy import deepcopy
+import os.path as op
 import pytest
 
+import mne
+from mne.datasets import testing
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
                        _check_mayavi_version)
+
+data_path = testing.data_path(download=False)
+base_dir = op.join(data_path, 'MEG', 'sample')
+fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
+fname_event = op.join(base_dir, 'sample_audvis_trunc_raw-eve.fif')
+fname_fwd = op.join(base_dir, 'sample_audvis_trunc-meg-vol-7-fwd.fif')
+fname_cov = op.join(base_dir, 'sample_audivis_trunc_cov.fif')
+reject = dict(grad=4000e-13, mag=4e-12)
 
 
 def test_check():
@@ -20,3 +32,42 @@ def test_check():
 def test_check_mayavi():
     """Test mayavi version check."""
     pytest.raises(RuntimeError, _check_mayavi_version, '100.0.0')
+
+
+def _get_data():
+    """Read in data used in tests."""
+    # read forward model
+    forward = mne.read_forward_solution(fname_fwd)
+    # read data
+    raw = mne.io.read_raw_fif(fname_raw, preload=True)
+    events = mne.read_events(fname_event)
+    event_id, tmin, tmax = 1, -0.1, 0.15
+
+    # decimate for speed
+    left_temporal_channels = mne.read_selection('Left-temporal')
+    picks = mne.pick_types(raw.info, selection=left_temporal_channels)
+    picks = picks[::2]
+    raw.pick_channels([raw.ch_names[ii] for ii in picks])
+    del picks
+
+    raw.info.normalize_proj()  # avoid projection warnings
+
+    epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
+                        baseline=(None, 0.), preload=True, reject=reject)
+
+    noise_cov = mne.read_cov(fname_cov)
+    noise_cov['projs'] = []
+
+    data_cov = mne.compute_covariance(epochs, tin=0.01, tmax=0.15)
+
+    return epochs, data_cov, noise_cov, forward
+
+
+@testing.requires_testing_data
+def test_check_info_inv():
+    """Test checks for common channels acros fwd model and cov matrices."""
+    epochs, data_cov, noise_cov, forward = _get_data()
+
+    # test whether reference channels get deleted
+    info_ref = deepcopy(epochs.info)
+    info_ref['chs']


### PR DESCRIPTION
Moved some of the channel picking facility to ``utils``: 
``_check_info_inv`` (formerly ``_compute_beamformer._setup_picks``) picks channels based on the data / noise cov matrix and forward model, taking into account channels marked as bad in ``info`` and reference channels.
Next step for this PR is to write tests for this function.

Two additional functionalities have been added: check for compensation and dropping ref channels  during computation of spatial filter (will comment in code to mark those).

ping @agramfort

To Do:
- [x] add tests