### PR TITLE
MRG, FIX: Remove BAD and EDGE from events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -175,6 +175,8 @@ Bug
 
 - Fix 32bits annotations in :func:`mne.io.read_raw_cnt` by `Joan Massich`_
 
+- Fix :func:`mne.events_from_annotations` to ignore ``'BAD_'` and ``'EDGE_'`` annotations by default using a new default ``regexp`` by `Eric Larson`_
+
 - Fix bug in :func:`mne.preprocessing.mark_flat` where ``raw.first_samp`` was not taken into account by `kalenkovich`_
 
 - Fix date parsing in :func:`mne.io.read_raw_cnt` by `Joan Massich`_

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -63,7 +63,7 @@ raw.rename_channels(lambda x: x.strip('.'))
 # Apply band-pass filter
 raw.filter(7., 30., fir_design='firwin', skip_by_annotation='edge')
 
-events, _ = events_from_annotations(raw)
+events, _ = events_from_annotations(raw, event_id=dict(T1=2, T2=3))
 
 picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
                    exclude='bads')

--- a/examples/decoding/plot_decoding_csp_timefreq.py
+++ b/examples/decoding/plot_decoding_csp_timefreq.py
@@ -41,7 +41,7 @@ raw = concatenate_raws([read_raw_edf(f, preload=True) for f in raw_fnames])
 
 # Extract information from the raw file
 sfreq = raw.info['sfreq']
-events, _ = events_from_annotations(raw)
+events, _ = events_from_annotations(raw, event_id=dict(T1=2, T2=3))
 raw.pick_types(meg=False, eeg=True, stim=False, eog=False, exclude='bads')
 
 # Assemble the classifier using scikit-learn pipeline

--- a/examples/time_frequency/plot_time_frequency_erds.py
+++ b/examples/time_frequency/plot_time_frequency_erds.py
@@ -61,7 +61,7 @@ raw = concatenate_raws(raws)
 
 raw.rename_channels(lambda x: x.strip('.'))  # remove dots from channel names
 
-events, _ = mne.events_from_annotations(raw)
+events, _ = mne.events_from_annotations(raw, event_id=dict(T1=2, T2=3))
 
 picks = mne.pick_channels(raw.info["ch_names"], ["C3", "Cz", "C4"])
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -815,7 +815,8 @@ def _select_annotations_based_on_description(descriptions, event_id, regexp):
 
 
 @verbose
-def events_from_annotations(raw, event_id="auto", regexp=None,
+def events_from_annotations(raw, event_id="auto",
+                            regexp=r'^(?![Bb][Aa][Dd]|[Ee][Dd][Gg][Ee]).*$',
                             use_rounding=True, chunk_duration=None,
                             verbose=None):
     """Get events and event_id from an Annotations object.
@@ -844,7 +845,11 @@ def events_from_annotations(raw, event_id="auto", regexp=None,
           .. versionadded:: 0.18
     regexp : str | None
         Regular expression used to filter the annotations whose
-        descriptions is a match.
+        descriptions is a match. The default ignores descriptions beginning
+        ``'bad'`` or ``'edge'`` (case-insensitive).
+
+        .. versionchanged:: 0.18
+           Default ignores bad and edge descriptions.
     use_rounding : boolean
         If True, use rounding (instead of truncation) when converting
         times to indices. This can help avoid non-unique indices.
@@ -865,6 +870,7 @@ def events_from_annotations(raw, event_id="auto", regexp=None,
         The event_id variable that can be passed to Epochs.
     """
     if len(raw.annotations) == 0:
+        event_id = dict() if not isinstance(event_id, dict) else event_id
         return np.empty((0, 3), dtype=int), event_id
 
     annotations = raw.annotations

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -15,7 +15,7 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 from mne.utils import _TempDir, run_tests_if_main
-from mne import pick_types, read_annotations
+from mne import pick_types, read_annotations, concatenate_raws
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
 from mne.io.tests.test_raw import _test_raw_reader
@@ -502,6 +502,13 @@ def test_read_vhdr_annotations_and_events():
     expected_event_id.update(YYY=10001, ZZZ=10002)  # others starting at 10001
     expected_event_id[s_10] = 10
     _, event_id = events_from_annotations(raw)
+    assert event_id == expected_event_id
+
+    # Concatenating two shouldn't change the resulting event_id
+    # (BAD and EDGE should be ignored)
+    with pytest.warns(RuntimeWarning, match='expanding outside'):
+        raw_concat = concatenate_raws([raw.copy(), raw.copy()])
+    _, event_id = events_from_annotations(raw_concat)
     assert event_id == expected_event_id
 
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -582,6 +582,17 @@ def test_events_from_annot_in_raw_objects():
     with pytest.raises(ValueError, match='not find any of the events'):
         events_from_annotations(raw, regexp='not_there')
 
+    # concat does not introduce BAD or EDGE
+    raw_concat = concatenate_raws([raw.copy(), raw.copy()])
+    _, event_id = events_from_annotations(raw_concat)
+    assert isinstance(event_id, dict)
+    assert len(event_id) > 0
+    for kind in ('BAD', 'EDGE'):
+        assert '%s boundary' % kind in raw_concat.annotations.description
+        for key in event_id.keys():
+            assert kind not in key
+
+    # remove all events
     raw.set_annotations(None)
     events7, _ = events_from_annotations(raw)
     assert_array_equal(events7, np.empty((0, 3), dtype=int))


### PR DESCRIPTION
The "arbitrary integer assignment" change we made broke the EEGBCI example. There probably always should have been an `event_id` to prevent the assignments from being arbitrary, this fixes it.