### PR TITLE
cnt: use set_montage at the end of the __init__

### DIFF
--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -14,7 +14,7 @@ from ..constants import FIFF
 from ..utils import (_mult_cal_one, _find_channels, _create_chs, read_str,
                      _deprecate_stim_channel, _synthesize_stim_channel)
 from ..meas_info import _empty_info
-from ..base import BaseRaw, _check_update_montage
+from ..base import BaseRaw
 from ...annotations import Annotations
 
 
@@ -432,7 +432,6 @@ class RawCNT(BaseRaw):
         info, cnt_info = _get_cnt_info(input_fname, eog, ecg, emg, misc,
                                        data_format, _date_format, stim_channel)
         last_samps = [cnt_info['n_samples'] - 1]
-        _check_update_montage(info, montage)
         super(RawCNT, self).__init__(
             info, preload, filenames=[input_fname], raw_extras=[cnt_info],
             last_samps=last_samps, orig_format='int', verbose=verbose)
@@ -440,6 +439,8 @@ class RawCNT(BaseRaw):
         data_format = 'int32' if cnt_info['n_bytes'] == 4 else 'int16'
         self.set_annotations(
             _read_annotations_cnt(input_fname, data_format=data_format))
+        if montage is not None:
+            self.set_montage(montage)
 
     @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -8,17 +8,35 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_equal
+from copy import deepcopy
 import pytest
 
 from mne import pick_types
 from mne.utils import run_tests_if_main
+from mne.utils.numerics import object_diff
 from mne.datasets import testing
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
 from mne.annotations import read_annotations
+from mne.digitization import Digitization
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
+
+
+@testing.requires_testing_data
+def test_montage():
+    """Test setting up one of the default montages."""
+    with pytest.warns(RuntimeWarning, match='number of bytes'):
+        raw = read_raw_cnt(fname, montage=None, eog='auto',
+                           misc=['NA1', 'LEFT_EAR'])
+    assert raw.info['dig'] is None
+    original_chs = deepcopy(raw.info['chs'])
+
+    raw.set_montage('biosemi128')  # set a random montage of same num channels
+    assert isinstance(raw.info['dig'], Digitization)
+    assert raw.info['dig']
+    assert object_diff(raw.info['chs'], original_chs)
 
 
 @testing.requires_testing_data

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -19,6 +19,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.cnt import read_raw_cnt
 from mne.annotations import read_annotations
 from mne.digitization import Digitization
+from mne.channels import Montage
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'CNT', 'scan41_short.cnt')
@@ -33,7 +34,13 @@ def test_montage():
     assert raw.info['dig'] is None
     original_chs = deepcopy(raw.info['chs'])
 
-    raw.set_montage('biosemi128')  # set a random montage of same num channels
+    n_channels = len(raw.ch_names)
+    pos = np.random.RandomState(42).randn(n_channels, 3)
+    ch_names = map(str, range(n_channels))
+    kind = 'random'
+    selection = np.arange(n_channels)
+    montage = Montage(pos, ch_names, kind, selection)
+    raw.set_montage(montage)  # set a random montage of same num channels
     assert isinstance(raw.info['dig'], Digitization)
     assert raw.info['dig']
     assert object_diff(raw.info['chs'], original_chs)


### PR DESCRIPTION
This PR is part of #6461. The concrete goal here is to make sure that:
1 - `RawCNT` is always called with `montage=None`
2 - ensure `self.set_montage(montage)` is called at the end of __init__