### PR TITLE
MRG: Add FIR filtering to raw.plot and fix filtering bug

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 
 - :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_
 
+- Add support for FIR filtering in :meth:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` by passing ``filtorder=0`` or ``--filtorder 0``, respectively, by `Eric Larson`_
+
 - Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
 
 - :func:`mne.io.read_raw_edf` now detects analog stim channels labeled ``'STATUS'`` and sets them as stim channel. :func:`mne.io.read_raw_edf` no longer synthesize TAL annotations into stim channel but stores them in ``raw.annotations`` when reading by `Joan Massich`_
@@ -94,6 +96,8 @@ Bug
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
 - Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_
+
+- Fix bug where filtering was not performed with ``lowpass`` or ``highpass`` in :meth:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` by `Eric Larson`_
 
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -58,7 +58,7 @@ def run():
                       help="Display low-pass filter corner frequency",
                       default=-1)
     parser.add_option("--filtorder", dest="filtorder", type="int",
-                      help="Display filtering IIR order",
+                      help="Display filtering IIR order (or 0 to use FIR)",
                       default=4)
     parser.add_option("--clipping", dest="clipping",
                       help="Enable trace clipping mode, either 'clip' or "
@@ -105,9 +105,8 @@ def run():
                 'Raw data must be preloaded for chpi, use --preload')
         raw = mne.chpi.filter_chpi(raw)
 
-    highpass = None if highpass < 0 or filtorder <= 0 else highpass
-    lowpass = None if lowpass < 0 or filtorder <= 0 else lowpass
-    filtorder = 4 if filtorder <= 0 else filtorder
+    highpass = None if highpass < 0 or filtorder < 0 else highpass
+    lowpass = None if lowpass < 0 or filtorder < 0 else lowpass
     raw.plot(duration=duration, start=start, n_channels=n_channels,
              group_by=group_by, show_options=show_options, events=events,
              highpass=highpass, lowpass=lowpass, filtorder=filtorder,

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -184,8 +184,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         Filtering order. 0 will use FIR filtering with MNE defaults.
         Other values will construct an IIR filter of the given order
         and apply it with :func:`~scipy.signal.filtfilt` (making the effective
-        order will be twice ``filtorder``). Filtering may produce some edge
-        artifacts (at the left and right edges) of the signals during display.
+        order twice ``filtorder``). Filtering may produce some edge artifacts
+        (at the left and right edges) of the signals during display.
 
         .. versionchanged:: 0.18
            Support for ``filtorder=0`` to use FIR filtering.

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -277,19 +277,26 @@ def test_plot_annotations():
     with pytest.warns(RuntimeWarning, match='expanding outside'):
         raw.set_annotations(annot)
     _annotation_helper(raw)
+    plt.close('all')
 
 
 def test_plot_raw_filtered():
     """Test filtering of raw plots."""
     raw = _get_raw()
-    pytest.raises(ValueError, raw.plot, lowpass=raw.info['sfreq'] / 2.)
-    pytest.raises(ValueError, raw.plot, highpass=0)
-    pytest.raises(ValueError, raw.plot, lowpass=1, highpass=1)
-    pytest.raises(ValueError, raw.plot, lowpass=1, filtorder=0)
-    pytest.raises(ValueError, raw.plot, clipping='foo')
+    with pytest.raises(ValueError, match='lowpass must be < Nyquist'):
+        raw.plot(lowpass=raw.info['sfreq'] / 2.)
+    with pytest.raises(ValueError, match='highpass must be > 0'):
+        raw.plot(highpass=0)
+    with pytest.raises(ValueError, match=r'lowpass \(1\) must be > highpass'):
+        raw.plot(lowpass=1, highpass=1)
+    with pytest.raises(ValueError, match=r'filtorder \(-1\) must be >= 0'):
+        raw.plot(lowpass=1, filtorder=-1)
+    with pytest.raises(ValueError, match="Invalid value for the 'clipping'"):
+        raw.plot(clipping='foo')
     raw.plot(lowpass=1, clipping='transparent')
     raw.plot(highpass=1, clipping='clamp')
-    raw.plot(highpass=1, lowpass=2, butterfly=True)
+    raw.plot(lowpass=40, butterfly=True, filtorder=0)
+    plt.close('all')
 
 
 def test_plot_raw_psd():


### PR DESCRIPTION
This PR:

- Adds FIR filtering (using MNE defaults) when browsing, since sometimes the IIR filtering does not provide sufficient attenuation
- Fixes a bug where filtering wasn't actually applied at all