### PR TITLE
MRG: Use prelease of NumPy and SciPy in a build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ before_install:
       fi;
     - if [ -z "$CONDA_ENVIRONMENT" ] && [ -z "$CONDA_DEPENDENCIES" ]; then
         pip uninstall -y numpy;
-        pip install numpy scipy vtk;
+        pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" --pre numpy scipy;
+        pip install vtk;
         pip install --upgrade -r requirements.txt;
       else
         git clone https://github.com/astropy/ci-helpers.git;


### PR DESCRIPTION
Should help us stay ahead of the curve on finding bugs. Follows what `pandas` does to get preleases (they just found a `sparse` matrix construction bug via this process).