### PR TITLE
FIX resampling events indices

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1631,7 +1631,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
             events[:, 0] = np.minimum(
                 np.round(events[:, 0] * ratio).astype(int),
-                self._data.shape[1] + self.first_samp
+                self._data.shape[1] + self.first_samp - 1
             )
             return self, events
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1064,7 +1064,7 @@ def test_resample(tmpdir):
     events = find_events(raw)
     raw, events = raw.resample(n_sfreq, events=events, npad='auto')
     # Try index into raw.times with resampled events:
-    raw.times[events[:, 0]-raw.first_samp]
+    raw.times[events[:, 0] - raw.first_samp]
     n_fsamp = int(first_samp * sfreq_ratio)  # how it's calc'd in base.py
     # NB np.round used for rounding event times, which has 0.5 as corner case:
     # https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html
@@ -1072,8 +1072,8 @@ def test_resample(tmpdir):
         events,
         np.array([[np.round(1 * sfreq_ratio) + n_fsamp, 0, 1],
                   [np.round(10 * sfreq_ratio) + n_fsamp, 0, 1],
-                  [np.minimum(np.round(15 * sfreq_ratio), raw._data.shape[1]
-                   - 1) + n_fsamp, 0, 1]]))
+                  [np.minimum(np.round(15 * sfreq_ratio),
+                              raw._data.shape[1] - 1) + n_fsamp, 0, 1]]))
 
     # test copy flag
     stim = [1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0]

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1054,7 +1054,7 @@ def test_resample(tmpdir):
 
     # test resampling events: this should no longer give a warning
     # we often have first_samp != 0, include it here too
-    stim = [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]
+    stim = [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1]  # an event at end
     # test is on half the sfreq, but should work with trickier ones too
     o_sfreq, sfreq_ratio = len(stim), 0.5
     n_sfreq = o_sfreq * sfreq_ratio
@@ -1063,13 +1063,17 @@ def test_resample(tmpdir):
                    first_samp=first_samp)
     events = find_events(raw)
     raw, events = raw.resample(n_sfreq, events=events, npad='auto')
+    # Try index into raw.times with resampled events:
+    raw.times[events[:, 0]-raw.first_samp]
     n_fsamp = int(first_samp * sfreq_ratio)  # how it's calc'd in base.py
     # NB np.round used for rounding event times, which has 0.5 as corner case:
     # https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html
     assert_array_equal(
         events,
         np.array([[np.round(1 * sfreq_ratio) + n_fsamp, 0, 1],
-                  [np.round(10 * sfreq_ratio) + n_fsamp, 0, 1]]))
+                  [np.round(10 * sfreq_ratio) + n_fsamp, 0, 1],
+                  [np.minimum(np.round(15 * sfreq_ratio), raw._data.shape[1]
+                   - 1) + n_fsamp, 0, 1]]))
 
     # test copy flag
     stim = [1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0]


### PR DESCRIPTION
This is a one-character fix for inst.resample, when also resampling events.

The ceiling-check of the max. index of the resampled events was missing a -1, so e.g. cropping to the same data-segment between two events before and and again after resampling resulted in an error.