### PR TITLE
FIX: CNT 32bits annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -90,6 +90,8 @@ Changelog
 Bug
 ~~~
 
+- Fix 32bits annotations in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
+
 - Fix date parsing in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
 
 - Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -53,7 +53,6 @@ def _read_annotations_cnt(fname, data_format='int16'):
         if event_type == CNTEventType3:
             offset *= n_bytes * n_channels
         event_time = offset - 900 - (75 * n_channels)
-        print(event_time.dtype)
         event_time //= n_channels * n_bytes
         return event_time - 1
 


### PR DESCRIPTION
Tested locally like this:

```py
@pytest.mark.parametrize(
    'fname',
    [
        op.join(data_path(download=False), 'CNT', 'scan41_short.cnt'),
        # flankers_path,   # This fails due to #5493
        op.join(confidential_path, 'BoyoAEpic1_16bit.cnt'),
        op.join(confidential_path, 'cont_67chan_resp_32bit.cnt'),
        op.join(confidential_path, 'SampleCNTFile_16bit.cnt'),
    ],
    ids=op.basename
)
def test_events_and_annotations_are_the_same(fname, recwarn):
    """This test is meant to inspect int16-int32 issues"""
    raw_cnt = mne.io.read_raw_cnt(fname, montage=None, stim_channel=True)
    events = mne.find_events(raw_cnt)

    events_id_without_0 = {str(x): x for x in (set(events[:, 2]))}
    annot_events, events_id = mne.events_from_annotations(
        raw_cnt, event_id=events_id_without_0)
    np.testing.assert_array_equal(events[:, 0], annot_events[:, 0])
```
This is the trace comparing master and the branch
```sh
~/code/mne-python master*
(mne) ❯ pytest sandbox/mwe/5493_montage_index_error.py -k events_and_annot --tb=short
Test session starts (platform: linux, Python 3.6.6, pytest 4.0.0, pytest-sugar 0.9.2)
rootdir: /home/sik/code/mne-python, inifile: setup.cfg
plugins: sugar-0.9.2, pudb-0.7.0, faulthandler-1.5.0, cov-2.6.0
collecting ... 
 sandbox/mwe/5493_montage_index_error.py ✓✓                                                                                                                                                                                                                                 50% █████     

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_events_and_annotations_are_the_same[cont_67chan_resp_32bit.cnt] ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
sandbox/mwe/5493_montage_index_error.py:41: in test_events_and_annotations_are_the_same
    np.testing.assert_array_equal(events[:, 0], annot_events[:, 0])
E   AssertionError: 
E   Arrays are not equal
E   
E   (shapes (121,), (62,) mismatch)
E    x: array([  2557,   2990,   2995,   5865,   6299,   9273,   9707,  12590,
E           13023,  15665,  16098,  18881,  19315,  22331,  22764,  25797,
E           26231,  29147,  29581,  32439,  32872,  35647,  36080,  38963,...
E    y: array([  5115,   5981,   5991,  11731,  12599,  18547,  19415,  25181,
E           26047,  31331,  32197,  37763,  38631,  44663,  45529,  51595,
E           52463,  58295,  59163,  64879,  65745,  71295,  72161,  77927,...

 sandbox/mwe/5493_montage_index_error.py ⨯✓                                                                                                                                                                                                                                100% ██████████
------------------------------------------------------------------------------------------------------------ generated xml file: /home/sik/code/mne-python/junit-results.xml -------------------------------------------------------------------------------------------------------------
================================================================================================================================ short test summary info =================================================================================================================================
FAIL sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[cont_67chan_resp_32bit.cnt]
=============================================================================================================================== slowest 20 test durations ================================================================================================================================
1.33s setup    sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[scan41_short.cnt]
0.60s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[BoyoAEpic1_16bit.cnt]
0.22s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[cont_67chan_resp_32bit.cnt]
0.01s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[scan41_short.cnt]
0.01s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[SampleCNTFile_16bit.cnt]

(0.00 durations hidden.  Use -vv to show these durations.)

Results (2.44s):
       3 passed
       1 failed
         - sandbox/mwe/5493_montage_index_error.py:22 test_events_and_annotations_are_the_same[cont_67chan_resp_32bit.cnt]
      11 deselected

~/code/mne-python master*
(mne) ❯ git checkout fix_CNT_int32
Switched to branch 'fix_CNT_int32'

~/code/mne-python fix_CNT_int32*
(mne) ❯ pytest sandbox/mwe/5493_montage_index_error.py -k events_and_annot --tb=short
Test session starts (platform: linux, Python 3.6.6, pytest 4.0.0, pytest-sugar 0.9.2)
rootdir: /home/sik/code/mne-python, inifile: setup.cfg
plugins: sugar-0.9.2, pudb-0.7.0, faulthandler-1.5.0, cov-2.6.0
collecting ... 
 sandbox/mwe/5493_montage_index_error.py ✓✓✓✓                                                                                                                                                                                                                              100% ██████████
------------------------------------------------------------------------------------------------------------ generated xml file: /home/sik/code/mne-python/junit-results.xml -------------------------------------------------------------------------------------------------------------
=============================================================================================================================== slowest 20 test durations ================================================================================================================================
1.32s setup    sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[scan41_short.cnt]
0.61s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[BoyoAEpic1_16bit.cnt]
0.21s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[cont_67chan_resp_32bit.cnt]
0.01s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[scan41_short.cnt]
0.01s call     sandbox/mwe/5493_montage_index_error.py::test_events_and_annotations_are_the_same[SampleCNTFile_16bit.cnt]

(0.00 durations hidden.  Use -vv to show these durations.)

Results (2.33s):
       4 passed
      11 deselected

```