### PR TITLE
MRG, FIX: Imports

### DIFF
--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -107,6 +107,7 @@ from . import externals
 from . import io
 from . import filter
 from . import gui
+from . import inverse_sparse
 from . import minimum_norm
 from . import preprocessing
 from . import simulation

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -4,7 +4,7 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy import linalg, signal
+from scipy import linalg
 
 from ..source_estimate import (SourceEstimate, VolSourceEstimate,
                                _BaseSourceEstimate)
@@ -455,11 +455,9 @@ def _window_evoked(evoked, size):
     sfreq = float(evoked.info['sfreq'])
     lsize = int(lsize * sfreq)
     rsize = int(rsize * sfreq)
-    lhann = signal.hann(lsize * 2)
-    rhann = signal.hann(rsize * 2)
-    window = np.r_[lhann[:lsize],
-                   np.ones(len(evoked.times) - lsize - rsize),
-                   rhann[-rsize:]]
+    lhann = np.hanning(lsize * 2)[:lsize]
+    rhann = np.hanning(rsize * 2)[-rsize:]
+    window = np.r_[lhann, np.ones(len(evoked.times) - lsize - rsize), rhann]
     evoked.data *= window[None, :]
     return evoked
 

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -140,6 +140,10 @@ def test_docstring_parameters():
 
     incorrect = []
     for name in public_modules_:
+        # Assert that by default we import all public names with `import mne`
+        if name not in ('mne', 'mne.gui'):
+            extra = name.split('.')[1]
+            assert hasattr(mne, extra)
         with pytest.warns(None):  # traits warnings
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:


### PR DESCRIPTION
We missed `from . import inverse_sparse` so you cannot currently do:
```
import mne
mne.inverse_sparse.mixed_norm(...)
```