### PR TITLE
FIX: match date_str in vmrk also when chn ref is negative

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug in :func:`mne.io.read_raw_brainvision` so that recording date timestamps are also recognized if channel reference data is negative, by `Stefan Appelhoff`_
+
 - Fix order of ``info['dig']`` that was alphabetical based on channel names and not following the channel order when using :meth:`mne.io.Raw.set_montage` and a :class:`mne.channels.Montage` object by `Joan Massich`_ and `Alex Gramfort`_.
 
 - Fix reading CNT files larger than 2Gb by `Joan Massich`_

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -463,7 +463,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
 
     # Try to get measurement date from marker file
     # Usually saved with a marker "New Segment", see BrainVision documentation
-    regexp = r'^Mk\d+=New Segment,.*,\d+,\d+,[-]?\d+,(\d{20})$'
+    regexp = r'^Mk\d+=New Segment,.*,\d+,\d+,-?\d+,(\d{20})$'
     with open(mrk_fname, 'r') as tmp_mrk_f:
         lines = tmp_mrk_f.readlines()
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -463,7 +463,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
 
     # Try to get measurement date from marker file
     # Usually saved with a marker "New Segment", see BrainVision documentation
-    regexp = r'^Mk\d+=New Segment,.*,\d+,\d+,\d+,(\d{20})$'
+    regexp = r'^Mk\d+=New Segment,.*,\d+,\d+,[-]?\d+,(\d{20})$'
     with open(mrk_fname, 'r') as tmp_mrk_f:
         lines = tmp_mrk_f.readlines()
 


### PR DESCRIPTION
Reference, [mailling list issue](https://mail.nmr.mgh.harvard.edu/pipermail//mne_analysis/2019-July/005992.html)

The regexp for BrainVision did not catch negative numbers in the slot that is responsible for telling us to which channels an event refers to.

see the regexp example: https://regex101.com/r/sDiTVs/2

the string to match is taken from the Demo files as shared in the mailing thread. The regexp is taken from here: https://github.com/mne-tools/mne-python/blob/7d27ad33bdfaa59465e45c620c8bb864adc7375f/mne/io/brainvision/brainvision.py#L466

This fix will repair this behavior. Although it is unclear, why in the BrainVision files there was a negative number. The numbers in that slot should be positive integers (=channel indices) ... or 0 (=event relates to ALL channels) --> what could a negative number mean? Is this an error in the BrainVision file?

According to the demo files, the data was written by PyCorder, not BrainVision Recorder. that could be a potential lead.