### PR TITLE
Fix docstr db in tfr.plot_joint

### DIFF
--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1103,7 +1103,7 @@ class AverageTFR(_BaseTFR):
                 amount of images.
 
         dB : bool
-            If True, 20*log10 is applied to the data to get dB.
+            If True, 10*log10 is applied to the data to get dB.
         colorbar : bool
             If true, colorbar will be added to the plot. For user defined axes,
             the colorbar cannot be drawn. Defaults to True.
@@ -1694,7 +1694,7 @@ class AverageTFR(_BaseTFR):
         title : str
             Title of the figure.
         dB : bool
-            If True, 20*log10 is applied to the data to get dB.
+            If True, 10*log10 is applied to the data to get dB.
         colorbar : bool
             If true, colorbar will be added to the plot
         layout_scale : float

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1317,7 +1317,7 @@ class AverageTFR(_BaseTFR):
         cmap : matplotlib colormap
             The colormap to use.
         dB : bool
-            If True, 20*log10 is applied to the data to get dB.
+            If True, 10*log10 is applied to the data to get dB.
         colorbar : bool
             If true, colorbar will be added to the plot (relating to the
             topomaps). For user defined axes, the colorbar cannot be drawn.


### PR DESCRIPTION
When ```db=True```, tfr.plot_joint multiplies by 10. The info for the funtion states, however, that it multiplies by 20.
Or did I misunderstand something?..