### PR TITLE
MRG: Simplify file retrieval

### DIFF
--- a/mne/datasets/sleep_physionet/tests/test_physionet.py
+++ b/mne/datasets/sleep_physionet/tests/test_physionet.py
@@ -60,6 +60,7 @@ def _check_mocked_function_calls(mocked_func, call_fname_hash_pairs,
         assert call_kwargs['print_destination'] is False
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.xfail(strict=False)
 @requires_good_network
 @requires_pandas

--- a/mne/utils/fetching.py
+++ b/mne/utils/fetching.py
@@ -22,18 +22,9 @@ def _get_http(url, temp_file_name, initial_size, file_size, timeout,
     # Actually do the reading
     req = request.Request(url)
     if initial_size > 0:
+        logger.debug('  Resuming at %s' % (initial_size,))
         req.headers['Range'] = 'bytes=%s-' % (initial_size,)
-    try:
-        response = request.urlopen(req, timeout=timeout)
-    except Exception:
-        # There is a problem that may be due to resuming, some
-        # servers may not support the "Range" header. Switch
-        # back to complete download method
-        logger.info('Resuming download failed (server '
-                    'rejected the request). Attempting to '
-                    'restart downloading the entire file.')
-        del req.headers['Range']
-        response = request.urlopen(req, timeout=timeout)
+    response = request.urlopen(req, timeout=timeout)
     total_size = int(response.headers.get('Content-Length', '1').strip())
     if initial_size > 0 and file_size == total_size:
         logger.info('Resuming download failed (resume file size '

--- a/mne/utils/tests/test_fetching.py
+++ b/mne/utils/tests/test_fetching.py
@@ -10,7 +10,7 @@ from mne.utils import _fetch_file, requires_good_network, catch_logging
 @requires_good_network
 @pytest.mark.parametrize('url', (
     'https://raw.githubusercontent.com/mne-tools/mne-python/master/README.rst',
-    ))
+))
 def test_fetch_file(url, tmpdir):
     """Test URL retrieval."""
     tempdir = str(tmpdir)

--- a/mne/utils/tests/test_fetching.py
+++ b/mne/utils/tests/test_fetching.py
@@ -3,26 +3,41 @@ import os.path as op
 
 import pytest
 
-from mne.utils import _fetch_file, requires_good_network
+from mne.utils import _fetch_file, requires_good_network, catch_logging
 
 
+@pytest.mark.timeout(60)
 @requires_good_network
-@pytest.mark.parametrize('url', ('https://www.github.com',))
+@pytest.mark.parametrize('url', (
+    'https://raw.githubusercontent.com/mne-tools/mne-python/master/README.rst',
+    ))
 def test_fetch_file(url, tmpdir):
     """Test URL retrieval."""
     tempdir = str(tmpdir)
     archive_name = op.join(tempdir, "download_test")
-    _fetch_file(url, archive_name, timeout=30., verbose=False,
-                resume=False)
-    pytest.raises(Exception, _fetch_file, 'NOT_AN_ADDRESS',
-                  op.join(tempdir, 'test'), verbose=False)
+    with catch_logging() as log:
+        _fetch_file(url, archive_name, timeout=30., verbose='debug')
+    log = log.getvalue()
+    assert 'Resuming at' not in log
+    with open(archive_name, 'rb') as fid:
+        data = fid.read()
+    stop = len(data) // 2
+    assert 0 < stop < len(data)
+    with open(archive_name + '.part', 'wb') as fid:
+        fid.write(data[:stop])
+    with catch_logging() as log:
+        _fetch_file(url, archive_name, timeout=30., verbose='debug')
+    log = log.getvalue()
+    assert 'Resuming at %s' % stop in log
+    with pytest.raises(Exception, match='unknown url type'):
+        _fetch_file('NOT_AN_ADDRESS', op.join(tempdir, 'test'), verbose=False)
     resume_name = op.join(tempdir, "download_resume")
     # touch file
     with open(resume_name + '.part', 'w'):
         os.utime(resume_name + '.part', None)
     _fetch_file(url, resume_name, resume=True, timeout=30.,
                 verbose=False)
-    pytest.raises(ValueError, _fetch_file, url, archive_name,
-                  hash_='a', verbose=False)
-    pytest.raises(RuntimeError, _fetch_file, url, archive_name,
-                  hash_='a' * 32, verbose=False)
+    with pytest.raises(ValueError, match='Bad hash value'):
+        _fetch_file(url, archive_name, hash_='a', verbose=False)
+    with pytest.raises(RuntimeError, match='Hash mismatch'):
+        _fetch_file(url, archive_name, hash_='a' * 32, verbose=False)


### PR DESCRIPTION
Our old handling of `resume` failures was buggy, and I'm not convinced we need it anyway given that modern servers should handle resume requests. This simplifies our code and hopefully will make our tests a bit more robust.