### PR TITLE
ENH: 3.7 for conda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,8 @@ jobs:
         - run:
             name: Patch Qt
             command: |
-              conda remove --yes qt pyqt matplotlib sip libxcb icu vtk
-              pip uninstall --yes mayavi vtk
-              pip install vtk mayavi PyQt5 PyQt5-sip sip matplotlib
+              conda remove --yes qt pyqt matplotlib sip libxcb icu
+              pip install PyQt5 PyQt5-sip sip matplotlib
               echo "export LD_PRELOAD=~/miniconda/envs/mne/lib/libgobject-2.0.so.0" >> $BASH_ENV
               pip install --upgrade "https://api.github.com/repos/nipy/PySurfer/zipball/master"
         - save_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
     # TRAVIS_PYTHON_VERSION is only needed for neo's setup.py
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
-    global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
+    global: PYTHON_VERSION=3.7 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
             PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout nitime"
-            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
+            TRAVIS_PYTHON_VERSION=3.7 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ environment:
   global:
       PYTHON: "C:\\conda"
       # CONDA_ENVIRONMENT: "environment.yml"
-      CONDA_DEPENDENCIES: "python>=3.6 pip mkl numpy scipy matplotlib cython pyqt>=5.9 pandas xlrd scikit-learn h5py pillow statsmodels jupyter pytest pytest-cov joblib psutil numpydoc flake8 spyder numexpr traits>=4.6.0 pyface>=6 traitsui>=6 testpath<0.4"
+      CONDA_DEPENDENCIES: "python>=3.7 pip mkl numpy scipy matplotlib cython pyqt>=5.9 pandas xlrd scikit-learn h5py pillow statsmodels jupyter pytest pytest-cov joblib psutil numpydoc flake8 spyder numexpr traits>=4.6.0 pyface>=6 traitsui>=6 testpath<0.4"
       PIP_DEPENDENCIES: "codecov pytest-sugar pytest-timeout vtk https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12 PySurfer[save_movie] dipy --only-binary dipy nibabel nilearn neo pytest-faulthandler pytest-mock pydocstyle codespell python-picard"
   matrix:
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
         PYTHON_ARCH: "64"
 
 install:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -356,6 +356,7 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(  # needed until SciPy 1.2.0 is released
         'ignore', '.*will be interpreted as an array index.*', module='scipy')
     for key in ('HasTraits', r'numpy\.testing', 'importlib', r'np\.loads',
+                'Using or importing the ABCs from',  # internal modules on 3.7
                 r"it will be an error for 'np\.bool_'",  # ndimage
                 "'U' mode is deprecated",  # sphinx io
                 ):

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - matplotlib
 - cython
 - pyqt>=5.9
-- vtk>=8
 - pandas
 - xlrd
 - scikit-learn
@@ -34,6 +33,7 @@ dependencies:
 - testpath<0.4
 - pip:
   - mne
+  - vtk
   - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mne
 channels:
 - defaults
 dependencies:
-- python>=3.6
+- python>=3.7
 - pip
 - mkl
 - numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ filterwarnings =
     ignore:covariance is not positive-semidefinite:RuntimeWarning
     ignore:Can only plot ICA components:RuntimeWarning
     ignore:Matplotlib is building the font cache using fc-list:UserWarning
-    ignore:.*Using or importing the ABCs.*:DeprecationWarning
+    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
     ignore:`formatargspec` is deprecated:DeprecationWarning
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ filterwarnings =
     ignore:covariance is not positive-semidefinite:RuntimeWarning
     ignore:Can only plot ICA components:RuntimeWarning
     ignore:Matplotlib is building the font cache using fc-list:UserWarning
-    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
+    ignore:.*Using or importing the ABCs.*:DeprecationWarning
     ignore:`formatargspec` is deprecated:DeprecationWarning
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning


### PR DESCRIPTION
I noticed that 3.7 is the default now on the Anaconda site. Let's see if tests pass on OSX and Windows now. If so we can update our install instructions.

I might also try to fix the Windows bug here, we'll see.