### PR TITLE
MRG+1: better title in plot_compare_evokeds (closes #6165)

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1875,6 +1875,9 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     _validate_type(vlines, (list, tuple), "vlines", "list or tuple")
 
     picks = [] if picks is None else picks
+    picked_a_type = isinstance(picks, str) and picks in _DATA_CH_TYPES_SPLIT
+    if title is None and picked_a_type:
+        title = 'GFP, ' + picks
     picks = _picks_to_idx(info, picks, allow_empty=True)
     if len(picks) == 0:
         logger.info("No picks, plotting the GFP ...")

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1875,8 +1875,7 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     _validate_type(vlines, (list, tuple), "vlines", "list or tuple")
 
     picks = [] if picks is None else picks
-    picked_a_type = isinstance(picks, str) and picks in _DATA_CH_TYPES_SPLIT
-    if title is None and picked_a_type:
+    if title is None and picks in _DATA_CH_TYPES_SPLIT:
         title = _handle_default('titles')[picks]
     picks = _picks_to_idx(info, picks, allow_empty=True)
     if len(picks) == 0:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1877,7 +1877,7 @@ def plot_compare_evokeds(evokeds, picks=None, gfp=False, colors=None,
     picks = [] if picks is None else picks
     picked_a_type = isinstance(picks, str) and picks in _DATA_CH_TYPES_SPLIT
     if title is None and picked_a_type:
-        title = 'GFP, ' + picks
+        title = _handle_default('titles')[picks]
     picks = _picks_to_idx(info, picks, allow_empty=True)
     if len(picks) == 0:
         logger.info("No picks, plotting the GFP ...")

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -32,7 +32,8 @@ from ..io.pick import (channel_type, channel_indices_by_type, pick_channels,
                        pick_info, _picks_by_type, pick_channels_cov)
 from ..rank import compute_rank
 from ..io.proj import setup_proj
-from ..utils import verbose, set_config, warn, _check_ch_locs, _check_option
+from ..utils import (verbose, set_config, warn, _check_ch_locs, _check_option,
+                     logger)
 
 from ..selection import (read_selection, _SELECTIONS, _EEG_SELECTIONS,
                          _divide_to_regions)
@@ -2557,7 +2558,7 @@ def _set_title_multiple_electrodes(title, combine, ch_names, max_chans=6,
             title = "{} of {} {}".format(
                 combine, len(ch_names), ch_type)
         elif len(ch_names) > max_chans and combine != "gfp":
-            warn("More than {} channels, truncating title ...".format(
+            logger.info("More than {} channels, truncating title ...".format(
                 max_chans))
             title += ", ...\n({} of {} {})".format(
                 combine, len(ch_names), ch_type,)


### PR DESCRIPTION
This PR:

- uses `logger.info` instead of `warn` when truncating long titles
- when `mne.viz.plot_compare_evokeds(..., picks='grad')` (or any `picks` that is a single channel type), sets title to the channel type instead of listing out (and truncating) channel names.