### PR TITLE
[ENH] ensure simulate_sparse_stc throws error when n_dipoles > len(labels)

### DIFF
--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -176,7 +176,7 @@ def simulate_sparse_stc(src, n_dipoles, times,
               for n, s in zip(n_dipoles_ss, src)]
         datas = data
     elif n_dipoles > len(labels):
-        raise ValueError('Number of labels (%d) smaller than n_dipoles (%d)'
+        raise ValueError('Number of labels (%d) smaller than n_dipoles (%d) '
                          'is not allowed.' % (len(labels), n_dipoles))
     else:
         if n_dipoles != len(labels):

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -176,9 +176,8 @@ def simulate_sparse_stc(src, n_dipoles, times,
               for n, s in zip(n_dipoles_ss, src)]
         datas = data
     elif n_dipoles > len(labels):
-        raise ValueError('labels != None and n_dipoles = %i is larger than'
-            'len(labels) = %i. This is not allowed, make sure than n_dipoles'
-            '<= len(labels)' % (n_dipoles, len(labels)))        
+        raise ValueError('Number of labels (%d) smaller than n_dipoles (%d)'
+                         'is not allowed.' % (len(labels), n_dipoles))        
     else:
         if n_dipoles != len(labels):
             warn('The number of labels is different from the number of '

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -175,6 +175,10 @@ def simulate_sparse_stc(src, n_dipoles, times,
         vs = [s['vertno'][np.sort(rng.permutation(np.arange(s['nuse']))[:n])]
               for n, s in zip(n_dipoles_ss, src)]
         datas = data
+    elif n_dipoles > len(labels):
+        raise ValueError('labels != None and n_dipoles = %i is larger than'
+            'len(labels) = %i. This is not allowed, make sure than n_dipoles'
+            '<= len(labels)' % (n_dipoles, len(labels)))        
     else:
         if n_dipoles != len(labels):
             warn('The number of labels is different from the number of '

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -177,7 +177,7 @@ def simulate_sparse_stc(src, n_dipoles, times,
         datas = data
     elif n_dipoles > len(labels):
         raise ValueError('Number of labels (%d) smaller than n_dipoles (%d)'
-                         'is not allowed.' % (len(labels), n_dipoles))        
+                         'is not allowed.' % (len(labels), n_dipoles))
     else:
         if n_dipoles != len(labels):
             warn('The number of labels is different from the number of '

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -149,7 +149,11 @@ def test_simulate_sparse_stc():
     pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels) + 1,
                   times, labels=labels, random_state=random_state,
                   location=location, subjects_dir=subjects_dir)
-
+    err_str = 'Number of labels'
+    with pytest.raises(ValueError, match=err_str):
+        simulate_sparse_stc(fwd['src'], len(labels) + 1, times, labels=labels,
+            random_state=random_state, location=location,
+            subjects_dir=subjects_dir)
 
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -146,6 +146,9 @@ def test_simulate_sparse_stc():
                   subjects_dir=subjects_dir)  # no subject
     pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='foo')  # bad location
+    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels) + 1,
+                  times, labels=labels, random_state=random_state,
+                  location=location, subjects_dir=subjects_dir)
 
 
 @testing.requires_testing_data

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -146,9 +146,6 @@ def test_simulate_sparse_stc():
                   subjects_dir=subjects_dir)  # no subject
     pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='foo')  # bad location
-    pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels) + 1,
-                  times, labels=labels, random_state=random_state,
-                  location=location, subjects_dir=subjects_dir)
     err_str = 'Number of labels'
     with pytest.raises(ValueError, match=err_str):
         simulate_sparse_stc(fwd['src'], len(labels) + 1, times, labels=labels,

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -148,9 +148,11 @@ def test_simulate_sparse_stc():
                   times, labels=labels, location='foo')  # bad location
     err_str = 'Number of labels'
     with pytest.raises(ValueError, match=err_str):
-        simulate_sparse_stc(fwd['src'], len(labels) + 1, times, labels=labels,
+        simulate_sparse_stc(
+            fwd['src'], len(labels) + 1, times, labels=labels,
             random_state=random_state, location=location,
             subjects_dir=subjects_dir)
+
 
 @testing.requires_testing_data
 def test_generate_stc_single_hemi():


### PR DESCRIPTION
 ```simulate_sparse_stc ```  throws an assertion error when   ```n_dipoles > len(labels) ```.
It should generate   ```min(n_dipoles, len(labels))  ``` dipoles.

Fixes #5953
