### PR TITLE
MRG: Beamformer: compute ad-hoc noise cov with right dimensions

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -126,8 +126,10 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     if 'estimator' in noise_cov:
         del noise_cov['estimator']
 
-    data_rank = compute_rank(data_cov, rank=rank, info=info)
-    noise_rank = compute_rank(noise_cov, rank=rank, info=info)
+    info_pick = pick_info(info, picks)
+    data_rank = compute_rank(data_cov, rank=rank, info=info_pick)
+    noise_rank = compute_rank(noise_cov, rank=rank, info=info_pick)
+    del info_pick
     for key in data_rank:
         if key not in noise_rank or data_rank[key] != noise_rank[key]:
             raise ValueError('%s data rank (%s) did not match the noise '

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -446,6 +446,15 @@ def test_make_lcmv(tmpdir, reg, proj):
                         noise_cov=noise_cov)
     assert_array_equal(filters['weights'], 0)
 
+    # Test condition where one channel type is picked
+    # (avoid "grad data rank (13) did not match the noise rank (None)")
+    data_cov_grad = mne.pick_channels_cov(
+        data_cov, [ch_name for ch_name in epochs.info['ch_names']
+                   if ch_name.endswith(('2', '3'))])
+    assert len(data_cov_grad['names']) > 4
+    make_lcmv(epochs.info, forward_fixed, data_cov_grad, reg=0.01,
+              noise_cov=noise_cov)
+
 
 @testing.requires_testing_data
 def test_lcmv_raw():

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -421,7 +421,7 @@ def _check_one_ch_type(info, picks, noise_cov, method):
                 'The use of several sensor types with the DICS beamformer is '
                 'not supported yet.')
     if noise_cov is None:
-        noise_cov = make_ad_hoc_cov(info, std=1.)
+        noise_cov = make_ad_hoc_cov(info_pick, std=1.)
     _validate_type(noise_cov, Covariance, 'noise_cov')
     return noise_cov
 


### PR DESCRIPTION
This makes sure the right ``picks`` are used when creating an ad-hoc noise covariance matrix in the beamformer computation. 

If no noise covariance matrix is supplied to ``make_lcmv``, an ad-hoc noise covariance matrix is computed. This computation did not take channel selections into account, i.e., the output noise covariance matrix had the wrong dimensions.

@larsoner