### PR TITLE
make mne's optParser more adaptable

### DIFF
--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -34,7 +34,7 @@ def load_module(name, path):
     return mod
 
 
-def get_optparser(cmdpath, usage=None, prog=None, version=None):
+def get_optparser(cmdpath, usage=None, prog_prefix='mne', version=None):
     """Create OptionParser with cmd specific settings (e.g., prog value)."""
     # Fetch description
     mod = load_module('__temp', cmdpath)
@@ -46,15 +46,13 @@ def get_optparser(cmdpath, usage=None, prog=None, version=None):
         if len(doc_lines) > 1:
             epilog = '\n'.join(doc_lines[1:])
 
-    # Set prog without command name for now
-    if prog is None:
-        prog = 'mne'
-
-    # Get the name of the command and update prog with that name
+    # Get the name of the command
     command = os.path.basename(cmdpath)
     command, _ = os.path.splitext(command)
-    command = command[len(prog) + 1:]  # +1 is for `_` character
-    prog += ' {}'.format(command)
+    command = command[len(prog_prefix) + 1:]  # +1 is for `_` character
+
+    # Set prog
+    prog = prog_prefix + ' {}'.format(command)
 
     # Set version
     if version is None:

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -1,6 +1,7 @@
-"""Some utility functions for commands (e.g. for cmdline handling)."""
+"""Some utility functions for commands (e.g., for cmdline handling)."""
 
 # Authors: Yaroslav Halchenko <debian@onerussian.com>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 
@@ -25,6 +26,7 @@ def load_module(name, path):
     -------
     mod : module
         Imported module.
+
     """
     from importlib.util import spec_from_file_location, module_from_spec
     spec = spec_from_file_location(name, path)
@@ -33,8 +35,8 @@ def load_module(name, path):
     return mod
 
 
-def get_optparser(cmdpath, usage=None):
-    """Create OptionParser with cmd specific settings (e.g. prog value)."""
+def get_optparser(cmdpath, usage=None, prog=None, version=None):
+    """Create OptionParser with cmd specific settings (e.g., prog value)."""
     command = os.path.basename(cmdpath)
     if re.match('mne_(.*).py', command):
         command = command[4:-3]
@@ -51,10 +53,18 @@ def get_optparser(cmdpath, usage=None):
         if len(doc_lines) > 1:
             epilog = '\n'.join(doc_lines[1:])
 
+    # Set prog
+    if prog is None:
+        prog = 'mne {}'.format(command)
+
+    # Set version
+    if version is None:
+        version = mne.__version__
+
     # monkey patch OptionParser to not wrap epilog
     OptionParser.format_epilog = lambda self, formatter: self.epilog
-    parser = OptionParser(prog="mne %s" % command,
-                          version=mne.__version__,
+    parser = OptionParser(prog=prog,
+                          version=version,
                           description=description,
                           epilog=epilog, usage=usage)
 

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -6,7 +6,6 @@
 # License: BSD (3-clause)
 
 import os
-import re
 from optparse import OptionParser
 
 import mne
@@ -37,12 +36,6 @@ def load_module(name, path):
 
 def get_optparser(cmdpath, usage=None, prog=None, version=None):
     """Create OptionParser with cmd specific settings (e.g., prog value)."""
-    command = os.path.basename(cmdpath)
-    if re.match('mne_(.*).py', command):
-        command = command[4:-3]
-    elif re.match('mne_(.*).pyc', command):
-        command = command[4:-4]
-
     # Fetch description
     mod = load_module('__temp', cmdpath)
     if mod.__doc__:
@@ -53,9 +46,15 @@ def get_optparser(cmdpath, usage=None, prog=None, version=None):
         if len(doc_lines) > 1:
             epilog = '\n'.join(doc_lines[1:])
 
-    # Set prog
+    # Set prog without command name for now
     if prog is None:
-        prog = 'mne {}'.format(command)
+        prog = 'mne'
+
+    # Get the name of the command and update prog with that name
+    command = os.path.basename(cmdpath)
+    command, _ = os.path.splitext(command)
+    command = command[len(prog) + 1:]  # +1 is for `_` character
+    prog += ' {}'.format(command)
 
     # Set version
     if version is None:


### PR DESCRIPTION
I expose the `prog_prefix` and `version` parameters for `get_optparser`. I need this for mne-bids: https://github.com/mne-tools/mne-bids/pull/225

it does not affect MNE-Python beyond making it more versatile / ready to use in other packages and modules.


Example:

in mne-bids I can now call:


```Python
from mne.commands.utils import get_optparser

import mne_bids

v = mne_bids.__version__
parser = get_optparser(__file__, usage=None, prog_prefix='mne_bids', version=v):
```

which will give me a parser that is aware of mne_bids' version and use the correct "prog" param (instead of `mne.__version__` as version and `mne` as prog_prefix)

For MNE-Python, nothing will change
