### PR TITLE
EEGLAB: use set_montage at the end of the __init__

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,8 @@ API
 
 - :func:`mne.io.read_raw_brainvision` no longer raises an error when there are inconsistencies between ``info['chs']`` and ``montage`` but warns instead by `Joan Massich`_
 
+- Add ``update_ch_names`` parameter to :meth:`mne.io.Raw.set_montage` to allow updating the channel names based on the montage by `Joan Massich`_
+
 .. _changes_0_18:
 
 Version 0.18

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -437,7 +437,8 @@ class SetChannelsMixin(object):
         rename_channels(self.info, mapping)
 
     @verbose
-    def set_montage(self, montage, set_dig=True, verbose=None):
+    def set_montage(self, montage, set_dig=True, update_ch_names=False,
+                    verbose=None):
         """Set EEG sensor configuration and head digitization.
 
         Parameters
@@ -449,6 +450,11 @@ class SetChannelsMixin(object):
             in addition to the channel positions (``info['chs'][idx]['loc']``).
 
             .. versionadded: 0.15
+        update_ch_names : bool
+            If True, overwrite the info channel names with the ones from
+            montage. Defaults to False.
+
+            .. versionadded: 0.19
         %(verbose_meth)s
 
         Notes
@@ -458,7 +464,8 @@ class SetChannelsMixin(object):
         .. versionadded:: 0.9.0
         """
         from .montage import _set_montage
-        _set_montage(self.info, montage, set_dig=set_dig)
+        _set_montage(self.info, montage, update_ch_names=update_ch_names,
+                     set_dig=set_dig)
         return self
 
     def plot_sensors(self, kind='topomap', ch_type=None, title=None,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -133,7 +133,10 @@ def _get_info(eeg, montage, eog=()):
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
         if n_channels_with_pos > 0:
             selection = np.arange(n_channels_with_pos)
-            montage = Montage(np.array(pos), pos_ch_names, kind, selection)
+            new_montage = Montage(np.array(pos), pos_ch_names, kind, selection)
+            montage = new_montage
+            # new_montage = montage
+
     elif isinstance(montage, str):
         path = op.dirname(montage)
     else:  # if eeg.chanlocs is empty, we still need default chan names
@@ -148,17 +151,26 @@ def _get_info(eeg, montage, eog=()):
             ch['coil_type'] = FIFF.FIFFV_COIL_NONE
             ch['kind'] = FIFF.FIFFV_EOG_CH
 
+    # assert_equal_montage(xx_montage, montage)
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         from mne.channels.montage import _set_montage
-        _set_montage(info, montage, update_ch_names=update_ch_names,
-                     set_dig=True)
+
+        if 'new_montage' in locals():
+            _set_montage(info, montage=new_montage,
+                         update_ch_names=update_ch_names, set_dig=True)
+        else:
+            _set_montage(info, montage=montage,
+                         update_ch_names=update_ch_names, set_dig=True)
         # _check_update_montage(
         #     info, montage, path=path, update_ch_names=update_ch_names,
         #     raise_missing=False)
 
     assert_equal_montage(xx_montage, montage)
+
+    montage = new_montage if 'new_montage' in locals() else montage
+
     return info
 
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -86,8 +86,6 @@ def _eeg_has_montage_information(eeg):
 def _get_eeg_montage_information(eeg, get_pos):
 
     pos_ch_names, ch_names, pos = list(), list(), list()
-    kind = 'user_defined'
-    update_ch_names = False
     for chanloc in eeg.chanlocs:
         ch_names.append(chanloc['labels'])
         if get_pos:
@@ -99,14 +97,15 @@ def _get_eeg_montage_information(eeg, get_pos):
                 pos_ch_names.append(chanloc['labels'])
                 pos.append(locs)
 
-    n_channels_with_pos = len(pos_ch_names)
-    if n_channels_with_pos > 0:
-        selection = np.arange(n_channels_with_pos)
-        montage = Montage(np.array(pos), pos_ch_names, kind, selection)
+    if pos_ch_names:
+        montage = Montage(pos=np.array(pos),
+                          ch_names=pos_ch_names,
+                          kind='user_defined',
+                          selection=np.arange(len(pos_ch_names)))
     else:
         montage = None
 
-    return ch_names, montage, update_ch_names
+    return ch_names, montage
 
 
 def _get_info(eeg, montage, eog=()):
@@ -122,8 +121,8 @@ def _get_info(eeg, montage, eog=()):
 
     if eeg_has_ch_names_info:
         has_pos = _eeg_has_montage_information(eeg)
-        ch_names, eeg_montage, update_ch_names = _get_eeg_montage_information(
-            eeg, get_pos=has_pos)
+        ch_names, eeg_montage = _get_eeg_montage_information(eeg, has_pos)
+        update_ch_names = False
 
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -60,17 +60,6 @@ def _to_loc(ll):
         return np.nan
 
 
-def _massage_eeg(eeg):
-    # add the ch_names and info['chs'][idx]['loc']
-    if not isinstance(eeg.chanlocs, np.ndarray) and eeg.nbchan == 1:
-        eeg.chanlocs = [eeg.chanlocs]
-
-    if isinstance(eeg.chanlocs, dict):
-        eeg.chanlocs = _dol_to_lod(eeg.chanlocs)
-
-    return eeg
-
-
 def _eeg_has_montage_information(eeg):
     from scipy import io
 
@@ -120,9 +109,14 @@ def _get_eeg_montage_information(eeg, get_pos):
     return ch_names, montage, update_ch_names
 
 
-def _get_info_no_montage(eeg, montage, eog=()):
-    eeg_montage = None
-    update_ch_names = True
+def _get_info(eeg, montage, eog=()):
+    """Get measurement info."""
+    # add the ch_names and info['chs'][idx]['loc']
+    if not isinstance(eeg.chanlocs, np.ndarray) and eeg.nbchan == 1:
+        eeg.chanlocs = [eeg.chanlocs]
+
+    if isinstance(eeg.chanlocs, dict):
+        eeg.chanlocs = _dol_to_lod(eeg.chanlocs)
 
     eeg_has_ch_names_info = len(eeg.chanlocs) > 0
 
@@ -133,19 +127,8 @@ def _get_info_no_montage(eeg, montage, eog=()):
 
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
-
-    return eeg_montage, update_ch_names, ch_names
-
-
-def _get_info(eeg, montage, eog=()):
-    """Get measurement info."""
-    # import pdb; pdb.set_trace()
-
-    eeg = _massage_eeg(eeg)
-
-    # import pdb; pdb.set_trace()
-    eeg_montage, update_ch_names, ch_names = _get_info_no_montage(
-        eeg, montage, eog)
+        eeg_montage = None
+        update_ch_names = True
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -138,7 +138,8 @@ def _get_info_no_montage(eeg, montage, eog=()):
     elif isinstance(montage, str):
         path = op.dirname(montage)
     else:  # if eeg.chanlocs is empty, we still need default chan names
-        ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
+        info = create_info(ch_names, eeg.srate, ch_types='eeg')
+        # ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
 
     if eog == 'auto':
         eog = _find_channels(ch_names)
@@ -161,8 +162,10 @@ def _get_info(eeg, montage, eog=()):
         eeg, montage, eog)
 
     if montage is None and new_montage is None:
-        assert ch_names is not None, 'something went wrong'
-        info = create_info(ch_names, eeg.srate, ch_types='eeg')
+        if ch_names is None:
+            pass
+        else:
+            info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         from mne.channels.montage import _set_montage
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -362,8 +362,6 @@ class RawEEGLAB(BaseRaw):
 
         montage = eeg_montage if montage is None else montage
         del eeg_montage
-        _set_montage(info, montage=montage, update_ch_names=update_ch_names,
-                     set_dig=True)
 
         # read the data
         if isinstance(eeg.data, str):
@@ -395,8 +393,9 @@ class RawEEGLAB(BaseRaw):
         # create event_ch from annotations
         annot = read_annotations(input_fname)
         self.set_annotations(annot)
-
         _check_boundary(annot, None)
+
+        self.set_montage(montage=montage, update_ch_names=update_ch_names)
 
         latencies = np.round(annot.onset * self.info['sfreq'])
         _check_latencies(latencies)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -123,7 +123,7 @@ def _get_info(eeg, montage, eog=()):
     if eeg_has_ch_names_info:
         has_pos = _eeg_has_montage_information(eeg)
         ch_names, eeg_montage, update_ch_names = _get_eeg_montage_information(
-            eeg, has_pos)
+            eeg, get_pos=has_pos)
 
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -115,6 +115,15 @@ def _get_info(eeg, montage, eog=()):
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
 
+    if eog == 'auto':
+        eog = _find_channels(ch_names)
+
+    for idx, ch in enumerate(info['chs']):
+        ch['cal'] = CAL
+        if ch['ch_name'] in eog or idx in eog:
+            ch['coil_type'] = FIFF.FIFFV_COIL_NONE
+            ch['kind'] = FIFF.FIFFV_EOG_CH
+
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
@@ -125,14 +134,6 @@ def _get_info(eeg, montage, eog=()):
         #     info, montage, path=path, update_ch_names=update_ch_names,
         #     raise_missing=False)
 
-    if eog == 'auto':
-        eog = _find_channels(ch_names)
-
-    for idx, ch in enumerate(info['chs']):
-        ch['cal'] = CAL
-        if ch['ch_name'] in eog or idx in eog:
-            ch['coil_type'] = FIFF.FIFFV_COIL_NONE
-            ch['kind'] = FIFF.FIFFV_EOG_CH
     return info
 
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -194,6 +194,7 @@ def _get_info(eeg, montage, eog=()):
             if object_diff(info, info_xx):
                 assert eog == ()
                 info = info_xx
+                assert False
             else:
                 assert eog == 'auto'
     else:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -6,7 +6,6 @@
 
 import os.path as op
 
-from copy import deepcopy
 import numpy as np
 
 from ..utils import _read_segments_file, _find_channels
@@ -20,30 +19,9 @@ from ...event import read_events
 from ...annotations import Annotations, read_annotations
 
 from mne.channels.montage import _set_montage
-from mne.utils import object_diff
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6
-
-
-def assert_equal_montage(aa, bb):
-    for elem in [aa, bb]:
-        assert type(elem) in [str, Montage, type(None)], 'invalid montage type'
-
-    if aa is None or bb is None:
-        assert aa is None and bb is None, 'montge should both be None'
-    elif isinstance(aa, str):
-        assert aa == bb, 'montage not equal strings'
-    else:  # Montage
-        assert aa.ch_names == bb.ch_names, 'montage ch_names differ'
-        assert aa.kind == bb.kind, 'montage kind differ'
-        assert aa.lpa == bb.lpa, 'montage lpa differ'
-        assert aa.nasion == bb.nasion, 'montage nasion differ'
-        assert aa.rpa == bb.rpa, 'montage rpa differ'
-        np.testing.assert_array_equal(aa.pos, bb.pos, err_msg='different pos')
-        np.testing.assert_array_equal(aa.selection, bb.selection,
-                                      err_msg='different pos')
-
 
 
 def _check_fname(fname):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -89,7 +89,6 @@ def _get_info_no_montage(eeg, montage, eog=()):
     update_ch_names = True
 
     # add the ch_names and info['chs'][idx]['loc']
-    path = None
     if not isinstance(eeg.chanlocs, np.ndarray) and eeg.nbchan == 1:
         eeg.chanlocs = [eeg.chanlocs]
 
@@ -136,10 +135,10 @@ def _get_info_no_montage(eeg, montage, eog=()):
             new_montage = Montage(np.array(pos), pos_ch_names, kind, selection)
 
     elif isinstance(montage, str):
-        path = op.dirname(montage)
+        pass  # noqa
     else:  # if eeg.chanlocs is empty, we still need default chan names
-        info = create_info(ch_names, eeg.srate, ch_types='eeg')
-        # ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
+        ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
+        info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 
     if eog == 'auto':
         eog = _find_channels(ch_names)
@@ -158,6 +157,7 @@ def _get_info(eeg, montage, eog=()):
     # import pdb; pdb.set_trace()
     xx_montage = deepcopy(montage)
 
+    import pdb; pdb.set_trace()
     info, new_montage, update_ch_names, ch_names = _get_info_no_montage(
         eeg, montage, eog)
 
@@ -165,7 +165,13 @@ def _get_info(eeg, montage, eog=()):
         if ch_names is None:
             pass
         else:
-            info = create_info(ch_names, eeg.srate, ch_types='eeg')
+            info_xx = create_info(ch_names, eeg.srate, ch_types='eeg')
+            # assert len(object_diff(info, info_xx)) == 0
+            if object_diff(info, info_xx):
+                assert eog == ()
+                info = info_xx
+            else:
+                assert eog == 'auto'
     else:
         from mne.channels.montage import _set_montage
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -80,12 +80,10 @@ def _to_loc(ll):
     else:
         return np.nan
 
+def _get_info_no_montage(eeg, montage, eog=()):
 
-def _get_info(eeg, montage, eog=()):
-    """Get measurement info."""
-    # import pdb; pdb.set_trace()
-    xx_montage = deepcopy(montage)
     new_montage = None
+    ch_names = None   # XXXX: This adds logic to the value which is nasty but it will change at the end of the refactor # noqa
     from scipy import io
     info = _empty_info(sfreq=eeg.srate)
     update_ch_names = True
@@ -142,8 +140,6 @@ def _get_info(eeg, montage, eog=()):
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
 
-    montage = new_montage if new_montage is not None else montage  # XXXX This
-
     if eog == 'auto':
         eog = _find_channels(ch_names)
 
@@ -153,7 +149,19 @@ def _get_info(eeg, montage, eog=()):
             ch['coil_type'] = FIFF.FIFFV_COIL_NONE
             ch['kind'] = FIFF.FIFFV_EOG_CH
 
+    return info, new_montage, update_ch_names, ch_names
+
+
+def _get_info(eeg, montage, eog=()):
+    """Get measurement info."""
+    # import pdb; pdb.set_trace()
+    xx_montage = deepcopy(montage)
+
+    info, new_montage, update_ch_names, ch_names = _get_info_no_montage(
+        eeg, montage, eog)
+
     if montage is None and new_montage is None:
+        assert ch_names is not None, 'something went wrong'
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         from mne.channels.montage import _set_montage

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -118,9 +118,12 @@ def _get_info(eeg, montage, eog=()):
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
-        _check_update_montage(
-            info, montage, path=path, update_ch_names=update_ch_names,
-            raise_missing=False)
+        from mne.channels.montage import _set_montage
+        _set_montage(info, montage, update_ch_names=update_ch_names,
+                     set_dig=True)
+        # _check_update_montage(
+        #     info, montage, path=path, update_ch_names=update_ch_names,
+        #     raise_missing=False)
 
     if eog == 'auto':
         eog = _find_channels(ch_names)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -13,12 +13,10 @@ from ..constants import FIFF
 from ..meas_info import create_info
 from ..base import BaseRaw
 from ...utils import logger, verbose, warn, fill_doc, Bunch
-from ...channels.montage import Montage
+from ...channels.montage import Montage, _set_montage
 from ...epochs import BaseEpochs
 from ...event import read_events
 from ...annotations import Annotations, read_annotations
-
-from mne.channels.montage import _set_montage
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -83,6 +83,7 @@ def _to_loc(ll):
 
 def _get_info(eeg, montage, eog=()):
     """Get measurement info."""
+    # import pdb; pdb.set_trace()
     xx_montage = deepcopy(montage)
     new_montage = None
     from scipy import io
@@ -135,12 +136,13 @@ def _get_info(eeg, montage, eog=()):
         if n_channels_with_pos > 0:
             selection = np.arange(n_channels_with_pos)
             new_montage = Montage(np.array(pos), pos_ch_names, kind, selection)
-            # montage = deepcopy(new_montage)    # XXXX: this breaks the test
 
     elif isinstance(montage, str):
         path = op.dirname(montage)
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
+
+    montage = new_montage if new_montage is not None else montage  # XXXX This
 
     if eog == 'auto':
         eog = _find_channels(ch_names)
@@ -151,7 +153,7 @@ def _get_info(eeg, montage, eog=()):
             ch['coil_type'] = FIFF.FIFFV_COIL_NONE
             ch['kind'] = FIFF.FIFFV_EOG_CH
 
-    if montage is None:
+    if montage is None and new_montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         from mne.channels.montage import _set_montage
@@ -163,7 +165,7 @@ def _get_info(eeg, montage, eog=()):
             _set_montage(info, montage=montage,
                          update_ch_names=update_ch_names, set_dig=True)
 
-    montage = new_montage if new_montage is not None else montage
+    assert_equal_montage(xx_montage, montage)
 
     return info
 
@@ -333,7 +335,10 @@ class RawEEGLAB(BaseRaw):
                             ' the .set file contains epochs.' % eeg.trials)
 
         last_samps = [eeg.pnts - 1]
+        aa = deepcopy(montage)
         info = _get_info(eeg, montage, eog=eog)
+        bb = deepcopy(montage)
+        assert_equal_montage(aa, bb)
 
         # read the data
         if isinstance(eeg.data, str):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -84,6 +84,7 @@ def _to_loc(ll):
 def _get_info(eeg, montage, eog=()):
     """Get measurement info."""
     xx_montage = deepcopy(montage)
+    new_montage = None
     from scipy import io
     info = _empty_info(sfreq=eeg.srate)
     update_ch_names = True
@@ -134,8 +135,7 @@ def _get_info(eeg, montage, eog=()):
         if n_channels_with_pos > 0:
             selection = np.arange(n_channels_with_pos)
             new_montage = Montage(np.array(pos), pos_ch_names, kind, selection)
-            montage = new_montage
-            # new_montage = montage
+            # montage = deepcopy(new_montage)    # XXXX: this breaks the test
 
     elif isinstance(montage, str):
         path = op.dirname(montage)
@@ -151,25 +151,19 @@ def _get_info(eeg, montage, eog=()):
             ch['coil_type'] = FIFF.FIFFV_COIL_NONE
             ch['kind'] = FIFF.FIFFV_EOG_CH
 
-    # assert_equal_montage(xx_montage, montage)
     if montage is None:
         info = create_info(ch_names, eeg.srate, ch_types='eeg')
     else:
         from mne.channels.montage import _set_montage
 
-        if 'new_montage' in locals():
+        if new_montage is not None:
             _set_montage(info, montage=new_montage,
                          update_ch_names=update_ch_names, set_dig=True)
         else:
             _set_montage(info, montage=montage,
                          update_ch_names=update_ch_names, set_dig=True)
-        # _check_update_montage(
-        #     info, montage, path=path, update_ch_names=update_ch_names,
-        #     raise_missing=False)
 
-    assert_equal_montage(xx_montage, montage)
-
-    montage = new_montage if 'new_montage' in locals() else montage
+    montage = new_montage if new_montage is not None else montage
 
     return info
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -118,7 +118,6 @@ def _eeg_has_montage_information(eeg):
 
 def _get_eeg_montage_information(eeg, get_pos):
 
-    # assert get_pos == False
     pos_ch_names, ch_names, pos = list(), list(), list()
     kind = 'user_defined'
     update_ch_names = False
@@ -151,18 +150,13 @@ def _get_info_no_montage(eeg, montage, eog=()):
 
     if eeg_has_ch_names_info:
         has_pos = _eeg_has_montage_information(eeg)
-
-    if eeg_has_ch_names_info:
-        # assert False
-        get_pos = has_pos and montage is None
         ch_names, eeg_montage, update_ch_names = _get_eeg_montage_information(
-            eeg, get_pos)
+            eeg, has_pos)
 
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
 
     return eeg_montage, update_ch_names, ch_names
-
 
 
 def _get_info(eeg, montage, eog=()):
@@ -177,10 +171,8 @@ def _get_info(eeg, montage, eog=()):
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 
-    if montage is None and eeg_montage is None:
-        pass
-    else:  # XXX: This is kept for backcompat, we should check the logic
-
+    if not(montage is None and eeg_montage is None):
+        # XXX: This is kept for back compatibility, we should check the logic
         if eog == 'auto':
             eog = _find_channels(ch_names)
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -11,8 +11,8 @@ import numpy as np
 
 from ..utils import _read_segments_file, _find_channels
 from ..constants import FIFF
-from ..meas_info import _empty_info, create_info
-from ..base import BaseRaw, _check_update_montage
+from ..meas_info import create_info
+from ..base import BaseRaw
 from ...utils import logger, verbose, warn, fill_doc, Bunch
 from ...channels.montage import Montage
 from ...epochs import BaseEpochs
@@ -116,6 +116,7 @@ def _eeg_has_montage_information(eeg):
 
 def _get_eeg_montage_information(eeg, get_pos):
 
+    # assert get_pos == False
     pos_ch_names, ch_names, pos = list(), list(), list()
     kind = 'user_defined'
     update_ch_names = False
@@ -144,12 +145,12 @@ def _get_info_no_montage(eeg, montage, eog=()):
     ch_names = None   # XXXX: This adds logic to the value which is nasty but it will change at the end of the refactor # noqa
     update_ch_names = True
 
-    good = len(eeg.chanlocs) > 0
+    eeg_has_ch_names_info = len(eeg.chanlocs) > 0
 
-    if good:
+    if eeg_has_ch_names_info:
         has_pos = _eeg_has_montage_information(eeg)
 
-    if good:
+    if eeg_has_ch_names_info:
         # assert False
         get_pos = has_pos and montage is None
         ch_names, new_montage, update_ch_names = _get_eeg_montage_information(

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -164,6 +164,7 @@ def test_io_set_raw(fnames, tmpdir):
     # load it
     with pytest.warns(RuntimeWarning, match='did not have a position'):
         raw = read_raw_eeglab(input_fname=one_chanpos_fname, preload=True)
+
     # position should be present for first two channels
     for i in range(2):
         assert_array_equal(raw.info['chs'][i]['loc'][:3],

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -22,7 +22,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
 from mne.utils import run_tests_if_main, requires_h5py, object_diff
 from mne.annotations import events_from_annotations, read_annotations
-
+from mne.channels import Montage
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
 
@@ -308,17 +308,27 @@ def test_eeglab_event_from_annot():
     assert len(events_b) == 154
 
 
+def _fake_montage(ch_names):
+    return Montage(
+        pos=np.random.RandomState(42).randn(len(ch_names), 3),
+        ch_names=ch_names,
+        kind='foo',
+        selection=np.arange(len(ch_names))
+    )
+
+
 @testing.requires_testing_data
 def test_montage():
     """Test montage."""
     base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
     fname = op.join(base_dir, 'test_raw.set')
-    montage = op.join(base_dir, 'test_chans.locs')
+    # montage = op.join(base_dir, 'test_chans.locs')
+
+    raw_none = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
+    montage = _fake_montage(raw_none.info['ch_names'])
 
     raw_montage = read_raw_eeglab(input_fname=fname, montage=montage,
                                   preload=False)
-
-    raw_none = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
     raw_none.set_montage(montage)
 
     assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -20,7 +20,7 @@ from mne import write_events, read_epochs_eeglab
 from mne.io import read_raw_eeglab
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
-from mne.utils import run_tests_if_main, requires_h5py
+from mne.utils import run_tests_if_main, requires_h5py, object_diff
 from mne.annotations import events_from_annotations, read_annotations
 
 
@@ -306,6 +306,23 @@ def test_eeglab_event_from_annot():
     raw1.set_annotations(annotations)
     events_b, _ = events_from_annotations(raw1, event_id=event_id)
     assert len(events_b) == 154
+
+
+@testing.requires_testing_data
+def test_montage():
+    """Test montage."""
+    base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
+    fname = op.join(base_dir, 'test_raw.set')
+    montage = op.join(base_dir, 'test_chans.locs')
+
+    raw_montage = read_raw_eeglab(input_fname=fname, montage=montage,
+                                  preload=False)
+
+    raw_none = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
+    raw_none.set_montage(montage)
+
+    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
+    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
 
 
 run_tests_if_main()

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -312,6 +312,7 @@ def _fake_montage(ch_names):
     return Montage(
         pos=np.random.RandomState(42).randn(len(ch_names), 3),
         ch_names=ch_names,
+        # kind=4,
         kind='foo',
         selection=np.arange(len(ch_names))
     )
@@ -330,9 +331,12 @@ def test_montage():
     raw_montage = read_raw_eeglab(input_fname=fname, montage=montage,
                                   preload=False)
     raw_none.set_montage(montage)
-
-    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
+    # assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
+    diff = object_diff(raw_none.info['chs'],
+                       raw_montage.info['chs']).splitlines()
+    for dd in diff:
+        assert 'coord_frame' in dd
 
 
 run_tests_if_main()


### PR DESCRIPTION
This PR is part of #6461. The concrete goal here is to make sure that:
1 - `RawEEGLAB` is always called with `montage=None`
2 - ensure `self.set_montage(montage)` is called at the end of __init__