### PR TITLE
MRG, BUG: Set info["lowpass"] when resampling

### DIFF
--- a/doc/manual/datasets_index.rst
+++ b/doc/manual/datasets_index.rst
@@ -241,7 +241,7 @@ Triggers include:
 * Magnetic trigger (in OPM measurement only): trigger value 260.
   1 second before the median nerve stimulation, a magnetic trigger is piped into the MSR.
   This was to be able to check the synchronization between OPMs retrospectively, as each
-  sensor runs on an indepent clock. Synchronization turned out to be satisfactory
+  sensor runs on an independent clock. Synchronization turned out to be satisfactory.
 
 .. topic:: Examples
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,8 @@ Bug
 
 - Fix :func:`mne.read_epochs_eeglab` when epochs are stored as float. By `Thomas Radman`_
 
+- Fix :func:`mne.Evoked.resample` and :func:`mne.Epochs.resample` not setting ``inst.info['lowpass']`` properly by `Eric Larson`_
+
 - Fix checks when constructing volumetric and surface source spaces with :func:`mne.setup_volume_source_space` and :func:`mne.setup_source_space`, respectively, by `Eric Larson`_
 
 - Fix bug in handling of :class:`mne.Evoked` types that were not produced by MNE-Python (e.g., alternating average) by `Eric Larson`_

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -25,3 +25,7 @@ fo
 files'
 ser
 vas
+coo
+hist
+datas
+dof

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -41,7 +41,7 @@ from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
-from .filter import detrend, FilterMixin, HilbertMixin
+from .filter import detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import _get_args
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
@@ -185,8 +185,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
 @fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
-                 ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin,
-                 HilbertMixin):
+                 ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin):
     """Abstract base class for Epochs-type classes.
 
     This class provides basic functionality and should never be instantiated

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -16,7 +16,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin,
                                 equalize_channels)
 from .channels.layout import _merge_grad_data, _pair_grad_sensors
-from .filter import detrend, FilterMixin, HilbertMixin
+from .filter import detrend, FilterMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     SizeMixin, copy_function_doc_to_method_doc, _validate_type,
                     fill_doc, _check_option)
@@ -57,7 +57,7 @@ _aspect_rev = {val: key for key, val in _aspect_dict.items()}
 @fill_doc
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              InterpolationMixin, FilterMixin, ToDataFrameMixin, TimeMixin,
-             SizeMixin, HilbertMixin):
+             SizeMixin):
     """Evoked data.
 
     Parameters

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -6,6 +6,7 @@ from functools import partial
 import numpy as np
 from scipy.fftpack import ifftshift, fftfreq
 
+from .annotations import _annotations_starts_stops
 from .io.pick import _picks_to_idx
 from .cuda import (_setup_cuda_fft_multiply_repeated, _fft_multiply_repeated,
                    _setup_cuda_fft_resample, _fft_resample, _smart_pad)
@@ -1839,7 +1840,8 @@ class FilterMixin(object):
                l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
                method='fir', iir_params=None, phase='zero',
                fir_window='hamming', fir_design='firwin',
-               pad='edge', verbose=None):
+               skip_by_annotation=('edge', 'bad_acq_skip'), pad='edge',
+               verbose=None):
         """Filter a subset of channels.
 
         Parameters
@@ -1856,19 +1858,34 @@ class FilterMixin(object):
         %(phase)s
         %(fir_window)s
         %(fir_design)s
+        skip_by_annotation : str | list of str
+            If a string (or list of str), any annotation segment that begins
+            with the given string will not be included in filtering, and
+            segments on either side of the given excluded annotated segment
+            will be filtered separately (i.e., as independent signals).
+            The default (``('edge', 'bad_acq_skip')`` will separately filter
+            any segments that were concatenated by :func:`mne.concatenate_raws`
+            or :meth:`mne.io.Raw.append`, or separated during acquisition.
+            To disable, provide an empty list. Only used if ``inst`` is raw.
+
+            .. versionadded:: 0.16.
         %(pad-fir)s
-            The default is ``'edge'``, which pads with the edge values of each
-            vector.
         %(verbose_meth)s
 
         Returns
         -------
-        inst : instance of Epochs or Evoked
+        inst : instance of Epochs, Evoked, or Raw
             The filtered data.
 
         See Also
         --------
         mne.filter.create_filter
+        mne.Evoked.savgol_filter
+        mne.io.Raw.notch_filter
+        mne.io.Raw.resample
+        mne.filter.create_filter
+        mne.filter.filter_data
+        mne.filter.construct_iir_filter
 
         Notes
         -----
@@ -1894,17 +1911,39 @@ class FilterMixin(object):
                   ``len(picks) * n_times`` additional time points need to
                   be temporaily stored in memory.
 
+        For more information, see the tutorials
+        :ref:`disc-filtering` and :ref:`tut-filter-resample` and
+        :func:`mne.filter.create_filter`.
+
         .. versionadded:: 0.15
         """
+        from .io.base import BaseRaw
         _check_preload(self, 'inst.filter')
         if pad is None and method != 'iir':
             pad = 'edge'
         update_info, picks = _filt_check_picks(self.info, picks,
                                                l_freq, h_freq)
-        filter_data(self._data, self.info['sfreq'], l_freq, h_freq, picks,
-                    filter_length, l_trans_bandwidth, h_trans_bandwidth,
-                    n_jobs, method, iir_params, copy=False, phase=phase,
-                    fir_window=fir_window, fir_design=fir_design, pad=pad)
+        if isinstance(self, BaseRaw):
+            # Deal with annotations
+            onsets, ends = _annotations_starts_stops(
+                self, skip_by_annotation, 'skip_by_annotation', invert=True)
+            logger.info('Filtering raw data in %d contiguous segment%s'
+                        % (len(onsets), _pl(onsets)))
+        else:
+            onsets, ends = np.array([0]), np.array([self._data.shape[1]])
+        max_idx = (ends - onsets).argmax()
+        for si, (start, stop) in enumerate(zip(onsets, ends)):
+            # Only output filter params once (for info level), and only warn
+            # once about the length criterion (longest segment is too short)
+            use_verbose = verbose if si == max_idx else 'error'
+            filter_data(
+                self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,
+                picks, filter_length, l_trans_bandwidth, h_trans_bandwidth,
+                n_jobs, method, iir_params, copy=False, phase=phase,
+                fir_window=fir_window, fir_design=fir_design, pad=pad,
+                verbose=use_verbose)
+        # update info if filter is applied to all data channels,
+        # and it's not a band-stop filter
         _filt_update_info(self.info, update_info, l_freq, h_freq)
         return self
 
@@ -1944,27 +1983,32 @@ class FilterMixin(object):
         artifacts. This is dataset dependent -- check your data!
         """
         from .epochs import BaseEpochs
+        from .evoked import Evoked
+        # Should be guaranteed by our inheritance, and the fact that
+        # mne.io.base.BaseRaw overrides this method
+        assert isinstance(self, (BaseEpochs, Evoked))
+
         _check_preload(self, 'inst.resample')
+
         sfreq = float(sfreq)
         o_sfreq = self.info['sfreq']
         self._data = resample(self._data, sfreq, o_sfreq, npad, window=window,
                               n_jobs=n_jobs, pad=pad)
         self.info['sfreq'] = float(sfreq)
+        lowpass = self.info.get('lowpass')
+        lowpass = np.inf if lowpass is None else lowpass
+        self.info['lowpass'] = min(lowpass, sfreq / 2.)
         new_times = (np.arange(self._data.shape[-1], dtype=np.float) /
                      sfreq + self.times[0])
         # adjust indirectly affected variables
         if isinstance(self, BaseEpochs):
             self._set_times(new_times)
             self._raw_times = self.times
-        else:
+        else:  # isinstance(self, Evoked)
             self.times = new_times
             self.first = int(self.times[0] * self.info['sfreq'])
             self.last = len(self.times) + self.first - 1
         return self
-
-
-class HilbertMixin(object):
-    """Object for Epoch/Evoked/Raw Hilbert transformations."""
 
     @verbose
     def apply_hilbert(self, picks=None, envelope=False, n_jobs=1, n_fft='auto',

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1949,7 +1949,7 @@ class FilterMixin(object):
 
     @verbose
     def resample(self, sfreq, npad='auto', window='boxcar', n_jobs=1,
-                 pad='edge', verbose=None):
+                 pad='edge', verbose=None):  # lgtm
         """Resample data.
 
         .. note:: Data must be loaded.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -32,12 +32,11 @@ from .write import (start_file, end_file, start_block, end_block,
 
 from ..annotations import (_annotations_starts_stops, _write_annotations,
                            _handle_meas_date)
-from ..filter import (filter_data, notch_filter, resample,
-                      _resample_stim_channels, _filt_check_picks,
-                      _filt_update_info, _check_fun, HilbertMixin)
+from ..filter import (FilterMixin, notch_filter, resample,
+                      _resample_stim_channels, _check_fun)
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
-                     _check_pandas_index_arguments, _pl, fill_doc,
+                     _check_pandas_index_arguments, fill_doc, copy_doc,
                      check_fname, _get_stim_channel, deprecated,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc,
@@ -266,7 +265,7 @@ class TimeMixin(object):
 @fill_doc
 class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
               InterpolationMixin, ToDataFrameMixin, TimeMixin, SizeMixin,
-              HilbertMixin):
+              FilterMixin):
     """Base class for Raw data.
 
     Parameters
@@ -1104,111 +1103,18 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         return self
 
-    @verbose
+    # Need a separate method because the default pad is different for raw
+    @copy_doc(FilterMixin.filter)
     def filter(self, l_freq, h_freq, picks=None, filter_length='auto',
                l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
                method='fir', iir_params=None, phase='zero',
                fir_window='hamming', fir_design='firwin',
                skip_by_annotation=('edge', 'bad_acq_skip'),
-               pad='reflect_limited', verbose=None):
-        """Filter a subset of channels.
-
-        Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
-        filter to the channels selected by ``picks``. By default the data
-        of the Raw object is modified inplace.
-
-        Parameters
-        ----------
-        %(l_freq)s
-        %(h_freq)s
-        %(picks_all_data)s
-        %(filter_length)s
-        %(l_trans_bandwidth)s
-        %(h_trans_bandwidth)s
-        %(n_jobs-fir)s
-        %(method-fir)s
-        %(iir_params)s
-        %(phase)s
-        %(fir_window)s
-        %(fir_design)s
-        skip_by_annotation : str | list of str
-            If a string (or list of str), any annotation segment that begins
-            with the given string will not be included in filtering, and
-            segments on either side of the given excluded annotated segment
-            will be filtered separately (i.e., as independent signals).
-            The default (``('edge', 'bad_acq_skip')`` will separately filter
-            any segments that were concatenated by :func:`mne.concatenate_raws`
-            or :meth:`mne.io.Raw.append`, or separated during acquisition.
-            To disable, provide an empty list.
-
-            .. versionadded:: 0.16.
-        %(pad-fir)s
-            The default is ``'reflect-limited'``.
-
-            .. versionadded:: 0.15
-        %(verbose_meth)s
-
-        Returns
-        -------
-        raw : instance of Raw
-            The raw instance with filtered data.
-
-        See Also
-        --------
-        mne.Epochs.savgol_filter
-        mne.io.Raw.notch_filter
-        mne.io.Raw.resample
-        mne.filter.create_filter
-        mne.filter.filter_data
-        mne.filter.construct_iir_filter
-
-        Notes
-        -----
-        The Raw object has to have the data loaded e.g. with ``preload=True``
-        or ``self.load_data()``.
-
-        ``l_freq`` and ``h_freq`` are the frequencies below which and above
-        which, respectively, to filter out of the data. Thus the uses are:
-
-            * ``l_freq < h_freq``: band-pass filter
-            * ``l_freq > h_freq``: band-stop filter
-            * ``l_freq is not None and h_freq is None``: high-pass filter
-            * ``l_freq is None and h_freq is not None``: low-pass filter
-
-        ``self.info['lowpass']`` and ``self.info['highpass']`` are only
-        updated with picks=None.
-
-        .. note:: If n_jobs > 1, more memory is required as
-                  ``len(picks) * n_times`` additional time points need to
-                  be temporaily stored in memory.
-
-        For more information, see the tutorials
-        :ref:`disc-filtering` and :ref:`tut-filter-resample` and
-        :func:`mne.filter.create_filter`.
-        """
-        _check_preload(self, 'raw.filter')
-        update_info, picks = _filt_check_picks(self.info, picks,
-                                               l_freq, h_freq)
-        # Deal with annotations
-        onsets, ends = _annotations_starts_stops(
-            self, skip_by_annotation, 'skip_by_annotation', invert=True)
-        logger.info('Filtering raw data in %d contiguous segment%s'
-                    % (len(onsets), _pl(onsets)))
-        max_idx = (ends - onsets).argmax()
-        for si, (start, stop) in enumerate(zip(onsets, ends)):
-            # Only output filter params once (for info level), and only warn
-            # once about the length criterion (longest segment is too short)
-            use_verbose = verbose if si == max_idx else 'error'
-            filter_data(
-                self._data[:, start:stop], self.info['sfreq'], l_freq, h_freq,
-                picks, filter_length, l_trans_bandwidth, h_trans_bandwidth,
-                n_jobs, method, iir_params, copy=False, phase=phase,
-                fir_window=fir_window, fir_design=fir_design, pad=pad,
-                verbose=use_verbose)
-        # update info if filter is applied to all data channels,
-        # and it's not a band-stop filter
-        _filt_update_info(self.info, update_info, l_freq, h_freq)
-        return self
+               pad='reflect_limited', verbose=None):  # noqa: D102
+        return super().filter(
+            l_freq, h_freq, picks, filter_length, l_trans_bandwidth,
+            h_trans_bandwidth, n_jobs, method, iir_params, phase,
+            fir_window, fir_design, skip_by_annotation, pad, verbose)
 
     @verbose
     def notch_filter(self, freqs, picks=None, filter_length='auto',
@@ -1403,8 +1309,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         self._data = np.concatenate(new_data, axis=1)
         self.info['sfreq'] = sfreq
-        if self.info.get('lowpass') is not None:
-            self.info['lowpass'] = min(self.info['lowpass'], sfreq / 2.)
+        lowpass = self.info.get('lowpass')
+        lowpass = np.inf if lowpass is None else lowpass
+        self.info['lowpass'] = min(self.info['lowpass'], sfreq / 2.)
         self._update_times()
 
         # See the comment above why we ignore all errors here.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1197,7 +1197,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def resample(self, sfreq, npad='auto', window='boxcar', stim_picks=None,
-                 n_jobs=1, events=None, pad='reflect_limited', verbose=None):
+                 n_jobs=1, events=None, pad='reflect_limited',
+                 verbose=None):  # lgtm
         """Resample all channels.
 
         The Raw object has to have the data loaded e.g. with ``preload=True``
@@ -1311,7 +1312,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.info['sfreq'] = sfreq
         lowpass = self.info.get('lowpass')
         lowpass = np.inf if lowpass is None else lowpass
-        self.info['lowpass'] = min(self.info['lowpass'], sfreq / 2.)
+        self.info['lowpass'] = min(lowpass, sfreq / 2.)
         self._update_times()
 
         # See the comment above why we ignore all errors here.

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -216,7 +216,6 @@ BaseEstimator
 ContainsMixin
 CrossSpectralDensity
 FilterMixin
-HilbertMixin
 GeneralizationAcrossTime
 RawFIF
 TimeMixin

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -246,8 +246,10 @@ def test_evoked_resample():
     tempdir = _TempDir()
     # upsample, write it out, read it in
     ave = read_evokeds(fname, 0)
+    orig_lp = ave.info['lowpass']
     sfreq_normal = ave.info['sfreq']
     ave.resample(2 * sfreq_normal, npad=100)
+    assert ave.info['lowpass'] == orig_lp
     write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
     ave_up = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
 
@@ -257,6 +259,7 @@ def test_evoked_resample():
     # and compare the original to the downsampled upsampled version
     ave_new = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
     ave_new.resample(sfreq_normal, npad=100)
+    assert ave.info['lowpass'] == orig_lp
 
     assert_array_almost_equal(ave_normal.data, ave_new.data, 2)
     assert_array_almost_equal(ave_normal.times, ave_new.times)
@@ -270,6 +273,10 @@ def test_evoked_resample():
     # we'll add a couple extra checks anyway
     assert (len(ave_up.times) == 2 * len(ave_normal.times))
     assert (ave_up.data.shape[1] == 2 * ave_normal.data.shape[1])
+
+    ave_new.resample(50)
+    assert ave_new.info['sfreq'] == 50.
+    assert ave_new.info['lowpass'] == 25.
 
 
 def test_evoked_filter():

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -10,7 +10,7 @@ out = []
 
 # check scipy
 ok_scipy_submodules = set(['scipy', 'numpy',  # these appear in old scipy
-                           'fftpack', 'lib', 'linalg',
+                           'fftpack', 'lib', 'linalg', 'fft',
                            'misc', 'sparse', 'version'])
 scipy_submodules = set(x.split('.')[1] for x in sys.modules.keys()
                        if x.startswith('scipy.') and '__' not in x and


### PR DESCRIPTION
Closes #6468.

Took this opportunity to unify `mne.filter.FilterMixin.filter` with `mne.io.BaseRaw.filter` to reduce code dup, too. This led to removing `HilbertMixin`, which was really only created because we couldn't previously put it in `FilterMixin` because the latter was only used for Epochs/Evoked -- in this PR it's also used in BaseRaw, which is nice.

The one method that has not been unified is `raw.resample`, mostly because it does a lot of extra/different stuff because of concatenation and events handling.

Also contains a fix for a spelling error, and a future compatible fix for check for `scipy.fft` module (lands in SciPy `master` very soon) nesting.