### PR TITLE
doc magical 85 factor (=radius of head in mm), improve bvef handling

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,8 @@ Changelog
 Bug
 ~~~
 
+- Fix wrong assumptions about units in BrainVision montages and add test asserting units in "mm" or "auto", by `Stefan Appelhoff`_
+
 - Fix scaling issue with signals in mV in EDF files read with :func:`mne.io.read_raw_edf` by `Alex Gramfort`_
 
 - Fix bug in :func:`mne.io.read_raw_brainvision` so that recording date timestamps are also recognized if channel reference data is negative, by `Stefan Appelhoff`_

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -138,7 +138,7 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         a sphere with a radius capturing the average head size (8.5cm).
         Defaults to 'auto'.
     transform : bool
-        If True, points will be transformed to Neuromag space. The fidicuals,
+        If True, points will be transformed to Neuromag space. The fiducials,
         'nasion', 'lpa', 'rpa' must be specified in the montage file. Useful
         for points captured using Polhemus FastSCAN. Default is False.
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -6,6 +6,7 @@
 #          Jona Sassenhagen <jona.sassenhagen@gmail.com>
 #          Teon Brooks <teon.brooks@gmail.com>
 #          Christian Brodbeck <christianbrodbeck@nyu.edu>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: Simplified BSD
 
@@ -134,7 +135,8 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         mne/channels/data/montages folder in your mne-python installation.
     unit : 'm' | 'cm' | 'mm' | 'auto'
         Unit of the input file. When 'auto' the montage is normalized to
-        a sphere of radius equal to the average brain size. Defaults to 'auto'.
+        a sphere with a radius capturing the average head size (8.5cm).
+        Defaults to 'auto'.
     transform : bool
         If True, points will be transformed to Neuromag space. The fidicuals,
         'nasion', 'lpa', 'rpa' must be specified in the montage file. Useful
@@ -278,7 +280,9 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         ch_names_ = data[:, 0].tolist()
         az = np.deg2rad(data[:, 2].astype(float))
         pol = np.deg2rad(data[:, 1].astype(float))
-        pos = _sph_to_cart(np.array([np.ones(len(az)) * 85., az, pol]).T)
+        rad = np.ones(len(az))  # spherical head model
+        rad *= 85.  # scale up to realistic head radius (8.5cm == 85mm)
+        pos = _sph_to_cart(np.array([rad, az, pol]).T)
     elif ext == '.csd':
         # CSD toolbox
         try:  # newer version
@@ -305,7 +309,9 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         az = np.deg2rad(np.array([h if a >= 0. else 180 + h
                                   for h, a in zip(horiz, az)]))
         pol = radius * np.pi
-        pos = _sph_to_cart(np.array([np.ones(len(az)) * 85., az, pol]).T)
+        rad = np.ones(len(az))  # spherical head model
+        rad *= 85.  # scale up to realistic head radius (8.5cm == 85mm)
+        pos = _sph_to_cart(np.array([rad, az, pol]).T)
     elif ext == '.hpts':
         # MNE-C specified format for generic digitizer data
         fid_names = ['1', '2', '3']
@@ -322,19 +328,31 @@ def read_montage(kind, ch_names=None, path=None, unit='m', transform=False):
         pos[:, [0, 1]] = pos[:, [1, 0]] * [-1, 1]
     elif ext == '.bvef':
         # 'BrainVision Electrodes File' format
+        # Based on BrainVision Analyzer coordinate system: Defined between
+        # standard electrode positions: X-axis from T7 to T8, Y-axis from Oz to
+        # Fpz, Z-axis orthogonal from XY-plane through Cz, fit to a sphere if
+        # idealized (when radius=1), specified in millimeters
+        if unit not in ['auto', 'mm']:
+            raise ValueError('`unit` must be "auto" or "mm" for .bvef files.')
         root = ElementTree.parse(fname).getroot()
         ch_names_ = [s.text for s in root.findall("./Electrode/Name")]
         theta = [float(s.text) for s in root.findall("./Electrode/Theta")]
         pol = np.deg2rad(np.array(theta))
         phi = [float(s.text) for s in root.findall("./Electrode/Phi")]
         az = np.deg2rad(np.array(phi))
-        pos = _sph_to_cart(np.array([np.ones(len(az)) * 85., az, pol]).T)
+        rad = [float(s.text) for s in root.findall("./Electrode/Radius")]
+        rad = np.array(rad)  # specified in mm
+        if set(rad) == set([1]):
+            # idealized montage (spherical head model), scale up to realistic
+            # head radius (8.5cm == 85mm)
+            rad = np.array(rad) * 85.
+        pos = _sph_to_cart(np.array([rad, az, pol]).T)
     else:
         raise ValueError('Currently the "%s" template is not supported.' %
                          kind)
     selection = np.arange(len(pos))
 
-    if unit == 'auto':  # rescale to 0.085
+    if unit == 'auto':  # rescale to realistic head radius in meters: 0.085
         pos -= np.mean(pos, axis=0)
         pos = 0.085 * (pos / np.linalg.norm(pos, axis=1).mean())
     elif unit == 'mm':

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1,4 +1,5 @@
 # Author: Teon Brooks <teon.brooks@gmail.com>
+#         Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 
@@ -196,17 +197,18 @@ def test_montage():
         elp=[[-48.20043, 57.55106, 39.86971], [0.0, 60.73848, 59.4629],
              [48.1426, 57.58403, 39.89198], [41.64599, 66.91489, 31.8278]],
         hpts=[[-95, -3, -3], [-1, -1., -3.], [-2, -2, 2.], [0, 0, 0]],
-        bvef=[[-26.266444, 80.839803, 5.204748e-15],
-              [3.680313e-15, 60.104076, 60.104076],
-              [-46.325632, 57.207392, 42.500000],
-              [-68.766444, 49.961746, 5.204748e-15]],
+        bvef=[[-2.62664445e-02,  8.08398039e-02,  5.20474890e-18],
+              [3.68031324e-18,  6.01040764e-02,  6.01040764e-02],
+              [-4.63256329e-02,  5.72073923e-02,  4.25000000e-02],
+              [-6.87664445e-02,  4.99617464e-02,  5.20474890e-18]],
     )
     for key, text in inputs.items():
         kind = key.split('_')[-1]
         fname = op.join(tempdir, 'test.' + kind)
         with open(fname, 'w') as fid:
             fid.write(text)
-        montage = read_montage(fname)
+        unit = 'mm' if kind == 'bvef' else 'm'
+        montage = read_montage(fname, unit=unit)
         if kind in ('sfp', 'txt'):
             assert ('very_very_very_long_name' in montage.ch_names)
         assert_equal(len(montage.ch_names), 4)
@@ -231,6 +233,11 @@ def test_montage():
             assert_array_less(distance_from_centroid, 0.2)
             assert_array_less(0.01, distance_from_centroid)
         assert_array_almost_equal(poss[key], montage.pos, 4, err_msg=key)
+
+    # Bvef is either auto or mm in terms of "units"
+    with pytest.raises(ValueError, match='be "auto" or "mm" for .bvef files.'):
+        bvef_file = op.join(tempdir, 'test.' + 'bvef')
+        read_montage(bvef_file, unit='m')
 
     # Test reading in different letter case.
     ch_names = ["F3", "FZ", "F4", "FC3", "FCz", "FC4", "C3", "CZ", "C4", "CP3",

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -536,6 +536,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
         montage_pos = list()
         montage_names = list()
         to_misc = list()
+        # Go through channels
         for ch in cfg.items('Coordinates'):
             ch_name = ch_dict[ch[0]]
             montage_names.append(ch_name)
@@ -551,6 +552,9 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             if (pos == 0).all() and ch_name not in list(eog) + misc:
                 to_misc.append(ch_name)
             montage_pos.append(pos)
+        # Make a montage, normalizing from BrainVision units "mm" to "m", the
+        # unit used for montages in MNE
+        montage_pos = np.array(montage_pos) / 1e3
         montage_sel = np.arange(len(montage_pos))
         montage = Montage(montage_pos, montage_names, 'Brainvision',
                           montage_sel)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Conversion tool from Brain Vision EEG to FIF."""
-
 # Authors: Teon Brooks <teon.brooks@gmail.com>
 #          Christian Brodbeck <christianbrodbeck@nyu.edu>
 #          Eric Larson <larson.eric.d@gmail.com>

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -544,9 +544,9 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale, montage):
             pol = np.deg2rad(theta)
             az = np.deg2rad(phi)
             # Coordinates could be "idealized" (spherical head model)
-            if set(rad) == set([1]):
+            if rad == 1:
                 # scale up to realistic head radius (8.5cm == 85mm)
-                rad = [r_ * 85. for r_ in rad]
+                rad *= 85.
             pos = _sph_to_cart(np.array([[rad, az, pol]]))[0]
             if (pos == 0).all() and ch_name not in list(eog) + misc:
                 to_misc.append(ch_name)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -690,7 +690,19 @@ def _cart_to_sph(cart):
 
 
 def _sph_to_cart(sph):
-    """Convert spherical coordinates to Cartesion coordinates."""
+    """Convert spherical coordinates to Cartesion coordinates.
+
+    Parameters
+    ----------
+    sph_pts : ndarray, shape (n_points, 3)
+        Array containing points in spherical coordinates (rad, azimuth, polar)
+
+    Returns
+    -------
+    cart_pts : ndarray, shape (n_points, 3)
+        Array containing points in Cartesian coordinates (x, y, z)
+
+    """
     assert sph.ndim == 2 and sph.shape[1] == 3
     sph = np.atleast_2d(sph)
     out = np.empty((len(sph), 3))

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -689,7 +689,7 @@ def _cart_to_sph(cart):
     return out
 
 
-def _sph_to_cart(sph):
+def _sph_to_cart(sph_pts):
     """Convert spherical coordinates to Cartesion coordinates.
 
     Parameters
@@ -703,14 +703,14 @@ def _sph_to_cart(sph):
         Array containing points in Cartesian coordinates (x, y, z)
 
     """
-    assert sph.ndim == 2 and sph.shape[1] == 3
-    sph = np.atleast_2d(sph)
-    out = np.empty((len(sph), 3))
-    out[:, 2] = sph[:, 0] * np.cos(sph[:, 2])
-    xy = sph[:, 0] * np.sin(sph[:, 2])
-    out[:, 0] = xy * np.cos(sph[:, 1])
-    out[:, 1] = xy * np.sin(sph[:, 1])
-    return out
+    assert sph_pts.ndim == 2 and sph_pts.shape[1] == 3
+    sph_pts = np.atleast_2d(sph_pts)
+    cart_pts = np.empty((len(sph_pts), 3))
+    cart_pts[:, 2] = sph_pts[:, 0] * np.cos(sph_pts[:, 2])
+    xy = sph_pts[:, 0] * np.sin(sph_pts[:, 2])
+    cart_pts[:, 0] = xy * np.cos(sph_pts[:, 1])
+    cart_pts[:, 1] = xy * np.sin(sph_pts[:, 1])
+    return cart_pts
 
 
 def _get_n_moments(order):


### PR DESCRIPTION
This is related to my search of:

- what the magical factor of "85" means in the [montage reading code](https://github.com/mne-tools/mne-python/blob/d75bce15717ee4cbf2abbdb5c6e5148959000a91/mne/channels/montage.py#L331)
- what the difference between "BVCT" and "BVEF" files is
  - related to #6402, where @alexrockhill wants to introduce BVCT files

Long story short:

- **BVCT** = BrainVision CapTrack ... a digitization device: We get xyz coords in mm for the coordsystem bounded between LPA, RPA, and Nasion
  - this can be used as a proper DigMontage
- **BVEF** = BrainVision Electrode File ... the format that Brain Products uses in their "BrainVision Analyzer" software ... coords in mm for coordsystem between T7 and T8, Oz and Fpz, and that plane and Cz (see pics below)
  - this is **usually** based on a spherical head model (radius=1), and is more of a Montage, than a DigMontage ... HOWEVER, one *can* export from BVCT to BVEF ... and in that case, the BVEF actually contains proper radii 

In this PR I improve the docstrings and comments, to make life a tiny bit easier to understand (for users and future devs).

I also add a check to BVEF handling
- this MUST be in units of "mm" or "auto"
- I actually read the radii instead of automatically assuming they are 1 (which they are not necessarily, but most of the time)


# Long story long:
- Previous comments and inquiries:
  - https://gitter.im/mne-tools/mne-python?at=5d3239b7ec5abe7bbc13ab87
  - https://gitter.im/mne-tools/mne-python?at=5d3472c135e05c099376ce44
  - https://github.com/mne-tools/mne-python/pull/4109#issuecomment-513444467
  - https://github.com/mne-tools/mne-python/pull/4531/files#r305528241

I also wrote several Emails with BrainProducts customer support, ping me if you need more info.

# Pictures

#### BVCT

![image](https://user-images.githubusercontent.com/9084751/61800582-93539300-ae2d-11e9-9d8d-606f03b9e72d.png)


#### BVEF

![image](https://user-images.githubusercontent.com/9084751/61800539-820a8680-ae2d-11e9-8a82-af3a44692a9e.png)


