### PR TITLE
Update link to contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,4 +31,4 @@ conduct`_.
 .. _`pull request`: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 
 .. _`code of conduct`: https://github.com/mne-tools/mne-python/blob/master/CODE_OF_CONDUCT.md
-.. _`contributing guide`: https://mne-tools.github.io/dev/contributing.html
+.. _`contributing guide`: https://mne-tools.github.io/stable/install/contributing.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,4 +31,4 @@ conduct`_.
 .. _`pull request`: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 
 .. _`code of conduct`: https://github.com/mne-tools/mne-python/blob/master/CODE_OF_CONDUCT.md
-.. _`contributing guide`: https://mne-tools.github.io/stable/install/contributing.html
+.. _`contributing guide`: https://mne-tools.github.io/dev/install/contributing.html


### PR DESCRIPTION
The link to our contributing guide in `CONTRIBUTING.rst` doesn't work anymore. I've changed it to https://mne-tools.github.io/stable/install/contributing.html, but this link will not work until we release 0.19 (https://mne-tools.github.io/dev/install/contributing.html does work now).