### PR TITLE
DOC: Fixes activation of Anaconda environemnt

### DIFF
--- a/doc/install_mne_python.rst
+++ b/doc/install_mne_python.rst
@@ -34,7 +34,7 @@ From the command line, install the MNE dependencies to a dedicated ``mne`` Anaco
 
     $ curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
     $ conda env create -f environment.yml
-    $ conda activate mne
+    $ source activate mne
 
 You can also use a web browser to `download the required environment file <https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml>`_
 if you do not have ``curl``.


### PR DESCRIPTION
Changes ```conda activate mne``` to ```source activate mne``` in the installation instructions.