### PR TITLE
Add .venv folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ examples/visualization/foobar.html
 *.py#
 *.rst#
 
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ examples/visualization/foobar.html
 *.rst#
 
 .venv/
+venv/


### PR DESCRIPTION
I started to use a virtualenv for my MNE-Python dev env, which I put into `.venv` inside the project folder. I don't know how and where others use venvs (I'd be interested, let me know), but if possible it would be nice to include this in `.gitignore`. 