### PR TITLE
MRG, ENH: Make `mne` runnable

### DIFF
--- a/bin/mne
+++ b/bin/mne
@@ -1,40 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
-import glob
-import subprocess
-import os.path as op
-
 import mne
-
-mne_bin_dir = op.dirname(mne.__file__)
-valid_commands = sorted(glob.glob(op.join(mne_bin_dir,
-                                          'commands', 'mne_*.py')))
-valid_commands = [c.split(op.sep)[-1][4:-3] for c in valid_commands]
-
-
-def print_help():
-    print("Usage : mne command options\n")
-    print("Accepted commands :\n")
-    for c in valid_commands:
-        print("\t- %s" % c)
-    print("\nExample : mne browse_raw --raw sample_audvis_raw.fif")
-    print("\nGetting help example : mne compute_proj_eog -h")
-    sys.exit(0)
-
-
-if len(sys.argv) == 1:
-    print_help()
-elif ("help" in sys.argv[1] or "-h" in sys.argv[1]):
-    print_help()
-elif sys.argv[1] == "--version":
-    print("MNE %s" % mne.__version__)
-elif sys.argv[1] not in valid_commands:
-    print('Invalid command: "%s"\n' % sys.argv[1])
-    print_help()
-    sys.exit(0)
-else:
-    cmd = sys.argv[1]
-    cmd_path = op.join(mne_bin_dir, 'commands', 'mne_%s.py' % cmd)
-    sys.exit(subprocess.call([sys.executable, cmd_path] + sys.argv[2:]))
+mne.commands.utils.main()

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -551,6 +551,12 @@ we link to.
     ``:func:`mne.set_config``` will work but ``:func:`mne.utils.set_config```
     will not).
 
+A list of external modules available for referencing using ``intersphinx`` can
+be found in ``doc/conf.py``, and thein inventories can be dumped to file and
+examined with commands like::
+
+    $ python -msphinx.ext.intersphinx https://docs.python.org/3/objects.inv > python.txt
+
 
 Other style guidance
 --------------------
@@ -689,6 +695,31 @@ recipes are available; run ``make help`` from the :file:`doc` directory or
 consult the `Sphinx-Gallery`_ documentation for additional details.
 
 
+Modifying command-line tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MNE-Python provides support for a limited set of :ref:`python_commands`.
+These are typically used with a call like::
+
+    $ mne browse_raw ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
+
+These are generally available for convenience, and can be useful for quick
+debugging (in this case, for :class:`mne.io.Raw.plot`).
+
+If a given command-line function fails, they can also be executed as part of
+the ``mne`` module with ``python -m``. For example::
+
+    $ python -i -m mne browse_raw ...
+
+Because this was launched with ``python -i``, once the script completes
+it will drop to a Python terminal. This is useful when there are errors,
+because then you can drop into a :func:`post-mortem debugger <python:pdb.pm>`:
+
+.. code-block:: python
+
+    >>> import pdb; pdb.pm()
+
+
 .. _`github-workflow`:
 
 GitHub workflow
@@ -770,6 +801,7 @@ the upstream master branch; it separates different kinds of changes into
 separate commits and uses labels like ``DOC``, ``FIX``, and ``STY`` to make it
 easier for maintainers to review the changeset; etc. If you are new to GitHub
 it can serve as a useful example of what to expect from the PR review process.
+
 
 .. MNE
 

--- a/mne/__main__.py
+++ b/mne/__main__.py
@@ -1,0 +1,7 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+# License: BSD Style.
+
+from .commands.utils import main
+
+if __name__ == '__main__':
+    main()

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -121,6 +121,4 @@ def run():
     plt.show(block=True)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_bti2fiff.py
+++ b/mne/commands/mne_bti2fiff.py
@@ -31,6 +31,7 @@ Examples
 
 import sys
 
+import mne
 from mne.io import read_raw_bti
 
 
@@ -89,9 +90,5 @@ def run():
 
     raw.save(out_fname)
     raw.close()
-    if is_main:
-        sys.exit(0)
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_clean_eog_ecg.py
+++ b/mne/commands/mne_clean_eog_ecg.py
@@ -139,6 +139,4 @@ def run():
     clean_ecg_eog(raw_in, raw_out, eog=eog, ecg=ecg, quiet=quiet)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_compare_fiff.py
+++ b/mne/commands/mne_compare_fiff.py
@@ -26,6 +26,4 @@ def run():
     mne.viz.compare_fiff(args[0], args[1])
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_compute_proj_ecg.py
+++ b/mne/commands/mne_compute_proj_ecg.py
@@ -208,6 +208,4 @@ def run():
     print("Writing ECG events in %s" % ecg_event_fname)
     mne.write_events(ecg_event_fname, events)
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -12,7 +12,6 @@ Examples
 """
 
 import os.path as op
-import sys
 
 import mne
 from mne.utils import ETSContext
@@ -118,10 +117,5 @@ def run():
             scale=options.scale,
             advanced_rendering=options.advanced_rendering,
             verbose=options.verbose)
-    if is_main:
-        sys.exit(0)
 
-
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_flash_bem.py
+++ b/mne/commands/mne_flash_bem.py
@@ -41,6 +41,7 @@ Before running this script do the following:
 """
 # Authors: Lorenzo De Santis
 
+import mne
 from mne.bem import convert_flash_mris, make_flash_bem
 
 
@@ -104,6 +105,4 @@ def run():
                    copy=copy, verbose=True)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -14,6 +14,7 @@ import sys
 import os
 import os.path as op
 
+import mne
 from mne.utils import run_subprocess, get_subjects_dir
 
 
@@ -101,6 +102,4 @@ def run():
     freeview_bem_surfaces(subject, subjects_dir, method)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_kit2fiff.py
+++ b/mne/commands/mne_kit2fiff.py
@@ -81,8 +81,5 @@ def run():
 
     raw.save(out_fname)
     raw.close()
-    sys.exit(0)
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_make_scalp_surfaces.py
+++ b/mne/commands/mne_make_scalp_surfaces.py
@@ -15,10 +15,11 @@ Examples
     $ mne make_scalp_surfaces --overwrite --subject sample
 
 """
-import os
 import copy
+import os
 import os.path as op
 import sys
+
 import mne
 from mne.utils import (run_subprocess, verbose, logger, ETSContext,
                        get_subjects_dir)
@@ -134,5 +135,4 @@ def _run(subjects_dir, subject, force, overwrite, no_decimate, verbose=None):
         mne.write_bem_surfaces(dec_fname, dec_surf)
 
 
-if (__name__ == '__main__'):
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_maxfilter.py
+++ b/mne/commands/mne_maxfilter.py
@@ -146,6 +146,4 @@ def run():
         with open(origin_out, 'w') as fid:
             fid.write(origin + '\n')
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_report.py
+++ b/mne/commands/mne_report.py
@@ -15,6 +15,7 @@ Examples
 import sys
 import time
 
+import mne
 from mne.report import Report
 from mne.utils import verbose, logger
 
@@ -98,6 +99,4 @@ def run():
     log_elapsed(time.time() - t0, verbose=verbose)
     report.save(open_browser=open_browser, overwrite=overwrite)
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_show_fiff.py
+++ b/mne/commands/mne_show_fiff.py
@@ -18,7 +18,6 @@ To see only tag 102:
 
 # Authors : Eric Larson, PhD
 
-import codecs
 import sys
 import mne
 
@@ -30,19 +29,10 @@ def run():
     parser.add_option("-t", "--tag", dest="tag",
                       help="provide information about this tag", metavar="TAG")
     options, args = parser.parse_args()
-
     if len(args) != 1:
         parser.print_help()
         sys.exit(1)
-    if sys.platform == "win32" and int(sys.version[0]) < 3:
-        # This works around an annoying bug on Windows for show_fiff, see:
-        # https://pythonhosted.org/kitchen/unicode-frustrations.html
-        UTF8Writer = codecs.getwriter('utf8')
-        sys.stdout = UTF8Writer(sys.stdout)
     msg = mne.io.show_fiff(args[0], tag=options.tag).strip()
     print(msg)
 
-
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_show_info.py
+++ b/mne/commands/mne_show_info.py
@@ -34,6 +34,4 @@ def run():
     print(info)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_surf2bem.py
+++ b/mne/commands/mne_surf2bem.py
@@ -44,6 +44,4 @@ def run():
     mne.write_bem_surfaces(options.fif, surf)
 
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/mne_watershed_bem.py
+++ b/mne/commands/mne_watershed_bem.py
@@ -12,6 +12,7 @@ Examples
 
 import sys
 
+import mne
 from mne.bem import make_watershed_bem
 from mne.utils import _check_option
 
@@ -81,6 +82,4 @@ def run():
                        gcaatlas=gcaatlas, preflood=preflood, copy=copy,
                        T1=T1, brainmask=brainmask, verbose=verbose)
 
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+mne.utils.run_command_if_main()

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -98,6 +98,5 @@ def main():
     else:
         cmd = sys.argv[1]
         cmd = importlib.import_module('.mne_%s' % (cmd,), 'mne.commands')
-        print(sys.argv)
-        sys.argv = sys.argv[2:]
+        sys.argv = sys.argv[1:]
         cmd.run()

--- a/mne/commands/utils.py
+++ b/mne/commands/utils.py
@@ -5,8 +5,12 @@
 #
 # License: BSD (3-clause)
 
+import glob
+import importlib
 import os
+import os.path as op
 from optparse import OptionParser
+import sys
 
 import mne
 
@@ -66,3 +70,34 @@ def get_optparser(cmdpath, usage=None, prog_prefix='mne', version=None):
                           epilog=epilog, usage=usage)
 
     return parser
+
+
+def main():
+    """Entrypoint for mne <command> usage."""
+    mne_bin_dir = op.dirname(op.dirname(__file__))
+    valid_commands = sorted(glob.glob(op.join(mne_bin_dir,
+                                              'commands', 'mne_*.py')))
+    valid_commands = [c.split(op.sep)[-1][4:-3] for c in valid_commands]
+
+
+    def print_help():  # noqa
+        print("Usage : mne command options\n")
+        print("Accepted commands :\n")
+        for c in valid_commands:
+            print("\t- %s" % c)
+        print("\nExample : mne browse_raw --raw sample_audvis_raw.fif")
+        print("\nGetting help example : mne compute_proj_eog -h")
+
+    if len(sys.argv) == 1 or "help" in sys.argv[1] or "-h" in sys.argv[1]:
+        print_help()
+    elif sys.argv[1] == "--version":
+        print("MNE %s" % mne.__version__)
+    elif sys.argv[1] not in valid_commands:
+        print('Invalid command: "%s"\n' % sys.argv[1])
+        print_help()
+    else:
+        cmd = sys.argv[1]
+        cmd = importlib.import_module('.mne_%s' % (cmd,), 'mne.commands')
+        print(sys.argv)
+        sys.argv = sys.argv[2:]
+        cmd.run()

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -28,7 +28,8 @@ from .misc import (run_subprocess, _pl, _clean_names, pformat,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser)
 from .progressbar import ProgressBar
-from ._testing import (run_tests_if_main, requires_sklearn,
+from ._testing import (run_tests_if_main, run_command_if_main,
+                       requires_sklearn,
                        requires_version, requires_nibabel, requires_mayavi,
                        requires_good_network, requires_mne, requires_pandas,
                        requires_h5py, traits_test, requires_pysurfer,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -262,6 +262,13 @@ def run_tests_if_main():
         raise AssertionError('pytest finished with errors (%d)' % (code,))
 
 
+def run_command_if_main():
+    """Run a given command if it's __main__."""
+    local_vars = inspect.currentframe().f_back.f_locals
+    if local_vars.get('__name__', '') == '__main__':
+        local_vars['run']()
+
+
 class ArgvSetter(object):
     """Temporarily set sys.argv."""
 


### PR DESCRIPTION
I wanted to be able to debug after a `mne` command failed, such as:
```
mne watershed_bem -o -s fsaverage --verbose
```
This PR enables `python -m mne ...` to do the same things as `mne ...`. For example I can do (to debug after running):
```
python -uim mne watershed_bem -o -s fsaverage --verbose
```
The key is the addition of the `mne/__main__.py` file, the rest is cleanups and unifications related to that.