### PR TITLE
FIX: don't use .keys when looking up dict

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1951,7 +1951,7 @@ def _plot_histogram(params):
         plt.ylabel('Count')
         color = colors[types[idx]]
         rej = None
-        if epochs.reject is not None and types[idx] in epochs.reject.keys():
+        if epochs.reject is not None and types[idx] in epochs.reject:
             rej = epochs.reject[types[idx]] * scalings[types[idx]]
             rng = [0., rej * 1.1]
         else:


### PR DESCRIPTION
See discussion [here](https://github.com/autoreject/autoreject/pull/130#discussion_r260618474) with @agramfort 

Basically list look up is slower than dictionary lookup. So we should not use `keys()`