### PR TITLE
FIX: check weight_norm parameter

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -136,6 +136,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     rank = data_rank
     logger.info('Making LCMV beamformer with rank %s' % (rank,))
     del data_rank
+    _check_option('weight_norm', weight_norm, ['unit-noise-gain', 'nai', None])
 
     is_free_ori, ch_names, proj, vertno, G, nn = \
         _prepare_beamformer_input(info, forward, label, picks, pick_ori)


### PR DESCRIPTION
#### Reference issue
Example: Fixes #5945


#### What does this implement/fix?
checks that `weight_norm : 'unit-noise-gain' | 'nai' | None`


#### Additional information
@jaaval now this snipped errors with a meaningful error

``` python
import mne
from mne.datasets import sample
from mne.beamformer import make_lcmv

data_path = sample.data_path()
raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
event_fname = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
label_name = 'Aud-lh'
fname_label = data_path + '/MEG/sample/labels/%s.label' % label_name
subjects_dir = data_path + '/subjects'

event_id, tmin, tmax = 1, -0.2, 0.5

# Setup for reading the raw data
raw = mne.io.read_raw_fif(raw_fname, preload=True)
raw.info['bads'] = ['MEG 2443', 'EEG 053']  # 2 bads channels
events = mne.read_events(event_fname)

# Set up pick list: EEG + MEG - bad channels (modify to your needs)
picks = mne.pick_types(raw.info, meg=True, eeg=False, stim=True, eog=True,
                       exclude='bads')

# Pick the channels of interest
raw.pick_channels([raw.ch_names[pick] for pick in picks])
# Re-normalize our empty-room projectors, so they are fine after subselection
raw.info.normalize_proj()

# Read epochs
epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                    baseline=(None, 0), preload=True, proj=True,
                    reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
evoked = epochs.average()

forward = mne.read_forward_solution(fname_fwd)
forward = mne.convert_forward_solution(forward, surf_ori=True)

# Compute regularized noise and data covariances
noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk',
                                   rank=None)
data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
                                  method='shrunk', rank=None)

filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
                    noise_cov=noise_cov, pick_ori=None,
                    weight_norm='asdf', rank=None)
```

This is the result of runing the MWE

``` shell
ValueError: Unrecognized weight normalization option in weight_norm, available choices are "nai", "unit-noise-gain" and None; got "asdf".
```

--
@wmvanvliet can you make sure that this is ok? The `'nai'` option was added in
#5447. I've seen that `tf_lcmw` the `'nai'` option is not there. And this PR now
makes `'nai'` valid for `_lcmv_source_power`.

Maybe we can also use this PR to update the doc and make use of the **doccer** that 
@larsoner put in place.

I also see this kind of checkings in many places, maybe we should factor it out and
have a prameter checker or something, that unifies the errors etc.