### PR TITLE
MRG, MAINT: DRY code

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -165,7 +165,7 @@ def backend_name(request):
 
 
 @pytest.yield_fixture
-def backends_3d(backend_name):
+def renderer(backend_name):
     """Yield the 3D backends."""
     from mne.viz.backends.renderer import _use_test_3d_backend
     from mne.viz.backends.tests._utils import has_mayavi, has_pyvista
@@ -176,4 +176,6 @@ def backends_3d(backend_name):
         if not has_pyvista():
             pytest.skip("Test skipped, requires pyvista.")
     with _use_test_3d_backend(backend_name):
-        yield
+        from mne.viz.backends import renderer
+        yield renderer
+        renderer._close_all()

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -289,3 +289,8 @@ def _get_view_to_display_matrix(scene):
                                  [0.,            0.,   1.,        0.],
                                  [0.,            0.,   0.,        1.]])
     return view_to_disp_mat
+
+
+def _close_all():
+    from mayavi import mlab
+    mlab.close(all=True)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -316,3 +316,7 @@ def _get_view_to_display_matrix(size):
                                  [0.,            0.,   1.,        0.],
                                  [0.,            0.,   0.,        1.]])
     return view_to_disp_mat
+
+
+def _close_all():
+    pass

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -7,8 +7,8 @@
 #
 # License: Simplified BSD
 
-import importlib
 from contextlib import contextmanager
+import importlib
 import sys
 
 from ._utils import _get_backend_based_on_env_and_defaults, VALID_3D_BACKENDS
@@ -24,10 +24,16 @@ except NameError:
 
 logger.info('Using %s 3d backend.\n' % MNE_3D_BACKEND)
 
-if MNE_3D_BACKEND == 'mayavi':
-    from ._pysurfer_mayavi import _Renderer, _Projection  # lgtm # noqa: F401
-elif MNE_3D_BACKEND == 'pyvista':
-    from ._pyvista import _Renderer, _Projection  # lgtm # noqa: F401
+_fromlist = ('_Renderer', '_Projection', '_close_all')
+_name_map = dict(mayavi='_pysurfer_mayavi', pyvista='_pyvista')
+if MNE_3D_BACKEND in VALID_3D_BACKENDS:
+    # This is (hopefully) the equivalent to:
+    #    from ._whatever_name import ...
+    _mod = importlib.__import__(
+        _name_map[MNE_3D_BACKEND], {'__name__': __name__},
+        level=1, fromlist=_fromlist)
+    for key in _fromlist:
+        locals()[key] = getattr(_mod, key)
 
 
 def set_3d_backend(backend_name):
@@ -102,7 +108,6 @@ def get_3d_backend():
     backend_used : str
         The 3d backend currently in use.
     """
-    global MNE_3D_BACKEND
     return MNE_3D_BACKEND
 
 

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -15,8 +15,6 @@ from mne.viz.backends.tests._utils import (skips_if_not_mayavi,
 
 DEFAULT_3D_BACKEND = 'mayavi'  # This should be done with the import
 
-print(DEFAULT_3D_BACKEND)
-
 
 @pytest.fixture
 def backend_mocker():
@@ -46,10 +44,8 @@ def test_backend_environment_setup(backend, backend_mocker, monkeypatch):
     assert get_3d_backend() == backend
 
 
-def test_3d_backend(backends_3d):
+def test_3d_backend(renderer):
     """Test default plot."""
-    from mne.viz.backends.renderer import _Renderer
-
     # set data
     win_size = (600, 600)
     win_color = (0, 0, 0)
@@ -95,38 +91,38 @@ def test_3d_backend(backends_3d):
     cam_distance = 5 * tet_size
 
     # init scene
-    renderer = _Renderer(size=win_size, bgcolor=win_color)
-    renderer.set_interactive()
+    rend = renderer._Renderer(size=win_size, bgcolor=win_color)
+    rend.set_interactive()
 
     # use mesh
-    renderer.mesh(x=tet_x, y=tet_y, z=tet_z,
-                  triangles=tet_indices,
-                  color=tet_color)
+    rend.mesh(x=tet_x, y=tet_y, z=tet_z,
+              triangles=tet_indices,
+              color=tet_color)
 
     # use contour
-    renderer.contour(surface=ct_surface, scalars=ct_scalars,
-                     contours=ct_levels)
+    rend.contour(surface=ct_surface, scalars=ct_scalars,
+                 contours=ct_levels)
 
     # use sphere
-    renderer.sphere(center=sph_center, color=sph_color,
-                    scale=sph_scale)
+    rend.sphere(center=sph_center, color=sph_color,
+                scale=sph_scale)
 
     # use quiver3d
-    renderer.quiver3d(x=qv_center[:, 0],
-                      y=qv_center[:, 1],
-                      z=qv_center[:, 2],
-                      u=qv_dir[:, 0],
-                      v=qv_dir[:, 1],
-                      w=qv_dir[:, 2],
-                      color=qv_color,
-                      scale=qv_scale,
-                      scale_mode=qv_scale_mode,
-                      scalars=qv_scalars,
-                      mode=qv_mode)
+    rend.quiver3d(x=qv_center[:, 0],
+                  y=qv_center[:, 1],
+                  z=qv_center[:, 2],
+                  u=qv_dir[:, 0],
+                  v=qv_dir[:, 1],
+                  w=qv_dir[:, 2],
+                  color=qv_color,
+                  scale=qv_scale,
+                  scale_mode=qv_scale_mode,
+                  scalars=qv_scalars,
+                  mode=qv_mode)
 
     # use text
-    renderer.text(x=txt_x, y=txt_y, text=txt_text, width=txt_width)
-    renderer.set_camera(azimuth=180.0, elevation=90.0,
-                        distance=cam_distance,
-                        focalpoint=center)
-    renderer.show()
+    rend.text(x=txt_x, y=txt_y, text=txt_text, width=txt_width)
+    rend.set_camera(azimuth=180.0, elevation=90.0,
+                    distance=cam_distance,
+                    focalpoint=center)
+    rend.show()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -24,8 +24,7 @@ from mne.io.pick import pick_info
 from mne.io.constants import FIFF
 from mne.viz import (plot_sparse_source_estimates, plot_source_estimates,
                      snapshot_brain_montage, plot_head_positions,
-                     plot_alignment, plot_volume_source_estimates,
-                     get_3d_backend)
+                     plot_alignment, plot_volume_source_estimates)
 from mne.viz.utils import _fake_click
 from mne.utils import (requires_mayavi, requires_pysurfer, run_tests_if_main,
                        _import_mlab, requires_nibabel, check_version,
@@ -97,9 +96,8 @@ def test_plot_head_positions():
 @testing.requires_testing_data
 @requires_pysurfer
 @traits_test
-def test_plot_sparse_source_estimates(backends_3d):
+def test_plot_sparse_source_estimates(renderer):
     """Test plotting of (sparse) source estimates."""
-    backend_name = get_3d_backend()
     sample_src = read_source_spaces(src_fname)
 
     # dense version
@@ -132,16 +130,15 @@ def test_plot_sparse_source_estimates(backends_3d):
     stc = SourceEstimate(stc_data, vertices, 1, 1)
     surf = plot_sparse_source_estimates(sample_src, stc, bgcolor=(1, 1, 1),
                                         opacity=0.5, high_resolution=False)
-    if backend_name == 'mayavi':
+    if renderer.get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(surf, mayavi.modules.surface.Surface)
 
 
 @testing.requires_testing_data
 @traits_test
-def test_plot_evoked_field(backends_3d):
+def test_plot_evoked_field(renderer):
     """Test plotting evoked field."""
-    backend_name = get_3d_backend()
     evoked = read_evokeds(evoked_fname, condition='Left Auditory',
                           baseline=(-0.2, 0.0))
     evoked = pick_channels_evoked(evoked, evoked.ch_names[::10])  # speed
@@ -151,7 +148,7 @@ def test_plot_evoked_field(backends_3d):
                                   subjects_dir=subjects_dir, n_jobs=1,
                                   ch_type=t)
         fig = evoked.plot_field(maps, time=0.1)
-        if backend_name == 'mayavi':
+        if renderer.get_3d_backend() == 'mayavi':
             import mayavi  # noqa: F401 analysis:ignore
             assert isinstance(fig, mayavi.core.scene.Scene)
 
@@ -159,10 +156,8 @@ def test_plot_evoked_field(backends_3d):
 @testing.requires_testing_data
 @traits_test
 @pytest.mark.timeout(120)
-def test_plot_alignment(tmpdir, backends_3d):
+def test_plot_alignment(tmpdir, renderer):
     """Test plotting of -trans.fif files and MEG sensor layouts."""
-    from mne.viz.backends.renderer import _Renderer
-    backend_name = get_3d_backend()
     # generate fiducials file for testing
     tempdir = str(tmpdir)
     fiducials_path = op.join(tempdir, 'fiducials.fif')
@@ -174,8 +169,7 @@ def test_plot_alignment(tmpdir, backends_3d):
             'r': [0.08436285, -0.02850276, -0.04127743]}]
     write_dig(fiducials_path, fid, 5)
 
-    if backend_name == 'mayavi':
-        mlab = _import_mlab()
+    renderer._close_all()
     evoked = read_evokeds(evoked_fname)[0]
     sample_src = read_source_spaces(src_fname)
     bti = read_raw_bti(pdf_fname, config_fname, hs_fname, convert=True,
@@ -192,11 +186,10 @@ def test_plot_alignment(tmpdir, backends_3d):
             meg.append('ref')
         fig = plot_alignment(info, trans_fname, subject='sample',
                              subjects_dir=subjects_dir, meg=meg)
-        renderer = _Renderer(fig=fig)
-        renderer.close()
+        rend = renderer._Renderer(fig=fig)
+        rend.close()
     # KIT ref sensor coil def is defined
-    if backend_name == 'mayavi':
-        mlab.close(all=True)
+    renderer._close_all()
     info = infos['Neuromag']
     pytest.raises(TypeError, plot_alignment, 'foo', trans_fname,
                   subject='sample', subjects_dir=subjects_dir)
@@ -207,11 +200,9 @@ def test_plot_alignment(tmpdir, backends_3d):
                   src=sample_src)
     sample_src.plot(subjects_dir=subjects_dir, head=True, skull=True,
                     brain='white')
-    if backend_name == 'mayavi':
-        mlab.close(all=True)
+    renderer._close_all()
     # no-head version
-    if backend_name == 'mayavi':
-        mlab.close(all=True)
+    renderer._close_all()
     # all coord frames
     pytest.raises(ValueError, plot_alignment, info)
     plot_alignment(info, surfaces=[])
@@ -220,8 +211,7 @@ def test_plot_alignment(tmpdir, backends_3d):
                              coord_frame=coord_frame, trans=trans_fname,
                              subject='sample', mri_fiducials=fiducials_path,
                              subjects_dir=subjects_dir, src=src_fname)
-        renderer = _Renderer(fig=fig)
-        renderer.close()
+    renderer._close_all()
     # EEG only with strange options
     evoked_eeg_ecog_seeg = evoked.copy().pick_types(meg=False, eeg=True)
     evoked_eeg_ecog_seeg.info['projs'] = []  # "remove" avg proj
@@ -233,8 +223,7 @@ def test_plot_alignment(tmpdir, backends_3d):
                        surfaces=['white', 'outer_skin', 'outer_skull'],
                        meg=['helmet', 'sensors'],
                        eeg=['original', 'projected'], ecog=True, seeg=True)
-    if backend_name == 'mayavi':
-        mlab.close(all=True)
+    renderer._close_all()
 
     sphere = make_sphere_model(info=evoked.info, r0='auto', head_radius='auto')
     bem_sol = read_bem_solution(op.join(subjects_dir, 'sample', 'bem',
@@ -279,7 +268,8 @@ def test_plot_alignment(tmpdir, backends_3d):
     fig = plot_alignment(trans=trans_fname, subject='sample', meg=False,
                          coord_frame='mri', subjects_dir=subjects_dir,
                          surfaces=['brain'], bem=sphere, show_axes=True)
-    if backend_name == 'mayavi':
+    renderer._close_all()
+    if renderer.get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(fig, mayavi.core.scene.Scene)
 
@@ -321,8 +311,7 @@ def test_plot_alignment(tmpdir, backends_3d):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['foo'])
-    if backend_name == 'mayavi':
-        mlab.close(all=True)
+    renderer._close_all()
 
 
 @testing.requires_testing_data
@@ -432,10 +421,9 @@ def test_plot_dipole_mri_orthoview():
 
 @testing.requires_testing_data
 @traits_test
-def test_snapshot_brain_montage(backends_3d):
+def test_snapshot_brain_montage(renderer):
     """Test snapshot brain montage."""
-    from mne.viz import get_3d_backend
-    if get_3d_backend() == 'pyvista':
+    if renderer.get_3d_backend() == 'pyvista':
         pytest.skip("This feature is not available yet on PyVista")
 
     info = read_info(evoked_fname)


### PR DESCRIPTION
While looking at #6403 I realized our 3D backend code / testing infrastructure could be simplified:

1. `yield mne.viz.renderer` instead of plain `yield` to give us access to the renderer functionality directly (no need for most `import` statements in tests anymore)
2. Rename `backends_3d` to `renderer` to reflect what the fixture will actually yield
3. DRY code for importing by using a dict lookup and `importlib` call rather than duplicated functions in conditional branches`from ._whatever import ...`
4. Add a private `_close_all()` function to each module that will close all open figures (this was used a lot in the 3D code)

Currently only `mayavi` supports (4) but we should inquire with `pyvista` if there is a way to keep track. If not, we might want to have a way of tracking Renderer-created figures, at least within a context manager for testing purposes. I think right now we are accumulating `pyvista` figures (?) which would not be so good memory or OpenGL-wise.