### PR TITLE
MRG: set_annotations orig_time

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -105,6 +105,8 @@ Bug
 
 - Fix :ref:`gen_mne_flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used, and to properly deal with non-standard acquisition affines by `Eric Larson`_
 
+- Fix :meth:`mne.io.Raw.set_annotations` with ``annotations=None`` to create an empty annotations object with ``orig_time`` that matches the :class:`mne.io.Raw` instance by `Eric Larson`_
+
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
 - Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -735,8 +735,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self : instance of Raw
             The raw object with annotations.
         """
+        meas_date = _handle_meas_date(self.info['meas_date'])
         if annotations is None:
-            self._annotations = Annotations([], [], [])
+            if self.info['meas_date'] is not None:
+                orig_time = meas_date
+            else:
+                orig_time = None
+            self._annotations = Annotations([], [], [], orig_time)
         else:
             _ensure_annotation_object(annotations)
 
@@ -752,10 +757,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                    ' taken in reference to the first sample of'
                                    ' the raw object.')
 
-            meas_date = _handle_meas_date(self.info['meas_date'])
             delta = 1. / self.info['sfreq']
             time_of_first_sample = meas_date + self.first_samp * delta
-
             new_annotations = annotations.copy()
             if annotations.orig_time is None:
                 # Assume annotations to be relative to the data

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -103,8 +103,7 @@ def test_basics():
     for empty_annot in (
             Annotations([], [], [], expected_orig_time),
             Annotations([], [], [], None),
-            None,
-            ):
+            None):
         raw.set_annotations(empty_annot)
         assert isinstance(raw.annotations, Annotations)
         assert len(raw.annotations) == 0

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -97,6 +97,19 @@ def test_basics():
     assert_array_equal(raw.annotations.description,
                        ['y', 'x', 'x', 'x', 'x', 'x', 'x'])
 
+    # These three things should be equivalent
+    expected_orig_time = (raw.info['meas_date'][0] +
+                          raw.info['meas_date'][1] / 1000000)
+    for empty_annot in (
+            Annotations([], [], [], expected_orig_time),
+            Annotations([], [], [], None),
+            None,
+            ):
+        raw.set_annotations(empty_annot)
+        assert isinstance(raw.annotations, Annotations)
+        assert len(raw.annotations) == 0
+        assert raw.annotations.orig_time == expected_orig_time
+
 
 def test_crop():
     """Test cropping with annotations."""


### PR DESCRIPTION
For consistency, whenever you call `set_annotations`, the resulting `raw.annotations` should have its `orig_time` set to match that of `raw`. See added test, which fails in `master` because previously calling it with `None` would have `orig_time=None`.