### PR TITLE
FIX: Fix mne flash_bem

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,6 +95,8 @@ Bug
 - Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
   If your code uses ``Epochs(..., preload=True).drop_bad(reject=..., flat=...)``, we recommend regenerating these data.
 
+- Fix :ref:`gen_mne_flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used by `Eric Larson`_
+  
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
 - Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1606,9 +1606,9 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
         logger.info("\n---- Converting Flash images ----")
         echos = ['001', '002', '003', '004', '005', '006', '007', '008']
         if flash30:
-            flashes = ['05']
-        else:
             flashes = ['05', '30']
+        else:
+            flashes = ['05']
         #
         missing = False
         for flash in flashes:

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -89,9 +89,11 @@ def run():
         raise RuntimeError('The subject argument must be set')
 
     convert_flash_mris(subject=subject, subjects_dir=subjects_dir,
-                       flash30=flash30, convert=convert, unwarp=unwarp)
+                       flash30=flash30, convert=convert, unwarp=unwarp,
+                       verbose=True)
     make_flash_bem(subject=subject, subjects_dir=subjects_dir,
-                   overwrite=overwrite, show=show, flash_path=flash_path)
+                   overwrite=overwrite, show=show, flash_path=flash_path,
+                   verbose=True)
 
 
 is_main = (__name__ == '__main__')


### PR DESCRIPTION
Fixes a bug where flash30 images would not be converted.

Also turns `verbose` on since people will presumably always want it on.