### PR TITLE
[FIX] Fix channel-picking in _calculate_head_pos_ctf

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -184,7 +184,7 @@ def _calculate_head_pos_ctf(raw, gof_limit=0.98):
     """
     # Pick channels cooresponding to the cHPI positions
     hpi_picks = pick_channels_regexp(raw.info['ch_names'],
-                                     'HLC00[123][123]-.*')
+                                     'HLC00[123][123].*')
 
     # make sure we get 9 channels
     if len(hpi_picks) != 9:

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -178,9 +178,9 @@ def _calculate_head_pos_ctf(raw, gof_limit=0.98):
     -----
     CTF continuous head monitoring stores the x,y,z location (m) of each chpi
     coil as separate channels in the dataset.
-    HLC001[123]-\\* - nasion
-    HLC002[123]-\\* - lpa
-    HLC003[123]-\\* - rpa
+    HLC001[123]\\* - nasion
+    HLC002[123]\\* - lpa
+    HLC003[123]\\* - rpa
     """
     # Pick channels cooresponding to the cHPI positions
     hpi_picks = pick_channels_regexp(raw.info['ch_names'],


### PR DESCRIPTION
This PR consists of exactly one character of code, which had to be removed from the matching pattern in order to match CTF headloc channels of data loaded with the `clean_names` option set to `True`. See comment in #4088.