### PR TITLE
[pick.py] changed checking for int to include int64

### DIFF
--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -832,6 +832,7 @@ def _picks_to_idx(info, picks, none='data', exclude='bads', allow_empty=False,
     if picks.dtype.kind not in ['i', 'u']:
         raise TypeError('picks must be a list of int or list of str, got '
                         'a data type of %s' % (picks.dtype,))
+    picks = picks.astype(int)
 
     #
     # ensure we have (optionally non-empty) ndarray of valid int

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -829,7 +829,7 @@ def _picks_to_idx(info, picks, none='data', exclude='bads', allow_empty=False,
         raise ValueError('picks must be 1D, got %sD' % (picks.ndim,))
     if picks.dtype.char in ('S', 'U'):
         picks = _picks_str_to_idx(info, picks, exclude, with_ref_meg)
-    if picks.dtype.kind != 'i':
+    if picks.dtype.kind not in ['i', 'u']:
         raise TypeError('picks must be a list of int or list of str, got '
                         'a data type of %s' % (picks.dtype,))
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -829,7 +829,7 @@ def _picks_to_idx(info, picks, none='data', exclude='bads', allow_empty=False,
         raise ValueError('picks must be 1D, got %sD' % (picks.ndim,))
     if picks.dtype.char in ('S', 'U'):
         picks = _picks_str_to_idx(info, picks, exclude, with_ref_meg)
-    if picks.dtype != np.int:
+    if picks.dtype.kind != 'i':
         raise TypeError('picks must be a list of int or list of str, got '
                         'a data type of %s' % (picks.dtype,))
 


### PR DESCRIPTION
#### Reference issue
Fixes #5977 

#### What does this implement/fix?
Many numpy functions return `int64`.
The picks-routine should accept all kind of ints

instead of
```Python
array.dtype!=np.int
```
I implemented
```Python
array.dtype.kind not in ['i', 'u']
```
which checks for any kind of integer
