### PR TITLE
Use title of slider in HTML report menu

### DIFF
--- a/mne/report.py
+++ b/mne/report.py
@@ -1321,7 +1321,7 @@ class Report(object):
         slider_klass = sectionvar
 
         self._add_or_replace(
-            '%s-#-%s-#-custom' % (section, sectionvar), sectionvar,
+            '%s-#-%s-#-custom' % (title, sectionvar), sectionvar,
             slider_full_template.substitute(id=global_id, title=title,
                                             div_klass=slider_klass,
                                             slider_id=slider_id, html=html,

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -349,7 +349,8 @@ def test_remove():
     r = Report()
     fig1, fig2 = _get_example_figures()
     r.add_figs_to_section(fig1, 'figure1', 'mysection')
-    r.add_figs_to_section(fig1, 'figure1', 'othersection')
+    r.add_slider_to_section([fig1, fig2], title='figure1',
+                            section='othersection')
     r.add_figs_to_section(fig2, 'figure1', 'mysection')
     r.add_figs_to_section(fig2, 'figure2', 'mysection')
 

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -279,7 +279,8 @@ def test_add_slider_to_section():
                     subject='sample', subjects_dir=subjects_dir)
     section = 'slider_section'
     figs = _get_example_figures()
-    report.add_slider_to_section(figs, section=section)
+    report.add_slider_to_section(figs, section=section, title='my title')
+    assert report.fnames[0] == 'my title-#-report_slider_section-#-custom'
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
     pytest.raises(NotImplementedError, report.add_slider_to_section,


### PR DESCRIPTION
When adding sliders to an HTML `Report`, the entry made in the menu on the left took the section name, instead of the title of the figure:

![Screen Shot 2019-04-14 at 09 45 16](https://user-images.githubusercontent.com/428273/56089352-452c0c80-5e9a-11e9-81ac-5a99e7fafb7c.png)

This PR fixes this.