### PR TITLE
[FIX] Make report context manager stop swallowing exceptions

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,6 +97,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_brainvision` not handling ``Event`` markers created by PyCorder correctly by `Richard Höchenberger`_
 
+- Fix :class:`mne.Report` silently suppressing exceptions when used as a context manager by `Marijn van Vliet`_
+
 API
 ~~~
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1617,7 +1617,6 @@ class Report(object):
         """Save the report when leaving the context block."""
         if self._fname is not None:
             self.save(self._fname, open_browser=False, overwrite=True)
-        return self
 
     @verbose
     def _render_toc(self, verbose=None):

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -343,6 +343,11 @@ def test_open_report():
     pytest.raises(ValueError, open_report, hdf5, subjects_dir='foo')
     open_report(hdf5, subjects_dir=subjects_dir)  # This should work
 
+    # Check that the context manager doesn't swallow exceptions
+    with pytest.raises(ZeroDivisionError):
+        with open_report(hdf5, subjects_dir=subjects_dir) as report:
+            1/0
+
 
 def test_remove():
     """Test removing figures from a report."""

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -346,7 +346,7 @@ def test_open_report():
     # Check that the context manager doesn't swallow exceptions
     with pytest.raises(ZeroDivisionError):
         with open_report(hdf5, subjects_dir=subjects_dir) as report:
-            1/0
+            1 / 0
 
 
 def test_remove():


### PR DESCRIPTION
You can open HTML reports with a context manager, e.g.:
```python
with mne.open_report('report.h5') as report:
    # Do things with report
```

When I implemented this, in my ignorance about how to properly implement context managers, I made `mne.Report.__exit__` return `self`. Returning truthy values causes the context manager to suppress all exceptions within the context block! `mne.Report.__exit__` should not return anything.