### PR TITLE
WIP: adds to bdf file documentation

### DIFF
--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -353,7 +353,8 @@ called BioSemi. It can also be read in using :func:`mne.io.read_raw_edf`.
 BioSemi amplifiers do not perform "common mode noise rejection" automatically.
 The signals in the EEG file are the voltages between each electrode and CMS
 active electrode, which still contain some CM noise (50 Hz, ADC reference noise,
-etc., see `here <https://www.biosemi.com/faq/cms&drl.htm>`_ for further detail).
+etc., see `the BioSemi FAQ <https://www.biosemi.com/faq/cms&drl.htm>`__
+for further detail).
 Thus, it is advisable to choose a reference (e.g., a single channel like Cz,
 average of linked mastoids, average of all electrodes, etc.) on import of BioSemi
 data to avoid losing signal information. The data can be re-referenced later after

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -350,6 +350,14 @@ The `BDF format <http://www.biosemi.com/faq/file_format.htm>`_ is a 24-bit
 variant of the EDF format used by the EEG systems manufactured by a company
 called BioSemi. It can also be read in using :func:`mne.io.read_raw_edf`.
 
+BioSemi amplifiers do not perform "common mode noise rejection" automatically.
+The signals in the EEG file are the voltages between each electrode and CMS
+active electrode, which still contain some CM noise (50 Hz, ADC reference noise,
+etc., see `here <https://www.biosemi.com/faq/cms&drl.htm>`_ for further detail).
+Thus, it is advisable to use any single channel (e.g., Cz) on import of
+BioSemi data to avoid losing signal information. The data can be re-referenced
+(e.g., common average, average of mastoids) later after cleaning.
+
 .. warning:: The data samples in a BDF file are represented in a 3-byte (24-bit) format. Since 3-byte raw data buffers are not presently supported in the fif format these data will be changed to 4-byte integers in the conversion.
 
 General data format (.gdf)

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -354,9 +354,10 @@ BioSemi amplifiers do not perform "common mode noise rejection" automatically.
 The signals in the EEG file are the voltages between each electrode and CMS
 active electrode, which still contain some CM noise (50 Hz, ADC reference noise,
 etc., see `here <https://www.biosemi.com/faq/cms&drl.htm>`_ for further detail).
-Thus, it is advisable to use any single channel (e.g., Cz) on import of
-BioSemi data to avoid losing signal information. The data can be re-referenced
-(e.g., common average, average of mastoids) later after cleaning.
+Thus, it is advisable to chose a reference (e.g., a single channel like Cz,
+average of linked mastoids, average of all electrodes, etc.) on import of BioSemi
+data to avoid losing signal information. The data can be re-referenced later after
+cleaning if desired.
 
 .. warning:: The data samples in a BDF file are represented in a 3-byte (24-bit) format. Since 3-byte raw data buffers are not presently supported in the fif format these data will be changed to 4-byte integers in the conversion.
 

--- a/doc/manual/io.rst
+++ b/doc/manual/io.rst
@@ -354,7 +354,7 @@ BioSemi amplifiers do not perform "common mode noise rejection" automatically.
 The signals in the EEG file are the voltages between each electrode and CMS
 active electrode, which still contain some CM noise (50 Hz, ADC reference noise,
 etc., see `here <https://www.biosemi.com/faq/cms&drl.htm>`_ for further detail).
-Thus, it is advisable to chose a reference (e.g., a single channel like Cz,
+Thus, it is advisable to choose a reference (e.g., a single channel like Cz,
 average of linked mastoids, average of all electrodes, etc.) on import of BioSemi
 data to avoid losing signal information. The data can be re-referenced later after
 cleaning if desired.


### PR DESCRIPTION
#### Reference issue
Fixes [#4059.](https://github.com/mne-tools/mne-python/issues/4059)


#### What does this implement/fix?
Adds information on BioSemi BDF-Files in the documentation, suggesting to chose a reference channel upon import to avoid losing signal.

#### Additional information
New passage summarises info from BioSemi [FAQs](https://www.biosemi.com/faq/cms&drl.htm)
