### PR TITLE
ENH: Simpler syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             command: |
               pip install --user --upgrade --progress-bar off pip numpy vtk
               pip install --user --upgrade --progress-bar off -r requirements.txt
-              pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master" "https://api.github.com/repos/larsoner/sphinx-bootstrap-divs/zipball/master"
+              pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
 
         - save_cache:
             key: pip-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             command: |
               pip install --user --upgrade --progress-bar off pip numpy vtk
               pip install --user --upgrade --progress-bar off -r requirements.txt
-              pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
+              pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master" "https://api.github.com/repos/larsoner/sphinx-bootstrap-divs/zipball/master"
 
         - save_cache:
             key: pip-cache

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -296,6 +296,9 @@ h4.list-group-item-heading {
       display:block !important;
   }
 }
+details.example_details summary {
+    font-weight: bold;
+}
 
 .skinnytable {
     width: auto;

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -299,6 +299,9 @@ h4.list-group-item-heading {
 details.example_details summary {
     font-weight: bold;
 }
+.panel {
+    margin-bottom: 3px;
+}
 
 .skinnytable {
     width: auto;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,6 +65,7 @@ extensions = [
     'numpydoc',
     'gen_commands',
     'sphinx_bootstrap_theme',
+    'sphinx_bootstrap_divs',
 ]
 
 linkcheck_ignore = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,7 +178,7 @@ html_theme_options = {
         ("Tutorials", "auto_tutorials/index"),
         ("Contribute", "install/contributing"),
     ],
-    }
+}
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -81,7 +81,7 @@ this package. You can also find a gallery of these examples in the
         manual/memory.rst
         manual/migrating.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::
@@ -138,7 +138,7 @@ this package. You can also find a gallery of these examples in the
         auto_tutorials/preprocessing/plot_artifacts_correction_maxwell_filtering.rst
 
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
       .. toctree::
@@ -171,7 +171,7 @@ this package. You can also find a gallery of these examples in the
         auto_tutorials/evoked/plot_whitened.rst
         tutorials/report.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::
@@ -204,7 +204,7 @@ this package. You can also find a gallery of these examples in the
         auto_tutorials/time-freq/plot_sensors_time_frequency.rst
         manual/time_frequency.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::
@@ -320,7 +320,7 @@ this package. You can also find a gallery of these examples in the
         auto_tutorials/stats-sensor-space/plot_stats_cluster_time_frequency.rst
         auto_tutorials/stats-sensor-space/plot_stats_cluster_erp.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::
@@ -351,7 +351,7 @@ this package. You can also find a gallery of these examples in the
 
         auto_tutorials/machine-learning/plot_sensors_decoding.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::
@@ -375,7 +375,7 @@ this package. You can also find a gallery of these examples in the
 
         auto_tutorials/machine-learning/plot_receptive_field.rst
 
-    .. details:: **Examples**
+    .. details:: Examples
         :class: example_details
 
         .. toctree::

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -5,39 +5,6 @@
 Documentation
 =============
 
-.. raw:: html
-
-    <style class='text/css'>
-    .panel-title a {
-        display: block;
-        padding: 5px;
-        text-decoration: none;
-    }
-
-    .plus {
-        float: right;
-        color: #212121;
-    }
-
-    .panel {
-        margin-bottom: 3px;
-    }
-
-    .example_details {
-        padding-left: 20px;
-        margin-bottom: 10px;
-    }
-    </style>
-
-    <script type="text/javascript">
-    $(document).ready(function () {
-        if(location.hash != null && location.hash != ""){
-            $('.collapse').removeClass('in');
-            $(location.hash + '.collapse').addClass('in');
-        }
-    });
-    </script>
-
 This is where you can learn about all the things you can do with MNE. It
 contains **background information** and **tutorials** for taking a deep-dive
 into the techniques that MNE-python covers. You'll find practical information
@@ -51,678 +18,423 @@ this package. You can also find a gallery of these examples in the
 
 **See the links below for an introduction to MNE-python, or click one of the sections on this page to see more.**
 
-.. raw:: html
-
-    <div class="panel-group">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_intro">Introduction to MNE and Python</a>
-          </h4>
-        </div>
+.. collapse:: Introduction to MNE and Python
+    :open:
 
-        <div id="collapse_intro" class="panel-collapse collapse in">
-          <div class="panel-body">
+    **Getting started**
 
-**Getting started**
+    .. toctree::
+        :maxdepth: 1
 
-.. toctree::
-    :maxdepth: 1
-
-    install/index
-    install/advanced
+        install/index
+        install/advanced
 
-**MNE basics**
+    **MNE basics**
 
-.. toctree::
-    :maxdepth: 1
+    .. toctree::
+        :maxdepth: 1
 
-    tutorials/philosophy.rst
-    manual/cookbook.rst
-    whats_new.rst
-    python_reference.rst
-    glossary.rst
-    auto_examples/index.rst
-    generated/commands.rst
-    auto_tutorials/intro/plot_configuration.rst
-    cited.rst
-    faq.rst
+        tutorials/philosophy.rst
+        manual/cookbook.rst
+        whats_new.rst
+        python_reference.rst
+        glossary.rst
+        auto_examples/index.rst
+        generated/commands.rst
+        auto_tutorials/intro/plot_configuration.rst
+        cited.rst
+        faq.rst
 
-**More help**
-
-- :ref:`Cite MNE <cite>`
-- `Mailing list <https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis/>`_ for analysis talk
-- `GitHub issues <https://github.com/mne-tools/mne-python/issues/>`_ for
-  requests and bug reports
-- `Gitter <https://gitter.im/mne-tools/mne-python>`_ to chat with devs
+    **More help**
 
-.. raw:: html
+    - :ref:`Cite MNE <cite>`
+    - `Mailing list <https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis/>`_ for analysis talk
+    - `GitHub issues <https://github.com/mne-tools/mne-python/issues/>`_ for
+      requests and bug reports
+    - `Gitter <https://gitter.im/mne-tools/mne-python>`_ to chat with devs
+
+.. collapse:: Data structures and containers
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/raw/plot_object_raw.rst
+        auto_tutorials/epochs/plot_object_epochs.rst
+        auto_tutorials/evoked/plot_object_evoked.rst
+        auto_tutorials/source-modeling/plot_object_source_estimate.rst
+        auto_tutorials/intro/plot_info.rst
+        auto_tutorials/intro/plot_object_annotations.rst
+
+
+.. collapse:: Data I/O and datasets
+
+    **Getting your data into MNE**
+
+    .. toctree::
+        :maxdepth: 1
+
+        manual/io.rst
+        auto_tutorials/simulation/plot_creating_data_structures.rst
+        auto_tutorials/epochs/plot_metadata_epochs.rst
+        auto_tutorials/misc/plot_modifying_data_inplace.rst
+        auto_tutorials/misc/plot_ecog.rst
+        manual/memory.rst
+        manual/migrating.rst
+
+    .. details:: **Examples**
+        :class: example_details
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/io/plot_elekta_epochs.rst
+            auto_examples/io/plot_objects_from_arrays.rst
+            auto_examples/io/plot_read_and_write_raw_data.rst
+            auto_examples/io/plot_read_epochs.rst
+            auto_examples/io/plot_read_events.rst
+            auto_examples/io/plot_read_evoked.rst
+            auto_examples/io/plot_read_noise_covariance_matrix.rst
+
+    **Working with public datasets**
+
+    .. toctree::
+        :maxdepth: 1
+
+        manual/datasets_index.rst
+        auto_tutorials/sample-datasets/plot_brainstorm_auditory.rst
+        auto_tutorials/sample-datasets/plot_brainstorm_phantom_ctf.rst
+        auto_tutorials/sample-datasets/plot_brainstorm_phantom_elekta.rst
+        auto_tutorials/sample-datasets/plot_phantom_4DBTi.rst
+        auto_tutorials/sample-datasets/plot_sleep.rst
+        auto_examples/datasets/plot_brainstorm_data.rst
+        auto_examples/datasets/plot_opm_data.rst
+        auto_examples/datasets/plot_megsim_data.rst
+        auto_examples/datasets/plot_megsim_data_single_trial.rst
+        auto_examples/datasets/spm_faces_dataset.rst
+
+.. collapse:: Preprocessing (filtering, SSP, ICA, Maxwell filtering, ...)
+
+    **Background**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/discussions/plot_background_filtering.rst
+        manual/preprocessing/ssp.rst
+        manual/preprocessing/ica.rst
+        manual/preprocessing/maxwell.rst
+        manual/channel_interpolation.rst
+
+    **Preprocessing your data**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/preprocessing/plot_artifacts_detection.rst
+        auto_tutorials/preprocessing/plot_artifacts_correction_filtering.rst
+        auto_tutorials/preprocessing/plot_artifacts_correction_rejection.rst
+        auto_tutorials/preprocessing/plot_artifacts_correction_ssp.rst
+        auto_tutorials/preprocessing/plot_artifacts_correction_ica.rst
+        auto_tutorials/preprocessing/plot_artifacts_correction_maxwell_filtering.rst
+
+
+    .. details:: **Examples**
+        :class: example_details
+
+      .. toctree::
+          :maxdepth: 1
+
+          auto_examples/preprocessing/plot_define_target_events.rst
+          auto_examples/preprocessing/plot_eog_artifact_histogram.rst
+          auto_examples/preprocessing/plot_find_ecg_artifacts.rst
+          auto_examples/preprocessing/plot_find_eog_artifacts.rst
+          auto_examples/preprocessing/plot_head_positions.rst
+          auto_examples/preprocessing/plot_ica_comparison.rst
+          auto_examples/preprocessing/plot_interpolate_bad_channels.rst
+          auto_examples/preprocessing/plot_movement_compensation.rst
+          auto_examples/preprocessing/plot_rereference_eeg.rst
+          auto_examples/preprocessing/plot_resample.rst
+          auto_examples/preprocessing/plot_run_ica.rst
+          auto_examples/preprocessing/plot_shift_evoked.rst
+          auto_examples/preprocessing/plot_virtual_evoked.rst
+          auto_examples/preprocessing/plot_xdawn_denoising.rst
+
+.. collapse:: Visualization
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/raw/plot_visualize_raw.rst
+        auto_tutorials/epochs/plot_visualize_epochs.rst
+        auto_tutorials/evoked/plot_visualize_evoked.rst
+        auto_tutorials/source-modeling/plot_visualize_stc.rst
+        auto_tutorials/evoked/plot_whitened.rst
+        tutorials/report.rst
+
+    .. details:: **Examples**
+        :class: example_details
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/visualization/make_report.rst
+            auto_examples/visualization/plot_3d_to_2d.rst
+            auto_examples/visualization/plot_channel_epochs_image.rst
+            auto_examples/visualization/plot_eeg_on_scalp.rst
+            auto_examples/visualization/plot_evoked_topomap.rst
+            auto_examples/visualization/plot_evoked_whitening.rst
+            auto_examples/visualization/plot_meg_sensors.rst
+            auto_examples/visualization/plot_parcellation.rst
+            auto_examples/visualization/plot_sensor_noise_level.rst
+            auto_examples/visualization/plot_ssp_projs_sensitivity_map.rst
+            auto_examples/visualization/plot_topo_compare_conditions.rst
+            auto_examples/visualization/plot_topo_customized.rst
+            auto_examples/visualization/plot_xhemi.rst
+
+.. collapse:: Time- and frequency-domain analyses
+
+    **Tutorials**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/intro/plot_introduction.rst
+        auto_tutorials/intro/plot_epoching_and_averaging.rst
+        auto_tutorials/evoked/plot_eeg_erp.rst
+        auto_tutorials/time-freq/plot_sensors_time_frequency.rst
+        manual/time_frequency.rst
+
+    .. details:: **Examples**
+        :class: example_details
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/time_frequency/plot_compute_raw_data_spectrum.rst
+            auto_examples/time_frequency/plot_compute_source_psd_epochs.rst
+            auto_examples/time_frequency/plot_source_label_time_frequency.rst
+            auto_examples/time_frequency/plot_source_power_spectrum.rst
+            auto_examples/time_frequency/plot_source_space_time_frequency.rst
+            auto_examples/time_frequency/plot_temporal_whitening.rst
+            auto_examples/time_frequency/plot_time_frequency_global_field_power.rst
+            auto_examples/time_frequency/plot_time_frequency_simulated.rst
+            auto_examples/time_frequency/plot_compute_csd.rst
+
+.. collapse:: Source-level analysis
+
+    **Background**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/source-modeling/plot_background_freesurfer.rst
+        manual/source_localization/forward.rst
+        manual/source_localization/inverse.rst
+        manual/source_localization/morph_stc.rst
+
+    **Getting data to source space**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/source-modeling/plot_source_alignment.rst
+        auto_tutorials/source-modeling/plot_forward.rst
+        auto_tutorials/source-modeling/plot_compute_covariance.rst
+        auto_tutorials/source-modeling/plot_eeg_no_mri.rst
+        auto_tutorials/source-modeling/plot_mne_dspm_source_localization.rst
+        auto_tutorials/source-modeling/plot_mne_solutions.rst
+        auto_tutorials/source-modeling/plot_dipole_fit.rst
+        auto_tutorials/simulation/plot_point_spread.rst
+        auto_tutorials/source-modeling/plot_dipole_orientations.rst
+        auto_tutorials/simulation/plot_dics.rst
+
+
+    .. details:: **Forward examples**
+        :class: example_details
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/forward/plot_decimate_head_surface.rst
+            auto_examples/forward/plot_forward_sensitivity_maps.rst
+            auto_examples/forward/plot_left_cerebellum_volume_source.rst
+            auto_examples/forward/plot_source_space_morphing.rst
+
+    .. details:: **Inverse examples**
+        :class: example_details
+
+        auto_examples/datasets/plot_opm_rest_data.rst
+        auto_examples/inverse/plot_compute_mne_inverse_epochs_in_label.rst
+        auto_examples/inverse/plot_compute_mne_inverse_raw_in_label.rst
+        auto_examples/inverse/plot_compute_mne_inverse_volume.rst
+        auto_examples/inverse/plot_covariance_whitening_dspm.rst
+        auto_examples/inverse/plot_custom_inverse_solver.rst
+        auto_examples/inverse/plot_dics_source_power.rst
+        auto_examples/inverse/plot_gamma_map_inverse.rst
+        auto_examples/inverse/plot_label_activation_from_stc.rst
+        auto_examples/inverse/plot_label_from_stc.rst
+        auto_examples/inverse/plot_label_source_activations.rst
+        auto_examples/inverse/plot_lcmv_beamformer.rst
+        auto_examples/inverse/plot_lcmv_beamformer_volume.rst
+        auto_examples/inverse/plot_mixed_source_space_inverse.rst
+        auto_examples/inverse/plot_mixed_norm_inverse.rst
+        auto_examples/inverse/plot_mne_crosstalk_function.rst
+        auto_examples/inverse/plot_mne_point_spread_function.rst
+        auto_examples/inverse/plot_morph_surface_stc.rst
+        auto_examples/inverse/plot_morph_volume_stc.rst
+        auto_examples/inverse/plot_rap_music.rst
+        auto_examples/inverse/plot_read_stc.rst
+        auto_examples/inverse/plot_read_inverse.rst
+        auto_examples/inverse/plot_read_source_space.rst
+        auto_examples/inverse/plot_snr_estimate.rst
+        auto_examples/inverse/plot_tf_dics.rst
+        auto_examples/inverse/plot_tf_lcmv.rst
+        auto_examples/inverse/plot_time_frequency_mixed_norm_inverse.rst
+        auto_examples/inverse/plot_vector_mne_solution.rst
+
+    .. details:: **Simulation examples**
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/simulation/plot_simulate_evoked_data.rst
+            auto_examples/simulation/plot_simulate_raw_data.rst
+            auto_examples/simulation/plot_simulated_raw_data_using_subject_anatomy.rst
+
+.. collapse:: Statistics
+
+    **Background**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/discussions/plot_background_statistics.rst
+
+    **Sensor Space**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.rst
+        auto_tutorials/stats-sensor-space/plot_stats_cluster_1samp_test_time_frequency.rst
+        auto_tutorials/stats-sensor-space/plot_stats_cluster_time_frequency.rst
+        auto_tutorials/stats-sensor-space/plot_stats_cluster_erp.rst
+
+    .. details:: **Examples**
+        :class: example_details
+
+        .. toctree::
+            :maxdepth: 1
+
+            auto_examples/stats/plot_fdr_stats_evoked.rst
+            auto_examples/stats/plot_cluster_stats_evoked.rst
+            auto_examples/stats/plot_sensor_permutation_test.rst
+            auto_examples/stats/plot_sensor_regression.rst
+            auto_examples/stats/plot_linear_regression_raw.rst
+
+    **Source Space**
+
+    .. toctree::
+        :maxdepth: 1
+
+        auto_tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.rst
+        auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.rst
+        auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.rst
+        auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.rst
 
-          </div>
-        </div>
-      </div>
+.. collapse:: Machine learning (decoding, encoding, MVPA)
 
+    **Decoding**
 
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_data">Data structures and containers</a>
-          </h4>
-        </div>
+    .. toctree::
+        :maxdepth: 1
 
-        <div id="collapse_data" class="panel-collapse collapse">
-          <div class="panel-body">
+        auto_tutorials/machine-learning/plot_sensors_decoding.rst
 
-.. toctree::
-    :maxdepth: 1
+    .. details:: **Examples**
+        :class: example_details
 
-    auto_tutorials/raw/plot_object_raw.rst
-    auto_tutorials/epochs/plot_object_epochs.rst
-    auto_tutorials/evoked/plot_object_evoked.rst
-    auto_tutorials/source-modeling/plot_object_source_estimate.rst
-    auto_tutorials/intro/plot_info.rst
-    auto_tutorials/intro/plot_object_annotations.rst
+        .. toctree::
+            :maxdepth: 1
 
+            auto_examples/decoding/decoding_rsa.rst
+            auto_examples/decoding/plot_decoding_csp_eeg.rst
+            auto_examples/decoding/plot_decoding_csp_timefreq.rst
+            auto_examples/decoding/plot_decoding_spatio_temporal_source.rst
+            auto_examples/decoding/plot_decoding_spoc_CMC.rst
+            auto_examples/decoding/plot_decoding_time_generalization_conditions.rst
+            auto_examples/decoding/plot_decoding_unsupervised_spatial_filter.rst
+            auto_examples/decoding/plot_decoding_xdawn_eeg.rst
+            auto_examples/decoding/plot_ems_filtering.rst
+            auto_examples/decoding/plot_linear_model_patterns.rst
 
-.. raw:: html
+    **Encoding**
 
-          </div>
-        </div>
-      </div>
-
+    .. toctree::
+        :maxdepth: 1
 
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_io">Data I/O and datasets</a>
-          </h4>
-        </div>
-        <div id="collapse_io" class="panel-collapse collapse">
-          <div class="panel-body">
+        auto_tutorials/machine-learning/plot_receptive_field.rst
 
-**Getting your data into MNE**
+    .. details:: **Examples**
+        :class: example_details
 
-.. toctree::
-    :maxdepth: 1
-
-    manual/io.rst
-    auto_tutorials/simulation/plot_creating_data_structures.rst
-    auto_tutorials/epochs/plot_metadata_epochs.rst
-    auto_tutorials/misc/plot_modifying_data_inplace.rst
-    auto_tutorials/misc/plot_ecog.rst
-    manual/memory.rst
-    manual/migrating.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/io/plot_elekta_epochs.rst
-    auto_examples/io/plot_objects_from_arrays.rst
-    auto_examples/io/plot_read_and_write_raw_data.rst
-    auto_examples/io/plot_read_epochs.rst
-    auto_examples/io/plot_read_events.rst
-    auto_examples/io/plot_read_evoked.rst
-    auto_examples/io/plot_read_noise_covariance_matrix.rst
-
-.. raw:: html
-
-    </details>
-
-**Working with public datasets**
-
-.. toctree::
-    :maxdepth: 1
-
-    manual/datasets_index.rst
-    auto_tutorials/sample-datasets/plot_brainstorm_auditory.rst
-    auto_tutorials/sample-datasets/plot_brainstorm_phantom_ctf.rst
-    auto_tutorials/sample-datasets/plot_brainstorm_phantom_elekta.rst
-    auto_tutorials/sample-datasets/plot_phantom_4DBTi.rst
-    auto_tutorials/sample-datasets/plot_sleep.rst
-    auto_examples/datasets/plot_brainstorm_data.rst
-    auto_examples/datasets/plot_opm_data.rst
-    auto_examples/datasets/plot_megsim_data.rst
-    auto_examples/datasets/plot_megsim_data_single_trial.rst
-    auto_examples/datasets/spm_faces_dataset.rst
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="preprocessing" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_preprocessing">Preprocessing (filtering, SSP, ICA, Maxwell filtering, ...)</a>
-          </h4>
-        </div>
-        <div id="collapse_preprocessing" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**Background**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/discussions/plot_background_filtering.rst
-    manual/preprocessing/ssp.rst
-    manual/preprocessing/ica.rst
-    manual/preprocessing/maxwell.rst
-    manual/channel_interpolation.rst
-
-**Preprocessing your data**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/preprocessing/plot_artifacts_detection.rst
-    auto_tutorials/preprocessing/plot_artifacts_correction_filtering.rst
-    auto_tutorials/preprocessing/plot_artifacts_correction_rejection.rst
-    auto_tutorials/preprocessing/plot_artifacts_correction_ssp.rst
-    auto_tutorials/preprocessing/plot_artifacts_correction_ica.rst
-    auto_tutorials/preprocessing/plot_artifacts_correction_maxwell_filtering.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/preprocessing/plot_define_target_events.rst
-    auto_examples/preprocessing/plot_eog_artifact_histogram.rst
-    auto_examples/preprocessing/plot_find_ecg_artifacts.rst
-    auto_examples/preprocessing/plot_find_eog_artifacts.rst
-    auto_examples/preprocessing/plot_head_positions.rst
-    auto_examples/preprocessing/plot_ica_comparison.rst
-    auto_examples/preprocessing/plot_interpolate_bad_channels.rst
-    auto_examples/preprocessing/plot_movement_compensation.rst
-    auto_examples/preprocessing/plot_rereference_eeg.rst
-    auto_examples/preprocessing/plot_resample.rst
-    auto_examples/preprocessing/plot_run_ica.rst
-    auto_examples/preprocessing/plot_shift_evoked.rst
-    auto_examples/preprocessing/plot_virtual_evoked.rst
-    auto_examples/preprocessing/plot_xdawn_denoising.rst
-
-.. raw:: html
-
-    </details>
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="visualization" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_visualization">Visualization</a>
-          </h4>
-        </div>
-        <div id="collapse_visualization" class="panel-collapse collapse">
-          <div class="panel-body">
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/raw/plot_visualize_raw.rst
-    auto_tutorials/epochs/plot_visualize_epochs.rst
-    auto_tutorials/evoked/plot_visualize_evoked.rst
-    auto_tutorials/source-modeling/plot_visualize_stc.rst
-    auto_tutorials/evoked/plot_whitened.rst
-    tutorials/report.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/visualization/make_report.rst
-    auto_examples/visualization/plot_3d_to_2d.rst
-    auto_examples/visualization/plot_channel_epochs_image.rst
-    auto_examples/visualization/plot_eeg_on_scalp.rst
-    auto_examples/visualization/plot_evoked_topomap.rst
-    auto_examples/visualization/plot_evoked_whitening.rst
-    auto_examples/visualization/plot_meg_sensors.rst
-    auto_examples/visualization/plot_parcellation.rst
-    auto_examples/visualization/plot_sensor_noise_level.rst
-    auto_examples/visualization/plot_ssp_projs_sensitivity_map.rst
-    auto_examples/visualization/plot_topo_compare_conditions.rst
-    auto_examples/visualization/plot_topo_customized.rst
-    auto_examples/visualization/plot_xhemi.rst
-
-.. raw:: html
-
-    </details>
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="time-freq" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_tf">Time- and frequency-domain analyses</a>
-          </h4>
-        </div>
-        <div id="collapse_tf" class="panel-collapse collapse">
-          <div class="panel-body">
+        .. toctree::
+            :maxdepth: 1
 
-**Tutorials**
+            auto_examples/decoding/plot_receptive_field_mtrf.rst
 
-.. toctree::
-    :maxdepth: 1
+.. collapse:: Connectivity
 
-    auto_tutorials/intro/plot_introduction.rst
-    auto_tutorials/intro/plot_epoching_and_averaging.rst
-    auto_tutorials/evoked/plot_eeg_erp.rst
-    auto_tutorials/time-freq/plot_sensors_time_frequency.rst
-    manual/time_frequency.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/time_frequency/plot_compute_raw_data_spectrum.rst
-    auto_examples/time_frequency/plot_compute_source_psd_epochs.rst
-    auto_examples/time_frequency/plot_source_label_time_frequency.rst
-    auto_examples/time_frequency/plot_source_power_spectrum.rst
-    auto_examples/time_frequency/plot_source_space_time_frequency.rst
-    auto_examples/time_frequency/plot_temporal_whitening.rst
-    auto_examples/time_frequency/plot_time_frequency_global_field_power.rst
-    auto_examples/time_frequency/plot_time_frequency_simulated.rst
-    auto_examples/time_frequency/plot_compute_csd.rst
-
-.. raw:: html
-
-  </details>
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="source-analysis" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_source">Source-level analysis</a>
-          </h4>
-        </div>
-        <div id="collapse_source" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**Background**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/source-modeling/plot_background_freesurfer.rst
-    manual/source_localization/forward.rst
-    manual/source_localization/inverse.rst
-    manual/source_localization/morph_stc.rst
-
-**Getting data to source space**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/source-modeling/plot_source_alignment.rst
-    auto_tutorials/source-modeling/plot_forward.rst
-    auto_tutorials/source-modeling/plot_compute_covariance.rst
-    auto_tutorials/source-modeling/plot_eeg_no_mri.rst
-    auto_tutorials/source-modeling/plot_mne_dspm_source_localization.rst
-    auto_tutorials/source-modeling/plot_mne_solutions.rst
-    auto_tutorials/source-modeling/plot_dipole_fit.rst
-    auto_tutorials/simulation/plot_point_spread.rst
-    auto_tutorials/source-modeling/plot_dipole_orientations.rst
-    auto_tutorials/simulation/plot_dics.rst
-
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Forward examples</strong></summary>
+    **Examples**
 
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/forward/plot_decimate_head_surface.rst
-    auto_examples/forward/plot_forward_sensitivity_maps.rst
-    auto_examples/forward/plot_left_cerebellum_volume_source.rst
-    auto_examples/forward/plot_source_space_morphing.rst
+    .. toctree::
+        :maxdepth: 1
 
-.. raw:: html
+        auto_examples/connectivity/plot_cwt_sensor_connectivity.rst
+        auto_examples/connectivity/plot_mixed_source_space_connectivity.rst
+        auto_examples/connectivity/plot_mne_inverse_coherence_epochs.rst
+        auto_examples/connectivity/plot_mne_inverse_envelope_correlation.rst
+        auto_examples/connectivity/plot_mne_inverse_envelope_correlation_volume.rst
+        auto_examples/connectivity/plot_mne_inverse_connectivity_spectrum.rst
+        auto_examples/connectivity/plot_mne_inverse_label_connectivity.rst
+        auto_examples/connectivity/plot_mne_inverse_psi_visual.rst
+        auto_examples/connectivity/plot_sensor_connectivity.rst
 
-    </details>
+.. collapse:: Realtime
 
-.. raw:: html
+    **All realtime functionality has migrated to** :mod:`mne_realtime`.
 
-  <details class="example_details">
-  <summary><strong>Inverse examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
+.. collapse:: MNE-C and MNE-MATLAB
 
-    auto_examples/datasets/plot_opm_rest_data.rst
-    auto_examples/inverse/plot_compute_mne_inverse_epochs_in_label.rst
-    auto_examples/inverse/plot_compute_mne_inverse_raw_in_label.rst
-    auto_examples/inverse/plot_compute_mne_inverse_volume.rst
-    auto_examples/inverse/plot_covariance_whitening_dspm.rst
-    auto_examples/inverse/plot_custom_inverse_solver.rst
-    auto_examples/inverse/plot_dics_source_power.rst
-    auto_examples/inverse/plot_gamma_map_inverse.rst
-    auto_examples/inverse/plot_label_activation_from_stc.rst
-    auto_examples/inverse/plot_label_from_stc.rst
-    auto_examples/inverse/plot_label_source_activations.rst
-    auto_examples/inverse/plot_lcmv_beamformer.rst
-    auto_examples/inverse/plot_lcmv_beamformer_volume.rst
-    auto_examples/inverse/plot_mixed_source_space_inverse.rst
-    auto_examples/inverse/plot_mixed_norm_inverse.rst
-    auto_examples/inverse/plot_mne_crosstalk_function.rst
-    auto_examples/inverse/plot_mne_point_spread_function.rst
-    auto_examples/inverse/plot_morph_surface_stc.rst
-    auto_examples/inverse/plot_morph_volume_stc.rst
-    auto_examples/inverse/plot_rap_music.rst
-    auto_examples/inverse/plot_read_stc.rst
-    auto_examples/inverse/plot_read_inverse.rst
-    auto_examples/inverse/plot_read_source_space.rst
-    auto_examples/inverse/plot_snr_estimate.rst
-    auto_examples/inverse/plot_tf_dics.rst
-    auto_examples/inverse/plot_tf_lcmv.rst
-    auto_examples/inverse/plot_time_frequency_mixed_norm_inverse.rst
-    auto_examples/inverse/plot_vector_mne_solution.rst
+    **MNE-C**
 
-.. raw:: html
+    .. toctree::
+        :maxdepth: 1
 
-    </details>
+        tutorials/command_line.rst
+        manual/c_reference.rst
+        manual/gui/analyze.rst
+        manual/gui/browse.rst
+        manual/source_localization/c_forward.rst
+        manual/source_localization/c_inverse.rst
+        manual/source_localization/c_morph.rst
+        manual/appendix/bem_model.rst
+        manual/appendix/c_misc.rst
+        manual/appendix/c_release_notes.rst
+        manual/appendix/c_EULA.rst
+        manual/appendix/martinos.rst
 
-.. raw:: html
+    **MNE-MATLAB**
 
-  <details class="example_details">
-  <summary><strong>Simulation examples</strong></summary>
+    .. toctree::
+        :maxdepth: 1
 
-.. toctree::
-    :maxdepth: 1
+        manual/matlab.rst
 
-    auto_examples/simulation/plot_simulate_evoked_data.rst
-    auto_examples/simulation/plot_simulate_raw_data.rst
-    auto_examples/simulation/plot_simulated_raw_data_using_subject_anatomy.rst
 
-.. raw:: html
+.. collapse:: Contributing
 
-    </details>
+    .. toctree::
+        :maxdepth: 1
 
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_statistics">Statistics</a>
-          </h4>
-        </div>
-        <div id="collapse_statistics" class="panel-collapse collapse">
-          <div class="panel-body">
-
-
-**Background**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/discussions/plot_background_statistics.rst
-
-**Sensor Space**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.rst
-    auto_tutorials/stats-sensor-space/plot_stats_cluster_1samp_test_time_frequency.rst
-    auto_tutorials/stats-sensor-space/plot_stats_cluster_time_frequency.rst
-    auto_tutorials/stats-sensor-space/plot_stats_cluster_erp.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/stats/plot_fdr_stats_evoked.rst
-    auto_examples/stats/plot_cluster_stats_evoked.rst
-    auto_examples/stats/plot_sensor_permutation_test.rst
-    auto_examples/stats/plot_sensor_regression.rst
-    auto_examples/stats/plot_linear_regression_raw.rst
-
-.. raw:: html
-
-    </details>
-
-**Source Space**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.rst
-    auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.rst
-    auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.rst
-    auto_tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.rst
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="machine-learning" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_ml">Machine learning (decoding, encoding, MVPA)</a>
-          </h4>
-        </div>
-        <div id="collapse_ml" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**Decoding**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/machine-learning/plot_sensors_decoding.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/decoding/decoding_rsa.rst
-    auto_examples/decoding/plot_decoding_csp_eeg.rst
-    auto_examples/decoding/plot_decoding_csp_timefreq.rst
-    auto_examples/decoding/plot_decoding_spatio_temporal_source.rst
-    auto_examples/decoding/plot_decoding_spoc_CMC.rst
-    auto_examples/decoding/plot_decoding_time_generalization_conditions.rst
-    auto_examples/decoding/plot_decoding_unsupervised_spatial_filter.rst
-    auto_examples/decoding/plot_decoding_xdawn_eeg.rst
-    auto_examples/decoding/plot_ems_filtering.rst
-    auto_examples/decoding/plot_linear_model_patterns.rst
-
-.. raw:: html
-
-    </details>
-
-**Encoding**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_tutorials/machine-learning/plot_receptive_field.rst
-
-.. raw:: html
-
-  <details class="example_details">
-  <summary><strong>Examples</strong></summary>
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/decoding/plot_receptive_field_mtrf.rst
-
-.. raw:: html
-
-    </details>
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a id="connectivity" class="anchor-doc"></a>
-            <a data-toggle="collapse" href="#collapse_connectivity">Connectivity</a>
-          </h4>
-        </div>
-        <div id="collapse_connectivity" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**Examples**
-
-.. toctree::
-    :maxdepth: 1
-
-    auto_examples/connectivity/plot_cwt_sensor_connectivity.rst
-    auto_examples/connectivity/plot_mixed_source_space_connectivity.rst
-    auto_examples/connectivity/plot_mne_inverse_coherence_epochs.rst
-    auto_examples/connectivity/plot_mne_inverse_envelope_correlation.rst
-    auto_examples/connectivity/plot_mne_inverse_envelope_correlation_volume.rst
-    auto_examples/connectivity/plot_mne_inverse_connectivity_spectrum.rst
-    auto_examples/connectivity/plot_mne_inverse_label_connectivity.rst
-    auto_examples/connectivity/plot_mne_inverse_psi_visual.rst
-    auto_examples/connectivity/plot_sensor_connectivity.rst
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_realtime">Realtime</a>
-          </h4>
-        </div>
-        <div id="collapse_realtime" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**All realtime functionality has migrated to** :mod:`mne_realtime`.
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_c">MNE-C and MNE-MATLAB</a>
-          </h4>
-        </div>
-        <div id="collapse_c" class="panel-collapse collapse">
-          <div class="panel-body">
-
-**MNE-C**
-
-.. toctree::
-    :maxdepth: 1
-
-    tutorials/command_line.rst
-    manual/c_reference.rst
-    manual/gui/analyze.rst
-    manual/gui/browse.rst
-    manual/source_localization/c_forward.rst
-    manual/source_localization/c_inverse.rst
-    manual/source_localization/c_morph.rst
-    manual/appendix/bem_model.rst
-    manual/appendix/c_misc.rst
-    manual/appendix/c_release_notes.rst
-    manual/appendix/c_EULA.rst
-    manual/appendix/martinos.rst
-
-**MNE-MATLAB**
-
-.. toctree::
-    :maxdepth: 1
-
-    manual/matlab.rst
-
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <a data-toggle="collapse" href="#collapse_contributing">Contributing</a>
-          </h4>
-        </div>
-
-        <div id="collapse_contributing" class="panel-collapse collapse">
-          <div class="panel-body">
-
-.. toctree::
-    :maxdepth: 1
-
-    install/contributing
-
-.. raw:: html
-
-          </div>
-        </div>
-      </div>
-    </div>
+        install/contributing

--- a/doc/sphinxext/sphinx_bootstrap_divs/__init__.py
+++ b/doc/sphinxext/sphinx_bootstrap_divs/__init__.py
@@ -1,0 +1,160 @@
+"""A .. collapse:: directive for sphinx-bootstrap-theme."""
+
+import os.path as op
+from docutils import nodes
+from docutils.parsers.rst.directives import flag
+
+from sphinx.locale import _
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util.fileutil import copy_asset
+
+this_dir = op.dirname(__file__)
+
+__version__ = '0.1.0.dev0'
+
+
+###############################################################################
+# Super classes
+
+class DivNode(nodes.General, nodes.Element):
+    """Generic DivNode class."""
+
+    def __init__(self, **options):
+        diff = set(options.keys()).symmetric_difference(set(self.OPTION_KEYS))
+        assert len(diff) == 0, (diff, self.__class__.__name__)
+        self.options = options
+        super().__init__()
+
+    @staticmethod
+    def visit_node(self, node):
+        """Visit the node."""
+        self.body.append(node.HEADER.format(**node.options))
+
+    @staticmethod
+    def depart_node(self, node):
+        """Depart the node."""
+        self.body.append(node.FOOTER)
+
+
+###############################################################################
+# .. collapse::
+
+class CollapseNode(DivNode):
+    """Class for .. collapse:: directive."""
+
+    OPTION_KEYS = ('title', 'id_', 'extra', 'class_')
+    HEADER = """
+    <div class="panel panel-{class_}">
+    <div class="panel-heading"><h4 class="panel-title">
+    <a data-toggle="collapse" href="#collapse_{id_}">{title}</a>
+    </h4></div>
+    <div id="collapse_{id_}" class="panel-collapse collapse{extra}">
+    <div class="panel-body">
+    """
+    FOOTER = "</div></div></div>"
+    KNOWN_CLASSES = (
+        'default', 'primary', 'success', 'info', 'warning', 'danger')
+
+    @staticmethod
+    def _check_class(class_):
+        if class_ not in CollapseNode.KNOWN_CLASSES:
+            raise ValueError(':class: option %r must be one of %s'
+                             % (class_, CollapseNode.KNOWN_CLASSES))
+        return class_
+
+
+class CollapseDirective(SphinxDirective):
+    """Collapse directive."""
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'open': flag,
+                   'class': CollapseNode._check_class}
+    has_content = True
+
+    def run(self):
+        """Parse."""
+        env = self.state.document.settings.env
+        self.assert_has_content()
+        extra = _(' in' if 'open' in self.options else '')
+        title = _(self.arguments[0])
+        class_ = self.options.get('class', 'default')
+        id_ = env.new_serialno('Collapse')
+        collapse_node = CollapseNode(title=title, id_=id_, extra=extra,
+                                     class_=class_)
+        self.add_name(collapse_node)
+        self.state.nested_parse(
+            self.content, self.content_offset, collapse_node)
+        return [collapse_node]
+
+
+###############################################################################
+# .. details::
+
+class DetailsNode(DivNode):
+    """Class for .. details:: directive."""
+
+    OPTION_KEYS = ('title', 'class_')
+    HEADER = """
+    <details class="{class_}"><summary>{title}</summary>"""
+    FOOTER = "</details>"
+
+
+class DetailsDirective(SphinxDirective):
+    """Details directive."""
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'class': str}
+    has_content = True
+
+    def run(self):
+        """Parse."""
+        self.assert_has_content()
+        title = _(self.arguments[0])
+        class_ = self.options.get('class', '')
+        details_node = DetailsNode(title=title, class_=class_)
+        self.add_name(details_node)
+        self.state.nested_parse(
+            self.content, self.content_offset, details_node)
+        return [details_node]
+
+
+###############################################################################
+# Generic setup
+
+def setup(app):
+    """Set up for Sphinx app."""
+    directives = dict(
+        collapse=CollapseDirective,
+        details=DetailsDirective,
+    )
+    for key, value in directives.items():
+        app.add_directive(key, value)
+    try:
+        app.add_css_file('bootstrap_divs.css')
+    except AttributeError:
+        app.add_stylesheet('bootstrap_divs.css')
+    try:
+        app.add_js_file('bootstrap_divs.js')
+    except AttributeError:
+        app.add_javascript('bootstrap_divs.js')
+    app.connect('build-finished', copy_asset_files)
+    for node in (CollapseNode, DetailsNode):
+        app.add_node(node,
+                     html=(node.visit_node, node.depart_node),
+                     latex=(node.visit_node, node.depart_node),
+                     text=(node.visit_node, node.depart_node))
+    return dict(version='0.1', parallel_read_safe=True,
+                parallel_write_safe=True)
+
+
+def copy_asset_files(app, exc):
+    """Copy static assets."""
+    asset_files = ['bootstrap_divs.css', 'bootstrap_divs.js']
+    if exc is None:  # build succeeded
+        for path in asset_files:
+            copy_asset(op.join(this_dir, path),
+                       op.join(app.outdir, '_static'))

--- a/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.css
+++ b/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.css
@@ -1,23 +1,7 @@
 .panel-title a {
     display: block !important;
-    padding: 5px;
     text-decoration: none;
 }
-
-.plus {
-    float: right;
-    color: #212121;
-}
-
-.panel {
-    margin-bottom: 3px;
-}
-
-.example_details {
-    padding-left: 20px;
-    margin-bottom: 10px;
-}
-
 @media (max-width: 991px) {
     .collapse.in{
         display:block !important;

--- a/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.css
+++ b/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.css
@@ -1,0 +1,25 @@
+.panel-title a {
+    display: block !important;
+    padding: 5px;
+    text-decoration: none;
+}
+
+.plus {
+    float: right;
+    color: #212121;
+}
+
+.panel {
+    margin-bottom: 3px;
+}
+
+.example_details {
+    padding-left: 20px;
+    margin-bottom: 10px;
+}
+
+@media (max-width: 991px) {
+    .collapse.in{
+        display:block !important;
+    }
+  }

--- a/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.js
+++ b/doc/sphinxext/sphinx_bootstrap_divs/bootstrap_divs.js
@@ -1,0 +1,6 @@
+$(document).ready(function () {
+    if(location.hash != null && location.hash != ""){
+        $('.collapse').removeClass('in');
+        $(location.hash + '.collapse').addClass('in');
+    }
+});


### PR DESCRIPTION
I went to implement `panel`-style clickables to tackle #6365, and got a bit tired of how the raw HTML calls in our doc made things difficult to do and difficult to read. So I made a `sphinx_bootstrap_divs` package that bundles this stuff into `.. collapse::` and `.. details::` directives:

https://github.com/larsoner/sphinx-bootstrap-divs

If people agree that this is a useful change, I can push 1.0 to `pypi` and I'll add the requirement to the dev docs. Also maybe this should be hosted by `mne-tools` and not on my personal repo...