### PR TITLE
MRG, ENH: Add real datatype check, avoid joblib for now

### DIFF
--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -89,7 +89,7 @@ def _get_data(tmin=-0.1, tmax=0.15, all_forward=True, epochs=True,
             raw, events, event_id, tmin, tmax, proj=True,
             baseline=(None, 0), preload=epochs_preload, reject=reject)
         if epochs_preload:
-            epochs.resample(200, npad=0, n_jobs=2)
+            epochs.resample(200, npad=0)
         epochs.crop(0, None)
         evoked = epochs.average()
         info = evoked.info

--- a/mne/connectivity/tests/test_spectral.py
+++ b/mne/connectivity/tests/test_spectral.py
@@ -150,8 +150,7 @@ def test_spectral_connectivity(method, mode):
             stc_data, method=test_methods, mode=mode, indices=indices,
             sfreq=sfreq, mt_adaptive=adaptive, mt_low_bias=True,
             mt_bandwidth=mt_bandwidth, tmin=tmin, tmax=tmax,
-            cwt_freqs=cwt_freqs,
-            cwt_n_cycles=cwt_n_cycles, n_jobs=2)
+            cwt_freqs=cwt_freqs, cwt_n_cycles=cwt_n_cycles)
 
         assert isinstance(con2, list)
         assert len(con2) == len(test_methods)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -227,8 +227,8 @@ def test_temporal_filter():
         assert (X.shape == Xt.shape)
 
     # Test fit and transform numpy type check
-    with pytest.warns(RuntimeWarning, match='longer than the signal'):
-        pytest.raises(TypeError, filt.transform, [1, 2])
+    with pytest.raises(ValueError, match='Data to be filtered must be'):
+        filt.transform([1, 2])
 
     # Test with 2 dimensional data array
     X = np.random.rand(101, 500)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2032,21 +2032,8 @@ def combine_event_ids(epochs, old_event_ids, new_event_id, copy=True):
 def equalize_epoch_counts(epochs_list, method='mintime'):
     """Equalize the number of trials in multiple Epoch instances.
 
-    It tries to make the remaining epochs occurring as close as possible in
-    time. This method works based on the idea that if there happened to be some
-    time-varying (like on the scale of minutes) noise characteristics during
-    a recording, they could be compensated for (to some extent) in the
-    equalization process. This method thus seeks to reduce any of those effects
-    by minimizing the differences in the times of the events in the two sets of
-    epochs. For example, if one had event times [1, 2, 3, 4, 120, 121] and the
-    other one had [3.5, 4.5, 120.5, 121.5], it would remove events at times
-    [1, 2] in the first epochs and not [120, 121].
-
-    Note that this operates on the Epochs instances in-place.
-
-    Example:
-
-        equalize_epoch_counts(epochs1, epochs2)
+    .. note::
+       This operates on the Epochs instances in-place.
 
     Parameters
     ----------
@@ -2056,6 +2043,22 @@ def equalize_epoch_counts(epochs_list, method='mintime'):
         If 'truncate', events will be truncated from the end of each event
         list. If 'mintime', timing differences between each event list will be
         minimized.
+
+    Notes
+    -----
+    This tries to make the remaining epochs occurring as close as possible in
+    time. This method works based on the idea that if there happened to be some
+    time-varying (like on the scale of minutes) noise characteristics during
+    a recording, they could be compensated for (to some extent) in the
+    equalization process. This method thus seeks to reduce any of those effects
+    by minimizing the differences in the times of the events in the two sets of
+    epochs. For example, if one had event times [1, 2, 3, 4, 120, 121] and the
+    other one had [3.5, 4.5, 120.5, 121.5], it would remove events at times
+    [1, 2] in the first epochs and not [120, 121].
+
+    Examples
+    --------
+    >>> equalize_epoch_counts(epochs1, epochs2)  # doctest: +SKIP
     """
     if not all(isinstance(e, BaseEpochs) for e in epochs_list):
         raise ValueError('All inputs must be Epochs instances')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -44,7 +44,7 @@ from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
 from .filter import detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
-from .fixes import _get_args
+from .fixes import _get_args, rng_uniform
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
                   plot_epochs_image, plot_topo_image_epochs, plot_drop_log)
 from .utils import (_check_fname, check_fname, logger, verbose,
@@ -2520,7 +2520,7 @@ def bootstrap(epochs, random_state=None):
     rng = check_random_state(random_state)
     epochs_bootstrap = epochs.copy()
     n_events = len(epochs_bootstrap.events)
-    idx = rng.randint(0, n_events, n_events)
+    idx = rng_uniform(rng)(0, n_events, n_events)
     epochs_bootstrap = epochs_bootstrap[idx]
     return epochs_bootstrap
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -307,6 +307,15 @@ def _get_dpss():
 
 
 ###############################################################################
+# Triaging FFT functions to get fast pocketfft
+
+try:
+    from scipy.fft import fft, ifft, fftfreq, rfft, irfft, rfftfreq, ifftshift
+except ImportError:
+    from numpy.fft import fft, ifft, fftfreq, rfft, irfft, rfftfreq, ifftshift
+
+
+###############################################################################
 # Backporting scipy.signal.sosfiltfilt (0.18)
 
 def _sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
@@ -489,7 +498,6 @@ def minimum_phase(h):
         pass
     else:
         return minimum_phase(h)
-    from scipy.fftpack import fft, ifft
     h = np.asarray(h)
     if np.iscomplexobj(h):
         raise ValueError('Complex filters not supported')
@@ -521,15 +529,6 @@ def minimum_phase(h):
     h_minimum = h_temp.real
     n_out = n_half + len(h) % 2
     return h_minimum[:n_out]
-
-
-###############################################################################
-# Triaging FFT functions to get fast pocketfft
-
-try:
-    from scipy.fft import rfft, irfft, rfftfreq
-except ImportError:
-    from numpy.fft import rfft, irfft, rfftfreq
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -316,6 +316,15 @@ except ImportError:
 
 
 ###############################################################################
+# NumPy Generator
+
+def rng_uniform(rng):
+    """Get the unform/randint from the rng."""
+    # prefer Generator.integers, fall back to RandomState.randint
+    return getattr(rng, 'integers', getattr(rng, 'randint', None))
+
+
+###############################################################################
 # Backporting scipy.signal.sosfiltfilt (0.18)
 
 def _sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -178,9 +178,10 @@ def test_mxne_vol_sphere():
                   maxit=3, tol=1e-8, active_set_size=10)
 
     # irMxNE tests
+    random_state = 0
     stc = mixed_norm(evoked_l21, fwd, cov, alpha,
                      n_mxne_iter=1, maxit=30, tol=1e-8,
-                     active_set_size=10)
+                     active_set_size=10, random_state=random_state)
     assert isinstance(stc, VolSourceEstimate)
     assert_array_almost_equal(stc.times, evoked_l21.times, 5)
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -178,10 +178,9 @@ def test_mxne_vol_sphere():
                   maxit=3, tol=1e-8, active_set_size=10)
 
     # irMxNE tests
-    random_state = 0
     stc = mixed_norm(evoked_l21, fwd, cov, alpha,
                      n_mxne_iter=1, maxit=30, tol=1e-8,
-                     active_set_size=10, random_state=random_state)
+                     active_set_size=10)
     assert isinstance(stc, VolSourceEstimate)
     assert_array_almost_equal(stc.times, evoked_l21.times, 5)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -397,8 +397,9 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, chs, filenames):
                         # it forces edge artifacts to appear at
                         # each buffer boundary :(
                         # it can also be very slow...
-                        ch_data = resample(ch_data, buf_len, n_samps[ci],
-                                           npad=0, axis=-1)
+                        ch_data = resample(
+                            ch_data.astype(np.float64), buf_len, n_samps[ci],
+                            npad=0, axis=-1)
                 assert ch_data.shape == (len(ch_data), buf_len)
                 data[ii, d_sidx:d_eidx] = ch_data.ravel()[r_sidx:r_eidx]
 

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -193,7 +193,7 @@ def _generate_noise(info, cov, iir_filter, random_state, n_samples, zi=None,
     rng = check_random_state(random_state)
     _, _, colorer = compute_whitener(cov, info, pca=True, return_colorer=True,
                                      picks=picks, verbose=False)
-    noise = np.dot(colorer, rng.randn(colorer.shape[1], n_samples))
+    noise = np.dot(colorer, rng.standard_normal((colorer.shape[1], n_samples)))
     if iir_filter is not None:
         if zi is None:
             zi = np.zeros((len(colorer), len(iir_filter) - 1))

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -587,8 +587,8 @@ def _add_exg(raw, kind, head_pos, interp, n_jobs, random_state):
         blink_rate = (1 + np.cos(2 * np.pi * 1. / 60. * times)) / 2.
         blink_rate *= 12.5 / 60.
         blink_rate += 4.5 / 60.
-        blink_data = rng.rand(len(times)) < blink_rate / info['sfreq']
-        blink_data = blink_data * (rng.rand(len(times)) + 0.5)  # varying amps
+        blink_data = rng.uniform(size=len(times)) < blink_rate / info['sfreq']
+        blink_data = blink_data * (rng.uniform(size=len(times)) + 0.5)  # amps
         # Activation kernel is a simple hanning window
         blink_kernel = np.hanning(int(0.25 * info['sfreq']))
         exg_data = np.convolve(blink_data, blink_kernel,
@@ -622,7 +622,7 @@ def _add_exg(raw, kind, head_pos, interp, n_jobs, random_state):
         picks = meg_picks
         del cardiac_data, cardiac_kernel, max_beats, cardiac_idx
     del meg_picks, meeg_picks
-    noise = rng.randn(exg_data.shape[1]) * 5e-6
+    noise = rng.standard_normal(exg_data.shape[1]) * 5e-6
     if len(ch) >= 1:
         ch = ch[-1]
         data[ch, :] = exg_data * 1e3 + noise

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ..source_estimate import SourceEstimate, VolSourceEstimate
 from ..source_space import _ensure_src
+from ..fixes import rng_uniform
 from ..utils import check_random_state, warn, _check_option, fill_doc
 from ..label import Label
 
@@ -77,7 +78,7 @@ def select_source_in_label(src, label, random_state=None, location='random',
         hemi_idx = 1
     src_sel = np.intersect1d(src[hemi_idx]['vertno'], label.vertices)
     if location == 'random':
-        idx = src_sel[rng.randint(0, len(src_sel), 1)[0]]
+        idx = src_sel[rng_uniform(rng)(0, len(src_sel), 1)[0]]
     else:  # 'center'
         idx = label.center_of_mass(
             subject, restrict_vertices=src_sel, subjects_dir=subjects_dir,

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -17,7 +17,7 @@ from mne.simulation import simulate_sparse_stc, simulate_evoked, add_noise
 from mne.io import read_raw_fif
 from mne.io.pick import pick_channels_cov
 from mne.cov import regularize, whiten_evoked
-from mne.utils import run_tests_if_main, catch_logging
+from mne.utils import run_tests_if_main, catch_logging, check_version
 
 data_path = testing.data_path(download=False)
 fwd_fname = op.join(data_path, 'MEG', 'sample',
@@ -91,7 +91,10 @@ def test_simulate_evoked():
 @pytest.mark.filterwarnings('ignore:Epochs are not baseline corrected')
 def test_add_noise():
     """Test noise addition."""
-    rng = np.random.RandomState(0)
+    if check_version('numpy', '1.17'):
+        rng = np.random.default_rng(0)
+    else:
+        rng = np.random.RandomState(0)
     raw = read_raw_fif(raw_fname)
     raw.del_proj()
     picks = pick_types(raw.info, eeg=True, exclude=())

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -28,7 +28,7 @@ from mne.surface import _get_ico_surface
 from mne.io import read_raw_fif, RawArray
 from mne.io.constants import FIFF
 from mne.time_frequency import psd_welch
-from mne.utils import run_tests_if_main, catch_logging
+from mne.utils import run_tests_if_main, catch_logging, check_version
 
 base_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname_short = op.join(base_path, 'test_raw.fif')
@@ -333,7 +333,13 @@ def test_simulate_raw_sphere(raw_data, tmpdir):
         raw_sim_hann = simulate_raw(raw, stc, trans, src, sphere, cov=None,
                                     head_pos=head_pos_sim, interp='hann')
     assert_allclose(raw_sim[:][0], raw_sim_hann[:][0], rtol=1e-1, atol=1e-14)
-    del raw_sim, raw_sim_hann
+    del raw_sim_hann
+
+    # check that new Generator objects can be used
+    if check_version('numpy', '1.17'):
+        random_state = np.random.default_rng(seed)
+        add_ecg(raw_sim, random_state=random_state)
+        add_eog(raw_sim, random_state=random_state)
 
 
 def test_degenerate(raw_data):

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -16,7 +16,7 @@ from mne import (read_label, read_forward_solution, pick_types_forward,
 from mne.label import Label
 from mne.simulation.source import simulate_stc, simulate_sparse_stc
 from mne.simulation.source import SourceSimulator
-from mne.utils import run_tests_if_main
+from mne.utils import run_tests_if_main, check_version
 
 
 data_path = testing.data_path(download=False)
@@ -227,6 +227,12 @@ def test_simulate_sparse_stc_single_hemi(_get_fwd_labels):
 
     assert_array_equal(stc_1.lh_vertno, stc_2.lh_vertno)
     assert_array_equal(stc_1.rh_vertno, stc_2.rh_vertno)
+
+    # smoke test for new API
+    if check_version('numpy', '1.17'):
+        simulate_sparse_stc(fwd['src'], len(labels_single_hemi), times,
+                            labels=labels_single_hemi,
+                            random_state=np.random.default_rng(0))
 
 
 @testing.requires_testing_data

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -637,7 +637,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         self._remove_kernel_sens_data_()
 
         o_sfreq = 1.0 / self.tstep
-        self.data = resample(self.data, sfreq, o_sfreq, npad, n_jobs=n_jobs)
+        data = self.data
+        if data.dtype == np.float32:
+            data = data.astype(np.float64)
+        self.data = resample(data, sfreq, o_sfreq, npad, n_jobs=n_jobs)
 
         # adjust indirectly affected variables
         self.tstep = 1.0 / sfreq

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -716,10 +716,10 @@ def _get_1samp_orders(n_samples, n_permutations, tail, rng):
         # to prevent positive/negative equivalent collisions
         use_samples = n_samples - (tail == 0)
         while ii < n_permutations - 1:
-            signs = tuple((rng.rand(use_samples) < 0.5).astype(int))
+            signs = tuple((rng.uniform(size=use_samples) < 0.5).astype(int))
             if signs not in hashes:
                 orders[ii, :use_samples] = signs
-                if tail == 0 and rng.rand() < 0.5:
+                if tail == 0 and rng.uniform() < 0.5:
                     # To undo the non-flipping of the last subject in the
                     # tail == 0 case, half the time we use the positive
                     # last subject, half the time negative last subject

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -18,7 +18,7 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      spatio_temporal_cluster_test,
                                      spatio_temporal_cluster_1samp_test,
                                      ttest_1samp_no_p, summarize_clusters_stc)
-from mne.utils import run_tests_if_main, _TempDir, catch_logging
+from mne.utils import run_tests_if_main, _TempDir, catch_logging, check_version
 
 
 n_space = 50
@@ -101,10 +101,14 @@ def test_cache_dir():
         assert 'independently' not in log_file.getvalue()
         # ensure that non-independence yields warning
         stat_fun = partial(ttest_1samp_no_p, sigma=1e-3)
+        if check_version('numpy', '1.17'):
+            random_state = np.random.default_rng(0)
+        else:
+            random_state = 0
         with pytest.warns(RuntimeWarning, match='independently'):
             permutation_cluster_1samp_test(
                 X, buffer_size=10, n_jobs=2, n_permutations=1,
-                seed=0, stat_fun=stat_fun, verbose=False)
+                seed=random_state, stat_fun=stat_fun, verbose=False)
     finally:
         if orig_dir is not None:
             os.environ['MNE_CACHE_DIR'] = orig_dir

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -8,7 +8,7 @@ from scipy import stats, sparse
 
 from mne.stats import permutation_cluster_1samp_test
 from mne.stats.permutations import permutation_t_test, _ci, _bootstrap_ci
-from mne.utils import run_tests_if_main
+from mne.utils import run_tests_if_main, check_version
 
 
 def test_permutation_t_test():
@@ -71,6 +71,10 @@ def test_ci():
     assert_allclose(_bootstrap_ci(arr, stat_fun="median", random_state=0),
                     _bootstrap_ci(arr, stat_fun="mean", random_state=0),
                     rtol=.1)
+    # smoke test for new API
+    if check_version('numpy', '1.17'):
+        random_state = np.random.default_rng(0)
+        _bootstrap_ci(arr, random_state=random_state)
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -30,7 +30,7 @@ from mne.epochs import (
     EpochsArray, concatenate_epochs, BaseEpochs, average_movements)
 from mne.utils import (requires_pandas, run_tests_if_main, object_diff,
                        requires_version, catch_logging, _FakeNoPandas,
-                       assert_meg_snr)
+                       assert_meg_snr, check_version)
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 
 from mne.io import RawArray, read_raw_fif
@@ -1387,9 +1387,13 @@ def test_bootstrap():
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events[:5], event_id, tmin, tmax, picks=picks,
                     preload=True, reject=reject, flat=flat)
-    epochs2 = bootstrap(epochs, random_state=0)
-    assert (len(epochs2.events) == len(epochs.events))
-    assert (epochs._data.shape == epochs2._data.shape)
+    random_states = [0]
+    if check_version('numpy', '1.17'):
+        random_states += [np.random.default_rng(0)]
+    for random_state in random_states:
+        epochs2 = bootstrap(epochs, random_state=random_state)
+        assert (len(epochs2.events) == len(epochs.events))
+        assert (epochs._data.shape == epochs2._data.shape)
 
 
 def test_epochs_copy():

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -5,10 +5,8 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
-from scipy.fftpack import fft
 from scipy import sparse
 
-from mne.datasets import testing
 from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  VolSourceEstimate, Label, read_source_spaces,
                  read_evokeds, MixedSourceEstimate, find_events, Epochs,
@@ -18,8 +16,9 @@ from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  spatial_inter_hemi_connectivity,
                  spatial_src_connectivity, spatial_tris_connectivity,
                  SourceSpaces, VolVectorSourceEstimate)
+from mne.datasets import testing
+from mne.fixes import fft
 from mne.source_estimate import grade_to_tris, _get_vol_mask
-
 from mne.minimum_norm import (read_inverse_operator, apply_inverse,
                               apply_inverse_epochs)
 from mne.label import read_labels_from_annot, label_sign_flip

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -638,9 +638,6 @@ def csd_array_fourier(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
     csd_morlet
     csd_multitaper
     """
-    # Local import to keep "import mne" fast
-    # from scipy.fftpack import fftfreq
-
     X, times, tmin, tmax, fmin, fmax = _prepare_csd_array(
         X, sfreq, t0, tmin, tmax, fmin, fmax)
 

--- a/mne/time_frequency/stft.py
+++ b/mne/time_frequency/stft.py
@@ -1,7 +1,7 @@
 from math import ceil
 import numpy as np
-from scipy.fftpack import fft, ifft, fftfreq
 
+from ..fixes import fft, ifft, fftfreq
 from ..utils import logger, verbose
 
 

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os.path as op
 from numpy.testing import assert_array_almost_equal, assert_allclose
+from scipy.signal import welch
 import pytest
 
 from mne import pick_types, Epochs, read_events
@@ -182,10 +183,10 @@ def test_compares_psd():
     # Compute psds with plt.psd
     start, stop = raw.time_as_index([tmin, tmax])
     data, times = raw[picks, start:(stop + 1)]
-    from matplotlib.pyplot import psd
-    out = [psd(d, Fs=raw.info['sfreq'], NFFT=n_fft) for d in data]
-    freqs_mpl = out[0][1]
-    psds_mpl = np.array([o[0] for o in out])
+    out = [welch(d, fs=raw.info['sfreq'], nperseg=n_fft, noverlap=0)
+           for d in data]
+    freqs_mpl = out[0][0]
+    psds_mpl = np.array([o[1] for o in out])
 
     mask = (freqs_mpl >= fmin) & (freqs_mpl <= fmax)
     freqs_mpl = freqs_mpl[mask]

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -15,11 +15,11 @@ from math import sqrt
 
 import numpy as np
 from scipy import linalg
-from scipy.fftpack import fft, ifft
 
 from .multitaper import dpss_windows
 
 from ..baseline import rescale
+from ..fixes import fft, ifft
 from ..parallel import parallel_func
 from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
                      sizeof_fmt, GetEpochsMixin, _prepare_read_metadata,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -87,6 +87,7 @@ def _check_mayavi_version(min_version='4.3.0'):
         raise RuntimeError("Need mayavi >= %s" % min_version)
 
 
+# adapted from scikit-learn utils/validation.py
 def check_random_state(seed):
     """Turn seed into a numpy.random.mtrand.RandomState instance.
 
@@ -101,6 +102,12 @@ def check_random_state(seed):
         return np.random.mtrand.RandomState(seed)
     if isinstance(seed, np.random.mtrand.RandomState):
         return seed
+    try:
+        # Generator is only available in numpy >= 1.17
+        if isinstance(seed, np.random.Generator):
+            return seed
+    except AttributeError:
+        pass
     raise ValueError('%r cannot be used to seed a '
                      'numpy.random.mtrand.RandomState instance' % seed)
 

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -287,7 +287,9 @@ def random_permutation(n_samples, random_state=None):
         Randomly permuted sequence between 0 and n-1.
     """
     rng = check_random_state(random_state)
-    idx = rng.rand(n_samples)
+    # This can't just be rng.permutation(n_samples) because it's not identical
+    # to what MATLAB produces
+    idx = rng.uniform(size=n_samples)
     randperm = np.argsort(idx)
     return randperm
 

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -14,8 +14,8 @@ from mne.datasets import testing
 from mne.io.pick import pick_channels_cov
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
-                       _check_mayavi_version, _check_info_inv, _check_option)
-
+                       _check_mayavi_version, _check_info_inv, _check_option,
+                       check_version)
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
@@ -37,7 +37,7 @@ def test_check():
     check_random_state(None).choice(1)
     check_random_state(0).choice(1)
     check_random_state(np.random.RandomState(0)).choice(1)
-    if hasattr(np.random, 'default_rng'):
+    if check_version('numpy', '1.17'):
         check_random_state(np.random.default_rng(0)).choice(1)
 
     # _meg.fif is a valid ending and should not raise an error

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -34,11 +34,11 @@ def test_check():
     pytest.raises(TypeError, _check_subject, None, 1)
     pytest.raises(TypeError, _check_subject, 1, None)
     # smoke tests for permitted types
-    check_random_state(None).random(1)
-    check_random_state(0).random(1)
-    check_random_state(np.random.RandomState(0)).random(1)
+    check_random_state(None).choice(1)
+    check_random_state(0).choice(1)
+    check_random_state(np.random.RandomState(0)).choice(1)
     if hasattr(np.random, 'default_rng'):
-        check_random_state(np.random.default_rng(0)).random(1)
+        check_random_state(np.random.default_rng(0)).choice(1)
 
     # _meg.fif is a valid ending and should not raise an error
     sh.copyfile(fname_raw, fname_raw.replace('_raw.', '_meg.'))

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -5,6 +5,8 @@
 # License: BSD (3-clause)
 import os.path as op
 import shutil as sh
+
+import numpy as np
 import pytest
 
 import mne
@@ -31,6 +33,12 @@ def test_check():
     pytest.raises(ValueError, _check_subject, None, None)
     pytest.raises(TypeError, _check_subject, None, 1)
     pytest.raises(TypeError, _check_subject, 1, None)
+    # smoke tests for permitted types
+    check_random_state(None).random(1)
+    check_random_state(0).random(1)
+    check_random_state(np.random.RandomState(0)).random(1)
+    if hasattr(np.random, 'default_rng'):
+        check_random_state(np.random.default_rng(0)).random(1)
 
     # _meg.fif is a valid ending and should not raise an error
     sh.copyfile(fname_raw, fname_raw.replace('_raw.', '_meg.'))

--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -135,7 +135,8 @@ MNE-Python.
 # values for our data that are reasonable for M/EEG.
 
 import numpy as np
-from scipy import signal, fftpack
+from numpy.fft import fft, fftfreq
+from scipy import signal
 import matplotlib.pyplot as plt
 
 from mne.time_frequency.tfr import morlet
@@ -216,7 +217,7 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 s)', flim=flim, compensate=True)
 #        :func:`scipy.signal.firwin`, and `MATLAB fir2`_)
 #     3. Least squares designs (:func:`scipy.signal.firls`, `MATLAB firls`_)
 #     4. Frequency-domain design (construct filter in Fourier
-#        domain and use an :func:`IFFT <scipy.fftpack.ifft>` to invert it)
+#        domain and use an :func:`IFFT <numpy.ifft>` to invert it)
 #
 # .. note:: Remez and least squares designs have advantages when there are
 #           "do not care" regions in our frequency response. However, we want
@@ -448,8 +449,8 @@ def plot_signal(x, offset):
     t = np.arange(len(x)) / sfreq
     axes[0].plot(t, x + offset)
     axes[0].set(xlabel='Time (s)', xlim=t[[0, -1]])
-    X = fftpack.fft(x)
-    freqs = fftpack.fftfreq(len(x), 1. / sfreq)
+    X = fft(x)
+    freqs = fftfreq(len(x), 1. / sfreq)
     mask = freqs >= 0
     X = X[mask]
     freqs = freqs[mask]

--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -217,7 +217,7 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 s)', flim=flim, compensate=True)
 #        :func:`scipy.signal.firwin`, and `MATLAB fir2`_)
 #     3. Least squares designs (:func:`scipy.signal.firls`, `MATLAB firls`_)
 #     4. Frequency-domain design (construct filter in Fourier
-#        domain and use an :func:`IFFT <numpy.ifft>` to invert it)
+#        domain and use an :func:`IFFT <numpy.fft.ifft>` to invert it)
 #
 # .. note:: Remez and least squares designs have advantages when there are
 #           "do not care" regions in our frequency response. However, we want


### PR DESCRIPTION
joblib and SciPy's FFT do not get along:

https://github.com/joblib/joblib/issues/906

For now set `n_jobs=1` in the tests to make things green again, and make our dtype check a bit stricter/consistent (only allow np.float64 in resampling and filtering). Once joblib or SciPy are fixed we can put `n_jobs=2` in a test somewhere.