### PR TITLE
[MRG] Allow str argument in raw.drop_channels

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,8 @@ Changelog
 
 - Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_
 
+- Allow string argument in :meth:`mne.io.Raw.drop_channels` to remove a single channel by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -763,12 +763,12 @@ class UpdateChannelsMixin(object):
         return self._pick_drop_channels(idx)
 
     def drop_channels(self, ch_names):
-        """Drop some channels.
+        """Drop channel(s).
 
         Parameters
         ----------
-        ch_names : list
-            List of the names of the channels to remove.
+        ch_names : list or str
+            List of channel name(s) or channel name to remove.
 
         Returns
         -------
@@ -785,23 +785,23 @@ class UpdateChannelsMixin(object):
         -----
         .. versionadded:: 0.9.0
         """
-        msg = ("'ch_names' should be a list of strings (the name[s] of the "
-               "channel to be dropped), not a {0}.")
-        if isinstance(ch_names, str):
-            raise ValueError(msg.format("string"))
+        if isinstance(ch_names, list):
+            if not all([isinstance(ch, str) for ch in ch_names]):
+                raise ValueError("'ch_names' must be a list of strings, got "
+                                 "{}.".format([type(ch) for ch in ch_names]))
+        elif isinstance(ch_names, str):
+            ch_names = [ch_names]
         else:
-            if not all([isinstance(ch_name, str)
-                        for ch_name in ch_names]):
-                raise ValueError(msg.format(type(ch_names[0])))
+            raise ValueError("'ch_names' must be a list or a string, got "
+                             "{}.".format(type(ch_names)))
 
-        missing = [ch_name for ch_name in ch_names
-                   if ch_name not in self.ch_names]
+        missing = [ch for ch in ch_names if ch not in self.ch_names]
         if len(missing) > 0:
             msg = "Channel(s) {0} not found, nothing dropped."
             raise ValueError(msg.format(", ".join(missing)))
 
-        bad_idx = [self.ch_names.index(ch_name) for ch_name in ch_names
-                   if ch_name in self.ch_names]
+        bad_idx = [self.ch_names.index(ch) for ch in ch_names
+                   if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
         return self._pick_drop_channels(idx)
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -293,4 +293,12 @@ def test_find_ch_connectivity():
     pytest.raises(ValueError, find_ch_connectivity, raw.info, 'eog')
 
 
+def test_drop_channels():
+    raw = read_raw_fif(raw_fname, preload=True).crop(0, 0.1)
+    raw.drop_channels(["MEG 0111"])  # list argument
+    raw.drop_channels("MEG 0112")  # str argument
+    pytest.raises(ValueError, raw.drop_channels, ["MEG 0111", 5])
+    pytest.raises(ValueError, raw.drop_channels, 5)  # must be list or str
+
+
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -294,6 +294,7 @@ def test_find_ch_connectivity():
 
 
 def test_drop_channels():
+    """Test if dropping channels works with various arguments."""
     raw = read_raw_fif(raw_fname, preload=True).crop(0, 0.1)
     raw.drop_channels(["MEG 0111"])  # list argument
     raw.drop_channels("MEG 0112")  # str argument

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -522,7 +522,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     # Drop remaining channels.
     if drop_refs:
-        drop_channels = (set(anode) | set(cathode)) & set(inst.ch_names)
+        drop_channels = list((set(anode) | set(cathode)) & set(inst.ch_names))
         inst.drop_channels(drop_channels)
 
     return inst


### PR DESCRIPTION
This allows to provide a string argument (the channel name) if only a single channel should be dropped.