### PR TITLE
MRG: Percent signs, regression test

### DIFF
--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -650,7 +650,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         Use adaptive weights to combine the tapered spectra into CSD. Only used
         in 'multitaper' mode. Defaults to False.
     mt_low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth. Only used in 'multitaper' mode. Defaults to True.
     cwt_n_cycles: float | list of float | None
         Number of cycles to use when constructing Morlet wavelets. Fixed number

--- a/mne/connectivity/effective.py
+++ b/mne/connectivity/effective.py
@@ -76,7 +76,7 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
         Use adaptive weights to combine the tapered spectra into PSD.
         Only used in 'multitaper' mode.
     mt_low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth. Only used in 'multitaper' mode.
     cwt_freqs : array
         Array of frequencies of interest. Only used in 'cwt_morlet' mode.

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -583,7 +583,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
         Use adaptive weights to combine the tapered spectra into PSD.
         Only used in 'multitaper' mode.
     mt_low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth. Only used in 'multitaper' mode.
     cwt_freqs : array
         Array of frequencies of interest. Only used in 'cwt_morlet' mode.

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -338,7 +338,7 @@ class PSDEstimator(TransformerMixin):
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     n_jobs : int
         Number of parallel jobs to use (only used if adaptive=True).

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1080,27 +1080,12 @@ def compute_depth_prior(forward, info, is_fixed_ori=None,
     patch_areas : ndarray | None
         Deprecated, will be removed in 0.19.
     limit_depth_chs : bool | 'whiten'
-        How to deal with multiple channel types in depth weighting. Options:
+        How to deal with multiple channel types in depth weighting.
+        The default is True, which whitens based on the source sensitivity
+        of the highest-SNR channel type. See Notes for details.
 
-        :data:`python:True` (default)
-            Use only grad channels in depth weighting (equivalent to MNE C
-            minimum-norm code). If grad channels aren't present, only mag
-            channels will be used (if no mag, then eeg). This makes the depth
-            prior dependent only on the sensor geometry (and relationship
-            to the sources).
-        ``'whiten'``
-            Compute a whitener and apply it to the channels before computing
-            the depth prior. In this case ``noise_cov`` must not be None.
-
-            .. versionadded:: 0.18
-        :data:`python:False`
-            Use all channels. Only recommended when the gain matrix has
-            already been whitened (otherwise it will be arbitrarily
-            biased toward whichever channel type has the largest values in
-            SI units). Whitening the gain matrix makes the depth prior
-            depend on both sensor geometry and the data of interest captured
-            by the noise covariance (e.g., projections, SNR).
-
+        .. versionchanged:: 0.18
+           Added the "whiten" option.
     combine_xyz : 'spectral' | 'fro'
         When a loose (or free) orientation is used, how the depth weighting
         for each triplet should be calculated.
@@ -1139,6 +1124,27 @@ def compute_depth_prior(forward, info, is_fixed_ori=None,
 
         compute_depth_prior(..., limit=None, limit_depth_chs='whiten',
                             combine_xyz='fro')
+
+    The ``limit_depth_chs`` argument can take the following values:
+
+    * :data:`python:True` (default)
+          Use only grad channels in depth weighting (equivalent to MNE C
+          minimum-norm code). If grad channels aren't present, only mag
+          channels will be used (if no mag, then eeg). This makes the depth
+          prior dependent only on the sensor geometry (and relationship
+          to the sources).
+    * ``'whiten'``
+          Compute a whitener and apply it to the gain matirx before computing
+          the depth prior. In this case ``noise_cov`` must not be None.
+          Whitening the gain matrix makes the depth prior
+          depend on both sensor geometry and the data of interest captured
+          by the noise covariance (e.g., projections, SNR).
+
+          .. versionadded:: 0.18
+    * :data:`python:False`
+          Use all channels. Not recommended since the depth weighting will be
+          biased toward whichever channel type has the largest values in
+          SI units (such as EEG being orders of magnitude larger than MEG).
 
     """
     from ..cov import Covariance, compute_whitener

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -461,7 +461,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
 
         .. versionadded:: 0.17
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
 
         .. versionadded:: 0.17
@@ -722,7 +722,7 @@ def compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     return_generator : bool
         Return a generator object instead of a list. This allows iterating

--- a/mne/preprocessing/flat.py
+++ b/mne/preprocessing/flat.py
@@ -28,7 +28,7 @@ def mark_flat(raw, bad_percent=5., min_duration=0.005, picks=None,
     min_duration : float
         The minimum duration (sec) to consider as actually flat.
         For some systems with low bit data representations, adjacent
-        channels with exactly the same value are not totally uncommon.
+        time samples with exactly the same value are not totally uncommon.
         Defaults to 0.005 (5 ms).
     %(picks_good_data)s
     %(verbose)s

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1012,16 +1012,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
             The transform to be applied, including parameters (see, e.g.,
             :func:`functools.partial`). The first parameter of the function is
             the input data. The first two dimensions of the transformed data
-            should be (i) vertices and (ii) time.  Transforms which yield 3D
-            output (e.g. time-frequency transforms) are valid, so long as the
-            first two dimensions are vertices and time.  In this case, the
-            copy parameter (see below) must be True and a list of
-            SourceEstimates, rather than a single instance of SourceEstimate,
-            will be returned, one for each index of the 3rd dimension of the
-            transformed data.  In the case of transforms yielding 2D output
-            (e.g. filtering), the user has the option of modifying the input
-            inplace (copy = False) or returning a new instance of
-            SourceEstimate (copy = True) with the transformed data.
+            should be (i) vertices and (ii) time.  See Notes for details.
         idx : array | None
             Indices of source time courses for which to compute transform.
             If None, all time courses are used.
@@ -1042,6 +1033,17 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
         Notes
         -----
+        Transforms which yield 3D
+        output (e.g. time-frequency transforms) are valid, so long as the
+        first two dimensions are vertices and time.  In this case, the
+        copy parameter must be True and a list of
+        SourceEstimates, rather than a single instance of SourceEstimate,
+        will be returned, one for each index of the 3rd dimension of the
+        transformed data.  In the case of transforms yielding 2D output
+        (e.g. filtering), the user has the option of modifying the input
+        inplace (copy = False) or returning a new instance of
+        SourceEstimate (copy = True) with the transformed data.
+
         Applying transforms can be significantly faster if the
         SourceEstimate object was created using "(kernel, sens_data)", for
         the "data" parameter as the transform is applied in sensor space.

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -769,7 +769,7 @@ def csd_array_multitaper(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD.
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     projs : list of Projection | None
         List of projectors to store in the CSD object. Defaults to ``None``,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -382,7 +382,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     normalization : str
         Either "full" or "length" (default). If "full", the PSD will

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -233,7 +233,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     normalization : str
         Either "full" or "length" (default). If "full", the PSD will

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -54,9 +54,9 @@ picks : list | slice | None
 # Rank
 docdict['rank'] = """
 rank : None | dict | 'info' | 'full'
-        This controls the rank computation that can be read from the
-        measurement info or estimated from the data. See ``Notes``
-        of :func:`mne.compute_rank` for details."""
+    This controls the rank computation that can be read from the
+    measurement info or estimated from the data. See ``Notes``
+    of :func:`mne.compute_rank` for details."""
 docdict['rank_None'] = docdict['rank'] + 'The default is None.'
 docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -856,7 +856,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
     low_bias : bool
-        Only use tapers with more than 90% spectral concentration within
+        Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     normalization : str
         Either "full" or "length" (default). If "full", the PSD will


### PR DESCRIPTION
Closes #6102.

Also shortens a few very long param descriptions, which should help readability.

I thought about adding the `mt_*` params to the `docdict` but figured we can do it later if we need to, since there weren't too many of them (and the text has been stable for years).