### PR TITLE
MRG, MAINT: Fix license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the names of MNE-Python authors nor the names of any
+    * Neither the name of the copyright holder nor the names of its
       contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
 


### PR DESCRIPTION
Fixes our license to be compliant with the somewhat strict `Licensee` parsing [used by GitHub](https://developer.github.com/v3/licenses/). For example after this PR we should see at the top of the page the same thing you see here:

https://github.com/scipy/scipy/blob/master/LICENSE.txt

Tested with the following Ruby script, inspired from a recent SciPy PR:
```
require "licensee"
  
mne = Licensee.project("mne-python")

print mne.license.name
print "\n"
print mne.matched_file.filename
print "\n\n"
```
Which now says:
```
BSD 3-Clause "New" or "Revised" License
LICENSE.txt
```
Instead of on `master`:
```
Other
LICENSE.txt
```