### PR TITLE
MRG: Make doc build env static

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -322,6 +322,16 @@ else:
     push_exception_handler(reraise_exceptions=True)
 
 
+class Resetter(object):
+    """Simple class to make the str(obj) static for Sphinx build env hash."""
+
+    def __repr__(self):
+        return '<%s>' % (self.__class__.__name__,)
+
+    def __call__(self, gallery_conf, fname):
+        reset_warnings(gallery_conf, fname)
+
+
 def reset_warnings(gallery_conf, fname):
     """Ensure we are future compatible and ignore silly warnings."""
     # In principle, our examples should produce no warnings.
@@ -392,7 +402,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (160, 112),
     'min_reported_time': 1.,
     'abort_on_example_error': False,
-    'reset_modules': ('matplotlib', reset_warnings),  # called w/each script
+    'reset_modules': ('matplotlib', Resetter()),  # called w/each script
     'image_scrapers': scrapers,
     'show_memory': True,
     'line_numbers': False,  # XXX currently (0.3.dev0) messes with style

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -6,7 +6,7 @@ from os import path as op
 import subprocess
 import sys
 
-from mne.utils import run_subprocess
+from mne.utils import run_subprocess, _replace_md5
 
 
 def setup(app):
@@ -56,7 +56,7 @@ def generate_commands_rst(app):
     out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
     if not op.isdir(out_dir):
         os.mkdir(out_dir)
-    out_fname = op.join(out_dir, 'commands.rst')
+    out_fname = op.join(out_dir, 'commands.rst.new')
 
     command_path = op.abspath(
         op.join(os.path.dirname(__file__), '..', '..', 'mne', 'commands'))
@@ -76,6 +76,7 @@ def generate_commands_rst(app):
                                    cmd_name.replace('mne_', 'mne '),
                                    '-' * len(cmd_name),
                                    output))
+    _replace_md5(out_fname)
     print('[Done]')
 
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -42,6 +42,6 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _time_mask, grand_average, object_diff, object_hash,
                        object_size, _apply_scaling_cov, _undo_scaling_cov,
                        _apply_scaling_array, _undo_scaling_array,
-                       _scaled_array)
+                       _scaled_array, _replace_md5)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -8,7 +8,10 @@ from contextlib import contextmanager
 import hashlib
 from io import BytesIO, StringIO
 import operator
+import os
+import os.path as op
 from math import ceil
+import shutil
 import sys
 
 import numpy as np
@@ -431,6 +434,17 @@ def hashfunc(fname, block_size=1048576, hash_type="md5"):  # 2 ** 20
                 break
             hasher.update(data)
     return hasher.hexdigest()
+
+
+def _replace_md5(fname):
+    """Replace a file based on MD5sum."""
+    # adapted from sphinx-gallery
+    assert fname.endswith('.new')
+    fname_old = fname[:-4]
+    if op.isfile(fname_old) and hashfunc(fname) == hashfunc(fname_old):
+        os.remove(fname)
+    else:
+        shutil.move(fname, fname_old)
 
 
 def create_slices(start, stop, step=None, length=1):


### PR DESCRIPTION
This PR:

- [x] Adds a class whose `__repr__` is static (rather than, by default, having the memory loc in it) to make incremental sphinx doc builds possible
- [x] Fixes `gen_commands` to only overwrite existing files if they have changed.

This is useful when combined with https://github.com/sphinx-gallery/sphinx-gallery/pull/448, you can see this when running `make html_dev-noplot` twice in a row:
```
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
```
This makes incremental doc building much simpler.