### PR TITLE
FIX: `Evoked.decimate` is not updating `.first` and `.last`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Bug
 
 - Fix bug in :func:`mne.Epochs.plot_psd` when some channels had zero/infinite ``psd`` values causing erroneous error messages by `Luke Bloy`_
 
+- Fix :func:`mne.Evoked.decimate` not setting ``inst.first`` and ``inst.last`` properly by `Marijn van Vliet`_
 
 API
 ~~~

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -274,6 +274,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.info['sfreq'] = new_sfreq
         self.data = self.data[:, decim_slice].copy()
         self.times = self.times[decim_slice].copy()
+        self.first = int(self.times[0] * self.info['sfreq'])
+        self.last = len(self.times) + self.first - 1
         return self
 
     def shift_time(self, tshift, relative=True):

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -46,8 +46,8 @@ def test_decim():
     evoked_dec = evoked.copy().decimate(decim)
     evoked_dec_2 = evoked.copy().decimate(decim, offset=1)
     evoked_dec_3 = evoked.decimate(dec_1).decimate(dec_2)
-    assert_array_equal(evoked_dec.data, data[:, :, ::decim])
-    assert_array_equal(evoked_dec_2.data, data[:, :, 1::decim])
+    assert_array_equal(evoked_dec.data, data[:, ::decim])
+    assert_array_equal(evoked_dec_2.data, data[:, 1::decim])
     assert_array_equal(evoked_dec.data, evoked_dec_3.data)
 
     # Check proper updating of various fields

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -34,22 +34,32 @@ event_name = op.join(base_dir, 'test-eve.fif')
 def test_decim():
     """Test evoked decimation."""
     rng = np.random.RandomState(0)
-    n_epochs, n_channels, n_times = 5, 10, 20
+    n_channels, n_times = 10, 20
     dec_1, dec_2 = 2, 3
     decim = dec_1 * dec_2
-    sfreq = 1000.
+    sfreq = 10.
     sfreq_new = sfreq / decim
-    data = rng.randn(n_epochs, n_channels, n_times)
-    events = np.array([np.arange(n_epochs), [0] * n_epochs, [1] * n_epochs]).T
+    data = rng.randn(n_channels, n_times)
     info = create_info(n_channels, sfreq, 'eeg')
     info['lowpass'] = sfreq_new / float(decim)
-    epochs = EpochsArray(data, info, events)
-    data_epochs = epochs.copy().decimate(decim).get_data()
-    data_epochs_2 = epochs.copy().decimate(decim, offset=1).get_data()
-    data_epochs_3 = epochs.decimate(dec_1).decimate(dec_2).get_data()
-    assert_array_equal(data_epochs, data[:, :, ::decim])
-    assert_array_equal(data_epochs_2, data[:, :, 1::decim])
-    assert_array_equal(data_epochs, data_epochs_3)
+    evoked = EvokedArray(data, info, tmin=-1)
+    evoked_dec = evoked.copy().decimate(decim)
+    evoked_dec_2 = evoked.copy().decimate(decim, offset=1)
+    evoked_dec_3 = evoked.decimate(dec_1).decimate(dec_2)
+    assert_array_equal(evoked_dec.data, data[:, :, ::decim])
+    assert_array_equal(evoked_dec_2.data, data[:, :, 1::decim])
+    assert_array_equal(evoked_dec.data, evoked_dec_3.data)
+
+    # Check proper updating of various fields
+    assert evoked_dec.first == -1
+    assert evoked_dec.last == 2
+    assert_array_equal(evoked_dec.times, [-1, -0.4, 0.2, 0.8])
+    assert evoked_dec_2.first == -1
+    assert evoked_dec_2.last == 2
+    assert_array_equal(evoked_dec_2.times, [-0.9, -0.3, 0.3, 0.9])
+    assert evoked_dec_3.first == -1
+    assert evoked_dec_3.last == 2
+    assert_array_equal(evoked_dec_3.times, [-1, -0.4, 0.2, 0.8])
 
     # Now let's do it with some real data
     raw = read_raw_fif(raw_fname)


### PR DESCRIPTION
`Evoked.decimate()` fails to update the `.first` and `.last` attributes. I stumbled across the error when trying to save and then load a decimated `Evoked` object. This PR fixes it and extends the unit test to check these things.