### PR TITLE
MRG: Add a test for 3d mode of plot_dipole_locations

### DIFF
--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -424,6 +424,19 @@ def test_plot_dipole_mri_orthoview():
 
 
 @testing.requires_testing_data
+def test_plot_dipole_orientations(renderer):
+    """Test dipole plotting in 3d."""
+    dipoles = read_dipole(dip_fname)
+    trans = read_trans(trans_fname)
+    for coord_frame, idx, show_all in zip(['head', 'mri'],
+                                          ['gof', 'amplitude'], [True, False]):
+        dipoles.plot_locations(trans=trans, subject='sample',
+                               subjects_dir=subjects_dir,
+                               mode='arrow', coord_frame=coord_frame)
+    renderer._close_all()
+
+
+@testing.requires_testing_data
 @traits_test
 def test_snapshot_brain_montage(renderer):
     """Test snapshot brain montage."""

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -428,11 +428,11 @@ def test_plot_dipole_orientations(renderer):
     """Test dipole plotting in 3d."""
     dipoles = read_dipole(dip_fname)
     trans = read_trans(trans_fname)
-    for coord_frame, idx, show_all in zip(['head', 'mri'],
-                                          ['gof', 'amplitude'], [True, False]):
+    for coord_frame, mode in zip(['head', 'mri'],
+                                 ['arrow', 'sphere']):
         dipoles.plot_locations(trans=trans, subject='sample',
                                subjects_dir=subjects_dir,
-                               mode='arrow', coord_frame=coord_frame)
+                               mode=mode, coord_frame=coord_frame)
     renderer._close_all()
 
 


### PR DESCRIPTION
Following @agramfort [advice(comment)](https://github.com/mne-tools/mne-python/pull/6505#issuecomment-506404576), this PR adds simple testing of the '3d' `mode` (`sphere` or `arrow`) of the `plot_dipole_locations()` function.