### PR TITLE
BUG: Restore conftest to doctests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-no-sample-with-coverage: in testing_data
 	$(PYTESTS) --cov=mne --cov-report html:coverage
 
 test-doc: sample_data testing_data
-	$(PYTESTS) --doctest-modules --doctest-ignore-import-errors --doctest-glob='*.rst' ./doc/ --ignore=./doc/auto_examples --ignore=./doc/auto_tutorials --ignore=./doc/_build
+	$(PYTESTS) --doctest-modules --doctest-ignore-import-errors --doctest-glob='*.rst' ./doc/ --ignore=./doc/auto_examples --ignore=./doc/auto_tutorials --ignore=./doc/_build --fulltrace
 
 test-coverage: testing_data
 	rm -rf coverage .coverage

--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -1,0 +1,1 @@
+from mne.conftest import *


### PR DESCRIPTION
We moved `conftest.py` into `mne` which is nice, but it made it so that it was not used in `doctests` because this is called with a variant of `pytest doc/`. This fixes it by writing a little wrapper within `doc/`.