### PR TITLE
MRG, FIX: Clipping on uint32 dtype

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -852,7 +852,7 @@ def _read_gdf_header(fname, exclude):
                 else:
                     chn = np.zeros(n_events, dtype=np.int32)
                     dur = np.ones(n_events, dtype=np.uint32)
-                np.clip(dur, 1, np.inf, out=dur)
+                np.maximum(dur, 1, out=dur)
                 events = [n_events, pos, typ, chn, dur]
 
         # GDF 2.x


### PR DESCRIPTION
Should fix failures on `master` with NumPy dev. Doing `np.maximum(x, 1, out=x)` should be effectively the same as  `np.clip(x, 1, np.inf, out=x)` (because the `np.inf` shouldn't actually clip), slightly more efficient, and avoid the casting warning.