### PR TITLE
[MRG] Show epoch name in window title instead of axis

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1006,7 +1006,7 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
         if title is None or len(title) == 0:
             title = ''
     fig = figure_nobar(facecolor='w', figsize=size, dpi=80)
-    fig.canvas.set_window_title(title if title else "Epochs")
+    fig.canvas.set_window_title(title or "Epochs")
     ax = plt.subplot2grid((10, 15), (0, 1), colspan=13, rowspan=9)
     color = _handle_default('color', None)
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1006,12 +1006,8 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
         if title is None or len(title) == 0:
             title = ''
     fig = figure_nobar(facecolor='w', figsize=size, dpi=80)
-    fig.canvas.set_window_title('mne_browse_epochs')
+    fig.canvas.set_window_title(title if title else "Epochs")
     ax = plt.subplot2grid((10, 15), (0, 1), colspan=13, rowspan=9)
-
-    ax.annotate(title, xy=(0.5, 1), xytext=(0, ax.get_ylim()[1] + 15),
-                ha='center', va='bottom', size=12, xycoords='axes fraction',
-                textcoords='offset points')
     color = _handle_default('color', None)
 
     ax.axis([0, duration, 0, 200])

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -658,7 +658,7 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
         size = tuple([float(s) for s in size])
 
     fig = figure_nobar(facecolor=bgcolor, figsize=size)
-    fig.canvas.set_window_title(title if title else "Raw")
+    fig.canvas.set_window_title(title or "Raw")
     ax = plt.subplot2grid((10, 10), (0, 1), colspan=8, rowspan=9)
     ax_hscroll = plt.subplot2grid((10, 10), (9, 1), colspan=8)
     ax_hscroll.get_yaxis().set_visible(False)


### PR DESCRIPTION
`raw.plot` already shows the name in the window title, so I think `epochs.plot` should be consistent. This PR moves the name from the axis to the window title.

Before:
![before](https://user-images.githubusercontent.com/4377312/60958548-d4fd1d80-a306-11e9-9f19-9d03958ea1a1.png)

After:
![after](https://user-images.githubusercontent.com/4377312/60958568-dcbcc200-a306-11e9-8de6-fd1f656ea1f0.png)
