### PR TITLE
MRG, DOC: update tutorial for Info object

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -99,6 +99,8 @@ File I/O
    :toctree: generated
 
    decimate_surface
+   channel_type
+   channel_indices_by_type
    get_head_surf
    get_meg_helmet_surf
    get_volume_labels_from_aseg

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -25,7 +25,8 @@ from .utils import (set_log_level, set_log_file, verbose, set_config,
 from .io.pick import (pick_types, pick_channels,
                       pick_channels_regexp, pick_channels_forward,
                       pick_types_forward, pick_channels_cov,
-                      pick_channels_evoked, pick_info)
+                      pick_channels_evoked, pick_info,
+                      channel_type, channel_indices_by_type)
 from .io.base import concatenate_raws
 from .io.meas_info import create_info, Info
 from .io.proj import Projection

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -99,17 +99,17 @@ def channel_type(info, idx):
 
     Parameters
     ----------
-    info : dict
-        Measurement info
+    info : instance of Info
+        A measurement info object.
     idx : int
-        Index of channel
+        Index of channel.
 
     Returns
     -------
     type : str
         Type of channel. Will be one of::
 
-            {'grad','mag', 'eeg', 'stim', 'eog', 'emg', 'ecg', 'ref_meg',
+            {'grad', 'mag', 'eeg', 'stim', 'eog', 'emg', 'ecg', 'ref_meg',
              'resp', 'exci', 'ias', 'syst', 'misc', 'seeg', 'bio', 'chpi',
              'dipole', 'gof', 'ecog', 'hbo', 'hbr'}
 
@@ -663,15 +663,15 @@ def channel_indices_by_type(info, picks=None):
 
     Parameters
     ----------
-    info : instance of mne.measuerment_info.Info
-        The info.
+    info : instance of Info
+        A measurement info object.
     %(picks_all)s
 
     Returns
     -------
     idx_by_type : dict
-        The dictionary that maps each channel type to the list of
-        channel indidces.
+        A dictionary that maps each channel type to a (possibly empty) list of
+        channel indices.
     """
     idx_by_type = {key: list() for key in _PICK_TYPES_KEYS if
                    key not in ('meg', 'fnirs')}

--- a/tutorials/intro/plot_info.py
+++ b/tutorials/intro/plot_info.py
@@ -136,7 +136,7 @@ print(mne.pick_channels_regexp(info['ch_names'], '^E.G'))
 # Python standard module :mod:`re` to perform regular expression matching; see
 # the documentation of the :mod:`re` module for implementation details.
 #
-# ..warning::
+# .. warning::
 #    Both :func:`~mne.pick_channels` and :func:`~mne.pick_channels_regexp`
 #    operate on lists of channel names, so they are unaware of which channels
 #    (if any) have been marked as "bad" in ``info['bads']``. Use caution to


### PR DESCRIPTION
also exposes `mne.io.pick.channel_type` and `mne.io.pick.channel_indices_by_type` in the main `mne` namespace, adds them to the `python_reference`, and makes minor fixes to their docstrings.

Note: I'm not married to the that namespace location for `channel_type` and `channel_indices_by_type`, I just chose it because that's where most of the other functions in `mne.io.pick` get exposed.