### PR TITLE
FIX - plot_psd_epochs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,9 @@ Bug
 
 - Fix bug in :func:`mne.viz.plot_compare_evokeds` when using Neuromag 122 system by `Eric Larson`_
 
+- Fix bug in :func:`mne.viz.epochs.plot_epochs_psd` when some channels had zero/infinite ``psd`` values causing erroneous error messages by `Luke Bloy`_
+
+
 API
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ Bug
 
 - Fix bug in :func:`mne.viz.plot_compare_evokeds` when using Neuromag 122 system by `Eric Larson`_
 
-- Fix bug in :func:`mne.viz.epochs.plot_epochs_psd` when some channels had zero/infinite ``psd`` values causing erroneous error messages by `Luke Bloy`_
+- Fix bug in :func:`mne.Epochs.plot_psd` when some channels had zero/infinite ``psd`` values causing erroneous error messages by `Luke Bloy`_
 
 
 API

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -935,19 +935,22 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                                      normalization=normalization, proj=proj,
                                      n_jobs=n_jobs)
 
+        # average across epochs before conversion
+        psds = np.mean(psds, axis=0)
+
         ylabel = _convert_psds(psds, dB, 'auto', scalings_list[ii],
                                units_list[ii],
                                [epochs.ch_names[pi] for pi in picks])
 
-        # mean across epochs and channels
-        psd_mean = np.mean(psds, axis=0).mean(axis=0)
+        # mean across channels
+        psd_mean = np.mean(psds, axis=0)
         if area_mode == 'std':
             # std across channels
-            psd_std = np.std(np.mean(psds, axis=0), axis=0)
+            psd_std = np.std(psds, axis=0)
             hyp_limits = (psd_mean - psd_std, psd_mean + psd_std)
         elif area_mode == 'range':
-            hyp_limits = (np.min(np.mean(psds, axis=0), axis=0),
-                          np.max(np.mean(psds, axis=0), axis=0))
+            hyp_limits = (np.min(psds, axis=0),
+                          np.max(psds, axis=0))
         else:  # area_mode is None
             hyp_limits = None
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -224,10 +224,19 @@ def test_plot_butterfly():
 def test_plot_psd_epochs():
     """Test plotting epochs psd (+topomap)."""
     epochs = _get_epochs()
+    epochs.load_data()
     epochs.plot_psd()
     pytest.raises(RuntimeError, epochs.plot_psd_topomap,
                   bands=[(0, 0.01, 'foo')])  # no freqs in range
     epochs.plot_psd_topomap()
+
+    # with a flat channel
+    err_str = r'channel\(s\) (%s){1}\.' % epochs.ch_names[2]
+    epochs.get_data()[0, 2, :] = 0
+    for dB in [True, False]:
+        with pytest.warns(UserWarning, match=err_str):
+            epochs.plot_psd(dB=dB)
+
     plt.close('all')
 
 


### PR DESCRIPTION
As seen below `_convert_psds` expects the psds to be of shape `(n_channels, n_freqs)`

https://github.com/mne-tools/mne-python/blob/a2c75903d4471587582bc2715985dc82eff9ac12/mne/viz/raw.py#L641-L642

However in plot `plot_epochs_psd` we were passing in an `(n_epochs, n_channels, n_freqs)` array which was causing the flat channel error checking to be wrong. 