### PR TITLE
[MRG] Change multiprocessing import to a try statement

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -462,8 +462,7 @@ def sys_info(fid=None, show_paths=False):
         out += ('number of processors unavailable ' +
                 '(requires "multiprocessing" package)\n')
     else:
-        out += 'CPU:'.ljust(ljust) + ('%s cores\n' %
-                                      multiprocessing.cpu_count())
+        out += '%s cores\n' % multiprocessing.cpu_count()
     out += 'Memory:'.ljust(ljust)
     try:
         import psutil

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -9,7 +9,6 @@ from functools import partial
 import inspect
 from io import StringIO
 import json
-import multiprocessing
 import os
 import os.path as op
 import platform
@@ -456,9 +455,15 @@ def sys_info(fid=None, show_paths=False):
     out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'
     out += 'Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n'
     out += 'Executable:'.ljust(ljust) + sys.executable + '\n'
-    out += 'CPU:'.ljust(ljust) + ('%s: %s cores\n' %
-                                  (platform.processor(),
-                                   multiprocessing.cpu_count()))
+    out += 'CPU:'.ljust(ljust) + ('%s: ' % platform.processor())
+    try:
+        import multiprocessing
+    except ImportError:
+        out += ('number of processors unavailable ' +
+                '(requires "multiprocessing" package)\n')
+    else:
+        out += 'CPU:'.ljust(ljust) + ('%s cores\n' %
+                                      multiprocessing.cpu_count())
     out += 'Memory:'.ljust(ljust)
     try:
         import psutil


### PR DESCRIPTION
To run mne in the browser using Pyodide (cPython + WebAssembly), we need to replace the `import multiprocessing` in `config.py` with a try statement within the `sys_config` function. Multiprocessing is not currently support in WebAssembly, which is why `multiprocessing` isn't packaged in the Pyodide build.

Is there way to have this backported to `0.17`? The build process for pyodide uses pypi and i've managed to get it to build for `0.17.1` (https://github.com/iodide-project/pyodide/pull/372)