### PR TITLE
MRG: Fix inconsistencies with compute_proj_raw

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -154,6 +154,8 @@ Bug
 
 - Fix issue with bad channels ignored in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` by `Alex Gramfort`_
 
+- Fix :func:`mne.compute_proj_raw` when ``duration != None`` not to apply existing proj and to avoid using duplicate raw data samples by `Eric Larson`_
+
 - Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <gen_mne_clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -297,11 +297,14 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
     compute_proj_epochs, compute_proj_evoked
     """
     if duration is not None:
+        duration = np.round(duration * raw.info['sfreq']) / raw.info['sfreq']
         events = make_fixed_length_events(raw, 999, start, stop, duration)
         picks = pick_types(raw.info, meg=True, eeg=True, eog=True, ecg=True,
                            emg=True, exclude='bads')
-        epochs = Epochs(raw, events, None, tmin=0., tmax=duration,
-                        picks=picks, reject=reject, flat=flat)
+        epochs = Epochs(raw, events, None, tmin=0.,
+                        tmax=duration - 1. / raw.info['sfreq'],
+                        picks=picks, reject=reject, flat=flat,
+                        baseline=None, proj=False)
         data = _compute_cov_epochs(epochs, n_jobs)
         info = epochs.info
         if not stop:

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -20,7 +20,7 @@ from mne.preprocessing import maxwell_filter
 from mne.proj import (read_proj, write_proj, make_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj)
 from mne.rank import _compute_rank_int
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import _TempDir, run_tests_if_main, requires_version
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -280,6 +280,7 @@ def test_compute_proj_raw():
     assert_array_almost_equal(proj, np.eye(len(raw.ch_names)))
 
 
+@requires_version('scipy', '1.0')
 @pytest.mark.parametrize('duration', [1, np.pi / 2.])
 @pytest.mark.parametrize('sfreq', [600.614990234375, 1000.])
 def test_proj_raw_duration(duration, sfreq):


### PR DESCRIPTION
Makes `duration=None` and `duration=1.` (default) equivalent when possible. Bugs:

1. `baseline=None` should have been used in Epochs constructor
2. `proj=False` should have been used in Epochs constructor
3. `tmax=duration - 1. / sfreq` should have been used in Epochs constructor
4. More careful handling of `duration` for non-integer sample rates