### PR TITLE
FIX: Only write when necessary

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -190,8 +190,9 @@ def _get_path(path, key, name):
 def _do_path_update(path, update_path, key, name):
     """Update path."""
     path = op.abspath(path)
-    if update_path is None:
-        if get_config(key, '') != path:
+    identical = get_config(key, '', use_env=False) == path
+    if not identical:
+        if update_path is None:
             update_path = True
             if '--update-dataset-path' in sys.argv:
                 answer = 'y'
@@ -202,11 +203,9 @@ def _do_path_update(path, update_path, key, name):
                 answer = input(msg)
             if answer.lower() == 'n':
                 update_path = False
-        else:
-            update_path = False
 
-    if update_path is True:
-        set_config(key, path, set_env=False)
+        if update_path:
+            set_config(key, path, set_env=False)
     return path
 
 

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -163,7 +163,8 @@ def get_config_path(home_dir=None):
     return val
 
 
-def get_config(key=None, default=None, raise_error=False, home_dir=None):
+def get_config(key=None, default=None, raise_error=False, home_dir=None,
+               use_env=True):
     """Read MNE-Python preferences from environment or config file.
 
     Parameters
@@ -181,6 +182,11 @@ def get_config(key=None, default=None, raise_error=False, home_dir=None):
     home_dir : str | None
         The folder that contains the .mne config folder.
         If None, it is found automatically.
+    use_env : bool
+        If True, consider env vars, if available.
+        If False, only use MNE-Python configuration file values.
+
+        .. versionadded:: 0.18
 
     Returns
     -------
@@ -194,7 +200,7 @@ def get_config(key=None, default=None, raise_error=False, home_dir=None):
     _validate_type(key, (str, type(None)), "key", 'string or None')
 
     # first, check to see if key is in env
-    if key is not None and key in os.environ:
+    if use_env and key is not None and key in os.environ:
         return os.environ[key]
 
     # second, look for it in mne-python config file
@@ -206,21 +212,24 @@ def get_config(key=None, default=None, raise_error=False, home_dir=None):
 
     if key is None:
         # update config with environment variables
-        env_keys = (set(config).union(known_config_types).
-                    intersection(os.environ))
-        config.update({key: os.environ[key] for key in env_keys})
+        if use_env:
+            env_keys = (set(config).union(known_config_types).
+                        intersection(os.environ))
+            config.update({key: os.environ[key] for key in env_keys})
         return config
     elif raise_error is True and key not in config:
-        meth_1 = 'os.environ["%s"] = VALUE' % key
-        meth_2 = 'mne.utils.set_config("%s", VALUE, set_env=True)' % key
-        raise KeyError('Key "%s" not found in environment or in the '
-                       'mne-python config file: %s '
-                       'Try either:'
-                       ' %s for a temporary solution, or:'
-                       ' %s for a permanent one. You can also '
-                       'set the environment variable before '
-                       'running python.'
-                       % (key, config_path, meth_1, meth_2))
+        loc_env = 'the environment or in the ' if use_env else ''
+        meth_env = ('either os.environ["%s"] = VALUE for a temporary '
+                    'solution, or ' % key) if use_env else ''
+        extra_env = (' You can also set the environment variable before '
+                     'running python.' if use_env else '')
+        meth_file = ('mne.utils.set_config("%s", VALUE, set_env=True) '
+                     'for a permanent one' % key)
+        raise KeyError('Key "%s" not found in %s'
+                       'the mne-python config file (%s). '
+                       'Try %s%s.%s'
+                       % (key, loc_env, config_path, meth_env, meth_file,
+                          extra_env))
     else:
         return config.get(key, default)
 

--- a/mne/utils/tests/test_fetching.py
+++ b/mne/utils/tests/test_fetching.py
@@ -3,27 +3,26 @@ import os.path as op
 
 import pytest
 
-from mne.utils import _fetch_file, ArgvSetter, requires_good_network
+from mne.utils import _fetch_file, requires_good_network
 
 
 @requires_good_network
-@pytest.mark.parametrize('url', ('http://google.com',))
+@pytest.mark.parametrize('url', ('https://www.github.com',))
 def test_fetch_file(url, tmpdir):
     """Test URL retrieval."""
     tempdir = str(tmpdir)
-    with ArgvSetter(disable_stderr=False):  # to capture stdout
-        archive_name = op.join(tempdir, "download_test")
-        _fetch_file(url, archive_name, timeout=30., verbose=False,
-                    resume=False)
-        pytest.raises(Exception, _fetch_file, 'NOT_AN_ADDRESS',
-                      op.join(tempdir, 'test'), verbose=False)
-        resume_name = op.join(tempdir, "download_resume")
-        # touch file
-        with open(resume_name + '.part', 'w'):
-            os.utime(resume_name + '.part', None)
-        _fetch_file(url, resume_name, resume=True, timeout=30.,
-                    verbose=False)
-        pytest.raises(ValueError, _fetch_file, url, archive_name,
-                      hash_='a', verbose=False)
-        pytest.raises(RuntimeError, _fetch_file, url, archive_name,
-                      hash_='a' * 32, verbose=False)
+    archive_name = op.join(tempdir, "download_test")
+    _fetch_file(url, archive_name, timeout=30., verbose=False,
+                resume=False)
+    pytest.raises(Exception, _fetch_file, 'NOT_AN_ADDRESS',
+                  op.join(tempdir, 'test'), verbose=False)
+    resume_name = op.join(tempdir, "download_resume")
+    # touch file
+    with open(resume_name + '.part', 'w'):
+        os.utime(resume_name + '.part', None)
+    _fetch_file(url, resume_name, resume=True, timeout=30.,
+                verbose=False)
+    pytest.raises(ValueError, _fetch_file, url, archive_name,
+                  hash_='a', verbose=False)
+    pytest.raises(RuntimeError, _fetch_file, url, archive_name,
+                  hash_='a' * 32, verbose=False)


### PR DESCRIPTION
When using `pytest-xdist` locally with `-n 2` to spawn multiple jobs, I got lots of errors because during test collection each `testing.data_path(download=False)` was trying to read/write the `mne-python.json` file simultaneously. We should really only write it if necessary, i.e. if the config value in the file does not match the new one. This PR adds that behavior.

Also fixes a small problem with `test_fetch_file` I was hitting.

This is such a minor change that shouldn't really affect end users that I don't think it's worth a `whats_new.rst` update.