### PR TITLE
NICOLET: use set_montage at the end of the __init__

### DIFF
--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -9,7 +9,7 @@ import calendar
 
 from ...utils import logger, fill_doc
 from ..utils import _read_segments_file, _find_channels, _create_chs
-from ..base import BaseRaw, _check_update_montage
+from ..base import BaseRaw
 from ..meas_info import _empty_info
 from ..constants import FIFF
 
@@ -171,11 +171,12 @@ class RawNicolet(BaseRaw):
         info, header_info = _get_nicolet_info(input_fname, ch_type, eog, ecg,
                                               emg, misc)
         last_samps = [header_info['num_samples'] - 1]
-        _check_update_montage(info, montage)
+        # _check_update_montage(info, montage)
         super(RawNicolet, self).__init__(
             info, preload, filenames=[input_fname], raw_extras=[header_info],
             last_samps=last_samps, orig_format='int',
             verbose=verbose)
+        self.set_montage(montage)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -171,7 +171,6 @@ class RawNicolet(BaseRaw):
         info, header_info = _get_nicolet_info(input_fname, ch_type, eog, ecg,
                                               emg, misc)
         last_samps = [header_info['num_samples'] - 1]
-        # _check_update_montage(info, montage)
         super(RawNicolet, self).__init__(
             info, preload, filenames=[input_fname], raw_extras=[header_info],
             last_samps=last_samps, orig_format='int',

--- a/mne/io/nicolet/tests/test_nicolet.py
+++ b/mne/io/nicolet/tests/test_nicolet.py
@@ -5,9 +5,14 @@
 
 import os.path as op
 import inspect
+import numpy as np
 
+from numpy.testing import assert_array_equal
+
+from mne.utils import run_tests_if_main, object_diff
 from mne.io import read_raw_nicolet
 from mne.io.tests.test_raw import _test_raw_reader
+from mne.channels import Montage
 
 FILE = inspect.getfile(inspect.currentframe())
 base_dir = op.join(op.dirname(op.abspath(FILE)), 'data')
@@ -18,3 +23,31 @@ def test_data():
     """Test reading raw nicolet files."""
     _test_raw_reader(read_raw_nicolet, input_fname=fname, ch_type='eeg',
                      ecg='auto', eog='auto', emg='auto', misc=['PHO'])
+
+
+def _fake_montage(ch_names):
+    return Montage(
+        pos=np.random.RandomState(42).randn(len(ch_names), 3),
+        ch_names=ch_names,
+        kind='foo',
+        selection=np.arange(len(ch_names))
+    )
+
+
+def test_montage():
+    """Test montage."""
+    raw_none = read_raw_nicolet(input_fname=fname, ch_type='eeg',
+                                montage=None, preload=False)
+    montage = _fake_montage(raw_none.info['ch_names'])
+
+    raw_montage = read_raw_nicolet(input_fname=fname, ch_type='eeg',
+                                   montage=montage, preload=False)
+    raw_none.set_montage(montage)
+
+    # Check they are the same
+    assert_array_equal(raw_none.get_data(), raw_montage.get_data())
+    assert object_diff(raw_none.info['dig'], raw_montage.info['dig']) == ''
+    assert object_diff(raw_none.info['chs'], raw_montage.info['chs']) == ''
+
+
+run_tests_if_main()


### PR DESCRIPTION
This PR is part of #6461. The concrete goal here is to make sure that:
1 - RawNicolet is always called with montage=None
2 - ensure self.set_montage(montage) is called at the end of init