### PR TITLE
FIX: Revert 3.7, conda on Windows is problematic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
     # TRAVIS_PYTHON_VERSION is only needed for neo's setup.py
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
-    global: PYTHON_VERSION=3.7 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
+    global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
             PIP_DEPENDENCIES="codecov pytest-faulthandler pytest-sugar pytest-timeout nitime"
-            TRAVIS_PYTHON_VERSION=3.7 CONDA_VERSION=">=4.3.27"
+            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,10 @@ image: Visual Studio 2013
 environment:
   global:
       PYTHON: "C:\\conda"
-      # CONDA_ENVIRONMENT: "environment.yml"
-      CONDA_DEPENDENCIES: "python>=3.7 pip mkl numpy scipy matplotlib cython pyqt>=5.9 pandas xlrd scikit-learn h5py pillow statsmodels jupyter pytest pytest-cov joblib psutil numpydoc flake8 spyder numexpr traits>=4.6.0 pyface>=6 traitsui>=6 testpath<0.4"
-      PIP_DEPENDENCIES: "codecov pytest-sugar pytest-timeout vtk https://api.github.com/repos/enthought/mayavi/zipball/b3fc35218dda9776d8f1a407663bfb49783dca12 PySurfer[save_movie] dipy --only-binary dipy nibabel nilearn neo pytest-faulthandler pytest-mock pydocstyle codespell python-picard"
+      CONDA_ENVIRONMENT: "environment.yml"
+      PIP_DEPENDENCIES: "codecov pytest-sugar pytest-timeout"
   matrix:
-      - PYTHON_VERSION: "3.7"
+      - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
 
 install:
@@ -15,7 +14,7 @@ install:
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
-  # "pip uninstall -yq mne"
+  - "pip uninstall -yq mne"
   - "python setup.py develop"
   - "python -c \"import mne; print(mne.sys_info())\""
   - "SET MNE_FORCE_SERIAL=true"  # otherwise joblib will bomb

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -80,7 +80,7 @@ all default dependencies are installed by listing their versions with::
 
     >>> mne.sys_info()  # doctest:+SKIP
     Platform:      Linux-4.18.0-13-generic-x86_64-with-debian-buster-sid
-    Python:        3.7.2 (default, Dec 29 2018, 06:19:36)  [GCC 7.3.0]
+    Python:        3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34)  [GCC 7.3.0]
     Executable:    /home/travis/miniconda/envs/test/bin/python
     CPU:           x86_64: 48 cores
     Memory:        62.7 GB

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mne
 channels:
 - defaults
 dependencies:
-- python>=3.7
+- python<3.7
 - pip
 - mkl
 - numpy


### PR DESCRIPTION
Closes #5858.

Some changes the `conda` folks made to the Windows Python3.7 version make things not install properly. Let's revert to 3.6 until they sort it out.