### PR TITLE
Modifier key has to be pressed for snapping to annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,8 @@ Changelog
 
 - Change the behavior of :meth:`mne.io.Raw.plot` for ``scalings='auto'`` and ``remove_dc=True`` to compute the scalings on the data with DC removed by `Clemens Brunner`_
 
+- Allow creating annotations within existing annotations in :func:`mne.io.Raw.plot` by default (the old snapping behavior can be toggled by pressing 'p') by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -406,7 +406,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   group_by=group_by, orig_inds=inds.copy(), decim=decim,
                   data_picks=data_picks, event_id_rev=event_id_rev,
                   noise_cov=noise_cov, use_noise_cov=noise_cov is not None,
-                  filt_bounds=filt_bounds, units=units,
+                  filt_bounds=filt_bounds, units=units, snap_annotations=False,
                   unit_scalings=unit_scalings, use_scalebars=True)
 
     if group_by in ['selection', 'position']:

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -79,6 +79,7 @@ def _annotation_helper(raw, events=False):
     _annotation_radio_clicked('', ann_fig.radio, data_ax.selector)
 
     # draw annotation
+    fig.canvas.key_press_event('p')  # use snap mode
     _fake_click(fig, data_ax, [1., 1.], xform='data', button=1, kind='press')
     _fake_click(fig, data_ax, [5., 1.], xform='data', button=1, kind='motion')
     _fake_click(fig, data_ax, [5., 1.], xform='data', button=1, kind='release')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -389,15 +389,19 @@ def _get_help_text(params):
             text2.insert(3, 'Navigate channels up\n')
             text.insert(6, u'a : \n')
             text2.insert(6, 'Toggle annotation mode\n')
-            text.insert(7, u'b : \n')
-            text2.insert(7, 'Toggle butterfly plot on/off\n')
-            text.insert(8, u'd : \n')
-            text2.insert(8, 'Toggle remove DC on/off\n')
-            text.insert(9, u's : \n')
-            text2.insert(9, 'Toggle scale bars\n')
+
+            text.insert(7, u'p : \n')
+            text2.insert(7, 'Toggle snap to annotations on/off\n')
+
+            text.insert(8, u'b : \n')
+            text2.insert(8, 'Toggle butterfly plot on/off\n')
+            text.insert(9, u'd : \n')
+            text2.insert(9, 'Toggle remove DC on/off\n')
+            text.insert(10, u's : \n')
+            text2.insert(10, 'Toggle scale bars\n')
             if 'fig_selection' not in params:
-                text2.insert(12, 'Reduce the number of channels per view\n')
-                text2.insert(13, 'Increase the number of channels per view\n')
+                text2.insert(13, 'Reduce the number of channels per view\n')
+                text2.insert(14, 'Increase the number of channels per view\n')
             text2.append('Mark bad channel\n')
             text2.append('Vertical line at a time instant\n')
             text2.append('Mark bad channel\n')
@@ -886,6 +890,8 @@ def _plot_raw_onkey(event, params):
     elif event.key == 's':
         params['use_scalebars'] = not params['use_scalebars']
         params['plot_fun']()
+    elif event.key == 'p':
+        params['snap_annotations'] = not params['snap_annotations']
 
 
 def _setup_annotation_fig(params):
@@ -2066,7 +2072,8 @@ def _annotations_closed(event, params):
 
 def _on_hover(event, params):
     """Handle hover event."""
-    if event.key != "v":
+    if not params["snap_annotations"]:  # don't snap to annotations
+        _remove_segment_line(params)
         return
     from matplotlib.patheffects import Stroke, Normal
     if (event.button is not None or

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -892,6 +892,10 @@ def _plot_raw_onkey(event, params):
         params['plot_fun']()
     elif event.key == 'p':
         params['snap_annotations'] = not params['snap_annotations']
+        # remove the line if present
+        if not params['snap_annotations']:
+            _on_hover(None, params)
+        params['plot_fun']()
 
 
 def _setup_annotation_fig(params):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2066,6 +2066,8 @@ def _annotations_closed(event, params):
 
 def _on_hover(event, params):
     """Handle hover event."""
+    if event.key != "v":
+        return
     from matplotlib.patheffects import Stroke, Normal
     if (event.button is not None or
             event.inaxes != params['ax'] or event.xdata is None):


### PR DESCRIPTION
Fixes #5907. Currently, I had to set the modifier key to 'v', because 'shift' or 'control' don't work. @larsoner I think I don't even need to manually check for key press and release events as you suggested, because a [`MouseEvent`](https://matplotlib.org/api/backend_bases_api.html#matplotlib.backend_bases.MouseEvent) also has a `key` attribute (seems to be new).

WDYT? Do you have any idea why it doesn't work with shift? Also, I really would like to have the snapping behavior mapped to the modifier (I received some feedback from people telling me the snapping is really strange, they just want to create annotations wherever they click - and I agree).