### PR TITLE
FIX: proper channel-type-specific vmin/vmax in topo image plots

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -958,7 +958,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @copy_function_doc_to_method_doc(plot_topo_image_epochs)
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,
-                        colorbar=True, order=None, cmap='RdBu_r',
+                        colorbar=None, order=None, cmap='RdBu_r',
                         layout_scale=.95, title=None, scalings=None,
                         border='none', fig_facecolor='k', fig_background=None,
                         font_color='w', show=True):

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -192,6 +192,14 @@ def test_plot_topo_image_epochs():
     num_figures_before = len(plt.get_fignums())
     _fake_click(fig, fig.axes[0], (0.08, 0.64))
     assert num_figures_before + 1 == len(plt.get_fignums())
+    # test for auto-showing a colorbar when only 1 sensor type
+    ep = epochs.copy().pick_types(meg=False, eeg=True)
+    fig = plot_topo_image_epochs(ep, vmin=None, vmax=None, colorbar=None,
+                                 cmap=cmap)
+    ax = [x for x in fig.get_children() if isinstance(x, matplotlib.axes.Axes)]
+    qm_cmap = [y.cmap for x in ax for y in x.get_children()
+               if isinstance(y, matplotlib.collections.QuadMesh)]
+    assert qm_cmap[0] is cmap
     plt.close('all')
 
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -825,7 +825,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         fT for magnetometers and fT/cm for gradiometers.
     colorbar : bool | None
         Whether to display a colorbar or not. If ``None`` a colorbar will be
-        shown only if all channels are of the same type. Defaults to None.
+        shown only if all channels are of the same type. Defaults to ``None``.
     order : None | array of int | callable
         If not None, order is used to reorder the epochs on the y-axis
         of the image. If it's an array of int it should be of length
@@ -841,18 +841,18 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         Title of the figure.
     scalings : dict | None
         The scalings of the channel types to be applied for plotting. If
-        None, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
+        ``None``, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
     border : str
         matplotlib borders style to be used for each sensor plot.
     fig_facecolor : color
         The figure face color. Defaults to black.
     fig_background : None | array
         A background image for the figure. This must be a valid input to
-        :func:`matplotlib.pyplot.imshow`. Defaults to None.
+        :func:`matplotlib.pyplot.imshow`. Defaults to ``None``.
     font_color : color
         The color of tick labels in the colorbar. Defaults to white.
     show : bool
-        Whether to show the figure. Defaults to True.
+        Whether to show the figure. Defaults to ``True``.
 
     Returns
     -------

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -524,7 +524,7 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
     extent = (bn.x_t + bn.x_s * tmin, bn.x_t + bn.x_s * tmax, bn.y_t,
               bn.y_t + bn.y_s * len(epochs.events))
     this_data = data[:, ch_idx, :]
-    vmin, vmax = None, None if vlim_array is None else vlim_array[ch_index]
+    vmin, vmax = None, None if vlim_array is None else vlim_array[ch_idx]
 
     if callable(order):
         order = order(epochs.times, this_data)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -187,7 +187,7 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
     click_func = show_func if click_func is None else click_func
     on_pick = partial(click_func, tmin=tmin, tmax=tmax, vmin=vmin,
                       vmax=vmax, ylim=ylim, x_label=x_label,
-                      y_label=y_label, colorbar=colorbar)
+                      y_label=y_label)
 
     if axes is None:
         fig = plt.figure()
@@ -481,11 +481,13 @@ def _plot_timeseries_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim, data,
 def _erfimage_imshow(ax, ch_idx, tmin, tmax, vmin, vmax, ylim=None, data=None,
                      epochs=None, sigma=None, order=None, scalings=None,
                      vline=None, x_label=None, y_label=None, colorbar=False,
-                     cmap='RdBu_r'):
+                     cmap='RdBu_r', vlim_array=None):
     """Plot erfimage on sensor topography."""
     from scipy import ndimage
     import matplotlib.pyplot as plt
-    this_data = data[:, ch_idx, :].copy() * scalings[ch_idx]
+    this_data = data[:, ch_idx, :]
+    if vlim_array is not None:
+        vmin, vmax = vlim_array[ch_idx]
 
     if callable(order):
         order = order(epochs.times, this_data)
@@ -512,7 +514,8 @@ def _erfimage_imshow(ax, ch_idx, tmin, tmax, vmin, vmax, ylim=None, data=None,
 def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
                              data=None, epochs=None, sigma=None, order=None,
                              scalings=None, vline=None, x_label=None,
-                             y_label=None, colorbar=False, cmap='RdBu_r'):
+                             y_label=None, colorbar=False, cmap='RdBu_r',
+                             vlim_array=None):
     """Plot erfimage topography using a single axis."""
     from scipy import ndimage
     _compute_scalings(bn, (tmin, tmax), (0, len(epochs.events)))
@@ -520,7 +523,8 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
     data_lines = bn.data_lines
     extent = (bn.x_t + bn.x_s * tmin, bn.x_t + bn.x_s * tmax, bn.y_t,
               bn.y_t + bn.y_s * len(epochs.events))
-    this_data = data[:, ch_idx, :].copy() * scalings[ch_idx]
+    this_data = data[:, ch_idx, :]
+    vmin, vmax = None, None if vlim_array is None else vlim_array[ch_index]
 
     if callable(order):
         order = order(epochs.times, this_data)
@@ -798,7 +802,7 @@ def _plot_update_evoked_topo_proj(params, bools):
 
 
 def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
-                           vmax=None, colorbar=True, order=None, cmap='RdBu_r',
+                           vmax=None, colorbar=None, order=None, cmap='RdBu_r',
                            layout_scale=.95, title=None, scalings=None,
                            border='none', fig_facecolor='k',
                            fig_background=None, font_color='w', show=True):
@@ -853,23 +857,44 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     -------
     fig : instance of matplotlib.figure.Figure
         Figure distributing one image per channel across sensor topography.
+
+    Notes
+    -----
+    In an interactive Python session, this plot will be interactive; clicking
+    on a channel image will pop open a larger view of the image; this image
+    will always have a colorbar even when the topo plot does not (because it
+    shows multiple sensor types).
     """
     scalings = _handle_default('scalings', scalings)
-    data = epochs.get_data()
-    scale_coeffs = list()
-    for idx in range(epochs.info['nchan']):
-        ch_type = channel_type(epochs.info, idx)
-        scale_coeffs.append(scalings.get(ch_type, 1))
-    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
 
+    epochs = epochs.copy()
     if layout is None:
         layout = find_layout(epochs.info)
+    ch_names = set(layout.names) & set(epochs.ch_names)
+    idxs = [epochs.ch_names.index(ch_name) for ch_name in ch_names]
+    epochs = epochs.pick(idxs)
+    ch_idxs = range(epochs.info['nchan'])
+    ch_types = [channel_type(epochs.info, idx) for idx in ch_idxs]
+    scale_coeffs = [scalings.get(ch_type, 1) for ch_type in ch_types]
+    epochs._data *= np.array(scale_coeffs)[:, np.newaxis]
+    data = epochs.get_data()
+    vlim_dict = dict()
+    for ch_type in set(ch_types):
+        this_data = data[:, np.where(np.array(ch_types) == ch_type)]
+        vlim_dict[ch_type] = _setup_vmin_vmax(this_data, vmin, vmax)
+    vlim_array = np.array([vlim_dict[ch_type] for ch_type in ch_types])
+    if colorbar is None:
+        colorbar = (len(set(ch_types)) == 1)
+    if colorbar and vmin is None and vmax is None:
+        vmin, vmax = vlim_array[0]
 
     show_func = partial(_erfimage_imshow_unified, scalings=scale_coeffs,
                         order=order, data=data, epochs=epochs, sigma=sigma,
-                        cmap=cmap)
+                        cmap=cmap, vlim_array=vlim_array)
+
     erf_imshow = partial(_erfimage_imshow, scalings=scale_coeffs, order=order,
-                         data=data, epochs=epochs, sigma=sigma, cmap=cmap)
+                         data=data, epochs=epochs, sigma=sigma, cmap=cmap,
+                         vlim_array=vlim_array, colorbar=True)
 
     fig = _plot_topo(info=epochs.info, times=epochs.times,
                      click_func=erf_imshow, show_func=show_func, layout=layout,

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -823,8 +823,9 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     vmax : float
         The max value in the image. The unit is uV for EEG channels,
         fT for magnetometers and fT/cm for gradiometers.
-    colorbar : bool
-        Display or not a colorbar.
+    colorbar : bool | None
+        Display or not a colorbar. If ``None`` (the default) a colorbar will be
+        shown only if all channels are of the same type.
     order : None | array of int | callable
         If not None, order is used to reorder the epochs on the y-axis
         of the image. If it's an array of int it should be of length

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -524,7 +524,7 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
     extent = (bn.x_t + bn.x_s * tmin, bn.x_t + bn.x_s * tmax, bn.y_t,
               bn.y_t + bn.y_s * len(epochs.events))
     this_data = data[:, ch_idx, :]
-    vmin, vmax = None, None if vlim_array is None else vlim_array[ch_idx]
+    vmin, vmax = (None, None) if vlim_array is None else vlim_array[ch_idx]
 
     if callable(order):
         order = order(epochs.times, this_data)

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -868,24 +868,32 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     """
     scalings = _handle_default('scalings', scalings)
 
+    # make a copy because we discard non-data channels and scale the data
     epochs = epochs.copy()
+    # use layout to subset channels present in epochs object
     if layout is None:
         layout = find_layout(epochs.info)
     ch_names = set(layout.names) & set(epochs.ch_names)
     idxs = [epochs.ch_names.index(ch_name) for ch_name in ch_names]
     epochs = epochs.pick(idxs)
+    # iterate over a sequential index to get lists of chan. type & scale coef.
     ch_idxs = range(epochs.info['nchan'])
     ch_types = [channel_type(epochs.info, idx) for idx in ch_idxs]
     scale_coeffs = [scalings.get(ch_type, 1) for ch_type in ch_types]
+    # scale the data
     epochs._data *= np.array(scale_coeffs)[:, np.newaxis]
     data = epochs.get_data()
+    # get vlims for each channel type
     vlim_dict = dict()
     for ch_type in set(ch_types):
         this_data = data[:, np.where(np.array(ch_types) == ch_type)]
         vlim_dict[ch_type] = _setup_vmin_vmax(this_data, vmin, vmax)
     vlim_array = np.array([vlim_dict[ch_type] for ch_type in ch_types])
+    # only show colorbar if we have a single channel type
     if colorbar is None:
         colorbar = (len(set(ch_types)) == 1)
+    # if colorbar=True, we know we have only 1 channel type so all entries
+    # in vlim_array are the same, just take the first one
     if colorbar and vmin is None and vmax is None:
         vmin, vmax = vlim_array[0]
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -824,8 +824,8 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         The max value in the image. The unit is uV for EEG channels,
         fT for magnetometers and fT/cm for gradiometers.
     colorbar : bool | None
-        Display or not a colorbar. If ``None`` (the default) a colorbar will be
-        shown only if all channels are of the same type.
+        Whether to display a colorbar or not. If ``None`` a colorbar will be
+        shown only if all channels are of the same type. Defaults to None.
     order : None | array of int | callable
         If not None, order is used to reorder the epochs on the y-axis
         of the image. If it's an array of int it should be of length
@@ -852,7 +852,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     font_color : color
         The color of tick labels in the colorbar. Defaults to white.
     show : bool
-        Show figure if True.
+        Whether to show the figure. Defaults to True.
 
     Returns
     -------

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -810,7 +810,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
 
     Parameters
     ----------
-    epochs : instance of Epochs
+    epochs : instance of :class:`~mne.Epochs`
         The epochs.
     layout: instance of Layout
         System specific sensor positions.
@@ -848,7 +848,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         The figure face color. Defaults to black.
     fig_background : None | array
         A background image for the figure. This must be a valid input to
-        `matplotlib.pyplot.imshow`. Defaults to None.
+        :func:`matplotlib.pyplot.imshow`. Defaults to None.
     font_color : color
         The color of tick labels in the colorbar. Defaults to white.
     show : bool
@@ -856,7 +856,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure
+    fig : instance of :class:`matplotlib.figure.Figure`
         Figure distributing one image per channel across sensor topography.
 
     Notes


### PR DESCRIPTION
closes #6112 

color limits on `epochs.plot_topo_image()` are messed up. Example code:
```py
import os
import mne
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
# get events
events = mne.find_events(raw, stim_channel='STI 014')
event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
              'visual/right': 4, 'face': 5, 'button': 32}
# make epochs
raw.info['bads'].append('EEG 007')
reject_criteria = dict(mag=4e-12, grad=4e-10, eeg=150e-6, eog=250e-6)
epochs = mne.Epochs(raw, events, event_id=event_dict, reject=reject_criteria,
                    preload=True)
# plot
epochs.plot_topo_image(sigma=0.5)
```

## Results on current master (note the same colorbar limits on the 2 popups)

### overview plot
![before_mixed](https://user-images.githubusercontent.com/1810515/56767440-3970fd80-6758-11e9-9c51-31e50f63ec2d.png)

### popup plot (magnetometer)
![before_mag_popup](https://user-images.githubusercontent.com/1810515/56767460-4beb3700-6758-11e9-871f-3e8411a7dd40.png)

### popup plot (gradiometer)
![before_grad_popup](https://user-images.githubusercontent.com/1810515/56767479-54437200-6758-11e9-85a7-cec846b30832.png)

## Results after this PR (note the different colorbars on the 2 popups)

### overview plot
![after_mixed](https://user-images.githubusercontent.com/1810515/56767532-72a96d80-6758-11e9-9642-cffc96375cf5.png)

### popup plot (magnetometer)
![after_mag_popup](https://user-images.githubusercontent.com/1810515/56767520-6f15e680-6758-11e9-8129-257d87443d3f.png)

### popup plot (gradiometer)
![after_grad_popup](https://user-images.githubusercontent.com/1810515/56767515-6b825f80-6758-11e9-9bdd-acb7ea744d8a.png)
