### PR TITLE
MRG: Use gen for STCs in envelope correlation example

### DIFF
--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -71,10 +71,11 @@ del fwd, src
 
 labels = mne.read_labels_from_annot(subject, 'aparc_sub',
                                     subjects_dir=subjects_dir)
-stcs = apply_inverse_epochs(epochs, inv, lambda2=1. / 9., pick_ori='normal')
+stcs = apply_inverse_epochs(epochs, inv, lambda2=1. / 9., pick_ori='normal',
+                            return_generator=True)
 label_ts = mne.extract_label_time_course(
     stcs, labels, inv['src'], return_generator=True)
-corr = envelope_correlation(label_ts)
+corr = envelope_correlation(label_ts, verbose=True)
 
 # let's plot this matrix
 fig, ax = plt.subplots(figsize=(4, 4))

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -7,10 +7,11 @@
 import numpy as np
 
 from ..filter import next_fast_len
-from ..utils import _validate_type
+from ..utils import _validate_type, verbose
 
 
-def envelope_correlation(data, combine='median'):
+@verbose
+def envelope_correlation(data, combine='median', verbose=None):
     """Compute the envelope correlation.
 
     Parameters
@@ -24,6 +25,7 @@ def envelope_correlation(data, combine='median'):
     combine : 'median' | None
         How to combine correlation estimates across epochs.
         Default is 'median'. Can be None to return without combining.
+    %(verbose)s
 
     Returns
     -------


### PR DESCRIPTION
- Uses `return_generator=True` for hopefully some memory savings in the example
- Adds `verbose` kwarg which is useful in generator mode to see the progress
- Adds count to the epoch processing output
- Cleans up the checking of orientations in `apply_inverse_epochs` a tiny bit