### PR TITLE
MRG, MAINT: Move conftest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include LICENSE.txt
 include requirements.txt
 include mne/__init__.py
 
-include conftest.py
 recursive-include examples *.py
 recursive-include examples *.txt
 recursive-include tutorials *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,44 +14,6 @@ release = egg_info -RDb ''
 [bdist_rpm]
 doc-files = doc
 
-[tool:pytest]
-addopts = --showlocals --durations=20 --doctest-modules -ra --cov-report=
-          --doctest-ignore-import-errors --junit-xml=junit-results.xml
-          --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials
-          --ignore=mne/gui/_*.py
-markers =
-    slowtest
-    ultraslowtest
-usefixtures = matplotlib_config
-# Set this pretty low to ensure we do not by default add really long tests,
-# or make changes that make things a lot slower
-timeout = 30
-# Once SciPy updates not to have non-integer and non-tuple errors (1.2.0) we
-# should remove them from here.
-# This list should also be considered alongside reset_warnings in doc/conf.py
-filterwarnings =
-    error::
-    ignore::ImportWarning
-    ignore:the matrix subclass:PendingDeprecationWarning
-    ignore:numpy.dtype size changed:RuntimeWarning
-    ignore:.*HasTraits.trait_.*:DeprecationWarning
-    ignore:.*takes no parameters:DeprecationWarning
-    ignore:joblib not installed:RuntimeWarning
-    ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
-    ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
-    ignore:Importing from numpy.testing.decorators is deprecated:DeprecationWarning
-    ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
-    ignore:The oldnumeric module will be dropped:DeprecationWarning
-    ignore:Collection picker None could not be converted to float:UserWarning
-    ignore:covariance is not positive-semidefinite:RuntimeWarning
-    ignore:Can only plot ICA components:RuntimeWarning
-    ignore:Matplotlib is building the font cache using fc-list:UserWarning
-    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
-    ignore:`formatargspec` is deprecated:DeprecationWarning
-    # This is only necessary until sklearn updates their wheels for NumPy 1.16
-    ignore:numpy.ufunc size changed:RuntimeWarning
-
-
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py
 ignore = E241,E305,W504


### PR DESCRIPTION
Inspired by https://github.com/scipy/scipy/pull/10178, I realized there is a nice way to unify where we keep all of our global `pytest` options. We can remove them from `setup.cfg` and put them in `conftest.py` (and move that to `mne/` instead of the root directory).

Should be useful for maintenance purposes, but let's make sure it does not break anything.