### PR TITLE
MRG, ENH: Speed up eLORETA

### DIFF
--- a/mne/minimum_norm/_eloreta.py
+++ b/mne/minimum_norm/_eloreta.py
@@ -47,6 +47,10 @@ def _compute_eloreta(inv, lambda2, options):
     if n_orient == 3:
         logger.info('        Using %s orientation weights'
                     % ('uniform' if force_equal else 'independent',))
+        # src, sens, 3
+        G_3 = np.ascontiguousarray(G.reshape(-1, n_src, 3).transpose(1, 0, 2))
+    else:
+        G_3 = None
 
     # The following was adapted under BSD license by permission of Guido Nolte
     shape = (n_src,)
@@ -62,7 +66,7 @@ def _compute_eloreta(inv, lambda2, options):
     svd_lwork = _svd_lwork((G.shape[0], G.shape[0]))
     for kk in range(max_iter):
         # Compute inverse of the weights (stabilized) and corresponding M
-        M, _ = _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2,
+        M, _ = _compute_eloreta_inv(G, G_3, W, n_orient, n_nzero, lambda2,
                                     force_equal, pinv2_lwork, svd_lwork)
 
         # Update the weights
@@ -73,9 +77,8 @@ def _compute_eloreta(inv, lambda2, options):
         else:
             norm = 0.
             for ii in range(n_src):
-                sl = slice(n_orient * ii, n_orient * (ii + 1))
                 this_w, this_s = _sqrtm_sym(
-                    np.dot(np.dot(G[:, sl].T, M), G[:, sl]),
+                    np.dot(np.dot(G_3[ii].T, M), G_3[ii]),
                     overwrite_a=True, check_finite=False)
                 W[ii] = np.mean(this_s) if force_equal else this_w
                 norm += np.mean(this_s)
@@ -93,7 +96,7 @@ def _compute_eloreta(inv, lambda2, options):
     else:
         warn('eLORETA weight fitting did not converge (>= %s)' % eps)
     logger.info('        Assembling eLORETA kernel and modifying inverse')
-    M, W_inv = _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2,
+    M, W_inv = _compute_eloreta_inv(G, G_3, W, n_orient, n_nzero, lambda2,
                                     force_equal, pinv2_lwork, svd_lwork)
     K = np.zeros((n_src * n_orient, n_chan))
     for ii in range(n_src):
@@ -111,7 +114,7 @@ def _compute_eloreta(inv, lambda2, options):
     return W
 
 
-def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal,
+def _compute_eloreta_inv(G, G_3, W, n_orient, n_nzero, lambda2, force_equal,
                          pinv2_lwork, svd_lwork):
     """Invert weights and compute M."""
     W_inv = np.empty(W.shape)
@@ -126,10 +129,17 @@ def _compute_eloreta_inv(G, W, n_orient, n_nzero, lambda2, force_equal,
             W_inv[ii] = _repeated_pinv2(W[ii], rcond=1e-7, lwork=pinv2_lwork)
 
     # Weight the gain matrix
-    W_inv_Gt = np.empty(G.shape[::-1])
-    for ii in range(n_src):
-        sl = slice(n_orient * ii, n_orient * (ii + 1))
-        W_inv_Gt[sl, :] = np.dot(W_inv[ii], G[:, sl].T)
+    if n_orient == 1 or force_equal:
+        if n_orient == 3:
+            W_inv_rep = np.repeat(W_inv, 3)
+        else:
+            W_inv_rep = W_inv
+        W_inv_Gt = G.T * W_inv_rep[:, np.newaxis]
+    else:
+        W_inv_Gt = np.empty((n_src, 3, G.shape[0]))
+        for ii in range(n_src):
+            W_inv_Gt[ii] = np.dot(W_inv[ii], G_3[ii].T)
+        W_inv_Gt.shape = (n_src * 3, -1)
 
     # Compute the inverse, normalizing by the trace
     G_W_inv_Gt = np.dot(G, W_inv_Gt)
@@ -144,7 +154,7 @@ def _sqrtm_sym(C, overwrite_a=False, check_finite=True):
     """Compute the square root of a symmetric matrix."""
     # Same as linalg.sqrtm(C) but faster, also yields the eigenvalues
     s, u = eigh(C, overwrite_a=overwrite_a, check_finite=check_finite)
-    mask = s > s.max() * 1e-7
+    mask = s > s[-1] * 1e-7
     u = u[:, mask]
     s = np.sqrt(s[mask])
     a = np.dot(s * u, u.T)

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -89,8 +89,8 @@ def _repeated_pinv2(x, lwork, rcond=None):
         t = u.dtype.char.lower()
         factor = {'f': 1E3, 'd': 1E6}
         rcond = factor[t] * np.finfo(t).eps
-    rank = np.sum(s > rcond * np.max(s))
-    psigma_diag = 1.0 / s[: rank]
+    rank = np.sum(s > rcond * s[0])
+    psigma_diag = 1.0 / s[:rank]
     u[:, :rank] *= psigma_diag
     B = np.transpose(np.conjugate(np.dot(u[:, :rank], vh[:rank])))
     return B


### PR DESCRIPTION
While playing with numba I found a few ways to speed up the eLORETA computations 10-20%.