### PR TITLE
MRG, BUG: empty should return ndarray

### DIFF
--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -539,7 +539,7 @@ def make_projector(projs, ch_names, bads=(), include_active=True):
     nproj : int
         How many items in the projector.
     U : array
-        The orthogonal basis of the projection vectors (optional).
+        The orthogonal basis of the projection vectors.
     """
     return _make_projector(projs, ch_names, bads, include_active)
 
@@ -556,7 +556,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
     if nchan == 0:
         raise ValueError('No channel names specified')
 
-    default_return = (np.eye(nchan, nchan), 0, [])
+    default_return = (np.eye(nchan, nchan), 0, np.empty((nchan, 0)))
 
     #   Check trivial cases first
     if projs is None:

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -273,11 +273,15 @@ def test_compute_proj_raw():
     raw.load_bad_channels(bads_fname)  # adds 2 bad mag channels
     with pytest.warns(RuntimeWarning, match='Too few samples'):
         projs = compute_proj_raw(raw, n_grad=0, n_mag=0, n_eeg=1)
+    assert len(projs) == 1
 
-    # test that bad channels can be excluded
-    proj, nproj, U = make_projector(projs, raw.ch_names,
-                                    bads=raw.ch_names)
-    assert_array_almost_equal(proj, np.eye(len(raw.ch_names)))
+    # test that bad channels can be excluded, and empty support
+    for projs_ in (projs, []):
+        proj, nproj, U = make_projector(projs_, raw.ch_names,
+                                        bads=raw.ch_names)
+        assert_array_almost_equal(proj, np.eye(len(raw.ch_names)))
+        assert nproj == 0  # all channels excluded
+        assert U.shape == (len(raw.ch_names), nproj)
 
 
 @requires_version('scipy', '1.0')


### PR DESCRIPTION
`make_projector` should always return `ndarray` for `U`. 