### PR TITLE
[MRG+1] Fixed error when there are no annotations in vmrk file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,7 +121,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :func:`mne.io.brainvision.brainvision._read_annotations_brainvision` to accomodate vmrk files which do not have any annotations by `Alexander Kovrig`_
+- Fix :meth:`mne.io.brainvision.brainvision._read_annotations_brainvision` to accomodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3309,3 +3309,5 @@ of commits):
 .. _Ivana Kojcic: https://github.com/ikojcic
 
 .. _Nikolas Chalas: https://github.com/Nichalas
+
+.. _Alexander Kovrig: https://github.com/OpenSatori

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,7 +121,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :meth:`mne.io.brainvision.brainvision._read_annotations_brainvision` to accomodate vmrk files which do not have any annotations by `Alexander Kovrig`_
+- Fix :func:`mne.io.read_raw_brainvision` to accomodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,8 @@ Changelog
 
 Bug
 ~~~
+- Fix :func:`mne.io.brainvision.brainvision._read_annotations_brainvision` to accomodate vmrk files which do not have any annotations by `Alexander Kovrig`_
+
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 
 - Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -256,8 +256,9 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
     annotations : instance of Annotations
         The annotations present in the file.
     """
-    if np.size(_read_vmrk(fname)) > 0:
-        onset, duration, description, date_str = _read_vmrk(fname)
+    markers = _read_vmrk(fname)
+    if len(markers) > 0:
+        onset, duration, description, date_str = markers
         orig_time = _str_to_meas_date(date_str)
 
         if sfreq == 'auto':

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -256,21 +256,25 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
     annotations : instance of Annotations
         The annotations present in the file.
     """
-    onset, duration, description, date_str = _read_vmrk(fname)
-    orig_time = _str_to_meas_date(date_str)
+    if np.size(_read_vmrk(fname)) > 0:
+        onset, duration, description, date_str = _read_vmrk(fname)
+        orig_time = _str_to_meas_date(date_str)
 
-    if sfreq == 'auto':
-        vhdr_fname = op.splitext(fname)[0] + '.vhdr'
-        logger.info("Finding 'sfreq' from header file: %s" % vhdr_fname)
-        _, _, _, info = _aux_vhdr_info(vhdr_fname)
-        sfreq = info['sfreq']
+        if sfreq == 'auto':
+            vhdr_fname = op.splitext(fname)[0] + '.vhdr'
+            logger.info("Finding 'sfreq' from header file: %s" % vhdr_fname)
+            _, _, _, info = _aux_vhdr_info(vhdr_fname)
+            sfreq = info['sfreq']
 
-    onset = np.array(onset, dtype=float) / sfreq
-    duration = np.array(duration, dtype=float) / sfreq
-    annotations = Annotations(onset=onset, duration=duration,
-                              description=description,
-                              orig_time=orig_time)
-
+        onset = np.array(onset, dtype=float) / sfreq
+        duration = np.array(duration, dtype=float) / sfreq
+        annotations = Annotations(onset=onset, duration=duration,
+                                  description=description,
+                                  orig_time=orig_time)
+    else:
+        annotations = Annotations(onset=0, duration=0,
+                                  description=None,
+                                  orig_time=None)
     return annotations
 
 

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -6,6 +6,7 @@
 
 import inspect
 import os.path as op
+from os import unlink
 import shutil
 
 import numpy as np
@@ -454,12 +455,18 @@ def test_read_vmrk_annotations():
     assert_array_equal(annotations.onset, annotations_auto.onset)
 
     # Test vmrk file without annotations
+    # delete=False is for Windows compatibility
     with open(vmrk_path) as myfile:
         head = [next(myfile) for x in range(6)]
-    with NamedTemporaryFile(mode='w+', suffix='.vmrk') as temp:
+    with NamedTemporaryFile(mode='w+', suffix='.vmrk', delete=False) as temp:
         for item in head:
             temp.write(item)
         temp.seek(0)
         annotations = read_annotations(temp.name, sfreq=sfreq)
+    try:
+        temp.close()
+        unlink(temp.name)
+    except FileNotFoundError:
+        pass
 
 run_tests_if_main()

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
+from tempfile import NamedTemporaryFile
 
 from mne.utils import _TempDir, run_tests_if_main
 from mne import pick_types, read_annotations
@@ -452,5 +453,13 @@ def test_read_vmrk_annotations():
     annotations_auto = read_annotations(vmrk_path)
     assert_array_equal(annotations.onset, annotations_auto.onset)
 
+    # Test vmrk file without annotations
+    with open(vmrk_path) as myfile:
+        head = [next(myfile) for x in range(6)]
+    with NamedTemporaryFile(mode='w+', suffix='.vmrk') as temp:
+        for item in head:
+            temp.write(item)
+        temp.seek(0)
+        annotations = read_annotations(temp.name, sfreq=sfreq)
 
 run_tests_if_main()


### PR DESCRIPTION
Before this fix, attempting to access a vhdr file with associated vmrk would give the following error:
```
~mne-python/mne/io/brainvision/brainvision.py in _read_annotations_brainvision(fname, sfreq)
    257         The annotations present in the file.
    258     """
--> 259     onset, duration, description, date_str = _read_vmrk(fname)
    260     orig_time = _str_to_meas_date(date_str)
    261 

ValueError: not enough values to unpack (expected 4, got 0)
```
Presumably because there were no annotations. Now the code skips attempting to retrieve annotations when there are none.