### PR TITLE
MRG, ENH: Optimize using low-level BLAS/LAPACK

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ omit =
     */bin/*
     */setup.py
     */mne/fixes*
+    */mne/utils/linalg.py

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -241,7 +241,8 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
 
     logger.info('Computing beamformer filters for %d source%s'
                 % (n_sources, _pl(n_sources)))
-    svd_lwork = _svd_lwork((3, 3), Cm.dtype)
+    svd_lwork = _svd_lwork((3, 3), Cm.dtype)  # for real or complex
+    real_svd_lwork = _svd_lwork((3, 3))  # for one that will always be real
     eig_lwork = _eig_lwork((3, 3), Cm.dtype)
     inv_lwork = _inv_lwork((3, 3), Cm.dtype)
     for k in range(n_sources):
@@ -293,7 +294,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                     power = Wk.dot(Cm).dot(Wk.T)
 
                 # Compute the direction of max power
-                u, s, _ = _repeated_svd(power.real, svd_lwork)
+                u, s, _ = _repeated_svd(power.real, real_svd_lwork)
                 max_power_ori = u[:, 0]
 
                 # set the (otherwise arbitrary) sign to match the normal

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import linalg
 
 from ..rank import compute_rank
+from ..io.meas_info import _simplify_info
 from ..io.pick import pick_channels_cov, pick_info
 from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference, _check_depth
@@ -123,6 +124,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
            brain imaging (2008) Springer Science & Business Media
     """
     # check number of sensor types present in the data and ensure a noise cov
+    info = _simplify_info(info)
     noise_cov, _ = _check_one_ch_type('lcmv', info, forward,
                                       data_cov, noise_cov)
     # XXX we need this extra picking step (can't just rely on minimum norm's

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -48,7 +48,7 @@ from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
-                    _check_option, _gesdd_lwork, _repeated_svd,
+                    _check_option, _svd_lwork, _repeated_svd,
                     ddot, dgemm, dgemv)
 
 # Eventually we should add:
@@ -396,7 +396,7 @@ def _fit_magnetic_dipole(B_orig, x0, coils, scale, method, too_close):
     from scipy.optimize import fmin_cobyla
     B = dgemv(alpha=1, a=scale, x=B_orig)  # np.dot(scale, B_orig)
     B2 = ddot(B, B)  # np.dot(B, B)
-    lwork = _gesdd_lwork((3, B_orig.shape[0]))
+    lwork = _svd_lwork((3, B_orig.shape[0]))
     objective = partial(_magnetic_dipole_objective, B=B, B2=B2,
                         coils=coils, scale=scale, method=method,
                         too_close=too_close, lwork=lwork)

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -372,7 +372,8 @@ def _get_hpi_initial_fit(info, adjust=False, verbose=None):
     return hpi_rrs
 
 
-def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close):
+def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close,
+                               dot, gemv, gemm, gesdd, lwork):
     """Project data onto right eigenvectors of whitened forward."""
     if method == 'forward':
         fwd = _magnetic_dipole_field_vec(x[np.newaxis, :], coils, too_close)
@@ -381,21 +382,38 @@ def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close):
         # Eventually we can try incorporating external bases here, which
         # is why the :3 is on the SVD below
         fwd = _sss_basis(dict(origin=x, int_order=1, ext_order=0), coils).T
-    fwd = np.dot(fwd, scale.T)
-    one = np.dot(linalg.svd(fwd, full_matrices=False)[2][:3], B)
-    one *= one
-    Bm2 = one.sum()
+    # Here we use .T to get scale to Fortran order, which speeds things up
+    fwd = gemm(alpha=1., a=fwd, b=scale.T)  # np.dot(fwd, scale.T)
+    _, _, one, info = gesdd(fwd, compute_uv=True, lwork=lwork,
+                            full_matrices=False, overwrite_a=True)
+    if info > 0:
+        raise linalg.LinAlgError("SVD did not converge")
+    if info < 0:
+        raise ValueError('illegal value in %d-th argument of internal gesdd'
+                         % -info)
+    one = gemv(alpha=1, a=one, x=B)
+    Bm2 = dot(one, one)
     return B2 - Bm2
 
 
 def _fit_magnetic_dipole(B_orig, x0, coils, scale, method, too_close):
     """Fit a single bit of data (x0 = pos)."""
     from scipy.optimize import fmin_cobyla
-    B = np.dot(scale, B_orig)
-    B2 = np.dot(B, B)
+    # We will operate on B-like matrices
+    gemm = linalg.get_blas_funcs("gemm", (B_orig,))
+    gemv = linalg.get_blas_funcs("gemv", (B_orig,))
+    dot = linalg.get_blas_funcs("dot", (B_orig,))
+    gesdd, lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (B_orig,))
+    lwork = linalg.decomp_svd._compute_lwork(
+        lwork, 3, B_orig.shape[0], compute_uv=True, full_matrices=False)
+    # actually do the math
+    B = gemv(alpha=1, a=scale, x=B_orig)  # np.dot(scale, B_orig)
+    B2 = dot(B, B)
     objective = partial(_magnetic_dipole_objective, B=B, B2=B2,
                         coils=coils, scale=scale, method=method,
-                        too_close=too_close)
+                        too_close=too_close,
+                        dot=dot, gemv=gemv,
+                        gemm=gemm, gesdd=gesdd, lwork=lwork)
     x = fmin_cobyla(objective, x0, (), rhobeg=1e-4, rhoend=1e-5, disp=False)
     return x, 1. - objective(x) / B2
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -48,7 +48,7 @@ from .cov import make_ad_hoc_cov, compute_whitener
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
-                    _check_option, _dgesdd_lwork, _repeated_svd,
+                    _check_option, _gesdd_lwork, _repeated_svd,
                     ddot, dgemm, dgemv)
 
 # Eventually we should add:
@@ -396,7 +396,7 @@ def _fit_magnetic_dipole(B_orig, x0, coils, scale, method, too_close):
     from scipy.optimize import fmin_cobyla
     B = dgemv(alpha=1, a=scale, x=B_orig)  # np.dot(scale, B_orig)
     B2 = ddot(B, B)  # np.dot(B, B)
-    lwork = _dgesdd_lwork((3, B_orig.shape[0]))
+    lwork = _gesdd_lwork((3, B_orig.shape[0]))
     objective = partial(_magnetic_dipole_objective, B=B, B2=B2,
                         coils=coils, scale=scale, method=method,
                         too_close=too_close, lwork=lwork)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -36,7 +36,7 @@ from .rank import compute_rank
 from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     warn, copy_function_doc_to_method_doc, _pl,
                     _undo_scaling_cov, _scaled_array, _validate_type,
-                    _check_option)
+                    _check_option, eigh)
 from . import viz
 
 from .fixes import BaseEstimator, EmpiricalCovariance, _logdet
@@ -892,7 +892,7 @@ def _eigvec_subspace(eig, eigvec, mask):
     """Compute the subspace from a subset of eigenvectors."""
     # We do the same thing we do with projectors:
     P = np.eye(len(eigvec)) - np.dot(eigvec[~mask].T, eigvec[~mask])
-    eig, eigvec = linalg.eigh(P)
+    eig, eigvec = eigh(P)
     eigvec = eigvec.T
     return eig, eigvec
 
@@ -1289,7 +1289,7 @@ def _unpack_epochs(epochs):
 def _get_ch_whitener(A, pca, ch_type, rank):
     """Get whitener params for a set of channels."""
     # whitening operator
-    eig, eigvec = linalg.eigh(A, overwrite_a=True)
+    eig, eigvec = eigh(A, overwrite_a=True)
     eigvec = eigvec.T
     mask = np.ones(len(eig), bool)
     eig[:-rank] = 0.0

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -32,7 +32,8 @@ from .source_space import (_make_volume_source_space, SourceSpaces,
                            _points_outside_surface)
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
-                    check_fname, _pl, fill_doc, _check_option)
+                    check_fname, _pl, fill_doc, _check_option,
+                    _svd_lwork, _repeated_svd)
 
 
 @fill_doc
@@ -649,11 +650,12 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs):
     return SourceSpaces([src])
 
 
-def _fit_eval(rd, B, B2, fwd_svd=None, fwd_data=None, whitener=None):
+def _fit_eval(rd, B, B2, fwd_svd=None, fwd_data=None, whitener=None,
+              lwork=None):
     """Calculate the residual sum of squares."""
     if fwd_svd is None:
         fwd = _dipole_forwards(fwd_data, whitener, rd[np.newaxis, :])[0]
-        uu, sing, vv = linalg.svd(fwd, overwrite_a=True, full_matrices=False)
+        uu, sing, vv = _repeated_svd(fwd, lwork, overwrite_a=True)
     else:
         uu, sing, vv = fwd_svd
     gof = _dipole_gof(uu, sing, vv, B, B2)[0]
@@ -931,7 +933,9 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
     idx = np.argmin([_fit_eval(guess_rrs[[fi], :], B, B2, fwd_svd)
                      for fi, fwd_svd in enumerate(guess_data['fwd_svd'])])
     x0 = guess_rrs[idx]
-    fun = partial(_fit_eval, B=B, B2=B2, fwd_data=fwd_data, whitener=whitener)
+    lwork = _svd_lwork((3, B.shape[0]))
+    fun = partial(_fit_eval, B=B, B2=B2, fwd_data=fwd_data, whitener=whitener,
+                  lwork=lwork)
 
     # Tested minimizers:
     #    Simplex, BFGS, CG, COBYLA, L-BFGS-B, Powell, SLSQP, TNC

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1038,7 +1038,7 @@ def log_likelihood(emp_cov, precision):
 
 def _logdet(A):
     """Compute the log det of a positive semidefinite matrix."""
-    vals = linalg.eigh(A)[0]
+    vals = linalg.eigvalsh(A)
     # avoid negative (numerical errors) or zero (semi-definite matrix) values
     tol = vals.max() * vals.size * np.finfo(np.float64).eps
     vals = np.where(vals > tol, vals, tol)

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -646,7 +646,7 @@ def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
     else:
         rmags, cosmags, ws, bins = _concatenate_coils(coils)
     del coils
-    fwd = np.empty((3 * len(rrs), bins[-1] + 1))
+    fwd = np.empty((3 * len(rrs), bins[-1] + 1), order='F')
     for ri, rr in enumerate(rrs):
         diff = rmags - rr
         dist2 = np.sum(diff * diff, axis=1)[:, np.newaxis]

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -621,6 +621,10 @@ def _eeg_spherepot_coil(rrs, coils, sphere):
     return B
 
 
+def _triage_coils(coils):
+    return coils if isinstance(coils, tuple) else _concatenate_coils(coils)
+
+
 # #############################################################################
 # MAGNETIC DIPOLE (e.g. CHPI)
 
@@ -641,10 +645,7 @@ def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
     #                                   axis=1)[:, np.newaxis] -
     #                 dist2 * this_coil['cosmag']) / dist5
     #         fwd[3*ri:3*ri+3, k] = 1e-7 * np.dot(this_coil['w'], sum_)
-    if isinstance(coils, tuple):
-        rmags, cosmags, ws, bins = coils
-    else:
-        rmags, cosmags, ws, bins = _concatenate_coils(coils)
+    rmags, cosmags, ws, bins = _triage_coils(coils)
     del coils
     fwd = np.empty((3 * len(rrs), bins[-1] + 1), order='F')
     for ri, rr in enumerate(rrs):

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -427,6 +427,7 @@ def _bem_pot_or_field(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs,
 
     # Only MEG coils are sensitive to the primary current distribution.
     if coil_type == 'meg':
+        # Primary current contribution (can be calc. in coil/dipole coords)
         parallel, p_fun, _ = parallel_func(_do_prim_curr, n_jobs)
         pcc = np.concatenate(parallel(p_fun(r, coils)
                                       for r in nas(rr, n_jobs)), axis=0)

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -779,8 +779,8 @@ def _prep_field_computation(rr, bem, fwd_data, n_jobs, verbose=None):
                          coils_list=coils_list, ccoils_list=ccoils_list))
 
 
-@verbose
-def _compute_forwards_meeg(rr, fd, n_jobs, verbose=None):
+@fill_doc
+def _compute_forwards_meeg(rr, fd, n_jobs, silent=False):
     """Compute MEG and EEG forward solutions for all sensor types.
 
     Parameters
@@ -790,7 +790,9 @@ def _compute_forwards_meeg(rr, fd, n_jobs, verbose=None):
     fd : dict
         Dict containing forward data after update in _prep_field_computation
     %(n_jobs)s
-    %(verbose)s
+    silent : bool
+        If True, don't emit logger.info.
+        This saves time over ``verbose`` when this function is called a lot.
 
     Returns
     -------
@@ -816,9 +818,10 @@ def _compute_forwards_meeg(rr, fd, n_jobs, verbose=None):
         info = fd['infos'][ci]
 
         # Do the actual forward calculation for a list MEG/EEG sensors
-        logger.info('Computing %s at %d source location%s '
-                    '(free orientations)...'
-                    % (coil_type.upper(), len(rr), _pl(rr)))
+        if not silent:
+            logger.info('Computing %s at %d source location%s '
+                        '(free orientations)...'
+                        % (coil_type.upper(), len(rr), _pl(rr)))
         # Calculate forward solution using spherical or BEM model
         B = fun(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs,
                 coil_type)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -547,7 +547,7 @@ def read_forward_solution(fname, include=(), exclude=(), verbose=None):
     fwd['_orig_source_ori'] = fwd['source_ori']
 
     #   Deal with include and exclude
-    fwd = pick_channels_forward(fwd, include=include, exclude=exclude)
+    pick_channels_forward(fwd, include=include, exclude=exclude, copy=False)
 
     if is_fixed_orient(fwd, orig=True):
         fwd['source_nn'] = np.concatenate([_src['nn'][_src['vertno'], :]
@@ -951,8 +951,7 @@ def write_forward_meas_info(fid, info):
     end_block(fid, FIFF.FIFFB_MNE_PARENT_MEAS_FILE)
 
 
-@verbose
-def _select_orient_forward(forward, info, noise_cov=None, verbose=None):
+def _select_orient_forward(forward, info, noise_cov=None, copy=True):
     """Prepare forward solution for inverse solvers."""
     # fwd['sol']['row_names'] may be different order from fwd['info']['chs']
     fwd_sol_ch_names = forward['sol']['row_names']
@@ -977,7 +976,8 @@ def _select_orient_forward(forward, info, noise_cov=None, verbose=None):
 
     n_chan = len(ch_names)
     logger.info("Computing inverse operator with %d channels." % n_chan)
-    forward = pick_channels_forward(forward, ch_names, ordered=True)
+    forward = pick_channels_forward(forward, ch_names, ordered=True,
+                                    copy=copy)
     info_idx = [info['ch_names'].index(name) for name in ch_names]
     info_picked = pick_info(info, info_idx)
     forward['info']._check_consistency()

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -538,7 +538,7 @@ def pick_channels_evoked(orig, include=[], exclude='bads'):
 
 @verbose
 def pick_channels_forward(orig, include=[], exclude=[], ordered=False,
-                          verbose=None):
+                          copy=True, verbose=None):
     """Pick channels from forward operator.
 
     Parameters
@@ -556,6 +556,10 @@ def pick_channels_forward(orig, include=[], exclude=[], ordered=False,
         rather than a set.
 
         .. versionadded:: 0.18
+    copy : bool
+        If True (default), make a copy.
+
+        .. versionadded:: 0.19
     %(verbose)s
 
     Returns
@@ -566,7 +570,7 @@ def pick_channels_forward(orig, include=[], exclude=[], ordered=False,
     """
     orig['info']._check_consistency()
     if len(include) == 0 and len(exclude) == 0:
-        return orig
+        return orig.copy() if copy else orig
     exclude = _check_excludes_includes(exclude,
                                        info=orig['info'], allow_bads=True)
 
@@ -577,7 +581,7 @@ def pick_channels_forward(orig, include=[], exclude=[], ordered=False,
     sel_info = pick_channels(orig['info']['ch_names'], include=include,
                              exclude=exclude, ordered=ordered)
 
-    fwd = deepcopy(orig)
+    fwd = deepcopy(orig) if copy else orig
 
     # Check that forward solution and original data file agree on #channels
     if len(sel_sol) != len(sel_info):

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -8,7 +8,7 @@ from scipy import linalg
 
 from ..defaults import _handle_default
 from ..fixes import _safe_svd
-from ..utils import warn, logger, _dgesdd_lwork, _repeated_pinv2
+from ..utils import warn, logger, _gesdd_lwork, _repeated_pinv2
 
 
 # For the reference implementation of eLORETA (force_equal=False),
@@ -113,7 +113,7 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
     """Invert weights and compute M."""
     W_inv = np.empty_like(W)
     n_src = W_inv.shape[0]
-    lwork = _dgesdd_lwork((3, 3))
+    lwork = _gesdd_lwork((3, 3))
     if n_orient == 1 or force_equal:
         W_inv[:] = 1. / W
     else:

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -84,8 +84,8 @@ def _compute_eloreta(inv, lambda2, options):
             W /= norm / n_src
 
         # Check for weight convergence
-        delta = (linalg.norm(W.ravel() - W_last.ravel()) /
-                 linalg.norm(W_last.ravel()))
+        delta = (np.linalg.norm(W.ravel() - W_last.ravel()) /
+                 np.linalg.norm(W_last.ravel()))
         logger.debug('            Iteration %s / %s ...%s'
                      % (kk + 1, max_iter, extra))
         if delta < eps:
@@ -116,7 +116,7 @@ def _compute_eloreta(inv, lambda2, options):
 def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal,
                          pinv2_lwork, svd_lwork):
     """Invert weights and compute M."""
-    W_inv = np.empty_like(W)
+    W_inv = np.empty(W.shape)
     n_src = W_inv.shape[0]
     if n_orient == 1 or force_equal:
         W_inv[:] = 1. / W

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -8,7 +8,8 @@ from scipy import linalg
 
 from ..defaults import _handle_default
 from ..fixes import _safe_svd
-from ..utils import warn, logger, _svd_lwork, _repeated_pinv2
+from ..utils import (warn, logger, _svd_lwork, _repeated_svd, _repeated_pinv2,
+                     eigh)
 
 
 # For the reference implementation of eLORETA (force_equal=False),
@@ -59,10 +60,12 @@ def _compute_eloreta(inv, lambda2, options):
     extra = ' (this make take a while)' if n_orient == 3 else ''
     logger.info('        Fitting up to %d iterations%s...'
                 % (max_iter, extra))
+    pinv2_lwork = _svd_lwork((3, 3))
+    svd_lwork = _svd_lwork((G.shape[0], G.shape[0]))
     for kk in range(max_iter):
         # Compute inverse of the weights (stabilized) and corresponding M
         M, _ = _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2,
-                                    force_equal)
+                                    force_equal, pinv2_lwork, svd_lwork)
 
         # Update the weights
         W_last = W.copy()
@@ -74,7 +77,8 @@ def _compute_eloreta(inv, lambda2, options):
             for ii in range(n_src):
                 sl = slice(n_orient * ii, n_orient * (ii + 1))
                 this_w, this_s = _sqrtm_sym(
-                    np.dot(np.dot(G[:, sl].T, M), G[:, sl]))
+                    np.dot(np.dot(G[:, sl].T, M), G[:, sl]),
+                    overwrite_a=True, check_finite=False)
                 W[ii] = np.mean(this_s) if force_equal else this_w
                 norm += np.mean(this_s)
             W /= norm / n_src
@@ -92,7 +96,7 @@ def _compute_eloreta(inv, lambda2, options):
         warn('eLORETA weight fitting did not converge (>= %s)' % eps)
     logger.info('        Assembling eLORETA kernel and modifying inverse')
     M, W_inv = _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2,
-                                    force_equal)
+                                    force_equal, pinv2_lwork, svd_lwork)
     K = np.zeros((n_src * n_orient, n_chan))
     for ii in range(n_src):
         sl = slice(n_orient * ii, n_orient * (ii + 1))
@@ -109,11 +113,11 @@ def _compute_eloreta(inv, lambda2, options):
     return W
 
 
-def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
+def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal,
+                         pinv2_lwork, svd_lwork):
     """Invert weights and compute M."""
     W_inv = np.empty_like(W)
     n_src = W_inv.shape[0]
-    lwork = _svd_lwork((3, 3))
     if n_orient == 1 or force_equal:
         W_inv[:] = 1. / W
     else:
@@ -121,10 +125,10 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
             # Here we use a single-precision-suitable `rcond` (given our
             # 3x3 matrix size) because the inv could be saved in single
             # precision.
-            W_inv[ii] = _repeated_pinv2(W[ii], lwork, rcond=1e-7)
+            W_inv[ii] = _repeated_pinv2(W[ii], rcond=1e-7, lwork=pinv2_lwork)
 
     # Weight the gain matrix
-    W_inv_Gt = np.empty_like(G).T
+    W_inv_Gt = np.empty(G.shape[::-1])
     for ii in range(n_src):
         sl = slice(n_orient * ii, n_orient * (ii + 1))
         W_inv_Gt[sl, :] = np.dot(W_inv[ii], G[:, sl].T)
@@ -132,16 +136,16 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
     # Compute the inverse, normalizing by the trace
     G_W_inv_Gt = np.dot(G, W_inv_Gt)
     G_W_inv_Gt *= n_nzero / np.trace(G_W_inv_Gt)
-    u, s, v = linalg.svd(G_W_inv_Gt)
+    u, s, v = _repeated_svd(G_W_inv_Gt, lwork=svd_lwork)
     s = s / (s ** 2 + lambda2)
     M = np.dot(v.T[:, :n_nzero] * s[:n_nzero], u.T[:n_nzero])
     return M, W_inv
 
 
-def _sqrtm_sym(C):
+def _sqrtm_sym(C, overwrite_a=False, check_finite=True):
     """Compute the square root of a symmetric matrix."""
     # Same as linalg.sqrtm(C) but faster, also yields the eigenvalues
-    s, u = linalg.eigh(C)
+    s, u = eigh(C, overwrite_a=overwrite_a, check_finite=check_finite)
     mask = s > s.max() * 1e-7
     u = u[:, mask]
     s = np.sqrt(s[mask])

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -8,7 +8,7 @@ from scipy import linalg
 
 from ..defaults import _handle_default
 from ..fixes import _safe_svd
-from ..utils import warn, logger
+from ..utils import warn, logger, _dgesdd_lwork, _repeated_pinv2
 
 
 # For the reference implementation of eLORETA (force_equal=False),
@@ -113,6 +113,7 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
     """Invert weights and compute M."""
     W_inv = np.empty_like(W)
     n_src = W_inv.shape[0]
+    lwork = _dgesdd_lwork((3, 3))
     if n_orient == 1 or force_equal:
         W_inv[:] = 1. / W
     else:
@@ -120,7 +121,7 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
             # Here we use a single-precision-suitable `rcond` (given our
             # 3x3 matrix size) because the inv could be saved in single
             # precision.
-            W_inv[ii] = linalg.pinv2(W[ii], rcond=1e-7)
+            W_inv[ii] = _repeated_pinv2(W[ii], lwork, rcond=1e-7)
 
     # Weight the gain matrix
     W_inv_Gt = np.empty_like(G).T

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -4,8 +4,6 @@
 
 import numpy as np
 
-from scipy import linalg
-
 from ..defaults import _handle_default
 from ..fixes import _safe_svd
 from ..utils import (warn, logger, _svd_lwork, _repeated_svd, _repeated_pinv2,

--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -8,7 +8,7 @@ from scipy import linalg
 
 from ..defaults import _handle_default
 from ..fixes import _safe_svd
-from ..utils import warn, logger, _gesdd_lwork, _repeated_pinv2
+from ..utils import warn, logger, _svd_lwork, _repeated_pinv2
 
 
 # For the reference implementation of eLORETA (force_equal=False),
@@ -113,7 +113,7 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal):
     """Invert weights and compute M."""
     W_inv = np.empty_like(W)
     n_src = W_inv.shape[0]
-    lwork = _gesdd_lwork((3, 3))
+    lwork = _svd_lwork((3, 3))
     if n_orient == 1 or force_equal:
         W_inv[:] = 1. / W
     else:

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1272,6 +1272,9 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     # 11. Do appropriate source weighting to the forward computation matrix
     #
 
+    # make a copy immediately so we do it exactly once
+    forward = forward.copy()
+
     # Deal with "fixed" and "loose"
     src_kind = forward['src'].kind
     if fixed == 'auto':
@@ -1318,8 +1321,8 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
             if allow_fixed_depth:
                 # can convert now
                 logger.info('Converting forward solution to fixed orietnation')
-                forward = convert_forward_solution(
-                    forward, force_fixed=True, use_cps=True)
+                convert_forward_solution(
+                    forward, force_fixed=True, use_cps=True, copy=False)
         elif exp is not None and not allow_fixed_depth:
             raise ValueError(
                 'For a fixed orientation inverse solution with depth '
@@ -1333,10 +1336,11 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
                 'operator.')
         if loose < 1. and not forward['surf_ori']:  # loose ori
             logger.info('Converting forward solution to surface orientation')
-            forward = convert_forward_solution(
-                forward, surf_ori=True, use_cps=True)
+            convert_forward_solution(
+                forward, surf_ori=True, use_cps=True, copy=False)
 
-    forward, info_picked = _select_orient_forward(forward, info, noise_cov)
+    forward, info_picked = _select_orient_forward(forward, info, noise_cov,
+                                                  copy=False)
     logger.info("Selected %d channels" % (len(info_picked['ch_names'],)))
 
     if exp is None:
@@ -1356,9 +1360,9 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
                             'depth-weighting prior into the fixed-orientation '
                             'one')
                 depth_prior = depth_prior[2::3]
-            forward = convert_forward_solution(
+            convert_forward_solution(
                 forward, surf_ori=True, force_fixed=True,
-                use_cps=use_cps)
+                use_cps=use_cps, copy=False)
     else:
         # In theory we could have orient_prior=None for loose=1., but
         # the MNE-C code does not do this

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -473,8 +473,8 @@ def test_inverse_residual(evoked):
     evoked = evoked.pick_types()
     inv = read_inverse_operator(fname_inv_fixed_depth)
     fwd = read_forward_solution(fname_fwd)
+    pick_channels_forward(fwd, evoked.ch_names, copy=False)
     fwd = convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
-    fwd = pick_channels_forward(fwd, evoked.ch_names)
     matcher = re.compile(r'.* ([0-9]?[0-9]?[0-9]?\.[0-9])% variance.*')
     for method in ('MNE', 'dSPM', 'sLORETA'):
         with catch_logging() as log:

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -209,12 +209,12 @@ def fast_cross_3d(x, y):
     assert y.shape[-1] == 3
     if max(x.size, y.size) >= 500:
         out = np.empty(np.broadcast(x, y).shape)
-        np.multiply(x[..., 1], y[..., 2], out=out[:, 0])
-        out[:, 0] -= x[..., 2] * y[..., 1]
-        np.multiply(x[..., 2], y[..., 0], out=out[:, 1])
-        out[:, 1] -= x[..., 0] * y[..., 2]
-        np.multiply(x[..., 0], y[..., 1], out=out[:, 2])
-        out[:, 2] -= x[..., 1] * y[..., 0]
+        np.multiply(x[..., 1], y[..., 2], out=out[..., 0])
+        out[..., 0] -= x[..., 2] * y[..., 1]
+        np.multiply(x[..., 2], y[..., 0], out=out[..., 1])
+        out[..., 1] -= x[..., 0] * y[..., 2]
+        np.multiply(x[..., 0], y[..., 1], out=out[..., 2])
+        out[..., 2] -= x[..., 1] * y[..., 0]
         return out
     else:
         return np.cross(x, y)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -184,7 +184,7 @@ def fast_cross_3d(x, y):
     """Compute cross product between list of 3D vectors.
 
     Much faster than np.cross() when the number of cross products
-    becomes large (>500). This is because np.cross() methods become
+    becomes large (>= 500). This is because np.cross() methods become
     less memory efficient at this stage.
 
     Parameters
@@ -207,13 +207,15 @@ def fast_cross_3d(x, y):
     assert y.ndim >= 1
     assert x.shape[-1] == 3
     assert y.shape[-1] == 3
-    if max(x.size, y.size) >= 1500:
-        a = x[..., 1] * y[..., 2] - x[..., 2] * y[..., 1]
-        b = x[..., 2] * y[..., 0] - x[..., 0] * y[..., 2]
-        c = x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
-        # Once we bump to NumPy 1.10, np.stack simplifies this
-        return np.concatenate([
-            a[..., np.newaxis], b[..., np.newaxis], c[..., np.newaxis]], -1)
+    if max(x.size, y.size) >= 500:
+        out = np.empty(np.broadcast(x, y).shape)
+        np.multiply(x[..., 1], y[..., 2], out=out[:, 0])
+        out[:, 0] -= x[..., 2] * y[..., 1]
+        np.multiply(x[..., 2], y[..., 0], out=out[:, 1])
+        out[:, 1] -= x[..., 0] * y[..., 2]
+        np.multiply(x[..., 0], y[..., 1], out=out[:, 2])
+        out[:, 2] -= x[..., 1] * y[..., 0]
+        return out
     else:
         return np.cross(x, y)
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -51,5 +51,6 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _mask_to_onsets_offsets, _array_equal_nan)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)
-from .linalg import (_dgesdd_lwork, _repeated_svd, _repeated_pinv2,
-                     dgesdd, dgemm, dgemv, ddot)
+from .linalg import (_gesdd_lwork, _repeated_svd, _repeated_pinv2,
+                     _geev_lwork, _repeated_eig,
+                     dgesdd, dgemm, zgemm, dgemv, ddot)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -51,6 +51,6 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _mask_to_onsets_offsets, _array_equal_nan)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)
-from .linalg import (_gesdd_lwork, _repeated_svd, _repeated_pinv2,
-                     _geev_lwork, _repeated_eig,
-                     dgesdd, dgemm, zgemm, dgemv, ddot)
+from .linalg import (_svd_lwork, _repeated_svd, _repeated_pinv2,
+                     _eig_lwork, _repeated_eig, _inv_lwork, _repeated_inv,
+                     dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -53,4 +53,4 @@ from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas)
 from .linalg import (_svd_lwork, _repeated_svd, _repeated_pinv2,
                      _eig_lwork, _repeated_eig, _inv_lwork, _repeated_inv,
-                     dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError)
+                     dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -50,4 +50,6 @@ from .numerics import (hashfunc, md5sum, _compute_row_norms,
                        _undo_scaling_array, _scaled_array, _replace_md5, _PCA,
                        _mask_to_onsets_offsets, _array_equal_nan)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
-_prepare_write_metadata, _FakeNoPandas)
+                    _prepare_write_metadata, _FakeNoPandas)
+from .linalg import (_dgesdd_lwork, _repeated_svd, _repeated_pinv2,
+                     dgesdd, dgemm, dgemv, ddot)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -102,8 +102,8 @@ class use_log_level(object):
         The level to use.
     """
 
-    def __init__(self, verbose):  # noqa: D102
-        self.level = verbose
+    def __init__(self, level):  # noqa: D102
+        self.level = level
 
     def __enter__(self):  # noqa: D105
         self.old_level = set_log_level(self.level, True)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -102,8 +102,8 @@ class use_log_level(object):
         The level to use.
     """
 
-    def __init__(self, level):  # noqa: D102
-        self.level = level
+    def __init__(self, verbose):  # noqa: D102
+        self.level = verbose
 
     def __enter__(self):  # noqa: D105
         self.old_level = set_log_level(self.level, True)

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -40,8 +40,8 @@ _I = np.cast['F'](1j)
 ###############################################################################
 # linalg.svd and linalg.pinv2
 dgesdd, dgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_d,))
-dgesvd, dgesvd_lwork = linalg.get_lapack_funcs(('gesvd', 'gesvd_lwork'), (_d,))
 zgesdd, zgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_z,))
+dgesvd, dgesvd_lwork = linalg.get_lapack_funcs(('gesvd', 'gesvd_lwork'), (_d,))
 zgesvd, zgesvd_lwork = linalg.get_lapack_funcs(('gesvd', 'gesvd_lwork'), (_z,))
 
 
@@ -189,7 +189,26 @@ zheevd, = linalg.get_lapack_funcs(('heevd',), (_z,))
 
 
 def eigh(a, overwrite_a=False, check_finite=True):
-    """Efficient wrapper for eigh."""
+    """Efficient wrapper for eigh.
+
+    Parameters
+    ----------
+    a : ndarray, shape (n_components, n_components)
+        The symmetric array operate on.
+    overwrite_a : bool
+        If True, the contents of a can be overwritten for efficiency.
+    check_finite : bool
+        If True, check that all elements are finite.
+
+    Returns
+    -------
+    w : ndarray, shape (n_components,)
+        The N eigenvalues, in ascending order, each repeated according to
+        its multiplicity.
+    v : ndarray, shape (n_components, n_components)
+        The normalized eigenvector corresponding to the eigenvalue ``w[i]``
+        is the column ``v[:, i]``.
+    """
     # We use SYEVD, see https://github.com/scipy/scipy/issues/9212
     if check_finite:
         a = _asarray_validated(a, check_finite=check_finite)

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Utility functions to speed up linear algebraic operations.
+
+In general, things like np.dot and linalg.svd should be used directly
+because they are smart about checking for bad values. However, in cases where
+things are done repeatedly (e.g., thousands of times on tiny matrices), the
+overhead can become problematic from a performance standpoint. Examples:
+
+- Optimization routines:
+  - Dipole fitting
+  - Sparse solving
+  - cHPI fitting
+- Inverse computation
+  - Beamformers (LCMV/DICS)
+  - eLORETA minimum norm
+
+Significant performance gains can be achieved by ensuring that inputs
+are Fortran contiguous because that's what LAPACK requires. Without this,
+inputs will be memcopied.
+"""
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+from scipy import linalg
+
+
+_x = np.empty(0)
+dgemm = linalg.get_blas_funcs('gemm', (_x,))
+dgemv = linalg.get_blas_funcs('gemv', (_x,))
+ddot = linalg.get_blas_funcs('dot', (_x,))
+dgesdd = linalg.get_lapack_funcs('gesdd', (_x,))
+dgesdd, dgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_x,))
+
+
+def _dgesdd_lwork(shape):
+    """Set up repeated SVD calculations on identical shape float64 arrays."""
+    lwork = linalg.decomp_svd._compute_lwork(
+        dgesdd_lwork, *shape, compute_uv=True, full_matrices=False)
+    return lwork
+
+
+def _repeated_svd(x, lwork, overwrite_a=False):
+    """Mimic scipy.linalg.svd, avoid lwork and get_lapack_funcs overhead."""
+    assert lwork is not None
+    u, s, v, info = dgesdd(x, compute_uv=True, lwork=lwork,
+                           full_matrices=False, overwrite_a=True)
+    if info > 0:
+        raise linalg.LinAlgError("SVD did not converge")
+    if info < 0:
+        raise ValueError('illegal value in %d-th argument of internal gesdd'
+                         % -info)
+    return u, s, v
+
+
+def _repeated_pinv2(x, lwork, rcond=None):
+    """Mimic scipy.linalg.pinv2, avoid lwork and get_lapack_funcs overhead."""
+    # Adapted from SciPy
+    assert x.dtype == np.float64
+    u, s, vh = _repeated_svd(x, lwork)
+    if rcond in [None, -1]:
+        t = u.dtype.char.lower()
+        factor = {'f': 1E3, 'd': 1E6}
+        rcond = factor[t] * np.finfo(t).eps
+    rank = np.sum(s > rcond * np.max(s))
+    psigma_diag = 1.0 / s[: rank]
+    u[:, :rank] *= psigma_diag
+    B = np.transpose(np.conjugate(np.dot(u[:, :rank], vh[:rank])))
+    return B

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -35,6 +35,7 @@ dgemv = linalg.get_blas_funcs('gemv', (_d,))
 ddot = linalg.get_blas_funcs('dot', (_d,))
 _I = np.cast['F'](1j)
 
+
 ###############################################################################
 # linalg.svd and linalg.pinv2
 dgesdd, dgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_d,))
@@ -64,12 +65,13 @@ def _repeated_svd(x, lwork, overwrite_a=False):
     else:
         assert x.dtype == np.complex128
         gesdd, gesvd = zgesdd, zgesvd
+    # this has to use overwrite_a=False in case we need to fall back to gesvd
     u, s, v, info = gesdd(x, compute_uv=True, lwork=lwork[0],
-                          full_matrices=False, overwrite_a=True)
+                          full_matrices=False, overwrite_a=False)
     if info > 0:
         # Fall back to slower gesvd, sometimes gesdd fails
         u, s, v, info = gesvd(x, compute_uv=True, lwork=lwork[1],
-                              full_matrices=False, overwrite_a=True)
+                              full_matrices=False, overwrite_a=overwrite_a)
     if info > 0:
         raise LinAlgError("SVD did not converge")
     if info < 0:


### PR DESCRIPTION
In profiling, a full 1/3 of the time in `linalg.svd` is spent in `_compute_lwork`, which is wasteful if we are going to do `svd` on data that is always the same shape (or at most some shape).

So far I've sped up HPI coil fitting a bit using this technique. I plan to try it with LCMV, too, since there are a bunch of pseudo-inverses done there with `pinv2` (which internally calls `svd`). I'll probably refactor into our own `_repeated_svd` for this purpose.

It also speeds things up by using `gemm`, `gemv`, and `dot` directly rather than calling `np.dot` and dealing with the overhead, similar to #6220.