### PR TITLE
MRG, FIX: Restore working "addopts", epochs test

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -33,15 +33,6 @@ fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
 
 def pytest_configure(config):
     """Configure pytest options."""
-    # Set the timeout pretty low to ensure we do not by default add really long
-    # tests, or make changes that make things a lot slower
-    config.addinivalue_line(
-        'addopts',
-        '--showlocals --durations=20 --doctest-modules -ra --cov-report= '
-        '--doctest-ignore-import-errors --junit-xml=junit-results.xml '
-        '--ignore=doc --ignore=logo --ignore=examples --ignore=tutorials '
-        '--ignore=mne/gui/_*.py --timeout 30')
-
     # Markers
     for marker in ('slowtest', 'ultraslowtest'):
         config.addinivalue_line('markers', marker)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,13 @@ doc-files = doc
 exclude = __init__.py,*externals*,constants.py,fixes.py
 ignore = E241,E305,W504
 
+[tool:pytest]
+addopts =
+     --showlocals --durations=20 --doctest-modules -ra --cov-report=
+    --doctest-ignore-import-errors --junit-xml=junit-results.xml
+    --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials
+    --ignore=mne/gui/_*.py
+
 [pycodestyle]
 exclude = __init__.py,*externals*,constants.py,fixes.py
 ignore = E241,E305,W504


### PR DESCRIPTION
I noticed locally that the `pytest` `addopts` entry was not working with `pytest_configure`. This is perhas a `pytest` bug, or maybe it's not since it has probably already parsed the options before it calls our `conftest.py`. There might be a way to set these in `pytest_configure`, but for now let's restore it in `setup.cfg` so things work properly.

Also split a slow `epochs` test that was causing spurious Azure failures, and modernized a few of the `pytest.raises` checks there.