### PR TITLE
Fixed error when there are no annotations in vmrk file

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -235,9 +235,9 @@ def _read_vmrk(fname):
 
 
 def _read_annotations_brainvision(fname, sfreq='auto'):
-    """Create Annotations from BrainVision vrmk.
+    """Create Annotations from BrainVision vmrk.
 
-    This function reads a .vrmk file and makes an
+    This function reads a .vmrk file and makes an
     :class:`mne.Annotations` object.
 
     Parameters
@@ -250,7 +250,7 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
         files are in samples. If set to 'auto' then
         the sfreq is taken from the .vhdr file that
         has the same name (without file extension). So
-        data.vrmk looks for sfreq in data.vhdr.
+        data.vmrk looks for sfreq in data.vhdr.
 
     Returns
     -------

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -108,8 +108,9 @@ class RawBrainVision(BaseRaw):
             raw_extras=[offsets], orig_units=orig_units)
 
         # Get annotations from vmrk file
-        annots = read_annotations(mrk_fname, info['sfreq'])
-        self.set_annotations(annots)
+        if _read_vmrk(mrk_fname).size > 0:
+            annots = read_annotations(mrk_fname, info['sfreq'])
+            self.set_annotations(annots)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -256,7 +256,7 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
     annotations : instance of Annotations
         The annotations present in the file.
     """
-    if _read_vmrk(fname).size > 0:
+    if np.size(_read_vmrk(fname)) > 0:
         onset, duration, description, date_str = _read_vmrk(fname)
         orig_time = _str_to_meas_date(date_str)
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -272,8 +272,9 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
                                   description=description,
                                   orig_time=orig_time)
     else:
-        annotations = Annotations(onset=0, duration=0, description=None,
-                 orig_time=None)
+        annotations = Annotations(onset=0, duration=0,
+                                  description=None,
+                                  orig_time=None)
 
     return annotations
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -108,9 +108,8 @@ class RawBrainVision(BaseRaw):
             raw_extras=[offsets], orig_units=orig_units)
 
         # Get annotations from vmrk file
-        if _read_vmrk(mrk_fname).size > 0:
-            annots = read_annotations(mrk_fname, info['sfreq'])
-            self.set_annotations(annots)
+        annots = read_annotations(mrk_fname, info['sfreq'])
+        self.set_annotations(annots)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
@@ -235,9 +234,9 @@ def _read_vmrk(fname):
 
 
 def _read_annotations_brainvision(fname, sfreq='auto'):
-    """Create Annotations from BrainVision vmrk.
+    """Create Annotations from BrainVision vrmk.
 
-    This function reads a .vmrk file and makes an
+    This function reads a .vrmk file and makes an
     :class:`mne.Annotations` object.
 
     Parameters
@@ -250,27 +249,31 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
         files are in samples. If set to 'auto' then
         the sfreq is taken from the .vhdr file that
         has the same name (without file extension). So
-        data.vmrk looks for sfreq in data.vhdr.
+        data.vrmk looks for sfreq in data.vhdr.
 
     Returns
     -------
     annotations : instance of Annotations
         The annotations present in the file.
     """
-    onset, duration, description, date_str = _read_vmrk(fname)
-    orig_time = _str_to_meas_date(date_str)
+    if _read_vmrk(fname).size > 0:
+        onset, duration, description, date_str = _read_vmrk(fname)
+        orig_time = _str_to_meas_date(date_str)
 
-    if sfreq == 'auto':
-        vhdr_fname = op.splitext(fname)[0] + '.vhdr'
-        logger.info("Finding 'sfreq' from header file: %s" % vhdr_fname)
-        _, _, _, info = _aux_vhdr_info(vhdr_fname)
-        sfreq = info['sfreq']
+        if sfreq == 'auto':
+            vhdr_fname = op.splitext(fname)[0] + '.vhdr'
+            logger.info("Finding 'sfreq' from header file: %s" % vhdr_fname)
+            _, _, _, info = _aux_vhdr_info(vhdr_fname)
+            sfreq = info['sfreq']
 
-    onset = np.array(onset, dtype=float) / sfreq
-    duration = np.array(duration, dtype=float) / sfreq
-    annotations = Annotations(onset=onset, duration=duration,
-                              description=description,
-                              orig_time=orig_time)
+        onset = np.array(onset, dtype=float) / sfreq
+        duration = np.array(duration, dtype=float) / sfreq
+        annotations = Annotations(onset=onset, duration=duration,
+                                  description=description,
+                                  orig_time=orig_time)
+    else:
+        annotations = Annotations(onset=0, duration=0, description=None,
+                 orig_time=None)
 
     return annotations
 

--- a/mne/realtime/lsl_client.py
+++ b/mne/realtime/lsl_client.py
@@ -83,8 +83,13 @@ class LSLClient(_BaseClient):
             yield np.vstack(samples).T
 
     def _connect(self):
+<<<<<<< HEAD
         # To use this function with an LSL stream which has a 'name' but no
         # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+=======
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+>>>>>>> Comment use of keywords in pylsl.resolve_byprop.
         pylsl = _check_pylsl_installed(strict=True)
         stream_info = pylsl.resolve_byprop('source_id', self.host,
                                            timeout=self.wait_max)[0]

--- a/mne/realtime/lsl_client.py
+++ b/mne/realtime/lsl_client.py
@@ -84,12 +84,17 @@ class LSLClient(_BaseClient):
 
     def _connect(self):
 <<<<<<< HEAD
+<<<<<<< HEAD
         # To use this function with an LSL stream which has a 'name' but no
         # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
 =======
         """To use this function with an LSL stream which has a 'name' but no 
         'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
 >>>>>>> Comment use of keywords in pylsl.resolve_byprop.
+=======
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+>>>>>>> STY: Comments to please the pedantic CIs
         pylsl = _check_pylsl_installed(strict=True)
         stream_info = pylsl.resolve_byprop('source_id', self.host,
                                            timeout=self.wait_max)[0]

--- a/mne/realtime/lsl_client_BACKUP_21901.py
+++ b/mne/realtime/lsl_client_BACKUP_21901.py
@@ -1,0 +1,132 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+<<<<<<< HEAD
+<<<<<<< HEAD
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+=======
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+>>>>>>> Comment use of keywords in pylsl.resolve_byprop.
+=======
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+>>>>>>> STY: Comments to please the pedantic CIs
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_BACKUP_22025.py
+++ b/mne/realtime/lsl_client_BACKUP_22025.py
@@ -1,0 +1,132 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+<<<<<<< HEAD
+<<<<<<< HEAD
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+=======
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+>>>>>>> Comment use of keywords in pylsl.resolve_byprop.
+=======
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+>>>>>>> STY: Comments to please the pedantic CIs
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_BASE_21901.py
+++ b/mne/realtime/lsl_client_BASE_21901.py
@@ -1,0 +1,122 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_BASE_22025.py
+++ b/mne/realtime/lsl_client_BASE_22025.py
@@ -1,0 +1,122 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_LOCAL_21901.py
+++ b/mne/realtime/lsl_client_LOCAL_21901.py
@@ -1,0 +1,127 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+<<<<<<< HEAD
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+=======
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+>>>>>>> Comment use of keywords in pylsl.resolve_byprop.
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_LOCAL_22025.py
+++ b/mne/realtime/lsl_client_LOCAL_22025.py
@@ -1,0 +1,127 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+<<<<<<< HEAD
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+=======
+        """To use this function with an LSL stream which has a 'name' but no 
+        'source_id', change the keyword in pylsl.resolve_byprop accordingly."""
+>>>>>>> Comment use of keywords in pylsl.resolve_byprop.
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_REMOTE_21901.py
+++ b/mne/realtime/lsl_client_REMOTE_21901.py
@@ -1,0 +1,122 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self

--- a/mne/realtime/lsl_client_REMOTE_22025.py
+++ b/mne/realtime/lsl_client_REMOTE_22025.py
@@ -1,0 +1,122 @@
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Mainak Jas <mainakjas@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from .base_client import _BaseClient
+from ..epochs import EpochsArray
+from ..io.meas_info import create_info
+from ..io.pick import _picks_to_idx, pick_info
+from ..utils import fill_doc, _check_pylsl_installed
+
+
+class LSLClient(_BaseClient):
+    """LSL Realtime Client.
+
+    Parameters
+    ----------
+    info : instance of mne.Info | None
+        The measurement info read in from a file. If None, it is generated from
+        the LSL stream. This method may result in less info than expected. If
+        the channel type is EEG, the `standard_1005` montage is used for
+        electrode location.
+    host : str
+        The LSL identifier of the server. This is the source_id designated
+        when the LSL stream was created. Make sure the source_id is unique on
+        the LSL subnet. For more information on LSL, please check the
+        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+    port : int | None
+        Port to use for the connection.
+    wait_max : float
+        Maximum time (in seconds) to wait for real-time buffer to start
+    tmin : float | None
+        Time instant to start receiving buffers. If None, start from the latest
+        samples available.
+    tmax : float
+        Time instant to stop receiving buffers.
+    buffer_size : int
+        Size of each buffer in terms of number of samples.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
+    """
+
+    @fill_doc
+    def get_data_as_epoch(self, n_samples=1024, picks=None):
+        """Return last n_samples from current time.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to fetch.
+        %(picks_all)s
+
+        Returns
+        -------
+        epoch : instance of Epochs
+            The samples fetched as an Epochs object.
+
+        See Also
+        --------
+        mne.Epochs.iter_evoked
+        """
+        # set up timeout in case LSL process hang. wait arb 5x expected time
+        wait_time = n_samples * 5. / self.info['sfreq']
+
+        # create an event at the start of the data collection
+        events = np.expand_dims(np.array([0, 1, 1]), axis=0)
+        samples, _ = self.client.pull_chunk(max_samples=n_samples,
+                                            timeout=wait_time)
+        data = np.vstack(samples).T
+
+        picks = _picks_to_idx(self.info, picks, 'all', exclude=())
+        info = pick_info(self.info, picks)
+        return EpochsArray(data[picks][np.newaxis], info, events)
+
+    def iter_raw_buffers(self):
+        """Return an iterator over raw buffers."""
+        while True:
+            samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
+
+            yield np.vstack(samples).T
+
+    def _connect(self):
+        # To use this function with an LSL stream which has a 'name' but no
+        # 'source_id', change the keyword in pylsl.resolve_byprop accordingly.
+        pylsl = _check_pylsl_installed(strict=True)
+        stream_info = pylsl.resolve_byprop('source_id', self.host,
+                                           timeout=self.wait_max)[0]
+        self.client = pylsl.StreamInlet(info=stream_info,
+                                        max_buflen=self.buffer_size)
+
+        return self
+
+    def _create_info(self):
+        montage = None
+        sfreq = self.client.info().nominal_srate()
+
+        lsl_info = self.client.info()
+        ch_info = lsl_info.desc().child("channels").child("channel")
+        ch_names = list()
+        ch_types = list()
+        ch_type = lsl_info.type().lower()
+        for k in range(1,  lsl_info.channel_count() + 1):
+            ch_names.append(ch_info.child_value("label") or
+                            '{} {:03d}'.format(ch_type.upper(), k))
+            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_info = ch_info.next_sibling()
+        if ch_type == "eeg":
+            try:
+                montage = 'standard_1005'
+                info = create_info(ch_names, sfreq, ch_types, montage=montage)
+            except ValueError:
+                info = create_info(ch_names, sfreq, ch_types)
+
+        return info
+
+    def _disconnect(self):
+        self.client.close_stream()
+
+        return self


### PR DESCRIPTION
Before this fix, attempting to access a vhdr file with associated vmrk would give the following error:
```
~mne-python/mne/io/brainvision/brainvision.py in _read_annotations_brainvision(fname, sfreq)
    257         The annotations present in the file.
    258     """
--> 259     onset, duration, description, date_str = _read_vmrk(fname)
    260     orig_time = _str_to_meas_date(date_str)
    261 

ValueError: not enough values to unpack (expected 4, got 0)
```
Presumably because there were no annotations. Now the code skips attempting to retrieve annotations when there are none.