### PR TITLE
 n_pad[1] is included in r_z_pad  #6130

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,7 +95,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :func:`mne.cuda.cuda._smart_pad` so that it takes into account the two elements in `n_pad` parameter by `Bruno Nicenboim`_
+- Fix :func:`mne.cuda._smart_pad` so that it takes into account the two elements in `n_pad` parameter by `Bruno Nicenboim`_
 
 - Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,7 +95,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :func:`mne.cuda._smart_pad` so that it takes into account the two elements in `n_pad` parameter by `Bruno Nicenboim`_
+- Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 
 - Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -321,7 +321,7 @@ def _smart_pad(x, n_pad, pad='reflect_limited'):
     if pad == 'reflect_limited':
         # need to pad with zeros if len(x) <= npad
         l_z_pad = np.zeros(max(n_pad[0] - len(x) + 1, 0), dtype=x.dtype)
-        r_z_pad = np.zeros(max(n_pad[0] - len(x) + 1, 0), dtype=x.dtype)
+        r_z_pad = np.zeros(max(n_pad[1] - len(x) + 1, 0), dtype=x.dtype)
         return np.concatenate([l_z_pad, 2 * x[0] - x[n_pad[0]:0:-1], x,
                                2 * x[-1] - x[-2:-n_pad[1] - 2:-1], r_z_pad])
     else:


### PR DESCRIPTION
#### Reference issue
Fixes #6130


#### What does this implement/fix?
both `r_z_pad` and `l_z_pad` were using only  `n_pad[0]`; I've changed `r_z_pad` so that it takes `n_pad[1]` 

