### PR TITLE
[MRG] ENH: Add orthogonal power envelope correlation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ jobs:
                     if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_auditory.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.brainstorm.bst_auditory.data_path(update_path=True))" --accept-brainstorm-license;
                     fi;
+                    if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_resting.*" | wc -l) -gt 0 ]]; then
+                      python -c "import mne; print(mne.datasets.brainstorm.bst_resting.data_path(update_path=True))" --accept-brainstorm-license;
+                    fi;
                     if [[ $(cat $FNAME | grep -x ".*brainstorm.*bst_raw.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.brainstorm.bst_raw.data_path(update_path=True))" --accept-brainstorm-license;
                     fi;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -486,7 +486,7 @@ numpydoc_xref_ignore = {
     'n_parts', 'n_features_new', 'n_components', 'n_labels', 'n_events_in',
     'n_splits', 'n_scores', 'n_outputs', 'n_trials', 'n_estimators', 'n_tasks',
     'nd_features', 'n_classes', 'n_targets', 'n_slices', 'n_hpi', 'n_fids',
-    'n_elp', 'n_pts', 'n_tris',
+    'n_elp', 'n_pts', 'n_tris', 'n_nodes',
     # Undocumented (on purpose)
     'RawKIT', 'RawEximia', 'RawEGI', 'RawEEGLAB', 'RawEDF', 'RawCTF', 'RawBTi',
     'RawBrainVision',

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -624,6 +624,7 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
     auto_examples/connectivity/plot_cwt_sensor_connectivity.rst
     auto_examples/connectivity/plot_mixed_source_space_connectivity.rst
     auto_examples/connectivity/plot_mne_inverse_coherence_epochs.rst
+    auto_examples/connectivity/plot_mne_inverse_envelope_correlation.rst
     auto_examples/connectivity/plot_mne_inverse_connectivity_spectrum.rst
     auto_examples/connectivity/plot_mne_inverse_label_connectivity.rst
     auto_examples/connectivity/plot_mne_inverse_psi_visual.rst

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -793,9 +793,11 @@ Connectivity Estimation
 .. autosummary::
    :toctree: generated/
 
+   degree
+   envelope_correlation
+   phase_slope_index
    seed_target_indices
    spectral_connectivity
-   phase_slope_index
 
 
 .. _api_reference_statistics:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,8 @@ Changelog
 
 - Add data fetchers for polysomnography (PSG) recordings from Physionet (:func:`mne.datasets.sleep_physionet.age.fetch_data` and :func:`mne.datasets.sleep_physionet.temazepam.fetch_data`) by `Alex Gramfort`_ and `Joan Massich`_
 
+- Add envelope correlation code in :func:`mne.connectivity.envelope_correlation` by `Denis Engemann`_, `Sheraz Khan`_, and `Eric Larson`_
+
 - Add support for indexing, slicing, and iterating :class:`mne.Annotations` by `Joan Massich`_
 
 - :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -3,9 +3,11 @@
 Compute envelope correlations in source space
 =============================================
 
-Compute envelope correlations of orthogonalized activity [1]_ in source space
-using resting state CTF data.
+Compute envelope correlations of orthogonalized activity [1]_ [2]_ in source
+space using resting state CTF data.
 """
+# sphinx_gallery_thumbnail_number = 2
+
 # Authors: Eric Larson <larson.eric.d@gmail.com>
 #          Sheraz Khan <sheraz@khansheraz.com>
 #          Denis Engemann <denis.engemann@gmail.com>
@@ -98,3 +100,6 @@ brain = stc.plot(
 # .. [1] Hipp JF, Hawellek DJ, Corbetta M, Siegel M, Engel AK (2012)
 #        Large-scale cortical correlation structure of spontaneous
 #        oscillatory activity. Nature Neuroscience 15:884–890
+# .. [2] Khan S et al. (2018). Maturation trajectories of cortical
+#        resting-state networks depend on the mediating frequency band.
+#        Neuroimage 174:57–68

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -1,0 +1,85 @@
+"""
+=============================================
+Compute envelope correlations in source space
+=============================================
+
+Compute orthogonal envelope correlations of activity in source space
+using resting state CTF data.
+"""
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Sheraz Khan <sheraz@khansheraz.com>
+#          Denis Engemann <denis.engemann@gmail.com>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+
+import mne
+from mne.connectivity import envelope_correlation
+from mne.datasets import fetch_aparc_sub_parcellation
+from mne.minimum_norm import make_inverse_operator, apply_inverse_epochs
+from mne.preprocessing import compute_proj_ecg, compute_proj_eog
+
+data_path = mne.datasets.brainstorm.bst_resting.data_path()
+subjects_dir = op.join(data_path, 'subjects')
+subject = 'bst_resting'
+trans = op.join(data_path, 'MEG', 'bst_resting', 'bst_resting-trans.fif')
+src = op.join(subjects_dir, subject, 'bem', subject + '-oct-6-src.fif')
+bem = op.join(subjects_dir, subject, 'bem', subject + '-5120-bem-sol.fif')
+erm_fname = op.join(data_path, 'MEG', 'bst_resting',
+                    'subj002_noise_20111104_02.ds')
+raw_fname = op.join(data_path, 'MEG', 'bst_resting',
+                    'subj002_spontaneous_20111102_01_AUX.ds')
+
+##############################################################################
+# Here we do some things in the name of speed, such as crop (which will
+# hurt SNR) and downsample. Then we compute SSP projectors and apply them.
+
+raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
+raw.crop(0, 60).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.apply_gradient_compensation(3)
+projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
+projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')
+raw.info['projs'] += projs_ecg
+raw.info['projs'] += projs_eog
+raw.apply_proj()
+cov = mne.compute_raw_covariance(raw)  # compute before band-pass of interest
+
+##############################################################################
+# Now we band-pass filter our data and create epochs.
+
+raw.filter(14, 30, n_jobs='cuda')
+events = mne.make_fixed_length_events(raw, duration=5.)
+epochs = mne.Epochs(raw, events=events, tmin=0, tmax=5.,
+                    baseline=None, reject=None, preload=True)
+del raw
+
+##############################################################################
+# Compute the forward and inverse
+
+src = mne.read_source_spaces(src)
+fwd = mne.make_forward_solution(epochs.info, trans, src, bem)
+inv = make_inverse_operator(epochs.info, fwd, cov)
+
+##############################################################################
+# Compute activity in labels and envelope correlation
+fetch_aparc_sub_parcellation(subjects_dir=subjects_dir)
+labels = mne.read_labels_from_annot('fsaverage', 'aparc_sub',
+                                    subjects_dir=subjects_dir)
+labels = mne.morph_labels(labels, subject, subjects_dir=subjects_dir)
+stcs = apply_inverse_epochs(epochs, inv, lambda2=1. / 9., pick_ori='normal')
+label_ts = mne.extract_label_time_course(
+    stcs, labels, inv['src'], return_generator=True)
+corr = envelope_correlation(label_ts)
+
+##############################################################################
+# Compute the degree and plot it
+
+degree = mne.connectivity.degree(corr, 0.15)
+stc = mne.labels_to_stc(labels, degree)
+stc = stc.in_label(mne.Label(src[0]['vertno'], hemi='lh') +
+                   mne.Label(src[1]['vertno'], hemi='rh'))
+brain = stc.plot(
+    clim=dict(kind='percent', lims=[75, 85, 95]),
+    subjects_dir=subjects_dir, views='dorsal', hemi='both',
+    smoothing_steps=25, time_label='Beta band')

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -33,7 +33,7 @@ raw_fname = op.join(data_path, 'MEG', 'bst_resting',
 # hurt SNR) and downsample. Then we compute SSP projectors and apply them.
 
 raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
-raw.crop(0, 120).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.crop(0, 60).load_data().pick_types(meg=True, eeg=False).resample(80)
 raw.apply_gradient_compensation(3)
 projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
 projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -3,7 +3,7 @@
 Compute envelope correlations in source space
 =============================================
 
-Compute orthogonal envelope correlations of activity in source space
+Compute envelope correlations of orthogonalized activity [1]_ in source space
 using resting state CTF data.
 """
 # Authors: Eric Larson <larson.eric.d@gmail.com>
@@ -91,3 +91,10 @@ brain = stc.plot(
     clim=dict(kind='percent', lims=[75, 85, 95]), colormap='gnuplot',
     subjects_dir=subjects_dir, views='dorsal', hemi='both',
     smoothing_steps=25, time_label='Beta band')
+
+##############################################################################
+# References
+# ----------
+# .. [1] Hipp JF, Hawellek DJ, Corbetta M, Siegel M, Engel AK (2012)
+#        Large-scale cortical correlation structure of spontaneous
+#        oscillatory activity. Nature Neuroscience 15:884–890

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -16,7 +16,6 @@ import os.path as op
 
 import mne
 from mne.connectivity import envelope_correlation
-from mne.datasets import fetch_aparc_sub_parcellation
 from mne.minimum_norm import make_inverse_operator, apply_inverse_epochs
 from mne.preprocessing import compute_proj_ecg, compute_proj_eog
 
@@ -26,8 +25,6 @@ subject = 'bst_resting'
 trans = op.join(data_path, 'MEG', 'bst_resting', 'bst_resting-trans.fif')
 src = op.join(subjects_dir, subject, 'bem', subject + '-oct-6-src.fif')
 bem = op.join(subjects_dir, subject, 'bem', subject + '-5120-bem-sol.fif')
-erm_fname = op.join(data_path, 'MEG', 'bst_resting',
-                    'subj002_noise_20111104_02.ds')
 raw_fname = op.join(data_path, 'MEG', 'bst_resting',
                     'subj002_spontaneous_20111102_01_AUX.ds')
 
@@ -36,7 +33,7 @@ raw_fname = op.join(data_path, 'MEG', 'bst_resting',
 # hurt SNR) and downsample. Then we compute SSP projectors and apply them.
 
 raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
-raw.crop(0, 60).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.crop(0, 120).load_data().pick_types(meg=True, eeg=False).resample(80)
 raw.apply_gradient_compensation(3)
 projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
 projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')
@@ -51,22 +48,23 @@ cov = mne.compute_raw_covariance(raw)  # compute before band-pass of interest
 raw.filter(14, 30, n_jobs='cuda')
 events = mne.make_fixed_length_events(raw, duration=5.)
 epochs = mne.Epochs(raw, events=events, tmin=0, tmax=5.,
-                    baseline=None, reject=None, preload=True)
+                    baseline=None, reject=dict(mag=8e-13), preload=True)
 del raw
 
 ##############################################################################
 # Compute the forward and inverse
+# -------------------------------
 
 src = mne.read_source_spaces(src)
 fwd = mne.make_forward_solution(epochs.info, trans, src, bem)
 inv = make_inverse_operator(epochs.info, fwd, cov)
 
 ##############################################################################
-# Compute activity in labels and envelope correlation
-fetch_aparc_sub_parcellation(subjects_dir=subjects_dir)
-labels = mne.read_labels_from_annot('fsaverage', 'aparc_sub',
+# Compute label time series and do envelope correlation
+# -----------------------------------------------------
+
+labels = mne.read_labels_from_annot(subject, 'aparc_sub',
                                     subjects_dir=subjects_dir)
-labels = mne.morph_labels(labels, subject, subjects_dir=subjects_dir)
 stcs = apply_inverse_epochs(epochs, inv, lambda2=1. / 9., pick_ori='normal')
 label_ts = mne.extract_label_time_course(
     stcs, labels, inv['src'], return_generator=True)
@@ -74,6 +72,7 @@ corr = envelope_correlation(label_ts)
 
 ##############################################################################
 # Compute the degree and plot it
+# ------------------------------
 
 degree = mne.connectivity.degree(corr, 0.15)
 stc = mne.labels_to_stc(labels, degree)

--- a/examples/inverse/plot_label_source_activations.py
+++ b/examples/inverse/plot_label_source_activations.py
@@ -44,20 +44,18 @@ stc = apply_inverse(evoked, inverse_operator, lambda2, method,
 label = mne.read_label(label_fname)
 
 stc_label = stc.in_label(label)
-mean = stc.extract_label_time_course(label, src, mode='mean')
-mean_flip = stc.extract_label_time_course(label, src, mode='mean_flip')
-pca = stc.extract_label_time_course(label, src, mode='pca_flip')
-
+modes = ('mean', 'mean_flip', 'pca_flip')
+tcs = dict()
+for mode in modes:
+    tcs[mode] = stc.extract_label_time_course(label, src, mode=mode)
 print("Number of vertices : %d" % len(stc_label.data))
 
 # View source activations
-plt.figure()
-plt.plot(1e3 * stc_label.times, stc_label.data.T, 'k', linewidth=0.5)
-h0, = plt.plot(1e3 * stc_label.times, mean.T, 'r', linewidth=3)
-h1, = plt.plot(1e3 * stc_label.times, mean_flip.T, 'g', linewidth=3)
-h2, = plt.plot(1e3 * stc_label.times, pca.T, 'b', linewidth=3)
-plt.legend([h0, h1, h2], ['mean', 'mean flip', 'PCA flip'])
-plt.xlabel('Time (ms)')
-plt.ylabel('Source amplitude')
-plt.title('Activations in Label : %s' % label)
-plt.show()
+fig, ax = plt.subplots(1)
+t = 1e3 * stc_label.times
+ax.plot(t, stc_label.data.T, 'k', linewidth=0.5)
+for mode, tc in tcs.items():
+    ax.plot(t, tc[0], linewidth=3, label=str(mode))
+ax.legend(loc='upper right')
+ax.set(xlabel='Time (ms)', ylabel='Source amplitude',
+       title='Activations in Label : %s' % label)

--- a/mne/connectivity/__init__.py
+++ b/mne/connectivity/__init__.py
@@ -1,5 +1,7 @@
 """Spectral and effective connectivity measures."""
 
-from .utils import seed_target_indices
+from .utils import seed_target_indices, degree
 from .spectral import spectral_connectivity
 from .effective import phase_slope_index
+from .envelope import envelope_correlation
+

--- a/mne/connectivity/__init__.py
+++ b/mne/connectivity/__init__.py
@@ -4,4 +4,3 @@ from .utils import seed_target_indices, degree
 from .spectral import spectral_connectivity
 from .effective import phase_slope_index
 from .envelope import envelope_correlation
-

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -29,8 +29,14 @@ def envelope_correlation(data):
 
     Notes
     -----
-    This function computes the orthogonal envelope correlation between
-    time series.
+    This function computes the power envelope correlation between
+    orthogonalized signals [1]_.
+
+    References
+    ----------
+    .. [1] Hipp JF, Hawellek DJ, Corbetta M, Siegel M, Engel AK (2012)
+           Large-scale cortical correlation structure of spontaneous
+           oscillatory activity. Nature Neuroscience 15:884–890
     """
     from scipy.signal import hilbert
     corrs = list()

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -25,6 +25,7 @@ def envelope_correlation(data):
     -------
     corr : ndarray, shape (n_nodes, n_nodes)
         The pairwise orthogonal envelope correlations.
+        This matrix is symmetric.
 
     Notes
     -----
@@ -65,6 +66,7 @@ def envelope_correlation(data):
         corr = np.einsum('it,ijt->ij', data_mag, data_orth)
         corr /= np.sqrt(data_mag_var)
         corr /= np.sqrt(data_orth_var)
+        # we always make the matrix symmetric
         corr = np.abs(corr)
         corrs.append((corr.T + corr) / 2.)
     corr = np.median(corrs, axis=0)

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -60,14 +60,14 @@ def envelope_correlation(data):
         data_mag -= np.mean(data_mag, axis=-1, keepdims=True)
         data_orth -= np.mean(data_orth, axis=-1, keepdims=True)
         # compute variances using dot products
-        data_mag_var = np.sum(data_mag * data_mag, axis=-1, keepdims=True)
-        data_orth_var = np.einsum('ijt,ijt->ij', data_orth, data_orth)
+        data_mag_var = np.linalg.norm(data_mag, axis=-1)[:, np.newaxis]
+        data_orth_var = np.linalg.norm(data_orth, axis=-1)
         # correlation is dot product divided by variances
         corr = np.einsum('it,ijt->ij', data_mag, data_orth)
         corr /= np.sqrt(data_mag_var)
         corr /= np.sqrt(data_orth_var)
         # we always make the matrix symmetric
-        corr = np.abs(corr)
+        np.abs(corr, out=corr)
         corrs.append((corr.T + corr) / 2.)
     corr = np.median(corrs, axis=0)
     return corr

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -1,0 +1,71 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Sheraz Khan <sheraz@khansheraz.com>
+#          Denis Engemann <denis.engemann@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from ..filter import next_fast_len
+
+
+def envelope_correlation(data):
+    """Compute the envelope correlation.
+
+    Parameters
+    ----------
+    data : array-like, shape=(n_epochs, n_signals, n_times) | generator
+        The data from which to compute connectivity.
+        The array-like object can also be a list/generator of array,
+        each with shape (n_signals, n_times). If it's float data,
+        the Hilbert transform will be applied; if it's complex data,
+        it's assumed the Hilbert has already been applied.
+
+    Returns
+    -------
+    corr : ndarray, shape (n_nodes, n_nodes)
+        The pairwise orthogonal envelope correlations.
+
+    Notes
+    -----
+    This function computes the orthogonal envelope correlation between
+    time series.
+    """
+    from scipy.signal import hilbert
+    corrs = list()
+    n_nodes = None
+    for data_ in data:
+        if data_.ndim != 2:
+            raise ValueError('Each entry in data must be 2D, got shape %s'
+                             % (data_.shape,))
+        this_n_nodes, n_times = data_.shape
+        if n_nodes is None:
+            n_nodes = this_n_nodes
+        if this_n_nodes != n_nodes:
+            raise ValueError('n_nodes mismatch between epochs, got %s and %s'
+                             % (n_nodes, this_n_nodes))
+        # Get the complex envelope (allowing complex inputs allows people
+        # to do raw.apply_hilbert if they want)
+        if data_.dtype in (np.float32, np.float64):
+            n_fft = next_fast_len(n_times)
+            data_ = hilbert(data_, N=n_fft, axis=-1)[..., :n_times]
+        if data_.dtype not in (np.complex64, np.complex128):
+            raise ValueError('data.dtype must be float or complex, got %s'
+                             % (data_.dtype,))
+        data_mag = np.abs(data_)
+        data_orth = np.einsum('it,jt->ijt', data_,
+                              data_.conj() / data_mag).imag
+        # subtract means
+        data_mag -= np.mean(data_mag, axis=-1, keepdims=True)
+        data_orth -= np.mean(data_orth, axis=-1, keepdims=True)
+        # compute variances using dot products
+        data_mag_var = np.sum(data_mag * data_mag, axis=-1, keepdims=True)
+        data_orth_var = np.einsum('ijt,ijt->ij', data_orth, data_orth)
+        # correlation is dot product divided by variances
+        corr = np.einsum('it,ijt->ij', data_mag, data_orth)
+        corr /= np.sqrt(data_mag_var)
+        corr /= np.sqrt(data_orth_var)
+        corr = np.abs(corr)
+        corrs.append((corr.T + corr) / 2.)
+    corr = np.median(corrs, axis=0)
+    return corr

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -30,13 +30,16 @@ def envelope_correlation(data):
     Notes
     -----
     This function computes the power envelope correlation between
-    orthogonalized signals [1]_.
+    orthogonalized signals [1]_ [2]_.
 
     References
     ----------
     .. [1] Hipp JF, Hawellek DJ, Corbetta M, Siegel M, Engel AK (2012)
            Large-scale cortical correlation structure of spontaneous
            oscillatory activity. Nature Neuroscience 15:884–890
+    .. [2] Khan S et al. (2018). Maturation trajectories of cortical
+           resting-state networks depend on the mediating frequency band.
+           Neuroimage 174:57–68
     """
     from scipy.signal import hilbert
     corrs = list()

--- a/mne/connectivity/tests/test_envelope.py
+++ b/mne/connectivity/tests/test_envelope.py
@@ -1,3 +1,9 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Sheraz Khan <sheraz@khansheraz.com>
+#          Denis Engemann <denis.engemann@gmail.com>
+#
+# License: BSD (3-clause)
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/mne/connectivity/tests/test_envelope.py
+++ b/mne/connectivity/tests/test_envelope.py
@@ -1,0 +1,48 @@
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+from scipy.signal import hilbert
+
+from mne.connectivity import envelope_correlation
+
+
+def _compute_corrs_orig(data):
+    # This is the version of the code by Sheraz and Denis.
+    # For this version (epochs, labels, time) must be -> (labels, time, epochs)
+    data = np.transpose(data, (1, 2, 0))
+    corr_mats = np.empty((data.shape[0], data.shape[0], data.shape[2]))
+    for index, label_data in enumerate(data):
+        label_data_orth = np.imag(label_data * (data.conj() / np.abs(data)))
+        label_data_orig = np.abs(label_data)
+        label_data_cont = np.transpose(
+            np.dstack((label_data_orig, np.transpose(label_data_orth,
+                                                     (1, 2, 0)))), (1, 2, 0))
+        corr_mats[index] = np.array([np.corrcoef(dat)
+                                     for dat in label_data_cont])[:, 0, 1:].T
+    corr_mats = np.transpose(corr_mats, (2, 0, 1))
+    corr = np.median(np.array([(np.abs(corr_mat) + np.abs(corr_mat).T) / 2.
+                               for corr_mat in corr_mats]), axis=0)
+    return corr
+
+
+def test_envelope_correlation():
+    """Test the envelope correlation function."""
+    rng = np.random.RandomState(0)
+    data = rng.randn(2, 4, 64)
+    data_hilbert = hilbert(data, axis=-1)
+    corr_orig = _compute_corrs_orig(data_hilbert)
+    assert (0 < corr_orig).all()
+    assert (corr_orig < 1).all()
+    # using complex data
+    corr = envelope_correlation(data_hilbert)
+    assert_allclose(corr, corr_orig)
+    # do Hilbert internally
+    corr = envelope_correlation(data)
+    assert_allclose(corr, corr_orig)
+    # degenerate
+    with pytest.raises(ValueError, match='float'):
+        envelope_correlation(data.astype(int))
+    with pytest.raises(ValueError, match='entry in data must be 2D'):
+        envelope_correlation(data[np.newaxis])
+    with pytest.raises(ValueError, match='n_nodes mismatch'):
+        envelope_correlation([rng.randn(2, 8), rng.randn(3, 8)])

--- a/mne/connectivity/tests/test_envelope.py
+++ b/mne/connectivity/tests/test_envelope.py
@@ -42,8 +42,10 @@ def test_envelope_correlation():
     # using complex data
     corr = envelope_correlation(data_hilbert)
     assert_allclose(corr, corr_orig)
-    # do Hilbert internally
-    corr = envelope_correlation(data)
+    # do Hilbert internally, and don't combine
+    corr = envelope_correlation(data, combine=None)
+    assert corr.shape == (data.shape[0],) + corr_orig.shape
+    corr = np.median(corr, axis=0)
     assert_allclose(corr, corr_orig)
     # degenerate
     with pytest.raises(ValueError, match='float'):
@@ -52,3 +54,7 @@ def test_envelope_correlation():
         envelope_correlation(data[np.newaxis])
     with pytest.raises(ValueError, match='n_nodes mismatch'):
         envelope_correlation([rng.randn(2, 8), rng.randn(3, 8)])
+    with pytest.raises(TypeError, match='instance of str or None'):
+        envelope_correlation(data, 1.)
+    with pytest.raises(ValueError, match='Unknown combine option'):
+        envelope_correlation(data, 'foo')

--- a/mne/connectivity/tests/test_utils.py
+++ b/mne/connectivity/tests/test_utils.py
@@ -39,9 +39,12 @@ def test_degree():
                      [0.2, 0.8, 0.9]])
     deg = degree(corr, 1)
     assert_array_equal(deg, [2, 2, 2])
-    # wanted values obtained with:
-    # import bct
-    # want = bct.degrees_und(bct.utils.threshold_proportional(corr, 0.25) > 0)
+
+    # The values for assert_array_equal below were obtained with:
+    #
+    # >>> import bct
+    # >>> bct.degrees_und(bct.utils.threshold_proportional(corr, 0.25) > 0)
+    #
     # But they can also be figured out just from the structure.
 
     # Asymmetric (6 usable nodes)

--- a/mne/connectivity/tests/test_utils.py
+++ b/mne/connectivity/tests/test_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
 
-from mne.connectivity import seed_target_indices
+from mne.connectivity import seed_target_indices, degree
 
 
 def test_indices():
@@ -21,3 +23,31 @@ def test_indices():
                 assert np.sum(indices[0] == seed) == n_targets
             for target in targets:
                 assert np.sum(indices[1] == target) == n_seeds
+
+
+def test_degree():
+    """Test degree function."""
+    # degenerate conditions
+    with pytest.raises(ValueError, match='threshold'):
+        degree(np.eye(3), 2.)
+    # a simple one
+    corr = np.eye(10)
+    assert_array_equal(degree(corr), np.zeros(10))
+    # more interesting
+    corr = np.array([[0.5, 0.7, 0.4],
+                     [0.1, 0.3, 0.6],
+                     [0.2, 0.8, 0.9]])
+    deg = degree(corr, 1)
+    assert_array_equal(deg, np.full(3, 2))
+    # wanted values obtained with:
+    # import bct
+    # want = bct.degrees_und(bct.utils.threshold_proportional(corr, 0.25) > 0)
+    # But they can also be figured out just from the structure.
+
+    # Asymmetric (6 usable nodes)
+    assert_array_equal(degree(corr, 0.33), [0, 2, 0])
+    assert_array_equal(degree(corr, 0.5), [0, 2, 1])
+    # Symmetric (3 usable nodes)
+    corr = (corr + corr.T) / 2.
+    assert_array_equal(degree(corr, 0.33), [0, 1, 1])
+    assert_array_equal(degree(corr, 0.66), [1, 2, 1])

--- a/mne/connectivity/tests/test_utils.py
+++ b/mne/connectivity/tests/test_utils.py
@@ -38,7 +38,7 @@ def test_degree():
                      [0.1, 0.3, 0.6],
                      [0.2, 0.8, 0.9]])
     deg = degree(corr, 1)
-    assert_array_equal(deg, np.full(3, 2))
+    assert_array_equal(deg, [2, 2, 2])
     # wanted values obtained with:
     # import bct
     # want = bct.degrees_und(bct.utils.threshold_proportional(corr, 0.25) > 0)

--- a/mne/connectivity/utils.py
+++ b/mne/connectivity/utils.py
@@ -59,20 +59,33 @@ def degree(connectivity, threshold=1.):
     -------
     degree : ndarray, shape (n_nodes,)
         The computed degree.
+
+    Notes
+    -----
+    During thresholding, the symmetry of the connectivity matrix is
+    auto-detected based on :func:`numpy.allclose` of it with its transpose.
     """
     connectivity = np.array(connectivity)
-    threshold = float(threshold)
-    if not 0 < threshold <= 1:
-        raise ValueError('threshold must be 0 <= threshold < 1, got %s'
-                         % (threshold,))
     if connectivity.ndim != 2 or \
             connectivity.shape[0] != connectivity.shape[1]:
         raise ValueError('connectivity must be have shape (n_nodes, n_nodes), '
                          'got %s' % (connectivity.shape,))
+    n_nodes = len(connectivity)
+    if np.allclose(connectivity, connectivity.T):
+        split = 2.
+        connectivity[np.tril_indices(n_nodes)] = 0
+    else:
+        split = 1.
+    threshold = float(threshold)
+    if not 0 < threshold <= 1:
+        raise ValueError('threshold must be 0 <= threshold < 1, got %s'
+                         % (threshold,))
     degree = connectivity.ravel()  # no need to copy because np.array does
-    degree[::connectivity.shape[0] + 1] = 0
-    n_keep = int(round((degree.size - len(connectivity)) * threshold))
+    degree[::n_nodes + 1] = 0.
+    n_keep = int(round((degree.size - len(connectivity)) * threshold / split))
     degree[np.argsort(degree)[:-n_keep]] = 0
     degree.shape = connectivity.shape
+    if split == 2:
+        degree += degree.T  # normally unsafe, but we know where our zeros are
     degree = np.sum(degree > 0, axis=0)
     return degree

--- a/mne/connectivity/utils.py
+++ b/mne/connectivity/utils.py
@@ -42,3 +42,37 @@ def seed_target_indices(seeds, targets):
                np.tile(targets, n_seeds))
 
     return indices
+
+
+def degree(connectivity, threshold=1.):
+    """Compute the undirected degree of a connectivity matrix.
+
+    Parameters
+    ----------
+    connectivity : ndarray, shape (n_nodes, n_nodes)
+        The connectivity matrix.
+    threshold : float
+        The proportion of activations to keep before computing
+        the degree.
+
+    Returns
+    -------
+    degree : ndarray, shape (n_nodes,)
+        The computed degree.
+    """
+    connectivity = np.array(connectivity)
+    threshold = float(threshold)
+    if not 0 < threshold <= 1:
+        raise ValueError('threshold must be 0 <= threshold < 1, got %s'
+                         % (threshold,))
+    if connectivity.ndim != 2 or \
+            connectivity.shape[0] != connectivity.shape[1]:
+        raise ValueError('connectivity must be have shape (n_nodes, n_nodes), '
+                         'got %s' % (connectivity.shape,))
+    degree = connectivity.ravel()  # no need to copy because np.array does
+    degree[::connectivity.shape[0] + 1] = 0
+    n_keep = int(round((degree.size - len(connectivity)) * threshold))
+    degree[np.argsort(degree)[:-n_keep]] = 0
+    degree.shape = connectivity.shape
+    degree = np.sum(degree > 0, axis=0)
+    return degree

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -570,9 +570,7 @@ def _download_all_example_data(verbose=True):
     try:
         brainstorm.bst_raw.data_path()
         brainstorm.bst_auditory.data_path()
-        # not currently used; remember to add entry to .circleci/config.yml if
-        # we ever do use it
-        # brainstorm.bst_resting.data_path()
+        brainstorm.bst_resting.data_path()
         brainstorm.bst_phantom_elekta.data_path()
         brainstorm.bst_phantom_ctf.data_path()
     finally:

--- a/mne/io/ctf_comp.py
+++ b/mne/io/ctf_comp.py
@@ -14,7 +14,7 @@ from .tree import dir_tree_find
 from .write import start_block, end_block, write_int
 from .matrix import write_named_matrix, _read_named_matrix
 
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _pl
 
 
 def _add_kind(one):
@@ -41,7 +41,8 @@ def _calibrate_comp(comp, chs, row_names, col_names,
             p = ch_names.count(names[ii])
             if p != 1:
                 raise RuntimeError('Channel %s does not appear exactly once '
-                                   'in data' % names[ii])
+                                   'in data, found %d instance%s'
+                                   % (names[ii], p, _pl(p)))
             idx = ch_names.index(names[ii])
             val = chs[idx][mult_keys[0]] * chs[idx][mult_keys[1]]
             val = float(1. / val) if inv else float(val)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2647,25 +2647,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
 
     This function will extract one time course for each label and source
     estimate. The way the time courses are extracted depends on the mode
-    parameter.
-
-    Valid values for mode are:
-
-        - 'mean': Average within each label.
-        - 'mean_flip': Average within each label with sign flip depending
-          on source orientation.
-        - 'pca_flip': Apply an SVD to the time courses within each label
-          and use the scaled and sign-flipped first right-singular vector
-          as the label time course. The scaling is performed such that the
-          power of the label time course is the same as the average
-          per-vertex time course power within the label. The sign of the
-          resulting time course is adjusted by multiplying it with
-          "sign(dot(u, flip))" where u is the first left-singular vector,
-          and flip is a sing-flip vector based on the vertex normals. This
-          procedure assures that the phase does not randomly change by 180
-          degrees from one stc to the next.
-        - 'max': Max value within each label.
-
+    parameter (see Notes).
 
     Parameters
     ----------
@@ -2690,6 +2672,30 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
     -------
     label_tc : array | list (or generator) of array, shape (n_labels, n_times)
         Extracted time course for each label and source estimate.
+
+    Notes
+    -----
+    Valid values for mode are:
+
+    ``'mean'``
+        Average within each label.
+    ``'mean_flip'``
+        Average within each label with sign flip depending
+        on source orientation.
+    ``'pca_flip'``
+        Apply an SVD to the time courses within each label
+        and use the scaled and sign-flipped first right-singular vector
+        as the label time course. The scaling is performed such that the
+        power of the label time course is the same as the average
+        per-vertex time course power within the label. The sign of the
+        resulting time course is adjusted by multiplying it with
+        "sign(dot(u, flip))" where u is the first left-singular vector,
+        and flip is a sing-flip vector based on the vertex normals. This
+        procedure assures that the phase does not randomly change by 180
+        degrees from one stc to the next.
+    ``'max'``
+        Max value within each label.
+
     """
     # convert inputs to lists
     if isinstance(stcs, SourceEstimate):

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -538,7 +538,8 @@ def test_extract_label_time_course():
     for mode in modes:
         label_tc = extract_label_time_course(stcs, labels, src, mode=mode)
         label_tc_method = [stc.extract_label_time_course(labels, src,
-                           mode=mode) for stc in stcs]
+                                                         mode=mode)
+                           for stc in stcs]
         assert (len(label_tc) == n_stcs)
         assert (len(label_tc_method) == n_stcs)
         for tc1, tc2 in zip(label_tc, label_tc_method):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -316,12 +316,22 @@ def _validate_type(item, types=None, item_name=None, type_name=None):
         from mne.io import Info as types
         type_name = "Info" if type_name is None else type_name
         item_name = "Info" if item_name is None else item_name
+    if not isinstance(types, (list, tuple)):
+        types = [types]
 
-    if type_name is None:
-        iter_types = ([types] if not isinstance(types, (list, tuple))
-                      else types)
-        type_name = ', '.join(cls.__name__ for cls in iter_types)
-    if not isinstance(item, types):
+    check_types = tuple(type(None) if type_ is None else type_
+                        for type_ in types)
+    if not isinstance(item, check_types):
+        if type_name is None:
+            type_name = ['None' if cls_ is None else cls_.__name__
+                         for cls_ in types]
+            if len(type_name) == 1:
+                type_name = type_name[0]
+            elif len(type_name) == 2:
+                type_name = ' or '.join(type_name)
+            else:
+                type_name[-1] = 'or ' + type_name[-1]
+                type_name = ', '.join(type_name)
         raise TypeError('%s must be an instance of %s, got %s instead'
                         % (item_name, type_name, type(item),))
 


### PR DESCRIPTION
Adds orthogonal envelope correlation code. Still needs:

- [x] add tests for new functions (e.g., random matrix equiv to @SherazKhan's calculations for orth corr?)
- [x] fix memory problems
- [x] check example works on CircleCI
- [x] add ref to Hipp 2012, Khan 2018
- [x] add reduction argument and allow returning single-epoch matrices

Closes #5389.

Next PR:

- [ ] more methods (don't orth?)
- [ ] add `n_jobs`
- [ ] add `logger` output

Also cleans up a flake8 error in `test_source_estimate.py`, a docstring in `source_estimate.py`, and simplifies `plot_label_source_activations.py`. (I changed these while adding a new `mode` to `extract_label_time_course` which I eventually did not need, but they're nice things to have anyway.