### PR TITLE
[MRG+1]fix bug in estimate_stc

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug in :func:`mne.simulation.simulate_stc` to avoid empty stc if label vertices and source space do not intersect, by `Kostiantyn Maksymenko`_
+
 - Fix ``event_id='auto'`` in :func:`mne.events_from_annotations` to recover Brainvision markers after saving it in ``.fif`` by `Joan Massich`_
 
 - Fix :func:`mne.read_epochs_eeglab` when epochs are stored as float. By `Thomas Radman`_

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -270,8 +270,8 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
         if len(src_sel) == 0:
             idx = np.searchsorted(src[hemi_ind]['vertno'],
                                   label.vertices)
-            l = len(src[hemi_ind]['vertno']) - 1
-            idx[idx > l] = l
+            src_len = len(src[hemi_ind]['vertno']) - 1
+            idx[idx > src_len] = src_len
             src_sel = np.unique(src[hemi_ind]['vertno'][idx])
 
         if value_fun is not None:

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -268,11 +268,15 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
         src_sel = np.intersect1d(src[hemi_ind]['vertno'],
                                  label.vertices)
         if len(src_sel) == 0:
-            idx = np.searchsorted(src[hemi_ind]['vertno'],
-                                  label.vertices)
-            src_len = len(src[hemi_ind]['vertno']) - 1
-            idx[idx > src_len] = src_len
-            src_sel = np.unique(src[hemi_ind]['vertno'][idx])
+            idx = src[hemi_ind]['inuse'].astype('bool')
+            rr = src[hemi_ind]['rr'][idx]
+            closest_src = np.empty(len(label.vertices), dtype=np.int)
+            for j, vert in enumerate(label.vertices):
+                vert_pos = src[hemi_ind]['rr'][vert:vert + 1, :]
+                vert_matrix = np.tile(vert_pos, (rr.shape[0], 1))
+                distances = np.sum((rr - vert_matrix) ** 2, axis=1)
+                closest_src[j] = np.argmin(distances)
+            src_sel = src[hemi_ind]['vertno'][np.unique(closest_src)]
 
         if value_fun is not None:
             idx_sel = np.searchsorted(label.vertices, src_sel)

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -267,6 +267,13 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
         hemi_ind = hemi_to_ind[label.hemi]
         src_sel = np.intersect1d(src[hemi_ind]['vertno'],
                                  label.vertices)
+        if len(src_sel) == 0:
+            idx = np.unique(np.searchsorted(src[hemi_ind]['vertno'],
+                                            label.vertices))
+            l = len(src[hemi_ind]['vertno']) - 1
+            idx[idx > l] = l
+            src_sel = src[hemi_ind]['vertno'][idx]
+
         if value_fun is not None:
             idx_sel = np.searchsorted(label.vertices, src_sel)
             values_sel = np.array([value_fun(v) for v in

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -14,6 +14,7 @@ from ..source_estimate import SourceEstimate, VolSourceEstimate
 from ..source_space import _ensure_src
 from ..utils import check_random_state, warn, _check_option, fill_doc
 from ..label import Label
+from ..surface import _compute_nearest
 
 
 @fill_doc
@@ -269,13 +270,9 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
                                  label.vertices)
         if len(src_sel) == 0:
             idx = src[hemi_ind]['inuse'].astype('bool')
-            rr = src[hemi_ind]['rr'][idx]
-            closest_src = np.empty(len(label.vertices), dtype=np.int)
-            for j, vert in enumerate(label.vertices):
-                vert_pos = src[hemi_ind]['rr'][vert:vert + 1, :]
-                vert_matrix = np.tile(vert_pos, (rr.shape[0], 1))
-                distances = np.sum((rr - vert_matrix) ** 2, axis=1)
-                closest_src[j] = np.argmin(distances)
+            xhs = src[hemi_ind]['rr'][idx]
+            rr = src[hemi_ind]['rr'][label.vertices]
+            closest_src = _compute_nearest(xhs, rr)
             src_sel = src[hemi_ind]['vertno'][np.unique(closest_src)]
 
         if value_fun is not None:

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -268,11 +268,11 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
         src_sel = np.intersect1d(src[hemi_ind]['vertno'],
                                  label.vertices)
         if len(src_sel) == 0:
-            idx = np.unique(np.searchsorted(src[hemi_ind]['vertno'],
-                                            label.vertices))
+            idx = np.searchsorted(src[hemi_ind]['vertno'],
+                                  label.vertices)
             l = len(src[hemi_ind]['vertno']) - 1
             idx[idx > l] = l
-            src_sel = src[hemi_ind]['vertno'][idx]
+            src_sel = np.unique(src[hemi_ind]['vertno'][idx])
 
         if value_fun is not None:
             idx_sel = np.searchsorted(label.vertices, src_sel)

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -98,6 +98,14 @@ def test_simulate_stc(_get_fwd_labels):
     pytest.raises(RuntimeError, simulate_stc, fwd['src'], label_subset * 2,
                   np.concatenate([data_subset] * 2, axis=0), tmin, tstep, fun)
 
+    i = np.where(fwd['src'][0]['inuse'] == 0)[0][0]
+    label_single_vert = Label(vertices=[i],
+                              pos=fwd['src'][0]['rr'][i:i + 1, :],
+                              hemi='lh')
+    stc = simulate_stc(fwd['src'], [label_single_vert], stc_data[:1], tmin,
+                       tstep)
+    assert_equal(len(stc.lh_vertno), 1)
+
 
 def test_simulate_sparse_stc(_get_fwd_labels):
     """Test generation of sparse source estimate."""


### PR DESCRIPTION
To simulate an stc from label the function `estimate_stc` uses the intersection between label vertices and source space. However, if label contains only one or few vertices (for example only the center of mass of a region) the intersection can be empty. This possibility is not currently taken into account which may result in  outputting empty stcs.

I added the code which returns a source even if the intersection is empty. For a moment I just select the source from source space whose index is the nearest (from right) to the label vertices. 
