### PR TITLE
MRG, FIX: make combine_evoked consistent with Matti's manual

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,11 +24,13 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.
+
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_
 
-- Butterfly channel plots now possible for :func:mne.Epochs.plot_epochs_psd with ``average=False`` Infrastructure for this function now shared with analogous Raw function, found in mne.viz.utils by `Jeff Hanna` _
+- Butterfly channel plots now possible for :meth:`mne.Epochs.plot_psd` with ``average=False``. Infrastructure for this function now shared with analogous Raw function, found in ``mne.viz.utils`` by `Jeff Hanna` _
 
-- Accept filenames of raw .fif files to end on `_meg.fif` to enable complicance with the Brain Imaging Data Structure by `Stefan Appelhoff`_
+- Accept filenames of raw .fif files that end in ``_meg.fif`` to enable complicance with the Brain Imaging Data Structure by `Stefan Appelhoff`_
 
 - Add :class:`mne.digitization.Digitization` class to simplify montage by `Joan Massich`_
 
@@ -46,6 +48,8 @@ Changelog
 
 Bug
 ~~~
+
+- Fix formula for effective number of averages in :func:`mne.combine_evoked` when ``weights='equal'`` by `Daniel McCloy`_.
 
 - Fix ``event_id='auto'`` in :func:`mne.events_from_annotations` to recover Brainvision markers after saving it in ``.fif`` by `Joan Massich`_
 
@@ -3255,8 +3259,6 @@ of commits):
 .. _Olaf Hauk: http://www.neuroscience.cam.ac.uk/directory/profile.php?olafhauk
 
 .. _Lukas Breuer: http://www.researchgate.net/profile/Lukas_Breuer
-
-.. _Federico Raimondo: https://github.com/fraimondo
 
 .. _Alan Leggitt: https://github.com/leggitta
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -825,7 +825,8 @@ def grand_average(all_evoked, interpolate_bads=True):
 
     equalize_channels(all_evoked)  # apply equalize_channels
     # make grand_average object using combine_evoked
-    grand_average = combine_evoked(all_evoked, weights='equal')
+    weights = [1. / len(all_evoked)] * len(all_evoked)
+    grand_average = combine_evoked(all_evoked, weights=weights)
     # change the grand_average.nave to the number of Evokeds
     grand_average.nave = len(all_evoked)
     # change comment field

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -541,6 +541,8 @@ def test_arithmetic():
     assert_equal(ch_names, gave.ch_names)
     assert_equal(gave.nave, 2)
     pytest.raises(TypeError, grand_average, [1, evoked1])
+    gave = grand_average([ev1, ev1, ev2])
+    assert_allclose(gave.data, np.ones_like(gave.data))
 
     # test channel (re)ordering
     evoked1, evoked2 = read_evokeds(fname, condition=[0, 1], proj=True)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -478,30 +478,30 @@ def test_arithmetic():
     # data should be added according to their `nave` weights
     # nave = ev1.nave + ev2.nave
     ev = combine_evoked([ev1, ev2], weights='nave')
-    assert_equal(ev.nave, ev1.nave + ev2.nave)
+    assert_allclose(ev.nave, ev1.nave + ev2.nave)
     assert_allclose(ev.data, 1. / 3. * np.ones_like(ev.data))
 
     # with same trial counts, a bunch of things should be equivalent
     for weights in ('nave', [0.5, 0.5]):
         ev = combine_evoked([ev1, ev1], weights=weights)
         assert_allclose(ev.data, ev1.data)
-        assert_equal(ev.nave, 2 * ev1.nave)
+        assert_allclose(ev.nave, 2 * ev1.nave)
         ev = combine_evoked([ev1, -ev1], weights=weights)
         assert_allclose(ev.data, 0., atol=1e-20)
-        assert_equal(ev.nave, 2 * ev1.nave)
+        assert_allclose(ev.nave, 2 * ev1.nave)
     # adding evoked to itself
     ev = combine_evoked([ev1, ev1], weights='equal')
     assert_allclose(ev.data, 2 * ev1.data)
-    assert_equal(ev.nave, ev1.nave / 2)
+    assert_allclose(ev.nave, ev1.nave / 2)
     # subtracting evoked from itself
     ev = combine_evoked([ev1, -ev1], weights='equal')
     assert_allclose(ev.data, 0., atol=1e-20)
-    assert_equal(ev.nave, ev1.nave / 2)
+    assert_allclose(ev.nave, ev1.nave / 2)
     # subtracting different evokeds
     ev = combine_evoked([ev1, -ev2], weights='equal')
     assert_allclose(ev.data, 2., atol=1e-20)
     expected_nave = 1. / (1. / ev1.nave + 1. / ev2.nave)
-    assert_equal(ev.nave, expected_nave)
+    assert_allclose(ev.nave, expected_nave)
 
     # default comment behavior if evoked.comment is None
     old_comment1 = ev1.comment
@@ -520,7 +520,7 @@ def test_arithmetic():
 
     # combine_evoked([ev1, ev2], weights=[1, 0]) should yield the same as ev1
     ev = combine_evoked([ev1, ev2], weights=[1, 0])
-    assert_equal(ev.nave, ev1.nave)
+    assert_allclose(ev.nave, ev1.nave)
     assert_allclose(ev.data, ev1.data)
 
     # simple subtraction (like in oddball)


### PR DESCRIPTION
Per offline discussion w/ @agramfort @larsoner @jasmainak and @jona-sassenhagen. Needs input:

- here when `weights='equal'` the weights are all `1` (previously `1/N`). `combine_tfr` still uses the `1/N` convention; should it be changed too? `mne.grand_average` uses both `combine_evoked` and `combine_tfr` internally, so it might be good if they worked the same way? 
- Regardless of whether we change the behavior of `combine_tfr`, the new behavior of `combine_evoked(..., weights='equal')` is not really consistent with the intuitive meaning of "grand average" (it's really a "grand sum" now). Should `mne.grand_average` be changed to effectively undo this change to `combine_evoked` (by passing pre-computed weights, or by dividing the data afterwards)?
