### PR TITLE
Fix : simulate evoked with different sensor types + take into account…

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,7 +73,7 @@ Bug
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
-- Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance `Alex Gramfort`_
+- Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
+- Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance `Alex Gramfort`_
+
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 
 - Fix :func:`mne.io.read_raw_edf` reading duplicate channel names by `Larry Eisenman`_

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -38,7 +38,7 @@ def _get_data(ch_decim=1):
 
     noise_cov = mne.read_cov(fname_cov)
     noise_cov['projs'] = []
-    noise_cov = regularize(noise_cov, evoked.info)
+    noise_cov = regularize(noise_cov, evoked.info, rank='full', proj=False)
     return evoked, noise_cov
 
 

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -38,7 +38,7 @@ def _get_data(ch_decim=1):
 
     noise_cov = mne.read_cov(fname_cov)
     noise_cov['projs'] = []
-    noise_cov = regularize(noise_cov, evoked.info, rank=None)
+    noise_cov = regularize(noise_cov, evoked.info)
     return evoked, noise_cov
 
 
@@ -128,7 +128,7 @@ def test_rap_music_simulated():
     dipoles = rap_music(sim_evoked, forward_fixed, noise_cov,
                         n_dipoles=n_dipoles)
     _check_dipoles(dipoles, forward_fixed, stc, sim_evoked)
-    assert (0.98 < dipoles[0].gof.max() < 1.)
+    assert (0.97 < dipoles[0].gof.max() < 1.)
     assert (dipoles[0].gof.min() >= 0.)
     assert_array_equal(dipoles[0].gof, dipoles[1].gof)
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1380,7 +1380,7 @@ def _get_whitener(noise_cov, info=None, ch_names=None, rank=None,
 
 
 @verbose
-def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
+def prepare_noise_cov(noise_cov, info, ch_names=None, rank=None,
                       scalings=None, verbose=None):
     """Prepare noise covariance matrix.
 
@@ -1390,8 +1390,9 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
         The noise covariance to process.
     info : dict
         The measurement info (used to get channel types and bad channels).
-    ch_names : list
-        The channel names to be considered.
+    ch_names : list | None
+        The channel names to be considered. Can be None to use
+        ``info['ch_names']``.
     rank : None | int | dict (default None)
         Specified rank of the noise covariance matrix. If None, the rank is
         detected automatically. If int, the rank is specified for the MEG
@@ -1413,6 +1414,7 @@ def prepare_noise_cov(noise_cov, info, ch_names, rank=None,
         and parameters updated.
     """
     # reorder C and info to match ch_names order
+    ch_names = info['ch_names'] if ch_names is None else ch_names
     noise_cov_idx = [noise_cov.ch_names.index(c) for c in ch_names]
     if not noise_cov['diag']:
         C = noise_cov.data[np.ix_(noise_cov_idx, noise_cov_idx)]

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -373,7 +373,7 @@ def test_make_forward_dipole():
     # Now simulate evoked responses for each of the test dipoles,
     # and fit dipoles to them (sphere model, MEG and EEG)
     times, pos, amplitude, ori, gof = [], [], [], [], []
-    nave = 100  # add a tiny amount of noise to the simulated evokeds
+    nave = 200  # add a tiny amount of noise to the simulated evokeds
     for s in stc:
         evo_test = simulate_evoked(fwd, s, info, cov,
                                    nave=nave, random_state=rng)

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -77,7 +77,7 @@ def simulate_evoked(fwd, stc, info, cov, nave=30, iir_filter=None,
         noise = _simulate_noise_evoked(evoked, cov, iir_filter, random_state)
         evoked.data += noise.data / math.sqrt(nave)
         evoked.nave = np.int(nave)
-    if cov['projs']:
+    if cov is not None and cov.get('projs', None):
         evoked.add_proj(cov['projs']).apply_proj()
     return evoked
 

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -204,6 +204,7 @@ def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None):
     c = np.diag(stds_inv).dot(c).dot(np.diag(stds_inv))
     # we almost always get a positive semidefinite warning here, so squash it
     with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore')
         noise = rng.multivariate_normal(mu_channels, c, n_samples).T
         noise *= stds[:, None]
     if iir_filter is not None:

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -3,12 +3,12 @@
 #          Martin Luessi <mluessi@nmr.mgh.harvard.edu>
 #
 # License: BSD (3-clause)
-import warnings
 import math
 
 import numpy as np
 
-from ..io.pick import pick_channels_cov, pick_info
+from ..cov import _get_whitener
+from ..io.pick import pick_info
 from ..forward import apply_forward
 from ..utils import (logger, verbose, check_random_state, _check_preload,
                      deprecated, _validate_type)
@@ -188,28 +188,12 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
 def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None):
     """Create spatially colored and temporally IIR-filtered noise."""
     from scipy.signal import lfilter
-    noise_cov = pick_channels_cov(cov, include=info['ch_names'], exclude=[])
-    if set(info['ch_names']) != set(noise_cov.ch_names):
-        raise ValueError('Evoked and covariance channel names are not '
-                         'identical. Cannot generate the noise matrix. '
-                         'Channels missing in covariance %s.' %
-                         np.setdiff1d(info['ch_names'], noise_cov.ch_names))
-
     rng = check_random_state(random_state)
-    c = np.diag(noise_cov.data) if noise_cov['diag'] else noise_cov.data
-    mu_channels = np.zeros(len(c))
-    stds = np.sqrt(np.diag(c))
-    stds_inv = np.zeros_like(stds)
-    stds_inv[stds != 0.] = 1. / stds[stds != 0.]
-    c = np.diag(stds_inv).dot(c).dot(np.diag(stds_inv))
-    # we almost always get a positive semidefinite warning here, so squash it
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter('ignore')
-        noise = rng.multivariate_normal(mu_channels, c, n_samples).T
-        noise *= stds[:, None]
+    _, colorer, _, _ = _get_whitener(cov, info)
+    noise = np.dot(colorer, rng.randn(len(colorer), n_samples))
     if iir_filter is not None:
         if zi is None:
-            zi = np.zeros((len(c), len(iir_filter) - 1))
+            zi = np.zeros((len(colorer), len(iir_filter) - 1))
         noise, zf = lfilter([1], iir_filter, noise, axis=-1, zi=zi)
     else:
         zf = None

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -15,6 +15,7 @@ from mne import (read_cov, read_forward_solution, convert_forward_solution,
 from mne.datasets import testing
 from mne.simulation import simulate_sparse_stc, simulate_evoked, add_noise
 from mne.io import read_raw_fif
+from mne.io.pick import pick_channels_cov
 from mne.cov import regularize, whiten_evoked
 from mne.utils import run_tests_if_main, catch_logging
 
@@ -83,12 +84,15 @@ def test_simulate_evoked():
                   cov, nave=nave, iir_filter=None)
 
 
-@testing.requires_testing_data
+# We don't use an avg ref here, but let's ignore it. Also we know we have
+# few samples, and that our epochs are not baseline corrected.
+@pytest.mark.filterwarnings('ignore:No average EEG reference present')
+@pytest.mark.filterwarnings('ignore:Too few samples')
+@pytest.mark.filterwarnings('ignore:Epochs are not baseline corrected')
 def test_add_noise():
     """Test noise addition."""
     rng = np.random.RandomState(0)
-    data_path = testing.data_path()
-    raw = read_raw_fif(data_path + '/MEG/sample/sample_audvis_trunc_raw.fif')
+    raw = read_raw_fif(raw_fname)
     raw.del_proj()
     picks = pick_types(raw.info, eeg=True, exclude=())
     cov = compute_raw_covariance(raw, picks=picks)
@@ -122,13 +126,35 @@ def test_add_noise():
         if inst is evoked:
             inst = EpochsArray(inst.data[np.newaxis], inst.info)
         if inst is raw:
-            cov_new = compute_raw_covariance(inst, picks=picks,
-                                             verbose='error')  # samples
+            cov_new = compute_raw_covariance(inst, picks=picks)
         else:
-            cov_new = compute_covariance(inst, verbose='error')  # avg ref
+            cov_new = compute_covariance(inst)
         assert cov['names'] == cov_new['names']
         r = np.corrcoef(cov['data'].ravel(), cov_new['data'].ravel())[0, 1]
         assert r > 0.99
+
+
+def test_rank_deficiency():
+    """Test adding noise from M/EEG float32 (I/O) cov with projectors."""
+    # See gh-5940
+    evoked = read_evokeds(ave_fname, 0, baseline=(None, 0))
+    evoked.info['bads'] = ['MEG 2443']
+    evoked.info['lowpass'] = 20  # fake for decim
+    picks = pick_types(evoked.info, meg=True, eeg=False)
+    picks = picks[::16]
+    evoked.pick_channels([evoked.ch_names[pick] for pick in picks])
+    evoked.info.normalize_proj()
+    cov = read_cov(cov_fname)
+    cov['projs'] = []
+    cov = regularize(cov, evoked.info, rank=None)
+    cov = pick_channels_cov(cov, evoked.ch_names)
+    evoked.data[:] = 0
+    add_noise(evoked, cov)
+    cov_new = compute_covariance(
+        EpochsArray(evoked.data[np.newaxis], evoked.info), verbose='error')
+    assert cov['names'] == cov_new['names']
+    r = np.corrcoef(cov['data'].ravel(), cov_new['data'].ravel())[0, 1]
+    assert r > 0.98
 
 
 run_tests_if_main()

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -15,7 +15,7 @@ from mne import (read_cov, read_forward_solution, convert_forward_solution,
 from mne.datasets import testing
 from mne.simulation import simulate_sparse_stc, simulate_evoked, add_noise
 from mne.io import read_raw_fif
-from mne.cov import regularize
+from mne.cov import regularize, whiten_evoked
 from mne.utils import run_tests_if_main, catch_logging
 
 data_path = testing.data_path(download=False)
@@ -61,6 +61,9 @@ def test_simulate_evoked():
     assert_array_almost_equal(evoked.times, stc.times)
     assert len(evoked.data) == len(fwd['sol']['data'])
     assert_equal(evoked.nave, nave)
+    assert len(evoked.info['projs']) == len(cov['projs'])
+    evoked_white = whiten_evoked(evoked, cov)
+    assert abs(evoked_white.data[:, 0].std() - 1.) < 0.1
 
     # make a vertex that doesn't exist in fwd, should throw error
     stc_bad = stc.copy()

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -97,12 +97,16 @@ def test_simulate_raw_sphere():
     #
     # Test raw simulation with basic parameters
     #
-    raw_sim = simulate_raw(raw, stc, trans, src, sphere, read_cov(cov_fname),
+    raw.info.normalize_proj()
+    cov = read_cov(cov_fname)
+    cov['projs'] = raw.info['projs']
+    raw_sim = simulate_raw(raw, stc, trans, src, sphere, cov,
                            head_pos=head_pos_sim,
                            blink=True, ecg=True, random_state=seed)
-    raw_sim_2 = simulate_raw(raw, stc, trans_fname, src_fname, sphere,
-                             cov_fname, head_pos=head_pos_sim,
-                             blink=True, ecg=True, random_state=seed)
+    with pytest.warns(RuntimeWarning, match='applying projector with'):
+        raw_sim_2 = simulate_raw(raw, stc, trans_fname, src_fname, sphere,
+                                 cov_fname, head_pos=head_pos_sim,
+                                 blink=True, ecg=True, random_state=seed)
     assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
     std = dict(grad=2e-13, mag=10e-15, eeg=0.1e-6)
     raw_sim = simulate_raw(raw, stc, trans, src, sphere,

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -139,8 +139,8 @@ def test_dipole_fitting():
     # Sanity check: do our residuals have less power than orig data?
     data_rms = np.sqrt(np.sum(evoked.data ** 2, axis=0))
     resi_rms = np.sqrt(np.sum(residual.data ** 2, axis=0))
-    assert (data_rms > resi_rms * 0.95).all(), \
-        '%s (factor: %s)' % ((data_rms / resi_rms).min(), 0.95)
+    assert (data_rms > resi_rms * 0.90).all(), \
+        '%s (factor: %s)' % ((data_rms / resi_rms).min(), 0.90)
 
     # Compare to original points
     transform_surface_to(fwd['src'][0], 'head', fwd['mri_head_t'])

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -139,8 +139,8 @@ def test_dipole_fitting():
     # Sanity check: do our residuals have less power than orig data?
     data_rms = np.sqrt(np.sum(evoked.data ** 2, axis=0))
     resi_rms = np.sqrt(np.sum(residual.data ** 2, axis=0))
-    assert (data_rms > resi_rms * 0.90).all(), \
-        '%s (factor: %s)' % ((data_rms / resi_rms).min(), 0.90)
+    assert (data_rms > resi_rms * 0.95).all(), \
+        '%s (factor: %s)' % ((data_rms / resi_rms).min(), 0.95)
 
     # Compare to original points
     transform_surface_to(fwd['src'][0], 'head', fwd['mri_head_t'])


### PR DESCRIPTION
this fixes 2 problems:

- simulate evoked with different sensor types. Symptom was not the noise was not scaled properly for mags. Noise was too strong.
- take into account projs from the cov to make sure that the noise and the signal belong to the same subspace.

thanks @QB3 for the bug report.