### PR TITLE
Add params to raw.plot figure

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -491,7 +491,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         plt_show(show, block=block)
     except TypeError:  # not all versions have this
         plt_show(show)
-
+    params['fig']._mne_params = params
     return params['fig']
 
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -491,7 +491,17 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         plt_show(show, block=block)
     except TypeError:  # not all versions have this
         plt_show(show)
+
+    # add MNE params dict to the resulting figure object so that parameters can
+    # be modified after the figure has been created; this is useful e.g. to
+    # remove the keyboard shortcut to close the figure with the 'Esc' key,
+    # which can be done with
+    #
+    # fig._mne_params['close_key'] = None
+    #
+    # (assuming that the figure object is fig)
     params['fig']._mne_params = params
+
     return params['fig']
 
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -285,6 +285,10 @@ def test_plot_raw():
             break
     for key in ['down', 'up', 'escape']:
         fig.canvas.key_press_event(key)
+
+    # make sure fig._mne_params is present
+    assert isinstance(fig._mne_params, dict)
+
     plt.close('all')
 
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -186,6 +186,10 @@ def test_plot_raw():
     assert len(plt.get_fignums()) == 0
     fig = raw.plot(events=events, order=[1, 7, 3], group_by='original')
     assert len(plt.get_fignums()) == 1
+
+    # make sure fig._mne_params is present
+    assert isinstance(fig._mne_params, dict)
+
     # test mouse clicks
     x = fig.get_axes()[0].lines[1].get_xdata().mean()
     y = fig.get_axes()[0].lines[1].get_ydata().mean()
@@ -285,9 +289,6 @@ def test_plot_raw():
             break
     for key in ['down', 'up', 'escape']:
         fig.canvas.key_press_event(key)
-
-    # make sure fig._mne_params is present
-    assert isinstance(fig._mne_params, dict)
 
     plt.close('all')
 


### PR DESCRIPTION
Fixes #6425. This allows manipulating keybinds after the raw plot has been created, which is useful e.g. if you want to remove the Escape shortcut to close the window.