### PR TITLE
[MRG][FIX] fix epochs.plot for ctf data

### DIFF
--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -13,11 +13,11 @@ DEFAULTS = dict(
                gof='k', bio='k', ecog='k', hbo='darkblue', hbr='b'),
     units=dict(mag='fT', grad='fT/cm', eeg='uV', eog='uV', ecg='uV', emg='uV',
                misc='AU', seeg='mV', dipole='nAm', gof='GOF', bio='uV',
-               ecog='uV', hbo='uM', hbr='uM'),
+               ecog='uV', hbo='uM', hbr='uM', ref_meg='fT'),
     # scalings for the units
     scalings=dict(mag=1e15, grad=1e13, eeg=1e6, eog=1e6, emg=1e6, ecg=1e6,
                   misc=1.0, seeg=1e3, dipole=1e9, gof=1.0, bio=1e6, ecog=1e6,
-                  hbo=1e6, hbr=1e6),
+                  hbo=1e6, hbr=1e6, ref_meg=1e15),
     # rough guess for a good plot
     scalings_plot_raw=dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6,
                            ecg=5e-4, emg=1e-3, ref_meg=1e-12, misc='auto',
@@ -33,6 +33,7 @@ DEFAULTS = dict(
     titles=dict(mag='Magnetometers', grad='Gradiometers', eeg='EEG', eog='EOG',
                 ecg='ECG', emg='EMG', misc='misc', seeg='sEEG', bio='BIO',
                 dipole='Dipole', ecog='ECoG', hbo='Oxyhemoglobin',
+                ref_meg='Reference Magnetometers',
                 hbr='Deoxyhemoglobin', gof='Goodness of fit'),
     mask_params=dict(marker='o',
                      markerfacecolor='w',

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -846,8 +846,7 @@ _PICK_TYPES_DATA_DICT = dict(
     misc=False, resp=False, chpi=False, exci=False, ias=False, syst=False,
     seeg=True, dipole=False, gof=False, bio=False, ecog=True, fnirs=True)
 _PICK_TYPES_KEYS = tuple(list(_PICK_TYPES_DATA_DICT.keys()) + ['ref_meg'])
-_DATA_CH_TYPES_SPLIT = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr',
-                        'ref_meg')
+_DATA_CH_TYPES_SPLIT = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr')
 _DATA_CH_TYPES_ORDER_DEFAULT = ('mag', 'grad', 'eeg', 'eog', 'ecg', 'emg',
                                 'ref_meg', 'misc', 'stim', 'resp',
                                 'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio',

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -846,11 +846,12 @@ _PICK_TYPES_DATA_DICT = dict(
     misc=False, resp=False, chpi=False, exci=False, ias=False, syst=False,
     seeg=True, dipole=False, gof=False, bio=False, ecog=True, fnirs=True)
 _PICK_TYPES_KEYS = tuple(list(_PICK_TYPES_DATA_DICT.keys()) + ['ref_meg'])
-_DATA_CH_TYPES_SPLIT = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr')
+_DATA_CH_TYPES_SPLIT = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'hbo', 'hbr',
+                        'ref_meg')
 _DATA_CH_TYPES_ORDER_DEFAULT = ('mag', 'grad', 'eeg', 'eog', 'ecg', 'emg',
-                                'reg_mag', 'misc', 'stim', 'resp', 'chpi',
-                                'exci', 'ias', 'syst', 'seeg', 'bio', 'ecog',
-                                'hbo', 'hbr', 'whitened')
+                                'ref_meg', 'misc', 'stim', 'resp',
+                                'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio',
+                                'ecog', 'hbo', 'hbr', 'whitened')
 
 # Valid data types, ordered for consistency, used in viz/evoked.
 _VALID_CHANNEL_TYPES = ('eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'emg',

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -345,7 +345,7 @@ def test_plot_psd_epochs_ctf():
         with pytest.warns(UserWarning, match=err_str):
             epochs.plot_psd(dB=dB)
     epochs.drop_channels(['EEG060'])
-    epochs.plot_psd()
+    epochs.plot_psd(spatial_colors=False, average=False)
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -303,6 +303,7 @@ def test_plot_psd_epochs():
     plt.close('all')
 
 
+@testing.requires_testing_data
 def test_plot_epochs_ctf():
     """Test of basic CTF plotting."""
     raw = read_raw_ctf(ctf_fname, preload=True)
@@ -328,6 +329,7 @@ def test_plot_epochs_ctf():
     plt.close('all')
 
 
+@testing.requires_testing_data
 def test_plot_psd_epochs_ctf():
     """Test plotting CTF epochs psd (+topomap)."""
     raw = read_raw_ctf(ctf_fname, preload=True)

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -333,20 +333,17 @@ def test_plot_psd_epochs_ctf():
     raw = read_raw_ctf(ctf_fname, preload=True)
     evts = make_fixed_length_events(raw)
     epochs = Epochs(raw, evts, preload=True)
-
     pytest.raises(RuntimeError, epochs.plot_psd_topomap,
                   bands=[(0, 0.01, 'foo')])  # no freqs in range
     epochs.plot_psd_topomap()
 
-    # XXX This fails until PR #6439 is merged.
-    # epochs.plot_psd()
-    # with a flat channel
-    # err_str = r'channel\(s\) (%s){1}\.' % epochs.ch_names[2]
-    # epochs.get_data()[0, 2, :] = 0
-    # for dB in [True, False]:
-    #     with pytest.warns(UserWarning, match=err_str):
-    #         epochs.plot_psd(dB=dB)
-
+    # EEG060 is flat in this dataset
+    err_str = r'channel\(s\) EEG060\.'
+    for dB in [True, False]:
+        with pytest.warns(UserWarning, match=err_str):
+            epochs.plot_psd(dB=dB)
+    epochs.drop_channels(['EEG060'])
+    epochs.plot_psd()
     plt.close('all')
 
 


### PR DESCRIPTION
With an update to MNE 18, epochs plotting for ctf data (with ref channels) was failing.
I assume this was introduced in #6210 or #6320.

This PR at least gets through plotting and adds tests. Although I don't know if there was another plan for ref channels. @stfnrpplngr and @larsoner please let me know what you think.

Additional issues,

picks option is ignored (at least on butterfly plots)

ica.plot_sources(epochs) doesn't have a scaling option and the default scaling is too small, at least using my datasets.