### PR TITLE
[MRG] Allow iterable in drop_channels

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -761,11 +761,12 @@ class UpdateChannelsMixin(object):
         try:
             all_str = all([isinstance(ch, str) for ch in ch_names])
         except TypeError:
-            raise ValueError("'ch_names' must be iterable.")
-        else:
-            if not all_str:
-                raise ValueError("Each element in 'ch_names' must be str, got "
-                                 "{}.".format([type(ch) for ch in ch_names]))
+            raise ValueError("'ch_names' must be iterable, got "
+                             "type {} ({}).".format(type(ch_names), ch_names))
+
+        if not all_str:
+            raise ValueError("Each element in 'ch_names' must be str, got "
+                             "{}.".format([type(ch) for ch in ch_names]))
 
         missing = [ch for ch in ch_names if ch not in self.ch_names]
         if len(missing) > 0:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -737,8 +737,8 @@ class UpdateChannelsMixin(object):
 
         Parameters
         ----------
-        ch_names : list, set or str
-            List/set of channel name(s) or channel name to remove.
+        ch_names : iterable or str
+            Iterable (e.g. list) of channel name(s) or channel name to remove.
 
         Returns
         -------
@@ -755,15 +755,17 @@ class UpdateChannelsMixin(object):
         -----
         .. versionadded:: 0.9.0
         """
-        if isinstance(ch_names, list) or isinstance(ch_names, set):
-            if not all([isinstance(ch, str) for ch in ch_names]):
-                raise ValueError("'ch_names' must be a list of strings, got "
-                                 "{}.".format([type(ch) for ch in ch_names]))
-        elif isinstance(ch_names, str):
+        if isinstance(ch_names, str):
             ch_names = [ch_names]
+
+        try:
+            all_str = all([isinstance(ch, str) for ch in ch_names])
+        except TypeError:
+            raise ValueError("'ch_names' must be iterable.")
         else:
-            raise ValueError("'ch_names' must be a list or a string, got "
-                             "{}.".format(type(ch_names)))
+            if not all_str:
+                raise ValueError("Each element in 'ch_names' must be str, got "
+                                 "{}.".format([type(ch) for ch in ch_names]))
 
         missing = [ch for ch in ch_names if ch not in self.ch_names]
         if len(missing) > 0:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -737,8 +737,8 @@ class UpdateChannelsMixin(object):
 
         Parameters
         ----------
-        ch_names : list or str
-            List of channel name(s) or channel name to remove.
+        ch_names : list, set or str
+            List/set of channel name(s) or channel name to remove.
 
         Returns
         -------
@@ -755,7 +755,7 @@ class UpdateChannelsMixin(object):
         -----
         .. versionadded:: 0.9.0
         """
-        if isinstance(ch_names, list):
+        if isinstance(ch_names, list) or isinstance(ch_names, set):
             if not all([isinstance(ch, str) for ch in ch_names]):
                 raise ValueError("'ch_names' must be a list of strings, got "
                                  "{}.".format([type(ch) for ch in ch_names]))

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -298,6 +298,7 @@ def test_drop_channels():
     raw = read_raw_fif(raw_fname, preload=True).crop(0, 0.1)
     raw.drop_channels(["MEG 0111"])  # list argument
     raw.drop_channels("MEG 0112")  # str argument
+    raw.drop_channels({"MEG 0132", "MEG 0133"})  # set argument
     pytest.raises(ValueError, raw.drop_channels, ["MEG 0111", 5])
     pytest.raises(ValueError, raw.drop_channels, 5)  # must be list or str
 


### PR DESCRIPTION
I have a use case where I have a set of channel names which I want to drop. It would be nice if I could directly pass the set to `raw.drop_channels`, which I have implemented in this PR.