### PR TITLE
ENH: Add distance-based source space setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ build
 coverage
 .cache/
 .pytest_cache/
+prof/
 
 dist/
 doc/_build/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,8 @@ Changelog
 
 - Add ``overlap`` argument to :func:`mne.make_fixed_length_events` by `Eric Larson`_
 
+- Add approximate distance-based ``spacing`` source space decimation algorithm to :func:`mne.setup_source_space` by `Eric Larson`_
+
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
 - Add option to improve rendering in :ref:`gen_mne_coreg` for modern graphics cards by `Eric Larson`_

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -763,7 +763,7 @@ def _decimate_surface_spacing(s, spacing):
     assert isinstance(spacing, int)
     assert spacing > 0
     logger.info('    Decimating...')
-    d = np.full(s['np'], 10000)
+    d = np.full(s['np'], 10000, int)
 
     # A mysterious algorithm follows
     for k in range(s['np']):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -378,8 +378,11 @@ def complete_surface_info(surf, do_neighbor_vert=False, copy=True,
 
 def _get_surf_neighbors(surf, k):
     """Calculate the surface neighbors based on triangulation."""
-    verts = surf['tris'][surf['neighbor_tri'][k]]
-    verts = np.setdiff1d(verts, [k], assume_unique=False)
+    verts = set()
+    for v in surf['tris'][surf['neighbor_tri'][k]].flat:
+        verts.add(v)
+    verts.remove(k)
+    verts = np.array(sorted(verts))
     assert np.all(verts < surf['np'])
     nneighbors = len(verts)
     nneigh_max = len(surf['neighbor_tri'][k])
@@ -693,10 +696,15 @@ def _create_surf_spacing(surf, hemi, subject, stype, ico_surf, subjects_dir):
     """Load a surf and use the subdivided icosahedron to get points."""
     # Based on load_source_space_surf_spacing() in load_source_space.c
     surf = read_surface(surf, return_dict=True)[-1]
-    complete_surface_info(surf, copy=False)
+    do_neighbor_vert = (stype == 'spacing')
+    complete_surface_info(surf, do_neighbor_vert, copy=False)
     if stype == 'all':
         surf['inuse'] = np.ones(surf['np'], int)
         surf['use_tris'] = None
+    elif stype == 'spacing':
+        _decimate_surface_spacing(surf, ico_surf)
+        surf['use_tris'] = None
+        del surf['neighbor_vert']
     else:  # ico or oct
         # ## from mne_ico_downsample.c ## #
         surf_name = op.join(subjects_dir, subject, 'surf', hemi + '.sphere')
@@ -749,6 +757,38 @@ def _create_surf_spacing(surf, hemi, subject, stype, ico_surf, subjects_dir):
     surf['nuse'] = np.sum(surf['inuse'])
     surf['subject_his_id'] = subject
     return surf
+
+
+def _decimate_surface_spacing(s, spacing):
+    assert isinstance(spacing, int)
+    assert spacing > 0
+    logger.info('    Decimating...')
+    d = np.full(s['np'], 10000)
+
+    # A mysterious algorithm follows
+    for k in range(s['np']):
+        neigh = s['neighbor_vert'][k]
+        d[k] = min(np.min(d[neigh]) + 1, d[k])
+        if d[k] >= spacing:
+            d[k] = 0
+        d[neigh] = np.minimum(d[neigh], d[k] + 1)
+
+    if spacing == 2.0:
+        for k in range(s['np'] - 1, -1, -1):
+            for n in s['neighbor_vert'][k]:
+                d[k] = min(d[k], d[n] + 1)
+                d[n] = min(d[n], d[k] + 1)
+        for k in range(s['np']):
+            if d[k] > 0:
+                neigh = s['neighbor_vert'][k]
+                n = np.sum(d[neigh] == 0)
+                if n <= 2:
+                    d[k] = 0
+                d[neigh] = np.minimum(d[neigh], d[k] + 1)
+
+    s['inuse'] = np.zeros(s['np'], int)
+    s['inuse'][d == 0] = 1
+    return s
 
 
 def write_surface(fname, coords, faces, create_stamp='', volume_info=None):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -759,36 +759,36 @@ def _create_surf_spacing(surf, hemi, subject, stype, ico_surf, subjects_dir):
     return surf
 
 
-def _decimate_surface_spacing(s, spacing):
+def _decimate_surface_spacing(surf, spacing):
     assert isinstance(spacing, int)
     assert spacing > 0
     logger.info('    Decimating...')
-    d = np.full(s['np'], 10000, int)
+    d = np.full(surf['np'], 10000, int)
 
     # A mysterious algorithm follows
-    for k in range(s['np']):
-        neigh = s['neighbor_vert'][k]
+    for k in range(surf['np']):
+        neigh = surf['neighbor_vert'][k]
         d[k] = min(np.min(d[neigh]) + 1, d[k])
         if d[k] >= spacing:
             d[k] = 0
         d[neigh] = np.minimum(d[neigh], d[k] + 1)
 
     if spacing == 2.0:
-        for k in range(s['np'] - 1, -1, -1):
-            for n in s['neighbor_vert'][k]:
+        for k in range(surf['np'] - 1, -1, -1):
+            for n in surf['neighbor_vert'][k]:
                 d[k] = min(d[k], d[n] + 1)
                 d[n] = min(d[n], d[k] + 1)
-        for k in range(s['np']):
+        for k in range(surf['np']):
             if d[k] > 0:
-                neigh = s['neighbor_vert'][k]
+                neigh = surf['neighbor_vert'][k]
                 n = np.sum(d[neigh] == 0)
                 if n <= 2:
                     d[k] = 0
                 d[neigh] = np.minimum(d[neigh], d[k] + 1)
 
-    s['inuse'] = np.zeros(s['np'], int)
-    s['inuse'][d == 0] = 1
-    return s
+    surf['inuse'] = np.zeros(surf['np'], int)
+    surf['inuse'][d == 0] = 1
+    return surf
 
 
 def write_surface(fname, coords, faces, create_stamp='', volume_info=None):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -37,7 +37,8 @@ from ._testing import (_memory_usage, run_tests_if_main, requires_sklearn,
                        requires_nitime, requires_fs_or_nibabel, requires_dipy,
                        requires_neuromag2ft, assert_object_equal,
                        assert_and_remove_boundary_annot, _raw_annot,
-                       assert_dig_allclose, assert_meg_snr, assert_snr)
+                       assert_dig_allclose, assert_meg_snr, assert_snr,
+                       modified_env)
 from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _reg_pinv, random_permutation, _reject_data_segments,
                        compute_corr, _get_inst_data, array_split_idx,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -536,6 +536,13 @@ def assert_dig_allclose(info_py, info_bin, limit=None):
 
 @contextmanager
 def modified_env(**d):
+    """Use a modified os.environ with temporarily replaced key/value pairs.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        The key/value pairs of environment variables to replace.
+    """
     orig_env = dict()
     for key, val in d.items():
         orig_env[key] = os.getenv(key)

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -532,3 +532,17 @@ def assert_dig_allclose(info_py, info_bin, limit=None):
         assert_allclose(r_py, r_bin, atol=1e-6)
         assert_allclose(o_dev_py, o_dev_bin, rtol=1e-5, atol=1e-6)
         assert_allclose(o_head_py, o_head_bin, rtol=1e-5, atol=1e-6)
+
+
+@contextmanager
+def modified_env(**d):
+    orig_env = dict()
+    for key, val in d.items():
+        orig_env[key] = os.getenv(key)
+        os.environ[key] = val
+    yield
+    for key, val in orig_env.items():
+        if val is not None:
+            os.environ[key] = val
+        else:
+            del os.environ[key]


### PR DESCRIPTION
Adds an algorithm to `mne.setup_source_space` that MNE-C had that we did not that uses approximate distance-based vertex choosing:
```
import numpy as np
import matplotlib.pyplot as plt
import mne
src = mne.setup_source_space('sample', 7, add_dist=True, n_jobs=2, verbose=True)
# there gymnastics are because .min() includes zeros, which we don't want
for ii in range(2):
    src[ii]['dist'].data = 1 - src[ii]['dist'].data
min_dists = 1000 * np.concatenate([
    1 - src[0]['dist'].max(axis=1).data, 1 - src[1]['dist'].max(axis=1).data])
plt.hist(min_dists, 100)
```
Gave:
```
Subject      = sample
Surface      = white
Approximate spacing 7 mm

1. Creating the source space...

Loading /mnt/bakraid/data/structurals/sample/surf/lh.white...
Mapping lh sample -> spacing (7) ...
    Triangle neighbors and vertex normals...
    Vertex neighbors...
    Decimating...
loaded lh.white 3567/155407 selected to source space (spacing = 7)

Loading /mnt/bakraid/data/structurals/sample/surf/rh.white...
Mapping rh sample -> spacing (7) ...
    Triangle neighbors and vertex normals...
    Vertex neighbors...
    Decimating...
loaded rh.white 3620/156866 selected to source space (spacing = 7)

Calculating source space distances (limit=inf mm)...
[Parallel(n_jobs=2)]: Using backend LokyBackend with 2 concurrent workers.
[Parallel(n_jobs=2)]: Done   2 out of   2 | elapsed:  1.9min remaining:    0.0s
[Parallel(n_jobs=2)]: Done   2 out of   2 | elapsed:  1.9min finished
[Parallel(n_jobs=2)]: Using backend LokyBackend with 2 concurrent workers.
[Parallel(n_jobs=2)]: Done   2 out of   2 | elapsed:  1.9min remaining:    0.0s
[Parallel(n_jobs=2)]: Done   2 out of   2 | elapsed:  1.9min finished
    Computing patch statistics...
    Patch information added...
    Computing patch statistics...
    Patch information added...
You are now one step closer to computing the gain matrix
```
![Figure_1](https://user-images.githubusercontent.com/2365790/55747958-707ea980-5a0b-11e9-8467-2286795056d4.png)

And if I plot the standard `oct-6` distances for comparison:

![Figure_2](https://user-images.githubusercontent.com/2365790/55748418-9f494f80-5a0c-11e9-8c47-989f7e8e7317.png)

I assume this is part of the reason these oct/ico are the preferred way to construct source spaces. But this algorithm is useful for completeness and in cases where we have surfaces with approx 1mm spacing but no spherical representation for them.

FYI in the process I:
- sped up the vertex neighbor stuff quite a bit by using builtin set computations instead of `np.setdiff1d`
- added `prof` to `gitignore` because I used [pytest-profiling](https://pypi.org/project/pytest-profiling/) to find some sources of speed loss (including the setdiff1d one)
- added a context manager `modified_env` for temporarily modifying the environment. At some point we should use this in other tests since I know we do this other places, too.