### PR TITLE
brainvision: use set_montage at the end of the __init__

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Bug
 API
 ~~~
 
+- :func:`mne.io.read_raw_brainvision` no longer raises an error when there are inconsistencies between ``info['chs']`` and ``montage`` but warns instead by `Joan Massich`_
+
 .. _changes_0_18:
 
 Version 0.18

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1939,7 +1939,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Does nothing for objects that close their file descriptors.
         Things like RawFIF will override this method.
         """
-        pass
+        pass  # noqa
 
     def copy(self):
         """Return copy of Raw instance."""
@@ -2398,7 +2398,28 @@ def concatenate_raws(raws, preload=None, events_list=None, verbose=None):
 
 def _check_update_montage(info, montage, path=None, update_ch_names=False,
                           raise_missing=True):
-    """Help eeg readers to add montage."""
+    """Help eeg readers to add montage.
+
+    Parameters
+    ----------
+    info : instance of Info
+        The measurement info to update.
+    montage : instance of Montage | instance of DigMontage | str | None
+        The montage to apply (None removes any location information). If
+        montage is a string, a builtin montage with that name will be used.
+    path : 'str' | None
+        Where to search for standard montages in case montage is a str
+    update_ch_names : bool
+        If True, overwrite the info channel names with the ones from montage.
+        Defaults to False.
+    montage : instance of Montage | instance of DigMontage | str | None
+        The montage to apply (None removes any location information). If
+        montage is a string, a builtin montage with that name will be used.
+    raise_missing : 'warn' | 'err' | True | False
+        What to do when missing positions are detected. 'warn' to emit a
+        warning, 'err' or True to raise an error, False to do nothing.
+        defaults to True.
+    """
     if montage is not None:
         if not isinstance(montage, (str, Montage)):
             err = ("Montage must be str, None, or instance of Montage. "
@@ -2418,8 +2439,15 @@ def _check_update_montage(info, montage, path=None, update_ch_names=False,
                         missing_positions.append(ch['ch_name'])
 
             # raise error if positions are missing
-            if missing_positions and raise_missing:
+            raise_missing = 'err' if raise_missing is True else raise_missing
+            if missing_positions and raise_missing == 'err':
                 raise KeyError(
+                    "The following positions are missing from the montage "
+                    "definitions: %s. If those channels lack positions "
+                    "because they are EOG channels use the eog parameter."
+                    % str(missing_positions))
+            if missing_positions and raise_missing == 'warn':
+                warn(
                     "The following positions are missing from the montage "
                     "definitions: %s. If those channels lack positions "
                     "because they are EOG channels use the eog parameter."

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2398,28 +2398,7 @@ def concatenate_raws(raws, preload=None, events_list=None, verbose=None):
 
 def _check_update_montage(info, montage, path=None, update_ch_names=False,
                           raise_missing=True):
-    """Help eeg readers to add montage.
-
-    Parameters
-    ----------
-    info : instance of Info
-        The measurement info to update.
-    montage : instance of Montage | instance of DigMontage | str | None
-        The montage to apply (None removes any location information). If
-        montage is a string, a builtin montage with that name will be used.
-    path : 'str' | None
-        Where to search for standard montages in case montage is a str
-    update_ch_names : bool
-        If True, overwrite the info channel names with the ones from montage.
-        Defaults to False.
-    montage : instance of Montage | instance of DigMontage | str | None
-        The montage to apply (None removes any location information). If
-        montage is a string, a builtin montage with that name will be used.
-    raise_missing : 'warn' | 'err' | True | False
-        What to do when missing positions are detected. 'warn' to emit a
-        warning, 'err' or True to raise an error, False to do nothing.
-        defaults to True.
-    """
+    """Help eeg readers to add montage."""
     if montage is not None:
         if not isinstance(montage, (str, Montage)):
             err = ("Montage must be str, None, or instance of Montage. "
@@ -2439,15 +2418,8 @@ def _check_update_montage(info, montage, path=None, update_ch_names=False,
                         missing_positions.append(ch['ch_name'])
 
             # raise error if positions are missing
-            raise_missing = 'err' if raise_missing is True else raise_missing
-            if missing_positions and raise_missing == 'err':
+            if missing_positions and raise_missing:
                 raise KeyError(
-                    "The following positions are missing from the montage "
-                    "definitions: %s. If those channels lack positions "
-                    "because they are EOG channels use the eog parameter."
-                    % str(missing_positions))
-            if missing_positions and raise_missing == 'warn':
-                warn(
                     "The following positions are missing from the montage "
                     "definitions: %s. If those channels lack positions "
                     "because they are EOG channels use the eog parameter."

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -102,7 +102,9 @@ class RawBrainVision(BaseRaw):
         # Get annotations from vmrk file
         annots = read_annotations(mrk_fname, info['sfreq'])
         self.set_annotations(annots)
-        self.set_montage(montage)
+
+        if montage is not None:
+            self.set_montage(montage)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -76,7 +76,6 @@ class RawBrainVision(BaseRaw):
         self._order = order
         self._n_samples = n_samples
 
-        _check_update_montage(info, montage)
         with open(data_fname, 'rb') as f:
             if isinstance(fmt, dict):  # ASCII, this will be slow :(
                 if self._order == 'F':  # multiplexed, channels in columns
@@ -103,6 +102,7 @@ class RawBrainVision(BaseRaw):
         # Get annotations from vmrk file
         annots = read_annotations(mrk_fname, info['sfreq'])
         self.set_annotations(annots)
+        _check_update_montage(self.info, montage, raise_missing='warn')
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -102,7 +102,7 @@ class RawBrainVision(BaseRaw):
         # Get annotations from vmrk file
         annots = read_annotations(mrk_fname, info['sfreq'])
         self.set_annotations(annots)
-        _check_update_montage(self.info, montage, raise_missing='warn')
+        _check_update_montage(self.info, montage, raise_missing=False)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -24,7 +24,7 @@ import numpy as np
 from ...utils import verbose, logger, warn, fill_doc, _DefaultEventParser
 from ..constants import FIFF
 from ..meas_info import _empty_info
-from ..base import BaseRaw, _check_update_montage
+from ..base import BaseRaw
 from ..utils import _read_segments_file, _mult_cal_one
 from ...annotations import Annotations, read_annotations
 
@@ -102,7 +102,7 @@ class RawBrainVision(BaseRaw):
         # Get annotations from vmrk file
         annots = read_annotations(mrk_fname, info['sfreq'])
         self.set_annotations(annots)
-        _check_update_montage(self.info, montage, raise_missing=False)
+        self.set_montage(montage)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -80,8 +80,7 @@ def test_same_behaviour_in_init_and_set_montage(montage):
 
     # Assert equal objects
     for key in ['chs', 'dig']:
-        diff = object_diff(raw_none.info[key], raw_montage.info[key],
-                           ignore_nan=True)
+        diff = object_diff(raw_none.info[key], raw_montage.info[key])
         assert diff == ''
 
     # Assert equal warnings

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -6,6 +6,7 @@
 
 import os.path as op
 from os import unlink
+import warnings
 import shutil
 
 import numpy as np
@@ -63,26 +64,19 @@ eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
 
 
-def test_same_behaviour_in_init_and_set_montage():
-    """Test that __init__ and set_montage lead to equal results."""
-    raw_montage = read_raw_brainvision(vhdr_path, montage=montage)
-    raw_none = read_raw_brainvision(vhdr_path, montage=None)
-    assert raw_none.info['dig'] is None
-    raw_none.set_montage(montage)
-    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
-    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
-
-
-def test_same_behaviour_in_init_and_set_montage_biosemi():
+@pytest.mark.parametrize('montage', [montage, 'biosemi32'])
+def test_same_behaviour_in_init_and_set_montage(montage):
     """Test that __init__ and set_montage lead to equal results."""
     with pytest.warns(RuntimeWarning) as init_warns:
-        raw_montage = read_raw_brainvision(vhdr_path, montage='biosemi32')
+        warnings.warn('dummy', RuntimeWarning)
+        raw_montage = read_raw_brainvision(vhdr_path, montage=montage)
 
     raw_none = read_raw_brainvision(vhdr_path, montage=None)
     assert raw_none.info['dig'] is None
 
     with pytest.warns(RuntimeWarning) as set_montage_warns:
-        raw_none.set_montage('biosemi32')
+        warnings.warn('dummy', RuntimeWarning)
+        raw_none.set_montage(montage)
 
     # Assert equal objects
     assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -84,11 +84,16 @@ def test_same_behaviour_in_init_and_set_montage_biosemi():
     with pytest.warns(RuntimeWarning) as set_montage_warns:
         raw_none.set_montage('biosemi32')
 
-    len(init_warns)
-    len(set_montage_warns)
-    # assert init_warns == set_montage_warns
+    # Assert equal objects
     assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
+
+    # Assert equal warnings
+    assert len(init_warns) == len(set_montage_warns)
+    for ii in len(init_warns):
+        msg_a = init_warns[ii].message.args[0]
+        msg_b = set_montage_warns[ii].message.args[0]
+        assert msg_a == msg_b
 
 
 def test_orig_units(recwarn):

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -90,7 +90,7 @@ def test_same_behaviour_in_init_and_set_montage_biosemi():
 
     # Assert equal warnings
     assert len(init_warns) == len(set_montage_warns)
-    for ii in len(init_warns):
+    for ii in range(len(init_warns)):
         msg_a = init_warns[ii].message.args[0]
         msg_b = set_montage_warns[ii].message.args[0]
         assert msg_a == msg_b

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -15,6 +15,7 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 from mne.utils import _TempDir, run_tests_if_main
+from mne.utils.numerics import object_diff
 from mne import pick_types, read_annotations, concatenate_raws
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
@@ -60,6 +61,16 @@ vhdr_bad_date = op.join(data_dir, 'test_bad_date.vhdr')
 montage = op.join(data_dir, 'test.hpts')
 eeg_bin = op.join(data_dir, 'test_bin_raw.fif')
 eog = ['HL', 'HR', 'Vb']
+
+
+def test_same_behaviour_in_init_and_set_montage():
+    """Test that __init__ and set_montage lead to equal results."""
+    raw_montage = read_raw_brainvision(vhdr_path, montage=montage)
+    raw_none = read_raw_brainvision(vhdr_path, montage=None)
+    assert raw_none.info['dig'] is None
+    raw_none.set_montage(montage)
+    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
+    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
 
 
 def test_orig_units(recwarn):

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -79,8 +79,10 @@ def test_same_behaviour_in_init_and_set_montage(montage):
         raw_none.set_montage(montage)
 
     # Assert equal objects
-    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
-    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
+    for key in ['chs', 'dig']:
+        diff = object_diff(raw_none.info[key], raw_montage.info[key],
+                           ignore_nan=True)
+        assert diff == ''
 
     # Assert equal warnings
     assert len(init_warns) == len(set_montage_warns)

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -73,6 +73,24 @@ def test_same_behaviour_in_init_and_set_montage():
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
 
 
+def test_same_behaviour_in_init_and_set_montage_biosemi():
+    """Test that __init__ and set_montage lead to equal results."""
+    with pytest.warns(RuntimeWarning) as init_warns:
+        raw_montage = read_raw_brainvision(vhdr_path, montage='biosemi32')
+
+    raw_none = read_raw_brainvision(vhdr_path, montage=None)
+    assert raw_none.info['dig'] is None
+
+    with pytest.warns(RuntimeWarning) as set_montage_warns:
+        raw_none.set_montage('biosemi32')
+
+    len(init_warns)
+    len(set_montage_warns)
+    # assert init_warns == set_montage_warns
+    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
+    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
+
+
 def test_orig_units(recwarn):
     """Test exposure of original channel units."""
     raw = read_raw_brainvision(vhdr_path)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -48,6 +48,6 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        object_hash, object_size, _apply_scaling_cov,
                        _undo_scaling_cov, _apply_scaling_array,
                        _undo_scaling_array, _scaled_array, _replace_md5, _PCA,
-                       _mask_to_onsets_offsets)
+                       _mask_to_onsets_offsets, _array_equal_nan)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
 _prepare_write_metadata, _FakeNoPandas)

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -703,7 +703,7 @@ def _sort_keys(x):
     return keys
 
 
-def object_diff(a, b, pre=''):
+def object_diff(a, b, pre='', ignore_nan=False):
     """Compute all differences between two python variables.
 
     Parameters
@@ -715,6 +715,8 @@ def object_diff(a, b, pre=''):
         Must be same type as ``a``.
     pre : str
         String to prepend to each line.
+    ignore_nan : bool
+        If True, NaN values are ignored when comparing arrays.
 
     Returns
     -------
@@ -748,8 +750,12 @@ def object_diff(a, b, pre=''):
         if b is not None:
             out += pre + ' left is None, right is not (%s)\n' % (b)
     elif isinstance(a, np.ndarray):
-        if not np.array_equal(a[~np.isnan(a)], b[~np.isnan(b)]):
-            out += pre + ' array mismatch\n'
+        if ignore_nan:
+            if not np.array_equal(a[~np.isnan(a)], b[~np.isnan(b)]):
+                out += pre + ' array mismatch\n'
+        else:
+            if not np.array_equal(a, b):
+                out += pre + ' array mismatch\n'
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():
             out += pre + ' StringIO mismatch\n'

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -703,6 +703,12 @@ def _sort_keys(x):
     return keys
 
 
+def _array_equal_nan(a, b, ignore_nan):
+    a_idx = ~np.isnan(a) if ignore_nan else slice(None)
+    b_idx = ~np.isnan(b) if ignore_nan else slice(None)
+    return np.array_equal(a[a_idx], b[b_idx]) and np.array_equal(a_idx, b_idx)
+
+
 def object_diff(a, b, pre='', ignore_nan=False):
     """Compute all differences between two python variables.
 
@@ -752,11 +758,8 @@ def object_diff(a, b, pre='', ignore_nan=False):
         if b is not None:
             out += pre + ' left is None, right is not (%s)\n' % (b)
     elif isinstance(a, np.ndarray):
-        a_idx = ~np.isnan(a) if ignore_nan else slice(None)
-        b_idx = ~np.isnan(b) if ignore_nan else slice(None)
-        if (not np.array_equal(a[a_idx], b[b_idx]) or
-                not np.array_equal(a_idx, b_idx)):
-            out += pre + ' array mismatch\n'
+        if not _array_equal_nan(a, b, ignore_nan):
+            out += + ' array mismatch\n'
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():
             out += pre + ' StringIO mismatch\n'

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -752,12 +752,11 @@ def object_diff(a, b, pre='', ignore_nan=False):
         if b is not None:
             out += pre + ' left is None, right is not (%s)\n' % (b)
     elif isinstance(a, np.ndarray):
-        if ignore_nan:
-            if not np.array_equal(a[~np.isnan(a)], b[~np.isnan(b)]):
-                out += pre + ' array mismatch\n'
-        else:
-            if not np.array_equal(a, b):
-                out += pre + ' array mismatch\n'
+        a_idx = ~np.isnan(a) if ignore_nan else slice(None)
+        b_idx = ~np.isnan(b) if ignore_nan else slice(None)
+        if (not np.array_equal(a[a_idx], b[b_idx]) or
+                not np.array_equal(a_idx, b_idx)):
+            out += pre + ' array mismatch\n'
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():
             out += pre + ' StringIO mismatch\n'

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -736,13 +736,15 @@ def object_diff(a, b, pre='', ignore_nan=False):
             if key not in k2s:
                 out += pre + ' right missing key %s\n' % key
             else:
-                out += object_diff(a[key], b[key], pre + '[%s]' % repr(key))
+                out += object_diff(a[key], b[key],
+                                   pre=(pre + '[%s]' % repr(key)),
+                                   ignore_nan=ignore_nan)
     elif isinstance(a, (list, tuple)):
         if len(a) != len(b):
             out += pre + ' length mismatch (%s, %s)\n' % (len(a), len(b))
         else:
             for ii, (xx1, xx2) in enumerate(zip(a, b)):
-                out += object_diff(xx1, xx2, pre + '[%s]' % ii)
+                out += object_diff(xx1, xx2, pre + '[%s]' % ii, ignore_nan)
     elif isinstance(a, (str, int, float, bytes, np.generic)):
         if a != b:
             out += pre + ' value mismatch (%s, %s)\n' % (a, b)
@@ -771,7 +773,7 @@ def object_diff(a, b, pre='', ignore_nan=False):
                 out += pre + (' sparse matrix a and b differ on %s '
                               'elements' % c.nnz)
     elif hasattr(a, '__getstate__'):
-        out += object_diff(a.__getstate__(), b.__getstate__(), pre)
+        out += object_diff(a.__getstate__(), b.__getstate__(), pre, ignore_nan)
     else:
         raise RuntimeError(pre + ': unsupported type %s (%s)' % (type(a), a))
     return out

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -704,9 +704,17 @@ def _sort_keys(x):
 
 
 def _array_equal_nan(a, b, ignore_nan):
-    a_idx = ~np.isnan(a) if ignore_nan else slice(None)
-    b_idx = ~np.isnan(b) if ignore_nan else slice(None)
-    return np.array_equal(a[a_idx], b[b_idx]) and np.array_equal(a_idx, b_idx)
+    a = np.asarray(a)
+    b = np.asarray(b)
+    a_idx = b_idx = slice(None)
+    same_nans = True
+    if ignore_nan:
+        a_idx = ~np.isnan(a)
+        b_idx = ~np.isnan(b)
+        same_nans = np.array_equal(a_idx, b_idx)
+        if np.all(a_idx):
+            return same_nans
+    return np.array_equal(a[a_idx], b[b_idx]) and same_nans
 
 
 def object_diff(a, b, pre='', ignore_nan=False):

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -706,15 +706,9 @@ def _sort_keys(x):
 def _array_equal_nan(a, b, ignore_nan):
     a = np.asarray(a)
     b = np.asarray(b)
-    a_idx = b_idx = slice(None)
-    same_nans = True
-    if ignore_nan:
-        a_idx = ~np.isnan(a)
-        b_idx = ~np.isnan(b)
-        same_nans = np.array_equal(a_idx, b_idx)
-        if np.all(a_idx):
-            return same_nans
-    return np.array_equal(a[a_idx], b[b_idx]) and same_nans
+    a_idx = ~np.isnan(a) if ignore_nan else slice(None)
+    b_idx = ~np.isnan(b) if ignore_nan else slice(None)
+    return np.array_equal(a[a_idx], b[b_idx]) and np.array_equal(a_idx, b_idx)
 
 
 def object_diff(a, b, pre='', ignore_nan=False):

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -759,7 +759,7 @@ def object_diff(a, b, pre='', ignore_nan=False):
             out += pre + ' left is None, right is not (%s)\n' % (b)
     elif isinstance(a, np.ndarray):
         if not _array_equal_nan(a, b, ignore_nan):
-            out += + ' array mismatch\n'
+            out += pre + ' array mismatch\n'
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():
             out += pre + ' StringIO mismatch\n'

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -748,7 +748,7 @@ def object_diff(a, b, pre=''):
         if b is not None:
             out += pre + ' left is None, right is not (%s)\n' % (b)
     elif isinstance(a, np.ndarray):
-        if not np.array_equal(a, b):
+        if not np.array_equal(a[~np.isnan(a)], b[~np.isnan(b)]):
             out += pre + ' array mismatch\n'
     elif isinstance(a, (StringIO, BytesIO)):
         if a.getvalue() != b.getvalue():

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -18,7 +18,8 @@ from mne.utils import (_get_inst_data, md5sum, hashfunc,
                        _freq_mask, random_permutation, _reg_pinv, object_size,
                        object_hash, object_diff, _apply_scaling_cov,
                        _undo_scaling_cov, _apply_scaling_array,
-                       _undo_scaling_array, _PCA, requires_sklearn)
+                       _undo_scaling_array, _PCA, requires_sklearn,
+                       _array_equal_nan)
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -447,3 +448,11 @@ def test_pca(n_components, whiten):
     else:
         assert n_components is None
         assert pca_mne.n_components_ == n_dim
+
+
+def test_array_equal_nan():
+    """Test comparing arrays with NaNs."""
+    assert not _array_equal_nan([1, np.nan, 0], [1, np.nan, 0], False)
+    assert _array_equal_nan([1, np.nan, 0], [1, np.nan, 0], True)
+    assert not _array_equal_nan([1, 0, np.nan], [1, np.nan, 0], True)
+    assert _array_equal_nan([np.nan, np.nan], [np.nan, np.nan], True)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -316,14 +316,14 @@ def test_object_size():
             '%s < %s < %s:\n%s' % (lower, size, upper, obj)
 
 
-def test_object_diff_with_nans():
+def test_object_diff_with_nan():
     """Test object diff can handle NaNs."""
-    d0 = dict(nan=np.array([1, np.nan, 0]))
-    d1 = dict(nan=np.array([1, np.nan, 0]))
-    d2 = dict(nan=np.array([np.nan, 1, 0]))
+    d0 = np.array([1, np.nan, 0])
+    d1 = np.array([1, np.nan, 0])
+    d2 = np.array([np.nan, 1, 0])
 
-    assert len(object_diff(d0, d1, ignore_nan=True)) == 0
-    assert (len(object_diff(d0, d2, ignore_nan=True)) > 0)
+    assert object_diff(d0, d1) == ''
+    assert object_diff(d0, d2) != ''
 
 
 def test_hash():
@@ -452,7 +452,10 @@ def test_pca(n_components, whiten):
 
 def test_array_equal_nan():
     """Test comparing arrays with NaNs."""
-    assert not _array_equal_nan([1, np.nan, 0], [1, np.nan, 0], False)
-    assert _array_equal_nan([1, np.nan, 0], [1, np.nan, 0], True)
-    assert not _array_equal_nan([1, 0, np.nan], [1, np.nan, 0], True)
-    assert _array_equal_nan([np.nan, np.nan], [np.nan, np.nan], True)
+    a = b = [1, np.nan, 0]
+    assert not np.array_equal(a, b)  # this is the annoying behavior we avoid
+    assert _array_equal_nan(a, b)
+    b = [np.nan, 1, 0]
+    assert not _array_equal_nan(a, b)
+    a = b = [np.nan] * 2
+    assert _array_equal_nan(a, b)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -315,6 +315,16 @@ def test_object_size():
             '%s < %s < %s:\n%s' % (lower, size, upper, obj)
 
 
+def test_object_diff_with_nans():
+    """Test object diff can handle NaNs."""
+    d0 = dict(nan=np.array([1, np.nan, 0]))
+    d1 = dict(nan=np.array([1, np.nan, 0]))
+    d2 = dict(nan=np.array([np.nan, 1, 0]))
+
+    assert len(object_diff(d0, d1, ignore_nan=True)) == 0
+    assert (len(object_diff(d0, d2, ignore_nan=True)) > 0)
+
+
 def test_hash():
     """Test dictionary hashing and comparison functions."""
     # does hashing all of these types work:


### PR DESCRIPTION
This PR is part of #6461. The concrete goal here is to make sure that:
1 - `RawBrainVision` is always called with `montage=None`
2 - ensure `self.set_montage(montage)` is called at the end of __init__
