### PR TITLE
MRG: Better shape checks for SourceEstimate

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -685,6 +685,7 @@ Source Space Data
    SourceEstimate
    VectorSourceEstimate
    VolSourceEstimate
+   VolVectorSourceEstimate
    SourceMorph
    compute_source_morph
    head_to_mni

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -112,6 +112,8 @@ API
 
 - Python 2 is no longer supported; MNE-Python now requires Python 3.5+, by `Eric Larson`_
 
+- A new class :class:`mne.VolVectorSourceEstimate` is returned by :func:`mne.minimum_norm.apply_inverse` (and related functions) when a volume source space and ``pick_ori='vector'`` is used, by `Eric Larson`_
+
 - ``raw.estimate_rank`` has been deprecated and will be removed in 0.19 in favor of :func:`mne.compute_rank`  by `Eric Larson`_
 
 - :class:`Annotations` are now kept sorted (by onset time) during instantiation and :meth:`~Annotations.append` operations, by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,8 @@ Bug
 
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
+- Fix checking of ``data`` dimensionality in :class:`mne.SourceEstimate` and related constructors by `Eric Larson`_
+
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 
 - Fix hash bug in the ``mne.io.edf`` module when installing on Windows by `Eric Larson`_

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -48,7 +48,7 @@ from .forward import (read_forward_solution, apply_forward, apply_forward_raw,
                       make_forward_dipole, use_coil_def)
 from .source_estimate import (read_source_estimate, MixedSourceEstimate,
                               SourceEstimate, VectorSourceEstimate,
-                              VolSourceEstimate,
+                              VolSourceEstimate, VolVectorSourceEstimate,
                               grade_to_tris,
                               spatial_src_connectivity,
                               spatial_tris_connectivity,

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -12,7 +12,8 @@ from scipy import sparse
 
 from .parallel import parallel_func
 from .source_estimate import (VolSourceEstimate, SourceEstimate,
-                              VectorSourceEstimate, _get_ico_tris)
+                              VolVectorSourceEstimate, VectorSourceEstimate,
+                              _get_ico_tris)
 from .source_space import SourceSpaces
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
@@ -327,10 +328,11 @@ class SourceMorph(object):
 
         Parameters
         ----------
-        stc_from : VolSourceEstimate | SourceEstimate | VectorSourceEstimate
+        stc_from : VolSourceEstimate | VolVectorSourceEstimate | SourceEstimate | VectorSourceEstimate
             The source estimate to morph.
         output : str
             Can be 'stc' (default), 'nifti1', or 'nifti2'.
+            If a V
         mri_resolution: bool | tuple | int | float
             If True the image is saved in MRI resolution. Default False.
             WARNING: if you have many time points the file produced can be
@@ -361,6 +363,11 @@ class SourceMorph(object):
                             % (type(output), output))
         out = _apply_morph_data(self, stc)
         if output != 'stc':  # convert to volume
+            if isinstance(stc, VolVectorSourceEstimate):
+                out = out.magnitude()
+            # Should be guaranteed by _apply_morph_data
+            assert isinstance(stc, (VolSourceEstimate,
+                                    VolVectorSourceEstimate))
             out = _morphed_stc_as_volume(
                 self, out, mri_resolution=mri_resolution, mri_space=mri_space,
                 output=output)
@@ -1128,9 +1135,16 @@ def _apply_morph_data(morph, stc_from):
         raise ValueError('stc.subject (%s) != morph.subject_from (%s)'
                          % (stc_from.subject, morph.subject_from))
     if morph.kind == 'volume':
+        if isinstance(stc_from, VolSourceEstimate):
+            klass = VolSourceEstimate
+        elif isinstance(stc_from, VolVectorSourceEstimate):
+            klass = VolVectorSourceEstimate
+        else:
+            raise ValueError('stc_from was type %s but must be a volume '
+                             'source estimate' % (type(stc_from),))
         from dipy.align.reslice import reslice
 
-        n_times = stc_from.data.shape[1]
+        n_times = np.prod(stc_from.data.shape[1:])
 
         def _morph_one(stc_one):
             # prepare data to be morphed
@@ -1152,22 +1166,26 @@ def _apply_morph_data(morph, stc_from):
             return img_to
 
         # First get the vertices (vertices_to) you will need the values for
-        stc_ones = VolSourceEstimate(np.ones_like(stc_from.data[:, :1]),
+        stc_ones = VolSourceEstimate(np.ones((stc_from.data.shape[0], 1),
+                                             stc_from.data.dtype),
                                      stc_from.vertices,
                                      tmin=0., tstep=1.)
         img_to = _morph_one(stc_ones)
         vertices_to = np.where(img_to.sum(axis=1) != 0)[0]
         data = np.empty((len(vertices_to), n_times))
+        data_from = np.reshape(stc_from.data, (stc_from.data.shape[0], -1))
         # Loop over time points to save memory
         for k in range(n_times):
-            this_stc = VolSourceEstimate(stc_from.data[:, k:k + 1],
-                                         stc_from.vertices,
-                                         tmin=0., tstep=1.)
+            this_stc = VolSourceEstimate(
+                data_from[:, k:k + 1], stc_from.vertices, tmin=0., tstep=1.)
             this_img_to = _morph_one(this_stc)
             data[:, k] = this_img_to[vertices_to, 0]
-        klass = VolSourceEstimate
+        data.shape = (len(vertices_to),) + stc_from.data.shape[1:]
     else:
         assert morph.kind == 'surface'
+        if not isinstance(stc_from, (SourceEstimate, VectorSourceEstimate)):
+            raise ValueError('stc_from was type %s but must be a surface '
+                             'source estimate' % (type(stc_from),))
         morph_mat = morph.morph_mat
         vertices_to = morph.vertices_to
         for hemi, v1, v2 in zip(('left', 'right'),

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -363,11 +363,6 @@ class SourceMorph(object):
                             % (type(output), output))
         out = _apply_morph_data(self, stc)
         if output != 'stc':  # convert to volume
-            if isinstance(stc, VolVectorSourceEstimate):
-                out = out.magnitude()
-            # Should be guaranteed by _apply_morph_data
-            assert isinstance(stc, (VolSourceEstimate,
-                                    VolVectorSourceEstimate))
             out = _morphed_stc_as_volume(
                 self, out, mri_resolution=mri_resolution, mri_space=mri_space,
                 output=output)
@@ -474,6 +469,8 @@ def _check_dep(nibabel='2.1.0', dipy='0.10.1'):
 def _morphed_stc_as_volume(morph, stc, mri_resolution=False, mri_space=True,
                            output='nifti1'):
     """Return volume source space as Nifti1Image and/or save to disk."""
+    if isinstance(stc, VolVectorSourceEstimate):
+        stc = stc.magnitude()
     if not isinstance(stc, VolSourceEstimate):
         raise ValueError('Only volume source estimates can be converted to '
                          'volumes')

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -318,11 +318,10 @@ def read_source_estimate(fname, subject=None):
         # w files only have a single time point
         kwargs['tmin'] = 0.0
         kwargs['tstep'] = 1.0
+        ftype = 'surface'
     elif ftype == 'h5':
         kwargs = read_hdf5(fname + '.h5', title='mnepython')
-        if "src_type" in kwargs:
-            ftype = kwargs['src_type']
-            del kwargs['src_type']
+        ftype = kwargs.pop('src_type', 'surface')
 
     if ftype != 'volume':
         # Make sure the vertices are ordered
@@ -345,10 +344,12 @@ def read_source_estimate(fname, subject=None):
         stc = VolSourceEstimate(**kwargs)
     elif ftype == 'mixed':
         stc = MixedSourceEstimate(**kwargs)
-    elif ftype == 'h5' and kwargs['data'].ndim == 3:
-        stc = VectorSourceEstimate(**kwargs)
     else:
-        stc = SourceEstimate(**kwargs)
+        assert ftype == 'surface'
+        if kwargs['data'].ndim == 3:
+            stc = VectorSourceEstimate(**kwargs)
+        else:
+            stc = SourceEstimate(**kwargs)
 
     return stc
 
@@ -407,10 +408,16 @@ def _make_stc(data, vertices, src_type=None, tmin=None, tstep=None,
     elif src_type in ('volume', 'discrete'):
         if vector:
             data = data.reshape((-1, 3, data.shape[-1]))
-        stc = VolSourceEstimate(data, vertices=vertices, tmin=tmin,
-                                tstep=tstep, subject=subject)
+            class_ = VolVectorSourceEstimate
+        else:
+            class_ = VolSourceEstimate
+        stc = class_(data, vertices=vertices, tmin=tmin, tstep=tstep,
+                     subject=subject)
     elif src_type == 'mixed':
         # make a mixed source estimate
+        if vector:
+            raise RuntimeError('Vector source estimates for mixed source '
+                               'spaces are not supported yet')
         stc = MixedSourceEstimate(data, vertices=vertices, tmin=tmin,
                                   tstep=tstep, subject=subject)
     else:
@@ -437,7 +444,7 @@ def _verify_source_estimate_compat(a, b):
 
 
 class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
-    """Abstract base class for source estimates.
+    """Base class for all source estimates.
 
     Parameters
     ----------
@@ -472,11 +479,11 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         The shape of the data. A tuple of int (n_dipoles, n_times).
     """
 
-    _data_ndim = 2
-
     @verbose
     def __init__(self, data, vertices=None, tmin=None, tstep=None,
                  subject=None, verbose=None):  # noqa: D102
+        assert hasattr(self, '_data_ndim'), self.__class__.__name__
+        assert hasattr(self, '_src_type'), self.__class__.__name__
         kernel, sens_data = None, None
         if isinstance(data, tuple):
             if len(data) != 2:
@@ -528,6 +535,48 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         self._times = None
         self._update_times()
         self.subject = _check_subject(None, subject, False)
+
+    def __repr__(self):  # noqa: D105
+        if isinstance(self.vertices, list):
+            nv = sum([len(v) for v in self.vertices])
+        else:
+            nv = self.vertices.size
+        s = "%d vertices" % nv
+        if self.subject is not None:
+            s += ", subject : %s" % self.subject
+        s += ", tmin : %s (ms)" % (1e3 * self.tmin)
+        s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
+        s += ", tstep : %s (ms)" % (1e3 * self.tstep)
+        s += ", data shape : %s" % (self.shape,)
+        return "<%s  |  %s>" % (type(self).__name__, s)
+
+    @property
+    def _vertices_list(self):
+        return self.vertices
+
+    @verbose
+    def save(self, fname, ftype='h5', verbose=None):
+        """Save the full source estimate to an HDF5 file.
+
+        Parameters
+        ----------
+        fname : string
+            The file name to write the source estimate to, should end in
+            '-stc.h5'.
+        ftype : string
+            File format to use. Currently, the only allowed values is "h5".
+        %(verbose_meth)s
+        """
+        if ftype != 'h5':
+            raise ValueError('%s objects can only be written as HDF5 files.'
+                             % (self.__class__.__name__,))
+        if not fname.endswith('.h5'):
+            fname += '-stc.h5'
+        write_hdf5(fname,
+                   dict(vertices=self.vertices, data=self.data, tmin=self.tmin,
+                        tstep=self.tstep, subject=self.subject,
+                        src_type=self._src_type),
+                   title='mnepython', overwrite=True)
 
     @property
     def sfreq(self):
@@ -1108,6 +1157,9 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
         The shape of the data. A tuple of int (n_dipoles, n_times).
     """
 
+    _data_ndim = 2
+    _src_type = 'surface'
+
     @verbose
     def __init__(self, data, vertices=None, tmin=None, tstep=None,
                  subject=None, verbose=None):  # noqa: D102
@@ -1120,20 +1172,6 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
         _BaseSourceEstimate.__init__(self, data, vertices=vertices, tmin=tmin,
                                      tstep=tstep, subject=subject,
                                      verbose=verbose)
-
-    def __repr__(self):  # noqa: D105
-        if isinstance(self.vertices, list):
-            nv = sum([len(v) for v in self.vertices])
-        else:
-            nv = self.vertices.size
-        s = "%d vertices" % nv
-        if self.subject is not None:
-            s += ", subject : %s" % self.subject
-        s += ", tmin : %s (ms)" % (1e3 * self.tmin)
-        s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
-        s += ", tstep : %s (ms)" % (1e3 * self.tstep)
-        s += ", data shape : %s" % (self.shape,)
-        return "<%s  |  %s>" % (type(self).__name__, s)
 
     @property
     def lh_data(self):
@@ -1385,13 +1423,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
                      data=rh_data[:, 0])
 
         elif ftype == 'h5':
-            if not fname.endswith('.h5'):
-                fname += '-stc.h5'
-            write_hdf5(fname,
-                       dict(vertices=self.vertices, data=self.data,
-                            tmin=self.tmin, tstep=self.tstep,
-                            subject=self.subject), title='mnepython',
-                       overwrite=True)
+            super().save(fname)
         logger.info('[done]')
 
     @copy_function_doc_to_method_doc(plot_source_estimates)
@@ -1606,52 +1638,58 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         return vertex, hemi, t
 
 
-@fill_doc
-class VolSourceEstimate(_BaseSourceEstimate):
-    """Container for volume source estimates.
+class _BaseVectorSourceEstimate(_BaseSourceEstimate):
+    _data_ndim = 3
 
-    Parameters
-    ----------
-    data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. The data can either be a single array or
-        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
-        "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : array
-        Vertex numbers corresponding to the data.
-    tmin : scalar
-        Time point of the first sample in data.
-    tstep : scalar
-        Time step between successive samples in data.
-    subject : str | None
-        The subject name. While not necessary, it is safer to set the
-        subject parameter to avoid analysis errors.
-    %(verbose)s
+    @verbose
+    def __init__(self, data, vertices=None, tmin=None, tstep=None,
+                 subject=None, verbose=None):  # noqa: D102
+        assert hasattr(self, '_scalar_class')
+        super().__init__(data, vertices, tmin, tstep, subject, verbose)
+        if self._data is not None and self._data.shape[1] != 3:
+            raise ValueError('Data for VectorSourceEstimate must have second '
+                             'dimension of length 3, got length %s'
+                             % (self._data.shape[1],))
 
-    Attributes
-    ----------
-    subject : str | None
-        The subject name.
-    times : array of shape (n_times,)
-        The time vector.
-    vertices : array of shape (n_dipoles,)
-        The indices of the dipoles in the source space.
-    data : array of shape (n_dipoles, n_times)
-        The data in source space.
-    shape : tuple
-        The shape of the data. A tuple of int (n_dipoles, n_times).
+    def magnitude(self):
+        """Compute magnitude of activity without directionality.
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            The source estimate without directionality information.
+        """
+        data_mag = np.linalg.norm(self.data, axis=1)
+        return self._scalar_class(
+            data_mag, self.vertices, self.tmin, self.tstep, self.subject,
+            self.verbose)
 
-    See Also
-    --------
-    SourceEstimate : A container for surface source estimates.
-    VectorSourceEstimate : A container for vector source estimates.
-    MixedSourceEstimate : A container for mixed surface + volume source
-                          estimates.
-    """
+    def normal(self, src):
+        """Compute activity orthogonal to the cortex.
+
+        Parameters
+        ----------
+        src : instance of SourceSpaces
+            The source space for which this source estimate is specified.
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            The source estimate only retaining the activity orthogonal to the
+            cortex.
+        """
+        normals = np.vstack([s['nn'][v] for s, v in
+                             zip(src, self._vertices_list)])
+        data_norm = einsum('ijk,ij->ik', self.data, normals)
+        return self._scalar_class(
+            data_norm, self.vertices, self.tmin, self.tstep, self.subject,
+            self.verbose)
+
+
+class _BaseVolSourceEstimate(_BaseSourceEstimate):
+
+    _data_ndim = 2
+    _src_type = 'volume'
 
     @verbose
     def __init__(self, data, vertices=None, tmin=None, tstep=None,
@@ -1665,55 +1703,19 @@ class VolSourceEstimate(_BaseSourceEstimate):
                                      tstep=tstep, subject=subject,
                                      verbose=verbose)
 
+    @property
+    def _vertices_list(self):
+        return [self.vertices]
+
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
              bg_img=None, colorbar=True, colormap='auto', clim='auto',
              transparent='auto', show=True, verbose=None):
+        data = self.magnitude() if self._data_ndim == 3 else self
         return plot_volume_source_estimates(
-            self, src=src, subject=subject, subjects_dir=subjects_dir,
+            data, src=src, subject=subject, subjects_dir=subjects_dir,
             mode=mode, bg_img=bg_img, colorbar=colorbar, colormap=colormap,
             clim=clim, transparent=transparent, show=show, verbose=verbose)
-
-    @verbose
-    def save(self, fname, ftype='stc', verbose=None):
-        """Save the source estimates to a file.
-
-        Parameters
-        ----------
-        fname : string
-            The stem of the file name. The stem is extended with "-vl.stc"
-            or "-vl.w".
-        ftype : string
-            File format to use. Allowed values are "stc" (default), "w",
-            and "h5". The "w" format only supports a single time point.
-        %(verbose_meth)s
-        """
-        if ftype not in ['stc', 'w', 'h5']:
-            raise ValueError('ftype must be "stc", "w" or "h5", not "%s"' %
-                             ftype)
-
-        if ftype == 'stc':
-            logger.info('Writing STC to disk...')
-            if not (fname.endswith('-vl.stc') or fname.endswith('-vol.stc')):
-                fname += '-vl.stc'
-            _write_stc(fname, tmin=self.tmin, tstep=self.tstep,
-                       vertices=self.vertices, data=self.data)
-        elif ftype == 'w':
-            logger.info('Writing STC to disk (w format)...')
-            if not (fname.endswith('-vl.w') or fname.endswith('-vol.w')):
-                fname += '-vl.w'
-            _write_w(fname, vertices=self.vertices, data=self.data)
-        elif ftype == 'h5':
-            if not fname.endswith('.h5'):
-                fname += '-stc.h5'
-            write_hdf5(fname,
-                       dict(vertices=self.vertices, data=self.data,
-                            tmin=self.tmin, tstep=self.tstep,
-                            subject=self.subject, src_type='volume'),
-                       title='mnepython',
-                       overwrite=True)
-
-        logger.info('[done]')
 
     def save_as_volume(self, fname, src, dest='mri', mri_resolution=False,
                        format='nifti1'):
@@ -1782,22 +1784,9 @@ class VolSourceEstimate(_BaseSourceEstimate):
         .. versionadded:: 0.9.0
         """
         from .morph import _interpolate_data
-        return _interpolate_data(self, src, mri_resolution=mri_resolution,
+        data = self.magnitude() if self._data_ndim == 3 else self
+        return _interpolate_data(data, src, mri_resolution=mri_resolution,
                                  mri_space=True, output=format)
-
-    def __repr__(self):  # noqa: D105
-        if isinstance(self.vertices, list):
-            nv = sum([len(v) for v in self.vertices])
-        else:
-            nv = self.vertices.size
-        s = "%d vertices" % nv
-        if self.subject is not None:
-            s += ", subject : %s" % self.subject
-        s += ", tmin : %s (ms)" % (1e3 * self.tmin)
-        s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
-        s += ", tstep : %s (ms)" % (1e3 * self.tstep)
-        s += ", data size : %s" % ' x '.join(map(str, self.shape))
-        return "<VolSourceEstimate  |  %s>" % s
 
     def get_peak(self, tmin=None, tmax=None, mode='abs',
                  vert_as_index=False, time_as_index=False):
@@ -1828,7 +1817,8 @@ class VolSourceEstimate(_BaseSourceEstimate):
         latency : float
             The latency in seconds.
         """
-        vert_idx, time_idx, _ = _get_peak(self.data, self.times, tmin, tmax,
+        stc = self.magnitude() if self._data_ndim == 3 else self
+        vert_idx, time_idx, _ = _get_peak(stc.data, self.times, tmin, tmax,
                                           mode)
 
         return (vert_idx if vert_as_index else self.vertices[vert_idx],
@@ -1836,7 +1826,139 @@ class VolSourceEstimate(_BaseSourceEstimate):
 
 
 @fill_doc
-class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
+class VolSourceEstimate(_BaseVolSourceEstimate):
+    """Container for volume source estimates.
+
+    Parameters
+    ----------
+    data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
+        The data in source space. The data can either be a single array or
+        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
+        "sens_data" shape (n_sensors, n_times). In this case, the source
+        space data corresponds to "numpy.dot(kernel, sens_data)".
+    vertices : array
+        Vertex numbers corresponding to the data.
+    tmin : scalar
+        Time point of the first sample in data.
+    tstep : scalar
+        Time step between successive samples in data.
+    subject : str | None
+        The subject name. While not necessary, it is safer to set the
+        subject parameter to avoid analysis errors.
+    %(verbose)s
+
+    Attributes
+    ----------
+    subject : str | None
+        The subject name.
+    times : array of shape (n_times,)
+        The time vector.
+    vertices : array of shape (n_dipoles,)
+        The indices of the dipoles in the source space.
+    data : array of shape (n_dipoles, n_times)
+        The data in source space.
+    shape : tuple
+        The shape of the data. A tuple of int (n_dipoles, n_times).
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
+
+    See Also
+    --------
+    SourceEstimate : A container for surface source estimates.
+    VolVectorSourceEstimate : A container for volume vector source estimates.
+    MixedSourceEstimate : A container for mixed surface + volume source
+                          estimates.
+    """
+    @verbose
+    def save(self, fname, ftype='stc', verbose=None):
+        """Save the source estimates to a file.
+
+        Parameters
+        ----------
+        fname : string
+            The stem of the file name. The stem is extended with "-vl.stc"
+            or "-vl.w".
+        ftype : string
+            File format to use. Allowed values are "stc" (default), "w",
+            and "h5". The "w" format only supports a single time point.
+        %(verbose_meth)s
+        """
+        if ftype not in ['stc', 'w', 'h5']:
+            raise ValueError('ftype must be "stc", "w" or "h5", not "%s"' %
+                             ftype)
+
+        if ftype == 'stc':
+            logger.info('Writing STC to disk...')
+            if not (fname.endswith('-vl.stc') or fname.endswith('-vol.stc')):
+                fname += '-vl.stc'
+            _write_stc(fname, tmin=self.tmin, tstep=self.tstep,
+                       vertices=self.vertices, data=self.data)
+        elif ftype == 'w':
+            logger.info('Writing STC to disk (w format)...')
+            if not (fname.endswith('-vl.w') or fname.endswith('-vol.w')):
+                fname += '-vl.w'
+            _write_w(fname, vertices=self.vertices, data=self.data)
+        elif ftype == 'h5':
+            super().save(fname, 'h5')
+
+        logger.info('[done]')
+
+
+@fill_doc
+class VolVectorSourceEstimate(_BaseVectorSourceEstimate,
+                              _BaseVolSourceEstimate):
+    """Container for volume source estimates.
+
+    Parameters
+    ----------
+    data : array of shape (n_dipoles, 3, n_times)
+        The data in source space. Each dipole contains three vectors that
+        denote the dipole strength in X, Y and Z directions over time.
+    vertices : array
+        Vertex numbers corresponding to the data.
+    tmin : scalar
+        Time point of the first sample in data.
+    tstep : scalar
+        Time step between successive samples in data.
+    subject : str | None
+        The subject name. While not necessary, it is safer to set the
+        subject parameter to avoid analysis errors.
+    %(verbose)s
+
+    Attributes
+    ----------
+    subject : str | None
+        The subject name.
+    times : array of shape (n_times,)
+        The time vector.
+    vertices : array of shape (n_dipoles,)
+        The indices of the dipoles in the source space.
+    data : array of shape (n_dipoles, n_times)
+        The data in source space.
+    shape : tuple
+        The shape of the data. A tuple of int (n_dipoles, n_times).
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
+
+    See Also
+    --------
+    SourceEstimate : A container for surface source estimates.
+    VectorSourceEstimate : A container for vector source estimates.
+    MixedSourceEstimate : A container for mixed surface + volume source
+                          estimates.
+    """
+
+    _data_ndim = 3
+    _scalar_class = VolSourceEstimate
+
+
+@fill_doc
+class VectorSourceEstimate(_BaseVectorSourceEstimate,
+                           _BaseSurfaceSourceEstimate):
     """Container for vector surface source estimates.
 
     For each vertex, the magnitude of the current is defined in the X, Y and Z
@@ -1880,71 +2002,7 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
     """
 
     _data_ndim = 3
-
-    @verbose
-    def __init__(self, data, vertices=None, tmin=None, tstep=None,
-                 subject=None, verbose=None):  # noqa: D102
-        super().__init__(data, vertices, tmin, tstep, subject, verbose)
-        if self._data is not None and self._data.shape[1] != 3:
-            raise ValueError('Data for VectorSourceEstimate must have second '
-                             'dimension of length 3, got length %s'
-                             % (self._data.shape[1],))
-
-    @verbose
-    def save(self, fname, ftype='h5', verbose=None):
-        """Save the full source estimate to an HDF5 file.
-
-        Parameters
-        ----------
-        fname : string
-            The file name to write the source estimate to, should end in
-            '-stc.h5'.
-        ftype : string
-            File format to use. Currently, the only allowed values is "h5".
-        %(verbose_meth)s
-        """
-        if ftype != 'h5':
-            raise ValueError('VectorSourceEstimate objects can only be '
-                             'written as HDF5 files.')
-
-        if not fname.endswith('.h5'):
-            fname += '-stc.h5'
-
-        write_hdf5(fname,
-                   dict(vertices=self.vertices, data=self.data, tmin=self.tmin,
-                        tstep=self.tstep, subject=self.subject),
-                   title='mnepython', overwrite=True)
-
-    def magnitude(self):
-        """Compute magnitude of activity without directionality.
-
-        Returns
-        -------
-        stc : instance of SourceEstimate
-            The source estimate without directionality information.
-        """
-        data_mag = np.linalg.norm(self.data, axis=1)
-        return SourceEstimate(data_mag, self.vertices, self.tmin, self.tstep,
-                              self.subject, self.verbose)
-
-    def normal(self, src):
-        """Compute activity orthogonal to the cortex.
-
-        Parameters
-        ----------
-        src : instance of SourceSpaces
-            The source space for which this source estimate is specified.
-
-        Returns
-        -------
-        stc : instance of SourceEstimate
-            The source estimate only retaining the activity orthogonal to the
-            cortex.
-        """
-        normals = np.vstack([s['nn'][v] for s, v in zip(src, self.vertices)])
-        data_norm = einsum('ijk,ij->ik', self.data, normals)
-        return SourceEstimate(data_norm, self.vertices, self.tmin, self.tstep,
-                              self.subject, self.verbose)
+    _scalar_class = SourceEstimate
 
     @copy_function_doc_to_method_doc(plot_vector_source_estimates)
     def plot(self, subject=None, hemi='lh', colormap='hot', time_label='auto',
@@ -1966,21 +2024,6 @@ class VectorSourceEstimate(_BaseSurfaceSourceEstimate):
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit
         )
-
-    def __abs__(self):
-        """Compute the absolute value of each component.
-
-        Returns
-        -------
-        stc_abs : VectorSourceEstimate
-            A vector source estimate where the data attribute is set to
-            abs(self.data).
-
-        See Also
-        --------
-        VectorSourceEstimate.magnitude
-        """
-        return super(VectorSourceEstimate, self).__abs__()
 
 
 @fill_doc
@@ -2027,7 +2070,11 @@ class MixedSourceEstimate(_BaseSourceEstimate):
     SourceEstimate : A container for surface source estimates.
     VectorSourceEstimate : A container for vector source estimates.
     VolSourceEstimate : A container for volume source estimates.
+    VolVectorSourceEstimate : A container for Volume vector source estimates.
     """
+
+    _data_ndim = 2
+    _src_type = 'mixed'
 
     @verbose
     def __init__(self, data, vertices=None, tmin=None, tstep=None,
@@ -2121,37 +2168,6 @@ class MixedSourceEstimate(_BaseSourceEstimate):
                                      config_opts=config_opts,
                                      subjects_dir=subjects_dir, figure=figure,
                                      views=views, colorbar=colorbar, clim=clim)
-
-    @verbose
-    def save(self, fname, ftype='h5', verbose=None):
-        """Save the source estimates to a file.
-
-        Parameters
-        ----------
-        fname : string
-            The stem of the file name. The file names used for surface source
-            spaces are obtained by adding "-lh.stc" and "-rh.stc" (or "-lh.w"
-            and "-rh.w") to the stem provided, for the left and the right
-            hemisphere, respectively.
-        ftype : string
-            File format to use. Allowed values are "stc" (default), "w",
-            and "h5". The "w" format only supports a single time point.
-        %(verbose_meth)s
-        """
-        if ftype != 'h5':
-            raise ValueError('MixedSourceEstimate objects can only be '
-                             'written as HDF5 files.')
-
-        if not fname.endswith('.h5'):
-            fname += '-stc.h5'
-
-        write_hdf5(fname,
-                   dict(vertices=self.vertices, data=self.data,
-                        tmin=self.tmin, tstep=self.tstep,
-                        subject=self.subject, src_type='mixed'),
-                   title='mnepython',
-                   overwrite=True)
-        logger.info('[done]')
 
 
 ###############################################################################

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1871,6 +1871,7 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
     MixedSourceEstimate : A container for mixed surface + volume source
                           estimates.
     """
+
     @verbose
     def save(self, fname, ftype='stc', verbose=None):
         """Save the source estimates to a file.
@@ -2011,7 +2012,7 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
              time_viewer=False, subjects_dir=None, figure=None, views='lat',
              colorbar=True, clim='auto', cortex='classic', size=800,
              background='black', foreground='white', initial_time=None,
-             time_unit='s'):
+             time_unit='s'):  # noqa: D102
 
         return plot_vector_source_estimates(
             self, subject=subject, hemi=hemi, colormap=colormap,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -408,11 +408,11 @@ def _make_stc(data, vertices, src_type=None, tmin=None, tstep=None,
     elif src_type in ('volume', 'discrete'):
         if vector:
             data = data.reshape((-1, 3, data.shape[-1]))
-            class_ = VolVectorSourceEstimate
+            klass = VolVectorSourceEstimate
         else:
-            class_ = VolSourceEstimate
-        stc = class_(data, vertices=vertices, tmin=tmin, tstep=tstep,
-                     subject=subject)
+            klass = VolSourceEstimate
+        stc = klass(data, vertices=vertices, tmin=tmin, tstep=tstep,
+                    subject=subject)
     elif src_type == 'mixed':
         # make a mixed source estimate
         if vector:

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -804,9 +804,9 @@ def test_mixed_stc():
     assert isinstance(stc_out, MixedSourceEstimate)
 
 
-@pytest.mark.parametrize('class_',
+@pytest.mark.parametrize('klass',
                          (VectorSourceEstimate, VolVectorSourceEstimate))
-def test_vec_stc(class_):
+def test_vec_stc(klass):
     """Test (vol)vector source estimate."""
     nn = np.array([
         [1, 0, 0],
@@ -821,13 +821,13 @@ def test_vec_stc(class_):
         [3, 0, 0],
         [1, 1, 1],
     ])[:, :, np.newaxis]
-    if class_ is VolVectorSourceEstimate:
+    if klass is VolVectorSourceEstimate:
         src = [dict(nn=nn)]
         verts = np.arange(4)
     else:
         src = [dict(nn=nn[:2]), dict(nn=nn[2:])]
         verts = [np.array([0, 1]), np.array([0, 1])]
-    stc = class_(data, verts, 0, 1, 'foo')
+    stc = klass(data, verts, 0, 1, 'foo')
 
     # Magnitude of the vectors
     assert_array_equal(stc.magnitude().data[:, 0], [1, 2, 3, np.sqrt(3)])
@@ -836,14 +836,14 @@ def test_vec_stc(class_):
     normal = stc.normal(src)
     assert_array_equal(normal.data[:, 0], [1, 2, 0, np.sqrt(3)])
 
-    stc = class_(data[:, :, 0], verts, 0, 1)  # upbroadcast
+    stc = klass(data[:, :, 0], verts, 0, 1)  # upbroadcast
     assert stc.data.shape == (len(data), 3, 1)
     # Bad data
     with pytest.raises(ValueError, match='of length 3'):
-        class_(data[:, :2], verts, 0, 1)
+        klass(data[:, :2], verts, 0, 1)
     data = data[:, :, np.newaxis]
     with pytest.raises(ValueError, match='3 dimensions for .*VectorSource'):
-        class_(data, verts, 0, 1)
+        klass(data, verts, 0, 1)
 
 
 @testing.requires_testing_data

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -16,7 +16,8 @@ import matplotlib.pyplot as plt
 from mne import (make_field_map, pick_channels_evoked, read_evokeds,
                  read_trans, read_dipole, SourceEstimate, VectorSourceEstimate,
                  VolSourceEstimate, make_sphere_model, use_coil_def,
-                 setup_volume_source_space, read_forward_solution)
+                 setup_volume_source_space, read_forward_solution,
+                 VolVectorSourceEstimate)
 from mne.io import read_raw_ctf, read_raw_bti, read_raw_kit, read_info
 from mne.io.meas_info import write_dig
 from mne.io.pick import pick_info
@@ -437,11 +438,14 @@ def test_plot_volume_source_estimates():
     data = np.random.RandomState(0).rand(n_verts, n_time)
     vol_stc = VolSourceEstimate(data, vertices, 1, 1)
 
-    for mode in ['glass_brain', 'stat_map']:
+    vol_vec_stc = VolVectorSourceEstimate(
+        np.tile(vol_stc.data[:, np.newaxis], (1, 3, 1)), vol_stc.vertices,
+        0, 1)
+    for mode, stc in zip(['glass_brain', 'stat_map'], (vol_stc, vol_vec_stc)):
         with pytest.warns(None):  # sometimes get scalars/index warning
-            fig = vol_stc.plot(sample_src, subject='sample',
-                               subjects_dir=subjects_dir,
-                               mode=mode)
+            fig = stc.plot(sample_src, subject='sample',
+                           subjects_dir=subjects_dir,
+                           mode=mode)
         # [ax_time, ax_y, ax_x, ax_z]
         for ax_idx in [0, 2, 3, 4]:
             _fake_click(fig, fig.axes[ax_idx], (0.3, 0.5))


### PR DESCRIPTION
I've run into tricky problems accidentally passing vector data `(n, 3, t)` to SourceEstimate. This implements `data` size checks for our classes.