### PR TITLE
MRG: add new compute_rank function

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -500,7 +500,7 @@ numpydoc_xref_ignore = {
     'n_parts', 'n_features_new', 'n_components', 'n_labels', 'n_events_in',
     'n_splits', 'n_scores', 'n_outputs', 'n_trials', 'n_estimators', 'n_tasks',
     'nd_features', 'n_classes', 'n_targets', 'n_slices', 'n_hpi', 'n_fids',
-    'n_elp', 'n_pts', 'n_tris', 'n_nodes',
+    'n_elp', 'n_pts', 'n_tris', 'n_nodes', 'n_nonzero',
     # Undocumented (on purpose)
     'RawKIT', 'RawEximia', 'RawEGI', 'RawEEGLAB', 'RawEDF', 'RawCTF', 'RawBTi',
     'RawBrainVision',

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -490,6 +490,7 @@ Covariance computation
    compute_raw_covariance
    cov.regularize
    cov.compute_whitener
+   compute_rank
    make_ad_hoc_cov
    read_cov
    write_cov

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Changelog
 
 - Add ``reject_by_annotation`` argument to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
+- Add ``pca`` argument to return the rank-reduced whitener in :func:`mne.cov.compute_whitener` by `Eric Larson`_
+
 - Add ``extrapolate`` argument to :func:`mne.viz.plot_topomap` for better control of extrapolation points placement by `Mikołaj Magnuski`_
 
 - Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -106,6 +106,8 @@ API
 
 - Python 2 is no longer supported; MNE-Python now requires Python 3.5+, by `Eric Larson`_
 
+- ``raw.estimate_rank`` has been deprecated and will be removed in 0.19 in favor of :func:`mne.compute_rank`  by `Eric Larson`_
+
 - :class:`Annotations` are now kept sorted (by onset time) during instantiation and :meth:`~Annotations.append` operations, by `Eric Larson`_
 
 - Deprecate :func:`mne.io.find_edf_events` by `Joan Massich`_

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -90,6 +90,7 @@ from .channels import equalize_channels, rename_channels, find_layout
 from .report import Report, open_report
 
 from .io import read_epochs_fieldtrip, read_evoked_fieldtrip
+from .rank import compute_rank
 
 from . import beamformer
 from . import channels

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -18,7 +18,7 @@ from ..io.proj import make_projector, Projection
 from ..io.pick import pick_channels_forward
 from ..minimum_norm.inverse import _get_vertno
 from ..source_space import label_src_vertno_sel
-from ..utils import logger, verbose, check_fname, _reg_pinv
+from ..utils import verbose, check_fname, _reg_pinv
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -7,7 +7,6 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
-import operator
 
 import numpy as np
 from scipy import linalg
@@ -19,7 +18,7 @@ from ..io.proj import make_projector, Projection
 from ..io.pick import pick_channels_forward
 from ..minimum_norm.inverse import _get_vertno
 from ..source_space import label_src_vertno_sel
-from ..utils import warn, verbose, check_fname, _reg_pinv
+from ..utils import logger, verbose, check_fname, _reg_pinv
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
@@ -236,14 +235,8 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         The source orientation to compute the beamformer in.
     reduce_rank : bool
         Whether to reduce the rank by one during computation of the filter.
-    rank : int | None | 'full'
-        This controls the effective rank of the covariance matrix when
-        computing the inverse. The rank can be set explicitly by specifying an
-        integer value. If ``None``, the rank will be automatically estimated.
-        Since applying regularization will always make the covariance matrix
-        full rank, the rank is estimated before regularization in this case. If
-        'full', the rank will be estimated after regularization and hence
-        will mean using the full rank, unless ``reg=0`` is used.
+    rank : dict | None | 'full' | 'info'
+        See compute_rank.
     inversion : 'matrix' | 'single'
         The inversion scheme to compute the weights.
     nn : ndarray, shape (n_dipoles, 3)

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -16,48 +16,13 @@ from ..cov import Covariance
 from ..io.compensator import get_current_comp
 from ..io.constants import FIFF
 from ..io.proj import make_projector, Projection
-from ..io.pick import (pick_channels_forward, pick_info)
+from ..io.pick import pick_channels_forward
 from ..minimum_norm.inverse import _get_vertno
 from ..source_space import label_src_vertno_sel
 from ..utils import warn, verbose, check_fname, _reg_pinv
-from ..channels.channels import _contains_ch_type
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
-
-
-def _check_rank(rank):
-    """Check rank parameter and deal with deprecation."""
-    if isinstance(rank, str):
-        # XXX we can use rank='' to deprecate to get to None eventually:
-        # if rank == '':
-        #     warn('The rank parameter default in 0.18 of "full" will change '
-        #          'to None in 0.19, set it explicitly to avoid this warning',
-        #          DeprecationWarning)
-        #     rank = 'full'
-        if rank != 'full':
-            raise ValueError('rank, if str, must be "full", got %s' % (rank,))
-    elif rank is not None and not isinstance(rank, dict):
-        try:
-            rank = int(operator.index(rank))
-        except TypeError:
-            raise TypeError('rank must be None, dict, "full", or int-like, '
-                            'got %s (type %s)' % (rank, type(rank)))
-    return rank
-
-
-def _check_one_ch_type(info, picks, noise_cov, method):
-    """Check number of sensor types and presence of noise covariance matrix."""
-    info_pick = pick_info(info, sel=picks)
-    ch_types =\
-        [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
-    if method == 'lcmv' and sum(ch_types) > 1 and noise_cov is None:
-        raise ValueError('Source reconstruction with several sensor types '
-                         'requires a noise covariance matrix to be '
-                         'able to apply whitening.')
-    elif method == 'dics' and sum(ch_types) > 1:
-        warn('The use of several sensor types with the DICS beamformer is '
-             'not heavily tested yet.')
 
 
 def _check_proj_match(info, filters):

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -10,13 +10,14 @@ import numpy as np
 
 from ..utils import (logger, verbose, warn, _reg_pinv, _check_info_inv,
                      _check_channels_spatial_filter)
+from ..utils import _check_one_ch_type, _check_rank
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
 from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
 from ._compute_beamformer import (_check_proj_match, _prepare_beamformer_input,
-                                  _compute_beamformer, _check_one_ch_type,
-                                  _check_src_type, Beamformer, _check_rank)
+                                  _compute_beamformer,
+                                  _check_src_type, Beamformer)
 
 
 @verbose

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -9,8 +9,8 @@
 import numpy as np
 
 from ..utils import (logger, verbose, warn, _reg_pinv, _check_info_inv,
-                     _check_channels_spatial_filter)
-from ..utils import _check_one_ch_type, _check_rank
+                     _check_channels_spatial_filter, _check_one_ch_type,
+                     _check_rank)
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -15,8 +15,10 @@ from scipy import linalg
 from .mixin import TransformerMixin
 from .base import BaseEstimator
 from ..cov import _regularized_covariance
+from ..utils import fill_doc
 
 
+@fill_doc
 class CSP(TransformerMixin, BaseEstimator):
     u"""M/EEG signal decomposition using the Common Spatial Patterns (CSP).
 
@@ -60,8 +62,7 @@ class CSP(TransformerMixin, BaseEstimator):
         Parameters to pass to :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.16
-    rank : None | int | dict | 'full'
-        See :func:`mne.compute_covariance`.
+    %(rank_None)s
 
         .. versionadded:: 0.17
 
@@ -671,6 +672,7 @@ def _ajd_pham(X, eps=1e-6, max_iter=15):
     return V, D
 
 
+@fill_doc
 class SPoC(CSP):
     """Implementation of the SPoC spatial filtering.
 
@@ -706,8 +708,7 @@ class SPoC(CSP):
         Parameters to pass to :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.16
-    rank : None | int | dict | 'full'
-        See :func:`mne.compute_covariance`.
+    %(rank_None)s
 
         .. versionadded:: 0.17
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -38,7 +38,7 @@ from ..filter import (filter_data, notch_filter, resample, next_fast_len,
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_pandas_index_arguments, _pl, fill_doc,
-                     check_fname, _get_stim_channel,
+                     check_fname, _get_stim_channel, deprecated,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc,
                      _check_preload, _get_argvalues)
@@ -1850,6 +1850,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                  show=show, block=block, n_jobs=n_jobs,
                                  axes=axes, verbose=verbose)
 
+    @deprecated('raw.estimate_rank is deprecated and will be removed in 0.19, '
+                'use mne.compute_rank instead.')
     @verbose
     def estimate_rank(self, tstart=0.0, tstop=30.0, tol=1e-4,
                       return_singular=False, picks=None, scalings='norm',

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1850,9 +1850,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                  show=show, block=block, n_jobs=n_jobs,
                                  axes=axes, verbose=verbose)
 
-    @fill_doc
+    @verbose
     def estimate_rank(self, tstart=0.0, tstop=30.0, tol=1e-4,
-                      return_singular=False, picks=None, scalings='norm'):
+                      return_singular=False, picks=None, scalings='norm',
+                      verbose=None):
         """Estimate rank of the raw data.
 
         This function is meant to provide a reasonable estimate of the rank.
@@ -1875,7 +1876,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             If True, also return the singular values that were used
             to determine the rank.
         %(picks_good_data)s
-        scalings : dict | 'norm'
+        scalings : dict | 'norm' | None
             To achieve reliable rank estimation on multiple sensors,
             sensors have to be rescaled. This parameter controls the
             rescaling. If dict, it will update the
@@ -1884,8 +1885,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                 dict(mag=1e11, grad=1e9, eeg=1e5)
 
             If 'norm' data will be scaled by internally computed
-            channel-wise norms.
+            channel-wise norms. None will perform no scaling.
             Defaults to 'norm'.
+        %(verbose)s
 
         Returns
         -------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -590,7 +590,9 @@ def _simplify_info(info):
     chs = [{key: ch[key]
             for key in ('ch_name', 'kind', 'unit', 'coil_type', 'loc')}
            for ch in info['chs']]
-    sub_info = Info(chs=chs, bads=info['bads'], comps=info['comps'])
+    sub_info = Info(chs=chs, bads=info['bads'], comps=info['comps'],
+                    projs=info['projs'],
+                    custom_ref_applied=info['custom_ref_applied'])
     sub_info._update_redundant()
     return sub_info
 

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1370,11 +1370,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
         If True, use only grad channels in depth weighting (equivalent to MNE
         C code). If grad channels aren't present, only mag channels will be
         used (if no mag, then eeg). If False, use all channels.
-    rank : None | int | dict
-        Specified rank of the noise covariance matrix. If None, the rank is
-        detected automatically. If int, the rank is specified for the MEG
-        channels. A dictionary with entries 'eeg' and/or 'meg' can be used
-        to specify the rank for each modality.
+    %(rank_None)s
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal
         orientations. Only used when converting to surface orientation

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -25,6 +25,7 @@ from mne.preprocessing.ica import (get_score_funcs, corrmap, _sort_components,
 from mne.io import read_raw_fif, Info, RawArray, read_raw_ctf, read_raw_eeglab
 from mne.io.meas_info import _kind_dict
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
+from mne.rank import _compute_rank_int
 from mne.utils import (catch_logging, _TempDir, requires_sklearn,
                        run_tests_if_main)
 from mne.datasets import testing
@@ -158,10 +159,10 @@ def test_ica_rank_reduction(method):
                       n_pca_components=n_pca_components,
                       method=method, max_iter=1).fit(raw, picks=picks)
 
-        rank_before = raw.estimate_rank(picks=picks)
+        rank_before = _compute_rank_int(raw.copy().pick(picks))
         assert_equal(rank_before, len(picks))
         raw_clean = ica.apply(raw.copy())
-        rank_after = raw_clean.estimate_rank(picks=picks)
+        rank_after = _compute_rank_int(raw_clean.copy().pick(picks))
         # interaction between ICA rejection and PCA components difficult
         # to preduct. Rank_after often seems to be 1 higher then
         # n_pca_components

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -545,7 +545,7 @@ def test_spatiotemporal():
         # as mentioned above.
         raw_tsss = maxwell_filter(
             raw, st_duration=st_duration, **kwargs)
-        assert_equal(raw_tsss.estimate_rank(), 140)
+        assert_equal(_compute_rank_int(raw_tsss), 140)
         assert_meg_snr(raw_tsss, tsss_bench, *tol)
         py_st = raw_tsss.info['proc_history'][0]['max_info']['max_st']
         assert (len(py_st) > 0)
@@ -572,18 +572,18 @@ def test_spatiotemporal_only():
     # basics
     raw_tsss = maxwell_filter(raw, st_duration=tmax / 2., st_only=True)
     assert_equal(len(raw.info['projs']), len(raw_tsss.info['projs']))
-    assert_equal(raw_tsss.estimate_rank(), len(picks))
+    assert_equal(_compute_rank_int(raw_tsss), len(picks))
     _assert_shielding(raw_tsss, power, 9)
     # with movement
     head_pos = read_head_pos(pos_fname)
     raw_tsss = maxwell_filter(raw, st_duration=tmax / 2., st_only=True,
                               head_pos=head_pos)
-    assert_equal(raw_tsss.estimate_rank(), len(picks))
+    assert_equal(_compute_rank_int(raw_tsss), len(picks))
     _assert_shielding(raw_tsss, power, 9)
     with pytest.warns(RuntimeWarning, match='st_fixed'):
         raw_tsss = maxwell_filter(raw, st_duration=tmax / 2., st_only=True,
                                   head_pos=head_pos, st_fixed=False)
-    assert_equal(raw_tsss.estimate_rank(), len(picks))
+    assert_equal(_compute_rank_int(raw_tsss), len(picks))
     _assert_shielding(raw_tsss, power, 9)
     # should do nothing
     raw_tsss = maxwell_filter(raw, st_duration=tmax, st_correlation=1.,

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -27,6 +27,7 @@ from mne.fixes import _get_args
 from mne.io import read_raw_fif, RawArray, read_raw_ctf
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
 from mne.preprocessing import maxwell_filter
+from mne.rank import _compute_rank_int
 from mne.tests.common import assert_snr
 from mne.utils import (_TempDir, requires_version, run_tests_if_main,
                        catch_logging)
@@ -95,9 +96,9 @@ def test_cov_order():
     # regularize
     with pytest.raises(ValueError, match='rank, if str'):
         regularize(cov, info, rank='foo')
-    with pytest.raises(ValueError, match='or "full"'):
+    with pytest.raises(TypeError, match='rank must be'):
         regularize(cov, info, rank=False)
-    with pytest.raises(ValueError, match='or "full"'):
+    with pytest.raises(TypeError, match='rank must be'):
         regularize(cov, info, rank=1.)
     cov_reg = regularize(cov, info, rank='full')
     cov_reg_reorder = regularize(cov_reorder, info, rank='full')
@@ -108,10 +109,21 @@ def test_cov_order():
     _assert_reorder(cov_prep, cov_prep_reorder,
                     order=np.arange(len(cov_prep['names'])))
     # compute_whitener
-    whitener, w_ch_names = compute_whitener(cov, info)
-    whitener_2, w_ch_names_2 = compute_whitener(cov_reorder, info)
+    whitener, w_ch_names, n_nzero = compute_whitener(
+        cov, info, return_rank=True)
+    assert whitener.shape[0] == whitener.shape[1]
+    whitener_2, w_ch_names_2, n_nzero_2 = compute_whitener(
+        cov_reorder, info, return_rank=True)
     assert_array_equal(w_ch_names_2, w_ch_names)
     assert_allclose(whitener_2, whitener)
+    assert n_nzero == n_nzero_2
+    # with pca
+    assert n_nzero < whitener.shape[0]
+    whitener_pca, w_ch_names_pca, n_nzero_pca = compute_whitener(
+        cov, info, pca=True, return_rank=True)
+    assert_array_equal(w_ch_names_pca, w_ch_names)
+    assert n_nzero_pca == n_nzero
+    assert whitener_pca.shape == (n_nzero_pca, len(w_ch_names))
     # whiten_evoked
     evoked = read_evokeds(ave_fname)[0]
     evoked_white = whiten_evoked(evoked, cov)
@@ -195,13 +207,16 @@ def test_cov_estimation_on_raw(method):
     # The pure-string uses the more efficient numpy-based method, the
     # the list gets triaged to compute_covariance (should be equivalent
     # but use more memory)
-    cov = compute_raw_covariance(raw, tstep=None, method=method, rank='full')
+    with pytest.warns(None):  # can warn about EEG ref
+        cov = compute_raw_covariance(raw, tstep=None, method=method,
+                                     rank='full')
     assert_equal(cov.ch_names, cov_mne.ch_names)
     assert_equal(cov.nfree, cov_mne.nfree)
     assert_snr(cov.data, cov_mne.data, 1e4)
 
     # tstep=0.2 (default)
-    cov = compute_raw_covariance(raw, method=method, rank='full')
+    with pytest.warns(None):  # can warn about EEG ref
+        cov = compute_raw_covariance(raw, method=method, rank='full')
     assert_equal(cov.nfree, cov_mne.nfree - 119)  # cutoff some samples
     assert_snr(cov.data, cov_mne.data, 1e2)
 
@@ -288,7 +303,7 @@ def test_cov_estimation_with_triggers(rank):
 
     # cov using a list of epochs and keep_sample_mean=True
     epochs = [Epochs(raw, events, ev_id, tmin=-0.2, tmax=0,
-              baseline=(-0.2, -0.1), proj=True, reject=reject)
+                     baseline=(-0.2, -0.1), proj=True, reject=reject)
               for ev_id in event_ids]
     cov2 = compute_covariance(epochs, keep_sample_mean=True)
     assert_array_almost_equal(cov.data, cov2.data)
@@ -440,7 +455,7 @@ def test_auto_low_rank():
 
 
 @pytest.mark.slowtest
-@pytest.mark.parametrize('rank', ('full', None))
+@pytest.mark.parametrize('rank', ('full', None, 'info'))
 @requires_version('sklearn', '0.15')
 def test_compute_covariance_auto_reg(rank):
     """Test automated regularization."""
@@ -496,9 +511,17 @@ def test_compute_covariance_auto_reg(rank):
     methods = ['empirical', 'ledoit_wolf', 'oas', 'shrunk', 'shrinkage']
     if rank == 'full':
         methods.extend(['factor_analysis', 'pca'])
-    cov3 = compute_covariance(epochs, method=methods,
-                              method_params=method_params, projs=None,
-                              return_estimators=True, rank=rank)
+    with catch_logging() as log:
+        cov3 = compute_covariance(epochs, method=methods,
+                                  method_params=method_params, projs=None,
+                                  return_estimators=True, rank=rank,
+                                  verbose=True)
+    log = log.getvalue().split('\n')
+    if rank is None:
+        assert 'Not doing PCA for MAG.' in log
+        assert 'Reducing data rank from 10 -> 7' in log
+    else:
+        assert 'Reducing' not in log
     method_names = [cov['method'] for cov in cov3]
     best_bounds = [-45, -35]
     bounds = [-55, -45] if rank == 'full' else best_bounds
@@ -527,8 +550,11 @@ def test_compute_covariance_auto_reg(rank):
 
 
 def _cov_rank(cov, info):
-    # XXX : this should use the to appear compute_rank function
-    return compute_whitener(cov, info, return_rank=True, verbose='error')[2]
+    # ignore warnings about rank mismatches: sometimes we will intentionally
+    # violate the computed/info assumption, such as when using SSS with
+    # `rank='full'`
+    with pytest.warns(None):
+        return _compute_rank_int(cov, info=info)
 
 
 @requires_version('sklearn', '0.15')
@@ -536,6 +562,7 @@ def test_low_rank():
     """Test low-rank covariance matrix estimation."""
     raw = read_raw_fif(raw_fname).set_eeg_reference(projection=True).crop(0, 3)
     raw = maxwell_filter(raw, regularize=None)  # heavily reduce the rank
+    assert raw.info['bads'] == []  # no bads
     sss_proj_rank = 139  # 80 MEG + 60 EEG - 1 proj
     n_ch = 366
     proj_rank = 365  # one EEG proj
@@ -549,8 +576,11 @@ def test_low_rank():
         'full': dict(empirical=(-9000, -8000),
                      diagonal_fixed=(-2000, -1600),
                      oas=(-1600, -1000)),
+        'info': dict(empirical=(-6000, -5000),
+                     diagonal_fixed=(-700, -600),
+                     oas=(-700, -600)),
     }
-    for rank in ('full', None):
+    for rank in ('full', 'info', None):
         covs = compute_covariance(
             epochs, method=methods, return_estimators=True,
             verbose='error', rank=rank)
@@ -558,10 +588,10 @@ def test_low_rank():
             method = cov['method']
             these_bounds = bounds[str(rank)][method]
             this_rank = _cov_rank(cov, epochs.info)
-            if rank is None or method == 'empirical':
-                assert this_rank == sss_proj_rank
+            if rank == 'full' and method != 'empirical':
+                assert this_rank == n_ch
             else:
-                assert this_rank == proj_rank
+                assert this_rank == sss_proj_rank
             assert these_bounds[0] < cov['loglik'] < these_bounds[1], \
                 (rank, method)
             if method == 'empirical':
@@ -573,6 +603,8 @@ def test_low_rank():
     assert _cov_rank(emp_cov, epochs.info) == sss_proj_rank
     reg_cov = regularize(emp_cov, epochs.info, proj=True, rank='full')
     assert _cov_rank(reg_cov, epochs.info) == proj_rank
+    with pytest.warns(RuntimeWarning, match='exceeds the theoretical'):
+        _compute_rank_int(reg_cov, info=epochs.info)
     del reg_cov
     with catch_logging() as log:
         reg_r_cov = regularize(emp_cov, epochs.info, proj=True, rank=None,
@@ -592,8 +624,12 @@ def test_low_rank():
     cov_full = compute_covariance(epochs_meg, method='oas',
                                   rank='full', verbose='error')
     assert _cov_rank(cov_full, epochs_meg.info) == 306
+    with pytest.deprecated_call(match='int is deprecated'):
+        cov_dict = compute_covariance(epochs_meg, method='oas', rank=306)
+    assert _cov_rank(cov_dict, epochs_meg.info) == 306
+    assert_allclose(cov_full['data'], cov_dict['data'])
     cov_dict = compute_covariance(epochs_meg, method='oas',
-                                  rank=306, verbose='error')
+                                  rank=dict(meg=306), verbose='error')
     assert _cov_rank(cov_dict, epochs_meg.info) == 306
     assert_allclose(cov_full['data'], cov_dict['data'])
 

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -1,21 +1,21 @@
 import os.path as op
 import itertools as itt
 
-from numpy.testing import assert_equal, assert_array_equal
+from numpy.testing import assert_array_equal
 import numpy as np
 
 import pytest
 
-from mne.datasets import testing
-from mne import read_evokeds, read_cov
+from mne import (read_evokeds, read_cov, compute_raw_covariance, pick_types,
+                 pick_info)
 from mne.cov import prepare_noise_cov
-from mne import compute_raw_covariance, pick_types, pick_info
-from mne.io.proj import _has_eeg_average_ref_proj
-from mne.io.pick import channel_type, _picks_by_type
+from mne.datasets import testing
 from mne.io import read_raw_fif
+from mne.io.pick import channel_type, _picks_by_type
+from mne.io.proj import _has_eeg_average_ref_proj
 from mne.proj import compute_proj_raw
-from mne.rank import estimate_rank, _estimate_rank_meeg_cov
-from mne.rank import _get_rank_sss, _get_sss_rank
+from mne.rank import (estimate_rank, compute_rank, _get_rank_sss,
+                      _compute_rank_int)
 
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
@@ -27,6 +27,7 @@ hp_fif_fname = op.join(base_dir, 'test_chpi_raw_sss.fif')
 testing_path = testing.data_path(download=False)
 data_dir = op.join(testing_path, 'MEG', 'sample')
 fif_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
+mf_fif_fname = op.join(testing_path, 'SSS', 'test_move_anon_raw_sss.fif')
 
 
 def test_estimate_rank():
@@ -35,7 +36,7 @@ def test_estimate_rank():
     assert_array_equal(estimate_rank(data, return_singular=True)[1],
                        np.ones(10))
     data[0, 0] = 0
-    assert_equal(estimate_rank(data), 9)
+    assert estimate_rank(data) == 9
     pytest.raises(ValueError, estimate_rank, data, 'foo')
 
 
@@ -71,7 +72,8 @@ def test_rank_estimation():
 
 
 @pytest.mark.slowtest
-def test_rank():
+@pytest.mark.parametrize('rank_method', ['info', None])
+def test_cov_rank_estimation(rank_method):
     """Test cov rank estimation."""
     # Test that our rank estimation works properly on a simple case
     evoked = read_evokeds(ave_fname, condition=0, baseline=(None, 0),
@@ -80,8 +82,8 @@ def test_rank():
     ch_names = [ch for ch in evoked.info['ch_names'] if '053' not in ch and
                 ch.startswith('EEG')]
     cov = prepare_noise_cov(cov, evoked.info, ch_names, None)
-    assert_equal(cov['eig'][0], 0.)  # avg projector should set this to zero
-    assert (cov['eig'][1:] > 0).all()  # all else should be > 0
+    assert cov['eig'][0] <= 1e-25  # avg projector should set this to zero
+    assert (cov['eig'][1:] > 1e-16).all()  # all else should be > 0
 
     # Now do some more comprehensive tests
     raw_sample = read_raw_fif(raw_fname)
@@ -120,50 +122,96 @@ def test_rank():
          (cov_sample_proj, picks_stack_sample, info_sample),
          (cov_sss, picks_stack_somato, info_sss),
          (cov_sss_proj, picks_stack_somato, info_sss)],  # sss
-        [dict(mag=1e15, grad=1e13, eeg=1e6)]
+        [dict(mag=1e15, grad=1e13, eeg=1e6)],
     ))
 
-    for (cov, picks_list, this_info), scalings in iter_tests:
+    for (cov, picks_list, iter_info), scalings in iter_tests:
+        rank = compute_rank(cov, rank_method, scalings, iter_info)
+        rank['all'] = sum(rank.values())
         for ch_type, picks in picks_list:
 
-            this_very_info = pick_info(this_info, picks)
+            this_info = pick_info(iter_info, picks)
 
-            # compute subset of projs
-            this_projs = [c['active'] and
-                          len(set(c['data']['col_names'])
-                              .intersection(set(this_very_info['ch_names']))) >
-                          0 for c in cov['projs']]
-            n_projs = sum(this_projs)
+            # compute subset of projs, active and inactive
+            n_projs_applied = sum(proj['active'] and
+                                  len(set(proj['data']['col_names']) &
+                                      set(this_info['ch_names'])) > 0
+                                  for proj in cov['projs'])
+            n_projs_info = sum(len(set(proj['data']['col_names']) &
+                                   set(this_info['ch_names'])) > 0
+                               for proj in this_info['projs'])
 
             # count channel types
-            ch_types = [channel_type(this_very_info, idx)
+            ch_types = [channel_type(this_info, idx)
                         for idx in range(len(picks))]
             n_eeg, n_mag, n_grad = [ch_types.count(k) for k in
                                     ['eeg', 'mag', 'grad']]
             n_meg = n_mag + n_grad
+            has_sss = (n_meg > 0 and len(this_info['proc_history']) > 0)
+            if has_sss:
+                n_meg = _get_rank_sss(this_info)
 
-            # check sss
-            if len(this_very_info['proc_history']) > 0:
-                mf = this_very_info['proc_history'][0]['max_info']
-                n_free = _get_sss_rank(mf)
-                if 'mag' not in ch_types and 'grad' not in ch_types:
-                    n_free = 0
-                # - n_projs XXX clarify
-                expected_rank = n_free + n_eeg
+            expected_rank = n_meg + n_eeg
+            if rank_method is None:
+                if not has_sss:  # XXX see below and gh-5146
+                    expected_rank -= n_projs_applied
             else:
-                expected_rank = n_meg + n_eeg - n_projs
+                # XXX for now it just uses the total count
+                assert rank_method == 'info'
+                expected_rank -= n_projs_info
 
-            C = cov['data'][np.ix_(picks, picks)]
-            est_rank = _estimate_rank_meeg_cov(C, this_very_info,
-                                               scalings=scalings)
-
-            assert_equal(expected_rank, est_rank)
+            assert rank[ch_type] == expected_rank
 
 
-def test_maxfilter_get_rank():
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname, rank_orig', ((hp_fif_fname, 120),
+                                              (mf_fif_fname, 67)))
+@pytest.mark.parametrize('n_proj', (0, 10))
+def test_maxfilter_get_rank(n_proj, fname, rank_orig):
     """Test maxfilter rank lookup."""
-    raw = read_raw_fif(hp_fif_fname)
+    raw = read_raw_fif(fname).crop(0, 5).load_data().pick_types()
+    assert raw.info['projs'] == []
     mf = raw.info['proc_history'][0]['max_info']
-    rank1 = mf['sss_info']['nfree']
-    rank2 = _get_rank_sss(raw)
-    assert rank1 == rank2
+    assert mf['sss_info']['nfree'] == rank_orig
+    assert _get_rank_sss(raw) == rank_orig
+    rank = rank_orig - 2 * n_proj
+    if n_proj > 0:
+        # Let's do some projection
+        raw.add_proj(compute_proj_raw(raw, n_mag=n_proj, n_grad=n_proj))
+    raw.apply_proj()
+    data_orig = raw[:][0]
+
+    # degenerate cases
+    with pytest.raises(ValueError, match='tol must be'):
+        raw.estimate_rank(tol='foo')
+    with pytest.raises(TypeError, match='must be a string or a number'):
+        raw.estimate_rank(tol=None)
+    # multiple ways of hopefully getting the same thing
+    rank_new = raw.estimate_rank(tol=1e-4)  # default tol=1e-4, scalings='norm'
+
+    # XXX this should be "rank" not "rank_orig", see gh-5146
+    allowed_rank = [rank_orig]
+    if fname == mf_fif_fname:
+        # Here we permit a -1 because for mf_fif_fname we miss by 1, which is
+        # probably acceptable. If we use the entire duration instead of 5 sec
+        # this problem goes away, but the test is much slower.
+        allowed_rank.append(allowed_rank[0] - 1)
+    tol = 'float32'  # temporary option until we can fix things
+    rank_new = raw.estimate_rank(tol=tol)
+    assert rank_new in allowed_rank
+    rank_new = raw.estimate_rank(scalings=dict(), tol=tol)
+    assert rank_new in allowed_rank
+    scalings = dict(grad=1e13, mag=1e15)
+    rank_new = _compute_rank_int(raw, None, scalings=scalings, tol=tol,
+                                 verbose='debug')
+    assert rank_new in allowed_rank
+    # XXX default scalings mis-estimate sometimes :(
+    if fname == hp_fif_fname:
+        allowed_rank.append(allowed_rank[0] - 2)
+    rank_new = _compute_rank_int(raw, None, tol=tol, verbose='debug')
+    assert rank_new in allowed_rank
+    del allowed_rank
+
+    rank_new = _compute_rank_int(raw, 'info')
+    assert rank_new == rank
+    assert_array_equal(raw[:][0], data_orig)

--- a/mne/time_frequency/ar.py
+++ b/mne/time_frequency/ar.py
@@ -8,7 +8,7 @@ from scipy import linalg
 
 from ..defaults import _handle_default
 from ..io.pick import _picks_to_idx, _picks_by_type, pick_info
-from ..utils import verbose
+from ..utils import verbose, _apply_scaling_array
 
 
 def _yule_walker(X, order=1):
@@ -62,7 +62,6 @@ def fit_iir_model_raw(raw, order=2, picks=None, tmin=None, tmax=None,
     a : ndarray
         Denominator filter coefficients
     """
-    from ..cov import _apply_scaling_array
     start, stop = None, None
     if tmin is not None:
         start = raw.time_as_index(tmin)[0]

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -11,7 +11,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_event_id, _check_ch_locs, _check_compensation_grade,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_pyface_backend, _check_info_inv,
-                    _check_channels_spatial_filter)
+                    _check_channels_spatial_filter, _check_rank,
+                    _check_rank_cov)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -11,8 +11,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_event_id, _check_ch_locs, _check_compensation_grade,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_pyface_backend, _check_info_inv,
-                    _check_channels_spatial_filter, _check_rank,
-                    _check_rank_cov)
+                    _check_channels_spatial_filter, _check_rank)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,
@@ -41,6 +40,7 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        sum_squared, split_list, _gen_events, create_slices,
                        _time_mask, grand_average, object_diff, object_hash,
                        object_size, _apply_scaling_cov, _undo_scaling_cov,
-                       _apply_scaling_array, _undo_scaling_array)
+                       _apply_scaling_array, _undo_scaling_array,
+                       _scaled_array)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -11,7 +11,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_event_id, _check_ch_locs, _check_compensation_grade,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_pyface_backend, _check_info_inv,
-                    _check_channels_spatial_filter, _check_rank)
+                    _check_channels_spatial_filter, _check_one_ch_type,
+                    _check_rank)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -417,3 +417,18 @@ def _check_rank(rank):
             rank = dict(meg=rank)
     return rank
 
+
+def _check_one_ch_type(info, picks, noise_cov, method):
+    """Check number of sensor types and presence of noise covariance matrix."""
+    from ..io.pick import pick_info
+    from ..channels.channels import _contains_ch_type
+    info_pick = pick_info(info, sel=picks)
+    ch_types =\
+        [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
+    if method == 'lcmv' and sum(ch_types) > 1 and noise_cov is None:
+        raise ValueError('Source reconstruction with several sensor types '
+                         'requires a noise covariance matrix to be '
+                         'able to apply whitening.')
+    elif method == 'dics' and sum(ch_types) > 1:
+        warn('The use of several sensor types with the DICS beamformer is '
+             'not heavily tested yet.')

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -392,6 +392,8 @@ def _check_channels_spatial_filter(ch_names, filters):
 
 def _check_rank(rank):
     """Check rank parameter and deal with deprecation."""
+    err_msg = ('rank must be None, dict, "full", or int, '
+               'got %s (type %s)' % (rank, type(rank)))
     if isinstance(rank, str):
         # XXX we can use rank='' to deprecate to get to None eventually:
         # if rank == '':
@@ -399,39 +401,19 @@ def _check_rank(rank):
         #          'to None in 0.19, set it explicitly to avoid this warning',
         #          DeprecationWarning)
         #     rank = 'full'
-        if rank not in ['full', 'auto']:
-            raise ValueError('rank, if str, must be "full" or "auto", '
+        if rank not in ['full', 'info']:
+            raise ValueError('rank, if str, must be "full" or "info", '
                              'got %s' % (rank,))
+    elif isinstance(rank, bool):
+        raise TypeError(err_msg)
     elif rank is not None and not isinstance(rank, dict):
         try:
             rank = int(operator.index(rank))
         except TypeError:
-            raise TypeError('rank must be None, dict, "full", or int-like, '
-                            'got %s (type %s)' % (rank, type(rank)))
-    return rank
-
-
-def _check_rank_cov(rank, methods, was_auto=False):
-    """Check validity of rank input argument."""
-    if isinstance(rank, str) and rank != 'full':
-        raise ValueError('rank, if str, must be "full", got %s' % (rank,))
-    if not (isinstance(rank, str) and rank == 'full'):
-        if was_auto:
-            methods.pop(methods.index('factor_analysis'))
-        for method in methods:
-            if method in ('pca', 'factor_analysis'):
-                raise ValueError('%s can so far only be used with rank="full",'
-                                 ' got rank=%r' % (method, rank))
-        rank = dict() if rank is None else rank
-        orig_rank = rank
-        try:
-            rank = int(operator.index(rank))
-        except Exception:
-            pass
+            raise TypeError(err_msg)
         else:
+            warn('rank as int is deprecated and will be removed in 0.19. '
+                 'use rank=dict(meg=...) instead.', DeprecationWarning)
             rank = dict(meg=rank)
-        if not isinstance(rank, dict) or orig_rank is False:
-            raise ValueError('rank must be an int, dict, None, or "full", '
-                             'got %s (type %s)' % (rank, type(rank)))
-    return rank, methods
+    return rank
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -15,14 +15,19 @@ from .config import get_config
 from ..externals.doccer import filldoc, unindent_dict
 
 
-docdict = dict(
-    verbose="""
+##############################################################################
+# Define our standard documentation entries
+
+docdict = dict()
+
+# Verbose
+docdict['verbose'] = """
 verbose : bool, str, int, or None
     If not None, override default verbose level (see :func:`mne.verbose`
     and :ref:`Logging documentation <tut_logging>` for more)."""
-)
 docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
 
+# Picks
 docdict['picks_header'] = 'picks : str | list | slice | None'
 docdict['picks_base'] = docdict['picks_header'] + """
     Channels to include. Slices and lists of integers will be
@@ -45,9 +50,22 @@ picks : list | slice | None
     interpreted as channel indices. None (default) will pick all channels.
 """
 
+# Rank
+docdict['rank'] = """
+rank : None | dict | 'info' | 'full'
+        This controls the rank computation that can be read from the
+        measurement info or estimated from the data. See ``Notes``
+        of :func:`mne.compute_rank` for details."""
+docdict['rank_None'] = docdict['rank'] + 'The default is None.'
+docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
+# Finalize
+
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)
 
+
+##############################################################################
+# Utilities for docstring manipulation.
 
 def copy_doc(source):
     """Copy the docstring from another function (decorator).

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1013,14 +1013,7 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
         The noise covariance. Can be a string to load a covariance from disk.
     show : bool
         Show figure if True.
-    rank : dict of int | None
-        Dict of ints where keys are 'eeg', 'meg', mag' or 'grad'. If None,
-        the rank is detected automatically. Defaults to None. 'mag' or
-        'grad' cannot be specified jointly with 'meg'. For SSS'd data,
-        only 'meg' is valid. For non-SSS'd data, 'mag' and/or 'grad' must be
-        specified separately. If only one is specified, the other one gets
-        estimated. Note. The rank estimation will be printed by the logger for
-        each noise covariance estimator that is passed.
+    %(rank_None)s
     time_unit : str
         The units for the time axis, can be "ms" or "s" (default).
 


### PR DESCRIPTION
the idea is to rely on this single function to compute rank of data / cov

- [x] get tests passing
- [x] unify old and new `_smart_eigh` methods
- [x] deprecate `int` rank
- [x] wait for #5753, then update docstrings