### PR TITLE
ENH: Add ecog functionality to set_eeg_reference.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,7 +38,7 @@ Changelog
 
 - Add a new :func:`mne.viz.plot_sensors_connectivity` function to visualize the sensor connectivity in 3D by `Guillaume Favelier`_ and `Alex Gramfort`_
 
-- Add re-referencing functionality for ecog and seeg channel types in :func:`mne.io.reference.set_eeg_reference` by `Keith Doelling`_
+- Add re-referencing functionality for ecog and seeg channel types in :func:`mne.set_eeg_reference` by `Keith Doelling`_
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,8 @@ Changelog
 
 - Add a new :func:`mne.viz.plot_sensors_connectivity` function to visualize the sensor connectivity in 3D by `Guillaume Favelier`_ and `Alex Gramfort`_
 
+- Add re-referencing functionality for ecog and seeg channel types in :func:`mne.io.reference.set_eeg_reference` by `Keith Doelling`_
+
 Bug
 ~~~
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -220,7 +220,7 @@ class SetChannelsMixin(object):
 
     @verbose
     def set_eeg_reference(self, ref_channels='average', projection=False,
-                          verbose=None):
+                          ch_type='auto', verbose=None):
         """Specify which reference to use for EEG data.
 
         By default, MNE-Python will automatically re-reference the EEG signal
@@ -274,6 +274,12 @@ class SetChannelsMixin(object):
             ``projection=False``, the average reference is directly applied to
             the data. If ``ref_channels`` is not ``'average'``, ``projection``
             must be set to ``False`` (the default in this case).
+        ch_type : 'auto' | 'eeg' | 'ecog' | 'seeg'
+            The name of the channel type to apply the reference to. If 'auto',
+            the first channel type of eeg, ecog or seeg that is found (in that
+            order) will be selected.
+
+            .. versionadded:: 0.19
         %(verbose_meth)s
 
         Returns
@@ -306,7 +312,7 @@ class SetChannelsMixin(object):
         """
         from ..io.reference import set_eeg_reference
         return set_eeg_reference(self, ref_channels=ref_channels, copy=False,
-                                 projection=projection)[0]
+                                 projection=projection, ch_type=ch_type)[0]
 
     def _get_channel_positions(self, picks=None):
         """Get channel locations from info.

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -124,10 +124,10 @@ def get_raw_data(system, drop_extra_chs=False):
     if system == 'eximia':
         crop -= 0.5 * (1.0 / raw_data.info['sfreq'])
     raw_data.crop(0, crop)
-    if 'eeg' in raw_data:
+    if any([type_ in raw_data for type_ in ['eeg', 'ecog', 'seeg']]):
         raw_data.set_eeg_reference([])
     else:
-        with pytest.raises(ValueError, match='No EEG channels'):
+        with pytest.raises(ValueError, match='No EEG, ECoG or sEEG channels'):
             raw_data.set_eeg_reference([])
     raw_data.del_proj('all')
     raw_data.info['comps'] = []

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -266,7 +266,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
 
 @verbose
 def set_eeg_reference(inst, ref_channels='average', copy=True,
-                      projection=False, verbose=None):
+                      projection=False, ch_type='auto', verbose=None):
     """Specify which reference to use for EEG data.
 
     By default, MNE-Python will automatically re-reference the EEG signal to
@@ -322,6 +322,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         the average reference is directly applied to the data.
         If ``ref_channels`` is not ``'average'``, ``projection`` must be set to
         ``False`` (the default in this case).
+    ch_type : 'auto' | 'eeg' | 'ecog' | 'seeg'
+        The name of the channel type to apply the reference to. If 'auto', the
+        first channel type of eeg, ecog or seeg that is found (in that order)
+        will be selected.
     %(verbose)s
 
     Returns
@@ -386,20 +390,36 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
             return inst, None
 
     inst = inst.copy() if copy else inst
+    # if ch_type is 'auto', search through list to find first reasonable
+    # reference-able channel type.
+    possible_types = ['eeg', 'ecog', 'seeg']
+    if ch_type == 'auto':
+        for type in possible_types:
+            if type in inst:
+                ch_type = type
+                break
+        logger.info('%s channel type selected for re-referencing' % ch_type)
+    # if auto comes up empty, or the user specifies a bad ch_type.
+    if ch_type not in possible_types:
+        raise ValueError('None of the possible channel types for '
+                         're-referencing were found.')
+
+    ch_dict = {ch_type: True, 'meg': False, 'ref_meg': False}
+    eeg_idx = pick_types(inst.info, **ch_dict)
+    ch_sel = [inst.ch_names[i] for i in eeg_idx]
 
     if ref_channels == 'average' and not projection:  # apply average reference
         logger.info('Applying average reference.')
-        eeg_idx = pick_types(inst.info, eeg=True, meg=False, ref_meg=False)
-        ref_channels = [inst.ch_names[i] for i in eeg_idx]
+        ref_channels = ch_sel
 
     if ref_channels == []:
         logger.info('EEG data marked as already having the desired reference. '
                     'Preventing automatic future re-referencing to an average '
                     'reference.')
     else:
-        logger.info('Applying a custom EEG reference.')
+        logger.info('Applying a custom reference.')
 
-    return _apply_reference(inst, ref_channels)
+    return _apply_reference(inst, ref_channels, ch_sel)
 
 
 @verbose

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -226,10 +226,10 @@ def test_set_eeg_reference():
 
     # gh-6454
     rng = np.random.RandomState(0)
-    data = rng.randn(2, 1000)
-    raw = RawArray(data, create_info(2, 1000., 'ecog'))
-    with pytest.raises(ValueError, match='No EEG channels found to apply'):
-        raw.set_eeg_reference()
+    data = rng.randn(3, 1000)
+    raw = RawArray(data, create_info(3, 1000., ['ecog'] * 2 + ['misc']))
+    reref, ref_data = set_eeg_reference(raw.copy())
+    _test_reference(raw, reref, ref_data, ['0', '1'])
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Following discussion in #6478 to add ch_type parameter which can specify which data-type to apply the reference to. 

If ch_type is 'auto,' it searches first for eeg, ecog and then seeg channels. Whichever it finds first, it selects that channel type to apply the reference to.
