### PR TITLE
MRG, ENH: Allow reading file-like objects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -441,6 +441,7 @@ numpydoc_attributes_as_param_list = False
 numpydoc_xref_param_type = True
 numpydoc_xref_aliases = {
     'Popen': 'python:subprocess.Popen',
+    'file-like': ':term:`file-like <python:file object>`',
     # Matplotlib
     'colormap': ':doc:`colormap <matplotlib:tutorials/colors/colormaps>`',
     'color': ':doc:`color <matplotlib:api/colors_api>`',

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -105,6 +105,8 @@ Changelog
 
 - Add support for CUDA-based correlation computations and progress bars in :class:`mne.decoding.ReceptiveField` by `Eric Larson`_
 
+- Add support for file-like objects in :func:`mne.io.read_raw_fif` as long as preloading is used by `Eric Larson`_
+
 - Add keyboard shortcuts to nativate volume source estimates in time using (shift+)left/right arrow keys by `Mainak Jas`_
 
 - Add option to SSP preprocessing functions (e.g., :func:`mne.preprocessing.compute_proj_eog` and :func:`mne.compute_proj_epochs`) to process MEG channels jointly with ``meg='combined'`` by `Eric Larson`_

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -92,7 +92,8 @@ class Raw(BaseRaw):
                          'exist.' % next_fname)
                     break
         if not isinstance(fname, str):
-            fname = None  # avoid serialization error when copying file-like
+            # avoid serialization error when copying file-like
+            fname = None  # noqa
 
         _check_raw_compatibility(raws)
         super(Raw, self).__init__(

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -34,11 +34,15 @@ class Raw(BaseRaw):
 
     Parameters
     ----------
-    fname : str
-        The raw file to load. For files that have automatically been split,
+    fname : str | file-like
+        The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz,
-        raw_tsss.fif or raw_tsss.fif.gz.
+        raw_tsss.fif or raw_tsss.fif.gz. If a file-like object is provided,
+        preloading must be used.
+
+        .. versionchanged:: 0.18
+           Support for file-like objects.
     allow_maxshield : bool | str (default False)
         If True, allow loading of data that has been recorded with internal
         active compensation (MaxShield). Data recorded with MaxShield should
@@ -73,24 +77,22 @@ class Raw(BaseRaw):
     @verbose
     def __init__(self, fname, allow_maxshield=False, preload=False,
                  verbose=None):  # noqa: D102
-        fnames = [op.realpath(fname)]
-        split_fnames = []
-
         raws = []
-        for ii, this_fname in enumerate(fnames):
-            do_check_fname = this_fname not in split_fnames
+        do_check_fname = isinstance(fname, str)
+        next_fname = fname
+        while next_fname is not None:
             raw, next_fname, buffer_size_sec = \
-                self._read_raw_file(this_fname, allow_maxshield,
+                self._read_raw_file(next_fname, allow_maxshield,
                                     preload, do_check_fname)
+            do_check_fname = False
             raws.append(raw)
             if next_fname is not None:
                 if not op.exists(next_fname):
                     warn('Split raw file detected but next file %s does not '
                          'exist.' % next_fname)
-                    continue
-                # process this file next
-                fnames.insert(ii + 1, next_fname)
-                split_fnames.append(next_fname)
+                    break
+        if not isinstance(fname, str):
+            fname = None  # avoid serialization error when copying file-like
 
         _check_raw_compatibility(raws)
         super(Raw, self).__init__(
@@ -129,6 +131,9 @@ class Raw(BaseRaw):
             self._preload_data(preload)
         else:
             self.preload = False
+        # If using a file-like object, fix the filenames to be representative
+        # strings now instead of the file-like objects
+        self._filenames = [_get_fname_rep(fname) for fname in self._filenames]
 
     @verbose
     def _read_raw_file(self, fname, allow_maxshield, preload,
@@ -142,8 +147,18 @@ class Raw(BaseRaw):
                                        'raw_sss.fif.gz', 'raw_tsss.fif.gz'))
 
         #   Read in the whole file if preload is on and .fif.gz (saves time)
-        ext = os.path.splitext(fname)[1].lower()
-        whole_file = preload if '.gz' in ext else False
+        if isinstance(fname, str):
+            # filename
+            fname = op.realpath(fname)
+            ext = os.path.splitext(fname)[1].lower()
+            whole_file = preload if '.gz' in ext else False
+            del ext
+        else:
+            # file-like
+            if not preload:
+                raise ValueError('preload must be used with file-like objects')
+            whole_file = True
+        fname_rep = _get_fname_rep(fname)
         ff, tree, _ = fiff_open(fname, preload=whole_file)
         with ff as fid:
             #   Read the measurement info
@@ -158,7 +173,7 @@ class Raw(BaseRaw):
                 if (len(raw_node) == 0):
                     raw_node = dir_tree_find(meas, FIFF.FIFFB_SMSH_RAW_DATA)
                     if (len(raw_node) == 0):
-                        raise ValueError('No raw data in %s' % fname)
+                        raise ValueError('No raw data in %s' % fname_rep)
                     _check_maxshield(allow_maxshield)
                     info['maxshield'] = True
 
@@ -260,7 +275,7 @@ class Raw(BaseRaw):
                                            nsamp=nsamp))
                     first_samp += nsamp
 
-            next_fname = _get_next_fname(fid, fname, tree)
+            next_fname = _get_next_fname(fid, fname_rep, tree)
 
         raw.last_samp = first_samp - 1
         raw.orig_format = orig_format
@@ -409,6 +424,13 @@ class Raw(BaseRaw):
         return self._acqparser
 
 
+def _get_fname_rep(fname):
+    if isinstance(fname, str):
+        return fname
+    else:
+        return 'File-like %r' % (fname,)
+
+
 def _check_entry(first, nent):
     """Sanity check entries."""
     if first >= nent:
@@ -421,11 +443,15 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        The raw file to load. For files that have automatically been split,
+    fname : str | file-like
+        The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz,
-        raw_tsss.fif or raw_tsss.fif.gz.
+        raw_tsss.fif or raw_tsss.fif.gz. If a file-like object is provided,
+        preloading must be used.
+
+        .. versionchanged:: 0.18
+           Support for file-like objects.
     allow_maxshield : bool | str (default False)
         If True, allow loading of data that has been recorded with internal
         active compensation (MaxShield). Data recorded with MaxShield should

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -5,7 +5,7 @@
 # License: BSD (3-clause)
 
 import os.path as op
-from io import BytesIO
+from io import BytesIO, SEEK_SET
 from gzip import GzipFile
 
 import numpy as np
@@ -15,6 +15,25 @@ from .tag import read_tag_info, read_tag, read_big, Tag, _call_dict_names
 from .tree import make_dir_tree, dir_tree_find
 from .constants import FIFF
 from ..utils import logger, verbose
+
+
+class _NoCloseRead(object):
+    """Create a wrapper that will not close when used as a context manager."""
+
+    def __init__(self, fid):
+        self.fid = fid
+
+    def __enter__(self):
+        return self.fid
+
+    def __exit__(self, type_, value, traceback):
+        return
+
+    def seek(self, offset, whence=SEEK_SET):
+        return self.fid.seek(offset, whence)
+
+    def read(self, size=-1):
+        return self.fid.read(size)
 
 
 def _fiff_get_fid(fname):
@@ -27,7 +46,7 @@ def _fiff_get_fid(fname):
             logger.debug('Using normal I/O')
             fid = open(fname, "rb")  # Open in binary mode
     else:
-        fid = fname
+        fid = _NoCloseRead(fname)
         fid.seek(0)
     return fid
 
@@ -102,9 +121,8 @@ def fiff_open(fname, preload=False, verbose=None):
     if preload:
         # note that StringIO objects instantiated this way are read-only,
         # but that's okay here since we are using mode "rb" anyway
-        fid_old = fid
-        fid = BytesIO(read_big(fid_old))
-        fid_old.close()
+        with fid as fid_old:
+            fid = BytesIO(read_big(fid_old))
 
     tag = read_tag_info(fid)
 

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -3,8 +3,8 @@
 #
 # License: BSD (3-clause)
 
-import gzip
 from functools import partial
+import gzip
 import os
 import struct
 
@@ -109,9 +109,12 @@ def read_big(fid, size=None):
     # buf_size is chosen as a largest working power of 2 (16 MB):
     buf_size = 16777216
     if size is None:
-        # it's not possible to get .gz uncompressed file size
+        # it's not possible to get .gz uncompressed or file-like file size
         if not isinstance(fid, gzip.GzipFile):
-            size = os.fstat(fid.fileno()).st_size - fid.tell()
+            try:
+                size = os.fstat(fid.fileno()).st_size - fid.tell()
+            except Exception:  # e.g., io.UnsupportedOperation: fileno
+                pass
 
     if size is not None:
         # Use pre-buffering method

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -39,7 +39,7 @@ def test_orig_units():
         BaseRaw(info, last_samps=[1], orig_units=True)
 
 
-def _test_raw_reader(reader, test_preloading=True, **kwargs):
+def _test_raw_reader(reader, test_preloading=True, test_kwargs=True, **kwargs):
     """Test reading, writing and slicing of raw classes.
 
     Parameters
@@ -92,9 +92,10 @@ def _test_raw_reader(reader, test_preloading=True, **kwargs):
     assert _handle_meas_date(raw.info['meas_date']) >= 0
 
     # test resetting raw
-    raw2 = reader(**raw._init_kwargs)
-    assert set(raw.info.keys()) == set(raw2.info.keys())
-    assert_array_equal(raw.times, raw2.times)
+    if test_kwargs:
+        raw2 = reader(**raw._init_kwargs)
+        assert set(raw.info.keys()) == set(raw2.info.keys())
+        assert_array_equal(raw.times, raw2.times)
 
     # Test saving and reading
     out_fname = op.join(tempdir, 'test_raw.fif')


### PR DESCRIPTION
Closes #5867.

@arokem is it easy for you to test what you wanted to do in #5867? The caveat is that you must use `preload=True` or `preload='/some/memmap/filename'`.