### PR TITLE
MRG: avoid empty misc row in raw butterfly plots

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2147,15 +2147,20 @@ def _setup_butterfly(params):
             inds = params['inds']
             labels = [t for t in _DATA_CH_TYPES_SPLIT + ('eog', 'ecg')
                       if t in types] + ['misc']
-            ticks = np.arange(5, 5 * (len(labels) + 1), 5)
+            last_yval = 5 * (len(labels) + 1)
+            ticks = np.arange(5, last_yval, 5)
             offs = {l: t for (l, t) in zip(labels, ticks)}
-
             params['offsets'] = np.zeros(len(params['types']))
             for ind in inds:
                 params['offsets'][ind] = offs.get(params['types'][ind],
-                                                  5 * (len(labels)))
+                                                  last_yval - 5)
+            # in case there were no non-data channels, skip the final row
+            if (last_yval - 5) not in params['offsets']:
+                ticks = ticks[:-1]
+                labels = labels[:-1]
+                last_yval -= 5
             ax.set_yticks(ticks)
-            params['ax'].set_ylim(5 * (len(labels) + 1), 0)
+            params['ax'].set_ylim(last_yval, 0)
             ax.set_yticklabels(labels)
         else:
             if 'selections' not in params:


### PR DESCRIPTION
closes #6219 

## BEFORE

```py
import os
import mne
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
raw.crop(10).load_data().pick_types(meg=False, eeg=True).plot(butterfly=True)
```

![before](https://user-images.githubusercontent.com/1810515/56751853-770f5f80-6733-11e9-87b8-3fb04981dbe9.png)

## AFTER

(same code as above)

![eeg_only](https://user-images.githubusercontent.com/1810515/56751876-855d7b80-6733-11e9-8bab-f669d6dda9ca.png)

## MAKE SURE WE DIDN'T BREAK SOMETHING

```py
import os
import mne
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
# without pick_types
raw.crop(10).load_data().plot(butterfly=True)
```

![all_chans](https://user-images.githubusercontent.com/1810515/56751901-90181080-6733-11e9-87db-8e9324c5c338.png)

```py
import os
import mne
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
raw.crop(10).load_data().pick_types(meg=False, eeg=True, stim=True).plot(butterfly=True)
```

![eeg_plus_stim](https://user-images.githubusercontent.com/1810515/56751912-95755b00-6733-11e9-836b-8f3b63f3a129.png)
