### PR TITLE
MRG: Better error message

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -1835,13 +1835,15 @@ def _read_annot(fname):
             raise IOError('Directory for annotation does not exist: %s',
                           fname)
         cands = os.listdir(dir_name)
-        cands = [c for c in cands if '.annot' in c]
+        cands = sorted(set(c.lstrip('lh.').lstrip('rh.').rstrip('.annot')
+                           for c in cands if '.annot' in c),
+                       key=lambda x: x.lower())
         if len(cands) == 0:
             raise IOError('No such file %s, no candidate parcellations '
                           'found in directory' % fname)
         else:
             raise IOError('No such file %s, candidate parcellations in '
-                          'that directory: %s' % (fname, ', '.join(cands)))
+                          'that directory:\n%s' % (fname, '\n'.join(cands)))
     with open(fname, "rb") as fid:
         n_verts = np.fromfile(fid, '>i4', 1)[0]
         data = np.fromfile(fid, '>i4', n_verts * 2).reshape(n_verts, 2)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -347,8 +347,9 @@ def test_annot_io():
     shutil.copy(os.path.join(surf_src, 'rh.white'), surf_dir)
 
     # read original labels
-    pytest.raises(IOError, read_labels_from_annot, subject, 'PALS_B12_Lobesey',
-                  subjects_dir=tempdir)
+    with pytest.raises(IOError, match='\nPALS_B12_Lobes$'):
+        read_labels_from_annot(subject, 'PALS_B12_Lobesey',
+                               subjects_dir=tempdir)
     labels = read_labels_from_annot(subject, 'PALS_B12_Lobes',
                                     subjects_dir=tempdir)
 


### PR DESCRIPTION
On `master` doing `read_labels_from_annot('fsaverage', 'HCPMMP1.combined')` gives an impenetrable wall of text:
> OSError: No such file Anatomy/fsaverage/label/lh.HCPMMP1.combined.annot, candidate parcellations in that directory: lh.PALS_B12_Lobes.annot, rh.aparc.annot, rh.aparc.a2009s.annot, rh.PALS_B12_Visuotopic.annot, rh.HCPMMP1.annot, rh.aparc_sub.annot, rh.PALS_B12_Brodmann.annot, lh.aparc.a2009s.annot, lh.PALS_B12_Brodmann.annot, rh.PALS_B12_Lobes.annot, lh.oasis.chubs.annot, lh.aparc_sub.annot, lh.Yeo2011_17Networks_N1000.annot, lh.HCPMMP1.annot, lh.PALS_B12_OrbitoFrontal.annot, lh.Yeo2011_7Networks_N1000.annot, lh.aparc.a2005s.annot, lh.HCPMMP1_combined.annot, rh.Yeo2011_17Networks_N1000.annot, rh.PALS_B12_OrbitoFrontal.annot, rh.aparc.a2005s.annot, rh.HCPMMP1_combined.annot, rh.oasis.chubs.annot, lh.PALS_B12_Visuotopic.annot, rh.Yeo2011_7Networks_N1000.annot, lh.aparc.annot

On this PR it gives:

> OSError: No such file Anatomy/fsaverage/label/lh.HCPMMP1.combined.annot, candidate parcellations in that directory:
> aparc
> aparc.a2005s
> aparc.a2009s
> aparc_sub
> HCPMMP1
> HCPMMP1_combined
> oasis.chubs
> PALS_B12_Brodm
> PALS_B12_Lobes
> PALS_B12_OrbitoFrontal
> PALS_B12_Visuotopic
>Yeo2011_17Networks_N1000
> Yeo2011_7Networks_N1000
```