### PR TITLE
FIX: Use 8-char string for channel names from .locs (#6090)

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -313,8 +313,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         ch_names_ = data['name'].astype(str).tolist()
         pos = np.vstack((data['x'], data['y'], data['z'])).T
     elif ext in ('.loc', '.locs', '.eloc'):
-        ch_names_ = np.loadtxt(fname, dtype='S4',
-                               usecols=[3]).astype(str).tolist()
+        ch_names_ = np.genfromtxt(fname, dtype=str, usecols=3).tolist()
         topo = np.loadtxt(fname, dtype=float, usecols=[1, 2])
         sph = _topo_to_sph(topo)
         pos = _sph_to_cart(sph)


### PR DESCRIPTION
Channel names read from .loc, .locs, and .eloc files were truncated to 4 character strings ("S4" numpy dtype).  Using `dtype=str` lets numpy determine the required string length.

-------

_PR description edited after amending.  Original message follows_

Channel names read from .loc, .locs, and .eloc files were truncated to 4 character strings ("S4" numpy dtype).  Increasing to "S8" for consistency with other formats.

Fixes #6090

I considered making the dtype longer (perhaps as long as `S256`) to allow for more flexibility, but I didn't want to break consistency with channel names from other formats.  I could make the change for the other formats as well, but I don't know much about the formats to know if there are any limitations the parser should account for.  I also wonder whether supporting unicode characters in channel names (`dtype("U8")`) might be useful.