### PR TITLE
[MRG] Deprecate extended-infomax method

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -118,6 +118,8 @@ API
 
 - Reading BDF and GDF files with :func:`mne.io.read_raw_edf` is deprecated and replaced by :func:`mne.io.read_raw_bdf` and :func:`mne.io.read_raw_gdf`, by `Clemens Brunner`_
 
+- Deprecate ``method='extended-infomax'`` in :class:`mne.preprocessing.ICA`; Extended Infomax can now be computed with ``method='infomax'`` and ``fit_params=dict(extended=True)`` by `Clemens Brunner`_
+
 .. _changes_0_17:
 
 Version 0.17

--- a/examples/preprocessing/plot_ica_comparison.py
+++ b/examples/preprocessing/plot_ica_comparison.py
@@ -62,4 +62,4 @@ run_ica('infomax')
 
 ###############################################################################
 # Extended Infomax
-run_ica('extended-infomax')
+run_ica('infomax', fit_params=dict(extended=True))

--- a/examples/preprocessing/plot_ica_comparison.py
+++ b/examples/preprocessing/plot_ica_comparison.py
@@ -40,8 +40,9 @@ raw.filter(1, 30, fir_design='firwin')
 # Define a function that runs ICA on the raw MEG data and plots the components
 
 
-def run_ica(method):
-    ica = ICA(n_components=20, method=method, random_state=0)
+def run_ica(method, fit_params):
+    ica = ICA(n_components=20, method=method, fit_params=fit_params,
+              random_state=0)
     t0 = time()
     ica.fit(raw, picks=picks, reject=reject)
     fit_time = time() - t0

--- a/examples/preprocessing/plot_ica_comparison.py
+++ b/examples/preprocessing/plot_ica_comparison.py
@@ -40,7 +40,7 @@ raw.filter(1, 30, fir_design='firwin')
 # Define a function that runs ICA on the raw MEG data and plots the components
 
 
-def run_ica(method, fit_params):
+def run_ica(method, fit_params=None):
     ica = ICA(n_components=20, method=method, fit_params=fit_params,
               random_state=0)
     t0 = time()

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -333,9 +333,7 @@ class ICA(ContainsMixin):
         if fit_params is None:
             fit_params = {}
         fit_params = deepcopy(fit_params)  # avoid side effects
-        if "extended" in fit_params:
-            raise ValueError("'extended' parameter provided. You should "
-                             "rather use method='extended-infomax'.")
+
         if method == 'fastica':
             update = {'algorithm': 'parallel', 'fun': 'logcosh',
                       'fun_args': None}

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -166,9 +166,12 @@ class ICA(ContainsMixin):
         by PCA.
     random_state : None | int | instance of np.random.RandomState
         Random state to initialize ICA estimation for reproducible results.
-    method : {'fastica', 'infomax', 'extended-infomax', 'picard'}
-        The ICA method to use in the fit() method. Defaults to 'fastica'.
-        For reference, see [1]_, [2]_, [3]_ and [4]_.
+    method : {'fastica', 'infomax', 'picard'}
+        The ICA method to use in the fit method. Use the fit_params argument to
+        set additional parameters. Specifically, if you want Extended Infomax,
+        set method='infomax' and fit_params=dict(extended=True) (this also
+        works for method='picard'). Defaults to 'fastica'. For reference, see
+        [1]_, [2]_, [3]_ and [4]_.
     fit_params : dict | None
         Additional parameters passed to the ICA estimator as specified by
         `method`.
@@ -259,10 +262,10 @@ class ICA(ContainsMixin):
         >> ica.fit(raw)
         >> raw.info['projs'] = projs
 
-    Methods currently implemented are FastICA (default), Infomax,
-    Extended Infomax, and Picard. Infomax can be quite sensitive to differences
-    in floating point arithmetic. Extended Infomax seems to be more stable in
-    this respect enhancing reproducibility and stability of results.
+    Methods currently implemented are FastICA (default), Infomax, and Picard.
+    Standard Infomax can be quite sensitive to differences in floating point
+    arithmetic. Extended Infomax seems to be more stable in this respect,
+    enhancing reproducibility and stability of results.
 
     Reducing the tolerance (set in `fit_params`) speeds up estimation at the
     cost of consistency of the obtained results. It is difficult to directly
@@ -305,6 +308,10 @@ class ICA(ContainsMixin):
         if method not in methods:
             raise ValueError('`method` must be "%s". You passed: "%s"' %
                              ('" or "'.join(methods), method))
+        if method == 'extended-infomax':
+            warn("method='extended-infomax' is deprecated. If you want to use "
+                 "Extended Infomax, specify method='infomax' together with "
+                 "fit_params=dict(extended=True).", DeprecationWarning)
         if not check_version('sklearn', '0.15'):
             raise RuntimeError('the scikit-learn package (version >= 0.15) '
                                'is required for ICA')
@@ -343,10 +350,7 @@ class ICA(ContainsMixin):
             fit_params.update({'extended': False})
         elif method == 'extended-infomax':
             fit_params.update({'extended': True})
-        elif method == 'picard':
-            update = {'ortho': True, 'fun': 'tanh', 'tol': 1e-5}
-            fit_params.update({k: v for k, v in update.items() if k
-                               not in fit_params})
+            method = 'infomax'
         if 'max_iter' not in fit_params:
             fit_params['max_iter'] = max_iter
         self.max_iter = max_iter

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -309,8 +309,9 @@ class ICA(ContainsMixin):
             raise ValueError('`method` must be "%s". You passed: "%s"' %
                              ('" or "'.join(methods), method))
         if method == 'extended-infomax':
-            warn("method='extended-infomax' is deprecated. If you want to use "
-                 "Extended Infomax, specify method='infomax' together with "
+            warn("method='extended-infomax' is deprecated and will be removed "
+                 "in 0.19. If you want to use Extended Infomax, specify "
+                 "method='infomax' together with "
                  "fit_params=dict(extended=True).", DeprecationWarning)
         if not check_version('sklearn', '0.15'):
             raise RuntimeError('the scikit-learn package (version >= 0.15) '

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -708,7 +708,6 @@ def test_ica_twice(method):
 def test_fit_params(method):
     """Test fit_params for ICA."""
     _skip_check_picard(method)
-    pytest.raises(ValueError, ICA, fit_params=dict(extended=True))
     fit_params = {}
     ICA(fit_params=fit_params, method=method)  # test no side effects
     assert_equal(fit_params, {})

--- a/tutorials/plot_artifacts_correction_ica.py
+++ b/tutorials/plot_artifacts_correction_ica.py
@@ -55,8 +55,8 @@ raw.filter(1., None, n_jobs=1, fir_design='firwin')
 # Fit ICA
 # -------
 #
-# First, choose the ICA method. There are currently four possible choices:
-# ``fastica``, ``picard``, ``infomax`` and ``extended-infomax``.
+# First, choose the ICA method. There are currently three possible choices:
+# ``fastica``, ``picard``, and ``infomax``.
 #
 # .. note:: The default method in MNE is FastICA, which along with Infomax is
 #           one of the most widely used ICA algorithms. Picard is a

--- a/tutorials/plot_ica_from_raw.py
+++ b/tutorials/plot_ica_from_raw.py
@@ -39,7 +39,7 @@ raw.set_annotations(mne.Annotations([0], [10], 'BAD'))
 
 ###############################################################################
 # 1) Fit ICA model using the FastICA algorithm.
-# Other available choices are ``picard``, ``infomax`` or ``extended-infomax``.
+# Other available choices are ``picard`` or ``infomax``.
 #
 # .. note:: The default method in MNE is FastICA, which along with Infomax is
 #           one of the most widely used ICA algorithm. Picard is a


### PR DESCRIPTION
Picard has a new `extended` argument ([which will hopefully be on PyPI soon](https://github.com/pierreablin/picard/issues/16)), but MNE currently does not allow this argument in the `fit_params` dict. I have removed this check.

On a related note, is there a specific reason why some Picard arguments are explicitly set although they are identical to the defaults (`ortho` and `fun`)? Also, why does MNE set `tol` to `1e-5` instead of using the default of `1e-7`?

@pierreablin WDYT?