### PR TITLE
MRG: Fix instruction copy-paste

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -291,3 +291,7 @@ span.classifier a span.xref {
 span.classifier a code.docutils.literal.notranslate {
     color: #2c3e50;
 }
+/* Allow easier copy-paste in code blocks */
+div.highlight-console div.highlight span.gp {
+    user-select: none;
+}

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -10,6 +10,7 @@ There are many ways to install a Python interpreter and MNE. Here we show a simp
 1. Get Python
 #############
 
+MNE-Python 0.18 only supports Python 3.5+.
 We recommend the `Anaconda distribution <https://www.anaconda.com/distribution/>`_.
 Follow the `installation instructions <http://docs.continuum.io/anaconda/install>`_.
 When you are done, you should see a similar output if you type the following command in a terminal:
@@ -17,13 +18,13 @@ When you are done, you should see a similar output if you type the following com
 .. code-block:: console
 
     $ conda --version && python --version
-    conda 4.5.4
-    Python 3.6.5 :: Anaconda, Inc.
+    conda 4.6.1
+    Python 3.7.2
 
 If you get an error message, consult the Anaconda documentation and search for Anaconda install
 tips (`Stack Overflow <https://stackoverflow.com/>`_ results are often helpful).
 
-.. note:: MNE-Python 0.18 only supports Python 3.5+.
+.. note::
 
 2. Get MNE and its dependencies
 ###############################
@@ -32,7 +33,7 @@ From the command line, install the MNE dependencies to a dedicated ``mne`` Anaco
 
 .. code-block:: console
 
-    $ curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+    $ curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
     $ conda env create -f environment.yml
     $ conda activate mne
 
@@ -79,22 +80,23 @@ The ``$ conda env create ...`` step sometimes emits warnings, but you can ensure
 all default dependencies are installed by listing their versions with::
 
     >>> mne.sys_info()  # doctest:+SKIP
-    Platform:      Linux-4.4.0-112-generic-x86_64-with-debian-jessie-sid
-    Python:        3.6.6 |Anaconda, Inc.| (default, Jun 28 2018, 17:14:51)  [GCC 7.2.0]
+    Platform:      Linux-4.18.0-13-generic-x86_64-with-debian-buster-sid
+    Python:        3.7.2 (default, Dec 29 2018, 06:19:36)  [GCC 7.3.0]
     Executable:    /home/travis/miniconda/envs/test/bin/python
     CPU:           x86_64: 48 cores
     Memory:        62.7 GB
 
-    mne:           0.16.2
-    numpy:         1.15.0 {blas=mkl_rt, lapack=mkl_rt}
-    scipy:         1.1.0
-    matplotlib:    2.2.2 {backend=Qt5Agg}
+    mne:           0.17.0
+    numpy:         1.15.4 {blas=mkl_rt, lapack=mkl_rt}
+    scipy:         1.2.0
+    matplotlib:    3.0.2 {backend=Qt5Agg}
 
-    sklearn:       0.19.1
-    nibabel:       2.3.0
-    mayavi:        4.6.1 {qt_api=pyqt5, PyQt5=5.10.1}
+    sklearn:       0.20.2
+    nibabel:       2.3.3
+    mayavi:        4.7.0.dev0 {qt_api=pyqt5, PyQt5=5.10.1}
     cupy:          Not found
-    pandas:        0.23.4
+    pandas:        0.24.0
+    dipy:          0.15.0
 
 
 For advanced topics like how to get :ref:`CUDA` support or if you are experiencing other issues, check out :ref:`advanced_setup`.

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -24,7 +24,6 @@ When you are done, you should see a similar output if you type the following com
 If you get an error message, consult the Anaconda documentation and search for Anaconda install
 tips (`Stack Overflow <https://stackoverflow.com/>`_ results are often helpful).
 
-.. note::
 
 2. Get MNE and its dependencies
 ###############################

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - pip:
   - mne
   - vtk
-  - https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12
+  - https://api.github.com/repos/enthought/mayavi/zipball/226189a6ad3dc3c01d031ef21d0d0cde554ac851
   - PySurfer[save_movie]
   - dipy --only-binary dipy
   - nibabel

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -139,7 +139,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
         orientations. Only used when surf_ori and/or force_fixed are True.
     forward : instance of Forward | None
         The forward operator to use. If None (default) it will be computed
-        using `bem`, `trans`, and `src`.
+        using ``bem``, ``trans``, and ``src``.
 
         .. versionadded:: 0.17
     duration : float | None

--- a/tutorials/plot_object_source_estimate.py
+++ b/tutorials/plot_object_source_estimate.py
@@ -19,7 +19,7 @@ An STC object contains the amplitudes of the sources over time.
 It only stores the amplitudes of activations but
 not the locations of the sources. To get access to the locations
 you need to have the :class:`source space <mne.SourceSpaces>`
-(often abbreviated `src`) used to compute the
+(often abbreviated ``src``) used to compute the
 :class:`forward operator <mne.Forward>` (often abbreviated `fwd`).
 
 See :ref:`tut_forward` for more details on forward modeling, and


### PR DESCRIPTION
Take care of a number of paper cuts:

1. Change OSX instructions to use explicit `curl --remote-name ` instead of `curl -O`
2. Set CSS style of console separators in Pygments highlighting to be non-selectable, so copy-paste is easier. This is not done for Python because we have the `>>>` on the right to hide the separators.
3. Update entries in example outputs to reflect Python 3.7.
4. Update mayavi pin in environment.yml.
5. Fix a couple of minor bugs with linking:
    ```
    /home/larsoner/python/mne-python/doc/auto_tutorials/plot_object_source_estimate.rst:26: WARNING: py:obj reference target not found: src
    /home/larsoner/python/mne-python/mne/simulation/raw.py:docstring of mne.simulation.simulate_raw:88: WARNING: py:obj reference target not found: src
    ```

Closes #5884