### PR TITLE
[FIX] Exclude ref_meg for channel interpolation of CTF data 2nd try

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -186,6 +186,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_egi` when cropping non-preloaded EGI MFF data by `Alex Gramfort`_
 
+- Fix :meth:`mne.io.Raw.interpolate_bads` for interpolating CTF MEG channels when reference sensors are present by `jeythekey`_
+
 API
 ~~~
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -173,6 +173,8 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
         Can be ``'auto'``, which means a head-digitization-based origin
         fit. Default is ``(0., 0., 0.04)``.
     %(verbose)s
+    ref_meg : bool
+        Should always be False; only exists for testing purpose.
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
                            ref_meg=ref_meg, exclude=[])

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -175,9 +175,9 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
     %(verbose)s
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
-                           ref_meg=True, exclude=[])
+                           ref_meg=False, exclude=[])
     picks_good = pick_types(inst.info, meg=True, eeg=False,
-                            ref_meg=True, exclude='bads')
+                            ref_meg=False, exclude='bads')
     meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -157,7 +157,7 @@ def _interpolate_bads_eeg(inst, verbose=None):
 
 @verbose
 def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
-                          verbose=None):
+                          verbose=None, ref_meg=False):
     """Interpolate bad channels from data in good channels.
 
     Parameters
@@ -175,9 +175,9 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
     %(verbose)s
     """
     picks_meg = pick_types(inst.info, meg=True, eeg=False,
-                           ref_meg=False, exclude=[])
+                           ref_meg=ref_meg, exclude=[])
     picks_good = pick_types(inst.info, meg=True, eeg=False,
-                            ref_meg=False, exclude='bads')
+                            ref_meg=ref_meg, exclude='bads')
     meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
     bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
 


### PR DESCRIPTION
Replaces #5966 due to problems with git history there.
