### PR TITLE
[MRG] Do not exclude bads if channel indices are supplied

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2884,7 +2884,7 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
     for meg, eeg, seeg, ecog, name in zip(megs, eegs, seegs, ecogs,
                                           _data_types):
         these_picks = pick_types(info, meg=meg, eeg=eeg, seeg=seeg, ecog=ecog,
-                                 ref_meg=False)
+                                 ref_meg=False, exclude=[])
         these_picks = np.intersect1d(these_picks, picks)
         if len(these_picks) > 0:
             picks_list.append(these_picks)


### PR DESCRIPTION
Fixes #6637. The following example correctly produces the PSD for all channels supplied in `picks`:

```
import mne
from mne.datasets import sample


data_path = sample.data_path()
raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
raw = mne.io.read_raw_fif(raw_fname, preload=True)

raw.drop_channels(raw.info["ch_names"][:315])
raw.drop_channels(raw.info["ch_names"][4:])
raw.info["bads"] = ['EEG 003', 'EEG 004']

raw.plot_psd(spatial_colors=False, picks=range(4))  # plot all 4 channels
```

The default behavior is still to exclude bad channels, that is

```
raw.plot_psd(spatial_colors=False)
raw.plot_psd(spatial_colors=False, picks="all")
````

generate PSDs only for the 2 good channels just like before.

However, I don't know what's the deal with `spatial_colors=True`, which only plots 3 channels ("EEG 001", "EEG 002", and "EEG 004"). But maybe this should be fixed in a different PR.