### PR TITLE
FIX: read_epochs_eeglab for floats

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -127,3 +127,4 @@ Thomas Donoghue <tdonoghue.research@gmail.com> Tom <tdonoghue.research@gmail.com
 Steve Matindi <stevematindi@gmail.com> stevemats <stevematindi@gmail.com>
 Legrand Nicolas <legrand@cyceron.fr> LegrandNico <legrand@cyceron.fr>
 Johannes Kasper <jeythekey@tutanota.com> jeythekey <44215387+jeythekey@users.noreply.github.com>
+Thomas Radman <radman.thomas@gmail.com>

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,8 @@ Changelog
 Bug
 ~~~
 
+- Fix :func:`mne.read_epochs_eeglab` when epochs are stored as float. By `Thomas Radman`_
+
 - Fix bug in handling of :class:`mne.Evoked` types that were not produced by MNE-Python (e.g., alternating average) by `Eric Larson`_
 
 - Fix bug in :func:`mne.inverse_sparse.mixed_norm` and :func:`mne.inverse_sparse.tf_mixed_norm` where ``weights`` was supplied but ``weights_min`` was not, by `Eric Larson`_
@@ -3403,3 +3405,5 @@ of commits):
 .. _Alexander Kovrig: https://github.com/OpenSatori
 
 .. _Kostiantyn Maksymenko: https://github.com/makkostya
+
+.. _Thomas Radman: https://github.com/tradman

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -441,7 +441,7 @@ class EpochsEEGLAB(BaseEpochs):
             epochs = _bunchify(eeg.epoch)
             events = _bunchify(eeg.event)
             for ep in epochs:
-                if isinstance(ep.eventtype, int):
+                if isinstance(ep.eventtype, (int, float)):
                     ep.eventtype = str(ep.eventtype)
                 if not isinstance(ep.eventtype, str):
                     event_type = '/'.join([str(et) for et in ep.eventtype])


### PR DESCRIPTION
#### What does this implement/fix?
Fixed error with: 
epochs = mne.read_epochs_eeglab(epochs_fname) 
when attempting to load preprocessed eeg data from eeglab

```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-3bb48e976843> in <module>
----> 1 epochs = mne.read_epochs_eeglab(epochs_fname)

~/Documents/administrative/training/MNE-python/mne-python/mne/io/eeglab/eeglab.py in read_epochs_eeglab(input_fname, events, event_id, montage, eog, verbose, uint16_codec)
    244     epochs = EpochsEEGLAB(input_fname=input_fname, events=events, eog=eog,
    245                           event_id=event_id, montage=montage, verbose=verbose,
--> 246                           uint16_codec=uint16_codec)
    247     return epochs
    248 

</Users/radmantc/Documents/administrative/training/MNE-python/mne-python/mne/externals/decorator.py:decorator-gen-189> in __init__(self, input_fname, events, event_id, tmin, baseline, reject, flat, reject_tmin, reject_tmax, montage, eog, verbose, uint16_codec)

~/Documents/administrative/training/MNE-python/mne-python/mne/utils/_logging.py in wrapper(*args, **kwargs)
     87             with use_log_level(verbose_level):
     88                 return function(*args, **kwargs)
---> 89         return function(*args, **kwargs)
     90     return FunctionMaker.create(
     91         function, 'return decfunc(%(signature)s)',

~/Documents/administrative/training/MNE-python/mne-python/mne/io/eeglab/eeglab.py in __init__(self, input_fname, events, event_id, tmin, baseline, reject, flat, reject_tmin, reject_tmax, montage, eog, verbose, uint16_codec)
    445                     ep.eventtype = str(ep.eventtype)
    446                 if not isinstance(ep.eventtype, str):
--> 447                     event_type = '/'.join([str(et) for et in ep.eventtype])
    448                     event_name.append(event_type)
    449                     # store latency of only first event

TypeError: 'float' object is not iterable
```