### PR TITLE
ENH: Make only one copy during crop

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -132,8 +132,8 @@ def test_time_frequency():
     assert 'mag' not in power
     assert 'eeg' not in power
 
-    assert_equal(power.nave, nave)
-    assert_equal(itc.nave, nave)
+    assert power.nave == nave
+    assert itc.nave == nave
     assert (power.data.shape == (len(picks), len(freqs), len(times)))
     assert (power.data.shape == itc.data.shape)
     assert (power_.data.shape == (len(picks), len(freqs), 2))
@@ -145,11 +145,11 @@ def test_time_frequency():
     itc2 = itc.copy()
     itc2.info['bads'] = [itc2.ch_names[0]]  # test channel drop
     gave = grand_average([itc2, itc])
-    assert_equal(gave.data.shape, (itc2.data.shape[0] - 1,
-                                   itc2.data.shape[1],
-                                   itc2.data.shape[2]))
-    assert_equal(itc2.ch_names[1:], gave.ch_names)
-    assert_equal(gave.nave, 2)
+    assert gave.data.shape == (itc2.data.shape[0] - 1,
+                               itc2.data.shape[1],
+                               itc2.data.shape[2])
+    assert itc2.ch_names[1:] == gave.ch_names
+    assert gave.nave == 2
     itc2.drop_channels(itc2.info["bads"])
     assert_array_almost_equal(gave.data, itc2.data)
     itc2.data = np.ones(itc2.data.shape)
@@ -365,17 +365,20 @@ def test_crop():
 
     tfr.crop(tmin=0.2)
     assert_array_equal(tfr.times, [0.2, 0.3, 0.4, 0.5])
-    assert_equal(tfr.data.shape[-1], 4)
+    assert tfr.data.ndim == 3
+    assert tfr.data.shape[-1] == 4
 
     tfr.crop(fmax=0.3)
-    assert_equal(tfr.freqs, [0.1, 0.2, 0.3])
-    assert_equal(tfr.data.shape[-2], 3)
+    assert_array_equal(tfr.freqs, [0.1, 0.2, 0.3])
+    assert tfr.data.ndim == 3
+    assert tfr.data.shape[-2] == 3
 
     tfr.crop(tmin=0.3, tmax=0.4, fmin=0.1, fmax=0.2)
     assert_array_equal(tfr.times, [0.3, 0.4])
-    assert_equal(tfr.data.shape[-1], 2)
-    assert_equal(tfr.freqs, [0.1, 0.2])
-    assert_equal(tfr.data.shape[-2], 2)
+    assert tfr.data.ndim == 3
+    assert tfr.data.shape[-1] == 2
+    assert_array_equal(tfr.freqs, [0.1, 0.2])
+    assert tfr.data.shape[-2] == 2
 
 
 @requires_h5py

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -907,7 +907,12 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
 
         self.times = self.times[time_mask]
         self.freqs = self.freqs[freq_mask]
-        self.data = self.data[..., freq_mask, :][..., time_mask]
+        # Deal with broadcasting (boolean arrays do not broadcast, but indices
+        # do, so we need to convert freq_mask to make use of broadcasting)
+        if isinstance(time_mask, np.ndarray) and \
+                isinstance(freq_mask, np.ndarray):
+            freq_mask = np.where(freq_mask)[0][:, np.newaxis]
+        self.data = self.data[..., freq_mask, time_mask]
         return self
 
     def copy(self):


### PR DESCRIPTION
The more efficient version of #6080.

It was even trickier than I realized, since boolean indices do not broadcast, but proper integer indices do, so first we convert with `np.where` then use broadcasting rules to achieve the desired result.

@DiGyt can you take a look?

I also converted some of our old `assert_equal` to simpler/more explicit `assert ` or `assert_array_equal` statements.