### PR TITLE
list inputs to tfr functions

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -3,7 +3,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+                           assert_equal, assert_allclose)
 import pytest
 import matplotlib.pyplot as plt
 
@@ -769,6 +769,13 @@ def _epochs_generator(ep_start, ep_stop):
         yield _prepare_epochs(cur_ep, cur_ep + 1)
 
 
+def _assert_tfr_equal(actual, desired):
+    assert_allclose(actual.times, desired.times)
+    assert_allclose(actual.data, desired.data)
+    if isinstance(actual, AverageTFR):
+        assert_equal(actual.nave, desired.nave)
+
+
 @pytest.mark.parametrize('return_itc, average', [[True, True], [False, False], [False, True]])
 def test_tfr_with_lists(return_itc, average):
     epochs_ref = _prepare_epochs(0, 5)
@@ -782,16 +789,13 @@ def test_tfr_with_lists(return_itc, average):
     tfr_list = tfr_morlet(epochs_list, freqs, n_cycles, return_itc=return_itc, average=average)
     tfr_gen = tfr_morlet(epochs_gen, freqs, n_cycles, return_itc=return_itc, average=average)
 
-    from numpy.testing import assert_allclose
-
     if isinstance(tfr_ref, AverageTFR):
-        assert_allclose(tfr_list.data, tfr_ref.data)
-        assert_allclose(tfr_gen.data, tfr_ref.data)
+        _assert_tfr_equal(tfr_list, tfr_ref)
+        _assert_tfr_equal(tfr_gen, tfr_ref)
     else:
-        for ind, obj in enumerate(tfr_ref):
-            assert_allclose(tfr_list[ind].data, tfr_ref[ind].data)
-            assert_allclose(tfr_gen[ind].data, tfr_ref[ind].data)
-
+        for index, _ in enumerate(tfr_ref):
+            _assert_tfr_equal(tfr_list[index], tfr_ref[index])
+            _assert_tfr_equal(tfr_gen[index], tfr_ref[index])
 
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -780,7 +780,8 @@ def _assert_tfr_equal(actual, desired):
 
 
 @pytest.mark.parametrize('return_itc, average', [[True, True], [False, False], [False, True]])
-def test_tfr_with_lists(return_itc, average):
+@pytest.mark.parametrize('func', [tfr_morlet, tfr_multitaper])
+def test_tfr_with_lists(return_itc, average, func):
     """Test whether tfr_morlet works the same for lists as for epochs."""
     epochs_ref = _prepare_epochs(0, 3)
     epochs_list = [_prepare_epochs(cur_ep, cur_ep + 1) for cur_ep in range(0, 3)]
@@ -789,17 +790,17 @@ def test_tfr_with_lists(return_itc, average):
     freqs = [10, 12]
     n_cycles = 2
 
-    tfr_ref = tfr_morlet(epochs_ref, freqs, n_cycles, return_itc=return_itc, average=average)
-    tfr_list = tfr_morlet(epochs_list, freqs, n_cycles, return_itc=return_itc, average=average)
-    tfr_gen = tfr_morlet(epochs_gen, freqs, n_cycles, return_itc=return_itc, average=average)
+    tfr_ref = func(epochs_ref, freqs, n_cycles, return_itc=return_itc, average=average)
+    tfr_list = func(epochs_list, freqs, n_cycles, return_itc=return_itc, average=average)
+    tfr_gen = func(epochs_gen, freqs, n_cycles, return_itc=return_itc, average=average)
 
-    if isinstance(tfr_ref, AverageTFR):
-        _assert_tfr_equal(tfr_list, tfr_ref)
-        _assert_tfr_equal(tfr_gen, tfr_ref)
-    else:
+    if return_itc is True:
         for index, _ in enumerate(tfr_ref):
             _assert_tfr_equal(tfr_list[index], tfr_ref[index])
             _assert_tfr_equal(tfr_gen[index], tfr_ref[index])
+    else:
+        _assert_tfr_equal(tfr_list, tfr_ref)
+        _assert_tfr_equal(tfr_gen, tfr_ref)
 
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -755,6 +755,7 @@ def test_getitem_epochsTFR():
 
 
 def _prepare_epochs(ep_start, ep_stop):
+    """Load data and create and Epochs object from it."""
     raw = read_raw_fif(raw_fname)
     tmin, tmax, event_id = -0.2, 0.5, 1
     events = find_events(raw, stim_channel='STI 014')
@@ -765,11 +766,13 @@ def _prepare_epochs(ep_start, ep_stop):
 
 
 def _epochs_generator(ep_start, ep_stop):
+    """Create a generator object of epochs"""
     for cur_ep in range(ep_start, ep_stop):
         yield _prepare_epochs(cur_ep, cur_ep + 1)
 
 
 def _assert_tfr_equal(actual, desired):
+    """Assert equality of some TFR attributes-"""
     assert_allclose(actual.times, desired.times)
     assert_allclose(actual.data, desired.data)
     if isinstance(actual, AverageTFR):
@@ -778,9 +781,10 @@ def _assert_tfr_equal(actual, desired):
 
 @pytest.mark.parametrize('return_itc, average', [[True, True], [False, False], [False, True]])
 def test_tfr_with_lists(return_itc, average):
-    epochs_ref = _prepare_epochs(0, 5)
-    epochs_list = [_prepare_epochs(cur_ep, cur_ep + 1) for cur_ep in range(0, 5)]
-    epochs_gen = _epochs_generator(0, 5)
+    """Test whether tfr_morlet works the same for lists as for epochs."""
+    epochs_ref = _prepare_epochs(0, 3)
+    epochs_list = [_prepare_epochs(cur_ep, cur_ep + 1) for cur_ep in range(0, 3)]
+    epochs_gen = _epochs_generator(0, 3)
 
     freqs = [10, 12]
     n_cycles = 2

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -8,7 +8,8 @@ import pytest
 import matplotlib.pyplot as plt
 
 import mne
-from mne import Epochs, read_events, pick_types, create_info, EpochsArray, find_events
+from mne import (Epochs, read_events, find_events, pick_types, create_info,
+                 EpochsArray)
 from mne.io import read_raw_fif
 from mne.utils import (_TempDir, run_tests_if_main, requires_h5py,
                        requires_pandas, grand_average)
@@ -757,7 +758,7 @@ def test_getitem_epochsTFR():
 def _prepare_epochs(ep_start, ep_stop):
     """Load data and create and Epochs object from it."""
     raw = read_raw_fif(raw_fname)
-    tmin, tmax, event_id = -0.2, 0.5, 1
+    tmin, tmax = -0.2, 0.5
     events = find_events(raw, stim_channel='STI 014')
     sel_events = events[ep_start:ep_stop]
     epochs = Epochs(raw, sel_events, tmin=tmin, tmax=tmax, preload=True)
@@ -766,33 +767,39 @@ def _prepare_epochs(ep_start, ep_stop):
 
 
 def _epochs_generator(ep_start, ep_stop):
-    """Create a generator object of epochs"""
+    """Create a generator object of epochs."""
     for cur_ep in range(ep_start, ep_stop):
         yield _prepare_epochs(cur_ep, cur_ep + 1)
 
 
 def _assert_tfr_equal(actual, desired):
-    """Assert equality of some TFR attributes-"""
+    """Assert equality of some TFR attributes."""
     assert_allclose(actual.times, desired.times)
     assert_allclose(actual.data, desired.data)
     if isinstance(actual, AverageTFR):
         assert_equal(actual.nave, desired.nave)
 
 
-@pytest.mark.parametrize('return_itc, average', [[True, True], [False, False], [False, True]])
+@pytest.mark.parametrize('return_itc, average', [[True, True],
+                                                 [False, False],
+                                                 [False, True]])
 @pytest.mark.parametrize('func', [tfr_morlet, tfr_multitaper])
 def test_tfr_with_lists(return_itc, average, func):
     """Test whether tfr_morlet works the same for lists as for epochs."""
     epochs_ref = _prepare_epochs(0, 3)
-    epochs_list = [_prepare_epochs(cur_ep, cur_ep + 1) for cur_ep in range(0, 3)]
+    epochs_list = [_prepare_epochs(cur_ep, cur_ep + 1)
+                   for cur_ep in range(0, 3)]
     epochs_gen = _epochs_generator(0, 3)
 
     freqs = [10, 12]
     n_cycles = 2
 
-    tfr_ref = func(epochs_ref, freqs, n_cycles, return_itc=return_itc, average=average)
-    tfr_list = func(epochs_list, freqs, n_cycles, return_itc=return_itc, average=average)
-    tfr_gen = func(epochs_gen, freqs, n_cycles, return_itc=return_itc, average=average)
+    tfr_ref = func(epochs_ref, freqs, n_cycles,
+                   return_itc=return_itc, average=average)
+    tfr_list = func(epochs_list, freqs, n_cycles,
+                    return_itc=return_itc, average=average)
+    tfr_gen = func(epochs_gen, freqs, n_cycles,
+                   return_itc=return_itc, average=average)
 
     if return_itc is True:
         for index, _ in enumerate(tfr_ref):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -670,8 +670,9 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 
     Parameters
     ----------
-    inst : Epochs | Evoked
-        The epochs or evoked object.
+    inst : Epochs | Evoked | list (or generator object) of (Epochs | Evoked)
+        The epochs or evoked object. If a list or generator object, single
+        elements will be joined and treated as Epochs.
     freqs : ndarray, shape (n_freqs,)
         The frequencies in Hz.
     n_cycles : float | ndarray, shape (n_freqs,)
@@ -814,8 +815,9 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
 
     Parameters
     ----------
-    inst : Epochs | Evoked
-        The epochs or evoked object.
+    inst : Epochs | Evoked | list (or generator object) of (Epochs | Evoked)
+        The epochs or evoked object. If a list or generator object, single
+        elements will be joined and treated as Epochs.
     freqs : ndarray, shape (n_freqs,)
         The frequencies in Hz.
     n_cycles : float | ndarray, shape (n_freqs,)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -680,7 +680,10 @@ def _tfr_aux(method, inst, freqs, decim, return_itc, picks, average,
             power, itc = out.real, out.imag
         else:
             power = out
-        nave = len(data)
+        if isinstance(inst, list) or isgenerator(inst):
+            nave = ind + 1
+        else:
+            nave = len(data)
         out = AverageTFR(info, power, times, freqs, nave,
                          method='%s-power' % method)
         if return_itc:


### PR DESCRIPTION
#### Reference issue
This is one step for the GSoC TFR in Source Space Project (See: Issue #6290  ).

#### What does this implement/fix?
This will allow tfr_morlet and tfr_multitaper to take lists or generator objects as input, which is necessary in order to process SourceEstimate types like epochs and, e.g. calculate the Inter-Trial-Coherence.

#### Additional information
This is a simple first solution in order to proceed with further steps of the project. Processing the list elements subsequently in order to reduce memory load will require more significant changes and will be implemented later.