### PR TITLE
MRG, FIX: VolVectorSourceEstimate read

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,8 @@ Bug
 
 - Fix bug in handling of :class:`mne.Evoked` types that were not produced by MNE-Python (e.g., alternating average) by `Eric Larson`_
 
+- Fix bug in :func:`mne.read_source_estimate` where vector volumetric source estimates could not be read by `Eric Larson`_
+
 - Fix bug in :func:`mne.inverse_sparse.mixed_norm` and :func:`mne.inverse_sparse.tf_mixed_norm` where ``weights`` was supplied but ``weights_min`` was not, by `Eric Larson`_
 
 - Fix bug in :func:`mne.io.Raw.plot` when using HiDPI displays and the MacOSX backend of matplotlib by `Eric Larson`_

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -340,18 +340,19 @@ def read_source_estimate(fname, subject=None):
                            'subject name from the file "%s'
                            % (subject, kwargs['subject']))
 
+    vector = kwargs['data'].ndim == 3
     if ftype in ('volume', 'discrete'):
-        stc = VolSourceEstimate(**kwargs)
+        klass = VolVectorSourceEstimate if vector else VolSourceEstimate
     elif ftype == 'mixed':
-        stc = MixedSourceEstimate(**kwargs)
+        if vector:
+            # XXX we should really support this at some point
+            raise NotImplementedError('Vector mixed source estimates not yet '
+                                      'supported')
+        klass = MixedSourceEstimate
     else:
         assert ftype == 'surface'
-        if kwargs['data'].ndim == 3:
-            stc = VectorSourceEstimate(**kwargs)
-        else:
-            stc = SourceEstimate(**kwargs)
-
-    return stc
+        klass = VectorSourceEstimate if vector else SourceEstimate
+    return klass(**kwargs)
 
 
 def _get_src_type(src, vertices, warn_text=None):
@@ -415,7 +416,7 @@ def _make_stc(data, vertices, src_type=None, tmin=None, tstep=None,
                     subject=subject)
     elif src_type == 'mixed':
         # make a mixed source estimate
-        if vector:
+        if vector:  # XXX this should be supported someday
             raise RuntimeError('Vector source estimates for mixed source '
                                'spaces are not supported yet')
         stc = MixedSourceEstimate(data, vertices=vertices, tmin=tmin,

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -93,18 +93,32 @@ def test_volume_stc():
     tempdir = _TempDir()
     N = 100
     data = np.arange(N)[:, np.newaxis]
-    datas = [data, data, np.arange(2)[:, np.newaxis]]
+    datas = [data,
+             data,
+             np.arange(2)[:, np.newaxis],
+             np.arange(6).reshape(2, 3, 1)]
     vertno = np.arange(N)
-    vertnos = [vertno, vertno[:, np.newaxis], np.arange(2)[:, np.newaxis]]
-    vertno_reads = [vertno, vertno, np.arange(2)]
+    vertnos = [vertno,
+               vertno[:, np.newaxis],
+               np.arange(2)[:, np.newaxis],
+               np.arange(2)]
+    vertno_reads = [vertno, vertno, np.arange(2), np.arange(2)]
     for data, vertno, vertno_read in zip(datas, vertnos, vertno_reads):
-        stc = VolSourceEstimate(data, vertno, 0, 1)
-        fname_temp = op.join(tempdir, 'temp-vl.stc')
+        if data.ndim in (1, 2):
+            stc = VolSourceEstimate(data, vertno, 0, 1)
+            ext = 'stc'
+            klass = VolSourceEstimate
+        else:
+            assert data.ndim == 3
+            stc = VolVectorSourceEstimate(data, vertno, 0, 1)
+            ext = 'h5'
+            klass = VolVectorSourceEstimate
+        fname_temp = op.join(tempdir, 'temp-vl.' + ext)
         stc_new = stc
         for _ in range(2):
             stc_new.save(fname_temp)
             stc_new = read_source_estimate(fname_temp)
-            assert (isinstance(stc_new, VolSourceEstimate))
+            assert isinstance(stc_new, klass)
             assert_array_equal(vertno_read, stc_new.vertices)
             assert_array_almost_equal(stc.data, stc_new.data)
 


### PR DESCRIPTION
Fixes broken reading of VolVectorSourceEstimate H5 files. I guess I'm the first one to `read_source_estimate` a `VolVectorSourceEstimate`!