### PR TITLE
BUG: Fix picks when "info" is int-like

### DIFF
--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -11,7 +11,7 @@ import re
 import numpy as np
 
 from .constants import FIFF
-from ..utils import logger, verbose, _validate_type, fill_doc
+from ..utils import logger, verbose, _validate_type, fill_doc, _ensure_int
 
 
 def get_channel_types():
@@ -796,14 +796,16 @@ def _pick_data_or_ica(info, exclude=()):
 def _picks_to_idx(info, picks, none='data', exclude='bads', allow_empty=False,
                   with_ref_meg=True):
     """Convert and check pick validity."""
+    from .meas_info import Info
     #
     # None -> all, data, or data_or_ica (ndarray of int)
     #
     orig_picks = picks
-    if isinstance(info, int):
-        n_chan = info
-    else:
+    if isinstance(info, Info):
         n_chan = info['nchan']
+    else:
+        info = _ensure_int(info, 'info', 'an int or Info')
+        n_chan = info
     assert n_chan >= 0
 
     if picks is None:

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -286,9 +286,9 @@ class ICA(ContainsMixin):
            subgaussian and supergaussian sources. Neural computation, 11(2),
            pp.417-441.
 
-    .. [4] Ablin, P., Cardoso, J.F., Gramfort, A., 2017. Faster Independent
-           Component Analysis by preconditioning with Hessian approximations.
-           arXiv:1706.08171
+    .. [4] Ablin P, Cardoso J, Gramfort A (2018). Faster Independent Component
+           Analysis by Preconditioning With Hessian Approximations.
+           IEEE Transactions on Signal Processing 66:4040–4049
 
     .. [5] Artoni, F., Delorme, A., und Makeig, S, 2018. Applying Dimension
            Reduction to EEG Data by Principal Component Analysis Reduces the

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -5,6 +5,7 @@
 
 import os.path as op
 
+import numpy as np
 from numpy.testing import assert_equal, assert_array_equal
 import pytest
 import matplotlib.pyplot as plt
@@ -180,9 +181,12 @@ def test_plot_ica_sources():
     fig.canvas.key_press_event('escape')
     # Sadly close_event isn't called on Agg backend and the test always passes.
     assert_array_equal(ica.exclude, [1])
+    plt.close('all')
 
+    # dtype can change int->np.int after load, test it explicitly
+    ica.n_components_ = np.int64(ica.n_components_)
     fig = ica.plot_sources(raw, [1])
-    # test mouse clicks
+    # also test mouse clicks
     data_ax = fig.axes[0]
     _fake_click(fig, data_ax, [-0.1, 0.9])  # click on y-label
 

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -298,6 +298,6 @@ eog_component = reference_ica.get_components()[:, eog_inds[0]]
 ###############################################################################
 # References
 # ----------
-# .. [1] Ablin, P., Cardoso, J.F., Gramfort, A., 2017. Faster Independent
-#        Component Analysis by preconditioning with Hessian approximations.
-#        arXiv:1706.08171
+# .. [1] Ablin P, Cardoso J, Gramfort A (2018). Faster Independent Component
+#        Analysis by Preconditioning With Hessian Approximations.
+#        IEEE Transactions on Signal Processing 66:4040–4049

--- a/tutorials/plot_ica_from_raw.py
+++ b/tutorials/plot_ica_from_raw.py
@@ -124,6 +124,6 @@ ica.plot_overlay(raw)  # EOG artifacts remain
 ###############################################################################
 # References
 # ----------
-# .. [1] Ablin, P., Cardoso, J.F., Gramfort, A., 2017. Faster Independent
-#        Component Analysis by preconditioning with Hessian approximations.
-#        arXiv:1706.08171
+# .. [1] Ablin P, Cardoso J, Gramfort A (2018). Faster Independent Component
+#        Analysis by Preconditioning With Hessian Approximations.
+#        IEEE Transactions on Signal Processing 66:4040–4049


### PR DESCRIPTION
A `int` vs `np.int` bug snuck through #4511, this adds a test and updates a ref in the process to trigger CircleCI on the example that [was failing](https://circleci.com/gh/mne-tools/mne-python/11299).