### PR TITLE
MRG, ENH: Speed up clustering using numba

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,8 @@ omit =
     */setup.py
     */mne/fixes*
     */mne/utils/linalg.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1285,3 +1285,6 @@ except ImportError:
             return func
         return _jit
     prange = range
+    has_numba = False
+else:
+    has_numba = True

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -51,7 +51,7 @@ def _where_first_fallback(x):
     return next_ind
 
 
-if has_numba:
+if has_numba:  # pragma: no cover
     @jit()
     def _get_buddies(r, s, neighbors, indices=None):
         buddies = list()
@@ -93,7 +93,8 @@ if has_numba:
             if x[ii]:
                 return ii
         return -1
-else:  # fastest way we've found with NumPy
+else:  # pragma: no cover
+    # fastest ways we've found with NumPy
     _get_buddies = _get_buddies_fallback
     _get_selves = _get_selves_fallback
     _where_first = _where_first_fallback

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -34,6 +34,7 @@ if has_numba:
 @pytest.fixture(scope="function", params=params)
 def numba_conditional(monkeypatch, request):
     """Test both code paths on machines that have Numba."""
+    assert request.param in ('Without Numba', 'With Numba')
     if request.param == 'Without Numba' and has_numba:
         monkeypatch.setattr(
             cluster_level, '_get_buddies', cluster_level._get_buddies_fallback)

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -23,26 +23,23 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
 from mne.utils import run_tests_if_main, catch_logging, check_version
 
 
-n_space = 50
-
-
-params = ['Without Numba']
-if has_numba:
-    params += ['With Numba']
-
-
-@pytest.fixture(scope="function", params=params)
+@pytest.fixture(scope="function", params=('Numba', 'NumPy'))
 def numba_conditional(monkeypatch, request):
     """Test both code paths on machines that have Numba."""
-    assert request.param in ('Without Numba', 'With Numba')
-    if request.param == 'Without Numba' and has_numba:
+    assert request.param in ('Numba', 'NumPy')
+    if request.param == 'NumPy' and has_numba:
         monkeypatch.setattr(
             cluster_level, '_get_buddies', cluster_level._get_buddies_fallback)
         monkeypatch.setattr(
             cluster_level, '_get_selves', cluster_level._get_selves_fallback)
         monkeypatch.setattr(
             cluster_level, '_where_first', cluster_level._where_first_fallback)
+    if request.param == 'Numba' and not has_numba:
+        pytest.skip('Numba not installed')
     yield request.param
+
+
+n_space = 50
 
 
 def _get_conditions():

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -263,7 +263,7 @@ def _triangle_neighbors(tris, npts):
 
 
 @jit()
-def _triangle_coords(r, best, r1, nn, r12, r13, a, b, c):
+def _triangle_coords(r, best, r1, nn, r12, r13, a, b, c):  # pragma: no cover
     """Get coordinates of a vertex projected to a triangle."""
     r1 = r1[best]
     tri_nn = nn[best]
@@ -1061,7 +1061,7 @@ def _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2):
 
 
 @jit()
-def _get_tri_dist(p, q, p0, q0, a, b, c, dist):
+def _get_tri_dist(p, q, p0, q0, a, b, c, dist):  # pragma: no cover
     """Get the distance to a triangle edge."""
     p1 = p - p0
     q1 = q - q0
@@ -1161,7 +1161,7 @@ def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from,
 @jit(parallel=True)
 def _find_nearest_tri_pts(rrs, pt_triss, pt_lens,
                           a, b, c, nn, r1, r12, r13, r1213, mat,
-                          run_all=True, reproject=False):
+                          run_all=True, reproject=False):  # pragma: no cover
     """Find nearest point mapping to a set of triangles.
 
     If run_all is False, if the point lies within a triangle, it stops.
@@ -1241,7 +1241,7 @@ def _find_nearest_tri_pts(rrs, pt_triss, pt_lens,
 
 
 @jit()
-def _nearest_tri_edge(pt_tris, to_pt, pqs, dist, a, b, c):
+def _nearest_tri_edge(pt_tris, to_pt, pqs, dist, a, b, c):  # pragma: no cover
     """Get nearest location from a point to the edge of a set of triangles."""
     # We might do something intelligent here. However, for now
     # it is ok to do it in the hard way

--- a/tutorials/stats-sensor-space/plot_stats_cluster_1samp_test_time_frequency.py
+++ b/tutorials/stats-sensor-space/plot_stats_cluster_1samp_test_time_frequency.py
@@ -8,7 +8,7 @@ in time-frequency power estimates. It uses a non-parametric
 statistical procedure based on permutations and cluster
 level statistics.
 
-The procedure consists in:
+The procedure consists of:
 
   - extracting epochs
   - compute single trial power estimates

--- a/tutorials/stats-sensor-space/plot_stats_cluster_erp.py
+++ b/tutorials/stats-sensor-space/plot_stats_cluster_erp.py
@@ -11,15 +11,6 @@ and how to visualise the results.
 
 The underlying data comes from [1]_; we contrast long vs. short words.
 TFCE is described in [2]_.
-
-References
-----------
-.. [1] Dufau, S., Grainger, J., Midgley, KJ., Holcomb, PJ. A thousand
-   words are worth a picture: Snapshots of printed-word processing in an
-   event-related potential megastudy. Psychological Science, 2015
-.. [2] Smith and Nichols 2009, "Threshold-free cluster enhancement:
-   addressing problems of smoothing, threshold dependence, and
-   localisation in cluster inference", NeuroImage 44 (2009) 83-98.
 """
 
 import numpy as np
@@ -125,3 +116,13 @@ plt.colorbar(axes["Left"].images[-1], ax=list(axes.values()), shrink=.3,
              label="uV")
 
 plt.show()
+
+###############################################################################
+# References
+# ----------
+# .. [1] Dufau, S., Grainger, J., Midgley, KJ., Holcomb, PJ. A thousand
+#    words are worth a picture: Snapshots of printed-word processing in an
+#    event-related potential megastudy. Psychological Science, 2015
+# .. [2] Smith and Nichols 2009, "Threshold-free cluster enhancement:
+#    addressing problems of smoothing, threshold dependence, and
+#    localisation in cluster inference", NeuroImage 44 (2009) 83-98.

--- a/tutorials/stats-sensor-space/plot_stats_cluster_time_frequency.py
+++ b/tutorials/stats-sensor-space/plot_stats_cluster_time_frequency.py
@@ -8,7 +8,7 @@ power estimates between conditions. It uses a non-parametric
 statistical procedure based on permutations and cluster
 level statistics.
 
-The procedure consists in:
+The procedure consists of:
 
   - extracting epochs for 2 conditions
   - compute single trial power estimates

--- a/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
@@ -10,8 +10,8 @@ the adjacency between sensors. This serves as a spatial prior
 to the clustering. Spatiotemporal clusters will then
 be visualized using custom matplotlib code.
 
-Caveat for the interpretation of "significant" clusters: see
-the `FieldTrip website`_.
+See the `FieldTrip website`_ for a caveat regarding
+the possible interpretation of "significant" clusters.
 """
 # Authors: Denis Engemann <denis.engemann@gmail.com>
 #          Jona Sassenhagen <jona.sassenhagen@gmail.com>

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
@@ -13,7 +13,6 @@ permutation test across space and time.
 #          Eric Larson <larson.eric.d@gmail.com>
 # License: BSD (3-clause)
 
-
 import os.path as op
 
 import numpy as np

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
@@ -8,7 +8,6 @@ Tests if the source space data are significantly different between
 The multiple comparisons problem is addressed with a cluster-level
 permutation test across space and time.
 """
-
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Eric Larson <larson.eric.d@gmail.com>
 # License: BSD (3-clause)
@@ -111,4 +110,3 @@ brain = stc_all_cluster_vis.plot('fsaverage', hemi='both',
                                  views='lateral', subjects_dir=subjects_dir,
                                  time_label='Duration significant (ms)',
                                  clim=dict(kind='value', lims=[0, 1, 40]))
-brain.save_image('clusters.png')

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
@@ -246,7 +246,7 @@ brain.show_view('medial')
 
 ###############################################################################
 # Finally, let's investigate interaction effect by reconstructing the time
-# courses
+# courses:
 
 inds_t, inds_v = [(clusters[cluster_ind]) for ii, cluster_ind in
                   enumerate(good_cluster_inds)][0]  # first cluster

--- a/tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.py
@@ -237,4 +237,4 @@ plt.show()
 
 ###############################################################################
 # Both cluster level and FDR correction help get rid of
-# putatively spots we saw in the naive f-images.
+# potential spots we saw in the naive f-images.


### PR DESCRIPTION
This code snippet:
```
import time
import numpy as np
import mne
src_fname = (mne.datasets.sample.data_path() +
             '/subjects/fsaverage/bem/fsaverage-ico-5-src.fif')
X = np.random.RandomState(0).randn(8, 5, 20484) * 0.1
src = mne.read_source_spaces(src_fname)
connectivity = mne.spatial_src_connectivity(src)
t0 = time.time()
mne.stats.spatio_temporal_cluster_1samp_test(
    X, connectivity=connectivity, n_jobs=1, buffer_size=None, verbose=True,
    max_step=1)
print(time.time() - t0)
```
on `master` takes 16.7 sec, on this PR it takes 4.5 sec.

Changing `max_step=2` then on `master` it takes 23.1 sec, on this PR it takes 6.1 sec.

So `numba` gets us a ~4x speedup in time-consuming code. ~~I don't love the code dup, but both paths should be tested for correctness by Travis.~~ On systems with numba, both code paths are tested.

The changes to tests were developed on and pass on `master`, just wanted to add some extra sanity checks about the p values. Touched a bunch of clustering examples so that I can check the outputs on CircleCI, but they should match.