### PR TITLE
STY: prefer _DefaultEventParser to _Counter

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -21,7 +21,7 @@ from io import StringIO
 
 import numpy as np
 
-from ...utils import verbose, logger, warn, fill_doc
+from ...utils import verbose, logger, warn, fill_doc, _DefaultEventParser
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..base import BaseRaw, _check_update_montage
@@ -832,11 +832,8 @@ _OTHER_ACCEPTED_MARKERS = {
 _OTHER_OFFSET = 10001  # where to start "unknown" event_ids
 
 
-class _BVEventParser(object):
+class _BVEventParser(_DefaultEventParser):
     """Parse standard brainvision events, accounting for non-standard ones."""
-
-    def __init__(self):
-        self.other_event_ids = dict()
 
     def __call__(self, description):
         """Parse BrainVision event codes (like `Stimulus/S 11`) to ints."""
@@ -849,10 +846,6 @@ class _BVEventParser(object):
         elif description in _OTHER_ACCEPTED_MARKERS:
             code = _OTHER_ACCEPTED_MARKERS[description]
         else:
-            if description not in self.other_event_ids:
-                # Each time a new one is added, len(self.other_event_ids)
-                # will grow, so implicitly this is a counter for us
-                self.other_event_ids[description] = \
-                    _OTHER_OFFSET + len(self.other_event_ids)
-            code = self.other_event_ids[description]
+            code = (super(_BVEventParser, self)
+                    .__call__(description, offset=_OTHER_OFFSET))
         return code

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -582,6 +582,9 @@ def test_events_from_annot_in_raw_objects():
     with pytest.raises(ValueError, match='not find any of the events'):
         events_from_annotations(raw, regexp='not_there')
 
+    with pytest.raises(ValueError, match='Invalid input event_id'):
+        events_from_annotations(raw, event_id='wrong')
+
     # concat does not introduce BAD or EDGE
     raw_concat = concatenate_raws([raw.copy(), raw.copy()])
     _, event_id = events_from_annotations(raw_concat)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -24,9 +24,9 @@ from .fetching import _fetch_file, _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
                        ETSContext)
-from .misc import (run_subprocess, _pl, _clean_names, _Counter, pformat,
+from .misc import (run_subprocess, _pl, _clean_names, pformat,
                    _explain_exception, _get_argvalues, sizeof_fmt,
-                   running_subprocess)
+                   running_subprocess, _DefaultEventParser)
 from .progressbar import ProgressBar
 from ._testing import (run_tests_if_main, requires_sklearn,
                        requires_version, requires_nibabel, requires_mayavi,

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -50,6 +50,7 @@ def _sort_keys(x):
 
 class _DefaultEventParser:
     """Parse none standard events."""
+
     def __init__(self):
         self.event_ids = dict()
 

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -48,13 +48,16 @@ def _sort_keys(x):
     return keys
 
 
-class _Counter():
-    count = 1
+class _DefaultEventParser:
+    """Parse none standard events."""
+    def __init__(self):
+        self.event_ids = dict()
 
-    def __call__(self, *args, **kargs):
-        c = self.count
-        self.count += 1
-        return c
+    def __call__(self, description, offset=1):
+        if description not in self.event_ids:
+            self.event_ids[description] = offset + len(self.event_ids)
+
+        return self.event_ids[description]
 
 
 class _FormatDict(dict):


### PR DESCRIPTION
Things I wanted to ask in #6326 but I didn't have the chance. 

It avoids returning `lambda: None` + adds a test in case `event_id='random string'`. What I did not got away with is a form to not pass `raw` to `_check_event_id`. (which can be big and so on). @larsoner can you see a way? Maybe defining the function within or braking it again in two functions which we end up at the same place as we started.

Anyways, feel free to push in the branch or close