### PR TITLE
MRG, DOC: Better error message for bad spacing

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -37,6 +37,8 @@ Bug
 
 - Fix :func:`mne.read_epochs_eeglab` when epochs are stored as float. By `Thomas Radman`_
 
+- Fix checks when constructing volumetric and surface source spaces with :func:`mne.setup_volume_source_space` and :func:`mne.setup_source_space`, respectively, by `Eric Larson`_
+
 - Fix bug in handling of :class:`mne.Evoked` types that were not produced by MNE-Python (e.g., alternating average) by `Eric Larson`_
 
 - Fix bug in :func:`mne.read_source_estimate` where vector volumetric source estimates could not be read by `Eric Larson`_

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1336,7 +1336,8 @@ def _check_spacing(spacing, verbose=None):
     """Check spacing parameter."""
     # check to make sure our parameters are good, parse 'spacing'
     types = ('a string with values "ico#", "oct#", "all", or an int >= 2')
-    space_err = '"spacing" must be ' + types
+    space_err = ('"spacing" must be %s, got type %s (%r)'
+                 % (types, type(spacing), spacing))
     if isinstance(spacing, str):
         if spacing == 'all':
             stype = 'all'
@@ -1347,8 +1348,12 @@ def _check_spacing(spacing, verbose=None):
             try:
                 sval = int(sval)
             except Exception:
-                raise ValueError('ico and oct numbers must be integers, got %r'
-                                 % (sval,))
+                raise ValueError('%s subdivision must be an integer, got %r'
+                                 % (stype, sval))
+            lim = 0 if stype == 'ico' else 1
+            if sval < lim:
+                raise ValueError('%s subdivision must be >= %s, got %s'
+                                 % (stype, lim, sval))
         else:
             raise ValueError(space_err)
     else:

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1691,8 +1691,15 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                         % (bem, surf['np']))
         elif bem is not None and bem.get('is_sphere') is False:
             # read bem surface in the MRI coordinate frame
-            surf = bem['surfs'][0]
+            which = np.where([surf['id'] == FIFF.FIFFV_BEM_SURF_ID_BRAIN
+                              for surf in bem['surfs']])[0]
+            if len(which) != 1:
+                raise ValueError('Could not get inner skull surface from BEM')
+            surf = bem['surfs'][which[0]]
             assert surf['id'] == FIFF.FIFFV_BEM_SURF_ID_BRAIN
+            if surf['coord_frame'] != FIFF.FIFFV_COORD_MRI:
+                raise ValueError('BEM is not in MRI coordinates, got %s'
+                                 % (_coord_frame_name(surf['coord_frame']),))
             logger.info('Taking inner skull from %s'
                         % bem)
         elif surface is not None:

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -630,7 +630,7 @@ def _tessellate_sphere(mylevel):
 
     # A unit octahedron
     if mylevel < 1:
-        raise ValueError('# of levels must be >= 1')
+        raise ValueError('oct subdivision must be >= 1')
 
     # Reverse order of points in each triangle
     # for counter-clockwise ordering


### PR DESCRIPTION
I used `oct-4` or `ico-4` and got a cryptic error message about not finding a BEM surface. This fixes it by explicitly checking that the int we get is >=0 for ico and >=1 for oct.