### PR TITLE
Add cone mode to quiver3d

### DIFF
--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -14,7 +14,7 @@ of good practice to analyse your data.
 
 The example makes use of 2 functions ``apply_solver`` and ``solver``
 so changes can be limited to the ``solver`` function (which only takes three
-parameters: the whitened data, the gain matrix, and the number of orientations)
+parameters: the whitened data, the gain matrix and the number of orientations)
 in order to try out another inverse algorithm.
 """
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -239,7 +239,7 @@ class _Renderer(object):
             The color of the quiver: (red, green, blue).
         scale: float
             The scale of the quiver.
-        mode: 'arrow' or 'cylinder'
+        mode: 'arrow', 'cone' or 'cylinder'
             The type of the quiver.
         resolution: float
             The resolution of the arrow.
@@ -263,6 +263,10 @@ class _Renderer(object):
                                color=color, scale_factor=scale,
                                scale_mode=scale_mode,
                                resolution=resolution, scalars=scalars,
+                               opacity=opacity, figure=self.fig)
+        elif mode == 'cone':
+            self.mlab.quiver3d(x, y, z, u, v, w, color=color,
+                               mode=mode, scale_factor=scale,
                                opacity=opacity, figure=self.fig)
         elif mode == 'cylinder':
             quiv = self.mlab.quiver3d(x, y, z, u, v, w, mode=mode,


### PR DESCRIPTION
#### Reference issue
Fixes #5985.


#### What does this implement/fix?
Add the missing `cone` mode to the `quiver3d` function in the default pysurfer/mayavi 3d backend.
