### PR TITLE
Improve camera focus of plot_read_inverse

### DIFF
--- a/examples/inverse/plot_read_inverse.py
+++ b/examples/inverse/plot_read_inverse.py
@@ -12,6 +12,7 @@ The inverse operator's source space is shown in 3D.
 import mne
 from mne.datasets import sample
 from mne.minimum_norm import read_inverse_operator
+from mne.viz import set_3d_view
 
 print(__doc__)
 
@@ -42,5 +43,6 @@ print("Number of triangles on right hemisphere: %d" % len(src[1]['use_tris']))
 ###############################################################################
 # Show result on 3D source space
 
-mne.viz.plot_alignment(subject='sample', subjects_dir=subjects_dir,
-                       trans=fname_trans, surfaces='white', src=src)
+fig = mne.viz.plot_alignment(subject='sample', subjects_dir=subjects_dir,
+                             trans=fname_trans, surfaces='white', src=src)
+set_3d_view(fig, focalpoint=[0., 0., 0.06])

--- a/examples/inverse/plot_read_inverse.py
+++ b/examples/inverse/plot_read_inverse.py
@@ -45,4 +45,4 @@ print("Number of triangles on right hemisphere: %d" % len(src[1]['use_tris']))
 
 fig = mne.viz.plot_alignment(subject='sample', subjects_dir=subjects_dir,
                              trans=fname_trans, surfaces='white', src=src)
-set_3d_view(fig, focalpoint=[0., 0., 0.06])
+set_3d_view(fig, focalpoint=(0., 0., 0.06))


### PR DESCRIPTION
This PR improves the focus of the camera of the `plot_read_inverse-py` example.

Before:
![image](https://user-images.githubusercontent.com/18143289/60446170-16b00900-9c21-11e9-8a05-ed72315c6013.png)

After:
![image](https://user-images.githubusercontent.com/18143289/60446177-1a439000-9c21-11e9-8183-9c73e9fc3cb3.png)