### PR TITLE
MAINT: Template needs super

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -42,6 +42,9 @@
     })();
     </script>
 {% endif %}
+
+{{ super() }}
+
 {% endblock %}
 
 {% block relbar2 %}{% endblock %}


### PR DESCRIPTION
We needed a `super()` call in our `extrahead` block of our Sphinx template.

Closes #6269.
