### PR TITLE
MRG: Fix custom inverse solver

### DIFF
--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -145,7 +145,9 @@ def solver(M, G, n_orient):
         We have ``X_full[active_set] == X`` where X_full is the full X matrix
         such that ``M = G X_full``.
     """
-    K = linalg.solve(np.dot(G, G.T) + 1e15 * np.eye(G.shape[0]), G).T
+    inner = np.dot(G, G.T)
+    trace = np.trace(inner)
+    K = linalg.solve(inner + 4e-6 * trace * np.eye(G.shape[0]), G).T
     K /= np.linalg.norm(K, axis=1)[:, None]
     X = np.dot(K, M)
 


### PR DESCRIPTION
The regularization term had no dependence on the scale of the whitened gain matrix, so when #5947 added the `trace_GRGT` scaling to the `source_cov` it broke the solver by effectively over-regularizing. This makes the solver invariant to scale and restores the right hemi sources.

FWIW the solution depends quite a bit on the particular regularization value.