### PR TITLE
FIX: allow raw_fif to parse brainvision events

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,8 @@ Changelog
 Bug
 ~~~
 
+- Fix ``event_id='auto'`` in :func:`mne.events_from_annotations` to recover Brainvision markers after saving it in ``.fif`` by `Joan Massich`_
+
 - Fix :func:`mne.read_epochs_eeglab` when epochs are stored as float. By `Thomas Radman`_
 
 - Fix bug in handling of :class:`mne.Evoked` types that were not produced by MNE-Python (e.g., alternating average) by `Eric Larson`_

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -825,10 +825,11 @@ def _check_event_id(event_id, raw):
     if event_id is None:
         return _DefaultEventParser()
     elif event_id == 'auto':
-        if isinstance(raw, RawBrainVision) or (
-            isinstance(raw, (RawFIF, RawArray)) and
-            _check_bv_annot(raw.annotations.description)
-        ):
+        if isinstance(raw, RawBrainVision):
+            return _BVEventParser()
+        elif (isinstance(raw, (RawFIF, RawArray)) and
+              _check_bv_annot(raw.annotations.description)):
+            logger.info('Non-RawBrainVision raw using branvision markers')
             return _BVEventParser()
         else:
             return _DefaultEventParser()

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -819,16 +819,19 @@ def _select_annotations_based_on_description(descriptions, event_id, regexp):
 def _check_event_id(event_id, raw):
     from .io.brainvision.brainvision import _BVEventParser
     from .io.brainvision.brainvision import _check_bv_annot
+    from .io.brainvision.brainvision import RawBrainVision
+    from .io import RawFIF, RawArray
 
     if event_id is None:
         return _DefaultEventParser()
     elif event_id == 'auto':
-        if _check_bv_annot(raw.annotations.description):
+        if isinstance(raw, RawBrainVision) or (
+            isinstance(raw, (RawFIF, RawArray)) and
+            _check_bv_annot(raw.annotations.description)
+        ):
             return _BVEventParser()
         else:
             return _DefaultEventParser()
-    elif event_id == 'brainvision':
-        return _BVEventParser()
     elif callable(event_id) or isinstance(event_id, dict):
         return event_id
     else:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -823,12 +823,12 @@ def _check_event_id(event_id, raw):
     if event_id is None:
         return _DefaultEventParser()
     elif event_id == 'auto':
-        candidate = getattr(raw, '_get_auto_event_id', _DefaultEventParser)
-        if candidate == _DefaultEventParser and \
-           _check_bv_annot(raw.annotations.description):
+        if _check_bv_annot(raw.annotations.description):
             return _BVEventParser()
         else:
-            return candidate()
+            return _DefaultEventParser()
+    elif event_id == 'brainvision':
+        return _BVEventParser()
     elif callable(event_id) or isinstance(event_id, dict):
         return event_id
     else:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -817,8 +817,8 @@ def _select_annotations_based_on_description(descriptions, event_id, regexp):
 
 
 def _check_event_id(event_id, raw):
-    from mne.io.brainvision.brainvision import _BVEventParser
-    from mne.io.brainvision.brainvision import _check_bv_annot
+    from .io.brainvision.brainvision import _BVEventParser
+    from .io.brainvision.brainvision import _check_bv_annot
 
     if event_id is None:
         return _DefaultEventParser()

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -817,10 +817,18 @@ def _select_annotations_based_on_description(descriptions, event_id, regexp):
 
 
 def _check_event_id(event_id, raw):
+    from mne.io.brainvision.brainvision import _BVEventParser
+    from mne.io.brainvision.brainvision import _check_bv_annot
+
     if event_id is None:
         return _DefaultEventParser()
     elif event_id == 'auto':
-        return getattr(raw, '_get_auto_event_id', _DefaultEventParser)()
+        candidate = getattr(raw, '_get_auto_event_id', _DefaultEventParser)
+        if candidate == _DefaultEventParser and \
+           _check_bv_annot(raw.annotations.description):
+            return _BVEventParser()
+        else:
+            return candidate()
     elif callable(event_id) or isinstance(event_id, dict):
         return event_id
     else:

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -18,7 +18,6 @@ import re
 from datetime import datetime
 from math import modf
 from io import StringIO
-from itertools import chain
 
 import numpy as np
 
@@ -849,6 +848,6 @@ class _BVEventParser(_DefaultEventParser):
 
 def _check_bv_annot(descriptions):
     markers_basename = set([dd.rstrip('0123456789 ') for dd in descriptions])
-    bv_markers = set(chain(_BV_EVENT_IO_OFFSETS.keys(),
-                           _OTHER_ACCEPTED_MARKERS.keys()))
+    bv_markers = set(_BV_EVENT_IO_OFFSETS.keys()).union(
+        set(_OTHER_ACCEPTED_MARKERS.keys()))
     return len(markers_basename - bv_markers) == 0

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -848,6 +848,6 @@ class _BVEventParser(_DefaultEventParser):
 
 def _check_bv_annot(descriptions):
     markers_basename = set([dd.rstrip('0123456789 ') for dd in descriptions])
-    bv_markers = set(_BV_EVENT_IO_OFFSETS.keys()).union(
-        set(_OTHER_ACCEPTED_MARKERS.keys()))
+    bv_markers = (set(_BV_EVENT_IO_OFFSETS.keys())
+                  .union(set(_OTHER_ACCEPTED_MARKERS.keys())))
     return len(markers_basename - bv_markers) == 0

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -847,7 +847,7 @@ class _BVEventParser(_DefaultEventParser):
 
 
 def _check_bv_annot(descriptions):
-    markers_basename = set([dd.rstrip('0123456789 ') for dd in descriptions])
+    markers_basename = set([dd[:-3] for dd in descriptions])
     bv_markers = (set(_BV_EVENT_IO_OFFSETS.keys())
                   .union(set(_OTHER_ACCEPTED_MARKERS.keys())))
     return len(markers_basename - bv_markers) == 0

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -847,7 +847,7 @@ class _BVEventParser(_DefaultEventParser):
 
 
 def _check_bv_annot(descriptions):
-    markers_basename = set([dd[:-3] for dd in descriptions])
+    markers_basename = set([dd.rstrip('0123456789 ') for dd in descriptions])
     bv_markers = (set(_BV_EVENT_IO_OFFSETS.keys())
                   .union(set(_OTHER_ACCEPTED_MARKERS.keys())))
     return len(markers_basename - bv_markers) == 0

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -18,6 +18,7 @@ import re
 from datetime import datetime
 from math import modf
 from io import StringIO
+from itertools import chain
 
 import numpy as np
 
@@ -849,3 +850,10 @@ class _BVEventParser(_DefaultEventParser):
             code = (super(_BVEventParser, self)
                     .__call__(description, offset=_OTHER_OFFSET))
         return code
+
+
+def _check_bv_annot(descriptions):
+    markers_basename = set([dd.rstrip('0123456789 ') for dd in descriptions])
+    bv_markers = set(chain(_BV_EVENT_IO_OFFSETS.keys(),
+                           _OTHER_ACCEPTED_MARKERS.keys()))
+    return len(markers_basename - bv_markers) == 0

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -126,11 +126,6 @@ class RawBrainVision(BaseRaw):
                     block[:n_data_ch, ii] = [float(l) for l in line]
             _mult_cal_one(data, block, idx, cals, mult)
 
-    @classmethod
-    def _get_auto_event_id(cls):
-        """Return default ``event_id`` behavior for Brainvision."""
-        return _BVEventParser()
-
 
 def _read_segments_c(raw, data, idx, fi, start, stop, cals, mult):
     """Read chunk of vectorized raw data."""

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -5,6 +5,7 @@
 # License: BSD (3-clause)
 
 import os.path as op
+from pathlib import Path
 from os import unlink
 import shutil
 
@@ -518,5 +519,19 @@ def test_automatic_vmrk_sfreq_recovery():
     assert_array_equal(read_annotations(vmrk_path, sfreq='auto'),
                        read_annotations(vmrk_path, sfreq=1000.0))
 
+
+@testing.requires_testing_data
+def test_event_id_stability_when_save_and_fif_reload(tmpdir):
+    """Test load events from brainvision annotations when read_raw_fif."""
+    fname = str(Path(tmpdir, 'bv-raw.fif'))
+    raw = read_raw_brainvision(vhdr_path, eog=eog)
+    original_events, original_event_id = events_from_annotations(raw)
+
+    raw.save(fname)
+    raw = read_raw_fif(fname)
+    events, event_id = events_from_annotations(raw)
+
+    assert event_id == original_event_id
+    assert_array_equal(events, original_events)
 
 run_tests_if_main()

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -501,7 +501,7 @@ def test_read_vhdr_annotations_and_events():
     raw.annotations.append([1, 2, 3], 10, ['ZZZ', s_10, 'YYY'])
     expected_event_id.update(YYY=10001, ZZZ=10002)  # others starting at 10001
     expected_event_id[s_10] = 10
-    _, event_id = events_from_annotations(raw)
+    _, event_id = events_from_annotations(raw, event_id='brainvision')
     assert event_id == expected_event_id
 
     # Concatenating two shouldn't change the resulting event_id

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 
 import os.path as op
-from pathlib import Path
 from os import unlink
 import shutil
 
@@ -523,7 +522,7 @@ def test_automatic_vmrk_sfreq_recovery():
 @testing.requires_testing_data
 def test_event_id_stability_when_save_and_fif_reload(tmpdir):
     """Test load events from brainvision annotations when read_raw_fif."""
-    fname = str(Path(tmpdir, 'bv-raw.fif'))
+    fname = op.join(str(tmpdir), 'bv-raw.fif')
     raw = read_raw_brainvision(vhdr_path, eog=eog)
     original_events, original_event_id = events_from_annotations(raw)
 

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -501,7 +501,7 @@ def test_read_vhdr_annotations_and_events():
     raw.annotations.append([1, 2, 3], 10, ['ZZZ', s_10, 'YYY'])
     expected_event_id.update(YYY=10001, ZZZ=10002)  # others starting at 10001
     expected_event_id[s_10] = 10
-    _, event_id = events_from_annotations(raw, event_id='brainvision')
+    _, event_id = events_from_annotations(raw)
     assert event_id == expected_event_id
 
     # Concatenating two shouldn't change the resulting event_id


### PR DESCRIPTION
This PR fixes this (see discussion in #6326):
```py
raw = read_raw_brainvision(...)
raw.save(fname)
raw_read = read_raw_fif(fname)
events_from_annotations(raw_read, event_id='auto') == events_from_annotations(raw, event_id='auto') # now they are equal!!
```

