### PR TITLE
ENH: Fix regressions in master

### DIFF
--- a/examples/connectivity/plot_mixed_source_space_connectivity.py
+++ b/examples/connectivity/plot_mixed_source_space_connectivity.py
@@ -178,7 +178,7 @@ fig = plt.figure(num=None, figsize=(8, 8), facecolor='black')
 plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
-                         'Condition (PLI)', fig=fig, interactive=False)
+                         'Condition (PLI)', fig=fig)
 
 ###############################################################################
 # Save the figure (optional)

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -135,8 +135,7 @@ label_ts = mne.extract_label_time_course(
 # plot the times series of 2 labels
 fig, axes = plt.subplots(1)
 axes.plot(1e3 * stc.times, label_ts[0][0, :], 'k', label='bankssts-lh')
-axes.plot(1e3 * stc.times, label_ts[0][71, :].T, 'r',
-          label='Brain-stem')
+axes.plot(1e3 * stc.times, label_ts[0][71, :].T, 'r', label='Brain-stem')
 axes.set(xlabel='Time (ms)', ylabel='MNE current (nAm)')
 axes.legend()
 mne.viz.tight_layout()

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1281,14 +1281,16 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
             raise ValueError('When using fixed=True, loose must be 0. or '
                              '"auto", got %s' % (loose,))
         loose = 0.
-    if loose == 0.:
-        if not fixed:
-            raise ValueError('If loose==0., then fixed must be True or "auto",'
-                             'got %s' % (fixed,))
+    elif loose == 'auto':
+        loose = 0.2 if src_kind == 'surface' else 1.
+    elif loose == 0.:
+        raise ValueError('If loose==0., then fixed must be True or "auto",'
+                         'got %s' % (fixed,))
+    del fixed
+
     loose = float(loose)
     if not 0 <= loose <= 1:
         raise ValueError('loose must be between 0 and 1, got %s' % loose)
-    del fixed
     if src_kind != 'surface':
         if loose != 1:
             raise ValueError('loose parameter has to be 1 or "auto" for '

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -230,7 +230,8 @@ def test_make_inverse_operator(evoked):
     # Test MNE inverse computation starting from forward operator
     with catch_logging() as log:
         my_inv_op = make_inverse_operator(evoked.info, fwd_op, noise_cov,
-                                          loose=0.2, depth=0.8, verbose=True)
+                                          loose='auto', depth=0.8,
+                                          fixed=False, verbose=True)
     log = log.getvalue()
     assert 'rank 302 (3 small eigenvalues omitted)' in log
     _compare_io(my_inv_op)


### PR DESCRIPTION
Fixes a regression introduced by #5999 when `fixed=False` and `loose='auto'`.