### PR TITLE
Add tube() to pyvista 3d backend

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2673,7 +2673,6 @@ def plot_sensors_connectivity(info, con, picks=None):
                              destination=np.c_[x2, y2, z2],
                              scalars=np.c_[val, val],
                              vmin=vmin, vmax=vmax, radius=0.001,
-                             colormap='RdBu',
                              reverse_lut=True)
 
     renderer.scalarbar(source=tube, title='Phase Lag Index (PLI)', n_labels=4)

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -147,8 +147,7 @@ class _Renderer(_BaseRenderer):
 
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
              scalars=None, vmin=None, vmax=None, colormap='RdBu',
-             normalized_colormap=False, opacity=1.0, backface_culling=False,
-             reverse_lut=False):
+             normalized_colormap=False, reverse_lut=False):
         if scalars is None:
             surface = self.mlab.plot3d([origin[:, 0], destination[:, 0]],
                                        [origin[:, 1], destination[:, 1]],
@@ -166,7 +165,6 @@ class _Renderer(_BaseRenderer):
                                        vmax=vmax,
                                        colormap=colormap,
                                        figure=self.fig)
-        surface.actor.property.backface_culling = backface_culling
         surface.module_manager.scalar_lut_manager.reverse_lut = reverse_lut
         return surface
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -146,8 +146,9 @@ class _Renderer(_BaseRenderer):
         surface.actor.property.backface_culling = backface_culling
 
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
-             scalars=None, vmin=None, vmax=None, colormap=None,
-             opacity=1.0, backface_culling=False, reverse_lut=False):
+             scalars=None, vmin=None, vmax=None, colormap='RdBu',
+             normalized_colormap=False, opacity=1.0, backface_culling=False,
+             reverse_lut=False):
         if scalars is None:
             surface = self.mlab.plot3d([origin[:, 0], destination[:, 0]],
                                        [origin[:, 1], destination[:, 1]],

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -183,8 +183,7 @@ class _Renderer(_BaseRenderer):
 
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
              scalars=None, vmin=None, vmax=None, colormap='RdBu',
-             normalized_colormap=False, opacity=1.0, backface_culling=False,
-             reverse_lut=False):
+             normalized_colormap=False, reverse_lut=False):
         cmap = _get_colormap_from_array(colormap, normalized_colormap)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
@@ -203,9 +202,7 @@ class _Renderer(_BaseRenderer):
                                       rng=[vmin, vmax],
                                       color=color,
                                       show_scalar_bar=False,
-                                      opacity=opacity,
                                       cmap=cmap,
-                                      backface_culling=backface_culling,
                                       smooth_shading=self.smooth_shading)
 
     def quiver3d(self, x, y, z, u, v, w, color, scale, mode, resolution=8,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -182,10 +182,31 @@ class _Renderer(_BaseRenderer):
                                   smooth_shading=self.smooth_shading)
 
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
-             scalars=None, vmin=None, vmax=None, colormap=None,
-             opacity=1.0, backface_culling=False, reverse_lut=False):
-        raise NotImplementedError('tube() feature '
-                                  'is not supported yet for this backend.')
+             scalars=None, vmin=None, vmax=None, colormap='RdBu',
+             normalized_colormap=False, opacity=1.0, backface_culling=False,
+             reverse_lut=False):
+        cmap = _get_colormap_from_array(colormap, normalized_colormap)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            for (pointa, pointb) in zip(origin, destination):
+                line = pyvista.Line(pointa, pointb)
+                if scalars is not None:
+                    line.point_arrays['scalars'] = scalars[0, :]
+                    scalars = 'scalars'
+                    color = None
+                else:
+                    scalars = None
+                tube = line.tube(radius)
+                self.plotter.add_mesh(mesh=tube,
+                                      scalars=scalars,
+                                      flip_scalars=reverse_lut,
+                                      rng=[vmin, vmax],
+                                      color=color,
+                                      show_scalar_bar=False,
+                                      opacity=opacity,
+                                      cmap=cmap,
+                                      backface_culling=backface_culling,
+                                      smooth_shading=self.smooth_shading)
 
     def quiver3d(self, x, y, z, u, v, w, color, scale, mode, resolution=8,
                  glyph_height=None, glyph_center=None, glyph_resolution=None,

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -27,6 +27,8 @@ def _get_colormap_from_array(colormap=None, normalized_colormap=False,
     from matplotlib.colors import ListedColormap
     if colormap is None:
         cmap = cm.get_cmap(default_colormap)
+    elif isinstance(colormap, str):
+        cmap = cm.get_cmap(colormap)
     elif normalized_colormap:
         cmap = ListedColormap(colormap)
     else:

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -142,8 +142,9 @@ class _BaseRenderer(metaclass=ABCMeta):
 
     @abstractclassmethod
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
-             scalars=None, vmin=None, vmax=None, colormap=None,
-             opacity=1.0, backface_culling=False, reverse_lut=False):
+             scalars=None, vmin=None, vmax=None, colormap='RdBu',
+             normalized_colormap=False, opacity=1.0, backface_culling=False,
+             reverse_lut=False):
         """Add tube in the scene.
 
         Parameters

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -143,8 +143,7 @@ class _BaseRenderer(metaclass=ABCMeta):
     @abstractclassmethod
     def tube(self, origin, destination, radius=1.0, color=(1.0, 1.0, 1.0),
              scalars=None, vmin=None, vmax=None, colormap='RdBu',
-             normalized_colormap=False, opacity=1.0, backface_culling=False,
-             reverse_lut=False):
+             normalized_colormap=False, reverse_lut=False):
         """Add tube in the scene.
 
         Parameters

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -121,13 +121,11 @@ def test_3d_backend(renderer):
                   mode=qv_mode)
 
     # use tube
-    if renderer.get_3d_backend() == "pyvista":
-        with pytest.raises(NotImplementedError):
-            rend.tube(origin=np.array([[0, 0, 0]]),
-                      destination=np.array([[0, 1, 0]]))
-    else:
-        rend.tube(origin=np.array([[0, 0, 0]]),
-                  destination=np.array([[0, 1, 0]]))
+    rend.tube(origin=np.array([[0, 0, 0]]),
+              destination=np.array([[0, 1, 0]]))
+    rend.tube(origin=np.array([[1, 0, 0]]),
+              destination=np.array([[1, 1, 0]]),
+              scalars=np.array([[1.0, 1.0]]))
 
     # use text
     rend.text2d(x=txt_x, y=txt_y, text=txt_text, width=txt_width)


### PR DESCRIPTION
Fixes part of #6518.

This PR adds the missing `tube()` function to the pyvista 3d backend and updates the tests accordingly.