### PR TITLE
[WIP] Use _Renderer in tutorials

### DIFF
--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -319,6 +319,10 @@ class _Renderer(object):
         """Take a screenshot of the scene."""
         return self.mlab.screenshot(self.fig)
 
+    def title(self, title, height):
+        """Create a title for the scene."""
+        self.mlab.title(title, height=height)
+
     def project(self, xyz, ch_names):
         """Convert 3d points to a 2d perspective.
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -215,7 +215,7 @@ class _Renderer(object):
                                      figure=self.fig)
         surface.actor.property.backface_culling = backface_culling
 
-    def quiver3d(self, x, y, z, u, v, w, color, scale, mode, resolution=8,
+    def quiver3d(self, x, y, z, u, v, w, color, scale, mode='arrow', resolution=8,
                  glyph_height=None, glyph_center=None, glyph_resolution=None,
                  opacity=1.0, scale_mode='none', scalars=None,
                  backface_culling=False):

--- a/tutorials/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/plot_brainstorm_phantom_elekta.py
@@ -30,8 +30,8 @@ import mne
 from mne import find_events, fit_dipole
 from mne.datasets.brainstorm import bst_phantom_elekta
 from mne.io import read_raw_fif
+from mne.viz.backends.renderer import _Renderer
 
-from mayavi import mlab
 print(__doc__)
 
 ###############################################################################
@@ -161,23 +161,24 @@ plt.show()
 ###############################################################################
 # Let's plot the positions and the orientations of the actual and the estimated
 # dipoles
-def plot_pos_ori(pos, ori, color=(0., 0., 0.), opacity=1.):
+def plot_pos_ori(figure, pos, ori, color=(0., 0., 0.), opacity=1.):
     x, y, z = pos.T
     u, v, w = ori.T
-    mlab.points3d(x, y, z, scale_factor=0.005, opacity=opacity, color=color)
-    q = mlab.quiver3d(x, y, z, u, v, w,
-                      scale_factor=0.03, opacity=opacity,
+    renderer = _Renderer(fig=figure)
+    renderer.set_camera(azimuth=70, elevation=80, distance=0.5)
+    renderer.sphere(np.column_stack((x, y, z)), scale=0.005, opacity=opacity,
+                    color=color)
+    renderer.quiver3d(x=x, y=y, z=z, u=u, v=v, w=w,
+                      scale=0.03, opacity=opacity,
                       color=color, mode='arrow')
-    q.glyph.glyph_source.glyph_source.shaft_radius = 0.02
-    q.glyph.glyph_source.glyph_source.tip_length = 0.1
-    q.glyph.glyph_source.glyph_source.tip_radius = 0.05
 
 
-mne.viz.plot_alignment(evoked.info, bem=sphere, surfaces='inner_skull',
-                       coord_frame='head', meg='helmet', show_axes=True)
+figure = mne.viz.plot_alignment(evoked.info, bem=sphere,
+                                surfaces='inner_skull',
+                                coord_frame='head', meg='helmet',
+                                show_axes=True)
 
 # Plot the position and the orientation of the actual dipole
-plot_pos_ori(actual_pos, actual_ori, color=(0., 0., 0.), opacity=0.5)
+plot_pos_ori(figure, actual_pos, actual_ori, color=(0., 0., 0.), opacity=0.5)
 # Plot the position and the orientation of the estimated dipole
-plot_pos_ori(dip.pos, dip.ori, color=(0.2, 1., 0.5))
-mlab.view(70, 80, distance=0.5)
+plot_pos_ori(figure, dip.pos, dip.ori, color=(0.2, 1., 0.5))

--- a/tutorials/plot_dics.py
+++ b/tutorials/plot_dics.py
@@ -23,7 +23,6 @@ sources.
 import os.path as op
 import numpy as np
 from scipy.signal import welch, coherence
-from mayavi import mlab
 from matplotlib import pyplot as plt
 
 import mne
@@ -32,6 +31,7 @@ from mne.datasets import sample
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.time_frequency import csd_morlet
 from mne.beamformer import make_dics, apply_dics_csd
+from mne.viz.backends.renderer import _Renderer
 
 # We use the MEG and MRI setup from the MNE-sample dataset
 data_path = sample.data_path(download=False)
@@ -237,8 +237,9 @@ brain.add_foci(source_vert1, coords_as_verts=True, hemi='lh')
 brain.add_foci(source_vert2, coords_as_verts=True, hemi='rh')
 
 # Rotate the view and add a title.
-mlab.view(0, 0, 550, [0, 0, 0])
-mlab.title('MNE-dSPM inverse (RMS)', height=0.9)
+renderer = _Renderer(fig=brain._figures[0][0])
+renderer.set_camera(azimuth=0, elevation=0, distance=550, focalpoint=[0, 0, 0])
+renderer.title('MNE-dSPM inverse (RMS)', height=0.9)
 
 ###############################################################################
 # We will now compute the cortical power map at 10 Hz. using a DICS beamformer.
@@ -289,8 +290,10 @@ for approach, power in enumerate([power_approach1, power_approach2], 1):
     brain.add_foci(source_vert2, coords_as_verts=True, hemi='rh')
 
     # Rotate the view and add a title.
-    mlab.view(0, 0, 550, [0, 0, 0])
-    mlab.title('DICS power map, approach %d' % approach, height=0.9)
+    renderer = _Renderer(fig=brain._figures[0][0])
+    renderer.set_camera(azimuth=0, elevation=0, distance=550,
+                        focalpoint=[0, 0, 0])
+    renderer.title('DICS power map, approach %d' % approach, height=0.9)
 
 ###############################################################################
 # Excellent! All methods found our two simulated sources. Of course, with a

--- a/tutorials/plot_ecog.py
+++ b/tutorials/plot_ecog.py
@@ -15,10 +15,10 @@ electrocorticography (ECoG) data.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.io import loadmat
-from mayavi import mlab
 
 import mne
 from mne.viz import plot_alignment, snapshot_brain_montage
+from mne.viz.backends.renderer import _Renderer
 
 print(__doc__)
 
@@ -48,7 +48,8 @@ info = mne.create_info(ch_names, 1000., 'ecog', montage=mon)
 subjects_dir = mne.datasets.sample.data_path() + '/subjects'
 fig = plot_alignment(info, subject='sample', subjects_dir=subjects_dir,
                      surfaces=['pial'])
-mlab.view(200, 70)
+renderer = _Renderer(fig=fig)
+renderer.set_camera(azimuth=200, elevation=70)
 
 ###############################################################################
 # Sometimes it is useful to make a scatterplot for the current figure view.
@@ -59,7 +60,8 @@ mlab.view(200, 70)
 # We'll once again plot the surface, then take a snapshot.
 fig_scatter = plot_alignment(info, subject='sample', subjects_dir=subjects_dir,
                              surfaces='pial')
-mlab.view(200, 70)
+renderer = _Renderer(fig=fig_scatter)
+renderer.set_camera(azimuth=200, elevation=70)
 xy, im = snapshot_brain_montage(fig_scatter, mon)
 
 # Convert from a dictionary to array to plot

--- a/tutorials/plot_forward.py
+++ b/tutorials/plot_forward.py
@@ -15,6 +15,7 @@ concepts for forward modeling. See :ref:`ch_forward`.
 import os.path as op
 import mne
 from mne.datasets import sample
+from mne.viz.backends.renderer import _Renderer
 data_path = sample.data_path()
 
 # the raw file containing the channel location + types
@@ -159,7 +160,6 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
 # slices are shown. Let's write a few lines of mayavi to see all sources in 3D.
 
 import numpy as np  # noqa
-from mayavi import mlab  # noqa
 from surfer import Brain  # noqa
 
 brain = Brain('sample', 'lh', 'inflated', subjects_dir=subjects_dir)
@@ -167,8 +167,11 @@ surf = brain.geo['lh']
 
 vertidx = np.where(src[0]['inuse'])[0]
 
-mlab.points3d(surf.x[vertidx], surf.y[vertidx],
-              surf.z[vertidx], color=(1, 1, 0), scale_factor=1.5)
+renderer = _Renderer(fig=brain._figures[0][0])
+renderer.sphere(np.column_stack((surf.x[vertidx],
+                                 surf.y[vertidx],
+                                 surf.z[vertidx])),
+                color=(1, 1, 0), scale=1.5)
 
 
 ###############################################################################

--- a/tutorials/plot_phantom_4DBTi.py
+++ b/tutorials/plot_phantom_4DBTi.py
@@ -17,9 +17,9 @@ Data are provided by Jean-Michel Badier from MEG center in Marseille, France.
 
 import os.path as op
 import numpy as np
-from mayavi import mlab
 from mne.datasets import phantom_4dbti
 import mne
+from mne.viz.backends.renderer import _Renderer
 
 ###############################################################################
 # Read data and compute a dipole fit at the peak of the evoked response
@@ -64,13 +64,14 @@ print("errors (mm) : %s" % errors)
 # Plot the dipoles in 3D
 
 
-def plot_pos(pos, color=(0., 0., 0.)):
-    mlab.points3d(pos[:, 0], pos[:, 1], pos[:, 2], scale_factor=0.005,
-                  color=color)
+def plot_pos(fig, pos, color=(0., 0., 0.)):
+    renderer = _Renderer(fig=fig)
+    renderer.sphere(np.column_stack((pos[:, 0], pos[:, 1], pos[:, 2])),
+                    scale=0.005, color=color)
 
 
-mne.viz.plot_alignment(evoked.info, bem=sphere, surfaces=[])
+fig = mne.viz.plot_alignment(evoked.info, bem=sphere, surfaces=[])
 # Plot the position of the actual dipole
-plot_pos(actual_pos, color=(1., 0., 0.))
+plot_pos(fig, actual_pos, color=(1., 0., 0.))
 # Plot the position of the estimated dipole
-plot_pos(pos, color=(1., 1., 0.))
+plot_pos(fig, pos, color=(1., 1., 0.))

--- a/tutorials/plot_point_spread.py
+++ b/tutorials/plot_point_spread.py
@@ -10,13 +10,12 @@ signal with point-spread by applying a forward and inverse solution.
 import os.path as op
 
 import numpy as np
-from mayavi import mlab
 
 import mne
 from mne.datasets import sample
-
 from mne.minimum_norm import read_inverse_operator, apply_inverse
 from mne.simulation import simulate_stc, simulate_evoked
+from mne.viz.backends.renderer import _Renderer
 
 ###############################################################################
 # First, we set some parameters.
@@ -136,7 +135,8 @@ kwargs = dict(subjects_dir=subjects_dir, hemi='split', smoothing_steps=4,
               time_unit='s', initial_time=0.05, size=1200,
               views=['lat', 'med'])
 clim = dict(kind='value', pos_lims=[1e-9, 1e-8, 1e-7])
-figs = [mlab.figure(1), mlab.figure(2), mlab.figure(3), mlab.figure(4)]
+figs = [_Renderer(name='1').scene(), _Renderer(name='2').scene(),
+        _Renderer(name='3').scene(), _Renderer(name='4').scene()]
 brain_gen = stc_gen.plot(clim=clim, figure=figs, **kwargs)
 
 ###############################################################################
@@ -163,7 +163,8 @@ stc_inv = apply_inverse(evoked_gen, inv_op, lambda2, method=method)
 # This spread is due to the minimum norm solution so that the signal leaks to
 # nearby vertices with similar orientations so that signal ends up crossing the
 # sulci and gyri.
-figs = [mlab.figure(5), mlab.figure(6), mlab.figure(7), mlab.figure(8)]
+figs = [_Renderer(name='5').scene(), _Renderer(name='6').scene(),
+        _Renderer(name='7').scene(), _Renderer(name='8').scene()]
 brain_inv = stc_inv.plot(figure=figs, **kwargs)
 
 ###############################################################################

--- a/tutorials/plot_source_alignment.py
+++ b/tutorials/plot_source_alignment.py
@@ -18,10 +18,10 @@ Let's start out by loading some data.
 import os.path as op
 
 import numpy as np
-from mayavi import mlab
 
 import mne
 from mne.datasets import sample
+from mne.viz.backends.renderer import _Renderer
 
 print(__doc__)
 
@@ -64,11 +64,14 @@ src = mne.read_source_spaces(op.join(subjects_dir, 'sample', 'bem',
 #
 # Let's take a look:
 
-mne.viz.plot_alignment(raw.info, trans=trans, subject='sample',
-                       subjects_dir=subjects_dir, surfaces='head-dense',
-                       show_axes=True, dig=True, eeg=[], meg='sensors',
-                       coord_frame='meg')
-mlab.view(45, 90, distance=0.6, focalpoint=(0., 0., 0.))
+fig = mne.viz.plot_alignment(raw.info, trans=trans, subject='sample',
+                             subjects_dir=subjects_dir, surfaces='head-dense',
+                             show_axes=True, dig=True, eeg=[], meg='sensors',
+                             coord_frame='meg')
+renderer = _Renderer(fig=fig)
+renderer.set_camera(azimuth=45, elevation=90,
+                    distance=0.6, focalpoint=(0., 0., 0.))
+
 print('Distance from head origin to MEG origin: %0.1f mm'
       % (1000 * np.linalg.norm(raw.info['dev_head_t']['trans'][:3, 3])))
 print('Distance from head origin to MRI origin: %0.1f mm'


### PR DESCRIPTION
#### Reference issue
Follow-up of #5822


#### What does this implement/fix?
I noticed the `tutorials` scripts still use heavily the object `mlab` from `mayavi` so this PR isolates those calls behind the `_Renderer` class in `mne/viz/backends/renderer.py`.