### PR TITLE
MRG+1: Fix weight_norm='nai' on DICS

### DIFF
--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -262,7 +262,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
 
             if pick_ori == 'max-power':
                 # Compute the power
-                if inversion == 'single' and weight_norm == 'unit-noise-gain':
+                if inversion == 'single' and weight_norm is not None:
                     # First make the filters unit gain, then apply them to the
                     # cov matrix to compute power.
                     Wk_norm = Wk / np.sqrt(np.sum(Wk ** 2, axis=1,

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -220,11 +220,13 @@ def test_make_dics(tmpdir):
 
     # Test neural-activity-index weight normalization. It should be a scaled
     # version of the unit-noise-gain beamformer.
-    filters_nai = make_dics(epochs.info, fwd_surf, csd, label=label,
-                            weight_norm='nai', normalize_fwd=False)
+    filters_nai = make_dics(
+        epochs.info, fwd_surf, csd, label=label, pick_ori='max-power',
+        weight_norm='nai', normalize_fwd=False)
     w_nai = filters_nai['weights'][0]
-    filters_ung = make_dics(epochs.info, fwd_surf, csd, label=label,
-                            weight_norm='unit-noise-gain', normalize_fwd=False)
+    filters_ung = make_dics(
+        epochs.info, fwd_surf, csd, label=label, pick_ori='max-power',
+        weight_norm='unit-noise-gain', normalize_fwd=False)
     w_ung = filters_ung['weights'][0]
     assert np.allclose(np.corrcoef(np.abs(w_nai).ravel(),
                                    np.abs(w_ung).ravel()), 1)


### PR DESCRIPTION
The case when `inversion='single', pick_ori='max-power', weight_norm='ai'` was not caught by the if-statements in `_compute_beamformer`.