### PR TITLE
MRG, MAINT: Update logo code

### DIFF
--- a/logo/generate_mne_logos.py
+++ b/logo/generate_mne_logos.py
@@ -14,7 +14,7 @@ import numpy as np
 import os.path as op
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
-from matplotlib.mlab import bivariate_normal
+from scipy.stats import multivariate_normal
 from matplotlib.path import Path
 from matplotlib.text import TextPath
 from matplotlib.patches import PathPatch
@@ -25,8 +25,6 @@ dpi = 72.
 center_fudge = np.array([2, 0])  # compensate for font bounding box padding
 tagline_scale_fudge = 0.98  # to get justification right
 tagline_offset_fudge = np.array([0.4, 0])
-
-static_dir = op.join('..', 'doc', '_static')
 
 # font, etc
 rcp = {'font.sans-serif': ['Primetime'], 'font.style': 'normal',
@@ -46,8 +44,11 @@ delta = 0.1
 x = np.arange(-8.0, 8.0, delta)
 y = np.arange(-3.0, 3.0, delta)
 X, Y = np.meshgrid(x, y)
-Z1 = bivariate_normal(X, Y, 8.0, 7.0, -5.0, 0.9, 1.0)
-Z2 = bivariate_normal(X, Y, 15.0, 2.5, 2.6, -2.5, 2.5)
+xy = np.array([X, Y]).transpose(1, 2, 0)
+Z1 = multivariate_normal.pdf(xy, mean=[-5.0, 0.9],
+                             cov=np.array([[8.0, 1.0], [1.0, 7.0]]) ** 2)
+Z2 = multivariate_normal.pdf(xy, mean=[2.6, -2.5],
+                             cov=np.array([[15.0, 2.5], [2.5, 2.5]]) ** 2)
 Z = Z2 - 0.7 * Z1
 
 # color map: field gradient (yellow-red-gray-blue-cyan)
@@ -109,6 +110,8 @@ ax.set_ylim(np.ceil(yy), yl[-1])
 
 # only save actual image extent plus a bit of padding
 plt.draw()
+static_dir = op.join(op.dirname(__file__), '..', 'doc', '_static')
+assert op.isdir(static_dir)
 plt.savefig(op.join(static_dir, 'mne_logo.png'), transparent=True)
 plt.close()
 


### PR DESCRIPTION
I wanted to create a bigger MNE logo for an upcoming workshop. These changes were needed to get it to run with latest `matplotlib` where `bivariate_normal` is gone. FYI here is the output I came up with after tweaking `dpi=600`, `delta=0.01`, and `tagline_offset_fudge = [0.4, -100]` (the lower right N is a tiny bit cut off but it's good enough for me):

![mne_logo](https://user-images.githubusercontent.com/2365790/57867688-97c95300-77cf-11e9-88c1-286a2fbd07e8.png)

Thanks again to @drammock for scripting this so it was easy to make a higher-res PNG!
