### PR TITLE
MRG: Add mne.preprocessing.mark_flat

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -333,6 +333,7 @@ Projections:
    ica_find_ecg_events
    ica_find_eog_events
    infomax
+   mark_flat
    maxwell_filter
    oversampled_temporal_projection
    read_ica

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Changelog
 
 - Add option to improve rendering in :ref:`gen_mne_coreg` for modern graphics cards by `Eric Larson`_
 
+- Add :func:`mne.preprocessing.mark_flat` to automate marking of flat channels and segments of raw data by `Eric Larson`_
+
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
 - Add option to SSP preprocessing functions (e.g., :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs`) to process MEG channels jointly with ``meg='combined'`` by `Eric Larson`_

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1932,7 +1932,7 @@ class FilterMixin(object):
         h_freq : float | None
             High cut-off frequency in Hz. If None the data are only
             high-passed.
-        %(picks_good_data)s
+        %(picks_all_data)s
         filter_length : str | int
             Length of the FIR filter to use (if applicable):
 
@@ -2161,6 +2161,7 @@ def design_mne_c_filter(sfreq, l_freq=None, h_freq=40.,
 def _filt_check_picks(info, picks, h_freq, l_freq):
     from .io.pick import _picks_to_idx
     update_info = False
+    # This will pick *all* data channels
     picks = _picks_to_idx(info, picks, 'data_or_ica', exclude=())
     if h_freq is not None or l_freq is not None:
         data_picks = _picks_to_idx(info, None, 'data_or_ica', exclude=())

--- a/mne/preprocessing/__init__.py
+++ b/mne/preprocessing/__init__.py
@@ -7,6 +7,7 @@
 #
 # License: BSD (3-clause)
 
+from .flat import mark_flat
 from .maxfilter import apply_maxfilter
 from .ssp import compute_proj_ecg, compute_proj_eog
 from .eog import find_eog_events, create_eog_epochs

--- a/mne/preprocessing/flat.py
+++ b/mne/preprocessing/flat.py
@@ -1,0 +1,116 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from ..io import BaseRaw
+from ..io.pick import _picks_to_idx
+from ..utils import (_validate_type, verbose, logger, _pl,
+                     _mask_to_onsets_offsets, ProgressBar)
+
+
+@verbose
+def mark_flat(raw, ratio=1., min_duration=0.005, picks=None, verbose=None):
+    r"""Mark flat segments of raw data using annotations or in info['bads'].
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        The raw data.
+    ratio : float
+        The ratio of the temporal proportion (time spent flat) to spatial
+        proportion (the reciprocal of the number of channels in picks)
+        below which temporal bad marking (:class:`~mne.Annotations`) will be
+        used instead of spatial bad marking (:class:`info['bads'] <mne.Info>`).
+        See Notes.
+    min_duration : float
+        The minimum duration (sec) to consider as actually flat.
+        For some systems with low bit data representations, adjacent
+        channels with exactly the same value are not totally uncommon.
+    %(picks_good_data)s
+    %(verbose)s
+
+    Returns
+    -------
+    raw : instance of Raw
+        The modified raw instance. Operates in place.
+
+    Notes
+    -----
+    For a given channel :math:`i` in `picks` that is flat (considering only
+    flat segments of at least `min_duration`)
+    for :math:`p_{i,t}` proportion of time points, given the spatial fraction
+    of picks that the channel represents (constant
+    :math:`p_{i,s} = 1 / N_\mathrm{picks}`), the `ratio`
+    parameter sets the ratio :math:`\frac{p_{i,t}}{p_{i,s}}` below which
+    temporal marking (:class:`~mne.Annotations`) will be used instead of
+    spatial marking (:clasS:`~mne.Info`). Or more simply:
+
+    - ``ratio < 1. / len(picks)`` always marks temporally.
+        - This risks the entire recording being marked bad if there is
+          (at least) one channel that is flat at all times.
+    - ``1. / len(picks) <= ratio < len(picks)`` marks spatially or temporally.
+        - Values in the range ``0 < ratio < 1`` prefer temporal marking to
+          spatial marking.
+        - The default value ``ratio = 1.`` uses the temporal method
+          if and only if the proportion of time a given channel is flat is
+          less than the reciprocal of the number of channels in ``picks``.
+        - Values in the range ``1 < ratio < len(picks)`` prefer spatial
+          marking to temporal marking.
+    - ``ratio >= len(picks)`` always marks spatially.
+        - This risks a channel being marked as bad for the entire recording if
+          it is flat for a contiguous `min_duration` chunk of time.
+
+    .. note:: This function may perform much faster if data are loaded
+              in memory, as it loads data one channel at a time (across all
+              time points), which is typically not an efficient way to read
+              raw data from disk.
+
+    .. versionadded:: 0.18
+    """
+    _validate_type(raw, BaseRaw, 'raw')
+    ratio = float(ratio)
+    min_duration = float(min_duration)
+    picks = _picks_to_idx(raw.info, picks, 'data_or_ica', exclude='bads')
+    # This will not be so efficient for most readers, but we can optimize
+    # it later
+    any_flat = np.zeros(len(raw.times), bool)
+    bads = list()
+    time_thresh = int(np.round(min_duration * raw.info['sfreq']))
+    with ProgressBar(picks, mesg='Finding flat segments', spinner=True,
+                     verbose_bool='auto') as pb:
+        for pick in pb:
+            data = raw[pick][0][0]
+            flat = np.diff(data) == 0
+            flat = np.concatenate(
+                [flat[[0]], flat[1:] | flat[:-1], flat[[-1]]])
+            starts, stops = _mask_to_onsets_offsets(flat)
+            for start, stop in zip(starts, stops):
+                if stop - start < time_thresh:
+                    flat[start:stop] = False
+            flat_mean = flat.mean()
+            with np.errstate(divide='ignore'):
+                bad_ratio = np.divide(1., flat_mean * len(picks))
+            if flat_mean:  # only do something if there are actually flat parts
+                if bad_ratio < ratio:
+                    kind, comp = 'bads', '<'
+                    bads.append(raw.ch_names[pick])
+                else:
+                    kind, comp = 'BAD_', '≥'
+                    any_flat |= flat
+                logger.debug('%s: %s (%s %s %s)' % (kind, raw.ch_names[pick],
+                                                    bad_ratio, comp, ratio))
+    starts, stops = _mask_to_onsets_offsets(any_flat)
+    logger.info('Marking %0.2f%% of time points (%d segment%s) and '
+                '%d/%d channel%s bad: %s'
+                % (100 * any_flat.mean(), len(starts), _pl(starts),
+                   len(bads), len(picks), _pl(bads), bads))
+    add_bads = [bad for bad in bads if bad not in raw.info['bads']]
+    raw.info['bads'] = list(raw.info['bads']) + add_bads
+    if len(starts) > 0:
+        starts, stops = np.array(starts), np.array(stops)
+        onsets = starts / raw.info['sfreq']
+        durations = (stops - starts) / raw.info['sfreq']
+        raw.annotations.append(onsets, durations, ['BAD_flat'] * len(onsets))
+    return raw

--- a/mne/preprocessing/tests/test_flat.py
+++ b/mne/preprocessing/tests/test_flat.py
@@ -27,8 +27,8 @@ def test_mark_flat():
     raw_0._data[0] = 0.
     for kwargs, bads, want_times in [
             # Anything < 1 will mark spatially
-            (dict(threshold=1.), [], 0),
-            (dict(threshold=0.999), [raw.ch_names[0]], n_times),
+            (dict(bad_percent=100.), [], 0),
+            (dict(bad_percent=99.9), [raw.ch_names[0]], n_times),
             (dict(), [raw.ch_names[0]], n_times)]:  # default (1)
         raw_time = mark_flat(raw_0.copy(), verbose='debug', **kwargs)
         want_bads = raw.info['bads'] + bads
@@ -42,12 +42,12 @@ def test_mark_flat():
     raw_0 = raw.copy()
     n_good_times = int(round(0.8 * n_times))
     raw_0._data[0, n_good_times:] = 0.
-    threshold = (n_times - n_good_times) / n_times
+    threshold = 100 * (n_times - n_good_times) / n_times
     for kwargs, bads, want_times in [
-            # Should change behavior at threshold=0.2
-            (dict(threshold=1), [], n_good_times),
-            (dict(threshold=threshold), [], n_good_times),
-            (dict(threshold=threshold - 1e-5), [raw.ch_names[0]], n_times),
+            # Should change behavior at bad_percent=20
+            (dict(bad_percent=100), [], n_good_times),
+            (dict(bad_percent=threshold), [], n_good_times),
+            (dict(bad_percent=threshold - 1e-5), [raw.ch_names[0]], n_times),
             (dict(), [raw.ch_names[0]], n_times)]:
         raw_time = mark_flat(raw_0.copy(), verbose='debug', **kwargs)
         want_bads = raw.info['bads'] + bads

--- a/mne/preprocessing/tests/test_flat.py
+++ b/mne/preprocessing/tests/test_flat.py
@@ -1,0 +1,74 @@
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+import pytest
+
+from mne import create_info
+from mne.io import RawArray
+from mne.preprocessing import mark_flat
+
+
+def test_mark_flat():
+    """Test marking flat segments."""
+    # Test if ECG analysis will work on data that is not preloaded
+    n_ch, n_times = 11, 1000
+    data = np.random.RandomState(0).randn(n_ch, n_times)
+    assert not (np.diff(data, axis=-1) == 0).any()  # nothing flat at first
+    info = create_info(n_ch, 1000., 'eeg')
+    raw = RawArray(data, info)
+    raw.info['bads'] = [raw.ch_names[-1]]
+    n_good = n_ch - 1
+
+    #
+    # First make a channel flat the whole time
+    #
+    raw_0 = raw.copy()
+    raw_0._data[0] = 0.
+    for kwargs, bads, want_times in [
+            # These will all mark spatially
+            (dict(ratio='inf'), [raw.ch_names[0]], n_times),
+            (dict(ratio=n_good), [raw.ch_names[0]], n_times),
+            (dict(), [raw.ch_names[0]], n_times),  # default (1)
+            # right at this limit is the same
+            (dict(ratio=1. / (n_good - 0.1)), [raw.ch_names[0]], n_times),
+            # then it switches
+            (dict(ratio=1. / n_good), [], 0),  # same
+            (dict(ratio=0), [], 0)]:  # ratio=0 will mark all times
+        raw_time = mark_flat(raw_0.copy(), verbose='debug', **kwargs)
+        want_bads = raw.info['bads'] + bads
+        assert raw_time.info['bads'] == want_bads
+        n_good_times = raw_time.get_data(reject_by_annotation='omit').shape[1]
+        assert n_good_times == want_times
+
+    #
+    # Now make a channel flat for 20% of the time points
+    #
+    raw_0 = raw.copy()
+    bad_t_div = 5
+    above_thresh = float(bad_t_div + 0.1) / n_good
+    below_thresh = float(bad_t_div) / n_good
+    assert n_times % bad_t_div == 0
+    raw_0._data[0, :n_times // bad_t_div] = 0.
+    n_good_times = n_times - n_times // bad_t_div
+    for kwargs, bads, want_times in [
+            # These will all mark spatially
+            (dict(ratio='inf'), [raw.ch_names[0]], n_times),
+            (dict(ratio=n_good), [raw.ch_names[0]], n_times),
+            (dict(), [raw.ch_names[0]], n_times),  # default (1)
+            # right at this limit is the same
+            (dict(ratio=above_thresh), [raw.ch_names[0]], n_times),
+            # then it switches
+            (dict(ratio=below_thresh), [], n_good_times),  # same
+            (dict(ratio=0), [], n_good_times)]:  # ratio=0 will mark all times
+        raw_time = mark_flat(raw_0.copy(), verbose='debug', **kwargs)
+        want_bads = raw.info['bads'] + bads
+        assert raw_time.info['bads'] == want_bads
+        n_good_times = raw_time.get_data(reject_by_annotation='omit').shape[1]
+        assert n_good_times == want_times
+
+    with pytest.raises(TypeError, match='must be an instance of BaseRaw'):
+        mark_flat(0.)
+    with pytest.raises(ValueError, match='not convert string to float'):
+        mark_flat(raw, 'x')

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -43,6 +43,7 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _time_mask, grand_average, object_diff, object_hash,
                        object_size, _apply_scaling_cov, _undo_scaling_cov,
                        _apply_scaling_array, _undo_scaling_array,
-                       _scaled_array, _replace_md5, _PCA)
+                       _scaled_array, _replace_md5, _PCA,
+                       _mask_to_onsets_offsets)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -831,3 +831,18 @@ class _PCA(object):
         self.singular_values_ = singular_values_[:n_components]
 
         return U, S, V
+
+
+def _mask_to_onsets_offsets(mask):
+    """Group boolean mask into contiguous onset:offset pairs."""
+    assert mask.dtype == bool and mask.ndim == 1
+    mask = mask.astype(int)
+    diff = np.diff(mask)
+    onsets = np.where(diff > 0)[0] + 1
+    if mask[0]:
+        onsets = np.concatenate([[0], onsets])
+    offsets = np.where(diff < 0)[0] + 1
+    if mask[-1]:
+        offsets = np.concatenate([offsets, [len(mask)]])
+    assert len(onsets) == len(offsets)
+    return onsets, offsets

--- a/mne/utils/progressbar.py
+++ b/mne/utils/progressbar.py
@@ -47,8 +47,8 @@ class ProgressBar(object):
     max_total_width : int | str
         Maximum total message width. Can use "auto" (default) to try to set
         a sane value based on the current terminal width.
-    verbose_bool : bool
-        If True, show progress.
+    verbose_bool : bool | 'auto'
+        If True, show progress. 'auto' will use the current MNE verbose level.
 
     Example
     -------


### PR DESCRIPTION
I got some data that, due to being recorded right after a helium fill, tended to hit the ADC rails, e.g.:

![Screenshot from 2019-03-26 17-58-57](https://user-images.githubusercontent.com/2365790/55036409-edb02480-4ff0-11e9-95d4-38b42bacee4f.png)


With this PR I get:
```
Marking 0.56% of time points (11 segments) and 2/160 channels bad: ['MEG 142', 'MEG 155']
```
And you can see both modes of operation present in the result:

![Screenshot from 2019-03-26 17-59-01](https://user-images.githubusercontent.com/2365790/55036413-f3a60580-4ff0-11e9-8487-7e3e75b8c3ad.png)
