### PR TITLE
Duration must also be in seconds for loading EEGLAB files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -119,6 +119,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_
 
+- Fix :func:`mne.io.read_raw_eeglab` incorrectly parsing event durations by `Clemens Brunner`_
+
 API
 ~~~
 

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -234,7 +234,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.61', misc='0.3')
+    releases = dict(testing='0.62', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -316,7 +316,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='fc2d5b9eb0a144b1d6ba84dc3b983602',
         somato='77a7601948c9e38d2da52446e2eab10f',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='db282fff3ac5eaeade52f9237da181da',
+        testing='91926a4dd77cdac4f682ac76d939b250',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         opm='370ad1dcfd5c47e029e692c85358a374',
         visual_92_categories=['74f50bbeb65740903eadc229c9fa759f',

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -234,7 +234,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.62', misc='0.3')
+    releases = dict(testing='0.63', misc='0.3')
     # And also update the "hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -316,7 +316,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='fc2d5b9eb0a144b1d6ba84dc3b983602',
         somato='77a7601948c9e38d2da52446e2eab10f',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='91926a4dd77cdac4f682ac76d939b250',
+        testing='6efcfc1202020918afc28d2552d8d82d',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         opm='370ad1dcfd5c47e029e692c85358a374',
         visual_92_categories=['74f50bbeb65740903eadc229c9fa759f',

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -604,7 +604,7 @@ def _read_annotations_eeglab(eeg, uint16_codec=None):
         duration[:] = [event.duration for event in events]
 
     return Annotations(onset=np.array(onset) / eeg.srate,
-                       duration=duration,
+                       duration=duration / eeg.srate,
                        description=description,
                        orig_time=None)
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -12,7 +12,7 @@ from unittest import SkipTest
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal)
+                           assert_equal, assert_allclose)
 import pytest
 from scipy import io
 
@@ -28,6 +28,7 @@ base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
 
 raw_fname_mat = op.join(base_dir, 'test_raw.set')
 raw_fname_onefile_mat = op.join(base_dir, 'test_raw_onefile.set')
+raw_fname_event_duration = op.join(base_dir, 'test_raw_event_duration.set')
 epochs_fname_mat = op.join(base_dir, 'test_epochs.set')
 epochs_fname_onefile_mat = op.join(base_dir, 'test_epochs_onefile.set')
 raw_mat_fnames = [raw_fname_mat, raw_fname_onefile_mat]
@@ -287,6 +288,11 @@ def test_eeglab_read_annotations():
     assert annotations.orig_time is None
     assert_array_almost_equal(annotations.onset[validation_samples],
                               expected_onset, decimal=2)
+
+    # test if event durations are imported correctly
+    raw = read_raw_eeglab(raw_fname_event_duration, preload=True)
+    # file contains 16 annotations with 1 s (128 samples) duration each
+    assert_allclose(raw.annotations.duration, np.ones(16))
 
 
 @testing.requires_testing_data

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -291,8 +291,8 @@ def test_eeglab_read_annotations():
 
     # test if event durations are imported correctly
     raw = read_raw_eeglab(raw_fname_event_duration, preload=True)
-    # file contains 16 annotations with 1 s (128 samples) duration each
-    assert_allclose(raw.annotations.duration, np.ones(16))
+    # file contains 3 annotations with 0.5 s (64 samples) duration each
+    assert_allclose(raw.annotations.duration, np.ones(3) * 0.5)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
EEGLAB stores event durations in samples, so we need to convert that to seconds.