### PR TITLE
MRG: Simplify LCMV whitening

### DIFF
--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -3,9 +3,8 @@
 Compute LCMV beamformer on evoked data
 ======================================
 
-Compute LCMV beamformer solutions on an evoked dataset for three different
-choices of source orientation and store the solutions in stc files for
-visualisation.
+Compute LCMV beamformer on an evoked dataset for three different choices of
+source orientation and store the solutions in stc files for visualization.
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -3,8 +3,7 @@
 Compute LCMV inverse solution in volume source space
 ====================================================
 
-Compute LCMV inverse solution on an auditory evoked dataset in a volume source
-space.
+Compute LCMV beamformer on an auditory evoked dataset in a volume source space.
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #
@@ -46,7 +45,7 @@ proj = False  # already applied
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                     baseline=(None, 0), preload=True, proj=proj,
                     reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
-evoked = epochs.average().pick_types(meg='grad')
+evoked = epochs.average()
 
 # Visualize sensor space data
 evoked.plot_joint(ts_args=dict(time_unit='s'),
@@ -70,8 +69,8 @@ data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
 # which computes a vector beamfomer. Note, however, that not all combinations
 # of orientation selection and weight normalization are implemented yet.
 filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
-                    noise_cov=None, pick_ori='max-power',
-                    weight_norm='unit-noise-gain', rank=None)
+                    noise_cov=noise_cov, pick_ori='max-power',
+                    weight_norm='nai', rank=None)
 print(filters)
 
 # You can save these with:

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -46,7 +46,7 @@ proj = False  # already applied
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                     baseline=(None, 0), preload=True, proj=proj,
                     reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
-evoked = epochs.average()
+evoked = epochs.average().pick_types(meg='grad')
 
 # Visualize sensor space data
 evoked.plot_joint(ts_args=dict(time_unit='s'),
@@ -70,8 +70,8 @@ data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
 # which computes a vector beamfomer. Note, however, that not all combinations
 # of orientation selection and weight normalization are implemented yet.
 filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
-                    noise_cov=noise_cov, pick_ori='max-power',
-                    weight_norm='nai', rank=None)
+                    noise_cov=None, pick_ori='max-power',
+                    weight_norm='unit-noise-gain', rank=None)
 print(filters)
 
 # You can save these with:

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -17,8 +17,7 @@ from ..source_estimate import _make_stc, SourceEstimate, _get_src_type
 from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
                      _check_info_inv, _check_channels_spatial_filter,
                      _check_option)
-from ..utils import _check_one_ch_type
-from ..utils import _check_rank
+from ..utils import _check_one_ch_type, _check_rank
 from .. import Epochs
 from ._compute_beamformer import (
     _check_proj_match, _prepare_beamformer_input,
@@ -122,53 +121,39 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     picks = _check_info_inv(info, forward, data_cov, noise_cov)
+    # check number of sensor types present in the data and ensure a noise cov
+    noise_cov = _check_one_ch_type(info, picks, noise_cov, 'lcmv').copy()
+    if 'estimator' in noise_cov:
+        del noise_cov['estimator']
 
     data_rank = compute_rank(data_cov, rank=rank, info=info)
-    if noise_cov is not None:
-        noise_rank = compute_rank(noise_cov, rank=rank, info=info)
-        for key in data_rank:
-            if key not in noise_rank or data_rank[key] != noise_rank[key]:
-                raise ValueError('%s data rank (%s) did not match the noise '
-                                 'rank (%s)'
-                                 % (key, data_rank[key],
-                                    noise_rank.get(key, None)))
-        del noise_rank
+    noise_rank = compute_rank(noise_cov, rank=rank, info=info)
+    for key in data_rank:
+        if key not in noise_rank or data_rank[key] != noise_rank[key]:
+            raise ValueError('%s data rank (%s) did not match the noise '
+                             'rank (%s)'
+                             % (key, data_rank[key],
+                                noise_rank.get(key, None)))
+    del noise_rank
     rank = data_rank
     logger.info('Making LCMV beamformer with rank %s' % (rank,))
     del data_rank
     _check_option('weight_norm', weight_norm, ['unit-noise-gain', 'nai', None])
 
     is_free_ori, ch_names, proj, vertno, G, nn = \
-        _prepare_beamformer_input(info, forward, label, picks, pick_ori)
+        _prepare_beamformer_input(info, forward, label, picks, pick_ori,
+                                  apply_proj=False)
 
     data_cov = pick_channels_cov(data_cov, include=ch_names)
     Cm = data_cov['data']
     if 'estimator' in data_cov:
         del data_cov['estimator']
 
-    # check number of sensor types present in the data
-    _check_one_ch_type(info, picks, noise_cov, 'lcmv')
-
-    # apply SSPs
-    is_ssp = False
-    if info['projs']:
-        Cm = np.dot(proj, np.dot(Cm, proj.T))
-        is_ssp = True
-
-    if noise_cov is not None:
-        # Handle whitening + data covariance
-        whitener, _ = compute_whitener(noise_cov, info, picks, rank=rank)
-        # whiten the leadfield
-        G = np.dot(whitener, G)
-        # whiten data covariance
-        Cm = np.dot(whitener, np.dot(Cm, whitener.T))
-        noise_cov = noise_cov.copy()
-        if 'estimator' in noise_cov:
-            del noise_cov['estimator']
-        rank_int = sum(rank.values())
-    else:
-        whitener = None
-        rank_int = G.shape[0]
+    # Handle whitening + data covariance
+    whitener, _ = compute_whitener(noise_cov, info, picks, rank=rank)
+    G = np.dot(whitener, G)
+    Cm = np.dot(whitener, np.dot(Cm, whitener.T))
+    rank_int = sum(rank.values())
     del rank
 
     # leadfield rank and optional rank reduction
@@ -194,6 +179,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
 
     # Is the computed beamformer a scalar or vector beamformer?
     is_free_ori = is_free_ori if pick_ori in [None, 'vector'] else False
+    is_ssp = bool(info['projs'])
 
     filters = Beamformer(
         kind='LCMV', weights=W, data_cov=data_cov, noise_cov=noise_cov,
@@ -430,21 +416,13 @@ def _lcmv_source_power(info, forward, noise_cov, data_cov, reg=0.05,
 
     # XXX this could maybe use pca=True to avoid needing to use
     # _reg_pinv(..., rank=rank) later
-    if noise_cov is not None:
-        whitener_rank = None if rank == 'full' else rank
-        whitener, _ = compute_whitener(noise_cov, info, rank=whitener_rank)
+    whitener_rank = None if rank == 'full' else rank
+    whitener, _ = compute_whitener(noise_cov, info, rank=whitener_rank)
+    G = np.dot(whitener, G)
 
-        # whiten the leadfield
-        G = np.dot(whitener, G)
-
-    # Apply SSPs + whitener to data covariance
+    # Apply whitener to data covariance
     data_cov = pick_channels_cov(data_cov, include=ch_names)
-    Cm = data_cov['data']
-    if info['projs']:
-        Cm = np.dot(proj, np.dot(Cm, proj.T))
-
-    if noise_cov is not None:
-        Cm = np.dot(whitener, np.dot(Cm, whitener.T))
+    Cm = np.dot(whitener, np.dot(data_cov['data'], whitener.T))
 
     # Tikhonov regularization using reg parameter to control for
     # trade-off between spatial resolution and noise sensitivity
@@ -610,7 +588,10 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
     ch_names = [epochs.ch_names[k] for k in picks]
 
     # check number of sensor types present in the data
-    _check_one_ch_type(epochs.info, picks, noise_covs, 'lcmv')
+    if noise_covs is None:
+        noise_covs = [None] * len(win_lengths)
+    noise_covs = [_check_one_ch_type(epochs.info, picks, noise_cov, 'lcmv')
+                  for noise_cov in noise_covs]
 
     # Use picks from epochs for picking channels in the raw object
     raw_picks = [raw.ch_names.index(c) for c in ch_names]
@@ -620,10 +601,6 @@ def tf_lcmv(epochs, forward, noise_covs, tmin, tmax, tstep, win_lengths,
 
     # Multiplying by 1e3 to avoid numerical issues, e.g. 0.3 // 0.05 == 5
     n_time_steps = int(((tmax - tmin) * 1e3) // (tstep * 1e3))
-
-    # create a list to iterate over if no noise covariances are given
-    if noise_covs is None:
-        noise_covs = [None] * len(win_lengths)
 
     sol_final = []
     for (l_freq, h_freq), win_length, noise_cov in \

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -731,7 +731,7 @@ def test_lcmv_reg_proj(proj, weight_norm):
         np.linalg.norm(stc_cov.data, axis=0), rtol=0.3)
 
     if weight_norm == 'nai':
-        # NAI always represents something normalized
+        # NAI is always normalized by noise-level (based on eigenvalues)
         for stc in (stc_nocov, stc_cov):
             assert_allclose(stc.data.std(), 0.39, rtol=0.1)
     elif weight_norm is None:
@@ -741,7 +741,7 @@ def test_lcmv_reg_proj(proj, weight_norm):
             assert_allclose(stc.data.std(), 1.4e-8, rtol=0.1)
     else:
         assert weight_norm == 'unit-noise-gain'
-        # unit-noise-gain normalization depends on `noise_cov`
+        # Channel scalings depend on presence of noise_cov
         assert_allclose(stc_nocov.data.std(), 5.3e-13, rtol=0.1)
         assert_allclose(stc_cov.data.std(), 0.12, rtol=0.1)
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -392,18 +392,25 @@ def _check_rank(rank):
 
 def _check_one_ch_type(info, picks, noise_cov, method):
     """Check number of sensor types and presence of noise covariance matrix."""
+    from ..cov import make_ad_hoc_cov, Covariance
     from ..io.pick import pick_info
     from ..channels.channels import _contains_ch_type
     info_pick = pick_info(info, sel=picks)
     ch_types =\
         [_contains_ch_type(info_pick, tt) for tt in ('mag', 'grad', 'eeg')]
-    if method == 'lcmv' and sum(ch_types) > 1 and noise_cov is None:
-        raise ValueError('Source reconstruction with several sensor types '
-                         'requires a noise covariance matrix to be '
-                         'able to apply whitening.')
-    elif method == 'dics' and sum(ch_types) > 1:
-        warn('The use of several sensor types with the DICS beamformer is '
-             'not heavily tested yet.')
+    if sum(ch_types) > 1:
+        if method == 'lcmv' and noise_cov is None:
+            raise ValueError('Source reconstruction with several sensor types'
+                             ' requires a noise covariance matrix to be '
+                             'able to apply whitening.')
+        if method == 'dics':
+            raise RuntimeError(
+                'The use of several sensor types with the DICS beamformer is '
+                'not supported yet.')
+    if noise_cov is None:
+        noise_cov = make_ad_hoc_cov(info)
+    _validate_type(noise_cov, Covariance, 'noise_cov')
+    return noise_cov
 
 
 def _check_depth(depth, kind='depth_mne'):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -408,7 +408,7 @@ def _check_one_ch_type(info, picks, noise_cov, method):
                 'The use of several sensor types with the DICS beamformer is '
                 'not supported yet.')
     if noise_cov is None:
-        noise_cov = make_ad_hoc_cov(info)
+        noise_cov = make_ad_hoc_cov(info, std=1.)
     _validate_type(noise_cov, Covariance, 'noise_cov')
     return noise_cov
 


### PR DESCRIPTION
Follow-up to #5947. This first step modifies LCMV to make it easier to eventually use `_prepare_forward`, specifically by:

- [x] Always using a `noise_cov`. This simplifies later calculations and branching (see more - lines than + here). In the case of a single channel type, we can just use `make_ad_hoc_cov`, which makes a diagonal matrix. This makes it so we don't need to do anything extra with `projs` manually, `compute_whitener` does it for us. In principle `make_ad_hoc_cov` could also be a solution for the multiple-ch-types-no-cov problem, but we can stick with the error and let users use `make_ad_hoc_cov` themselves in that case.
- [x] Applying the same projectors / whitener to `G` and `Cm`, as noted [here](https://github.com/mne-tools/mne-python/issues/5881#issuecomment-466055623).
- [x] Applying the projectors/whitener after lead-field normalization. This is how it's done in the minimum norm code (though not mixed-norm), and at least does not seem to break things.
- [x] Leave for later: adding check for subspace equivalence rather than just rank match (see below).

Let's see if tests still pass. They do locally.

One potential problem I foresee is that `make_ad_hoc_cov` should be fine with projections, but will create problems with data that has been rank-reduced with SSS when `noise_cov=None` is used. However, this should be exceedingly rare since most SSS'ed data is Neuromag, which has two sensor types. To cover this, we'd need some way to project our `make_ad_hoc_cov` into the same data subspace as `data_cov`, which actually would be pretty straightforward given `_smart_eigh` gives us that projection already and it's used in the `cov` code. We can wait to deal with this until we hit a use case. But I'm assuming YAGNI for now.

At some point it might be useful regardless not just to check that `data_cov` and `noise_cov` match rank, but that they actually occupy *the same vector subspace* (have the same null space). Matching effective rank is a necessary but not sufficient condition for this. But in most cases (projection, even SSS when using baseline cov) it should be okay. The one place I see this being useful is if someone uses SSS and takes a noise cov from the empty room instead of the baseline -- these could have the same effective rank but occupy different subspaces (unless the empty room was processed identically to the data, which is probably not what most people do, properly at least). But in this case, you'll just amplify some near-zero components a bit (so should stay near zero) and drop a few components you otherwise shouldn't from the `data_cov`, so this is perhaps not a deal-breaker either.

cc @britta-wstnr to see if this makes some sense.

Closes #5882.