### PR TITLE
DOC: Cleaner command line doc

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -340,15 +340,14 @@ div.highlight-console div.highlight span.gp {
 dl.cmd-list span.option {
     white-space: nowrap;
 }
-dl.cmd-list dt {
-    margin-top: 15px;
+dl.cmd-list dt, dl.cmd-list dd {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    padding-top: 0px;
+    padding-bottom: 5px;
     text-align: left;
     border-bottom: 1px solid #ddd;
 }
 dl.cmd-list dt::after {
     visibility: hidden;
-}
-dl.cmd-list dd {
-    margin-top: 15px;
-    border-bottom: 1px solid #ddd;
 }

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -322,3 +322,33 @@ div.highlight-console div.highlight span.gp {
     max-width: unset !important;
     min-width: unset !important;
 }
+/* Callout */
+.callout {
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #eee;
+    border-left-width: 5px;
+    border-left-color: #ddd;
+    /* background-color: #eee; */
+}
+.callout h3:first-child {
+    margin-top: 0;
+}
+.callout p:last-child {
+    margin-bottom: 0;
+}
+dl.cmd-list span.option {
+    white-space: nowrap;
+}
+dl.cmd-list dt {
+    margin-top: 15px;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+dl.cmd-list dt::after {
+    visibility: hidden;
+}
+dl.cmd-list dd {
+    margin-top: 15px;
+    border-bottom: 1px solid #ddd;
+}

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -18,8 +18,16 @@ def setup_module():
     pass
 
 
-header = """.. _python_commands:
+# Header markings go:
+# 1. =/= : Page title
+# 2. =   : Command name
+# 3. -/- : Command description
+# 4. -   : Command sections (Examples, Notes)
 
+header = """\
+.. _python_commands:
+
+===============================
 Command line tools using Python
 ===============================
 
@@ -36,22 +44,14 @@ command_rst = """
 %s
 %s
 
-.. raw:: html
-
-   <div>
-   <pre>
+.. rst-class:: callout
 
 %s
-
-.. raw:: html
-
-   </pre>
-   </div>
 
 """
 
 
-def generate_commands_rst(app):
+def generate_commands_rst(app=None):
     from sphinx_gallery import sphinx_compatibility
     out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
     if not op.isdir(out_dir):
@@ -60,8 +60,9 @@ def generate_commands_rst(app):
 
     command_path = op.abspath(
         op.join(os.path.dirname(__file__), '..', '..', 'mne', 'commands'))
-    fnames = [op.basename(fname)
-              for fname in glob.glob(op.join(command_path, 'mne_*.py'))]
+    fnames = sorted([
+        op.basename(fname)
+        for fname in glob.glob(op.join(command_path, 'mne_*.py'))])
     iterator = sphinx_compatibility.status_iterator(
         fnames, 'generating MNE command help ... ', length=len(fnames))
     with open(out_fname, 'w') as f:
@@ -72,9 +73,33 @@ def generate_commands_rst(app):
             output, _ = run_subprocess([sys.executable, run_name, '--help'],
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE, verbose=False)
+            output = output.splitlines()
+
+            # Swap usage and title lines
+            output[0], output[2] = output[2], output[0]
+
+            # Add header marking
+            for idx in (1, 0):
+                output.insert(idx, '-' * len(output[0]))
+
+            # Add "callout" styling for the "Usage: " line
+            for li, line in enumerate(output):
+                if line.startswith('Usage: mne '):
+                    output[li] = 'Usage: ``%s``' % line[7:]
+                    break
+
+            # Turn "Options:" into field list
+            if 'Options:' in output:
+                ii = output.index('Options:')
+                output[ii] = 'Options'
+                output.insert(ii + 1, '-------')
+                output.insert(ii + 2, '')
+                output.insert(ii + 3, '.. rst-class:: field-list cmd-list')
+                output.insert(ii + 4, '')
+            output = '\n'.join(output)
             f.write(command_rst % (cmd_name,
                                    cmd_name.replace('mne_', 'mne '),
-                                   '-' * len(cmd_name),
+                                   '=' * len(cmd_name),
                                    output))
     _replace_md5(out_fname)
     print('[Done]')

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -82,7 +82,7 @@ def generate_commands_rst(app=None):
             for idx in (1, 0):
                 output.insert(idx, '-' * len(output[0]))
 
-            # Add "callout" styling for the "Usage: " line
+            # Add code styling for the "Usage: " line
             for li, line in enumerate(output):
                 if line.startswith('Usage: mne '):
                     output[li] = 'Usage: ``%s``' % line[7:]

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 r"""Browse raw data.
 
-You can do for example:
+Examples
+--------
 
-$ mne browse_raw --raw sample_audvis_raw.fif \
-                 --proj sample_audvis_ecg-proj.fif \
-                 --eve sample_audvis_raw-eve.fif
+.. code-block:: console
+
+    $ mne browse_raw --raw sample_audvis_raw.fif \
+                     --proj sample_audvis_ecg-proj.fif \
+                     --eve sample_audvis_raw-eve.fif
 """
 
 # Authors : Eric Larson, PhD

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -3,7 +3,6 @@ r"""Browse raw data.
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne browse_raw --raw sample_audvis_raw.fif \

--- a/mne/commands/mne_bti2fiff.py
+++ b/mne/commands/mne_bti2fiff.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python
 r"""Import BTi / 4D MagnesWH3600 data to fif file.
 
-example usage: mne bti2fiff --pdf C,rfDC -o my_raw.fif
+Notes
+-----
+1. Currently direct inclusion of reference channel weights
+   is not supported. Please use \'mne_create_comp_data\' to include
+   the weights or use the low level functions from this module to
+   include them by yourself.
+2. The informed guess for the 4D name is E31 for the ECG channel and
+   E63, E63 for the EOG channels. Pleas check and adjust if those channels
+   are present in your dataset but 'ECG 01' and 'EOG 01', 'EOG 02' don't
+   appear in the channel names of the raw object.
 
-Note.
-1) Currently direct inclusion of reference channel weights
-is not supported. Please use \'mne_create_comp_data\' to include
-the weights or use the low level functions from this module to
-include them by yourself.
-2) The informed guess for the 4D name is E31 for the ECG channel and
-E63, E63 for the EOG channels. Pleas check and adjust if those channels
-are present in your dataset but 'ECG 01' and 'EOG 01', 'EOG 02' don't
-appear in the channel names of the raw object.
+Examples
+--------
+.. code-block:: console
+
+     $ mne bti2fiff --pdf C,rfDC -o my_raw.fif
+
 """
 
 # Authors: Denis A. Engemann  <denis.engemann@gmail.com>

--- a/mne/commands/mne_clean_eog_ecg.py
+++ b/mne/commands/mne_clean_eog_ecg.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne clean_eog_ecg -i in_raw.fif -o clean_raw.fif -e -c

--- a/mne/commands/mne_clean_eog_ecg.py
+++ b/mne/commands/mne_clean_eog_ecg.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 """Clean a raw file from EOG and ECG artifacts with PCA (ie SSP).
 
-You can do for example:
+Examples
+--------
 
-$ mne clean_eog_ecg -i in_raw.fif -o clean_raw.fif -e -c
+.. code-block:: console
+
+    $ mne clean_eog_ecg -i in_raw.fif -o clean_raw.fif -e -c
+
 """
 # Authors : Dr Engr. Sheraz Khan,  P.Eng, Ph.D.
 #           Engr. Nandita Shetty,  MS.

--- a/mne/commands/mne_compare_fiff.py
+++ b/mne/commands/mne_compare_fiff.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 """Compare FIFF files.
 
-You can do for example:
+Examples
+--------
 
-$ mne compare_fiff test_raw.fif test_raw_sss.fif
+.. code-block:: console
+
+    $ mne compare_fiff test_raw.fif test_raw_sss.fif
+
 """
 
 # Authors : Eric Larson, PhD

--- a/mne/commands/mne_compare_fiff.py
+++ b/mne/commands/mne_compare_fiff.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne compare_fiff test_raw.fif test_raw_sss.fif

--- a/mne/commands/mne_compute_proj_ecg.py
+++ b/mne/commands/mne_compute_proj_ecg.py
@@ -3,7 +3,6 @@ r"""Compute SSP/PCA projections for ECG artifacts.
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne compute_proj_ecg -i sample_audvis_raw.fif -c "MEG 1531" \

--- a/mne/commands/mne_compute_proj_ecg.py
+++ b/mne/commands/mne_compute_proj_ecg.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 r"""Compute SSP/PCA projections for ECG artifacts.
 
-You can do for example:
+Examples
+--------
 
-$ mne compute_proj_ecg -i sample_audvis_raw.fif -c "MEG 1531" \
-                       --l-freq 1 --h-freq 100 \
-                       --rej-grad 3000 --rej-mag 4000 --rej-eeg 100
+.. code-block:: console
+
+    $ mne compute_proj_ecg -i sample_audvis_raw.fif -c "MEG 1531" \
+                           --l-freq 1 --h-freq 100 \
+                           --rej-grad 3000 --rej-mag 4000 --rej-eeg 100
+
 """
 # Authors : Alexandre Gramfort, Ph.D.
 #           Martin Luessi, Ph.D.

--- a/mne/commands/mne_compute_proj_eog.py
+++ b/mne/commands/mne_compute_proj_eog.py
@@ -1,18 +1,23 @@
 #!/usr/bin/env python
 r"""Compute SSP/PCA projections for EOG artifacts.
 
-You can do for example:
+Examples
+--------
 
-$ mne compute_proj_eog -i sample_audvis_raw.fif \
-                       --l-freq 1 --h-freq 35 \
-                       --rej-grad 3000 --rej-mag 4000 --rej-eeg 100
+.. code-block:: console
+
+    $ mne compute_proj_eog -i sample_audvis_raw.fif \
+                           --l-freq 1 --h-freq 35 \
+                           --rej-grad 3000 --rej-mag 4000 --rej-eeg 100
 
 or
 
-$ mne compute_proj_eog -i sample_audvis_raw.fif \
-                       --l-freq 1 --h-freq 35 \
-                       --rej-grad 3000 --rej-mag 4000 --rej-eeg 100 \
-                       --proj sample_audvis_ecg-proj.fif
+.. code-block:: console
+
+    $ mne compute_proj_eog -i sample_audvis_raw.fif \
+                           --l-freq 1 --h-freq 35 \
+                           --rej-grad 3000 --rej-mag 4000 --rej-eeg 100 \
+                           --proj sample_audvis_ecg-proj.fif
 
 to exclude ECG artifacts from projection computation.
 """

--- a/mne/commands/mne_compute_proj_eog.py
+++ b/mne/commands/mne_compute_proj_eog.py
@@ -3,7 +3,6 @@ r"""Compute SSP/PCA projections for EOG artifacts.
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne compute_proj_eog -i sample_audvis_raw.fif \

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -3,7 +3,13 @@
 
 """Open the coregistration GUI.
 
-example usage:  $ mne coreg
+Examples
+--------
+
+.. code-block:: console
+
+    $ mne coreg
+
 """
 
 import os.path as op

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -5,7 +5,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne coreg

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne flash_bem --subject=sample

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
 """Create 3-layer BEM model from Flash MRI images.
 
+Examples
+--------
+
+.. code-block:: console
+
+    $ mne flash_bem --subject=sample
+
+Notes
+-----
 This program assumes that FreeSurfer and MNE are installed and
 sourced properly.
 
@@ -14,26 +23,22 @@ should be, as usual, in the subject's mri directory.
 Before running this script do the following:
 (unless the --noconvert option is specified)
 
-    1. Copy all of your FLASH images in a single directory <source> and
-       create a directory <dest> to hold the output of mne_organize_dicom
-    2. cd to <dest> and run
-       $ mne_organize_dicom <source>
-       to create an appropriate directory structure
-    3. Create symbolic links to make flash05 and flash30 point to the
-       appropriate series:
-       $ ln -s <FLASH 5 series dir> flash05
-       $ ln -s <FLASH 30 series dir> flash30
-       Some partition formats (e.g. FAT32) do not support symbolic links.
-       In this case, copy the file to the appropriate series:
-       $ cp <FLASH 5 series dir> flash05
-       $ cp <FLASH 30 series dir> flash30
-    4. cd to the directory where flash05 and flash30 links are
-    5. Set SUBJECTS_DIR and SUBJECT environment variables appropriately
-    6. Run this script
-
-Example usage:
-
-$ mne flash_bem --subject=sample
+1. Copy all of your FLASH images in a single directory <source> and
+   create a directory <dest> to hold the output of mne_organize_dicom
+2. cd to <dest> and run
+   $ mne_organize_dicom <source>
+   to create an appropriate directory structure
+3. Create symbolic links to make flash05 and flash30 point to the
+   appropriate series:
+   $ ln -s <FLASH 5 series dir> flash05
+   $ ln -s <FLASH 30 series dir> flash30
+   Some partition formats (e.g. FAT32) do not support symbolic links.
+   In this case, copy the file to the appropriate series:
+   $ cp <FLASH 5 series dir> flash05
+   $ cp <FLASH 30 series dir> flash30
+4. cd to the directory where flash05 and flash30 links are
+5. Set SUBJECTS_DIR and SUBJECT environment variables appropriately
+6. Run this script
 """
 # Authors: Lorenzo De Santis
 

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 """View the 3-Layers BEM model using Freeview.
 
-You can do for example:
+Examples
+--------
 
-$ mne freeview_bem_surfaces -s sample
+.. code-block:: console
+
+    $ mne freeview_bem_surfaces -s sample
+
 """
 # Authors:  Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne freeview_bem_surfaces -s sample

--- a/mne/commands/mne_kit2fiff.py
+++ b/mne/commands/mne_kit2fiff.py
@@ -5,7 +5,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne kit2fiff --input input.sqd --output output.fif

--- a/mne/commands/mne_kit2fiff.py
+++ b/mne/commands/mne_kit2fiff.py
@@ -3,8 +3,18 @@
 
 """Import KIT / NYU data to fif file.
 
-example usage:  $ mne kit2fiff --input input.sqd --output output.fif
-Use without arguments to invoke GUI:  $ mne kt2fiff
+Examples
+--------
+
+.. code-block:: console
+
+    $ mne kit2fiff --input input.sqd --output output.fif
+
+Use without arguments to invoke GUI:
+
+.. code-block:: console
+
+    $ mne kt2fiff
 
 """
 

--- a/mne/commands/mne_make_scalp_surfaces.py
+++ b/mne/commands/mne_make_scalp_surfaces.py
@@ -8,7 +8,13 @@
 
 """Create high-resolution head surfaces for coordinate alignment.
 
-example usage: mne make_scalp_surfaces --overwrite --subject sample
+Examples
+--------
+
+.. code-block:: console
+
+    $ mne make_scalp_surfaces --overwrite --subject sample
+
 """
 import os
 import copy

--- a/mne/commands/mne_make_scalp_surfaces.py
+++ b/mne/commands/mne_make_scalp_surfaces.py
@@ -10,7 +10,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne make_scalp_surfaces --overwrite --subject sample

--- a/mne/commands/mne_maxfilter.py
+++ b/mne/commands/mne_maxfilter.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne maxfilter -i sample_audvis_raw.fif --st

--- a/mne/commands/mne_maxfilter.py
+++ b/mne/commands/mne_maxfilter.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 """Apply MaxFilter.
 
-Example usage:
+Examples
+--------
 
-$ mne maxfilter -i sample_audvis_raw.fif --st
+.. code-block:: console
+
+    $ mne maxfilter -i sample_audvis_raw.fif --st
 
 This will apply MaxFilter with the MaxSt extension. The origin used
 by MaxFilter is computed by mne-python by fitting a sphere to the

--- a/mne/commands/mne_report.py
+++ b/mne/commands/mne_report.py
@@ -3,7 +3,6 @@ r"""Create mne report for a folder.
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne report -p MNE-sample-data/ \

--- a/mne/commands/mne_report.py
+++ b/mne/commands/mne_report.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 r"""Create mne report for a folder.
 
-Example usage
+Examples
+--------
 
-mne report -p MNE-sample-data/ -i \
-MNE-sample-data/MEG/sample/sample_audvis-ave.fif -d MNE-sample-data/subjects/ \
--s sample
+.. code-block:: console
+
+    $ mne report -p MNE-sample-data/ \
+        -i MNE-sample-data/MEG/sample/sample_audvis-ave.fif \
+        -d MNE-sample-data/subjects/ \
+        -s sample
 
 """
 

--- a/mne/commands/mne_show_fiff.py
+++ b/mne/commands/mne_show_fiff.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python
 """Show the contents of a FIFF file.
 
-You can do for example:
+Examples
+--------
 
-$ mne show_fiff test_raw.fif
+.. code-block:: console
+
+    $ mne show_fiff test_raw.fif
+
 
 To see only tag 102:
 
-$ mne show_fiff test_raw.fif --tag=102
+.. code-block:: console
+
+    $ mne show_fiff test_raw.fif --tag=102
+
 """
 
 # Authors : Eric Larson, PhD

--- a/mne/commands/mne_show_fiff.py
+++ b/mne/commands/mne_show_fiff.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne show_fiff test_raw.fif

--- a/mne/commands/mne_show_info.py
+++ b/mne/commands/mne_show_info.py
@@ -3,7 +3,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne show_info sample_audvis_raw.fif
@@ -33,6 +32,7 @@ def run():
     info = mne.io.read_info(fname)
     print("File : %s" % fname)
     print(info)
+
 
 is_main = (__name__ == '__main__')
 if is_main:

--- a/mne/commands/mne_show_info.py
+++ b/mne/commands/mne_show_info.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 """Show measurement info from .fif file.
 
-You can do for example:
+Examples
+--------
 
-$ mne show_info sample_audvis_raw.fif
+.. code-block:: console
+
+    $ mne show_info sample_audvis_raw.fif
+
 """
 
 # Authors : Alexandre Gramfort, Ph.D.

--- a/mne/commands/mne_surf2bem.py
+++ b/mne/commands/mne_surf2bem.py
@@ -3,7 +3,6 @@ r"""Convert surface to BEM FIF file.
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne surf2bem --surf ${SUBJECTS_DIR}/${SUBJECT}/surf/lh.seghead \

--- a/mne/commands/mne_surf2bem.py
+++ b/mne/commands/mne_surf2bem.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 r"""Convert surface to BEM FIF file.
 
-Example usage
+Examples
+--------
 
-mne surf2bem --surf ${SUBJECTS_DIR}/${SUBJECT}/surf/lh.seghead --fif \
-${SUBJECTS_DIR}/${SUBJECT}/bem/${SUBJECT}-head.fif --id=4
+.. code-block:: console
+
+    $ mne surf2bem --surf ${SUBJECTS_DIR}/${SUBJECT}/surf/lh.seghead \
+        --fif ${SUBJECTS_DIR}/${SUBJECT}/bem/${SUBJECT}-head.fif \
+        --id=4
+
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #

--- a/mne/commands/mne_watershed_bem.py
+++ b/mne/commands/mne_watershed_bem.py
@@ -2,9 +2,13 @@
 # Authors: Lorenzo De Santis
 """Create BEM surfaces using the watershed algorithm included with FreeSurfer.
 
-You can do for example:
+Examples
+--------
 
-$ mne watershed_bem -s sample
+.. code-block:: console
+
+    $ mne watershed_bem -s sample
+
 """
 
 import sys

--- a/mne/commands/mne_watershed_bem.py
+++ b/mne/commands/mne_watershed_bem.py
@@ -4,7 +4,6 @@
 
 Examples
 --------
-
 .. code-block:: console
 
     $ mne watershed_bem -s sample


### PR DESCRIPTION
I find it not so easy to read our [command-line docs](http://mne-tools.github.io/dev/generated/commands.html#mne-flash-bem):

![Screenshot from 2019-03-29 17-46-04](https://user-images.githubusercontent.com/2365790/55264390-8db4ba80-524a-11e9-8513-b39746933326.png)

Basically I tried to compromise between:

1. Compactness
2. Readability
3. Our API doc style/sections
4. What's standard in command-line utils, which is:
    ```console
    larsoner@bunk:~/python/mne-python/doc$ grep --help
    Usage: grep [OPTION]... PATTERN [FILE]...
    Search for PATTERN in each FILE.
    Example: grep -i 'hello world' menu.h main.c

    Pattern selection and interpretation:
      -E, --extended-regexp     PATTERN is an extended regular expression
      -F, --fixed-strings       PATTERN is a set of newline-separated strings
      -G, --basic-regexp        PATTERN is a basic regular expression (default)
      -P, --perl-regexp         PATTERN is a Perl regular expression
    ...
    ```

This is the result:

![Screenshot from 2019-03-29 17-45-31](https://user-images.githubusercontent.com/2365790/55264369-74ac0980-524a-11e9-9c3e-a9cae04584f3.png)