### PR TITLE
MRG, BUG: Fix contextmanager use

### DIFF
--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -6,7 +6,7 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
-import contextlib
+from contextlib import contextmanager
 import os
 import os.path as op
 
@@ -764,7 +764,7 @@ def _to_forward_dict(fwd, names, fwd_grad=None,
     return fwd
 
 
-@contextlib.contextmanager
+@contextmanager
 def use_coil_def(fname):
     """Use a custom coil definition file.
 

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -491,9 +491,11 @@ def modified_env(**d):
             os.environ[key] = val
         elif key in os.environ:
             del os.environ[key]
-    yield
-    for key, val in orig_env.items():
-        if val is not None:
-            os.environ[key] = val
-        elif key in os.environ:
-            del os.environ[key]
+    try:
+        yield
+    finally:
+        for key, val in orig_env.items():
+            if val is not None:
+                os.environ[key] = val
+            elif key in os.environ:
+                del os.environ[key]

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -180,9 +180,11 @@ def running_subprocess(command, after="wait", verbose=None, *args, **kwargs):
             command_name = command[0]
         logger.error('Command not found: %s' % command_name)
         raise
-    yield p
-    getattr(p, after)()
-    p.wait()
+    try:
+        yield p
+    finally:
+        getattr(p, after)()
+        p.wait()
 
 
 def _clean_names(names, remove_whitespace=False, before_dash=True):

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -70,8 +70,10 @@ def use_3d_backend(backend_name):
     """
     old_backend = get_3d_backend()
     set_3d_backend(backend_name)
-    yield
-    set_3d_backend(old_backend)
+    try:
+        yield
+    finally:
+        set_3d_backend(old_backend)
 
 
 @contextmanager

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -295,8 +295,10 @@ def _toggle_options(event, params):
 @contextmanager
 def _events_off(obj):
     obj.eventson = False
-    yield
-    obj.eventson = True
+    try:
+        yield
+    finally:
+        obj.eventson = True
 
 
 def _toggle_proj(event, params, all_=False):


### PR DESCRIPTION
Follow-up to #5775 to fix `contextlib.contextmanager` use to use `try/finally` pattern, because I can't seem to internalize that I need to use it in the first place.