### PR TITLE
MRG, FIX: avoid spurious "showing first five" message

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from ..utils import (verbose, get_config, set_config, logger, warn, _pl,
                      fill_doc)
-from ..utils.check import _is_numeric
 from ..io.pick import (pick_types, channel_type, _get_channel_types,
                        _picks_to_idx, _DATA_CH_TYPES_SPLIT,
                        _DATA_CH_TYPES_ORDER_DEFAULT)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from ..utils import (verbose, get_config, set_config, logger, warn, _pl,
                      fill_doc)
+from ..utils.check import _is_numeric
 from ..io.pick import (pick_types, channel_type, _get_channel_types,
                        _picks_to_idx, _DATA_CH_TYPES_SPLIT,
                        _DATA_CH_TYPES_ORDER_DEFAULT)
@@ -168,7 +169,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     if combine is not None:
         ts_args["show_sensors"] = False
 
-    picks = [picks] if isinstance(picks, str) else picks
+    picks = [picks] if isinstance(picks, str) or _is_numeric(picks) else picks
     too_many_picks = (picks is None or
                       all(pick in _DATA_CH_TYPES_SPLIT for pick in picks))
     picks = _picks_to_idx(epochs.info, picks)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -169,11 +169,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     if combine is not None:
         ts_args["show_sensors"] = False
 
-    picks = [picks] if isinstance(picks, str) or _is_numeric(picks) else picks
-    too_many_picks = (picks is None or
-                      all(pick in _DATA_CH_TYPES_SPLIT for pick in picks))
-    picks = _picks_to_idx(epochs.info, picks)
-    if too_many_picks and group_by is None:
+    picks, picked_ch_type_or_generic = _picks_to_idx(epochs.info, picks,
+                                                     return_kind=True)
+    if picked_ch_type_or_generic and group_by is None:
         logger.info("No picks and no groupby, showing the first five "
                     "channels ...")
         picks = picks[:5]  # take 5 picks to prevent spawning too many figs

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from ..utils import (verbose, get_config, set_config, logger, warn, _pl,
                      fill_doc)
-from ..utils.check import _is_numeric
 from ..io.pick import (pick_types, channel_type, _get_channel_types,
                        _picks_to_idx, _DATA_CH_TYPES_SPLIT,
                        _DATA_CH_TYPES_ORDER_DEFAULT)
@@ -169,14 +168,14 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     if combine is not None:
         ts_args["show_sensors"] = False
 
-    if picks is None or not _is_numeric(picks):
-        picks = _picks_to_idx(epochs.info, picks)
-        if group_by is None:
-            logger.info("No picks and no groupby, showing the first five "
-                        "channels ...")
-            picks = picks[:5]  # take 5 picks to prevent spawning many figs
-    else:
-        picks = _picks_to_idx(epochs.info, picks)
+    picks = [picks] if isinstance(picks, str) else picks
+    too_many_picks = (picks is None or
+                      all(pick in _DATA_CH_TYPES_SPLIT for pick in picks))
+    picks = _picks_to_idx(epochs.info, picks)
+    if too_many_picks and group_by is None:
+        logger.info("No picks and no groupby, showing the first five "
+                    "channels ...")
+        picks = picks[:5]  # take 5 picks to prevent spawning too many figs
 
     if "invert_y" in ts_args:
         raise NotImplementedError("'invert_y' found in 'ts_args'. "

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -137,6 +137,7 @@ def test_plot_epochs_image():
     """Test plotting of epochs image."""
     epochs = _get_epochs()
     epochs.plot_image(picks=[1, 2])
+    epochs.plot_image(picks='mag')
     overlay_times = [0.1]
     epochs.plot_image(picks=[1], order=[0], overlay_times=overlay_times,
                       vmin=0.01, title="test"


### PR DESCRIPTION
the info message `No picks and no groupby, showing the first five channels ...` is incorrectly shown when the `picks` parameter to `epochs.plot_info()` is a (list of) channel *names* (the message should only happen when `picks` is a channel type or list of channel types).

on current master, this (wrongly) generates the info message; after this PR it does not:

```python
from mne.viz.tests.test_epochs import _get_epochs
epochs = _get_epochs().load_data()
epochs.plot_image(picks='MEG 1332')
```
after this PR, the message is still (correctly) generated for:

```python
epochs.plot_image(picks='mag')
```