### PR TITLE
MRG: Default Label to empty vertex list

### DIFF
--- a/mne/label.py
+++ b/mne/label.py
@@ -196,9 +196,9 @@ class Label(object):
     """
 
     @verbose
-    def __init__(self, vertices, pos=None, values=None, hemi=None, comment="",
-                 name=None, filename=None, subject=None, color=None,
-                 verbose=None):  # noqa: D102
+    def __init__(self, vertices=(), pos=None, values=None, hemi=None,
+                 comment="", name=None, filename=None, subject=None,
+                 color=None, verbose=None):  # noqa: D102
         # check parameters
         if not isinstance(hemi, str):
             raise ValueError('hemi must be a string, not %s' % type(hemi))

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -376,6 +376,11 @@ def test_annot_io():
     for l1, l in zip(parc1, parc_lh):
         assert_labels_equal(l1, l)
 
+    # test that the annotation is complete (test Label() support)
+    rr = read_surface(op.join(surf_dir, 'lh.white'))[0]
+    label = sum(labels, Label(hemi='lh', subject='fsaverage')).lh
+    assert_array_equal(label.vertices, np.arange(len(rr)))
+
 
 @testing.requires_testing_data
 def test_morph_labels():


### PR DESCRIPTION
I often want to combine labels using `sum`, this PR at least makes it so that instead of having to do:
```
label = sum(labels, mne.Label([], hemi='lh', subject='fsaverage'))
```
I can now do it a tiny bit more easily:
```
label = sum(labels, mne.Label(hemi='lh', subject='fsaverage'))
```
I could fairly easily get rid of the `subject` requirement (I think?) by being more permissive about `subject=None` in our label-addition code, but that doesn't seem worth the risk. Allowing `hemi=None` would probably be brittle and require a lot more code logistics, so probably not worth it, either.