### PR TITLE
[DOC] apply_inverse docu update

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -775,7 +775,9 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
         Use minimum norm [1]_, dSPM (default) [2]_, sLORETA [3]_, or
         eLORETA [4]_.
     pick_ori : None | "normal" | "vector"
-        By default (None) pooling is performed by taking the norm of loose/free orientations. In case of a fixed source space no norm is computed leading to signed source activity.
+        By default (None) pooling is performed by taking the norm of loose/free
+        orientations. In case of a fixed source space no norm is computed
+        leading to signed source activity.
         If "normal" only the radial component is kept. This is only implemented
         when working with loose orientations.
         If "vector", no pooling of the orientations is done and the vector

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -775,8 +775,8 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
         Use minimum norm [1]_, dSPM (default) [2]_, sLORETA [3]_, or
         eLORETA [4]_.
     pick_ori : None | "normal" | "vector"
-        If "normal", rather than pooling the orientations by taking the norm,
-        only the radial component is kept. This is only implemented
+        By default (None) pooling is performed by taking the norm of loose/free orientations. In case of a fixed source space no norm is computed leading to signed source activity.
+        If "normal" only the radial component is kept. This is only implemented
         when working with loose orientations.
         If "vector", no pooling of the orientations is done and the vector
         result will be returned in the form of a


### PR DESCRIPTION
Small docu update regarding `apply_inverse`'s behavior when using `pick_ori=None` in conjunction with a fixed source space. 