### PR TITLE
MAINT: Reduce memory usage in examples

### DIFF
--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -207,14 +207,15 @@ def _bem_specify_coils(bem, coils, coord_frame, mults, n_jobs):
     sol = np.zeros((bins[-1] + 1, bem['solution'].shape[1]))
 
     lims = np.concatenate([np.arange(0, sol.shape[0], 100), [sol.shape[0]]])
-    # Compute coeffs for each surface, one at a time
-    for o1, o2, surf, mult in zip(lens[:-1], lens[1:],
-                                  bem['surfs'], bem['field_mult']):
-        coeff = _lin_field_coeff(surf, mult, rmags, cosmags, ws, bins, n_jobs)
-        # put through the bem (in chunks to save memory)
-        for start, stop in zip(lims[:-1], lims[1:]):
-            sol[start:stop] += np.dot(coeff[start:stop],
-                                      bem['solution'][o1:o2])
+    # Put through the bem (in channel-based chunks to save memory)
+    for start, stop in zip(lims[:-1], lims[1:]):
+        mask = np.logical_and(bins >= start, bins < stop)
+        r, c, w, b = rmags[mask], cosmags[mask], ws[mask], bins[mask] - start
+        # Compute coeffs for each surface, one at a time
+        for o1, o2, surf, mult in zip(lens[:-1], lens[1:],
+                                      bem['surfs'], bem['field_mult']):
+            coeff = _lin_field_coeff(surf, mult, r, c, w, b, n_jobs)
+            sol[start:stop] += np.dot(coeff, bem['solution'][o1:o2])
     sol *= mults
     return sol
 

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1495,6 +1495,7 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
     logger.info('Computing SVD of whitened and weighted lead field '
                 'matrix.')
     eigen_fields, sing, eigen_leads = _safe_svd(gain, full_matrices=False)
+    del gain
     logger.info('    largest singular value = %g' % np.max(sing))
     logger.info('    scaling factor to adjust the trace = %g' % trace_GRGT)
 
@@ -1536,17 +1537,20 @@ def make_inverse_operator(info, forward, noise_cov, loose='auto', depth=0.8,
                       kind=FIFF.FIFFV_MNE_SOURCE_COV, diag=True,
                       names=[], projs=[], eig=None, eigvec=None,
                       nfree=1, bads=[])
+    # no need to copy any attributes of forward here because there is
+    # a deepcopy in _prepare_forward
     inv_op = dict(eigen_fields=eigen_fields, eigen_leads=eigen_leads,
                   sing=sing, nave=1., depth_prior=depth_prior,
                   source_cov=source_cov, noise_cov=noise_cov,
                   orient_prior=orient_prior,
                   projs=deepcopy(gain_info['projs']),
                   eigen_leads_weighted=False, source_ori=forward['source_ori'],
-                  mri_head_t=deepcopy(forward['mri_head_t']),
+                  mri_head_t=forward['mri_head_t'],
                   methods=methods, nsource=forward['nsource'],
                   coord_frame=forward['coord_frame'],
-                  source_nn=forward['source_nn'].copy(),
-                  src=deepcopy(forward['src']), fmri_prior=None)
+                  source_nn=forward['source_nn'],
+                  src=forward['src'],
+                  fmri_prior=None)
     inv_info = deepcopy(forward['info'])
     inv_info['bads'] = [bad for bad in info['bads']
                         if bad in forward['info']['ch_names']]

--- a/tutorials/preprocessing/plot_10_preprocessing_overview.py
+++ b/tutorials/preprocessing/plot_10_preprocessing_overview.py
@@ -24,6 +24,7 @@ sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                     'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(sample_data_raw_file)
+raw.crop(0, 60).load_data()  # just use a fraction of data for speed here
 
 ###############################################################################
 # What are artifacts?


### PR DESCRIPTION
Should fix failures on CircleCI due to memory by bringing them < 1.5GB:

1. https://circleci.com/gh/mne-tools/mne-python/14549
   `master`:
   ![Screenshot from 2019-08-05 10-59-29](https://user-images.githubusercontent.com/2365790/62474242-76de2180-b770-11e9-89a1-2c51b948c32b.png)
   PR: 
   ![Screenshot from 2019-08-05 12-12-17](https://user-images.githubusercontent.com/2365790/62478911-4bf8cb00-b77a-11e9-91ef-57f53c7ed9de.png)

2. https://circleci.com/gh/mne-tools/mne-python/14556
   `master`
   ![Screenshot from 2019-08-05 10-54-59](https://user-images.githubusercontent.com/2365790/62474227-6b8af600-b770-11e9-9273-f28b154ddd5c.png)
   PR:
   ![Screenshot from 2019-08-05 10-56-21](https://user-images.githubusercontent.com/2365790/62474234-704faa00-b770-11e9-8d66-c68e7f9a08ed.png)

Changes in forward looping logic didn't seem to have much effect on speed, but did improve memory quite a bit.