### PR TITLE
Update requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,5 +46,4 @@ dependencies:
   - pydocstyle
   - codespell
   - python-picard
-  - pylsl>=1.12
   - panel

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,4 @@ xlrd
 pydocstyle
 flake8
 pyvista>=0.21.3
-pylsl>=1.12
 panel


### PR DESCRIPTION
just noticed that pylsl was still listed in the `requirements.txt`. it's no longer a requirement after the realtime module moved to `mne-realtime`