### PR TITLE
Re-enable vertical green line in raw.plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -85,6 +85,8 @@ Changelog
 
 - Allow toggling of DC removal in :meth:`mne.io.Raw.plot` by pressing the 'd' key by `Clemens Brunner`_
 
+- Improved clicking in :meth:`mne.io.Raw.plot` (left click on trace toggles bad, left click on background sets green line, right click anywhere removes green line) by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -944,33 +944,33 @@ def _mouse_click(event, params):
             params['plot_fun']()
         else:  # right click in browse mode does nothing
             return
+    else:
+        if event.inaxes is None:  # check if channel label is clicked
+            if params['n_channels'] > 100:
+                return
+            ax = params['ax']
+            ylim = ax.get_ylim()
+            pos = ax.transData.inverted().transform((event.x, event.y))
+            if pos[0] > params['t_start'] or pos[1] < 0 or pos[1] > ylim[0]:
+                return
+            params['label_click_fun'](pos)
+        # vertical scrollbar changed
+        elif event.inaxes == params['ax_vscroll']:
+            if 'fig_selection' in params.keys():
+                _handle_change_selection(event, params)
+            else:
+                ch_start = max(int(event.ydata) - params['n_channels'] // 2, 0)
+                if params['ch_start'] != ch_start:
+                    params['ch_start'] = ch_start
+                    params['plot_fun']()
+        # horizontal scrollbar changed
+        elif event.inaxes == params['ax_hscroll']:
+            _plot_raw_time(event.xdata - params['duration'] / 2, params)
+            params['update_fun']()
+            params['plot_fun']()
 
-    if event.inaxes is None:  # check if channel label is clicked
-        if params['n_channels'] > 100:
-            return
-        ax = params['ax']
-        ylim = ax.get_ylim()
-        pos = ax.transData.inverted().transform((event.x, event.y))
-        if pos[0] > params['t_start'] or pos[1] < 0 or pos[1] > ylim[0]:
-            return
-        params['label_click_fun'](pos)
-    # vertical scrollbar changed
-    elif event.inaxes == params['ax_vscroll']:
-        if 'fig_selection' in params.keys():
-            _handle_change_selection(event, params)
-        else:
-            ch_start = max(int(event.ydata) - params['n_channels'] // 2, 0)
-            if params['ch_start'] != ch_start:
-                params['ch_start'] = ch_start
-                params['plot_fun']()
-    # horizontal scrollbar changed
-    elif event.inaxes == params['ax_hscroll']:
-        _plot_raw_time(event.xdata - params['duration'] / 2, params)
-        params['update_fun']()
-        params['plot_fun']()
-
-    elif event.inaxes == params['ax']:
-        params['pick_bads_fun'](event)
+        elif event.inaxes == params['ax']:
+            params['pick_bads_fun'](event)
 
 
 def _handle_topomap_bads(ch_name, params):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1087,8 +1087,12 @@ def _onclick_help(event, params):
     table.auto_set_font_size(False)
     table.set_fontsize(12)
     ax.set_axis_off()
-    for _, cell in table.get_celld().items():
+    for (row, col), cell in table.get_celld().items():
         cell.set_edgecolor(None)  # remove cell borders
+        # right justify, following:
+        # https://stackoverflow.com/questions/48210749/matplotlib-table-assign-different-text-alignments-to-different-columns?rq=1  # noqa: E501
+        if col == 0:
+            cell._loc = 'right'
 
     fig_help.canvas.mpl_connect('key_press_event', _key_press)
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1022,14 +1022,11 @@ def _select_bads(event, params, bads):
         _draw_vert_line(event.xdata, params)
         return bads
 
-    def f(x, y):
-        return y(np.mean(x), x.std() * 2)
     lines = event.inaxes.lines
     for line in lines:
         ydata = line.get_ydata()
         if not isinstance(ydata, list) and not np.isnan(ydata).any():
-            ymin, ymax = f(ydata, np.subtract), f(ydata, np.add)
-            if ymin <= event.ydata <= ymax:
+            if line.contains(event)[0]:  # click on a signal: toggle bad
                 this_chan = vars(line)['ch_name']
                 if this_chan in params['info']['ch_names']:
                     if 'fig_selection' in params:
@@ -1051,7 +1048,7 @@ def _select_bads(event, params, bads):
                     for idx in ch_idx:
                         params['ax_vscroll'].patches[idx].set_color(color)
                     break
-    else:
+    else:  # click in the background (not on a signal): set green line
         _draw_vert_line(event.xdata, params)
 
     return bads

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -942,7 +942,9 @@ def _mouse_click(event, params):
             _remove_segment_line(params)
             _plot_annotations(raw, params)
             params['plot_fun']()
-        else:  # right click in browse mode does nothing
+        elif event.inaxes == params['ax']:  # hide green line
+            _draw_vert_line(None, params, hide=True)
+        else:  # do nothing
             return
     else:
         if event.inaxes is None:  # check if channel label is clicked
@@ -1007,11 +1009,15 @@ def _find_channel_idx(ch_name, params):
     return indices
 
 
-def _draw_vert_line(xdata, params):
+def _draw_vert_line(xdata, params, hide=False):
     """Draw vertical line."""
-    params['ax_vertline'].set_xdata(xdata)
-    params['ax_hscroll_vertline'].set_xdata(xdata)
-    params['vertline_t'].set_text('%0.2f  ' % xdata)
+    if not hide:
+        params['ax_vertline'].set_xdata(xdata)
+        params['ax_hscroll_vertline'].set_xdata(xdata)
+        params['vertline_t'].set_text('%0.2f  ' % xdata)
+    params['ax_vertline'].set_visible(not hide)
+    params['ax_hscroll_vertline'].set_visible(not hide)
+    params['vertline_t'].set_visible(not hide)
 
 
 def _select_bads(event, params, bads):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -16,6 +16,7 @@ import difflib
 import webbrowser
 import tempfile
 import numpy as np
+import platform
 from copy import deepcopy
 from distutils.version import LooseVersion
 from itertools import cycle
@@ -313,6 +314,7 @@ def _toggle_proj(event, params):
 
 def _get_help_text(params):
     """Customize help dialogs text."""
+    is_mac = platform.system() == 'Darwin'
     text, text2 = list(), list()
 
     text.append(u'(Shift +) \u2190 : \n')  # left arrow
@@ -321,11 +323,18 @@ def _get_help_text(params):
     text.append(u'\u2191 : \n')  # up arrow
     text.append(u'- : \n')
     text.append(u'+ or = : \n')
-    text.append(u'Home : \n')
-    text.append(u'End : \n')
-    if 'fig_selection' not in params:
-        text.append(u'Page down : \n')
-        text.append(u'Page up : \n')
+    if is_mac:
+        text.append(u'fn + \u2190 : \n')
+        text.append(u'fn + \u2192 : \n')
+        if 'fig_selection' not in params:
+            text.append(u'fn + \u2193 : \n')
+            text.append(u'fn + \u2191 : \n')
+    else:
+        text.append(u'Home : \n')
+        text.append(u'End : \n')
+        if 'fig_selection' not in params:
+            text.append(u'Page down : \n')
+            text.append(u'Page up : \n')
 
     text.append(u'F11 : \n')
     text.append(u'? : \n')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1071,31 +1071,26 @@ def _select_bads(event, params, bads):
 
 def _onclick_help(event, params):
     """Draw help window."""
-    import matplotlib.pyplot as plt
     text, text2 = _get_help_text(params)
 
-    width = 6
-    height = 5
+    width, height = 9, 5
 
     fig_help = figure_nobar(figsize=(width, height), dpi=80)
     fig_help.canvas.set_window_title('Help')
     params['fig_help'] = fig_help
-    ax = plt.subplot2grid((8, 5), (0, 0), colspan=5)
-    ax.set_title('Keyboard shortcuts')
-    plt.axis('off')
-    ax1 = plt.subplot2grid((8, 5), (1, 0), rowspan=7, colspan=2)
-    ax1.set_yticklabels(list())
-    plt.text(0.99, 1, text, fontname='STIXGeneral', va='top', ha='right')
-    plt.axis('off')
 
-    ax2 = plt.subplot2grid((8, 5), (1, 2), rowspan=7, colspan=3)
-    ax2.set_yticklabels(list())
-    plt.text(0, 1, text2, fontname='STIXGeneral', va='top')
-    plt.axis('off')
+    ax = fig_help.add_subplot(111)
+    celltext = [[c1, c2] for c1, c2 in zip(text.strip().split("\n"),
+                                           text2.strip().split("\n"))]
+    table = ax.table(cellText=celltext, loc="center", cellLoc="left")
+    table.auto_set_font_size(False)
+    table.set_fontsize(12)
+    ax.set_axis_off()
+    for _, cell in table.get_celld().items():
+        cell.set_edgecolor(None)  # remove cell borders
 
     fig_help.canvas.mpl_connect('key_press_event', _key_press)
 
-    tight_layout(fig=fig_help)
     # this should work for non-test cases
     try:
         fig_help.canvas.draw()

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Utility functions for plotting M/EEG data."""
 
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
@@ -317,18 +318,18 @@ def _get_help_text(params):
     is_mac = platform.system() == 'Darwin'
     text, text2 = list(), list()
 
-    text.append(u'(Shift +) \u2190 : \n')  # left arrow
-    text.append(u'(Shift +) \u2192 : \n')  # right arrow
-    text.append(u'\u2193 : \n')  # down arrow
-    text.append(u'\u2191 : \n')  # up arrow
+    text.append(u'(Shift +) ← : \n')
+    text.append(u'(Shift +) → : \n')
+    text.append(u'↓ : \n')
+    text.append(u'↑ : \n')
     text.append(u'- : \n')
     text.append(u'+ or = : \n')
     if is_mac:
-        text.append(u'fn + \u2190 : \n')
-        text.append(u'fn + \u2192 : \n')
+        text.append(u'fn + ← : \n')
+        text.append(u'fn + → : \n')
         if 'fig_selection' not in params:
-            text.append(u'fn + \u2193 : \n')
-            text.append(u'fn + \u2191 : \n')
+            text.append(u'fn + ↓ : \n')
+            text.append(u'fn + ↑ : \n')
     else:
         text.append(u'Home : \n')
         text.append(u'End : \n')


### PR DESCRIPTION
This PR re-enables the vertical green line when you left-click inside the plot. I've disabled marking bad channels by clicking on a trace, because this never worked reliably. Instead, bad channels can (still) be marked by clicking on the label. Right-clicking inside the plot hides the green line.