### PR TITLE
MRG, DOC: Better org of source PSD

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -214,6 +214,7 @@ this package. You can also find a gallery of these examples in the
             auto_examples/time_frequency/plot_compute_source_psd_epochs.rst
             auto_examples/time_frequency/plot_source_label_time_frequency.rst
             auto_examples/time_frequency/plot_source_power_spectrum.rst
+            auto_examples/time_frequency/plot_source_power_spectrum_opm.rst
             auto_examples/time_frequency/plot_source_space_time_frequency.rst
             auto_examples/time_frequency/plot_temporal_whitening.rst
             auto_examples/time_frequency/plot_time_frequency_global_field_power.rst
@@ -263,7 +264,6 @@ this package. You can also find a gallery of these examples in the
     .. details:: **Inverse examples**
         :class: example_details
 
-        auto_examples/datasets/plot_opm_rest_data.rst
         auto_examples/inverse/plot_compute_mne_inverse_epochs_in_label.rst
         auto_examples/inverse/plot_compute_mne_inverse_raw_in_label.rst
         auto_examples/inverse/plot_compute_mne_inverse_volume.rst

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -355,7 +355,7 @@ Changelog
 
 - Add ability to read and write beamformers with :func:`mne.beamformer.read_beamformer` and :class:`mne.beamformer.Beamformer.save` by `Eric Larson`_
 
-- Add resting-state source power spectral estimation example :ref:`sphx_glr_auto_examples_datasets_plot_opm_rest_data.py` by `Eric Larson`_, `Denis Engemann`_, and `Luke Bloy`_
+- Add resting-state source power spectral estimation example ``sphx_glr_auto_examples_datasets_plot_opm_rest_data.py`` by `Eric Larson`_, `Denis Engemann`_, and `Luke Bloy`_
 
 - Add :func:`mne.channels.make_1020_channel_selections` to group 10/20-named EEG channels by location, by `Jona Sassenhagen`_
 

--- a/examples/time_frequency/plot_source_power_spectrum.py
+++ b/examples/time_frequency/plot_source_power_spectrum.py
@@ -1,10 +1,10 @@
 """
-=========================================================
-Compute power spectrum densities of the sources with dSPM
-=========================================================
+======================================================
+Compute source power spectral density (PSD) in a label
+======================================================
 
-Returns an STC file containing the PSD (in dB) of each of the sources.
-
+Returns an STC file containing the PSD (in dB) of each of the sources
+within a label.
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #

--- a/examples/time_frequency/plot_source_power_spectrum_opm.py
+++ b/examples/time_frequency/plot_source_power_spectrum_opm.py
@@ -1,9 +1,9 @@
 """
 .. _ex-opm-resting-state:
 
-=========================================
-VectorView and OPM resting state datasets
-=========================================
+======================================================================
+Compute source power spectral density (PSD) of VectorView and OPM data
+======================================================================
 
 Here we compute the resting state from raw for data recorded using
 a Neuromag VectorView system and a custom OPM system.
@@ -14,7 +14,7 @@ The steps we use are:
 1. Filtering: downsample heavily.
 2. Artifact detection: use SSP for EOG and ECG.
 3. Source localization: dSPM, depth weighting, cortically constrained.
-4. Frequency: power spectrum density (Welch), 4 sec window, 50% overlap.
+4. Frequency: power spectral density (Welch), 4 sec window, 50% overlap.
 5. Standardize: normalize by relative power for each source.
 
 .. contents::

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -322,7 +322,7 @@ class Vectorizer(TransformerMixin):
 
 @fill_doc
 class PSDEstimator(TransformerMixin):
-    """Compute power spectrum density (PSD) using a multi-taper method.
+    """Compute power spectral density (PSD) using a multi-taper method.
 
     Parameters
     ----------
@@ -367,7 +367,7 @@ class PSDEstimator(TransformerMixin):
         self.normalization = normalization
 
     def fit(self, epochs_data, y):
-        """Compute power spectrum density (PSD) using a multi-taper method.
+        """Compute power spectral density (PSD) using a multi-taper method.
 
         Parameters
         ----------
@@ -388,7 +388,7 @@ class PSDEstimator(TransformerMixin):
         return self
 
     def transform(self, epochs_data):
-        """Compute power spectrum density (PSD) using a multi-taper method.
+        """Compute power spectral density (PSD) using a multi-taper method.
 
         Parameters
         ----------

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -397,7 +397,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
                        inv_split=None, bandwidth='hann', adaptive=False,
                        low_bias=False, n_jobs=1, return_sensor=False, dB=False,
                        verbose=None):
-    """Compute source power spectrum density (PSD).
+    """Compute source power spectral density (PSD).
 
     Parameters
     ----------
@@ -681,7 +681,7 @@ def compute_source_psd_epochs(epochs, inverse_operator, lambda2=1. / 9.,
                               return_generator=False, n_jobs=1,
                               prepared=False, method_params=None,
                               return_sensor=False, verbose=None):
-    """Compute source power spectrum density (PSD) from Epochs.
+    """Compute source power spectral density (PSD) from Epochs.
 
     This uses the multi-taper method to compute the PSD for each epoch.
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -364,7 +364,7 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
 def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
                          adaptive=False, low_bias=True, normalization='length',
                          n_jobs=1, verbose=None):
-    """Compute power spectrum density (PSD) using a multi-taper method.
+    """Compute power spectral density (PSD) using a multi-taper method.
 
     Parameters
     ----------

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -162,7 +162,7 @@ print(epochs_test)
 # Feature Engineering
 # -------------------
 #
-# Observing the power spectrum density (PSD) plot of the :term:`epochs` grouped
+# Observing the power spectral density (PSD) plot of the :term:`epochs` grouped
 # by sleeping stage we can see that different sleep stages have different
 # signatures. These signatures remain similar between Alice and Bob's data.
 #


### PR DESCRIPTION
Yesterday I wanted to show a colleague our source PSD normalization, but it was difficult to find. This re-tittles and moves it to a more appropriate location with better title keywords.

Also I changed "power spectrum density" (PSD) to be the more standard (AFAIK) "power spectral density".

@drammock feel free to merge if you're happy