### PR TITLE
ENH: Add the ids='all'  as an option for mne.event.shift_time_events

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -437,6 +437,7 @@ Events
    :toctree: generated/
 
    define_target_events
+   shift_time_events
 
 :py:mod:`mne.epochs`:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,6 +97,8 @@ Changelog
 
 - Add :class:`mne.realtime.LSLClient` for realtime data acquisition with LSL streams of data by `Teon Brooks`_ and `Mainak Jas`_
 
+- Add option ``ids = None`` in :func:`mne.shift_time_events` for considering all events by `Nikolas Chalas`_ and `Joan Massich`_
+
 Bug
 ~~~
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
@@ -3273,3 +3275,5 @@ of commits):
 .. _Katarina Slama: https://katarinaslama.github.io
 
 .. _Bruno Nicenboim: http://nicenboim.org
+
+.. _Nikolas Chalas: https://github.com/Nichalas

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,7 +97,7 @@ Changelog
 
 - Add :class:`mne.realtime.LSLClient` for realtime data acquisition with LSL streams of data by `Teon Brooks`_ and `Mainak Jas`_
 
-- Add option ``ids = None`` in :func:`mne.shift_time_events` for considering all events by `Nikolas Chalas`_ and `Joan Massich`_
+- Add option ``ids = None`` in :func:`mne.events.shift_time_events` for considering all events by `Nikolas Chalas`_ and `Joan Massich`_
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,7 +97,7 @@ Changelog
 
 - Add :class:`mne.realtime.LSLClient` for realtime data acquisition with LSL streams of data by `Teon Brooks`_ and `Mainak Jas`_
 
-- Add option ``ids = None`` in :func:`mne.events.shift_time_events` for considering all events by `Nikolas Chalas`_ and `Joan Massich`_
+- Add option ``ids = None`` in :func:`mne.event.shift_time_events` for considering all events by `Nikolas Chalas`_ and `Joan Massich`_
 
 Bug
 ~~~

--- a/mne/event.py
+++ b/mne/event.py
@@ -800,7 +800,7 @@ def shift_time_events(events, ids, tshift, sfreq):
     ----------
     events : array, shape=(n_events, 3)
         The events
-    ids : array int | None
+    ids : ndarray of int | None
         The ids of events to shift.
     tshift : float
         Time-shift event. Use positive value tshift for forward shifting
@@ -815,10 +815,10 @@ def shift_time_events(events, ids, tshift, sfreq):
     """
     events = events.copy()
     if ids is None:
-        events[:, 0] += int(tshift * sfreq)
-    elif isinstance(ids, list):
-        for ii in ids:
-            events[events[:, 2] == ii, 0] += int(tshift * sfreq)
+        mask = slice(None)
+    else:
+        mask = np.in1d(events[:, 2], ids)
+    events[mask, 0] += int(tshift * sfreq)
 
     return events
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -800,7 +800,7 @@ def shift_time_events(events, ids, tshift, sfreq):
     ----------
     events : array, shape=(n_events, 3)
         The events
-    ids : array int | 'all' 
+    ids : array int | None
         The ids of events to shift.
     tshift : float
         Time-shift event. Use positive value tshift for forward shifting
@@ -814,8 +814,7 @@ def shift_time_events(events, ids, tshift, sfreq):
         The new events.
     """
     events = events.copy()
-    
-    if ids == 'all':
+    if ids is None:
         events[:, 0] += int(tshift * sfreq)
     elif isinstance(ids, list):
         for ii in ids:

--- a/mne/event.py
+++ b/mne/event.py
@@ -800,7 +800,7 @@ def shift_time_events(events, ids, tshift, sfreq):
     ----------
     events : array, shape=(n_events, 3)
         The events
-    ids : array int
+    ids : array int | 'all' 
         The ids of events to shift.
     tshift : float
         Time-shift event. Use positive value tshift for forward shifting
@@ -814,8 +814,13 @@ def shift_time_events(events, ids, tshift, sfreq):
         The new events.
     """
     events = events.copy()
-    for ii in ids:
-        events[events[:, 2] == ii, 0] += int(tshift * sfreq)
+    
+    if ids == 'all':
+        events[:, 0] += int(tshift * sfreq)
+    elif isinstance(ids, list):
+        for ii in ids:
+            events[events[:, 2] == ii, 0] += int(tshift * sfreq)
+
     return events
 
 

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -11,7 +11,8 @@ from mne import (read_events, write_events, make_fixed_length_events,
                  read_evokeds, Epochs, create_info, compute_raw_covariance)
 from mne.io import read_raw_fif, RawArray
 from mne.utils import _TempDir, run_tests_if_main
-from mne.event import define_target_events, merge_events, AcqParserFIF
+from mne.event import (define_target_events, merge_events, AcqParserFIF,
+                       shift_time_events)
 from mne.datasets import testing
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
@@ -219,16 +220,16 @@ def test_find_events():
                        [[1, 0, 1], [2, 1, 2], [3, 2, 3]])
     # testing with mask_type = 'and'
     assert_array_equal(find_events(raw, shortest_event=1, mask=1,
-                       mask_type='and'),
+                                   mask_type='and'),
                        [[1, 0, 1], [3, 0, 1]])
     assert_array_equal(find_events(raw, shortest_event=1, mask=2,
-                       mask_type='and'),
+                                   mask_type='and'),
                        [[2, 0, 2]])
     assert_array_equal(find_events(raw, shortest_event=1, mask=3,
-                       mask_type='and'),
+                                   mask_type='and'),
                        [[1, 0, 1], [2, 1, 2], [3, 2, 3]])
     assert_array_equal(find_events(raw, shortest_event=1, mask=4,
-                       mask_type='and'),
+                                   mask_type='and'),
                        [[4, 0, 4]])
 
     # test empty events channel
@@ -541,7 +542,7 @@ def test_acqparser_averaging():
         assert_allclose(ev_grad.data[::-1], ev_ref_grad.data,
                         rtol=0, atol=1e-13)  # tol = 1 fT/cm
 
-from mne.event import shift_time_events
+
 def test_shift_time_events():
     events = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
     EXPECTED = [1, 2, 3]

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -541,5 +541,17 @@ def test_acqparser_averaging():
         assert_allclose(ev_grad.data[::-1], ev_ref_grad.data,
                         rtol=0, atol=1e-13)  # tol = 1 fT/cm
 
+from mne.event import shift_time_events
+def test_shift_time_events():
+    events = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+    EXPECTED = [1, 2, 3]
+    new_events = shift_time_events(events, ids=None, tshift=1, sfreq=1)
+    assert all(new_events[:, 0] == EXPECTED)
+
+    events = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+    EXPECTED = [0, 2, 3]
+    new_events = shift_time_events(events, ids=[1, 2], tshift=1, sfreq=1)
+    assert all(new_events[:, 0] == EXPECTED)
+
 
 run_tests_if_main()

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -544,6 +544,7 @@ def test_acqparser_averaging():
 
 
 def test_shift_time_events():
+    """Test events latency shift by a given amount."""
     events = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
     EXPECTED = [1, 2, 3]
     new_events = shift_time_events(events, ids=None, tshift=1, sfreq=1)


### PR DESCRIPTION
I added this option so that I can call `shift_time_events` in this manner:

```diff
- events = mne.event.shift_time_events( events, ids=np.unique(events[:,2]),  tshift=trigger_offset,  tshift, sfreq=raw.info['sfreq'])
+ events = mne.event.shift_time_events( events, ids='all',  tshift=trigger_offset,  tshift, sfreq=raw.info['sfreq'])
```