### PR TITLE
[MRG] FIX: always handle BrainVision recording date as string

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,6 +55,8 @@ Changelog
 Bug
 ~~~
 
+- Fix reading of dates in BrainVision files if no "New Segment" marker is specified, no date is given, or data is missing, by `Stefan Appelhoff`_
+
 - Fix side-effect where :func:`mne.viz.plot_ica_sources` and :meth:`mne.preprocessing.ICA.plot_sources` changed the ``ICA.exclude`` attribute even when users didn't interact with the plot by `Daniel McCloy`_.
 
 - Fix wrong assumptions about units in BrainVision montages and add test asserting units in "mm" or "auto", by `Stefan Appelhoff`_


### PR DESCRIPTION
Fixes an issue with the way `date_str` was handled.

Sometimes it could be `None`, but we would rather have it a string always ... and if undefined, let it be one of `['', '0', '00000000000000000000']`

While fixing this, I also noticed that we are not strict enough with checking what we read in as a recording date - So this is a preemptive bugfix as well:

- before reading a recording time, we make sure that it is present at all (the `len==5` on line 212)