### PR TITLE
WIP: Try 3.7 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
     # TRAVIS_PYTHON_VERSION is only needed for neo's setup.py
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
-    global: PYTHON_VERSION=3.6 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
+    global: PYTHON_VERSION=3.7 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning TEST_LOCATION=src
             PIP_DEPENDENCIES="codecov nitime"
-            TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
+            TRAVIS_PYTHON_VERSION=3.7 CONDA_VERSION=">=4.6.4"
             OPENBLAS_NUM_THREADS=1
 
 matrix:
@@ -32,7 +32,6 @@ matrix:
         # PIP + non-default stim channel
         - os: linux
           env: MNE_STIM_CHANNEL=STI101
-               PYTHON_VERSION=3.7
           language: python
           python: "3.7"
           addons:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
       # to get it to download 32-bit Anaconda properly, and VTK does not ship
       # 32-bit Windows binaries via pip.
       Python36-64bit-full-conda:
-        PYTHON_VERSION: '3.6'
+        PYTHON_VERSION: '3.7'
         PLATFORM: 'x86-64'
         TEST_MODE: 'conda'
         CONDA_ENVIRONMENT: 'environment.yml'

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mne
 channels:
 - defaults
 dependencies:
-- python<3.7
+- python>=3.7
 - pip
 - mkl
 - numpy


### PR DESCRIPTION
The `conda` folks just pushed 4.6.4, which should fix the `pip` bug on AppVeyor. Let's find out.

Closes #5916.