### PR TITLE
MRG: flash bem orientation

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -301,3 +301,8 @@ div.highlight-console div.highlight span.gp {
             user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome and Opera */
 }
+/* Sizing */
+.body {
+    max-width: unset !important;
+    min-width: unset !important;
+}

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -99,7 +99,7 @@ Bug
 - Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
   If your code uses ``Epochs(..., preload=True).drop_bad(reject=..., flat=...)``, we recommend regenerating these data.
 
-- Fix :ref:`gen_mne_flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used by `Eric Larson`_
+- Fix :ref:`gen_mne_flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used, and to properly deal with non-standard acquisition affines by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1823,14 +1823,9 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
         out_fname = op.join(flash_bem_dir, surf + '.tri')
         shutil.move(op.join(bem_dir, surf + '.tri'), out_fname)
         nodes, tris = read_tri(out_fname, swap=True)
-        vol_info = _extract_volume_info(flash5_reg)
-        if vol_info is None:
-            warn('nibabel is required to update the volume info. Volume info '
-                 'omitted from the written surface.')
-        else:
-            vol_info['head'] = np.array([20])
-        write_surface(op.splitext(out_fname)[0] + '.surf', nodes, tris,
-                      volume_info=vol_info)
+        # Do not write volume info here because the tris are already in
+        # standard Freesurfer coords
+        write_surface(op.splitext(out_fname)[0] + '.surf', nodes, tris)
 
     # Cleanup section
     logger.info("\n---- Cleaning up ----")

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -26,8 +26,8 @@ from ..fixes import einsum, _crop_colorbar
 from ..io import _loc_to_coil_trans
 from ..io.pick import pick_types
 from ..io.constants import FIFF
-from ..io.meas_info import read_fiducials
-from ..source_space import SourceSpaces, _create_surf_spacing, _check_spacing
+from ..io.meas_info import read_fiducials, create_info
+from ..source_space import _ensure_src, _create_surf_spacing, _check_spacing
 
 from ..surface import (get_meg_helmet_surf, read_surface,
                        transform_surface_to, _project_onto_surface,
@@ -524,7 +524,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
 
 
 @verbose
-def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
+def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                    surfaces='head', coord_frame='head',
                    meg=None, eeg='original',
                    dig=False, ecog=True, src=None, mri_fiducials=False,
@@ -534,8 +534,9 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
 
     Parameters
     ----------
-    info : dict
+    info : dict | None
         The measurement info.
+        If None (default), no sensor information will be shown.
     trans : str | 'auto' | dict | None
         The full path to the head<->MRI transform ``*-trans.fif`` file
         produced during coregistration. If trans is None, an identity matrix
@@ -669,6 +670,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
         raise ValueError('eeg must only contain "original" and '
                          '"projected", got %s' % (eeg,))
 
+    info = create_info(1, 1000., 'misc') if info is None else info
     _validate_type(info, "info")
 
     if isinstance(surfaces, str):
@@ -686,9 +688,7 @@ def plot_alignment(info, trans=None, subject=None, subjects_dir=None,
 
     _check_option('coord_frame', coord_frame, ['head', 'meg', 'mri'])
     if src is not None:
-        if not isinstance(src, SourceSpaces):
-            raise TypeError('src must be None or SourceSpaces, got %s'
-                            % (type(src),))
+        src = _ensure_src(src)
         src_subject = src[0].get('subject_his_id', None)
         subject = src_subject if subject is None else subject
         if src_subject is not None and subject != src_subject:

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -193,7 +193,7 @@ def test_plot_alignment(tmpdir):
     info = infos['Neuromag']
     pytest.raises(TypeError, plot_alignment, 'foo', trans_fname,
                   subject='sample', subjects_dir=subjects_dir)
-    pytest.raises(TypeError, plot_alignment, info, trans_fname,
+    pytest.raises(OSError, plot_alignment, info, trans_fname,
                   subject='sample', subjects_dir=subjects_dir, src='foo')
     pytest.raises(ValueError, plot_alignment, info, trans_fname,
                   subject='fsaverage', subjects_dir=subjects_dir,
@@ -210,7 +210,7 @@ def test_plot_alignment(tmpdir):
         plot_alignment(info, meg=['helmet', 'sensors'], dig=True,
                        coord_frame=coord_frame, trans=trans_fname,
                        subject='sample', mri_fiducials=fiducials_path,
-                       subjects_dir=subjects_dir, src=sample_src)
+                       subjects_dir=subjects_dir, src=src_fname)
         mlab.close(all=True)
     # EEG only with strange options
     evoked_eeg_ecog_seeg = evoked.copy().pick_types(meg=False, eeg=True)
@@ -254,7 +254,8 @@ def test_plot_alignment(tmpdir):
                    src=src, dig=True, surfaces=['brain', 'inner_skull',
                                                 'outer_skull', 'outer_skin'])
     sphere = make_sphere_model('auto', None, evoked.info)  # one layer
-    fig = plot_alignment(info, trans_fname, subject='sample', meg=False,
+    # no info is permitted
+    fig = plot_alignment(trans=trans_fname, subject='sample', meg=False,
                          coord_frame='mri', subjects_dir=subjects_dir,
                          surfaces=['brain'], bem=sphere, show_axes=True)
     assert isinstance(fig, mayavi.core.scene.Scene)


### PR DESCRIPTION
The `.tri` files appear to already have the affine applied to them, so attaching it in the metadata causes it to reapplied. Using `master` on one MR I get:

<img width="1325" alt="Screen Shot 2019-03-18 at 19 45 08" src="https://user-images.githubusercontent.com/2365790/54579767-2aac7200-4a59-11e9-918a-5e0d4e22969a.png">

And on this PR I get:

<img width="1325" alt="Screen Shot 2019-03-19 at 15 10 19" src="https://user-images.githubusercontent.com/2365790/54579774-3861f780-4a59-11e9-979e-fc1d22c46530.png">

Confirmed everything should now be okay with `plot_alignment`:

![snapshot](https://user-images.githubusercontent.com/2365790/54580284-77914800-4a5b-11e9-906b-07461510a491.png)

Also contains a small CSS tweak to work with https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/193, and a couple of minor usability tweaks/shortcuts for `plot_alignment`.