### PR TITLE
MRG, ENH: Auto-scale misc channels by default

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -158,6 +158,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
+- Fix :meth:`mne.io.Raw.plot` and :meth:`mne.Epochs.plot` to auto-scale ``misc`` channel types by default by `Eric Larson`_
+
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 
 - Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -20,7 +20,7 @@ DEFAULTS = dict(
                   hbo=1e6, hbr=1e6),
     # rough guess for a good plot
     scalings_plot_raw=dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6,
-                           ecg=5e-4, emg=1e-3, ref_meg=1e-12, misc=1e-3,
+                           ecg=5e-4, emg=1e-3, ref_meg=1e-12, misc='auto',
                            stim=1, resp=1, chpi=1e-4, exci=1, ias=1, syst=1,
                            seeg=1e-4, bio=1e-6, ecog=1e-4, hbo=10e-6,
                            hbr=10e-6, whitened=10.),

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -264,6 +264,14 @@ def test_ica_core(method):
         assert_equal(raw_sources._filenames, [None])
         print(raw_sources)
 
+        # test for gh-6271 (scaling of ICA traces)
+        fig = raw_sources.plot()
+        assert len(fig.axes[0].lines) in (4, 5)
+        for line in fig.axes[0].lines[1:-1]:  # first and last are markers
+            y = line.get_ydata()
+            assert np.ptp(y) < 10
+        plt.close('all')
+
         sources = raw_sources[:, :][0]
         assert (sources.shape[0] == ica.n_components_)
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -287,11 +287,21 @@ def plot_head_positions(pos, mode='traces', cmap='viridis', direction='z',
         scale = (maxs - mins).max() / 2.
         xlim, ylim, zlim = (maxs + mins)[:, np.newaxis] / 2. + [-scale, scale]
         ax.set(xlabel='x', ylabel='y', zlabel='z',
-               xlim=xlim, ylim=ylim, zlim=zlim, aspect='equal')
+               xlim=xlim, ylim=ylim, zlim=zlim)
+        _set_aspect_equal(ax)
         ax.view_init(30, 45)
     tight_layout(fig=fig)
     plt_show(show)
     return fig
+
+
+def _set_aspect_equal(ax):
+    # XXX recent MPL throws an error for 3D axis aspect setting, not much
+    # we can do about it at this point
+    try:
+        ax.set_aspect('equal')
+    except NotImplementedError:
+        pass
 
 
 def _pivot_kwargs():
@@ -1386,7 +1396,7 @@ def _smooth_plot(this_time, params):
     colors[:, 3] = 1.
     facecolors[:] = colors
     ax.set_title(params['time_label'] % (times[time_idx] * scaler), color='w')
-    ax.set_aspect('equal')
+    _set_aspect_equal(ax)
     ax.axis('off')
     ax.set(xlim=[-80, 80], ylim=(-80, 80), zlim=[-80, 80])
     ax.figure.canvas.draw()

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -839,7 +839,6 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     """
     epochs.drop_bad()
     scalings = _compute_scalings(scalings, epochs)
-    scalings = _handle_default('scalings_plot_raw', scalings)
     decim, data_picks = _handle_decim(epochs.info.copy(), decim, None)
     projs = epochs.info['projs']
     noise_cov = _check_cov(noise_cov, epochs.info)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -275,7 +275,6 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     from ..io.base import BaseRaw
     color = _handle_default('color', color)
     scalings = _compute_scalings(scalings, raw)
-    scalings = _handle_default('scalings_plot_raw', scalings)
     _validate_type(raw, BaseRaw, 'raw', 'Raw')
     n_channels = min(len(raw.info['chs']), n_channels)
     _check_option('clipping', clipping, [None, 'clamp', 'transparent'])

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -12,9 +12,9 @@ import pytest
 import matplotlib
 import matplotlib.pyplot as plt
 
-from mne import read_events, pick_types, Annotations
+from mne import read_events, pick_types, Annotations, create_info
 from mne.datasets import testing
-from mne.io import read_raw_fif, read_raw_ctf
+from mne.io import read_raw_fif, read_raw_ctf, RawArray
 from mne.utils import run_tests_if_main
 from mne.viz.utils import _fake_click, _annotation_radio_clicked, _sync_onset
 from mne.viz import plot_raw, plot_sensors
@@ -278,6 +278,14 @@ def test_plot_ref_meg():
     raw_ctf.plot()
     plt.close('all')
     pytest.raises(ValueError, raw_ctf.plot, group_by='selection')
+
+
+def test_plot_misc_auto():
+    """Test plotting of data with misc auto scaling."""
+    data = np.random.RandomState(0).randn(1, 1000)
+    raw = RawArray(data, create_info(1, 1000., 'misc'))
+    raw.plot()
+    plt.close('all')
 
 
 def test_plot_annotations():

--- a/mne/viz/tests/test_utils.py
+++ b/mne/viz/tests/test_utils.py
@@ -120,19 +120,18 @@ def test_auto_scale():
                              ('stim', 'auto')])
 
         # Test for wrong inputs
-        pytest.raises(ValueError, inst.plot, scalings='foo')
-        pytest.raises(ValueError, _compute_scalings, 'foo', inst)
+        with pytest.raises(ValueError, match=r".*scalings.*'foo'.*"):
+            inst.plot(scalings='foo')
 
         # Make sure compute_scalings doesn't change anything not auto
         scalings_new = _compute_scalings(scalings_def, inst)
         assert (scale_grad == scalings_new['grad'])
         assert (scalings_new['eeg'] != 'auto')
 
-    pytest.raises(ValueError, _compute_scalings, scalings_def, rand_data)
+    with pytest.raises(ValueError, match='Must supply either Raw or Epochs'):
+        _compute_scalings(scalings_def, rand_data)
     epochs = epochs[0].load_data()
     epochs.pick_types(eeg=True, meg=False)
-    pytest.raises(ValueError, _compute_scalings,
-                  dict(grad='auto'), epochs)
 
 
 def test_validate_if_list_of_axes():

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -286,7 +286,7 @@ def _plot_topo_onpick(event, show_func):
         raise
 
 
-def _compute_scalings(bn, xlim, ylim):
+def _compute_ax_scalings(bn, xlim, ylim):
     """Compute scale factors for a unified plot."""
     if isinstance(ylim[0], (tuple, list, np.ndarray)):
         ylim = (ylim[0][0], ylim[1][0])
@@ -342,7 +342,7 @@ def _imshow_tfr_unified(bn, ch_idx, tmin, tmax, vmin, vmax, onselect,
                         x_label=None, y_label=None, colorbar=False,
                         picker=True, cmap='RdBu_r', title=None, hline=None):
     """Show multiple tfrs on topo using a single axes."""
-    _compute_scalings(bn, (tmin, tmax), (freq[0], freq[-1]))
+    _compute_ax_scalings(bn, (tmin, tmax), (freq[0], freq[-1]))
     ax = bn.ax
     data_lines = bn.data_lines
     extent = (bn.x_t + bn.x_s * tmin, bn.x_t + bn.x_s * tmax,
@@ -469,7 +469,7 @@ def _plot_timeseries_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim, data,
     if not (ylim and not any(v is None for v in ylim)):
         ylim = [min(np.min(d) for d in data), max(np.max(d) for d in data)]
     # Translation and scale parameters to take data->under_ax normalized coords
-    _compute_scalings(bn, (tmin, tmax), ylim)
+    _compute_ax_scalings(bn, (tmin, tmax), ylim)
     pos = bn.pos
     data_lines = bn.data_lines
     ax = bn.ax
@@ -538,7 +538,7 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
                              vlim_array=None):
     """Plot erfimage topography using a single axis."""
     from scipy import ndimage
-    _compute_scalings(bn, (tmin, tmax), (0, len(epochs.events)))
+    _compute_ax_scalings(bn, (tmin, tmax), (0, len(epochs.events)))
     ax = bn.ax
     data_lines = bn.data_lines
     extent = (bn.x_t + bn.x_s * tmin, bn.x_t + bn.x_s * tmax, bn.y_t,


### PR DESCRIPTION
Closes #6271.

Tested on `master` by adding `ica.get_sources(raw).plot()` on line 90 of `plot_artifacts_correction_ica.py` which looks like:

![Screenshot from 2019-05-15 11-50-29](https://user-images.githubusercontent.com/2365790/57789853-b9f79e00-7707-11e9-89b4-eb3b8e3ba188.png)

And on this PR:

![Screenshot from 2019-05-15 11-51-01](https://user-images.githubusercontent.com/2365790/57789858-bc59f800-7707-11e9-8550-d9fc35f30db1.png)
