### PR TITLE
ENH: improve error message when trying to fit an ICA on empty epochs

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -547,6 +547,11 @@ class ICA(ContainsMixin):
         if self.current_fit != 'unfitted':
             self._reset()
 
+        if epochs.events.size == 0:
+            raise RuntimeError('Tried to fit ICA with epochs, but none were '
+                               'found: epochs.events is "{}".'
+                               .format(epochs.events))
+
         logger.info('Fitting ICA to data using %i channels '
                     '(please be patient, this may take a while)' % len(picks))
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -247,6 +247,10 @@ def test_ica_core(method):
         pytest.raises(RuntimeError, ica.get_sources, raw)
         pytest.raises(RuntimeError, ica.get_sources, epochs)
 
+        # Test error upon empty epochs fitting
+        with pytest.raises(RuntimeError, match='none were found'):
+            ica.fit(epochs[0:0])
+
         # test decomposition
         with pytest.warns(UserWarning, match='did not converge'):
             ica.fit(raw, picks=pcks, start=start, stop=stop)


### PR DESCRIPTION
fixes https://github.com/mne-tools/mne-study-template/pull/41#issuecomment-518920458

cc @jasmainak 

Previous error triggered in `np.hstack`:

```
ValueError: need at least one array to concatenate
```

New error message triggered earlier, in `_fit_epochs`:

```
RuntimeError: Tried to fit ICA with epochs, but none were found: epochs.events is "[]".

```