### PR TITLE
MRG, ENH: Add support for scaling volumetric subjects

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,8 @@ Changelog
 
 - Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.
 
+- Add support for :ref:`mne coreg <gen_mne_coreg>` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
+
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_
 
 - Butterfly channel plots now possible for :meth:`mne.Epochs.plot_psd` with ``average=False``. Infrastructure for this function now shared with analogous Raw function, found in ``mne.viz.utils`` by `Jeff Hanna` _

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -496,7 +496,7 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
     paths['dirs'] = [bem_dirname, surf_dirname]
 
     # surf/ files
-    paths['surf'] = surf = []
+    paths['surf'] = []
     surf_fname = os.path.join(surf_dirname, '{name}')
     surf_names = ('inflated', 'white', 'orig', 'orig_avg', 'inflated_avg',
                   'inflated_pre', 'pial', 'pial_avg', 'smoothwm', 'white_avg',
@@ -509,15 +509,15 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
             path = surf_fname.format(subjects_dir=subjects_dir,
                                      subject=subject, name=name)
             if os.path.exists(path):
-                surf.append(pformat(surf_fname, name=name))
+                paths['surf'].append(pformat(surf_fname, name=name))
     surf_fname = os.path.join(bem_dirname, '{name}')
     surf_names = ('inner_skull.surf', 'outer_skull.surf', 'outer_skin.surf')
     for surf_name in surf_names:
         path = surf_fname.format(subjects_dir=subjects_dir,
                                  subject=subject, name=surf_name)
         if os.path.exists(path):
-            surf.append(pformat(surf_fname, name=surf_name))
-    del surf_names, surf_name, path, surf, hemi
+            paths['surf'].append(pformat(surf_fname, name=surf_name))
+    del surf_names, surf_name, path, hemi
 
     # BEM files
     paths['bem'] = bem = []
@@ -548,22 +548,18 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
                           "skip_fiducials=True." % subject)
 
     # duplicate files (curvature and some surfaces)
-    paths['duplicate'] = dup = []
+    paths['duplicate'] = []
     path = os.path.join(surf_dirname, '{name}')
     surf_fname = os.path.join(surf_dirname, '{name}')
-    for name in ['lh.curv', 'rh.curv']:
-        fname = pformat(path, name=name)
-        dup.append(fname)
-    del path, name, fname
-    surf_dup_names = ('sphere', 'sphere.reg', 'sphere.reg.avg')
+    surf_dup_names = ('curv', 'sphere', 'sphere.reg', 'sphere.reg.avg')
     for surf_dup_name in surf_dup_names:
         for hemi in ('lh.', 'rh.'):
             name = hemi + surf_dup_name
             path = surf_fname.format(subjects_dir=subjects_dir,
                                      subject=subject, name=name)
             if os.path.exists(path):
-                dup.append(pformat(surf_fname, name=name))
-    del surf_dup_name, name, path, dup, hemi
+                paths['duplicate'].append(pformat(surf_fname, name=name))
+    del surf_dup_name, name, path, hemi
 
     # transform files (talairach)
     paths['transforms'] = []
@@ -572,14 +568,6 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
     if os.path.exists(path):
         paths['transforms'].append(transform_fname)
     del transform_fname, path
-
-    # check presence of required files
-    for ftype in ['surf', 'duplicate']:
-        for fname in paths[ftype]:
-            path = fname.format(subjects_dir=subjects_dir, subject=subject)
-            path = os.path.realpath(path)
-            if not os.path.exists(path):
-                raise IOError("Required file not found: %r" % path)
 
     # find source space files
     paths['src'] = src = []


### PR DESCRIPTION
I am working with some subjects (infants) for which surface reconstructions are not very well defined and volumetric analyses are done. Basically `recon-all -autorecon1` is done (one step at a time with manual intervention to fix the transformations), then volumetric analysis can be carried out as usual. But `mne coreg` in `master` has some checks during surrogate scaling that prevent this

It turns out the only surface files that were actually being checked were the `lh.curv`/`rh.curv` ones (since all others were only added to the list if they existed), which wasn't very useful anyway. So that has been eliminated.