### PR TITLE
suppress filter param messages when not user-specifiable

### DIFF
--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -58,7 +58,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
 
     filtecg = filter_data(ecg, sfreq, l_freq, h_freq, None, filter_length,
                           0.5, 0.5, phase='zero-double', fir_window='hann',
-                          fir_design='firwin2', verbose=verbose)
+                          fir_design='firwin2')
 
     ecg_abs = np.abs(filtecg)
     init = int(sfreq)

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -18,8 +18,10 @@ from ..io.pick import _picks_to_idx
 from .. import create_info
 
 
+@verbose
 def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
-                 l_freq=5, h_freq=35, tstart=0, filter_length='10s'):
+                 l_freq=5, h_freq=35, tstart=0, filter_length='10s',
+                 verbose=None):
     """Detect QRS component in ECG channels.
 
     QRS is the main wave on the heart beat.
@@ -45,6 +47,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
         Start detection after tstart seconds.
     filter_length : str | int | None
         Number of taps to use for filtering.
+    %(verbose)s
 
     Returns
     -------
@@ -55,7 +58,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
 
     filtecg = filter_data(ecg, sfreq, l_freq, h_freq, None, filter_length,
                           0.5, 0.5, phase='zero-double', fir_window='hann',
-                          fir_design='firwin2')
+                          fir_design='firwin2', verbose=verbose)
 
     ecg_abs = np.abs(filtecg)
     init = int(sfreq)
@@ -217,10 +220,11 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
             verbose=use_verbose))
     ecg = np.concatenate(ecgs)
 
-    # detecting QRS and generating event file
+    # detecting QRS and generating event file. Since not user-controlled, don't
+    # output filter params here (hardcode verbose=False)
     ecg_events = qrs_detector(raw.info['sfreq'], ecg, tstart=tstart,
                               thresh_value=qrs_threshold, l_freq=None,
-                              h_freq=None)
+                              h_freq=None, verbose=False)
 
     # map ECG events back to original times
     remap = np.empty(len(ecg), int)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -99,7 +99,7 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     filteog = filter_data(
         eog[indexmax], sampling_rate, l_freq, h_freq, None,
         filter_length, 0.5, 0.5, phase='zero-double', fir_window='hann',
-        fir_design='firwin2', verbose=verbose)
+        fir_design='firwin2')
 
     # detecting eog blinks and generating event file
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -67,25 +67,30 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
                                   sampling_rate=raw.info['sfreq'],
                                   first_samp=raw.first_samp,
                                   filter_length=filter_length,
-                                  tstart=tstart, thresh=thresh)
+                                  tstart=tstart, thresh=thresh,
+                                  verbose=verbose)
     # Map times to corresponding samples.
     eog_events[:, 0] = np.round(times[eog_events[:, 0] -
                                       raw.first_samp]).astype(int)
     return eog_events
 
 
+@verbose
 def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
-                     filter_length='10s', tstart=0., thresh=None):
+                     filter_length='10s', tstart=0., thresh=None,
+                     verbose=None):
     """Find EOG events."""
     logger.info('Filtering the data to remove DC offset to help '
                 'distinguish blinks from saccades')
 
     # filtering to remove dc offset so that we know which is blink and saccades
+    # hardcode verbose=False to suppress filter param messages (since this
+    # filter is not under user control)
     fmax = np.minimum(45, sampling_rate / 2.0 - 0.75)  # protect Nyquist
     filteog = np.array([filter_data(
         x, sampling_rate, 2, fmax, None, filter_length, 0.5, 0.5,
-        phase='zero-double', fir_window='hann', fir_design='firwin2')
-        for x in eog])
+        phase='zero-double', fir_window='hann', fir_design='firwin2',
+        verbose=False) for x in eog])
     temp = np.sqrt(np.sum(filteog ** 2, axis=1))
 
     indexmax = np.argmax(temp)
@@ -94,7 +99,7 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
     filteog = filter_data(
         eog[indexmax], sampling_rate, l_freq, h_freq, None,
         filter_length, 0.5, 0.5, phase='zero-double', fir_window='hann',
-        fir_design='firwin2')
+        fir_design='firwin2', verbose=verbose)
 
     # detecting eog blinks and generating event file
 


### PR DESCRIPTION
closes #6562 

I ended up taking a middle-road approach: hardcoding `verbose=False` where the user has no control over filter params, but leaving things as-is for filters where the params are passed through from the calling function. Now a call to `create_ecg_epochs` will spit out only one set of filter params instead of two (yes for the initial filtering step, but not for the call to `qrs_detector`). Passing `verbose=False` to `create_ecg_epochs` will of course suppress both filter param messages (as well as all the other ones like "reconstructing ECG from gradiometers" etc). 

Similar changes were made for EOG (only show filter param messages for the filters that users can control).