### PR TITLE
Fix topo image cmap

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -52,7 +52,7 @@ def _setup_vmin_vmax(data, vmin, vmax, norm=False):
     For the normal use-case (when `vmin` and `vmax` are None), the parameter
     `norm` drives the computation. When norm=False, data is supposed to come
     from a mag and the output tuple (vmin, vmax) is symmetric range
-    (-x, x) where x is the max(abs(data)). When norm=False (aka data is the L2
+    (-x, x) where x is the max(abs(data)). When norm=True (aka data is the L2
     norm of a gradiometer pair) the output tuple corresponds to (0, x).
 
     Otherwise, vmin and vmax are callables that drive the operation.


### PR DESCRIPTION
hopefully fixes #6112

So far this makes the following two approaches consistent (see #6112 for screenshots of how they are currently not consistent):

```
epochs.copy().pick_types(meg=False, eeg=True).plot_topo_image()
epochs.plot_topo_image(layout=mne.channels.find_layout(epochs.info, ch_type='eeg'))
```

However, this makes many topo_image plots for MEG sensors not very informative since the images are mostly grey/white (at least with the sample data).  I'm very open to suggestions for other approaches.

cc @larsoner @jona-sassenhagen 