### PR TITLE
MRG: use doccer to fill docstrings

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -838,10 +838,7 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
         If not, :func:`mne.events_from_annotations` returns as many events as
         they fit within the annotation duration spaced according to
         `chunk_duration`, which is given in seconds.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see
-        :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more). Defaults to self.verbose.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -61,9 +61,7 @@ def rescale(data, times, baseline, mode='mean', copy=True, picks=None,
         Whether to return a new instance or modify in place.
     picks : list of int | None
         Data to process along the axis=-2 (None, default, processes all).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -503,10 +503,7 @@ class Beamformer(dict):
             Should end in ``'-lcmv.h5'`` or ``'-dics.h5'``.
         overwrite : bool
             If True, overwrite the file (if it exists).
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
         """
         ending = '-%s.h5' % (self['kind'].lower(),)
         check_fname(fname, self['kind'], (ending,))

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -100,9 +100,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         each spatial location, prior to inversion. This may be necessary when
         you use a single sphere model for MEG and ``mode='vertex'``.
         Defaults to ``False``.
-    verbose : bool, str, int, None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -332,9 +330,7 @@ def apply_dics(evoked, filters, verbose=None):
     filters : instance of Beamformer
         DICS spatial filter (beamformer weights)
         Filter weights returned from :func:`make_dics`.
-    verbose : bool, str, int, None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -389,9 +385,7 @@ def apply_dics_epochs(epochs, filters, return_generator=False, verbose=None):
     return_generator : bool
         Return a generator object instead of a list. This allows iterating
         over the stcs without having to keep them all in memory.
-    verbose : bool, str, int, None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -444,9 +438,7 @@ def apply_dics_csd(csd, filters, verbose=None):
     filters : instance of Beamformer
         DICS spatial filter (beamformer weights)
         Filter weights returned from `make_dics`.
-    verbose : bool, str, int, None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -733,9 +725,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         each spatial location, prior to inversion. This may be necessary when
         you use a single sphere model for MEG and ``mode='vertex'``.
         Defaults to ``False``.
-    verbose : bool, str, int, None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -77,9 +77,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         If True, the rank of the leadfield will be reduced by 1 for each
         spatial location. Setting reduce_rank to True is typically necessary
         if you use a single sphere model for MEG.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -275,9 +273,7 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
         Filter weights returned from :func:`make_lcmv`.
     max_ori_out: 'signed'
         Specify in case of pick_ori='max-power'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -323,9 +319,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='signed',
     return_generator : bool
          Return a generator object instead of a list. This allows iterating
          over the stcs without having to keep them all in memory.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
 
     Returns
@@ -377,9 +371,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
         Index of first time sample not to include (index not time is seconds).
     max_ori_out: 'signed'
         Specify in case of pick_ori='max-power'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -567,9 +559,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
         The raw instance used to construct the epochs.
         Must be provided unless epochs are constructed with
         ``preload=False``.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -208,9 +208,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
         The number of dipoles to look for. The default value is 5.
     return_residual : bool
         If True, the residual is returned as an Evoked instance.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -289,9 +289,7 @@ def make_bem_solution(surfs, verbose=None):
     ----------
     surfs : list of dict
         The BEM surfaces to use (`from make_bem_model`)
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -528,9 +526,7 @@ def make_bem_model(subject, ico=4, conductivity=(0.3, 0.006, 0.3),
         single-layer model would be ``[0.3]``.
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -718,9 +714,7 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
         Relative radii for the spherical shells.
     sigmas : array-like
         Sigma values for the spherical shells.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -835,9 +829,7 @@ def fit_sphere_to_headshape(info, dig_kinds='auto', units='m', verbose=None):
 
         .. versionadded:: 0.12
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -878,8 +870,7 @@ def get_fitting_dig(info, dig_kinds='auto', verbose=None):
         be 'auto' (default), which will use only the 'extra' points if
         enough (more than 10) are available, and if not, uses 'extra' and
         'eeg' points.
-    verbose : bool, str or None
-        If not None, override default verbose level
+    %(verbose)s
 
     Returns
     -------
@@ -1052,8 +1043,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
 
         .. versionadded:: 0.12
 
-    verbose : bool, str or None
-        If not None, override default verbose level
+    %(verbose)s
 
     Notes
     -----
@@ -1202,9 +1192,7 @@ def read_bem_surfaces(fname, patch_stats=False, s_id=None, verbose=None):
         If int, only read and return the surface with the given s_id.
         An error will be raised if it doesn't exist. If None, all
         surfaces are read and returned.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1335,9 +1323,7 @@ def read_bem_solution(fname, verbose=None):
     ----------
     fname : string
         The file containing the BEM solution.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1582,9 +1568,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
         installed.
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1738,9 +1722,7 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
         within the subject reconstruction is used.
 
         .. versionadded:: 0.13.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -121,9 +121,7 @@ def equalize_channels(candidates, verbose=None):
     ----------
     candidates : list
         list Raw | Epochs | Evoked | AverageTFR
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -306,10 +304,7 @@ class SetChannelsMixin(object):
             ``projection=False``, the average reference is directly applied to
             the data. If ``ref_channels`` is not ``'average'``, ``projection``
             must be set to ``False`` (the default in this case).
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -486,10 +481,7 @@ class SetChannelsMixin(object):
             in addition to the channel positions (``info['chs'][idx]['loc']``).
 
             .. versionadded: 0.15
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Notes
         -----
@@ -664,10 +656,7 @@ class UpdateChannelsMixin(object):
             in ``info['bads']``.
         selection : list of string
             Restrict sensor channels (MEG, EEG) to this list of channel names.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -935,10 +924,7 @@ class InterpolationMixin(object):
             fit. Default is ``(0., 0., 0.04)``.
 
             .. versionadded:: 0.17
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -172,9 +172,7 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
         Origin of the sphere in the head coordinate frame and in meters.
         Can be ``'auto'``, which means a head-digitization-based origin
         fit. Default is ``(0., 0., 0.04)``.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
                            ref_meg=True, exclude=[])

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -625,9 +625,7 @@ def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
     too_close : str
         How to handle HPI positions too close to the sensors,
         can be 'raise', 'warning', or 'info'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -707,9 +705,7 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
     too_close : str
         How to handle HPI positions too close to the sensors,
         can be 'raise', 'warning', or 'info'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -935,9 +931,7 @@ def _calculate_chpi_coil_locs(raw, t_step_min=0.1, t_step_max=10.,
     too_close : str
         How to handle HPI positions too close to the sensors,
         can be 'raise', 'warning', or 'info'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1062,9 +1056,7 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window=0.2,
     t_window : float
         Time window to use to estimate the amplitudes, default is
         0.2 (200 ms).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/connectivity/effective.py
+++ b/mne/connectivity/effective.py
@@ -88,9 +88,7 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
         but require more memory).
     n_jobs : int
         How many epochs to process in parallel.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -701,9 +701,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
         but require more memory).
     n_jobs : int
         How many epochs to process in parallel.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -129,9 +129,7 @@ def create_default_subject(fs_home=None, update=False, subjects_dir=None,
     subjects_dir : None | str
         Override the SUBJECTS_DIR environment variable
         (os.environ['SUBJECTS_DIR']) as destination for the new subject.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -814,9 +812,7 @@ def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
         otherwise it is read from subject_to's config file.
     subjects_dir : None | str
         Override the SUBJECTS_DIR environment variable.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     subjects_dir, subject_from, scale, uniform = \
         _scale_params(subject_to, subject_from, scale, subjects_dir)
@@ -919,9 +915,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
         Also scale all labels (default True).
     annot : bool
         Copy ``*.annot`` files to the new location (default False).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -1052,9 +1046,7 @@ def scale_source_space(subject_to, src_name, subject_from=None, scale=None,
         Number of jobs to run in parallel if recomputing distances (only
         applies if scale is an array of length 3, and will not use more cores
         than there are source spaces).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -247,9 +247,7 @@ def read_cov(fname, verbose=None):
     fname : string
         The name of file containing the covariance matrix. It should end with
         -cov.fif or -cov.fif.gz.
-    verbose : bool, str, int, or None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -283,9 +281,7 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
         Standard_deviation of the diagonal elements. If dict, keys should be
         `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
         channels. If None, default values will be used (see Notes).
-    verbose : bool, str, int, or None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -411,9 +407,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         the covariance is assumed to be full-rank when regularizing.
 
         .. versionadded:: 0.17
-    verbose : bool | str | int | None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -682,9 +676,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         the covariance is assumed to be full-rank when regularizing.
 
         .. versionadded:: 0.17
-    verbose : bool | str | int | or None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1412,9 +1404,7 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
 
             dict(mag=1e12, grad=1e11, eeg=1e5)
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1555,8 +1545,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
         See :func:`mne.compute_covariance`.
 
         .. versionadded:: 0.17
-    verbose : bool | str | int | None (default None)
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------
@@ -1734,9 +1723,7 @@ def compute_whitener(noise_cov, info, picks=None, rank=None,
         If True, return the rank used to compute the whitener.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1803,9 +1790,7 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=None, rank=None,
 
             dict(mag=1e12, grad=1e11, eeg=1e5)
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -50,8 +50,7 @@ def init_cuda(ignore_config=False, verbose=None):
     ----------
     ignore_config : bool
         If True, ignore the config value MNE_USE_CUDA and force init.
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
     """
     global _cuda_capable
     if _cuda_capable:

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -50,9 +50,7 @@ def init_cuda(ignore_config=False, verbose=None):
     ----------
     ignore_config : bool
         If True, ignore the config value MNE_USE_CUDA and force init.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
     """
     global _cuda_capable

--- a/mne/datasets/eegbci/eegbci.py
+++ b/mne/datasets/eegbci/eegbci.py
@@ -35,8 +35,7 @@ def data_path(url, path=None, force_update=False, update_path=None,
     update_path : bool | None
         If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------
@@ -124,9 +123,7 @@ def load_data(subject, runs, path=None, force_update=False, update_path=None,
     update_path : bool | None
         If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/hf_sef/hf_sef.py
+++ b/mne/datasets/hf_sef/hf_sef.py
@@ -35,8 +35,7 @@ def data_path(dataset='evoked', path=None, force_update=False,
     update_path : bool | None
         If True, set the MNE_DATASETS_HF_SEF_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/kiloword/kiloword.py
+++ b/mne/datasets/kiloword/kiloword.py
@@ -27,8 +27,7 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
     update_path : bool | None
         If True, set the MNE_DATASETS_KILOWORD_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/megsim/megsim.py
+++ b/mne/datasets/megsim/megsim.py
@@ -36,8 +36,7 @@ def data_path(url, path=None, force_update=False, update_path=None,
     update_path : bool | None
         If True, set the MNE_DATASETS_MEGSIM_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------
@@ -127,8 +126,7 @@ def load_data(condition='visual', data_format='raw', data_type='experimental',
     update_path : bool | None
         If True, set the ``MNE_DATASETS_MEGSIM_PATH`` in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -52,8 +52,7 @@ def _data_path(path=None, force_update=False, update_path=None, verbose=None):
     update_path : bool | None
         If True, set the MNE_DATASETS_PHYSIONET_SLEEP_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/sleep_physionet/age.py
+++ b/mne/datasets/sleep_physionet/age.py
@@ -47,9 +47,7 @@ def fetch_data(subjects, recording=[1, 2], path=None, force_update=False,
     update_path : bool | None
         If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/sleep_physionet/temazepam.py
+++ b/mne/datasets/sleep_physionet/temazepam.py
@@ -45,9 +45,7 @@ def fetch_data(subjects, path=None, force_update=False,
     update_path : bool | None
         If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -20,6 +20,8 @@ from .. import __version__ as mne_version
 from ..label import read_labels_from_annot, Label, write_labels_to_annot
 from ..utils import (get_config, set_config, _fetch_file, logger, warn,
                      verbose, get_subjects_dir, hashfunc)
+from ..utils.docs import docdict
+from ..externals.doccer import docformat
 
 
 _data_path_doc = """Get path to local copy of {name} dataset.
@@ -43,15 +45,14 @@ _data_path_doc = """Get path to local copy of {name} dataset.
         it will not be downloaded and the path will be returned as
         '' (empty string). This is mostly used for debugging purposes
         and can be safely ignored by most users.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------
     path : str
         Path to {name} dataset directory.
 """
-
+_data_path_doc = docformat(_data_path_doc, docdict)
 
 _version_doc = """Get version of the local {name} dataset.
 
@@ -603,8 +604,7 @@ def fetch_aparc_sub_parcellation(subjects_dir=None, verbose=None):
     subjects_dir : str | None
         The subjects directory to use. The file will be placed in
         ``subjects_dir + '/fsaverage/label'``.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     References
     ----------
@@ -639,8 +639,7 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
     combine : bool
         If True, also produce the combined/reduced set of 23 labels per
         hemisphere as ``HCPMMP1_combined.annot`` [3]_.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/datasets/visual_92_categories/visual_92_categories.py
+++ b/mne/datasets/visual_92_categories/visual_92_categories.py
@@ -28,8 +28,7 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
     update_path : bool | None
         If True, set the MNE_DATASETS_VISUAL_92_CATEGORIES_PATH in mne-python
         config to the given path. If None, the user is prompted.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/decoding/ems.py
+++ b/mne/decoding/ems.py
@@ -92,8 +92,8 @@ class EMS(TransformerMixin, EstimatorMixin):
 
 
 @verbose
-def compute_ems(epochs, conditions=None, picks=None, n_jobs=1, verbose=None,
-                cv=None):
+def compute_ems(epochs, conditions=None, picks=None, n_jobs=1, cv=None,
+                verbose=None):
     """Compute event-matched spatial filter on epochs.
 
     This version of EMS [1]_ operates on the entire time course. No time
@@ -125,11 +125,9 @@ def compute_ems(epochs, conditions=None, picks=None, n_jobs=1, verbose=None,
         Channels to be included. If None only good data channels are used.
     n_jobs : int, default 1
         Number of jobs to run in parallel.
-    verbose : bool, str, int, or None, default self.verbose
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
     cv : cross-validation object | str | None, default LeaveOneOut
         The cross-validation scheme.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -8,9 +8,10 @@ from .mixin import TransformerMixin
 from .base import BaseEstimator, _check_estimator
 from ..parallel import parallel_func
 from ..utils import (_validate_type, array_split_idx, ProgressBar,
-                     verbose)
+                     verbose, fill_doc)
 
 
+@fill_doc
 class SlidingEstimator(BaseEstimator, TransformerMixin):
     """Search Light.
 
@@ -32,10 +33,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
     n_jobs : int, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
         If -1, then the number of jobs is set to the number of cores.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see
-        :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -420,6 +418,7 @@ def _check_method(estimator, method):
     return method
 
 
+@fill_doc
 class GeneralizingEstimator(SlidingEstimator):
     """Generalization Light.
 
@@ -440,10 +439,7 @@ class GeneralizingEstimator(SlidingEstimator):
     n_jobs : int, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
         If -1, then the number of jobs is set to the number of cores.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see
-        :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
     """
 
     def __repr__(self):  # noqa: D105

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -6,8 +6,10 @@ import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator
 from ..time_frequency.tfr import _compute_tfr, _check_tfr_param
+from ..utils import fill_doc
 
 
+@fill_doc
 class TimeFrequency(TransformerMixin, BaseEstimator):
     """Time frequency transformer.
 
@@ -49,9 +51,7 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
     n_jobs : int, default 1
         The number of epochs to process at the same time. The parallelization
         is implemented across channels.
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -13,7 +13,7 @@ from .base import BaseEstimator
 from .. import pick_types
 from ..filter import filter_data, _triage_filter_params
 from ..time_frequency.psd import psd_array_multitaper
-from ..utils import _check_type_picks, check_version
+from ..utils import _check_type_picks, check_version, fill_doc
 from ..io.pick import pick_info, _pick_data_channels, _picks_by_type
 from ..cov import _check_scalings_user
 
@@ -321,6 +321,7 @@ class Vectorizer(TransformerMixin):
         return X.reshape((len(X),) + self.features_shape_)
 
 
+@fill_doc
 class PSDEstimator(TransformerMixin):
     """Compute power spectrum density (PSD) using a multi-taper method.
 
@@ -346,9 +347,7 @@ class PSDEstimator(TransformerMixin):
         Either "full" or "length" (default). If "full", the PSD will
         be normalized by the sampling rate as well as the length of
         the signal (as in nitime).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -413,6 +412,7 @@ class PSDEstimator(TransformerMixin):
         return psd
 
 
+@fill_doc
 class FilterEstimator(TransformerMixin):
     """Estimator to filter RtEpochs.
 
@@ -471,9 +471,7 @@ class FilterEstimator(TransformerMixin):
         attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
 
     See Also
@@ -700,6 +698,7 @@ class UnsupervisedSpatialFilter(TransformerMixin, BaseEstimator):
         return X
 
 
+@fill_doc
 class TemporalFilter(TransformerMixin):
     """Estimator to filter data array along the last dimension.
 
@@ -774,10 +773,7 @@ class TemporalFilter(TransformerMixin):
         attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
-        self.verbose.
+    %(verbose)s
 
     See Also
     --------

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -471,8 +471,7 @@ class FilterEstimator(TransformerMixin):
         attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
 
     See Also
     --------

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -32,9 +32,10 @@ from .source_space import (_make_volume_source_space, SourceSpaces,
                            _points_outside_surface)
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
-                    check_fname, _pl)
+                    check_fname, _pl, fill_doc)
 
 
+@fill_doc
 class Dipole(object):
     u"""Dipole class for sequential dipole fits.
 
@@ -76,6 +77,7 @@ class Dipole(object):
         The number of free parameters for each fit.
 
         .. versionadded:: 0.15
+    %(verbose)s
 
     See Also
     --------
@@ -90,8 +92,10 @@ class Dipole(object):
     position is fixed as a function of time, use :class:`mne.DipoleFixed`.
     """
 
+    @verbose
     def __init__(self, times, pos, amplitude, ori, gof,
-                 name=None, conf=None, khi2=None, nfree=None):  # noqa: D102
+                 name=None, conf=None, khi2=None, nfree=None,
+                 verbose=None):  # noqa: D102
         self.times = np.array(times)
         self.pos = np.array(pos)
         self.amplitude = np.array(amplitude)
@@ -101,6 +105,7 @@ class Dipole(object):
         self.conf = deepcopy(conf) if conf is not None else dict()
         self.khi2 = np.array(khi2) if khi2 is not None else None
         self.nfree = np.array(nfree) if nfree is not None else None
+        self.verbose = verbose
 
     def __repr__(self):  # noqa: D105
         s = "n_times : %s" % len(self.times)
@@ -252,10 +257,7 @@ class Dipole(object):
             Only used if mode equals 'orthoview'.
 
             .. versionadded:: 0.14.0
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -358,6 +360,7 @@ def _read_dipole_fixed(fname):
                        comment)
 
 
+@fill_doc
 class DipoleFixed(object):
     """Dipole class for fixed-position dipole fits.
 
@@ -382,9 +385,7 @@ class DipoleFixed(object):
         Last sample.
     comment : str
         The dipole comment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -450,10 +451,7 @@ class DipoleFixed(object):
             The name of the .fif file. Must end with ``'.fif'`` or
             ``'.fif.gz'`` to make it explicit that the file contains
             dipole information in FIF format.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
         """
         check_fname(fname, 'DipoleFixed', ('-dip.fif', '-dip.fif.gz',
                                            '_dip.fif', '_dip.fif.gz',),
@@ -495,9 +493,7 @@ def read_dipole(fname, verbose=None):
     ----------
     fname : str
         The name of the .dip or .fif file.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1036,9 +1032,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
 
         .. versionadded:: 0.12
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -51,6 +51,7 @@ from .utils import (check_fname, logger, verbose, _check_type_picks,
                     _check_pandas_installed, _check_preload, GetEpochsMixin,
                     _prepare_read_metadata, _prepare_write_metadata,
                     _check_event_id, _gen_events)
+from .utils.docs import fill_doc
 
 
 def _pack_reject_params(epochs):
@@ -180,6 +181,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
     end_file(fid)
 
 
+@fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
                  ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin):
@@ -241,10 +243,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         See :class:`mne.Epochs` docstring.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
-        raw.verbose.
+    %(verbose)s
 
     Notes
     -----
@@ -253,6 +252,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     used as a constructor for Epochs objects (use instead :class:`mne.Epochs`).
     """
 
+    @verbose
     def __init__(self, info, data, events, event_id=None, tmin=-0.2, tmax=0.5,
                  baseline=(None, 0), raw=None, picks=None, reject=None,
                  flat=None, decim=1, reject_tmin=None, reject_tmax=None,
@@ -467,10 +467,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             .. versionadded:: 0.12
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -527,10 +524,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             applied by computing mean of the baseline period and subtracting it
             from the data. The baseline (a, b) includes both endpoints, i.e.
             all timepoints t such that a <= t <= b.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1023,10 +1017,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             are floats that set the minimum acceptable peak-to-peak amplitude.
             If flat is None then no rejection is done. If 'existing',
             then the flat parameters set at instantiation are used.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1121,10 +1112,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         reason : str
             Reason for dropping the epochs ('ECG', 'timeout', 'blink' etc).
             Default: 'USER'.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1174,10 +1162,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         out : bool
             Return the data. Setting this to False is used to reject bad
             epochs without caching all the data, which saves memory.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
         """
         n_events = len(self.events)
         # in case there are no good events
@@ -1401,10 +1386,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             will slightly differ due to the reduction in precision.
 
             .. versionadded:: 0.17
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Notes
         -----
@@ -1631,6 +1613,7 @@ def _drop_log_stats(drop_log, ignore=('IGNORED',)):
     return perc
 
 
+@fill_doc
 class Epochs(BaseEpochs):
     """Epochs extracted from a Raw instance.
 
@@ -1736,10 +1719,7 @@ class Epochs(BaseEpochs):
         MNE will modify the row indices to match ``epochs.selection``.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
-        raw.verbose.
+    %(verbose)s
 
     Attributes
     ----------
@@ -1772,8 +1752,7 @@ class Epochs(BaseEpochs):
         Time vector in seconds. Goes from `tmin` to `tmax`. Time interval
         between consecutive time samples is equal to the inverse of the
         sampling frequency.
-    verbose : bool, str, int, or None
-        See above.
+    %(verbose)s
 
     See Also
     --------
@@ -1846,6 +1825,7 @@ class Epochs(BaseEpochs):
         return data
 
 
+@fill_doc
 class EpochsArray(BaseEpochs):
     """Epochs object from numpy array.
 
@@ -1917,9 +1897,7 @@ class EpochsArray(BaseEpochs):
         Can be None to use ``np.arange(len(events))``.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -2341,9 +2319,7 @@ def read_epochs(fname, proj=True, preload=True, verbose=None):
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2369,6 +2345,7 @@ class _RawContainer(object):
         self.fid.close()
 
 
+@fill_doc
 class EpochsFIF(BaseEpochs):
     """Epochs read from disk.
 
@@ -2390,10 +2367,7 @@ class EpochsFIF(BaseEpochs):
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
-        raw.verbose.
+    %(verbose)s
 
     See Also
     --------
@@ -2544,10 +2518,7 @@ def add_channels_epochs(epochs_list, verbose=None):
     ----------
     epochs_list : list of Epochs
         Epochs object to concatenate.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
-        True if any of the input epochs have verbose=True.
+    %(verbose)s Defaults to True if any of the input epochs have verbose=True.
 
     Returns
     -------
@@ -2806,9 +2777,7 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
         .. versionadded:: 0.13
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/event.py
+++ b/mne/event.py
@@ -577,9 +577,7 @@ def find_events(raw, stim_channel=None, output='onset',
         at t=0s is present.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -18,7 +18,8 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
 from .channels.layout import _merge_grad_data, _pair_grad_sensors
 from .filter import detrend, FilterMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
-                    SizeMixin, copy_function_doc_to_method_doc, _validate_type)
+                    SizeMixin, copy_function_doc_to_method_doc, _validate_type,
+                    fill_doc)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import plot_evoked_white, plot_evoked_joint
@@ -42,6 +43,7 @@ _aspect_rev = {str(FIFF.FIFFV_ASPECT_AVERAGE): 'average',
                str(FIFF.FIFFV_ASPECT_STD_ERR): 'standard_error'}
 
 
+@fill_doc
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              InterpolationMixin, FilterMixin, ToDataFrameMixin, TimeMixin,
              SizeMixin):
@@ -66,9 +68,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         generally not be loaded directly, but should first be processed using
         SSS/tSSS to remove the compensation signals that may also affect brain
         activity. Can also be "yes" to load without eliciting a warning.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -94,8 +94,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Time vector in seconds. Goes from `tmin` to `tmax`. Time interval
         between consecutive time samples is equal to the inverse of the
         sampling frequency.
-    verbose : bool, str, int, or None.
-        See above.
+    %(verbose)s
 
     Notes
     -----
@@ -143,10 +142,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             applied by computing mean of the baseline period and subtracting it
             from the data. The baseline (a, b) includes both endpoints, i.e.
             all timepoints t such that a <= t <= b.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -646,6 +642,7 @@ def _check_decim(info, decim, offset):
     return decim, offset, new_sfreq
 
 
+@fill_doc
 class EvokedArray(Evoked):
     """Evoked object from numpy array.
 
@@ -664,9 +661,7 @@ class EvokedArray(Evoked):
         Number of averaged epochs. Defaults to 1.
     kind : str
         Type of data, either average or standard_error. Defaults to 'average'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -942,9 +937,7 @@ def read_evokeds(fname, condition=None, baseline=None, kind='average',
         generally not be loaded directly, but should first be processed using
         SSS/tSSS to remove the compensation signals that may also affect brain
         activity. Can also be "yes" to load without eliciting a warning.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/externals/decorator.py
+++ b/mne/externals/decorator.py
@@ -1,6 +1,6 @@
-##########################     LICENCE     ###############################
+# #########################     LICENSE     ############################ #
 
-# Copyright (c) 2005-2012, Michele Simionato
+# Copyright (c) 2005-2018, Michele Simionato
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -33,33 +33,48 @@ for the documentation.
 """
 from __future__ import print_function
 
-__version__ = '3.4.0'
+import re
+import sys
+import inspect
+import operator
+import itertools
+import collections
 
-__all__ = ["decorator", "FunctionMaker", "contextmanager"]
+__version__ = '4.3.2'
 
-
-import sys, re, inspect
 if sys.version >= '3':
     from inspect import getfullargspec
+
     def get_init(cls):
         return cls.__init__
 else:
-    class getfullargspec(object):
+    FullArgSpec = collections.namedtuple(
+        'FullArgSpec', 'args varargs varkw defaults '
+        'kwonlyargs kwonlydefaults annotations')
+
+    def getfullargspec(f):
         "A quick and dirty replacement for getfullargspec for Python 2.X"
-        def __init__(self, f):
-            self.args, self.varargs, self.varkw, self.defaults = \
-                inspect.getargspec(f)
-            self.kwonlyargs = []
-            self.kwonlydefaults = None
-        def __iter__(self):
-            yield self.args
-            yield self.varargs
-            yield self.varkw
-            yield self.defaults
+        return FullArgSpec._make(inspect.getargspec(f) + ([], None, {}))
+
     def get_init(cls):
         return cls.__init__.__func__
 
+try:
+    iscoroutinefunction = inspect.iscoroutinefunction
+except AttributeError:
+    # let's assume there are no coroutine functions in old Python
+    def iscoroutinefunction(f):
+        return False
+try:
+    from inspect import isgeneratorfunction
+except ImportError:
+    # assume no generator function in old Python versions
+    def isgeneratorfunction():
+        return False
+
+
 DEF = re.compile(r'\s*def\s*([_\w][_\w\d]*)\s*\(')
+
 
 # basic functionality
 class FunctionMaker(object):
@@ -68,45 +83,46 @@ class FunctionMaker(object):
     It has attributes name, doc, module, signature, defaults, dict and
     methods update and make.
     """
+
+    # Atomic get-and-increment provided by the GIL
+    _compile_count = itertools.count()
+
+    # make pylint happy
+    args = varargs = varkw = defaults = kwonlyargs = kwonlydefaults = ()
+
     def __init__(self, func=None, name=None, signature=None,
                  defaults=None, doc=None, module=None, funcdict=None):
         self.shortsignature = signature
         if func:
             # func can be a class or a callable, but not an instance method
             self.name = func.__name__
-            if self.name == '<lambda>': # small hack for lambda functions
+            if self.name == '<lambda>':  # small hack for lambda functions
                 self.name = '_lambda_'
             self.doc = func.__doc__
             self.module = func.__module__
             if inspect.isfunction(func):
                 argspec = getfullargspec(func)
-                if hasattr(self, 'set_annotations'):
-                    self.set_annotations(getattr(func, '__annotations__', {}))
+                self.annotations = getattr(func, '__annotations__', {})
                 for a in ('args', 'varargs', 'varkw', 'defaults', 'kwonlyargs',
                           'kwonlydefaults'):
                     setattr(self, a, getattr(argspec, a))
                 for i, arg in enumerate(self.args):
                     setattr(self, 'arg%d' % i, arg)
-                if sys.version < '3': # easy way
-                    self.shortsignature = self.signature = \
-                        inspect.formatargspec(
-                        formatvalue=lambda val: "", *argspec)[1:-1]
-                else: # Python 3 way
-                    allargs = list(self.args)
-                    allshortargs = list(self.args)
-                    if self.varargs:
-                        allargs.append('*' + self.varargs)
-                        allshortargs.append('*' + self.varargs)
-                    elif self.kwonlyargs:
-                        allargs.append('*') # single star syntax
-                    for a in self.kwonlyargs:
-                        allargs.append('%s=None' % a)
-                        allshortargs.append('%s=%s' % (a, a))
-                    if self.varkw:
-                        allargs.append('**' + self.varkw)
-                        allshortargs.append('**' + self.varkw)
-                    self.signature = ', '.join(allargs)
-                    self.shortsignature = ', '.join(allshortargs)
+                allargs = list(self.args)
+                allshortargs = list(self.args)
+                if self.varargs:
+                    allargs.append('*' + self.varargs)
+                    allshortargs.append('*' + self.varargs)
+                elif self.kwonlyargs:
+                    allargs.append('*')  # single star syntax
+                for a in self.kwonlyargs:
+                    allargs.append('%s=None' % a)
+                    allshortargs.append('%s=%s' % (a, a))
+                if self.varkw:
+                    allargs.append('**' + self.varkw)
+                    allshortargs.append('**' + self.varkw)
+                self.signature = ', '.join(allargs)
+                self.shortsignature = ', '.join(allshortargs)
                 self.dict = func.__dict__.copy()
         # func=None happens when decorating a caller
         if name:
@@ -131,33 +147,44 @@ class FunctionMaker(object):
         func.__name__ = self.name
         func.__doc__ = getattr(self, 'doc', None)
         func.__dict__ = getattr(self, 'dict', {})
-        func.__defaults__ = getattr(self, 'defaults', ())
-        func.__kwdefaults__ = getattr(self, 'kwonlydefaults', None)
+        func.__defaults__ = self.defaults
+        func.__kwdefaults__ = self.kwonlydefaults or None
         func.__annotations__ = getattr(self, 'annotations', None)
-        callermodule = sys._getframe(3).f_globals.get('__name__', '?')
+        try:
+            frame = sys._getframe(3)
+        except AttributeError:  # for IronPython and similar implementations
+            callermodule = '?'
+        else:
+            callermodule = frame.f_globals.get('__name__', '?')
         func.__module__ = getattr(self, 'module', callermodule)
         func.__dict__.update(kw)
 
     def make(self, src_templ, evaldict=None, addsource=False, **attrs):
         "Make a new function from a given template and update the signature"
-        src = src_templ % vars(self) # expand name and signature
+        src = src_templ % vars(self)  # expand name and signature
         evaldict = evaldict or {}
-        mo = DEF.match(src)
+        mo = DEF.search(src)
         if mo is None:
             raise SyntaxError('not a valid function template\n%s' % src)
-        name = mo.group(1) # extract the function name
+        name = mo.group(1)  # extract the function name
         names = set([name] + [arg.strip(' *') for arg in
-                             self.shortsignature.split(',')])
+                              self.shortsignature.split(',')])
         for n in names:
             if n in ('_func_', '_call_'):
                 raise NameError('%s is overridden in\n%s' % (n, src))
-        if not src.endswith('\n'): # add a newline just for safety
-            src += '\n' # this is needed in old versions of Python
+
+        if not src.endswith('\n'):  # add a newline for old Pythons
+            src += '\n'
+
+        # Ensure each generated function has a unique filename for profilers
+        # (such as cProfile) that depend on the tuple of (<filename>,
+        # <definition line>, <function name>) being unique.
+        filename = '<%s:decorator-gen-%d>' % (
+            __file__, next(self._compile_count))
         try:
-            code = compile(src, '<string>', 'single')
-            # print >> sys.stderr, 'Compiling %s' % src
+            code = compile(src, filename, 'single')
             exec(code, evaldict)
-        except:
+        except Exception:
             print('Error in generated code:', file=sys.stderr)
             print(src, file=sys.stderr)
             raise
@@ -172,83 +199,257 @@ class FunctionMaker(object):
                doc=None, module=None, addsource=True, **attrs):
         """
         Create a function from the strings name, signature and body.
-        evaldict is the evaluation dictionary. If addsource is true an attribute
-        __source__ is added to the result. The attributes attrs are added,
-        if any.
+        evaldict is the evaluation dictionary. If addsource is true an
+        attribute __source__ is added to the result. The attributes attrs
+        are added, if any.
         """
-        if isinstance(obj, str): # "name(signature)"
+        if isinstance(obj, str):  # "name(signature)"
             name, rest = obj.strip().split('(', 1)
-            signature = rest[:-1] #strip a right parens
+            signature = rest[:-1]  # strip a right parens
             func = None
-        else: # a function
+        else:  # a function
             name = None
             signature = None
             func = obj
         self = cls(func, name, signature, defaults, doc, module)
         ibody = '\n'.join('    ' + line for line in body.splitlines())
-        return self.make('def %(name)s(%(signature)s):\n' + ibody,
-                        evaldict, addsource, **attrs)
+        caller = evaldict.get('_call_')  # when called from `decorate`
+        if caller and iscoroutinefunction(caller):
+            body = ('async def %(name)s(%(signature)s):\n' + ibody).replace(
+                'return', 'return await')
+        else:
+            body = 'def %(name)s(%(signature)s):\n' + ibody
+        return self.make(body, evaldict, addsource, **attrs)
 
-def decorator(caller, func=None):
+
+def decorate(func, caller, extras=()):
     """
-    decorator(caller) converts a caller function into a decorator;
-    decorator(caller, func) decorates a function using a caller.
+    decorate(func, caller) decorates a function using a caller.
+    If the caller is a generator function, the resulting function
+    will be a generator function.
     """
-    if func is not None: # returns a decorated function
-        evaldict = func.__globals__.copy()
-        evaldict['_call_'] = caller
-        evaldict['_func_'] = func
-        return FunctionMaker.create(
-            func, "return _call_(_func_, %(shortsignature)s)",
-            evaldict, undecorated=func, __wrapped__=func)
-    else: # returns a decorator
-        if inspect.isclass(caller):
-            name = caller.__name__.lower()
-            callerfunc = get_init(caller)
-            doc = 'decorator(%s) converts functions/generators into ' \
-                'factories of %s objects' % (caller.__name__, caller.__name__)
-            fun = getfullargspec(callerfunc).args[1] # second arg
-        elif inspect.isfunction(caller):
-            name = '_lambda_' if caller.__name__ == '<lambda>' \
-                else caller.__name__
-            callerfunc = caller
-            doc = caller.__doc__
-            fun = getfullargspec(callerfunc).args[0] # first arg
-        else: # assume caller is an object with a __call__ method
-            name = caller.__class__.__name__.lower()
-            callerfunc = caller.__call__.__func__
-            doc = caller.__call__.__doc__
-            fun = getfullargspec(callerfunc).args[1] # second arg
-        evaldict = callerfunc.__globals__.copy()
-        evaldict['_call_'] = caller
-        evaldict['decorator'] = decorator
-        return FunctionMaker.create(
-            '%s(%s)' % (name, fun),
-            'return decorator(_call_, %s)' % fun,
-            evaldict, undecorated=caller, __wrapped__=caller,
-            doc=doc, module=caller.__module__)
+    evaldict = dict(_call_=caller, _func_=func)
+    es = ''
+    for i, extra in enumerate(extras):
+        ex = '_e%d_' % i
+        evaldict[ex] = extra
+        es += ex + ', '
 
-######################### contextmanager ########################
+    if '3.5' <= sys.version < '3.6':
+        # with Python 3.5 isgeneratorfunction returns True for all coroutines
+        # however we know that it is NOT possible to have a generator
+        # coroutine in python 3.5: PEP525 was not there yet
+        generatorcaller = isgeneratorfunction(
+            caller) and not iscoroutinefunction(caller)
+    else:
+        generatorcaller = isgeneratorfunction(caller)
+    if generatorcaller:
+        fun = FunctionMaker.create(
+            func, "for res in _call_(_func_, %s%%(shortsignature)s):\n"
+                  "    yield res" % es, evaldict, __wrapped__=func)
+    else:
+        fun = FunctionMaker.create(
+            func, "return _call_(_func_, %s%%(shortsignature)s)" % es,
+            evaldict, __wrapped__=func)
+    if hasattr(func, '__qualname__'):
+        fun.__qualname__ = func.__qualname__
+    return fun
 
-def __call__(self, func):
-    'Context manager decorator'
-    return FunctionMaker.create(
-        func, "with _self_: return _func_(%(shortsignature)s)",
-        dict(_self_=self, _func_=func), __wrapped__=func)
 
-try: # Python >= 3.2
+def decorator(caller, _func=None):
+    """decorator(caller) converts a caller function into a decorator"""
+    if _func is not None:  # return a decorated function
+        # this is obsolete behavior; you should use decorate instead
+        return decorate(_func, caller)
+    # else return a decorator function
+    defaultargs, defaults = '', ()
+    if inspect.isclass(caller):
+        name = caller.__name__.lower()
+        doc = 'decorator(%s) converts functions/generators into ' \
+            'factories of %s objects' % (caller.__name__, caller.__name__)
+    elif inspect.isfunction(caller):
+        if caller.__name__ == '<lambda>':
+            name = '_lambda_'
+        else:
+            name = caller.__name__
+        doc = caller.__doc__
+        nargs = caller.__code__.co_argcount
+        ndefs = len(caller.__defaults__ or ())
+        defaultargs = ', '.join(caller.__code__.co_varnames[nargs-ndefs:nargs])
+        if defaultargs:
+            defaultargs += ','
+        defaults = caller.__defaults__
+    else:  # assume caller is an object with a __call__ method
+        name = caller.__class__.__name__.lower()
+        doc = caller.__call__.__doc__
+    evaldict = dict(_call=caller, _decorate_=decorate)
+    dec = FunctionMaker.create(
+        '%s(%s func)' % (name, defaultargs),
+        'if func is None: return lambda func:  _decorate_(func, _call, (%s))\n'
+        'return _decorate_(func, _call, (%s))' % (defaultargs, defaultargs),
+        evaldict, doc=doc, module=caller.__module__, __wrapped__=caller)
+    if defaults:
+        dec.__defaults__ = defaults + (None,)
+    return dec
 
+
+# ####################### contextmanager ####################### #
+
+try:  # Python >= 3.2
     from contextlib import _GeneratorContextManager
-    ContextManager = type(
-        'ContextManager', (_GeneratorContextManager,), dict(__call__=__call__))
+except ImportError:  # Python >= 2.5
+    from contextlib import GeneratorContextManager as _GeneratorContextManager
 
-except ImportError: # Python >= 2.5
 
-    from contextlib import GeneratorContextManager
-    def __init__(self, f, *a, **k):
-        return GeneratorContextManager.__init__(self, f(*a, **k))
-    ContextManager = type(
-        'ContextManager', (GeneratorContextManager,),
-        dict(__call__=__call__, __init__=__init__))
+class ContextManager(_GeneratorContextManager):
+    def __call__(self, func):
+        """Context manager decorator"""
+        return FunctionMaker.create(
+            func, "with _self_: return _func_(%(shortsignature)s)",
+            dict(_self_=self, _func_=func), __wrapped__=func)
 
-contextmanager = decorator(ContextManager)
+
+init = getfullargspec(_GeneratorContextManager.__init__)
+n_args = len(init.args)
+if n_args == 2 and not init.varargs:  # (self, genobj) Python 2.7
+    def __init__(self, g, *a, **k):
+        return _GeneratorContextManager.__init__(self, g(*a, **k))
+    ContextManager.__init__ = __init__
+elif n_args == 2 and init.varargs:  # (self, gen, *a, **k) Python 3.4
+    pass
+elif n_args == 4:  # (self, gen, args, kwds) Python 3.5
+    def __init__(self, g, *a, **k):
+        return _GeneratorContextManager.__init__(self, g, a, k)
+    ContextManager.__init__ = __init__
+
+_contextmanager = decorator(ContextManager)
+
+
+def contextmanager(func):
+    # Enable Pylint config: contextmanager-decorators=decorator.contextmanager
+    return _contextmanager(func)
+
+
+# ############################ dispatch_on ############################ #
+
+def append(a, vancestors):
+    """
+    Append ``a`` to the list of the virtual ancestors, unless it is already
+    included.
+    """
+    add = True
+    for j, va in enumerate(vancestors):
+        if issubclass(va, a):
+            add = False
+            break
+        if issubclass(a, va):
+            vancestors[j] = a
+            add = False
+    if add:
+        vancestors.append(a)
+
+
+# inspired from simplegeneric by P.J. Eby and functools.singledispatch
+def dispatch_on(*dispatch_args):
+    """
+    Factory of decorators turning a function into a generic function
+    dispatching on the given arguments.
+    """
+    assert dispatch_args, 'No dispatch args passed'
+    dispatch_str = '(%s,)' % ', '.join(dispatch_args)
+
+    def check(arguments, wrong=operator.ne, msg=''):
+        """Make sure one passes the expected number of arguments"""
+        if wrong(len(arguments), len(dispatch_args)):
+            raise TypeError('Expected %d arguments, got %d%s' %
+                            (len(dispatch_args), len(arguments), msg))
+
+    def gen_func_dec(func):
+        """Decorator turning a function into a generic function"""
+
+        # first check the dispatch arguments
+        argset = set(getfullargspec(func).args)
+        if not set(dispatch_args) <= argset:
+            raise NameError('Unknown dispatch arguments %s' % dispatch_str)
+
+        typemap = {}
+
+        def vancestors(*types):
+            """
+            Get a list of sets of virtual ancestors for the given types
+            """
+            check(types)
+            ras = [[] for _ in range(len(dispatch_args))]
+            for types_ in typemap:
+                for t, type_, ra in zip(types, types_, ras):
+                    if issubclass(t, type_) and type_ not in t.mro():
+                        append(type_, ra)
+            return [set(ra) for ra in ras]
+
+        def ancestors(*types):
+            """
+            Get a list of virtual MROs, one for each type
+            """
+            check(types)
+            lists = []
+            for t, vas in zip(types, vancestors(*types)):
+                n_vas = len(vas)
+                if n_vas > 1:
+                    raise RuntimeError(
+                        'Ambiguous dispatch for %s: %s' % (t, vas))
+                elif n_vas == 1:
+                    va, = vas
+                    mro = type('t', (t, va), {}).mro()[1:]
+                else:
+                    mro = t.mro()
+                lists.append(mro[:-1])  # discard t and object
+            return lists
+
+        def register(*types):
+            """
+            Decorator to register an implementation for the given types
+            """
+            check(types)
+
+            def dec(f):
+                check(getfullargspec(f).args, operator.lt, ' in ' + f.__name__)
+                typemap[types] = f
+                return f
+            return dec
+
+        def dispatch_info(*types):
+            """
+            An utility to introspect the dispatch algorithm
+            """
+            check(types)
+            lst = []
+            for anc in itertools.product(*ancestors(*types)):
+                lst.append(tuple(a.__name__ for a in anc))
+            return lst
+
+        def _dispatch(dispatch_args, *args, **kw):
+            types = tuple(type(arg) for arg in dispatch_args)
+            try:  # fast path
+                f = typemap[types]
+            except KeyError:
+                pass
+            else:
+                return f(*args, **kw)
+            combinations = itertools.product(*ancestors(*types))
+            next(combinations)  # the first one has been already tried
+            for types_ in combinations:
+                f = typemap.get(types_)
+                if f is not None:
+                    return f(*args, **kw)
+
+            # else call the default implementation
+            return func(*args, **kw)
+
+        return FunctionMaker.create(
+            func, 'return _f_(%s, %%(shortsignature)s)' % dispatch_str,
+            dict(_f_=_dispatch), register=register, default=func,
+            typemap=typemap, vancestors=vancestors, ancestors=ancestors,
+            dispatch_info=dispatch_info, __wrapped__=func)
+
+    gen_func_dec.__name__ = 'dispatch_on' + dispatch_str
+    return gen_func_dec

--- a/mne/externals/doccer.py
+++ b/mne/externals/doccer.py
@@ -1,0 +1,144 @@
+# Trimmed from SciPy's version
+
+''' Utilities to allow inserting docstring fragments for common
+parameters into function and method docstrings'''
+
+from __future__ import division, print_function, absolute_import
+
+import sys
+
+__all__ = ['docformat', 'indentcount_lines',
+           'filldoc', 'unindent_dict', 'unindent_string']
+
+
+def docformat(docstring, docdict=None):
+    ''' Fill a function docstring from variables in dictionary
+
+    Adapt the indent of the inserted docs
+
+    Parameters
+    ----------
+    docstring : string
+        docstring from function, possibly with dict formatting strings
+    docdict : dict, optional
+        dictionary with keys that match the dict formatting strings
+        and values that are docstring fragments to be inserted.  The
+        indentation of the inserted docstrings is set to match the
+        minimum indentation of the ``docstring`` by adding this
+        indentation to all lines of the inserted string, except the
+        first
+
+    Returns
+    -------
+    outstring : string
+        string with requested ``docdict`` strings inserted
+
+    Examples
+    --------
+    >>> docformat(' Test string with %(value)s', {'value':'inserted value'})
+    ' Test string with inserted value'
+    >>> docstring = 'First line\\n    Second line\\n    %(value)s'
+    >>> inserted_string = "indented\\nstring"
+    >>> docdict = {'value': inserted_string}
+    >>> docformat(docstring, docdict)
+    'First line\\n    Second line\\n    indented\\n    string'
+    '''
+    if not docstring:
+        return docstring
+    if docdict is None:
+        docdict = {}
+    if not docdict:
+        return docstring
+    lines = docstring.expandtabs().splitlines()
+    # Find the minimum indent of the main docstring, after first line
+    if len(lines) < 2:
+        icount = 0
+    else:
+        icount = indentcount_lines(lines[1:])
+    indent = ' ' * icount
+    # Insert this indent to dictionary docstrings
+    indented = {}
+    for name, dstr in docdict.items():
+        lines = dstr.expandtabs().splitlines()
+        try:
+            newlines = [lines[0]]
+            for line in lines[1:]:
+                newlines.append(indent+line)
+            indented[name] = '\n'.join(newlines)
+        except IndexError:
+            indented[name] = dstr
+    return docstring % indented
+
+
+def indentcount_lines(lines):
+    ''' Minimum indent for all lines in line list
+
+    >>> lines = [' one', '  two', '   three']
+    >>> indentcount_lines(lines)
+    1
+    >>> lines = []
+    >>> indentcount_lines(lines)
+    0
+    >>> lines = [' one']
+    >>> indentcount_lines(lines)
+    1
+    >>> indentcount_lines(['    '])
+    0
+    '''
+    indentno = sys.maxsize
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped:
+            indentno = min(indentno, len(line) - len(stripped))
+    if indentno == sys.maxsize:
+        return 0
+    return indentno
+
+
+def filldoc(docdict, unindent_params=True):
+    ''' Return docstring decorator using docdict variable dictionary
+
+    Parameters
+    ----------
+    docdict : dictionary
+        dictionary containing name, docstring fragment pairs
+    unindent_params : {False, True}, boolean, optional
+        If True, strip common indentation from all parameters in
+        docdict
+
+    Returns
+    -------
+    decfunc : function
+        decorator that applies dictionary to input function docstring
+
+    '''
+    if unindent_params:
+        docdict = unindent_dict(docdict)
+
+    def decorate(f):
+        f.__doc__ = docformat(f.__doc__, docdict)
+        return f
+    return decorate
+
+
+def unindent_dict(docdict):
+    ''' Unindent all strings in a docdict '''
+    can_dict = {}
+    for name, dstr in docdict.items():
+        can_dict[name] = unindent_string(dstr)
+    return can_dict
+
+
+def unindent_string(docstring):
+    ''' Set docstring to minimum indent for all lines, including first
+
+    >>> unindent_string(' two')
+    'two'
+    >>> unindent_string('  two\\n   three')
+    'two\\n three'
+    '''
+    lines = docstring.expandtabs().splitlines()
+    icount = indentcount_lines(lines)
+    if icount == 0:
+        return docstring
+    return '\n'.join([line[icount:] for line in lines])

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -822,8 +822,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
         Only used for ``method='fir'``.
 
         .. versionadded:: 0.15
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
 
     Returns
     -------
@@ -946,8 +945,7 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
         attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
 
     Returns
     -------
@@ -2116,8 +2114,7 @@ def design_mne_c_filter(sfreq, l_freq=None, h_freq=40.,
         Low transition bandwidthin Hz. Can be None (default) to use 3 samples.
     h_trans_bandwidth : float
         High transition bandwidth in Hz.
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -822,9 +822,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
         Only used for ``method='fir'``.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
 
     Returns
@@ -948,9 +946,7 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
         attenuation using fewer samples than "firwin2".
 
         ..versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
 
     Returns
@@ -1258,9 +1254,7 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
         Only used for ``method='fir'``.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1499,9 +1493,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
         values of the vector, followed by zeros.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1864,10 +1856,7 @@ class FilterMixin(object):
             done using polynomial fits instead of FIR/IIR filtering.
             This parameter is thus used to determine the length of the
             window over which a 5th-order polynomial smoothing is used.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -2021,10 +2010,7 @@ class FilterMixin(object):
             values of the vector, followed by zeros. The default is "edge",
             which pads with the edge values of each vector.
             Only used for ``method='fir'``.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -2074,10 +2060,7 @@ class FilterMixin(object):
             which pads with the edge values of each vector.
 
             .. versionadded:: 0.15
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` :ref:`Logging documentation <tut_logging>` for
-            more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -2133,9 +2116,7 @@ def design_mne_c_filter(sfreq, l_freq=None, h_freq=40.,
         Low transition bandwidthin Hz. Can be None (default) to use 3 samples.
     h_trans_bandwidth : float
         High transition bandwidth in Hz.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
 
     Returns

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -688,9 +688,7 @@ def _prep_field_computation(rr, bem, fwd_data, n_jobs, verbose=None):
         sensor information for later forward calculations
     n_jobs : int
         Number of jobs to run in parallel
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     bem_rr = mults = mri_Q = head_mri_t = None
     if not bem['is_sphere']:
@@ -773,9 +771,7 @@ def _compute_forwards_meeg(rr, fd, n_jobs, verbose=None):
         Dict containing forward data after update in _prep_field_computation
     n_jobs : int
         Number of jobs to run in parallel
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -245,9 +245,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
         Origin of the sphere in the head coordinate frame and in meters.
         The default is ``'auto'``, which means a head-digitization-based
         origin fit.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -373,9 +371,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         .. versionadded:: 0.11
     n_jobs : int
         The number of jobs to run in parallel.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -41,9 +41,7 @@ def _read_coil_defs(verbose=None):
 
     Parameters
     ----------
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -282,9 +280,7 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
         If True, compute and store ex, ey, ez, and r0_exey.
     do_picking : bool
         If True, pick info and return it.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -381,9 +377,7 @@ def _prep_eeg_channels(info, exclude=(), verbose=None):
     exclude : list of str | str
         List of channels to exclude. If 'bads', exclude channels in
         info['bads']
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -541,9 +535,7 @@ def make_forward_solution(info, trans, src, bem, meg=True, eeg=True,
         with reference channels is not currently supported.
     n_jobs : int
         Number of jobs to run in parallel.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -627,6 +619,7 @@ def make_forward_solution(info, trans, src, bem, meg=True, eeg=True,
     return fwd
 
 
+@verbose
 def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
     """Convert dipole object to source estimate and calculate forward operator.
 
@@ -657,9 +650,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
         is a sphere model.
     n_jobs : int
         Number of jobs to run in parallel (used in making forward solution).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -392,9 +392,7 @@ def read_forward_solution(fname, include=(), exclude=(), verbose=None):
     exclude : list, optional
         List of names of channels to exclude. If empty include all
         channels.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -581,9 +579,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
     use_cps : bool (default True)
         Whether to use cortical patch statistics to define normal
         orientations. Only used when surf_ori and/or force_fixed are True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -725,9 +721,7 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
         Forward solution.
     overwrite : bool
         If True, overwrite destination file (if it exists).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -952,9 +946,7 @@ def compute_orient_prior(forward, loose=0.2, verbose=None):
         Forward operator.
     loose : float in [0, 1]
         The loose orientation parameter.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1180,9 +1172,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
         orientations when converting to fixed orientation (if necessary).
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1243,9 +1233,7 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
         Index of first time sample (index not time is seconds).
     stop : int, optional
         Index of first time sample not to include (index not time is seconds).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1513,9 +1501,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
         If False (default), an error will be raised if the file exists.
     subjects_dir : None | str
         Override the SUBJECTS_DIR environment variable.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -111,9 +111,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         bugs.
 
         .. versionadded:: 0.18
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -38,9 +38,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
     gammas : array, shape=(n_sources,)
         Initial values for posterior variances (gammas). If None, a
         variance of 1.0 is used.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -217,9 +215,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
         If True, the residual is returned as an Evoked instance.
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/inverse_sparse/mxne_debiasing.py
+++ b/mne/inverse_sparse/mxne_debiasing.py
@@ -83,9 +83,7 @@ def compute_bias(M, G, X, max_iter=1000, tol=1e-6, n_orient=1, verbose=None):
         The tolerance on convergence.
     n_orient : int
         The number of orientations (1 for fixed and 3 otherwise).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -234,9 +234,7 @@ def make_stc_from_dipoles(dipoles, src, verbose=None):
         The dipoles to convert.
     src : instance of SourceSpaces
         The source space used to generate the forward operator.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -343,9 +341,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     dgap_freq : int or np.inf
         The duality gap is evaluated every dgap_freq iterations. Ignored if
         solver is 'cd'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -584,9 +580,7 @@ def tf_mixed_norm(evoked, forward, noise_cov,
         * l1_ratio. 0 means no time regularization aka MxNE.
     dgap_freq : int or np.inf
         The duality gap is evaluated every dgap_freq iterations.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
 
     Returns

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -402,9 +402,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
         The number of iterations.
     tol : float
         Tolerance on dual gap for convergence checking.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     active_set_size : int
         Size of active set increase at each iteration.
     debias : bool
@@ -589,9 +587,7 @@ def iterative_mixed_norm_solver(M, G, alpha, n_mxne_iter, maxit=3000,
         The number of iterations.
     tol : float
         Tolerance on dual gap for convergence checking.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     active_set_size : int
         Size of active set increase at each iteration.
     debias : bool
@@ -1239,9 +1235,7 @@ def tf_mixed_norm_solver(M, G, alpha_space, alpha_time, wsize=64, tstep=4,
         Return final duality gap.
     dgap_freq : int or np.inf
         The duality gap is evaluated every dgap_freq iterations.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -7,9 +7,10 @@
 import numpy as np
 
 from ..base import BaseRaw
-from ...utils import verbose, logger, _validate_type
+from ...utils import verbose, logger, _validate_type, fill_doc
 
 
+@fill_doc
 class RawArray(BaseRaw):
     """Raw object from numpy array.
 
@@ -25,9 +26,7 @@ class RawArray(BaseRaw):
 
         .. versionadded:: 0.12
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -34,8 +34,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
     pos_fname : str or None (default None)
         If not None, load digitized head points from this file
     add_head_trans : bool (default True)
@@ -306,8 +305,7 @@ class RawArtemis123(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -37,7 +37,7 @@ from ..filter import (filter_data, notch_filter, resample, next_fast_len,
                       _filt_update_info)
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
-                     _check_pandas_index_arguments, _pl,
+                     _check_pandas_index_arguments, _pl, fill_doc,
                      check_fname, _get_stim_channel,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc,
@@ -250,6 +250,7 @@ def _check_fun(fun, d, *args, **kwargs):
     return d
 
 
+@fill_doc
 class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
               InterpolationMixin, ToDataFrameMixin, TimeMixin, SizeMixin):
     """Base class for Raw data.
@@ -292,9 +293,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         the header file. Example: {'FC1': 'nV'}
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -423,10 +422,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ----------
         grade : int
             CTF gradient compensation level.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -483,10 +479,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             to store the data.
         projector : array
             SSP operator to apply to the data.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -633,10 +626,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -955,10 +945,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             'bad' are omitted. If 'NaN', the bad samples are filled with NaNs.
         return_times : bool
             Whether to return times as well. Defaults to False.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1165,10 +1152,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             will be padded with zeros before computing Hilbert, then cut back
             to original length. If None, n == self.n_times. If 'auto',
             the next highest fast FFT length will be use.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1333,10 +1317,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Only used for ``method='fir'``.
 
             .. versionadded:: 0.15
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1478,10 +1459,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Only used for ``method='fir'``.
 
             .. versionadded:: 0.15
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1569,10 +1547,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             values of the vector, followed by zeros.
 
             .. versionadded:: 0.15
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1795,10 +1770,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
             .. versionadded:: 0.17
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Notes
         -----
@@ -2642,9 +2614,7 @@ def concatenate_raws(raws, preload=None, events_list=None, verbose=None):
         have or not have data preloaded.
     events_list : None | list
         The events to concatenate. Defaults to None.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -21,7 +21,7 @@ from io import StringIO
 
 import numpy as np
 
-from ...utils import verbose, logger, warn
+from ...utils import verbose, logger, warn, fill_doc
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
@@ -29,6 +29,7 @@ from ..utils import _read_segments_file, _mult_cal_one, _deprecate_stim_channel
 from ...annotations import Annotations, read_annotations
 
 
+@fill_doc
 class RawBrainVision(BaseRaw):
     """Raw object from Brain Vision EEG file.
 
@@ -61,9 +62,7 @@ class RawBrainVision(BaseRaw):
         :func:`mne.events_from_annotations` instead.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -776,6 +775,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             orig_units)
 
 
+@fill_doc
 def read_raw_brainvision(vhdr_fname, montage=None,
                          eog=('HEOGL', 'HEOGR', 'VEOGb'), misc='auto',
                          scale=1., preload=False, stim_channel=False,
@@ -810,9 +810,7 @@ def read_raw_brainvision(vhdr_fname, montage=None,
         :func:`mne.events_from_annotations` instead.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1020,9 +1020,7 @@ class RawBTi(BaseRaw):
 
         ..versionadded:: 0.11
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
 
     @verbose
@@ -1386,9 +1384,7 @@ def read_raw_bti(pdf_fname, config_fname='config',
 
         ..versionadded:: 0.11
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -9,15 +9,15 @@ import calendar
 
 import numpy as np
 
-from ...utils import warn, verbose
+from ...utils import warn, verbose, fill_doc
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
-from ..utils import _mult_cal_one, _find_channels, _create_chs
+from ..utils import _mult_cal_one, _find_channels, _create_chs, read_str
 from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
-from ..utils import read_str
 
 
+@fill_doc
 def read_raw_cnt(input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
                  data_format='auto', date_format='mm/dd/yy', preload=False,
                  verbose=None):
@@ -73,9 +73,7 @@ def read_raw_cnt(input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -292,6 +290,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     return info, cnt_info
 
 
+@fill_doc
 class RawCNT(BaseRaw):
     """Raw object from Neuroscan CNT file.
 
@@ -344,9 +343,7 @@ class RawCNT(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -9,7 +9,7 @@ import os.path as op
 
 import numpy as np
 
-from ...utils import verbose, logger, _clean_names
+from ...utils import verbose, logger, _clean_names, fill_doc
 
 from ..base import BaseRaw
 from ..utils import _mult_cal_one, _blk_read_lims
@@ -22,6 +22,7 @@ from .info import _compose_meas_info, _read_bad_chans, _annotate_bad_segments
 from .constants import CTF
 
 
+@fill_doc
 def read_raw_ctf(directory, system_clock='truncate', preload=False,
                  clean_names=False, verbose=None):
     """Raw object from CTF directory.
@@ -44,9 +45,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
     clean_names : bool, optional
         If True main channel names and compensation channel names will
         be cleaned from CTF suffixes. The default is False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -65,6 +64,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
                   clean_names=clean_names, verbose=verbose)
 
 
+@fill_doc
 class RawCTF(BaseRaw):
     """Raw object from CTF directory.
 
@@ -86,9 +86,7 @@ class RawCTF(BaseRaw):
     clean_names : bool, optional
         If True main channel names and compensation channel names will
         be cleaned from CTF suffixes. The default is False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/io/ctf_comp.py
+++ b/mne/io/ctf_comp.py
@@ -66,9 +66,7 @@ def read_ctf_comp(fid, node, chs, verbose=None):
     chs : list
         The list of channels from info['chs'] to match with
         compensators that are read.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -24,7 +24,7 @@ from ..base import BaseRaw, _check_update_montage
 from ..meas_info import _empty_info, _unique_channel_names, DATE_NONE
 from ..constants import FIFF
 from ...filter import resample
-from ...utils import copy_function_doc_to_method_doc, deprecated
+from ...utils import copy_function_doc_to_method_doc, deprecated, fill_doc
 from ...annotations import Annotations, events_from_annotations
 from ._utils import _load_gdf_events_lut
 
@@ -78,6 +78,7 @@ def find_edf_events(raw):
     return events_from_annotations(raw)
 
 
+@fill_doc
 class RawEDF(BaseRaw):
     """Raw object from EDF, EDF+ or BDF file.
 
@@ -119,9 +120,7 @@ class RawEDF(BaseRaw):
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard drive
         (slower, but requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -210,6 +209,7 @@ class RawEDF(BaseRaw):
         return events_from_annotations(self)
 
 
+@fill_doc
 class RawGDF(BaseRaw):
     """Raw object from GDF file.
 
@@ -243,9 +243,7 @@ class RawGDF(BaseRaw):
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard drive
         (slower, but requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1163,6 +1161,7 @@ def _find_tal_idx(ch_names):
     return tal_channel_idx
 
 
+@fill_doc
 def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
                  stim_channel='auto', exclude=(), preload=False, verbose=None):
     """Reader function for EDF or EDF+ files.
@@ -1205,9 +1204,7 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard drive
         (slower, but requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1250,6 +1247,7 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
                   verbose=verbose)
 
 
+@fill_doc
 def read_raw_bdf(input_fname, montage=None, eog=None, misc=None,
                  stim_channel='auto', exclude=(), preload=False, verbose=None):
     """Reader function for BDF files.
@@ -1292,9 +1290,7 @@ def read_raw_bdf(input_fname, montage=None, eog=None, misc=None,
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard drive
         (slower, but requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1347,6 +1343,7 @@ def read_raw_bdf(input_fname, montage=None, eog=None, misc=None,
                   verbose=verbose)
 
 
+@fill_doc
 def read_raw_gdf(input_fname, montage=None, eog=None, misc=None,
                  stim_channel='auto', exclude=(), preload=False, verbose=None):
     """Reader function for GDF files.
@@ -1381,9 +1378,7 @@ def read_raw_gdf(input_fname, montage=None, eog=None, misc=None,
         amount of memory). If preload is a string, preload is the file name of
         a memory-mapped file which is used to store the data on the hard drive
         (slower, but requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -13,7 +13,7 @@ from ..utils import (_read_segments_file, _find_channels,
 from ..constants import FIFF, Bunch
 from ..meas_info import _empty_info, create_info
 from ..base import BaseRaw, _check_update_montage
-from ...utils import logger, verbose, warn
+from ...utils import logger, verbose, warn, fill_doc
 from ...channels.montage import Montage
 from ...epochs import BaseEpochs
 from ...event import read_events
@@ -134,6 +134,7 @@ def _get_info(eeg, montage, eog=()):
     return info
 
 
+@fill_doc
 def read_raw_eeglab(input_fname, montage=None, eog=(), preload=False,
                     uint16_codec=None, stim_channel=False, verbose=None):
     r"""Read an EEGLAB .set file.
@@ -170,9 +171,7 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), preload=False,
         :func:`mne.events_from_annotations` instead.
 
         .. versionadded:: 0.17
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -192,6 +191,7 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), preload=False,
                      stim_channel=stim_channel)
 
 
+@fill_doc
 def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
                        eog=(), verbose=None, uint16_codec=None):
     r"""Reader function for EEGLAB epochs files.
@@ -226,9 +226,7 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is
@@ -256,6 +254,7 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None, montage=None,
     return epochs
 
 
+@fill_doc
 class RawEEGLAB(BaseRaw):
     r"""Raw object from EEGLAB .set file.
 
@@ -289,9 +288,7 @@ class RawEEGLAB(BaseRaw):
         :func:`mne.events_from_annotations` instead.
 
         .. versionadded:: 0.17
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -421,9 +418,7 @@ class EpochsEEGLAB(BaseEpochs):
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -127,15 +127,13 @@ def read_raw_egi(input_fname, montage=None, eog=None, misc=None,
         ..versionadded:: 0.11
 
     channel_naming : str
-        Channel naming convention for the data channels. Defaults to 'E%d'
+        Channel naming convention for the data channels. Defaults to 'E%%d'
         (resulting in channel names 'E1', 'E2', 'E3'...). The effective default
-        prior to 0.14.0 was 'EEG %03d'.
+        prior to 0.14.0 was 'EEG %%03d'.
 
          ..versionadded:: 0.14.0
 
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -254,8 +254,7 @@ def _read_raw_egi_mff(input_fname, montage=None, eog=None, misc=None,
         Channel naming convention for the data channels. Defaults to 'E%d'
         (resulting in channel names 'E1', 'E2', 'E3'...). The effective default
         prior to 0.14.0 was 'EEG %03d'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -8,9 +8,10 @@ import os.path as op
 from ..base import BaseRaw
 from ..utils import _read_segments_file, _file_size
 from ..meas_info import create_info
-from ...utils import logger, verbose, warn
+from ...utils import logger, verbose, warn, fill_doc
 
 
+@fill_doc
 def read_raw_eximia(fname, preload=False, verbose=None):
     """Reader for an eXimia EEG file.
 
@@ -20,8 +21,7 @@ def read_raw_eximia(fname, preload=False, verbose=None):
         Path to the eXimia data file (.nxe).
     preload : bool
         If True, all data are loaded at initialization.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Returns
     -------
@@ -35,6 +35,7 @@ def read_raw_eximia(fname, preload=False, verbose=None):
     return RawEximia(fname, preload, verbose)
 
 
+@fill_doc
 class RawEximia(BaseRaw):
     """Raw object from an Eximia EEG file.
 
@@ -44,8 +45,7 @@ class RawEximia(BaseRaw):
         Path to the eXimia data file (.nxe).
     preload : bool
         If True, all data are loaded at initialization.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -25,9 +25,10 @@ from ...annotations import (Annotations, _combine_annotations,
                             _read_annotations_fif)
 
 from ...event import AcqParserFIF
-from ...utils import check_fname, logger, verbose, warn
+from ...utils import check_fname, logger, verbose, warn, fill_doc
 
 
+@fill_doc
 class Raw(BaseRaw):
     """Raw data in FIF format.
 
@@ -50,9 +51,7 @@ class Raw(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -68,9 +67,7 @@ class Raw(BaseRaw):
         inverse of the sampling frequency.
     preload : bool
         Indicates whether raw data are in memory.
-    verbose : bool, str, int, or None
-        See above.
-
+    %(verbose)s
     """
 
     @verbose
@@ -418,6 +415,7 @@ def _check_entry(first, nent):
         raise IOError('Could not read data, perhaps this is a corrupt file')
 
 
+@fill_doc
 def read_raw_fif(fname, allow_maxshield=False, preload=False, verbose=None):
     """Reader function for Raw FIF data.
 
@@ -440,9 +438,7 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False, verbose=None):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -18,7 +18,7 @@ from scipy import linalg
 
 from ..pick import pick_types
 from ...coreg import fit_matched_points, _decimate_points
-from ...utils import verbose, logger, warn
+from ...utils import verbose, logger, warn, fill_doc
 from ...transforms import (apply_trans, als_ras_trans,
                            get_ras_to_neuromag_trans, Transform)
 from ..base import BaseRaw
@@ -39,6 +39,7 @@ class UnsupportedKITFormat(ValueError):
         ValueError.__init__(self, *args, **kwargs)
 
 
+@fill_doc
 class RawKIT(BaseRaw):
     """Raw object from KIT SQD file.
 
@@ -83,9 +84,7 @@ class RawKIT(BaseRaw):
     allow_unknown_format : bool
         Force reading old data that is not officially supported. Alternatively,
         read and re-save the data with the KIT MEG Laboratory application.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -353,9 +352,7 @@ class EpochsKIT(BaseEpochs):
     allow_unknown_format : bool
         Force reading old data that is not officially supported. Alternatively,
         read and re-save the data with the KIT MEG Laboratory application.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -794,6 +791,7 @@ def get_kit_info(rawfile, allow_unknown_format):
     return info, sqd
 
 
+@fill_doc
 def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
                  slope='-', stimthresh=1, preload=False, stim_code='binary',
                  allow_unknown_format=False, verbose=None):
@@ -837,9 +835,7 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
     allow_unknown_format : bool
         Force reading old data that is not officially supported. Alternatively,
         read and re-save the data with the KIT MEG Laboratory application.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -861,6 +857,7 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
                   allow_unknown_format=allow_unknown_format, verbose=verbose)
 
 
+@fill_doc
 def read_epochs_kit(input_fname, events, event_id=None, mrk=None, elp=None,
                     hsp=None, allow_unknown_format=False, verbose=None):
     """Reader function for KIT epochs files.
@@ -895,9 +892,7 @@ def read_epochs_kit(input_fname, events, event_id=None, mrk=None, elp=None,
     allow_unknown_format : bool
         Force reading old data that is not officially supported. Alternatively,
         read and re-save the data with the KIT MEG Laboratory application.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/matrix.py
+++ b/mne/io/matrix.py
@@ -32,9 +32,7 @@ def _read_named_matrix(fid, node, matkind, indent='    ', transpose=False,
         The type of matrix.
     transpose : bool
         If True, transpose the matrix. Default is False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -603,9 +603,7 @@ def read_fiducials(fname, verbose=None):
     ----------
     fname : str
         The filename to read.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -653,9 +651,7 @@ def write_fiducials(fname, pts, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
     coord_frame : int
         The coordinate frame of the points (one of
         mne.io.constants.FIFF.FIFFV_COORD_...).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     write_dig(fname, pts, coord_frame)
 
@@ -892,9 +888,7 @@ def read_info(fname, verbose=None):
     ----------
     fname : str
         File name.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -948,9 +942,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
         If True, clean info['bads'] before running consistency check.
         Should only be needed for old files where we did not check bads
         before saving.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1710,9 +1702,7 @@ def _merge_info(infos, force_update_to_first=False, verbose=None):
         If True, force the fields for objects in `info` will be updated
         to match those in the first item. Use at your own risk, as this
         may overwrite important metadata.
-    verbose : bool, str, int, or NonIe
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1815,9 +1805,7 @@ def create_info(ch_names, sfreq, ch_types=None, montage=None, verbose=None):
         digitizer information will be updated. A list of unique montages,
         can be specified and applied to the info. See also the documentation of
         :func:`mne.channels.read_montage` for more information.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -7,13 +7,14 @@ from os import path
 import datetime
 import calendar
 
-from ...utils import logger
+from ...utils import logger, fill_doc
 from ..utils import _read_segments_file, _find_channels, _create_chs
 from ..base import BaseRaw, _check_update_montage
 from ..meas_info import _empty_info
 from ..constants import FIFF
 
 
+@fill_doc
 def read_raw_nicolet(input_fname, ch_type, montage=None, eog=(), ecg=(),
                      emg=(), misc=(), preload=False, verbose=None):
     """Read Nicolet data as raw object.
@@ -54,9 +55,7 @@ def read_raw_nicolet(input_fname, ch_type, montage=None, eog=(), ecg=(),
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -159,9 +158,7 @@ class RawNicolet(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -85,9 +85,7 @@ def fiff_open(fname, preload=False, verbose=None):
         If True, all data from the file is read into a memory buffer. This
         requires more memory, but can be faster for I/O operations that require
         frequent seeks.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -154,6 +152,7 @@ def fiff_open(fname, preload=False, verbose=None):
     return fid, tree, directory
 
 
+@verbose
 def show_fiff(fname, indent='    ', read_limit=np.inf, max_str=30,
               output=str, tag=None, verbose=None):
     """Show FIFF information.
@@ -177,9 +176,7 @@ def show_fiff(fname, indent='    ', read_limit=np.inf, max_str=30,
     tag : int | None
         Provide information about this tag. If None (default), all information
         is shown.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     if output not in [list, str]:
         raise ValueError('output must be list or str')

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -379,9 +379,7 @@ def pick_info(info, sel=(), copy=True, verbose=None):
         are included.
     copy : bool
         If copy is False, info is modified inplace.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -501,9 +499,7 @@ def pick_channels_forward(orig, include=[], exclude=[], verbose=None):
     exclude : list of string | 'bads'
         Channels to exclude (if empty, do not exclude any). Defaults to [].
         If 'bads', then exclude bad channels in orig.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -156,10 +156,7 @@ class ProjMixin(object):
             List with projection vectors.
         remove_existing : bool
             Remove the projection vectors currently in the file.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -353,9 +350,7 @@ def _read_proj(fid, node, verbose=None):
         The file descriptor of the open file.
     node : tree node
         The node of the tree where to look.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -700,9 +695,7 @@ def activate_proj(projs, copy=True, verbose=None):
         The projectors.
     copy : bool
         Modify projs in place or operate on a copy.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -733,9 +726,7 @@ def deactivate_proj(projs, copy=True, verbose=None):
         The projectors.
     copy : bool
         Modify projs in place or operate on a copy.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -764,9 +755,7 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
         Measurement info.
     activate : bool
         If True projections are activated.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -840,9 +829,7 @@ def setup_proj(info, add_eeg_ref=True, activate=True, verbose=None):
         already exists).
     activate : bool
         If True projections are activated.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -313,9 +313,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         the average reference is directly applied to the data.
         If ``ref_channels`` is not ``'average'``, ``projection`` must be set to
         ``False`` (the default in this case).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -435,9 +433,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     copy : bool
         Whether to operate on a copy of the data (True) or modify it in-place
         (False). Defaults to True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/label.py
+++ b/mne/label.py
@@ -23,7 +23,7 @@ from .stats.cluster_level import _find_clusters, _get_components
 from .surface import (read_surface, fast_cross_3d, mesh_edges, mesh_dist,
                       read_morph_map)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose, warn,
-                    check_random_state, _validate_type)
+                    check_random_state, _validate_type, fill_doc)
 
 
 def _blend_colors(color_1, color_2):
@@ -137,6 +137,7 @@ def _n_colors(n, bytes_=False, cmap='hsv'):
     return colors
 
 
+@fill_doc
 class Label(object):
     """A FreeSurfer/MNE label with vertices restricted to one hemisphere.
 
@@ -168,9 +169,7 @@ class Label(object):
         Name of the subject the label is from.
     color : None | matplotlib color
         Default label color and alpha (e.g., ``(1., 0., 0., 1.)`` for red).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -190,8 +189,7 @@ class Label(object):
         value on initialization, but it can also be set manually.
     values : array, shape (N,)
         Values at the vertices.
-    verbose : bool, str, int, or None
-        See above.
+    %(verbose)s
     vertices : array, shape (N,)
         Vertex indices (0 based)
     """
@@ -489,10 +487,7 @@ class Label(object):
             Path to SUBJECTS_DIR if it is not set in the environment.
         n_jobs : int
             Number of jobs to run in parallel
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -542,10 +537,7 @@ class Label(object):
             Path to SUBJECTS_DIR if it is not set in the environment.
         n_jobs : int
             Number of jobs to run in parallel.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -943,9 +935,7 @@ def write_label(filename, label, verbose=None):
         Path to label file to produce.
     label : Label
         The label object to save.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1287,9 +1277,7 @@ def stc_to_label(stc, src=None, smooth=True, connected=False,
         of the maximum value in the stc.
     subjects_dir : str | None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1971,9 +1959,7 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
         substring is contained.
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2073,9 +2059,7 @@ def morph_labels(labels, subject_to, subject_from=None, subjects_dir=None,
         Path to SUBJECTS_DIR if it is not set in the environment.
     surf_name : str
         Surface used to obtain vertex locations, e.g., 'white', 'pial'
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2133,9 +2117,7 @@ def labels_to_stc(labels, values, tmin=0, tstep=1, subject=None, verbose=None):
         The tstep to use for the STC.
     subject : str | None
         The subject for which to create the STC.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2260,9 +2242,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
     hemi : 'both' | 'lh' | 'rh'
         The hemisphere(s) for which to write \*.annot files (only applies if
         annot_fname is not specified; default is 'both').
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -91,9 +91,7 @@ def read_inverse_operator(fname, verbose=None):
     ----------
     fname : string
         The name of the FIF file, which ends with -inv.fif or -inv.fif.gz.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -316,9 +314,7 @@ def write_inverse_operator(fname, inv, verbose=None):
         The name of the FIF file, which ends with -inv.fif or -inv.fif.gz.
     inv : dict
         The inverse operator.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -507,9 +503,7 @@ def prepare_inverse_operator(orig, nave, lambda2, method='dSPM',
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -851,9 +845,7 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
         Cannot be used with ``method=='eLORETA'``.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1038,9 +1030,7 @@ def apply_inverse_raw(raw, inverse_operator, lambda2, method="dSPM",
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1232,9 +1222,7 @@ def apply_inverse_epochs(epochs, inverse_operator, lambda2, method="dSPM",
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1391,8 +1379,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
         Whether to use cortical patch statistics to define normal
         orientations. Only used when converting to surface orientation
         (i.e., for surface source spaces and ``loose < 1``).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------
@@ -1684,8 +1671,7 @@ def estimate_snr(evoked, inv, verbose=None):
         Evoked instance.
     inv : instance of InverseOperator
         The inverse operator.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -82,9 +82,7 @@ def point_spread_function(inverse_operator, forward, labels, method='dSPM',
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal
         orientations. Only used when surf_ori and/or force_fixed are True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -364,9 +362,7 @@ def cross_talk_function(inverse_operator, forward, labels,
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal
         orientations. Only used when surf_ori and/or force_fixed are True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -124,9 +124,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -376,9 +374,7 @@ def source_induced_power(epochs, inverse_operator, freqs, label=None,
         If True, do not call :func:`prepare_inverse_operator`.
     method_params : dict | None
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """  # noqa: E501
     _check_method(method)
     _check_ori(pick_ori, inverse_operator['source_ori'])
@@ -481,9 +477,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
         If True (default False), return output it decibels.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -745,9 +739,7 @@ def compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
         If True, also return the sensor PSD for each epoch as an EvokedArray.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -219,7 +219,7 @@ def _compute_sparse_morph(vertices_from, subject_from, subject_to,
 _SOURCE_MORPH_ATTRIBUTES = [  # used in writing
     'subject_from', 'subject_to', 'kind', 'zooms', 'niter_affine', 'niter_sdr',
     'spacing', 'smooth', 'xhemi', 'morph_mat', 'vertices_to',
-    'shape', 'affine', 'pre_affine', 'sdr_morph', 'src_data']
+    'shape', 'affine', 'pre_affine', 'sdr_morph', 'src_data', 'verbose']
 
 
 @fill_doc

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -16,10 +16,11 @@ from .source_estimate import (VolSourceEstimate, SourceEstimate,
 from .source_space import SourceSpaces
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
-                    warn as warn_, deprecated)
+                    warn as warn_, deprecated, fill_doc)
 from .externals.h5io import read_hdf5, write_hdf5
 
 
+@verbose
 def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
                          subjects_dir=None, zooms=5,
                          niter_affine=(100, 100, 10), niter_sdr=(5, 5, 3),
@@ -77,10 +78,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         Morph as a sparse source estimate. Works only with (Vector)
         SourceEstimate. If True the only parameters used are subject_to and
         subject_from, and spacing has to be None. Default is sparse=False.
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). The default
-        is verbose=None.
+    %(verbose)s
 
     Notes
     -----
@@ -224,6 +222,7 @@ _SOURCE_MORPH_ATTRIBUTES = [  # used in writing
     'shape', 'affine', 'pre_affine', 'sdr_morph', 'src_data']
 
 
+@fill_doc
 class SourceMorph(object):
     """Morph source space data from one subject to another.
 
@@ -279,6 +278,7 @@ class SourceMorph(object):
         the symmetric diffeomorphic registration (SDR) morph.
     src_data : dict
         Additional source data necessary to perform morphing.
+    %(verbose)s
 
     References
     ----------
@@ -295,7 +295,7 @@ class SourceMorph(object):
     def __init__(self, subject_from, subject_to, kind, zooms,
                  niter_affine, niter_sdr, spacing, smooth, xhemi,
                  morph_mat, vertices_to, shape,
-                 affine, pre_affine, sdr_morph, src_data):
+                 affine, pre_affine, sdr_morph, src_data, verbose=None):
         # universal
         self.subject_from = subject_from
         self.subject_to = subject_to
@@ -318,6 +318,7 @@ class SourceMorph(object):
         self.pre_affine = pre_affine
         # used by both
         self.src_data = src_data
+        self.verbose = verbose
 
     @verbose
     def apply(self, stc_from, output='stc', mri_resolution=False,
@@ -337,10 +338,7 @@ class SourceMorph(object):
         mri_space : bool
             Whether the image to world registration should be in mri space. The
             default is mri_space=mri_resolution.
-        verbose : bool | str | int | None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). The default is verbose=None.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -393,10 +391,7 @@ class SourceMorph(object):
             not end with '.h5'
         overwrite : bool
             If True, overwrite existing file.
-        verbose : bool | str | int | None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
         """
         if not fname.endswith('.h5'):
             fname = '%s-morph.h5' % fname
@@ -800,9 +795,7 @@ def compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
         Morph across hemisphere. Currently only implemented for
         ``subject_to == subject_from``. See notes below. The default is
         xhemi=False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). The default
+    %(verbose)s The default
         is verbose=None.
 
     Returns
@@ -915,9 +908,7 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
         Path to SUBJECTS_DIR if it is not set in the environment
     n_jobs : int
         Number of jobs to run in parallel. The default is n_jobs=1.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -991,9 +982,7 @@ def _morph_buffer(data, idx_use, e, smooth, n_vertices, nearest, maps,
         Morph map from one subject to the other.
     warn : bool
         If True, warn if not all vertices were used.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). The default
+    %(verbose)s The default
         is verbose=None.
 
     Returns

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -43,9 +43,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         jobs. This should only be used when directly iterating, not when
         using ``split_list`` or :func:`np.array_split`.
         If None (default), do not add a progress bar.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). INFO or DEBUG
+    %(verbose)s INFO or DEBUG
         will print parallel status, others will not.
 
     Returns

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -166,9 +166,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
         Whether to omit data that is annotated as bad.
 
         .. versionadded:: 0.18
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -340,9 +338,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
         rejected. If False, no rejection based on annotations is performed.
 
         .. versionadded:: 0.14.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -39,9 +39,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
         Whether to omit data that is annotated as bad.
     thresh : float
         Threshold to trigger EOG event.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -218,9 +216,7 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
         .. versionadded:: 0.14.0
     thresh : float
         Threshold to trigger EOG event.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -48,7 +48,7 @@ from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state,
                      compute_corr, _get_inst_data, _ensure_int,
                      copy_function_doc_to_method_doc, _pl, warn,
-                     _check_preload, _check_compensation_grade)
+                     _check_preload, _check_compensation_grade, fill_doc)
 
 from ..fixes import _get_args
 from ..filter import filter_data
@@ -116,6 +116,7 @@ def _check_for_unsupported_ica_channels(picks, info, allow_ref_meg=False):
                          .format(types, chs))
 
 
+@fill_doc
 class ICA(ContainsMixin):
     u"""M/EEG signal decomposition using Independent Component Analysis (ICA).
 
@@ -181,9 +182,7 @@ class ICA(ContainsMixin):
         Allow ICA on MEG reference channels. Defaults to False.
 
         .. versionadded:: 0.18
-    verbose : bool | str | int | None
-        If not None, override default verbosity level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>`).
+    %(verbose)s
 
     Attributes
     ----------
@@ -445,10 +444,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -964,10 +960,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1134,10 +1127,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1231,10 +1221,7 @@ class ICA(ContainsMixin):
             High pass frequency.
         reject_by_annotation : bool
             If True, data annotated as bad will be omitted. Defaults to True.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1311,10 +1298,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1795,9 +1779,7 @@ def ica_find_ecg_events(raw, ecg_source, event_id=999,
         Between 0 and 1. qrs detection threshold. Can also be "auto" to
         automatically choose the threshold that generates a reasonable
         number of heartbeats (40-160 beats / min).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1840,9 +1822,7 @@ def ica_find_eog_events(raw, eog_source=None, event_id=998, l_freq=1,
         Low cut-off frequency in Hz.
     h_freq : float
         High cut-off frequency in Hz.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2063,9 +2043,7 @@ def read_ica(fname, verbose=None):
     fname : str
         Absolute path to fif file containing ICA matrices.
         The file name should end with -ica.fif or -ica.fif.gz.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2358,9 +2336,7 @@ def run_ica(raw, n_components, max_pca_components=100,
         Allow ICA on MEG reference channels. Defaults to False.
 
         .. versionadded:: 0.18
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2508,9 +2484,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         to True.
     show : bool
         Show figures if True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     outlines : 'head' | dict | None
         The outlines to be drawn. If 'head', a head scheme will be drawn. If
         dict, each key refers to a tuple of x and y positions. The values in

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -82,9 +82,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
     use_bias : bool
         This quantity indicates if the bias should be computed.
         Defaults to True.
-    verbose : bool, str, int, or None
-        If not None, override default verbosity level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/maxfilter.py
+++ b/mne/preprocessing/maxfilter.py
@@ -85,9 +85,7 @@ def apply_maxfilter(in_fname, out_fname, origin=None, frame='device',
         Additional command line arguments to pass to MaxFilter
     overwrite : bool
         Overwrite output file if it already exists
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -160,9 +160,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         To disable, provide an empty list.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/otp.py
+++ b/mne/preprocessing/otp.py
@@ -42,8 +42,7 @@ def oversampled_temporal_projection(raw, duration=10., picks=None,
     picks : list of int | None
         The channels to process. If None, all data channels will be
         processed together.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose)
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/peak_finder.py
+++ b/mne/preprocessing/peak_finder.py
@@ -18,9 +18,7 @@ def peak_finder(x0, thresh=None, extrema=1, verbose=None):
     extrema : {-1, 1}
         1 if maxima are desired, -1 if minima are desired
         (default = maxima, 1).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -214,9 +214,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
         If True, return the drop log.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -318,9 +316,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         If True, return the drop log.
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -137,9 +137,7 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
     desc_prefix : str | None
         The description prefix to use. If None, one will be created based on
         the event_id, tmin, and tmax.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -198,9 +196,7 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
         tmin and tmax.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -246,9 +242,7 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
         Epoch flat configuration (see Epochs).
     n_jobs : int
         Number of jobs to use to compute covariance.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -287,6 +281,7 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
     return projs
 
 
+@verbose
 def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
                     verbose=None):
     """Compute sensitivity map.
@@ -310,9 +305,7 @@ def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
     exclude : list of string | str
         List of channels to exclude. If empty do not exclude any (default).
         If 'bads', exclude channels in fwd['info']['bads'].
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/realtime/client.py
+++ b/mne/realtime/client.py
@@ -11,7 +11,7 @@ import threading
 
 import numpy as np
 
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fill_doc
 from ..io.constants import FIFF
 from ..io.meas_info import read_meas_info
 from ..io.tag import Tag, read_tag
@@ -70,6 +70,7 @@ def _buffer_recv_worker(rt_client, nchan):
         print('Buffer receive thread stopped: %s' % err)
 
 
+@fill_doc
 class RtClient(object):
     """Realtime Client.
 
@@ -85,9 +86,7 @@ class RtClient(object):
         Port to use for the data connection.
     timeout : float
         Communication timeout in seconds.
-    verbose : bool, str, int, or None
-        Log verbosity (see :func:`mne.verbose` and
-        :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
 
     @verbose

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -110,8 +110,7 @@ class RtEpochs(BaseEpochs):
                                verbose='ERROR')
 
         See :func:`mne.find_events` for detailed explanation of these options.
-    %(verbose)s Defaults to
-        client.verbose.
+    %(verbose)s Defaults to client.verbose.
 
     Attributes
     ----------

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -11,11 +11,12 @@ import copy
 import numpy as np
 
 from .. import pick_channels
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fill_doc
 from ..epochs import BaseEpochs
 from ..event import _find_events
 
 
+@fill_doc
 class RtEpochs(BaseEpochs):
     """Realtime Epochs.
 
@@ -109,9 +110,7 @@ class RtEpochs(BaseEpochs):
                                verbose='ERROR')
 
         See :func:`mne.find_events` for detailed explanation of these options.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         client.verbose.
 
     Attributes
@@ -124,8 +123,7 @@ class RtEpochs(BaseEpochs):
         List of channels' names.
     events : array, shape (n_events, 3)
         The events associated with the epochs currently in the queue.
-    verbose : bool, str, int, or None
-        See above.
+    %(verbose)s
 
     Notes
     -----
@@ -546,10 +544,7 @@ class RtEpochs(BaseEpochs):
 
             .. versionadded:: 0.12
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -13,7 +13,7 @@ from ..io import _empty_info
 from ..io.pick import pick_info
 from ..io.constants import FIFF
 from ..epochs import EpochsArray
-from ..utils import logger, warn
+from ..utils import logger, warn, fill_doc
 from ..externals.FieldTrip import Client as FtClient
 
 
@@ -28,6 +28,7 @@ def _buffer_recv_worker(ft_client):
         logger.error('Buffer receive thread stopped: %s' % err)
 
 
+@fill_doc
 class FieldTripClient(object):
     """Realtime FieldTrip client.
 
@@ -49,9 +50,7 @@ class FieldTripClient(object):
         Time instant to stop receiving buffers.
     buffer_size : int
         Size of each buffer in terms of number of samples.
-    verbose : bool, str, int, or None
-        Log verbosity (see :func:`mne.verbose` and
-        :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
 
     def __init__(self, info=None, host='localhost', port=1972, wait_max=30,

--- a/mne/realtime/mockclient.py
+++ b/mne/realtime/mockclient.py
@@ -6,9 +6,12 @@
 
 import copy
 import numpy as np
+
 from ..event import find_events
+from ..utils import fill_doc
 
 
+@fill_doc
 class MockRtClient(object):
     """Mock Realtime Client.
 
@@ -16,9 +19,7 @@ class MockRtClient(object):
     ----------
     raw : instance of Raw object
         The raw object which simulates the RtClient
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
 
     def __init__(self, raw, verbose=None):  # noqa: D102

--- a/mne/realtime/stim_server_client.py
+++ b/mne/realtime/stim_server_client.py
@@ -9,7 +9,7 @@ import threading
 
 import numpy as np
 
-from ..utils import logger, verbose
+from ..utils import logger, verbose, fill_doc
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -133,10 +133,7 @@ class StimServer(object):
         ----------
         timeout : float
             Maximum time to wait for clients to be added.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
         """
         # Start server
         if not self._running:
@@ -164,10 +161,7 @@ class StimServer(object):
             IP address of the client.
         sock : instance of socket.socket
             The client socket.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
         """
         logger.info("Adding client with ip = %s" % ip)
 
@@ -182,10 +176,7 @@ class StimServer(object):
 
         Parameters
         ----------
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
         """
         logger.info("Shutting down ...")
 
@@ -208,10 +199,7 @@ class StimServer(object):
         ----------
         trigger : int
             The trigger to be added to the queue for sending to StimClient.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         See Also
         --------
@@ -224,6 +212,7 @@ class StimServer(object):
             client['socket']._tx_queue.put(trigger)
 
 
+@fill_doc
 class StimClient(object):
     """Stimulation Client.
 
@@ -237,9 +226,7 @@ class StimClient(object):
         Port to use for the connection.
     timeout : float
         Communication timeout in seconds.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -285,10 +272,7 @@ class StimClient(object):
         ----------
         timeout : float
             maximum time to wait for a valid trigger from the server
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         See Also
         --------

--- a/mne/report.py
+++ b/mne/report.py
@@ -20,7 +20,8 @@ import numpy as np
 
 from . import read_evokeds, read_events, pick_types, read_cov
 from .io import read_raw_fif, read_info, _stamp_to_dt
-from .utils import logger, verbose, get_subjects_dir, warn, _import_mlab
+from .utils import (logger, verbose, get_subjects_dir, warn, _import_mlab,
+                    fill_doc)
 from .viz import plot_events, plot_alignment, plot_cov
 from .viz._3d import _plot_mri_contours
 from .forward import read_forward_solution
@@ -822,6 +823,7 @@ def _check_image_format(rep, image_format):
     return image_format
 
 
+@fill_doc
 class Report(object):
     """Object for rendering HTML.
 
@@ -861,9 +863,7 @@ class Report(object):
         :meth:`mne.io.Raw.plot_psd`.
 
         .. versionadded:: 0.17
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -1414,10 +1414,7 @@ class Report(object):
             If True (default), try to render the BEM.
 
             .. versionadded:: 0.16
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
         """
         image_format = _check_image_format(self, image_format)
         valid_errors = ['ignore', 'warn', 'raise']

--- a/mne/selection.py
+++ b/mne/selection.py
@@ -56,9 +56,7 @@ def read_selection(name, fname=None, info=None, verbose=None):
         Measurement info file, which will be used to determine the spacing
         of channel names to return, e.g. ``'MEG 0111'`` for old Neuromag
         systems and ``'MEG0111'`` for new ones.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -48,9 +48,7 @@ def simulate_evoked(fwd, stc, info, cov, nave=30, iir_filter=None,
         orientations when converting to fixed orientation (if necessary).
 
         .. versionadded:: 0.15
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -136,9 +134,7 @@ def add_noise(inst, cov, iir_filter=None, random_state=None,
         IIR filter coefficients (denominator).
     random_state : None | int | np.random.RandomState
         To specify the random generator state.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -147,9 +147,7 @@ def simulate_raw(raw, stc, trans, src, bem, cov='simple',
         Must be supplied if ``raw`` is an instance of :class:`mne.Info`.
 
         .. versionadded:: 0.18
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -18,7 +18,8 @@ from .surface import read_surface, _get_ico_surface, mesh_edges
 from .source_space import (_ensure_src, _get_morph_src_reordering,
                            _ensure_src_subject, SourceSpaces)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose,
-                    _time_mask, warn as warn_, copy_function_doc_to_method_doc)
+                    _time_mask, warn as warn_, copy_function_doc_to_method_doc,
+                    fill_doc)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
 from .io.base import ToDataFrameMixin, TimeMixin
@@ -454,9 +455,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -567,10 +566,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
             Window to use in resampling. See scipy.signal.resample.
         n_jobs : int
             Number of jobs to run in parallel.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
 
         Notes
         -----
@@ -1067,6 +1063,7 @@ def _center_of_mass(vertices, values, hemi, surf, subject, subjects_dir,
     return vertex
 
 
+@fill_doc
 class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
     """Abstract base class for surface source estimates.
 
@@ -1083,9 +1080,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -1269,10 +1264,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
             to be provided, since it is stored in the source space itself.
         subjects_dir : string, or None
             Path to SUBJECTS_DIR if it is not set in the environment.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1297,6 +1289,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
                               self.tmin, self.tstep, subject_orig)
 
 
+@fill_doc
 class SourceEstimate(_BaseSurfaceSourceEstimate):
     """Container for surface source estimates.
 
@@ -1316,9 +1309,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -1355,10 +1346,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         ftype : string
             File format to use. Allowed values are "stc" (default), "w",
             and "h5". The "w" format only supports a single time point.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
         """
         if ftype not in ('stc', 'w', 'h5'):
             raise ValueError('ftype must be "stc", "w", or "h5", not "%s"'
@@ -1432,10 +1420,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         allow_empty : bool
             Instead of emitting an error, return all-zero time course for
             labels that do not have any vertices in the source estimate.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1609,6 +1594,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         return vertex, hemi, t
 
 
+@fill_doc
 class VolSourceEstimate(_BaseSourceEstimate):
     """Container for volume source estimates.
 
@@ -1628,9 +1614,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -1690,10 +1674,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
         ftype : string
             File format to use. Allowed values are "stc" (default), "w",
             and "h5". The "w" format only supports a single time point.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
         """
         if ftype not in ['stc', 'w', 'h5']:
             raise ValueError('ftype must be "stc", "w" or "h5", not "%s"' %
@@ -1842,6 +1823,7 @@ class VolSourceEstimate(_BaseSourceEstimate):
                 time_idx if time_as_index else self.times[time_idx])
 
 
+@fill_doc
 class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
     """Container for vector surface source estimates.
 
@@ -1862,8 +1844,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose).
+    %(verbose)s
 
     Attributes
     ----------
@@ -1897,9 +1878,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
             '-stc.h5'.
         ftype : string
             File format to use. Currently, the only allowed values is "h5".
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see mne.verbose).
-            Defaults to self.verbose.
+        %(verbose_meth)s
         """
         if ftype != 'h5':
             raise ValueError('VectorSourceEstimate objects can only be '
@@ -1981,6 +1960,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
         return super(VectorSourceEstimate, self).__abs__()
 
 
+@fill_doc
 class MixedSourceEstimate(_BaseSourceEstimate):
     """Container for mixed surface and volume source estimates.
 
@@ -2000,9 +1980,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
     subject : str | None
         The subject name. While not necessary, it is safer to set the
         subject parameter to avoid analysis errors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -2135,10 +2113,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         ftype : string
             File format to use. Allowed values are "stc" (default), "w",
             and "h5". The "w" format only supports a single time point.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more). Defaults to self.verbose.
+        %(verbose_meth)s
         """
         if ftype != 'h5':
             raise ValueError('MixedSourceEstimate objects can only be '
@@ -2227,9 +2202,7 @@ def spatio_temporal_src_connectivity(src, n_times, dist=None, verbose=None):
         Maximal geodesic distance (in m) between vertices in the
         source space to consider neighbors. If None, immediate neighbors
         are extracted from an ico surface.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2264,9 +2237,7 @@ def grade_to_tris(grade, verbose=None):
     ----------
     grade : int
         Grade of an icosahedral mesh.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2293,9 +2264,7 @@ def spatio_temporal_tris_connectivity(tris, n_times, remap_vertices=False,
     remap_vertices : bool
         Reassign vertex indices based on unique values. Useful
         to process a subset of triangles. Defaults to False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2329,9 +2298,7 @@ def spatio_temporal_dist_connectivity(src, n_times, dist, verbose=None):
     dist : float
         Maximal geodesic distance (in m) between vertices in the
         source space to consider neighbors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2368,9 +2335,7 @@ def spatial_src_connectivity(src, dist=None, verbose=None):
         Maximal geodesic distance (in m) between vertices in the
         source space to consider neighbors. If None, immediate neighbors
         are extracted from an ico surface.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2391,9 +2356,7 @@ def spatial_tris_connectivity(tris, remap_vertices=False, verbose=None):
     remap_vertices : bool
         Reassign vertex indices based on unique values. Useful
         to process a subset of triangles. Defaults to False.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2403,6 +2366,7 @@ def spatial_tris_connectivity(tris, remap_vertices=False, verbose=None):
     return spatio_temporal_tris_connectivity(tris, 1, remap_vertices)
 
 
+@verbose
 def spatial_dist_connectivity(src, dist, verbose=None):
     """Compute connectivity from distances in a source space.
 
@@ -2415,9 +2379,7 @@ def spatial_dist_connectivity(src, dist, verbose=None):
     dist : float
         Maximal geodesic distance (in m) between vertices in the
         source space to consider neighbors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2427,6 +2389,7 @@ def spatial_dist_connectivity(src, dist, verbose=None):
     return spatio_temporal_dist_connectivity(src, 1, dist)
 
 
+@verbose
 def spatial_inter_hemi_connectivity(src, dist, verbose=None):
     """Get vertices on each hemisphere that are close to the other hemisphere.
 
@@ -2437,9 +2400,7 @@ def spatial_inter_hemi_connectivity(src, dist, verbose=None):
     dist : float
         Maximal Euclidean distance (in m) between vertices in one hemisphere
         compared to the other to consider neighbors.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2682,9 +2643,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         that do not have any vertices in the source estimate.
     return_generator : bool
         If True, a generator instead of a list is returned.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -120,10 +120,7 @@ class SourceSpaces(list):
             produced during coregistration. If trans is None, an identity
             matrix is assumed. This is only needed when the source space is in
             head coordinates.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -270,10 +267,7 @@ class SourceSpaces(list):
         use_lut : bool
             If True, assigns a numeric value to each source space that
             corresponds to a color on the freesurfer lookup table.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose_meth)s
 
         Notes
         -----
@@ -556,9 +550,7 @@ def _read_source_spaces_from_tree(fid, tree, patch_stats=False,
         The FIF tree structure if source is a file id.
     patch_stats : bool, optional (default False)
         Calculate and add cortical patch statistics to the surfaces.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -595,9 +587,7 @@ def read_source_spaces(fname, patch_stats=False, verbose=None):
         -src.fif.gz.
     patch_stats : bool, optional (default False)
         Calculate and add cortical patch statistics to the surfaces.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -968,9 +958,7 @@ def _write_source_spaces_to_fid(fid, src, verbose=None):
         An open file descriptor.
     src : list
         The list of source spaces.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     for s in src:
         logger.info('    Write a source space...')
@@ -995,9 +983,7 @@ def write_source_spaces(fname, src, overwrite=False, verbose=None):
     overwrite : bool
         If True, the destination file (if it exists) will be overwritten.
         If False (default), an error will be raised if the file exists.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     See Also
     --------
@@ -1144,9 +1130,7 @@ def head_to_mri(pos, subject, mri_head_t, subjects_dir=None,
         MRI<->Head coordinate transformation
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1198,9 +1182,7 @@ def vertex_to_mni(vertices, hemis, subject, subjects_dir=None, mode=None,
         obtain the transforms. If None, 'nibabel' is tried first, falling
         back to 'freesurfer' if it fails. Results should be equivalent with
         either option, but nibabel may be quicker (and more pythonic).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1257,9 +1239,7 @@ def head_to_mni(pos, subject, mri_head_t, subjects_dir=None,
         MRI<->Head coordinate transformation
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1417,9 +1397,7 @@ def setup_source_space(subject, spacing='oct6', surface='white',
     n_jobs : int
         Number of jobs to run in parallel. Will use at most 2 jobs
         (one for each hemisphere).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1552,9 +1530,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     add_interpolator : bool
         If True and ``mri`` is not None, then an interpolation matrix
         will be produced.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2346,9 +2322,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
     n_jobs : int
         Number of jobs to run in parallel. Will only use (up to) as many
         cores as there are source spaces.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2654,9 +2628,7 @@ def morph_source_spaces(src_from, subject_to, surf='white', subject_from=None,
         to be provided, since it is stored in the source space itself.
     subjects_dir : str | None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -2725,9 +2697,7 @@ def _get_morph_src_reordering(vertices, src_from, subject_from, subject_to,
         The destination subject.
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1041,9 +1041,7 @@ def permutation_cluster_test(
         processes is enabled (see set_cache_dir()), as X will be shared
         between processes and each process only needs to allocate space
         for a small block of variables.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1112,9 +1110,7 @@ def permutation_cluster_1samp_test(
         Use square n_vertices matrix for datasets with a large temporal
         extent to save on memory and computation time. Can also be False
         to assume no connectivity. Can also be False to assume no connectivity.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     n_jobs : int
         Number of permutations to run in parallel (requires joblib package).
     seed : int | instance of RandomState | None
@@ -1291,9 +1287,7 @@ def spatio_temporal_cluster_1samp_test(
         processes is enabled (see set_cache_dir()), as X will be shared
         between processes and each process only needs to allocate space
         for a small block of variables.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1365,9 +1359,7 @@ def spatio_temporal_cluster_test(
         Defines connectivity between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
         Default is None, i.e, a regular lattice connectivity.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     n_jobs : int
         Number of permutations to run in parallel (requires joblib package).
     seed : int | instance of RandomState | None

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -53,9 +53,7 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
         Number of CPUs to use for computation.
     seed : int | instance of RandomState | None
         Seed the random number generator for results reproducibility.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -51,9 +51,7 @@ def get_head_surf(subject, source=('bem', 'head'), subjects_dir=None,
     subjects_dir : str, or None
         Path to the SUBJECTS_DIR. If None, the path is obtained by using
         the environment variable SUBJECTS_DIR.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -124,9 +122,7 @@ def get_meg_helmet_surf(info, trans=None, verbose=None):
         The head<->MRI transformation, usually obtained using
         read_trans(). Can be None, in which case the surface will
         be in head coordinates instead of MRI coordinates.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -326,9 +322,7 @@ def complete_surface_info(surf, do_neighbor_vert=False, copy=True,
         If True, add neighbor vertex information.
     copy : bool
         If True (default), make a copy. If False, operate in-place.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -556,9 +550,7 @@ def read_surface(fname, read_metadata=False, return_dict=False, verbose=None):
 
     return_dict : bool
         If True, a dictionary with surface parameters is returned.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -909,9 +901,7 @@ def read_morph_map(subject_from, subject_to, subjects_dir=None, xhemi=False,
         Morph across hemisphere. Currently only implemented for
         ``subject_to == subject_from``. See notes of
         :func:`mne.compute_source_morph`.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1285,9 +1275,7 @@ def read_tri(fname_in, swap=False, verbose=None):
     swap : bool
         Assume the ASCII file vertex ordering is clockwise instead of
         counterclockwise.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -45,14 +45,14 @@ public_modules = [
 ]
 
 
-def get_name(func):
+def get_name(func, cls=None):
     """Get the name."""
     parts = []
     module = inspect.getmodule(func)
     if module:
         parts.append(module.__name__)
-    if hasattr(func, 'im_class'):
-        parts.append(func.im_class.__name__)
+    if cls is not None:
+        parts.append(cls.__name__)
     parts.append(func.__name__)
     return '.'.join(parts)
 
@@ -69,11 +69,11 @@ _tab_ignores = [
 ]
 
 
-def check_parameters_match(func, doc=None):
+def check_parameters_match(func, doc=None, cls=None):
     """Check docstring, return list of incorrect results."""
     from numpydoc import docscrape
     incorrect = []
-    name_ = get_name(func)
+    name_ = get_name(func, cls=cls)
     if not name_.startswith('mne.') or name_.startswith('mne.externals'):
         return incorrect
     if inspect.isdatadescriptor(func):
@@ -140,12 +140,12 @@ def test_docstring_parameters():
                     raise RuntimeError('Error for __init__ of %s in %s:\n%s'
                                        % (cls, name, ww))
             if hasattr(cls, '__init__'):
-                incorrect += check_parameters_match(cls.__init__, cdoc)
+                incorrect += check_parameters_match(cls.__init__, cdoc, cls)
             for method_name in cdoc.methods:
                 method = getattr(cls, method_name)
-                incorrect += check_parameters_match(method)
+                incorrect += check_parameters_match(method, cls=cls)
             if hasattr(cls, '__call__'):
-                incorrect += check_parameters_match(cls.__call__)
+                incorrect += check_parameters_match(cls.__call__, cls=cls)
         functions = inspect.getmembers(module, inspect.isfunction)
         for fname, func in functions:
             if fname.startswith('_'):

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -227,9 +227,7 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
         Return intertrial coherence (ITC) as well as averaged power.
     n_jobs : int
         The number of jobs to run in parallel (over channels).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/ar.py
+++ b/mne/time_frequency/ar.py
@@ -54,9 +54,7 @@ def fit_iir_model_raw(raw, order=2, picks=None, tmin=None, tmax=None,
         The beginning of time interval in seconds.
     tmax : float
         The end of time interval in seconds.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -567,10 +567,7 @@ def csd_fourier(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None, picks=None,
         which means the projectors defined in the Epochs object will by copied.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -629,10 +626,7 @@ def csd_array_fourier(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
         which means no projectors are stored.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -717,10 +711,7 @@ def csd_multitaper(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
         which means the projectors defined in the Epochs object will by copied.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -789,10 +780,7 @@ def csd_array_multitaper(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
         which means no projectors are stored.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -878,10 +866,7 @@ def csd_morlet(epochs, frequencies, tmin=None, tmax=None, picks=None,
         which means the projectors defined in the Epochs object will be copied.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -949,10 +934,7 @@ def csd_array_morlet(X, sfreq, frequencies, t0=0, tmin=None, tmax=None,
         which means the projectors defined in the Epochs object will be copied.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1095,10 +1077,7 @@ def _execute_csd_function(X, times, frequencies, csd_function, params, n_fft,
         which means the projectors defined in the Epochs object will be copied.
     n_jobs : int
         Number of jobs to run in parallel. Defaults to 1.
-    verbose : bool | str | int | None
-        If not ``None``, override default verbose level
-        (see :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-        for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -390,9 +390,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
         the signal (as in nitime).
     n_jobs : int
         Number of parallel jobs to use (only used if adaptive=True).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -510,9 +508,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     n_jobs : int
         The number of epochs to process at the same time. The parallelization
         is implemented across channels. Defaults to 1.
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -87,9 +87,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
         to None, which sets n_per_seg equal to n_fft.
     n_jobs : int
         Number of CPUs to use in the computation.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -178,9 +176,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
         Evoked object. Defaults to True.
 
         .. versionadded:: 0.15.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -253,9 +249,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
         Apply SSP projection vectors. If inst is ndarray this is not used.
     n_jobs : int
         Number of CPUs to use in the computation.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/stft.py
+++ b/mne/time_frequency/stft.py
@@ -21,9 +21,7 @@ def stft(x, wsize, tstep=None, verbose=None):
     tstep : int
         step between successive windows in samples (must be a multiple of 2,
         a divider of wsize and smaller than wsize/2) (default: wsize/2)
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -27,7 +27,7 @@ from ..channels.layout import _pair_grad_sensors
 from ..io.pick import (pick_info, _pick_data_channels,
                        channel_type, _pick_inst, _get_channel_types)
 from ..io.meas_info import Info
-from ..utils import SizeMixin, _is_numeric
+from ..utils import SizeMixin, _is_numeric, fill_doc
 from .multitaper import dpss_windows
 from ..viz.utils import (figure_nobar, plt_show, _setup_cmap, warn,
                          _connection_line, _prepare_joint_axes,
@@ -312,9 +312,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     n_jobs : int, default 1
         The number of epochs to process at the same time. The parallelization
         is implemented across channels.
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -691,9 +689,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
         average must be False.
 
         .. versionadded:: 0.15.0
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -763,9 +759,7 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
     n_jobs : int
         The number of epochs to process at the same time. The parallelization
         is implemented across channels. default 1
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -839,9 +833,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
         If True average across Epochs.
 
         .. versionadded:: 0.13.0
-    verbose : bool, str, int, or None, default None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -940,9 +932,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
               dividing by the standard deviation of log baseline values
               ('zlogratio')
 
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose`).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -965,6 +955,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         write_tfrs(fname, self, overwrite=overwrite)
 
 
+@fill_doc
 class AverageTFR(_BaseTFR):
     """Container for Time-Frequency data.
 
@@ -987,9 +978,7 @@ class AverageTFR(_BaseTFR):
         Comment on the data, e.g., the experimental condition.
     method : str | None, default None
         Comment on the method used to compute the data, e.g., morlet wavelet.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------
@@ -1165,9 +1154,7 @@ class AverageTFR(_BaseTFR):
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
             bad channels are excluded. Defaults to an empty list.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose`).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1354,9 +1341,7 @@ class AverageTFR(_BaseTFR):
             to style the image. `axes` and `show` are ignored. Beyond that,
             if ``None``, no customizable arguments will be passed.
             Defaults to ``None``.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose`).
+        %(verbose_meth)s
 
         Returns
         -------
@@ -1949,6 +1934,7 @@ class AverageTFR(_BaseTFR):
         return "<AverageTFR  |  %s>" % s
 
 
+@fill_doc
 class EpochsTFR(_BaseTFR, GetEpochsMixin):
     """Container for Time-Frequency data on epochs.
 
@@ -1979,9 +1965,7 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin):
     metadata : instance of pandas.DataFrame | None
         A :class:`pandas.DataFrame` containing pertinent information for each
         trial. See :class:`mne.Epochs` for further details
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Attributes
     ----------

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1003,10 +1003,7 @@ class _SphericalSurfaceWarp(object):
             The uniformly-spaced points to match on the two surfaces.
             Can be "ico#" or "oct#" where "#" is an integer.
             The default is "oct5".
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
 
         Returns
         -------
@@ -1081,10 +1078,7 @@ class _SphericalSurfaceWarp(object):
             points that were used to generate the model, although ideally
             they will be inside the convex hull formed by the original
             source points.
-        verbose : bool, str, int, or None
-            If not None, override default verbose level (see
-            :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
-            for more).
+        %(verbose)s
 
         Returns
         -------

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -16,7 +16,7 @@ from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      sys_info, _get_extra_data_path, _get_root_dir,
                      _get_call_line)
 from .docs import (copy_function_doc_to_method_doc, copy_doc, linkcode_resolve,
-                   open_docs, deprecated)
+                   open_docs, deprecated, fill_doc)
 from .fetching import _fetch_file, _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -12,6 +12,18 @@ import warnings
 import webbrowser
 
 from .config import get_config
+from ..externals.doccer import filldoc, unindent_dict
+
+
+docdict = dict(
+    verbose="""
+verbose : bool, str, int, or None
+    If not None, override default verbose level (see :func:`mne.verbose`
+    and :ref:`Logging documentation <tut_logging>` for more)."""
+)
+docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
+docdict = unindent_dict(docdict)
+fill_doc = filldoc(docdict, unindent_params=False)
 
 
 def copy_doc(source):
@@ -223,6 +235,9 @@ def linkcode_resolve(domain, info):
             obj = getattr(obj, part)
         except Exception:
             return None
+    # deal with our decorators properly
+    while hasattr(obj, '__wrapped__'):
+        obj = obj.__wrapped__
 
     try:
         fn = inspect.getsourcefile(obj)
@@ -235,8 +250,6 @@ def linkcode_resolve(domain, info):
             fn = None
     if not fn:
         return None
-    if fn == '<string>':  # verbose decorator
-        fn = inspect.getmodule(obj).__file__
     fn = op.relpath(fn, start=op.dirname(mne.__file__))
     fn = '/'.join(op.normpath(fn).split(os.sep))  # in case on Windows
 

--- a/mne/utils/fetching.py
+++ b/mne/utils/fetching.py
@@ -98,9 +98,7 @@ def _fetch_file(url, file_name, print_destination=True, resume=True,
         The URL open timeout.
     hash_type : str
         The type of hashing to use such as "md5" or "sha1"
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
     """
     # Adapted from NISL:
     # https://github.com/nisl/tutorial/blob/master/nisl/datasets.py

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -88,8 +88,7 @@ def run_subprocess(command, verbose=None, *args, **kwargs):
     ----------
     command : list of str | str
         Command to run as subprocess (see subprocess.Popen documentation).
-    %(verbose)s Defaults to
-        self.verbose.
+    %(verbose)s
     *args, **kwargs : arguments
         Additional arguments to pass to subprocess.Popen.
 

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -88,9 +88,7 @@ def run_subprocess(command, verbose=None, *args, **kwargs):
     ----------
     command : list of str | str
         Command to run as subprocess (see subprocess.Popen documentation).
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more). Defaults to
+    %(verbose)s Defaults to
         self.verbose.
     *args, **kwargs : arguments
         Additional arguments to pass to subprocess.Popen.

--- a/mne/utils/tests/test_docs.py
+++ b/mne/utils/tests/test_docs.py
@@ -1,9 +1,19 @@
 import pytest
 
-from mne import open_docs
+from mne import open_docs, grade_to_tris
+from mne.epochs import add_channels_epochs
 from mne.utils import (copy_function_doc_to_method_doc, copy_doc,
                        linkcode_resolve, deprecated)
 import webbrowser
+
+
+@pytest.mark.parametrize('obj', (grade_to_tris, add_channels_epochs))
+def test_doc_filling(obj):
+    """Test that docs are filled properly."""
+    doc = obj.__doc__
+    assert 'verbose : ' in doc
+    if obj is add_channels_epochs:
+        assert 'for more). Defaults to True if' in doc
 
 
 @deprecated('message')

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -612,9 +612,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
         camera.
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1578,7 +1576,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
     time_label : str | callable | None
         Format of the time label (a format string, a function that maps
         floating point time values to strings, or None for no label). The
-        default is ``time=%0.2f ms``.
+        default is ``time=%%0.2f ms``.
     smoothing_steps : int
         The amount of smoothing
     transparent : bool
@@ -1657,9 +1655,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         Title for the figure. If None, the subject name will be used.
 
         .. versionadded:: 0.17.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1829,9 +1825,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
         None will choose automatically based on colormap type.
     show : bool
         Show figures if True. Defaults to True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Notes
     -----
@@ -2261,6 +2255,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     return brain
 
 
+@verbose
 def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
                                  fontsize=18, bgcolor=(.05, 0, .1),
                                  opacity=0.2, brain_color=(0.7,) * 3,
@@ -2311,10 +2306,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
         to specify how the dipoles should be shown.
     scale_factors : list
         List of floating point scale factors for the markers.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
-
+    %(verbose)s
     **kwargs : kwargs
         Keyword arguments to pass to mlab.triangular_mesh.
 
@@ -2434,6 +2426,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     return surface
 
 
+@verbose
 def plot_dipole_locations(dipoles, trans, subject, subjects_dir=None,
                           mode='orthoview', coord_frame='mri', idx='gof',
                           show_all=True, ax=None, block=False,
@@ -2498,9 +2491,7 @@ def plot_dipole_locations(dipoles, trans, subject, subjects_dir=None,
         Only used if mode equals 'orthoview'.
 
         .. versionadded:: 0.14.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -880,9 +880,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
         Number of jobs to run in parallel.
     show : bool
         Show figure if True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -713,9 +713,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1030,9 +1028,7 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1047,7 +1043,7 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
     -----
     If baseline signals match the assumption of Gaussian white noise,
     values should be centered at 0, and be within 2 standard deviations
-    (±1.96) for 95% of the time points. For the global field power (GFP),
+    (±1.96) for 95%% of the time points. For the global field power (GFP),
     we expect it to fluctuate around a value of 1.
 
     If one single covariance object is passed, the GFP panel (bottom)
@@ -1233,9 +1229,7 @@ def plot_snr_estimate(evoked, inv, show=True, verbose=None):
         The minimum-norm inverse operator.
     show : bool
         Show figure if True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -55,9 +55,7 @@ def plot_cov(cov, info, exclude=[], colorbar=True, proj=False, show_svd=True,
         type. We show square roots ie. standard deviations.
     show : bool
         Show figure if True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -740,9 +740,7 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         Evoked object. Defaults to True.
 
         .. versionadded:: 0.15.0
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------
@@ -1102,6 +1100,7 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
         params['fig_proj'].canvas.draw()
 
 
+@verbose
 def plot_raw_psd_topo(raw, tmin=0., tmax=None, fmin=0., fmax=100., proj=False,
                       n_fft=2048, n_overlap=0, layout=None, color='w',
                       fig_facecolor='k', axis_facecolor='k', dB=True,
@@ -1151,9 +1150,7 @@ def plot_raw_psd_topo(raw, tmin=0., tmax=None, fmin=0., fmax=100., proj=False,
         Number of jobs to run in parallel. Defaults to 1.
     axes : instance of matplotlib Axes | None
         Axes to plot into. If None, axes will be created.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1894,7 +1894,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     normalization : str
         Either "full" or "length" (default). If "full", the PSD will
@@ -1934,7 +1934,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         If True, each band will be divided by the total power. Defaults to
         False.
     cbar_fmt : str
-        The colorbar format. Defaults to '%0.3f'.
+        The colorbar format. Defaults to '%%0.3f'.
     outlines : 'head' | 'skirt' | dict | None
         The outlines to be drawn. If 'head', the default head scheme will be
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
@@ -1951,9 +1951,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         will be created automatically. Defaults to None.
     show : bool
         Show figure if True.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -547,9 +547,7 @@ def compare_fiff(fname_1, fname_2, fname_out=None, show=True, indent='    ',
     max_str : int
         Max number of characters of string representation to print for
         each tag's data.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+    %(verbose)s
 
     Returns
     -------


### PR DESCRIPTION
This is a proof-of-concept for #5753. Done:

- [x] updated `decorator.py` to get any bugfixes
- [x] convert `verbose` decorator itself to be a docfiller
- [x] changed two files to use the new format: `epochs.py` and `source_estimate.py`.
- [x] update all files

Posting to get comments before I replace the remaining 334 (!) instances of `verbose : ` in our codebase.

Closes #5753.