### PR TITLE
fix ICA.plot_scores() barplot xlims

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -661,7 +661,7 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
                 label = ', '.join(label.split('/'))
             ax.set_title('(%s)' % label)
         ax.set_xlabel('ICA components')
-        ax.set_xlim(0, len(this_scores))
+        ax.set_xlim(-0.6, len(this_scores) - 0.4)
 
     tight_layout(fig=fig)
     plt_show(show)


### PR DESCRIPTION
Before this PR:

![before](https://user-images.githubusercontent.com/1810515/61679541-fff65280-acb2-11e9-9653-51a4720fefe0.png)

After this PR:

![after](https://user-images.githubusercontent.com/1810515/61679550-05ec3380-acb3-11e9-9765-1aefc7f823a5.png)
