### PR TITLE
DOC: Include examples for classes

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -8,3 +8,5 @@
 
    {% block methods %}
    {% endblock %}
+
+.. include:: {{module}}.{{objname}}.examples


### PR DESCRIPTION
We have the SG backrefs for functions but not classes. This fixes that oversight.