### PR TITLE
MAINT: Fix pytest

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -574,8 +574,9 @@ def test_add_channels():
                for ch in tfr_stim.ch_names + tfr_meg.ch_names)
     tfr_new = tfr_meg.copy().add_channels([tfr_eeg])
 
-    assert all(ch in tfr_new.ch_names
-               for ch in tfr.ch_names if ch != 'STIM 001')
+    have_all = all(ch in tfr_new.ch_names
+                   for ch in tfr.ch_names if ch != 'STIM 001')
+    assert have_all
     assert_array_equal(tfr_new.data, tfr_eeg_meg.data)
     assert all(ch not in tfr_new.ch_names for ch in tfr_stim.ch_names)
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -210,9 +210,11 @@ def test_plot_topomap():
     subplot = [x for x in p.get_children() if 'Subplot' in str(type(x))]
     assert len(subplot) >= 1, [type(x) for x in p.get_children()]
     subplot = subplot[0]
-    assert (all('MEG' not in x.get_text()
-                for x in subplot.get_children()
-                if isinstance(x, matplotlib.text.Text)))
+
+    have_all = all('MEG' not in x.get_text()
+                   for x in subplot.get_children()
+                   if isinstance(x, matplotlib.text.Text))
+    assert have_all
 
     # Plot array
     for ch_type in ('mag', 'grad'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 numexpr
 python-picard
 statsmodels
-pytest
+pytest!=4.6.0
 pytest-cov
 pytest-faulthandler
 pytest-mock


### PR DESCRIPTION
Closes #6397.

If this does not work with the newly released 4.6.1, I'll add another `!=` in there to get things green. Eventually we can investigate why things are not working but it would be good to get CIs back in the meantime.