### PR TITLE
ENH: Include more realistic simulations to example for simulating raw data using subject anatomy

### DIFF
--- a/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
+++ b/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
@@ -19,7 +19,6 @@ using dynamic statistical parametric mapping (dSPM) inverse operator.
 import os.path as op
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 import mne
 from mne.datasets import sample
@@ -109,6 +108,7 @@ region_names = list(activations.keys())
 # simulate source activity for a single condition at a time. Therefore, each
 # evoked response will be parametrized by latency and duration.
 
+
 def data_fun(times, latency, duration):
     """Function to generate source time courses for evoked responses,
     parametrized by latency and duration."""
@@ -116,7 +116,7 @@ def data_fun(times, latency, duration):
     sigma = 0.375 * duration
     sin = np.sin(2 * np.pi * f * (times - latency))
     gf = np.exp(- (times - latency - (sigma / 4.) * rng.rand(1)) ** 2 /
-                 (2 * (sigma ** 2)))
+                (2 * (sigma ** 2)))
     return 1e-9 * sin * gf
 
 

--- a/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
+++ b/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
@@ -64,7 +64,7 @@ event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
 
 
 # Take only a few events for speed
-events = events[:100]
+events = events[:80]
 
 ###############################################################################
 # In order to simulate source time courses, labels of desired active regions
@@ -83,17 +83,17 @@ events = events[:100]
 
 activations = {
     'auditory/left':
-        [('G_temp_sup-G_T_transv-lh', 100),          # label, activation (nAm)
-         ('G_temp_sup-G_T_transv-rh', 200)],
+        [('G_temp_sup-G_T_transv-lh', 30),          # label, activation (nAm)
+         ('G_temp_sup-G_T_transv-rh', 60)],
     'auditory/right':
-        [('G_temp_sup-G_T_transv-lh', 200),
-         ('G_temp_sup-G_T_transv-rh', 100)],
+        [('G_temp_sup-G_T_transv-lh', 60),
+         ('G_temp_sup-G_T_transv-rh', 30)],
     'visual/left':
-        [('S_calcarine-lh', 100),
-         ('S_calcarine-rh', 200)],
+        [('S_calcarine-lh', 30),
+         ('S_calcarine-rh', 60)],
     'visual/right':
-        [('S_calcarine-lh', 200),
-         ('S_calcarine-rh', 100)],
+        [('S_calcarine-lh', 60),
+         ('S_calcarine-rh', 30)],
 }
 
 annot = 'aparc.a2009s'


### PR DESCRIPTION
The changes included in this PR are proposed in the discussion
of PR #6256 and #6261.

This PR changes the simulation of source time courses in the example for
simulating raw data using subject anatomy. Initially, sine wave was used for
source time courses and it was the same for each of the 4 simulation conditions.
In this PR, a new function is added which enables to generate source activity for
evoked responses, parametrized by latency and duration. Stcs are simulated for
a single condition at the time.
