### PR TITLE
ENH: Allow reading file-like objects for EpochsFIF

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -214,7 +214,7 @@ Changelog
 
 - Add ``mne.realtime.MockLSLStream`` to simulate an LSL stream for testing and examples by `Teon Brooks`_
 
-- Add support for file-like objects in :func:`mne.epochs.read_epochs` as long as preloading is used by `Paul Roujansky`_
+- Add support for file-like objects in :func:`mne.read_epochs` as long as preloading is used by `Paul Roujansky`_
 
 Bug
 ~~~
@@ -3450,3 +3450,5 @@ of commits):
 .. _Kostiantyn Maksymenko: https://github.com/makkostya
 
 .. _Thomas Radman: https://github.com/tradman
+
+.. _Paul Roujansky: https://github.com/paulroujansky

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -214,6 +214,8 @@ Changelog
 
 - Add ``mne.realtime.MockLSLStream`` to simulate an LSL stream for testing and examples by `Teon Brooks`_
 
+- Add support for file-like objects in :func:`mne.epochs.read_epochs` as long as preloading is used by `Paul Roujansky`_
+
 Bug
 ~~~
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2320,7 +2320,7 @@ def read_epochs(fname, proj=True, preload=True, verbose=None):
     Parameters
     ----------
     fname : str | file-like
-        The epochs filename to load. Filenames should end with -epo.fif or
+        The epochs filename to load. Filename should end with -epo.fif or
         -epo.fif.gz. If a file-like object is provided, preloading must be
         used.
     proj : bool | 'delayed'

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2408,7 +2408,8 @@ class EpochsFIF(BaseEpochs):
         ep_list = list()
         raw = list()
         for fname in fnames:
-            logger.info('Reading %s ...' % _get_fname_rep(fname))
+            fname_rep = _get_fname_rep(fname)
+            logger.info('Reading %s ...' % fname_rep)
             fid, tree, _ = fiff_open(fname, preload=preload)
             next_fname = _get_next_fname(fid, fname, tree)
             (info, data, data_tag, events, event_id, metadata, tmin, tmax,
@@ -2455,7 +2456,7 @@ class EpochsFIF(BaseEpochs):
         super(EpochsFIF, self).__init__(
             info, data, events, event_id, tmin, tmax, baseline, raw=raw,
             proj=proj, preload_at_end=False, on_missing='ignore',
-            selection=selection, drop_log=drop_log, filename=fname,
+            selection=selection, drop_log=drop_log, filename=fname_rep,
             metadata=metadata, verbose=verbose, **reject_params)
         # use the private property instead of drop_bad so that epochs
         # are not all read from disk for preload=False

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -7,6 +7,7 @@
 from copy import deepcopy
 from distutils.version import LooseVersion
 from functools import partial
+from io import BytesIO
 import os.path as op
 import pickle
 
@@ -2678,6 +2679,30 @@ def test_epochs_drop_selection(fname, preload):
     selection = np.round(epochs.get_data()[:, 0].max(axis=-1) / scale)
     selection = selection.astype(int) - 1
     assert_array_equal(selection, epochs.selection)
+
+
+@pytest.mark.parametrize('kind', ('file', 'bytes'))
+@pytest.mark.parametrize('preload', (True, False))
+def test_file_like(kind, preload, tmpdir):
+    """Test handling with file-like objects."""
+    print(kind, preload)
+    tempdir = str(tmpdir)
+    raw = mne.io.RawArray(np.random.RandomState(0).randn(100, 10000),
+                          mne.create_info(100, 1000.))
+    events = mne.make_fixed_length_events(raw, 1)
+    epochs = mne.Epochs(raw, events, preload=preload)
+    fname = op.join(tempdir, 'test-epo.fif')
+    epochs.save(fname, overwrite=True)
+
+    with open(fname, 'rb') as file_fid:
+        fid = BytesIO(file_fid.read()) if kind == 'bytes' else file_fid
+        assert not fid.closed
+        assert not file_fid.closed
+        with pytest.raises(ValueError, match='preload must be used with file'):
+            read_epochs(fid, preload=False)
+        assert not fid.closed
+        assert not file_fid.closed
+    assert file_fid.closed
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2685,7 +2685,6 @@ def test_epochs_drop_selection(fname, preload):
 @pytest.mark.parametrize('preload', (True, False))
 def test_file_like(kind, preload, tmpdir):
     """Test handling with file-like objects."""
-    print(kind, preload)
     tempdir = str(tmpdir)
     raw = mne.io.RawArray(np.random.RandomState(0).randn(100, 10000),
                           mne.create_info(100, 1000.))


### PR DESCRIPTION
## Description
In the light of https://github.com/mne-tools/mne-python/pull/6291 which enabled to read `mne.io.fiff.raw.Raw` FIF object from file-like object, the hereby PR aims at extending this feature to `mne.epochs.EpochsFIF` object (cf. issue https://github.com/mne-tools/mne-python/issues/6009).