### PR TITLE
DOC: Fix some docstrings in filter.py

### DIFF
--- a/mne/filter.py
+++ b/mne/filter.py
@@ -29,7 +29,7 @@ def is_power2(num):
 
     Returns
     -------
-    bool
+    b : bool
         True if is power of 2.
 
     Examples

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -44,8 +44,7 @@ def is_power2(num):
 
 
 def next_fast_len(target):
-    """
-    Find the next fast size of input data to `fft`, for zero-padding, etc.
+    """Find the next fast size of input data to `fft`, for zero-padding, etc.
 
     SciPy's FFTPACK has efficient functions for radix {2, 3, 4, 5}, so this
     returns the next composite of the prime factors 2, 3, and 5 which is
@@ -1458,7 +1457,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
 
     Parameters
     ----------
-    x : n-d array
+    x : ndarray
         Signal to resample.
     up : float
         Factor to upsample by.

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -29,7 +29,7 @@ def is_power2(num):
 
     Returns
     -------
-    b : bool
+    bool
         True if is power of 2.
 
     Examples
@@ -154,7 +154,7 @@ def _overlap_add_filter(x, h, n_fft=None, phase='zero', picks=None,
 
     Returns
     -------
-    xf : array, shape (n_signals, n_times)
+    x : array, shape (n_signals, n_times)
         x filtered.
     """
     n_jobs = check_n_jobs(n_jobs, allow_cuda=True)
@@ -334,7 +334,7 @@ def _construct_fir_filter(sfreq, freq, gain, filter_length, phase, fir_window,
 
     Parameters
     ----------
-    Fs : float
+    sfreq : float
         Sampling rate in Hz.
     freq : 1d array
         Frequency sampling points in Hz.
@@ -1485,7 +1485,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
 
     Returns
     -------
-    xf : array
+    y : array
         x resampled.
 
     Notes
@@ -1654,7 +1654,7 @@ def detrend(x, order=1, axis=-1):
 
     Returns
     -------
-    xf : array
+    y : array
         x detrended.
 
     Examples
@@ -2029,7 +2029,7 @@ class FilterMixin(object):
         Parameters
         ----------
         sfreq : float
-            New sample rate to use
+            New sample rate to use.
         npad : int | str
             Amount to pad the start and end of the data.
             Can also be "auto" to use a padding that will result in


### PR DESCRIPTION
#### What does this implement/fix?
Fixes some small docstring errors in the filter.py file. 

As I was looking through `filter.py`, I realized there were some small mistakes in the docstrings of a couple functions (for examples, `sfreq` being described as `Fs` in the docstring), so I figured I could make a quick fix on those. 