### PR TITLE
replaced preload in IO

### DIFF
--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -29,12 +29,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
         Path to the data file (extension ``.bin``). The header file with the
         same file name stem and an extension ``.txt`` is expected to be found
         in the same directory.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
     pos_fname : str or None (default None)
         If not None, load digitized head points from this file
@@ -300,12 +295,7 @@ class RawArtemis123(BaseRaw):
     ----------
     input_fname : str
         Path to the Artemis123 data file (ending in ``'.bin'``).
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
 
     See Also

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -54,9 +54,7 @@ class RawBrainVision(BaseRaw):
     scale : float
         The scaling factor for EEG data. Unless specified otherwise by
         header file, units are in microvolts. Default scale factor is 1.
-    preload : bool
-        If True, all data are loaded at initialization.
-        If False, data are not read until save.
+    %(preload)s
     %(verbose)s
 
     See Also
@@ -802,9 +800,7 @@ def read_raw_brainvision(vhdr_fname, montage=None,
     scale : float
         The scaling factor for EEG data. Unless specified otherwise by
         header file, units are in microvolts. Default scale factor is 1.
-    preload : bool
-        If True, all data are loaded at initialization.
-        If False, data are not read until save.
+    %(preload)s
     %(verbose)s
 
     Returns

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -923,12 +923,7 @@ class RawBTi(BaseRaw):
     eog_ch : tuple of str | None
         The 4D names of the EOG channels. If None, the channels will be treated
         as regular EEG channels.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
 
         .. versionadded:: 0.11
 
@@ -1264,12 +1259,7 @@ def read_raw_bti(pdf_fname, config_fname='config',
     eog_ch : tuple of str | None
         The 4D names of the EOG channels. If None, the channels will be treated
         as regular EEG channels.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
 
         .. versionadded:: 0.11
     %(verbose)s

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -142,12 +142,7 @@ def read_raw_cnt(input_fname, montage=None, eog=(), misc=(), ecg=(), emg=(),
         Defaults to 'auto'.
     date_format : 'mm/dd/yy' | 'dd/mm/yy'
         Format of date in the header. Defaults to 'mm/dd/yy'.
-    preload : bool | str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     stim_channel : bool | None
         Add a stim channel from the events. Defaults to None to trigger a
         future warning.
@@ -394,12 +389,7 @@ class RawCNT(BaseRaw):
         Defaults to 'auto'.
     date_format : 'mm/dd/yy' | 'dd/mm/yy'
         Format of date in the header. Defaults to 'mm/dd/yy'.
-    preload : bool | str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     stim_channel : bool | None
         Add a stim channel from the events. Defaults to None to trigger a
         future warning.

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -38,12 +38,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
         the data file when the system clock drops to zero, and use "ignore"
         to ignore the system clock (e.g., if head positions are measured
         multiple times during a recording).
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     clean_names : bool, optional
         If True main channel names and compensation channel names will
         be cleaned from CTF suffixes. The default is False.
@@ -79,12 +74,7 @@ class RawCTF(BaseRaw):
         the data file when the system clock drops to zero, and use "ignore"
         to ignore the system clock (e.g., if head positions are measured
         multiple times during a recording).
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     clean_names : bool, optional
         If True main channel names and compensation channel names will
         be cleaned from CTF suffixes. The default is False.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -111,12 +111,7 @@ class RawEDF(BaseRaw):
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing. If
-        True, data will be preloaded into memory (fast, but requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard drive
-        (slower, but requires less memory).
+    %(preload)s
     %(verbose)s
 
     Notes
@@ -236,12 +231,7 @@ class RawGDF(BaseRaw):
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing. If
-        True, data will be preloaded into memory (fast, but requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard drive
-        (slower, but requires less memory).
+    %(preload)s
     %(verbose)s
 
     Notes
@@ -1199,12 +1189,7 @@ def read_raw_edf(input_fname, montage=None, eog=None, misc=None,
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing. If
-        True, data will be preloaded into memory (fast, but requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard drive
-        (slower, but requires less memory).
+    %(preload)s
     %(verbose)s
 
     Notes
@@ -1285,12 +1270,7 @@ def read_raw_bdf(input_fname, montage=None, eog=None, misc=None,
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing. If
-        True, data will be preloaded into memory (fast, but requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard drive
-        (slower, but requires less memory).
+    %(preload)s
     %(verbose)s
 
     Notes
@@ -1373,12 +1353,7 @@ def read_raw_gdf(input_fname, montage=None, eog=None, misc=None,
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing. If
-        True, data will be preloaded into memory (fast, but requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard drive
-        (slower, but requires less memory).
+    %(preload)s
     %(verbose)s
 
     Notes

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -270,12 +270,7 @@ class RawEEGLAB(BaseRaw):
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires large
-        amount of memory). If preload is a string, preload is the file name of
-        a memory-mapped file which is used to store the data on the hard
-        drive (slower, requires less memory).
+    %(preload)s
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -157,14 +157,9 @@ def read_raw_eeglab(input_fname, montage=None, eog=(), preload=False,
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory). Note that
-        preload=False will be effective only if the data is stored in a
-        separate binary file.
+    %(preload)s
+        Note that preload=False will be effective only if the data is stored
+        in a separate binary file.
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is
@@ -271,6 +266,8 @@ class RawEEGLAB(BaseRaw):
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
     %(preload)s
+        Note that preload=False will be effective only if the data is stored
+        in a separate binary file.
     uint16_codec : str | None
         If your \*.set file contains non-ascii characters, sometimes reading
         it may fail and give rise to error message stating that "buffer is

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -117,12 +117,7 @@ def read_raw_egi(input_fname, montage=None, eog=None, misc=None,
        trigger. Defaults to None. If None, channels that have more than
        one event and the ``sync`` and ``TREV`` channels will be
        ignored.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
 
         .. versionadded:: 0.11
     channel_naming : str

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -244,12 +244,7 @@ def _read_raw_egi_mff(input_fname, montage=None, eog=None, misc=None,
        trigger. Defaults to None. If None, channels that have more than
        one event and the ``sync`` and ``TREV`` channels will be
        ignored.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     channel_naming : str
         Channel naming convention for the data channels. Defaults to 'E%d'
         (resulting in channel names 'E1', 'E2', 'E3'...). The effective default

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -19,8 +19,7 @@ def read_raw_eximia(fname, preload=False, verbose=None):
     ----------
     fname : str
         Path to the eXimia data file (.nxe).
-    preload : bool
-        If True, all data are loaded at initialization.
+    %(preload)s
     %(verbose)s
 
     Returns
@@ -43,8 +42,7 @@ class RawEximia(BaseRaw):
     ----------
     fname : str
         Path to the eXimia data file (.nxe).
-    preload : bool
-        If True, all data are loaded at initialization.
+    %(preload)s
     %(verbose)s
 
     See Also

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -48,12 +48,7 @@ class Raw(BaseRaw):
         generally not be loaded directly, but should first be processed using
         SSS/tSSS to remove the compensation signals that may also affect brain
         activity. Can also be "yes" to load without eliciting a warning.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
 
     Attributes
@@ -450,12 +445,7 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False, verbose=None):
         generally not be loaded directly, but should first be processed using
         SSS/tSSS to remove the compensation signals that may also affect brain
         activity. Can also be "yes" to load without eliciting a warning.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
 
     Returns

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -757,9 +757,7 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
     stimthresh : float
         The threshold level for accepting voltage changes in KIT trigger
         channels as a trigger event.
-    preload : bool
-        If True, all data are loaded at initialization.
-        If False, data are not read until save.
+    %(preload)s
     stim_code : 'binary' | 'channel'
         How to decode trigger values from stim channels. 'binary' read stim
         channel events as binary code, 'channel' encodes channel number.

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -93,12 +93,7 @@ class RawKIT(BaseRaw):
     stimthresh : float
         The threshold level for accepting voltage changes in KIT trigger
         channels as a trigger event. If None, stim must also be set to None.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     stim_code : 'binary' | 'channel'
         How to decode trigger values from stim channels. 'binary' read stim
         channel events as binary code, 'channel' encodes channel number.

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -49,12 +49,7 @@ def read_raw_nicolet(input_fname, ch_type, montage=None, eog=(), ecg=(),
     misc : list or tuple
         Names of channels or list of indices that should be designated
         MISC channels. Defaults to empty tuple.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
 
     Returns
@@ -152,12 +147,7 @@ class RawNicolet(BaseRaw):
     misc : list or tuple
         Names of channels or list of indices that should be designated
         MISC channels. Defaults to empty tuple.
-    preload : bool or str (default False)
-        Preload data into memory for data manipulation and faster indexing.
-        If True, the data will be preloaded into memory (fast, requires
-        large amount of memory). If preload is a string, preload is the
-        file name of a memory-mapped file which is used to store the data
-        on the hard drive (slower, requires less memory).
+    %(preload)s
     %(verbose)s
 
     See Also

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -31,11 +31,11 @@ docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
 # Preload
 docdict['preload'] = """
 preload : bool or str (default False)
-    Preload data into memory for data manipulation and faster indexing. If
-    True, data will be preloaded into memory (fast, but requires large
-    amount of memory). If preload is a string, preload is the file name of
-    a memory-mapped file which is used to store the data on the hard drive
-    (slower, but requires less memory)."""
+    Preload data into memory for data manipulation and faster indexing.
+    If True, the data will be preloaded into memory (fast, requires
+    large amount of memory). If preload is a string, preload is the
+    file name of a memory-mapped file which is used to store the data
+    on the hard drive (slower, requires less memory)."""
 
 # General plotting
 docdict["show"] = """


### PR DESCRIPTION
As mentioned in PR #6272,
This PR will change the "preload" documentation in all relevant io read_raw_xy and RawXY docstrings to be read from utils/docs.py::docdict instead of being written out each time.

#### Additional information

The following "preload" docstrings were not replaced for various reasons. Please give a short note whether any of them should be replaced additionally:

- (array, fieldtrip): No preload option

- brainvision: String not equal/ not sure if equivalent
    `preload : bool
        If True, all data are loaded at initialization.
        If False, data are not read until save.`

- eximia: String not equal/ not sure if equivalent
    `preload : bool
        If True, all data are loaded at initialization.`

- eeglab::read_raw_eeglab: Additional information after preload string:
        `[...]Note that preload=False will be effective only if the data is stored in a
        separate binary file.`
    However, RawEEGLAB string did not have this addition and therefore was replaced

- kit::read_raw_kit: String not equal/ not sure if equivalent
    `preload : bool
        If True, all data are loaded at initialization.
        If False, data are not read until save.`
     However, RawKIT string was equal to docdict and therefore was replaced

- open::fiff_open: String not equal/ not sure if equivalent
    `preload : bool
        If True, all data from the file is read into a memory buffer. This
        requires more memory, but can be faster for I/O operations that require
        frequent seeks.`

- base::BaseRaw Additional information after preload string:
	` [...]If preload is an ndarray, the data are taken from that array. If False, data are not
        read until save.`

- base::BaseRaw.append: Additional information after preload string:
	`If preload is None, preload=True or False is inferred using the preload status
            of the raw files passed in.`

- base::BaseRaw.concatenate_raws: String not equal/ not sure if equivalent
	`If None, preload status is inferred using the preload status of the
        raw files passed in. True or False sets the resulting raw file to
        have or not have data preloaded.`
