### PR TITLE
[MRG] Update pymatreader to version 0.0.19.

### DIFF
--- a/mne/externals/pymatreader/utils.py
+++ b/mne/externals/pymatreader/utils.py
@@ -143,7 +143,7 @@ def _assign_types(values):
 def _handle_ndarray(values):
     """Handle conversion of ndarrays."""
     values = numpy.squeeze(values).T
-    if values.dtype in ("uint8", "uint16", "uint32", "uint64"):
+    if values.dtype in ("uint8", "uint16", "uint32"):
         values = _handle_hdf5_strings(values)
 
     if isinstance(values, numpy.ndarray) and \


### PR DESCRIPTION
This PR updates pymatreader to the latest version. The only (but important) change is that the uint64 datatype of matlab used to be handled as a character. This created problems when reading some FieldTrip structures.
