### PR TITLE
MRG: Add scalarbar() and text3d() to pyvista 3d backend

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2675,7 +2675,7 @@ def plot_sensors_connectivity(info, con, picks=None):
                              vmin=vmin, vmax=vmax, radius=0.001,
                              reverse_lut=True)
 
-    renderer.scalarbar(source=tube, title='Phase Lag Index (PLI)', n_labels=4)
+    renderer.scalarbar(source=tube, title='Phase Lag Index (PLI)')
 
     # Add the sensor names for the connections shown
     nodes_shown = list(set([n[0] for n in con_nodes] +

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -203,7 +203,7 @@ class _Renderer(_BaseRenderer):
             self.mlab.text3d(x, y, z, text, scale=scale, color=color,
                              figure=self.fig)
 
-    def scalarbar(self, source, title=None, n_labels=None):
+    def scalarbar(self, source, title=None, n_labels=4):
         with warnings.catch_warnings(record=True):  # traits
             self.mlab.scalarbar(source, title=title, nb_labels=n_labels)
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -289,7 +289,8 @@ class _Renderer(_BaseRenderer):
                                       labels=[text],
                                       point_size=scale,
                                       text_color=color,
-                                      name=text)
+                                      name=text,
+                                      shape_opacity=0)
 
     def scalarbar(self, source, title=None, n_labels=4):
         self.plotter.add_scalar_bar(title=title, n_labels=n_labels,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -280,21 +280,27 @@ class _Renderer(_BaseRenderer):
                                       smooth_shading=self.smooth_shading)
 
     def text2d(self, x, y, text, width, color=(1.0, 1.0, 1.0)):
-        self.plotter.add_text(text, position=(x, y),
-                              font_size=int(width * 100),
-                              color=color)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            self.plotter.add_text(text, position=(x, y),
+                                  font_size=int(width * 100),
+                                  color=color)
 
     def text3d(self, x, y, z, text, scale, color=(1.0, 1.0, 1.0)):
-        self.plotter.add_point_labels(points=[x, y, z],
-                                      labels=[text],
-                                      point_size=scale,
-                                      text_color=color,
-                                      name=text,
-                                      shape_opacity=0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            self.plotter.add_point_labels(points=[x, y, z],
+                                          labels=[text],
+                                          point_size=scale,
+                                          text_color=color,
+                                          name=text,
+                                          shape_opacity=0)
 
     def scalarbar(self, source, title=None, n_labels=4):
-        self.plotter.add_scalar_bar(title=title, n_labels=n_labels,
-                                    position_x=0.15, width=0.7)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            self.plotter.add_scalar_bar(title=title, n_labels=n_labels,
+                                        position_x=0.15, width=0.7)
 
     def show(self):
         self.display = self.plotter.show(title=self.name)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -204,6 +204,7 @@ class _Renderer(_BaseRenderer):
                                       show_scalar_bar=False,
                                       cmap=cmap,
                                       smooth_shading=self.smooth_shading)
+        return tube
 
     def quiver3d(self, x, y, z, u, v, w, color, scale, mode, resolution=8,
                  glyph_height=None, glyph_center=None, glyph_resolution=None,
@@ -288,8 +289,8 @@ class _Renderer(_BaseRenderer):
                                   'is not supported yet for this backend.')
 
     def scalarbar(self, source, title=None, n_labels=None):
-        raise NotImplementedError('scalarbar() feature '
-                                  'is not supported yet for this backend.')
+        self.plotter.add_scalar_bar(title=title, n_labels=n_labels,
+                                    position_x=0.15, width=0.7)
 
     def show(self):
         self.display = self.plotter.show(title=self.name)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -285,10 +285,13 @@ class _Renderer(_BaseRenderer):
                               color=color)
 
     def text3d(self, x, y, z, text, scale, color=(1.0, 1.0, 1.0)):
-        raise NotImplementedError('text3d() feature '
-                                  'is not supported yet for this backend.')
+        self.plotter.add_point_labels(points=[x, y, z],
+                                      labels=[text],
+                                      point_size=scale,
+                                      text_color=color,
+                                      name=text)
 
-    def scalarbar(self, source, title=None, n_labels=None):
+    def scalarbar(self, source, title=None, n_labels=4):
         self.plotter.add_scalar_bar(title=title, n_labels=n_labels,
                                     position_x=0.15, width=0.7)
 

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -267,7 +267,7 @@ class _BaseRenderer(metaclass=ABCMeta):
         pass
 
     @abstractclassmethod
-    def scalarbar(self, source, title=None, n_labels=None):
+    def scalarbar(self, source, title=None, n_labels=4):
         """Add a scalar bar in the scene.
 
         Parameters

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -123,17 +123,16 @@ def test_3d_backend(renderer):
     # use tube
     rend.tube(origin=np.array([[0, 0, 0]]),
               destination=np.array([[0, 1, 0]]))
-    rend.tube(origin=np.array([[1, 0, 0]]),
-              destination=np.array([[1, 1, 0]]),
-              scalars=np.array([[1.0, 1.0]]))
+    tube = rend.tube(origin=np.array([[1, 0, 0]]),
+                     destination=np.array([[1, 1, 0]]),
+                     scalars=np.array([[1.0, 1.0]]))
+
+    # scalar bar
+    rend.scalarbar(source=tube, title="Scalar Bar")
 
     # use text
     rend.text2d(x=txt_x, y=txt_y, text=txt_text, width=txt_width)
-    if renderer.get_3d_backend() == "pyvista":
-        with pytest.raises(NotImplementedError):
-            rend.text3d(x=0, y=0, z=0, text=txt_text, scale=1.0)
-    else:
-        rend.text3d(x=0, y=0, z=0, text=txt_text, scale=1.0)
+    rend.text3d(x=0, y=0, z=0, text=txt_text, scale=1.0)
     rend.set_camera(azimuth=180.0, elevation=90.0,
                     distance=cam_distance,
                     focalpoint=center)


### PR DESCRIPTION
Fixes part of #6518.

This PR adds the missing `scalarbar()` function to the pyvista 3d backend.