### PR TITLE
WIP, VIZ: plot_compare_evokeds can plot epochs

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -45,7 +45,8 @@ from .filter import detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
-                  plot_epochs_image, plot_topo_image_epochs, plot_drop_log)
+                  plot_epochs_image, plot_topo_image_epochs, plot_drop_log,
+                  plot_compare_evokeds)
 from .utils import (_check_fname, check_fname, logger, verbose,
                     _time_mask, check_random_state, warn, _pl,
                     sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc,
@@ -968,6 +969,16 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             layout_scale=layout_scale, title=title, scalings=scalings,
             border=border, fig_facecolor=fig_facecolor,
             fig_background=fig_background, font_color=font_color, show=show)
+
+    @copy_function_doc_to_method_doc(plot_compare_evokeds)
+    def plot_compare_evokeds(self, conditions=None, **kwargs):
+        """TBD"""
+        if conditions is None:
+            conditions = self.event_id.keys()
+        elif isinstance(conditions, str):
+            conditions = [conditions]
+        return plot_compare_evokeds({cond: self for cond in conditions},
+                                    **kwargs)
 
     @verbose
     def drop_bad(self, reject='existing', flat='existing', verbose=None):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -495,3 +495,18 @@ def _check_combine(mode, valid=('mean', 'median', 'std')):
                          " or callable, got %s (type %s)." %
                          (mode, type(mode)))
     return fun
+
+
+def _check_all_same_type_nested(instances, legal_types=None):
+    """Check if all (potentially nested) things in a dict are the same type."""
+    all_types = []
+    for items in instances.values():
+        if isinstance(items, legal_types):
+            all_types.append(type(items))
+        else:
+            for item in items:
+                all_types.append(type(item))
+    all_types = set(all_types)
+    if len(all_types) != 1:
+        raise ValueError("All instances in `evokeds` must be of the same type "
+                         "(Evokeds OR Epochs), got " + str(all_types))

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -524,9 +524,8 @@ def _plot_epochs_image(epochs, data, ch_type, vmin=None, vmax=None,
     # draw the evoked
     if evoked:
         from mne.viz import plot_compare_evokeds
-        plot_compare_evokeds(
-            {"cond": list(epochs.iter_evoked())}, axes=axes_dict["evoked"],
-            **ts_args)
+        plot_compare_evokeds({"cond": list(epochs.iter_evoked())},
+                             axes=axes_dict["evoked"], **ts_args)
         axes_dict["evoked"].set_xlim(epochs.times[[0, -1]])
         ax.set_xticks(())
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1560,9 +1560,9 @@ def _check_loc_legal(loc, what='your choice', default=1):
 
 def _get_evokeds_from_epochs(instances, Epochs):
     """Transform a dict of lists of Epochs into a dict of lists of Evokeds."""
-    if all(isinstance(content, Epochs) for content in instances.values()):
-        instances = {key: list(epochs[key].iter_evoked())
-                     for key, epochs in evokeds.items()}
+    if all(isinstance(content[0], Epochs) for content in instances.values()):
+        instances = {key: list(epochs[0][key].iter_evoked())
+                     for key, epochs in instances.items()}
     elif all([all(isinstance(content, Epochs) for sublist in instances.values()
               for content in sublist)]):
         instances = {key: [epochs[key].average() for epochs in epochs_list]
@@ -1588,7 +1588,8 @@ def _format_evokeds_colors(instances, cmap, colors):
                             "(lists of) Evokeds.")
         if (cmap is not None) and (colors is None):
             colors = {str(ii + 1): ii for ii, _ in enumerate(instances)}
-        instances = {str(ii + 1): evoked for ii, evoked in enumerate(instances)}
+        instances = {str(ii + 1): evoked
+                     for ii, evoked in enumerate(instances)}
     else:
         assert isinstance(instances, dict)
         if (colors is None) and cmap is not None:
@@ -1601,7 +1602,7 @@ def _format_evokeds_colors(instances, cmap, colors):
         _validate_type(cond, str, "Conditions")
 
     _check_all_same_type_nested(instances, legal_types=(Epochs, Evoked))
-    
+
     list_of_values = list(instances.values())[0]
     if isinstance(list_of_values, Epochs) or isinstance(list_of_values[0],
                                                         Epochs):

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -16,7 +16,7 @@ from mne import read_events, Epochs, pick_types, read_cov
 from mne.channels import read_layout
 from mne.io import read_raw_fif
 from mne.utils import run_tests_if_main, requires_version
-from mne.viz import plot_drop_log
+from mne.viz import plot_drop_log, plot_compare_evokeds
 from mne.viz.utils import _fake_click
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -142,6 +142,15 @@ def test_plot_epochs(capsys):
     assert len(epochs) == 6
     plt.close('all')
 
+    # test that plot_compare_evokeds can plot epochs objects
+    plot_compare_evokeds({cond: epochs.pick_types(meg='mag')
+                          for cond in epochs.event_id})
+    plot_compare_evokeds({cond: [epochs.pick_types(meg='mag'),
+                                 epochs.pick_types(meg='mag')]
+                          for cond in epochs.event_id})
+    pytest.raises(ValueError, plot_compare_evokeds, {"1": epochs.average(),
+                                                     "2": epochs})
+    plt.close('all')
 
 def test_plot_epochs_image():
     """Test plotting of epochs image."""

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -152,6 +152,7 @@ def test_plot_epochs(capsys):
                                                      "2": epochs})
     plt.close('all')
 
+
 def test_plot_epochs_image():
     """Test plotting of epochs image."""
     epochs = _get_epochs()


### PR DESCRIPTION
As discussed in #5812: plot_compare_evokeds can take dicts of epochs. This allows:

- for a dict of epochs: plotting the confidence interval within a subject/across trials
- for a dict of lists of epochs: automatically selecting conditions from the epochs without having to construct the evoked objects

The API is unchanged. Only now code like this is legal:

```plot_compare_evokeds({"aud": epochs, "vis": epochs})```

@palday @mmagnuski 