### PR TITLE
FIX reading eeglab overlapping epochs with possibly duplicated events

### DIFF
--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -466,7 +466,7 @@ class EpochsEEGLAB(BaseEpochs):
 
                     # store latency of the event closest to zero
                     event_closer_to_zero_idx = np.abs(np.array(
-                            ep.eventlatency) - 0).argmin()
+                        ep.eventlatency) - 0).argmin()
                     event_ur = ep.eventurevent[event_closer_to_zero_idx]
                     ev_idx = ur2ev[event_ur]
                     event_latencies.append(events[ev_idx].latency)


### PR DESCRIPTION
In rare cases when two consecutive epochs were overlapping (just by chance) some of the events could be duplicated across these epochs. Then `ev_idx` (see the code) would be increased by too much leading to bad latencies and sometimes also to an indexing error.

### Example 1
It's easier to explain this using an example. Let's suppose we have epochs A and B, but they are ovelapping so that one of the events (event y) is present in both epochs:
```
epoch A contains:
event x at latency 0, event y at latency 223

epoch B contains:
event y at latency 0
```
(note: the latencies above are within-epoch with 0 being the time zeros - this is how `EEG.epoch` stores them)
Current implementation of the eeglab epoch reader does not assume duplicated events, so it just counts the occurrences of events and in this case even though there are 2 events in total the code would try to look at a third event in `EEG.event` structure. This leads to indexing error.
I fix it by using the `urevent` field of the event which contains unique event identifiers.

### Example 2
Now lets add epoch C, with two additional events - z and q:
```
epoch A contains:
event x at latency 0, event y at latency 223

epoch B contains:
event y at latency 0

epoch C contains:
event z at latency -100, event q at latency 0
```
(note: the latencies above are within-epoch with 0 being the time zeros - this is how `EEG.epoch` stores them)
Now, even though event `y` is duplicated, we don't get an indexing error. This is because when looking at epoch B, mne reader thinks it is seeing the third event, but we have four events in total (so no indexing error). Then when looking at epoch C, there are two events, mne reader considers only the first one for storing the `EEG.event` latency, which it assumes to be the fourth event. We have four unique events in total so still no indexing error.
However, when taking the latency from `EEG.event` in epoch B it takes the latency of event `z`, not `y` and for epoch C it takes the latency of event `g`, not `z`.
Taking the latencies of different events is not a big problem as these latencies are taken from `EEG.event` which for epoched data stores the latency of the events with respect to the epoched concatenated data (so I don't think anyone actually relies on these valuese). 

## Which latencies we should take
I also changed the code to take the latency of epoch-centering event, not the first one. This is not important to the fix so I can revert this if you prefer it stayed as it was. However I'd argue for saving the latencies of epoch-centering event (the one with respect to which the epoching was done) as this is what mne does in other cases. Additionally the latencies should be taken with respect to the raw data (`EEG.urevent.latency`), not epoched-concatenated data (`EEG.event.latency`) - as this is the convention in mne `events` array. But this is a separate issue, maybe not worth changing. :)