### PR TITLE
FIX: Raise exception for default value of baseline and `tmin=0` in `Epochs`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ Changelog
 Bug
 ~~~
 
-- Fix one-sample baseline issue in :class:`mne.epochs.BaseEpochs` when using `tmin=0` by `Milan Rybar`_
+- Fix one-sample baseline issue in :class:`mne.epochs.BaseEpochs` when using `tmin=0` by `Milan Rybář`_
 
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 
@@ -3523,3 +3523,5 @@ of commits):
 .. _Paul Roujansky: https://github.com/paulroujansky
 
 .. _Theodore Papadopoulo: https://github.com/papadop
+
+.. _Milan Rybář: http://milanrybar.cz

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ Changelog
 Bug
 ~~~
 
-- Fix one-sample baseline issue in :class:`mne.epochs.BaseEpochs` when using `tmin=0` by `Milan Rybář`_
+- Fix one-sample baseline issue in :class:`mne.Epochs` when using `tmin=0` by `Milan Rybář`_
 
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,8 @@ Changelog
 Bug
 ~~~
 
+- Fix one-sample baseline issue in :class:`mne.epochs.BaseEpochs` when using `tmin=0` by `Milan Rybar`_
+
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 
 - Fix horizontal spacing issues in :meth:`mne.io.Raw.plot_psd` by `Jeff Hanna`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ Changelog
 Bug
 ~~~
 
-- Fix one-sample baseline issue in :class:`mne.Epochs` when using `tmin=0` by `Milan Rybář`_
+- Fix one-sample baseline issue in :class:`mne.BaseEpochs` when using `tmin=0` by `Milan Rybář`_
 
 - Fix :meth:`mne.io.Raw.set_annotations` for ``meas_date`` previous to 1970 by `Joan Massich`_
 

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -85,9 +85,9 @@ def _simulate_data(fwd):
     noise = random.randn(*raw._data.shape) * 1e-14
     raw._data += noise
 
-    # Define a single epoch
+    # Define a single epoch (weird baseline but shouldn't matter)
     epochs = mne.Epochs(raw, [[0, 0, 1]], event_id=1, tmin=0,
-                        tmax=raw.times[-1], preload=True)
+                        tmax=raw.times[-1], baseline=(0., 0.), preload=True)
     evoked = epochs.average()
 
     # Compute the cross-spectral density matrix

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -670,7 +670,7 @@ def test_lcmv_ctf_comp():
     raw = mne.io.read_raw_ctf(raw_fname, preload=True)
 
     events = mne.make_fixed_length_events(raw, duration=0.2)[:2]
-    epochs = mne.Epochs(raw, events, tmin=0., tmax=0.2)
+    epochs = mne.Epochs(raw, events, tmin=-0.1, tmax=0.2)
     evoked = epochs.average()
 
     with pytest.warns(RuntimeWarning,

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -80,7 +80,7 @@ def test_scaler():
     pytest.raises(ValueError, Scaler, None, None)
     pytest.raises(ValueError, scaler.fit, epochs, y)
     pytest.raises(ValueError, scaler.transform, epochs)
-    epochs_bad = Epochs(raw, events, event_id, 0, 0.01,
+    epochs_bad = Epochs(raw, events, event_id, 0, 0.01, baseline=None,
                         picks=np.arange(len(raw.ch_names)))  # non-data chs
     scaler = Scaler(epochs_bad.info, None)
     pytest.raises(ValueError, scaler.fit, epochs_bad.get_data(), y)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1588,6 +1588,11 @@ def _check_baseline(baseline, tmin, tmax, sfreq):
         if not isinstance(baseline, tuple) or len(baseline) != 2:
             raise ValueError('`baseline=%s` is an invalid argument, must be '
                              'a tuple of length 2 or None' % str(baseline))
+        # check default value of baseline and `tmin=0`
+        if baseline == (None, 0) and tmin == 0:
+            raise ValueError('Baseline interval is only one sample. Use '
+                             '`baseline=(0, 0)` if this is desired.')
+
         baseline_tmin, baseline_tmax = baseline
         tstep = 1. / float(sfreq)
         if baseline_tmin is None:

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -68,7 +68,8 @@ def test_compensation_mne():
             raw.apply_gradient_compensation(comp)
         picks = pick_types(raw.info, meg=True, ref_meg=True)
         events = np.array([[0, 0, 1]], dtype=np.int)
-        evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks).average()
+        evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks,
+                        baseline=None).average()
         return evoked
 
     def compensate_mne(fname, comp):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -153,8 +153,7 @@ def test_info():
     event_id, tmin, tmax = 1, -0.2, 0.5
     events = read_events(event_name)
     event_id = int(events[0, 2])
-    epochs = Epochs(raw, events[:1], event_id, tmin, tmax, picks=None,
-                    baseline=(None, 0))
+    epochs = Epochs(raw, events[:1], event_id, tmin, tmax, picks=None)
 
     evoked = epochs.average()
 
@@ -507,7 +506,7 @@ def test_anonymize():
 
     # Test instance method
     events = read_events(event_name)
-    epochs = Epochs(raw, events[:1], 2, 0., 0.1)
+    epochs = Epochs(raw, events[:1], 2, 0., 0.1, baseline=None)
 
     assert not any(_is_anonymous(raw))
     raw.anonymize()

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -510,7 +510,8 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
     n_fft = int(n_fft)
     duration = ((1. - overlap) * n_fft) / raw.info['sfreq']
     events = make_fixed_length_events(raw, 1, tmin, tmax, duration)
-    epochs = Epochs(raw, events, 1, 0, (n_fft - 1) / raw.info['sfreq'])
+    epochs = Epochs(raw, events, 1, 0, (n_fft - 1) / raw.info['sfreq'],
+                    baseline=None)
     out = compute_source_psd_epochs(
         epochs, inverse_operator, lambda2, method, fmin, fmax,
         pick_ori, label, nave, pca, inv_split, bandwidth, adaptive, low_bias,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -361,7 +361,8 @@ def test_decim():
     pytest.raises(ValueError, epochs.decimate, 2, offset=2)
     for this_offset in range(decim):
         epochs = Epochs(raw, events, event_id,
-                        tmin=-this_offset / raw.info['sfreq'], tmax=tmax)
+                        tmin=-this_offset / raw.info['sfreq'], tmax=tmax,
+                        baseline=None)
         idx_offsets = np.arange(decim) + this_offset
         for offset, idx_offset in zip(np.arange(decim), idx_offsets):
             expected_times = epochs.times[idx_offset::decim]
@@ -587,7 +588,7 @@ def test_epochs_baseline():
         expected = data.copy()
         assert_array_equal(epochs_data[0], expected)
         # the baseline period (1 sample here)
-        epochs.apply_baseline((None, 0))
+        epochs.apply_baseline((0, 0))
         expected[0] = [0, 1]
         if preload:
             assert_allclose(epochs_data[0][0], expected[0])


### PR DESCRIPTION
Closes #6616

Raise an exception when using the default value of `baseline=(None, 0)` with `tmin=0` in `Epochs`. The result would be one-sample baseline which is not desired in most cases. One should use `baseline=(0, 0)` if this is desired.