### PR TITLE
MRG, BUG: Fix MacOSX backend HiDPI scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ doc/auto_tutorials/
 doc/modules/generated/
 doc/sphinxext/cachedir
 pip-log.txt
-.coverage
+.coverage*
 tags
 doc/coverages
 doc/samples

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Bug
 
 - Fix bug in :func:`mne.inverse_sparse.mixed_norm` and :func:`mne.inverse_sparse.tf_mixed_norm` where ``weights`` was supplied but ``weights_min`` was not, by `Eric Larson`_
 
+- Fix bug in :func:`mne.io.Raw.plot` when using HiDPI displays and the MacOSX backend of matplotlib by `Eric Larson`_
+
 API
 ~~~
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -510,7 +510,9 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
 def _layout_figure(params):
     """Set figure layout. Shared with raw and epoch plots."""
     size = params['fig'].get_size_inches() * params['fig'].dpi
-    dpi_ratio = getattr(params["fig"].canvas, '_dpi_ratio', 1)
+    dpi_ratio = 1.
+    for key in ('_dpi_ratio', '_device_scale'):
+        dpi_ratio = getattr(params["fig"].canvas, key, dpi_ratio)
     size /= dpi_ratio  # account for HiDPI resolutions
 
     scroll_width = 25


### PR DESCRIPTION
Closes #6367.

@cbrnr can you see if this fixes things for you? In case you're curious, I found it just by creating a MacOSX figure and inspecting `fig.canvas._` properties (actually I looked right at `fig.canvas._d`-tab-tab and got lucky that the MacOSX private propetry `_device_scale` started with the same letter as the Qt5Agg one `_dpi_ratio`).

Upstream report https://github.com/matplotlib/matplotlib/issues/14405