### PR TITLE
BUG: Fix broken links

### DIFF
--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -99,7 +99,7 @@
 .. _NVIDIA proprietary drivers: https://www.nvidia.com/Download/index.aspx
 
 .. _Sphinx documentation: http://sphinx-doc.org/rest.html
-.. _sphinx gallery documentation: https://sphinx-gallery.readthedocs.io/en/latest/configuration.html
+.. _sphinx gallery documentation: https://sphinx-gallery.github.io
 .. _NumPy docstring standard: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 .. _Stack Overflow: https://stackoverflow.com/
 

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -209,8 +209,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
 
     Notes
     -----
-    This code is based on the circle graph example by Nicolas P. Rougier
-    http://www.labri.fr/perso/nrougier/coding/.
+    This code is based on a circle graph example by Nicolas P. Rougier
 
     By default, :func:`matplotlib.pyplot.savefig` does not take ``facecolor``
     into account when saving, even if set when a figure is generated. This


### PR DESCRIPTION
Takes care of two broken links found by our weekly `linkcheck`:

https://circleci.com/gh/mne-tools/mne-python/12041?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

I couldn't find a newer version of Nicolas Rougier's example, so I removed it. (Hopefully the remaining attribution is enough.)