### PR TITLE
MRG: Much faster picking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ jobs:
     MNE_FORCE_SERIAL: 'true'
     PIP_DEPENDENCIES: 'codecov'
     OPENBLAS_NUM_THREADS: 1
+    AZURE_CI_WINDOWS: 'true'
   strategy:
     maxParallel: 4
     matrix:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,8 @@ Changelog
 
 - Add ``channel_wise`` argument to :func:`mne.io.Raw.apply_function` to allow applying a function on multiple channels at once by `Hubert Banville`_
 
+- Add option ``copy='auto'`` to control data copying in :class:`mne.io.RawArray` by `Eric Larson`_
+
 - The ``mri`` parameter in :func:`mne.setup_volume_source_space` is now automatically set to ``T1.mgz`` if ``subject`` is provided. This allows to get a :class:`mne.SourceSpaces` of kind ``volume`` more automatically. By `Alex Gramfort`_
 
 - Allow string argument in :meth:`mne.io.Raw.drop_channels` to remove a single channel by `Clemens Brunner`_

--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -9,8 +9,8 @@ orthogonal spatial filters that maximally correlate with a continuous target.
 SPoC can be seen as an extension of the CSP for continuous variables.
 
 Here, SPoC is applied to decode the (continuous) fluctuation of an
-electromyogram from MEG beta activity using data from `Cortico-Muscular
-Coherence example of fieldtrip
+electromyogram from MEG beta activity using data from
+`Cortico-Muscular Coherence example of FieldTrip
 <http://www.fieldtriptoolbox.org/tutorial/coherence>`_
 
 References
@@ -26,7 +26,8 @@ References
 # License: BSD (3-clause)
 
 import matplotlib.pyplot as plt
-
+import time
+t0 = time.time()
 import mne
 from mne import Epochs
 from mne.decoding import SPoC
@@ -89,3 +90,4 @@ plt.show()
 spoc.fit(X, y)
 layout = read_layout('CTF151.lay')
 spoc.plot_patterns(meg_epochs.info, layout=layout)
+print(time.time() - t0)

--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -26,8 +26,7 @@ References
 # License: BSD (3-clause)
 
 import matplotlib.pyplot as plt
-import time
-t0 = time.time()
+
 import mne
 from mne import Epochs
 from mne.decoding import SPoC
@@ -90,4 +89,3 @@ plt.show()
 spoc.fit(X, y)
 layout = read_layout('CTF151.lay')
 spoc.plot_patterns(meg_epochs.info, layout=layout)
-print(time.time() - t0)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -19,7 +19,7 @@ from ..io.compensator import get_current_comp
 from ..io.constants import FIFF
 from ..io.meas_info import anonymize_info, Info
 from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
-                       _check_excludes_includes, _PICK_TYPES_KEYS,
+                       _check_excludes_includes, _contains_ch_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx)
 
 
@@ -59,34 +59,6 @@ def _get_meg_system(info):
         system = 'unknown'
         have_helmet = False
     return system, have_helmet
-
-
-def _contains_ch_type(info, ch_type):
-    """Check whether a certain channel type is in an info object.
-
-    Parameters
-    ----------
-    info : instance of Info
-        The measurement information.
-    ch_type : str
-        the channel type to be checked for
-
-    Returns
-    -------
-    has_ch_type : bool
-        Whether the channel type is present or not.
-    """
-    _validate_type(ch_type, 'str', "ch_type")
-
-    meg_extras = ['mag', 'grad', 'planar1', 'planar2']
-    fnirs_extras = ['hbo', 'hbr']
-    valid_channel_types = sorted([key for key in _PICK_TYPES_KEYS
-                                  if key != 'meg'] + meg_extras + fnirs_extras)
-    _check_option('ch_type', ch_type, valid_channel_types)
-    if info is None:
-        raise ValueError('Cannot check for channels of type "%s" because info '
-                         'is None' % (ch_type,))
-    return ch_type in [channel_type(info, ii) for ii in range(info['nchan'])]
 
 
 def _get_ch_type(inst, ch_type, allow_ref_meg=False):

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -903,7 +903,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     """Compute covariance auto mode."""
     # rescale to improve numerical stability
     orig_rank = rank
-    rank = compute_rank(RawArray(data.T, info, copy=None),
+    rank = compute_rank(RawArray(data.T, info, copy=None, verbose=False),
                         rank, scalings, info)
     with _scaled_array(data.T, picks_list, scalings):
         C = np.dot(data.T, data)

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 from ..base import BaseRaw
-from ...utils import verbose, logger, _validate_type, fill_doc
+from ...utils import verbose, logger, _validate_type, fill_doc, _check_option
 
 
 @fill_doc
@@ -25,7 +25,12 @@ class RawArray(BaseRaw):
         First sample offset used during recording (default 0).
 
         .. versionadded:: 0.12
+    copy : {'data', 'info', 'both', 'auto', None}
+        Determines what gets copied on instantiation. "auto" (default)
+        will copy info, and copy "data" only if necessary to get to
+        double floating point precision.
 
+        .. versionadded:: 0.18
     %(verbose)s
 
     Notes
@@ -46,24 +51,32 @@ class RawArray(BaseRaw):
     """
 
     @verbose
-    def __init__(self, data, info, first_samp=0, verbose=None):  # noqa: D102
+    def __init__(self, data, info, first_samp=0, copy='auto',
+                 verbose=None):  # noqa: D102
         _validate_type(info, "info")
+        _check_option('copy', copy, ('data', 'info', 'both', 'auto', None))
         dtype = np.complex128 if np.any(np.iscomplex(data)) else np.float64
-        data = np.asanyarray(data, dtype=dtype)
-
+        orig_data = data
+        data = np.asanyarray(orig_data, dtype=dtype)
         if data.ndim != 2:
             raise ValueError('Data must be a 2D array of shape (n_channels, '
                              'n_samples), got shape %s' % (data.shape,))
-
-        logger.info('Creating RawArray with %s data, n_channels=%s, n_times=%s'
-                    % (dtype.__name__, data.shape[0], data.shape[1]))
-
         if len(data) != len(info['ch_names']):
             raise ValueError('len(data) (%s) does not match '
                              'len(info["ch_names"]) (%s)'
                              % (len(data), len(info['ch_names'])))
         assert len(info['ch_names']) == info['nchan']
-        info = info.copy()  # do not modify original info
+        if copy in ('auto', 'info', 'both'):
+            info = info.copy()
+        if copy in ('data', 'both'):
+            if data is orig_data:
+                data = data.copy()
+        elif copy != 'auto' and data is not orig_data:
+            raise ValueError('data copying was not requested by copy=%r but '
+                             'it was required to get to double floating point '
+                             'precision' % (copy,))
+        logger.info('Creating RawArray with %s data, n_channels=%s, n_times=%s'
+                    % (dtype.__name__, data.shape[0], data.shape[1]))
         super(RawArray, self).__init__(info, data,
                                        first_samps=(int(first_samp),),
                                        dtype=dtype, verbose=verbose)

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -33,6 +33,42 @@ def test_long_names():
     assert raw.ch_names == ['a' * 12 + '-%s' % ii for ii in range(11)]
 
 
+def test_array_copy():
+    """Test copying during construction."""
+    info = create_info(1, 1000.)
+    data = np.empty((1, 1000))
+    # 'auto' (default)
+    raw = RawArray(data, info)
+    assert raw._data is data
+    assert raw.info is not info
+    raw = RawArray(data.astype(np.float32), info)
+    assert raw._data is not data
+    assert raw.info is not info
+    # 'info' (more restrictive)
+    raw = RawArray(data, info, copy='info')
+    assert raw._data is data
+    assert raw.info is not info
+    with pytest.raises(ValueError, match="data copying was not .* copy='info"):
+        RawArray(data.astype(np.float32), info, copy='info')
+    # 'data'
+    raw = RawArray(data, info, copy='data')
+    assert raw._data is not data
+    assert raw.info is info
+    # 'both'
+    raw = RawArray(data, info, copy='both')
+    assert raw._data is not data
+    assert raw.info is not info
+    raw = RawArray(data.astype(np.float32), info, copy='both')
+    assert raw._data is not data
+    assert raw.info is not info
+    # None
+    raw = RawArray(data, info, copy=None)
+    assert raw._data is data
+    assert raw.info is info
+    with pytest.raises(ValueError, match='data copying was not .* copy=None'):
+        RawArray(data.astype(np.float32), info, copy=None)
+
+
 @pytest.mark.slowtest
 @requires_version('scipy', '0.12')
 def test_array_raw():

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -78,6 +78,11 @@ def test_read_evoked(cur_system, version, use_info):
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
 @pytest.mark.parametrize('cur_system, version, use_info',
                          all_test_params_epochs)
+# Strange, non-deterministic Pandas errors:
+# "ValueError: cannot expose native-only dtype 'g' in non-native
+# byte order '<' via buffer interface"
+@pytest.mark.skipif(os.getenv('AZURE_CI_WINDOWS', 'false').lower() == 'true',
+                    reason='Pandas problem on Azure CI')
 def test_read_epochs(cur_system, version, use_info):
     """Test comparing reading an Epochs object and the FieldTrip version."""
     pandas = _check_pandas_installed(strict=False)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -11,7 +11,8 @@ import re
 import numpy as np
 
 from .constants import FIFF
-from ..utils import logger, verbose, _validate_type, fill_doc, _ensure_int
+from ..utils import (logger, verbose, _validate_type, fill_doc, _ensure_int,
+                     _check_option)
 
 
 def get_channel_types():
@@ -54,6 +55,45 @@ def get_channel_types():
                          coil_type=FIFF.FIFFV_COIL_FNIRS_HBR))
 
 
+_first_rule = {
+    FIFF.FIFFV_MEG_CH: 'meg',
+    FIFF.FIFFV_REF_MEG_CH: 'ref_meg',
+    FIFF.FIFFV_EEG_CH: 'eeg',
+    FIFF.FIFFV_STIM_CH: 'stim',
+    FIFF.FIFFV_EOG_CH: 'eog',
+    FIFF.FIFFV_EMG_CH: 'emg',
+    FIFF.FIFFV_ECG_CH: 'ecg',
+    FIFF.FIFFV_RESP_CH: 'resp',
+    FIFF.FIFFV_MISC_CH: 'misc',
+    FIFF.FIFFV_EXCI_CH: 'exci',
+    FIFF.FIFFV_IAS_CH: 'ias',
+    FIFF.FIFFV_SYST_CH: 'syst',
+    FIFF.FIFFV_SEEG_CH: 'seeg',
+    FIFF.FIFFV_BIO_CH: 'bio',
+    FIFF.FIFFV_QUAT_0: 'chpi',
+    FIFF.FIFFV_QUAT_1: 'chpi',
+    FIFF.FIFFV_QUAT_2: 'chpi',
+    FIFF.FIFFV_QUAT_3: 'chpi',
+    FIFF.FIFFV_QUAT_4: 'chpi',
+    FIFF.FIFFV_QUAT_5: 'chpi',
+    FIFF.FIFFV_QUAT_6: 'chpi',
+    FIFF.FIFFV_HPI_G: 'chpi',
+    FIFF.FIFFV_HPI_ERR: 'chpi',
+    FIFF.FIFFV_HPI_MOV: 'chpi',
+    FIFF.FIFFV_DIPOLE_WAVE: 'dipole',
+    FIFF.FIFFV_GOODNESS_FIT: 'gof',
+    FIFF.FIFFV_ECOG_CH: 'ecog',
+    FIFF.FIFFV_FNIRS_CH: 'fnirs',
+}
+# How to reduce our categories in channel_type (originally)
+_second_rules = {
+    'meg': ('unit', {FIFF.FIFF_UNIT_T_M: 'grad',
+                     FIFF.FIFF_UNIT_T: 'mag'}),
+    'fnirs': ('coil_type', {FIFF.FIFFV_COIL_FNIRS_HBO: 'hbo',
+                            FIFF.FIFFV_COIL_FNIRS_HBR: 'hbr'}),
+}
+
+
 def channel_type(info, idx):
     """Get channel type.
 
@@ -66,22 +106,27 @@ def channel_type(info, idx):
 
     Returns
     -------
-    type : 'grad' | 'mag' | 'eeg' | 'stim' | 'eog' | 'emg' | 'ecg'
-           'ref_meg' | 'resp' | 'exci' | 'ias' | 'syst' | 'misc'
-           'seeg' | 'bio' | 'chpi' | 'dipole' | 'gof' | 'ecog' | 'hbo' | 'hbr'
-        Type of channel
+    type : str
+        Type of channel. Will be one of::
+
+            {'grad','mag', 'eeg', 'stim', 'eog', 'emg', 'ecg', 'ref_meg',
+             'resp', 'exci', 'ias', 'syst', 'misc', 'seeg', 'bio', 'chpi',
+             'dipole', 'gof', 'ecog', 'hbo', 'hbr'}
+
     """
+    # This is faster than the original _channel_type_old now in test_pick.py
+    # because it uses (at most!) two dict lookups plus one conditional
+    # to get the channel type string.
     ch = info['chs'][idx]
-
-    # iterate through all defined channel types until we find a match with ch
-    for t, rules in get_channel_types().items():
-        for key, vals in rules.items():  # all keys must match the values
-            if ch.get(key, None) not in np.array(vals):
-                break  # not channel type t, go to next iteration
-        else:
-            return t
-
-    raise ValueError('Unknown channel type for {}'.format(ch["ch_name"]))
+    try:
+        first_kind = _first_rule[ch['kind']]
+    except KeyError:
+        raise ValueError('Unknown channel type (%s) for channel "%s"'
+                         % (ch['kind'], ch["ch_name"]))
+    if first_kind in _second_rules:
+        key, second_rule = _second_rules[first_kind]
+        first_kind = second_rule[ch[key]]
+    return first_kind
 
 
 def pick_channels(ch_names, include, exclude=[], ordered=False):
@@ -222,6 +267,20 @@ def _check_meg_type(meg, allow_auto=False):
                              % (allowed_types, meg))
 
 
+def _check_info_exclude(info, exclude):
+    _validate_type(info, "info")
+    info._check_consistency()
+    if exclude is None:
+        raise ValueError('exclude must be a list of strings or "bads"')
+    elif exclude == 'bads':
+        exclude = info.get('bads', [])
+    elif not isinstance(exclude, (list, tuple)):
+        raise ValueError('exclude must either be "bads" or a list of strings.'
+                         ' If only one channel is to be excluded, use '
+                         '[ch_name] instead of passing ch_name.')
+    return exclude
+
+
 def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
                emg=False, ref_meg='auto', misc=False, resp=False, chpi=False,
                exci=False, ias=False, syst=False, seeg=False, dipole=False,
@@ -296,19 +355,9 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     """
     # NOTE: Changes to this function's signature should also be changed in
     # PickChannelsMixin
-    _validate_type(info, "info")
-    info._check_consistency()
+    exclude = _check_info_exclude(info, exclude)
     nchan = info['nchan']
     pick = np.zeros(nchan, dtype=np.bool)
-
-    if exclude is None:
-        raise ValueError('exclude must be a list of strings or "bads"')
-    elif exclude == 'bads':
-        exclude = info.get('bads', [])
-    elif not isinstance(exclude, (list, tuple)):
-        raise ValueError('exclude must either be "bads" or a list of strings.'
-                         ' If only one channel is to be excluded, use '
-                         '[ch_name] instead of passing ch_name.')
 
     _check_meg_type(ref_meg, allow_auto=True)
     _check_meg_type(meg)
@@ -324,50 +373,29 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
                  'not {0}.')
             raise ValueError(w.format(type(param)))
 
+    param_dict = dict(eeg=eeg, stim=stim, eog=eog, ecg=ecg, emg=emg,
+                      misc=misc, resp=resp, chpi=chpi, exci=exci,
+                      ias=ias, syst=syst, seeg=seeg, dipole=dipole,
+                      gof=gof, bio=bio, ecog=ecog)
+    # avoid triage if possible
+    if isinstance(meg, bool):
+        for key in ('grad', 'mag'):
+            param_dict[key] = meg
+    if isinstance(fnirs, bool):
+        for key in ('hbo', 'hbr'):
+            param_dict[key] = fnirs
     for k in range(nchan):
-        kind = info['chs'][k]['kind']
-        # XXX eventually we should de-duplicate this with channel_type!
-        if kind == FIFF.FIFFV_MEG_CH and meg:
-            pick[k] = _triage_meg_pick(info['chs'][k], meg)
-        elif kind == FIFF.FIFFV_EEG_CH and eeg:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_STIM_CH and stim:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_EOG_CH and eog:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_ECG_CH and ecg:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_EMG_CH and emg:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_MISC_CH and misc:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_REF_MEG_CH and ref_meg:
-            pick[k] = _triage_meg_pick(info['chs'][k], ref_meg)
-        elif kind == FIFF.FIFFV_RESP_CH and resp:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_SYST_CH and syst:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_SEEG_CH and seeg:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_IAS_CH and ias:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_EXCI_CH and exci:
-            pick[k] = True
-        elif kind in [FIFF.FIFFV_QUAT_0, FIFF.FIFFV_QUAT_1, FIFF.FIFFV_QUAT_2,
-                      FIFF.FIFFV_QUAT_3, FIFF.FIFFV_QUAT_4, FIFF.FIFFV_QUAT_5,
-                      FIFF.FIFFV_QUAT_6, FIFF.FIFFV_HPI_G, FIFF.FIFFV_HPI_ERR,
-                      FIFF.FIFFV_HPI_MOV] and chpi:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_DIPOLE_WAVE and dipole:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_GOODNESS_FIT and gof:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_BIO_CH and bio:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_ECOG_CH and ecog:
-            pick[k] = True
-        elif kind == FIFF.FIFFV_FNIRS_CH:
-            pick[k] = _triage_fnirs_pick(info['chs'][k], fnirs)
+        ch_type = channel_type(info, k)
+        try:
+            pick[k] = param_dict[ch_type]
+        except KeyError:  # not so simple
+            assert ch_type in ('grad', 'mag', 'hbo', 'hbr', 'ref_meg')
+            if ch_type in ('grad', 'mag'):
+                pick[k] = _triage_meg_pick(info['chs'][k], meg)
+            elif ch_type == 'ref_meg':
+                pick[k] = _triage_meg_pick(info['chs'][k], ref_meg)
+            else:  # ch_type in ('hbo', 'hbr')
+                pick[k] = _triage_fnirs_pick(info['chs'][k], fnirs)
 
     # restrict channels to selection if provided
     if selection is not None:
@@ -449,7 +477,6 @@ def pick_info(info, sel=(), copy=True, verbose=None):
             c['data']['row_names'] = row_names
             c['data']['data'] = c['data']['data'][row_idx]
         info['comps'] = comps
-    info._check_consistency()
     info._check_consistency()
     return info
 
@@ -697,6 +724,35 @@ def _mag_grad_dependent(info):
                for ph in info.get('proc_history', []))
 
 
+def _contains_ch_type(info, ch_type):
+    """Check whether a certain channel type is in an info object.
+
+    Parameters
+    ----------
+    info : instance of Info
+        The measurement information.
+    ch_type : str
+        the channel type to be checked for
+
+    Returns
+    -------
+    has_ch_type : bool
+        Whether the channel type is present or not.
+    """
+    _validate_type(ch_type, 'str', "ch_type")
+
+    meg_extras = ['mag', 'grad', 'planar1', 'planar2']
+    fnirs_extras = ['hbo', 'hbr']
+    valid_channel_types = sorted([key for key in _PICK_TYPES_KEYS
+                                  if key != 'meg'] + meg_extras + fnirs_extras)
+    _check_option('ch_type', ch_type, valid_channel_types)
+    if info is None:
+        raise ValueError('Cannot check for channels of type "%s" because info '
+                         'is None' % (ch_type,))
+    return any(ch_type == channel_type(info, ii)
+               for ii in range(info['nchan']))
+
+
 def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     """Get data channel indices as separate list of tuples.
 
@@ -718,35 +774,38 @@ def _picks_by_type(info, meg_combined=False, ref_meg=False, exclude='bads'):
     picks_list : list of tuples
         The list of tuples of picks and the type string.
     """
-    from ..channels.channels import _contains_ch_type
+    _validate_type(ref_meg, bool, 'ref_meg')
+    exclude = _check_info_exclude(info, exclude)
     if meg_combined == 'auto':
         meg_combined = _mag_grad_dependent(info)
     picks_list = []
-    has = [_contains_ch_type(info, k) for k in _DATA_CH_TYPES_SPLIT]
-    has = dict(zip(_DATA_CH_TYPES_SPLIT, has))
-    if has['mag'] and (meg_combined is not True or not has['grad']):
-        picks_list.append(
-            ('mag', pick_types(info, meg='mag', eeg=False, stim=False,
-             ref_meg=ref_meg, exclude=exclude))
+    picks_list = {ch_type: list() for ch_type in _DATA_CH_TYPES_SPLIT}
+    for k in range(info['nchan']):
+        if info['chs'][k]['ch_name'] not in exclude:
+            this_type = channel_type(info, k)
+            try:
+                picks_list[this_type].append(k)
+            except KeyError:
+                # This annoyance is due to differences in pick_types
+                # and channel_type behavior
+                if this_type == 'ref_meg':
+                    ch = info['chs'][k]
+                    if _triage_meg_pick(ch, ref_meg):
+                        if ch['unit'] == FIFF.FIFF_UNIT_T:
+                            picks_list['mag'].append(k)
+                        elif ch['unit'] == FIFF.FIFF_UNIT_T_M:
+                            picks_list['grad'].append(k)
+                else:
+                    pass  # not a data channel type
+    picks_list = [(ch_type, np.array(picks_list[ch_type], int))
+                  for ch_type in _DATA_CH_TYPES_SPLIT]
+    assert _DATA_CH_TYPES_SPLIT[:2] == ('mag', 'grad')
+    if meg_combined and len(picks_list[0][1]) and len(picks_list[1][1]):
+        picks_list.insert(
+            0, ('meg', np.unique(np.concatenate([picks_list.pop(0)[1],
+                                                 picks_list.pop(0)[1]])))
         )
-    if has['grad'] and (meg_combined is not True or not has['mag']):
-        picks_list.append(
-            ('grad', pick_types(info, meg='grad', eeg=False, stim=False,
-             ref_meg=ref_meg, exclude=exclude))
-        )
-    if has['mag'] and has['grad'] and meg_combined is True:
-        picks_list.append(
-            ('meg', pick_types(info, meg=True, eeg=False, stim=False,
-             ref_meg=ref_meg, exclude=exclude))
-        )
-    for ch_type in _DATA_CH_TYPES_SPLIT:
-        if ch_type in ['grad', 'mag']:  # exclude just MEG channels
-            continue
-        if has[ch_type]:
-            picks_list.append(
-                (ch_type, pick_types(info, meg=False, stim=False,
-                 ref_meg=ref_meg, exclude=exclude, **{ch_type: True}))
-            )
+    picks_list = [p for p in picks_list if len(p[1])]
     return picks_list
 
 
@@ -787,15 +846,15 @@ _PICK_TYPES_DATA_DICT = dict(
     misc=False, resp=False, chpi=False, exci=False, ias=False, syst=False,
     seeg=True, dipole=False, gof=False, bio=False, ecog=True, fnirs=True)
 _PICK_TYPES_KEYS = tuple(list(_PICK_TYPES_DATA_DICT.keys()) + ['ref_meg'])
-_DATA_CH_TYPES_SPLIT = ['mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr']
+_DATA_CH_TYPES_SPLIT = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr')
 
 # Valid data types, ordered for consistency, used in viz/evoked.
-_VALID_CHANNEL_TYPES = ['eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'emg',
+_VALID_CHANNEL_TYPES = ('eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'emg',
                         'dipole', 'gof', 'bio', 'ecog', 'hbo', 'hbr',
-                        'misc']
+                        'misc')
 
-_MEG_CH_TYPES_SPLIT = ['mag', 'grad', 'planar1', 'planar2']
-_FNIRS_CH_TYPES_SPLIT = ['hbo', 'hbr']
+_MEG_CH_TYPES_SPLIT = ('mag', 'grad', 'planar1', 'planar2')
+_FNIRS_CH_TYPES_SPLIT = ('hbo', 'hbr')
 
 
 def _pick_data_channels(info, exclude='bads', with_ref_meg=True):

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import inspect
 import os.path as op
 
@@ -12,16 +13,75 @@ from mne import __file__ as _root_init_fname
 from mne.io import (read_raw_fif, RawArray, read_raw_bti, read_raw_kit,
                     read_info)
 from mne.io.pick import (channel_indices_by_type, channel_type,
-                         pick_types_forward, _picks_by_type, _picks_to_idx)
+                         pick_types_forward, _picks_by_type, _picks_to_idx,
+                         get_channel_types, _DATA_CH_TYPES_SPLIT,
+                         _contains_ch_type)
 from mne.io.constants import FIFF
 from mne.datasets import testing
-from mne.utils import run_tests_if_main, catch_logging
+from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
 
 io_dir = op.join(op.dirname(inspect.getfile(inspect.currentframe())), '..')
 data_path = testing.data_path(download=False)
 fname_meeg = op.join(data_path, 'MEG', 'sample',
                      'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
 fname_mc = op.join(data_path, 'SSS', 'test_move_anon_movecomp_raw_sss.fif')
+
+base_dir = op.join(op.dirname(__file__), 'data')
+ctf_fname = op.join(base_dir, 'test_ctf_raw.fif')
+
+
+def _picks_by_type_old(info, meg_combined=False, ref_meg=False,
+                       exclude='bads'):
+    """Use the old, slower _picks_by_type code."""
+    picks_list = []
+    has = [_contains_ch_type(info, k) for k in _DATA_CH_TYPES_SPLIT]
+    has = dict(zip(_DATA_CH_TYPES_SPLIT, has))
+    if has['mag'] and (meg_combined is not True or not has['grad']):
+        picks_list.append(
+            ('mag', pick_types(info, meg='mag', eeg=False, stim=False,
+                               ref_meg=ref_meg, exclude=exclude))
+        )
+    if has['grad'] and (meg_combined is not True or not has['mag']):
+        picks_list.append(
+            ('grad', pick_types(info, meg='grad', eeg=False, stim=False,
+                                ref_meg=ref_meg, exclude=exclude))
+        )
+    if has['mag'] and has['grad'] and meg_combined is True:
+        picks_list.append(
+            ('meg', pick_types(info, meg=True, eeg=False, stim=False,
+                               ref_meg=ref_meg, exclude=exclude))
+        )
+    for ch_type in _DATA_CH_TYPES_SPLIT:
+        if ch_type in ['grad', 'mag']:  # exclude just MEG channels
+            continue
+        if has[ch_type]:
+            picks_list.append(
+                (ch_type, pick_types(info, meg=False, stim=False,
+                                     ref_meg=ref_meg, exclude=exclude,
+                                     **{ch_type: True}))
+            )
+    return picks_list
+
+
+def _channel_type_old(info, idx):
+    """Get channel type using old, slower scheme."""
+    ch = info['chs'][idx]
+
+    # iterate through all defined channel types until we find a match with ch
+    for t, rules in get_channel_types().items():
+        for key, vals in rules.items():  # all keys must match the values
+            if ch.get(key, None) not in np.array(vals):
+                break  # not channel type t, go to next iteration
+        else:
+            return t
+
+    raise ValueError('Unknown channel type for {}'.format(ch["ch_name"]))
+
+
+def _assert_channel_types(info):
+    for k in range(info['nchan']):
+        a, b = channel_type(info, k), _channel_type_old(info, k)
+        assert a == b
 
 
 def test_pick_refs():
@@ -48,6 +108,7 @@ def test_pick_refs():
     raw_ctf.apply_gradient_compensation(2)
     for info in infos:
         info['bads'] = []
+        _assert_channel_types(info)
         pytest.raises(ValueError, pick_types, info, meg='foo')
         pytest.raises(ValueError, pick_types, info, ref_meg='foo')
         picks_meg_ref = pick_types(info, meg=True, ref_meg=True)
@@ -100,6 +161,12 @@ def test_pick_refs():
                 pick_info(info, pick, verbose=True)
             assert ('Removing {} compensators'.format(len(info['comps']))
                     in log.getvalue())
+    picks_ref_grad = pick_types(info, meg=False, ref_meg='grad')
+    assert set(picks_ref_mag) == set(picks_ref)
+    assert len(picks_ref_grad) == 0
+    all_meg = np.arange(3, 306)
+    assert_array_equal(np.concatenate([picks_ref, picks_meg]), all_meg)
+    assert_array_equal(picks_meg_ref_mag, all_meg)
 
 
 def test_pick_channels_regexp():
@@ -110,16 +177,50 @@ def test_pick_channels_regexp():
     assert_array_equal(pick_channels_regexp(ch_names, 'MEG *'), [0, 1, 2])
 
 
+def assert_indexing(info, picks_by_type, ref_meg=False, all_data=True):
+    """Assert our indexing functions work properly."""
+    # First that our old and new channel typing functions are equivalent
+    _assert_channel_types(info)
+    # Next that channel_indices_by_type works
+    if not ref_meg:
+        idx = channel_indices_by_type(info)
+        for key in idx:
+            for p in picks_by_type:
+                if key == p[0]:
+                    assert_array_equal(idx[key], p[1])
+                    break
+            else:
+                assert len(idx[key]) == 0
+    # Finally, picks_by_type (if relevant)
+    if not all_data:
+        picks_by_type = [p for p in picks_by_type
+                         if p[0] in _DATA_CH_TYPES_SPLIT]
+    picks_by_type = [(p[0], np.array(p[1], int)) for p in picks_by_type]
+    actual = _picks_by_type(info, ref_meg=ref_meg)
+    assert_object_equal(actual, picks_by_type)
+    if not ref_meg and idx['hbo']:  # our old code had a bug
+        with pytest.raises(TypeError, match='unexpected keyword argument'):
+            _picks_by_type_old(info, ref_meg=ref_meg)
+    else:
+        old = _picks_by_type_old(info, ref_meg=ref_meg)
+        assert_object_equal(old, picks_by_type)
+    # test bads
+    info = info.copy()
+    info['bads'] = [info['chs'][picks_by_type[0][1][0]]['ch_name']]
+    picks_by_type = deepcopy(picks_by_type)
+    picks_by_type[0] = (picks_by_type[0][0], picks_by_type[0][1][1:])
+    actual = _picks_by_type(info, ref_meg=ref_meg)
+    assert_object_equal(actual, picks_by_type)
+
+
 def test_pick_seeg_ecog():
     """Test picking with sEEG and ECoG."""
     names = 'A1 A2 Fz O OTp1 OTp2 E1 OTp3 E2 E3'.split()
     types = 'mag mag eeg eeg seeg seeg ecog seeg ecog ecog'.split()
     info = create_info(names, 1024., types)
-    idx = channel_indices_by_type(info)
-    assert_array_equal(idx['mag'], [0, 1])
-    assert_array_equal(idx['eeg'], [2, 3])
-    assert_array_equal(idx['seeg'], [4, 5, 7])
-    assert_array_equal(idx['ecog'], [6, 8, 9])
+    picks_by_type = [('mag', [0, 1]), ('eeg', [2, 3]),
+                     ('seeg', [4, 5, 7]), ('ecog', [6, 8, 9])]
+    assert_indexing(info, picks_by_type)
     assert_array_equal(pick_types(info, meg=False, seeg=True), [4, 5, 7])
     for i, t in enumerate(types):
         assert_equal(channel_type(info, i), types[i])
@@ -140,6 +241,7 @@ def test_pick_chpi():
     """Test picking cHPI."""
     # Make sure we don't mis-classify cHPI channels
     info = read_info(op.join(io_dir, 'tests', 'data', 'test_chpi_raw_sss.fif'))
+    _assert_channel_types(info)
     channel_types = {channel_type(info, idx) for idx in range(info['nchan'])}
     assert 'chpi' in channel_types
     assert 'seeg' not in channel_types
@@ -151,10 +253,8 @@ def test_pick_bio():
     names = 'A1 A2 Fz O BIO1 BIO2 BIO3'.split()
     types = 'mag mag eeg eeg bio bio bio'.split()
     info = create_info(names, 1024., types)
-    idx = channel_indices_by_type(info)
-    assert_array_equal(idx['mag'], [0, 1])
-    assert_array_equal(idx['eeg'], [2, 3])
-    assert_array_equal(idx['bio'], [4, 5, 6])
+    picks_by_type = [('mag', [0, 1]), ('eeg', [2, 3]), ('bio', [4, 5, 6])]
+    assert_indexing(info, picks_by_type, all_data=False)
 
 
 def test_pick_fnirs():
@@ -162,11 +262,22 @@ def test_pick_fnirs():
     names = 'A1 A2 Fz O hbo1 hbo2 hbr1'.split()
     types = 'mag mag eeg eeg hbo hbo hbr'.split()
     info = create_info(names, 1024., types)
-    idx = channel_indices_by_type(info)
-    assert_array_equal(idx['mag'], [0, 1])
-    assert_array_equal(idx['eeg'], [2, 3])
-    assert_array_equal(idx['hbo'], [4, 5])
-    assert_array_equal(idx['hbr'], [6])
+    picks_by_type = [('mag', [0, 1]), ('eeg', [2, 3]),
+                     ('hbo', [4, 5]), ('hbr', [6])]
+    assert_indexing(info, picks_by_type)
+
+
+def test_pick_ref():
+    """Test picking ref_meg channels."""
+    info = read_info(ctf_fname)
+    picks_by_type = [('stim', [0]), ('eog', [306, 307]), ('ecg', [308]),
+                     ('misc', [1]),
+                     ('mag', np.arange(31, 306)),
+                     ('ref_meg', np.arange(2, 31))]
+    assert_indexing(info, picks_by_type, all_data=False)
+    picks_by_type.append(('mag', np.concatenate([picks_by_type.pop(-1)[1],
+                                                 picks_by_type.pop(-1)[1]])))
+    assert_indexing(info, picks_by_type, ref_meg=True, all_data=False)
 
 
 def _check_fwd_n_chan_consistent(fwd, n_expected):
@@ -232,6 +343,7 @@ def test_picks_by_channels():
     ch_types = ['grad', 'mag', 'mag', 'eeg']
     sfreq = 250.0
     info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    _assert_channel_types(info)
     raw = RawArray(test_data, info)
 
     pick_list = _picks_by_type(raw.info)
@@ -280,6 +392,7 @@ def test_clean_info_bads():
     raw_file = op.join(op.dirname(_root_init_fname), 'io', 'tests', 'data',
                        'test_raw.fif')
     raw = read_raw_fif(raw_file)
+    _assert_channel_types(raw.info)
 
     # select eeg channels
     picks_eeg = pick_types(raw.info, meg=False, eeg=True)
@@ -319,6 +432,7 @@ def test_clean_info_bads():
 def test_picks_to_idx():
     """Test checking type integrity checks of picks."""
     info = create_info(12, 1000., 'eeg')
+    _assert_channel_types(info)
     picks = np.arange(info['nchan'])
     # Array and list
     assert_array_equal(picks, _picks_to_idx(info, picks))

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -102,8 +102,8 @@ def _check_for_unsupported_ica_channels(picks, info, allow_ref_meg=False):
     This prevents the program from crashing without
     feedback when a bad channel is provided to ICA whitening.
     """
-    types = _DATA_CH_TYPES_SPLIT + ['eog']
-    types += ['ref_meg'] if allow_ref_meg else []
+    types = _DATA_CH_TYPES_SPLIT + ('eog',)
+    types += ('ref_meg',) if allow_ref_meg else ()
     chs = list({channel_type(info, j) for j in picks})
     check = all([ch in types for ch in chs])
     if not check:
@@ -570,7 +570,7 @@ class ICA(ContainsMixin):
             # Scale (z-score) the data by channel type
             info = pick_info(info, picks)
             pre_whitener = np.empty([len(data), 1])
-            for ch_type in _DATA_CH_TYPES_SPLIT + ['eog', "ref_meg"]:
+            for ch_type in _DATA_CH_TYPES_SPLIT + ('eog', "ref_meg"):
                 if _contains_ch_type(info, ch_type):
                     if ch_type == 'seeg':
                         this_picks = pick_types(info, meg=False, seeg=True)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -728,7 +728,7 @@ def test_bad_channels(method, allow_ref_meg):
     epochs = EpochsArray(data, info)
 
     n_components = 0.9
-    data_chs = _DATA_CH_TYPES_SPLIT + ['eog']
+    data_chs = list(_DATA_CH_TYPES_SPLIT + ('eog',))
     if allow_ref_meg:
         data_chs.append('ref_meg')
     chs_bad = list(set(chs) - set(data_chs))

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -49,8 +49,7 @@ def test_xdawn_picks():
     info = create_info(2, 1000., ('eeg', 'misc'))
     epochs = EpochsArray(data, info)
     xd = Xdawn(correct_overlap=False)
-    with pytest.warns(RuntimeWarning, match='No average EEG'):
-        xd.fit(epochs)
+    xd.fit(epochs)
     epochs_out = xd.apply(epochs)['1']
     assert epochs_out.info['ch_names'] == epochs.ch_names
     assert not (epochs_out.get_data()[:, 0] != data[:, 0]).any()
@@ -234,8 +233,7 @@ def test_XdawnTransformer():
 
     # Compare xdawn and _XdawnTransformer
     xd = Xdawn(correct_overlap=False)
-    with pytest.warns(RuntimeWarning, match='No average EEG'):
-        xd.fit(epochs)
+    xd.fit(epochs)
 
     xdt = _XdawnTransformer()
     xdt.fit(X, y)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -34,7 +34,7 @@ from .testing import (_memory_usage, run_tests_if_main, requires_sklearn,
                       _TempDir, has_nibabel, _import_mlab, buggy_mkl_svd,
                       requires_numpydoc, requires_tvtk, requires_freesurfer,
                       requires_nitime, requires_fs_or_nibabel, requires_dipy,
-                      requires_neuromag2ft)
+                      requires_neuromag2ft, assert_object_equal)
 from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _reg_pinv, random_permutation, _reject_data_segments,
                        compute_corr, _get_inst_data, array_split_idx,

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -183,11 +183,18 @@ def _get_argvalues():
     """Return all arguments (except self) and values of read_raw_xxx."""
     # call stack
     # read_raw_xxx -> EOF -> verbose() -> BaseRaw.__init__ -> get_argvalues
-    frame = inspect.stack()[4][0]
-    fname = frame.f_code.co_filename
-    if not fnmatch.fnmatch(fname, '*/mne/io/*'):
-        return None
-    args, _, _, values = inspect.getargvalues(frame)
+
+    # This is equivalent to `frame = inspect.stack(0)[4][0]` but faster
+    frame = inspect.currentframe()
+    try:
+        for _ in range(4):
+            frame = frame.f_back
+        fname = frame.f_code.co_filename
+        if not fnmatch.fnmatch(fname, '*/mne/io/*'):
+            return None
+        args, _, _, values = inspect.getargvalues(frame)
+    finally:
+        del frame
     params = dict()
     for arg in args:
         params[arg] = values[arg]

--- a/mne/utils/testing.py
+++ b/mne/utils/testing.py
@@ -21,6 +21,7 @@ import warnings
 import numpy as np
 
 from ._logging import warn
+from .numerics import object_diff
 
 
 def _memory_usage(*args, **kwargs):
@@ -414,3 +415,9 @@ def assert_and_remove_boundary_annot(annotations, n=1):
         idx = np.where(annotations.description == '%s boundary' % key)[0]
         assert len(idx) == n
         annotations.delete(idx)
+
+
+def assert_object_equal(a, b):
+    """Assert two objects are equal."""
+    d = object_diff(a, b)
+    assert d == '', d

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2123,7 +2123,7 @@ def _setup_butterfly(params):
         types = np.array(params['types'])[params['orig_inds']]
         if params['group_by'] in ['type', 'original']:
             inds = params['inds']
-            labels = [t for t in _DATA_CH_TYPES_SPLIT + ['eog', 'ecg']
+            labels = [t for t in _DATA_CH_TYPES_SPLIT + ('eog', 'ecg')
                       if t in types] + ['misc']
             ticks = np.arange(5, 5 * (len(labels) + 1), 5)
             offs = {l: t for (l, t) in zip(labels, ticks)}


### PR DESCRIPTION
On my machine:

- On 0656d8eef747ecb0d86631c18675feba3ab1fcae, the commit before the (noticed) regression, the example took 54s.
- On `master` it takes 232s.
- On this PR it takes 15s.

The big slowdown culprits:

- `mne.cov._compute_auto_covariance` constructed a `RawArray`, and it gets called ~700x by the example code. This exposed:
    - `mne.utils._get_argvalues` used a slow method of inspection
    - Needlessly copying `info` on instantiation of `RawArray`
    - inefficiencies in `mne.cov._smart_eigh` where it can and should short-cut when `rank='full'`
- `mne.io.pick` used a very slow method for `_picks_by_type`, which:
    - traversed the entire `info['chs']` array multiple times using `pick_types`, where...
    - `pick_types` used a `switch`-like branching based on channel types
- there has been a long-standing redundancy between `_picks_by_type`, which uses `channel_type`, and `pick_types`, which used the branching -- these have been unified to use the `channel_type` code since it uses a faster and simpler `dict`-style lookup.

There were also bugs in the picking code that were not caught before (having to do with handling of `ref_meg` channels), and have been fixed here. The redundancy / handling / consistency of `meg` string options between `pick_types` and `channel_type` is still not perfect, but it should be much improved at least.

Ready for review/merge from myend.