### PR TITLE
MAINT: Use prerelease SciPy 1.4.0 for speed boost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,11 +294,14 @@ jobs:
         - image: circleci/python:3.6-jessie
       steps:
         - checkout
+        # Here we use prelease NumPy and SciPy to get the speed boost from
+        # scipy.fft. Once SciPy 1.4.0 is released this can be removed.
         - run:
             name: pip install dependencies
             command: |
                set -e;
-               pip install --user --progress-bar off numpy scipy matplotlib pillow
+               pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" --pre numpy scipy
+               pip install --user --progress-bar off matplotlib pillow
                pip install --user --progress-bar off sphinx numpydoc sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler
                pip install --user -e .
         - run:


### PR DESCRIPTION
I suspect that part of the reason some examples take a long time is due to the FFTs being used, which should be faster with `scipy.fft`. Let's try using the prerelease wheels of SciPy to speed up CircleCI. If it does, we can just live with this for a few months until SciPy 1.4.0 is released.