### PR TITLE
MRG, MAINT: Update Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
       $ErrorActionPreference = "Stop"
       $PSDefaultParameterValues['*:ErrorAction']='Stop'
       $env:PYTHON = '$(System.DefaultWorkingDirectory)' + '\conda'
-      git clone git://github.com/larsoner/ci-helpers.git
+      git clone git://github.com/astropy/ci-helpers.git
       cd ci-helpers
       git checkout nopip
       cd ..


### PR DESCRIPTION
Now that https://github.com/astropy/ci-helpers/pull/390 is in, we can switch back to `astropy`'s version.