### PR TITLE
MRG+1: Add iterable support to simulate_raw

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,10 +28,6 @@ s_path = op.join(test_path, 'MEG', 'sample')
 fname_evoked = op.join(s_path, 'sample_audvis_trunc-ave.fif')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
-# turn anything that uses testing data into an auto-skipper by
-# setting params=[testing_param]
-testing_param = pytest.param('t', marks=pytest.mark.skipif(
-    testing._testing._skip_testing_data(), reason='Requires testing dataset'))
 
 
 @pytest.fixture(scope='session')
@@ -62,7 +58,7 @@ def matplotlib_config():
         mlab.options.backend = 'test'
 
 
-@pytest.fixture(scope='function', params=[testing_param])
+@pytest.fixture(scope='function', params=[testing._pytest_param()])
 def evoked():
     """Get evoked data."""
     evoked = mne.read_evokeds(fname_evoked, condition='Left Auditory',
@@ -71,7 +67,7 @@ def evoked():
     return evoked
 
 
-@pytest.fixture(scope='function', params=[testing_param])
+@pytest.fixture(scope='function', params=[testing._pytest_param()])
 def noise_cov():
     return mne.read_cov(fname_cov)
 

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -317,6 +317,7 @@ div.highlight-console div.highlight span.gp {
             user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome and Opera */
 }
+<<<<<<< HEAD
 /* Sizing */
 .body {
     max-width: unset !important;
@@ -354,4 +355,9 @@ dl.cmd-list dt::after {
 /* Attributes / methods not taking up entire width ends up looking odd */
 dd table.align-center {
     width: 100%;
+=======
+/* Table alignment */
+table.left-align-col td {
+    text-align: left
+>>>>>>> ENH: Add iterable support to simulate_raw
 }

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -317,7 +317,6 @@ div.highlight-console div.highlight span.gp {
             user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome and Opera */
 }
-<<<<<<< HEAD
 /* Sizing */
 .body {
     max-width: unset !important;
@@ -355,9 +354,4 @@ dl.cmd-list dt::after {
 /* Attributes / methods not taking up entire width ends up looking odd */
 dd table.align-center {
     width: 100%;
-=======
-/* Table alignment */
-table.left-align-col td {
-    text-align: left
->>>>>>> ENH: Add iterable support to simulate_raw
 }

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -893,6 +893,9 @@ Simulation
 .. autosummary::
    :toctree: generated/
 
+   add_blink
+   add_chpi
+   add_ecg
    add_noise
    simulate_evoked
    simulate_raw

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -893,9 +893,9 @@ Simulation
 .. autosummary::
    :toctree: generated/
 
-   add_blink
    add_chpi
    add_ecg
+   add_eog
    add_noise
    simulate_evoked
    simulate_raw

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -177,7 +177,7 @@ Bug
 API
 ~~~
 
-- Deprecate ``cov, iir_params, blink, ecg, chpi, random_state`` and support for :class:`mne.io.Raw` instance inputs in :func:`mne.simulation.simulate_raw`; use :func:`mne.simulation.add_noise`, :func:`mne.simulation.add_ecg`, :func:`mne.simulation.add_blink`, and :func:`mne.simulation.add_chpi` by `Eric Larson`_
+- Deprecate ``cov, iir_params, blink, ecg, chpi, random_state`` and support for :class:`mne.io.Raw` instance inputs in :func:`mne.simulation.simulate_raw`; use :func:`mne.simulation.add_noise`, :func:`mne.simulation.add_ecg`, :func:`mne.simulation.add_eog`, and :func:`mne.simulation.add_chpi` by `Eric Larson`_
 
 - Add ``overwrite`` parameter in :func:`mne.Epochs.save` by `Katarina Slama`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,7 +59,7 @@ Changelog
 
 - Add :func:`mne.labels_to_stc` to facilitate working with label data, by `Eric Larson`_
 
-- Add support for using :class:`mne.Info` and ``duration`` in :func:`mne.simulation.simulate_raw` instead of :class:`mne.io.Raw` by `Eric Larson`_
+- Add support for using :class:`mne.Info` in :func:`mne.simulation.simulate_raw` instead of :class:`mne.io.Raw` by `Eric Larson`_
 
 - Add support for passing an iterable and stim channel values using ``stc`` parameter of :func:`mne.simulation.simulate_raw` by `Eric Larson`_
 
@@ -177,7 +177,7 @@ Bug
 API
 ~~~
 
-- Deprecate ``cov, iir_params, duration`` and support for :class:`mne.io.Raw` instance inputs (in favor of :func:`mne.simulation.add_noise`) in :func:`mne.simulation.simulate_raw` by `Eric Larson`_
+- Deprecate ``cov, iir_params, blink, ecg, chpi, random_state`` and support for :class:`mne.io.Raw` instance inputs in :func:`mne.simulation.simulate_raw`; use :func:`mne.simulation.add_noise`, :func:`mne.simulation.add_ecg`, :func:`mne.simulation.add_blink`, and :func:`mne.simulation.add_chpi` by `Eric Larson`_
 
 - Add ``overwrite`` parameter in :func:`mne.Epochs.save` by `Katarina Slama`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -177,6 +177,8 @@ Bug
 API
 ~~~
 
+- Deprecate ``cov, iir_params, duration`` and support for :class:`mne.io.Raw` instance inputs (in favor of :func:`mne.simulation.add_noise`) in :func:`mne.simulation.simulate_raw` by `Eric Larson`_
+
 - Add ``overwrite`` parameter in :func:`mne.Epochs.save` by `Katarina Slama`_
 
 - Add ``stim_channel`` parameter in :func:`mne.io.read_raw_cnt` to toggle stim channel synthesis by `Joan Massich`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Changelog
 
 - Add support for using :class:`mne.Info` and ``duration`` in :func:`mne.simulation.simulate_raw` instead of :class:`mne.io.Raw` by `Eric Larson`_
 
+- Add support for passing an iterable and stim channel values using ``stc`` parameter of :func:`mne.simulation.simulate_raw` by `Eric Larson`_
+
 - Add ``overlap`` argument to :func:`mne.make_fixed_length_events` by `Eric Larson`_
 
 - Add approximate distance-based ``spacing`` source space decimation algorithm to :func:`mne.setup_source_space` by `Eric Larson`_
@@ -182,6 +184,8 @@ API
 - Python 2 is no longer supported; MNE-Python now requires Python 3.5+, by `Eric Larson`_
 
 - A new class :class:`mne.VolVectorSourceEstimate` is returned by :func:`mne.minimum_norm.apply_inverse` (and related functions) when a volume source space and ``pick_ori='vector'`` is used, by `Eric Larson`_
+
+- Converting a forward solution with a volume source space to fixed orientation using :func:`mne.convert_forward_solution` now raises an error, by `Eric Larson`_
 
 - ``raw.estimate_rank`` has been deprecated and will be removed in 0.19 in favor of :func:`mne.compute_rank`  by `Eric Larson`_
 

--- a/examples/simulation/plot_simulate_raw_data.py
+++ b/examples/simulation/plot_simulate_raw_data.py
@@ -3,8 +3,8 @@
 Generate simulated raw data
 ===========================
 
-This example generates raw data by repeating a desired source
-activation multiple times.
+This example generates raw data by repeating a desired source activation
+multiple times.
 """
 # Authors: Yousra Bekhti <yousra.bekhti@gmail.com>
 #          Mark Wronkiewicz <wronk.mark@gmail.com>

--- a/examples/simulation/plot_simulate_raw_data.py
+++ b/examples/simulation/plot_simulate_raw_data.py
@@ -16,29 +16,27 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import mne
-from mne import read_source_spaces, find_events, Epochs, compute_covariance
+from mne import find_events, Epochs, compute_covariance, make_ad_hoc_cov
 from mne.datasets import sample
-from mne.simulation import simulate_sparse_stc, simulate_raw
+from mne.simulation import (simulate_sparse_stc, simulate_raw,
+                            add_noise, add_ecg, add_blink)
 
 print(__doc__)
 
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
-trans_fname = data_path + '/MEG/sample/sample_audvis_raw-trans.fif'
-src_fname = data_path + '/subjects/sample/bem/sample-oct-6-src.fif'
-bem_fname = (data_path +
-             '/subjects/sample/bem/sample-5120-5120-5120-bem-sol.fif')
+fwd_fname = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
 
 # Load real data as the template
 raw = mne.io.read_raw_fif(raw_fname)
 raw.set_eeg_reference(projection=True)
-raw = raw.crop(0., 30.)  # 30 sec is enough
 
 ##############################################################################
 # Generate dipole time series
 n_dipoles = 4  # number of dipoles to create
 epoch_duration = 2.  # duration of each epoch/event
 n = 0  # harmonic number
+rng = np.random.RandomState(0)  # random state (make reproducible)
 
 
 def data_fun(times):
@@ -56,9 +54,10 @@ def data_fun(times):
 
 
 times = raw.times[:int(raw.info['sfreq'] * epoch_duration)]
-src = read_source_spaces(src_fname)
+fwd = mne.read_forward_solution(fwd_fname)
+src = fwd['src']
 stc = simulate_sparse_stc(src, n_dipoles=n_dipoles, times=times,
-                          data_fun=data_fun, random_state=0)
+                          data_fun=data_fun, random_state=rng)
 # look at our source data
 fig, ax = plt.subplots(1)
 ax.plot(times, 1e9 * stc.data.T)
@@ -67,15 +66,18 @@ mne.viz.utils.plt_show()
 
 ##############################################################################
 # Simulate raw data
-raw_sim = simulate_raw(raw, stc, trans_fname, src, bem_fname, cov='simple',
-                       iir_filter=[0.2, -0.2, 0.04], ecg=True, blink=True,
-                       n_jobs=1, verbose=True)
+raw_sim = simulate_raw(raw.info, [stc] * 10, forward=fwd, cov=None,
+                       verbose=True)
+cov = make_ad_hoc_cov(raw_sim.info)
+add_noise(raw_sim, cov, iir_filter=[0.2, -0.2, 0.04], random_state=rng)
+add_ecg(raw_sim, random_state=rng)
+add_blink(raw_sim, random_state=rng)
 raw_sim.plot()
 
 ##############################################################################
 # Plot evoked data
 events = find_events(raw_sim)  # only 1 pos, so event number == 1
-epochs = Epochs(raw_sim, events, 1, -0.2, epoch_duration)
+epochs = Epochs(raw_sim, events, 1, tmin=-0.2, tmax=epoch_duration)
 cov = compute_covariance(epochs, tmax=0., method='empirical',
                          verbose='error')  # quick calc
 evoked = epochs.average()

--- a/examples/simulation/plot_simulate_raw_data.py
+++ b/examples/simulation/plot_simulate_raw_data.py
@@ -19,7 +19,7 @@ import mne
 from mne import find_events, Epochs, compute_covariance, make_ad_hoc_cov
 from mne.datasets import sample
 from mne.simulation import (simulate_sparse_stc, simulate_raw,
-                            add_noise, add_ecg, add_blink)
+                            add_noise, add_ecg, add_eog)
 
 print(__doc__)
 
@@ -71,7 +71,7 @@ raw_sim = simulate_raw(raw.info, [stc] * 10, forward=fwd, cov=None,
 cov = make_ad_hoc_cov(raw_sim.info)
 add_noise(raw_sim, cov, iir_filter=[0.2, -0.2, 0.04], random_state=rng)
 add_ecg(raw_sim, random_state=rng)
-add_blink(raw_sim, random_state=rng)
+add_eog(raw_sim, random_state=rng)
 raw_sim.plot()
 
 ##############################################################################

--- a/mne/datasets/testing/__init__.py
+++ b/mne/datasets/testing/__init__.py
@@ -1,3 +1,4 @@
 """MNE testing dataset."""
 
-from ._testing import data_path, requires_testing_data, get_version
+from ._testing import (data_path, requires_testing_data, get_version,
+                       _pytest_param)

--- a/mne/datasets/testing/_testing.py
+++ b/mne/datasets/testing/_testing.py
@@ -50,3 +50,11 @@ def requires_testing_data(func):
     import pytest
     return pytest.mark.skipif(_skip_testing_data(),
                               reason='Requires testing dataset')(func)
+
+
+def _pytest_param():
+    import pytest
+    # turn anything that uses testing data into an auto-skipper by
+    # setting params=[testing._pytest_param()]
+    return pytest.param('testing_data', marks=pytest.mark.skipif(
+        _skip_testing_data(), reason='Requires testing dataset'))

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2255,7 +2255,7 @@ class _Interp2(object):
                              % (known_types, interp))
         self._interp = interp
         if self.n_samp is not None:
-            if self._interp == 'zero':
+            if self._interp == 'zero' or np.isinf(self.n_samp):  # ZOH
                 self._interpolators = None
             else:
                 if self._interp == 'linear':
@@ -2266,16 +2266,16 @@ class _Interp2(object):
                     interp = np.hanning(self.n_samp * 2 + 1)[self.n_samp:-1]
                 self._interpolators = np.array([interp, 1 - interp])
 
-    def interpolate(self, key, data, out, picks=None, time_sl=None):
+    def interpolate(self, key, data, out, picks=None, interp_sl=None):
         """Interpolate."""
         picks = slice(None) if picks is None else picks
-        time_sl = slice(None) if time_sl is None else time_sl
+        interp_sl = slice(None) if interp_sl is None else interp_sl
         # Process data in large chunks to save on memory
         this_data = np.dot(self._last[key], data)
         if self._interpolators is not None:
-            this_data *= self._interpolators[0][time_sl]
-        out[picks, time_sl] += this_data
+            this_data *= self._interpolators[0][interp_sl]
+        out[picks, ] += this_data
         if self._interpolators is not None:
             this_data = np.dot(self._current[key], data)
-            this_data *= self._interpolators[1][time_sl]
-            out[picks, time_sl] += this_data
+            this_data *= self._interpolators[1][interp_sl]
+            out[picks, :] += this_data

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2242,7 +2242,6 @@ class _Interp2(object):
         assert len(set(self._count.values())) == 1
         self._n_samp = n_samp
         self.interp = self.interp
-        self._chunks = np.concatenate((np.arange(0, n_samp, 10000), [n_samp]))
 
     @property
     def interp(self):
@@ -2267,24 +2266,16 @@ class _Interp2(object):
                     interp = np.hanning(self.n_samp * 2 + 1)[self.n_samp:-1]
                 self._interpolators = np.array([interp, 1 - interp])
 
-    def interpolate(self, key, data, out, picks=None, data_idx=None):
+    def interpolate(self, key, data, out, picks=None, time_sl=None):
         """Interpolate."""
         picks = slice(None) if picks is None else picks
+        time_sl = slice(None) if time_sl is None else time_sl
         # Process data in large chunks to save on memory
-        for start, stop in zip(self._chunks[:-1], self._chunks[1:]):
-            time_sl = slice(start, stop)
-            if data_idx is not None:
-                # This is useful e.g. when using circular access to the data.
-                # This prevents STC blowups in raw data simulation.
-                data_sl = data[:, data_idx[time_sl]]
-            else:
-                data_sl = data[:, time_sl]
-            this_data = np.dot(self._last[key], data_sl)
-            if self._interpolators is not None:
-                this_data *= self._interpolators[0][time_sl]
+        this_data = np.dot(self._last[key], data)
+        if self._interpolators is not None:
+            this_data *= self._interpolators[0][time_sl]
+        out[picks, time_sl] += this_data
+        if self._interpolators is not None:
+            this_data = np.dot(self._current[key], data)
+            this_data *= self._interpolators[1][time_sl]
             out[picks, time_sl] += this_data
-            if self._interpolators is not None:
-                this_data = np.dot(self._current[key], data_sl)
-                this_data *= self._interpolators[1][time_sl]
-                out[picks, time_sl] += this_data
-            del this_data

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -237,8 +237,7 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
         Either `'accurate'` or `'fast'`, determines the quality of the
         Legendre polynomial expansion used. `'fast'` should be sufficient
         for most applications.
-    n_jobs : int
-        Number of permutations to run in parallel (requires joblib package).
+    %(n_jobs)s
     origin : array-like, shape (3,) | str
         Origin of the sphere in the head coordinate frame and in meters.
         The default is ``'auto'``, which means a head-digitization-based
@@ -365,8 +364,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         fit. Default is ``(0., 0., 0.04)``.
 
         .. versionadded:: 0.11
-    n_jobs : int
-        The number of jobs to run in parallel.
+    %(n_jobs)s
     %(verbose)s
 
     Returns

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -33,13 +33,13 @@ from ..io.base import BaseRaw
 from ..evoked import Evoked, EvokedArray
 from ..epochs import BaseEpochs
 from ..source_space import (_read_source_spaces_from_tree,
-                            find_source_space_hemi,
+                            find_source_space_hemi, _set_source_space_vertices,
                             _write_source_spaces_to_fid)
-from ..source_estimate import VolSourceEstimate
+from ..source_estimate import _BaseSourceEstimate
 from ..transforms import (transform_surface_to, invert_transform,
                           write_trans)
 from ..utils import (_check_fname, get_subjects_dir, has_mne_c, warn,
-                     run_subprocess, check_fname, logger, verbose,
+                     run_subprocess, check_fname, logger, verbose, fill_doc,
                      _validate_type, _check_compensation_grade, _check_option)
 from ..label import Label
 from ..fixes import einsum
@@ -593,11 +593,11 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
         surf_ori = True
 
     if any([src['type'] == 'vol' for src in fwd['src']]) and force_fixed:
-        warn('Forward operator was generated with sources from a '
-             'volume source space. Conversion to fixed orientation is not '
-             'possible. Setting force_fixed to False. surf_ori is ignored for '
-             'volume source spaces.')
-        force_fixed = False
+        raise ValueError(
+            'Forward operator was generated with sources from a '
+            'volume source space. Conversion to fixed orientation is not '
+            'possible. Consider using a discrete source space if you have '
+            'meaningful normal orientations.')
 
     if surf_ori:
         if use_cps:
@@ -1238,24 +1238,46 @@ def compute_depth_prior(forward, info, is_fixed_ori=None,
     return depth_prior
 
 
-def _stc_src_sel(src, stc):
+def _stc_src_sel(src, stc, on_missing='raise',
+                 extra=', likely due to forward calculations'):
     """Select the vertex indices of a source space using a source estimate."""
-    if isinstance(stc, VolSourceEstimate):
-        vertices = [stc.vertices]
+    if isinstance(stc, list):
+        vertices = stc
     else:
-        vertices = stc.vertices
+        assert isinstance(stc, _BaseSourceEstimate)
+        vertices = stc._vertices_list
+    del stc
     if not len(src) == len(vertices):
         raise RuntimeError('Mismatch between number of source spaces (%s) and '
                            'STC vertices (%s)' % (len(src), len(vertices)))
-    src_sels = []
-    offset = 0
+    src_sels, stc_sels, out_vertices = [], [], []
+    src_offset = stc_offset = 0
     for s, v in zip(src, vertices):
-        src_sel = np.intersect1d(s['vertno'], v)
-        src_sel = np.searchsorted(s['vertno'], src_sel)
-        src_sels.append(src_sel + offset)
-        offset += len(s['vertno'])
+        joint_sel = np.intersect1d(s['vertno'], v)
+        src_sels.append(np.searchsorted(s['vertno'], joint_sel) + src_offset)
+        src_offset += len(s['vertno'])
+        idx = np.searchsorted(v, joint_sel)
+        stc_sels.append(idx + stc_offset)
+        stc_offset += len(v)
+        out_vertices.append(np.array(v)[idx])
     src_sel = np.concatenate(src_sels)
-    return src_sel
+    stc_sel = np.concatenate(stc_sels)
+    assert len(src_sel) == len(stc_sel) == sum(len(v) for v in out_vertices)
+
+    n_stc = sum(len(v) for v in vertices)
+    n_joint = len(src_sel)
+    if n_joint != n_stc:
+        msg = ('Only %i of %i SourceEstimate %s found in '
+               'source space%s'
+               % (n_joint, n_stc, 'vertex' if n_stc == 1 else 'vertices',
+                  extra))
+        if on_missing == 'raise':
+            raise RuntimeError(msg)
+        elif on_missing == 'warn':
+            warn(msg)
+        else:
+            assert on_missing == 'ignore'
+    return src_sel, stc_sel, out_vertices
 
 
 def _fill_measurement_info(info, fwd, sfreq):
@@ -1282,7 +1304,8 @@ def _fill_measurement_info(info, fwd, sfreq):
 
 
 @verbose
-def _apply_forward(fwd, stc, start=None, stop=None, verbose=None):
+def _apply_forward(fwd, stc, start=None, stop=None, on_missing='raise',
+                   verbose=None):
     """Apply forward model and return data, times, ch_names."""
     if not is_fixed_orient(fwd):
         raise ValueError('Only fixed-orientation forward operators are '
@@ -1301,19 +1324,13 @@ def _apply_forward(fwd, stc, start=None, stop=None, verbose=None):
              'correct if currents (in units of Am) are used.'
              % (1e9 * max_cur))
 
-    src_sel = _stc_src_sel(fwd['src'], stc)
-    if isinstance(stc, VolSourceEstimate):
-        n_src = len(stc.vertices)
-    else:
-        n_src = sum([len(v) for v in stc.vertices])
-    if len(src_sel) != n_src:
-        raise RuntimeError('Only %i of %i SourceEstimate vertices found in '
-                           'fwd' % (len(src_sel), n_src))
-
+    src_sel, stc_sel, _ = _stc_src_sel(fwd['src'], stc, on_missing=on_missing)
     gain = fwd['sol']['data'][:, src_sel]
+    # save some memory if possible
+    stc_sel = slice(None) if len(stc_sel) == len(stc.data) else stc_sel
 
     logger.info('Projecting source estimate to sensor space...')
-    data = np.dot(gain, stc.data[:, start:stop])
+    data = np.dot(gain, stc.data[stc_sel, start:stop])
     logger.info('[done]')
 
     times = deepcopy(stc.times[start:stop])
@@ -1323,7 +1340,7 @@ def _apply_forward(fwd, stc, start=None, stop=None, verbose=None):
 
 @verbose
 def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
-                  verbose=None):
+                  on_missing='raise', verbose=None):
     """Project source space currents to sensor space using a forward operator.
 
     The sensor space data is computed for all channels present in fwd. Use
@@ -1353,6 +1370,9 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
         orientations when converting to fixed orientation (if necessary).
 
         .. versionadded:: 0.15
+    %(on_missing)s Default is "raise".
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -1373,7 +1393,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
     # project the source estimate to the sensor space
     if not is_fixed_orient(fwd):
         fwd = convert_forward_solution(fwd, force_fixed=True, use_cps=use_cps)
-    data, times = _apply_forward(fwd, stc, start, stop)
+    data, times = _apply_forward(fwd, stc, start, stop, on_missing=on_missing)
 
     # fill the measurement info
     sfreq = float(1.0 / stc.tstep)
@@ -1390,7 +1410,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
 
 @verbose
 def apply_forward_raw(fwd, stc, info, start=None, stop=None,
-                      verbose=None):
+                      on_missing='raise', verbose=None):
     """Project source space currents to sensor space using a forward operator.
 
     The sensor space data is computed for all channels present in fwd. Use
@@ -1414,6 +1434,9 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
         Index of first time sample (index not time is seconds).
     stop : int, optional
         Index of first time sample not to include (index not time is seconds).
+    %(on_missing)s Default is "raise".
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     Returns
@@ -1432,7 +1455,7 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
                              'info.' % ch_name)
 
     # project the source estimate to the sensor space
-    data, times = _apply_forward(fwd, stc, start, stop)
+    data, times = _apply_forward(fwd, stc, start, stop, on_missing=on_missing)
 
     sfreq = 1.0 / stc.tstep
     info = _fill_measurement_info(info, fwd, sfreq)
@@ -1448,7 +1471,8 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
     return raw
 
 
-def restrict_forward_to_stc(fwd, stc):
+@fill_doc
+def restrict_forward_to_stc(fwd, stc, on_missing='ignore'):
     """Restrict forward operator to active sources in a source estimate.
 
     Parameters
@@ -1457,6 +1481,9 @@ def restrict_forward_to_stc(fwd, stc):
         Forward operator.
     stc : instance of SourceEstimate
         Source estimate.
+    %(on_missing)s Default is "ignore".
+
+        .. versionadded:: 0.18
 
     Returns
     -------
@@ -1468,7 +1495,10 @@ def restrict_forward_to_stc(fwd, stc):
     restrict_forward_to_label
     """
     fwd_out = deepcopy(fwd)
-    src_sel = _stc_src_sel(fwd['src'], stc)
+    _validate_type(on_missing, str, 'on_missing')
+    _check_option('on_missing', on_missing, ('ignore', 'warn', 'raise'))
+    src_sel, _, vertices = _stc_src_sel(fwd['src'], stc, on_missing=on_missing)
+    del stc
 
     fwd_out['source_rr'] = fwd['source_rr'][src_sel]
     fwd_out['nsource'] = len(src_sel)
@@ -1501,14 +1531,7 @@ def restrict_forward_to_stc(fwd, stc):
     if fwd['sol_grad'] is not None:
         fwd_out['_orig_sol_grad'] = fwd['_orig_sol_grad'][:, idx_grad]
 
-    for i in range(2):
-        fwd_out['src'][i]['vertno'] = stc.vertices[i]
-        fwd_out['src'][i]['nuse'] = len(stc.vertices[i])
-        fwd_out['src'][i]['inuse'] = fwd['src'][i]['inuse'].copy()
-        fwd_out['src'][i]['inuse'].fill(0)
-        fwd_out['src'][i]['inuse'][stc.vertices[i]] = 1
-        fwd_out['src'][i]['use_tris'] = np.array([[]], int)
-        fwd_out['src'][i]['nuse_tri'] = np.array([0])
+    _set_source_space_vertices(fwd_out['src'], vertices)
 
     return fwd_out
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1627,12 +1627,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             tmax = max_time
 
         if tmin > tmax:
-            raise ValueError('tmin must be less than tmax')
+            raise ValueError('tmin (%s) must be less than tmax (%s)'
+                             % (tmin, tmax))
         if tmin < 0.0:
-            raise ValueError('tmin must be >= 0')
+            raise ValueError('tmin (%s) must be >= 0' % (tmin,))
         elif tmax > max_time:
-            raise ValueError('tmax must be less than or equal to the max raw '
-                             'time (%0.4f sec)' % max_time)
+            raise ValueError('tmax (%s) must be less than or equal to the max '
+                             'time (%0.4f sec)' % (tmax, max_time))
 
         smin, smax = np.where(_time_mask(self.times, tmin, tmax,
                                          sfreq=self.info['sfreq']))[0][[0, -1]]

--- a/mne/label.py
+++ b/mne/label.py
@@ -892,7 +892,7 @@ def read_label(filename, subject=None, color=None):
         hemi = 'rh'
     else:
         raise ValueError('Cannot find which hemisphere it is. File should end'
-                         ' with lh.label or rh.label')
+                         ' with lh.label or rh.label: %s' % (basename,))
 
     # find name
     if basename.startswith(('lh.', 'rh.')):

--- a/mne/simulation/__init__.py
+++ b/mne/simulation/__init__.py
@@ -1,6 +1,6 @@
 """Data simulation code."""
 
 from .evoked import simulate_evoked, simulate_noise_evoked, add_noise
-from .raw import simulate_raw
+from .raw import simulate_raw, add_ecg, add_blink, add_chpi
 from .source import select_source_in_label, simulate_stc, simulate_sparse_stc
 from .metrics import source_estimate_quantification

--- a/mne/simulation/__init__.py
+++ b/mne/simulation/__init__.py
@@ -1,6 +1,6 @@
 """Data simulation code."""
 
 from .evoked import simulate_evoked, simulate_noise_evoked, add_noise
-from .raw import simulate_raw, add_ecg, add_blink, add_chpi
+from .raw import simulate_raw, add_ecg, add_eog, add_chpi
 from .source import select_source_in_label, simulate_stc, simulate_sparse_stc
 from .metrics import source_estimate_quantification

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -172,17 +172,17 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
         data = data[np.newaxis]
     # Subselect if necessary
     info = inst.info
-    picks = slice(None)
+    picks = gen_picks = slice(None)
     if allow_subselection:
         use_chs = list(set(info['ch_names']) & set(cov['names']))
         picks = np.where(np.in1d(info['ch_names'], use_chs))[0]
         logger.info('Adding noise to %d/%d channels (%d channels in cov)'
                     % (len(picks), len(info['chs']), len(cov['names'])))
         info = pick_info(inst.info, picks)
-        picks = np.arange(info['nchan'])
+        gen_picks = np.arange(info['nchan'])
     for epoch in data:
         epoch[picks] += _generate_noise(info, cov, iir_filter, random_state,
-                                        epoch.shape[1], picks=picks)[0]
+                                        epoch.shape[1], picks=gen_picks)[0]
     return inst
 
 

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -179,18 +179,20 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
         logger.info('Adding noise to %d/%d channels (%d channels in cov)'
                     % (len(picks), len(info['chs']), len(cov['names'])))
         info = pick_info(inst.info, picks)
+        picks = np.arange(info['nchan'])
     for epoch in data:
         epoch[picks] += _generate_noise(info, cov, iir_filter, random_state,
-                                        epoch.shape[1])[0]
+                                        epoch.shape[1], picks=picks)[0]
     return inst
 
 
-def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None):
+def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None,
+                    picks=None):
     """Create spatially colored and temporally IIR-filtered noise."""
     from scipy.signal import lfilter
     rng = check_random_state(random_state)
     _, _, colorer = compute_whitener(cov, info, pca=True, return_colorer=True,
-                                     verbose=False)
+                                     picks=picks, verbose=False)
     noise = np.dot(colorer, rng.randn(colorer.shape[1], n_samples))
     if iir_filter is not None:
         if zi is None:

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -189,7 +189,8 @@ def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None):
     """Create spatially colored and temporally IIR-filtered noise."""
     from scipy.signal import lfilter
     rng = check_random_state(random_state)
-    _, _, colorer = compute_whitener(cov, info, pca=True, return_colorer=True)
+    _, _, colorer = compute_whitener(cov, info, pca=True, return_colorer=True,
+                                     verbose=False)
     noise = np.dot(colorer, rng.randn(colorer.shape[1], n_samples))
     if iir_filter is not None:
         if zi is None:

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -216,7 +216,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
     %(n_jobs)s
     random_state : int | None
       Deprecated and will be removed in 0.19. Use dedicated noise-generation
-      functions :func:`add_noise`, :func:`add_ecg`, and :func:`add_eog`
+      functions :func:`add_noise`, :func:`add_ecg`, and :func:`add_blink`
       instead.
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal
@@ -536,7 +536,7 @@ def add_ecg(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
     See Also
     --------
     add_noise
-    add_eog
+    add_blink
     add_chpi
     simulate_raw
 

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -205,7 +205,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
         Valid cHPI information must encoded in ``raw.info['hpi_meas']``
         to use this option.
     %(head_pos)s
-        See for example [2]_.
+        See for example [1]_.
     mindist : float
         Minimum distance between sources and the inner skull boundary
         to use during forward calculation.
@@ -288,9 +288,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
 
     References
     ----------
-    .. [1] Bentivoglio et al. "Analysis of blink rate patterns in normal
-           subjects" Movement Disorders, 1997 Nov;12(6):1028-34.
-    .. [2] Larson E, Taulu S (2017). "The Importance of Properly Compensating
+    .. [1] Larson E, Taulu S (2017). "The Importance of Properly Compensating
            for Head Movements During MEG Acquisition Across Different Age
            Groups." Brain Topogr 30:172–181
     """  # noqa: E501
@@ -506,6 +504,11 @@ def add_blink(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
     visual inspection to yield amplitudes generally consistent with those
     seen in experimental data. Noisy versions of the activation will be
     stored in the first EOG channel in the raw instance, if it exists.
+
+    References
+    ----------
+    .. [1] Bentivoglio et al. "Analysis of blink rate patterns in normal
+           subjects" Movement Disorders, 1997 Nov;12(6):1028-34.
     """
     return _add_exg(raw, 'blink', head_pos, interp, n_jobs, random_state)
 

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -194,7 +194,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
         matrix will be generated with the values specified by the dict entries.
         If None, no noise will be added.
     blink : bool
-        Deprecated and will be removed in 0.19, use :func:`add_blink` instead.
+        Deprecated and will be removed in 0.19, use :func:`add_eog` instead.
         If true, add simulated blink artifacts. See Notes for details.
     ecg : bool
         Deprecated and will be removed in 0.19, use :func:`add_ecg` instead.
@@ -216,7 +216,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
     %(n_jobs)s
     random_state : int | None
       Deprecated and will be removed in 0.19. Use dedicated noise-generation
-      functions :func:`add_noise`, :func:`add_ecg`, and :func:`add_blink`
+      functions :func:`add_noise`, :func:`add_ecg`, and :func:`add_eog`
       instead.
     use_cps : None | bool (default True)
         Whether to use cortical patch statistics to define normal
@@ -249,10 +249,10 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
     See Also
     --------
     mne.chpi.read_head_pos
-    add_noise
-    add_blink
-    add_ecg
     add_chpi
+    add_noise
+    add_ecg
+    add_eog
     simulate_evoked
     simulate_stc
     simulate_sparse_stc
@@ -335,7 +335,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
         src = forward['src']
 
     if blink is not None:
-        warn('blink is deprecated and will be removed in 0.19, use add_blink '
+        warn('blink is deprecated and will be removed in 0.19, use add_eog '
              'instead', DeprecationWarning)
     if ecg is not None:
         warn('ecg is deprecated and will be removed in 0.19, use add_ecg '
@@ -445,7 +445,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
     raw_data = np.concatenate(raw_datas, axis=-1)
     raw = RawArray(raw_data, info, first_samp=first_samp, verbose=False)
     if blink:
-        add_blink(raw, head_pos, interp, n_jobs, random_state)
+        add_eog(raw, head_pos, interp, n_jobs, random_state)
     if ecg:
         add_ecg(raw, head_pos, interp, n_jobs, random_state)
     if chpi:
@@ -461,8 +461,8 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
 
 
 @verbose
-def add_blink(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
-              verbose=None):
+def add_eog(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
+            verbose=None):
     """Add blink noise to raw data.
 
     Parameters
@@ -482,9 +482,9 @@ def add_blink(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
 
     See Also
     --------
-    add_noise
-    add_blink
     add_chpi
+    add_ecg
+    add_noise
     simulate_raw
 
     Notes
@@ -535,9 +535,9 @@ def add_ecg(raw, head_pos=None, interp='cos2', n_jobs=1, random_state=None,
 
     See Also
     --------
-    add_noise
-    add_blink
     add_chpi
+    add_eog
+    add_noise
     simulate_raw
 
     Notes

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -57,20 +57,11 @@ def _check_stc_iterable(stc, info, n_samples=None):
     # 1. Check that our STC is iterable (or convert it to one using cycle)
     # 2. Do first iter so we can get the vertex subselection
     # 3. Get the list of verts, which must stay the same across iterations
-    do_cycle = False
     if isinstance(stc, _BaseSourceEstimate):
-        do_cycle = True
-        n_samp_stc = stc
-    elif isinstance(stc, (tuple, list)):
-        if len(stc) == 2 and isinstance(stc[0], _BaseSourceEstimate) and not \
-                isinstance(stc[1], _BaseSourceEstimate):
-            n_samp_stc = stc[0]
-            do_cycle = True
-    if do_cycle:
         if n_samples is None:
             stc = [stc]
         else:
-            n_samp_stc = n_samp_stc.times.size
+            n_samp_stc = stc.times.size
             n_stc = int(np.ceil(n_samples / n_samp_stc))
             logger.info('Making %d copies of STC to fit into raw' % (n_stc,))
             stc = [stc] * n_stc
@@ -159,13 +150,12 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
 
         .. versionchanged:: 0.18
            Support for :class:`mne.Info`.
-    stc : instance of SourceEstimate | tuple | iterable
-        The source estimate to use to simulate data. Must have the same
-        sample rate as the raw data. Can also be a tuple of
+    stc : iterable | SourceEstimate
+        The source estimates to use to simulate data. Each must have the same
+        sample rate as the raw data, and the vertices of all stcs in the
+        iterable must match. Each entry in the iterable can also be a tuple of
         ``(SourceEstimate, ndarray)`` to allow specifying the stim channel
         (e.g., STI001) data accompany the source estimate.
-        Can also be an iterable of these options to allow the stc to
-        vary in time, in which case all must have the same ``stc.vertices``.
         See Notes for details.
 
         .. versionchanged:: 0.18
@@ -180,11 +170,11 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, cov=None,
     src : str | instance of SourceSpaces | None
         Source space corresponding to the stc. If string, should be a source
         space filename. Can also be an instance of loaded or generated
-        SourceSpaces. Can be None if ``fwd`` is provided.
+        SourceSpaces. Can be None if ``forward`` is provided.
     bem : str | dict | None
         BEM solution  corresponding to the stc. If string, should be a BEM
         solution filename (e.g., "sample-5120-5120-5120-bem-sol.fif").
-        Can be None if ``fwd`` is provided.
+        Can be None if ``forward`` is provided.
     cov : instance of Covariance | str | dict of float | None
         Deprecated and will be removed in 0.18.
         Use :func:`mne.simulation.add_noise` instead.

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -173,8 +173,7 @@ def _make_stc(raw, src):
     return stc
 
 
-@testing.requires_testing_data
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='function', params=[testing._pytest_param()])
 def raw_data():
     """Get some starting data."""
     # raw with ECG channel

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -146,7 +146,6 @@ def test_iterable():
     with pytest.warns(RuntimeWarning,
                       match='1 of 2 SourceEstimate vertices') as w:
         simulate_raw(raw, stc, trans, src, bem, None)
-    assert len(w) == 1
 
 
 def _make_stc(raw, src):
@@ -435,14 +434,12 @@ def test_simulate_round_trip():
     vertices = [[0, fwd['src'][0]['vertno'][0]], []]
     stc_bad = SourceEstimate(data[:2], vertices, 0, 1. / raw.info['sfreq'])
     with pytest.warns(RuntimeWarning,
-                      match='1 of 2 SourceEstimate vertices') as w:
+                      match='1 of 2 SourceEstimate vertices'):
         simulate_raw(raw, stc_bad, trans, src, bem)
-    assert len(w) == 1
     assert 0 not in fwd['src'][0]['vertno']
     with pytest.warns(RuntimeWarning,
-                      match='1 of 2 SourceEstimate vertices') as w:
+                      match='1 of 2 SourceEstimate vertices'):
         simulate_raw(raw, stc_bad, None, None, None, forward=fwd)
-    assert len(w) == 1
     # dev_head_t mismatch
     fwd['info']['dev_head_t']['trans'][0, 0] = 1.
     with pytest.raises(ValueError, match='dev_head_t.*does not match'):

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -29,7 +29,7 @@ from mne.surface import _get_ico_surface
 from mne.io import read_raw_fif, RawArray
 from mne.io.constants import FIFF
 from mne.time_frequency import psd_welch
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import run_tests_if_main, catch_logging
 
 base_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname_short = op.join(base_path, 'test_raw.fif')
@@ -77,63 +77,77 @@ def test_iterable():
     stc = VolSourceEstimate(data, vertices, 0, tstep)
     assert isinstance(stc.vertices, np.ndarray)
     with pytest.raises(ValueError, match='at least three time points'):
-        simulate_raw(raw, stc, trans, src, sphere, None)
+        simulate_raw(raw.info, stc, trans, src, sphere, None)
     data = rng.randn(1, 1000)
     n_events = (len(raw.times) - 1) // 1000 + 1
     stc = VolSourceEstimate(data, vertices, 0, tstep)
     assert isinstance(stc.vertices, np.ndarray)
-    raw_sim = simulate_raw(raw, stc, trans, src, sphere, None)
+    with catch_logging() as log:
+        with pytest.deprecated_call():
+            raw_sim = simulate_raw(raw, stc, trans, src, sphere, None,
+                                   verbose=True)
+    log = log.getvalue()
+    assert 'Making 15 copies of STC' in log
+    assert_allclose(raw.times, raw_sim.times)
     events = find_events(raw_sim, initial_event=True)
     assert len(events) == n_events
     assert_array_equal(events[:, 2], 1)
+
     # Degenerate STCs
     with pytest.raises(RuntimeError,
                        match=r'Iterable did not provide stc\[0\]'):
-        simulate_raw(raw, [], trans, src, sphere, None)
+        simulate_raw(raw.info, [], trans, src, sphere, None)
     with pytest.raises(RuntimeError,
-                       match=r'Iterable did not provide stc\[2\].*interval'):
-        simulate_raw(raw, [stc, stc], trans, src, sphere, None)
+                       match=r'Iterable did not provide stc\[2\].*duration'):
+        with pytest.deprecated_call():
+            simulate_raw(raw, [stc, stc], trans, src, sphere, None)
     with pytest.raises(TypeError, match='stc must be an instance of SourceE'):
-        simulate_raw(raw, (stc, np.zeros(len(stc.times)), 'foo'),
+        simulate_raw(raw.info, (stc, np.zeros(len(stc.times)), 'foo'),
                      trans, src, sphere, None, verbose=True)
     # tuple with ndarray
     event_data = np.zeros(len(stc.times), int)
     event_data[0] = 3
-    raw_new = simulate_raw(raw, (stc, event_data), trans, src, sphere, None)
+    with pytest.deprecated_call():
+        raw_new = simulate_raw(raw, (stc, event_data), trans, src, sphere,
+                               None)
     _assert_iter_sim(raw_sim, raw_new, 3)
     with pytest.raises(ValueError, match='event data had shape .* but need'):
-        simulate_raw(raw, (stc, event_data[:-1]), trans, src, sphere, None)
+        simulate_raw(raw.info, (stc, event_data[:-1]), trans, src, sphere,
+                     None)
     with pytest.raises(ValueError, match='stim_data in a stc tuple .* int'):
-        simulate_raw(raw, (stc, event_data * 1.), trans, src, sphere, None)
-    # smoke test for exact duration match
-    simulate_raw(raw.info, [stc], trans, src, sphere, None,
-                 duration=len(stc.times) / raw.info['sfreq'], verbose=True)
+        simulate_raw(raw.info, (stc, event_data * 1.), trans, src, sphere,
+                     None)
 
     # iterable
     def stc_iter():
         stim_data = np.zeros(len(stc.times), int)
         stim_data[0] = 4
-        while True:
+        ii = 0
+        while ii < 100:
+            ii += 1
             yield (stc, stim_data)
-    raw_new = simulate_raw(raw, stc_iter(), trans, src, sphere, None)
-    _assert_iter_sim(raw_sim, raw_new, 4)
-
-    def stc_iter_bad():
-        while True:
-            yield (stc, 4, 3)
-    with pytest.raises(ValueError, match='stc, if tuple, must be length'):
-        simulate_raw(raw, stc_iter_bad(), trans, src, sphere, None)
+    with pytest.deprecated_call():
+        raw_new = simulate_raw(raw, stc_iter(), trans, src, sphere, None)
     _assert_iter_sim(raw_sim, raw_new, 4)
 
     def stc_iter_bad():
         ii = 0
-        while True:
+        while ii < 100:
+            ii += 1
+            yield (stc, 4, 3)
+    with pytest.raises(ValueError, match='stc, if tuple, must be length'):
+        simulate_raw(raw.info, stc_iter_bad(), trans, src, sphere, None)
+    _assert_iter_sim(raw_sim, raw_new, 4)
+
+    def stc_iter_bad():
+        ii = 0
+        while ii < 100:
             ii += 1
             stc_new = stc.copy()
             stc_new.vertices = np.array([ii % 2])
             yield stc_new
     with pytest.raises(RuntimeError, match=r'Vertex mismatch for stc\[1\]'):
-        simulate_raw(raw, stc_iter_bad(), trans, src, sphere, None)
+        simulate_raw(raw.info, stc_iter_bad(), trans, src, sphere, None)
 
     # Forward omission
     vertices = np.array([0, 1])
@@ -199,11 +213,12 @@ def _get_head_pos_sim(raw):
     return head_pos_sim
 
 
-def test_simulate_raw_sphere(raw_data):
+def test_simulate_raw_sphere(raw_data, tmpdir):
     """Test simulation of raw data with sphere model."""
     seed = 42
     raw, src, stc, trans, sphere = raw_data
     assert len(pick_types(raw.info, meg=False, ecg=True)) == 1
+    tempdir = str(tmpdir)
 
     # head pos
     head_pos_sim = _get_head_pos_sim(raw)
@@ -218,11 +233,15 @@ def test_simulate_raw_sphere(raw_data):
     with pytest.deprecated_call(match='cov is deprecated'):
         raw_sim = simulate_raw(raw, stc, trans, src, sphere, cov,
                                head_pos=head_pos_sim,
-                               blink=True, ecg=True, random_state=seed)
+                               blink=True, ecg=True, random_state=seed,
+                               verbose=True)
     with pytest.warns(RuntimeWarning, match='applying projector with'):
         raw_sim_2 = simulate_raw(raw, stc, trans_fname, src_fname, sphere,
                                  cov_fname, head_pos=head_pos_sim,
                                  blink=True, ecg=True, random_state=seed)
+    with pytest.raises(RuntimeError, match='Maximum number of STC iterations'):
+        simulate_raw(raw.info, [stc] * 5, trans_fname, src_fname, sphere,
+                     cov=None, max_iter=1)
     assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
     std = dict(grad=2e-13, mag=10e-15, eeg=0.1e-6)
     with pytest.deprecated_call():
@@ -248,7 +267,6 @@ def test_simulate_raw_sphere(raw_data):
                                  blink=True, ecg=True, random_state=seed)
     assert_array_equal(raw_sim_2[:][0], raw_sim[:][0])
     # Test IO on processed data
-    tempdir = _TempDir()
     test_outname = op.join(tempdir, 'sim_test_raw.fif')
     raw_sim.save(test_outname)
 
@@ -278,12 +296,13 @@ def test_simulate_raw_sphere(raw_data):
     del raw_sim_3, raw_sim_4
 
     # make sure it works with EEG-only and MEG-only
-    raw_sim_meg = simulate_raw(raw.copy().pick_types(meg=True, eeg=False),
-                               stc, trans, src, sphere, cov=None)
-    raw_sim_eeg = simulate_raw(raw.copy().pick_types(meg=False, eeg=True),
-                               stc, trans, src, sphere, cov=None)
-    raw_sim_meeg = simulate_raw(raw.copy().pick_types(meg=True, eeg=True),
-                                stc, trans, src, sphere, cov=None)
+    with pytest.deprecated_call():
+        raw_sim_meg = simulate_raw(raw.copy().pick_types(meg=True, eeg=False),
+                                   stc, trans, src, sphere, cov=None)
+        raw_sim_eeg = simulate_raw(raw.copy().pick_types(meg=False, eeg=True),
+                                   stc, trans, src, sphere, cov=None)
+        raw_sim_meeg = simulate_raw(raw.copy().pick_types(meg=True, eeg=True),
+                                    stc, trans, src, sphere, cov=None)
     for this_raw in (raw_sim_meg, raw_sim_eeg, raw_sim_meeg):
         add_blink(this_raw, random_state=seed)
     for this_raw in (raw_sim_meg, raw_sim_meeg):
@@ -295,21 +314,28 @@ def test_simulate_raw_sphere(raw_data):
     del raw_sim_meg, raw_sim_eeg, raw_sim_meeg
 
     # check that raw-as-info is supported
-    raw_sim = simulate_raw(raw, stc, trans, src, sphere, cov=None)
-    n_samp = int(round(raw.info['sfreq']))
-    for use_raw in (raw, raw.info):
-        raw_sim_2 = simulate_raw(use_raw, stc, trans, src, sphere, cov=None,
-                                 duration=1.)
-        assert len(raw_sim_2.times) == n_samp
-        assert_allclose(raw_sim[:, :n_samp][0],
-                        raw_sim_2[:, :n_samp][0], rtol=1e-5, atol=1e-30)
+    n_samp = len(stc.times)
+    raw_crop = raw.copy().crop(0., (n_samp - 1.) / raw.info['sfreq'])
+    assert len(raw_crop.times) == len(stc.times)
+    with pytest.deprecated_call():
+        raw_sim = simulate_raw(raw_crop, stc, trans, src, sphere, cov=None)
+    with catch_logging() as log:
+        raw_sim_2 = simulate_raw(raw_crop.info, stc, trans, src, sphere,
+                                 cov=None, verbose=True)
+    log = log.getvalue()
+    assert '1 STC iteration provided' in log
+    assert len(raw_sim_2.times) == n_samp
+    assert_allclose(raw_sim[:, :n_samp][0],
+                    raw_sim_2[:, :n_samp][0], rtol=1e-5, atol=1e-30)
     del raw_sim, raw_sim_2
 
     # check that different interpolations are similar given small movements
-    raw_sim = simulate_raw(raw, stc, trans, src, sphere, cov=None,
-                           head_pos=head_pos_sim, interp='linear')
-    raw_sim_hann = simulate_raw(raw, stc, trans, src, sphere, cov=None,
-                                head_pos=head_pos_sim, interp='hann')
+    with pytest.deprecated_call():
+        raw_sim = simulate_raw(raw, stc, trans, src, sphere, cov=None,
+                               head_pos=head_pos_sim, interp='linear')
+    with pytest.deprecated_call():
+        raw_sim_hann = simulate_raw(raw, stc, trans, src, sphere, cov=None,
+                                    head_pos=head_pos_sim, interp='hann')
     assert_allclose(raw_sim[:][0], raw_sim_hann[:][0], rtol=1e-1, atol=1e-14)
     del raw_sim, raw_sim_hann
 
@@ -317,42 +343,44 @@ def test_simulate_raw_sphere(raw_data):
 def test_degenerate(raw_data):
     """Test degenerate conditions."""
     raw, src, stc, trans, sphere = raw_data
+    info = raw.info
     # Make impossible transform (translate up into helmet) and ensure failure
     hp_err = _get_head_pos_sim(raw)
     hp_err[1.][2, 3] -= 0.1  # z trans upward 10cm
     with pytest.raises(RuntimeError, match='collided with inner skull'):
-        simulate_raw(raw, stc, trans, src, sphere, cov=None, head_pos=hp_err)
+        simulate_raw(info, stc, trans, src, sphere, cov=None,
+                     head_pos=hp_err)
     # other degenerate conditions
     with pytest.raises(TypeError, match='info must be an instance of'):
         simulate_raw('foo', stc, trans, src, sphere)
     with pytest.raises(TypeError, match='stc must be an instance of'):
-        simulate_raw(raw, 'foo', trans, src, sphere)
+        simulate_raw(info, 'foo', trans, src, sphere)
     with pytest.raises(ValueError, match='stc must have at least three time'):
-        simulate_raw(raw, stc.copy().crop(0, 0), trans, src, sphere)
-    with pytest.raises(ValueError, match='duration cannot be None'):
-        simulate_raw(raw.info, stc, trans, src, sphere)
+        simulate_raw(info, stc.copy().crop(0, 0), trans, src, sphere)
     with pytest.raises(TypeError, match='must be an instance of Raw or Info'):
         simulate_raw(0, stc, trans, src, sphere)
     stc_bad = stc.copy()
     stc_bad.tstep += 0.1
     with pytest.raises(ValueError, match='same sample rate'):
-        simulate_raw(raw, stc_bad, trans, src, sphere)
+        simulate_raw(info, stc_bad, trans, src, sphere)
     with pytest.raises(TypeError, match='Covariance matrix type'):
         with pytest.deprecated_call():
-            simulate_raw(raw, stc, trans, src, sphere, cov=0)
+            simulate_raw(info, stc, trans, src, sphere, cov=0)
     with pytest.raises(RuntimeError, match='cHPI information not found'):
         with pytest.deprecated_call():
-            simulate_raw(raw, stc, trans, src, sphere, chpi=True)
+            simulate_raw(info, stc, trans, src, sphere, chpi=True)
     with pytest.raises(ValueError, match='interp must be one of'):
-        simulate_raw(raw, stc, trans, src, sphere, interp='foo')
+        simulate_raw(info, stc, trans, src, sphere, interp='foo')
     with pytest.raises(TypeError, match='unknown head_pos type'):
-        simulate_raw(raw, stc, trans, src, sphere, head_pos=1.)
+        simulate_raw(info, stc, trans, src, sphere, head_pos=1.)
     with pytest.raises(RuntimeError, match='All position times'):
-        simulate_raw(raw, stc, trans, src, sphere, head_pos=pos_fname)
+        with pytest.deprecated_call():
+            simulate_raw(raw, stc, trans, src, sphere, head_pos=pos_fname)
     head_pos_sim_err = _get_head_pos_sim(raw)
     head_pos_sim_err[-1.] = head_pos_sim_err[1.]  # negative time
     with pytest.raises(RuntimeError, match='All position times'):
-        simulate_raw(raw, stc, trans, src, sphere, head_pos=head_pos_sim_err)
+        simulate_raw(info, stc, trans, src, sphere,
+                     head_pos=head_pos_sim_err)
     raw_bad = raw.copy()
     raw_bad.info['dig'] = None
     with pytest.raises(RuntimeError, match='Cannot fit headshape'):
@@ -376,9 +404,12 @@ def test_simulate_raw_bem(raw_data):
     vertices = [s['vertno'] for s in src]
     stc = SourceEstimate(np.eye(sum(len(v) for v in vertices)), vertices,
                          0, 1. / raw.info['sfreq'])
-    raw_sim_sph = simulate_raw(raw, stc, trans, src, sphere, cov=None)
-    raw_sim_bem = simulate_raw(raw, stc, trans, src, bem_fname, cov=None,
-                               n_jobs=2)
+    with pytest.deprecated_call():
+        raw_sim_sph = simulate_raw(raw, stc, trans, src, sphere, cov=None,
+                                   verbose=True)
+    with pytest.deprecated_call():
+        raw_sim_bem = simulate_raw(raw, stc, trans, src, bem_fname, cov=None,
+                                   n_jobs=2)
     # some components (especially radial) might not match that well,
     # so just make sure that most components have high correlation
     assert_array_equal(raw_sim_sph.ch_names, raw_sim_bem.ch_names)
@@ -436,38 +467,37 @@ def test_simulate_round_trip(raw_data):
             use_trans, use_src, use_bem = trans, src, bem
         else:
             use_trans = use_src = use_bem = None
-        for use_cps in (False, True):
+        with pytest.deprecated_call():
             this_raw = simulate_raw(raw, stc, use_trans, use_src, use_bem,
-                                    cov=None, use_cps=use_cps, forward=use_fwd)
-            this_raw.pick_types(meg=True, eeg=True)
-            assert (old_bem['surfs'][0]['coord_frame'] ==
-                    bem['surfs'][0]['coord_frame'])
-            assert trans == old_trans
-            _compare_source_spaces(src, old_src)
-            this_fwd = convert_forward_solution(fwd, force_fixed=True,
-                                                use_cps=use_cps)
-            assert_allclose(this_raw[:][0], this_fwd['sol']['data'],
-                            atol=1e-12, rtol=1e-6)
+                                    cov=None, forward=use_fwd)
+        this_raw.pick_types(meg=True, eeg=True)
+        assert (old_bem['surfs'][0]['coord_frame'] ==
+                bem['surfs'][0]['coord_frame'])
+        assert trans == old_trans
+        _compare_source_spaces(src, old_src)
+        this_fwd = convert_forward_solution(fwd, force_fixed=True)
+        assert_allclose(this_raw[:][0], this_fwd['sol']['data'],
+                        atol=1e-12, rtol=1e-6)
     with pytest.raises(ValueError, match='If forward is not None then'):
-        simulate_raw(raw, stc, trans, src, bem, forward=fwd)
+        simulate_raw(raw.info, stc, trans, src, bem, forward=fwd)
     # Not iterable
     with pytest.raises(TypeError, match='SourceEstimate, tuple, or iterable'):
-        simulate_raw(raw, 0., trans, src, bem, None)
+        simulate_raw(raw.info, 0., trans, src, bem, None)
     # STC with a source that `src` does not have
     assert 0 not in src[0]['vertno']
     vertices = [[0, fwd['src'][0]['vertno'][0]], []]
     stc_bad = SourceEstimate(data[:2], vertices, 0, 1. / raw.info['sfreq'])
     with pytest.warns(RuntimeWarning,
                       match='1 of 2 SourceEstimate vertices'):
-        simulate_raw(raw, stc_bad, trans, src, bem)
+        simulate_raw(raw.info, stc_bad, trans, src, bem)
     assert 0 not in fwd['src'][0]['vertno']
     with pytest.warns(RuntimeWarning,
                       match='1 of 2 SourceEstimate vertices'):
-        simulate_raw(raw, stc_bad, None, None, None, forward=fwd)
+        simulate_raw(raw.info, stc_bad, None, None, None, forward=fwd)
     # dev_head_t mismatch
     fwd['info']['dev_head_t']['trans'][0, 0] = 1.
     with pytest.raises(ValueError, match='dev_head_t.*does not match'):
-        simulate_raw(raw, stc, None, None, None, forward=fwd)
+        simulate_raw(raw.info, stc, None, None, None, forward=fwd)
 
 
 @pytest.mark.slowtest
@@ -485,8 +515,9 @@ def test_simulate_raw_chpi():
     src = setup_volume_source_space(sphere=sphere_vol, pos=70.)
     stc = _make_stc(raw, src)
     # simulate data with cHPI on
-    raw_sim = simulate_raw(raw, stc, None, src, sphere, cov=None,
-                           interp='zero')
+    with pytest.deprecated_call():
+        raw_sim = simulate_raw(raw, stc, None, src, sphere, cov=None,
+                               head_pos=pos_fname, interp='zero')
     # need to trim extra samples off this one
     with pytest.deprecated_call():
         raw_chpi = simulate_raw(raw, stc, None, src, sphere, cov=None,

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -100,21 +100,19 @@ def test_iterable():
                        match=r'Iterable did not provide stc\[2\].*duration'):
         with pytest.deprecated_call():
             simulate_raw(raw, [stc, stc], trans, src, sphere, None)
-    with pytest.raises(TypeError, match='stc must be an instance of SourceE'):
-        simulate_raw(raw.info, (stc, np.zeros(len(stc.times)), 'foo'),
-                     trans, src, sphere, None, verbose=True)
     # tuple with ndarray
     event_data = np.zeros(len(stc.times), int)
     event_data[0] = 3
-    with pytest.deprecated_call():
-        raw_new = simulate_raw(raw, (stc, event_data), trans, src, sphere,
-                               None)
+    raw_new = simulate_raw(raw.info, [(stc, event_data)] * 15,
+                           trans, src, sphere, None, first_samp=raw.first_samp)
+    assert raw_new.n_times == 15000
+    raw_new.crop(0, raw_sim.times[-1])
     _assert_iter_sim(raw_sim, raw_new, 3)
     with pytest.raises(ValueError, match='event data had shape .* but need'):
-        simulate_raw(raw.info, (stc, event_data[:-1]), trans, src, sphere,
+        simulate_raw(raw.info, [(stc, event_data[:-1])], trans, src, sphere,
                      None)
     with pytest.raises(ValueError, match='stim_data in a stc tuple .* int'):
-        simulate_raw(raw.info, (stc, event_data * 1.), trans, src, sphere,
+        simulate_raw(raw.info, [(stc, event_data * 1.)], trans, src, sphere,
                      None)
 
     # iterable

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -22,8 +22,7 @@ from mne.bem import _surfaces_to_bem
 from mne.chpi import _calculate_chpi_positions, read_head_pos, _get_hpi_info
 from mne.tests.test_chpi import _assert_quats
 from mne.datasets import testing
-from mne.simulation import (simulate_sparse_stc, simulate_raw,
-                            add_blink, add_ecg)
+from mne.simulation import simulate_sparse_stc, simulate_raw, add_eog, add_ecg
 from mne.source_space import _compare_source_spaces
 from mne.surface import _get_ico_surface
 from mne.io import read_raw_fif, RawArray
@@ -304,7 +303,7 @@ def test_simulate_raw_sphere(raw_data, tmpdir):
         raw_sim_meeg = simulate_raw(raw.copy().pick_types(meg=True, eeg=True),
                                     stc, trans, src, sphere, cov=None)
     for this_raw in (raw_sim_meg, raw_sim_eeg, raw_sim_meeg):
-        add_blink(this_raw, random_state=seed)
+        add_eog(this_raw, random_state=seed)
     for this_raw in (raw_sim_meg, raw_sim_meeg):
         add_ecg(this_raw, random_state=seed)
     with pytest.raises(RuntimeError, match='only add ECG artifacts if MEG'):
@@ -387,7 +386,7 @@ def test_degenerate(raw_data):
         with pytest.deprecated_call():
             simulate_raw(raw_bad, stc, trans, src, sphere, blink=True)
     with pytest.raises(RuntimeError, match='Cannot fit headshape'):
-        add_blink(raw_bad)
+        add_eog(raw_bad)
 
 
 @pytest.mark.slowtest

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -537,11 +537,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         self.subject = _check_subject(None, subject, False)
 
     def __repr__(self):  # noqa: D105
-        if isinstance(self.vertices, list):
-            nv = sum([len(v) for v in self.vertices])
-        else:
-            nv = self.vertices.size
-        s = "%d vertices" % nv
+        s = "%d vertices" % (sum(len(v) for v in self._vertices_list),)
         if self.subject is not None:
             s += ", subject : %s" % self.subject
         s += ", tmin : %s (ms)" % (1e3 * self.tmin)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2871,3 +2871,18 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
                 assert_(name in src1.info, '"%s" missing' % name)
             else:
                 assert_(name not in src1.info, '"%s" should not exist' % name)
+
+
+def _set_source_space_vertices(src, vertices):
+    """Reset the list of source space vertices."""
+    assert len(src) == len(vertices)
+    for s, v in zip(src, vertices):
+        s['inuse'].fill(0)
+        s['nuse'] = len(v)
+        s['vertno'] = np.array(v)
+        s['inuse'][s['vertno']] = 1
+        s['use_tris'] = np.array([[]], int)
+        s['nuse_tri'] = np.array([0])
+        # This will fix 'patch_info' and 'pinfo'
+        _adjust_patch_info(s, verbose=False)
+    return src

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -76,6 +76,35 @@ on_missing : str
         Behavior when ``stc`` has vertices that are not in ``fwd``.
         Can be "ignore", "warn"", or "raise"."""
 
+# Simulation
+docdict['random_state'] = """
+random_state : None | int | ~numpy.random.RandomState
+    The random generator state used for blink, ECG, and sensor
+    noise randomization. Default is None, which does not set the seed.
+"""
+docdict['interp'] = """
+interp : str
+    Either 'hann', 'cos2' (default), 'linear', or 'zero', the type of
+    forward-solution interpolation to use between forward solutions
+    at different head positions.
+"""
+docdict['head_pos'] = """
+head_pos : None | str | dict | tuple | array
+    Name of the position estimates file. Should be in the format of
+    the files produced by MaxFilter. If dict, keys should
+    be the time points and entries should be 4x4 ``dev_head_t``
+    matrices. If None, the original head position (from
+    ``info['dev_head_t']``) will be used. If tuple, should have the
+    same format as data returned by `head_pos_to_trans_rot_t`.
+    If array, should be of the form returned by
+    :func:`mne.chpi.read_head_pos`.
+"""
+docdict['n_jobs'] = """
+n_jobs : int
+    The number of jobs to run in parallel (default 1).
+    Requires the joblib package.
+"""
+
 # Finalize
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -70,6 +70,12 @@ depth : None | float | dict
     for details and defaults).
 """
 
+# Forward
+docdict['on_missing'] = """
+on_missing : str
+        Behavior when ``stc`` has vertices that are not in ``fwd``.
+        Can be "ignore", "warn"", or "raise"."""
+
 # Finalize
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -36,16 +36,13 @@ from mne.beamformer import make_dics, apply_dics_csd
 # We use the MEG and MRI setup from the MNE-sample dataset
 data_path = sample.data_path(download=False)
 subjects_dir = op.join(data_path, 'subjects')
-mri_path = op.join(subjects_dir, 'sample')
 
 # Filenames for various files we'll be using
 meg_path = op.join(data_path, 'MEG', 'sample')
 raw_fname = op.join(meg_path, 'sample_audvis_raw.fif')
-trans_fname = op.join(meg_path, 'sample_audvis_raw-trans.fif')
-src_fname = op.join(mri_path, 'bem/sample-oct-6-src.fif')
-bem_fname = op.join(mri_path, 'bem/sample-5120-5120-5120-bem-sol.fif')
 fwd_fname = op.join(meg_path, 'sample_audvis-meg-eeg-oct-6-fwd.fif')
 cov_fname = op.join(meg_path, 'sample_audvis-cov.fif')
+fwd = mne.read_forward_solution(fwd_fname)
 
 # Seed for the random number generator
 rand = np.random.RandomState(42)
@@ -175,7 +172,7 @@ cov['data'] *= (20. / snr) ** 2  # Scale the noise to achieve the desired SNR
 stcs = [(stc_signal, unit_impulse(n_samp, dtype=int) * 1),
         (stc_noise, unit_impulse(n_samp, dtype=int) * 2)]  # stacked in time
 duration = (len(stc_signal.times) * 2) / sfreq
-raw = simulate_raw(info, stcs, trans_fname, src_fname, bem_fname)
+raw = simulate_raw(info, stcs, forward=fwd)
 add_noise(raw, cov, iir_filter=[4, -4, 0.8], random_state=rand)
 
 

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -22,7 +22,7 @@ sources.
 # of filenames for various things we'll be using.
 import os.path as op
 import numpy as np
-from scipy.signal import welch, coherence
+from scipy.signal import welch, coherence, unit_impulse
 from mayavi import mlab
 from matplotlib import pyplot as plt
 
@@ -59,7 +59,8 @@ rand = np.random.RandomState(42)
 # We'll use this function to generate our two signals.
 
 sfreq = 50.  # Sampling frequency of the generated signal
-times = np.arange(10. * sfreq) / sfreq  # 10 seconds of signal
+n_samp = int(round(10. * sfreq))
+times = np.arange(n_samp) / sfreq  # 10 seconds of signal
 n_times = len(times)
 
 
@@ -134,22 +135,13 @@ fig.tight_layout()
 
 # The locations on the cortex where the signal will originate from. These
 # locations are indicated as vertex numbers.
-source_vert1 = 146374
-source_vert2 = 33830
+vertices = [[146374], [33830]]
 
-# The timeseries at each vertex: one part signal, one part silence
-timeseries1 = np.hstack([signal1, np.zeros_like(signal1)])
-timeseries2 = np.hstack([signal2, np.zeros_like(signal2)])
-
-# Construct a SourceEstimate object that describes the signal at the cortical
-# level.
-stc = mne.SourceEstimate(
-    np.vstack((timeseries1, timeseries2)),  # The two timeseries
-    vertices=[[source_vert1], [source_vert2]],  # Their locations
-    tmin=0,
-    tstep=1. / sfreq,
-    subject='sample',  # We use the brain model of the MNE-Sample dataset
-)
+# Construct SourceEstimates that describe the signals at the cortical level.
+data = np.vstack((signal1, signal2))
+stc_signal = mne.SourceEstimate(
+    data, vertices, tmin=0, tstep=1. / sfreq, subject='sample')
+stc_noise = stc_signal * 0.
 
 ###############################################################################
 # Before we simulate the sensor-level data, let's define a signal-to-noise
@@ -174,32 +166,29 @@ info.update(sfreq=sfreq, bads=[])
 picks = mne.pick_types(info, meg='grad', stim=True, exclude=())
 mne.pick_info(info, picks, copy=False)
 
-# This is the raw object that will be used as a template for the simulation.
-raw = mne.io.RawArray(np.zeros((info['nchan'], len(stc.times))), info)
-
 # Define a covariance matrix for the simulated noise. In this tutorial, we use
 # a simple diagonal matrix.
 cov = mne.cov.make_ad_hoc_cov(info)
 cov['data'] *= (20. / snr) ** 2  # Scale the noise to achieve the desired SNR
 
 # Simulate the raw data, with a lowpass filter on the noise
-raw = simulate_raw(raw, stc, trans_fname, src_fname, bem_fname, cov=cov,
-                   random_state=rand, iir_filter=[4, -4, 0.8])
+stcs = [(stc_signal, unit_impulse(n_samp, dtype=int) * 1),
+        (stc_noise, unit_impulse(n_samp, dtype=int) * 2)]  # stacked in time
+duration = (len(stc_signal.times) * 2) / sfreq
+raw = simulate_raw(info, stcs, trans_fname, src_fname, bem_fname, cov=cov,
+                   random_state=rand, iir_filter=[4, -4, 0.8],
+                   duration=duration)
 
 
 ###############################################################################
 # We create an :class:`mne.Epochs` object containing two trials: one with
 # both noise and signal and one with just noise
 
-t0 = raw.first_samp  # First sample in the data
-t1 = t0 + n_times - 1  # Sample just before the second trial
-epochs = mne.Epochs(
-    raw,
-    events=np.array([[t0, 0, 1], [t1, 0, 2]]),
-    event_id=dict(signal=1, noise=2),
-    tmin=0, tmax=10,
-    preload=True,
-)
+events = mne.find_events(raw, initial_event=True)
+tmax = (len(stc_signal.times) - 1) / sfreq
+epochs = mne.Epochs(raw, events, event_id=dict(signal=1, noise=2),
+                    tmin=0, tmax=tmax, baseline=None, preload=True)
+assert len(epochs) == 2  # ensure that we got the two expected events
 
 # Plot some of the channels of the simulated data that are situated above one
 # of our simulated sources.
@@ -233,8 +222,8 @@ brain = s_rms.plot('sample', subjects_dir=subjects_dir, hemi='both', figure=1,
                    size=600)
 
 # Indicate the true locations of the source activity on the plot.
-brain.add_foci(source_vert1, coords_as_verts=True, hemi='lh')
-brain.add_foci(source_vert2, coords_as_verts=True, hemi='rh')
+brain.add_foci(vertices[0][0], coords_as_verts=True, hemi='lh')
+brain.add_foci(vertices[1][0], coords_as_verts=True, hemi='rh')
 
 # Rotate the view and add a title.
 mlab.view(0, 0, 550, [0, 0, 0])
@@ -285,8 +274,8 @@ for approach, power in enumerate([power_approach1, power_approach2], 1):
                        figure=approach + 1, size=600)
 
     # Indicate the true locations of the source activity on the plot.
-    brain.add_foci(source_vert1, coords_as_verts=True, hemi='lh')
-    brain.add_foci(source_vert2, coords_as_verts=True, hemi='rh')
+    brain.add_foci(vertices[0][0], coords_as_verts=True, hemi='lh')
+    brain.add_foci(vertices[1][0], coords_as_verts=True, hemi='rh')
 
     # Rotate the view and add a title.
     mlab.view(0, 0, 550, [0, 0, 0])
@@ -298,8 +287,7 @@ for approach, power in enumerate([power_approach1, power_approach2], 1):
 # try playing with the SNR and see how the MNE-dSPM and DICS approaches hold up
 # in the presence of increasing noise. In the presence of more noise, you may
 # need to increase the regularization parameter of the DICS beamformer.
-
-###############################################################################
+#
 # References
 # ----------
 # .. [1] Gross et al. (2001). Dynamic imaging of coherent sources: Studying

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -27,7 +27,7 @@ from mayavi import mlab
 from matplotlib import pyplot as plt
 
 import mne
-from mne.simulation import simulate_raw
+from mne.simulation import simulate_raw, add_noise
 from mne.datasets import sample
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.time_frequency import csd_morlet
@@ -175,9 +175,8 @@ cov['data'] *= (20. / snr) ** 2  # Scale the noise to achieve the desired SNR
 stcs = [(stc_signal, unit_impulse(n_samp, dtype=int) * 1),
         (stc_noise, unit_impulse(n_samp, dtype=int) * 2)]  # stacked in time
 duration = (len(stc_signal.times) * 2) / sfreq
-raw = simulate_raw(info, stcs, trans_fname, src_fname, bem_fname, cov=cov,
-                   random_state=rand, iir_filter=[4, -4, 0.8],
-                   duration=duration)
+raw = simulate_raw(info, stcs, trans_fname, src_fname, bem_fname)
+add_noise(raw, cov, iir_filter=[4, -4, 0.8], random_state=rand)
 
 
 ###############################################################################


### PR DESCRIPTION
Todo list:

- [x] Add iterable support for stc
- [x] Ensure existing tests pass and examples still look good
- [x] Add degenerate tests for new checks
- [x] Add a test that the new iterable support actually works with some iterable
- [x] Rework `_Interp2` to maintain memory efficiency based on `len(stc.times)` rather than internal buffer and indexing tricks.
- [x] Update `whats_new.rst`
- [x] remove `(stc, int)` support (but still support `(stc, stim_array)`)
- [x] add `add_ecg`, `add_blink`, and `add_chpi` (by refactoring out of `simulate_raw`) to complement existing `add_noise`
- [x] deprecate `ecg` and `eog` parameters 
- [x] deprecate `duration, noise_cov, iir_filter`
- [x] remove `duration` (within-release change, no need to deprecate)
- [x] fix tests to deal with deprecation
- [x] update examples to use new API

Current monolithic API:
```
raw_sim = simulate_raw(raw, stc, trans, src, bem, cov='simple', blink=False, ecg=False, chpi=False, head_pos=None, mindist=1.0, interp='cos2', iir_filter=None, n_jobs=1, random_state=None, use_cps=True, forward=None, duration=None, verbose=None)
```
New API, treating `simulate_` functions as "smart apply_forward with head position support":
```
raw_sim = simulate_raw(raw, stc, trans, src, bem, chpi=False, head_pos=None, mindist=1.0, interp='cos2', n_jobs=1, use_cps=True, forward=None, verbose=None)
raw_sim = add_ecg(raw_sim, head_pos=None, random_state=None, verbose=None)
raw_sim = add_eog(raw_sim, random_state=None, verbose=None)
raw_sim = add_noise(raw_sim, noise_cov)
```

No example update to use the `iterable` support since it will probably make the most sense to do it with #5924.

Closes #5974.