### PR TITLE
MRG: Clean up and unify _prepare_forward

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -134,6 +134,8 @@ API
 
 - Reading BDF and GDF files with :func:`mne.io.read_raw_edf` is deprecated and replaced by :func:`mne.io.read_raw_bdf` and :func:`mne.io.read_raw_gdf`, by `Clemens Brunner`_
 
+- :func:`mne.forward.compute_depth_prior` has been reworked to operate directly on :class:`Forward` instance as ``forward`` rather than a representation scattered across the parameters ``G, is_fixed_ori, patch_info``, by `Eric Larson`_
+
 - Deprecate ``method='extended-infomax'`` in :class:`mne.preprocessing.ICA`; Extended Infomax can now be computed with ``method='infomax'`` and ``fit_params=dict(extended=True)`` by `Clemens Brunner`_
 
 .. _changes_0_17:

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -90,17 +90,15 @@ def apply_solver(solver, evoked, forward, noise_cov, loose=0.2, depth=0.8):
     """
     # Import the necessary private functions
     from mne.inverse_sparse.mxne_inverse import \
-        (_prepare_gain, _check_loose_forward, is_fixed_orient,
+        (_prepare_gain, is_fixed_orient,
          _reapply_source_weighting, _make_sparse_stc)
 
     all_ch_names = evoked.ch_names
 
-    loose, forward = _check_loose_forward(loose, forward)
-
     # Handle depth weighting and whitening (here is no weights)
-    gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
+    forward, gain, gain_info, whitener, source_weighting, mask = _prepare_gain(
         forward, evoked.info, noise_cov, pca=False, depth=depth,
-        loose=loose, weights=None, weights_min=None)
+        loose=loose, weights=None, weights_min=None, rank=None)
 
     # Select channels of interest
     sel = [all_ch_names.index(name) for name in gain_info['ch_names']]

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1021,10 +1021,11 @@ def compute_orient_prior(forward, loose=0.2, verbose=None):
                          'with fixed orientation.')
 
     orient_prior = np.ones(n_sources, dtype=np.float)
-    if not is_fixed_ori and loose < 1:
+    if 0 < loose < 1:
         logger.info('Applying loose dipole orientations. Loose value '
                     'of %s.' % loose)
-        orient_prior[np.mod(np.arange(n_sources), 3) != 2] *= loose
+        orient_prior[0::3] *= loose
+        orient_prior[1::3] *= loose
 
     return orient_prior
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1010,22 +1010,22 @@ def compute_orient_prior(forward, loose=0.2, verbose=None):
     n_sources = forward['sol']['data'].shape[1]
     loose = float(loose)
     if not (0 <= loose <= 1):
-        raise ValueError('loose value should be smaller than 1 and bigger '
-                         'than 0, got %s.' % (loose,))
-    if loose < 1 and not forward['surf_ori']:
-        raise ValueError('Forward operator is not oriented in surface '
-                         'coordinates. loose parameter should be 1 '
-                         'not %s.' % loose)
-    if is_fixed_ori and loose != 0:
-        raise ValueError('loose must be 0. with forward operator '
-                         'with fixed orientation.')
-
+        raise ValueError('loose value should be between 0 and 1, '
+                         'got %s.' % (loose,))
     orient_prior = np.ones(n_sources, dtype=np.float)
-    if 0 < loose < 1:
-        logger.info('Applying loose dipole orientations. Loose value '
-                    'of %s.' % loose)
-        orient_prior[0::3] *= loose
-        orient_prior[1::3] *= loose
+    if loose > 0.:
+        if is_fixed_ori:
+            raise ValueError('loose must be 0. with forward operator '
+                             'with fixed orientation, got %s' % (loose,))
+        if loose < 1:
+            if not forward['surf_ori']:
+                raise ValueError('Forward operator is not oriented in surface '
+                                 'coordinates. loose parameter should be 1 '
+                                 'not %s.' % (loose,))
+            logger.info('Applying loose dipole orientations. Loose value '
+                        'of %s.' % loose)
+            orient_prior[0::3] *= loose
+            orient_prior[1::3] *= loose
 
     return orient_prior
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -977,21 +977,12 @@ def _select_orient_forward(forward, info, noise_cov=None, verbose=None):
 
     n_chan = len(ch_names)
     logger.info("Computing inverse operator with %d channels." % n_chan)
-
-    gain = forward['sol']['data']
-
-    # This actually reorders the gain matrix to conform to the info ch order
-    fwd_idx = [fwd_sol_ch_names.index(name) for name in ch_names]
-    gain = gain[fwd_idx]
-    # Any function calling this helper will be using the returned fwd_info
-    # dict, so fwd['sol']['row_names'] becomes obsolete and is NOT re-ordered
-
+    forward = pick_channels_forward(forward, ch_names, ordered=True)
     info_idx = [info['ch_names'].index(name) for name in ch_names]
-    fwd_info = pick_info(info, info_idx)
+    info_picked = pick_info(info, info_idx)
     forward['info']._check_consistency()
-    fwd_info._check_consistency()
-
-    return fwd_info, gain
+    info_picked._check_consistency()
+    return forward, info_picked
 
 
 @verbose
@@ -1065,7 +1056,8 @@ def _restrict_gain_matrix(G, info):
 
 
 @verbose
-def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
+def compute_depth_prior(forward, info, is_fixed_ori=None,
+                        exp=0.8, limit=10.0,
                         patch_areas=None, limit_depth_chs=False,
                         combine_xyz='spectral', noise_cov=None, rank=None,
                         verbose=None):
@@ -1073,19 +1065,19 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
 
     Parameters
     ----------
-    G : ndarray, shape (n_channels, n_vertices)
-        The gain matrix.
-    gain_info : instance of Info
-        The info associated with the gain matrix.
-    is_fixed_ori : bool
-        Whether or not ``G`` is fixed orientation.
+    forward : instance of Forward
+        The forward solution.
+    info : instance of Info
+        The measurement info.
+    is_fixed_ori : bool | None
+        Deprecated, will be removed in 0.19.
     exp : float
         Exponent for the depth weighting, must be between 0 and 1.
     limit : float | None
         The upper bound on depth weighting.
         Can be None to be bounded by the largest finite prior.
     patch_areas : ndarray | None
-        Patch areas of the vertices from the forward solution.
+        Deprecated, will be removed in 0.19.
     limit_depth_chs : bool | 'whiten'
         How to deal with multiple channel types in depth weighting. Options:
 
@@ -1148,11 +1140,17 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
                             combine_xyz='fro')
 
     """
-    # XXX this perhaps should just take ``forward`` instead of ``G`` and
-    # ``gain_info``. However, it's not easy to do this given that the
-    # mixed norm code requires that ``G`` is whitened before this chunk
-    # of code executes.
     from ..cov import Covariance, compute_whitener
+    if isinstance(forward, Forward):
+        patch_areas = forward.get('patch_areas', None)
+        is_fixed_ori = is_fixed_orient(forward)
+        G = forward['sol']['data']
+    else:
+        warn('Parameters G, is_fixed_ori, and patch_areas are '
+             'deprecated and will be removed in 0.19, pass in the forward '
+             'solution directly.', DeprecationWarning)
+        G = forward
+    _validate_type(is_fixed_ori, bool, 'is_fixed_ori')
     logger.info('Creating the depth weighting matrix...')
     _validate_type(noise_cov, (Covariance, None), 'noise_cov',
                    'Covariance or None')
@@ -1168,10 +1166,10 @@ def compute_depth_prior(G, gain_info, is_fixed_ori, exp=0.8, limit=10.0,
 
     # If possible, pick best depth-weighting channels
     if limit_depth_chs is True:
-        G = _restrict_gain_matrix(G, gain_info)
+        G = _restrict_gain_matrix(G, info)
     elif limit_depth_chs == 'whiten':
-        whitener, _ = compute_whitener(noise_cov, gain_info, pca=True,
-                                       rank=rank)
+        whitener, _ = compute_whitener(noise_cov, info, pca=True, rank=rank,
+                                       verbose=False)
         G = np.dot(whitener, G)
 
     # Compute the gain matrix

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -737,41 +737,6 @@ def _check_ori(pick_ori, source_ori):
                            'inverse operator with fixed orientations.')
 
 
-def _check_loose_forward(loose, forward):
-    """Check the compatibility between loose and forward."""
-    src_kind = forward['src'].kind
-    if src_kind != 'surface':
-        if loose == 'auto':
-            loose = 1.
-        if loose != 1:
-            raise ValueError('loose parameter has to be 1 or "auto" for '
-                             'non-surface source space (Got loose=%s for %s '
-                             'source space).' % (loose, src_kind))
-    else:  # surface
-        if loose == 'auto':
-            loose = 0.2
-        # put the forward solution in fixed orientation if it's not already
-        if loose == 0. and not is_fixed_orient(forward):
-            logger.info('Converting forward solution to fixed orietnation')
-            forward = convert_forward_solution(forward, force_fixed=True,
-                                               use_cps=True)
-        elif loose < 1. and not forward['surf_ori']:
-            logger.info('Converting forward solution to surface orientation')
-            forward = convert_forward_solution(forward, surf_ori=True,
-                                               use_cps=True)
-
-    assert loose is not None
-    loose = float(loose)
-    if loose < 0 or loose > 1:
-        raise ValueError('loose must be between 0 and 1, got %s' % loose)
-
-    if loose == 0. and not is_fixed_orient(forward):
-        forward = convert_forward_solution(forward, force_fixed=True,
-                                           use_cps=True)
-
-    return loose, forward
-
-
 def _check_reference(inst, ch_names=None):
     """Check for EEG ref."""
     info = inst.info
@@ -1304,33 +1269,52 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     #
     depth = exp
     del exp
-
-    input_fixed_ori = is_fixed_orient(forward)
+    src_kind = forward['src'].kind
 
     # These gymnastics are necessary due to the redundancy between
     # "fixed" and "loose"
     if fixed == 'auto':
         if loose == 'auto':
-            fixed, loose = False, 0.2
+            fixed = False
+            loose = 0.2 if src_kind == 'surface' else 1.
         else:
             fixed = True if float(loose) == 0 else False
     if fixed:
         if loose not in ['auto', 0.]:
-            raise ValueError('When invoking make_inverse_operator with '
-                             'fixed=True, loose must be 0. or "auto", '
-                             'got %s' % (loose,))
+            raise ValueError('When using fixed=True, loose must be 0. or '
+                             '"auto", got %s' % (loose,))
         loose = 0.
     if loose == 0.:
-        if fixed not in (True, 'auto'):
+        if not fixed:
             raise ValueError('If loose==0., then fixed must be True or "auto",'
                              'got %s' % (fixed,))
         fixed = True
+    if src_kind != 'surface':
+        if loose != 1:
+            raise ValueError('loose parameter has to be 1 or "auto" for '
+                             'non-surface source space (Got loose=%s for %s '
+                             'source space).' % (loose, src_kind))
+    if allow_fixed_depth:
+        # put the forward solution in fixed orientation if it's not already
+        if loose == 0. and not is_fixed_orient(forward):
+            logger.info('Converting forward solution to fixed orietnation')
+            forward = convert_forward_solution(
+                forward, force_fixed=True, use_cps=True)
+        elif loose < 1. and not forward['surf_ori']:
+            logger.info('Converting forward solution to surface orientation')
+            forward = convert_forward_solution(
+                forward, surf_ori=True, use_cps=True)
+
+    loose = float(loose)
+    if not 0 <= loose <= 1:
+        raise ValueError('loose must be between 0 and 1, got %s' % loose)
+
     depth = None if depth == 0. else depth  # 0. is an alias for None
 
     if fixed:
         if allow_fixed_depth:
             assert loose == 0.
-        elif not input_fixed_ori:
+        elif not is_fixed_orient(forward):
             # Here we use loose=1. because computation of depth priors is
             # improved by operating on the free orientation forward; see code
             # at the comment "Deal with fixed orientation forward / inverse"
@@ -1340,7 +1324,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
                 'For a fixed orientation inverse solution with depth '
                 'weighting, the forward solution must be free-orientation and '
                 'in surface orientation')
-    elif input_fixed_ori:
+    elif is_fixed_orient(forward):
         raise ValueError(
             'Forward operator has fixed orientation and can only '
             'be used to make a fixed-orientation inverse '
@@ -1350,57 +1334,54 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     if depth is not None:
         if not (0 < depth <= 1):
             raise ValueError('depth should be a scalar between 0 and 1')
-        if input_fixed_ori and not allow_fixed_depth:
+        if is_fixed_orient(forward) and not allow_fixed_depth:
             raise ValueError('You need a free-orientation, surface-oriented '
                              'forward solution to do depth weighting even '
                              'when calculating a fixed-orientation inverse.')
 
-    loose, forward = _check_loose_forward(loose, forward)
-    assert isinstance(loose, float) and 0 <= loose <= 1
-
-    if (depth is not None or loose < 1) and not (forward['surf_ori'] or
-                                                 allow_fixed_depth):
-        logger.info('Forward is not surface oriented, converting.')
+    if loose == 0. and not is_fixed_orient(forward):
+        logger.info('Converting forward solution to fixed orietnation')
         forward = convert_forward_solution(
-            forward, surf_ori=True, use_cps=use_cps)
+            forward, force_fixed=True, use_cps=True)
+    elif loose < 1. and not forward['surf_ori']:
+        logger.info('Converting forward solution to surface orientation')
+        forward = convert_forward_solution(
+            forward, surf_ori=True, use_cps=True)
 
-    gain_info, gain = _select_orient_forward(forward, info, noise_cov)
-    logger.info("Selected %d channels" % (len(gain_info['ch_names'],)))
+    forward, info_picked = _select_orient_forward(forward, info, noise_cov)
+    logger.info("Selected %d channels" % (len(info_picked['ch_names'],)))
 
     if depth is None:
         depth_prior = None
     else:
-        patch_areas = forward.get('patch_areas', None)
         depth_prior = compute_depth_prior(
-            gain, gain_info, input_fixed_ori, exp=depth,
-            patch_areas=patch_areas,
-            limit_depth_chs=limit_depth_chs, combine_xyz=combine_xyz,
-            limit=limit, noise_cov=noise_cov)
+            forward, info_picked, exp=depth, limit_depth_chs=limit_depth_chs,
+            combine_xyz=combine_xyz, limit=limit, noise_cov=noise_cov)
 
     # Deal with fixed orientation forward / inverse
     if fixed:
         orient_prior = None
-        if not input_fixed_ori and depth is not None:
-            # Convert the depth prior into a fixed-orientation one
-            logger.info('    Picked elements from a free-orientation '
-                        'depth-weighting prior into the fixed-orientation '
-                        'one')
-            depth_prior = depth_prior[2::3]
-        forward = convert_forward_solution(
-            forward, surf_ori=forward['surf_ori'], force_fixed=True,
-            use_cps=use_cps)
-        gain_info, gain = _select_orient_forward(
-            forward, info, noise_cov, verbose=False)
+        if not is_fixed_orient(forward):
+            if depth_prior is not None:
+                # Convert the depth prior into a fixed-orientation one
+                logger.info('    Picked elements from a free-orientation '
+                            'depth-weighting prior into the fixed-orientation '
+                            'one')
+                depth_prior = depth_prior[2::3]
+            forward = convert_forward_solution(
+                forward, surf_ori=True, force_fixed=True,
+                use_cps=use_cps)
     else:
         # In theory we could have orient_prior=None for loose=1., but
         # the MNE-C code does not do this
         orient_prior = compute_orient_prior(forward, loose=loose)
 
     logger.info('Whitening the forward solution.')
-    noise_cov = prepare_noise_cov(noise_cov, info, gain_info['ch_names'], rank)
+    noise_cov = prepare_noise_cov(
+        noise_cov, info, info_picked['ch_names'], rank)
     whitener, _ = compute_whitener(
-        noise_cov, info, gain_info['ch_names'], pca=pca)
-    gain = np.dot(whitener, gain)
+        noise_cov, info, info_picked['ch_names'], pca=pca)
+    gain = np.dot(whitener, forward['sol']['data'])
 
     logger.info('Creating the source covariance matrix')
     source_std = np.ones(gain.shape[1])
@@ -1419,7 +1400,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     source_std *= scale
     gain *= scale
 
-    return (forward, gain_info, gain, depth_prior, orient_prior, source_std,
+    return (forward, info_picked, gain, depth_prior, orient_prior, source_std,
             trace_GRGT, noise_cov, whitener)
 
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -88,10 +88,10 @@ def _compare(a, b):
     """Compare two python objects."""
     global last_keys
     skip_types = ['whitener', 'proj', 'reginv', 'noisenorm', 'nchan',
-                  'command_line', 'working_dir', 'mri_file', 'mri_id']
+                  'command_line', 'working_dir', 'mri_file', 'mri_id', 'scanno']
     try:
-        if isinstance(a, (dict, Info)):
-            assert (isinstance(b, (dict, Info)))
+        if isinstance(a, dict):
+            assert isinstance(b, dict)
             for k, v in a.items():
                 if k not in b and k not in skip_types:
                     raise ValueError('First one had one second one didn\'t:\n'
@@ -115,7 +115,7 @@ def _compare(a, b):
         elif isinstance(a, np.ndarray):
             assert_array_almost_equal(a, b)
         else:
-            assert_equal(a, b)
+            assert a == b
     except Exception:
         print(last_keys)
         raise

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -22,7 +22,7 @@ from mne import (read_cov, read_forward_solution, read_evokeds, pick_types,
                  convert_forward_solution, Covariance, combine_evoked,
                  SourceEstimate, make_sphere_model, make_ad_hoc_cov,
                  pick_channels_forward)
-from mne.io import read_raw_fif, Info
+from mne.io import read_raw_fif
 from mne.io.proj import make_projector
 from mne.minimum_norm.inverse import (apply_inverse, read_inverse_operator,
                                       apply_inverse_raw, apply_inverse_epochs,
@@ -88,7 +88,8 @@ def _compare(a, b):
     """Compare two python objects."""
     global last_keys
     skip_types = ['whitener', 'proj', 'reginv', 'noisenorm', 'nchan',
-                  'command_line', 'working_dir', 'mri_file', 'mri_id', 'scanno']
+                  'command_line', 'working_dir', 'mri_file', 'mri_id',
+                  'scanno']
     try:
         if isinstance(a, dict):
             assert isinstance(b, dict)


### PR DESCRIPTION
This PR should not change any outputs, but internally it:

- [x] Refactors `_prepare_forward` and `_check_loose_forward` to greatly simplify the logic they use, and deduplicate checks/flows across MNE and sparse solvers.
- [x] Adds `ordered` argument to `pick_channels` and `pick_channels_forward`, which is something that I have often wanted. Eventually we can probably simplify a lot of our code using `ordered=True`, as there are a lot of places we do the same picking-with-order logic instead of picking-as-set logic.
- [x] Fixes the CircleCI [regression in master](https://circleci.com/gh/mne-tools/mne-python/11561).
- [x] Deprecates the old way of using `compute_depth_prior` in favor of a cleaner, `Forward`-based method.
- [x] Adds an ignore for `scanno` in the inv round-trip test (should not matter, and I think our result is now possibly more correct because it resets `scanno` to match the number of entries in info)

These are important for #5881, and are hopefully the last steps we need (along with #5979) before having easy, unified, drop-in lead-field normalization across all solvers (!).

Ready for review/merge from my end @agramfort 