### PR TITLE
FIX: test_scale_mri too slow on Travis OSX

### DIFF
--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -46,7 +46,7 @@ def test_coregister_fiducials():
     assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
-@pytest.mark.timeout(90)  # can take longer than 30 sec on Travis
+@pytest.mark.slowtest  # can take forever on OSX Travis
 @testing.requires_testing_data
 def test_scale_mri():
     """Test creating fsaverage and scaling it."""
@@ -129,8 +129,7 @@ def test_scale_mri():
         assert ssrc[0]['dist'] is not None
 
 
-@pytest.mark.slowtest
-@pytest.mark.timeout(60)  # >30 sec on Travis
+@pytest.mark.slowtest  # can take forever on OSX Travis
 @testing.requires_testing_data
 @requires_nibabel()
 def test_scale_mri_xfm():


### PR DESCRIPTION
We have been seeing too many of these lately:

https://travis-ci.org/mne-tools/mne-python/jobs/488680214

This commit skips `test_scale_mri` on Travis-OSX to avoid it.