### PR TITLE
Allow toggling of DC removal in Raw.plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,8 @@ Changelog
 
 - Add additional depth weighting options for inverse solvers (e.g., :func:`mne.inverse_sparse.gamma_map` and :func:`mne.inverse_sparse.mixed_norm`) by `Eric Larson`_
 
+- Allow toggling of DC removal in :meth:`mne.io.Raw.plot` by pressing the 'd' key by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -258,6 +258,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Annotation mode is toggled by pressing 'a', butterfly mode by pressing
     'b', and whitening mode (when ``noise_cov is not None``) by pressing 'w'.
+    By default, the channel means are removed when ``remove_dc`` is set to
+    ``True``. This flag can be toggled by pressing 'd'.
     """
     import matplotlib.pyplot as plt
     import matplotlib as mpl

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -171,6 +171,7 @@ def test_plot_raw():
     fig.canvas.button_press_event(1, 1, 1)  # outside any axes
     fig.canvas.scroll_event(0.5, 0.5, -0.5)  # scroll down
     fig.canvas.scroll_event(0.5, 0.5, 0.5)  # scroll up
+
     # sadly these fail when no renderer is used (i.e., when using Agg):
     # ssp_fig = set(plt.get_fignums()) - set([fig.number])
     # assert_equal(len(ssp_fig), 1)
@@ -181,15 +182,20 @@ def test_plot_raw():
     # pos = np.array(t[0].get_position()) + 0.01
     # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # off
     # _fake_click(ssp_fig, ssp_fig.get_axes()[0], pos, xform='data')  # on
-    #  test keypresses
-    for key in ['down', 'up', 'right', 'left', 'o', '-', '+', '=',
+
+    # test keypresses
+    # test for group_by='original'
+    for key in ['down', 'up', 'right', 'left', 'o', '-', '+', '=', 'd', 'd',
                 'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'escape']:
         fig.canvas.key_press_event(key)
+
+    # test for group_by='selection'
     fig = plot_raw(raw, events=events, group_by='selection')
-    for key in ['b', 'down', 'up', 'right', 'left', 'o', '-', '+', '=',
-                'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'b',
+    for key in ['b', 'down', 'up', 'right', 'left', 'o', '-', '+', '=', 'd',
+                'd', 'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'b',
                 'escape']:
         fig.canvas.key_press_event(key)
+
     # Color setting
     pytest.raises(KeyError, raw.plot, event_color={0: 'r'})
     pytest.raises(TypeError, raw.plot, event_color={'foo': 'r'})

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -315,8 +315,8 @@ def _get_help_text(params):
     """Customize help dialogs text."""
     text, text2 = list(), list()
 
-    text.append(u'\u2190 : \n')  # left arrow
-    text.append(u'\u2192 : \n')  # right arrow
+    text.append(u'(Shift +) \u2190 : \n')  # left arrow
+    text.append(u'(Shift +) \u2192 : \n')  # right arrow
     text.append(u'\u2193 : \n')  # down arrow
     text.append(u'\u2191 : \n')  # up arrow
     text.append(u'- : \n')
@@ -363,9 +363,11 @@ def _get_help_text(params):
             text2.insert(6, 'Toggle annotation mode\n')
             text.insert(7, u'b : \n')
             text2.insert(7, 'Toggle butterfly plot on/off\n')
+            text.insert(8, u'd : \n')
+            text2.insert(8, 'Toggle remove DC on/off\n')
             if 'fig_selection' not in params:
-                text2.insert(10, 'Reduce the number of channels per view\n')
-                text2.insert(11, 'Increase the number of channels per view\n')
+                text2.insert(11, 'Reduce the number of channels per view\n')
+                text2.insert(12, 'Increase the number of channels per view\n')
             text2.append('Mark bad channel\n')
             text2.append('Vertical line at a time instant\n')
             text2.append('Mark bad channel\n')
@@ -830,6 +832,10 @@ def _plot_raw_onkey(event, params):
     elif event.key == 'w':
         params['use_noise_cov'] = not params['use_noise_cov']
         params['plot_update_proj_callback'](params, None)
+    elif event.key == 'd':
+        params['remove_dc'] = not params['remove_dc']
+        params['update_fun']()
+        params['plot_fun']()
 
 
 def _setup_annotation_fig(params):


### PR DESCRIPTION
This PR adds the option to change the value of `remove_dc` in `mne.io.Raw.plot` so users can change this on the fly by pressing the 'd' key.