### PR TITLE
[MRG] Adding `channel_wise` argument to `Raw.apply_function`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,6 +53,8 @@ Changelog
 
 - Add ``extrapolate`` argument to :func:`mne.viz.plot_topomap` for better control of extrapolation points placement by `Mikołaj Magnuski`_
 
+- Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_
+
 Bug
 ~~~
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1059,7 +1059,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fun : function
             A function to be applied to the channels. The first argument of
             fun has to be a timeseries (numpy.ndarray). The function must
-            operate on an array of shape `(n_times,)` if ``channel_wise=True``
+            operate on an array of shape ``(n_times,)`` if ``channel_wise=True``
             and ``(len(picks), n_times)`` if ``channel_wise=False``. The
             function must return an numpy.ndarray with the same size as the
             input.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1059,7 +1059,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fun : function
             A function to be applied to the channels. The first argument of
             fun has to be a timeseries (numpy.ndarray). The function must
-            return an numpy.ndarray with the same size as the input.
+            operate on an array of shape `(n_times,)` if `channel_wise=True`
+            and `(len(picks), n_times)` if `channel_wise=False`. The function
+            must return an numpy.ndarray with the same size as the input.
         picks : array-like of int (default: None)
             Indices of channels to apply the function to. If None, all data
             channels are used.
@@ -1070,8 +1072,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             Whether to apply the function to each channel individually. If
             False, the function will be applied to all channels at once.
         n_jobs: int (default: 1)
-            Number of jobs to run in parallel. Only applicable if
-            `channel_wise` is True.
+            Number of jobs to run in parallel. Ignored if `channel_wise` is
+            False.
         *args :
             Additional positional arguments to pass to fun (first pos. argument
             of fun is the timeseries of a channel).

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1059,10 +1059,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fun : function
             A function to be applied to the channels. The first argument of
             fun has to be a timeseries (numpy.ndarray). The function must
-            operate on an array of shape ``(n_times,)`` if ``channel_wise=True``
-            and ``(len(picks), n_times)`` if ``channel_wise=False``. The
-            function must return an numpy.ndarray with the same size as the
-            input.
+            operate on an array of shape ``(n_times,)`` if
+            ``channel_wise=True`` and ``(len(picks), n_times)`` otherwise.
+            The function must return an ndarray shaped like its input.
         picks : array-like of int (default: None)
             Indices of channels to apply the function to. If None, all data
             channels are used.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1033,8 +1033,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         return data
 
     @verbose
-    def apply_function(self, fun, picks=None, dtype=None, channel_wise=True,
-                       n_jobs=1, *args, **kwargs):
+    def apply_function(self, fun, picks=None, dtype=None, n_jobs=1,
+                       channel_wise=True, *args, **kwargs):
         """Apply a function to a subset of channels.
 
         The function "fun" is applied to the channels defined in "picks". The
@@ -1059,21 +1059,24 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         fun : function
             A function to be applied to the channels. The first argument of
             fun has to be a timeseries (numpy.ndarray). The function must
-            operate on an array of shape `(n_times,)` if `channel_wise=True`
-            and `(len(picks), n_times)` if `channel_wise=False`. The function
-            must return an numpy.ndarray with the same size as the input.
+            operate on an array of shape `(n_times,)` if ``channel_wise=True``
+            and ``(len(picks), n_times)`` if ``channel_wise=False``. The
+            function must return an numpy.ndarray with the same size as the
+            input.
         picks : array-like of int (default: None)
             Indices of channels to apply the function to. If None, all data
             channels are used.
         dtype : numpy.dtype (default: None)
             Data type to use for raw data after applying the function. If None
             the data type is not modified.
-        channel_wise: bool (default: True)
-            Whether to apply the function to each channel individually. If
-            False, the function will be applied to all channels at once.
         n_jobs: int (default: 1)
             Number of jobs to run in parallel. Ignored if `channel_wise` is
             False.
+        channel_wise: bool (default: True)
+            Whether to apply the function to each channel individually. If
+            False, the function will be applied to all channels at once.
+
+            .. versionadded:: 0.18
         *args :
             Additional positional arguments to pass to fun (first pos. argument
             of fun is the timeseries of a channel).

--- a/mne/io/tests/test_apply_function.py
+++ b/mne/io/tests/test_apply_function.py
@@ -40,15 +40,21 @@ def test_apply_function_verbose():
     raw = RawArray(np.zeros((n_chan, n_times)),
                    create_info(ch_names, 1., 'mag'))
     # test return types in both code paths (parallel / 1 job)
-    pytest.raises(TypeError, raw.apply_function, bad_1)
-    pytest.raises(ValueError, raw.apply_function, bad_2)
-    pytest.raises(TypeError, raw.apply_function, bad_1, n_jobs=2)
-    pytest.raises(ValueError, raw.apply_function, bad_2, n_jobs=2)
+    with pytest.raises(TypeError, match='Return value must be an ndarray'):
+        raw.apply_function(bad_1)
+    with pytest.raises(ValueError, match='Return data must have shape'):
+        raw.apply_function(bad_2)
+    with pytest.raises(TypeError, match='Return value must be an ndarray'):
+        raw.apply_function(bad_1, n_jobs=2)
+    with pytest.raises(ValueError, match='Return data must have shape'):
+        raw.apply_function(bad_2, n_jobs=2)
 
     # test return type when `channel_wise=False`
     raw.apply_function(printer, channel_wise=False)
-    pytest.raises(TypeError, raw.apply_function, bad_1, channel_wise=False)
-    pytest.raises(ValueError, raw.apply_function, bad_3, channel_wise=False)
+    with pytest.raises(TypeError, match='Return value must be an ndarray'):
+        raw.apply_function(bad_1, channel_wise=False)
+    with pytest.raises(ValueError, match='Return data must have shape'):
+        raw.apply_function(bad_3, channel_wise=False)
 
     # check our arguments
     with catch_logging() as sio:

--- a/mne/io/tests/test_apply_function.py
+++ b/mne/io/tests/test_apply_function.py
@@ -20,6 +20,11 @@ def bad_2(x):
     return x[:-1]  # bad shape
 
 
+def bad_3(x):
+    """Fail."""
+    return x[0, :]
+
+
 def printer(x):
     """Print."""
     logger.info('exec')
@@ -39,6 +44,11 @@ def test_apply_function_verbose():
     pytest.raises(ValueError, raw.apply_function, bad_2)
     pytest.raises(TypeError, raw.apply_function, bad_1, n_jobs=2)
     pytest.raises(ValueError, raw.apply_function, bad_2, n_jobs=2)
+
+    # test return type when `channel_wise=False`
+    raw.apply_function(printer, channel_wise=False)
+    pytest.raises(TypeError, raw.apply_function, bad_1, channel_wise=False)
+    pytest.raises(ValueError, raw.apply_function, bad_3, channel_wise=False)
 
     # check our arguments
     with catch_logging() as sio:


### PR DESCRIPTION
See issue #5860.

This adds an argument `channel_wise` to `mne.io.Raw.apply_function()`. If `channel_wise` is True (default), the function is applied on each channel individually; if it is False, then the whole data array is passed to the function at once.

Questions:
1) Should we raise an error or display a warning if `channel_wise` is False and `n_jobs` is not 1?
2) I added a few lines to the existing test `test_apply_function_verbosity`. Would it better to create a separate test function?