### PR TITLE
ENH: make GDF unknown events codes visible

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Unknown events code in GDF are now visible in the ``event_id`` by `Theodore Papadopoulo`_
+
 - Now :func:`mne.io.read_raw_ctf` populates ``raw.annotations`` with the markers in ``MarkerFile.mrk`` if any by `Joan Massich`_
 
 - Add support to :func:`mne.read_annotations` to read CTF marker files by `Joan Massich`_
@@ -3509,3 +3511,5 @@ of commits):
 .. _Thomas Radman: https://github.com/tradman
 
 .. _Paul Roujansky: https://github.com/paulroujansky
+
+.. _Theodore Papadopoulo: https://github.com/papadop

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -28,6 +28,9 @@ from ...annotations import Annotations, events_from_annotations
 from ._utils import _load_gdf_events_lut
 
 
+GDF_EVENTS_LUT = _load_gdf_events_lut()
+
+
 @deprecated('find_edf_events is deprecated in 0.18, and will be removed'
             ' in 0.19. Please use `mne.events_from_annotations` instead')
 def find_edf_events(raw):
@@ -235,8 +238,6 @@ class RawGDF(BaseRaw):
     mne.io.Raw : Documentation of attributes and methods.
     mne.io.read_raw_gdf : Recommended way to read GDF files.
     """
-
-    GDF_EVENTS_LUT = _load_gdf_events_lut()
 
     @verbose
     def __init__(self, input_fname, montage, eog=None, misc=None,
@@ -1436,8 +1437,6 @@ def _get_annotations_gdf(edf_info, sfreq):
     if events is not None and events[1].shape[0] > 0:
         onset = events[1] / sfreq
         duration = events[4] / sfreq
-        desc = [RawGDF.GDF_EVENTS_LUT[key]
-                if key in RawGDF.GDF_EVENTS_LUT
-                else 'Undefined(%s)' % key
+        desc = [GDF_EVENTS_LUT.get(key, 'Undefined(%s)' % (key,))
                 for key in events[2]]
     return onset, duration, desc

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1436,6 +1436,6 @@ def _get_annotations_gdf(edf_info, sfreq):
         onset = events[1] / sfreq
         duration = events[4] / sfreq
         desc = [RawGDF.GDF_EVENTS_LUT[key]
-                if key in RawGDF.GDF_EVENTS_LUT else 'Undefined('+key+')'
+                if key in RawGDF.GDF_EVENTS_LUT else 'Undefined('+str(key)+')'
                 for key in events[2]]
     return onset, duration, desc

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -28,9 +28,6 @@ from ...annotations import Annotations, events_from_annotations
 from ._utils import _load_gdf_events_lut
 
 
-GDF_EVENTS_LUT = _load_gdf_events_lut()
-
-
 @deprecated('find_edf_events is deprecated in 0.18, and will be removed'
             ' in 0.19. Please use `mne.events_from_annotations` instead')
 def find_edf_events(raw):
@@ -239,6 +236,8 @@ class RawGDF(BaseRaw):
     mne.io.read_raw_gdf : Recommended way to read GDF files.
     """
 
+    GDF_EVENTS_LUT = _load_gdf_events_lut()
+
     @verbose
     def __init__(self, input_fname, montage, eog=None, misc=None,
                  stim_channel='auto', exclude=(), preload=False, verbose=None):
@@ -277,8 +276,7 @@ class RawGDF(BaseRaw):
                 ' in 0.19. Please use `mne.events_from_annotations` instead')
     def find_edf_events(self):
         return events_from_annotations(self)
-
-
+        
 def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):
     """Read a number of samples for a single channel."""
     # BDF
@@ -1437,8 +1435,7 @@ def _get_annotations_gdf(edf_info, sfreq):
     if events is not None and events[1].shape[0] > 0:
         onset = events[1] / sfreq
         duration = events[4] / sfreq
-        desc = [GDF_EVENTS_LUT[key]
-                if key in GDF_EVENTS_LUT else 'Unknown'
+        desc = [RawGDF.GDF_EVENTS_LUT[key]
+                if key in RawGDF.GDF_EVENTS_LUT else 'Undefined('+key+')'
                 for key in events[2]]
-
     return onset, duration, desc

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -276,7 +276,8 @@ class RawGDF(BaseRaw):
                 ' in 0.19. Please use `mne.events_from_annotations` instead')
     def find_edf_events(self):
         return events_from_annotations(self)
-        
+
+
 def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):
     """Read a number of samples for a single channel."""
     # BDF
@@ -1436,6 +1437,7 @@ def _get_annotations_gdf(edf_info, sfreq):
         onset = events[1] / sfreq
         duration = events[4] / sfreq
         desc = [RawGDF.GDF_EVENTS_LUT[key]
-                if key in RawGDF.GDF_EVENTS_LUT else 'Undefined('+str(key)+')'
+                if key in RawGDF.GDF_EVENTS_LUT
+                else 'Undefined(' + str(key) + ')'
                 for key in events[2]]
     return onset, duration, desc

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1438,6 +1438,6 @@ def _get_annotations_gdf(edf_info, sfreq):
         duration = events[4] / sfreq
         desc = [RawGDF.GDF_EVENTS_LUT[key]
                 if key in RawGDF.GDF_EVENTS_LUT
-                else 'Undefined(' + str(key) + ')'
+                else 'Undefined(%s)' % key
                 for key in events[2]]
     return onset, duration, desc

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -16,7 +16,7 @@ from mne.io.meas_info import DATE_NONE
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import run_tests_if_main
 from mne import pick_types, find_events, events_from_annotations
-from mne.io.edf.edf import RawGDF
+from mne.io.edf.edf import GDF_EVENTS_LUT
 
 data_path = testing.data_path(download=False)
 gdf1_path = op.join(data_path, 'GDF', 'test_gdf_1.25')
@@ -32,13 +32,14 @@ def test_gdf_data():
 
     # Test Status is added as event
     EXPECTED_EVS_ONSETS = raw._raw_extras[0]['events'][1]
+    EXPECTED_EVS_ID = {
+        'Undefined({})'.format(evs): i for i, evs in enumerate(
+            [32769, 32770, 33024, 33025, 33026, 33027, 33028, 33029, 33040,
+             33041, 33042, 33043, 33044, 33045, 33285, 33286], 1)
+    }
     evs, evs_id = events_from_annotations(raw)
     assert_array_equal(evs[:, 0], EXPECTED_EVS_ONSETS)
-    undefined_ids = [32769, 32770, 33024, 33025, 33026, 33027, 33028,
-                     33029, 33040, 33041, 33042, 33043, 33044, 33045,
-                     33285, 33286]
-    assert evs_id == {'Undefined(%s)' % index: i + 1
-                      for i, index in enumerate(undefined_ids)}
+    assert evs_id == EXPECTED_EVS_ID
 
     # this .npy was generated using the official biosig python package
     raw_biosig = np.load(gdf1_path + '_biosig.npy')
@@ -85,7 +86,7 @@ def test_gdf2_data():
 
 def test_gdf_events_lut():
     """Test something about GDF_EVENTS_LUT to make sure it has not changed."""
-    assert len(RawGDF.GDF_EVENTS_LUT) == 200
+    assert len(GDF_EVENTS_LUT) == 200
 
 
 run_tests_if_main()

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -16,7 +16,6 @@ from mne.io.meas_info import DATE_NONE
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import run_tests_if_main
 from mne import pick_types, find_events, events_from_annotations
-from mne.io.edf.edf import GDF_EVENTS_LUT
 
 data_path = testing.data_path(download=False)
 gdf1_path = op.join(data_path, 'GDF', 'test_gdf_1.25')
@@ -81,7 +80,7 @@ def test_gdf2_data():
 
 def test_gdf_events_lut():
     """Test something about GDF_EVENTS_LUT to make sure it has not changed."""
-    assert len(GDF_EVENTS_LUT) == 200
+    assert len(mne.io.edf.edf.RawGDF.GDF_EVENTS_LUT) == 200
 
 
 run_tests_if_main()

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -34,8 +34,11 @@ def test_gdf_data():
     EXPECTED_EVS_ONSETS = raw._raw_extras[0]['events'][1]
     evs, evs_id = events_from_annotations(raw)
     assert_array_equal(evs[:, 0], EXPECTED_EVS_ONSETS)
-    undefined_ids = [32769,32770,33024,33025,33026,33027,33028,33029,33040,33041,33042,33043,33044,33045,33285,33286]
-    assert evs_id == {'Undefined('+str(index)+')': i+1 for i,index in enumerate(undefined_ids) }
+    undefined_ids = [32769, 32770, 33024, 33025, 33026, 33027, 33028,
+                     33029, 33040, 33041, 33042, 33043, 33044, 33045,
+                     33285, 33286]
+    assert evs_id == {'Undefined(' + str(index) + ')': i + 1
+                      for i, index in enumerate(undefined_ids)}
 
     # this .npy was generated using the official biosig python package
     raw_biosig = np.load(gdf1_path + '_biosig.npy')

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -37,7 +37,7 @@ def test_gdf_data():
     undefined_ids = [32769, 32770, 33024, 33025, 33026, 33027, 33028,
                      33029, 33040, 33041, 33042, 33043, 33044, 33045,
                      33285, 33286]
-    assert evs_id == {'Undefined(' + str(index) + ')': i + 1
+    assert evs_id == {'Undefined(%s)' % index: i + 1
                       for i, index in enumerate(undefined_ids)}
 
     # this .npy was generated using the official biosig python package

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -34,7 +34,8 @@ def test_gdf_data():
     EXPECTED_EVS_ONSETS = raw._raw_extras[0]['events'][1]
     evs, evs_id = events_from_annotations(raw)
     assert_array_equal(evs[:, 0], EXPECTED_EVS_ONSETS)
-    assert evs_id == {'Unknown': 1}
+    undefined_ids = [32769,32770,33024,33025,33026,33027,33028,33029,33040,33041,33042,33043,33044,33045,33285,33286]
+    assert evs_id == {'Undefined('+str(index)+')': i+1 for i,index in enumerate(undefined_ids) }
 
     # this .npy was generated using the official biosig python package
     raw_biosig = np.load(gdf1_path + '_biosig.npy')

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -16,6 +16,7 @@ from mne.io.meas_info import DATE_NONE
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import run_tests_if_main
 from mne import pick_types, find_events, events_from_annotations
+from mne.io.edf.edf import RawGDF
 
 data_path = testing.data_path(download=False)
 gdf1_path = op.join(data_path, 'GDF', 'test_gdf_1.25')
@@ -80,7 +81,7 @@ def test_gdf2_data():
 
 def test_gdf_events_lut():
     """Test something about GDF_EVENTS_LUT to make sure it has not changed."""
-    assert len(mne.io.edf.edf.RawGDF.GDF_EVENTS_LUT) == 200
+    assert len(RawGDF.GDF_EVENTS_LUT) == 200
 
 
 run_tests_if_main()


### PR DESCRIPTION
#### Reference issue
Fix #6601.

#### What does this implement/fix?
This makes two things:
- The 'Unknown' description is replaced by 'Undefined(number)' where number is the number in the gdf event table. This avoids collapsing all 'Unknown' events under the same tag and allows to keep event identity.
- The global variable  GDF_EVENTS_LUT becomes a RawGDF static member. This at least allows the user to add its own events to the table before reading a file.

Example:
mne.io.edf.edf.RawGDF.GDF_EVENTS_LUT[198] = 'Non Target'
mne.io.edf.edf.RawGDF.GDF_EVENTS_LUT[190] = 'Target'
signal = mne.io.read_raw_edf('datafile.gdf',preload=True)
vents = mne.events_from_annotations(signal)
Used Annotations descriptions: ['Non Target', 'Target', 'Undefined(0)', 'Undefined(181)', 'Undefined(182)', 'Undefined(183)', 'Undefined(184)', 'Undefined(187)', 'Undefined(193)', 'Undefined(199)', 'Undefined(27)', 'Undefined(36)', 'Undefined(37)', 'Undefined(39)', 'Undefined(40)', 'Undefined(42)', 'Undefined(44)', 'Undefined(45)', 'Undefined(46)', 'condition 11', 'condition 12', 'condition 14', 'condition 17', 'condition 2', 'condition 20', 'condition 23', 'condition 3', 'condition 48']

Before the patch, all the 'Undefined(*)' as well as 'Non Target' and 'Target' where collapsed with the tag 'Unknown' and the identifier 1, which definitely looses information.

#### Additional information
As depicted in issue #6601, I think that mapping events to descriptions in _get_annotations_gdf is not desirable. My preference would be to keep the original event ids. The LUT can still be provided as an helper. But, I do not have the big picture here and I'm afraid that changing the code by just removing the computation of desc and returning (onset, duration, events[2]) might create issues somewhere else....
Honestly, I do not understand the whole _get_annotations_gdf function. In my opinion, it should do minimal stuff, i.e. just normalizing the data to a common data structure. I would even not change the representation of onset and duration (from sample id to seconds).

Given that desc mapping is gdf specific, I do not see a big risk in just keeping events[2] as the description (thus removing the major issue). As of changing onset and duration to sample instead of seconds, this probably requires work in other readers and functions such as events_from_annotations.... I can propose a patch but would need of some guidance/validation before doing too much work.
