### PR TITLE
Add _check_option function

### DIFF
--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -6,16 +6,14 @@
 
 import numpy as np
 
-from .utils import logger, verbose
+from .utils import logger, verbose, _check_option
 
 
 def _log_rescale(baseline, mode='mean'):
     """Log the rescaling method."""
     if baseline is not None:
-        valid_modes = ('logratio', 'ratio', 'zscore', 'mean', 'percent',
-                       'zlogratio')
-        if mode not in valid_modes:
-            raise Exception('mode should be any of : %s' % (valid_modes, ))
+        _check_option('mode', mode, ['logratio', 'ratio', 'zscore', 'mean',
+                                     'percent', 'zlogratio'])
         msg = 'Applying baseline correction (mode: %s)' % mode
     else:
         msg = 'No baseline correction applied'

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..utils import (logger, verbose, warn, _reg_pinv, _check_info_inv,
                      _check_channels_spatial_filter, _check_one_ch_type,
-                     _check_rank)
+                     _check_rank, _check_option)
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..source_estimate import _make_stc, _get_src_type
@@ -181,10 +181,10 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
            statistics in Python. bioRxiv, 245530.
            https://doi.org/10.1101/245530
     """  # noqa: E501
-    allowed_ori = [None, 'normal', 'max-power']
     rank = _check_rank(rank)
-    if pick_ori not in allowed_ori:
-        raise ValueError('"pick_ori" should be one of %s.' % allowed_ori)
+    _check_option('pick_ori', pick_ori, [None, 'normal', 'max-power'])
+    _check_option('inversion', inversion, ['single', 'matrix'])
+    _check_option('weight_norm', weight_norm, ['unit-noise-gain', 'nai', None])
 
     # Leadfield rank and optional rank reduction
     # (to deal with problems with complex eigenvalues within the computation
@@ -197,11 +197,6 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
             'reduce_rank=True is only implemented with pick_ori=="max-power" '
             'and inversion="matrix".'
         )
-
-    # Inversion mode
-    if inversion not in ['single', 'matrix']:
-        raise ValueError("The inversion parameter should be either 'single' "
-                         "or 'matrix'.")
 
     frequencies = [np.mean(freq_bin) for freq_bin in csd.frequencies]
     n_freqs = len(frequencies)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -15,7 +15,8 @@ from ..minimum_norm.inverse import combine_xyz, _check_reference
 from ..cov import compute_whitener, compute_covariance
 from ..source_estimate import _make_stc, SourceEstimate, _get_src_type
 from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
-                     _check_info_inv, _check_channels_spatial_filter)
+                     _check_info_inv, _check_channels_spatial_filter,
+                     _check_option)
 from ..utils import _check_one_ch_type
 from ..utils import _check_rank
 from .. import Epochs
@@ -410,10 +411,7 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
                        label=None, picks=None, pick_ori=None, rank=None,
                        weight_norm=None, verbose=None):
     """Linearly Constrained Minimum Variance (LCMV) beamformer."""
-    if weight_norm not in [None, 'unit-noise-gain']:
-        raise ValueError('Unrecognized weight normalization option in '
-                         'weight_norm, available choices are None and '
-                         '"unit-noise-gain", got "%s".' % weight_norm)
+    _check_option('weight_norm', weight_norm, [None, 'unit-noise-gain'])
 
     if picks is None:
         picks = pick_types(info, meg=True, eeg=True, ref_meg=False,
@@ -585,10 +583,7 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     """
     _check_reference(epochs)
     rank = _check_rank(rank)
-
-    if pick_ori not in [None, 'normal']:
-        raise ValueError('pick_ori must be one of "normal" and None, '
-                         'got %s' % (pick_ori,))
+    _check_option('pick_ori', pick_ori, [None, 'normal'])
     if noise_covs is not None and len(noise_covs) != len(freq_bins):
         raise ValueError('One noise covariance object expected per frequency '
                          'bin')

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -621,7 +621,7 @@ def test_tf_lcmv():
                   tstep, win_lengths, freq_bins, weight_norm='nai')
 
     # Test unsupported pick_ori (vector not supported here)
-    with pytest.raises(ValueError, match='pick_ori must be one of'):
+    with pytest.raises(ValueError, match='pick_ori'):
         tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
                 freq_bins, pick_ori='vector')
     # Test correct detection of preloaded epochs objects that do not contain

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -156,7 +156,7 @@ def test_lcmv_vector():
 
     # Now let's do LCMV
     data_cov = mne.make_ad_hoc_cov(info)  # just a stub for later
-    with pytest.raises(ValueError, match='pick_ori must be one of'):
+    with pytest.raises(ValueError, match="pick_ori"):
         make_lcmv(info, forward, data_cov, 0.05, noise_cov, pick_ori='bad')
 
     lcmv_ori = list()

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy import sparse
 
 from ..utils import (verbose, logger, warn, copy_function_doc_to_method_doc,
-                     _check_preload, _validate_type, fill_doc)
+                     _check_preload, _validate_type, fill_doc, _check_option)
 from ..io.compensator import get_current_comp
 from ..io.constants import FIFF
 from ..io.meas_info import anonymize_info, Info
@@ -82,9 +82,7 @@ def _contains_ch_type(info, ch_type):
     fnirs_extras = ['hbo', 'hbr']
     valid_channel_types = sorted([key for key in _PICK_TYPES_KEYS
                                   if key != 'meg'] + meg_extras + fnirs_extras)
-    if ch_type not in valid_channel_types:
-        raise ValueError('ch_type must be one of %s, not "%s"'
-                         % (valid_channel_types, ch_type))
+    _check_option('ch_type', ch_type, valid_channel_types)
     if info is None:
         raise ValueError('Cannot check for channels of type "%s" because info '
                          'is None' % (ch_type,))
@@ -1186,9 +1184,8 @@ def find_ch_connectivity(info, ch_type):
             raise ValueError('info must contain only one channel type if '
                              'ch_type is None.')
         ch_type = channel_type(info, 0)
-    elif ch_type not in ['mag', 'grad', 'eeg']:
-        raise ValueError("ch_type must be 'mag', 'grad' or 'eeg'. "
-                         "Got %s." % ch_type)
+    else:
+        _check_option('ch_type', ch_type, ['mag', 'grad', 'eeg'])
     (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
      has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
      has_eeg_coils_and_meg, has_eeg_coils_only,

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -20,7 +20,7 @@ from ..bem import fit_sphere_to_headshape
 from ..io.pick import pick_types, _picks_to_idx
 from ..io.constants import FIFF
 from ..io.meas_info import Info
-from ..utils import _clean_names, warn, _check_ch_locs, fill_doc
+from ..utils import _clean_names, warn, _check_ch_locs, fill_doc, _check_option
 from .channels import _get_ch_info
 
 
@@ -382,10 +382,7 @@ def find_layout(info, ch_type=None, exclude='bads'):
     layout : Layout instance | None
         None if layout not found.
     """
-    our_types = ' or '.join(['`None`', '`mag`', '`grad`', '`meg`'])
-    if ch_type not in (None, 'meg', 'mag', 'grad', 'eeg'):
-        raise ValueError('Invalid channel type (%s) requested '
-                         '`ch_type` must be %s' % (ch_type, our_types))
+    _check_option('ch_type', ch_type, [None, 'mag', 'grad', 'meg', 'eeg'])
 
     (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
      has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -47,7 +47,8 @@ from .forward import (_magnetic_dipole_field_vec, _create_meg_coils,
 from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
-from .utils import verbose, logger, use_log_level, _check_fname, warn
+from .utils import (verbose, logger, use_log_level, _check_fname, warn,
+                    _check_option)
 
 # Eventually we should add:
 #   hpicons
@@ -633,7 +634,7 @@ def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
     coil_dev_rrs : ndarray, shape (n_CHPI, 3)
         Fit locations of each cHPI coil in device coordinates
     """
-    _check_too_close(too_close)
+    _check_option('too_close', too_close, ['raise', 'warning', 'info'])
     # 0. determine samples to fit.
     if t_win is None:  # use the whole window
         i_win = [0, len(raw.times)]
@@ -670,13 +671,6 @@ def _fit_device_hpi_positions(raw, t_win=None, initial_dev_rrs=None,
     coil_g = np.array([o[0] for o in outs])
 
     return coil_dev_rrs, coil_g
-
-
-def _check_too_close(too_close):
-    if not isinstance(too_close, str) or \
-            too_close not in ('raise', 'warning', 'info'):
-        raise ValueError('too_close must be "raise", "warning", or "info", '
-                         'got %s (type %s)' % (too_close, type(too_close)))
 
 
 @verbose
@@ -726,7 +720,7 @@ def _calculate_chpi_positions(raw, t_step_min=0.1, t_step_max=10.,
     from scipy.spatial.distance import cdist
     # extract initial geometry from info['hpi_results']
     hpi_dig_head_rrs = _get_hpi_initial_fit(raw.info)
-    _check_too_close(too_close)
+    _check_option('too_close', too_close, ['raise', 'warning', 'info'])
 
     # extract hpi system information
     hpi = _setup_hpi_struct(raw.info, int(round(t_window * raw.info['sfreq'])))
@@ -952,7 +946,7 @@ def _calculate_chpi_coil_locs(raw, t_step_min=0.1, t_step_max=10.,
     read_head_pos
     write_head_pos
     """
-    _check_too_close(too_close)
+    _check_option('too_close', too_close, ['raise', 'warning', 'info'])
 
     # extract initial geometry from info['hpi_results']
     hpi_dig_head_rrs = _get_hpi_initial_fit(raw.info)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -33,7 +33,8 @@ from .event import make_fixed_length_events
 from .rank import compute_rank
 from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     warn, copy_function_doc_to_method_doc, _pl,
-                    _undo_scaling_cov, _scaled_array, _validate_type)
+                    _undo_scaling_cov, _scaled_array, _validate_type,
+                    _check_option)
 from . import viz
 
 from .fixes import BaseEstimator, EmpiricalCovariance, _logdet
@@ -756,10 +757,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
              'matrix may be inaccurate')
 
     orig = epochs[0].info['dev_head_t']
-    if not isinstance(on_mismatch, str) or \
-            on_mismatch not in ['raise', 'warn', 'ignore']:
-        raise ValueError('on_mismatch must be "raise", "warn", or "ignore", '
-                         'got %s' % on_mismatch)
+    _check_option('on_mismatch', on_mismatch, ['raise', 'warn', 'ignore'])
     for ei, epoch in enumerate(epochs):
         epoch.info._check_consistency()
         if (orig is None) != (epoch.info['dev_head_t'] is None) or \
@@ -882,9 +880,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
 def _check_scalings_user(scalings):
     if isinstance(scalings, dict):
         for k, v in scalings.items():
-            if k not in ('mag', 'grad', 'eeg'):
-                raise ValueError('The keys in `scalings` must be "mag" or'
-                                 '"grad" or "eeg". You gave me: %s' % k)
+            _check_option('the keys in `scalings`', k, ['mag', 'grad', 'eeg'])
     elif scalings is not None and not isinstance(scalings, np.ndarray):
         raise TypeError('scalings must be a dict, ndarray, or None, got %s'
                         % type(scalings))

--- a/mne/datasets/megsim/megsim.py
+++ b/mne/datasets/megsim/megsim.py
@@ -6,7 +6,7 @@ from os import path as op
 import zipfile
 from sys import stdout
 
-from ...utils import _fetch_file, _url_to_local_path, verbose
+from ...utils import _fetch_file, _url_to_local_path, verbose, _check_option
 from ..utils import _get_path, _do_path_update
 from .urls import (url_match, valid_data_types, valid_data_formats,
                    valid_conditions)
@@ -151,12 +151,9 @@ def load_data(condition='visual', data_format='raw', data_type='experimental',
            (2012) MEG-SIM: A Web Portal for Testing MEG Analysis Methods using
            Realistic Simulated and Empirical Data. Neuroinform 10:141-158
     """  # noqa: E501
-    if not condition.lower() in valid_conditions:
-        raise ValueError('Unknown condition "%s"' % condition)
-    if data_format not in valid_data_formats:
-        raise ValueError('Unknown data_format "%s"' % data_format)
-    if data_type not in valid_data_types:
-        raise ValueError('Unknown data_type "%s"' % data_type)
+    _check_option('condition', condition.lower(), valid_conditions)
+    _check_option('data_format', data_format, valid_data_formats)
+    _check_option('data_type', data_type, valid_data_types)
     urls = url_match(condition, data_format, data_type)
 
     data_paths = list()

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -15,7 +15,7 @@ from scipy import linalg
 from .mixin import TransformerMixin
 from .base import BaseEstimator
 from ..cov import _regularized_covariance
-from ..utils import fill_doc
+from ..utils import fill_doc, _check_option
 
 
 @fill_doc
@@ -113,9 +113,8 @@ class CSP(TransformerMixin, BaseEstimator):
         self.cov_est = cov_est
 
         # Init default transform_into
-        if transform_into not in ('average_power', 'csp_space'):
-            raise ValueError('transform_into must be "average_power" or '
-                             '"csp_space".')
+        _check_option('transform_into', transform_into,
+                      ['average_power', 'csp_space'])
         self.transform_into = transform_into
 
         # Init default log

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -6,7 +6,7 @@ import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator
 from ..time_frequency.tfr import _compute_tfr, _check_tfr_param
-from ..utils import fill_doc
+from ..utils import fill_doc, _check_option
 
 
 @fill_doc
@@ -74,9 +74,7 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
         self.use_fft = use_fft
         self.decim = decim
         # Check that output is not an average metric (e.g. ITC)
-        if output not in ['complex', 'power', 'phase']:
-            raise ValueError("output must be 'complex', 'power', 'phase'. "
-                             "Got %s instead." % output)
+        _check_option('output', output, ['complex', 'power', 'phase'])
         self.output = output
         self.n_jobs = n_jobs
         self.verbose = verbose

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -13,7 +13,7 @@ from .base import BaseEstimator
 from .. import pick_types
 from ..filter import filter_data, _triage_filter_params
 from ..time_frequency.psd import psd_array_multitaper
-from ..utils import check_version, fill_doc
+from ..utils import check_version, fill_doc, _check_option
 from ..io.pick import (pick_info, _pick_data_channels, _picks_by_type,
                        _picks_to_idx)
 from ..cov import _check_scalings_user
@@ -114,10 +114,8 @@ class Scaler(TransformerMixin, BaseEstimator):
         if not (scalings is None or isinstance(scalings, (dict, str))):
             raise ValueError('scalings type should be dict, str, or None, '
                              'got %s' % type(scalings))
-        if isinstance(scalings, str) and \
-                scalings not in ('mean', 'median'):
-            raise ValueError('Invalid method for scaling, must be "mean" or '
-                             '"median" but got %s' % scalings)
+        if isinstance(scalings, str):
+            _check_option('scalings', scalings, ['mean', 'median'])
         if scalings is None or isinstance(scalings, dict):
             if info is None:
                 raise ValueError('Need to specify "info" if scalings is'

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -32,7 +32,7 @@ from .source_space import (_make_volume_source_space, SourceSpaces,
                            _points_outside_surface)
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
-                    check_fname, _pl, fill_doc)
+                    check_fname, _pl, fill_doc, _check_option)
 
 
 @fill_doc
@@ -1326,10 +1326,7 @@ def get_phantom_dipoles(kind='vectorview'):
     The Elekta phantoms have a radius of 79.5mm, and HPI coil locations
     in the XY-plane at the axis extrema (e.g., (79.5, 0), (0, -79.5), ...).
     """
-    _valid_types = ('vectorview', 'otaniemi')
-    if not isinstance(kind, str) or kind not in _valid_types:
-        raise ValueError('kind must be one of %s, got %s'
-                         % (_valid_types, kind,))
+    _check_option('kind', kind, ['vectorview', 'otaniemi'])
     if kind == 'vectorview':
         # these values were pulled from a scanned image provided by
         # Elekta folks

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -51,7 +51,7 @@ from .utils import (check_fname, logger, verbose,
                     sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc,
                     _check_pandas_installed, _check_preload, GetEpochsMixin,
                     _prepare_read_metadata, _prepare_write_metadata,
-                    _check_event_id, _gen_events)
+                    _check_event_id, _gen_events, _check_option)
 from .utils.docs import fill_doc
 
 
@@ -99,8 +99,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
     # write events out after getting data to ensure bad events are dropped
     data = epochs.get_data()
 
-    if fmt not in ['single', 'double']:
-        raise ValueError('fmt must be "single" or "double". Got (%s)' % fmt)
+    _check_option('fmt', fmt, ['single', 'double'])
 
     if np.iscomplexobj(data):
         if fmt == 'single':
@@ -262,9 +261,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  filename=None, metadata=None, verbose=None):  # noqa: D102
         self.verbose = verbose
 
-        if on_missing not in ['error', 'warning', 'ignore']:
-            raise ValueError('on_missing must be one of: error, '
-                             'warning, ignore. Got: %s' % on_missing)
+        _check_option('on_missing', on_missing, ['error', 'warning', 'ignore'])
 
         if events is not None:  # RtEpochs can have events=None
             events = np.asarray(events)
@@ -1387,9 +1384,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                                       '_epo.fif', '_epo.fif.gz'))
         split_size = _get_split_size(split_size)
 
-        if fmt not in ('single', 'double'):
-            raise ValueError('fmt must be "single" or "double". Got (%s).' %
-                             fmt)
+        _check_option('fmt', fmt, ['single', 'double'])
 
         # to know the length accurately. The get_data() call would drop
         # bad epochs anyway
@@ -2046,9 +2041,7 @@ def _get_drop_indices(event_times, method):
     """Get indices to drop from multiple event timing lists."""
     small_idx = np.argmin([e.shape[0] for e in event_times])
     small_e_times = event_times[small_idx]
-    if method not in ['mintime', 'truncate']:
-        raise ValueError('method must be either mintime or truncate, not '
-                         '%s' % method)
+    _check_option('method', method, ['mintime', 'truncate'])
     indices = list()
     for e in event_times:
         if method == 'mintime':

--- a/mne/event.py
+++ b/mne/event.py
@@ -12,7 +12,7 @@ from os.path import splitext
 
 
 from .utils import (check_fname, logger, verbose, _get_stim_channel, warn,
-                    _validate_type)
+                    _validate_type, _check_option)
 from .io.constants import FIFF
 from .io.tree import dir_tree_find
 from .io.tag import read_tag
@@ -713,9 +713,7 @@ def find_events(raw, stim_channel=None, output='onset',
 
 def _mask_trigs(events, mask, mask_type):
     """Mask digital trigger values."""
-    if not isinstance(mask_type, str) or mask_type not in ('not_and', 'and'):
-        raise ValueError('mask_type must be "not_and" or "and", got %s'
-                         % (mask_type,))
+    _check_option('mask_type', mask_type, ['not_and', 'and'])
     if mask is not None:
         _validate_type(mask, "int", "mask", "int or None")
     n_events = len(events)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -19,7 +19,7 @@ from .channels.layout import _merge_grad_data, _pair_grad_sensors
 from .filter import detrend, FilterMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     SizeMixin, copy_function_doc_to_method_doc, _validate_type,
-                    fill_doc)
+                    fill_doc, _check_option)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import plot_evoked_white, plot_evoked_joint
@@ -551,13 +551,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         data_picks = _pick_data_channels(self.info, with_ref_meg=False)
         types_used = {channel_type(self.info, idx) for idx in data_picks}
 
-        if str(ch_type) not in supported:
-            raise ValueError('Channel type must be `{supported}`. You gave me '
-                             '`{ch_type}` instead.'
-                             .format(ch_type=ch_type,
-                                     supported='` or `'.join(supported)))
+        _check_option('ch_type', str(ch_type), supported)
 
-        elif ch_type is not None and ch_type not in types_used:
+        if ch_type is not None and ch_type not in types_used:
             raise ValueError('Channel type `{ch_type}` not found in this '
                              'evoked object.'.format(ch_type=ch_type))
 
@@ -863,9 +859,7 @@ def combine_evoked(all_evoked, weights):
     .. versionadded:: 0.9.0
     """
     if isinstance(weights, str):
-        if weights not in ('nave', 'equal'):
-            raise ValueError('weights must be a list of float, or "nave" or '
-                             '"equal"')
+        _check_option('weights', weights, ['nave', 'equal'])
         if weights == 'nave':
             weights = np.array([e.nave for e in all_evoked], float)
             weights /= weights.sum()
@@ -1248,11 +1242,7 @@ def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):
     max_amp : float
         Amplitude of the maximum response.
     """
-    modes = ('abs', 'neg', 'pos')
-    if mode not in modes:
-        raise ValueError('The `mode` parameter must be `{modes}`. You gave '
-                         'me `{mode}`'.format(modes='` or `'.join(modes),
-                                              mode=mode))
+    _check_option('mode', mode, ['abs', 'neg', 'pos'])
 
     if tmin is None:
         tmin = times[0]

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -13,7 +13,7 @@ from .fixes import get_sosfiltfilt, minimum_phase
 from .parallel import parallel_func, check_n_jobs
 from .time_frequency.multitaper import _mt_spectra, _compute_mt_params
 from .utils import (logger, verbose, sum_squared, check_version, warn,
-                    _check_preload, _validate_type)
+                    _check_preload, _validate_type, _check_option)
 
 # These values from Ifeachor and Jervis.
 _length_factors = dict(hann=3.1, hamming=3.3, blackman=5.0)
@@ -688,9 +688,7 @@ def _check_method(method, iir_params, extra_types=()):
     """Parse method arguments."""
     allowed_types = ['iir', 'fir', 'fft'] + list(extra_types)
     _validate_type(method, 'str', 'method')
-    if method not in allowed_types:
-        raise ValueError('method must be one of %s, not "%s"'
-                         % (allowed_types, method))
+    _check_option('method', method, allowed_types)
     if method == 'fft':
         method = 'fir'  # use the better name
     if method == 'iir':

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -349,6 +349,7 @@ def axis_reverse(a, axis=-1):
 
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
+    from .utils import _check_option  # avoid circular import
     _check_option('padtype', padtype, ['even', 'odd', 'constant', None])
 
     if padtype is None:

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -349,10 +349,7 @@ def axis_reverse(a, axis=-1):
 
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
-    if padtype not in ['even', 'odd', 'constant', None]:
-        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
-                          "must be 'even', 'odd', 'constant', or None.") %
-                         padtype)
+    _check_option('padtype', padtype, ['even', 'odd', 'constant', None])
 
     if padtype is None:
         padlen = 0

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -17,7 +17,7 @@ from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
                          _do_cross_dots)
 from ..parallel import check_n_jobs
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _check_option
 
 
 def _is_axial_coil(coil):
@@ -181,10 +181,8 @@ def _as_meg_type_evoked(evoked, ch_type='grad', mode='fast'):
         The transformed evoked object containing only virtual channels.
     """
     evoked = evoked.copy()
+    _check_option('ch_type', ch_type, ['mag', 'grad'])
 
-    if ch_type not in ['mag', 'grad']:
-        raise ValueError('to_type must be "mag" or "grad", not "%s"'
-                         % ch_type)
     # pick the original and destination channels
     pick_from = pick_types(evoked.info, meg=True, eeg=False,
                            ref_meg=False)
@@ -258,8 +256,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
     if 'coord_frame' not in surf:
         raise KeyError('The surface coordinate frame must be specified '
                        'in surf["coord_frame"]')
-    if mode not in ['accurate', 'fast']:
-        raise ValueError('mode must be "accurate" or "fast", not "%s"' % mode)
+    _check_option('mode', mode, ['accurate', 'fast'])
 
     # deal with coordinate frames here -- always go to "head" (easiest)
     orig_surf = surf
@@ -271,8 +268,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
     # Step 1. Prepare the coil definitions
     # Do the dot products, assume surf in head coords
     #
-    if ch_type not in ('meg', 'eeg'):
-        raise ValueError('unknown coil type "%s"' % ch_type)
+    _check_option('ch_type', ch_type, ['meg', 'eeg'])
     if ch_type == 'meg':
         picks = pick_types(info, meg=True, eeg=False, ref_meg=False)
         logger.info('Prepare MEG mapping...')
@@ -356,14 +352,14 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     ch_type : None | 'eeg' | 'meg'
         If None, a map for each available channel type will be returned.
         Else only the specified type will be used.
-    mode : str
+    mode : 'accurate' | 'fast'
         Either `'accurate'` or `'fast'`, determines the quality of the
         Legendre polynomial expansion used. `'fast'` should be sufficient
         for most applications.
-    meg_surf : str
+    meg_surf : 'helmet' | 'head'
         Should be ``'helmet'`` or ``'head'`` to specify in which surface
         to compute the MEG field map. The default value is ``'helmet'``
-    origin : array-like, shape (3,) | str
+    origin : array-like, shape (3,) | 'auto'
         Origin of the sphere in the head coordinate frame and in meters.
         Can be ``'auto'``, which means a head-digitization-based origin
         fit. Default is ``(0., 0., 0.04)``.
@@ -384,9 +380,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     if ch_type is None:
         types = [t for t in ['eeg', 'meg'] if t in evoked]
     else:
-        if ch_type not in ['eeg', 'meg']:
-            raise ValueError("ch_type should be 'eeg' or 'meg' (got %s)"
-                             % ch_type)
+        _check_option('ch_type', ch_type, ['eeg', 'meg'])
         types = [ch_type]
 
     if trans == 'auto':
@@ -405,9 +399,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
             trans = read_trans(trans)
         trans = _ensure_trans(trans, 'head', 'mri')
 
-    if meg_surf not in ['helmet', 'head']:
-        raise ValueError('Surface to plot MEG fields must be '
-                         '"helmet" or "head"')
+    _check_option('meg_surf', meg_surf, ['helmet', 'head'])
 
     surfs = []
     for this_type in types:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -28,7 +28,7 @@ from .compensator import set_current_comp, make_compensator
 from .write import (start_file, end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
-                    write_id, write_string, _get_split_size, _check_option)
+                    write_id, write_string, _get_split_size)
 
 from ..annotations import (_annotations_starts_stops, _write_annotations,
                            _handle_meas_date)
@@ -41,7 +41,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      check_fname, _get_stim_channel, deprecated,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc,
-                     _check_preload, _get_argvalues)
+                     _check_preload, _get_argvalues, _check_option)
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
 from ..defaults import _handle_default
 from ..event import find_events, concatenate_events

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -28,7 +28,7 @@ from .compensator import set_current_comp, make_compensator
 from .write import (start_file, end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,
                     write_complex64, write_complex128, write_int,
-                    write_id, write_string, _get_split_size)
+                    write_id, write_string, _get_split_size, _check_option)
 
 from ..annotations import (_annotations_starts_stops, _write_annotations,
                            _handle_meas_date)
@@ -938,9 +938,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         if len(self.annotations) == 0 or reject_by_annotation is None:
             data, times = self[picks, start:stop]
             return (data, times) if return_times else data
-        if reject_by_annotation.lower() not in ['omit', 'nan']:
-            raise ValueError("reject_by_annotation must be None, 'omit' or "
-                             "'NaN'. Got %s." % reject_by_annotation)
+        _check_option('reject_by_annotation', reject_by_annotation.lower(),
+                      ['omit', 'nan'])
         onsets, ends = _annotations_starts_stops(self, ['BAD'])
         keep = (onsets < stop) & (ends > start)
         onsets = np.maximum(onsets[keep], start)
@@ -1694,7 +1693,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             .. note:: If ``apply_proj()`` was used to apply the projections,
                       the projectons will be active even if ``proj`` is False.
 
-        fmt : str
+        fmt : 'single' | 'double' | 'int' | 'short'
             Format to use to save raw data. Valid options are 'double',
             'single', 'int', and 'short' for 64- or 32-bit float, or 32- or
             16-bit integers, respectively. It is **strongly** recommended to
@@ -1754,9 +1753,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                          int=FIFF.FIFFT_INT,
                          single=FIFF.FIFFT_FLOAT,
                          double=FIFF.FIFFT_DOUBLE)
-        if fmt not in type_dict:
-            raise ValueError('fmt must be "short", "int", "single", '
-                             'or "double"')
+        _check_option('fmt', fmt, type_dict.keys())
         reset_dict = dict(short=False, int=False, single=True, double=True)
         reset_range = reset_dict[fmt]
         data_type = type_dict[fmt]
@@ -2470,8 +2467,7 @@ def _write_raw_buffer(fid, buf, cals, fmt):
     if buf.shape[0] != len(cals):
         raise ValueError('buffer and calibration sizes do not match')
 
-    if fmt not in ['short', 'int', 'single', 'double']:
-        raise ValueError('fmt must be "short", "single", or "double"')
+    _check_option('fmt', fmt, ['short', 'int', 'single', 'double'])
 
     if np.isrealobj(buf):
         if fmt == 'short':

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -299,7 +299,7 @@ def _check_mrk_version(header):
             'Brain Vision Data Exchange Marker File, Version 2.0',
             'BrainVision Data Exchange Marker File, Version 1.0']
     if header not in tags:
-        raise ValueError("Currently only support %r, not %r"
+        raise ValueError("Currently, MNE-Python only supports %r, not %r"
                          "Contact MNE-Developers for support."
                          % (str(tags), header))
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -12,7 +12,8 @@ import numpy as np
 from ...utils import warn, verbose, fill_doc
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
-from ..utils import _mult_cal_one, _find_channels, _create_chs, read_str
+from ..utils import (_mult_cal_one, _find_channels, _create_chs, read_str,
+                     _check_option)
 from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
 
@@ -178,6 +179,8 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
             data_size = n_samples * n_channels
         else:
             data_size = event_offset - (data_offset + 75 * n_channels)
+
+        _check_option('data_format', ['auto', 'int16', 'int32'])
         if data_format == 'auto':
             if (n_samples == 0 or
                     data_size // (n_samples * n_channels) not in [2, 4]):
@@ -188,9 +191,6 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
             else:
                 n_bytes = data_size // (n_samples * n_channels)
         else:
-            if data_format not in ['int16', 'int32']:
-                raise ValueError("data_format should be 'auto', 'int16' or "
-                                 "'int32'. Got %s." % data_format)
             n_bytes = 2 if data_format == 'int16' else 4
             n_samples = data_size // (n_bytes * n_channels)
         # Channel offset refers to the size of blocks per channel in the file.

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -179,7 +179,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
         else:
             data_size = event_offset - (data_offset + 75 * n_channels)
 
-        _check_option('data_format', ['auto', 'int16', 'int32'])
+        _check_option('data_format', data_format, ['auto', 'int16', 'int32'])
         if data_format == 'auto':
             if (n_samples == 0 or
                     data_size // (n_samples * n_channels) not in [2, 4]):

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -9,11 +9,10 @@ import calendar
 
 import numpy as np
 
-from ...utils import warn, verbose, fill_doc
+from ...utils import warn, verbose, fill_doc, _check_option
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
-from ..utils import (_mult_cal_one, _find_channels, _create_chs, read_str,
-                     _check_option)
+from ..utils import _mult_cal_one, _find_channels, _create_chs, read_str
 from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
 

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -9,10 +9,10 @@ import os.path as op
 
 import numpy as np
 
-from ...utils import verbose, logger, _clean_names, fill_doc
+from ...utils import verbose, logger, _clean_names, fill_doc, _check_option
 
 from ..base import BaseRaw
-from ..utils import _mult_cal_one, _blk_read_lims, _check_option
+from ..utils import _mult_cal_one, _blk_read_lims
 
 from .res4 import _read_res4, _make_ctf_name
 from .hc import _read_hc

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -12,7 +12,7 @@ import numpy as np
 from ...utils import verbose, logger, _clean_names, fill_doc
 
 from ..base import BaseRaw
-from ..utils import _mult_cal_one, _blk_read_lims
+from ..utils import _mult_cal_one, _blk_read_lims, _check_option
 
 from .res4 import _read_res4, _make_ctf_name
 from .hc import _read_hc
@@ -102,11 +102,7 @@ class RawCTF(BaseRaw):
             raise TypeError('directory must be a directory ending with ".ds"')
         if not op.isdir(directory):
             raise ValueError('directory does not exist: "%s"' % directory)
-        known_types = ['ignore', 'truncate']
-        if not isinstance(system_clock, str) or \
-                system_clock not in known_types:
-            raise ValueError('system_clock must be one of %s, not %s'
-                             % (known_types, system_clock))
+        _check_option('system_clock', system_clock, ['ignore', 'truncate'])
         logger.info('ds directory : %s' % directory)
         res4 = _read_res4(directory)  # Read the magical res4 file
         coils = _read_hc(directory)  # Read the coil locations

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -18,7 +18,7 @@ from scipy import linalg
 
 from ..pick import pick_types
 from ...coreg import fit_matched_points, _decimate_points
-from ...utils import verbose, logger, warn, fill_doc
+from ...utils import verbose, logger, warn, fill_doc, _check_option
 from ...transforms import (apply_trans, als_ras_trans,
                            get_ras_to_neuromag_trans, Transform)
 from ..base import BaseRaw
@@ -188,9 +188,7 @@ class RawKIT(BaseRaw):
         if self.preload:
             raise NotImplementedError("Can't change stim channel after "
                                       "loading data")
-        elif stim_code not in ('binary', 'channel'):
-            raise ValueError("stim_code=%r, needs to be 'binary' or 'channel'"
-                             % (stim_code,))
+        _check_option('stim_code', stim_code, ['binary', 'channel'])
 
         if stim is not None:
             if isinstance(stim, str):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -31,7 +31,8 @@ from .write import (start_file, end_file, start_block, end_block,
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import _to_const
 from ..transforms import invert_transform
-from ..utils import logger, verbose, warn, object_diff, _validate_type
+from ..utils import (logger, verbose, warn, object_diff, _validate_type,
+                     _check_option)
 from .. import __version__
 from .compensator import get_current_comp
 
@@ -733,8 +734,7 @@ def _read_dig_points(fname, comments='%', unit='auto'):
     dig_points : np.ndarray, shape (n_points, 3)
         Array of dig points in [m].
     """
-    if unit not in ('auto', 'm', 'mm', 'cm'):
-        raise ValueError('unit must be one of "auto", "m", "mm", or "cm"')
+    _check_option('unit', unit, ['auto', 'm', 'mm', 'cm'])
 
     _, ext = op.splitext(fname)
     if ext == '.elp' or ext == '.hsp':

--- a/mne/label.py
+++ b/mne/label.py
@@ -23,7 +23,8 @@ from .stats.cluster_level import _find_clusters, _get_components
 from .surface import (read_surface, fast_cross_3d, mesh_edges, mesh_dist,
                       read_morph_map)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose, warn,
-                    check_random_state, _validate_type, fill_doc)
+                    check_random_state, _validate_type, fill_doc,
+                    _check_option)
 
 
 def _blend_colors(color_1, color_2):
@@ -1903,8 +1904,7 @@ def _get_annot_fname(annot_fname, subject, hemi, parc, subjects_dir):
         annot_fname = [annot_fname]
     else:
         # construct .annot file names for requested subject, parc, hemi
-        if hemi not in ['lh', 'rh', 'both']:
-            raise ValueError('hemi has to be "lh", "rh", or "both"')
+        _check_option('hemi', hemi, ['lh', 'rh', 'both'])
         if hemi == 'both':
             hemis = ['lh', 'rh']
         else:

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -37,7 +37,10 @@ from ..source_space import (_read_source_spaces_from_tree,
 from ..transforms import _ensure_trans, transform_surface_to
 from ..source_estimate import _make_stc, _get_src_type
 from ..utils import (check_fname, logger, verbose, warn,
-                     _check_compensation_grade)
+                     _check_compensation_grade, _check_option)
+
+
+INVERSE_METHODS = ['MNE', 'dSPM', 'sLORETA', 'eLORETA']
 
 
 class InverseOperator(dict):
@@ -725,18 +728,9 @@ def _assemble_kernel(inv, label, method, pick_ori, verbose=None):
     return K, noise_norm, vertno, source_nn
 
 
-def _check_method(method):
-    """Check the method."""
-    if method not in ['MNE', 'dSPM', 'sLORETA', 'eLORETA']:
-        raise ValueError('method parameter should be "MNE", "dSPM", '
-                         '"sLORETA" or "eLORETA", got %s.' % (method,))
-
-
 def _check_ori(pick_ori, source_ori):
     """Check pick_ori."""
-    if pick_ori not in [None, 'normal', 'vector']:
-        raise RuntimeError('pick_ori must be None, "normal" or "vector", not '
-                           '%s' % pick_ori)
+    _check_option('pick_ori', pick_ori, [None, 'normal', 'vector'])
     if pick_ori == 'vector' and source_ori != FIFF.FIFFV_MNE_FREE_ORI:
         raise RuntimeError('pick_ori="vector" cannot be combined with an '
                            'inverse operator with fixed orientations.')
@@ -904,7 +898,7 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
            localization. arXiv:0710.3341
     """
     _check_reference(evoked, inverse_operator['info']['ch_names'])
-    _check_method(method)
+    _check_option('method', method, INVERSE_METHODS)
     if method == 'eLORETA' and return_residual:
         raise ValueError('eLORETA does not currently support return_residual')
     _check_ori(pick_ori, inverse_operator['source_ori'])
@@ -1034,7 +1028,7 @@ def apply_inverse_raw(raw, inverse_operator, lambda2, method="dSPM",
     apply_inverse : Apply inverse operator to evoked object
     """
     _check_reference(raw, inverse_operator['info']['ch_names'])
-    _check_method(method)
+    _check_option('method', method, INVERSE_METHODS)
     _check_ori(pick_ori, inverse_operator['source_ori'])
     _check_ch_names(inverse_operator, raw.info)
 
@@ -1111,7 +1105,7 @@ def _apply_inverse_epochs_gen(epochs, inverse_operator, lambda2, method='dSPM',
                               prepared=False, method_params=None,
                               verbose=None):
     """Generate inverse solutions for epochs. Used in apply_inverse_epochs."""
-    _check_method(method)
+    _check_option('method', method, INVERSE_METHODS)
     _check_ori(pick_ori, inverse_operator['source_ori'])
     _check_ch_names(inverse_operator, epochs.info)
 

--- a/mne/minimum_norm/psf_ctf.py
+++ b/mne/minimum_norm/psf_ctf.py
@@ -10,7 +10,7 @@ from scipy import linalg
 
 from ..io.constants import FIFF
 from ..io.pick import pick_channels
-from ..utils import logger, verbose
+from ..utils import logger, verbose, _check_option
 from ..forward import convert_forward_solution
 from ..evoked import EvokedArray
 from ..source_estimate import SourceEstimate
@@ -101,9 +101,7 @@ def point_spread_function(inverse_operator, forward, labels, method='dSPM',
         (sum is taken across summary measures).
     """
     mode = mode.lower()
-    if mode not in ['mean', 'sum', 'svd']:
-        raise ValueError("mode must be 'svd', 'mean' or 'sum'. Got %s."
-                         % mode)
+    _check_option('mode', mode, ['mean', 'sum', 'svd'])
 
     logger.info("About to process %d labels" % len(labels))
 

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -16,10 +16,10 @@ from ..time_frequency.multitaper import (_psd_from_mt, _compute_mt_params,
                                          _psd_from_mt_adaptive, _mt_spectra)
 from ..baseline import rescale, _log_rescale
 from .inverse import (combine_xyz, _check_or_prepare, _assemble_kernel,
-                      _pick_channels_inverse_operator, _check_method,
+                      _pick_channels_inverse_operator, INVERSE_METHODS,
                       _check_ori, _subject_from_inverse)
 from ..parallel import parallel_func
-from ..utils import logger, verbose, ProgressBar
+from ..utils import logger, verbose, ProgressBar, _check_option
 
 
 def _prepare_source_params(inst, inverse_operator, label=None,
@@ -131,7 +131,7 @@ def source_band_induced_power(epochs, inverse_operator, bands, label=None,
     stcs : dict of SourceEstimate (or VolSourceEstimate)
         The estimated source space induced power estimates.
     """  # noqa: E501
-    _check_method(method)
+    _check_option('method', method, INVERSE_METHODS)
 
     freqs = np.concatenate([np.arange(band[0], band[1] + df / 2.0, df)
                             for _, band in bands.items()])
@@ -376,7 +376,7 @@ def source_induced_power(epochs, inverse_operator, freqs, label=None,
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
     %(verbose)s
     """  # noqa: E501
-    _check_method(method)
+    _check_option('method', method, INVERSE_METHODS)
     _check_ori(pick_ori, inverse_operator['source_ori'])
 
     power, plv, vertno = _source_induced_power(

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -17,7 +17,7 @@ from .source_estimate import (VolSourceEstimate, SourceEstimate,
 from .source_space import SourceSpaces
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
-                    warn as warn_, deprecated, fill_doc)
+                    warn as warn_, deprecated, fill_doc, _check_option)
 from .externals.h5io import read_hdf5, write_hdf5
 
 
@@ -476,10 +476,7 @@ def _morphed_stc_as_volume(morph, stc, mri_resolution=False, mri_space=True,
                          'volumes')
     _check_dep(nibabel='2.1.0', dipy=False)
 
-    known_types = ('nifti', 'nifti1', 'nifti2')
-    if output not in known_types:
-        raise ValueError('output must be one of %s, got %s'
-                         % (known_types, output))
+    _check_option('output', output, ['nifti', 'nifti1', 'nifti2'])
     if output in ('nifti', 'nifti1'):
         from nibabel import (Nifti1Image as NiftiImage,
                              Nifti1Header as NiftiHeader)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -48,7 +48,8 @@ from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,
                      compute_corr, _get_inst_data, _ensure_int,
                      copy_function_doc_to_method_doc, _pl, warn,
-                     _check_preload, _check_compensation_grade, fill_doc)
+                     _check_preload, _check_compensation_grade, fill_doc,
+                     _check_option)
 
 from ..fixes import _get_args
 from ..filter import filter_data
@@ -304,10 +305,8 @@ class ICA(ContainsMixin):
                  n_pca_components=None, noise_cov=None, random_state=None,
                  method='fastica', fit_params=None, max_iter=200,
                  allow_ref_meg=False, verbose=None):  # noqa: D102
-        methods = ('fastica', 'infomax', 'extended-infomax', 'picard')
-        if method not in methods:
-            raise ValueError('`method` must be "%s". You passed: "%s"' %
-                             ('" or "'.join(methods), method))
+        _check_option('method', method,
+                      ['fastica', 'infomax', 'extended-infomax', 'picard'])
         if method == 'extended-infomax':
             warn("method='extended-infomax' is deprecated and will be removed "
                  "in 0.19. If you want to use Extended Infomax, specify "

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -29,7 +29,8 @@ from ..io.proc_history import _read_ctc
 from ..io.write import _generate_meas_id, DATE_NONE
 from ..io import _loc_to_coil_trans, _coil_trans_to_loc, BaseRaw
 from ..io.pick import pick_types, pick_info
-from ..utils import verbose, logger, _clean_names, warn, _time_mask, _pl
+from ..utils import (verbose, logger, _clean_names, warn, _time_mask, _pl,
+                     _check_option)
 from ..fixes import _get_args, _safe_svd, einsum
 from ..channels.channels import _get_T1T2_mag_inds
 
@@ -284,9 +285,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
     if st_correlation <= 0. or st_correlation > 1.:
         raise ValueError('Need 0 < st_correlation <= 1., got %s'
                          % st_correlation)
-    if coord_frame not in ('head', 'meg'):
-        raise ValueError('coord_frame must be either "head" or "meg", not "%s"'
-                         % coord_frame)
+    _check_option('coord_frame', coord_frame, ['head', 'meg'])
     head_frame = True if coord_frame == 'head' else False
     recon_trans = _check_destination(destination, raw.info, head_frame)
     onsets, ends = _annotations_starts_stops(
@@ -303,10 +302,8 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         st_duration = int(round(st_duration * raw.info['sfreq']))
         if not 0. < st_correlation <= 1:
             raise ValueError('st_correlation must be between 0. and 1.')
-    if not isinstance(bad_condition, str) or \
-            bad_condition not in ['error', 'warning', 'ignore', 'info']:
-        raise ValueError('bad_condition must be "error", "warning", "info", or'
-                         ' "ignore", not %s' % bad_condition)
+    _check_option('bad_condition', bad_condition,
+                  ['error', 'warning', 'ignore', 'info'])
     if raw.info['dev_head_t'] is None and coord_frame == 'head':
         raise RuntimeError('coord_frame cannot be "head" because '
                            'info["dev_head_t"] is None; if this is an '

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -9,7 +9,7 @@ from ..io import BaseRaw
 from ..event import find_events
 
 from ..io.pick import _pick_data_channels
-from ..utils import _check_preload
+from ..utils import _check_preload, _check_option
 
 
 def _get_window(start, end):
@@ -67,8 +67,7 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
     inst : instance of Raw or Evoked or Epochs
         Instance with modified data
     """
-    if mode not in ('linear', 'window'):
-        raise ValueError("mode has to be 'linear' or 'window' (got %s)" % mode)
+    _check_option('mode', mode, ['linear', 'window'])
     s_start = int(np.ceil(inst.info['sfreq'] * tmin))
     s_end = int(np.ceil(inst.info['sfreq'] * tmax))
     if (mode == "window") and (s_end - s_start) < 4:

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -13,7 +13,7 @@ from ..decoding import TransformerMixin, BaseEstimator
 from ..epochs import BaseEpochs
 from ..io import BaseRaw
 from ..io.pick import _pick_data_channels, pick_info
-from ..utils import logger
+from ..utils import logger, _check_option
 
 
 def _construct_signal_from_epochs(epochs, events, sfreq, tmin):
@@ -409,8 +409,8 @@ class Xdawn(_XdawnTransformer):
         """Init."""
         super(Xdawn, self).__init__(n_components=n_components,
                                     signal_cov=signal_cov, reg=reg)
-        if correct_overlap not in ['auto', True, False]:
-            raise ValueError('correct_overlap must be a bool or "auto"')
+        _check_option('correct_overlap', correct_overlap,
+                      ['auto', True, False])
         self.correct_overlap = correct_overlap
 
     def fit(self, epochs, y=None):

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy import linalg
 
 from . import io, Epochs
-from .utils import check_fname, logger, verbose
+from .utils import check_fname, logger, verbose, _check_option
 from .io.pick import pick_types, pick_types_forward
 from .io.proj import Projection, _has_eeg_average_ref_proj
 from .event import make_fixed_length_events
@@ -78,9 +78,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
     eeg_ind = pick_types(info, meg=False, eeg=True, ref_meg=False,
                          exclude='bads')
 
-    if meg not in ('separate', 'combined'):
-        raise ValueError('meg must be "separate" or "combined", '
-                         'got %r' % (meg,))
+    _check_option('meg', meg, ['separate', 'combined'])
     if meg == 'combined':
         _get_rank_sss(info, msg='meg="combined" can only be used with '
                       'Maxfiltered data', verbose=False)
@@ -360,12 +358,9 @@ def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
         for visualization.
     """
     # check strings
-    if ch_type not in ['eeg', 'grad', 'mag']:
-        raise ValueError("ch_type should be 'eeg', 'mag' or 'grad (got %s)"
-                         % ch_type)
-    if mode not in ['free', 'fixed', 'ratio', 'radiality', 'angle',
-                    'remaining', 'dampening']:
-        raise ValueError('Unknown mode type (got %s)' % mode)
+    _check_option('ch_type', ch_type, ['eeg', 'grad', 'mag'])
+    _check_option('mode', mode, ['free', 'fixed', 'ratio', 'radiality',
+                                 'angle', 'remaining', 'dampening'])
 
     # check forward
     if is_fixed_orient(fwd, orig=True):

--- a/mne/report.py
+++ b/mne/report.py
@@ -21,7 +21,7 @@ import numpy as np
 from . import read_evokeds, read_events, pick_types, read_cov
 from .io import read_raw_fif, read_info, _stamp_to_dt
 from .utils import (logger, verbose, get_subjects_dir, warn, _import_mlab,
-                    fill_doc)
+                    fill_doc, _check_option)
 from .viz import plot_events, plot_alignment, plot_cov
 from .viz._3d import _plot_mri_contours
 from .forward import read_forward_solution
@@ -811,15 +811,12 @@ def _check_scale(scale):
 
 def _check_image_format(rep, image_format):
     """Ensure fmt is valid."""
-    if image_format not in ('png', 'svg'):
-        if rep is None:
-            raise ValueError('image_format must be "svg" or "png", got %s'
-                             % (image_format,))
-        elif image_format is not None:
-            raise ValueError('image_format must be one of "svg", "png", or '
-                             'None, got %s' % (image_format,))
-        else:  # rep is not None and image_format is None
-            image_format = rep.image_format
+    if rep is None:
+        _check_option('image_format', image_format, ['png', 'svg'])
+    elif image_format is not None:
+        _check_option('image_format', image_format, ['png', 'svg', None])
+    else:  # rep is not None and image_format is None
+        image_format = rep.image_format
     return image_format
 
 
@@ -1131,9 +1128,7 @@ class Report(object):
             image_format = os.path.splitext(fname)[1][1:]
             image_format = image_format.lower()
 
-            if image_format not in ['png', 'gif', 'svg']:
-                raise ValueError("Unknown image format. Only 'png', 'gif' or "
-                                 "'svg' are supported. Got %s" % image_format)
+            _check_option('image_format', image_format, ['png', 'gif', 'svg'])
 
             # Convert image to binary string.
             with open(fname, 'rb') as f:
@@ -1417,10 +1412,7 @@ class Report(object):
         %(verbose_meth)s
         """
         image_format = _check_image_format(self, image_format)
-        valid_errors = ['ignore', 'warn', 'raise']
-        if on_error not in valid_errors:
-            raise ValueError('on_error must be one of %s, not %s'
-                             % (valid_errors, on_error))
+        _check_option('on_error', on_error, ['ignore', 'warn', 'raise'])
         self._sort = sort_sections
 
         n_jobs = check_n_jobs(n_jobs)

--- a/mne/simulation/metrics.py
+++ b/mne/simulation/metrics.py
@@ -6,6 +6,8 @@
 import numpy as np
 from scipy.linalg import norm
 
+from ..utils import _check_option
+
 # TODO: Add more localization accuracy functions. For example, distance between
 #       true dipole position (in simulated stc) and the centroid of the
 #       estimated activity.
@@ -45,10 +47,7 @@ def source_estimate_quantification(stc1, stc2, metric='rms'):
 
     .. versionadded:: 0.10.0
     """
-    known_metrics = ['rms', 'cosine']
-    if metric not in known_metrics:
-        raise ValueError('metric must be a str from the known metrics: '
-                         '"rms" or "cosine"')
+    _check_option('metric', metric, ['rms', 'cosine'])
 
     # This is checking that the datas are having the same size meaning
     # no comparison between distributed and sparse can be done so far.

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..source_estimate import SourceEstimate, VolSourceEstimate
 from ..source_space import _ensure_src
-from ..utils import check_random_state, warn
+from ..utils import check_random_state, warn, _check_option
 
 
 def select_source_in_label(src, label, random_state=None, location='random',
@@ -61,10 +61,7 @@ def select_source_in_label(src, label, random_state=None, location='random',
     """
     lh_vertno = list()
     rh_vertno = list()
-    if not isinstance(location, str) or \
-            location not in ('random', 'center'):
-        raise ValueError('location must be "random" or "center", got %s'
-                         % (location,))
+    _check_option('location', location, ['random', 'center'])
 
     rng = check_random_state(random_state)
     if label.hemi == 'lh':

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -19,7 +19,7 @@ from .source_space import (_ensure_src, _get_morph_src_reordering,
                            _ensure_src_subject, SourceSpaces)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose,
                     _time_mask, warn as warn_, copy_function_doc_to_method_doc,
-                    fill_doc)
+                    fill_doc, _check_option)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
 from .io.base import ToDataFrameMixin, TimeMixin
@@ -1398,9 +1398,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
             and "h5". The "w" format only supports a single time point.
         %(verbose_meth)s
         """
-        if ftype not in ('stc', 'w', 'h5'):
-            raise ValueError('ftype must be "stc", "w", or "h5", not "%s"'
-                             % ftype)
+        _check_option('ftype', ftype, ['stc', 'w', 'h5'])
 
         lh_data = self.data[:len(self.lh_vertno)]
         rh_data = self.data[-len(self.rh_vertno):]
@@ -1622,8 +1620,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
             if not len(hemi) == 1:
                 raise ValueError('Could not infer hemisphere')
             hemi = hemi[0]
-        if hemi not in [0, 1]:
-            raise ValueError('hemi must be 0 or 1')
+        _check_option('hemi', hemi, [0, 1])
         vertices = self.vertices[hemi]
         values = values[vert_inds[hemi]]  # left or right
         del vert_inds
@@ -1886,10 +1883,7 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
             and "h5". The "w" format only supports a single time point.
         %(verbose_meth)s
         """
-        if ftype not in ['stc', 'w', 'h5']:
-            raise ValueError('ftype must be "stc", "w" or "h5", not "%s"' %
-                             ftype)
-
+        _check_option('ftype', ftype, ['stc', 'w', 'h5'])
         if ftype == 'stc':
             logger.info('Writing STC to disk...')
             if not (fname.endswith('-vl.stc') or fname.endswith('-vol.stc')):

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -16,7 +16,7 @@ from scipy import sparse
 from .parametric import f_oneway, ttest_1samp_no_p
 from ..parallel import parallel_func, check_n_jobs
 from ..utils import (split_list, logger, verbose, ProgressBar, warn, _pl,
-                     check_random_state)
+                     check_random_state, _check_option)
 from ..source_estimate import SourceEstimate
 
 
@@ -287,8 +287,7 @@ def _find_clusters(x, threshold, tail=0, connectivity=None, max_step=1,
         Sum of x values in clusters.
     """
     from scipy import ndimage
-    if tail not in [-1, 0, 1]:
-        raise ValueError('invalid tail parameter')
+    _check_option('tail', tail, [-1, 0, 1])
 
     x = np.asanyarray(x)
 
@@ -489,8 +488,7 @@ def _pval_from_histogram(T, H0, tail):
     For each stat compute a p-value as percentile of its statistics
     within all statistics in surrogate data
     """
-    if tail not in [-1, 0, 1]:
-        raise ValueError('invalid tail parameter')
+    _check_option('tail', tail, [-1, 0, 1])
 
     # from pct to fraction
     if tail == -1:  # up tail
@@ -743,8 +741,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     either a 1 sample t-test or an F test / more sample permutation scheme
     is elicited.
     """
-    if out_type not in ['mask', 'indices']:
-        raise ValueError('out_type must be either \'mask\' or \'indices\'')
+    _check_option('out_type', out_type, ['mask', 'indices'])
     if not isinstance(threshold, dict) and (tail < 0 and threshold > 0 or
                                             tail > 0 and threshold < 0 or
                                             tail == 0 and threshold < 0):

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -7,7 +7,7 @@
 import numpy as np
 from functools import reduce
 from string import ascii_uppercase
-from utils import _check_option
+from ..utils import _check_option
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -7,6 +7,7 @@
 import numpy as np
 from functools import reduce
 from string import ascii_uppercase
+from utils import _check_option
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
@@ -56,9 +57,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
        statistical parametric mapping; a new hat avoids a 'haircut'",
        NeuroImage. 2012 Feb 1;59(3):2131-41.
     """
-    if method not in ['absolute', 'relative']:
-        raise ValueError('method must be "absolute" or "relative", not %s'
-                         % method)
+    _check_option('method', method, ['absolute', 'relative'])
     var = np.var(X, axis=0, ddof=1)
     if sigma > 0:
         limit = sigma * np.max(var) if method == 'relative' else sigma

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -370,7 +370,7 @@ def test_calculate_chpi_coil_locs():
     assert_allclose(cHPI_digs[2][0]['gof'], 0.9980471794552791, atol=1e-3)
     assert_allclose(cHPI_digs[2][0]['r'],
                     [-0.0157762, 0.06655744, 0.00545172], atol=1e-3)
-    with pytest.raises(ValueError, match='too_close must be'):
+    with pytest.raises(ValueError, match='too_close'):
         _calculate_chpi_coil_locs(raw, too_close='foo')
 
 

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -361,7 +361,7 @@ def test_volume_source_morph():
         source_morph_vol.apply(stc_vol, output=1)
     with pytest.raises(ValueError, match='subject_from does not match'):
         compute_source_morph(src=src, subject_from='42')
-    with pytest.raises(ValueError, match='output must be one of'):
+    with pytest.raises(ValueError, match='output'):
         source_morph_vol.apply(stc_vol, output='42')
     with pytest.raises(TypeError, match='subject_to must'):
         compute_source_morph(src, 'sample', None,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..fixes import _get_dpss
 from ..parallel import parallel_func
-from ..utils import sum_squared, warn, verbose, logger
+from ..utils import sum_squared, warn, verbose, logger, _check_option
 
 
 def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
@@ -411,9 +411,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     -----
     .. versionadded:: 0.14.0
     """
-    if normalization not in ('length', 'full'):
-        raise ValueError('Normalization must be "length" or "full", not %s'
-                         % normalization)
+    _check_option('normalization', normalization, ['length', 'full'])
 
     # Reshape data so its 2-D for parallelization
     ndim_in = x.ndim

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -24,7 +24,7 @@ from ..parallel import parallel_func
 from ..utils import (logger, verbose, _time_mask, check_fname, sizeof_fmt,
                      GetEpochsMixin, _prepare_read_metadata, fill_doc,
                      _prepare_write_metadata, _check_event_id, _gen_events,
-                     SizeMixin, _is_numeric)
+                     SizeMixin, _is_numeric, _check_option)
 from ..channels.channels import ContainsMixin, UpdateChannelsMixin
 from ..channels.layout import _pair_grad_sensors
 from ..io.pick import (pick_info, _picks_to_idx, channel_type, _pick_inst,
@@ -188,9 +188,7 @@ def _cwt(X, Ws, mode="same", decim=1, use_fft=True):
     out : array, shape (n_signals, n_freqs, n_time_decim)
         The time-frequency transform of the signals.
     """
-    if mode not in ['same', 'valid', 'full']:
-        raise ValueError("`mode` must be 'same', 'valid' or 'full', "
-                         "got %s instead." % mode)
+    _check_option('mode', mode, ['same', 'valid', 'full'])
     decim = _check_decim(decim)
     X = np.asarray(X)
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -442,15 +442,9 @@ def _check_tfr_param(freqs, sfreq, method, zero_mean, n_cycles,
                          'got %s instead.' % type(decim))
 
     # Check output
-    allowed_ouput = ('complex', 'power', 'phase',
-                     'avg_power_itc', 'avg_power', 'itc')
-    if output not in allowed_ouput:
-        raise ValueError("Unknown output type. Allowed are %s but "
-                         "got %s." % (allowed_ouput, output))
-
-    if method not in ('multitaper', 'morlet'):
-        raise ValueError('method must be "morlet" or "multitaper", got %s '
-                         'instead.' % type(method))
+    _check_option('output', output, ['complex', 'power', 'phase',
+                                     'avg_power_itc', 'avg_power', 'itc'])
+    _check_option('method', method, ['multitaper', 'morlet'])
 
     return freqs, sfreq, zero_mean, n_cycles, time_bandwidth, decim
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -12,7 +12,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_pyface_backend, _check_info_inv,
                     _check_channels_spatial_filter, _check_one_ch_type,
-                    _check_rank)
+                    _check_rank, _check_option)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -449,10 +449,10 @@ def _check_option(parameter, value, allowed_values):
     allowed_values : list
         The list of allowed values for the parameter.
 
-    Returns
-    -------
-    is_valid : bool
-        Whether the value was valid or not.
+    Raises
+    ------
+    ValueError
+        When the value of the parameter was not one of the valid options.
     """
     if value in allowed_values:
         return True

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -458,7 +458,7 @@ def _check_option(parameter, value, allowed_values):
         return True
 
     # Prepare a nice error message for the user
-    msg = ('Invalid value for the {parameter} parameter. '
+    msg = ("Invalid value for the '{parameter}' parameter. "
            '{options}, but got {value!r} instead.')
     if len(allowed_values) == 1:
         options = 'The only allowed value is %r' % allowed_values[0]

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -433,3 +433,40 @@ def _check_one_ch_type(info, picks, noise_cov, method):
     elif method == 'dics' and sum(ch_types) > 1:
         warn('The use of several sensor types with the DICS beamformer is '
              'not heavily tested yet.')
+
+
+def _check_option(parameter, value, allowed_values, error=ValueError):
+    """Check the value of a parameter against a list of valid options.
+
+    Raises an exception with a readable error message if the value was invalid.
+
+    Parameters
+    ----------
+    parameter : str
+        The name of the parameter to check. This is used in the error message.
+    value : str
+        The value of the parameter to check.
+    allowed_values : list of str
+        The list of allowed values for the parameter.
+    error : type of Exception
+        The error type to raise if the value was invalid. Defaults to
+        ``ValueError``.
+
+    Returns
+    -------
+    is_valid : bool
+        Whether the value was valid or not.
+    """
+    if value in allowed_values:
+        return True
+
+    # Prepare a nice error message for the user
+    msg = ("Invalid value for the '{parameter}' parameter. "
+           "{options}, but got '{value}' instead.")
+    if len(allowed_values) == 1:
+        options = "The only allowed value is '%s'" % allowed_values[0]
+    else:
+        options = "Allowed values are "
+        options += ", ".join(["'%s'" % v for v in allowed_values[:-1]])
+        options += " and '%s'" % allowed_values[-1]
+    raise error(msg.format(parameter=parameter, options=options, value=value))

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -435,22 +435,19 @@ def _check_one_ch_type(info, picks, noise_cov, method):
              'not heavily tested yet.')
 
 
-def _check_option(parameter, value, allowed_values, error=ValueError):
+def _check_option(parameter, value, allowed_values):
     """Check the value of a parameter against a list of valid options.
 
-    Raises an exception with a readable error message if the value was invalid.
+    Raises a ValueError with a readable error message if the value was invalid.
 
     Parameters
     ----------
     parameter : str
         The name of the parameter to check. This is used in the error message.
-    value : str
+    value : any type
         The value of the parameter to check.
-    allowed_values : list of str
+    allowed_values : list
         The list of allowed values for the parameter.
-    error : type of Exception
-        The error type to raise if the value was invalid. Defaults to
-        ``ValueError``.
 
     Returns
     -------
@@ -461,12 +458,13 @@ def _check_option(parameter, value, allowed_values, error=ValueError):
         return True
 
     # Prepare a nice error message for the user
-    msg = ("Invalid value for the '{parameter}' parameter. "
-           "{options}, but got '{value}' instead.")
+    msg = ('Invalid value for the {parameter} parameter. '
+           '{options}, but got {value!r} instead.')
     if len(allowed_values) == 1:
-        options = "The only allowed value is '%s'" % allowed_values[0]
+        options = 'The only allowed value is %r' % allowed_values[0]
     else:
-        options = "Allowed values are "
-        options += ", ".join(["'%s'" % v for v in allowed_values[:-1]])
-        options += " and '%s'" % allowed_values[-1]
-    raise error(msg.format(parameter=parameter, options=options, value=value))
+        options = 'Allowed values are '
+        options += ', '.join(['%r' % v for v in allowed_values[:-1]])
+        options += ' and %r' % allowed_values[-1]
+    raise ValueError(msg.format(parameter=parameter, options=options,
+                                value=value))

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -13,6 +13,7 @@ import webbrowser
 
 from .config import get_config
 from ..externals.doccer import filldoc, unindent_dict
+from .check import _check_option
 
 
 ##############################################################################
@@ -330,16 +331,11 @@ def open_docs(kind=None, version=None):
         kind = get_config('MNE_DOCS_KIND', 'api')
     help_dict = dict(api='python_reference.html', tutorials='tutorials.html',
                      examples='auto_examples/index.html')
-    if kind not in help_dict:
-        raise ValueError('kind must be one of %s, got %s'
-                         % (sorted(help_dict.keys()), kind))
+    _check_option('kind', kind, sorted(help_dict.keys()))
     kind = help_dict[kind]
     if version is None:
         version = get_config('MNE_DOCS_VERSION', 'stable')
-    versions = ('stable', 'dev')
-    if version not in versions:
-        raise ValueError('version must be one of %s, got %s'
-                         % (version, versions))
+    _check_option('version', version, ['stable', 'dev'])
     webbrowser.open_new_tab('https://martinos.org/mne/%s/%s' % (version, kind))
 
 

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -111,7 +111,7 @@ def test_check_option():
     # Value is allowed
     assert _check_option('option', 'valid', allowed_values)
     assert _check_option('option', 'good', allowed_values)
-    assert _check_option('option', 'ok', allowed_values, error=RuntimeError)
+    assert _check_option('option', 'ok', allowed_values)
     assert _check_option('option', 'valid', ['valid'])
 
     # Check error message for invalid value
@@ -119,9 +119,6 @@ def test_check_option():
            "'valid', 'good' and 'ok', but got 'bad' instead.")
     with pytest.raises(ValueError, match=msg):
         assert _check_option('option', 'bad', allowed_values)
-    with pytest.raises(RuntimeError, match=msg):
-        assert _check_option('option', 'bad', allowed_values,
-                             error=RuntimeError)
 
     # Special error message if only one value is allowed
     msg = ("Invalid value for the 'option' parameter. The only allowed value "

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -6,7 +6,7 @@ from mne.datasets import testing
 from mne.io.pick import pick_channels_cov
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
-                       _check_mayavi_version, _check_info_inv)
+                       _check_mayavi_version, _check_info_inv, _check_option)
 
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
@@ -102,3 +102,29 @@ def test_check_info_inv():
     picks = _check_info_inv(epochs.info, forward, noise_cov=noise_cov,
                             data_cov=data_cov)
     assert list(range(7, 10)) == picks
+
+
+def test_check_option():
+    """Test checking the value of a parameter against a list of options."""
+    allowed_values = ['valid', 'good', 'ok']
+
+    # Value is allowed
+    assert _check_option('option', 'valid', allowed_values)
+    assert _check_option('option', 'good', allowed_values)
+    assert _check_option('option', 'ok', allowed_values, error=RuntimeError)
+    assert _check_option('option', 'valid', ['valid'])
+
+    # Check error message for invalid value
+    msg = ("Invalid value for the 'option' parameter. Allowed values are "
+           "'valid', 'good' and 'ok', but got 'bad' instead.")
+    with pytest.raises(ValueError, match=msg):
+        assert _check_option('option', 'bad', allowed_values)
+    with pytest.raises(RuntimeError, match=msg):
+        assert _check_option('option', 'bad', allowed_values,
+                             error=RuntimeError)
+
+    # Special error message if only one value is allowed
+    msg = ("Invalid value for the 'option' parameter. The only allowed value "
+           "is 'valid', but got 'bad' instead.")
+    with pytest.raises(ValueError, match=msg):
+        assert _check_option('option', 'bad', ['valid'])

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -38,7 +38,7 @@ from ..transforms import (read_trans, _find_trans, apply_trans, rot_to_quat,
                           invert_transform, Transform)
 from ..utils import (get_subjects_dir, logger, _check_subject, verbose, warn,
                      SilenceStdout, has_nibabel, check_version,
-                     _ensure_int, _validate_type)
+                     _ensure_int, _validate_type, _check_option)
 from .utils import (mne_analyze_colormap, _prepare_trellis, _get_color_list,
                     plt_show, tight_layout, figure_nobar, _check_time_unit)
 from ..bem import (ConductorModel, _bem_find_surface, _surf_dict, _surf_name,
@@ -126,8 +126,7 @@ def plot_head_positions(pos, mode='traces', cmap='viridis', direction='z',
     from ..chpi import head_pos_to_trans_rot_t
     from ..preprocessing.maxwell import _check_destination
     import matplotlib.pyplot as plt
-    if not isinstance(mode, str) or mode not in ('traces', 'field'):
-        raise ValueError('mode must be "traces" or "field", got %s' % (mode,))
+    _check_option('mode', mode, ['traces', 'field'])
     dest_info = dict(dev_head_t=None) if info is None else info
     destination = _check_destination(destination, dest_info, head_frame=True)
     if destination is not None:
@@ -440,9 +439,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
     import matplotlib.pyplot as plt
     import nibabel as nib
 
-    if orientation not in ['coronal', 'axial', 'sagittal']:
-        raise ValueError("Orientation must be 'coronal', 'axial' or "
-                         "'sagittal'. Got %s." % orientation)
+    _check_option('orientation', orientation, ['coronal', 'axial', 'sagittal'])
 
     # Load the T1 data
     nim = nib.load(mri_fname)
@@ -659,11 +656,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
     if isinstance(eeg, str):
         eeg = [eeg]
 
-    if not isinstance(interaction, str) or \
-            interaction not in ('trackball', 'terrain'):
-        raise ValueError('interaction must be "trackball" or "terrain", '
-                         'got "%s"' % (interaction,))
-
+    _check_option('interaction', interaction, ['trackball', 'terrain'])
     for kind, var in zip(('eeg', 'meg'), (eeg, meg)):
         if not isinstance(var, (list, tuple)) or \
                 not all(isinstance(x, str) for x in var):
@@ -691,9 +684,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
                              'layers for plotting skull and head.')
         is_sphere = True
 
-    valid_coords = ['head', 'meg', 'mri']
-    if coord_frame not in valid_coords:
-        raise ValueError('coord_frame must be one of %s' % (valid_coords,))
+    _check_option('coord_frame', coord_frame, ['head', 'meg', 'mri'])
     if src is not None:
         if not isinstance(src, SourceSpaces):
             raise TypeError('src must be None or SourceSpaces, got %s'
@@ -1280,13 +1271,11 @@ def _limits_to_control_points(clim, stc_data, colormap, transparent,
         raise ValueError('colormap limits must be monotonically '
                          'increasing, got %s' % (ctrl_pts,))
     clim_kind = clim.get('kind', 'percent')
+    _check_option("clim['kind']", clim_kind, ['value', 'values', 'percent'])
     if clim_kind == 'percent':
         perc_data = np.abs(stc_data) if diverging_lims else stc_data
         ctrl_pts = np.percentile(perc_data, ctrl_pts)
         logger.info('Using control points %s' % (ctrl_pts,))
-    elif clim_kind not in ('value', 'values'):
-        raise ValueError('clim["kind"] must be "value" or "percent", got %s'
-                         % (clim['kind'],))
     if len(set(ctrl_pts)) != 3:
         if len(set(ctrl_pts)) == 1:  # three points match
             if ctrl_pts[0] == 0:  # all are zero
@@ -1448,9 +1437,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
                  'fro': {'elev': 16.739, 'azim': 60},
                  'par': {'elev': 30, 'azim': -60}}
     kwargs = dict(lh=lh_kwargs, rh=rh_kwargs)
-    if views not in lh_kwargs:
-        raise ValueError("views must be one of ['lat', 'med', 'ros', 'cau', "
-                         "'dor' 'ven', 'fro', 'par']. Got %s." % views)
+    _check_option('views', views, sorted(lh_kwargs.keys()))
     colormap, scale_pts, _, _ = _limits_to_control_points(
         clim, stc.data, colormap, transparent, linearize=True)
     del transparent
@@ -1669,9 +1656,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
     subjects_dir = get_subjects_dir(subjects_dir=subjects_dir,
                                     raise_error=True)
     subject = _check_subject(stc.subject, subject, True)
-    if backend not in ['auto', 'matplotlib', 'mayavi']:
-        raise ValueError("backend must be 'auto', 'mayavi' or 'matplotlib'. "
-                         "Got %s." % backend)
+    _check_option('backend', backend, ['auto', 'matplotlib', 'mayavi'])
     plot_mpl = backend == 'matplotlib'
     if not plot_mpl:
         try:
@@ -1693,10 +1678,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                              spacing=spacing, time_viewer=time_viewer,
                              colorbar=colorbar, transparent=transparent)
     from surfer import Brain, TimeViewer
-
-    if hemi not in ['lh', 'rh', 'split', 'both']:
-        raise ValueError('hemi has to be either "lh", "rh", "split", '
-                         'or "both"')
+    _check_option('hemi', hemi, ['lh', 'rh', 'split', 'both'])
 
     time_label, times = _handle_time(time_label, time_unit, stc.times)
     # convert control points to locations in colormap
@@ -2195,15 +2177,10 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     from ..source_estimate import VectorSourceEstimate
 
     _validate_type(stc, VectorSourceEstimate, "stc", "Vector Source Estimate")
-
     subjects_dir = get_subjects_dir(subjects_dir=subjects_dir,
                                     raise_error=True)
     subject = _check_subject(stc.subject, subject, True)
-
-    if hemi not in ['lh', 'rh', 'split', 'both']:
-        raise ValueError('hemi has to be either "lh", "rh", "split", '
-                         'or "both"')
-
+    _check_option('hemi', hemi, ['lh', 'rh', 'split', 'both'])
     time_label, times = _handle_time(time_label, time_unit, stc.times)
 
     # convert control points to locations in colormap
@@ -2584,9 +2561,7 @@ def _plot_dipole_mri_orthoview(dipole, trans, subject, subjects_dir=None,
     import nibabel as nib
     from nibabel.processing import resample_from_to
 
-    if coord_frame not in ['head', 'mri']:
-        raise ValueError("coord_frame must be 'head' or 'mri'. "
-                         "Got %s." % coord_frame)
+    _check_option('coord_frame', coord_frame, ['head', 'mri'])
 
     if not isinstance(dipole, Dipole):
         from ..dipole import _concatenate_dipoles

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -26,7 +26,7 @@ from ..surface import read_surface
 from ..io.proj import make_projector
 from ..io.pick import _DATA_CH_TYPES_SPLIT, pick_types
 from ..source_space import read_source_spaces, SourceSpaces
-from ..utils import logger, verbose, get_subjects_dir, warn
+from ..utils import logger, verbose, get_subjects_dir, warn, _check_option
 from ..io.pick import _picks_by_type
 from ..filter import estimate_ringing_samples
 from .utils import tight_layout, _get_color_list, _prepare_trellis, plt_show
@@ -717,7 +717,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
     from scipy.signal import freqz, group_delay
     import matplotlib.pyplot as plt
     sfreq = float(sfreq)
-    _check_fscale(fscale)
+    _check_option('fscale', fscale, ['log', 'linear'])
     flim = _get_flim(flim, fscale, freq, sfreq)
     if fscale == 'log':
         omega = np.logspace(np.log10(flim[0]), np.log10(flim[1]), 1000)
@@ -852,7 +852,7 @@ def plot_ideal_filter(freq, gain, axes=None, title='', flim=None, fscale='log',
                          'Nyquist, but got %s for DC' % (freq[0],))
     freq = np.array(freq)
     # deal with semilogx problems @ x=0
-    _check_fscale(fscale)
+    _check_option('fscale', fscale, ['log', 'linear'])
     if fscale == 'log':
         freq[0] = 0.1 * freq[1] if flim is None else min(flim[0], freq[1])
     flim = _get_flim(flim, fscale, freq)

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -1,7 +1,7 @@
 """Functions to plot EEG sensor montages or digitizer montages."""
 from copy import deepcopy
 import numpy as np
-from ..utils import check_version, logger
+from ..utils import check_version, logger, _check_option
 from . import plot_sensors
 
 
@@ -41,8 +41,7 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
         raise TypeError("montage must be an instance of "
                         "mne.channels.montage.Montage or"
                         "mne.channels.montage.DigMontage")
-    if kind not in ['topomap', '3d']:
-        raise ValueError("kind must be 'topomap' or '3d'")
+    _check_option('kind', kind, ['topomap', '3d'])
 
     if isinstance(montage, Montage):  # check for duplicate labels
         dists = cdist(montage.pos, montage.pos)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -15,7 +15,8 @@ from ..io.pick import (pick_types, _pick_data_channels, pick_info,
                        _PICK_TYPES_KEYS, pick_channels, channel_type,
                        _picks_to_idx)
 from ..io.meas_info import create_info
-from ..utils import verbose, get_config, _ensure_int, _validate_type
+from ..utils import (verbose, get_config, _ensure_int, _validate_type,
+                     _check_option)
 from ..time_frequency import psd_welch
 from ..defaults import _handle_default
 from .topo import _plot_topo, _plot_timeseries, _plot_timeseries_unified
@@ -267,10 +268,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     scalings = _handle_default('scalings_plot_raw', scalings)
     _validate_type(raw, BaseRaw, 'raw', 'Raw')
     n_channels = min(len(raw.info['chs']), n_channels)
+    _check_option('clipping', clipping, [None, 'clamp', 'transparent'])
 
-    if clipping is not None and clipping not in ('clamp', 'transparent'):
-        raise ValueError('clipping must be None, "clamp", or "transparent", '
-                         'not %s' % clipping)
     # figure out the IIR filtering parameters
     nyq = raw.info['sfreq'] / 2.
     if highpass is None and lowpass is None:
@@ -547,8 +546,7 @@ _data_types = ('mag', 'grad', 'eeg', 'seeg', 'ecog')
 def _set_psd_plot_params(info, proj, picks, ax, area_mode):
     """Set PSD plot params."""
     import matplotlib.pyplot as plt
-    if area_mode not in [None, 'std', 'range']:
-        raise ValueError('"area_mode" must be "std", "range", or None')
+    _check_option('area_mode', area_mode, [None, 'std', 'range'])
     picks = _picks_to_idx(info, picks)
 
     # XXX this could be refactored more with e.g., plot_evoked

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -325,7 +325,7 @@ def test_limits_to_control_points():
         stc.plot(clim=dict(kind='value', pos_lims=[0, 1, 0]), **kwargs)
     with pytest.raises(ValueError, match=r'.*must be \(3,\)'):
         stc.plot(colormap='mne', clim=dict(pos_lims=(5, 10, 15, 20)), **kwargs)
-    with pytest.raises(ValueError, match='must be "value" or "percent"'):
+    with pytest.raises(ValueError, match="'value', 'values' and 'percent'"):
         stc.plot(clim=dict(pos_lims=(5, 10, 15), kind='foo'), **kwargs)
     with pytest.raises(ValueError, match='must be "auto" or dict'):
         stc.plot(colormap='mne', clim='foo', **kwargs)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ..io.constants import Bunch
 from ..io.pick import channel_type, pick_types
-from ..utils import _clean_names, warn
+from ..utils import _clean_names, warn, _check_option
 from ..channels.layout import _merge_grad_data, _pair_grad_sensors, find_layout
 from ..defaults import _handle_default
 from .utils import (_check_delayed_ssp, _get_color_list, _draw_proj_checkbox,
@@ -291,9 +291,7 @@ def _imshow_tfr(ax, ch_idx, tmin, tmax, vmin, vmax, onselect, ylim=None,
     from matplotlib import pyplot as plt
     from matplotlib.widgets import RectangleSelector
 
-    if yscale not in ['auto', 'linear', 'log']:
-        raise ValueError("yscale should be either 'auto', 'linear', or 'log'"
-                         ", got {}".format(yscale))
+    _check_option('yscale', yscale, ['auto', 'linear', 'log'])
 
     cmap, interactive_cmap = cmap
     times = np.linspace(tmin, tmax, num=tfr[ch_idx].shape[1])

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -30,7 +30,7 @@ from ..io.pick import (channel_type, channel_indices_by_type, pick_channels,
                        pick_info, _picks_by_type, pick_channels_cov)
 from ..rank import compute_rank
 from ..io.proj import setup_proj
-from ..utils import verbose, set_config, warn, _check_ch_locs
+from ..utils import verbose, set_config, warn, _check_ch_locs, _check_option
 
 from ..selection import (read_selection, _SELECTIONS, _EEG_SELECTIONS,
                          _divide_to_regions)
@@ -1392,9 +1392,7 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
 
     """
     from .evoked import _rgb
-    if kind not in ['topomap', '3d', 'select']:
-        raise ValueError("Kind must be 'topomap', '3d' or 'select'. Got %s." %
-                         kind)
+    _check_option('kind', kind, ['topomap', '3d', 'select'])
     if not isinstance(info, Info):
         raise TypeError('info must be an instance of Info not %s' % type(info))
     ch_indices = channel_indices_by_type(info)


### PR DESCRIPTION
As @massich noted in #5946, the following snippet is a common occurrence in our codebase:

```python
# Validate method parameter
if method not in ['foo', 'bar', 'baz']:
    raise ValueError("Invalid value for 'method' parameter. Valid options are ...")
```

Generating a good error message takes a bit more work. You can either do:
```python
valid_options = ['foo', 'bar', 'baz']
if method not in valid_options:
    raise ValueError("Invalid value for 'method' parameter. Valid options are %s, "
                     "but got '%s' instead." % (valid_options, method))
```

or go just write it all out if you don't like the list-like formatting of the valid options:

```python
if method not in ['foo', 'bar', 'baz']:
    raise ValueError("Invalid value for 'method' parameter. Valid options are "
                     "'foo', 'bar' and 'baz', but got '%s' instead." % method)
```

It's a little bit of a hassle and we're not very consistent across the code base in how we generate such errors.

This PR adds a private `_check_option` function that you can use to perform such a check and generate a friendly error message in a single line:

```python
_check_option('method', method, valid_options=['foo', 'bar', 'baz'])
```

Small QOL improvement or unnecessary bloat? You be the judge :)
If we agree that we want this function, I'll open a follow-up PR that changes the bulk of the occurrences of this pattern in our codebase.