### PR TITLE
MRG: Add initial arguments to vol viz

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -98,6 +98,8 @@ Bug
 
 - Fix bug in :meth:`mne.SourceMorph.apply` where output STCs had ``stc.vertices`` defined improperly, by `Eric Larson`_
 
+- Fix bug in :meth:`mne.SourceMorph.apply` where the default was errantly ``mri_space=False`` instead of ``mri_space=None`` (as documented), by `Eric Larson`_
+
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 
 - Fix horizontal spacing issues in :meth:`mne.io.Raw.plot_psd` by `Jeff Hanna`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -92,6 +92,12 @@ Bug
 
 - Fix one-sample baseline issue in :class:`mne.BaseEpochs` when using `tmin=0` by `Milan Rybář`_
 
+- Fix bug in :func:`mne.viz.plot_volume_source_estimates` where ``'glass_brain'`` MRIs were not transformed to MNI space, by `Eric Larson`_
+
+- Fix bug in :func:`mne.viz.plot_volume_source_estimates` where MRIs with voxels not in RAS orientation could not be browsed properly, by `Eric Larson`_
+
+- Fix bug in :meth:`mne.SourceMorph.apply` where output STCs had ``stc.vertices`` defined improperly, by `Eric Larson`_
+
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 
 - Fix horizontal spacing issues in :meth:`mne.io.Raw.plot_psd` by `Jeff Hanna`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,6 +53,8 @@ Changelog
 
 - Add function to check the type of a FIF file using :func:`mne.what` and `mne what <gen_mne_what>` by `Eric Larson`_
 
+- Add support for specifying the initial time and/or position and providing a :class:`mne.SourceMorph` instead of :class:`mne.SourceSpaces` in :func:`mne.viz.plot_volume_source_estimates` by `Eric Larson`_
+
 - Speed up morph map generation in :func:`mne.read_morph_map` by ~5-10x by using :func:`numba.jit` by `Eric Larson`_
 
 - Speed up :func:`mne.setup_volume_source_space`, especially when ``volume_label is not None`` by `Eric Larson`_

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -533,7 +533,7 @@ numpydoc_xref_aliases = {
     # nibabel
     'Nifti1Image': 'nibabel.nifti1.Nifti1Image',
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',
-    'SpatialImage': '~nibabel.spatialimages.SpatialImage',
+    'SpatialImage': 'nibabel.spatialimages.SpatialImage',
     # MNE
     'Label': 'mne.Label', 'Forward': 'mne.Forward', 'Evoked': 'mne.Evoked',
     'Info': 'mne.Info', 'SourceSpaces': 'mne.SourceSpaces',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -533,9 +533,11 @@ numpydoc_xref_aliases = {
     # nibabel
     'Nifti1Image': 'nibabel.nifti1.Nifti1Image',
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',
+    'SpatialImage': '~nibabel.spatialimages.SpatialImage',
     # MNE
     'Label': 'mne.Label', 'Forward': 'mne.Forward', 'Evoked': 'mne.Evoked',
     'Info': 'mne.Info', 'SourceSpaces': 'mne.SourceSpaces',
+    'SourceMorph': 'mne.SourceMorph',
     'Epochs': 'mne.Epochs', 'Layout': 'mne.channels.Layout',
     'EvokedArray': 'mne.EvokedArray', 'BiHemiLabel': 'mne.BiHemiLabel',
     'AverageTFR': 'mne.time_frequency.AverageTFR',

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -93,7 +93,6 @@ stc.plot(
 
 # sphinx_gallery_thumbnail_number = 4
 
-clim = dict(kind='value', lims=[0.3, 0.6, 0.9])
 stc.plot(
     src=forward['src'], subject='sample', subjects_dir=subjects_dir,
     mode='glass_brain', clim=dict(kind='value', lims=lims),
@@ -106,7 +105,6 @@ stc.plot(
 # argument to `mne.VolSourceEstimate.plot`. To save a bit of speed when
 # applying the morph, we will crop the STC:
 
-clim = dict(kind='value', pos_lims=[0.3, 0.6, 0.9])
 morph = mne.compute_source_morph(
     forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
     zooms=7, verbose=True)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -3,7 +3,8 @@
 Compute LCMV inverse solution in volume source space
 ====================================================
 
-Compute LCMV beamformer on an auditory evoked dataset in a volume source space.
+Compute LCMV beamformer on an auditory evoked dataset in a volume source space,
+and show activation on ``fsaverage``.
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
@@ -22,7 +23,7 @@ print(__doc__)
 
 data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
-raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
+raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-vol-7-fwd.fif'
 
@@ -35,7 +36,7 @@ forward = mne.read_forward_solution(fname_fwd)
 # Setup for reading the raw data
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 raw.info['bads'] = ['MEG 2443', 'EEG 053']  # 2 bads channels
-events = mne.read_events(event_fname)
+events = mne.find_events(raw)
 
 # Pick the channels of interest
 raw.pick(['meg', 'eog'])
@@ -89,9 +90,20 @@ stc.plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
          clim=clim)
 
 ###############################################################################
-# We can also visualize the activity on a "glass brain" (shown here with
-# absolute values):
+# Now let's:
+# - visualize the activity on a "glass brain",
+# - show absolute values, and
+# - morph data to ``'fsaverage'`` instead of `sample`
 
+# XXX The morph is still wrong. And even without morph it's wrong because it's
+# not in MNI space.
+
+# morph = mne.compute_source_morph(
+#     forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
+#     verbose='debug')
 clim = dict(kind='value', lims=[0.3, 0.6, 0.9])
-abs(stc).plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
-              mode='glass_brain', clim=clim)
+abs(stc).crop(0.08, 0.12).plot(
+    # src=morph,
+    src=forward['src'],
+    subject='sample', subjects_dir=subjects_dir,
+    mode='glass_brain', clim=clim)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -10,8 +10,6 @@ and show activation on ``fsaverage``.
 #
 # License: BSD (3-clause)
 
-# sphinx_gallery_thumbnail_number = 3
-
 import mne
 from mne.datasets import sample
 from mne.beamformer import make_lcmv, apply_lcmv
@@ -48,7 +46,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
 evoked = epochs.average()
 
 # Visualize sensor space data
-# evoked.plot_joint()
+evoked.plot_joint()
 
 ###############################################################################
 # Compute covariance matrices, fit and apply  spatial filter.
@@ -83,38 +81,36 @@ stc = apply_lcmv(evoked, filters, max_ori_out='signed')
 
 # You can save result in stc files with:
 # stc.save('lcmv-vol')
-clim = dict(kind='value', pos_lims=[0.3, 0.6, 0.9])
-#stc.plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
-#         clim=clim, mode='stat_map', verbose='debug')
+lims = [0.3, 0.6, 0.9]
+stc.plot(
+    src=forward['src'], subject='sample', subjects_dir=subjects_dir,
+    clim=dict(kind='value', pos_lims=lims), mode='stat_map',
+    initial_time=0.1, verbose=True)
 
 ###############################################################################
-# Now let's:
-# - visualize the activity on a "glass brain",
-# - show absolute values, and
-# - morph data to ``'fsaverage'`` instead of `sample`
+# Now let's plot this on a glass brain, which will automatically transform the
+# data to MNI Talairach space:
 
-morph = mne.compute_source_morph(
-    forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
-    verbose='debug', zooms=7)
-stc = abs(stc.crop(0.08, 0.12))
+# sphinx_gallery_thumbnail_number = 4
 
 clim = dict(kind='value', lims=[0.3, 0.6, 0.9])
-"""
-print('*' * 80)
 stc.plot(
-    src=forward['src'],
-    subject='sample', subjects_dir=subjects_dir,
-    mode='stat_map', clim=clim, verbose='debug')
-"""
-initial_pos = (-56.7, -44.1, -0.3)
-print('*' * 80)
-stc.plot(
-    src=forward['src'], initial_pos=initial_pos,
-    subject='sample', subjects_dir=subjects_dir,
-    mode='glass_brain', clim=clim, verbose='debug')
-print('*' * 80)
-stc.plot(
-    src=morph, initial_pos=initial_pos,
-    subject='fsaverage', subjects_dir=subjects_dir,
-    mode='glass_brain', clim=clim, verbose='debug')
-print('*' * 80)
+    src=forward['src'], subject='sample', subjects_dir=subjects_dir,
+    mode='glass_brain', clim=dict(kind='value', lims=lims),
+    initial_time=0.1, verbose=True)
+
+###############################################################################
+# Finally let's get another view, this time plotting again a ``'stat_map'``
+# style but using volumetric morphing to get data to fsaverage space,
+# which we can get by passing a :class:`mne.SourceMorph` as the ``src``
+# argument to `mne.VolSourceEstimate.plot`. To save a bit of speed when
+# applying the morph, we will crop the STC:
+
+clim = dict(kind='value', pos_lims=[0.3, 0.6, 0.9])
+morph = mne.compute_source_morph(
+    forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
+    zooms=7, verbose=True)
+stc.copy().crop(0.05, 0.18).plot(
+    src=morph, subject='fsaverage', subjects_dir=subjects_dir,
+    mode='stat_map', clim=dict(kind='value', pos_lims=lims),
+    initial_time=0.1, verbose=True)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -24,7 +24,6 @@ print(__doc__)
 data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-event_fname = data_path + '/MEG/sample/sample_audvis_raw-eve.fif'
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-vol-7-fwd.fif'
 
 # Get epochs
@@ -49,7 +48,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
 evoked = epochs.average()
 
 # Visualize sensor space data
-evoked.plot_joint()
+# evoked.plot_joint()
 
 ###############################################################################
 # Compute covariance matrices, fit and apply  spatial filter.
@@ -84,10 +83,9 @@ stc = apply_lcmv(evoked, filters, max_ori_out='signed')
 
 # You can save result in stc files with:
 # stc.save('lcmv-vol')
-
 clim = dict(kind='value', pos_lims=[0.3, 0.6, 0.9])
-stc.plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
-         clim=clim)
+#stc.plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
+#         clim=clim, mode='stat_map', verbose='debug')
 
 ###############################################################################
 # Now let's:
@@ -95,15 +93,28 @@ stc.plot(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
 # - show absolute values, and
 # - morph data to ``'fsaverage'`` instead of `sample`
 
-# XXX The morph is still wrong. And even without morph it's wrong because it's
-# not in MNI space.
+morph = mne.compute_source_morph(
+    forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
+    verbose='debug', zooms=7)
+stc = abs(stc.crop(0.08, 0.12))
 
-# morph = mne.compute_source_morph(
-#     forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
-#     verbose='debug')
 clim = dict(kind='value', lims=[0.3, 0.6, 0.9])
-abs(stc).crop(0.08, 0.12).plot(
-    # src=morph,
+"""
+print('*' * 80)
+stc.plot(
     src=forward['src'],
     subject='sample', subjects_dir=subjects_dir,
-    mode='glass_brain', clim=clim)
+    mode='stat_map', clim=clim, verbose='debug')
+"""
+initial_pos = (-56.7, -44.1, -0.3)
+print('*' * 80)
+stc.plot(
+    src=forward['src'], initial_pos=initial_pos,
+    subject='sample', subjects_dir=subjects_dir,
+    mode='glass_brain', clim=clim, verbose='debug')
+print('*' * 80)
+stc.plot(
+    src=morph, initial_pos=initial_pos,
+    subject='fsaverage', subjects_dir=subjects_dir,
+    mode='glass_brain', clim=clim, verbose='debug')
+print('*' * 80)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -73,6 +73,7 @@ def pytest_configure(config):
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:.*mne-realtime.*:DeprecationWarning
     ignore:.*imp.*:DeprecationWarning
+    always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -420,6 +420,14 @@ def minimum_phase(h):
 ###############################################################################
 # Misc utilities
 
+# Deal with nibabel 2.5 img.get_data() deprecation
+def _get_img_fdata(img):
+    try:
+        return img.get_fdata()
+    except AttributeError:
+        return img.get_data().astype(float)
+
+
 def _read_volume_info(fobj):
     """An implementation of nibabel.freesurfer.io._read_volume_info, since old
     versions of nibabel (<=2.1.0) don't have it.

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -143,7 +143,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
     shape = affine = pre_affine = sdr_morph = None
     morph_mat = vertices_to = None
     if kind == 'volume':
-        _check_dep(nibabel='2.1.0', dipy=False)
+        _check_dep(nibabel='2.1.0', dipy='0.10.1')
 
         logger.info('volume source space inferred...')
         import nibabel as nib
@@ -692,7 +692,6 @@ def _interpolate_data(stc, morph, mri_resolution=True, mri_space=True,
 def _compute_morph_sdr(mri_from, mri_to, niter_affine=(100, 100, 10),
                        niter_sdr=(5, 5, 3), zooms=(5., 5., 5.)):
     """Get a matrix that morphs data from one subject to another."""
-    _check_dep(nibabel='2.1.0', dipy='0.10.1')
     import nibabel as nib
     with np.testing.suppress_warnings():
         from dipy.align import imaffine, imwarp, metrics, transforms

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -14,7 +14,7 @@ from .parallel import parallel_func
 from .source_estimate import (VolSourceEstimate, SourceEstimate,
                               VolVectorSourceEstimate, VectorSourceEstimate,
                               _get_ico_tris)
-from .source_space import SourceSpaces
+from .source_space import SourceSpaces, _ensure_src
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, deprecated, fill_doc, _check_option,
@@ -119,6 +119,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         kind = 'surface'
         subject_from = _check_subject_from(subject_from, src.subject)
     else:
+        src = _ensure_src(src)
         src_data, kind = _get_src_data(src)
         subject_from = _check_subject_from(subject_from, src)
     if not isinstance(subject_to, str):

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1780,7 +1780,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
 
         Returns
         -------
-        img : instance Nifti1Image
+        img : instance of Nifti1Image
             The image object.
 
         Notes

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1331,7 +1331,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
         """
         if self.subject is None:
             raise ValueError('stc.subject must be set')
-        src_orig = _ensure_src(src_orig, kind='surf')
+        src_orig = _ensure_src(src_orig, kind='surface')
         subject_orig = _ensure_src_subject(src_orig, subject_orig)
         data_idx, vertices = _get_morph_src_reordering(
             self.vertices, src_orig, subject_orig, self.subject, subjects_dir)
@@ -1709,12 +1709,15 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
              bg_img=None, colorbar=True, colormap='auto', clim='auto',
-             transparent='auto', show=True, verbose=None):
+             transparent='auto', show=True, initial_time=None,
+             initial_pos=None, verbose=None):
         data = self.magnitude() if self._data_ndim == 3 else self
         return plot_volume_source_estimates(
             data, src=src, subject=subject, subjects_dir=subjects_dir,
             mode=mode, bg_img=bg_img, colorbar=colorbar, colormap=colormap,
-            clim=clim, transparent=transparent, show=show, verbose=verbose)
+            clim=clim, transparent=transparent, show=show,
+            initial_time=initial_time, initial_pos=initial_pos,
+            verbose=verbose)
 
     def save_as_volume(self, fname, src, dest='mri', mri_resolution=False,
                        format='nifti1'):
@@ -2151,7 +2154,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
             A instance of `surfer.Brain` from PySurfer.
         """
         # extract surface source spaces
-        surf = _ensure_src(src, kind='surf')
+        surf = _ensure_src(src, kind='surface')
 
         # extract surface source estimate
         data = self.data[:surf[0]['nuse'] + surf[1]['nuse']]
@@ -2450,7 +2453,7 @@ def spatial_inter_hemi_connectivity(src, dist, verbose=None):
         using geodesic distances.
     """
     from scipy.spatial.distance import cdist
-    src = _ensure_src(src, kind='surf')
+    src = _ensure_src(src, kind='surface')
     conn = cdist(src[0]['rr'][src[0]['vertno']],
                  src[1]['rr'][src[1]['vertno']])
     conn = sparse.csr_matrix(conn <= dist, dtype=int)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -22,6 +22,7 @@ from .io.write import (start_block, end_block, write_int,
                        write_float_matrix, write_int_matrix,
                        write_coord_trans, start_file, end_file, write_id)
 from .bem import read_bem_surfaces, ConductorModel
+from .fixes import _get_img_fdata
 from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _tessellate_sphere_surf, _get_surf_neighbors,
                       _normalize_vectors, _triangle_neighbors, mesh_dist,
@@ -354,7 +355,7 @@ class SourceSpaces(list):
                 # get the inuse array
                 if mri_resolution:
                     # read the mri file used to generate volumes
-                    aseg_data = nib.load(vs['mri_file']).get_data()
+                    aseg_data = _get_img_fdata(nib.load(vs['mri_file']))
                     # get the voxel space shape
                     shape3d = (vs['mri_height'], vs['mri_depth'],
                                vs['mri_width'])
@@ -1829,7 +1830,7 @@ def _get_volume_label_mask(mri, volume_label, rr):
 
     # Read the segmentation data using nibabel
     mgz = nib.load(mri)
-    mgz_data = mgz.get_data()
+    mgz_data = _get_img_fdata(mgz)
 
     # Get the numeric index for this volume label
     lut = _get_lut()
@@ -2513,7 +2514,7 @@ def get_volume_labels_from_aseg(mgz_fname, return_colors=False):
     import nibabel as nib
 
     # Read the mgz file using nibabel
-    mgz_data = nib.load(mgz_fname).get_data()
+    mgz_data = _get_img_fdata(nib.load(mgz_fname))
 
     # Get the unique label names
     lut = _get_lut()

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2326,8 +2326,9 @@ def _adjust_patch_info(s, verbose=None):
 
 
 @verbose
-def _ensure_src(src, kind=None, verbose=None):
+def _ensure_src(src, kind=None, extra='', verbose=None):
     """Ensure we have a source space."""
+    msg = 'src must be a string or instance of SourceSpaces%s' % (extra,)
     if _check_path_like(src):
         src = str(src)
         if not op.isfile(src):
@@ -2335,14 +2336,10 @@ def _ensure_src(src, kind=None, verbose=None):
         logger.info('Reading %s...' % src)
         src = read_source_spaces(src, verbose=False)
     if not isinstance(src, SourceSpaces):
-        raise ValueError('src must be a string or instance of SourceSpaces')
-    if kind is not None:
-        if kind == 'surf':
-            surf = [s for s in src if s['type'] == 'surf']
-            if len(surf) != 2 or len(src) != 2:
-                raise ValueError('Source space must contain exactly two '
-                                 'surfaces.')
-            src = surf
+        raise ValueError('%s, got %s (type %s)' % (msg, src, type(src)))
+    if kind is not None and src.kind != kind:
+        raise ValueError('Source space must be %s type, got '
+                         '%s' % (kind, src.kind))
     return src
 
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -36,7 +36,7 @@ from .parallel import parallel_func, check_n_jobs
 from .transforms import (invert_transform, apply_trans, _print_coord_trans,
                          combine_transforms, _get_trans,
                          _coord_frame_name, Transform, _str_to_frame,
-                         _ensure_trans, _read_fs_xfm)
+                         _ensure_trans, _read_ras_mni_t)
 
 
 def _get_lut():
@@ -1273,18 +1273,15 @@ def head_to_mni(pos, subject, mri_head_t, subjects_dir=None,
 
 @verbose
 def _read_talxfm(subject, subjects_dir, mode=None, verbose=None):
-    """Read MNI transform from FreeSurfer talairach.xfm file.
+    """Compute MNI transform from FreeSurfer talairach.xfm file.
 
     Adapted from freesurfer m-files. Altered to deal with Norig
     and Torig correctly.
     """
     if mode is not None and mode not in ['nibabel', 'freesurfer']:
         raise ValueError('mode must be "nibabel" or "freesurfer"')
-    fname = op.join(subjects_dir, subject, 'mri', 'transforms',
-                    'talairach.xfm')
-
     # Setup the RAS to MNI transform
-    ras_mni_t = Transform('ras', 'mni_tal', _read_fs_xfm(fname)[0])
+    ras_mni_t = _read_ras_mni_t(subject, subjects_dir)
 
     # We want to get from Freesurfer surface RAS ('mri') to MNI ('mni_tal').
     # This file only gives us RAS (non-zero origin) ('ras') to MNI ('mni_tal').

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -234,14 +234,14 @@ def test_volume_source_morph():
     stc_vol = read_source_estimate(fname_vol, 'sample')
 
     # check for invalid input type
-    with pytest.raises(TypeError, match='src must be an instance of'):
+    with pytest.raises(ValueError, match='src must be a string or instance'):
         compute_source_morph(src=42)
 
     # check for raising an error if neither
     # inverse_operator_vol['src'][0]['subject_his_id'] nor subject_from is set,
     # but attempting to perform a volume morph
     src = inverse_operator_vol['src']
-    src[0]['subject_his_id'] = None
+    assert src[0]['subject_his_id'] is None  # already None on disk (old!)
 
     with pytest.raises(ValueError, match='subject_from could not be inferred'):
         compute_source_morph(src=src, subjects_dir=subjects_dir)
@@ -259,7 +259,8 @@ def test_volume_source_morph():
     zooms = 20
     kwargs = dict(zooms=zooms, niter_sdr=(1,), niter_affine=(1,))
     source_morph_vol = compute_source_morph(
-        subjects_dir=subjects_dir, src=inverse_operator_vol['src'], **kwargs)
+        subjects_dir=subjects_dir, src=fname_inv_vol, subject_from='sample',
+        **kwargs)
     shape = (13,) * 3  # for the given zooms
 
     assert source_morph_vol.subject_from == 'sample'

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -17,7 +17,7 @@ from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  spatial_src_connectivity, spatial_tris_connectivity,
                  SourceSpaces, VolVectorSourceEstimate)
 from mne.datasets import testing
-from mne.fixes import fft
+from mne.fixes import fft, _get_img_fdata
 from mne.source_estimate import grade_to_tris, _get_vol_mask
 from mne.minimum_norm import (read_inverse_operator, apply_inverse,
                               apply_inverse_epochs)
@@ -948,7 +948,7 @@ def test_vol_mask():
     data = (1 + np.arange(n_vertices))[:, np.newaxis]
     stc_tmp = VolSourceEstimate(data, vertices, tmin=0., tstep=1.)
     img = stc_tmp.as_volume(src, mri_resolution=False)
-    img_data = img.get_data()[:, :, :, 0].T
+    img_data = _get_img_fdata(img)[:, :, :, 0].T
     mask_nib = (img_data != 0)
     assert_array_equal(img_data[mask_nib], data[:, 0])
     assert_array_equal(np.where(mask_nib.ravel())[0], src[0]['vertno'])

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -159,7 +159,7 @@ def test_stc_as_volume():
     assert isinstance(img, nib.Nifti1Image)
     assert img.shape[:3] == inverse_operator_vol['src'][0]['shape'][:3]
 
-    with pytest.raises(ValueError, match='invalid output'):
+    with pytest.raises(ValueError, match='Invalid value.*output.*'):
         stc_vol.as_volume(inverse_operator_vol['src'], format='42')
 
 

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -20,7 +20,7 @@ from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.write import start_file, end_file, write_coord_trans
 from .utils import (check_fname, logger, verbose, _ensure_int, _validate_type,
-                    _check_path_like, get_subjects_dir, _check_subject)
+                    _check_path_like, get_subjects_dir)
 
 
 # transformation from anterior/left/superior coordinate system to
@@ -174,15 +174,17 @@ def _coord_frame_name(cframe):
     return _verbose_frames.get(int(cframe), 'unknown')
 
 
-def _print_coord_trans(t, prefix='Coordinate transformation: ', units='m'):
+def _print_coord_trans(t, prefix='Coordinate transformation: ', units='m',
+                       level='info'):
     # Units gives the units of the transformation. This always prints in mm.
-    logger.info(prefix + '%s -> %s'
-                % (_coord_frame_name(t['from']), _coord_frame_name(t['to'])))
+    log_func = getattr(logger, level)
+    log_func(prefix + '%s -> %s'
+             % (_coord_frame_name(t['from']), _coord_frame_name(t['to'])))
     for ti, tt in enumerate(t['trans']):
         scale = 1000. if (ti != 3 and units != 'mm') else 1.
         text = ' mm' if ti != 3 else ''
-        logger.info('    % 8.6f % 8.6f % 8.6f    %7.2f%s' %
-                    (tt[0], tt[1], tt[2], scale * tt[3], text))
+        log_func('    % 8.6f % 8.6f % 8.6f    %7.2f%s' %
+                 (tt[0], tt[1], tt[2], scale * tt[3], text))
 
 
 def _find_trans(subject, subjects_dir=None):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -24,7 +24,7 @@ from .docs import (copy_function_doc_to_method_doc, copy_doc, linkcode_resolve,
 from .fetching import _fetch_file, _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
-                       ETSContext)
+                       ETSContext, wrapped_stdout)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -4,6 +4,7 @@
 #
 # License: BSD (3-clause)
 
+import contextlib
 import inspect
 from io import StringIO
 import re
@@ -356,3 +357,17 @@ class ETSContext(object):
             value.code += ("\nThis can probably be solved by setting "
                            "ETS_TOOLKIT=qt4. On bash, type\n\n    $ export "
                            "ETS_TOOLKIT=qt4\n\nand run the command again.")
+
+
+@contextlib.contextmanager
+def wrapped_stdout(indent=''):
+    """Wrap stdout writes to logger.info, with an optional indent prefix."""
+    orig_stdout = sys.stdout
+    my_out = StringIO()
+    sys.stdout = my_out
+    try:
+        yield
+    finally:
+        sys.stdout = orig_stdout
+        for line in my_out.getvalue().split('\n'):
+            logger.info(indent + line)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -149,20 +149,26 @@ def _check_fname(fname, overwrite=False, must_exist=False):
     return str(fname)
 
 
-def _check_subject(class_subject, input_subject, raise_error=True):
+def _check_subject(class_subject, input_subject, raise_error=True,
+                   kind='class subject attribute'):
     """Get subject name from class."""
+    mismatch_err = ('%s (%r) did not match input subject (%r)'
+                    % (kind, class_subject, input_subject))
     if input_subject is not None:
         _validate_type(input_subject, 'str', "subject input")
+        if class_subject is not None and input_subject != class_subject:
+            raise ValueError(mismatch_err)
         return input_subject
     elif class_subject is not None:
         _validate_type(class_subject, 'str',
-                       "Either subject input or class subject attribute")
+                       "Either subject input or %s" % (kind,))
+        if input_subject is not None and input_subject != class_subject:
+            raise ValueError(mismatch_err)
         return class_subject
-    else:
-        if raise_error is True:
-            raise ValueError('Neither subject input nor class subject '
-                             'attribute was a string')
-        return None
+    elif raise_error is True:
+        raise ValueError('Neither subject input nor %s '
+                            'was a string' % (kind,))
+    return None
 
 
 def _check_preload(inst, msg):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -152,22 +152,18 @@ def _check_fname(fname, overwrite=False, must_exist=False):
 def _check_subject(class_subject, input_subject, raise_error=True,
                    kind='class subject attribute'):
     """Get subject name from class."""
-    mismatch_err = ('%s (%r) did not match input subject (%r)'
-                    % (kind, class_subject, input_subject))
     if input_subject is not None:
         _validate_type(input_subject, 'str', "subject input")
         if class_subject is not None and input_subject != class_subject:
-            raise ValueError(mismatch_err)
+            raise ValueError('%s (%r) did not match input subject (%r)'
+                             % (kind, class_subject, input_subject))
         return input_subject
     elif class_subject is not None:
         _validate_type(class_subject, 'str',
                        "Either subject input or %s" % (kind,))
-        if input_subject is not None and input_subject != class_subject:
-            raise ValueError(mismatch_err)
         return class_subject
     elif raise_error is True:
-        raise ValueError('Neither subject input nor %s '
-                            'was a string' % (kind,))
+        raise ValueError('Neither subject input nor %s was a string' % (kind,))
     return None
 
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -29,10 +29,9 @@ from ..io.constants import FIFF
 from ..io.meas_info import read_fiducials, create_info
 from ..source_space import _ensure_src, _create_surf_spacing, _check_spacing
 
-from ..surface import (get_meg_helmet_surf, read_surface,
+from ..surface import (get_meg_helmet_surf, read_surface, _DistanceQuery,
                        transform_surface_to, _project_onto_surface,
-                       mesh_edges, _reorder_ccw, _compute_nearest,
-                       _complete_sphere_surf, _DistanceQuery)
+                       mesh_edges, _reorder_ccw, _complete_sphere_surf)
 from ..transforms import (read_trans, _find_trans, apply_trans, rot_to_quat,
                           combine_transforms, _get_trans, _ensure_trans,
                           invert_transform, Transform,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -27,8 +27,7 @@ from ..io import _loc_to_coil_trans
 from ..io.pick import pick_types, _picks_to_idx
 from ..io.constants import FIFF
 from ..io.meas_info import read_fiducials, create_info
-from ..source_space import (_ensure_src, _create_surf_spacing, _check_spacing,
-                            SourceSpaces)
+from ..source_space import _ensure_src, _create_surf_spacing, _check_spacing
 
 from ..surface import (get_meg_helmet_surf, read_surface,
                        transform_surface_to, _project_onto_surface,
@@ -1847,7 +1846,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
         raise RuntimeError('This function requires nilearn >= 0.4')
 
     from nilearn.plotting import plot_stat_map, plot_glass_brain
-    from nilearn.image import index_img, resample_to_img
+    from nilearn.image import index_img
 
     _check_option('mode', mode, ('stat_map', 'glass_brain'))
     plot_func = dict(stat_map=plot_stat_map,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -22,7 +22,7 @@ import numpy as np
 from scipy import linalg, sparse
 
 from ..defaults import DEFAULTS
-from ..fixes import einsum, _crop_colorbar
+from ..fixes import einsum, _crop_colorbar, _get_img_fdata
 from ..io import _loc_to_coil_trans
 from ..io.pick import pick_types, _picks_to_idx
 from ..io.constants import FIFF
@@ -432,7 +432,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
 
     # Load the T1 data
     nim = nib.load(mri_fname)
-    data = nim.get_data()
+    data = _get_img_fdata(nim)
     try:
         affine = nim.affine
     except AttributeError:  # old nibabel
@@ -1898,7 +1898,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
         cut_coords = np.array((x, y, z))
 
         if params['mode'] == 'glass_brain':  # find idx for MIP
-            img_data = np.abs(params['img_idx'].get_data())
+            img_data = np.abs(_get_img_fdata(params['img_idx']))
             ijk = _cut_coords_to_ijk(cut_coords, params['img_idx'])
             if ax == 'x':
                 ijk[0] = np.argmax(img_data[:, ijk[1], ijk[2]])
@@ -2720,7 +2720,7 @@ def _plot_dipole_mri_orthoview(dipole, trans, subject, subjects_dir=None,
                         coord_frame=coord_frame)
 
     zooms = t1.header.get_zooms()
-    data = t1.get_data()
+    data = _get_img_fdata(t1)
     dims = len(data)  # Symmetric size assumed.
     dd = dims / 2.
     dd *= t1.header.get_zooms()[0]

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1806,14 +1806,18 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
         Show figures if True. Defaults to True.
     initial_time : float | None
         The initial time to plot. Can be None (default) to use the time point
-        with the maximal absolute value activation.
+        with the maximal absolute value activation across all voxels
+        or the ``initial_pos`` voxel (if ``initial_pos is None`` or not,
+        respectively).
 
-        .. versionadded:: 0.18
+        .. versionadded:: 0.19
     initial_pos : ndarray, shape (3,) | None
         The initial position to use (in m). Can be None (default) to use the
-        voxel with the maximum absolute value activation.
+        voxel with the maximum absolute value activation across all time points
+        or at ``initial_time`` (if ``initial_time is None`` or not,
+        respectively).
 
-        .. versionadded:: 0.18
+        .. versionadded:: 0.19
     %(verbose)s
 
     Notes
@@ -1824,11 +1828,15 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     The left and right arrow keys can be used to navigate in time.
     To move in time by larger steps, use shift+left and shift+right.
 
+    In ``'glass_brain'`` mode, values are transformed to the standard MNI
+    brain using the FreeSurfer Talairach transformation
+    ``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talairach.xfm``.
+
     .. versionadded:: 0.17
 
-    In ``'glass_brain'`` mode, values are transformed to the standard MNI brain
-    using the FreeSurfer Talairach transformation
-    ``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talairach.xfm``.
+    .. versionchanged:: 0.19
+       MRI volumes are automatically transformed to MNI space in
+       ``'glass_brain'`` mode.
 
     Examples
     --------
@@ -2059,7 +2067,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     axes.set(xticks=[], yticks=[])
     marker = 'o' if len(stc.times) == 1 else None
     ydata = stc.data[loc_idx]
-    ax_time.plot(stc.times, ydata, color='k', marker=marker, clip_on=False)
+    ax_time.plot(stc.times, ydata, color='k', marker=marker)
     if len(stc.times) > 1:
         ax_time.set(xlim=stc.times[[0, -1]])
     ax_time.set(xlabel='Time (s)', ylabel='Activation')

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -477,9 +477,9 @@ def test_snapshot_brain_montage(renderer):
 @requires_nibabel()
 @requires_version('nilearn', '0.4')
 @pytest.mark.parametrize('mode, stype, init_t, want_t, init_p, want_p', [
-    ('glass_brain', 's', None, 2, None, (-33.3, 16.0, 63.7)),
+    ('glass_brain', 's', None, 2, None, (-30.9, 18.4, 56.7)),
     ('stat_map', 'vec', 1, 1, None, (15.7, 16.0, -6.3)),
-    ('glass_brain', 'vec', None, 2, (10, -10, 20), (8.7, -12.0, 21.7)),
+    ('glass_brain', 'vec', None, 1, (10, -10, 20), (6.6, -9.0, 19.9)),
     ('stat_map', 's', 1, 1, (-10, 5, 10), (-12.3, 2.0, 7.7))])
 def test_plot_volume_source_estimates(mode, stype, init_t, want_t,
                                       init_p, want_p):

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -530,7 +530,7 @@ def test_plot_volume_source_estimates_morph():
     n_time = 2
     data = np.random.RandomState(0).rand(n_verts, n_time)
     stc = VolSourceEstimate(data, vertices, 1, 1)
-    morph = compute_source_morph(sample_src, 'sample', 'fsaverage', zooms=10,
+    morph = compute_source_morph(sample_src, 'sample', 'fsaverage', zooms=5,
                                  subjects_dir=subjects_dir)
     initial_pos = (-0.05, -0.01, -0.006)
     with pytest.warns(None):  # sometimes get scalars/index warning
@@ -539,7 +539,7 @@ def test_plot_volume_source_estimates_morph():
                      initial_pos=initial_pos, verbose=True)
     log = log.getvalue()
     assert 't = 1.000 s' in log
-    assert '(-52.0, -8.0, -2.0) mm' in log
+    assert '(-52.0, -8.0, -7.0) mm' in log
 
     with pytest.raises(ValueError, match='Allowed values are'):
         stc.plot(sample_src, 'sample', subjects_dir, mode='abcd')


### PR DESCRIPTION
When using `VolSourceEstimate.plot()` I found myself wanting a way to specify the initial time and initial position. This PR thus:

- [x] Adds support for `initial_time` (like in surf source est plotting)
- [x] Adds support for `initial_position`
- [x] Adds support for passing a `morph` instead of `SourceSpaces` as `src` (see Notes for details/rationale)
- [x] Fixes indexing of morphed STC (see example)
- [x] Speeds up tests a little bit

My particular use case involved replicating a figure someone sent me with `initial_time=0.2` and `initial_pos=(-0.04, -0.034, -0.002)` and now I can script it to give:

![3089_0 2_nai](https://user-images.githubusercontent.com/2365790/54157662-26f86a00-441f-11e9-8e80-2bdd0e74948a.png)

Not ready for merge because there is some bug with indexing the morphed STC.