### PR TITLE
ENH: Get rid of custom condition [skip azp] [skip travis] [skip circle]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,6 @@ trigger:
 
 jobs:
 - job: Windows
-  condition: not(or(contains(variables['Build.SourceVersionMessage'], '[ci skip]'), contains(variables['Build.SourceVersionMessage'], '[skip azp]')))
   pool:
     vmIMage: 'VS2017-Win2016'
   variables:


### PR DESCRIPTION
Apparently `skip azp` [should work now](https://developercommunity.visualstudio.com/idea/420289/add-support-ci-skip-and-azure-skip-to-azure-pipeli.html?childToView=503497#comment-503497). Either way our custom step did not work so we should remove it.