### PR TITLE
MAINT: deprecate mne.realtime

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -393,6 +393,8 @@ def reset_warnings(gallery_conf, fname):
     # allow this ImportWarning, but don't show it
     warnings.filterwarnings(
         'ignore', message="can't resolve package from", category=ImportWarning)
+    warnings.filterwarnings(
+        'ignore', message='*mne-realtime*', category=DeprecationWarning)
 
 
 reset_warnings(None, None)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -394,7 +394,7 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(
         'ignore', message="can't resolve package from", category=ImportWarning)
     warnings.filterwarnings(
-        'ignore', message='*mne-realtime*', category=DeprecationWarning)
+        'ignore', message='.*mne-realtime.*', category=DeprecationWarning)
 
 
 reset_warnings(None, None)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -281,6 +281,8 @@ API
 
 - The peak finder that was formerly accessible via ``from mne.preprocessing.peak_finder import peak_finder`` should now be imported directly from the enclosing namespace as ``from mne.preprocessing import peak_finder`` by `Eric Larson`_
 
+- Deprecate `mne.realtime` module to make a standalone module `mne-realtime` that will live outside of this package by `Teon Brooks`_
+
 .. _changes_0_17:
 
 Version 0.17

--- a/examples/realtime/plot_compute_rt_average.py
+++ b/examples/realtime/plot_compute_rt_average.py
@@ -13,7 +13,7 @@ evoked responses using moving averages.
 
 
 # Authors: Martin Luessi <mluessi@nmr.mgh.harvard.edu>
-#          Mainak Jas <mainak@neuro.hut.fi>
+#          Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/examples/realtime/plot_compute_rt_decoder.py
+++ b/examples/realtime/plot_compute_rt_decoder.py
@@ -7,7 +7,7 @@ Supervised machine learning applied to MEG data in sensor space.
 Here the classifier is updated every 5 trials and the decoding
 accuracy is plotted.
 """
-# Authors: Mainak Jas <mainak@neuro.hut.fi>
+# Authors: Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/examples/realtime/plot_ftclient_rt_average.py
+++ b/examples/realtime/plot_ftclient_rt_average.py
@@ -26,7 +26,7 @@ measurement info from the Fieldtrip Header object.
 Together with RtEpochs, this can be used to compute evoked
 responses using moving averages.
 """
-# Author: Mainak Jas <mainak@neuro.hut.fi>
+# Author: Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/examples/realtime/plot_ftclient_rt_compute_psd.py
+++ b/examples/realtime/plot_ftclient_rt_compute_psd.py
@@ -11,7 +11,7 @@ computation of power spectra in real-time using the
 get_data_as_epoch function.
 
 """
-# Author: Mainak Jas <mainak@neuro.hut.fi>
+# Author: Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/examples/realtime/plot_lslclient_rt.py
+++ b/examples/realtime/plot_lslclient_rt.py
@@ -10,7 +10,7 @@ replace this with the stream of your choice by changing the host id to
 the desired stream.
 
 """
-# Author: Teon Brooks <teon.brooks@gmail.com>
+# Author: Teon L Brooks <teon.brooks@gmail.com>
 #
 # License: BSD (3-clause)
 import matplotlib.pyplot as plt

--- a/examples/realtime/plot_rt_feedback_server.py
+++ b/examples/realtime/plot_rt_feedback_server.py
@@ -17,7 +17,7 @@ All brain responses are simulated from a fiff file to make it easy
 to test. However, it should be possible to adapt this script
 for a real experiment.
 """
-# Author: Mainak Jas <mainak@neuro.hut.fi>
+# Author: Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/examples/realtime/rt_feedback_client.py
+++ b/examples/realtime/rt_feedback_client.py
@@ -24,7 +24,7 @@ to test. However, it should be possible to adapt this script
 for a real experiment.
 
 """
-# Author: Mainak Jas <mainak@neuro.hut.fi>
+# Author: Mainak Jas <mainakjas@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -67,7 +67,7 @@ def pytest_configure(config):
     ignore:`formatargspec` is deprecated:DeprecationWarning
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning
-    ignore:*mne-realtime*:DeprecationWarning
+    ignore:.*mne-realtime.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -67,6 +67,7 @@ def pytest_configure(config):
     ignore:`formatargspec` is deprecated:DeprecationWarning
     # This is only necessary until sklearn updates their wheels for NumPy 1.16
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:*mne-realtime*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/realtime/client.py
+++ b/mne/realtime/client.py
@@ -11,7 +11,7 @@ import threading
 
 import numpy as np
 
-from ..utils import logger, verbose, fill_doc
+from ..utils import logger, verbose, fill_doc, deprecated
 from ..io.constants import FIFF
 from ..io.meas_info import read_meas_info
 from ..io.tag import Tag, read_tag
@@ -20,6 +20,8 @@ from ..io.tree import make_dir_tree
 # Constants for fiff realtime fiff messages
 MNE_RT_GET_CLIENT_ID = 1
 MNE_RT_SET_CLIENT_ALIAS = 2
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
 
 def _recv_tag_raw(sock):
@@ -71,6 +73,7 @@ def _buffer_recv_worker(rt_client, nchan):
 
 
 @fill_doc
+@deprecated(RT_MSG)
 class RtClient(object):
     """Realtime Client.
 

--- a/mne/realtime/client.py
+++ b/mne/realtime/client.py
@@ -21,7 +21,8 @@ from ..io.tree import make_dir_tree
 MNE_RT_GET_CLIENT_ID = 1
 MNE_RT_SET_CLIENT_ALIAS = 2
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 def _recv_tag_raw(sock):

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -17,7 +17,8 @@ from ..event import _find_events
 from ..io.pick import _picks_to_idx
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 @fill_doc

--- a/mne/realtime/epochs.py
+++ b/mne/realtime/epochs.py
@@ -11,13 +11,17 @@ import copy
 import numpy as np
 
 from .. import pick_channels
-from ..utils import logger, verbose, fill_doc
+from ..utils import logger, verbose, fill_doc, deprecated
 from ..epochs import BaseEpochs
 from ..event import _find_events
 from ..io.pick import _picks_to_idx
 
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
+
 
 @fill_doc
+@deprecated(RT_MSG)
 class RtEpochs(BaseEpochs):
     """Realtime Epochs.
 

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -14,11 +14,15 @@ from ..io import _empty_info
 from ..io.pick import _picks_to_idx, pick_info
 from ..io.constants import FIFF
 from ..epochs import EpochsArray
-from ..utils import logger, warn, fill_doc
+from ..utils import logger, warn, fill_doc, deprecated
 from ..externals.FieldTrip import Client as FtClient
+
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
 
 @fill_doc
+@deprecated(RT_MSG)
 class FieldTripClient(_BaseClient):
     """Realtime FieldTrip client.
 

--- a/mne/realtime/fieldtrip_client.py
+++ b/mne/realtime/fieldtrip_client.py
@@ -18,7 +18,8 @@ from ..utils import logger, warn, fill_doc, deprecated
 from ..externals.FieldTrip import Client as FtClient
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 @fill_doc

--- a/mne/realtime/lsl_client.py
+++ b/mne/realtime/lsl_client.py
@@ -9,9 +9,13 @@ from .base_client import _BaseClient
 from ..epochs import EpochsArray
 from ..io.meas_info import create_info
 from ..io.pick import _picks_to_idx, pick_info
-from ..utils import fill_doc, _check_pylsl_installed
+from ..utils import fill_doc, _check_pylsl_installed, deprecated
+
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
 
+@deprecated(RT_MSG)
 class LSLClient(_BaseClient):
     """LSL Realtime Client.
 

--- a/mne/realtime/lsl_client.py
+++ b/mne/realtime/lsl_client.py
@@ -12,7 +12,8 @@ from ..io.pick import _picks_to_idx, pick_info
 from ..utils import fill_doc, _check_pylsl_installed, deprecated
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 @deprecated(RT_MSG)

--- a/mne/realtime/mock_lsl_stream.py
+++ b/mne/realtime/mock_lsl_stream.py
@@ -8,7 +8,8 @@ from ..utils import _check_pylsl_installed, deprecated
 from ..io import constants
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 @deprecated(RT_MSG)

--- a/mne/realtime/mock_lsl_stream.py
+++ b/mne/realtime/mock_lsl_stream.py
@@ -4,10 +4,14 @@
 import time
 from multiprocessing import Process
 
-from ..utils import _check_pylsl_installed
+from ..utils import _check_pylsl_installed, deprecated
 from ..io import constants
 
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
+
+@deprecated(RT_MSG)
 class MockLSLStream(object):
     """Mock LSL Stream.
 

--- a/mne/realtime/mockclient.py
+++ b/mne/realtime/mockclient.py
@@ -12,7 +12,8 @@ from ..io.pick import _picks_to_idx
 from ..utils import fill_doc, deprecated
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 @fill_doc

--- a/mne/realtime/mockclient.py
+++ b/mne/realtime/mockclient.py
@@ -9,10 +9,14 @@ import numpy as np
 
 from ..event import find_events
 from ..io.pick import _picks_to_idx
-from ..utils import fill_doc
+from ..utils import fill_doc, deprecated
+
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
 
 @fill_doc
+@deprecated(RT_MSG)
 class MockRtClient(object):
     """Mock Realtime Client.
 

--- a/mne/realtime/stim_server_client.py
+++ b/mne/realtime/stim_server_client.py
@@ -12,7 +12,8 @@ import numpy as np
 from ..utils import logger, verbose, fill_doc, deprecated
 
 RT_MSG = ('The realtime module is being deprecated from `mne-python` '
-          'and moved to its own repo, `mne-realtime`.')
+          'and moved to its own package, `mne-realtime`. '
+          'To install, please use `$ pip install mne_realtime`.')
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):

--- a/mne/realtime/stim_server_client.py
+++ b/mne/realtime/stim_server_client.py
@@ -9,7 +9,10 @@ import threading
 
 import numpy as np
 
-from ..utils import logger, verbose, fill_doc
+from ..utils import logger, verbose, fill_doc, deprecated
+
+RT_MSG = ('The realtime module is being deprecated from `mne-python` '
+          'and moved to its own repo, `mne-realtime`.')
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -80,6 +83,7 @@ class _TriggerHandler(socketserver.BaseRequestHandler):
                     self.request.sendall("Empty".encode('utf-8'))
 
 
+@deprecated(RT_MSG)
 class StimServer(object):
     """Stimulation Server.
 
@@ -213,6 +217,7 @@ class StimServer(object):
 
 
 @fill_doc
+@deprecated(RT_MSG)
 class StimClient(object):
     """Stimulation Client.
 


### PR DESCRIPTION
We would like to deprecate the realtime module object this release cycle so that they can be removed in the next. this PR attempts to do so.