### PR TITLE
MRG: Be explicit about exclusions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,10 @@ release = egg_info -RDb ''
 doc-files = doc
 
 [tool:pytest]
-addopts = --showlocals --durations=20 --doctest-modules -ra --cov-report= --doctest-ignore-import-errors --junit-xml=junit-results.xml --ignore=doc/sphinxext/cited_mne.py --ignore=mne/gui/_coreg_gui.py --ignore=mne/gui/_fiducials_gui.py --ignore=mne/gui/_file_traits.py --ignore=mne/gui/_kit2fiff_gui.py --ignore=mne/gui/_marker_gui.py --ignore=mne/gui/_viewer.py
+addopts = --showlocals --durations=20 --doctest-modules -ra --cov-report=
+          --doctest-ignore-import-errors --junit-xml=junit-results.xml
+          --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials
+          --ignore=mne/gui/_*.py
 usefixtures = matplotlib_config
 # Set this pretty low to ensure we do not by default add really long tests,
 # or make changes that make things a lot slower


### PR DESCRIPTION
Adds to the `ignores` list for `pytest`. I have accidentally done `$ pytest` (alone) in the `mne-python` directory and it's brutal because `pytest` tries to collect tests in `examples/` and `tutorials/`. This explicitly removes those so this will not happen. Now `pytest mne` is practically the same thing as `pytest`.

As a side effect it makes VSCode automated test discovery not make the same mistake...

cc @drammock feel free to try VSCode test discovery on this branch. (Do not try it on master unless you want your laptop to become a heater.)