### PR TITLE
FIX: Mark test_plot_alignment as slowtest

### DIFF
--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -154,9 +154,9 @@ def test_plot_evoked_field(renderer):
             assert isinstance(fig, mayavi.core.scene.Scene)
 
 
+@pytest.mark.slowtest  # can be slow on OSX
 @testing.requires_testing_data
 @traits_test
-@pytest.mark.timeout(120)
 def test_plot_alignment(tmpdir, renderer):
     """Test plotting of -trans.fif files and MEG sensor layouts."""
     # generate fiducials file for testing


### PR DESCRIPTION
Fixes #6566 by marking `test_plot_alignment()` as `slowtest`.