### PR TITLE
MRG: fix annot->events chunk size

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -867,18 +867,21 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
     else:
         inds = values = np.array([]).astype(int)
         for annot in annotations[event_sel]:
-            _onsets = np.arange(start=annot['onset'],
-                                stop=(annot['onset'] + annot['duration']),
+            annot_offset = annot['onset'] + annot['duration']
+            _onsets = np.arange(start=annot['onset'], stop=annot_offset,
                                 step=chunk_duration)
-            _inds = raw.time_as_index(_onsets,
-                                      use_rounding=use_rounding,
-                                      origin=annotations.orig_time)
-            _inds += raw.first_samp
-            inds = np.append(inds, _inds)
-            _values = np.full(shape=len(_inds),
-                              fill_value=event_id_[annot['description']],
-                              dtype=int)
-            values = np.append(values, _values)
+            good_events = annot_offset - _onsets >= annot['duration']
+            if good_events.any():
+                _onsets = _onsets[good_events]
+                _inds = raw.time_as_index(_onsets,
+                                          use_rounding=use_rounding,
+                                          origin=annotations.orig_time)
+                _inds += raw.first_samp
+                inds = np.append(inds, _inds)
+                _values = np.full(shape=len(_inds),
+                                  fill_value=event_id_[annot['description']],
+                                  dtype=int)
+                values = np.append(values, _values)
 
     events = np.c_[inds, np.zeros(len(inds)), values].astype(int)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -836,11 +836,12 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
         If True, use rounding (instead of truncation) when converting
         times to indices. This can help avoid non-unique indices.
     chunk_duration: float | None
-        If chunk_duration parameter in events_from_annotations is None, events
-        correspond to the annotation onsets.
+        Chunk duration in seconds. If ``chunk_duration`` is set to None
+        (default), generated events correspond to the annotation onsets.
         If not, :func:`mne.events_from_annotations` returns as many events as
         they fit within the annotation duration spaced according to
-        `chunk_duration`, which is given in seconds.
+        ``chunk_duration``. As a consequence annotations with duration shorter
+        than ``chunk_duration`` will not contribute events.
     %(verbose)s
 
     Returns

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -870,7 +870,7 @@ def events_from_annotations(raw, event_id=None, regexp=None, use_rounding=True,
             annot_offset = annot['onset'] + annot['duration']
             _onsets = np.arange(start=annot['onset'], stop=annot_offset,
                                 step=chunk_duration)
-            good_events = annot_offset - _onsets >= annot['duration']
+            good_events = annot_offset - _onsets >= chunk_duration
             if good_events.any():
                 _onsets = _onsets[good_events]
                 _inds = raw.time_as_index(_onsets,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -210,6 +210,13 @@ def test_chunk_duration():
                                                 use_rounding=False)
     assert_array_equal(events, expected_events)
 
+    # test chunk durations that do not fit equally in annotation duration
+    expected_events = np.zeros((3, 3))
+    expected_events[:, -1] = 1
+    expected_events[:, 0] = np.arange(0, 9, step=3)
+    events, events_id = events_from_annotations(raw, chunk_duration=3.)
+    assert_array_equal(events, expected_events)
+
 
 def test_crop_more():
     """Test more cropping."""


### PR DESCRIPTION
Closes #6258

Could also allow additional argument - `min_chunk_duration` (a bit shorter than `chunk_duration` by default for example 85%).
But in its current shape it seems to be simple enough. I could add warnings if some annotations cannot generate events due to chunk_size being too long.

- [x] add test
- [x] add warning when some annotations do not contribute any events?
- [x] decide whether to expose control over min chunk duration