### PR TITLE
FIX: ICA.plot_properties wont accept new extrapolate argument of viz.…

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -166,6 +166,9 @@ API
 
 - Deprecate ``method='extended-infomax'`` in :class:`mne.preprocessing.ICA`; Extended Infomax can now be computed with ``method='infomax'`` and ``fit_params=dict(extended=True)`` by `Clemens Brunner`_
 
+- Fix support for supplying ``extrapolate`` via :ref:`ica.plot_properties(..., topomap_args=dict(extrapolate=...)) <mne.preprocessing.ICA.plot_properties>` by `Sebastian Castano`_
+
+
 .. _changes_0_17:
 
 Version 0.17
@@ -3242,3 +3245,5 @@ of commits):
 .. _Jeff Hanna: https://github.com/jshanna100
 
 .. _Antoine Gauthier: https://github.com/Okamille
+
+.. _Sebastian Castano: https://github.com/jscastanoc

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -166,7 +166,7 @@ API
 
 - Deprecate ``method='extended-infomax'`` in :class:`mne.preprocessing.ICA`; Extended Infomax can now be computed with ``method='infomax'`` and ``fit_params=dict(extended=True)`` by `Clemens Brunner`_
 
-- Fix support for supplying ``extrapolate`` via :ref:`ica.plot_properties(..., topomap_args=dict(extrapolate=...)) <mne.preprocessing.ICA.plot_properties>` by `Sebastian Castano`_
+- Fix support for supplying ``extrapolate`` via :meth:`ica.plot_properties(..., topomap_args=dict(extrapolate=...)) <mne.preprocessing.ICA.plot_properties>` by `Sebastian Castano`_
 
 
 .. _changes_0_17:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -965,7 +965,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', colorbar=False,
                       title=None, show=True, outlines='head', contours=6,
                       image_interp='bilinear', head_pos=None, axes=None,
-                      sensors=True, allow_ref_meg=False):
+                      sensors=True, allow_ref_meg=False, extrapolate='box'):
     """Plot single ica map to axes."""
     from matplotlib.axes import Axes
     from ..channels import _get_ch_type
@@ -999,7 +999,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
     im = plot_topomap(
         data.ravel(), pos, vmin=vmin_, vmax=vmax_, res=res, axes=axes,
         cmap=cmap, outlines=outlines, contours=contours, sensors=sensors,
-        image_interp=image_interp, show=show)[0]
+        image_interp=image_interp, show=show, extrapolate=extrapolate)[0]
     if colorbar:
         cbar, cax = _add_colorbar(axes, im, cmap, pad=.05, title="AU",
                                   format='%3.2f')


### PR DESCRIPTION
…plot_topomap

#### Reference issue
--


#### What does this implement/fix?
plot_topomap has included recently a "extrapolate" argument (https://github.com/mne-tools/mne-python/pull/5754), however, the _plot_ica_topomap is not accepting this parameter. This pull request fixes this


#### Additional information
---
