### PR TITLE
MRG, FIX: Fix dipole orientations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Current
 Changelog
 ~~~~~~~~~
 - :func:`mne.beamformer.apply_lcmv_cov` returns static source power after supplying a data covariance matrix to the beamformer filter by `Britta Westner`_ and `Marijn van Vliet`_
-  
+
 - Add ``butterfly`` and ``order`` arguments to :func:`mne.viz.plot_epochs` and offer separated traces for non-meg data (seeg, eeg, ecog) in butterfly view by `Stefan Repplinger`_ and `Eric Larson`_
 
 - :meth:`mne.Epochs.get_data` now takes a ``picks`` parameter by `Jona Sassenhagen`_
@@ -193,6 +193,8 @@ Bug
 - Fix CTF helmet plotting in :func:`mne.viz.plot_evoked_field` by `Eric Larson`_
 
 - Fix saving of rejection parameters in :meth:`mne.Epochs.save` by `Eric Larson`_
+
+- Fix orientations returned by :func:`mne.dipole.get_phantom_dipoles` (half were flipped 180 degrees) by `Eric Larson`_
 
 - Fix bug in :func:`mne.viz.plot_compare_evokeds` when ``evoked.times[0] >= 0`` would cause a problem with ``vlines='auto'`` mode by `Eric Larson`_
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1337,6 +1337,7 @@ def get_phantom_dipoles(kind='vectorview'):
         c = [22.9, 23.5, 25.5, 23.1, 52.0, 46.4, 41.0, 33.0]
         d = [44.4, 34.0, 21.6, 12.7, 62.4, 51.5, 39.1, 27.9]
         z = np.concatenate((c, c, d, d))
+        signs = ([1, -1] * 4 + [-1, 1] * 4) * 2
     elif kind == 'otaniemi':
         # these values were pulled from an Neuromag manual
         # (NM20456A, 13.7.1999, p.65)
@@ -1346,18 +1347,20 @@ def get_phantom_dipoles(kind='vectorview'):
         x = np.concatenate((a, b, c, c, -a, -b, c, c))
         y = np.concatenate((c, c, -a, -b, c, c, b, a))
         z = np.concatenate((b, a, b, a, b, a, a, b))
+        signs = [-1] * 8 + [1] * 16 + [-1] * 8
     pos = np.vstack((x, y, z)).T / 1000.
     # Locs are always in XZ or YZ, and so are the oris. The oris are
     # also in the same plane and tangential, so it's easy to determine
     # the orientation.
     ori = list()
-    for this_pos in pos:
+    for pi, this_pos in enumerate(pos):
         this_ori = np.zeros(3)
         idx = np.where(this_pos == 0)[0]
         # assert len(idx) == 1
         idx = np.setdiff1d(np.arange(3), idx[0])
         this_ori[idx] = (this_pos[idx][::-1] /
                          np.linalg.norm(this_pos[idx])) * [1, -1]
+        this_ori *= signs[pi]
         # Now we have this quality, which we could uncomment to
         # double-check:
         # np.testing.assert_allclose(np.dot(this_ori, this_pos) /


### PR DESCRIPTION
The sign flips in our Elekta example always bothered me:

http://mne-tools.github.io/dev/auto_tutorials/sample-datasets/plot_brainstorm_phantom_elekta.html#sphx-glr-auto-tutorials-sample-datasets-plot-brainstorm-phantom-elekta-py

Turns out that `get_phantom_dipoles` had the orientations of some dipoles wrong by 180 degrees. This fixes it. It also removes `maxwell_filter` from the example to save a tiny bit of memory, since this example has been crashing CircleCI lately.