### PR TITLE
Minor fixes to docs

### DIFF
--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -63,7 +63,7 @@ def run():
                       help="Display filtering IIR order (or 0 to use FIR)",
                       default=4)
     parser.add_option("--clipping", dest="clipping",
-                      help="Enable trace clipping mode, either 'clip' or "
+                      help="Enable trace clipping mode, either 'clamp' or "
                       "'transparent'", default=None)
     parser.add_option("--filterchpi", dest="filterchpi",
                       help="Enable filtering cHPI signals.", default=None,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2686,7 +2686,6 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         degrees from one stc to the next.
     ``'max'``
         Max value within each label.
-    
     If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``stc`` object set
     ``src`` argument to ``fwd['src']`` to ensure the source space is

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2687,7 +2687,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
     ``'max'``
         Max value within each label.
     
-    If encountering a ``'ValueError'`` due to mismatch between number of
+    If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``'stc'`` object set
     ``'src'`` argument to ``'fwd['src']'`` to ensure the source space is
     compatible between forward and inverse routines.

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2689,7 +2689,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
     
     If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``stc`` object set
-    ``'src'`` argument to ``'fwd['src']'`` to ensure the source space is
+    ``src`` argument to ``fwd['src']`` to ensure the source space is
     compatible between forward and inverse routines.
 
     """

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2686,6 +2686,11 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         degrees from one stc to the next.
     ``'max'``
         Max value within each label.
+    
+    If encountering a ``'ValueError'`` due to mismatch between number of
+    source points in the subject source space and computed ``'stc'`` object set
+    ``'src'`` argument to ``'fwd['src']'`` to ensure the source space is
+    compatible between forward and inverse routines.
 
     """
     # convert inputs to lists

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2686,11 +2686,11 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         degrees from one stc to the next.
     ``'max'``
         Max value within each label.
+
     If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``stc`` object set
     ``src`` argument to ``fwd['src']`` to ensure the source space is
     compatible between forward and inverse routines.
-
     """
     # convert inputs to lists
     if isinstance(stcs, SourceEstimate):

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2688,7 +2688,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         Max value within each label.
     
     If encountering a ``ValueError`` due to mismatch between number of
-    source points in the subject source space and computed ``'stc'`` object set
+    source points in the subject source space and computed ``stc`` object set
     ``'src'`` argument to ``'fwd['src']'`` to ensure the source space is
     compatible between forward and inverse routines.
 


### PR DESCRIPTION
#### What does this implement/fix?
Minor fix to set the same expected `clipping` arg in `mne_browse_raw` help message as that of `raw.plot()` docstring. Along with additional _NB_ in `extract_label_time_course` as per @larsoner.
