### PR TITLE
[MRG] allow to pass a BEM as an instance not just as a string

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -36,6 +36,16 @@ MNE-Python core terminology and general concepts
         a type, such as gradiometer, and a unit, such as Tesla/Meter that
         is used in the code base, e.g. for plotting.
 
+    BEM
+        BEM is the acronym for boundary element method or boundary element
+        model. Both are related to the forward model computation and more
+        specifically the definion of the conductor model. The
+        boundary element model consists of surfaces such as the inner skull,
+        outer skull and outer skill that define compartments of tissues
+        of the head. You can compute the BEM surfaces with
+        :func:`mne.bem.make_watershed_bem` or :func:`mne.bem.make_flash_bem`.
+        See :ref:`sphx_glr_auto_tutorials_plot_forward.py` for usage demo.
+
     epochs
         Epochs are chunks of data extracted from raw continuous data. Typically,
         they correspond to the trials of an experimental design.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -41,8 +41,8 @@ MNE-Python core terminology and general concepts
         model. Both are related to the forward model computation and more
         specifically the definion of the conductor model. The
         boundary element model consists of surfaces such as the inner skull,
-        outer skull and outer skill that define compartments of tissues
-        of the head. You can compute the BEM surfaces with
+        outer skull and outer skiln (a.k.a. scalp) that define compartments
+        of tissues of the head. You can compute the BEM surfaces with
         :func:`mne.bem.make_watershed_bem` or :func:`mne.bem.make_flash_bem`.
         See :ref:`sphx_glr_auto_tutorials_plot_forward.py` for usage demo.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ Changelog
 
 - Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_
 
+- The ``mri`` parameter in :func:`mne.setup_volume_source_space` is now automatically set to ``T1.mgz`` if ``subject`` is provided. This allows to get a :class:`mne.SourceSpaces` of kind ``volume`` more automatically. By `Alex Gramfort`_
+
 - Allow string argument in :meth:`mne.io.Raw.drop_channels` to remove a single channel by `Clemens Brunner`_
 
 Bug

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -336,7 +336,7 @@ def test_simulate_raw_chpi():
     sphere = make_sphere_model('auto', 'auto', raw.info)
     # make sparse spherical source space
     sphere_vol = tuple(sphere['r0'] * 1000.) + (sphere.radius * 1000.,)
-    src = setup_volume_source_space('sample', sphere=sphere_vol, pos=70.)
+    src = setup_volume_source_space(sphere=sphere_vol, pos=70.)
     stc = _make_stc(raw, src)
     # simulate data with cHPI on
     raw_sim = simulate_raw(raw, stc, None, src, sphere, cov=None, chpi=False,

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1501,9 +1501,9 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume
         using this interpolator. If pos is a dict, this cannot be None.
-        If subject name is provided, `pos` or `volume_label` are not
-        provided then the `mri` parameter will default to 'T1.mgz' else
-        it will stay None.
+        If subject name is provided, `pos` is a float or `volume_label`
+        are not provided then the `mri` parameter will default to 'T1.mgz'
+        else it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel
         Define spherical source space bounds using origin and radius given
         by (ox, oy, oz, rad) in mm. Only used if ``bem`` and ``surface``
@@ -1573,7 +1573,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                          'specified')
 
     if (mri is None and subject is not None and
-            volume_label is None and pos is None):
+            volume_label is None and isinstance(pos, (float, int))):
         mri = 'T1.mgz'
 
     if volume_label is not None and mri == 'T1.mgz':

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1485,7 +1485,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     Parameters
     ----------
     subject : str | None
-        Subject to process. If None, the path to the mri volume must be
+        Subject to process. If None, the path to the MRI volume must be
         absolute to get a volume source space. If a subject name
         is provided the T1.mgz file will be found automatically.
         Defaults to None.
@@ -1501,8 +1501,8 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume
         using this interpolator. If pos is a dict, this cannot be None.
-        If subject name is provided then the mri will default to 'T1.mgz'
-        else it will stay None.
+        If subject name is provided then the `mri` parameter will
+        default to 'T1.mgz' else it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel
         Define spherical source space bounds using origin and radius given
         by (ox, oy, oz, rad) in mm. Only used if ``bem`` and ``surface``
@@ -1545,7 +1545,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     Volume source spaces are related to an MRI image such as T1 and allow to
     visualize source estimates overlaid on MRIs and to morph estimates
     to a template brain for group analysis. Discrete source spaces
-    don't allow this. If you provide a subject name the T1 mri will be
+    don't allow this. If you provide a subject name the T1 MRI will be
     used by default.
 
     When you work with a source space formed from a grid you need to specify

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1501,8 +1501,9 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume
         using this interpolator. If pos is a dict, this cannot be None.
-        If subject name is provided then the `mri` parameter will
-        default to 'T1.mgz' else it will stay None.
+        If subject name is provided, `pos` or `volume_label` are not
+        provided then the `mri` parameter will default to 'T1.mgz' else
+        it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel
         Define spherical source space bounds using origin and radius given
         by (ox, oy, oz, rad) in mm. Only used if ``bem`` and ``surface``
@@ -1571,8 +1572,12 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         raise ValueError('Only one of "bem" and "surface" should be '
                          'specified')
 
-    if mri is None and subject is not None:
+    if (mri is None and subject is not None and
+            volume_label is None and pos is None):
         mri = 'T1.mgz'
+
+    if volume_label is not None and mri == 'T1.mgz':
+        raise RuntimeError('Cannot use T1.mgz with some volume_label.')
 
     if mri is not None:
         if not op.isfile(mri):

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1482,18 +1482,29 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                               add_interpolator=True, verbose=None):
     """Set up a volume source space with grid spacing or discrete source space.
 
-    When you work with a volume source space you need to specify the domain in
-    which the grid will be defined. There are three ways of specifying this:
+    Volume source spaces are related to an MRI image such as T1 and allow to
+    visualize source estimates overlaid on MRIs and to morph estimates
+    to a template brain for group analysis. Discrete source spaces
+    don't allow this. If you provide a subject name the T1 mri will be
+    used by default.
+
+    When you work with a source space formed from a grid you need to specify
+    the domain in which the grid will be defined. There are three ways
+    of specifying this:
     (i) sphere, (ii) bem model, and (iii) surface.
     The default behavior is to use sphere model
     (``sphere=(0.0, 0.0, 0.0, 90.0)``) if ``bem`` or ``surface`` is not
     ``None`` then ``sphere`` is ignored.
+    If you're going to use a BEM conductor model for forward model
+    it is recommended to pass it here.
 
     Parameters
     ----------
     subject : str | None
         Subject to process. If None, the path to the mri volume must be
-        absolute. Defaults to None.
+        absolute to get a volume source space. If a subject name
+        is provided the T1.mgz file will be found automatically.
+        Defaults to None.
     pos : float | dict
         Positions to use for sources. If float, a grid will be constructed
         with the spacing given by `pos` in mm, generating a volume source
@@ -1505,7 +1516,9 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         The filename of an MRI volume (mgh or mgz) to create the
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume
-        using this interpolator. If pos is a dict, this can be None.
+        using this interpolator. If pos is a dict, this cannot be None.
+        If subject name is provided then the mri will default to 'T1.mgz'
+        else it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel
         Define spherical source space bounds using origin and radius given
         by (ox, oy, oz, rad) in mm. Only used if ``bem`` and ``surface``
@@ -1557,6 +1570,10 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     if bem is not None and surface is not None:
         raise ValueError('Only one of "bem" and "surface" should be '
                          'specified')
+
+    if mri is None and subject is not None:
+        mri = 'T1.mgz'
+
     if mri is not None:
         if not op.isfile(mri):
             if subject is None:

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1482,22 +1482,6 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                               add_interpolator=True, verbose=None):
     """Set up a volume source space with grid spacing or discrete source space.
 
-    Volume source spaces are related to an MRI image such as T1 and allow to
-    visualize source estimates overlaid on MRIs and to morph estimates
-    to a template brain for group analysis. Discrete source spaces
-    don't allow this. If you provide a subject name the T1 mri will be
-    used by default.
-
-    When you work with a source space formed from a grid you need to specify
-    the domain in which the grid will be defined. There are three ways
-    of specifying this:
-    (i) sphere, (ii) bem model, and (iii) surface.
-    The default behavior is to use sphere model
-    (``sphere=(0.0, 0.0, 0.0, 90.0)``) if ``bem`` or ``surface`` is not
-    ``None`` then ``sphere`` is ignored.
-    If you're going to use a BEM conductor model for forward model
-    it is recommended to pass it here.
-
     Parameters
     ----------
     subject : str | None
@@ -1558,6 +1542,22 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
 
     Notes
     -----
+    Volume source spaces are related to an MRI image such as T1 and allow to
+    visualize source estimates overlaid on MRIs and to morph estimates
+    to a template brain for group analysis. Discrete source spaces
+    don't allow this. If you provide a subject name the T1 mri will be
+    used by default.
+
+    When you work with a source space formed from a grid you need to specify
+    the domain in which the grid will be defined. There are three ways
+    of specifying this:
+    (i) sphere, (ii) bem model, and (iii) surface.
+    The default behavior is to use sphere model
+    (``sphere=(0.0, 0.0, 0.0, 90.0)``) if ``bem`` or ``surface`` is not
+    ``None`` then ``sphere`` is ignored.
+    If you're going to use a BEM conductor model for forward model
+    it is recommended to pass it here.
+
     To create a discrete source space, `pos` must be a dict, 'mri' must be
     None, and 'volume_label' must be None. To create a whole brain volume
     source space, `pos` must be a float and 'mri' must be provided. To create

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -141,7 +141,7 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
 
 ###############################################################################
 # Obviously here, the sphere is not perfect. It is not restricted to the
-# brain and it misses some parts of the cortex.
+# brain and it can miss some parts of the cortex.
 #
 # To compute a volume based source space defined with a grid of candidate
 # dipoles inside the brain (requires the :term:`BEM` surfaces) you can use the

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -12,6 +12,7 @@ concepts for forward modeling. See :ref:`ch_forward`.
 
 """
 
+import os.path as op
 import mne
 from mne.datasets import sample
 data_path = sample.data_path()
@@ -30,15 +31,15 @@ subject = 'sample'
 #
 #    - a ``-trans.fif`` file that contains the coregistration info.
 #    - a source space
-#    - the BEM surfaces
+#    - the :term:`BEM` surfaces
 
 ###############################################################################
 # Compute and visualize BEM surfaces
 # ----------------------------------
 #
-# The BEM surfaces are the triangulations of the interfaces between different
-# tissues needed for forward computation. These surfaces are for example
-# the inner skull surface, the outer skull surface and the outer skill
+# The :term:`BEM` surfaces are the triangulations of the interfaces between
+# different tissues needed for forward computation. These surfaces are for
+# example the inner skull surface, the outer skull surface and the outer skill
 # surface.
 #
 # Computing the BEM surfaces requires FreeSurfer and makes use of either of
@@ -46,6 +47,9 @@ subject = 'sample'
 #
 #   - :ref:`gen_mne_watershed_bem`
 #   - :ref:`gen_mne_flash_bem`
+#
+# Or by calling in a Python script one of the functions
+# :func:`mne.bem.make_watershed_bem` or :func:`mne.bem.make_flash_bem`.
 #
 # Here we'll assume it's already computed. It takes a few minutes per subject.
 #
@@ -105,27 +109,55 @@ mne.viz.plot_alignment(info, trans, subject=subject, dig=True,
 # :func:`mne.setup_source_space`, while **volumetric** source space is computed
 # using :func:`mne.setup_volume_source_space`.
 #
-# The rest of this tutorial uses a source-based source space with
-# an OCT-6 resolution.
+# We will now compute a source-based source space with an OCT-6 resolution.
 # See :ref:`setting_up_source_space` for details on source space definition
 # and spacing parameter.
-#
 
 src = mne.setup_source_space(subject, spacing='oct6',
                              subjects_dir=subjects_dir, add_dist=False)
 print(src)
 
 ###############################################################################
-# ``src`` contains two parts, one for the left hemisphere (4098 locations) and
-# one for the right hemisphere (4098 locations). Sources can be visualized on
-# top of the BEM surfaces.
+# The surface based source space ``src`` contains two parts, one for the left
+# hemisphere (4098 locations) and one for the right hemisphere
+# (4098 locations). Sources can be visualized on top of the BEM surfaces
+# in purple.
 
 mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
                  brain_surfaces='white', src=src, orientation='coronal')
 
 ###############################################################################
-# However, only sources that lie in the plotted MRI slices are shown.
-# Let's write a few lines of mayavi to see all sources.
+# To compute a volume based source space defined with a grid of candidate
+# dipoles inside a sphere of radius 90mm centered at (0.0, 0.0, 40.0)
+# you can use:
+
+sphere = (0.0, 0.0, 40.0, 90.0)
+vol_src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir,
+                                        sphere=sphere)
+print(vol_src)
+
+mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
+                 brain_surfaces='white', src=vol_src, orientation='coronal')
+
+###############################################################################
+# Obviously here, the sphere is not perfect. It is not restricted to the
+# brain and it misses some parts of the cortex.
+#
+# To compute a volume based source space defined with a grid of candidate
+# dipoles inside the brain (requires the :term:`BEM` surfaces) you can use the
+# following.
+
+surface = op.join(subjects_dir, subject, 'bem', 'inner_skull.surf')
+vol_src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir,
+                                        surface=surface)
+print(vol_src)
+
+mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
+                 brain_surfaces='white', src=vol_src, orientation='coronal')
+
+###############################################################################
+# With the surface-based source space only sources that lie in the plotted MRI
+# slices are shown. Let's write a few lines of mayavi to see all sources in 3D.
 
 import numpy as np  # noqa
 from mayavi import mlab  # noqa
@@ -138,6 +170,7 @@ vertidx = np.where(src[0]['inuse'])[0]
 
 mlab.points3d(surf.x[vertidx], surf.y[vertidx],
               surf.z[vertidx], color=(1, 1, 0), scale_factor=1.5)
+
 
 ###############################################################################
 # .. _plot_forward_compute_forward_solution:
@@ -163,7 +196,7 @@ model = mne.make_bem_model(subject='sample', ico=4,
 bem = mne.make_bem_solution(model)
 
 ###############################################################################
-# Note that the BEM does not involve any use of the trans file. The BEM
+# Note that the :term:`BEM` does not involve any use of the trans file. The BEM
 # only depends on the head geometry and conductivities.
 # It is therefore independent from the MEG data and the head position.
 #

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -39,8 +39,8 @@ subject = 'sample'
 #
 # The :term:`BEM` surfaces are the triangulations of the interfaces between
 # different tissues needed for forward computation. These surfaces are for
-# example the inner skull surface, the outer skull surface and the outer skill
-# surface.
+# example the inner skull surface, the outer skull surface and the outer skin
+# surface, a.k.a. scalp surface.
 #
 # Computing the BEM surfaces requires FreeSurfer and makes use of either of
 # the two following command line tools:

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -129,7 +129,9 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
 ###############################################################################
 # To compute a volume based source space defined with a grid of candidate
 # dipoles inside a sphere of radius 90mm centered at (0.0, 0.0, 40.0)
-# you can use:
+# you can use the following code.
+# Obviously here, the sphere is not perfect. It is not restricted to the
+# brain and it can miss some parts of the cortex.
 
 sphere = (0.0, 0.0, 40.0, 90.0)
 vol_src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir,
@@ -140,9 +142,6 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
                  brain_surfaces='white', src=vol_src, orientation='coronal')
 
 ###############################################################################
-# Obviously here, the sphere is not perfect. It is not restricted to the
-# brain and it can miss some parts of the cortex.
-#
 # To compute a volume based source space defined with a grid of candidate
 # dipoles inside the brain (requires the :term:`BEM` surfaces) you can use the
 # following.


### PR DESCRIPTION
Here are a few disturbing facts about the setup_volume_source_space.

`mne.setup_volume_source_space(subject, subjects_dir=subjects_dir)` returns by default a discrete source space that cannot be use for morphing. Even if i have a BEM computed form the T1 MRI if I pass the `bem=bem` parameter I get a discrete source space :( To have a volume source space which I assume is what most users want I need to type mri='T1.mgz'.

Illustration:

```
In [2]: src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir, bem=bem)

In [3]: src
Out[3]: <SourceSpaces: [<discrete, n_used=10376, coordinate_frame=MRI (surface RAS)>]>

In [4]: src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir, mri='T1.mgz')

In [5]: src.kind
Out[5]: 'volume'

In [6]: src
Out[6]: <SourceSpaces: [<volume, shape=[39 39 39], n_used=20377, coordinate_frame=MRI (surface RAS)>]>
```

I think we should have better defaults so you don't get trapped so easily as reported by @OlehKSS.

thoughts?