### PR TITLE
MRG: Power estimate for LCMV: apply_lcmv_cov

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -651,6 +651,7 @@ Inverse Solutions
    apply_lcmv
    apply_lcmv_epochs
    apply_lcmv_raw
+   apply_lcmv_cov
    make_dics
    apply_dics
    apply_dics_csd

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,8 @@ Current
 
 Changelog
 ~~~~~~~~~
+- :func:`mne.beamformer.apply_lcmv_cov` returns static source power after supplying a data covariance matrix to the beamformer filter by `Britta Westner`_ and `Marijn van Vliet`_
+  
 - Add ``butterfly`` and ``order`` arguments to :func:`mne.viz.plot_epochs` and offer separated traces for non-meg data (seeg, eeg, ecog) in butterfly view by `Stefan Repplinger`_ and `Eric Larson`_
 
 - :meth:`mne.Epochs.get_data` now takes a ``picks`` parameter by `Jona Sassenhagen`_

--- a/mne/beamformer/__init__.py
+++ b/mne/beamformer/__init__.py
@@ -1,7 +1,7 @@
 """Beamformers for source localization."""
 
 from ._lcmv import (make_lcmv, apply_lcmv, apply_lcmv_epochs, apply_lcmv_raw,
-                    tf_lcmv)
+                    tf_lcmv, apply_lcmv_cov)
 from ._dics import (make_dics, apply_dics, apply_dics_epochs, apply_dics_csd,
                     tf_dics)
 from ._rap_music import rap_music

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -336,7 +336,7 @@ def _compute_power(Cm, W, n_orient):
 
     Parameters
     ----------
-    Cm : ndarray, shape (nchannels, nchannels)
+    Cm : ndarray, shape (n_channels, n_channels)
         Data covariance matrix or CSD matrix.
     W : ndarray, shape (nvertices*norient, nchannels)
         Beamformer weights.

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -331,6 +331,36 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     return W
 
 
+def _compute_power(Cm, W, n_orient):
+    """Use beamformer filters to compute source power.
+
+    Parameters
+    ----------
+    Cm : ndarray, shape (nchannels, nchannels)
+        Data covariance matrix or CSD matrix.
+    W : ndarray, shape (nvertices*norient, nchannels)
+        Beamformer weights.
+
+    Returns
+    -------
+    power : ndarray, shape (nvertices,)
+        Source power.
+    """
+    n_sources = W.shape[0] // n_orient
+
+    source_power = np.zeros(n_sources)
+    for k in range(n_sources):
+        Wk = W[n_orient * k: n_orient * k + n_orient]
+        power = Wk.dot(Cm).dot(Wk.T)
+
+        if n_orient > 1:  # Pool the orientations
+            source_power[k] = np.abs(power.trace())
+        else:
+            source_power[k] = np.abs(power)
+
+    return source_power
+
+
 class Beamformer(dict):
     """A computed beamformer.
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -436,8 +436,9 @@ def apply_lcmv_cov(data_cov, filters, verbose=None):
     # compatibility with 0.16, add src_type as None if not present:
     filters, warn_text = _check_src_type(filters)
 
-    return(_make_stc(source_power, vertices=filters['vertices'], tmin=0.,
-                     tstep=1., subject=filters['subject'],
+    return(_make_stc(source_power, vertices=filters['vertices'],
+                     src_type=filters['src_type'], tmin=0., tstep=1.,
+                     subject=filters['subject'],
                      source_nn=filters['source_nn'], warn_text=warn_text))
 
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -407,7 +407,7 @@ def apply_lcmv_cov(data_cov, filters, verbose=None):
 
     Parameters
     ----------
-    data_cov : instance of Covariance.
+    data_cov : instance of Covariance
         Data covariance matrix
     filters : instance of Beamformer
         LCMV spatial filter (beamformer weights).

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -285,6 +285,10 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
     See Also
     --------
     make_lcmv, apply_lcmv_raw, apply_lcmv_epochs, apply_lcmv_cov
+
+    Notes
+    -----
+    .. versionadded:: 0.18
     """
     _check_reference(evoked)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -284,7 +284,7 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
 
     See Also
     --------
-    make_lcmv, apply_lcmv_raw, apply_lcmv_epochs
+    make_lcmv, apply_lcmv_raw, apply_lcmv_epochs, apply_lcmv_cov
     """
     _check_reference(evoked)
 
@@ -331,7 +331,7 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='signed',
 
     See Also
     --------
-    make_lcmv, apply_lcmv_raw, apply_lcmv
+    make_lcmv, apply_lcmv_raw, apply_lcmv, apply_lcmv_cov
     """
     _check_reference(epochs)
 
@@ -382,7 +382,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
 
     See Also
     --------
-    make_lcmv, apply_lcmv_epochs, apply_lcmv
+    make_lcmv, apply_lcmv_epochs, apply_lcmv, apply_lcmv_cov
     """
     _check_reference(raw)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -405,9 +405,6 @@ def apply_lcmv_cov(data_cov, filters, verbose=None):
     Apply Linearly Constrained Minimum Variance (LCMV) beamformer weights
     to a data covariance matrix to estimate source power.
 
-    NOTE : This implementation has not been heavily tested so please
-    report any issue or suggestions.
-
     Parameters
     ----------
     data_cov : instance of Covariance.

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -398,6 +398,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
     return next(stc)
 
 
+@verbose
 def apply_lcmv_cov(data_cov, filters, verbose=None):
     """Apply Linearly Constrained  Minimum Variance (LCMV) beamformer weights.
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -19,7 +19,7 @@ from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
 from ..utils import _check_one_ch_type, _check_rank, _check_info_inv
 from .. import Epochs
 from ._compute_beamformer import (
-    _check_proj_match, _prepare_beamformer_input,
+    _check_proj_match, _prepare_beamformer_input, _compute_power,
     _compute_beamformer, _check_src_type, Beamformer)
 
 
@@ -396,6 +396,49 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
                       tmin=tmin, max_ori_out=max_ori_out)
 
     return next(stc)
+
+
+def apply_lcmv_cov(data_cov, filters, verbose=None):
+    """Apply Linearly Constrained  Minimum Variance (LCMV) beamformer weights.
+
+    Apply Linearly Constrained Minimum Variance (LCMV) beamformer weights
+    to a data covariance matrix to estimate source power.
+
+    NOTE : This implementation has not been heavily tested so please
+    report any issue or suggestions.
+
+    Parameters
+    ----------
+    data_cov : Instance of Covariance.
+        Data covariance matrix
+    filters : instance of Beamformer
+        LCMV spatial filter (beamformer weights).
+        Filter weights returned from :func:`make_lcmv`.
+    %(verbose)s
+
+    Returns
+    -------
+    stc : SourceEstimate | VolSourceEstimate
+        Source power.
+
+    See Also
+    --------
+    make_lcmv, apply_lcmv, apply_lcmv_epochs, apply_lcmv_raw
+    """
+    sel = _check_channels_spatial_filter(data_cov.ch_names, filters)
+    sel_names = [data_cov.ch_names[ii] for ii in sel]
+    data_cov = pick_channels_cov(data_cov, sel_names)
+
+    n_orient = filters['weights'].shape[0] // filters['nsource']
+    source_power = _compute_power(data_cov['data'], filters['weights'],
+                                  n_orient)
+
+    # compatibility with 0.16, add src_type as None if not present:
+    filters, warn_text = _check_src_type(filters)
+
+    return(_make_stc(source_power, vertices=filters['vertices'], tmin=0.,
+                     tstep=1., subject=filters['subject'],
+                     source_nn=filters['source_nn'], warn_text=warn_text))
 
 
 @verbose

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -357,9 +357,6 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
     Apply Linearly Constrained Minimum Variance (LCMV) beamformer weights
     on raw data.
 
-    NOTE : This implementation has not been heavily tested so please
-    report any issue or suggestions.
-
     Parameters
     ----------
     raw : mne.io.Raw

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -410,7 +410,7 @@ def apply_lcmv_cov(data_cov, filters, verbose=None):
 
     Parameters
     ----------
-    data_cov : Instance of Covariance.
+    data_cov : instance of Covariance.
         Data covariance matrix
     filters : instance of Beamformer
         LCMV spatial filter (beamformer weights).


### PR DESCRIPTION
This allows to apply the LCMV spatial filter to the covariance matrix to obtain a power estimate (not time-resolved).
In the process, we refactored ``apply_dics_csd`` with @wmvanvliet to have one function ``_compute_power``, since the operations for LCMV and DICS are similar.

A test against FieldTrip is to follow, output converges.

Closes #5229