### PR TITLE
FIX: morph volumetric

### DIFF
--- a/mne/morph.py
+++ b/mne/morph.py
@@ -731,7 +731,7 @@ def _compute_morph_sdr(mri_from, mri_to, niter_affine=(100, 100, 10),
 
     # compute center of mass
     c_of_mass = imaffine.transform_centers_of_mass(
-        mri_to, affine, mri_from, affine)
+        mri_to, affine, mri_from, mri_from_affine)
 
     # set up Affine Registration
     affreg = imaffine.AffineRegistration(


### PR DESCRIPTION
I think `dipy.imaffine.transform_centers_of_mass` last param requires the `mri_from_affine` not the `mri_to_affine`, here simply called `affine` .

@agramfort 