### PR TITLE
MRG: Refactor last mlab out of tutorial

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2550,7 +2550,8 @@ def plot_dipole_locations(dipoles, trans=None, subject=None, subjects_dir=None,
 
         fig = renderer.scene()
     else:
-        raise ValueError('Mode must be "orthoview", got %s.' % (mode,))
+        raise ValueError('Mode must be "cone", "arrow" or orthoview", '
+                         'got %s.' % (mode,))
 
     return fig
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -716,8 +716,6 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
             fwd_nn = fwd['source_nn']
         else:
             fwd_nn = fwd['source_nn'].reshape(-1, 3, 3)
-    else:
-        fwd_rr = fwd_nn = np.empty((0, 3))
 
     ref_meg = 'ref' in meg
     meg_picks = pick_types(info, meg=True, ref_meg=ref_meg)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -713,7 +713,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         _validate_type(fwd, [Forward])
         fwd_rr = fwd['source_rr']
         if fwd['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI:
-            fwd_nn = fwd['source_nn']
+            fwd_nn = fwd['source_nn'].reshape(-1, 1, 3)
         else:
             fwd_nn = fwd['source_nn'].reshape(-1, 3, 3)
 
@@ -1137,23 +1137,14 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         red = (1.0, 0.0, 0.0)
         green = (0.0, 1.0, 0.0)
         blue = (0.0, 0.0, 1.0)
-        if fwd['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI:
+        for ori, color in zip(range(fwd_nn.shape[1]), (red, green, blue)):
             renderer.quiver3d(fwd_rr[:, 0],
                               fwd_rr[:, 1],
                               fwd_rr[:, 2],
-                              fwd_nn[:, 0],
-                              fwd_nn[:, 1],
-                              fwd_nn[:, 2],
-                              color=red, mode='arrow', scale=1.5e-3)
-        else:
-            for ori, color in zip((0, 1, 2), (red, green, blue)):
-                renderer.quiver3d(fwd_rr[:, 0],
-                                  fwd_rr[:, 1],
-                                  fwd_rr[:, 2],
-                                  fwd_nn[:, ori, 0],
-                                  fwd_nn[:, ori, 1],
-                                  fwd_nn[:, ori, 2],
-                                  color=color, mode='arrow', scale=1.5e-3)
+                              fwd_nn[:, ori, 0],
+                              fwd_nn[:, ori, 1],
+                              fwd_nn[:, ori, 2],
+                              color=color, mode='arrow', scale=1.5e-3)
     renderer.set_camera(azimuth=90, elevation=90,
                         distance=0.6, focalpoint=(0., 0., 0.))
     renderer.show()

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -577,8 +577,9 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         show EEG sensors in their digitized locations or projected onto the
         scalp, or a list of these options including ``[]`` (equivalent of
         False).
-    fwd : instance of Forward. If present, will plot the source normals.
-        The forward solution.
+    fwd : instance of Forward
+        The forward solution. If present, the orientations of the dipoles
+        present in the forward solution are displayed.
     dig : bool | 'fiducials'
         If True, plot the digitization points; 'fiducials' to plot fiducial
         points only.

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -577,7 +577,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         show EEG sensors in their digitized locations or projected onto the
         scalp, or a list of these options including ``[]`` (equivalent of
         False).
-    fwd : instance of Forward
+    fwd : instance of Forward. If present, will plot the source normals.
         The forward solution.
     dig : bool | 'fiducials'
         If True, plot the digitization points; 'fiducials' to plot fiducial

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -712,7 +712,10 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     if fwd is not None:
         _validate_type(fwd, [Forward])
         fwd_rr = fwd['source_rr']
-        fwd_nn = fwd['source_nn'].reshape(-1, 3, 3)
+        if fwd['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI:
+            fwd_nn = fwd['source_nn']
+        else:
+            fwd_nn = fwd['source_nn'].reshape(-1, 3, 3)
     else:
         fwd_rr = fwd_nn = np.empty((0, 3))
 
@@ -1134,14 +1137,23 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         red = (1.0, 0.0, 0.0)
         green = (0.0, 1.0, 0.0)
         blue = (0.0, 0.0, 1.0)
-        for ori, color in zip((0, 1, 2), (red, green, blue)):
+        if fwd['source_ori'] == FIFF.FIFFV_MNE_FIXED_ORI:
             renderer.quiver3d(fwd_rr[:, 0],
                               fwd_rr[:, 1],
                               fwd_rr[:, 2],
-                              fwd_nn[:, ori, 0],
-                              fwd_nn[:, ori, 1],
-                              fwd_nn[:, ori, 2],
-                              color=color, mode='arrow', scale=1E-3)
+                              fwd_nn[:, 0],
+                              fwd_nn[:, 1],
+                              fwd_nn[:, 2],
+                              color=red, mode='arrow', scale=1E-3)
+        else:
+            for ori, color in zip((0, 1, 2), (red, green, blue)):
+                renderer.quiver3d(fwd_rr[:, 0],
+                                  fwd_rr[:, 1],
+                                  fwd_rr[:, 2],
+                                  fwd_nn[:, ori, 0],
+                                  fwd_nn[:, ori, 1],
+                                  fwd_nn[:, ori, 2],
+                                  color=color, mode='arrow', scale=1E-3)
     renderer.set_camera(azimuth=90, elevation=90,
                         distance=0.6, focalpoint=(0., 0., 0.))
     renderer.show()

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -531,7 +531,7 @@ def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
 @verbose
 def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                    surfaces='head', coord_frame='head',
-                   meg=None, eeg='original',
+                   meg=None, eeg='original', fwd=None,
                    dig=False, ecog=True, src=None, mri_fiducials=False,
                    bem=None, seeg=True, show_axes=False, fig=None,
                    interaction='trackball', verbose=None):
@@ -577,6 +577,8 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         show EEG sensors in their digitized locations or projected onto the
         scalp, or a list of these options including ``[]`` (equivalent of
         False).
+    fwd : instance of Forward
+        The forward solution.
     dig : bool | 'fiducials'
         If True, plot the digitization points; 'fiducials' to plot fiducial
         points only.
@@ -1122,6 +1124,20 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
             opacity=0.75, glyph_height=0.25,
             glyph_center=(0., 0., 0.), glyph_resolution=20,
             backface_culling=True)
+    if fwd is not None:
+        red = (1.0, 0.0, 0.0)
+        green = (0.0, 1.0, 0.0)
+        blue = (0.0, 0.0, 1.0)
+        vec = fwd['source_nn'].reshape(-1, 3, 3)
+        pos = fwd['source_rr']
+        for ori, color in zip((0, 1, 2), (red, green, blue)):
+            renderer.quiver3d(pos[:, 0],
+                              pos[:, 1],
+                              pos[:, 2],
+                              vec[:, ori, 0],
+                              vec[:, ori, 1],
+                              vec[:, ori, 2],
+                              color=color, mode='arrow', scale=1E-3)
     renderer.set_camera(azimuth=90, elevation=90,
                         distance=0.6, focalpoint=(0., 0., 0.))
     renderer.show()

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -969,9 +969,11 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                                           [mri_trans, head_trans], copy=True)
 
     if src is not None:
-        _update_coord_frame(src[0], src_rr, src_nn, mri_trans, head_trans)
+        src_rr, src_nn = _update_coord_frame(src[0], src_rr, src_nn,
+                                             mri_trans, head_trans)
     if fwd is not None:
-        _update_coord_frame(fwd, fwd_rr, fwd_nn, mri_trans, head_trans)
+        fwd_rr, fwd_nn = _update_coord_frame(fwd, fwd_rr, fwd_nn,
+                                             mri_trans, head_trans)
 
     # determine points
     meg_rrs, meg_tris = list(), list()
@@ -2892,3 +2894,4 @@ def _update_coord_frame(obj, rr, nn, mri_trans, head_trans):
     elif obj['coord_frame'] == FIFF.FIFFV_COORD_HEAD:
         rr = apply_trans(head_trans, rr)
         nn = apply_trans(head_trans, nn, move=False)
+    return rr, nn

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1144,7 +1144,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                               fwd_nn[:, 0],
                               fwd_nn[:, 1],
                               fwd_nn[:, 2],
-                              color=red, mode='arrow', scale=1E-3)
+                              color=red, mode='arrow', scale=1.5e-3)
         else:
             for ori, color in zip((0, 1, 2), (red, green, blue)):
                 renderer.quiver3d(fwd_rr[:, 0],
@@ -1153,7 +1153,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                                   fwd_nn[:, ori, 0],
                                   fwd_nn[:, ori, 1],
                                   fwd_nn[:, ori, 2],
-                                  color=color, mode='arrow', scale=1E-3)
+                                  color=color, mode='arrow', scale=1.5e-3)
     renderer.set_camera(azimuth=90, elevation=90,
                         distance=0.6, focalpoint=(0., 0., 0.))
     renderer.show()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -315,6 +315,8 @@ def test_plot_alignment(tmpdir, renderer):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['foo'])
+    fwd_fname = op.join(data_dir, 'MEG', 'sample',
+                        'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
     fwd = read_forward_solution(fwd_fname)
     plot_alignment(subject='sample', subjects_dir=subjects_dir,
                    trans=trans_fname, fwd=fwd,

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -17,7 +17,7 @@ from mne import (make_field_map, pick_channels_evoked, read_evokeds,
                  read_trans, read_dipole, SourceEstimate, VectorSourceEstimate,
                  VolSourceEstimate, make_sphere_model, use_coil_def,
                  setup_volume_source_space, read_forward_solution,
-                 VolVectorSourceEstimate)
+                 VolVectorSourceEstimate, convert_forward_solution)
 from mne.io import read_raw_ctf, read_raw_bti, read_raw_kit, read_info
 from mne.digitization._utils import write_dig
 from mne.io.pick import pick_info
@@ -316,6 +316,10 @@ def test_plot_alignment(tmpdir, renderer):
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['foo'])
     fwd = read_forward_solution(fwd_fname)
+    plot_alignment(subject='sample', subjects_dir=subjects_dir,
+                   trans=trans_fname, fwd=fwd,
+                   surfaces='white', coord_frame='head')
+    fwd = convert_forward_solution(fwd, force_fixed=True)
     plot_alignment(subject='sample', subjects_dir=subjects_dir,
                    trans=trans_fname, fwd=fwd,
                    surfaces='white', coord_frame='head')

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -315,6 +315,11 @@ def test_plot_alignment(tmpdir, renderer):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['foo'])
+    fwd = read_forward_solution(fwd_fname)
+    plot_alignment(subject='sample', subjects_dir=subjects_dir,
+                   trans=trans_fname, fwd=fwd,
+                   surfaces='white', coord_frame='head')
+
     renderer._close_all()
 
 

--- a/tutorials/source-modeling/plot_dipole_orientations.py
+++ b/tutorials/source-modeling/plot_dipole_orientations.py
@@ -20,7 +20,6 @@ See :ref:`inverse_orientation_constrains`
 # ------------
 # Load everything we need to perform source localization on the sample dataset.
 
-from mayavi import mlab
 import mne
 import numpy as np
 from mne.datasets import sample
@@ -54,7 +53,6 @@ dip_ori = lh['nn'][lh['vertno']]
 dip_len = len(dip_pos)
 dip_times = [0]
 white = (1.0, 1.0, 1.0)  # RGB values for a white color
-red = (1.0, 0.0, 0.0)  # RGB valued for a red color
 
 actual_amp = np.ones(dip_len)  # misc amp to create Dipole instance
 actual_gof = np.ones(dip_len)  # misc GOF to create Dipole instance
@@ -148,10 +146,6 @@ brain_fixed = stc.plot(surface='white', subjects_dir=subjects_dir,
 # orthogonally to form a Cartesian coordinate system. Let's visualize this:
 fig = mne.viz.create_3d_figure(size=(600, 400))
 
-# Define some more colors
-green = (0.0, 1.0, 0.0)
-blue = (0.0, 0.0, 1.0)
-
 # Plot the cortex
 fig = mne.viz.plot_alignment(subject=subject, subjects_dir=subjects_dir,
                              trans=trans,
@@ -162,12 +156,9 @@ inv = make_inverse_operator(left_auditory.info, fwd, noise_cov, fixed=False,
                             loose=1.0)
 
 # Show the three dipoles defined at each location in the source space
-dip_dir = inv['source_nn'].reshape(-1, 3, 3)
-dip_dir = dip_dir[:len(dip_pos)]  # Only select left hemisphere
-for ori, color in zip((0, 1, 2), (red, green, blue)):
-    mlab.quiver3d(dip_pos[:, 0], dip_pos[:, 1], dip_pos[:, 2],
-                  dip_dir[:, ori, 0], dip_dir[:, ori, 1], dip_dir[:, ori, 2],
-                  color=color, scale_factor=1E-3)
+fig = mne.viz.plot_alignment(subject=subject, subjects_dir=subjects_dir,
+                             trans=trans, fwd=fwd,
+                             surfaces='white', coord_frame='head', fig=fig)
 
 mne.viz.set_3d_view(figure=fig, azimuth=180, distance=0.1)
 

--- a/tutorials/source-modeling/plot_dipole_orientations.py
+++ b/tutorials/source-modeling/plot_dipole_orientations.py
@@ -151,10 +151,6 @@ fig = mne.viz.plot_alignment(subject=subject, subjects_dir=subjects_dir,
                              trans=trans,
                              surfaces='white', coord_frame='head', fig=fig)
 
-# Make an inverse operator with loose dipole orientations
-inv = make_inverse_operator(left_auditory.info, fwd, noise_cov, fixed=False,
-                            loose=1.0)
-
 # Show the three dipoles defined at each location in the source space
 fig = mne.viz.plot_alignment(subject=subject, subjects_dir=subjects_dir,
                              trans=trans, fwd=fwd,
@@ -166,6 +162,10 @@ mne.viz.set_3d_view(figure=fig, azimuth=180, distance=0.1)
 # When computing the source estimate, the activity at each of the three dipoles
 # is collapsed into the XYZ components of a single vector, which leads to the
 # following source estimate for the sample data:
+
+# Make an inverse operator with loose dipole orientations
+inv = make_inverse_operator(left_auditory.info, fwd, noise_cov, fixed=False,
+                            loose=1.0)
 
 # Compute the source estimate, indicate that we want a vector solution
 stc = apply_inverse(left_auditory, inv, pick_ori='vector')


### PR DESCRIPTION
This PR is a follow-up of [#6483(comment)](https://github.com/mne-tools/mne-python/pull/6483#issuecomment-505806289). It introduces a new parameter `fwd` for `plot_alignment()` allowing the plotting of the dipole orientations. The script `plot_dipole_orientations.py` is slightly different now.

This is what I obtain locally:

![image](https://user-images.githubusercontent.com/18143289/60272617-ca995780-98f4-11e9-8e1e-551a52edba0b.png)

Compared to initially:

![image](https://user-images.githubusercontent.com/18143289/60272655-ddac2780-98f4-11e9-9de8-5f6a727cab28.png)

*The rendering may differ on Circle, I have some transparency issues to fix on my personal mayavi config.*