### PR TITLE
MRG: Add reject_by_annotation to find_ecg_events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -80,7 +80,7 @@ Bug
 
 - Fix issue with bad channels ignored in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` by `Alex Gramfort`_
 
-- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
+- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <gen_mne_clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,6 +53,8 @@ Changelog
 
 - Add Epoch selection and metadata functionality to :class:`mne.time_frequency.EpochsTFR` using new mixin class by `Keith Doelling`_
 
+- Add ``reject_by_annotation`` argument to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
+
 - Add ``extrapolate`` argument to :func:`mne.viz.plot_topomap` for better control of extrapolation points placement by `Mikołaj Magnuski`_
 
 - Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_
@@ -77,6 +79,8 @@ Bug
 - Fixed a bug where :meth:`mne.time_frequency.AverageTFR.plot_joint` would mishandle bad channels, by `David Haslacher`_ and `Jona Sassenhagen`_
 
 - Fix issue with bad channels ignored in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` by `Alex Gramfort`_
+
+- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 API
 ~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -456,7 +456,7 @@ def _annotations_starts_stops(raw, kinds, name='unknown', invert=False):
         order = np.argsort(onsets)
         onsets = raw.time_as_index(onsets[order], use_rounding=True)
         ends = raw.time_as_index(ends[order], use_rounding=True)
-    assert (onsets <= ends).all()  # all durations > 0
+    assert (onsets <= ends).all()  # all durations >= 0
     if invert:
         # We need to eliminate overlaps here, otherwise wacky things happen,
         # so we carefully invert the relationship
@@ -478,7 +478,7 @@ def _annotations_starts_stops(raw, kinds, name='unknown', invert=False):
 
 
 def _mask_to_onsets_offsets(mask):
-    """Group boolean mask into contiguous segments."""
+    """Group boolean mask into contiguous onset:offset pairs."""
     assert mask.dtype == bool and mask.ndim == 1
     mask = mask.astype(int)
     diff = np.diff(mask)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -456,16 +456,40 @@ def _annotations_starts_stops(raw, kinds, name='unknown', invert=False):
         order = np.argsort(onsets)
         onsets = raw.time_as_index(onsets[order], use_rounding=True)
         ends = raw.time_as_index(ends[order], use_rounding=True)
+    assert (onsets <= ends).all()  # all durations > 0
     if invert:
-        # We invert the relationship (i.e., get segments that do not satisfy)
-        if len(onsets) == 0 or onsets[0] != 0:
-            onsets = np.concatenate([[0], onsets])
-            ends = np.concatenate([[0], ends])
-        if len(ends) == 1 or ends[-1] != len(raw.times):
-            onsets = np.concatenate([onsets, [len(raw.times)]])
-            ends = np.concatenate([ends, [len(raw.times)]])
-        onsets, ends = ends[:-1], onsets[1:]
+        # We need to eliminate overlaps here, otherwise wacky things happen,
+        # so we carefully invert the relationship
+        mask = np.zeros(len(raw.times), bool)
+        for onset, end in zip(onsets, ends):
+            mask[onset:end] = True
+        mask = ~mask
+        extras = (onsets == ends)
+        extra_onsets, extra_ends = onsets[extras], ends[extras]
+        onsets, ends = _mask_to_onsets_offsets(mask)
+        # Keep ones where things were exactly equal
+        del extras
+        # we could do this with a np.insert+np.searchsorted, but our
+        # ordered-ness should get us it for free
+        onsets = np.sort(np.concatenate([onsets, extra_onsets]))
+        ends = np.sort(np.concatenate([ends, extra_ends]))
+        assert (onsets <= ends).all()
     return onsets, ends
+
+
+def _mask_to_onsets_offsets(mask):
+    """Group boolean mask into contiguous segments."""
+    assert mask.dtype == bool and mask.ndim == 1
+    mask = mask.astype(int)
+    diff = np.diff(mask)
+    onsets = np.where(diff > 0)[0] + 1
+    if mask[0]:
+        onsets = np.concatenate([[0], onsets])
+    offsets = np.where(diff < 0)[0] + 1
+    if mask[-1]:
+        offsets = np.concatenate([offsets, [len(mask)]])
+    assert len(onsets) == len(offsets)
+    return onsets, offsets
 
 
 def _write_annotations(fid, annotations):

--- a/mne/commands/mne_clean_eog_ecg.py
+++ b/mne/commands/mne_clean_eog_ecg.py
@@ -62,7 +62,8 @@ def clean_ecg_eog(in_fif_fname, out_fif_fname=None, eog=True, ecg=True,
 
     kwargs = dict() if quiet else dict(stdout=None, stderr=None)
     if ecg:
-        ecg_events, _, _ = mne.preprocessing.find_ecg_events(raw_in)
+        ecg_events, _, _ = mne.preprocessing.find_ecg_events(
+            raw_in, reject_by_annotation=True)
         print("Writing ECG events in %s" % ecg_event_fname)
         mne.write_events(ecg_event_fname, ecg_events)
         print('Computing ECG projector')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -264,7 +264,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                  'type %s' % (events.dtype))
             events = events.astype(int)
             if events.ndim != 2 or events.shape[1] != 3:
-                raise ValueError('events must be 2D with 3 columns')
+                raise ValueError('events must be of shape (N, 3), got %s'
+                                 % (events.shape,))
             for key, val in self.event_id.items():
                 if val not in events[:, 2]:
                     msg = ('No matching events found for %s '

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1839,7 +1839,7 @@ def _triage_filter_params(x, sfreq, l_freq, h_freq,
         len_x = x.shape[-1]
         if method != 'fir':
             filter_length = len_x
-        if filter_length > len_x:
+        if filter_length > len_x and not (l_freq is None and h_freq is None):
             warn('filter_length (%s) is longer than the signal (%s), '
                  'distortion is likely. Reduce filter length or filter a '
                  'longer signal.' % (filter_length, len_x))

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -54,7 +54,7 @@ class RawArray(BaseRaw):
 
         if data.ndim != 2:
             raise ValueError('Data must be a 2D array of shape (n_channels, '
-                             'n_samples')
+                             'n_samples), got shape %s' % (data.shape,))
 
         logger.info('Creating RawArray with %s data, n_channels=%s, n_times=%s'
                     % (dtype.__name__, data.shape[0], data.shape[1]))

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1365,15 +1365,17 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self, skip_by_annotation, 'skip_by_annotation', invert=True)
         logger.info('Filtering raw data in %d contiguous segment%s'
                     % (len(onsets), _pl(onsets)))
+        max_idx = (ends - onsets).argmax()
         for si, (start, stop) in enumerate(zip(onsets, ends)):
-            if si > 0:
-                verbose = 'warning' if verbose != 'error' else verbose
+            # Only output filter params once (for info level), and only warn
+            # once about the length criterion (longest segment is too short)
+            use_verbose = verbose if si == max_idx else 'error'
             filter_data(
                 self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,
                 picks, filter_length, l_trans_bandwidth, h_trans_bandwidth,
                 n_jobs, method, iir_params, copy=False, phase=phase,
                 fir_window=fir_window, fir_design=fir_design, pad=pad,
-                verbose=verbose)
+                verbose=use_verbose)
         # update info if filter is applied to all data channels,
         # and it's not a band-stop filter
         _filt_update_info(self.info, update_info, l_freq, h_freq)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -973,6 +973,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """
         if picks is None:
             picks = np.arange(self.info['nchan'])
+        # convert to ints
+        picks = np.atleast_1d(np.arange(self.info['nchan'])[picks])
         start = 0 if start is None else start
         stop = min(self.n_times if stop is None else stop, self.n_times)
         if len(self.annotations) == 0 or reject_by_annotation is None:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -37,7 +37,7 @@ from ..filter import (filter_data, notch_filter, resample, next_fast_len,
                       _filt_update_info)
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
-                     _check_pandas_index_arguments,
+                     _check_pandas_index_arguments, _pl,
                      check_fname, _get_stim_channel,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc,
@@ -1363,12 +1363,19 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         # Deal with annotations
         onsets, ends = _annotations_starts_stops(
             self, skip_by_annotation, 'skip_by_annotation', invert=True)
-        for start, stop in zip(onsets, ends):
+        logger.info('Filtering raw data in %d contiguous segment%s'
+                    % (len(onsets), _pl(onsets)))
+        for si, (start, stop) in enumerate(zip(onsets, ends)):
+            if si == 0:
+                verbose = verbose
+            else:
+                verbose = 'warning' if verbose != 'error' else verbose
             filter_data(
                 self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,
                 picks, filter_length, l_trans_bandwidth, h_trans_bandwidth,
                 n_jobs, method, iir_params, copy=False, phase=phase,
-                fir_window=fir_window, fir_design=fir_design, pad=pad)
+                fir_window=fir_window, fir_design=fir_design, pad=pad,
+                verbose=verbose)
         # update info if filter is applied to all data channels,
         # and it's not a band-stop filter
         _filt_update_info(self.info, update_info, l_freq, h_freq)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1366,9 +1366,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         logger.info('Filtering raw data in %d contiguous segment%s'
                     % (len(onsets), _pl(onsets)))
         for si, (start, stop) in enumerate(zip(onsets, ends)):
-            if si == 0:
-                verbose = verbose
-            else:
+            if si > 0:
                 verbose = 'warning' if verbose != 'error' else verbose
             filter_data(
                 self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -375,9 +375,8 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     if keep_ecg:
         # We know we have created a synthetic channel and epochs are preloaded
         ecg_raw = RawArray(
-            ecg[None],
-            create_info(ch_names=['ECG-SYN'],
-                        sfreq=raw.info['sfreq'], ch_types=['ecg']),
+            ecg, create_info(ch_names=['ECG-SYN'],
+                             sfreq=raw.info['sfreq'], ch_types=['ecg']),
             first_samp=raw.first_samp)
         ignore = ['ch_names', 'chs', 'nchan', 'bads']
         for k, v in raw.info.items():

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -208,6 +208,8 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     ecgs = list()
     max_idx = (ends - onsets).argmax()
     for si, (start, stop) in enumerate(zip(onsets, ends)):
+        # Only output filter params once (for info level), and only warn
+        # once about the length criterion (longest segment is too short)
         use_verbose = verbose if si == max_idx else 'error'
         ecgs.append(filter_data(
             ecg[start:stop], raw.info['sfreq'], l_freq, h_freq, [0],

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -26,14 +26,12 @@ def _safe_del_key(dict_, key):
         del dict_[key]
 
 
-@verbose
 def _compute_exg_proj(mode, raw, raw_event, tmin, tmax,
                       n_grad, n_mag, n_eeg, l_freq, h_freq,
                       average, filter_length, n_jobs, ch_name,
                       reject, flat, bads, avg_ref, no_proj, event_id,
                       exg_l_freq, exg_h_freq, tstart, qrs_threshold,
-                      filter_method, iir_params, return_drop_log, copy,
-                      verbose):
+                      filter_method, iir_params, return_drop_log, copy):
     """Compute SSP/PCA projections for ECG or EOG artifacts."""
     raw = raw.copy() if copy else raw
     del copy
@@ -245,8 +243,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         'ECG', raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg,
         l_freq, h_freq, average, filter_length, n_jobs, ch_name, reject, flat,
         bads, avg_ref, no_proj, event_id, ecg_l_freq, ecg_h_freq, tstart,
-        qrs_threshold, filter_method, iir_params, return_drop_log, copy,
-        verbose)
+        qrs_threshold, filter_method, iir_params, return_drop_log, copy)
 
 
 @verbose
@@ -350,4 +347,4 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         'EOG', raw, raw_event, tmin, tmax, n_grad, n_mag, n_eeg,
         l_freq, h_freq, average, filter_length, n_jobs, ch_name, reject, flat,
         bads, avg_ref, no_proj, event_id, eog_l_freq, eog_h_freq, tstart,
-        'auto', filter_method, iir_params, return_drop_log, copy, verbose)
+        'auto', filter_method, iir_params, return_drop_log, copy)


### PR DESCRIPTION
1. Adds `reject_by_annotation` to `find_ecg_events`.
2. Internally passes the `reject_by_annotation` value from `create_ecg_epochs` to `find_ecg_events` (I consider it a bug that this wasn't done, given that it is done in `create_eog_epochs` -> `find_eog_events`).
3. Fixes bugs with `_annotations_starts_stops(..., invert=True)` to properly give contiguous segments