### PR TITLE
Fix rendering bug of plot_evoked_field()

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -390,7 +390,7 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
         # Now show our field pattern
         with warnings.catch_warnings(record=True):  # traits
             renderer.surface(surface=surf, vmin=-vlim, vmax=vlim,
-                             colormap=colormap)
+                             scalars=data, colormap=colormap)
 
         # And the field lines on top
         with warnings.catch_warnings(record=True):  # traits

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -152,8 +152,8 @@ class _Renderer(object):
             opacity=opacity, figure=self.fig)
         cont.module_manager.scalar_lut_manager.lut.table = colormap
 
-    def surface(self, surface, color=(0.7, 0.7, 0.7), opacity=1.0,
-                vmin=None, vmax=None, colormap=None,
+    def surface(self, surface, color=None, opacity=1.0,
+                vmin=None, vmax=None, colormap=None, scalars=None,
                 backface_culling=False):
         """Add a surface in the scene.
 
@@ -177,7 +177,7 @@ class _Renderer(object):
             If True, enable backface culling on the surface.
         """
         # Make a solid surface
-        mesh = _create_mesh_surf(surface, self.fig)
+        mesh = _create_mesh_surf(surface, self.fig, scalars=scalars)
         surface = self.mlab.pipeline.surface(
             mesh, color=color, opacity=opacity, vmin=vmin, vmax=vmax,
             figure=self.fig)

--- a/tutorials/plot_visualize_evoked.py
+++ b/tutorials/plot_visualize_evoked.py
@@ -73,7 +73,7 @@ times = np.arange(0.05, 0.151, 0.05)
 evoked_r_aud.plot_topomap(times=times, ch_type='mag', time_unit='s')
 
 ###############################################################################
-# Or we can automatically select the peaks.
+# Or we can select automatically the peaks.
 evoked_r_aud.plot_topomap(times='peaks', ch_type='mag', time_unit='s')
 
 ###############################################################################


### PR DESCRIPTION
#### Reference issue
Fixes #5970.


#### What does this implement/fix?
Fix the rendering bug of `mne/viz/plot_evoked_field()`


#### Additional information
Remove the useless default `(0.7, 0.7, 0.7)` color and allow adding scalars on surfaces.
