### PR TITLE
ENH: improve error msg if key error in epochs[key]

### DIFF
--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -438,7 +438,8 @@ def _hid_match(event_id, keys):
         use_keys.extend(k for k in event_id.keys()
                         if set(key.split('/')).issubset(k.split('/')))
     if len(use_keys) == 0:
-        raise KeyError('Event "%s" is not in Epochs.' % key)
+        raise KeyError('Event "{}" is not in Epochs. Event_ids must be one of '
+                       '"{}"'.format(key, ', '.join(event_id.keys())))
     use_keys = list(set(use_keys))  # deduplicate if necessary
     return use_keys
 


### PR DESCRIPTION
fixes https://github.com/mne-tools/mne-study-template/pull/40#issuecomment-518913104

cc @jasmainak 

New error message:
```Python

    444     return use_keys

KeyError: 'Event "asd" is not in Epochs. Event_ids must be one of "button, deviant, standard"'
```