### PR TITLE
[backport] add try statement to multiprocessing import

### DIFF
--- a/mne/realtime/mock_lsl_stream.py
+++ b/mne/realtime/mock_lsl_stream.py
@@ -29,10 +29,6 @@ class MockLSLStream(object):
     """
 
     def __init__(self, host, raw, ch_type, time_dilation=1):
-        try:
-            from multiprocessing import Process
-        except ImportError('This requires multiprocessing to work properly.')
-
         self._host = host
         self._ch_type = ch_type
         self._time_dilation = time_dilation
@@ -43,6 +39,11 @@ class MockLSLStream(object):
 
     def start(self):
         """Start a mock LSL stream."""
+        try:
+            from multiprocessing import Process
+        except ImportError:
+            raise ImportError('This requires multiprocessing '
+                              'to work properly.')
         print("now sending data...")
         self.process = Process(target=self._initiate_stream)
         self.process.daemon = True

--- a/mne/realtime/mock_lsl_stream.py
+++ b/mne/realtime/mock_lsl_stream.py
@@ -2,7 +2,6 @@
 #
 # License: BSD (3-clause)
 import time
-from multiprocessing import Process
 
 from ..utils import _check_pylsl_installed, deprecated
 from ..io import constants
@@ -30,6 +29,10 @@ class MockLSLStream(object):
     """
 
     def __init__(self, host, raw, ch_type, time_dilation=1):
+        try:
+            from multiprocessing import Process
+        except ImportError('This requires multiprocessing to work properly.')
+
         self._host = host
         self._ch_type = ch_type
         self._time_dilation = time_dilation


### PR DESCRIPTION
I accidentally re-introduced the multiprocessing top-level import that causes problems when trying to use mne-python with webassembly. this corrects the issue.