### PR TITLE
MRG: Fix plot_compare_evokeds with tmin >= 0

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -93,6 +93,8 @@ Bug
 
 - Fix saving of rejection parameters in :meth:`mne.Epochs.save` by `Eric Larson`_
 
+- Fix bug in :func:`mne.viz.plot_compare_evokeds` when ``evoked.times[0] >= 0`` would cause a problem with ``vlines='auto'`` mode by `Eric Larson`_
+
 - Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_
 
 - Fix :meth:`mne.time_frequency.AverageTFR.plot_joint` mishandling bad channels, by `David Haslacher`_ and `Jona Sassenhagen`_

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1862,8 +1862,8 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     info = one_evoked.info
     tmin, tmax = times[0], times[-1]
 
-    if vlines == "auto" and (tmin < 0 and tmax > 0):
-        vlines = [0.]
+    if vlines == "auto":
+        vlines = [0.] if (tmin < 0 < tmax) else []
     _validate_type(vlines, (list, tuple), "vlines", "list or tuple")
 
     picks = [] if picks is None else picks

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -319,7 +319,7 @@ def test_plot_compare_evokeds():
     plot_compare_evokeds([red, blue], picks=[0], cmap="summer", ci=None,
                          split_legend=None)
     plot_compare_evokeds([red, blue], cmap=None, split_legend=True)
-    with pytest.raises(ValueError, match='more than 10'):
+    with pytest.raises(ValueError, match='more than [1-9]'):
         plot_compare_evokeds([red] * 20)
     with pytest.raises(ValueError, match='must specify the colors'):
         plot_compare_evokeds(contrasts, cmap='summer')

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -293,6 +293,7 @@ def test_plot_compare_evokeds():
                          ylim=dict(mag=(1, 10)), ci=_parametric_ci,
                          truncate_yaxis='max_ticks', show_sensors=False,
                          show_legend=False)
+    plt.close('all')
 
     # sequential colors
     evokeds = (evoked, blue, red)
@@ -318,10 +319,20 @@ def test_plot_compare_evokeds():
     plot_compare_evokeds([red, blue], picks=[0], cmap="summer", ci=None,
                          split_legend=None)
     plot_compare_evokeds([red, blue], cmap=None, split_legend=True)
-    pytest.raises(ValueError, plot_compare_evokeds, [red] * 20)
-    pytest.raises(ValueError, plot_compare_evokeds, contrasts,
-                  cmap='summer')
+    with pytest.raises(ValueError, match='more than 10'):
+        plot_compare_evokeds([red] * 20)
+    with pytest.raises(ValueError, match='must specify the colors'):
+        plot_compare_evokeds(contrasts, cmap='summer')
+    plt.close('all')
 
+    # smoke test for tmin >= 0 (from mailing list)
+    red.crop(0.01, None)
+    assert len(red.times) > 2
+    plot_compare_evokeds(red)
+    # smoke test for one time point (not useful but should not fail)
+    red.crop(0.01, 0.01)
+    assert len(red.times) == 1
+    plot_compare_evokeds(red)
     plt.close('all')
 
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -70,13 +70,9 @@ def _get_epochs_delayed_ssp():
     return epochs_delayed_ssp
 
 
-def test_plot_topo():
-    """Test plotting of ERP topography."""
-    # Show topography
+def test_plot_joint():
+    """Test joint plot."""
     evoked = _get_epochs().average()
-    # should auto-find layout
-    plot_evoked_topo([evoked, evoked], merge_grads=True, background_color='w')
-    # Test jointplot
     evoked.plot_joint(ts_args=dict(time_unit='s'),
                       topomap_args=dict(time_unit='s'))
 
@@ -92,9 +88,18 @@ def test_plot_topo():
     axes = plt.subplots(nrows=3)[-1].flatten().tolist()
     evoked.plot_joint(times=[0], picks=[6, 7, 8],  ts_args=dict(axes=axes[0]),
                       topomap_args={"axes": axes[1:], "time_unit": "s"})
-    plt.close()
-    pytest.raises(ValueError, evoked.plot_joint, picks=[6, 7, 8],
-                  ts_args=dict(axes=axes[0]), topomap_args=dict(axes=axes[2:]))
+    with pytest.raises(ValueError, match='array of length 6'):
+        evoked.plot_joint(picks=[6, 7, 8], ts_args=dict(axes=axes[0]),
+                          topomap_args=dict(axes=axes[2:]))
+    plt.close('all')
+
+
+def test_plot_topo():
+    """Test plotting of ERP topography."""
+    # Show topography
+    evoked = _get_epochs().average()
+    # should auto-find layout
+    plot_evoked_topo([evoked, evoked], merge_grads=True, background_color='w')
 
     picked_evoked = evoked.copy().pick_channels(evoked.ch_names[:3])
     picked_evoked_eeg = evoked.copy().pick_types(meg=False, eeg=True)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2316,6 +2316,8 @@ def _setup_ax_spines(axes, vlines, tmin, tmax, invert_y=False,
     xticks = sorted(list(set([x for x in axes.get_xticks()] + vlines)))
     axes.set_xticks(xticks)
     x_extrema = [t for t in xticks if tmax >= t >= tmin]
+    if len(x_extrema) == 0:  # can happen with one time point
+        x_extrema = [tmin, tmax]
     if truncate_xaxis is True:
         axes.spines['bottom'].set_bounds(x_extrema[0], x_extrema[-1])
     else:
@@ -2328,7 +2330,8 @@ def _setup_ax_spines(axes, vlines, tmin, tmax, invert_y=False,
     if invert_y:
         axes.invert_yaxis()
     axes.spines['right'].set_color('none')
-    axes.set_xlim(tmin, tmax)
+    if tmin != tmax:
+        axes.set_xlim(tmin, tmax)
     if truncate_xaxis is False:
         axes.axis("tight")
         axes.set_autoscale_on(False)


### PR DESCRIPTION
Fixes a bug found on the mailing list, and another one found while fixing that one.

Also separates a test in `plot_topo.py` along the way. I originally thought the problem with `plot_joint`, but it wasn't, but the tiny refactoring I did was still useful.

Closes #5972.