### PR TITLE
Add raw._first_time to time vec in chpi._calculate_head_pos_ctf

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -258,6 +258,7 @@ def _calculate_head_pos_ctf(raw, gof_limit=0.98):
 
     quats = np.array(quats, np.float64)
     quats = np.zeros((0, 10)) if quats.size == 0 else quats
+    quats[:, 0] += raw._first_time
     return quats
 
 


### PR DESCRIPTION
maxwell.axwell_filter and epochs.average_movements expect the time in the position matrix to be relative to 0 (start of recording), not relative to .first_sample. See post in #4088.

This PR adds `raw._first_time` to the time vector calculated in `mne.chpi._calculate_head_pos_ctf`.