### PR TITLE
FIX: EEGLAB calibration / remove montage

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -833,6 +833,7 @@ def _set_montage(info, montage, update_ch_names=False, set_dig=True):
 
             ch_idx = info_ch_names.index(ch_name)
             info['chs'][ch_idx]['loc'] = np.r_[pos, [0.] * 9]
+            info['chs'][ch_idx]['coord_frame'] = FIFF.FIFFV_COORD_HEAD
             sensors_found.append(ch_idx)
             dig[ch_name] = pos
         if set_dig:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -125,7 +125,7 @@ def _get_info(eeg, eog=()):
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
         eeg_montage = None
-        update_ch_names = False
+        update_ch_names = True
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 
@@ -350,6 +350,22 @@ class RawEEGLAB(BaseRaw):
         """Read a chunk of raw data."""
         _read_segments_file(self, data, idx, fi, start, stop, cals, mult,
                             dtype=np.float32, n_channels=self.info['nchan'])
+
+    # XXX: to be removed when deprecating montage
+    def set_montage(self, montage, set_dig=True, update_ch_names=False,
+                    verbose=None):
+        """To be removed."""  # noqa
+        cal = set([ch['cal'] for ch in self.info['chs']]).pop()
+        coord_frame = set([ch['coord_frame'] for ch in self.info['chs']]).pop()
+        super(RawEEGLAB, self).set_montage(montage, set_dig=set_dig,
+                                           update_ch_names=update_ch_names,
+                                           verbose=verbose)
+        # Revert update_ch_names modifications in cal and coord_frame
+        if update_ch_names:
+            for ch in self.info['chs']:
+                ch['cal'] = cal
+                ch['coord_frame'] = coord_frame
+    set_montage.__doc__ = BaseRaw.set_montage.__doc__
 
 
 class EpochsEEGLAB(BaseEpochs):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -106,7 +106,7 @@ def _get_eeg_montage_information(eeg, get_pos):
     return ch_names, montage
 
 
-def _get_info(eeg, montage, eog=()):
+def _get_info(eeg, eog=()):
     """Get measurement info."""
     # add the ch_names and info['chs'][idx]['loc']
     if not isinstance(eeg.chanlocs, np.ndarray) and eeg.nbchan == 1:
@@ -129,16 +129,12 @@ def _get_info(eeg, montage, eog=()):
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 
-    if not(montage is None and eeg_montage is None):
-        # XXX: This is kept for back compatibility, we should check the logic
-        if eog == 'auto':
-            eog = _find_channels(ch_names)
-
-        for idx, ch in enumerate(info['chs']):
-            ch['cal'] = CAL
-            if ch['ch_name'] in eog or idx in eog:
-                ch['coil_type'] = FIFF.FIFFV_COIL_NONE
-                ch['kind'] = FIFF.FIFFV_EOG_CH
+    eog = _find_channels(ch_names) if eog == 'auto' else eog
+    for idx, ch in enumerate(info['chs']):
+        ch['cal'] = CAL
+        if ch['ch_name'] in eog or idx in eog:
+            ch['coil_type'] = FIFF.FIFFV_COIL_NONE
+            ch['kind'] = FIFF.FIFFV_EOG_CH
 
     return info, eeg_montage, update_ch_names
 
@@ -308,7 +304,7 @@ class RawEEGLAB(BaseRaw):
                             ' the .set file contains epochs.' % eeg.trials)
 
         last_samps = [eeg.pnts - 1]
-        info, eeg_montage, update_ch_names = _get_info(eeg, montage, eog=eog)
+        info, eeg_montage, update_ch_names = _get_info(eeg, eog=eog)
 
         montage = eeg_montage if montage is None else montage
         del eeg_montage
@@ -497,7 +493,7 @@ class EpochsEEGLAB(BaseEpochs):
 
         logger.info('Extracting parameters from %s...' % input_fname)
         input_fname = op.abspath(input_fname)
-        info, eeg_montage, update_ch_names = _get_info(eeg, montage, eog=eog)
+        info, eeg_montage, update_ch_names = _get_info(eeg, eog=eog)
         montage = eeg_montage if montage is None else montage
         del eeg_montage
         _set_montage(info, montage=montage, update_ch_names=update_ch_names,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -125,7 +125,7 @@ def _get_info(eeg, eog=()):
     else:  # if eeg.chanlocs is empty, we still need default chan names
         ch_names = ["EEG %03d" % ii for ii in range(eeg.nbchan)]
         eeg_montage = None
-        update_ch_names = True
+        update_ch_names = False
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -129,7 +129,7 @@ def _get_info(eeg, eog=()):
 
     info = create_info(ch_names, sfreq=eeg.srate, ch_types='eeg')
 
-    eog = _find_channels(ch_names) if eog == 'auto' else eog
+    eog = _find_channels(ch_names, ch_type='EOG') if eog == 'auto' else eog
     for idx, ch in enumerate(info['chs']):
         ch['cal'] = CAL
         if ch['ch_name'] in eog or idx in eog:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -356,7 +356,6 @@ class RawEEGLAB(BaseRaw):
                     verbose=None):
         """To be removed."""  # noqa
         cal = set([ch['cal'] for ch in self.info['chs']]).pop()
-        coord_frame = set([ch['coord_frame'] for ch in self.info['chs']]).pop()
         super(RawEEGLAB, self).set_montage(montage, set_dig=set_dig,
                                            update_ch_names=update_ch_names,
                                            verbose=verbose)
@@ -364,7 +363,6 @@ class RawEEGLAB(BaseRaw):
         if update_ch_names:
             for ch in self.info['chs']:
                 ch['cal'] = cal
-                ch['coord_frame'] = coord_frame
     set_montage.__doc__ = BaseRaw.set_montage.__doc__
 
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -334,9 +334,31 @@ def test_montage():
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
     # assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
     diff = object_diff(raw_none.info['chs'],
-                       raw_montage.info['chs']).splitlines()
-    for dd in diff:
+                       raw_montage.info['chs'])
+    for dd in diff.splitlines():
         assert 'coord_frame' in dd or 'cal' in dd
+
+
+@testing.requires_testing_data
+def test_channel_calibration():
+    """Test ch['cal'] (regression test)."""
+    # fname = op.join(base_dir, 'test_raw.fdt')
+    fname = op.join(base_dir, 'test_raw.set')
+
+    original_raw = read_raw_eeglab(input_fname=fname,
+                                   montage=None,
+                                   preload=True)
+
+    raw = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
+    raw.set_montage(_fake_montage(raw.info['ch_names']), update_ch_names=True)
+    raw.load_data()
+
+    # data is the same
+    assert_array_equal(raw.get_data(), original_raw.get_data())
+
+    # calibration is not
+    assert set([ch['cal'] for ch in raw.info['chs']]) == {1.0}
+    assert set([ch['cal'] for ch in original_raw.info['chs']]) == {1e-06}
 
 
 run_tests_if_main()

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -332,11 +332,7 @@ def test_montage():
                                   preload=False)
     raw_none.set_montage(montage)
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
-    # assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
-    diff = object_diff(raw_none.info['chs'],
-                       raw_montage.info['chs'])
-    for dd in diff.splitlines():
-        assert 'coord_frame' in dd or 'cal' in dd
+    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
 
 
 @testing.requires_testing_data
@@ -357,7 +353,7 @@ def test_channel_calibration():
     assert_array_equal(raw.get_data(), original_raw.get_data())
 
     # calibration is not
-    assert set([ch['cal'] for ch in raw.info['chs']]) == {1.0}
+    assert set([ch['cal'] for ch in raw.info['chs']]) == {1e-06}
     assert set([ch['cal'] for ch in original_raw.info['chs']]) == {1e-06}
 
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -313,7 +313,6 @@ def _fake_montage(ch_names):
     return Montage(
         pos=np.random.RandomState(42).randn(len(ch_names), 3),
         ch_names=ch_names,
-        # kind=4,
         kind='foo',
         selection=np.arange(len(ch_names))
     )
@@ -337,7 +336,7 @@ def test_montage():
     diff = object_diff(raw_none.info['chs'],
                        raw_montage.info['chs']).splitlines()
     for dd in diff:
-        assert 'coord_frame' in dd
+        assert 'coord_frame' in dd or 'cal' in dd
 
 
 run_tests_if_main()

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -321,9 +321,7 @@ def _fake_montage(ch_names):
 @testing.requires_testing_data
 def test_montage():
     """Test montage."""
-    base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
     fname = op.join(base_dir, 'test_raw.set')
-    # montage = op.join(base_dir, 'test_chans.locs')
 
     raw_none = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
     montage = _fake_montage(raw_none.info['ch_names'])
@@ -331,30 +329,11 @@ def test_montage():
     raw_montage = read_raw_eeglab(input_fname=fname, montage=montage,
                                   preload=False)
     raw_none.set_montage(montage)
+
+    # Check they are the same
+    assert_array_equal(raw_none.get_data(), raw_montage.get_data())
     assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
     assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
-
-
-@testing.requires_testing_data
-def test_channel_calibration():
-    """Test ch['cal'] (regression test)."""
-    # fname = op.join(base_dir, 'test_raw.fdt')
-    fname = op.join(base_dir, 'test_raw.set')
-
-    original_raw = read_raw_eeglab(input_fname=fname,
-                                   montage=None,
-                                   preload=True)
-
-    raw = read_raw_eeglab(input_fname=fname, montage=None, preload=False)
-    raw.set_montage(_fake_montage(raw.info['ch_names']), update_ch_names=True)
-    raw.load_data()
-
-    # data is the same
-    assert_array_equal(raw.get_data(), original_raw.get_data())
-
-    # calibration is not
-    assert set([ch['cal'] for ch in raw.info['chs']]) == {1e-06}
-    assert set([ch['cal'] for ch in original_raw.info['chs']]) == {1e-06}
 
 
 run_tests_if_main()


### PR DESCRIPTION
Right now in master, setting the `ch['cal']` when reading eeglab is driven by `montage`.
(either because `read_raw_eeglab(.. , montage=something)` or because the eeglab file has location information.

If none of the two are preset, the calibration is not set to `1e-6`:

```py
[print(ch['ch_name'], ch['kind'], ch['cal']) for ch in info['chs']]

F3 2 (FIFFV_EEG_CH) 1.0
unknown 2 (FIFFV_EEG_CH) 1.0
FPz 2 (FIFFV_EEG_CH) 1.0
```

I'm not sure this is correct, I think eeglab reader should always set the calibration.
Or at least set the calibratoin for EEG channels.

in this PR:
```py
[print(ch['ch_name'], ch['kind'], ch['cal']) for ch in info['chs']]
F3 2 (FIFFV_EEG_CH) 1e-06
unknown 2 (FIFFV_EEG_CH) 1e-06
FPz 2 (FIFFV_EEG_CH) 1e-06
```

ofcourse this breaks the tests.

WDYT @jasmainak?
Shall we adapt the testsuit and call it a fix, shall we deprecate the behavior
remove montage from _get_info, or is the behavior in master correct?