### PR TITLE
MRG+2: Revise install docs

### DIFF
--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -9,8 +9,8 @@ Advanced setup of MNE-Python
    :local:
    :depth: 1
 
-IPython / Jupyter notebooks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using MNE-Python with IPython / Jupyter notebooks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When using MNE-Python within IPython or a Jupyter notebook, we strongly
 recommend using the Qt matplotlib backend for fast and correct rendering. On
@@ -114,8 +114,8 @@ updated to have the latest changes.
 If you plan to contribute to MNE-Python, please continue reading how to
 :doc:`contribute to MNE-Python <contributing>`.
 
-Using other Python distributions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using MNE-Python with other Python distributions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While the `Anaconda`_ Python distribution provides many conveniences, other
 distributions of Python should also work with MNE-Python.  In particular,
@@ -171,8 +171,8 @@ that state that they allow passing ``n_jobs='cuda'``, such as
 and they should run faster than the CPU-based multithreading such as
 ``n_jobs=8``.
 
-Off-screen rendering on Linux with MESA
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Off-screen rendering in MNE-Python on Linux with MESA
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On remote systems, it might be possible to use MESA software rendering
 (such as ``llvmpipe`` or ``swr``) for 3D visualization (with some tweaks).
@@ -187,8 +187,8 @@ to force MESA to use modern OpenGL by using this before executing
 Also, it's possible that different software rending backends might perform
 better than others, such as using the ``llvmpipe`` backend rather than ``swr``.
 
-Troubleshooting 3D plots
-^^^^^^^^^^^^^^^^^^^^^^^^
+Troubleshooting 3D plots in MNE-Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you run into trouble when visualizing source estimates (or anything else
 using mayavi), you can try setting a couple of environment variables at the

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -98,8 +98,18 @@ the latest version of the ``master`` development branch, you can do:
 
    $ git pull origin master
 
-from within the mne-python source folder, and MNE will be automatically updated
-to have the latest changes.
+from within the ``mne-python`` source folder, and MNE will be automatically
+updated to have the latest changes.
+
+.. note::
+
+    When using the `environment file`_ to install with Anaconda or Miniconda,
+    the name of the environment (``mne``) is built into the environment file
+    itself, but can be changed on the command line with the ``-n`` flag. This
+    can be helpful when maintaining separate environments for stable and
+    development versions of MNE-python, or when using the environment file as a
+    starting point for new projects.  See ``conda env create --help`` for more
+    info.
 
 If you plan to contribute to MNE-python, please continue reading how to
 :doc:`contribute to MNE-python <contributing>`.

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -104,8 +104,6 @@ to have the latest changes.
 If you plan to contribute to MNE-python, please continue reading how to
 :doc:`contribute to MNE-python <contributing>`.
 
-.. _CUDA:
-
 Using other Python distributions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -129,6 +127,8 @@ the provided `requirements file`_:
 Other configurations will probably also work, but we may be unable to offer
 support if you encounter difficulties related to your particular Python
 installation choices.
+
+.. _CUDA:
 
 Using MNE-python with CUDA (NVIDIA GPU acceleration)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -106,6 +106,30 @@ If you plan to contribute to MNE-python, please continue reading how to
 
 .. _CUDA:
 
+Using other Python distributions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While the `Anaconda`_ Python distribution provides many conveniences, other
+distributions of Python should also work with MNE-python.  In particular,
+`Miniconda`_ is a lightweight alternative to Anaconda that is fully compatible;
+like Anaconda, Miniconda includes the ``conda`` command line tool for
+installing new packages and managing environments; unlike Anaconda, Miniconda
+starts off with a minimal set of around 30 packages instead of Anaconda's
+hundreds. See the `Miniconda install page <miniconda-install>`__ for more info.
+
+It is also possible to use a system-level installation of Python (version 3.5
+or higher) and use ``pip`` to install MNE-python and its dependencies, using
+the provided `requirements file`_:
+
+.. code-block:: console
+
+    curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/requirements.txt
+    pip install --user requirements.txt
+
+Other configurations will probably also work, but we may be unable to offer
+support if you encounter difficulties related to your particular Python
+installation choices.
+
 Using MNE-python with CUDA (NVIDIA GPU acceleration)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -2,7 +2,7 @@
 
 .. _advanced_setup:
 
-Advanced setup of MNE-python
+Advanced setup of MNE-Python
 ============================
 
 .. contents::
@@ -12,7 +12,7 @@ Advanced setup of MNE-python
 IPython / Jupyter notebooks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When using MNE-python within IPython or a Jupyter notebook, we strongly
+When using MNE-Python within IPython or a Jupyter notebook, we strongly
 recommend using the Qt matplotlib backend for fast and correct rendering. On
 Linux, for example, Qt is the only matplotlib backend for which 3D rendering
 will work correctly. On macOS, certain matplotlib functions might not work as
@@ -34,7 +34,7 @@ that the 3D plots will retain rich interactivity (so, for example, you can
 click-and-drag to rotate cortical surface activation maps).
 
 If you are creating a static notebook or simply prefer Jupyter's inline plot
-display, MNE-python will work with the standard "inline" magic:
+display, MNE-Python will work with the standard "inline" magic:
 
 .. code-block:: ipython
 
@@ -47,9 +47,9 @@ interactivity within the scene is limited in non-blocking plot calls.
 .. admonition:: |windows| Windows
   :class: note
 
-  If you are using MNE-python on Windows through IPython or Jupyter, you might
+  If you are using MNE-Python on Windows through IPython or Jupyter, you might
   also have to use the IPython magic command ``%gui qt`` after importing
-  MNE-python, Mayavi or PySurfer (see `here
+  MNE-Python, Mayavi or PySurfer (see `here
   <https://github.com/ipython/ipython/issues/10384>`_). For example:
 
   .. code-block:: ipython
@@ -63,11 +63,11 @@ assistance.
 
 .. _installing_master:
 
-Using the development version of MNE-python (latest master)
+Using the development version of MNE-Python (latest master)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you want access to the latest features and bugfixes, you can easily switch
-from the stable version of MNE-python to the current development version.
+from the stable version of MNE-Python to the current development version.
 
 .. warning:: In between releases, function and class APIs can change without
              warning.
@@ -79,7 +79,7 @@ environment (``conda activate mne``), and use ``pip``:
 
    $ pip install --upgrade --no-deps git+https://github.com/mne-tools/mne-python.git
 
-If you plan to contribute to MNE-python, or if you prefer to update frequently,
+If you plan to contribute to MNE-Python, or if you prefer to update frequently,
 you can use ``git`` directly (again, within the ``mne`` conda environment):
 
 .. code-block:: console
@@ -107,18 +107,18 @@ updated to have the latest changes.
     the name of the environment (``mne``) is built into the environment file
     itself, but can be changed on the command line with the ``-n`` flag. This
     can be helpful when maintaining separate environments for stable and
-    development versions of MNE-python, or when using the environment file as a
+    development versions of MNE-Python, or when using the environment file as a
     starting point for new projects.  See ``conda env create --help`` for more
     info.
 
-If you plan to contribute to MNE-python, please continue reading how to
-:doc:`contribute to MNE-python <contributing>`.
+If you plan to contribute to MNE-Python, please continue reading how to
+:doc:`contribute to MNE-Python <contributing>`.
 
 Using other Python distributions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While the `Anaconda`_ Python distribution provides many conveniences, other
-distributions of Python should also work with MNE-python.  In particular,
+distributions of Python should also work with MNE-Python.  In particular,
 `Miniconda`_ is a lightweight alternative to Anaconda that is fully compatible;
 like Anaconda, Miniconda includes the ``conda`` command line tool for
 installing new packages and managing environments; unlike Anaconda, Miniconda
@@ -126,7 +126,7 @@ starts off with a minimal set of around 30 packages instead of Anaconda's
 hundreds. See the `Miniconda install page <miniconda-install>`__ for more info.
 
 It is also possible to use a system-level installation of Python (version 3.5
-or higher) and use ``pip`` to install MNE-python and its dependencies, using
+or higher) and use ``pip`` to install MNE-Python and its dependencies, using
 the provided `requirements file`_:
 
 .. code-block:: console
@@ -140,10 +140,10 @@ installation choices.
 
 .. _CUDA:
 
-Using MNE-python with CUDA (NVIDIA GPU acceleration)
+Using MNE-Python with CUDA (NVIDIA GPU acceleration)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some operations in MNE-python can utilize `NVIDIA CUDA GPU processing`_ to
+Some operations in MNE-Python can utilize `NVIDIA CUDA GPU processing`_ to
 speed up some operations (e.g. FIR filtering) by roughly an order of magnitude.
 To use CUDA, first  ensure that you are running the `NVIDIA proprietary
 drivers`_ on your operating system, and then do:

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -1,37 +1,79 @@
-:orphan:
-
 .. include:: links.inc
 
 .. _advanced_setup:
 
-Advanced setup and troubleshooting
-----------------------------------
+Advanced setup of MNE-python
+============================
 
-.. contents:: Steps
+.. contents::
    :local:
    :depth: 1
 
+IPython / Jupyter notebooks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Jupyter, we strongly recommend using the Qt matplotlib backend for
+fast and correct rendering:
+
+.. code-block:: console
+
+    $ ipython --matplotlib=qt
+
+On Linux, for example, QT is the only matplotlib backend for which 3D rendering
+will work correctly. On macOS, certain matplotlib functions might not work as
+expected on backends other than QT.
+
+To take full advantage of MNE-python's visualization capacities in combination
+with IPython notebooks and inline displaying, please explicitly add the
+following magic method invocation to your notebook or configure your notebook
+runtime accordingly:
+
+.. code-block:: ipython
+
+    In [1]: %matplotlib inline
+
+
+.. admonition:: |windows| Windows
+  :class: note
+
+  If you are using MNE-python on Windows through IPython or Jupyter,
+  you might have to use the IPython magic command ``%gui qt`` after importing
+  MNE-python, Mayavi or PySurfer (see `here
+  <https://github.com/ipython/ipython/issues/10384>`_). For example:
+
+  .. code-block:: ipython
+
+     In [1]: from mayavi import mlab
+     In [2]: %gui qt
+
+If you use another Python setup and you encounter some difficulties please
+report them on the `MNE mailing list`_ or on the `GitHub issues page`_ to get
+assistance.
+
 .. _installing_master:
 
-Using the development version of MNE (latest master)
-####################################################
+Using the development version of MNE-python (latest master)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is possible to update your version of MNE between releases for
-bugfixes or new features.
+If you want access to the latest features and bugfixes, you can easily switch
+from the stable version of MNE-python to the current development version.
 
 .. warning:: In between releases, function and class APIs can change without
              warning.
 
-You can use ``pip`` for a one-time update:
+For a one-time update to latest master, make sure you're in the ``mne`` conda
+environment (``conda activate mne``), and use ``pip``:
 
 .. code-block:: console
 
    $ pip install --upgrade --no-deps git+https://github.com/mne-tools/mne-python.git
 
-Or, if you prefer to be set up for frequent updates, you can use ``git`` directly:
+If you plan to contribute to MNE-python, or if you prefer to update frequently,
+you can use ``git`` directly (again, within the ``mne`` conda environment):
 
 .. code-block:: console
 
+   $ cd <path_to_where_you_want_mne-python_source_code_installed>
    $ git clone git://github.com/mne-tools/mne-python.git
    $ cd mne-python
    $ python setup.py develop
@@ -45,22 +87,21 @@ the latest version of the ``master`` development branch, you can do:
 
    $ git pull origin master
 
-and MNE will be updated to have the latest changes.
+from within the mne-python source folder, and MNE will be automatically updated
+to have the latest changes.
 
-
-If you plan to contribute to MNE, please continue reading how to
-:ref:`contribute_to_mne`.
+If you plan to contribute to MNE-python, please continue reading how to
+:doc:`contribute to MNE-python <contributing>`.
 
 .. _CUDA:
 
-CUDA (NVIDIA GPU acceleration)
-##############################
+Using MNE-python with CUDA (NVIDIA GPU acceleration)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some routines can utilize
-`NVIDIA CUDA GPU processing <https://developer.nvidia.com/cuda-zone>`_
-to speed up some operations (e.g. FIR filtering) by roughly an order of magnitude.
-To use CUDA, first  ensure that you are running the NVIDIA proprietary drivers
-on your operating system, and then do:
+Some operations in MNE-python can utilize `NVIDIA CUDA GPU processing`_ to
+speed up some operations (e.g. FIR filtering) by roughly an order of magnitude.
+To use CUDA, first  ensure that you are running the `NVIDIA proprietary
+drivers`_ on your operating system, and then do:
 
 .. code-block:: console
 
@@ -69,9 +110,9 @@ on your operating system, and then do:
     Enabling CUDA with 1.55 GB available memory
 
 If you receive a message reporting the GPU's available memory, CuPy_
-is woriking properly. To permanently enable CUDA in MNE, you can do::
+is working properly. To permanently enable CUDA in MNE, you can do::
 
-    >>> mne.utils.set_config('MNE_USE_CUDA', 'true') # doctest: +SKIP
+    >>> mne.utils.set_config('MNE_USE_CUDA', 'true')  # doctest: +SKIP
 
 You can then test MNE CUDA support by running the associated test:
 
@@ -85,53 +126,12 @@ that state that they allow passing ``n_jobs='cuda'``, such as
 and they should run faster than the CPU-based multithreading such as
 ``n_jobs=8``.
 
-IPython / Jupyter notebooks
-###########################
-
-In Jupyter, we strongly recommend using the Qt matplotlib backend for
-fast and correct rendering:
-
-.. code-block:: console
-
-    $ ipython --matplotlib=qt
-
-On Linux, for example, QT is the only matplotlib backend for which 3D rendering
-will work correctly. On Mac OS X for other backends certain matplotlib
-functions might not work as expected.
-
-To take full advantage of MNE-Python's visualization capacities in combination
-with IPython notebooks and inline displaying, please explicitly add the
-following magic method invocation to your notebook or configure your notebook
-runtime accordingly:
-
-.. code-block:: ipython
-
-    In [1]: %matplotlib inline
-
-If you use another Python setup and you encounter some difficulties please
-report them on the MNE mailing list or on github to get assistance.
-
-Troubleshooting
-###############
-
-If you run into trouble when visualizing source estimates (or anything else
-using mayavi), you can try setting the ``ETS_TOOLKIT`` environment variable::
-
-    >>> import os
-    >>> os.environ['ETS_TOOLKIT'] = 'qt4'
-    >>> os.environ['QT_API'] = 'pyqt5'
-
-This will tell Traits that we will use Qt with PyQt bindings.
-
-For more information, see
-http://docs.enthought.com/mayavi/mayavi/building_applications.html.
-
 Off-screen rendering on Linux with MESA
-#######################################
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On remote systems, it might be possible to use MESA software rendering
-(such as ``llvmpipe`` or ``swr``) for 3D visualization with some tweaks.
-For example, on CentOS 7.5 you might be able to use the environment variable
+(such as ``llvmpipe`` or ``swr``) for 3D visualization (with some tweaks).
+For example, on CentOS 7.5 you might be able to use an environment variable
 to force MESA to use modern OpenGL by using this before executing
 ``spyder`` or ``python``:
 
@@ -141,3 +141,18 @@ to force MESA to use modern OpenGL by using this before executing
 
 Also, it's possible that different software rending backends might perform
 better than others, such as using the ``llvmpipe`` backend rather than ``swr``.
+
+Troubleshooting 3D plots
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you run into trouble when visualizing source estimates (or anything else
+using mayavi), you can try setting a couple of environment variables at the
+beginning of your script, session, or notebook::
+
+    >>> import os
+    >>> os.environ['ETS_TOOLKIT'] = 'qt4'
+    >>> os.environ['QT_API'] = 'pyqt5'
+
+This will tell mayavi to use Qt backend with PyQt bindings, instead of the
+default PySide. For more information, see
+http://docs.enthought.com/mayavi/mayavi/building_applications.html#integrating-in-a-qt-application.

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -123,7 +123,7 @@ distributions of Python should also work with MNE-Python.  In particular,
 like Anaconda, Miniconda includes the ``conda`` command line tool for
 installing new packages and managing environments; unlike Anaconda, Miniconda
 starts off with a minimal set of around 30 packages instead of Anaconda's
-hundreds. See the `Miniconda install page <miniconda-install>`__ for more info.
+hundreds. See the `installation instructions for Miniconda`_ for more info.
 
 It is also possible to use a system-level installation of Python (version 3.5
 or higher) and use ``pip`` to install MNE-Python and its dependencies, using

--- a/doc/advanced_setup.rst
+++ b/doc/advanced_setup.rst
@@ -12,32 +12,43 @@ Advanced setup of MNE-python
 IPython / Jupyter notebooks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In Jupyter, we strongly recommend using the Qt matplotlib backend for
-fast and correct rendering:
+When using MNE-python within IPython or a Jupyter notebook, we strongly
+recommend using the Qt matplotlib backend for fast and correct rendering. On
+Linux, for example, Qt is the only matplotlib backend for which 3D rendering
+will work correctly. On macOS, certain matplotlib functions might not work as
+expected on backends other than Qt. Enabling Qt can be accomplished when
+starting IPython from a terminal:
 
 .. code-block:: console
 
     $ ipython --matplotlib=qt
 
-On Linux, for example, QT is the only matplotlib backend for which 3D rendering
-will work correctly. On macOS, certain matplotlib functions might not work as
-expected on backends other than QT.
+or in a Jupyter Notebook, you can use the "magic" command:
 
-To take full advantage of MNE-python's visualization capacities in combination
-with IPython notebooks and inline displaying, please explicitly add the
-following magic method invocation to your notebook or configure your notebook
-runtime accordingly:
+.. code-block:: ipython
+
+    In [1]: %matplotlib qt
+
+This will create separate pop-up windows for each figure, and has the advantage
+that the 3D plots will retain rich interactivity (so, for example, you can
+click-and-drag to rotate cortical surface activation maps).
+
+If you are creating a static notebook or simply prefer Jupyter's inline plot
+display, MNE-python will work with the standard "inline" magic:
 
 .. code-block:: ipython
 
     In [1]: %matplotlib inline
 
+but some functionality will be lost. For example, mayavi scenes will still
+pop-up a separate window, but only one window at a time is possible, and
+interactivity within the scene is limited in non-blocking plot calls.
 
 .. admonition:: |windows| Windows
   :class: note
 
-  If you are using MNE-python on Windows through IPython or Jupyter,
-  you might have to use the IPython magic command ``%gui qt`` after importing
+  If you are using MNE-python on Windows through IPython or Jupyter, you might
+  also have to use the IPython magic command ``%gui qt`` after importing
   MNE-python, Mayavi or PySurfer (see `here
   <https://github.com/ipython/ipython/issues/10384>`_). For example:
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -4,8 +4,8 @@
 
 .. _contribute_to_mne:
 
-How to contribute to MNE
-========================
+How to contribute to MNE-python
+===============================
 
 .. contents:: Contents
    :local:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -47,7 +47,7 @@ To check the installation, you can enter the following commands:
 Code guidelines
 ---------------
 
-* Standard python style guidelines set by pep8_ and pyflakes_ are followed
+* Standard Python style guidelines set by pep8_ and pyflakes_ are followed
   with very few exceptions. We recommend using an editor that calls out
   style violations automatcally, such as Spyder_. From the MNE code root, you
   can check for violations using flake8_ with:
@@ -209,7 +209,7 @@ You can use something like this::
 
 Profiling
 ---------
-To learn more about profiling python codes please see `the scikit learn profiling site <https://scikit-learn.org/stable/developers/performance.html#performance-howto>`_.
+To learn more about profiling Python codes please see `the scikit learn profiling site <https://scikit-learn.org/stable/developers/performance.html#performance-howto>`_.
 
 .. _troubleshooting:
 

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -38,9 +38,16 @@ Documentation
     });
     </script>
 
-This is where you can learn about all the things you can do with MNE. It contains **background information** and **tutorials** for taking a deep-dive into the techniques that MNE-python covers. You'll find practical information on how to use these methods with your data, and in many cases some high-level concepts underlying these methods.
+This is where you can learn about all the things you can do with MNE. It
+contains **background information** and **tutorials** for taking a deep-dive
+into the techniques that MNE-python covers. You'll find practical information
+on how to use these methods with your data, and in many cases some high-level
+concepts underlying these methods.
 
-There are also **examples**, which contain a short use-case to highlight MNE-functionality and provide inspiration for the many things you can do with this package. You can also find a gallery of these examples in the :ref:`examples gallery <sphx_glr_auto_examples>`.
+There are also **examples**, which contain a short use-case to highlight
+MNE-functionality and provide inspiration for the many things you can do with
+this package. You can also find a gallery of these examples in the
+:ref:`examples gallery <sphx_glr_auto_examples>`.
 
 **See the links below for an introduction to MNE-python, or click one of the sections on this page to see more.**
 
@@ -62,9 +69,9 @@ There are also **examples**, which contain a short use-case to highlight MNE-fun
 .. toctree::
     :maxdepth: 1
 
-    getting_started.rst
-    advanced_setup.rst
-    auto_tutorials/plot_python_intro.rst
+    getting_started
+    advanced_setup
+    auto_tutorials/plot_python_intro
 
 **MNE basics**
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -2,76 +2,18 @@
 
 .. include:: links.inc
 
-.. _installation:
+Getting started
+===============
 
-Installation
-============
+The MNE software products are open-source tools for processing, analysis, and
+visualization of functional neuroimaging data (EEG, MEG, sEEG, ECoG, and
+fNIRS). Pages describing the installation procedure are listed below.
 
-To get started with MNE, visit the installation instructions for
-the :ref:`MNE<install_python_and_mne_python>`. You can optionally also
-install :ref:`MNE-C <install_mne_c>`:
+.. toctree::
+    :maxdepth: 2
 
-.. container:: row
-
-  .. container:: panel panel-default halfpad
-
-    .. container:: panel-heading nosize
-
-      MNE python module
-
-    .. container:: panel-body nosize
-
-      .. toctree::
-        :maxdepth: 2
-
-        install_mne_python
-
-  .. container:: panel panel-default halfpad
-
-    .. container:: panel-heading nosize
-
-      MNE-C
-
-    .. container:: panel-body nosize
-
-      .. toctree::
-        :maxdepth: 2
-
-        install_mne_c
-
-.. container:: row
-
-  .. container:: panel panel-default
-
-    .. container:: panel-heading nosize
-
-      Historical notes
-
-    .. container:: panel-body nosize
-
-      MNE started as tool written in C by Matti Hämäläinen while at MGH in
-      Boston.
-
-      - :ref:`MNE-C <c_reference>` is Matti's C code. Historically, MNE was
-        a software package for computing cortically constrained Minimum Norm
-        Estimates from MEG and EEG data.
-
-      - The MNE python module was built in the Python programming language to
-        reimplement all MNE-C’s functionality, offer transparent scripting,
-        and extend MNE-C’s functionality considerably (see left). Thus it is
-        the primary focus of this documentation.
-
-      - :ref:`ch_matlab` is available mostly to allow reading and writing
-        FIF files.
-
-      - :ref:`mne_cpp`  aims to provide modular and open-source tools for
-        real-time acquisition, visualization, and analysis. It provides
-        a :ref:`separate website <mne_cpp>` for documentation and releases.
-
-      The MNE tools are based on the FIF file format from Neuromag.
-      However, MNE can read native CTF, BTI/4D, KIT and various
-      EEG formats (see :ref:`IO functions <ch_convert>`).
-
-      If you have been using MNE-C, there is no need to convert your fif
-      files to a new system or database -- MNE works nicely with
-      the historical fif files.
+    pre_install
+    install_freesurfer
+    install_mne_c
+    install_mne_python
+    advanced_setup

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -13,7 +13,7 @@ fNIRS). Pages describing the installation procedure are listed below.
     :maxdepth: 2
 
     pre_install
+    install_mne_python
     install_freesurfer
     install_mne_c
-    install_mne_python
     advanced_setup

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -2,8 +2,8 @@
 
 .. include:: links.inc
 
-Getting started
-===============
+Installation — overview
+=========================
 
 The MNE software products are open-source tools for processing, analysis, and
 visualization of functional neuroimaging data (EEG, MEG, sEEG, ECoG, and

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -78,8 +78,8 @@
 .. _Spyder: https://www.spyder-ide.org/
 .. _anaconda: https://www.anaconda.com/distribution/
 .. _miniconda: https://conda.io/en/latest/miniconda.html
-.. _anaconda-install: http://docs.continuum.io/anaconda/install
-.. _miniconda-install: https://conda.io/projects/conda/en/latest/user-guide/install/index.html
+.. _installation instructions for Anaconda: http://docs.continuum.io/anaconda/install
+.. _installation instructions for Miniconda: https://conda.io/projects/conda/en/latest/user-guide/install/index.html
 .. _EPD: https://www.enthought.com/products/epd/
 .. _sublime text: http://www.sublimetext.com/
 

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -93,6 +93,7 @@
 .. _MATLAB runtime: https://www.mathworks.com/products/compiler/matlab-runtime.html
 .. _MNE-C download page: http://www.nmr.mgh.harvard.edu/martinos/userInfo/data/MNE_register/index.php
 .. _environment file:  https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+.. _requirements file:  https://raw.githubusercontent.com/mne-tools/mne-python/master/requirements.txt
 .. _NVIDIA CUDA GPU processing: https://developer.nvidia.com/cuda-zone
 .. _NVIDIA proprietary drivers: https://www.nvidia.com/Download/index.aspx
 

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -76,15 +76,32 @@
 .. python editors
 .. _atom: https://atom.io/
 .. _Spyder: https://www.spyder-ide.org/
-.. _anaconda: http://www.continuum.io/downloads
+.. _anaconda: https://www.anaconda.com/distribution/
+.. _miniconda: https://conda.io/en/latest/miniconda.html
+.. _anaconda-install: http://docs.continuum.io/anaconda/install
+.. _miniconda-install: https://conda.io/projects/conda/en/latest/user-guide/install/index.html
 .. _EPD: https://www.enthought.com/products/epd/
 .. _sublime text: http://www.sublimetext.com/
 
-.. _FreeSurfer: http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall/
+.. installation links
+.. _FreeSurfer: https://surfer.nmr.mgh.harvard.edu/fswiki/
+.. _FreeSurfer download page: https://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall
+.. _libxp6-ubuntu: https://packages.ubuntu.com/search?keywords=libxp6
+.. _libxp6-debian: https://packages.debian.org/search?keywords=libxp6
+.. _netpbm: http://netpbm.sourceforge.net/
+.. _MacPorts: https://www.macports.org/
+.. _XCode developer tools: http://appstore.com/mac/apple/xcode
+.. _xquartz: https://www.xquartz.org/
+.. _MATLAB runtime: https://www.mathworks.com/products/compiler/matlab-runtime.html
+.. _MNE-C download page: http://www.nmr.mgh.harvard.edu/martinos/userInfo/data/MNE_register/index.php
+.. _environment file:  https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+.. _NVIDIA CUDA GPU processing: https://developer.nvidia.com/cuda-zone
+.. _NVIDIA proprietary drivers: https://www.nvidia.com/Download/index.aspx
 
 .. _Sphinx documentation: http://sphinx-doc.org/rest.html
 .. _sphinx gallery documentation: https://sphinx-gallery.readthedocs.io/en/latest/configuration.html
 .. _NumPy docstring standard: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. _Stack Overflow: https://stackoverflow.com/
 
 .. vim: ft=rst
 

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -88,6 +88,7 @@
 .. _FreeSurfer download page: https://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall
 .. _netpbm: http://netpbm.sourceforge.net/
 .. _MacPorts: https://www.macports.org/
+.. _Homebrew: https://brew.sh/
 .. _XCode developer tools: http://appstore.com/mac/apple/xcode
 .. _xquartz: https://www.xquartz.org/
 .. _MATLAB runtime: https://www.mathworks.com/products/compiler/matlab-runtime.html

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -86,8 +86,6 @@
 .. installation links
 .. _FreeSurfer: https://surfer.nmr.mgh.harvard.edu/fswiki/
 .. _FreeSurfer download page: https://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall
-.. _libxp6-ubuntu: https://packages.ubuntu.com/search?keywords=libxp6
-.. _libxp6-debian: https://packages.debian.org/search?keywords=libxp6
 .. _netpbm: http://netpbm.sourceforge.net/
 .. _MacPorts: https://www.macports.org/
 .. _XCode developer tools: http://appstore.com/mac/apple/xcode

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@
         Open-source Python software for exploring, visualizing, and
         analyzing human neurophysiological data: MEG, EEG, sEEG, ECoG,
         and more.
-        </h4>
+        </p>
       </div>
       <div class="cell-like col-sm-4 text-right">
         <h3><i class="fa fa-bolt"></i> Speed</h3>

--- a/doc/install_freesurfer.rst
+++ b/doc/install_freesurfer.rst
@@ -10,7 +10,7 @@ MNE ecosystem, freesurfer is used to convert structural MRI scans into models
 of the scalp, inner/outer skull, and cortical surfaces, which are used to
 
 1. model how changes in the electrical and magnetic field caused by neural
-   activity propogate to the sensor locations (part of computing the "forward
+   activity propagate to the sensor locations (part of computing the "forward
    solution"), and
 
 2. constrain the estimates of where brain activity may have occurred (in the

--- a/doc/install_freesurfer.rst
+++ b/doc/install_freesurfer.rst
@@ -1,0 +1,25 @@
+.. include:: links.inc
+
+.. _install_freesurfer:
+
+Installing FreeSurfer
+=====================
+
+`FreeSurfer`_ is software for analysis and visualization of MRI data. In the
+MNE ecosystem, freesurfer is used to convert structural MRI scans into models
+of the scalp, inner/outer skull, and cortical surfaces, which are used to
+
+1. model how changes in the electrical and magnetic field caused by neural
+   activity propogate to the sensor locations (part of computing the "forward
+   solution"), and
+
+2. constrain the estimates of where brain activity may have occurred (in the
+   "inverse imaging" step of source localization).
+
+System requirements, setup instructions, and test scripts are provided on the
+`FreeSurfer download page`_. Note that if you don't already have it, you will
+need to install ``tcsh`` for FreeSurfer to work; ``tcsh`` is usually
+pre-installed with macOS, and is available in the package repositories for
+Linux-based systems (e.g., ``sudo apt install tcsh`` on Ubuntu-like systems).
+
+**Next:** :doc:`install_mne_c`

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -23,8 +23,8 @@ sufficient. If MATLAB is not present, the utilities ``mne_convert_mne_data``,
 For boundary-element model (BEM) mesh generation (see :doc:`Creating the BEM
 meshes <manual/appendix/bem_model>`), and for accessing the ``tkmedit`` program
 from ``mne_analyze`` (see :ref:`CACCHCBF`), MNE-C needs access to a working
-installation of :doc:`install_freesurfer`, including the environment variables
-``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
+installation of :doc:`FreeSurfer <install_freesurfer>`, including the
+environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
 
 .. admonition:: |apple| macOS
   :class: note

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -30,10 +30,15 @@ including the environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and
 .. admonition:: |apple| macOS
   :class: note
 
-  For installation on macOS, you also need the `XCode developer tools`_, an X
-  Window System such as XQuartz_, and the netpbm_ library. The recommended way
-  to get netpbm is to install MacPorts_, and then run ``sudo port install
-  netpbm`` in the Terminal app.
+  For installation on macOS, you also need:
+
+  - the `XCode developer tools`_.
+  - an X Window System such as XQuartz_. Specifically, you need version 2.7.9
+    of XQuartz; the most current version (2.7.11, as of Feb. 2019) will not
+    work.
+  - the netpbm_ library. The recommended way to get netpbm is to install
+    MacPorts_, and then run ``sudo port install netpbm`` in the Terminal app.
+
 
 Download and Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +58,10 @@ install location, and unpack the software using ``tar``:
 
 To install from the macOS disk image, double-click the downloaded .dmg file. In
 the window that opens, double-click the installer package file (.pkg) to launch
-the installer, and follow its instructions.
+the installer, and follow its instructions. In newer versions of macOS, if you
+see an error that the app is from an untrusted developer, you can override this
+warning by opening it anyway from the Security & Privacy pane within the
+computer's System Preferences.
 
 .. _user_environment:
 

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -110,7 +110,7 @@ command in your ``.zshrc`` file:
 To configure MNE-C automatically for ``csh`` or ``tcsh`` shells, the
 corresponding commands in the ``.cshrc`` / ``.tcshrc`` file are:
 
-.. code-block:: sh
+.. code-block:: tcsh
 
     setenv MNE_ROOT <path_to_MNE>
     setenv MATLAB_ROOT <path_to_MATLAB>

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -52,7 +52,7 @@ install location, and unpack the software using ``tar``:
 
 .. code-block:: console
 
-    $ cd /path/to/install/location
+    $ cd <path_to_desired_install_location>
     $ tar zxvf <path_to_archive_file>
 
 To install from the macOS disk image, double-click the downloaded .dmg file. In

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -160,4 +160,4 @@ a typical 64-bit Ubuntu-like system this would be accomplished by:
 If you encounter other errors installing MNE-C, please send a message to the
 `MNE mailing list`_.
 
-**Next:** :doc:`install_mne_python`
+**Next:** :doc:`advanced_setup`

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -20,12 +20,11 @@ disk space. MATLAB is an optional dependency; the free `MATLAB runtime`_ is
 sufficient. If MATLAB is not present, the utilities ``mne_convert_mne_data``,
 ``mne_epochs2mat``, ``mne_raw2mat``, and ``mne_simu`` will not work.
 
-For boundary-element model (BEM) mesh generation (see
-:doc:`Creating the BEM meshes <manual/appendix/bem_model>`),
-and for accessing the ``tkmedit`` program from ``mne_analyze`` (see
-:ref:`CACCHCBF`), MNE-C needs access to a working installation of :doc:`install_freesurfer`,
-including the environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and
-``SUBJECT``.
+For boundary-element model (BEM) mesh generation (see :doc:`Creating the BEM
+meshes <manual/appendix/bem_model>`), and for accessing the ``tkmedit`` program
+from ``mne_analyze`` (see :ref:`CACCHCBF`), MNE-C needs access to a working
+installation of :doc:`install_freesurfer`, including the environment variables
+``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
 
 .. admonition:: |apple| macOS
   :class: note

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -36,7 +36,9 @@ environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
     of XQuartz; the most current version (2.7.11, as of Feb. 2019) will not
     work.
   - the netpbm_ library. The recommended way to get netpbm is to install
-    Homebrew_, and then run ``brew install netpbm`` in the Terminal app.
+    Homebrew_, and run ``brew install netpbm`` in the Terminal app.
+    Alternatively, if you prefer to use MacPorts_, you can run
+    ``sudo port install netpbm`` in the Terminal app.
 
 
 Download and Installation
@@ -96,7 +98,9 @@ your ``.bashrc``:
     source $MNE_ROOT/bin/mne_setup_sh
 
 where ``<path_to_MNE>`` and ``<path_to_MATLAB>`` are replaced by the absolute
-paths to MNE-C and MATLAB, respectively.
+paths to MNE-C and MATLAB, respectively. If you don't have MATLAB, you should
+still include the ``export MATLAB_ROOT=`` statement, but leave
+``<path_to_MATLAB>`` blank.
 
 To configure MNE-C automatically for ``zsh``, use the built-in ``emulate``
 command in your ``.zshrc`` file:

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -2,290 +2,160 @@
 
 .. _install_mne_c:
 
-Install MNE-C
--------------
+Installing MNE-C
+================
 
-The MNE-C commands can be downloaded
-`here <http://www.nmr.mgh.harvard.edu/martinos/userInfo/data/MNE_register/index.php>`_.
-The :ref:`c_reference` gives an overview of the MNE-C tools.
-
-.. contents:: Contents
+.. contents::
    :local:
    :depth: 1
 
-System requirements and installation
-####################################
+System requirements
+^^^^^^^^^^^^^^^^^^^
 
-The MNE-C runs on Mac OSX and LINUX, and requires:
+MNE-C runs on macOS (version 10.5 "Leopard" or later) and Linux (kernel 2.6.9
+or later). Both 32- and 64-bit operating systems are supported; a PowerPC
+version for macOS can be provided upon request. At least 2 GB of memory is
+required, 4 GB or more is recommended. The software requires at least 80 MB of
+disk space. MATLAB is an optional dependency; the free `MATLAB runtime`_ is
+sufficient. If MATLAB is not present, the utilities ``mne_convert_mne_data``,
+``mne_epochs2mat``, ``mne_raw2mat``, and ``mne_simu`` will not work.
 
-- Mac OSX version 10.5 (Leopard) or later.
-- LINUX kernel 2.6.9 or later
-- On both LINUX and Mac OSX 32-bit and 64-bit Intel platforms
-  are supported. PowerPC version on Mac OSX can be provided upon request.
-- At least 2 GB of memory, 4 GB or more recommended.
-- Disk space required for the MNE software: 80 MB
-- Additional open source software on Mac OSX, see :ref:`BABDBCJE`.
+For boundary-element model (BEM) mesh generation (see :ref:`create_bem_model`),
+and for accessing the ``tkmedit`` program from ``mne_analyze`` (see
+:ref:`CACCHCBF`), MNE-C needs access to a working installation of FreeSurfer_,
+including the environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and
+``SUBJECT``.
 
-The MNE software is distributed as a compressed tar archive
-(Mac OSX and LINUX) or a Mac OSX disk image (dmg).
+.. admonition:: |apple| macOS
+  :class: note
 
-The file names follow the convention:
+  For installation on macOS, you also need the `XCode developer tools`_, an X
+  Window System such as XQuartz_, and the netpbm_ library. The recommended way
+  to get netpbm is to install MacPorts_, and then run ``sudo port install
+  netpbm`` in the Terminal app.
 
-::
+Download and Installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  MNE-* <*version*>*- <*rev*> -* <*Operating system*>*-* <*Processor*>*.* <*ext*>*
+MNE-C is distributed as either a compressed tar archive (.tar.gz) or a macOS
+disk image (.dmg). The `MNE-C download page`_ requires registration with a
+valid email address.  The current stable version is 2.7.3; "nightly" builds of
+the development version are also available on the download page.
 
-The present version number is 2.7.4. The <*rev*> field
-is the SVN revision number at the time this package was created.
-The <*Operating system*> field
-is either Linux or MacOSX. The <*processor*> field
-is either i386 or x86_64. The <*ext*> field
-is 'gz' for compressed tar archive files and 'dmg' for
-Mac OSX disk images.
-
-Installing from a compressed tar archive
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Go to the directory where you want the software to be installed:
-
-.. code-block:: console
-
-    $ cd <dir>
-
-Unpack the tar archive:
+To install from the compressed tar archive, change directory to the desired
+install location, and unpack the software using ``tar``:
 
 .. code-block:: console
 
-    $ tar zxvf <software package>
+    $ cd /path/to/install/location
+    $ tar zxvf <path_to_archive_file>
 
-The name of the software directory under <*dir*> will
-be the same as the package file without the .gz extension.
-
-Installing from a Mac OSX disk image
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Double click on the disk image file.
-  A window opens with the installer package ( <*name*> .pkg)
-  inside.
-
-- Double click the the package file. The installer starts.
-
-- Follow the instructions in the installer.
-
-.. note::
-
-    The software will be installed to /Applications/ <*name*> by default.
-    If you want another location, select Choose Folder... on the Select a
-    Destination screen in the installer.
+To install from the macOS disk image, double-click the downloaded .dmg file. In
+the window that opens, double-click the installer package file (.pkg) to launch
+the installer, and follow its instructions.
 
 .. _user_environment:
 
-Setting up MNE-C environment
-############################
+Configuration
+^^^^^^^^^^^^^
 
-Your system-dependent path to the MNE Software will be referred to by
-the environment variable MNE_ROOT.
+MNE-C requires two environment variables to be defined manually:
 
-Your system-dependent path to MATLAB Software will be referred to by
-the environment variable MATLAB_ROOT.
+- ``MNE_ROOT`` should give the path to the folder where MNE-C is installed
+- ``MATLAB_ROOT`` should give the path to your MATLAB binary (e.g.,
+  ``/opt/MATLAB/R2018b`` or similar).  If you do not have MATLAB or the MATLAB
+  runtime, leave ``MATLAB_ROOT`` undefined.
 
-You can download a free runtime distribution of Matlab with the libraries
-necessary to run Matlab code from,
-https://www.mathworks.com/products/compiler/matlab-runtime.html
-
-If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined.
-Please note however that if Matlab is not available, the utilities
-mne_convert_mne_data, mne_epochs2mat, mne_raw2mat, and mne_simu will not work.
-
-To setup the MNE environment, a script must be sourced into your current shell.
-The result will be that additional environment variables like MNE_LIB_PATH
-will be set in your current shell in order to run the MNE Software.
-
-A note about source-ing scripts with "source" and "." (dot). The hash bang at
-the top of a script tells exec what shell to use by default to interpret the
-script. But the hash bang line is ignored when you source a script via either
-the builtin "source" or "." directive.  So there needs to be a setup script
-compatible with your current shell, i.e., if you use csh you cannot source a
-bash script.  (BTW, the "." (dot) directive will search for the script in
-$PATH if there is no slash in the script argument while "source" does not
-search $PATH).
-
-For Bourne or bash compatible shells, e.g., sh/bash/zsh, the script to source
-is ``$MNE_ROOT/bin/mne_setup_sh``.
-
-For C shells, e.g., csh/tcsh, the script to source
-is ``$MNE_ROOT/bin/mne_setup``.
-
-The SHELL variable should already be set in your current shell by your login or
-profile init file.  You can echo $SHELL on the command line to see what type of
-shell you are using with:
+Other environment variables are defined by setup scripts provided with MNE-C.
+You may either run the setup script each time you use MNE-C, or (recommended)
+configure your shell to run it automatically each time you open a terminal. For
+bash compatible shells, e.g., sh/bash/zsh, the script to source is
+``$MNE_ROOT/bin/mne_setup_sh``.  For C shells, e.g., csh/tcsh, the script to
+source is ``$MNE_ROOT/bin/mne_setup``.  If you don't know what shell you are
+using, you can run the following command to find out:
 
 .. code-block:: console
 
     $ echo $SHELL
 
-If the output indicates a POSIX shell ``bash`` or ``sh`` then you should export
-variables and source the bash/sh setup file with three commands:
+To configure MNE-C automatically for ``bash`` or ``sh`` shells, add this to
+your ``.bashrc``::
 
-.. code-block:: console
+    export MNE_ROOT=<path_to_MNE>
+    export MATLAB_ROOT=<path_to_MATLAB>
+    . $MNE_ROOT/bin/mne_setup_sh
 
-    $ export MNE_ROOT=<MNE>
-    $ export MATLAB_ROOT=<Matlab>
-    $ . $MNE_ROOT/bin/mne_setup_sh
+where ``<path_to_MNE>`` and ``<path_to_MATLAB>`` are replaced by the absolute
+paths to MNE-C and MATLAB, respectively.
 
-where ``<MNE>`` is replaced by the absolute path to where you have installed
-the MNE software. This path will be the parent path to the ./bin and ./lib
-subdirecotries in the MNE distribution. Or the command
-"ls $MNE_ROOT/bin/mne_setup_sh" should succeed if you have set MNE_ROOT
-correctly.
+To configure MNE-C automatically for ``zsh``, use the built-in ``emulate``
+command in your ``.zshrc`` file::
 
-If you do not have a Matlab distribution, then leave MATLAB_ROOT undefined.
+    export MNE_ROOT=<path_to_MNE>
+    export MATLAB_ROOT=<path_to_MATLAB>
+    emulate sh -c 'source $MNE_ROOT/bin/mne_setup_sh'
 
-For the bash compatible ``zsh`` use the builtin emulate command to source
-the bash/sh setup script (after exporting variables):
+To configure MNE-C automatically for ``csh`` or ``tcsh`` shells, the
+corresponding commands in the ``.cshrc`` / ``.tcshrc`` file are::
 
-.. code-block:: console
+    setenv MNE_ROOT <path_to_MNE>
+    setenv MATLAB_ROOT <path_to_MATLAB>
+    source $MNE_ROOT/bin/mne_setup
 
-    $ export MNE_ROOT=<MNE>
-    $ export MATLAB_ROOT=<Matlab>
-    $ emulate sh -c 'source $MNE_ROOT/bin/mne_setup_sh'
+If you have done this correctly, the command ``ls $MNE_ROOT/bin/mne_setup_sh``
+should succeed when run in a new terminal.
 
-For ``csh`` or ``tcsh`` shell, the corresponding commands are:
+Testing your installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: console
-
-    $ setenv MNE_ROOT <MNE>
-    $ setenv MATLAB_ROOT <Matlab>
-    $ source $MNE_ROOT/bin/mne_setup
-
-
-For BEM mesh generation using the watershed algorithm or
-on the basis of multi-echo FLASH MRI data (see :ref:`create_bem_model`) and
-for accessing the tkmedit program
-from mne_analyze, see :ref:`CACCHCBF`,
-the MNE software needs access to a FreeSurfer license
-and software. Therefore, to use these features it is mandatory that
-you set up the FreeSurfer environment
-as described in the FreeSurfer documentation.
-
-The environment variables relevant to the MNE software are
-listed in :ref:`CIHDGFAA`.
-
-.. tabularcolumns:: |p{0.3\linewidth}|p{0.55\linewidth}|
-.. _CIHDGFAA:
-.. table:: Environment variables
-
-    +-------------------------+--------------------------------------------+
-    | Name of the variable    |   Description                              |
-    +=========================+============================================+
-    | ``MNE_ROOT``            | Location of the MNE software, see above.   |
-    +-------------------------+--------------------------------------------+
-    | ``FREESURFER_HOME``     | Location of the FreeSurfer software.       |
-    |                         | Needed during FreeSurfer reconstruction    |
-    |                         | and if the FreeSurfer MRI viewer is used   |
-    |                         | with mne_analyze, see :ref:`CACCHCBF`.     |
-    +-------------------------+--------------------------------------------+
-    | ``SUBJECTS_DIR``        | Location of the MRI data.                  |
-    +-------------------------+--------------------------------------------+
-    | ``SUBJECT``             | Name of the current subject.               |
-    +-------------------------+--------------------------------------------+
-    | ``MNE_TRIGGER_CH_NAME`` | Name of the trigger channel in raw data,   |
-    |                         | see :ref:`mne_process_raw`.                |
-    +-------------------------+--------------------------------------------+
-    | ``MNE_TRIGGER_CH_MASK`` | Mask to be applied to the trigger channel  |
-    |                         | values, see :ref:`mne_process_raw`.        |
-    +-------------------------+--------------------------------------------+
-
-
-Troubleshooting
-###############
-
-Missing libXp.so.6
-^^^^^^^^^^^^^^^^^^
-
-If when running an MNE command you get an error about a missing library ``libXp.so.6`` such as:
-
-.. code-block:: console
-
-    $ mne_process_raw
-    mne_process_raw: error while loading shared libraries: libXp.so.6: cannot open shared object file: No such file or directory
-
-If you are using Ubuntu Linux and you have admin access to the machine you can do:
-
-.. code-block:: console
-
-    $ sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu precise-security main"
-    $ sudo apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update
-    $ sudo apt -o APT::Get::AllowUnauthenticated=true install libxp6
-    $ sudo add-apt-repository -r "deb http://security.ubuntu.com/ubuntu precise-security main"
-    $ sudo apt update
-
-.. _BABDBCJE:
-
-Additional options
-##################
-
-Additional software
-^^^^^^^^^^^^^^^^^^^
-
-MNE uses the `Netpbm package <http://netpbm.sourceforge.net/>`_
-to create image files in formats other than tif and rgb from
-``mne_analyze`` and ``mne_browse_raw``.
-This package is usually present on LINUX systems. On Mac OSX, you
-need to install the netpbm package. The recommended way to do this
-is to use the MacPorts Project tools, see https://www.macports.org/:
-
-- If you have not installed the MacPorts
-  software, goto https://www.macports.org/install.php and follow the
-  instructions to install MacPorts.
-
-- Install the netpbm package by saying: ``sudo port install netpbm``
-
-MacPorts requires that you have the XCode developer tools
-and X11 windowing environment installed. X11 is also needed by MNE.
-For Mac OSX Leopard, we recommend using `XQuartz <https://www.xquartz.org>`__.
-As of this writing, XQuartz does not yet exist for SnowLeopard;
-the X11 included with the operating system is sufficient.
-
-.. _CIHIIBDA:
-
-Testing the performance of your OpenGL graphics
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The graphics performance of mne_analyze depends
-on your graphics software and hardware configuration. You get the
-best performance if you are using mne_analyze locally
-on a computer and the hardware acceleration capabilities are in
-use. You can check the On GLX... item
-in the help menu of mne_analyze to
-see whether the hardware acceleration is in effect. If the dialog
-popping up says Direct rendering context ,
-you are using hardware acceleration. If this dialog indicates Nondirect rendering context , you are either using software
-emulation locally, rendering to a remote display, or employing VNC
-connection. If you are rendering to a local display and get an indication
-of Nondirect rendering context ,
-software emulation is in effect and you should contact your local
-computer support to enable hardware acceleration for GLX. In some
-cases, this may require acquiring a new graphics display card. Fortunately,
-relatively high-performance OpenGL-capable graphics cards are not expensive.
-
-There is also an utility mne_opengl_test to
-assess the graphics performance more quantitatively. This utility
-renders an inflated brain surface repeatedly, rotating it by 5 degrees
-around the *z* axis between redraws. At each
-revolution, the time spent for the full revolution is reported on
-the terminal window where mne_opengl_test was
-started from. The program renders the surface until the interrupt
-key (usually control-c) is pressed on the terminal window.
-
-mne_opengl_test is located
-in the ``bin`` directory and is thus started as:
+An easy way to verify whether your installation of MNE-C is working is to test
+the OpenGL graphics performance:
 
 .. code-block:: console
 
     $ $MNE_ROOT/bin/mne_opengl_test
 
-On the fastest graphics cards, the time per revolution is
-well below 1 second. If this time longer than 10 seconds either
-the graphics hardware acceleration is not in effect or you need
-a faster graphics adapter.
+This will render an inflated brain surface repeatedly, rotating it by 5 degrees
+around the z-axis between redraws. The time spent for each full revolution is
+printed to the terminal window where ``mne_opengl_test`` was invoked.  Switch
+focus to that terminal window and use the interrupt key (usually control-c) to
+halt the test.
+
+The best graphics performance occurs when MNE-C renders to a local display on a
+computer with hardware acceleration enabled. The ``mne_analyze`` GUI has a menu
+item "On GLX..." in the Help menu; if the GLX dialog says "Direct rendering
+context" then hardware acceleration is in use. If you are rendering to a local
+display and see "Nondirect rendering context", it is recommended that you
+enable hardware acceleration (consult a search engine or your local IT support
+staff for assistance). If you are rendering to a remote display or using a VNC
+connection, "Nondirect rendering context" is normal.
+
+On the fastest graphics cards, the time per revolution in the
+``mne_opengl_test`` is well below 1 second. If your time per revolution is
+longer than 10 seconds, either the graphics hardware acceleration is not in
+effect or you need a faster graphics adapter.
+
+Troubleshooting MNE-C installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If MNE-C can't find ``libxp.so.6``, download libxp6 from `ubuntu
+<libxp6-ubuntu>`_ or `debian <libxp6-debian>`_ and install with ``dpkg`` or
+similar:
+
+.. code-block:: console
+
+    $ sudo dpkg -i libxp6_1.0.2-1ubuntu1_amd64.deb
+
+If MNE-C can't find ``libgfortran.so.1``, you can probably safely link that
+filename to the current version of libfortran that came with your system. On
+a typical 64-bit Ubuntu-like system this would be accomplished by:
+
+.. code-block:: console
+
+    $ cd /usr/lib/x86_64-linux-gnu
+    $ sudo ln -s libgfortran.so.1 $(find . -maxdepth 1 -type f -name libgfortran.so*)
+
+If you encounter other errors installing MNE-C, please send a message to the
+`MNE mailing list`_.
+
+**Next:** :doc:`install_mne_python`

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -88,24 +88,30 @@ using, you can run the following command to find out:
     $ echo $SHELL
 
 To configure MNE-C automatically for ``bash`` or ``sh`` shells, add this to
-your ``.bashrc``::
+your ``.bashrc``:
+
+.. code-block:: sh
 
     export MNE_ROOT=<path_to_MNE>
     export MATLAB_ROOT=<path_to_MATLAB>
-    . $MNE_ROOT/bin/mne_setup_sh
+    source $MNE_ROOT/bin/mne_setup_sh
 
 where ``<path_to_MNE>`` and ``<path_to_MATLAB>`` are replaced by the absolute
 paths to MNE-C and MATLAB, respectively.
 
 To configure MNE-C automatically for ``zsh``, use the built-in ``emulate``
-command in your ``.zshrc`` file::
+command in your ``.zshrc`` file:
+
+.. code-block:: sh
 
     export MNE_ROOT=<path_to_MNE>
     export MATLAB_ROOT=<path_to_MATLAB>
     emulate sh -c 'source $MNE_ROOT/bin/mne_setup_sh'
 
 To configure MNE-C automatically for ``csh`` or ``tcsh`` shells, the
-corresponding commands in the ``.cshrc`` / ``.tcshrc`` file are::
+corresponding commands in the ``.cshrc`` / ``.tcshrc`` file are:
+
+.. code-block:: sh
 
     setenv MNE_ROOT <path_to_MNE>
     setenv MATLAB_ROOT <path_to_MATLAB>

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -41,8 +41,8 @@ environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
     ``sudo port install netpbm`` in the Terminal app.
 
 
-Download and Installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Downloading and Installing MNE-C
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 MNE-C is distributed as either a compressed tar archive (.tar.gz) or a macOS
 disk image (.dmg). The `MNE-C download page`_ requires registration with a
@@ -66,8 +66,8 @@ computer's System Preferences.
 
 .. _user_environment:
 
-Configuration
-^^^^^^^^^^^^^
+Configuring MNE-C
+^^^^^^^^^^^^^^^^^
 
 MNE-C requires two environment variables to be defined manually:
 
@@ -123,8 +123,8 @@ corresponding commands in the ``.cshrc`` / ``.tcshrc`` file are:
 If you have done this correctly, the command ``ls $MNE_ROOT/bin/mne_setup_sh``
 should succeed when run in a new terminal.
 
-Testing your installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing MNE-C installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 An easy way to verify whether your installation of MNE-C is working is to test
 the OpenGL graphics performance:

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -23,7 +23,7 @@ sufficient. If MATLAB is not present, the utilities ``mne_convert_mne_data``,
 For boundary-element model (BEM) mesh generation (see
 :doc:`Creating the BEM meshes <manual/appendix/bem_model>`),
 and for accessing the ``tkmedit`` program from ``mne_analyze`` (see
-:ref:`CACCHCBF`), MNE-C needs access to a working installation of FreeSurfer_,
+:ref:`CACCHCBF`), MNE-C needs access to a working installation of :doc:`install_freesurfer`,
 including the environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and
 ``SUBJECT``.
 

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -36,7 +36,7 @@ environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and ``SUBJECT``.
     of XQuartz; the most current version (2.7.11, as of Feb. 2019) will not
     work.
   - the netpbm_ library. The recommended way to get netpbm is to install
-    MacPorts_, and then run ``sudo port install netpbm`` in the Terminal app.
+    Homebrew_, and then run ``brew install netpbm`` in the Terminal app.
 
 
 Download and Installation

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -138,9 +138,10 @@ effect or you need a faster graphics adapter.
 Troubleshooting MNE-C installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If MNE-C can't find ``libxp.so.6``, download libxp6 from `ubuntu
-<libxp6-ubuntu>`_ or `debian <libxp6-debian>`_ and install with ``dpkg`` or
-similar:
+If MNE-C can't find ``libxp.so.6``, download libxp6 from
+`ubuntu <https://packages.ubuntu.com/search?keywords=libxp6>`_ or
+`debian <https://packages.debian.org/search?keywords=libxp6>`_ and install with
+``dpkg`` or similar:
 
 .. code-block:: console
 

--- a/doc/install_mne_c.rst
+++ b/doc/install_mne_c.rst
@@ -20,7 +20,8 @@ disk space. MATLAB is an optional dependency; the free `MATLAB runtime`_ is
 sufficient. If MATLAB is not present, the utilities ``mne_convert_mne_data``,
 ``mne_epochs2mat``, ``mne_raw2mat``, and ``mne_simu`` will not work.
 
-For boundary-element model (BEM) mesh generation (see :ref:`create_bem_model`),
+For boundary-element model (BEM) mesh generation (see
+:doc:`Creating the BEM meshes <manual/appendix/bem_model>`),
 and for accessing the ``tkmedit`` program from ``mne_analyze`` (see
 :ref:`CACCHCBF`), MNE-C needs access to a working installation of FreeSurfer_,
 including the environment variables ``FREESURFER_HOME``, ``SUBJECTS_DIR``, and

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -61,8 +61,8 @@ open a terminal, or put the activation command in your ``.bashrc`` or
 
     $ pip install --upgrade "pyqt5>=5.10"
 
-Testing your installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing MNE-Python installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To make sure MNE-Python installed correctly, type the following command in a
 terminal:

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -2,7 +2,7 @@
 
 .. _install_python_and_mne_python:
 
-Installing MNE-python
+Installing MNE-Python
 =====================
 
 .. contents::
@@ -12,8 +12,8 @@ Installing MNE-python
 Installing Python
 ^^^^^^^^^^^^^^^^^
 
-MNE-python runs within Python, and depends on several other Python packages.
-MNE-python 0.18 only supports Python version 3.5 or higher. We strongly
+MNE-Python runs within Python, and depends on several other Python packages.
+MNE-Python 0.18 only supports Python version 3.5 or higher. We strongly
 recommend the `Anaconda`_ distribution of Python, which comes with more than
 250 scientific packages pre-bundled, and includes the ``conda`` command line
 tool for installing new packages and managing different package sets
@@ -30,11 +30,11 @@ similar output if you type the following command in a terminal:
 If you get an error message, consult the Anaconda documentation and search for
 Anaconda install tips (`Stack Overflow`_ results are often helpful).
 
-Installing MNE-python and its dependencies
+Installing MNE-Python and its dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have Anaconda installed, the easiest way to install
-MNE-python is to use the provided `environment file`_ to install MNE-python
+MNE-Python is to use the provided `environment file`_ to install MNE-Python
 and its dependencies into a new conda environment:
 
 .. code-block:: console
@@ -64,7 +64,7 @@ open a terminal, or put the activation command in your ``.bashrc`` or
 Testing your installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To make sure MNE-python installed correctly, type the following command in a
+To make sure MNE-Python installed correctly, type the following command in a
 terminal:
 
 .. code-block:: console
@@ -72,7 +72,7 @@ terminal:
     $ python -c 'import mne; mne.sys_info()'
 
 This should display some system information along with the versions of
-MNE-python and its dependencies. Typical output looks like this:
+MNE-Python and its dependencies. Typical output looks like this:
 
 .. code-block:: console
 
@@ -94,7 +94,7 @@ MNE-python and its dependencies. Typical output looks like this:
     pandas:        0.24.0
     dipy:          0.15.0
 
-Troubleshooting MNE-python installation
+Troubleshooting MNE-Python installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If something went wrong during installation and you can't figure it out

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -32,10 +32,6 @@ terminal:
 If you get an error message, consult the Anaconda documentation and search for
 Anaconda install tips (`Stack Overflow`_ results are often helpful).
 
-.. note::
-
-    MNE-python 0.18 only works with Python version 3.5 or higher.
-
 Installing MNE-python and its dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -45,7 +41,7 @@ and its dependencies into a new conda environment:
 
 .. code-block:: console
 
-    $ curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+    $ curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
     $ conda env create -f environment.yml
     $ conda activate mne
 

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -107,7 +107,8 @@ Troubleshooting MNE-python installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If something went wrong during installation and you can't figure it out
-yourself, the `MNE mailing list`_ and `MNE gitter channel`_ are good resources
-for troubleshooting installation problems.
+yourself, check out the :doc:`advanced_setup` page to see if your problem is
+discussed there. If not, the `MNE mailing list`_ and `MNE gitter channel`_ are
+good resources for troubleshooting installation problems.
 
-**Next:** :doc:`advanced_setup`
+**Next:** :doc:`install_freesurfer`

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -13,10 +13,11 @@ Installing Python
 ^^^^^^^^^^^^^^^^^
 
 MNE-python runs within python, and depends on several other python packages.
-We strongly recommend the `Anaconda`_ or `Miniconda`_ distributions of python.
-The main difference is that Anaconda comes with more than 250 scientific
-packages pre-bundled, whereas Miniconda starts off with a minimal set of around
-30 packages. Both distributions include the ``conda`` command line tool for
+MNE-python 0.18 only supports Python version 3.5 or higher. We strongly
+recommend the `Anaconda`_ or `Miniconda`_ distributions of python. The main
+difference is that Anaconda comes with more than 250 scientific packages
+pre-bundled, whereas Miniconda starts off with a minimal set of around 30
+packages. Both distributions include the ``conda`` command line tool for
 installing new packages and managing different package sets ("environments")
 for different projects. Follow the installation instructions for `Anaconda
 <anaconda-install>`__ or `Miniconda <miniconda-install>`__; when you are done,

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -78,22 +78,22 @@ MNE-python and its dependencies. Typical output looks like this:
 
 .. code-block:: console
 
-    Platform:      Linux-4.15.0-44-generic-x86_64-with-debian-buster-sid
-    Python:        3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 19:16:44)  [GCC 7.3.0]
-    Executable:    /opt/miniconda3/envs/mne/bin/python
-    CPU:           x86_64: 8 cores
-    Memory:        7.6 GB
+    Platform:      Linux-4.18.0-13-generic-x86_64-with-debian-buster-sid
+    Python:        3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34)  [GCC 7.3.0]
+    Executable:    /home/travis/miniconda/envs/test/bin/python
+    CPU:           x86_64: 48 cores
+    Memory:        62.7 GB
 
-    mne:           0.18.dev0
+    mne:           0.17.0
     numpy:         1.15.4 {blas=mkl_rt, lapack=mkl_rt}
-    scipy:         1.1.0
+    scipy:         1.2.0
     matplotlib:    3.0.2 {backend=Qt5Agg}
 
     sklearn:       0.20.2
-    nibabel:       2.3.1
-    mayavi:        4.7.0.dev0 {qt_api=pyqt5, PyQt5=5.9.2}
+    nibabel:       2.3.3
+    mayavi:        4.7.0.dev0 {qt_api=pyqt5, PyQt5=5.10.1}
     cupy:          Not found
-    pandas:        0.23.4
+    pandas:        0.24.0
     dipy:          0.15.0
 
 Troubleshooting MNE-python installation

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -47,13 +47,7 @@ and its dependencies into a new conda environment:
 
 (You can also use a web browser to download the required `environment file`_ if
 you do not have ``curl``.) These commands will create a new environment called
-`mne` and then activate it.
-
-.. note::
-
-    The name of the environment is built into the environment file, but can be
-    changed on the command line with the ``-n`` flag; see ``conda env create
-    --help`` for more info.
+``mne`` and then activate it.
 
 Make sure you activate the environment (``conda activate mne``) each
 time you open a terminal, or put the activation command in your ``.bashrc``

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -16,12 +16,10 @@ MNE-python runs within Python, and depends on several other Python packages.
 MNE-python 0.18 only supports Python version 3.5 or higher. We strongly
 recommend the `Anaconda`_ distribution of Python, which comes with more than
 250 scientific packages pre-bundled, and includes the ``conda`` command line
-tool for
-installing new packages and managing different package sets ("environments")
-for different projects. Follow the installation instructions for `Anaconda
-<anaconda-install>`__; when you are done,
-you should see a similar output if you type the following command in a
-terminal:
+tool for installing new packages and managing different package sets
+("environments") for different projects. Follow the installation instructions
+for `Anaconda <anaconda-install>`__; when you are done, you should see a
+similar output if you type the following command in a terminal:
 
 .. code-block:: console
 
@@ -49,9 +47,9 @@ and its dependencies into a new conda environment:
 you do not have ``curl``.) These commands will create a new environment called
 ``mne`` and then activate it.
 
-Make sure you activate the environment (``conda activate mne``) each
-time you open a terminal, or put the activation command in your ``.bashrc``
-or ``.profile`` so that it happens automatically.
+Make sure you activate the environment (``conda activate mne``) each time you
+open a terminal, or put the activation command in your ``.bashrc`` or
+``.profile`` so that it happens automatically.
 
 .. admonition:: |apple| macOS
   :class: note

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -14,13 +14,12 @@ Installing Python
 
 MNE-python runs within python, and depends on several other python packages.
 MNE-python 0.18 only supports Python version 3.5 or higher. We strongly
-recommend the `Anaconda`_ or `Miniconda`_ distributions of python. The main
-difference is that Anaconda comes with more than 250 scientific packages
-pre-bundled, whereas Miniconda starts off with a minimal set of around 30
-packages. Both distributions include the ``conda`` command line tool for
+recommend the `Anaconda`_ distribution of python, which comes with more than
+250 scientific packages pre-bundled, and includes the ``conda`` command line
+tool for
 installing new packages and managing different package sets ("environments")
 for different projects. Follow the installation instructions for `Anaconda
-<anaconda-install>`__ or `Miniconda <miniconda-install>`__; when you are done,
+<anaconda-install>`__; when you are done,
 you should see a similar output if you type the following command in a
 terminal:
 
@@ -36,7 +35,7 @@ Anaconda install tips (`Stack Overflow`_ results are often helpful).
 Installing MNE-python and its dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once you have Anaconda or Miniconda installed, the easiest way to install
+Once you have Anaconda installed, the easiest way to install
 MNE-python is to use the provided `environment file`_ to install MNE-python
 and its dependencies into a new conda environment:
 

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -12,9 +12,9 @@ Installing MNE-python
 Installing Python
 ^^^^^^^^^^^^^^^^^
 
-MNE-python runs within python, and depends on several other python packages.
+MNE-python runs within Python, and depends on several other Python packages.
 MNE-python 0.18 only supports Python version 3.5 or higher. We strongly
-recommend the `Anaconda`_ distribution of python, which comes with more than
+recommend the `Anaconda`_ distribution of Python, which comes with more than
 250 scientific packages pre-bundled, and includes the ``conda`` command line
 tool for
 installing new packages and managing different package sets ("environments")

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -17,9 +17,9 @@ MNE-Python 0.18 only supports Python version 3.5 or higher. We strongly
 recommend the `Anaconda`_ distribution of Python, which comes with more than
 250 scientific packages pre-bundled, and includes the ``conda`` command line
 tool for installing new packages and managing different package sets
-("environments") for different projects. Follow the installation instructions
-for `Anaconda <anaconda-install>`__; when you are done, you should see a
-similar output if you type the following command in a terminal:
+("environments") for different projects. Follow the `installation instructions
+for Anaconda`_; when you are done, you should see a similar output if you type
+the following command in a terminal:
 
 .. code-block:: console
 

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -2,101 +2,113 @@
 
 .. _install_python_and_mne_python:
 
-Installing MNE-Python
----------------------
+Installing MNE-python
+=====================
 
-There are many ways to install a Python interpreter and MNE. Here we show a simple well tested solution.
+.. contents::
+   :local:
+   :depth: 1
 
-1. Get Python
-#############
+Installing Python
+^^^^^^^^^^^^^^^^^
 
-MNE-Python 0.18 only supports Python 3.5+.
-We recommend the `Anaconda distribution <https://www.anaconda.com/distribution/>`_.
-Follow the `installation instructions <http://docs.continuum.io/anaconda/install>`_.
-When you are done, you should see a similar output if you type the following command in a terminal:
-
-.. code-block:: console
-
-    $ conda --version && python --version
-    conda 4.6.1
-    Python 3.7.2
-
-If you get an error message, consult the Anaconda documentation and search for Anaconda install
-tips (`Stack Overflow <https://stackoverflow.com/>`_ results are often helpful).
-
-
-2. Get MNE and its dependencies
-###############################
-
-From the command line, install the MNE dependencies to a dedicated ``mne`` Anaconda environment.
+MNE-python runs within python, and depends on several other python packages.
+We strongly recommend the `Anaconda`_ or `Miniconda`_ distributions of python.
+The main difference is that Anaconda comes with more than 250 scientific
+packages pre-bundled, whereas Miniconda starts off with a minimal set of around
+30 packages. Both distributions include the ``conda`` command line tool for
+installing new packages and managing different package sets ("environments")
+for different projects. Follow the installation instructions for `Anaconda
+<anaconda-install>`__ or `Miniconda <miniconda-install>`__; when you are done,
+you should see a similar output if you type the following command in a
+terminal:
 
 .. code-block:: console
 
-    $ curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+        $ conda --version && python --version
+        conda 4.6.2
+        Python 3.6.7 :: Anaconda, Inc.
+
+If you get an error message, consult the Anaconda documentation and search for
+Anaconda install tips (`Stack Overflow`_ results are often helpful).
+
+.. note::
+
+    MNE-python 0.18 only works with Python version 3.5 or higher.
+
+Installing MNE-python and its dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once you have Anaconda or Miniconda installed, the easiest way to install
+MNE-python is to use the provided `environment file`_ to install MNE-python
+and its dependencies into a new conda environment:
+
+.. code-block:: console
+
+    $ curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
     $ conda env create -f environment.yml
     $ conda activate mne
 
-You can also use a web browser to `download the required environment file <https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml>`_
-if you do not have ``curl``.
+(You can also use a web browser to download the required `environment file`_ if
+you do not have ``curl``.) These commands will create a new environment called
+`mne` and then activate it.
+
+.. note::
+
+    The name of the environment is built into the environment file, but can be
+    changed on the command line with the ``-n`` flag; see ``conda env create
+    --help`` for more info.
+
+Make sure you activate the environment (`conda activate mne`) each
+time you open a terminal, or put the activation command in your ``.bashrc``
+or ``.profile`` so that it happens automatically.
 
 .. admonition:: |apple| macOS
   :class: note
 
-  If you are on macOS, you need to manually update PyQt5. This step is not needed on Linux, and even breaks things on Windows.
+  If you are on macOS, you need to manually update PyQt5. This step is not
+  needed on Linux, and even breaks things on Windows.
 
   .. code-block:: console
 
     $ pip install --upgrade "pyqt5>=5.10"
 
+Testing your installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-3. Check that everything works
-##############################
-
-To make sure everything installed correctly, type the following command in a terminal:
+To make sure MNE-python installed correctly, type the following command in a
+terminal:
 
 .. code-block:: console
 
-    $ python
+    $ python -c 'import mne; mne.sys_info()'
 
-This should open an interactive Python prompt, where you can type::
+This should display some system information along with the versions of
+MNE-python and its dependencies. Typical output looks like this::
 
-    >>> import mne
+    Platform:      Linux-4.15.0-44-generic-x86_64-with-debian-buster-sid
+    Python:        3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 19:16:44)  [GCC 7.3.0]
+    Executable:    /opt/miniconda3/envs/mne/bin/python
+    CPU:           x86_64: 8 cores
+    Memory:        7.6 GB
 
-If you get a new prompt with no error messages, you should be good to go!
-
-.. admonition:: |windows| Windows
-  :class: note
-
-  If you are on Windows, you might have to use the IPython magic command ``%gui qt``
-  after importing MNE, Mayavi or PySurfer (see `here <https://github.com/ipython/ipython/issues/10384>`_):
-
-  .. code-block:: ipython
-
-     In [1]: from mayavi import mlab
-     In [2]: %gui qt
-
-The ``$ conda env create ...`` step sometimes emits warnings, but you can ensure
-all default dependencies are installed by listing their versions with::
-
-    >>> mne.sys_info()  # doctest:+SKIP
-    Platform:      Linux-4.18.0-13-generic-x86_64-with-debian-buster-sid
-    Python:        3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34)  [GCC 7.3.0]
-    Executable:    /home/travis/miniconda/envs/test/bin/python
-    CPU:           x86_64: 48 cores
-    Memory:        62.7 GB
-
-    mne:           0.17.0
+    mne:           0.18.dev0
     numpy:         1.15.4 {blas=mkl_rt, lapack=mkl_rt}
-    scipy:         1.2.0
+    scipy:         1.1.0
     matplotlib:    3.0.2 {backend=Qt5Agg}
 
     sklearn:       0.20.2
-    nibabel:       2.3.3
-    mayavi:        4.7.0.dev0 {qt_api=pyqt5, PyQt5=5.10.1}
+    nibabel:       2.3.1
+    mayavi:        4.7.0.dev0 {qt_api=pyqt5, PyQt5=5.9.2}
     cupy:          Not found
-    pandas:        0.24.0
+    pandas:        0.23.4
     dipy:          0.15.0
 
+Troubleshooting MNE-python installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For advanced topics like how to get :ref:`CUDA` support or if you are experiencing other issues, check out :ref:`advanced_setup`.
+If something went wrong during installation and you can't figure it out
+yourself, the `MNE mailing list`_ and `MNE gitter channel`_ are good resources
+for troubleshooting installation problems.
 
+**Next:** :doc:`advanced_setup`

--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -56,7 +56,7 @@ you do not have ``curl``.) These commands will create a new environment called
     changed on the command line with the ``-n`` flag; see ``conda env create
     --help`` for more info.
 
-Make sure you activate the environment (`conda activate mne`) each
+Make sure you activate the environment (``conda activate mne``) each
 time you open a terminal, or put the activation command in your ``.bashrc``
 or ``.profile`` so that it happens automatically.
 
@@ -81,7 +81,9 @@ terminal:
     $ python -c 'import mne; mne.sys_info()'
 
 This should display some system information along with the versions of
-MNE-python and its dependencies. Typical output looks like this::
+MNE-python and its dependencies. Typical output looks like this:
+
+.. code-block:: console
 
     Platform:      Linux-4.15.0-44-generic-x86_64-with-debian-buster-sid
     Python:        3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 19:16:44)  [GCC 7.3.0]

--- a/doc/manual/c_reference.rst
+++ b/doc/manual/c_reference.rst
@@ -2561,7 +2561,8 @@ mne_process_raw
 
     Name of the composite digital trigger channel. The default value
     is 'STI 014'. Underscores in the channel name
-    will be replaced by spaces.
+    will be replaced by spaces. May also be specified by an environment
+    variable ``MNE_TRIGGER_CH_NAME``.
 
 ``--digtrigmask <*number*>``
 
@@ -2573,7 +2574,8 @@ mne_process_raw
     to the acquisition system. The number can be given in decimal or
     hexadecimal format (beginning with 0x or 0X). For example, the value
     255 (0xFF) means that only the lowest order byte (usually trigger
-    lines 1 - 8 or bits 0 - 7) will be considered.
+    lines 1 - 8 or bits 0 - 7) will be considered. May also be specified by an
+    environment variable ``MNE_TRIGGER_CH_MASK``.
 
 ``--proj <*name*>``
 

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -40,7 +40,9 @@ What should I install?
 If you intend only to perform ERP, ERF, or other sensor-level analyses,
 :doc:`MNE-python <install_mne_python>` is all you need. If you
 prefer MATLAB over Python, probably all you need is :doc:`MNE-C
-<install_mne_c>` — the MNE MATLAB toolbox is distributed with it.
+<install_mne_c>` — the MNE MATLAB toolbox is distributed with it — although
+note that the MATLAB toolbox is less actively developed than the
+MNE-python module, and hence the MATLAB code is considerably less feature-complete.
 
 If you want to transform sensor recordings into estimates of localized brain
 activity, you will most likely need:

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -17,9 +17,9 @@ Overview of the MNE tools suite
   computing cortically constrained Minimum Norm Estimates from MEG and EEG
   data. These tools were written in C by Matti Hämäläinen.
 
-- :doc:`MNE-python <python_reference>` reimplements the functionality of MNE-C,
+- :doc:`MNE-Python <python_reference>` reimplements the functionality of MNE-C,
   and extends considerably the analysis and visualization capabilities.
-  MNE-python is collaboratively developed and has more than 150 contributors.
+  MNE-Python is collaboratively developed and has more than 150 contributors.
 
 - The :doc:`manual/matlab` provides a MATLAB interface to the .fif file format
   and other MNE data structures, and provides example MATLAB implementations of
@@ -30,7 +30,7 @@ Overview of the MNE tools suite
   and is primarily intended for embedded and real-time applications.
 
 There are also Python tools for easily importing MEG data from the Human
-Connectome Project for use with MNE-python (`MNE-HCP`_), and tools for
+Connectome Project for use with MNE-Python (`MNE-HCP`_), and tools for
 managing MNE projects so that they comply with the Brain Imaging Data Structure
 specification (`MNE-BIDS`_).
 
@@ -38,10 +38,10 @@ What should I install?
 ^^^^^^^^^^^^^^^^^^^^^^
 
 If you intend only to perform ERP, ERF, or other sensor-level analyses,
-:doc:`MNE-python <install_mne_python>` is all you need. If you prefer MATLAB
+:doc:`MNE-Python <install_mne_python>` is all you need. If you prefer MATLAB
 over Python, probably all you need is :doc:`MNE-C <install_mne_c>` — the MNE
 MATLAB toolbox is distributed with it — although note that the MATLAB toolbox
-is less actively developed than the MNE-python module, and hence the MATLAB
+is less actively developed than the MNE-Python module, and hence the MATLAB
 code is considerably less feature-complete.
 
 If you want to transform sensor recordings into estimates of localized brain
@@ -54,7 +54,7 @@ activity, you will most likely need:
   model of tissue conductance, and for aligning coordinate frames between the
   structural MRI and the digitizations of M/EEG sensor locations
 
-- :doc:`MNE-python <install_mne_python>` can be used for everything else
+- :doc:`MNE-Python <install_mne_python>` can be used for everything else
 
 Getting help
 ^^^^^^^^^^^^
@@ -65,7 +65,7 @@ The `MNE mailing list`_ and `MNE gitter channel`_ are a good place to start for
 both troubleshooting and general questions.  If you want to request new
 features or if you're confident that you have found a bug, please create a new
 issue on the `GitHub issues page`_. When reporting bugs, please try to
-replicate the bug with the MNE-python sample data, and make every effort to
+replicate the bug with the MNE-Python sample data, and make every effort to
 simplify your example script to only the elements necessary to replicate the
 bug.
 

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -67,4 +67,4 @@ please try to replicate the bug with the MNE-python sample data, and make every
 effort to simplify your example script to only the elements necessary to
 replicate the bug.
 
-**Next:** :doc:`install_freesurfer`
+**Next:** :doc:`install_mne_python`

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -45,14 +45,14 @@ prefer MATLAB over Python, probably all you need is :doc:`MNE-C
 If you want to transform sensor recordings into estimates of localized brain
 activity, you will most likely need:
 
-- :doc:`FreeSurfer <install_freesurfer>` (to convert structural MRI scans into
-  models of the scalp, inner/outer skull, and cortical surfaces)
+- :doc:`FreeSurfer <install_freesurfer>` to convert structural MRI scans into
+  models of the scalp, inner/outer skull, and cortical surfaces
 
-- :doc:`MNE-C <install_mne_c>` (for constructing and solving a boundary-element
+- :doc:`MNE-C <install_mne_c>` for constructing and solving a boundary-element
   model of tissue conductance, and for aligning coordinate frames between the
-  structural MRI and the digitizations of M/EEG sensor locations)
+  structural MRI and the digitizations of M/EEG sensor locations
 
-- :doc:`MNE-python <install_mne_python>` (for everything else)
+- :doc:`MNE-python <install_mne_python>` can be used for everything else
 
 Getting help
 ^^^^^^^^^^^^

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -12,22 +12,22 @@ Before you install
 Overview of the MNE tools suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The project started with what is now called :doc:`MNE-C <manual/c_reference>` —
-a set of interrelated command-line and GUI programs focused on computing
-cortically constrained Minimum Norm Estimates from MEG and EEG data. These
-tools were written in C by Matti Hämäläinen.
+- :doc:`MNE-C <manual/c_reference>` was the initial stage of this project,
+  providing a set of interrelated command-line and GUI programs focused on
+  computing cortically constrained Minimum Norm Estimates from MEG and EEG
+  data. These tools were written in C by Matti Hämäläinen.
 
-:ref:`MNE-python <api_reference>` reimplements the functionality of MNE-C,
-and extends considerably the analysis and visualization capabilities.
-MNE-python is collaboratively developed and has more than 150 contributors.
+- :doc:`MNE-python <python_reference>` reimplements the functionality of MNE-C,
+  and extends considerably the analysis and visualization capabilities.
+  MNE-python is collaboratively developed and has more than 150 contributors.
 
-The :ref:`ch_matlab` provides a MATLAB interface to the .fif file format and
-other MNE data structures, and provides example MATLAB implementations of
-some of the core analysis functionality of MNE-C. It is distributed alongside
-MNE-C, and can also be downloaded from the `MNE-MATLAB git repository`_.
+- The :doc:`manual/matlab` provides a MATLAB interface to the .fif file format
+  and other MNE data structures, and provides example MATLAB implementations of
+  some of the core analysis functionality of MNE-C. It is distributed alongside
+  MNE-C, and can also be downloaded from the `MNE-MATLAB git repository`_.
 
-:ref:`mne_cpp` provides core MNE functionality implemented in C++ and is
-primarily intended for embedded and real-time applications.
+- :doc:`MNE-CPP <mne_cpp>` provides core MNE functionality implemented in C++
+  and is primarily intended for embedded and real-time applications.
 
 There are also python tools for easily importing MEG data from the Human
 Connectome Project for use with MNE-python (`MNE-HCP`_), and tools for

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -24,8 +24,7 @@ MNE-python is collaboratively developed and has more than 150 contributors.
 The :ref:`ch_matlab` provides a MATLAB interface to the .fif file format and
 other MNE data structures, and provides example MATLAB implementations of
 some of the core analysis functionality of MNE-C. It is distributed alongside
-MNE-C, and can also be downloaded from its
-`git repository <mne-matlab-git>`_.
+MNE-C, and can also be downloaded from the `MNE-MATLAB git repository`_.
 
 :ref:`mne_cpp` provides core MNE functionality implemented in C++ and is
 primarily intended for embedded and real-time applications.

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -12,10 +12,10 @@ Before you install
 Overview of the MNE tools suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The project started with what is now called :ref:`MNE-C <c_reference>` — a set
-of interrelated command-line and GUI programs focused on computing cortically
-constrained Minimum Norm Estimates from MEG and EEG data. These tools were
-written in C by Matti Hämäläinen.
+The project started with what is now called :doc:`MNE-C <manual/c_reference>` —
+a set of interrelated command-line and GUI programs focused on computing
+cortically constrained Minimum Norm Estimates from MEG and EEG data. These
+tools were written in C by Matti Hämäläinen.
 
 :ref:`MNE-python <api_reference>` reimplements the functionality of MNE-C,
 and extends considerably the analysis and visualization capabilities.
@@ -46,14 +46,14 @@ prefer MATLAB over python, probably all you need is :doc:`MNE-C
 If you want to transform sensor recordings into estimates of localized brain
 activity, you will most likely need:
 
-- :ref:`FreeSurfer <install_freesurfer>` (to convert structural MRI scans into
+- :doc:`FreeSurfer <install_freesurfer>` (to convert structural MRI scans into
   models of the scalp, inner/outer skull, and cortical surfaces)
 
-- :ref:`MNE-C <install_mne_c>` (for constructing and solving a boundary-element
+- :doc:`MNE-C <install_mne_c>` (for constructing and solving a boundary-element
   model of tissue conductance, and for aligning coordinate frames between the
   structural MRI and the digitizations of M/EEG sensor locations)
 
-- :ref:`MNE-python <install_python_and_mne_python>` (for everything else)
+- :doc:`MNE-python <install_mne_python>` (for everything else)
 
 Getting help
 ^^^^^^^^^^^^

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -29,7 +29,7 @@ Overview of the MNE tools suite
 - :doc:`MNE-CPP <mne_cpp>` provides core MNE functionality implemented in C++
   and is primarily intended for embedded and real-time applications.
 
-There are also python tools for easily importing MEG data from the Human
+There are also Python tools for easily importing MEG data from the Human
 Connectome Project for use with MNE-python (`MNE-HCP`_), and tools for
 managing MNE projects so that they comply with the Brain Imaging Data Structure
 specification (`MNE-BIDS`_).
@@ -39,7 +39,7 @@ What should I install?
 
 If you intend only to perform ERP, ERF, or other sensor-level analyses,
 :doc:`MNE-python <install_mne_python>` is all you need. If you
-prefer MATLAB over python, probably all you need is :doc:`MNE-C
+prefer MATLAB over Python, probably all you need is :doc:`MNE-C
 <install_mne_c>` — the MNE MATLAB toolbox is distributed with it.
 
 If you want to transform sensor recordings into estimates of localized brain

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -38,11 +38,11 @@ What should I install?
 ^^^^^^^^^^^^^^^^^^^^^^
 
 If you intend only to perform ERP, ERF, or other sensor-level analyses,
-:doc:`MNE-python <install_mne_python>` is all you need. If you
-prefer MATLAB over Python, probably all you need is :doc:`MNE-C
-<install_mne_c>` — the MNE MATLAB toolbox is distributed with it — although
-note that the MATLAB toolbox is less actively developed than the
-MNE-python module, and hence the MATLAB code is considerably less feature-complete.
+:doc:`MNE-python <install_mne_python>` is all you need. If you prefer MATLAB
+over Python, probably all you need is :doc:`MNE-C <install_mne_c>` — the MNE
+MATLAB toolbox is distributed with it — although note that the MATLAB toolbox
+is less actively developed than the MNE-python module, and hence the MATLAB
+code is considerably less feature-complete.
 
 If you want to transform sensor recordings into estimates of localized brain
 activity, you will most likely need:
@@ -61,12 +61,12 @@ Getting help
 
 There are three main channels for obtaining help with MNE software tools.
 
-The `MNE mailing list`_ and `MNE gitter channel`_ are a good
-place to start for both troubleshooting and general questions.  If you want to
-request new features or if you're confident that you have found a bug, please
-create a new issue on the `GitHub issues page`_. When reporting bugs,
-please try to replicate the bug with the MNE-python sample data, and make every
-effort to simplify your example script to only the elements necessary to
-replicate the bug.
+The `MNE mailing list`_ and `MNE gitter channel`_ are a good place to start for
+both troubleshooting and general questions.  If you want to request new
+features or if you're confident that you have found a bug, please create a new
+issue on the `GitHub issues page`_. When reporting bugs, please try to
+replicate the bug with the MNE-python sample data, and make every effort to
+simplify your example script to only the elements necessary to replicate the
+bug.
 
 **Next:** :doc:`install_mne_python`

--- a/doc/pre_install.rst
+++ b/doc/pre_install.rst
@@ -1,0 +1,71 @@
+.. include:: links.inc
+
+.. _preinstall:
+
+Before you install
+==================
+
+.. contents::
+   :local:
+   :depth: 1
+
+Overview of the MNE tools suite
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The project started with what is now called :ref:`MNE-C <c_reference>` — a set
+of interrelated command-line and GUI programs focused on computing cortically
+constrained Minimum Norm Estimates from MEG and EEG data. These tools were
+written in C by Matti Hämäläinen.
+
+:ref:`MNE-python <api_reference>` reimplements the functionality of MNE-C,
+and extends considerably the analysis and visualization capabilities.
+MNE-python is collaboratively developed and has more than 150 contributors.
+
+The :ref:`ch_matlab` provides a MATLAB interface to the .fif file format and
+other MNE data structures, and provides example MATLAB implementations of
+some of the core analysis functionality of MNE-C. It is distributed alongside
+MNE-C, and can also be downloaded from its
+`git repository <mne-matlab-git>`_.
+
+:ref:`mne_cpp` provides core MNE functionality implemented in C++ and is
+primarily intended for embedded and real-time applications.
+
+There are also python tools for easily importing MEG data from the Human
+Connectome Project for use with MNE-python (`MNE-HCP`_), and tools for
+managing MNE projects so that they comply with the Brain Imaging Data Structure
+specification (`MNE-BIDS`_).
+
+What should I install?
+^^^^^^^^^^^^^^^^^^^^^^
+
+If you intend only to perform ERP, ERF, or other sensor-level analyses,
+:doc:`MNE-python <install_mne_python>` is all you need. If you
+prefer MATLAB over python, probably all you need is :doc:`MNE-C
+<install_mne_c>` — the MNE MATLAB toolbox is distributed with it.
+
+If you want to transform sensor recordings into estimates of localized brain
+activity, you will most likely need:
+
+- :ref:`FreeSurfer <install_freesurfer>` (to convert structural MRI scans into
+  models of the scalp, inner/outer skull, and cortical surfaces)
+
+- :ref:`MNE-C <install_mne_c>` (for constructing and solving a boundary-element
+  model of tissue conductance, and for aligning coordinate frames between the
+  structural MRI and the digitizations of M/EEG sensor locations)
+
+- :ref:`MNE-python <install_python_and_mne_python>` (for everything else)
+
+Getting help
+^^^^^^^^^^^^
+
+There are three main channels for obtaining help with MNE software tools.
+
+The `MNE mailing list`_ and `MNE gitter channel`_ are a good
+place to start for both troubleshooting and general questions.  If you want to
+request new features or if you're confident that you have found a bug, please
+create a new issue on the `GitHub issues page`_. When reporting bugs,
+please try to replicate the bug with the MNE-python sample data, and make every
+effort to simplify your example script to only the elements necessary to
+replicate the bug.
+
+**Next:** :doc:`install_freesurfer`

--- a/doc/this_project.inc
+++ b/doc/this_project.inc
@@ -9,4 +9,4 @@
 .. _`MNE gitter channel`: https://gitter.im/mne-tools/mne-python
 .. _`MNE-BIDS`: https://mne-tools.github.io/mne-bids/
 .. _`MNE-HCP`: http://mne-tools.github.io/mne-hcp/
-.. _`mne-matlab-git`: https://github.com/mne-tools/mne-matlab
+.. _`MNE-MATLAB git repository`: https://github.com/mne-tools/mne-matlab

--- a/doc/this_project.inc
+++ b/doc/this_project.inc
@@ -6,3 +6,7 @@
 .. _`mne-scripts`: https://github.com/mne-tools/mne-scripts/
 .. _`MNE mailing list`: http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
 .. _`GitHub issues page`: https://github.com/mne-tools/mne-python/issues/
+.. _`MNE gitter channel`: https://gitter.im/mne-tools/mne-python
+.. _`MNE-BIDS`: https://mne-tools.github.io/mne-bids/
+.. _`MNE-HCP`: http://mne-tools.github.io/mne-hcp/
+.. _`mne-matlab-git`: https://github.com/mne-tools/mne-matlab


### PR DESCRIPTION
This is the first in a series of PRs to improve the documentation.  This PR targets the installation/setup docs.  Highlights:

- converts the Install landing page to a full TOC of all the install pages

- adds a "before you install" page to guide new users about which tools they need and an overview of what each tool does.

- adds a dedicated page on freesurfer installation.

- adds "next" links to the bottom of the main installation pages.  (for now I've avoided trying to hack the sphinx-bootstrap theme to generate these automatically, like the [sphinx-readthedocs theme](https://sphinx-rtd-theme.readthedocs.io/en/latest/) does, but I'm open to that possibility if there's general support for it.)

- attempts to avoid "MNE" in favor of explicit reference to "MNE-C", "MNE-python", or "the MNE MATLAB toolbox".  When reference to all tools in general is needed, I use "the MNE suite of software tools" or similar.

- re-orders `advanced_setup` page topics to follow what I'm guessing is most -> least frequently used topics (i.e., puts ipython/jupyter first).

- describes miniconda alongside anaconda as a valid setup option.

- overhauls the MNE-C install instructions (tightens up some parts, omits others, adds info about missing libxp6 and gfortran).

- a few of minor changes outside the "installation/setup" docs that I noticed along the way:
    - `index.rst`: closing tag now matches opening tag
    - `documentation.rst`: reflow the source text
    - `contributing.rst`: make title more consistent with install pages.

cc #5883 (although this PR doesn't overlap with #5883 much, subsequent ones likely will).
