### PR TITLE
Fix _compute_scalings() for autoscale

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -134,6 +134,8 @@ Changelog
 
 Bug
 ~~~
+- Fix :func:`mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
+
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -134,7 +134,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :meth:`mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
+- Fix `mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -134,7 +134,7 @@ Changelog
 
 Bug
 ~~~
-- Fix `mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
+- Fix :meth:`mne.Epochs.plot` with ``scalings='auto'`` to properly compute channel-wise scalings by `Stefan Repplinger`_
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -134,7 +134,7 @@ Changelog
 
 Bug
 ~~~
-- Fix :func:`mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
+- Fix :meth:`mne.viz.utils._compute_scalings` to do channel-wise autoscale by `Stefan Repplinger`_
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1658,7 +1658,7 @@ def _compute_scalings(scalings, inst):
     else:
         data = inst._data
     if isinstance(inst, BaseEpochs):
-        data = inst._data.reshape([len(inst.ch_names), -1])
+        data = inst._data.swapaxes(0, 1).reshape([len(inst.ch_names), -1])
     # Iterate through ch types and update scaling if ' auto'
     for key, value in scalings.items():
         if value != 'auto':


### PR DESCRIPTION
During reshaping of the axes channel data got dispersed.

#### Reference issue
Fixes #6226.

#### What does this implement/fix?
Axes need to be swapped to ensure correct reshaping according to channel attributions.
