### PR TITLE
MRG, ENH: Lower mem usage

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@
 
 from datetime import date
 from distutils.version import LooseVersion
+import gc
 import os
 import os.path as op
 import sys
@@ -332,6 +333,7 @@ class Resetter(object):
 
     def __call__(self, gallery_conf, fname):
         reset_warnings(gallery_conf, fname)
+        gc.collect()
 
 
 def reset_warnings(gallery_conf, fname):

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -822,7 +822,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
 
     info = pick_info(info, picks_meeg)
     tslice = _get_tslice(epochs[0], tmin, tmax)
-    epochs = [ee.get_data()[:, picks_meeg, tslice] for ee in epochs]
+    epochs = [ee.get_data(picks=picks_meeg)[..., tslice] for ee in epochs]
     picks_meeg = np.arange(len(picks_meeg))
     picks_list = _picks_by_type(info)
 

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -39,7 +39,7 @@ import matplotlib.pyplot as plt
 
 import mne
 from mne.datasets.sleep_physionet.age import fetch_data
-from mne.time_frequency import psd_array_welch
+from mne.time_frequency import psd_welch
 
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score
@@ -174,18 +174,17 @@ print(epochs_test)
 fig, (ax1, ax2) = plt.subplots(ncols=2)
 
 # iterate over the subjects
+stages = sorted(event_id.keys())
 for ax, title, epochs in zip([ax1, ax2],
                              ['Alice', 'Bob'],
                              [epochs_train, epochs_test]):
 
-    for stage, color in zip(event_id.keys(), stage_colors):
+    for stage, color in zip(stages, stage_colors):
         epochs[stage].plot_psd(area_mode=None, color=color, ax=ax,
                                fmin=0.1, fmax=20.)
-    ax.set_title(title)
-
-plt.xlabel('Frequency (Hz)')
-plt.ylabel('uV^2/hz (dB)')
-plt.legend(list(event_id.keys()))
+    ax.set(title=title, xlabel='Frequency (Hz)')
+ax2.set(ylabel='uV^2/hz (dB)')
+ax2.legend(stages)
 
 ##############################################################################
 # Design a scikit-learn transformer from a Python function
@@ -220,10 +219,7 @@ def eeg_power_band(epochs):
                   "sigma": [11.5, 15.5],
                   "beta": [15.5, 30]}
 
-    sfreq = epochs.info['sfreq']
-    data = epochs.get_data(picks="eeg")
-    psds, freqs = psd_array_welch(data, sfreq, fmin=0.5, fmax=30.,
-                                  n_fft=512, n_overlap=256)
+    psds, freqs = psd_welch(epochs, picks='eeg', fmin=0.5, fmax=30.)
     # Normalize the PSDs
     psds /= np.sum(psds, axis=-1, keepdims=True)
 


### PR DESCRIPTION
- Tweaks the brainstorm phantom Elekta dataset example to use ~500 MB less memory. The tradeoff is that we no longer filter / preprocess in any way. I think this is fine, especially since it takes the loc bias just from 2.0 mm to 2.6 mm. The memory bottleneck is now in `epochs.get_data()[..., time_slice]` in `cov` code, which could be solved by adding `tmin/tmax` to `epochs.get_data` but this is actually quite complicated due to our internal implementation of `epochs._get_data` doing many things. But hopefully it's good enough for now.
- Simplified a tiny bit the sleep tutorial while unsuccessfully looking for memory savings there.
- Added an explicit garbage collection during our between-example resets to hopefully help keep memory usage as low as possible.