### PR TITLE
FIX: match not message

### DIFF
--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -35,7 +35,7 @@ all_test_params_epochs = list(itertools.product(all_systems_epochs,
                                                 use_info))
 
 no_info_warning = {'expected_warning': RuntimeWarning,
-                   'message': NOINFO_WARNING}
+                   'match': NOINFO_WARNING}
 
 
 @testing.requires_testing_data

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -111,7 +111,7 @@ def test_read_epochs(cur_system, version, use_info):
             assert epoched_ft.metadata is None
             assert_warning_in_record(pandas_not_found_warning_msg, warn_record)
             if pytestwarning['expected_warning'] is not None:
-                assert_warning_in_record(pytestwarning['message'], warn_record)
+                assert_warning_in_record(pytestwarning['match'], warn_record)
 
     mne_data = mne_epoched.get_data()[:, :, :-1]
     ft_data = epoched_ft.get_data()


### PR DESCRIPTION
Fixes errors on `master` with the newest `pytest` release.