### PR TITLE
Jit the BCD optimization solver. Fixes #6164.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
 - pyface>=6
 - traitsui>=6
 - testpath<0.4
+- numba
 - pip:
   - mne
   - vtk

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -402,7 +402,8 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
             highest_d_obj = max(d_obj, highest_d_obj)
             gap = p_obj - highest_d_obj
             E.append(p_obj)
-            # logger.debug("Iteration %d :: p_obj %f :: dgap %f :: n_active %d" %
+            # logger.debug(
+            # "Iteration %d :: p_obj %f :: dgap %f :: n_active %d" %
             #              (i + 1, p_obj, gap, np.sum(active_set) / n_orient))
 
             if gap < tol:

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -344,6 +344,7 @@ def _mixed_norm_solver_cd(M, G, alpha, lipschitz_constant, maxit=10000,
 
 
 # @verbose
+@njit
 def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
                            tol=1e-8, verbose=None, init=None, n_orient=1,
                            dgap_freq=10):
@@ -364,7 +365,7 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
 
     E = []  # track primal objective function
     highest_d_obj = - np.inf
-    active_set = np.zeros(n_sources, dtype=np.bool)  # start with full AS
+    active_set = np.zeros(n_sources, dtype=np.bool_)  # start with full AS
 
     alpha_lc = alpha / lipschitz_constant
 
@@ -394,8 +395,10 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
                 active_set[idx] = True
 
         if (i + 1) % dgap_freq == 0:
-            _, p_obj, d_obj, _ = dgap_l21(M, G, X[active_set], active_set,
-                                          alpha, n_orient)
+            # numba does not accept _, _ if different types are assigned
+            # that is why I introduced useless variables
+            useless1, p_obj, d_obj, useless2 = dgap_l21(
+                M, G, X[active_set], active_set, alpha, n_orient)
             highest_d_obj = max(d_obj, highest_d_obj)
             gap = p_obj - highest_d_obj
             E.append(p_obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+numba
 scipy
 matplotlib
 mayavi


### PR DESCRIPTION
#### What does this implement/fix?
The goal is to jit the  Block Coordinate Descent (BCD) solvers, in particula _mixed_norm_solver_bcd, using numba.
