### PR TITLE
MRG: Fix sel

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,8 +64,8 @@ Changelog
 Bug
 ~~~
 
-- Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
-  If your code uses ``Epochs(..., preload=True).drop_bad(...)``, we recommend regenerating these data.
+- Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
+  If your code uses ``Epochs(..., preload=True).drop_bad(reject=..., flat=...)``, we recommend regenerating these data.
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,9 @@ Changelog
 Bug
 ~~~
 
+- Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
+  If your code uses ``Epochs(..., preload=True).drop_bad(...)``, we recommend regenerating these data.
+
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1247,9 +1247,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             self._bad_dropped = True
             logger.info("%d bad epochs dropped" % (n_events - len(good_idx)))
 
-            # Now update our properties
-            self._getitem(good_idx, None, copy=False, drop_event_id=False)
-
             # adjust the data size if there is a reason to (output or update)
             if out or self.preload:
                 if data.flags['OWNDATA'] and data.flags['C_CONTIGUOUS']:
@@ -1258,6 +1255,10 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                     data = data[:n_out]
                     if self.preload:
                         self._data = data
+
+            # Now update our properties (excepd data, which is already fixed)
+            self._getitem(good_idx, None, copy=False, drop_event_id=False,
+                          select_data=False)
 
         return data if out else None
 
@@ -1839,6 +1840,7 @@ class Epochs(BaseEpochs):
         start = int(round(event_samp + self._raw_times[0] * sfreq))
         start -= first_samp
         stop = start + len(self._raw_times)
+        logger.debug('    Getting epoch for %d-%d' % (start, stop))
         data = self._raw._check_bad_segment(start, stop, self.picks,
                                             self.reject_by_annotation)
         return data

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -38,6 +38,8 @@ from mne.datasets import testing
 from mne.tests.common import assert_meg_snr
 
 data_path = testing.data_path(download=False)
+fname_raw_testing = op.join(data_path, 'MEG', 'sample',
+                            'sample_audvis_trunc_raw.fif')
 fname_raw_move = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
 fname_raw_movecomp_sss = op.join(
     data_path, 'SSS', 'test_move_anon_movecomp_raw_sss.fif')
@@ -2537,6 +2539,71 @@ def test_shift_time_raises_when_not_loaded(preload):
         pytest.raises(RuntimeError, epochs.shift_time, timeshift)
     else:
         epochs.shift_time(timeshift)
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('preload', (True, False))
+@pytest.mark.parametrize('fname', (fname_raw_testing, raw_fname))
+def test_epochs_drop_selection(fname, preload):
+    """Test epochs drop and selection."""
+    raw = read_raw_fif(fname, preload=True)
+    raw.info['bads'] = ['MEG 2443']
+    events = mne.make_fixed_length_events(raw, id=1, start=0.5, duration=1.0)
+    assert len(events) > 10
+    kwargs = dict(tmin=-0.2, tmax=0.5, proj=False, baseline=(None, 0))
+    reject = dict(mag=4e-12, grad=4000e-13)
+
+    # Hack the first channel data to store the desired selection in epoch data
+    raw._data[0] = 0.
+    scale = 1e-13
+    vals = scale * np.arange(1, len(events) + 1)
+    raw._data[0, events[:, 0] - raw.first_samp + 1] = vals
+
+    def _get_selection(epochs):
+        """Get the desired selection from our modified epochs."""
+        selection = np.round(epochs.get_data()[:, 0].max(axis=-1) / scale)
+        return selection.astype(int) - 1
+
+    # No rejection
+    epochs = mne.Epochs(raw, events, preload=preload, **kwargs)
+    if not preload:
+        epochs.drop_bad()
+    assert len(epochs) == len(events)  # none dropped
+    selection = _get_selection(epochs)
+    assert_array_equal(np.arange(len(events)), selection)  # kept all
+    assert_array_equal(epochs.selection, selection)
+
+    # Dropping during construction
+    epochs = mne.Epochs(raw, events, preload=preload, reject=reject, **kwargs)
+    if not preload:
+        epochs.drop_bad()
+    assert 4 < len(epochs) < len(events)  # some dropped
+    selection = _get_selection(epochs)
+    assert_array_equal(selection, epochs.selection)
+    good_selection = selection
+
+    # Dropping after construction
+    epochs = mne.Epochs(raw, events, preload=preload, **kwargs)
+    if not preload:
+        epochs.drop_bad()
+    assert len(epochs) == len(events)
+    epochs.drop_bad(reject=reject, verbose=True)
+    assert_array_equal(epochs.selection, good_selection)  # same as before
+    selection = _get_selection(epochs)
+    assert_array_equal(selection, epochs.selection)
+
+    # Dropping after construction manually
+    epochs = mne.Epochs(raw, events, preload=preload, **kwargs)
+    if not preload:
+        epochs.drop_bad()
+    assert_array_equal(epochs.selection, np.arange(len(events)))  # no drops
+    drop_idx = [1, 3]
+    want_selection = np.setdiff1d(np.arange(len(events)), drop_idx)
+    epochs.drop(drop_idx)
+    assert_array_equal(epochs.selection, want_selection)
+    selection = np.round(epochs.get_data()[:, 0].max(axis=-1) / scale)
+    selection = selection.astype(int) - 1
+    assert_array_equal(selection, epochs.selection)
 
 
 run_tests_if_main()

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -148,9 +148,9 @@ class GetEpochsMixin(object):
         select_data: bool
             apply selection to data
             (use `select_data=False` if subclasses do not have a
-             valid `_data` field)
+             valid `_data` field, or data has already been subselected)
         return_indices: bool
-            return the indices of selected epochs from the original object)
+            return the indices of selected epochs from the original object
             in addition to the new `Epochs` objects
         Returns
         -------


### PR DESCRIPTION
Fixes a nasty `Epochs` bug where using `Epochs(..., preload=True)` followed by `epochs.drop_bad(...)` causes the data and selection to be incorrect. Things were broken in #4827, so have been broken since the 0.16.0 release.