### PR TITLE
RFC, WIP: Add numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 matplotlib
+numba
 mayavi
 pyqt5
 pyqt5-sip


### PR DESCRIPTION
POC for `numba` support. This speeds up for example:
```
3.36s call     mne/tests/test_dipole.py::test_accuracy  # master
2.79s call     mne/tests/test_dipole.py::test_accuracy  # this PR
```
It's possible there are other things we can speed up, but this is nice for dipole fitting (esp. with #6603).

Questions:
- [ ] Worth the dependency? I think probably yes since Numba seems mature enough now, and after #6603 these operations become a bottleneck. SciPy has seemed close to using it as an optional dependency, FWIW.
- [ ] Do we make the dependency required? If not, we'll probably have to maintain two code paths as shown here (so far). We could make a fake `jit` for non-Numba systems, but the non-vectorized code written for numba is unbearably slow (order of magnitude or more slower) compared to our current vectorized code.