### PR TITLE
MRG: Unify _prepare_gain

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,8 +27,8 @@ fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
 # turn anything that uses testing data into an auto-skipper by
 # setting params=[testing_param]
-testing_param = pytest.mark.skipif(testing._testing._skip_testing_data(),
-                                   reason='Requires testing dataset')('x')
+testing_param = pytest.param('t', marks=pytest.mark.skipif(
+    testing._testing._skip_testing_data(), reason='Requires testing dataset'))
 
 
 @pytest.fixture(scope='session')

--- a/conftest.py
+++ b/conftest.py
@@ -3,8 +3,9 @@
 #
 # License: BSD (3-clause)
 
-import pytest
+import os.path as op
 import warnings
+import pytest
 # For some unknown reason, on Travis-xenial there are segfaults caused on
 # the line pytest -> pdb.Pdb.__init__ -> "import readline". Forcing an
 # import here seems to prevent them (!?). This suggests a potential problem
@@ -14,6 +15,20 @@ import warnings
 # seemed to corrupt SciPy linalg function results (!), likely due to the
 # associated VTK import, so this could be another manifestation of that.
 import readline  # noqa
+
+import numpy as np
+import mne
+from mne.datasets import testing
+
+test_path = testing.data_path(download=False)
+s_path = op.join(test_path, 'MEG', 'sample')
+fname_data = op.join(s_path, 'sample_audvis_trunc-ave.fif')
+fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
+fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+# turn anything that uses testing data into an auto-skipper by
+# setting params=[testing_param]
+testing_param = pytest.mark.skipif(testing._testing._skip_testing_data(),
+                                   reason='Requires testing dataset')('x')
 
 
 @pytest.fixture(scope='session')
@@ -41,3 +56,32 @@ def matplotlib_config():
         pass
     else:
         mlab.options.backend = 'test'
+
+
+@pytest.fixture(scope='function', params=[testing_param])
+def evoked():
+    """Get evoked data."""
+    evoked = mne.read_evokeds(fname_data, condition='Left Auditory',
+                              baseline=(None, 0))
+    evoked.crop(0, 0.2)
+    return evoked
+
+
+@pytest.fixture(scope='function', params=[testing_param])
+def noise_cov():
+    return mne.read_cov(fname_cov)
+
+
+@pytest.fixture(scope='function')
+def bias_params(evoked, noise_cov):
+    """Provide inputs for bias functions."""
+    # Identity input
+    evoked.pick_types(meg=True, eeg=True, exclude=())
+    evoked = mne.EvokedArray(np.eye(len(evoked.data)), evoked.info)
+    # restrict to limited set of verts (small src here) and one hemi for speed
+    fwd_orig = mne.read_forward_solution(fname_fwd)
+    vertices = [fwd_orig['src'][0]['vertno'].copy(), []]
+    stc = mne.SourceEstimate(np.zeros((sum(len(v) for v in vertices), 1)),
+                             vertices, 0., 1.)
+    fwd_orig = mne.forward.restrict_forward_to_stc(fwd_orig, stc)
+    return evoked, fwd_orig, noise_cov

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,7 @@ from mne.datasets import testing
 
 test_path = testing.data_path(download=False)
 s_path = op.join(test_path, 'MEG', 'sample')
-fname_data = op.join(s_path, 'sample_audvis_trunc-ave.fif')
+fname_evoked = op.join(s_path, 'sample_audvis_trunc-ave.fif')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
 # turn anything that uses testing data into an auto-skipper by
@@ -61,7 +61,7 @@ def matplotlib_config():
 @pytest.fixture(scope='function', params=[testing_param])
 def evoked():
     """Get evoked data."""
-    evoked = mne.read_evokeds(fname_data, condition='Left Auditory',
+    evoked = mne.read_evokeds(fname_evoked, condition='Left Auditory',
                               baseline=(None, 0))
     evoked.crop(0, 0.2)
     return evoked

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -464,6 +464,7 @@ numpydoc_xref_aliases = {
     'DigMontage': '~mne.channels.DigMontage',
     'VectorSourceEstimate': '~mne.VectorSourceEstimate',
     'VolSourceEstimate': '~mne.VolSourceEstimate',
+    'VolVectorSourceEstimate': '~mne.VolVectorSourceEstimate',
     'MixedSourceEstimate': '~mne.MixedSourceEstimate',
     'SourceEstimate': '~mne.SourceEstimate', 'Projection': '~mne.Projection',
     'ConductorModel': '~mne.bem.ConductorModel',

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,7 +87,7 @@ Bug
 
 - Fix checking of ``data`` dimensionality in :class:`mne.SourceEstimate` and related constructors by `Eric Larson`_
 
-- Fix depth weighting for sparse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mxne_inverse`) to use the same depth weighting as minimum norm solvers, by `Eric Larson`_
+- Fix depth weighting for sparse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mixed_norm`) to use the same depth weighting as minimum norm solvers, by `Eric Larson`_
 
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,8 @@ Changelog
 
 - Allow string argument in :meth:`mne.io.Raw.drop_channels` to remove a single channel by `Clemens Brunner`_
 
+- Add additional depth weighting options for inverse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mixed_norm`) by `Eric Larson`_
+
 Bug
 ~~~
 
@@ -86,8 +88,6 @@ Bug
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
 - Fix checking of ``data`` dimensionality in :class:`mne.SourceEstimate` and related constructors by `Eric Larson`_
-
-- Fix depth weighting for sparse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mixed_norm`) to use the same depth weighting as minimum norm solvers, by `Eric Larson`_
 
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -130,6 +130,8 @@ API
 
 - Deprecate :func:`mne.io.find_edf_events` by `Joan Massich`_
 
+- Deprecate ``limit_depth_chs`` in :func:`mne.minimum_norm.make_inverse_operator` in favor of ``depth=dict(limit_depth_chs=...)`` by `Eric Larson`_
+
 - Reading BDF and GDF files with :func:`mne.io.read_raw_edf` is deprecated and replaced by :func:`mne.io.read_raw_bdf` and :func:`mne.io.read_raw_gdf`, by `Clemens Brunner`_
 
 - Deprecate ``method='extended-infomax'`` in :class:`mne.preprocessing.ICA`; Extended Infomax can now be computed with ``method='infomax'`` and ``fit_params=dict(extended=True)`` by `Clemens Brunner`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,8 @@ Bug
 
 - Fix checking of ``data`` dimensionality in :class:`mne.SourceEstimate` and related constructors by `Eric Larson`_
 
+- Fix depth weighting for sparse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mxne_inverse`) to use the same depth weighting as minimum norm solvers, by `Eric Larson`_
+
 - Fix :meth:`mne.io.Raw.append` annotations miss-alignment  by `Joan Massich`_
 
 - Fix hash bug in the ``mne.io.edf`` module when installing on Windows by `Eric Larson`_

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -692,7 +692,8 @@ def test_lcmv_reg_proj(proj):
 
 @pytest.mark.parametrize('reg, weight_norm, use_cov, lower, upper', [
     (0.05, 'unit-noise-gain', True, 96, 98),
-    (0.00, 'unit-noise-gain', True, 66, 69),
+    # the 0 reg is not so stable, can produce a wide range of scores
+    (0.00, 'unit-noise-gain', True, 44, 90),
     (0.05, 'nai', True, 96, 98),
     (0.05, None, True, 96, 98),
     (0.05, 'unit-noise-gain', False, 83, 86),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -690,4 +690,57 @@ def test_lcmv_reg_proj(proj):
     assert filters['rank'] == want_rank
 
 
+@pytest.mark.parametrize('reg, weight_norm, lower, upper', [
+    (0.05, 'unit-noise-gain', 100, 100),
+    (0., 'unit-noise-gain', 45, 55),
+    (0.05, 'nai', 100, 100),
+    (0.05, None, 100, 100),
+    ])
+def test_localization_bias_fixed(bias_params, reg, weight_norm, lower, upper):
+    """Test inverse localization bias for loose minimum-norm solvers."""
+    evoked, fwd, noise_cov = bias_params
+    data_cov = noise_cov.copy()
+    data_cov['data'] = np.dot(evoked.data, evoked.data.T)
+    fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
+    inv_op = apply_lcmv(evoked, make_lcmv(evoked.info, fwd, data_cov, reg,
+                                          noise_cov)).data
+    fwd = fwd['sol']['data']
+    want = np.arange(fwd.shape[1])
+    loc = np.abs(np.dot(inv_op, fwd))
+    # Compute the percentage of sources for which there is no localization
+    # bias:
+    perc = (want == np.argmax(loc, axis=0)).mean() * 100
+    assert lower <= perc <= upper
+
+
+@pytest.mark.parametrize('reg, pick_ori, weight_norm, lower, upper', [
+    (0.05, 'vector', 'unit-noise-gain', 30, 35),
+    (0.05, 'vector', 'nai', 30, 35),
+    (0.05, 'vector', None, 1, 3),
+    (0.00, 'vector', 'unit-noise-gain', 5, 10),
+    (0.05, 'max-power', 'unit-noise-gain', 30, 35),
+    (0.05, 'max-power', 'nai', 30, 35),
+    (0.05, 'max-power', None, 1, 3),
+    # (0., 'max-power', 5, 10),  # complex eigenspectrum error
+    ])
+def test_localization_bias_free(bias_params, reg, pick_ori, weight_norm,
+                                lower, upper):
+    evoked, fwd, noise_cov = bias_params
+    data_cov = noise_cov.copy()
+    data_cov['data'] = np.dot(evoked.data, evoked.data.T)
+    inv_op = apply_lcmv(evoked, make_lcmv(evoked.info, fwd, data_cov, reg,
+                                          noise_cov, pick_ori=pick_ori,
+                                          weight_norm=weight_norm)).data
+    fwd = fwd['sol']['data']
+    want = np.arange(fwd.shape[1]) // 3
+    if pick_ori == 'vector':
+        loc = np.linalg.norm(np.einsum('vos,sx->vxo', inv_op, fwd), axis=-1)
+    else:
+        loc = np.abs(np.dot(inv_op, fwd))
+    # Compute the percentage of sources for which there is no localization
+    # bias:
+    perc = (want == np.argmax(loc, axis=0)).mean() * 100
+    assert lower <= perc <= upper
+
+
 run_tests_if_main()

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -709,8 +709,7 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
     loc = apply_lcmv(evoked, make_lcmv(evoked.info, fwd, data_cov, reg,
                                        noise_cov)).data
     loc = np.abs(loc)
-    # Compute the percentage of sources for which there is no localization
-    # bias:
+    # Compute the percentage of sources for which there is no loc bias:
     perc = (want == np.argmax(loc, axis=0)).mean() * 100
     assert lower <= perc <= upper
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -699,7 +699,7 @@ def test_lcmv_reg_proj(proj):
 ])
 def test_localization_bias_fixed(bias_params, reg, weight_norm, use_cov,
                                  lower, upper):
-    """Test inverse localization bias for loose minimum-norm solvers."""
+    """Test localization bias for fixed-orientation LCMV."""
     evoked, fwd, noise_cov = bias_params
     data_cov = noise_cov.copy()
     data_cov['data'] = np.dot(evoked.data, evoked.data.T)
@@ -732,6 +732,7 @@ def test_localization_bias_fixed(bias_params, reg, weight_norm, use_cov,
 ])
 def test_localization_bias_free(bias_params, reg, pick_ori, weight_norm,
                                 use_cov, lower, upper):
+    """Test localization bias for free-orientation LCMV."""
     evoked, fwd, noise_cov = bias_params
     data_cov = noise_cov.copy()
     data_cov['data'] = np.dot(evoked.data, evoked.data.T)

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -63,9 +63,9 @@ DEFAULTS = dict(
     noise_std=dict(grad=5e-13, mag=20e-15, eeg=0.2e-6),
     eloreta_options=dict(eps=1e-6, max_iter=20, force_equal=None),
     depth_mne=dict(exp=0.8, limit=10., limit_depth_chs=True,
-                   loose_method='svd', allow_fixed_depth=False),
-    depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs=False,
-                      loose_method='sum', allow_fixed_depth=True),
+                   combine_xyz='spectral', allow_fixed_depth=False),
+    depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs='whiten',
+                      combine_xyz='L2', allow_fixed_depth=True),
 )
 
 

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -65,7 +65,7 @@ DEFAULTS = dict(
     depth_mne=dict(exp=0.8, limit=10., limit_depth_chs=True,
                    combine_xyz='spectral', allow_fixed_depth=False),
     depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs='whiten',
-                      combine_xyz='L2', allow_fixed_depth=True),
+                      combine_xyz='fro', allow_fixed_depth=True),
 )
 
 

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -62,6 +62,10 @@ DEFAULTS = dict(
     ),
     noise_std=dict(grad=5e-13, mag=20e-15, eeg=0.2e-6),
     eloreta_options=dict(eps=1e-6, max_iter=20, force_equal=None),
+    depth_mne=dict(exp=0.8, limit=10., limit_depth_chs=True,
+                   loose_method='svd', allow_fixed_depth=False),
+    depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs=False,
+                      loose_method='sum', allow_fixed_depth=True),
 )
 
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1108,11 +1108,11 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
             depend on both sensor geometry and the data of interest captured
             by the noise covariance (e.g., projections, SNR).
 
-    combine_xyz : 'spectral' | 'L2'
+    combine_xyz : 'spectral' | 'fro'
         When a loose (or free) orientation is used, how the depth weighting
         for each triplet should be calculated.
         If 'spectral', use the squared spectral norm of Gk.
-        If 'L2', use the squared L2 norm of Gk.
+        If 'fro', use the squared Frobenius norm of Gk.
 
         .. versionadded:: 0.18
     noise_cov : instance of Covariance | None
@@ -1145,7 +1145,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
     In sparse solvers, the values are::
 
         compute_depth_prior(..., limit=None, limit_depth_chs='whiten',
-                            combine_xyz='L2')
+                            combine_xyz='fro')
 
     """
     # XXX this perhaps should just take ``forward`` instead of ``G`` and
@@ -1174,7 +1174,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         G = np.dot(whitener, G)
 
     # Compute the gain matrix
-    if is_fixed_ori or combine_xyz == 'L2':
+    if is_fixed_ori or combine_xyz == 'fro':
         d = np.sum(G ** 2, axis=0)
         if not is_fixed_ori:
             d = d.reshape(-1, 3).sum(axis=1)
@@ -1182,7 +1182,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         d[d == 0.] = np.min(d[d != 0.])
     else:
         if combine_xyz != 'spectral':
-            raise ValueError('combine_xyz must be "L2" or "spectral", '
+            raise ValueError('combine_xyz must be "fro" or "spectral", '
                              'got %s' % (combine_xyz,))
         # n_pos = G.shape[1] // 3
         # The following is equivalent to this, but 4-10x faster

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1082,7 +1082,8 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
     exp : float
         Exponent for the depth weighting, must be between 0 and 1.
     limit : float | None
-        The upper bound on depth weighting. Can be None to be unbounded.
+        The upper bound on depth weighting.
+        Can be None to be bounded by the largest finite prior.
     patch_areas : ndarray | None
         Patch areas of the vertices from the forward solution.
     limit_depth_chs : bool | 'whiten'
@@ -1135,8 +1136,17 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
 
     Notes
     -----
-    The defaults used by the minimum norm code and sparse solvers differs.
-    XXX explain this
+    The defaults used by the minimum norm code and sparse solvers differ.
+    In particular, the values for MNE are::
+
+        compute_depth_prior(..., limit=10., limit_depth_chs=True,
+                            combine_xyz='spectral')
+
+    In sparse solvers, the values are::
+
+        compute_depth_prior(..., limit=None, limit_depth_chs='whiten',
+                            combine_xyz='L2')
+
     """
     # XXX this perhaps should just take ``forward`` instead of ``G`` and
     # ``gain_info``. However, it's not easy to do this given that the

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1064,9 +1064,10 @@ def _restrict_gain_matrix(G, info):
     return G
 
 
+@verbose
 def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
                         patch_areas=None, limit_depth_chs=False,
-                        loose_method='svd'):
+                        loose_method='svd', verbose=None):
     """Compute weighting for depth prior.
 
     Parameters
@@ -1083,10 +1084,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         The upper bound on depth weighting. Can be None to be unbounded.
     patch_areas : ndarray | None
         Patch areas of the vertices from the forward solution.
-    limit_depth_chs : bool
-        If True, limit depth weighting computation to gradiometers
-        if present (ignoring magnetometers). This can improve the
-        computations on systems that have both (e.g., Neuromag).
+    %(limit_depth_chs)s Default is False.
     loose_method : 'svd' | 'sum'
         When a loose (or free) orientation is used, how the depth weighting
         for each triplet should be calculated.
@@ -1095,6 +1093,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         If 'sum', then ``np.sum(Gk ** 2)`` will be used.
 
         .. versionadded:: 0.18
+    %(verbose)s
 
     Returns
     -------
@@ -1120,6 +1119,8 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         d = np.sum(G ** 2, axis=0)
         if not is_fixed_ori:
             d = d.reshape(-1, 3).sum(axis=1)
+        # Spherical leadfield can be zero at the center
+        d[d == 0.] = np.min(d[d != 0.])
     else:
         # n_pos = G.shape[1] // 3
         # The following is equivalent to this, but 4-10x faster

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1068,7 +1068,7 @@ def _restrict_gain_matrix(G, info):
 def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
                         patch_areas=None, limit_depth_chs=False,
                         loose_method='svd', verbose=None):
-    """Compute weighting for depth prior.
+    """Compute depth prior for depth weighting.
 
     Parameters
     ----------
@@ -1079,12 +1079,28 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
     is_fixed_ori : bool
         Whether or not ``G`` is fixed orientation.
     exp : float
-        Exponent for the depth weighting.
+        Exponent for the depth weighting, must be between 0 and 1.
     limit : float | None
         The upper bound on depth weighting. Can be None to be unbounded.
     patch_areas : ndarray | None
         Patch areas of the vertices from the forward solution.
-    %(limit_depth_chs)s Default is False.
+    limit_depth_chs : bool | 'whiten'
+        How to deal with multiple channel types in depth weighting. Options:
+
+        :data:`python:True` (default)
+            Use only grad channels in depth weighting (equivalent to MNE C
+            minimum-norm code). If grad channels aren't present, only mag
+            channels will be used (if no mag, then eeg). This makes the depth
+            prior dependent only on the sensor geometry (and relationship
+            to the sources).
+        :data:`python:False`
+            Use all channels. Only recommended when the gain matrix has
+            already been whitened (otherwise it will be arbitrarily
+            biased toward whichever channel type has the largest values in
+            SI units). Whitening the gain matrix makes the depth prior
+            depend on both sensor geometry and the data of interest captured
+            by the noise covariance (e.g., projections, SNR).
+
     loose_method : 'svd' | 'sum'
         When a loose (or free) orientation is used, how the depth weighting
         for each triplet should be calculated.
@@ -1103,6 +1119,11 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
     See Also
     --------
     compute_orient_prior
+
+    Notes
+    -----
+    The defaults used by the minimum norm code and sparse solvers differs.
+    XXX explain this
     """
     # XXX this perhaps should just take ``forward`` instead of ``G`` and
     # ``gain_info``. However, it's not easy to do this given that the

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -40,7 +40,7 @@ from ..transforms import (transform_surface_to, invert_transform,
                           write_trans)
 from ..utils import (_check_fname, get_subjects_dir, has_mne_c, warn,
                      run_subprocess, check_fname, logger, verbose,
-                     _validate_type, _check_compensation_grade)
+                     _validate_type, _check_compensation_grade, _check_option)
 from ..label import Label
 from ..fixes import einsum
 
@@ -1164,6 +1164,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
         if not isinstance(noise_cov, Covariance):
             raise ValueError('With limit_depth_chs="whiten", noise_cov must be'
                              ' a Covariance, got %s' % (type(noise_cov),))
+    _check_option('combine_xyz', combine_xyz, ('fro', 'spectral'))
 
     # If possible, pick best depth-weighting channels
     if limit_depth_chs is True:
@@ -1180,10 +1181,7 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
             d = d.reshape(-1, 3).sum(axis=1)
         # Spherical leadfield can be zero at the center
         d[d == 0.] = np.min(d[d != 0.])
-    else:
-        if combine_xyz != 'spectral':
-            raise ValueError('combine_xyz must be "fro" or "spectral", '
-                             'got %s' % (combine_xyz,))
+    else:  # 'spectral'
         # n_pos = G.shape[1] // 3
         # The following is equivalent to this, but 4-10x faster
         # d = np.zeros(n_pos)

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -165,8 +165,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
 def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
               xyz_same_gamma=True, maxit=10000, tol=1e-6, update_mode=1,
               gammas=None, pca=True, return_residual=False,
-              return_as_dipoles=False, rank=None, limit_depth_chs=True,
-              verbose=None):
+              return_as_dipoles=False, rank=None, verbose=None):
     """Hierarchical Bayes (Gamma-MAP) sparse source localization method.
 
     Models each source time course using a zero-mean Gaussian prior with an
@@ -196,8 +195,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
         If loose is 1, it corresponds to free orientations.
         The default value ('auto') is set to 0.2 for surface-oriented source
         space and set to 1.0 for volumic or discrete source space.
-    depth: None | float in [0, 1]
-        Depth weighting coefficients. If None, no depth weighting is performed.
+    %(depth)s
     xyz_same_gamma : bool
         Use same gamma for xyz current components at each source space point.
         Recommended for free-orientation forward solutions.
@@ -217,9 +215,6 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
     %(rank_None)s
-
-        .. versionadded:: 0.18
-    %(limit_depth_chs)s
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -258,8 +253,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
         group_size = 3
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
-        forward, evoked.info, noise_cov, pca, depth, loose, None, None,
-        rank, limit_depth_chs)
+        forward, evoked.info, noise_cov, pca, depth, loose, rank)
 
     # get the data
     sel = [evoked.ch_names.index(name) for name in gain_info['ch_names']]

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -165,7 +165,8 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
 def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
               xyz_same_gamma=True, maxit=10000, tol=1e-6, update_mode=1,
               gammas=None, pca=True, return_residual=False,
-              return_as_dipoles=False, verbose=None):
+              return_as_dipoles=False, rank=None, limit_depth_chs=True,
+              verbose=None):
     """Hierarchical Bayes (Gamma-MAP) sparse source localization method.
 
     Models each source time course using a zero-mean Gaussian prior with an
@@ -215,6 +216,12 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
         If True, the residual is returned as an Evoked instance.
     return_as_dipoles : bool
         If True, the sources are returned as a list of Dipole instances.
+    %(rank_None)s
+
+        .. versionadded:: 0.18
+    %(limit_depth_chs)s
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -251,7 +258,8 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
         group_size = 3
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
-        forward, evoked.info, noise_cov, pca, depth, loose, None, None)
+        forward, evoked.info, noise_cov, pca, depth, loose, None, None,
+        rank, limit_depth_chs)
 
     # get the data
     sel = [evoked.ch_names.index(name) for name in gain_info['ch_names']]

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -55,9 +55,8 @@ def _prepare_gain(forward, info, noise_cov, pca, depth, loose, rank,
                   weights=None, weights_min=None):
     depth = _check_depth(depth, 'depth_sparse')
     forward, gain_info, gain, _, _, source_weighting, _, _, whitener = \
-        _prepare_forward(
-            forward, info, noise_cov, 'auto', loose, rank, pca, use_cps=True,
-            whiten='before', **depth)
+        _prepare_forward(forward, info, noise_cov, 'auto', loose, rank, pca,
+                         use_cps=True, **depth)
 
     if weights is None:
         mask = None
@@ -479,7 +478,7 @@ def tf_mixed_norm(evoked, forward, noise_cov,
                   debias=True, wsize=64, tstep=4, window=0.02,
                   return_residual=False, return_as_dipoles=False,
                   alpha=None, l1_ratio=None, dgap_freq=10, rank=None,
-                  limit_depth_chs=False, verbose=None):
+                  verbose=None):
     """Time-Frequency Mixed-norm estimate (TF-MxNE).
 
     Compute L1/L2 + L1 mixed-norm solution on time-frequency

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -13,7 +13,7 @@ from ..minimum_norm.inverse import (combine_xyz, _prepare_forward,
 from ..forward import is_fixed_orient, convert_forward_solution
 from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
-from ..utils import logger, verbose, warn
+from ..utils import logger, verbose, warn, _check_depth
 from ..dipole import Dipole
 
 from .mxne_optim import (mixed_norm_solver, iterative_mixed_norm_solver, _Phi,
@@ -51,15 +51,13 @@ def _prepare_weights(forward, gain, source_weighting, weights, weights_min):
     return gain, source_weighting, mask
 
 
-def _prepare_gain(forward, info, noise_cov, pca, depth, loose, weights,
-                  weights_min, rank=None, limit_depth_chs=True):
-    # XXX This should be loose_method='svd' but it breaks the spherical
-    # conductor MxNE test
+def _prepare_gain(forward, info, noise_cov, pca, depth, loose, rank,
+                  weights=None, weights_min=None):
+    depth = _check_depth(depth, 'depth_sparse')
     forward, gain_info, gain, _, _, source_weighting, _, _, whitener = \
         _prepare_forward(
-            forward, info, noise_cov, 'auto', loose, depth, rank=rank,
-            pca=pca, limit_depth_chs=limit_depth_chs, loose_method='sum',
-            allow_fixed_depth=True)
+            forward, info, noise_cov, 'auto', loose, rank, pca, use_cps=True,
+            whiten='before', **depth)
 
     if weights is None:
         mask = None
@@ -242,7 +240,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
                debias=True, time_pca=True, weights=None, weights_min=None,
                solver='auto', n_mxne_iter=1, return_residual=False,
                return_as_dipoles=False, dgap_freq=10, rank=None,
-               limit_depth_chs=False, verbose=None):
+               verbose=None):
     """Mixed-norm estimate (MxNE) and iterative reweighted MxNE (irMxNE).
 
     Compute L1/L2 mixed-norm solution [1]_ or L0.5/L2 [2]_ mixed-norm
@@ -266,8 +264,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
         If loose is 1, it corresponds to free orientations.
         The default value ('auto') is set to 0.2 for surface-oriented source
         space and set to 1.0 for volumic or discrete source space.
-    depth: None | float in [0, 1]
-        Depth weighting coefficients. If None, no depth weighting is performed.
+    %(depth)s
     maxit : int
         Maximum number of iterations.
     tol : float
@@ -304,9 +301,6 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
         The duality gap is evaluated every dgap_freq iterations. Ignored if
         solver is 'cd'.
     %(rank_None)s
-
-        .. versionadded:: 0.18
-    %(limit_depth_chs)s
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -368,8 +362,8 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
             forward, surf_ori=True, force_fixed=True, copy=True, use_cps=True)
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
-        forward, evoked[0].info, noise_cov, pca, depth, loose, weights,
-        weights_min, rank, limit_depth_chs)
+        forward, evoked[0].info, noise_cov, pca, depth, loose, rank,
+        weights, weights_min)
 
     sel = [all_ch_names.index(name) for name in gain_info['ch_names']]
     M = np.concatenate([e.data[sel] for e in evoked], axis=1)
@@ -506,8 +500,7 @@ def tf_mixed_norm(evoked, forward, noise_cov,
         If loose is 1, it corresponds to free orientations.
         The default value ('auto') is set to 0.2 for surface-oriented source
         space and set to 1.0 for volumic or discrete source space.
-    depth: None | float in [0, 1]
-        Depth weighting coefficients. If None, no depth weighting is performed.
+    %(depth)s
     maxit : int
         Maximum number of iterations.
     tol : float
@@ -555,9 +548,6 @@ def tf_mixed_norm(evoked, forward, noise_cov,
     dgap_freq : int or np.inf
         The duality gap is evaluated every dgap_freq iterations.
     %(rank_None)s
-
-        .. versionadded:: 0.18
-    %(limit_depth_chs)s
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -632,8 +622,8 @@ def tf_mixed_norm(evoked, forward, noise_cov,
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
 
     gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
-        forward, evoked.info, noise_cov, pca, depth, loose, weights,
-        weights_min, rank, limit_depth_chs)
+        forward, evoked.info, noise_cov, pca, depth, loose, rank,
+        weights, weights_min)
 
     if window is not None:
         evoked = _window_evoked(evoked, window)

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -77,7 +77,7 @@ def test_gamma_map():
 
     stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                     xyz_same_gamma=False, update_mode=1)
-    _check_stc(stc, evoked, 82010, 'lh', dist_limit=9., fwd=forward)
+    _check_stc(stc, evoked, 82010, 'lh', fwd=forward)
 
     dips = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                      xyz_same_gamma=False, update_mode=1,

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -44,7 +44,7 @@ def _check_stcs(stc1, stc2):
 @pytest.mark.timeout(60)  # ~30 sec on AppVeyor and Travis Linux
 @pytest.mark.slowtest
 @testing.requires_testing_data
-def test_mxne_inverse():
+def test_mxne_inverse_standard():
     """Test (TF-)MxNE inverse computation."""
     # Read noise covariance matrix
     cov = read_cov(fname_cov)
@@ -59,6 +59,7 @@ def test_mxne_inverse():
     evoked_l21 = evoked.copy()
     evoked_l21.crop(tmin=0.081, tmax=0.1)
     label = read_label(fname_label)
+    assert label.hemi == 'rh'
 
     forward = read_forward_solution(fname_fwd)
     forward = convert_forward_solution(forward, surf_ori=True)
@@ -201,6 +202,8 @@ def test_mxne_vol_sphere():
 
     dip_fit = mne.fit_dipole(evoked_dip, cov, sphere)[0]
     assert np.abs(np.dot(dip_fit.ori[0], dip_mxne.ori[0])) > 0.99
+    dist = 1000 * np.linalg.norm(dip_fit.pos[0] - dip_mxne.pos[0])
+    assert dist < 2.  # within 2 mm
 
     # Do with TF-MxNE for test memory savings
     alpha = 60.  # overall regularization parameter

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -203,7 +203,7 @@ def test_mxne_vol_sphere():
     dip_fit = mne.fit_dipole(evoked_dip, cov, sphere)[0]
     assert np.abs(np.dot(dip_fit.ori[0], dip_mxne.ori[0])) > 0.99
     dist = 1000 * np.linalg.norm(dip_fit.pos[0] - dip_mxne.pos[0])
-    assert dist < 2.  # within 2 mm
+    assert dist < 4.  # within 4 mm
 
     # Do with TF-MxNE for test memory savings
     alpha = 60.  # overall regularization parameter

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1456,10 +1456,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
         Use fixed source orientations normal to the cortical mantle. If True,
         the loose parameter must be "auto" or 0. If 'auto', the loose value
         is used.
-    limit_depth_chs : bool
-        If True, use only grad channels in depth weighting (equivalent to MNE
-        C code). If grad channels aren't present, only mag channels will be
-        used (if no mag, then eeg). If False, use all channels.
+    %(limit_depth_chs)s Default is True.
     %(rank_None)s
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1397,6 +1397,8 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, depth, rank, pca,
                 use_cps=use_cps)
             gain_info, gain = _select_orient_forward(
                 forward, info, noise_cov, verbose=False)
+            if whiten == 'before':
+                gain = np.dot(whitener, gain)
     else:
         # In theory we could have orient_prior=None for loose=1., but
         # the MNE-C code does not do this

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1283,8 +1283,8 @@ def _xyz2lf(Lf_xyz, normals):
 # Assemble the inverse operator
 
 def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
-                     use_cps, exp, limit_depth_chs, loose_method,
-                     allow_fixed_depth, limit, whiten):
+                     use_cps, exp, limit_depth_chs, combine_xyz,
+                     allow_fixed_depth, limit):
     """Prepare a gain matrix and noise covariance for localization."""
     # Steps (according to MNE-C, we change the order of various steps
     # because our I/O is already done, and we create the objects
@@ -1302,11 +1302,10 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     # 10. Exclude the source space points within the labels (not done)
     # 11. Do appropriate source weighting to the forward computation matrix
     #
-    assert whiten in ('before', 'after')
     depth = exp
     del exp
 
-    is_fixed_ori = is_fixed_orient(forward)
+    input_fixed_ori = is_fixed_orient(forward)
 
     # These gymnastics are necessary due to the redundancy between
     # "fixed" and "loose"
@@ -1331,7 +1330,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     if fixed:
         if allow_fixed_depth:
             assert loose == 0.
-        elif not is_fixed_ori:
+        elif not input_fixed_ori:
             # Here we use loose=1. because computation of depth priors is
             # improved by operating on the free orientation forward; see code
             # at the comment "Deal with fixed orientation forward / inverse"
@@ -1341,7 +1340,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
                 'For a fixed orientation inverse solution with depth '
                 'weighting, the forward solution must be free-orientation and '
                 'in surface orientation')
-    elif is_fixed_ori:
+    elif input_fixed_ori:
         raise ValueError(
             'Forward operator has fixed orientation and can only '
             'be used to make a fixed-orientation inverse '
@@ -1351,7 +1350,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     if depth is not None:
         if not (0 < depth <= 1):
             raise ValueError('depth should be a scalar between 0 and 1')
-        if is_fixed_ori and not allow_fixed_depth:
+        if input_fixed_ori and not allow_fixed_depth:
             raise ValueError('You need a free-orientation, surface-oriented '
                              'forward solution to do depth weighting even '
                              'when calculating a fixed-orientation inverse.')
@@ -1366,49 +1365,42 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
             forward, surf_ori=True, use_cps=use_cps)
 
     gain_info, gain = _select_orient_forward(forward, info, noise_cov)
-    noise_cov = prepare_noise_cov(noise_cov, info, gain_info['ch_names'], rank)
-    whitener, _ = compute_whitener(
-        noise_cov, info, gain_info['ch_names'], pca=pca)
     logger.info("Selected %d channels" % (len(gain_info['ch_names'],)))
-    if whiten == 'before':
-        logger.info('Whitening the forward solution.')
-        gain = np.dot(whitener, gain)
 
     if depth is None:
         depth_prior = None
     else:
         patch_areas = forward.get('patch_areas', None)
         depth_prior = compute_depth_prior(
-            gain, gain_info, is_fixed_ori, exp=depth, patch_areas=patch_areas,
-            limit_depth_chs=limit_depth_chs, loose_method=loose_method,
-            limit=limit)
+            gain, gain_info, input_fixed_ori, exp=depth,
+            patch_areas=patch_areas,
+            limit_depth_chs=limit_depth_chs, combine_xyz=combine_xyz,
+            limit=limit, noise_cov=noise_cov)
 
     # Deal with fixed orientation forward / inverse
     if fixed:
         orient_prior = None
-        if not is_fixed_ori:
-            # Convert to the fixed orientation forward solution now
-            if depth is not None:
-                # Convert the depth prior into a fixed-orientation one
-                logger.info('    Picked elements from a free-orientation '
-                            'depth-weighting prior into the fixed-orientation '
-                            'one')
-                depth_prior = depth_prior[2::3]
-        if not allow_fixed_depth:
-            forward = convert_forward_solution(
-                forward, surf_ori=forward['surf_ori'], force_fixed=True,
-                use_cps=use_cps)
-            gain_info, gain = _select_orient_forward(
-                forward, info, noise_cov, verbose=False)
-            if whiten == 'before':
-                gain = np.dot(whitener, gain)
+        if not input_fixed_ori and depth is not None:
+            # Convert the depth prior into a fixed-orientation one
+            logger.info('    Picked elements from a free-orientation '
+                        'depth-weighting prior into the fixed-orientation '
+                        'one')
+            depth_prior = depth_prior[2::3]
+        forward = convert_forward_solution(
+            forward, surf_ori=forward['surf_ori'], force_fixed=True,
+            use_cps=use_cps)
+        gain_info, gain = _select_orient_forward(
+            forward, info, noise_cov, verbose=False)
     else:
         # In theory we could have orient_prior=None for loose=1., but
         # the MNE-C code does not do this
         orient_prior = compute_orient_prior(forward, loose=loose)
-    if whiten == 'after':
-        logger.info('Whitening the forward solution.')
-        gain = np.dot(whitener, gain)
+
+    logger.info('Whitening the forward solution.')
+    noise_cov = prepare_noise_cov(noise_cov, info, gain_info['ch_names'], rank)
+    whitener, _ = compute_whitener(
+        noise_cov, info, gain_info['ch_names'], pca=pca)
+    gain = np.dot(whitener, gain)
 
     logger.info('Creating the source covariance matrix')
     source_std = np.ones(gain.shape[1])
@@ -1521,7 +1513,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
     forward, gain_info, gain, depth_prior, orient_prior, source_std, \
         trace_GRGT, noise_cov, _ = _prepare_forward(
             forward, info, noise_cov, fixed, loose, rank, pca='white',
-            use_cps=use_cps, whiten='after', **depth)
+            use_cps=use_cps, **depth)
     del fixed, loose, depth, use_cps, limit_depth_chs
 
     # Decompose the combined matrix

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -228,9 +228,10 @@ def test_make_inverse_operator():
     fwd_op = convert_forward_solution(read_forward_solution_meg(fname_fwd),
                                       surf_ori=True, copy=False)
     with catch_logging() as log:
-        my_inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
-                                          loose=0.2, depth=0.8,
-                                          limit_depth_chs=False, verbose=True)
+        with pytest.deprecated_call():  # limit_depth_chs
+            my_inv_op = make_inverse_operator(
+                evoked.info, fwd_op, noise_cov, loose=0.2, depth=0.8,
+                limit_depth_chs=False, verbose=True)
     log = log.getvalue()
     assert 'rank 302 (3 small eigenvalues omitted)' in log
     _compare_io(my_inv_op)
@@ -261,9 +262,9 @@ def test_inverse_operator_channel_ordering():
     fwd_orig = make_forward_solution(evoked.info, fname_trans, src_fname,
                                      fname_bem, eeg=True, mindist=5.0)
     fwd_orig = convert_forward_solution(fwd_orig, surf_ori=True)
+    depth = dict(exp=0.8, limit_depth_chs=False)
     inv_orig = make_inverse_operator(evoked.info, fwd_orig, noise_cov,
-                                     loose=0.2, depth=0.8,
-                                     limit_depth_chs=False)
+                                     loose=0.2, depth=depth)
     stc_1 = apply_inverse(evoked, inv_orig, lambda2, "dSPM")
 
     # Assume that a raw reordering applies to both evoked and noise_cov,
@@ -288,8 +289,7 @@ def test_inverse_operator_channel_ordering():
                                         fname_bem, eeg=True, mindist=5.0)
     fwd_reorder = convert_forward_solution(fwd_reorder, surf_ori=True)
     inv_reorder = make_inverse_operator(evoked.info, fwd_reorder, noise_cov,
-                                        loose=0.2, depth=0.8,
-                                        limit_depth_chs=False)
+                                        loose=0.2, depth=depth)
 
     stc_2 = apply_inverse(evoked, inv_reorder, lambda2, "dSPM")
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -323,17 +323,19 @@ def bias_params():
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('method, lower, upper',
-                         [('MNE', 83, 87),
-                          ('dSPM', 96, 98),
-                          ('sLORETA', 100, 100),
-                          ('eLORETA', 100, 100)])
-def test_localization_bias_fixed(bias_params, method, lower, upper):
+@pytest.mark.parametrize('method, lower, upper, depth', [
+    ('MNE', 75, 80, dict(limit_depth_chs=False)),
+    ('MNE', 83, 87, 0.8),
+    ('MNE', 89, 92, dict(limit_depth_chs='whiten')),
+    ('dSPM', 96, 98, 0.8),
+    ('sLORETA', 100, 100, 0.8),
+    ('eLORETA', 100, 100, 0.8)])
+def test_localization_bias_fixed(bias_params, method, lower, upper, depth):
     """Test inverse localization bias for fixed minimum-norm solvers."""
     evoked, fwd_orig, noise_cov = bias_params
     fwd = fwd_orig.copy()
     inv_fixed = make_inverse_operator(evoked.info, fwd, noise_cov, loose=0.,
-                                      depth=0.8)
+                                      depth=depth)
     fwd = convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
     fwd = fwd['sol']['data']
     want = np.arange(fwd.shape[1])
@@ -346,11 +348,11 @@ def test_localization_bias_fixed(bias_params, method, lower, upper):
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('method, lower, upper',
-                         [('MNE', 25, 35),
-                          ('dSPM', 25, 35),
-                          ('sLORETA', 35, 40),
-                          ('eLORETA', 40, 45)])
+@pytest.mark.parametrize('method, lower, upper', [
+    ('MNE', 25, 35),
+    ('dSPM', 25, 35),
+    ('sLORETA', 35, 40),
+    ('eLORETA', 40, 45)])
 def test_localization_bias_loose(bias_params, method, lower, upper):
     """Test inverse localization bias for loose minimum-norm solvers."""
     evoked, fwd_orig, noise_cov = bias_params
@@ -369,19 +371,21 @@ def test_localization_bias_loose(bias_params, method, lower, upper):
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('method, lower, upper, kwargs',
-                         [('MNE', 45, 55, {}),
-                          ('dSPM', 40, 45, {}),
-                          ('sLORETA', 90, 95, {}),
-                          ('eLORETA', 90, 95,
-                           dict(method_params=dict(force_equal=True))),
-                          ('eLORETA', 100, 100, {})])
-def test_localization_bias_free(bias_params, method, lower, upper, kwargs):
+@pytest.mark.parametrize('method, lower, upper, kwargs, depth', [
+    ('MNE', 35, 40, {}, dict(limit_depth_chs=False)),
+    ('MNE', 45, 55, {}, 0.8),
+    ('MNE', 65, 70, {}, dict(limit_depth_chs='whiten')),
+    ('dSPM', 40, 45, {}, 0.8),
+    ('sLORETA', 90, 95, {}, 0.8),
+    ('eLORETA', 90, 95, dict(method_params=dict(force_equal=True)), 0.8),
+    ('eLORETA', 100, 100, {}, 0.8)])
+def test_localization_bias_free(bias_params, method, lower, upper,
+                                kwargs, depth):
     """Test inverse localization bias for free minimum-norm solvers."""
     evoked, fwd_orig, noise_cov = bias_params
     fwd = fwd_orig.copy()
     inv_free = make_inverse_operator(evoked.info, fwd, noise_cov, loose=1.,
-                                     depth=0.8)
+                                     depth=depth)
     fwd = fwd['sol']['data']
     want = np.arange(fwd.shape[1]) // 3
     inv_op = apply_inverse(evoked, inv_free, lambda2, method,

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -308,6 +308,7 @@ def test_inverse_operator_channel_ordering():
 
 @pytest.fixture(scope='module')
 def bias_params():
+    """Provide inputs for bias functions."""
     # Identity input
     evoked = _get_evoked()
     evoked.pick_types(meg=True, eeg=True, exclude=())

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -12,7 +12,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_pyface_backend, _check_info_inv,
                     _check_channels_spatial_filter, _check_one_ch_type,
-                    _check_rank, _check_option)
+                    _check_rank, _check_option, _check_depth)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -435,6 +435,14 @@ def _check_one_ch_type(info, picks, noise_cov, method):
              'not heavily tested yet.')
 
 
+def _check_depth(depth, kind='depth_mne'):
+    """Check depth options."""
+    from ..defaults import _handle_default
+    if not isinstance(depth, dict):
+        depth = dict(exp=None if depth is None else float(depth))
+    return _handle_default(kind, depth)
+
+
 def _check_option(parameter, value, allowed_values):
     """Check the value of a parameter against a list of valid options.
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -59,8 +59,16 @@ rank : None | dict | 'info' | 'full'
         of :func:`mne.compute_rank` for details."""
 docdict['rank_None'] = docdict['rank'] + 'The default is None.'
 docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
-# Finalize
 
+# Inverses
+docdict['limit_depth_chs'] = """
+limit_depth_chs : bool
+    If True (default), use only grad channels in depth weighting
+    (equivalent to MNE C code). If grad channels aren't present, only mag
+    channels will be used (if no mag, then eeg). If False, use all channels.
+"""
+
+# Finalize
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -61,11 +61,13 @@ docdict['rank_None'] = docdict['rank'] + 'The default is None.'
 docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
 
 # Inverses
-docdict['limit_depth_chs'] = """
-limit_depth_chs : bool
-    If True (default), use only grad channels in depth weighting
-    (equivalent to MNE C code). If grad channels aren't present, only mag
-    channels will be used (if no mag, then eeg). If False, use all channels.
+docdict['depth'] = """
+depth : None | float | dict
+    If float (default 0.8), it acts as the depth weighting exponent (``exp``)
+    to use (must be between 0 and 1). None is equivalent to 0, meaning no depth
+    weighting is performed. Can also be a `dict` containing additional keyword
+    arguments to pass to :func:`mne.forward.compute_depth_prior` (see docstring
+    for details and defaults).
 """
 
 # Finalize


### PR DESCRIPTION
Okay @agramfort I had to change a tolerance for one gamma_map test. All other tests should be passing except `mne/inverse_sparse/tests/test_mxne_inverse.py:test_mxne_inverse_standard`:
```
>       assert stc_prox.vertices[1][0] in label.vertices
E       IndexError: index 0 is out of bounds for axis 0 with size 0
```
*Then* the `loose_method='sum'` should change to `loose_method='svd'`, but this will break the sphere test. (The orientation only matches to 0.89, not 0.99, and the dipole fit is not 1.7mm away but 30mm :( ).

I'm out of my depth working on the MxNE stuff, so hopefully you find some hacking time soon.

Todo:
- [x] add `limit_depth_chs='whiten'` to MxNE and MNE
- [x] fix `test_mxne_inverse_standard`
- [x] ~~set `loose_method='svd'` and fix the failing sphere model test~~
- [x] add bias tests for LCMV

Next PR:
- rework `compute_depth_prior` to operate on `forward`