### PR TITLE
MRG: shifted onsets of annotations created by mark_flats

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -157,6 +157,8 @@ Bug
 
 - Fix 32bits annotations in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
 
+- Fix bug in :func:`mne.preprocessing.mark_flat` where ``raw.first_samp`` was not taken into account by `kalenkovich`_
+
 - Fix date parsing in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
 
 - Fix topological checks and error messages for BEM surfaces in :func:`mne.make_bem_model` by `Eric Larson`_
@@ -3335,6 +3337,8 @@ of commits):
 .. _Stanislas Chambon: https://github.com/Slasnista
 
 .. _Jeff Hanna: https://github.com/jshanna100
+
+.. _kalenkovich: https://github.com/kalenkovich
 
 .. _Antoine Gauthier: https://github.com/Okamille
 

--- a/mne/preprocessing/flat.py
+++ b/mne/preprocessing/flat.py
@@ -93,7 +93,7 @@ def mark_flat(raw, bad_percent=5., min_duration=0.005, picks=None,
     raw.info['bads'] = list(raw.info['bads']) + add_bads
     if len(starts) > 0:
         starts, stops = np.array(starts), np.array(stops)
-        onsets = starts / raw.info['sfreq']
+        onsets = (starts + raw.first_samp) / raw.info['sfreq']
         durations = (stops - starts) / raw.info['sfreq']
         raw.annotations.append(onsets, durations, ['BAD_flat'] * len(onsets))
     return raw

--- a/mne/preprocessing/tests/test_flat.py
+++ b/mne/preprocessing/tests/test_flat.py
@@ -10,14 +10,17 @@ from mne.io import RawArray
 from mne.preprocessing import mark_flat
 
 
-def test_mark_flat():
+@pytest.mark.parametrize('first_samp', (0, 10000))
+def test_mark_flat(first_samp):
     """Test marking flat segments."""
     # Test if ECG analysis will work on data that is not preloaded
     n_ch, n_times = 11, 1000
     data = np.random.RandomState(0).randn(n_ch, n_times)
     assert not (np.diff(data, axis=-1) == 0).any()  # nothing flat at first
     info = create_info(n_ch, 1000., 'eeg')
-    raw = RawArray(data, info)
+    info['meas_date'] = (1, 2)
+    # test first_samp != for gh-6295
+    raw = RawArray(data, info, first_samp=first_samp)
     raw.info['bads'] = [raw.ch_names[-1]]
 
     #


### PR DESCRIPTION
Onsets were calculated relative to the first sample and not to the `raw.info['meas_date']`.

#### Reference issue
Fixes #6295.


#### What does this implement/fix?
I shifted the onsets by `raw.first_samp / raw.info['sfreq']` to the right so that their timing is relative to  `raw.info['meas_date']`.