### PR TITLE
make bootstrap ci public

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -869,6 +869,7 @@ Non-parametric (clustering) resampling methods:
    spatio_temporal_cluster_test
    spatio_temporal_cluster_1samp_test
    summarize_clusters_stc
+   bootstrap_ci
 
 Compute ``connectivity`` matrices for cluster-level statistics:
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -869,7 +869,7 @@ Non-parametric (clustering) resampling methods:
    spatio_temporal_cluster_test
    spatio_temporal_cluster_1samp_test
    summarize_clusters_stc
-   bootstrap_ci
+   bootstrap_confidence_interval
 
 Compute ``connectivity`` matrices for cluster-level statistics:
 

--- a/examples/time_frequency/plot_time_frequency_global_field_power.py
+++ b/examples/time_frequency/plot_time_frequency_global_field_power.py
@@ -53,7 +53,7 @@ import matplotlib.pyplot as plt
 import mne
 from mne.datasets import somato
 from mne.baseline import rescale
-from mne.stats import _bootstrap_ci
+from mne.stats import bootstrap_ci
 
 ###############################################################################
 # Set parameters
@@ -121,8 +121,8 @@ for ((freq_name, fmin, fmax), average), color, ax in zip(
     gfp = mne.baseline.rescale(gfp, times, baseline=(None, 0))
     ax.plot(times, gfp, label=freq_name, color=color, linewidth=2.5)
     ax.axhline(0, linestyle='--', color='grey', linewidth=2)
-    ci_low, ci_up = _bootstrap_ci(average.data, random_state=0,
-                                  stat_fun=lambda x: np.sum(x ** 2, axis=0))
+    ci_low, ci_up = bootstrap_ci(average.data, random_state=0,
+                                 stat_fun=lambda x: np.sum(x ** 2, axis=0))
     ci_low = rescale(ci_low, average.times, baseline=(None, 0))
     ci_up = rescale(ci_up, average.times, baseline=(None, 0))
     ax.fill_between(times, gfp + ci_up, gfp - ci_low, color=color, alpha=0.3)

--- a/examples/time_frequency/plot_time_frequency_global_field_power.py
+++ b/examples/time_frequency/plot_time_frequency_global_field_power.py
@@ -53,7 +53,7 @@ import matplotlib.pyplot as plt
 import mne
 from mne.datasets import somato
 from mne.baseline import rescale
-from mne.stats import bootstrap_ci
+from mne.stats import bootstrap_confidence_interval
 
 ###############################################################################
 # Set parameters
@@ -112,6 +112,13 @@ for band, fmin, fmax in iter_freqs:
 #
 # We see dominant responses in the Alpha and Beta bands.
 
+
+# Helper function for plotting spread
+def stat_fun(x):
+    """Return sum of squares."""
+    return np.sum(x ** 2, axis=0)
+
+# Plot
 fig, axes = plt.subplots(4, 1, figsize=(10, 7), sharex=True, sharey=True)
 colors = plt.get_cmap('winter_r')(np.linspace(0, 1, 4))
 for ((freq_name, fmin, fmax), average), color, ax in zip(
@@ -121,8 +128,8 @@ for ((freq_name, fmin, fmax), average), color, ax in zip(
     gfp = mne.baseline.rescale(gfp, times, baseline=(None, 0))
     ax.plot(times, gfp, label=freq_name, color=color, linewidth=2.5)
     ax.axhline(0, linestyle='--', color='grey', linewidth=2)
-    ci_low, ci_up = bootstrap_ci(average.data, random_state=0,
-                                 stat_fun=lambda x: np.sum(x ** 2, axis=0))
+    ci_low, ci_up = bootstrap_confidence_interval(average.data, random_state=0,
+                                                  stat_fun=stat_fun)
     ci_low = rescale(ci_low, average.times, baseline=(None, 0))
     ci_up = rescale(ci_up, average.times, baseline=(None, 0))
     ax.fill_between(times, gfp + ci_up, gfp - ci_low, color=color, alpha=0.3)

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -2,7 +2,8 @@
 
 from .parametric import (f_threshold_mway_rm, f_mway_rm, f_oneway,
                          _parametric_ci, ttest_1samp_no_p)
-from .permutations import permutation_t_test, _ci, bootstrap_ci
+from .permutations import (permutation_t_test, _ci,
+                           bootstrap_confidence_interval)
 from .cluster_level import (
     permutation_cluster_test, permutation_cluster_1samp_test,
     spatio_temporal_cluster_test, spatio_temporal_cluster_1samp_test,

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -2,7 +2,7 @@
 
 from .parametric import (f_threshold_mway_rm, f_mway_rm, f_oneway,
                          _parametric_ci, ttest_1samp_no_p)
-from .permutations import permutation_t_test, _ci, _bootstrap_ci
+from .permutations import permutation_t_test, _ci, bootstrap_ci
 from .cluster_level import (
     permutation_cluster_test, permutation_cluster_1samp_test,
     spatio_temporal_cluster_test, spatio_temporal_cluster_1samp_test,

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -102,8 +102,8 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
     return T_obs, p_values, H0
 
 
-def bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
-                 random_state=None):
+def bootstrap_confidence_interval(arr, ci=.95, n_bootstraps=2000,
+                                  stat_fun='mean', random_state=None):
     """Get confidence intervals from non-parametric bootstrap.
 
     Parameters
@@ -149,8 +149,9 @@ def bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
 def _ci(arr, ci=.95, method="bootstrap", n_bootstraps=2000, random_state=None):
     """Calculate confidence interval. Aux function for plot_compare_evokeds."""
     if method == "bootstrap":
-        return bootstrap_ci(arr, ci=ci, n_bootstraps=n_bootstraps,
-                            random_state=random_state)
+        return bootstrap_confidence_interval(arr, ci=ci,
+                                             n_bootstraps=n_bootstraps,
+                                             random_state=random_state)
     else:
         from . import _parametric_ci
         return _parametric_ci(arr, ci=ci)

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -102,9 +102,31 @@ def permutation_t_test(X, n_permutations=10000, tail=0, n_jobs=1,
     return T_obs, p_values, H0
 
 
-def _bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
-                  random_state=None):
-    """Get confidence intervals from non-parametric bootstrap."""
+def bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
+                 random_state=None):
+    """Get confidence intervals from non-parametric bootstrap.
+
+    Parameters
+    ----------
+    arr : ndarray
+        The input data on which to calculate the confidence interval.
+    ci : float
+        Level of the confidence interval between 0 and 1.
+    n_bootstraps : int
+        Number of bootstraps
+    stat_fun : str | callable
+        Can be "mean", "median", or a callable operating along `axis=0`.
+    random_state : int | float | array_like | None
+        The seed at which to initialize the bootstrap.
+
+    Returns
+    -------
+    cis : ndarray
+        Containing the lower boundary of the CI at `cis[0, ...]` and the upper
+        boundary of the CI at `cis[1, ...]`.
+
+
+    """
     if stat_fun == "mean":
         def stat_fun(x):
             return x.mean(axis=0)
@@ -127,8 +149,8 @@ def _bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
 def _ci(arr, ci=.95, method="bootstrap", n_bootstraps=2000, random_state=None):
     """Calculate confidence interval. Aux function for plot_compare_evokeds."""
     if method == "bootstrap":
-        return _bootstrap_ci(arr, ci=ci, n_bootstraps=n_bootstraps,
-                             random_state=random_state)
+        return bootstrap_ci(arr, ci=ci, n_bootstraps=n_bootstraps,
+                            random_state=random_state)
     else:
         from . import _parametric_ci
         return _parametric_ci(arr, ci=ci)

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -108,7 +108,7 @@ def bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
 
     Parameters
     ----------
-    arr : ndarray
+    arr : ndarray, shape (n_samples, ...)
         The input data on which to calculate the confidence interval.
     ci : float
         Level of the confidence interval between 0 and 1.
@@ -121,7 +121,7 @@ def bootstrap_ci(arr, ci=.95, n_bootstraps=2000, stat_fun='mean',
 
     Returns
     -------
-    cis : ndarray
+    cis : ndarray, shape (2, ...)
         Containing the lower boundary of the CI at `cis[0, ...]` and the upper
         boundary of the CI at `cis[1, ...]`.
 

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -7,7 +7,8 @@ import numpy as np
 from scipy import stats, sparse
 
 from mne.stats import permutation_cluster_1samp_test
-from mne.stats.permutations import permutation_t_test, _ci, bootstrap_ci
+from mne.stats.permutations import (permutation_t_test, _ci,
+                                    bootstrap_confidence_interval)
 from mne.utils import run_tests_if_main, check_version
 
 
@@ -68,13 +69,15 @@ def test_ci():
     arr = np.linspace(0, 1, 1000)[..., np.newaxis]
     assert_allclose(_ci(arr, method="parametric"),
                     _ci(arr, method="bootstrap"), rtol=.005)
-    assert_allclose(bootstrap_ci(arr, stat_fun="median", random_state=0),
-                    bootstrap_ci(arr, stat_fun="mean", random_state=0),
+    assert_allclose(bootstrap_confidence_interval(arr, stat_fun="median",
+                                                  random_state=0),
+                    bootstrap_confidence_interval(arr, stat_fun="mean",
+                                                  random_state=0),
                     rtol=.1)
     # smoke test for new API
     if check_version('numpy', '1.17'):
         random_state = np.random.default_rng(0)
-        bootstrap_ci(arr, random_state=random_state)
+        bootstrap_confidence_interval(arr, random_state=random_state)
 
 
 run_tests_if_main()

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import stats, sparse
 
 from mne.stats import permutation_cluster_1samp_test
-from mne.stats.permutations import permutation_t_test, _ci, _bootstrap_ci
+from mne.stats.permutations import permutation_t_test, _ci, bootstrap_ci
 from mne.utils import run_tests_if_main, check_version
 
 
@@ -68,13 +68,13 @@ def test_ci():
     arr = np.linspace(0, 1, 1000)[..., np.newaxis]
     assert_allclose(_ci(arr, method="parametric"),
                     _ci(arr, method="bootstrap"), rtol=.005)
-    assert_allclose(_bootstrap_ci(arr, stat_fun="median", random_state=0),
-                    _bootstrap_ci(arr, stat_fun="mean", random_state=0),
+    assert_allclose(bootstrap_ci(arr, stat_fun="median", random_state=0),
+                    bootstrap_ci(arr, stat_fun="mean", random_state=0),
                     rtol=.1)
     # smoke test for new API
     if check_version('numpy', '1.17'):
         random_state = np.random.default_rng(0)
-        _bootstrap_ci(arr, random_state=random_state)
+        bootstrap_ci(arr, random_state=random_state)
 
 
 run_tests_if_main()


### PR DESCRIPTION
fixes https://github.com/mne-tools/mne-python/pull/6414#issuecomment-517267800

Earlier it came up that we are using a private function in our [example](https://mne.tools/dev/auto_examples/time_frequency/plot_time_frequency_global_field_power.html?highlight=global%20field%20power), look for `_bootstrap_ci`

The idea was to make it public (and potentially wrap it).
