### PR TITLE
MRG, MAINT: remove matplotlib version pin

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -81,9 +81,8 @@ def matplotlib_config():
     import matplotlib
     # "force" should not really be necessary but should not hurt
     kwargs = dict()
-    if 'warn' in _get_args(matplotlib.use):
-        kwargs['warn'] = False
-    matplotlib.use('agg', force=True, **kwargs)  # don't pop up windows
+    with warnings.catch_warnings(record=True):  # ignore warning
+        matplotlib.use('agg', force=True, **kwargs)  # don't pop up windows
     import matplotlib.pyplot as plt
     assert plt.get_backend() == 'agg'
     # overwrite some params that can horribly slow down tests that

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -22,7 +22,6 @@ except Exception:
 import numpy as np
 import mne
 from mne.datasets import testing
-from mne.fixes import _get_args
 
 test_path = testing.data_path(download=False)
 s_path = op.join(test_path, 'MEG', 'sample')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-matplotlib<3.1
+matplotlib
 https://api.github.com/repos/enthought/mayavi/zipball/e2569be1096be3deecb15f8fa8581a3ae3fb77d3
 pyqt5
 pyqt5-sip


### PR DESCRIPTION
Closes #6424.

Not sure why this was needed, @massich feel free to chime in. In the meantime maybe the CIs will tell us.