### PR TITLE
FIX: Receptive field feature_name does not comply with sklearn API

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -90,6 +90,8 @@ Changelog
 Bug
 ~~~
 
+- Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_
+
 - Fix index error in :func:`mne.io.read_raw_cnt` when creating stim_channel manually by `Joan Massich`_
 
 - Fix 32bits annotations in :func:`mne.io.read_raw_cnt` by `Joan Massich`_

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -211,9 +211,8 @@ class ReceptiveField(BaseEstimator):
         n_delays = len(self.delays_)
 
         # Update feature names if we have none
-        if self.feature_names is None:
-            self.feature_names = ['feature_%s' % ii for ii in range(n_feats)]
-        if len(self.feature_names) != n_feats:
+        if ((self.feature_names is not None) and
+                (len(self.feature_names) != n_feats)):
             raise ValueError('n_features in X does not match feature names '
                              '(%s != %s)' % (n_feats, len(self.feature_names)))
 

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -127,11 +127,12 @@ class ReceptiveField(BaseEstimator):
             estimator = type(self.estimator)
         s += "estimator : %s, " % (estimator,)
         if hasattr(self, 'coef_'):
-            feats = self.feature_names
-            if len(feats) == 1:
-                s += "feature: %s, " % feats[0]
-            else:
-                s += "features : [%s, ..., %s], " % (feats[0], feats[-1])
+            if self.feature_names is not None:
+                feats = self.feature_names
+                if len(feats) == 1:
+                    s += "feature: %s, " % feats[0]
+                else:
+                    s += "features : [%s, ..., %s], " % (feats[0], feats[-1])
             s += "fit: True"
         else:
             s += "fit: False"

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -188,9 +188,13 @@ def test_receptive_field():
     # stim features must match length of input data
     pytest.raises(ValueError, rf.fit, X[:, :1], y)
     # auto-naming features
+    feature_names = ['feature_%s' % ii for ii in [0, 1, 2]]
+    rf = ReceptiveField(tmin, tmax, 1, estimator=mod,
+                        feature_names=feature_names)
+    assert_equal(rf.feature_names, feature_names)
     rf = ReceptiveField(tmin, tmax, 1, estimator=mod)
     rf.fit(X, y)
-    assert_equal(rf.feature_names, ['feature_%s' % ii for ii in [0, 1, 2]])
+    assert_equal(rf.feature_names, None)
     # X/y same n timepoints
     pytest.raises(ValueError, rf.fit, X, y[:-2])
     # Float becomes ridge

--- a/tutorials/plot_receptive_field.py
+++ b/tutorials/plot_receptive_field.py
@@ -34,10 +34,6 @@ modeling with continuous inputs is described in:
        enhance speech intelligibility. Nature Communications, 7, 13654 (2016).
        doi:10.1038/ncomms13654
 
-.. [5] Crosse, M. J., Di Liberto, G. M., Bednar, A. & Lalor, E. C. (2016).
-       The Multivariate Temporal Response Function (mTRF) Toolbox:
-       A MATLAB Toolbox for Relating Neural Signals to Continuous Stimuli.
-       Frontiers in Human Neuroscience 10, 604. doi:10.3389/fnhum.2016.00604
 """
 # Authors: Chris Holdgraf <choldgraf@gmail.com>
 #          Eric Larson <larson.eric.d@gmail.com>
@@ -285,7 +281,7 @@ mne.viz.tight_layout()
 #           & & &    & -1 & 1\end{matrix}\right]
 #
 # This imposes a smoothness constraint of nearby time samples and/or features.
-# Quoting [5]_:
+# Quoting [3]_:
 #
 #    Tikhonov [identity] regularization (Equation 5) reduces overfitting by
 #    smoothing the TRF estimate in a way that is insensitive to


### PR DESCRIPTION
The current RF version can make successive fits crash because of different length in feature_names

```python
from numpy.random import randn
from mne.decoding import ReceptiveField
rf = ReceptiveField(0, 10, 1., estimator=1e-3)
n_times = 100
Y = randn(n_times, 1)
rf.fit(randn(n_times, 2), Y)
rf.fit(randn(n_times, 3), Y)
```

Sklearn API does not change parameter variables at fitting. `feature_names` is currently modified at fitting if it is `None`, as it needs the number of features. 

Here is a quick fix