### PR TITLE
DOC: better dataset crossrefs; move sidebar; better dataset page title

### DIFF
--- a/doc/manual/datasets_index.rst
+++ b/doc/manual/datasets_index.rst
@@ -1,7 +1,13 @@
 .. _datasets:
 
-Datasets
-########
+Datasets Overview
+#################
+
+.. sidebar:: Contributing datasets to MNE-Python
+
+    Do not hesitate to contact MNE-Python developers on the
+    `MNE mailing list <http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`_
+    to discuss the possibility of adding more publicly available datasets.
 
 All the dataset fetchers are available in :mod:`mne.datasets`. To download any of the datasets,
 use the ``data_path`` (fetches full dataset) or the ``load_data`` (fetches dataset partially) functions.
@@ -10,12 +16,6 @@ All fetchers will check the default download location first to see if the datase
 is already on your computer, and only download it if necessary. The default
 download location is also configurable; see the documentation of any of the
 ``data_path`` functions for more information.
-
-.. sidebar:: Contributing datasets in MNE-Python
-
-    Do not hesitate to contact MNE-Python developers on the
-    `MNE mailing list <http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`_
-    to discuss the possibility to add more publicly available datasets.
 
 .. contents:: Available datasets
    :local:

--- a/mne/datasets/__init__.py
+++ b/mne/datasets/__init__.py
@@ -1,6 +1,6 @@
 """Functions for fetching remote datasets.
 
-See `datasets`_ for more information.
+See :ref:`datasets` for more information.
 """
 
 from . import fieldtrip_cmc

--- a/tutorials/intro/plot_10_overview.py
+++ b/tutorials/intro/plot_10_overview.py
@@ -31,7 +31,7 @@ import mne
 # MNE-Python data structures are based around the FIF file format from
 # Neuromag, but there are reader functions for :ref:`a wide variety of other
 # data formats <data-formats>`. MNE-Python also has interfaces to a
-# variety of :doc:`publicly available datasets <../../manual/datasets_index>`,
+# variety of :ref:`publicly available datasets <datasets>`,
 # which MNE-Python can download and manage for you.
 #
 # We'll start this tutorial by loading one of the example datasets (called

--- a/tutorials/raw/plot_10_raw_overview.py
+++ b/tutorials/raw/plot_10_raw_overview.py
@@ -47,8 +47,8 @@ import mne
 # reader functions for :ref:`a wide variety of other data formats
 # <data-formats>` as well.
 #
-# There are also :doc:`several other example datasets
-# <../../manual/datasets_index>` that can be downloaded with just a few lines
+# There are also :ref:`several other example datasets
+# <datasets>` that can be downloaded with just a few lines
 # of code. Functions for downloading example datasets are in the
 # :mod:`mne.datasets` submodule; here we'll use
 # :func:`mne.datasets.sample.data_path` to download the ":ref:`sample-dataset`"


### PR DESCRIPTION
Main motivation for these changes is that when the docstring link in `mne.datasets.__init__.py` gets rendered by autodoc in `doc/python_reference.rst`, it ends up making a self-referential link.  Now it is a link to a different, more useful page (the datasets overview page). Also:

- changes a couple crossrefs targeting `datasets_index.rst` from `:doc:` to `:ref:` style
- updates the `datasets_index.rst` page title
- moves the sidebar in `datasets_index.rst` so it doesn't crash with the TOC