### PR TITLE
Add Annotations to CNT  + add code to deprecate stim_channel

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -84,12 +84,12 @@ Changelog
 Bug
 ~~~
 
+- Fix date parsing in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
+
 - Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
   If your code uses ``Epochs(..., preload=True).drop_bad(reject=..., flat=...)``, we recommend regenerating these data.
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
-
-- Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_
 
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
@@ -123,12 +123,10 @@ Bug
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_
 
-- Fix :func:`mne.io.read_raw_eeglab` incorrectly parsing event durations by `Clemens Brunner`_
-
 API
 ~~~
 
-- Deprecate stim channel synthesis in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
+- Add ``stim_channel`` parameter in :func:`mne.io.read_raw_cnt` to toggle stim channel synthesis by `Joan Massich`_
 
 - Python 2 is no longer supported; MNE-Python now requires Python 3.5+, by `Eric Larson`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -128,6 +128,8 @@ Bug
 API
 ~~~
 
+- Deprecate stim channel synthesis in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
+
 - Python 2 is no longer supported; MNE-Python now requires Python 3.5+, by `Eric Larson`_
 
 - A new class :class:`mne.VolVectorSourceEstimate` is returned by :func:`mne.minimum_norm.apply_inverse` (and related functions) when a volume source space and ``pick_ori='vector'`` is used, by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add support to :func:`mne.read_annotations` to read CNT formats by `Joan Massich`_
+
 - Add ``reject`` parameter to :meth:`mne.preprocessing.ICA.plot_properties` to visualize rejected epochs by `Antoine Gauthier`_
 
 - Add support for picking channels using channel name and type strings to functions with ``picks`` arguments, along with a convenience :meth:`mne.io.Raw.pick`, :meth:`mne.Epochs.pick`, and :meth:`mne.Evoked.pick` method, by `Eric Larson`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -91,6 +91,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
+- Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_
+
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
 - Fix checking of ``data`` dimensionality in :class:`mne.SourceEstimate` and related constructors by `Eric Larson`_
@@ -122,6 +124,8 @@ Bug
 - Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <gen_mne_clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_
+
+- Fix :func:`mne.io.read_raw_eeglab` incorrectly parsing event durations by `Clemens Brunner`_
 
 API
 ~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -595,6 +595,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     from .io.brainvision.brainvision import _read_annotations_brainvision
     from .io.eeglab.eeglab import _read_annotations_eeglab
     from .io.edf.edf import _read_annotations_edf
+    from .io.cnt.cnt import _read_annotations_cnt
 
     name = op.basename(fname)
     if name.endswith(('fif', 'fif.gz')):
@@ -614,6 +615,9 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
 
     elif name.endswith('csv'):
         annotations = _read_annotations_csv(fname)
+
+    elif name.endswith('cnt'):
+        annotations = _read_annotations_cnt(fname)
 
     elif name.endswith('set'):
         annotations = _read_annotations_eeglab(fname,

--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from ...utils import warn
 
 
-def _read_TEEG(f, teeg_offset):
+def _read_teeg(f, teeg_offset):
     """
     # from TEEG structure in http://paulbourke.net/dataformats/eeg/
     typedef struct {
@@ -26,7 +26,6 @@ def _read_TEEG(f, teeg_offset):
 
     f.seek(teeg_offset)
     return Teeg._make(teeg_parser.unpack(f.read(teeg_parser.size)))
-    # XXX: maybe add the warning if offset is not 0
 
 
 CNTEventType1 = namedtuple('CNTEventType1',

--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -26,7 +26,7 @@ def _read_teeg(f, teeg_offset):
     teeg_parser = Struct('<Bll')
 
     f.seek(teeg_offset)
-    return Teeg._make(teeg_parser.unpack(f.read(teeg_parser.size)))
+    return Teeg(*teeg_parser.unpack(f.read(teeg_parser.size)))
 
 
 CNTEventType1 = namedtuple('CNTEventType1',
@@ -78,7 +78,7 @@ def _get_event_parser(event_type):
     def parser(buffer):
         struct = Struct(struct_pattern)
         for chunk in struct.iter_unpack(buffer):
-            yield event_maker._make(chunk)
+            yield event_maker(*chunk)
 
     return parser
 

--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -4,6 +4,10 @@
 
 from struct import Struct
 from collections import namedtuple
+from math import modf
+from datetime import datetime
+
+from ...utils import warn
 
 
 def _read_TEEG(f, teeg_offset):
@@ -77,3 +81,15 @@ def _get_event_parser(event_type):
             yield event_maker._make(chunk)
 
     return parser
+
+
+def _session_date_2_meas_date(session_date, date_format):
+    try:
+        frac_part, int_part = modf(datetime
+                                   .strptime(session_date, date_format)
+                                   .timestamp())
+    except ValueError:
+        warn('  Could not parse meas date from the header. Setting to None.')
+        return None
+    else:
+        return (int_part, frac_part)

--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -12,6 +12,8 @@ from ...utils import warn
 
 def _read_teeg(f, teeg_offset):
     """
+    Read TEEG structure from an open CNT file.
+
     # from TEEG structure in http://paulbourke.net/dataformats/eeg/
     typedef struct {
        char Teeg;       /* Either 1 or 2                    */
@@ -19,7 +21,6 @@ def _read_teeg(f, teeg_offset):
        long Offset;     /* Hopefully always 0               */
     } TEEG;
     """
-
     # we use a more descriptive names based on TEEG doc comments
     Teeg = namedtuple('Teeg', 'event_type total_length offset')
     teeg_parser = Struct('<Bll')

--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -1,0 +1,84 @@
+# Author: Joan Massich <mailsik@gmail.com>
+#
+# License: BSD (3-clause)
+
+from struct import Struct
+from collections import namedtuple
+
+
+def _read_TEEG(f, teeg_offset):
+    """
+    # from TEEG structure in http://paulbourke.net/dataformats/eeg/
+    typedef struct {
+       char Teeg;       /* Either 1 or 2                    */
+       long Size;       /* Total length of all the events   */
+       long Offset;     /* Hopefully always 0               */
+    } TEEG;
+    """
+
+    # we use a more descriptive names based on TEEG doc comments
+    Teeg = namedtuple('Teeg', 'event_type total_length offset')
+    teeg_parser = Struct('<Bll')
+
+    f.seek(teeg_offset)
+    return Teeg._make(teeg_parser.unpack(f.read(teeg_parser.size)))
+    # XXX: maybe add the warning if offset is not 0
+
+
+CNTEventType1 = namedtuple('CNTEventType1',
+                           ('StimType KeyBoard KeyPad_Accept Offset'))
+# typedef struct {
+#    unsigned short StimType;     /* range 0-65535                           */
+#    unsigned char  KeyBoard;     /* range 0-11 corresponding to fcn keys +1 */
+#    char KeyPad_Accept;          /* 0->3 range 0-15 bit coded response pad  */
+#                                 /* 4->7 values 0xd=Accept 0xc=Reject       */
+#    long Offset;                 /* file offset of event                    */
+# } EVENT1;
+
+
+CNTEventType2 = namedtuple('CNTEventType2',
+                           ('StimType KeyBoard KeyPad_Accept Offset Type '
+                            'Code Latency EpochEvent Accept2 Accuracy'))
+# unsigned short StimType; /* range 0-65535                           */
+# unsigned char  KeyBoard; /* range 0-11 corresponding to fcn keys +1 */
+# char KeyPad_Accept;      /* 0->3 range 0-15 bit coded response pad  */
+#                          /* 4->7 values 0xd=Accept 0xc=Reject       */
+# long Offset;             /* file offset of event                    */
+# short Type;
+# short Code;
+# float Latency;
+# char EpochEvent;
+# char Accept2;
+# char Accuracy;
+
+
+CNTEventType3 = CNTEventType2
+
+
+def iter_parse_event_type_1(buffer):
+    event_1_parser = Struct('<HBcl')  # EVENT type 1
+    for chunk in event_1_parser.iter_unpack(buffer):
+        yield CNTEventType1._make(chunk)
+
+
+def iter_parse_event_type_2(buffer):
+    event_2_parser = Struct('<HBclhhfccc')  # EVENT type 2
+    for chunk in event_2_parser.iter_unpack(buffer):
+        yield CNTEventType2._make(chunk)
+
+
+def iter_parse_event_type_3(buffer):
+    event_3_parser = Struct('<HBclhhfccc')  # EVENT type 3 is the same as 2
+    for chunk in event_3_parser.iter_unpack(buffer):
+        yield CNTEventType3._make(chunk)
+
+
+def _get_event_parser(event_type):
+    if event_type == 1:
+        return iter_parse_event_type_1
+    elif event_type == 2:
+        return iter_parse_event_type_2
+    elif event_type == 3:
+        return iter_parse_event_type_3
+    else:
+        raise ValueError('unknown CNT even type')

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -37,14 +37,8 @@ def _read_annotations_cnt(fname):
 
     Returns
     -------
-    onset : array of float, shape (n_annotations,)
-        The starting time of annotations in seconds after ``orig_time``.
-    duration : array of float, shape (n_annotations,)
-        Durations of the annotations in seconds.
-    description : array of str, shape (n_annotations,)
-        Array of strings containing description for each annotation. If a
-        string, all the annotations are given the same description. To reject
-        epochs, use description starting with keyword 'bad'. See example above.
+    annot : instance of Annotations
+        The annotations.
     """
     # Offsets from SETUP structure in http://paulbourke.net/dataformats/eeg/
     SETUP_NCHANNELS_OFFSET = 370
@@ -151,8 +145,9 @@ def read_raw_cnt(input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    stim_channel : bool (default True)
-        Add a stim channel from the events.
+    stim_channel : bool | None
+        Add a stim channel from the events. Defaults to None to trigger a
+        future warning.
 
         .. warning:: This defaults to True in 0.18 but will change to False in
                      0.19 (when no stim channel synthesis will be allowed)
@@ -423,8 +418,9 @@ class RawCNT(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
-    stim_channel : bool (default True)
-        Add a stim channel from the events.
+    stim_channel : bool | None
+        Add a stim channel from the events. Defaults to None to trigger a
+        future warning.
 
         .. warning:: This defaults to True in 0.18 but will change to False in
                      0.19 (when no stim channel synthesis will be allowed)

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -324,9 +324,6 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format,
                 event_time //= n_channels * n_bytes
                 stim_channel[event_time - 1] = event_id
 
-        else:  # when stim_channel_toggle is False
-            pass
-
     info = _empty_info(sfreq)
     if lowpass_toggle == 1:
         info['lowpass'] = highcutoff
@@ -362,11 +359,10 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format,
                      'kind': FIFF.FIFFV_STIM_CH}
         chs.append(chan_info)
         baselines.append(0)  # For stim channel
-        cnt_info.update(baselines=np.array(baselines), n_samples=n_samples,
-                        stim_channel=stim_channel, n_bytes=n_bytes)
-    else:
-        cnt_info.update(baselines=np.array(baselines), n_samples=n_samples,
-                        n_bytes=n_bytes)
+        cnt_info.update(stim_channel=stim_channel)
+
+    cnt_info.update(baselines=np.array(baselines), n_samples=n_samples,
+                    n_bytes=n_bytes)
 
     session_label = None if str(session_label) == '' else str(session_label)
     info.update(meas_date=meas_date,
@@ -530,8 +526,7 @@ class RawCNT(BaseRaw):
                     _data_start = start + sample_start
                     _data_stop = start + sample_stop
                     data_[-1] = stim_ch[_data_start:_data_stop]
-                else:
-                    pass
+
                 data_[sel] -= baselines[sel][:, None]
                 _mult_cal_one(data[:, sample_start:sample_stop], data_, idx,
                               cals, mult=None)

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -47,7 +47,6 @@ def _read_annotations_cnt(fname):
         string, all the annotations are given the same description. To reject
         epochs, use description starting with keyword 'bad'. See example above.
     """
-
     # Offsets from SETUP structure in http://paulbourke.net/dataformats/eeg/
     SETUP_NCHANNELS_OFFSET = 370
     SETUP_RATE_OFFSET = 376

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -19,16 +19,16 @@ from ...annotations import Annotations
 
 from struct import unpack, calcsize
 
-from ._utils import _read_TEEG, _get_event_parser, _session_date_2_meas_date
+from ._utils import _read_teeg, _get_event_parser, _session_date_2_meas_date
 
 
 def _read_annotations_cnt(fname):
     """CNT Annotation File Reader.
 
-    This method opens the .cnt, files searches all the metadata to construct
+    This method opens the .cnt files, searches all the metadata to construct
     the annotations and parses the event table. Notice that CNT files, can
     point to a different file containing the events. This case when the
-    event table is separated from the main .cnt IS NOT COVER.
+    event table is separated from the main .cnt is not supported.
 
     Parameters
     ----------
@@ -70,7 +70,7 @@ def _read_annotations_cnt(fname):
         (event_table_pos,) = unpack('<l', fid.read(calcsize('<l')))
 
     with open(fname, 'rb') as fid:
-        teeg = _read_TEEG(fid, teeg_offset=event_table_pos)
+        teeg = _read_teeg(fid, teeg_offset=event_table_pos)
 
     event_parser = _get_event_parser(event_type=teeg.event_type)
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -5,7 +5,6 @@
 #
 # License: BSD (3-clause)
 from os import path
-from datetime import datetime
 
 import numpy as np
 
@@ -19,7 +18,7 @@ from ...annotations import Annotations
 
 from struct import unpack, calcsize
 
-from ._utils import _read_TEEG, _get_event_parser
+from ._utils import _read_TEEG, _get_event_parser, _session_date_2_meas_date
 
 
 def _read_annotations_cnt(fname):
@@ -202,12 +201,8 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
         session_label = read_str(fid, 20)
 
         session_date = ('%s %s' % (read_str(fid, 10), read_str(fid, 12)))
-        try:
-            meas_date = datetime.strptime(session_date, date_format)
-        except ValueError:
-            warn('  Could not parse meas date from the header. '
-                 'Setting to None.')
-            meas_date = None
+        print(session_date)
+        meas_date = _session_date_2_meas_date(session_date, date_format)
 
         fid.seek(370)
         n_channels = np.fromfile(fid, dtype='<u2', count=1)[0]

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -342,8 +342,9 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     baselines.append(0)  # For stim channel
     cnt_info.update(baselines=np.array(baselines), n_samples=n_samples,
                     stim_channel=stim_channel, n_bytes=n_bytes)
+    session_label = None if str(session_label) == '' else str(session_label)
     info.update(meas_date=meas_date,
-                description=str(session_label), bads=bads,
+                description=session_label, bads=bads,
                 subject_info=subject_info, chs=chs)
     info._update_redundant()
     return info, cnt_info

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -127,7 +127,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
         session_date = read_str(fid, 10)
         time = read_str(fid, 12)
         date = session_date.split('/')
-        if len(date) == 3 and len(time) == 3:
+        if len(date) == 3 and len(time) == 8:
             if date[2].startswith('9'):
                 date[2] = '19' + date[2]
             elif len(date[2]) == 2:

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -208,12 +208,16 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
             fid.seek(event_offset)
             event_type = np.fromfile(fid, dtype='<i1', count=1)[0]
             event_size = np.fromfile(fid, dtype='<i4', count=1)[0]
+            teeg_offset = np.fromfile(fid, dtype='<i4', count=1)[0]
+            assert teeg_offset == 0  # documentation say this should be 0
             if event_type == 1:
                 event_bytes = 8
             elif event_type in (2, 3):
                 event_bytes = 19
             else:
                 raise IOError('Unexpected event size.')
+
+            # XXX long NumEvents is available, why are not we using it?
             n_events = event_size // event_bytes
         else:
             n_events = 0

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -433,6 +433,8 @@ class RawCNT(BaseRaw):
             last_samps=last_samps, orig_format='int',
             verbose=verbose)
 
+        self.set_annotations(_read_annotations_cnt(input_fname))
+
     @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Take a chunk of raw data, multiply by mult or cals, and store."""

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -8,7 +8,7 @@ from os import path
 
 import numpy as np
 
-from ...utils import warn, verbose, fill_doc, _check_option
+from ...utils import warn, verbose, fill_doc, _check_option, deprecated
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
 from ..utils import _mult_cal_one, _find_channels, _create_chs, read_str
@@ -94,6 +94,10 @@ def _read_annotations_cnt(fname):
 
 
 @fill_doc
+@deprecated('read_raw_cnt no longer synthesize the stim channel '
+            'but stores the events as annotations instead. '
+            'Please use `mne.events_from_annotations(raw)` to recover the '
+            'events instead of `mne.find_events`.')
 def read_raw_cnt(input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
                  data_format='auto', date_format='mm/dd/yy', preload=False,
                  verbose=None):

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -100,7 +100,7 @@ def _read_annotations_cnt(fname):
 @fill_doc
 def read_raw_cnt(input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
                  data_format='auto', date_format='mm/dd/yy', preload=False,
-                 stim_channel=True, verbose=None):
+                 stim_channel=None, verbose=None):
     """Read CNT data as raw object.
 
     .. Note::
@@ -424,6 +424,15 @@ class RawCNT(BaseRaw):
         large amount of memory). If preload is a string, preload is the
         file name of a memory-mapped file which is used to store the data
         on the hard drive (slower, requires less memory).
+    stim_channel : bool (default True)
+        Add a stim channel from the events.
+
+        .. warning:: This defaults to True in 0.18 but will change to False in
+                     0.19 (when no stim channel synthesis will be allowed)
+                     and be removed in 0.20; migrate code to use
+                     :func:`mne.events_from_annotations` instead.
+
+        .. versionadded:: 0.18
     %(verbose)s
 
     See Also
@@ -433,7 +442,7 @@ class RawCNT(BaseRaw):
 
     def __init__(self, input_fname, montage, eog=(), misc=(), ecg=(), emg=(),
                  data_format='auto', date_format='mm/dd/yy', preload=False,
-                 stim_channel=True, verbose=None):  # noqa: D102
+                 stim_channel=None, verbose=None):  # noqa: D102
 
         _check_option('date_format', date_format, ['mm/dd/yy', 'dd/mm/yy'])
         if date_format == 'dd/mm/yy':

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -17,7 +17,6 @@ from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
 from ...annotations import Annotations
 
-from struct import unpack, calcsize
 
 from ._utils import (_read_teeg, _get_event_parser, _session_date_2_meas_date,
                      CNTEventType3)
@@ -63,13 +62,13 @@ def _read_annotations_cnt(fname):
 
     with open(fname, 'rb') as fid:
         fid.seek(SETUP_NCHANNELS_OFFSET)
-        (n_channels,) = unpack('<H', fid.read(calcsize('<H')))
+        (n_channels,) = np.frombuffer(fid.read(2), dtype='<u2')
 
         fid.seek(SETUP_RATE_OFFSET)
-        (sfreq,) = unpack('<H', fid.read(calcsize('<H')))
+        (sfreq,) = np.frombuffer(fid.read(2), dtype='<u2')
 
         fid.seek(SETUP_EVENTTABLEPOS_OFFSET)
-        (event_table_pos,) = unpack('<l', fid.read(calcsize('<l')))
+        (event_table_pos,) = np.frombuffer(fid.read(4), dtype='<i4')
 
     with open(fname, 'rb') as fid:
         teeg = _read_teeg(fid, teeg_offset=event_table_pos)

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -18,8 +18,15 @@ data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
 
 if socket.gethostname() == 'toothless':
-    test_files = [fname, op.join(op.dirname(_mne_file), '..',
-                                 'sandbox', 'data', '914flankers.cnt')]
+    regular_path = op.join(op.dirname(_mne_file), '..', 'sandbox', 'data')
+    confidential_path = op.join(regular_path, 'confidential', 'cnt')
+    test_files = [fname,
+                  op.join(regular_path, '914flankers.cnt'),
+                  # op.join(confidential_path, 'BoyoAEpic1_16bit.cnt'),
+                  # op.join(confidential_path, 'cont_67chan_resp_32bit.cnt'),
+                  # op.join(confidential_path, 'cont_68chan_32bit.cnt'),
+                  # op.join(confidential_path, 'SampleCNTFile_16bit.cnt')]
+                  ]
 else:
     test_files = [fname]
 
@@ -52,23 +59,124 @@ def test_explore_stuff_for_is5493(fname):
     # float  MeanLatency;    /* Average response latency            */
     # char   sortfile[46];   /* Path and name of sort file          */
     # long   NumEvents;      /* Number of events in eventable       */
+    # char   compoper;       /* Operation used in comparison        */
+    # char   avgmode;        /* Set during online averaging         */
+    # char   review;         /* Set during review of EEG data       */
 
     from struct import Struct
     from collections import namedtuple
 
     My_Struct = namedtuple('My_Struct',
                            ('mean_age stdev n compfile SpectWinComp '
-                            'MeanAccuracy MeanLatency sortfile NumEvents'))
+                            'MeanAccuracy MeanLatency sortfile NumEvents '
+                            'compoper avgmode review'))
 
-    my_struct_parser = Struct('ffh38sfff46sl')
+    my_struct_parser = Struct('<ffh38sfff46slBBB')
 
     with open(fname, 'rb') as file:
         file.seek(SETUP_MEAN_AGE_OFFSET)
-        records = My_Struct._make(my_struct_parser.unpack_from(
-            file.read(my_struct_parser.size)))
+        data = my_struct_parser.unpack_from(file.read(my_struct_parser.size))
+        records = My_Struct._make(data)
 
-    print(records)
+    # for name, val in records._asdict().items():
+    #     print('{}: {}'.format(name, val))
+    print('{} NumEvents: {}'.format(op.basename(fname), records.NumEvents))
+
     assert True
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', test_files, ids=op.basename)
+def test_read_bunch_of_files(fname, recwarn):
+    raw = read_raw_cnt(input_fname=fname, montage=None, preload=False)
+    assert raw is not None
+
+
+def _read_teeg(file_name):
+    from struct import Struct, unpack, calcsize
+    from collections import namedtuple
+
+    # My_Struct = namedtuple('My_Struct',
+    #                     ('mean_age stdev n compfile SpectWinComp '
+    #                         'MeanAccuracy MeanLatency sortfile NumEvents '
+    #                         'compoper avgmode review'))
+    teeg_reader = Struct('<Bll')
+    with open(file_name, 'rb') as fid:
+        SETUP_EVENTTABLEPOS_OFFSET = 886
+        fid.seek(SETUP_EVENTTABLEPOS_OFFSET)
+        (event_table_pos,) = unpack('<l', fid.read(calcsize('<l')))
+
+        print('mine :', event_table_pos)
+        fid.seek(event_table_pos)
+        data = teeg_reader.unpack(fid.read(teeg_reader.size))
+
+    (event_type, total_lenght, xx) = data
+    print(data)
+    if event_type == 1:
+        event_reader = Struct('<HBcl')  # EVENT type 1
+    elif event_type == 2:
+        event_reader = Struct('<HBclhhfccc')  # EVENT type 2
+    else:
+        raise RuntimeError('Event type can only be 1 or 2')
+
+    return (event_reader, event_table_pos, total_lenght, xx)
+
+
+@testing.requires_testing_data
+# @pytest.mark.parametrize('fname', test_files, ids=op.basename)
+# def test_read_events(fname, recwarn):
+def test_read_events(recwarn):
+
+    def _translating_function(offset, n_channels, n_bytes=2):
+        # n_bytes is related to _get_cnt_info's data_format parameter
+        # 'auto', 'int16', and 'int32'
+        event_time = offset - 900 - (75 * n_channels)
+        event_time //= n_channels * n_bytes
+        return event_time - 1
+
+    from mne import find_events
+    raw = read_raw_cnt(input_fname=fname, montage=None, preload=False)
+    events = find_events(raw)
+
+    print(events)
+
+    event_reader, event_table_pos, total_length, _ = _read_teeg(fname)
+    with open(fname, 'rb') as fid:
+        fid.seek(event_table_pos + 9)  # the real table stats at +9
+        buffer = fid.read(total_length)
+
+    # unsigned short StimType; /* range 0-65535                           */
+    # unsigned char  KeyBoard; /* range 0-11 corresponding to fcn keys +1 */
+    # char KeyPad_Accept;      /* 0->3 range 0-15 bit coded response pad  */
+    #                          /* 4->7 values 0xd=Accept 0xc=Reject       */
+    # long Offset;             /* file offset of event                    */
+    # short Type;
+    # short Code;
+    # float Latency;
+    # char EpochEvent;
+    # char Accept2;
+    # char Accuracy;
+
+    from collections import namedtuple
+    event_maker = namedtuple('Eevent_Type_2',
+                             ('StimType KeyBoard KeyPad_Accept Offset Type Code '
+                              'Latency EpochEvent Accept2 Accuracy'))
+
+    my_events = [event_maker._make(data)
+                 for data in event_reader.iter_unpack(buffer)]
+
+    import numpy as np
+    from numpy.testing import assert_array_equal
+
+    print('description: ', [e.StimType for e in my_events])
+    read_onset = np.array([e.Offset for e in my_events])
+    print('read onset:', read_onset)
+    transformed_onset = _translating_function(offset=read_onset,
+                                              n_channels=raw.info['nchan'] - 1)
+    print('transformed onset: ', transformed_onset)
+    print('duration: ', [e.Latency for e in my_events])
+
+    assert_array_equal(transformed_onset[:-1], events[:,0])
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -40,6 +40,7 @@ def test_data():
 
 @testing.requires_testing_data
 def test_compare_events_and_annotations(recwarn):
+    """Test comparing annotations and events."""
     from mne import find_events
     from numpy.testing import assert_array_equal
 
@@ -54,6 +55,7 @@ def test_compare_events_and_annotations(recwarn):
 @testing.requires_testing_data
 @pytest.mark.parametrize('stim_channel', [True, False])
 def test_stim_channel(stim_channel):
+    """Test making sure that stim_channel toggle works."""
     with pytest.warns(RuntimeWarning, match='Setting to None.'):
         raw = read_raw_cnt(input_fname=fname, montage=None, preload=False,
                            stim_channel=stim_channel)

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -26,5 +26,7 @@ def test_data():
     assert len(eog_chs) == 2  # test eog='auto'
     assert raw.info['bads'] == ['LEFT_EAR', 'VEOGR']  # test bads
 
+    assert raw.info['meas_date'] is not None
+
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -23,6 +23,7 @@ if socket.gethostname() == 'toothless':
 else:
     test_files = [fname]
 
+
 @testing.requires_testing_data
 def test_data():
     """Test reading raw cnt files."""
@@ -52,6 +53,21 @@ def test_explore_stuff_for_is5493(fname):
     # char   sortfile[46];   /* Path and name of sort file          */
     # long   NumEvents;      /* Number of events in eventable       */
 
+    from struct import Struct
+    from collections import namedtuple
+
+    My_Struct = namedtuple('My_Struct',
+                           ('mean_age stdev n compfile SpectWinComp '
+                            'MeanAccuracy MeanLatency sortfile NumEvents'))
+
+    my_struct_parser = Struct('ffh38sfff46sl')
+
+    with open(fname, 'rb') as file:
+        file.seek(SETUP_MEAN_AGE_OFFSET)
+        records = My_Struct._make(my_struct_parser.unpack_from(
+            file.read(my_struct_parser.size)))
+
+    print(records)
     assert True
 
 

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -5,8 +5,10 @@
 
 import os.path as op
 import pytest
+import socket
 
 from mne import pick_types
+from mne import __file__ as _mne_file
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
@@ -15,6 +17,11 @@ from mne.io.cnt import read_raw_cnt
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
 
+if socket.gethostname() == 'toothless':
+    test_files = [fname, op.join(op.dirname(_mne_file), '..',
+                                 'sandbox', 'data', '914flankers.cnt')]
+else:
+    test_files = [fname]
 
 @testing.requires_testing_data
 def test_data():
@@ -28,6 +35,24 @@ def test_data():
 
     # XXX: the data has "05/10/200 17:35:31" so it is set to None
     assert raw.info['meas_date'] is None
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', test_files, ids=op.basename)
+def test_explore_stuff_for_is5493(fname):
+    SETUP_MEAN_AGE_OFFSET = 247
+
+    # float  mean_age;       /* Mean age (Group files only)         */
+    # float  stdev;          /* Std dev of age (Group files only)   */
+    # short int n;           /* Number in group file                */
+    # char   compfile[38];   /* Path and name of comparison file    */
+    # float  SpectWinComp;   /* Spectral window compensation factor */
+    # float  MeanAccuracy;   /* Average respose accuracy            */
+    # float  MeanLatency;    /* Average response latency            */
+    # char   sortfile[46];   /* Path and name of sort file          */
+    # long   NumEvents;      /* Number of events in eventable       */
+
+    assert True
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -1,34 +1,21 @@
 
 # Author: Jaakko Leppakangas <jaeilepp@student.jyu.fi>
+#         Joan Massich <mailsik@gmail.com>
 #
 # License: BSD (3-clause)
 
 import os.path as op
 import pytest
-import socket
 
 from mne import pick_types
-from mne import __file__ as _mne_file
 from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
+from mne.io.cnt.cnt import _read_annotations_cnt
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
-
-if socket.gethostname() == 'toothless':
-    regular_path = op.join(op.dirname(_mne_file), '..', 'sandbox', 'data')
-    confidential_path = op.join(regular_path, 'confidential', 'cnt')
-    test_files = [fname,
-                  op.join(regular_path, '914flankers.cnt'),
-                  # op.join(confidential_path, 'BoyoAEpic1_16bit.cnt'),
-                  # op.join(confidential_path, 'cont_67chan_resp_32bit.cnt'),
-                  # op.join(confidential_path, 'cont_68chan_32bit.cnt'),
-                  # op.join(confidential_path, 'SampleCNTFile_16bit.cnt')]
-                  ]
-else:
-    test_files = [fname]
 
 
 @testing.requires_testing_data
@@ -46,137 +33,15 @@ def test_data():
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('fname', test_files, ids=op.basename)
-def test_explore_stuff_for_is5493(fname):
-    SETUP_MEAN_AGE_OFFSET = 247
-
-    # float  mean_age;       /* Mean age (Group files only)         */
-    # float  stdev;          /* Std dev of age (Group files only)   */
-    # short int n;           /* Number in group file                */
-    # char   compfile[38];   /* Path and name of comparison file    */
-    # float  SpectWinComp;   /* Spectral window compensation factor */
-    # float  MeanAccuracy;   /* Average respose accuracy            */
-    # float  MeanLatency;    /* Average response latency            */
-    # char   sortfile[46];   /* Path and name of sort file          */
-    # long   NumEvents;      /* Number of events in eventable       */
-    # char   compoper;       /* Operation used in comparison        */
-    # char   avgmode;        /* Set during online averaging         */
-    # char   review;         /* Set during review of EEG data       */
-
-    from struct import Struct
-    from collections import namedtuple
-
-    My_Struct = namedtuple('My_Struct',
-                           ('mean_age stdev n compfile SpectWinComp '
-                            'MeanAccuracy MeanLatency sortfile NumEvents '
-                            'compoper avgmode review'))
-
-    my_struct_parser = Struct('<ffh38sfff46slBBB')
-
-    with open(fname, 'rb') as file:
-        file.seek(SETUP_MEAN_AGE_OFFSET)
-        data = my_struct_parser.unpack_from(file.read(my_struct_parser.size))
-        records = My_Struct._make(data)
-
-    # for name, val in records._asdict().items():
-    #     print('{}: {}'.format(name, val))
-    print('{} NumEvents: {}'.format(op.basename(fname), records.NumEvents))
-
-    assert True
-
-
-@testing.requires_testing_data
-@pytest.mark.parametrize('fname', test_files, ids=op.basename)
-def test_read_bunch_of_files(fname, recwarn):
-    raw = read_raw_cnt(input_fname=fname, montage=None, preload=False)
-    assert raw is not None
-
-
-def _read_teeg(file_name):
-    from struct import Struct, unpack, calcsize
-    from collections import namedtuple
-
-    # My_Struct = namedtuple('My_Struct',
-    #                     ('mean_age stdev n compfile SpectWinComp '
-    #                         'MeanAccuracy MeanLatency sortfile NumEvents '
-    #                         'compoper avgmode review'))
-    teeg_reader = Struct('<Bll')
-    with open(file_name, 'rb') as fid:
-        SETUP_EVENTTABLEPOS_OFFSET = 886
-        fid.seek(SETUP_EVENTTABLEPOS_OFFSET)
-        (event_table_pos,) = unpack('<l', fid.read(calcsize('<l')))
-
-        print('mine :', event_table_pos)
-        fid.seek(event_table_pos)
-        data = teeg_reader.unpack(fid.read(teeg_reader.size))
-
-    (event_type, total_lenght, xx) = data
-    print(data)
-    if event_type == 1:
-        event_reader = Struct('<HBcl')  # EVENT type 1
-    elif event_type == 2:
-        event_reader = Struct('<HBclhhfccc')  # EVENT type 2
-    else:
-        raise RuntimeError('Event type can only be 1 or 2')
-
-    return (event_reader, event_table_pos, total_lenght, xx)
-
-
-@testing.requires_testing_data
-# @pytest.mark.parametrize('fname', test_files, ids=op.basename)
-# def test_read_events(fname, recwarn):
-def test_read_events(recwarn):
-
-    def _translating_function(offset, n_channels, n_bytes=2):
-        # n_bytes is related to _get_cnt_info's data_format parameter
-        # 'auto', 'int16', and 'int32'
-        event_time = offset - 900 - (75 * n_channels)
-        event_time //= n_channels * n_bytes
-        return event_time - 1
-
+def test_compare_events_and_annotations(recwarn):
     from mne import find_events
+    from numpy.testing import assert_array_equal
+
     raw = read_raw_cnt(input_fname=fname, montage=None, preload=False)
     events = find_events(raw)
 
-    print(events)
-
-    event_reader, event_table_pos, total_length, _ = _read_teeg(fname)
-    with open(fname, 'rb') as fid:
-        fid.seek(event_table_pos + 9)  # the real table stats at +9
-        buffer = fid.read(total_length)
-
-    # unsigned short StimType; /* range 0-65535                           */
-    # unsigned char  KeyBoard; /* range 0-11 corresponding to fcn keys +1 */
-    # char KeyPad_Accept;      /* 0->3 range 0-15 bit coded response pad  */
-    #                          /* 4->7 values 0xd=Accept 0xc=Reject       */
-    # long Offset;             /* file offset of event                    */
-    # short Type;
-    # short Code;
-    # float Latency;
-    # char EpochEvent;
-    # char Accept2;
-    # char Accuracy;
-
-    from collections import namedtuple
-    event_maker = namedtuple('Eevent_Type_2',
-                             ('StimType KeyBoard KeyPad_Accept Offset Type Code '
-                              'Latency EpochEvent Accept2 Accuracy'))
-
-    my_events = [event_maker._make(data)
-                 for data in event_reader.iter_unpack(buffer)]
-
-    import numpy as np
-    from numpy.testing import assert_array_equal
-
-    print('description: ', [e.StimType for e in my_events])
-    read_onset = np.array([e.Offset for e in my_events])
-    print('read onset:', read_onset)
-    transformed_onset = _translating_function(offset=read_onset,
-                                              n_channels=raw.info['nchan'] - 1)
-    print('transformed onset: ', transformed_onset)
-    print('duration: ', [e.Latency for e in my_events])
-
-    assert_array_equal(transformed_onset[:-1], events[:,0])
+    onset, duration, description = _read_annotations_cnt(fname)
+    assert_array_equal(onset[:-1], events[:, 0])
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -13,6 +13,7 @@ from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
 from mne.io.cnt.cnt import _read_annotations_cnt
+from mne.annotations import read_annotations
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
@@ -40,8 +41,17 @@ def test_compare_events_and_annotations(recwarn):
     raw = read_raw_cnt(input_fname=fname, montage=None, preload=False)
     events = find_events(raw)
 
-    onset, duration, description = _read_annotations_cnt(fname)
-    assert_array_equal(onset[:-1], events[:, 0])
+    annot = _read_annotations_cnt(fname)
+    assert_array_equal(annot.onset[:-1], events[:, 0] / raw.info['sfreq'])
+
+
+@testing.requires_testing_data
+def test_read_annotations():
+    """Test reading for annotations from a .CNT file."""
+
+    # XXX: scan41_short.cnt is broken for this file so it should warn
+    annot = read_annotations(fname)
+    assert len(annot) == 6
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -26,7 +26,8 @@ def test_data():
     assert len(eog_chs) == 2  # test eog='auto'
     assert raw.info['bads'] == ['LEFT_EAR', 'VEOGR']  # test bads
 
-    assert raw.info['meas_date'] is not None
+    # XXX: the data has "05/10/200 17:35:31" so it is set to None
+    assert raw.info['meas_date'] is None
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -27,7 +27,7 @@ def test_data():
         raw = _test_raw_reader(read_raw_cnt, montage=None, input_fname=fname,
                                eog='auto', misc=['NA1', 'LEFT_EAR'])
 
-    # make we use annotations event if we synthesized stim
+    # make sure we use annotations event if we synthesized stim
     assert len(raw.annotations) == 6
 
     eog_chs = pick_types(raw.info, eog=True, exclude=[])

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -13,7 +13,6 @@ from mne.utils import run_tests_if_main
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
-from mne.io.cnt.cnt import _read_annotations_cnt
 from mne.annotations import read_annotations
 
 data_path = testing.data_path(download=False)
@@ -48,7 +47,8 @@ def test_compare_events_and_annotations(recwarn):
                        stim_channel=True)
     events = find_events(raw)
 
-    annot = _read_annotations_cnt(fname)
+    annot = read_annotations(fname)
+    assert len(annot) == 6
     assert_array_equal(annot.onset[:-1], events[:, 0] / raw.info['sfreq'])
 
 
@@ -60,13 +60,6 @@ def test_stim_channel(stim_channel):
         raw = read_raw_cnt(input_fname=fname, montage=None, preload=False,
                            stim_channel=stim_channel)
     assert ('STI 014' in raw.info['ch_names']) == stim_channel
-
-
-@testing.requires_testing_data
-def test_read_annotations():
-    """Test reading for annotations from a .CNT file."""
-    annot = read_annotations(fname)
-    assert len(annot) == 6
 
 
 run_tests_if_main()

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -32,6 +32,10 @@ def test_data(recwarn):
                 for _ in recwarn])
     recwarn.clear()
 
+    # make we use annotations not synthesized stim
+    assert 'STI 014' not in raw.info['ch_names']
+    assert len(raw.annotations) == 6
+
     eog_chs = pick_types(raw.info, eog=True, exclude=[])
     assert len(eog_chs) == 2  # test eog='auto'
     assert raw.info['bads'] == ['LEFT_EAR', 'VEOGR']  # test bads

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -153,24 +153,17 @@ def get_epochs(system):
 
     if system == 'CNT':
         events, event_id = mne.events_from_annotations(raw_data)
+        events[:, 0] = events[:, 0] + 1
     else:
         events = mne.find_events(raw_data, stim_channel=stim_channel,
                                  shortest_event=1)
 
-    if system == 'CNT':
-        events[:, 0] = events[:, 0] + 1
-
-    if 'event_id' not in locals():
         if isinstance(cfg_local['eventvalue'], np.ndarray):
             event_id = list(cfg_local['eventvalue'].astype('int'))
         else:
             event_id = [int(cfg_local['eventvalue'])]
 
         event_id = [id for id in event_id if id in events[:, 2]]
-    else:
-        # this is CNT and event_id is recovered from events_from_annotations
-        # no need to hack around.
-        pass
 
     epochs = mne.Epochs(raw_data, events=events,
                         event_id=event_id,

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -23,7 +23,9 @@ ch_ignore_fields = ('logno', 'cal', 'range', 'scanno', 'coil_type', 'kind',
 info_long_fields = ('hpi_meas', )
 
 system_to_reader_fn_dict = {'neuromag306': mne.io.read_raw_fif,
-                            'CNT': partial(mne.io.read_raw_cnt, montage=None),
+                            'CNT': partial(mne.io.read_raw_cnt,
+                                           stim_channel=False,
+                                           montage=None),
                             'CTF': partial(mne.io.read_raw_ctf,
                                            clean_names=True),
                             'BTI': partial(mne.io.read_raw_bti,
@@ -106,7 +108,7 @@ def get_raw_info(system):
     return info
 
 
-def get_raw_data(system, drop_sti_cnt=True, drop_extra_chs=False):
+def get_raw_data(system, drop_extra_chs=False):
     """Find, load and process the raw data."""
     cfg_local = get_cfg_local(system)
 
@@ -124,11 +126,11 @@ def get_raw_data(system, drop_sti_cnt=True, drop_extra_chs=False):
     raw_data.info['comps'] = []
     raw_data.drop_channels(cfg_local['removed_chan_names'])
 
-    if system in ['CNT', 'EGI']:
+    if system in ['EGI']:
         raw_data._data[0:-1, :] = raw_data._data[0:-1, :] * 1e6
 
-    if system == 'CNT' and drop_sti_cnt:
-        raw_data.drop_channels(['STI 014'])
+    if system in ['CNT']:
+        raw_data._data = raw_data._data * 1e6
 
     if system in ignore_channels_dict:
         raw_data.drop_channels(ignore_channels_dict[system])
@@ -142,26 +144,33 @@ def get_raw_data(system, drop_sti_cnt=True, drop_extra_chs=False):
 def get_epochs(system):
     """Find, load and process the epoched data."""
     cfg_local = get_cfg_local(system)
-    raw_data = get_raw_data(system, drop_sti_cnt=False)
+    raw_data = get_raw_data(system)
 
     if cfg_local['eventtype'] in raw_data.ch_names:
         stim_channel = cfg_local['eventtype']
     else:
         stim_channel = 'STI 014'
 
-    events = mne.find_events(raw_data, stim_channel=stim_channel,
-                             shortest_event=1)
+    if system == 'CNT':
+        events, event_id = mne.events_from_annotations(raw_data)
+    else:
+        events = mne.find_events(raw_data, stim_channel=stim_channel,
+                                 shortest_event=1)
 
     if system == 'CNT':
-        raw_data.drop_channels(['STI 014'])
         events[:, 0] = events[:, 0] + 1
 
-    if isinstance(cfg_local['eventvalue'], np.ndarray):
-        event_id = list(cfg_local['eventvalue'].astype('int'))
-    else:
-        event_id = [int(cfg_local['eventvalue'])]
+    if 'event_id' not in locals():
+        if isinstance(cfg_local['eventvalue'], np.ndarray):
+            event_id = list(cfg_local['eventvalue'].astype('int'))
+        else:
+            event_id = [int(cfg_local['eventvalue'])]
 
-    event_id = [id for id in event_id if id in events[:, 2]]
+        event_id = [id for id in event_id if id in events[:, 2]]
+    else:
+        # this is CNT and event_id is recovered from events_from_annotations
+        # no need to hack around.
+        pass
 
     epochs = mne.Epochs(raw_data, events=events,
                         event_id=event_id,

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -16,13 +16,25 @@ import os
 from .constants import FIFF
 from .meas_info import _get_valid_units
 from .. import __version__
+from ..utils import warn
 
 
 def _deprecate_stim_channel(stim_channel, removed_in='0.19'):
     minor_current = int(__version__.split('.')[1])
     minor_removed_in = int(removed_in.split('.')[1])
     if minor_current == minor_removed_in - 2:
-        pass
+        if stim_channel is None:
+            _MSG = (
+                'The parameter `stim_channel` controlling the stim channel'
+                ' synthesis has not been specified. In 0.%s it defaults to'
+                ' True but will change to False in 0.%s (when no stim channel'
+                ' synthesis will be allowed) and be removed in %s; migrate'
+                ' code to use `stim_channel=False` and'
+                ' :func:`mne.events_from_annotations` or set'
+                ' `stim_channel=True` to avoid this warning.'
+                % (minor_removed_in - 2, minor_removed_in - 1, removed_in))
+            warn(_MSG, FutureWarning)
+
     elif minor_current == minor_removed_in - 1:
         if stim_channel is not False:
             _MSG = ('stim_channel must be False or omitted; it will be '

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -15,12 +15,23 @@ import os
 
 from .constants import FIFF
 from .meas_info import _get_valid_units
+from .. import __version__
 
 
-def _deprecate_stim_channel(stim_channel):
-    if stim_channel is not False:
-        raise ValueError('stim_channel must be False or omitted; it will be '
-                         'removed in 0.19', DeprecationWarning)
+def _deprecate_stim_channel(stim_channel, removed_in='0.19'):
+    minor_current = int(__version__.split('.')[1])
+    minor_removed_in = int(removed_in.split('.')[1])
+    if minor_current == minor_removed_in - 2:
+        pass
+    elif minor_current == minor_removed_in - 1:
+        if stim_channel is not False:
+            _MSG = ('stim_channel must be False or omitted; it will be '
+                    'removed in %s' % removed_in)
+            raise ValueError(_MSG, DeprecationWarning)
+    else:
+        raise RuntimeError('stim_channel was supposed to be removed in version'
+                           ' %s, and it is still present in %s' %
+                           (removed_in, __version__))
 
 
 def _check_orig_units(orig_units):


### PR DESCRIPTION
In this PR:
- [x] Fix CNT date parsing
- [x] Add CNT support in `mne.read_annotations`
- [x] Add `stim_channel` parameter to `mne.io.read_raw_cnt` (to later remove stim synthesis)
- [x] Fix tests to use `stim_channel=False`

This needs to go before #6025