### PR TITLE
MRG: envcorr for free ori source spaces

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -294,6 +294,7 @@ intersphinx_mapping = {
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
     'sklearn': ('https://scikit-learn.org/stable', None),
+    'joblib': ('https://joblib.readthedocs.io/en/latest', None),
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),
     'nibabel': ('https://nipy.org/nibabel', None),
     'nilearn': ('http://nilearn.github.io', None),
@@ -439,6 +440,8 @@ numpydoc_xref_aliases = {
     'mlab.Figure': 'mayavi.core.api.Scene',
     # sklearn
     'LeaveOneOut': 'sklearn.model_selection.LeaveOneOut',
+    # joblib
+    'joblib.Parallel': 'joblib.Parallel',
     # nibabel
     'Nifti1Image': 'nibabel.nifti1.Nifti1Image',
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -633,6 +633,7 @@ this package. You can also find a gallery of these examples in the
     auto_examples/connectivity/plot_mixed_source_space_connectivity.rst
     auto_examples/connectivity/plot_mne_inverse_coherence_epochs.rst
     auto_examples/connectivity/plot_mne_inverse_envelope_correlation.rst
+    auto_examples/connectivity/plot_mne_inverse_envelope_correlation_volume.rst
     auto_examples/connectivity/plot_mne_inverse_connectivity_spectrum.rst
     auto_examples/connectivity/plot_mne_inverse_label_connectivity.rst
     auto_examples/connectivity/plot_mne_inverse_psi_visual.rst

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,8 @@ Changelog
 
 - Add new tutorial on :ref:`plot_eeg_no_mri` by `Alex Gramfort`_, and `Joan Massich`_
 
+- Add :meth:`mne.Epochs.apply_hilbert` and :meth:`mne.Evoked.apply_hilbert` by `Eric Larson`_
+
 - Add convenience ``fsaverage`` subject dataset fetcher / updater :func:`mne.datasets.fetch_fsaverage` by `Eric Larson`_
 
 - Add ``fmin`` and ``fmax`` argument to :meth:`mne.time_frequency.AverageTFR.crop` and to :meth:`mne.time_frequency.EpochsTFR.crop` to crop TFR objects along frequency axis by `Dirk Gütlin`_

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
@@ -1,12 +1,11 @@
 """
-=============================================
-Compute envelope correlations in source space
-=============================================
+====================================================
+Compute envelope correlations in volume source space
+====================================================
 
 Compute envelope correlations of orthogonalized activity [1]_ [2]_ in source
-space using resting state CTF data.
+space using resting state CTF data in a volume source space.
 """
-# sphinx_gallery_thumbnail_number = 2
 
 # Authors: Eric Larson <larson.eric.d@gmail.com>
 #          Sheraz Khan <sheraz@khansheraz.com>
@@ -16,12 +15,9 @@ space using resting state CTF data.
 
 import os.path as op
 
-import numpy as np
-import matplotlib.pyplot as plt
-
 import mne
+from mne.beamformer import make_lcmv, apply_lcmv_epochs
 from mne.connectivity import envelope_correlation
-from mne.minimum_norm import make_inverse_operator, apply_inverse_epochs
 from mne.preprocessing import compute_proj_ecg, compute_proj_eog
 
 data_path = mne.datasets.brainstorm.bst_resting.data_path()
@@ -32,13 +28,14 @@ src = op.join(subjects_dir, subject, 'bem', subject + '-oct-6-src.fif')
 bem = op.join(subjects_dir, subject, 'bem', subject + '-5120-bem-sol.fif')
 raw_fname = op.join(data_path, 'MEG', 'bst_resting',
                     'subj002_spontaneous_20111102_01_AUX.ds')
+crop_to, method = 60., 'lcmv'
 
 ##############################################################################
 # Here we do some things in the name of speed, such as crop (which will
 # hurt SNR) and downsample. Then we compute SSP projectors and apply them.
 
 raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
-raw.crop(0, 60).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.crop(0, crop_to).load_data().pick_types(meg=True, eeg=False).resample(80)
 raw.apply_gradient_compensation(3)
 projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
 projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')
@@ -60,42 +57,34 @@ del raw
 # Compute the forward and inverse
 # -------------------------------
 
-src = mne.read_source_spaces(src)
+# This source space is really far too coarse, but we do this for speed
+# considerations here
+pos = 15.  # 1.5 cm is very broad, done here for speed!
+src = mne.setup_volume_source_space('bst_resting', pos, bem=bem,
+                                    subjects_dir=subjects_dir, verbose=True)
 fwd = mne.make_forward_solution(epochs.info, trans, src, bem)
-inv = make_inverse_operator(epochs.info, fwd, cov)
-del fwd, src
+data_cov = mne.compute_covariance(epochs)
+filters = make_lcmv(epochs.info, fwd, data_cov, 0.05, cov,
+                    pick_ori='max-power', weight_norm='nai')
+del fwd
 
 ##############################################################################
 # Compute label time series and do envelope correlation
 # -----------------------------------------------------
 
-labels = mne.read_labels_from_annot(subject, 'aparc_sub',
-                                    subjects_dir=subjects_dir)
-epochs.apply_hilbert()  # faster to apply in sensor space
-stcs = apply_inverse_epochs(epochs, inv, lambda2=1. / 9., pick_ori='normal',
-                            return_generator=True)
-label_ts = mne.extract_label_time_course(
-    stcs, labels, inv['src'], return_generator=True)
-corr = envelope_correlation(label_ts, verbose=True)
-
-# let's plot this matrix
-fig, ax = plt.subplots(figsize=(4, 4))
-ax.imshow(corr, cmap='viridis', clim=np.percentile(corr, [5, 95]))
-fig.tight_layout()
+epochs.apply_hilbert()  # faster to do in sensor space
+stcs = apply_lcmv_epochs(epochs, filters, return_generator=True)
+corr = envelope_correlation(stcs, verbose=True)
 
 ##############################################################################
 # Compute the degree and plot it
 # ------------------------------
 
-threshold_prop = 0.15  # percentage of strongest edges to keep in the graph
-degree = mne.connectivity.degree(corr, threshold_prop=threshold_prop)
-stc = mne.labels_to_stc(labels, degree)
-stc = stc.in_label(mne.Label(inv['src'][0]['vertno'], hemi='lh') +
-                   mne.Label(inv['src'][1]['vertno'], hemi='rh'))
+degree = mne.connectivity.degree(corr, 0.15)
+stc = mne.VolSourceEstimate(degree, src[0]['vertno'], 0, 1, 'bst_resting')
 brain = stc.plot(
-    clim=dict(kind='percent', lims=[75, 85, 95]), colormap='gnuplot',
-    subjects_dir=subjects_dir, views='dorsal', hemi='both',
-    smoothing_steps=25, time_label='Beta band')
+    src, clim=dict(kind='percent', lims=[75, 85, 95]), colormap='gnuplot',
+    subjects_dir=subjects_dir, mode='glass_brain')
 
 ##############################################################################
 # References

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
@@ -24,7 +24,6 @@ data_path = mne.datasets.brainstorm.bst_resting.data_path()
 subjects_dir = op.join(data_path, 'subjects')
 subject = 'bst_resting'
 trans = op.join(data_path, 'MEG', 'bst_resting', 'bst_resting-trans.fif')
-src = op.join(subjects_dir, subject, 'bem', subject + '-oct-6-src.fif')
 bem = op.join(subjects_dir, subject, 'bem', subject + '-5120-bem-sol.fif')
 raw_fname = op.join(data_path, 'MEG', 'bst_resting',
                     'subj002_spontaneous_20111102_01_AUX.ds')

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -7,6 +7,7 @@
 import numpy as np
 
 from ..filter import next_fast_len
+from ..source_estimate import _BaseSourceEstimate
 from ..utils import verbose, _check_combine
 
 
@@ -19,7 +20,8 @@ def envelope_correlation(data, combine='mean', verbose=None):
     data : array-like, shape=(n_epochs, n_signals, n_times) | generator
         The data from which to compute connectivity.
         The array-like object can also be a list/generator of array,
-        each with shape (n_signals, n_times). If it's float data,
+        each with shape (n_signals, n_times), or a :class:`~mne.SourceEstimate`
+        object (and ``stc.data`` will be used). If it's float data,
         the Hilbert transform will be applied; if it's complex data,
         it's assumed the Hilbert has already been applied.
     combine : 'mean' | callable | None
@@ -53,23 +55,28 @@ def envelope_correlation(data, combine='mean', verbose=None):
            Neuroimage 174:57–68
     """
     from scipy.signal import hilbert
-    corrs = list()
     n_nodes = None
     if combine is not None:
         fun = _check_combine(combine, valid=('mean',))
     else:  # None
         fun = np.array
 
+    corrs = list()
+    # Note: This is embarassingly parallel, but the overhead of sending
+    # the data to different workers is roughly the same as the gain of
+    # using multiple CPUs. And we require too much GIL for prefer='threading'
+    # to help.
     for epoch_data in data:
+        if isinstance(epoch_data, _BaseSourceEstimate):
+            epoch_data = epoch_data.data
         if epoch_data.ndim != 2:
             raise ValueError('Each entry in data must be 2D, got shape %s'
                              % (epoch_data.shape,))
-        this_n_nodes, n_times = epoch_data.shape
-        if n_nodes is None:
-            n_nodes = this_n_nodes
-        if this_n_nodes != n_nodes:
-            raise ValueError('n_nodes mismatch between epochs, got %s and %s'
-                             % (n_nodes, this_n_nodes))
+        n_nodes, n_times = epoch_data.shape
+        if ei > 0 and n_nodes != corrs[0].shape[0]:
+            raise ValueError('n_nodes mismatch between data[0] and data[%d], '
+                             'got %s and %s'
+                             % (ei, n_nodes, corrs[0].shape[0]))
         # Get the complex envelope (allowing complex inputs allows people
         # to do raw.apply_hilbert if they want)
         if epoch_data.dtype in (np.float32, np.float64):

--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -66,7 +66,7 @@ def envelope_correlation(data, combine='mean', verbose=None):
     # the data to different workers is roughly the same as the gain of
     # using multiple CPUs. And we require too much GIL for prefer='threading'
     # to help.
-    for epoch_data in data:
+    for ei, epoch_data in enumerate(data):
         if isinstance(epoch_data, _BaseSourceEstimate):
             epoch_data = epoch_data.data
         if epoch_data.ndim != 2:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -41,7 +41,7 @@ from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
-from .filter import detrend, FilterMixin
+from .filter import detrend, FilterMixin, HilbertMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
@@ -185,7 +185,8 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
 @fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
-                 ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin):
+                 ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin,
+                 HilbertMixin):
     """Abstract base class for Epochs-type classes.
 
     This class provides basic functionality and should never be instantiated
@@ -850,6 +851,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             data = np.zeros((n_channels, n_times))
             n_events = 0
             for e in self:
+                if np.iscomplexobj(e):
+                    data = data.astype(np.complex128)
                 data += e
                 n_events += 1
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -16,7 +16,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin,
                                 equalize_channels)
 from .channels.layout import _merge_grad_data, _pair_grad_sensors
-from .filter import detrend, FilterMixin
+from .filter import detrend, FilterMixin, HilbertMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     SizeMixin, copy_function_doc_to_method_doc, _validate_type,
                     fill_doc, _check_option)
@@ -46,7 +46,7 @@ _aspect_rev = {val: key for key, val in _aspect_dict.items()}
 @fill_doc
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              InterpolationMixin, FilterMixin, ToDataFrameMixin, TimeMixin,
-             SizeMixin):
+             SizeMixin, HilbertMixin):
     """Evoked data.
 
     Parameters

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2110,7 +2110,6 @@ class HilbertMixin(object):
 
         Notes
         -----
-
         **Parameters**
 
         If ``envelope=False``, the analytic signal for the channels defined in

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1116,7 +1116,7 @@ def test_hilbert():
     assert raw_filt._data.shape == raw_filt_2._data.shape
     assert_allclose(raw_filt._data[:, 50:-50], raw_filt_2._data[:, 50:-50],
                     atol=1e-13, rtol=1e-2)
-    with pytest.raises(ValueError, match='n_fft must be greater than n_times'):
+    with pytest.raises(ValueError, match='n_fft.*must be at least the number'):
         raw3.apply_hilbert(picks, n_fft=raw3.n_times - 100)
 
     env = np.abs(raw._data[picks, :])

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1114,8 +1114,8 @@ def _apply_inverse_epochs_gen(epochs, inverse_operator, lambda2, method='dSPM',
             # Compute solution and combine current components (non-linear)
             sol = np.dot(K, e[sel])  # apply imaging kernel
 
-            logger.info('combining the current components...')
             if pick_ori != 'vector':
+                logger.info('combining the current components...')
                 sol = combine_xyz(sol)
 
             if noise_norm is not None:

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -18,8 +18,8 @@ else:
 
 
 @verbose
-def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
-                  total=None, verbose=None):
+def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
+                  total=None, prefer=None, verbose=None):
     """Return parallel instance with delayed function.
 
     Util function to use joblib only if available
@@ -43,6 +43,11 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         jobs. This should only be used when directly iterating, not when
         using ``split_list`` or :func:`np.array_split`.
         If None (default), do not add a progress bar.
+    prefer : str | None
+        If str, can be "processes" or "threads". See :class:`joblib.Parallel`.
+        Ignored if the joblib version is too old to support this.
+
+        .. versionadded:: 0.18
     %(verbose)s INFO or DEBUG
         will print parallel status, others will not.
 
@@ -94,6 +99,8 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='2 * n_jobs',
         # create keyword arguments for Parallel
         kwargs = {'verbose': 5 if should_print and total is None else 0}
         kwargs['pre_dispatch'] = pre_dispatch
+        if 'prefer' in p_args:
+            kwargs['prefer'] = prefer
 
         if joblib_mmap:
             if cache_dir is None:

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2605,12 +2605,16 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
                              'stc has %s vertices but the source space '
                              'has %s vertices'
                              % (stc.shape[0], sum(nvert)))
+        if len(stc.shape) != 2 and mode != 'mean':
+            raise ValueError('mode == mean is the only mode supported for '
+                             'VectorSourceEstimate data, got mode %r and '
+                             'data.shape = %s' % (mode, stc.shape))
 
         logger.info('Extracting time courses for %d labels (mode: %s)'
                     % (n_labels, mode))
 
         # do the extraction
-        label_tc = np.zeros((n_labels, stc.data.shape[1]),
+        label_tc = np.zeros((n_labels,) + stc.data.shape[1:],
                             dtype=stc.data.dtype)
         for i, (vertidx, flip) in enumerate(zip(label_vertidx, src_flip)):
             if vertidx is not None:

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2605,16 +2605,12 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
                              'stc has %s vertices but the source space '
                              'has %s vertices'
                              % (stc.shape[0], sum(nvert)))
-        if len(stc.shape) != 2 and mode != 'mean':
-            raise ValueError('mode == mean is the only mode supported for '
-                             'VectorSourceEstimate data, got mode %r and '
-                             'data.shape = %s' % (mode, stc.shape))
 
         logger.info('Extracting time courses for %d labels (mode: %s)'
                     % (n_labels, mode))
 
         # do the extraction
-        label_tc = np.zeros((n_labels,) + stc.data.shape[1:],
+        label_tc = np.zeros((n_labels, stc.data.shape[1]),
                             dtype=stc.data.dtype)
         for i, (vertidx, flip) in enumerate(zip(label_vertidx, src_flip)):
             if vertidx is not None:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -213,6 +213,7 @@ BaseEstimator
 ContainsMixin
 CrossSpectralDensity
 FilterMixin
+HilbertMixin
 GeneralizationAcrossTime
 RawFIF
 TimeMixin

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1974,8 +1974,9 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     # Plot initial figure
     fig, (axes, ax_time) = plt.subplots(2)
     ax_time.plot(stc.times, stc.data[loc_idx].T, color='k')
-    ax_time.set(xlim=stc.times[[0, -1]],
-                xlabel='Time (s)', ylabel='Activation')
+    if len(stc.times) > 1:
+        ax_time.set(xlim=stc.times[[0, -1]])
+    ax_time.set(xlabel='Time (s)', ylabel='Activation')
     lx = ax_time.axvline(stc.times[idx], color='g')
     axes.set(xticks=[], yticks=[])
     fig.tight_layout()


### PR DESCRIPTION
Related to #6109 (cc @jhouck), this shows one way to use envelope correlations with a free-ori source space using `lcmv` beamforming. FWIW you can do the same thing with a surface source space if you want. In that case you get to use labels, which is nice. We don't currently have a good way of label-combining our volumetric source spaces, which is unfortunate.

I am working on a [correlation measure](https://gist.github.com/larsoner/17be3f92ae8cc7ed08bdf90f98ca60f0) that is rotation + scale invariant to deal with correlating two arrays, each of shape `(3, n_times)` so that you could in prinicple use `VectorSourceEstimate`s, but so far it does not give as nice parietal network results when I actually use it in `envelope_correlation`.

While working on this I found a few more things that should be done:

- [x] ~~Add parallelization to `envelope_correlation`~~
- [x] Figure out why parallelization of `envelope_correlation` does not speed anything up (profile): the overhead of sharing data (serialization) is roughly the same as the computation time; computations are not `nogil` so we can't use `prefer='threads'` in `joblib.Parallel` to get around this
- [x] Add `apply_hilbert` for epochs and evoked
- [x] Test `n_jobs` in `apply_hilbert` benefits from `prefer` arg?: no faster
- [x] Add tests for `apply_hilbert` for epochs and evoked
- [x] Unify `apply_hilbert` for raw, epochs, and evoked
- [ ] ~~Add tests for `mean` + `VectorSourceEstimate` for `extract_label_time_course`~~
- [ ] ~~Allow `mean_flip` for VectorSourceEstimate in `extract_label_time_course`~~
- [ ] ~~Add tests to `extract_label_time_course` that a VolSourceEstimate is not provided~~
- [ ] ~~Test on longer segments of time~~

In the meantime @jhouck feel free to try this approach with your data.

Sometime we should also unify `resample` and `filter` (maybe) for raw/epochs/evoked. But that's for another PR.