### PR TITLE
link examples to somato dataset

### DIFF
--- a/doc/manual/datasets_index.rst
+++ b/doc/manual/datasets_index.rst
@@ -3,12 +3,24 @@
 Datasets
 ########
 
-.. contents:: Contents
+All the dataset fetchers are available in :mod:`mne.datasets`. To download any of the datasets,
+use the ``data_path`` (fetches full dataset) or the ``load_data`` (fetches dataset partially) functions.
+
+All fetchers will check the default download location first to see if the dataset
+is already on your computer, and only download it if necessary. The default
+download location is also configurable; see the documentation of any of the
+``data_path`` functions for more information.
+
+.. sidebar:: Contributing datasets in MNE-Python
+
+    Do not hesitate to contact MNE-Python developers on the
+    `MNE mailing list <http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`_
+    to discuss the possibility to add more publicly available datasets.
+
+.. contents:: Available datasets
    :local:
    :depth: 2
 
-All the dataset fetchers are available in :mod:`mne.datasets`. To download any of the datasets,
-use the ``data_path`` (fetches full dataset) or the ``load_data`` (fetches dataset partially) functions.
 
 .. _sample-dataset:
 
@@ -25,18 +37,8 @@ a smiley face was presented at the center of the visual field.
 The subject was asked to press a key with the right index finger
 as soon as possible after the appearance of the face.
 
-Once the ``data_path`` is known, its contents can be examined using :ref:`IO functions <ch_convert>`.
-
-fsaverage
-=========
-:func:`mne.datasets.fetch_fsaverage`
-
-For convenience, we provide a function to separately download and extract the
-(or update an existing) fsaverage subject.
-
-.. topic:: Examples
-
-    :ref:`tut-eeg-fsaverage-source-modeling`
+In MNE-Python, the **sample** dataset is distributed with :ref:`fsaverage` for
+convenience.
 
 Brainstorm
 ==========
@@ -119,14 +121,6 @@ The recordings were made using the BCI2000 system. To load a subject, do::
 
     * :ref:`ex-decoding-csp-eeg`
 
-Do not hesitate to contact MNE-Python developers on the
-`MNE mailing list <http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`_
-to discuss the possibility to add more publicly available datasets.
-
-.. _auditory dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetAuditory
-.. _resting state dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetResting
-.. _median nerve dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetMedianNerveCtf
-.. _SPM faces dataset: https://www.fil.ion.ucl.ac.uk/spm/data/mmfaces/
 
 Somatosensory
 =============
@@ -163,6 +157,9 @@ a sampling frequency of 3 kHz. The dataset is suitable for investigating
 high-frequency somatosensory responses. Data from two subjects are included
 with MRI images in DICOM format and FreeSurfer reconstructions.
 
+.. topic:: Examples
+
+    * :doc:`high-frequency SEF responses<plot_hf_sef_data>`.
 
 Visual 92 object categories
 ===========================
@@ -196,26 +193,6 @@ More details and a description of the package can be found in [5]_.
 
     * :ref:`Receptive Field Estimation and Prediction <ex-receptive-field-mtrf>`: Partially replicates the results from Crosse et al. (2016).
 
-Miscellaneous Datasets
-======================
-These datasets are used for specific purposes in the documentation and in
-general are not useful for separate analyses.
-
-ECoG Dataset
-^^^^^^^^^^^^
-:func:`mne.datasets.misc.data_path`. Data exists at ``/ecog/sample_ecog.mat``.
-
-This dataset contains a sample Electrocorticography (ECoG) dataset. It includes
-a single grid of electrodes placed over the temporal lobe during an auditory
-listening task. This dataset is primarily used to demonstrate visualization
-functions in MNE and does not contain useful metadata for analysis.
-
-.. topic:: Examples
-
-    * :ref:`How to convert 3D electrode positions to a 2D image.
-      <ex-electrode-pos-2d>`: Demonstrates
-      how to project a 3D electrode location onto a 2D image, a common procedure
-      in electrocorticography.
 
 
 Kiloword dataset
@@ -234,6 +211,9 @@ multiple regression estimation of EEG correlates of printed word processing.
 This dataset was obtained with a phantom on a 4D Neuroimaging / BTi system at the MEG
 center in La Timone hospital in Marseille.
 
+.. topic:: Examples
+
+    * :ref:`tut_phantom_4dbti`
 
 OPM
 ===
@@ -284,6 +264,41 @@ data please cite [7]_ and [8]_.
 
     * :ref:`tut-sleep-stage-classif`
 
+Miscellaneous Datasets
+======================
+These datasets are used for specific purposes in the documentation and in
+general are not useful for separate analyses.
+
+.. _fsaverage:
+
+fsaverage
+^^^^^^^^^
+:func:`mne.datasets.fetch_fsaverage`
+
+For convenience, we provide a function to separately download and extract the
+(or update an existing) fsaverage subject.
+
+.. topic:: Examples
+
+    :ref:`tut-eeg-fsaverage-source-modeling`
+
+
+ECoG Dataset
+^^^^^^^^^^^^
+:func:`mne.datasets.misc.data_path`. Data exists at ``/ecog/sample_ecog.mat``.
+
+This dataset contains a sample Electrocorticography (ECoG) dataset. It includes
+a single grid of electrodes placed over the temporal lobe during an auditory
+listening task. This dataset is primarily used to demonstrate visualization
+functions in MNE and does not contain useful metadata for analysis.
+
+.. topic:: Examples
+
+    * :ref:`How to convert 3D electrode positions to a 2D image.
+      <ex-electrode-pos-2d>`: Demonstrates
+      how to project a 3D electrode location onto a 2D image, a common procedure
+      in electrocorticography.
+
 References
 ==========
 
@@ -302,3 +317,9 @@ References
 .. [7] B Kemp, AH Zwinderman, B Tuk, HAC Kamphuisen, JJL Oberyé. Analysis of a sleep-dependent neuronal feedback loop: the slow-wave microcontinuity of the EEG. IEEE-BME 47(9):1185-1194 (2000). https://ieeexplore.ieee.org/document/867928
 
 .. [8] Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and PhysioNet: Components of a New Research Resource for Complex Physiologic Signals. Circulation 101(23):e215-e220 [Circulation Electronic Pages; http://circ.ahajournals.org/cgi/content/full/101/23/e215]; 2000 (June 13).
+
+
+.. _auditory dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetAuditory
+.. _resting state dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetResting
+.. _median nerve dataset tutorial: https://neuroimage.usc.edu/brainstorm/DatasetMedianNerveCtf
+.. _SPM faces dataset: https://www.fil.ion.ucl.ac.uk/spm/data/mmfaces/

--- a/doc/manual/datasets_index.rst
+++ b/doc/manual/datasets_index.rst
@@ -159,7 +159,7 @@ with MRI images in DICOM format and FreeSurfer reconstructions.
 
 .. topic:: Examples
 
-    * :doc:`high-frequency SEF responses<plot_hf_sef_data>`.
+    * :ref:`high-frequency SEF responses <ex-hf-sef-data>`.
 
 Visual 92 object categories
 ===========================
@@ -213,7 +213,7 @@ center in La Timone hospital in Marseille.
 
 .. topic:: Examples
 
-    * :ref:`tut_phantom_4dbti`
+    * :ref:`tut_phantom_4Dbti`
 
 OPM
 ===

--- a/doc/manual/datasets_index.rst
+++ b/doc/manual/datasets_index.rst
@@ -138,6 +138,8 @@ This dataset contains somatosensory data with event-related synchronizations
 .. topic:: Examples
 
     * :ref:`tut-sensors-time-freq`
+    * :ref:`ex-inverse-source-power`
+    * :ref:`ex-time-freq-global-field-power`
 
 Multimodal
 ==========

--- a/examples/datasets/plot_hf_sef_data.py
+++ b/examples/datasets/plot_hf_sef_data.py
@@ -1,4 +1,6 @@
 """
+.. _ex-hf-sef-data:
+
 ==============
 HF-SEF dataset
 ==============
@@ -26,7 +28,7 @@ evoked = mne.Evoked(fname_evoked)
 ###############################################################################
 # Create a highpass filtered version
 evoked_hp = evoked.copy()
-evoked_hp.filter(l_freq=300, h_freq=None, fir_design='firwin')
+evoked_hp.filter(l_freq=300, h_freq=None)
 
 ###############################################################################
 # Compare high-pass filtered and unfiltered data on a single channel

--- a/examples/inverse/plot_dics_source_power.py
+++ b/examples/inverse/plot_dics_source_power.py
@@ -1,4 +1,6 @@
 """
+.. _ex-inverse-source-power:
+
 =========================================
 Compute source power using DICS beamfomer
 =========================================

--- a/examples/time_frequency/plot_time_frequency_global_field_power.py
+++ b/examples/time_frequency/plot_time_frequency_global_field_power.py
@@ -1,4 +1,6 @@
 """
+.. _ex-time-freq-global-field-power:
+
 ===========================================================
 Explore event-related dynamics for specific frequency bands
 ===========================================================

--- a/tutorials/sample-datasets/plot_phantom_4DBTi.py
+++ b/tutorials/sample-datasets/plot_phantom_4DBTi.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
+.. _tut_phantom_4dbti::
+
 ============================================
 4D Neuroimaging/BTi phantom dataset tutorial
 ============================================

--- a/tutorials/sample-datasets/plot_phantom_4DBTi.py
+++ b/tutorials/sample-datasets/plot_phantom_4DBTi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-.. _tut_phantom_4dbti::
+.. _tut_phantom_4Dbti:
 
 ============================================
 4D Neuroimaging/BTi phantom dataset tutorial


### PR DESCRIPTION
The [somato](http://martinos.org/mne/stable/manual/datasets_index.html?#somatosensory) dataset shipped with `mne.datasets` is used in more examples than the docs show. In this PR I am adding the missing links.

These links are already correct in the API documentation ([here](http://martinos.org/mne/stable/generated/mne.datasets.somato.data_path.html?highlight=somato#mne.datasets.somato.data_path))

Now they should also be correct in the datasets documentation page.