### PR TITLE
MRG, ENH: Add options to mne watershed_bem

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,8 @@ Changelog
 
 - Now :func:`mne.io.read_raw_ctf` populates ``raw.annotations`` with the markers in ``MarkerFile.mrk`` if any by `Joan Massich`_
 
+- Add options for controlling the use of the ``-T1`` flag and the location of the brainmask output in :ref:`mne watershed_bem <gen_mne_watershed_bem>` by `Eric Larson`_
+
 - Add support to :func:`mne.read_annotations` to read CTF marker files by `Joan Massich`_
 
 - Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -75,11 +75,11 @@ def run():
     parser.add_option('--scale',
                       type=float, default=None, dest='scale',
                       help='Scale factor for the scene.')
-    parser.add_option('--verbose', action='store_true', dest='verbose',
-                      help='Turn on verbose mode.')
     parser.add_option('--simple-rendering', action='store_false',
                       dest='advanced_rendering',
                       help='Use simplified OpenGL rendering')
+    parser.add_option('--verbose', action='store_true', dest='verbose',
+                      help='Turn on verbose mode.')
 
     options, args = parser.parse_args()
 

--- a/mne/commands/mne_report.py
+++ b/mne/commands/mne_report.py
@@ -49,8 +49,6 @@ def run():
                       help="The subjects directory")
     parser.add_option("-s", "--subject", dest="subject",
                       help="The subject name")
-    parser.add_option("-v", "--verbose", dest="verbose",
-                      action='store_true', help="run in verbose mode")
     parser.add_option("--no-browser", dest="no_browser", action='store_false',
                       help="Do not open MNE-Report in browser")
     parser.add_option("--overwrite", dest="overwrite", action='store_false',
@@ -63,6 +61,8 @@ def run():
     parser.add_option("--image-format", type="str", dest="image_format",
                       default='png', help="Image format to use "
                       "(can be 'png' or 'svg')")
+    parser.add_option("-v", "--verbose", dest="verbose",
+                      action='store_true', help="run in verbose mode")
 
     options, args = parser.parse_args()
     path = options.path

--- a/mne/commands/mne_watershed_bem.py
+++ b/mne/commands/mne_watershed_bem.py
@@ -13,6 +13,7 @@ Examples
 import sys
 
 from mne.bem import make_watershed_bem
+from mne.utils import _check_option
 
 
 def run():
@@ -33,16 +34,25 @@ def run():
                       help="Specify the --atlas option for mri_watershed",
                       default=False, action="store_true")
     parser.add_option("-g", "--gcaatlas", dest="gcaatlas",
-                      help="Use the subcortical atlas", default=False,
-                      action="store_true")
+                      help="Specify the --brain_atlas option for "
+                      "mri_watershed", default=False, action="store_true")
     parser.add_option("-p", "--preflood", dest="preflood",
                       help="Change the preflood height", default=None)
     parser.add_option("--copy", dest="copy",
                       help="Use copies instead of symlinks for surfaces",
                       action="store_true")
-    parser.add_option("--verbose", dest="verbose",
-                      help="If not None, override default verbose level",
+    parser.add_option("-t", "--T1", dest="T1",
+                      help="Whether or not to pass the -T1 flag "
+                      "(can be true, false, 0, or 1). "
+                      "By default it takes the same value as gcaatlas.",
                       default=None)
+    parser.add_option("-b", "--brainmask", dest="brainmask",
+                      help="The filename for the brainmask output file "
+                      "relative to the "
+                      "$SUBJECTS_DIR/$SUBJECT/bem/watershed/ directory.",
+                      default="ws")
+    parser.add_option("--verbose", dest="verbose",
+                      help="Turn on verbose mode.", action="store_true")
 
     options, args = parser.parse_args()
 
@@ -58,12 +68,18 @@ def run():
     gcaatlas = options.gcaatlas
     preflood = options.preflood
     copy = options.copy
+    brainmask = options.brainmask
+    T1 = options.T1
+    if T1 is not None:
+        T1 = T1.lower()
+        _check_option("--T1", T1, ('true', 'false', '0', '1'))
+        T1 = T1 in ('true', '1')
     verbose = options.verbose
 
     make_watershed_bem(subject=subject, subjects_dir=subjects_dir,
                        overwrite=overwrite, volume=volume, atlas=atlas,
                        gcaatlas=gcaatlas, preflood=preflood, copy=copy,
-                       verbose=verbose)
+                       T1=T1, brainmask=brainmask, verbose=verbose)
 
 is_main = (__name__ == '__main__')
 if is_main:


### PR DESCRIPTION
closes #6667

This PR for `mne watershed_bem`:

1. Adds control over the `-T1` option (which was otherwise always tied to our `--gcaatlas` option)
2. Adds control over where the brainmasked output ends up.
3. Allows passing `-v orig.mgz` instead of just `-v orig` (be more lenient)
4. Works with newer Freesurfer (the `gcaatlas` option assumed that a file from an older FS version was there, this finds whichever is newest even though there will probably only ever be one)

This is because for some subjects I've wanted to do:
```
mri_watershed -useSRAS -brain_atlas $FREESURFER_HOME/average/RB_all_withskull_2016-05-10.vc700.gca transforms/talairach_with_skull.lta -surf ../bem/watershed/SUBJECT -h 39 orig.mgz brainmask.mgz
```
In MNE we can just do now:
```
mne watershed_bem -s SUBJECT -v orig.mgz -g -p 39 --T1 False -b ../../mri/brainmask.mgz --verbose
```
Along the way I unified handling of `verbose` across commands so that you no longer need to do `--verbose info` in some and `--verbose` in others. Now it's just `--verbose` everywhere, which is nicer.