### PR TITLE
[MRG] Handle events with non-unique event time samples

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.19.dev0)
 Changelog
 ~~~~~~~~~
 
+- Add support for making epochs with duplicated events, by allowing three policies: "error" (default), "drop", or "merge" in :class:`mne.Epochs` by `Stefan Appelhoff`_
+
 - Add :func:`mne.channels.make_dig_montage` to create :class:`mne.channels.DigMontage` objects out of np.arrays by `Joan Massich`_
 
 - Add support for reading in BrainVision CapTrak (BVCT) digitization coordinate files in :func:`mne.channels.read_dig_montage` by `Stefan Appelhoff`_

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -218,7 +218,7 @@ def _merge_events(events, event_id):
             # Check if we already have an entry for merged keys of duplicate
             # events ... if yes, reuse it
             got_val = False
-            for key in event_id.keys():
+            for key in event_id:
                 if set(key.split('/')) == set(new_key_comps):
                     got_val = True
                     new_event_val = event_id[key]
@@ -227,7 +227,7 @@ def _merge_events(events, event_id):
             # Else, find an unused value for the new key and make an entry into
             # the event_id dict
             if not got_val:
-                ev_vals = np.concatenate((np.array(list(event_id.values())),
+                ev_vals = np.concatenate((list(event_id.values()),
                                           events[:, 1:].flatten()),
                                          axis=0)
                 new_event_val = np.setdiff1d(np.arange(1, 9999999),

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1894,7 +1894,7 @@ class Epochs(BaseEpochs):
                  flat=None, proj=True, decim=1, reject_tmin=None,
                  reject_tmax=None, detrend=None, on_missing='error',
                  reject_by_annotation=True, metadata=None,
-                 verbose=None):  # noqa: D102
+                 event_repeated='error', verbose=None):  # noqa: D102
         if not isinstance(raw, BaseRaw):
             raise ValueError('The first argument to `Epochs` must be an '
                              'instance of mne.io.BaseRaw')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -211,14 +211,15 @@ def _merge_events(events, event_id):
             new_key_comps = list()
             for val in ev_vals:
                 # inverse dict lookup, because event_id is a one-to-one map
-                kk = list(event_id.keys())[list(event_id.values()).index(val)]
-                new_key_comps.append(kk)
+                event_id_keys = list(event_id.keys())
+                event_id_vals = list(event_id.values())
+                new_key_comps = [event_id_keys[event_id_vals.index(code)]
+                                 for code in ev_vals]
 
             # Check if we already have a corresponding val, if yes, reuse it
             got_val = False
             for key in event_id.keys():
-                key_comps = key.split('/')
-                if set(key_comps) == set(new_key_comps):
+                if set(key.split('/')) == set(new_key_comps):
                     got_val = True
                     new_event_val = event_id[key]
                     break

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -268,12 +268,8 @@ def _handle_event_repeated(events, event_id, event_repeated):
         new_events = np.delete(new_events, to_delete, 0)
 
     # Remove obsolete kv-pairs from event_id after handling
-    to_delete = list()
-    for key, val in event_id.items():
-        if val not in new_events[:, 1:].flatten():
-            to_delete.append(key)
-    for key in to_delete:
-        event_id.pop(key)
+    keys = new_events[:, 1:].flatten()
+    event_id = {k: v for k, v in event_id.items() if v in keys}
 
     return new_events, event_id
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -227,24 +227,30 @@ def _handle_duplicate_events(events, event_id, event_repeated):
 
             if len(np.unique(ev_codes)) > 1:
 
-                new_event_id_key = list()
+                new_key_comps = list()
                 for code in ev_codes:
                     # inverse dict lookup, because event_id is a one-to-one map
                     kk = list(event_id.keys())[list(event_id.values())
                                                .index(code)]
-                    new_event_id_key.append(kk)
-                new_event_id_key = '/'.join(new_event_id_key)
+                    new_key_comps.append(kk)
 
                 # Check if we already have a corresponding code
-                new_event_code = event_id.get(new_event_id_key, False)
+                got_code = False
+                for key in event_id.keys():
+                    key_comps = key.split('/')
+                    if set(key_comps) == set(new_key_comps):
+                        got_code = True
+                        new_event_code = event_id[key]
+                        break
 
                 # Else, make one and add it to the event_id dict
-                if not new_event_code:
+                if not got_code:
                     ev_codes = np.concatenate((np.array(list(event_id.values())),  # noqa: E501
                                                events[:, 1:].flatten()),
                                               axis=0)
                     new_event_code = np.setdiff1d(np.arange(1, 9999999),
                                                   ev_codes).min()
+                    new_event_id_key = '/'.join(sorted(new_key_comps))
                     event_id[new_event_id_key] = int(new_event_code)
 
             # However, if duplicate time samples have same event code, revert

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -250,6 +250,14 @@ def _handle_duplicate_events(events, event_id, event_repeated):
         raise ValueError('`event_repeated` must be one of "error", "drop",'
                          ' "merge" but is "{}"'.format(event_repeated))
 
+    # Remove obsolete kv-pairs from event_id after handling
+    to_delete = list()
+    for key, val in event_id.items():
+        if val not in new_events[:, 1:].flatten():
+            to_delete.append(key)
+    for key in to_delete:
+        event_id.pop(key)
+
     return new_events, event_id
 
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -184,18 +184,78 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
     end_file(fid)
 
 
+def _merge_events(events, event_id):
+    """Merge repeated events."""
+    event_id = event_id.copy()
+    new_events = events.copy()
+    to_delete = list()
+    unique_events, counts = np.unique(events[:, 0], return_counts=True)
+    for ev in unique_events[counts > 1]:
+
+        # indices at which the non-unique events happened
+        idxs = (events[:, 0] == ev).nonzero()[0]
+
+        # Figure out new value for events[:, 1]. Set to 0, if mixed vals exist
+        new_prior = 0
+        if len(np.unique(events[idxs, 1])) == 1:
+            new_prior = np.unique(events[idxs, 1])[0]
+
+        # Make an event_id for the merged event
+        ev_vals = events[idxs, 2]
+
+        if len(np.unique(ev_vals)) > 1:
+
+            new_key_comps = list()
+            for val in ev_vals:
+                # inverse dict lookup, because event_id is a one-to-one map
+                kk = list(event_id.keys())[list(event_id.values()).index(val)]
+                new_key_comps.append(kk)
+
+            # Check if we already have a corresponding val
+            got_val = False
+            for key in event_id.keys():
+                key_comps = key.split('/')
+                if set(key_comps) == set(new_key_comps):
+                    got_val = True
+                    new_event_val = event_id[key]
+                    break
+
+            # Else, make one and add it to the event_id dict
+            if not got_val:
+                ev_vals = np.concatenate((np.array(list(event_id.values())),
+                                          events[:, 1:].flatten()),
+                                         axis=0)
+                new_event_val = np.setdiff1d(np.arange(1, 9999999),
+                                             ev_vals).min()
+                new_event_id_key = '/'.join(sorted(new_key_comps))
+                event_id[new_event_id_key] = int(new_event_val)
+
+        # However, if duplicate time samples have same event val, revert
+        # to "drop" behavior
+        else:
+            new_event_val = ev_vals[0]
+
+        # Replace duplicate event times with merged event
+        new_events[idxs[0], 1] = new_prior
+        new_events[idxs[0], 2] = new_event_val
+        to_delete += list(idxs[1:])
+
+    # Delete
+    new_events = np.delete(new_events, to_delete, 0)
+
+    return new_events, event_id
+
+
 def _handle_event_repeated(events, event_id, event_repeated):
     """Handle repeated events."""
-    u_evs, u_idxs, counts = np.unique(events[:, 0], return_index=True,
-                                      return_counts=True)
+    unique_events, u_ev_idxs = np.unique(events[:, 0], return_index=True)
 
     # Return early if no duplicates
-    if len(u_evs) == len(events):
+    if len(unique_events) == len(events):
         return events, event_id
 
     # Else, we have duplicates. Triage ...
     _check_option('event_repeated', event_repeated, ['error', 'drop', 'merge'])
-    event_id = event_id.copy()
     if event_repeated == 'error':
         raise RuntimeError('Event time samples were not unique. Consider '
                            'setting the `event_repeated` parameter."')
@@ -203,68 +263,12 @@ def _handle_event_repeated(events, event_id, event_repeated):
     elif event_repeated == 'drop':
         logger.info('Multiple event values for single event times found. '
                     'Keeping the first occurrence and dropping all others.')
-        new_events = events[u_idxs]
+        new_events = events[u_ev_idxs]
 
     elif event_repeated == 'merge':
         logger.info('Multiple event values for single event times found. '
                     'Creating new event value to reflect simultaneous events.')
-        new_events = events.copy()
-        to_delete = list()
-        non_u_evs = u_evs[counts > 1]
-        for ev in non_u_evs:
-
-            # indices at which the non-unique events happened
-            idxs = (events[:, 0] == ev).nonzero()[0]
-
-            # Figure out new value for events[:, 1]. Fall back to 0, if mixed
-            # values exist.
-            new_prior = 0
-            if len(np.unique(events[idxs, 1])) == 1:
-                new_prior = np.unique(events[idxs, 1])[0]
-
-            # Make an event_id for the merged event
-            ev_vals = events[idxs, 2]
-
-            if len(np.unique(ev_vals)) > 1:
-
-                new_key_comps = list()
-                for val in ev_vals:
-                    # inverse dict lookup, because event_id is a one-to-one map
-                    kk = list(event_id.keys())[list(event_id.values())
-                                               .index(val)]
-                    new_key_comps.append(kk)
-
-                # Check if we already have a corresponding val
-                got_val = False
-                for key in event_id.keys():
-                    key_comps = key.split('/')
-                    if set(key_comps) == set(new_key_comps):
-                        got_val = True
-                        new_event_val = event_id[key]
-                        break
-
-                # Else, make one and add it to the event_id dict
-                if not got_val:
-                    ev_vals = np.concatenate((np.array(list(event_id.values())),  # noqa: E501
-                                               events[:, 1:].flatten()),
-                                              axis=0)
-                    new_event_val = np.setdiff1d(np.arange(1, 9999999),
-                                                 ev_vals).min()
-                    new_event_id_key = '/'.join(sorted(new_key_comps))
-                    event_id[new_event_id_key] = int(new_event_val)
-
-            # However, if duplicate time samples have same event val, revert
-            # to "drop" behavior
-            else:
-                new_event_val = ev_vals[0]
-
-            # Replace duplicate event times with merged event
-            new_events[idxs[0], 1] = new_prior
-            new_events[idxs[0], 2] = new_event_val
-            to_delete += list(idxs[1:])
-
-        # Delete
-        new_events = np.delete(new_events, to_delete, 0)
+        new_events, event_id = _merge_events(events, event_id)
 
     # Remove obsolete kv-pairs from event_id after handling
     keys = new_events[:, 1:].flatten()

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -184,7 +184,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
     end_file(fid)
 
 
-def _handle_duplicate_events(events, event_id, event_repeated):
+def _handle_event_repeated(events, event_id, event_repeated):
     """Handle duplicated events."""
     u_evs, u_idxs, counts = np.unique(events[:, 0], return_index=True,
                                       return_counts=True)
@@ -412,9 +412,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                 self.drop_log = drop_log
             events = events[selected]
 
-            events, self.event_id = _handle_duplicate_events(events,
-                                                             self.event_id,
-                                                             event_repeated)
+            events, self.event_id = _handle_event_repeated(events,
+                                                           self.event_id,
+                                                           event_repeated)
 
             n_events = len(events)
             if n_events > 1:

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -217,16 +217,14 @@ def _merge_events(events, event_id):
 
             # Check if we already have an entry for merged keys of duplicate
             # events ... if yes, reuse it
-            got_val = False
-            for key in event_id:
+            for key in event_id.keys():
                 if set(key.split('/')) == set(new_key_comps):
-                    got_val = True
                     new_event_val = event_id[key]
                     break
 
             # Else, find an unused value for the new key and make an entry into
             # the event_id dict
-            if not got_val:
+            else:
                 ev_vals = np.concatenate((list(event_id.values()),
                                           events[:, 1:].flatten()),
                                          axis=0)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -215,7 +215,12 @@ def _handle_duplicate_events(events, event_id, event_repeated):
 
                 # Make an event_id for the merged event
                 ev_codes = events[idxs, 2]
-                new_event_id = '{}'.format(ev_codes)
+                new_event_id = list()
+                for code in ev_codes:
+                    # inverse dict lookup, because event_id is a one-to-one map
+                    key = event_id.keys()[event_id.values().index(code)]
+                    new_event_id.append(key)
+                new_event_id = '/'.join(new_event_id)
 
                 # Check if we already have a corresponding code
                 new_event_code = event_id.get(new_event_id, False)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -185,7 +185,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt):
 
 
 def _handle_event_repeated(events, event_id, event_repeated):
-    """Handle duplicated events."""
+    """Handle repeated events."""
     u_evs, u_idxs, counts = np.unique(events[:, 0], return_index=True,
                                       return_counts=True)
 
@@ -201,13 +201,13 @@ def _handle_event_repeated(events, event_id, event_repeated):
                            'setting the `event_repeated` parameter."')
 
     elif event_repeated == 'drop':
-        logger.info('Multiple event codes for single event times found. '
+        logger.info('Multiple event values for single event times found. '
                     'Keeping the first occurrence and dropping all others.')
         new_events = events[u_idxs]
 
     elif event_repeated == 'merge':
-        logger.info('Multiple event codes for single event times found. '
-                    'Creating new event code to reflect simultaneous events.')
+        logger.info('Multiple event values for single event times found. '
+                    'Creating new event value to reflect simultaneous events.')
         new_events = events.copy()
         to_delete = list()
         non_u_evs = u_evs[counts > 1]
@@ -223,44 +223,44 @@ def _handle_event_repeated(events, event_id, event_repeated):
                 new_prior = np.unique(events[idxs, 1])[0]
 
             # Make an event_id for the merged event
-            ev_codes = events[idxs, 2]
+            ev_vals = events[idxs, 2]
 
-            if len(np.unique(ev_codes)) > 1:
+            if len(np.unique(ev_vals)) > 1:
 
                 new_key_comps = list()
-                for code in ev_codes:
+                for val in ev_vals:
                     # inverse dict lookup, because event_id is a one-to-one map
                     kk = list(event_id.keys())[list(event_id.values())
-                                               .index(code)]
+                                               .index(val)]
                     new_key_comps.append(kk)
 
-                # Check if we already have a corresponding code
-                got_code = False
+                # Check if we already have a corresponding val
+                got_val = False
                 for key in event_id.keys():
                     key_comps = key.split('/')
                     if set(key_comps) == set(new_key_comps):
-                        got_code = True
-                        new_event_code = event_id[key]
+                        got_val = True
+                        new_event_val = event_id[key]
                         break
 
                 # Else, make one and add it to the event_id dict
-                if not got_code:
-                    ev_codes = np.concatenate((np.array(list(event_id.values())),  # noqa: E501
+                if not got_val:
+                    ev_vals = np.concatenate((np.array(list(event_id.values())),  # noqa: E501
                                                events[:, 1:].flatten()),
                                               axis=0)
-                    new_event_code = np.setdiff1d(np.arange(1, 9999999),
-                                                  ev_codes).min()
+                    new_event_val = np.setdiff1d(np.arange(1, 9999999),
+                                                 ev_vals).min()
                     new_event_id_key = '/'.join(sorted(new_key_comps))
-                    event_id[new_event_id_key] = int(new_event_code)
+                    event_id[new_event_id_key] = int(new_event_val)
 
-            # However, if duplicate time samples have same event code, revert
+            # However, if duplicate time samples have same event val, revert
             # to "drop" behavior
             else:
-                new_event_code = ev_codes[0]
+                new_event_val = ev_vals[0]
 
             # Replace duplicate event times with merged event
             new_events[idxs[0], 1] = new_prior
-            new_events[idxs[0], 2] = new_event_code
+            new_events[idxs[0], 2] = new_event_val
             to_delete += list(idxs[1:])
 
         # Delete

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1915,6 +1915,7 @@ class Epochs(BaseEpochs):
     events to be: {'aud/vis': 3} and [[0, 0, 3], ] respectively.
 
     """
+
     @verbose
     def __init__(self, raw, events, event_id=None, tmin=-0.2, tmax=0.5,
                  baseline=(None, 0), picks=None, preload=False, reject=None,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -223,23 +223,33 @@ def _handle_duplicate_events(events, event_id, event_repeated):
 
             # Make an event_id for the merged event
             ev_codes = events[idxs, 2]
-            new_event_id_key = list()
-            for code in ev_codes:
-                # inverse dict lookup, because event_id is a one-to-one map
-                kk = list(event_id.keys())[list(event_id.values()).index(code)]
-                new_event_id_key.append(kk)
-            new_event_id_key = '/'.join(new_event_id_key)
 
-            # Check if we already have a corresponding code
-            new_event_code = event_id.get(new_event_id_key, False)
+            if len(np.unique(ev_codes)) > 1:
 
-            # Else, make one and add it to the event_id dict
-            if not new_event_code:
-                ev_codes = np.concatenate((np.array(list(event_id.values())),
-                                           events[:, 1:].flatten()), axis=0)
-                new_event_code = np.setdiff1d(np.arange(1, 9999999),
-                                              ev_codes).min()
-                event_id[new_event_id_key] = int(new_event_code)
+                new_event_id_key = list()
+                for code in ev_codes:
+                    # inverse dict lookup, because event_id is a one-to-one map
+                    kk = list(event_id.keys())[list(event_id.values())
+                                               .index(code)]
+                    new_event_id_key.append(kk)
+                new_event_id_key = '/'.join(new_event_id_key)
+
+                # Check if we already have a corresponding code
+                new_event_code = event_id.get(new_event_id_key, False)
+
+                # Else, make one and add it to the event_id dict
+                if not new_event_code:
+                    ev_codes = np.concatenate((np.array(list(event_id.values())),  # noqa: E501
+                                               events[:, 1:].flatten()),
+                                              axis=0)
+                    new_event_code = np.setdiff1d(np.arange(1, 9999999),
+                                                  ev_codes).min()
+                    event_id[new_event_id_key] = int(new_event_code)
+
+            # However, if duplicate time samples have same event code, revert
+            # to "drop" behavior
+            else:
+                new_event_code = ev_codes[0]
 
             # Replace duplicate event times with merged event
             new_events[idxs[0], 1] = new_prior

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -213,9 +213,10 @@ def _handle_duplicate_events(events, event_id, event_repeated):
             # indices at which the non-unique events happened
             idxs = (events[:, 0] == ev).nonzero()[0]
 
-            # Figure out event_codes prior to events to be merged
+            # Figure out event_codes prior to events to be merged, fall back
+            # to 0, if heterogeneous codes exist
             prior_codes = events[idxs, 1]
-            new_prior = np.nan
+            new_prior = 0
             if len(np.unique(prior_codes)) == 1:
                 new_prior = np.unique(prior_codes)[0]
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -208,6 +208,7 @@ def _handle_duplicate_events(events, event_id, event_repeated):
         logger.info('{} Creating new event code to reflect simultaneous '
                     'events and updating event_id.'.format(msg))
         new_events = events.copy()
+        to_delete = list()
         non_u_evs = u_evs[counts > 1]
         for ev in non_u_evs:
 
@@ -254,7 +255,10 @@ def _handle_duplicate_events(events, event_id, event_repeated):
             # Replace duplicate event times with merged event
             new_events[idxs[0], 1] = new_prior
             new_events[idxs[0], 2] = new_event_code
-            new_events = np.delete(new_events, idxs[1:], 0)
+            to_delete += list(idxs[1:])
+
+        # Delete
+        new_events = np.delete(new_events, to_delete, 0)
 
     else:
         raise ValueError('`event_repeated` must be one of "error", "drop",'

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -7,6 +7,7 @@
 #          Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>
 #          Denis Engemann <denis.engemann@gmail.com>
 #          Mainak Jas <mainak@neuro.hut.fi>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 
@@ -1820,12 +1821,10 @@ class Epochs(BaseEpochs):
 
         .. versionadded:: 0.16
     event_repeated : str
-        How to handle duplicate time samples with different event codes.
-        Can be 'error' (default), to raise an error, 'drop' to only retain the
-        row occurring first in the events array, or 'merge' to create a new
-        event code that reflects a co-occurrence of several events at the same
-        time. For the 'merge' option, the event_id dictionary will be updated
-        accordingly (see Notes for details).
+        How to handle duplicates in `events[:, 0]`. Can be 'error' (default),
+        to raise an error, 'drop' to only retain the row occurring first in the
+        `events`, or 'merge' to combine the coinciding events (=duplicates)
+        into a new event (see Notes for details).
 
         .. versionadded:: 0.19
     %(verbose)s
@@ -1880,10 +1879,9 @@ class Epochs(BaseEpochs):
     :meth:`mne.Epochs.iter_evoked` or :meth:`mne.Epochs.next`) use the same
     internal state.
 
-    If `event_repeated` is set to "merge", the simultaneous events will be
-    merged into a single event_id and assigned a new id_number as follows:
-
-    event_id['{event_id_1}/{event_id_2}/...'] = new_id_number
+    If `event_repeated` is set to "merge", the coinciding events (duplicates)
+    will be merged into a single event_id and assigned a new id_number as
+    follows: `event_id['{event_id_1}/{event_id_2}/...'] = new_id_number`
 
     """
     @verbose

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -246,10 +246,12 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         .. versionadded:: 0.16
     event_repeated : str
-        Can be 'error' (default), to raise an error if event time samples are
-        not unique, or 'merge' to merge event codes with the same event time
-        sample according to the following general pattern:
-        '%s/%s' % (event_1_key, event_2_key)
+        How to handle duplicate time samples with different event codes.
+        Can be 'error' (default), to raise an error, 'drop' to only retain the
+        row occurring dirst in the events array, or 'merge' to create a new
+        event code that reflects a co-occurrence of several events at the same
+        time. For the 'merge' option, the event_id dictionary will be updated
+        accordingly.
 
         .. versionadded:: 0.19
     %(verbose)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -235,8 +235,8 @@ def _handle_duplicate_events(events, event_id, event_repeated):
 
             # Else, make one and add it to the event_id dict
             if not new_event_code:
-                ev_codes = np.array(list(event_id.values()))
-                ev_codes = np.concatenate((ev_codes, events[:, 2]), 0)
+                ev_codes = np.concatenate((np.array(list(event_id.values())),
+                                           events[:, 1:].flatten()), axis=0)
                 new_event_code = np.setdiff1d(np.arange(1, 9999999),
                                               ev_codes).min()
                 event_id[new_event_id_key] = int(new_event_code)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -216,12 +216,11 @@ def _handle_event_repeated(events, event_id, event_repeated):
             # indices at which the non-unique events happened
             idxs = (events[:, 0] == ev).nonzero()[0]
 
-            # Figure out event_codes prior to events to be merged, fall back
-            # to 0, if heterogeneous codes exist
-            prior_codes = events[idxs, 1]
+            # Figure out new value for events[:, 1]. Fall back to 0, if mixed
+            # values exist.
             new_prior = 0
-            if len(np.unique(prior_codes)) == 1:
-                new_prior = np.unique(prior_codes)[0]
+            if len(np.unique(events[idxs, 1])) == 1:
+                new_prior = np.unique(events[idxs, 1])[0]
 
             # Make an event_id for the merged event
             ev_codes = events[idxs, 2]

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -210,11 +210,10 @@ def _merge_events(events, event_id):
 
             # Find all event_id keys involved in duplicated events. These
             # keys will be merged to become a new entry in "event_id"
-            for val in ev_vals:
-                event_id_keys = list(event_id.keys())
-                event_id_vals = list(event_id.values())
-                new_key_comps = [event_id_keys[event_id_vals.index(value)]
-                                 for value in ev_vals]
+            event_id_keys = list(event_id.keys())
+            event_id_vals = list(event_id.values())
+            new_key_comps = [event_id_keys[event_id_vals.index(value)]
+                             for value in ev_vals]
 
             # Check if we already have an entry for merged keys of duplicate
             # events ... if yes, reuse it

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -248,7 +248,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     event_repeated : str
         How to handle duplicate time samples with different event codes.
         Can be 'error' (default), to raise an error, 'drop' to only retain the
-        row occurring dirst in the events array, or 'merge' to create a new
+        row occurring first in the events array, or 'merge' to create a new
         event code that reflects a co-occurrence of several events at the same
         time. For the 'merge' option, the event_id dictionary will be updated
         accordingly.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -196,18 +196,18 @@ def _handle_event_repeated(events, event_id, event_repeated):
     # Else, we have duplicates. Triage ...
     _check_option('event_repeated', event_repeated, ['error', 'drop', 'merge'])
     event_id = event_id.copy()
-    msg = 'Multiple event codes for single event times found.'
     if event_repeated == 'error':
-        raise RuntimeError('Event time samples were not unique')
+        raise RuntimeError('Event time samples were not unique. Consider '
+                           'setting the `event_repeated` parameter."')
 
     elif event_repeated == 'drop':
-        logger.info('{} Keeping the first occurrence and dropping all others.'
-                    .format(msg))
+        logger.info('Multiple event codes for single event times found. '
+                    'Keeping the first occurrence and dropping all others.')
         new_events = events[u_idxs]
 
     elif event_repeated == 'merge':
-        logger.info('{} Creating new event code to reflect simultaneous '
-                    'events and updating event_id.'.format(msg))
+        logger.info('Multiple event codes for single event times found. '
+                    'Creating new event code to reflect simultaneous events.')
         new_events = events.copy()
         to_delete = list()
         non_u_evs = u_evs[counts > 1]

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -224,8 +224,8 @@ def _handle_duplicate_events(events, event_id, event_repeated):
             new_event_id = list()
             for code in ev_codes:
                 # inverse dict lookup, because event_id is a one-to-one map
-                key = event_id.keys()[event_id.values().index(code)]
-                new_event_id.append(key)
+                kk = list(event_id.keys())[list(event_id.values()).index(code)]
+                new_event_id.append(kk)
             new_event_id = '/'.join(new_event_id)
 
             # Check if we already have a corresponding code
@@ -234,8 +234,8 @@ def _handle_duplicate_events(events, event_id, event_repeated):
             # Else, make one and add it to the event_id dict
             if not new_event_code:
                 ev_codes = np.array(list(event_id.values()))
-                ev_codes = np.concat((ev_codes, events[:, 2]), 0)
-                new_event_code = np.setdiff1d(np.arange(900, 9000),
+                ev_codes = np.concatenate((ev_codes, events[:, 2]), 0)
+                new_event_code = np.setdiff1d(np.arange(1, 9999999),
                                               ev_codes).min()
                 event_id[new_event_id] = int(new_event_code)
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -358,6 +358,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                         # Else, make one and add it to the event_id dict
                         if not new_event_code:
                             ev_codes = np.array(list(self.event_id.values()))
+                            ev_codes = np.concat((ev_codes, events[:, 2]), 0)
                             new_event_code = np.setdiff1d(np.arange(900, 9000),
                                                           ev_codes).min()
                             self.event_id[new_event_id] = int(new_event_code)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1902,7 +1902,10 @@ class Epochs(BaseEpochs):
 
     If `event_repeated` is set to "merge", the coinciding events (duplicates)
     will be merged into a single event_id and assigned a new id_number as
-    follows: `event_id['{event_id_1}/{event_id_2}/...'] = new_id_number`
+    follows: `event_id['{event_id_1}/{event_id_2}/...'] = new_id_number`.
+    For example with the event_id {'aud': 1, 'vis': 2} and the events
+    [[0, 0, 1], [0, 0, 2]], the "merge" behavior will update both event_id and
+    events to be: {'aud/vis': 3} and [[0, 0, 3], ] respectively.
 
     """
     @verbose

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -194,6 +194,7 @@ def _handle_event_repeated(events, event_id, event_repeated):
         return events, event_id
 
     # Else, we have duplicates. Triage ...
+    _check_option('event_repeated', event_repeated, ['error', 'drop', 'merge'])
     event_id = event_id.copy()
     msg = 'Multiple event codes for single event times found.'
     if event_repeated == 'error':
@@ -265,10 +266,6 @@ def _handle_event_repeated(events, event_id, event_repeated):
 
         # Delete
         new_events = np.delete(new_events, to_delete, 0)
-
-    else:
-        raise ValueError('`event_repeated` must be one of "error", "drop",'
-                         ' "merge" but is "{}"'.format(event_repeated))
 
     # Remove obsolete kv-pairs from event_id after handling
     to_delete = list()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -28,7 +28,8 @@ from mne.fixes import rfft, rfftfreq
 from mne.preprocessing import maxwell_filter
 from mne.epochs import (
     bootstrap, equalize_epoch_counts, combine_event_ids, add_channels_epochs,
-    EpochsArray, concatenate_epochs, BaseEpochs, average_movements)
+    EpochsArray, concatenate_epochs, BaseEpochs, average_movements,
+    _handle_duplicate_events)
 from mne.utils import (requires_pandas, run_tests_if_main, object_diff,
                        requires_version, catch_logging, _FakeNoPandas,
                        assert_meg_snr, check_version)
@@ -56,6 +57,14 @@ evoked_nf_name = op.join(base_dir, 'test-nf-ave.fif')
 event_id, tmin, tmax = 1, -0.2, 0.5
 event_id_2 = np.int64(2)  # to test non Python int types
 rng = np.random.RandomState(42)
+
+
+def test_handle_duplicate_events():
+    """Test handling of duplicate events."""
+    event_id = {'aud': 1, 'vis': 2}
+    events = np.array([[0, 0, 1], [0, 0, 2]])
+    with pytest.raises(ValueError, match='`event_repeated` must be one of '):
+        _handle_duplicate_events(events, event_id, event_repeated='Bogus')
 
 
 def _get_data(preload=False):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -78,7 +78,6 @@ def test_handle_event_repeated():
     events, event_id = _handle_event_repeated(EVENTS, EVENT_ID, 'merge')
     assert_array_equal(events[0][-1], events[1][-1])
     assert_array_equal(events, [[0, 0, 4], [3, 0, 4], [5, 0, 5], [7, 0, 1]])
-    assert 'aud/vis' in event_id.keys()
     assert set(event_id.keys()) == set(['aud', 'aud/vis', 'aud/foo/vis'])
     assert event_id['aud/vis'] == 4
 
@@ -96,7 +95,6 @@ def test_handle_event_repeated():
     heterogeneous_events = np.array([[0, 3, 2], [0, 4, 1]])
     events, event_id = _handle_event_repeated(heterogeneous_events,
                                               EVENT_ID, 'merge')
-    assert 'aud/vis' in event_id.keys()
     assert set(event_id.keys()) == set(['aud/vis'])
     assert event_id['aud/vis'] == 5
     np.testing.assert_array_equal(events, np.array([[0, 0, 5], ]))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -116,7 +116,6 @@ def test_handle_event_repeated():
                                               EVENT_ID, 'merge')
     np.testing.assert_array_equal(events, np.array([[0, 0, 1], ]))
     assert set(event_id.keys()) == set(['aud'])
-    del equal_events
 
 
 def _get_data(preload=False):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -78,6 +78,12 @@ def test_handle_duplicate_events():
     np.testing.assert_array_equal(events3, np.array([[0, 0, 3], ]))
     assert 'aud/vis' in event_id3.keys()
 
+    # Test early return with no changes
+    fine_events = np.array([[0, 0, 1], [1, 0, 2]])
+    events4, event_id4 = _handle_duplicate_events(fine_events, event_id, 'no')
+    assert event_id == event_id4
+    np.testing.assert_array_equal(events4, fine_events)
+
 
 def _get_data(preload=False):
     """Get data."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -108,6 +108,15 @@ def test_handle_duplicate_events():
     assert set(event_id.keys()) == set(['aud', 'vis', 'aud/vis'])
     np.testing.assert_array_equal(events, np.array([[0, 99, 3],
                                                     [1, 0, 1], [2, 0, 2]]))
+    del homogeneous_events
+
+    # Test dropping instead of merging, if event_codes to be merged are equal
+    equal_events = np.array([[0, 0, 1], [0, 0, 1]])
+    events, event_id = _handle_duplicate_events(equal_events,
+                                                EVENT_ID, 'merge')
+    np.testing.assert_array_equal(events, np.array([[0, 0, 1], ]))
+    assert set(event_id.keys()) == set(['aud'])
+    del equal_events
 
 
 def _get_data(preload=False):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -73,15 +73,15 @@ def test_handle_duplicate_events():
 
     events, event_id = _handle_duplicate_events(EVENTS, EVENT_ID, 'drop')
     np.testing.assert_array_equal(events, np.array([[0, 0, 1], ]))
-    assert event_id == EVENT_ID
+    assert event_id == {'aud': 1}
 
     events, event_id = _handle_duplicate_events(EVENTS, EVENT_ID, 'merge')
     np.testing.assert_array_equal(events, np.array([[0, 0, 3], ]))
     assert 'aud/vis' in event_id.keys()
-    assert set(event_id.keys()) == set(['aud', 'vis', 'aud/vis'])
+    assert set(event_id.keys()) == set(['aud/vis'])
     assert event_id['aud/vis'] == 3
 
-    # Test early return with no changes
+    # Test early return with no changes: no error for wrong event_repeated arg
     fine_events = np.array([[0, 0, 1], [1, 0, 2]])
     events, event_id = _handle_duplicate_events(fine_events, EVENT_ID, 'no')
     assert event_id == EVENT_ID
@@ -95,7 +95,7 @@ def test_handle_duplicate_events():
     events, event_id = _handle_duplicate_events(heterogeneous_events,
                                                 EVENT_ID, 'merge')
     assert 'vis/aud' in event_id.keys()
-    assert set(event_id.keys()) == set(['aud', 'vis', 'vis/aud'])
+    assert set(event_id.keys()) == set(['vis/aud'])
     assert event_id['vis/aud'] == 5
     np.testing.assert_array_equal(events, np.array([[0, 0, 5], ]))
     del heterogeneous_events

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -63,8 +63,20 @@ def test_handle_duplicate_events():
     """Test handling of duplicate events."""
     event_id = {'aud': 1, 'vis': 2}
     events = np.array([[0, 0, 1], [0, 0, 2]])
+
+    with pytest.raises(RuntimeError, match='Event time samples were not uniq'):
+        _handle_duplicate_events(events, event_id, event_repeated='error')
+
     with pytest.raises(ValueError, match='`event_repeated` must be one of '):
-        _handle_duplicate_events(events, event_id, event_repeated='Bogus')
+        _handle_duplicate_events(events, event_id, event_repeated='bogus')
+
+    events2, event_id2 = _handle_duplicate_events(events, event_id, 'drop')
+    np.testing.assert_array_equal(events2, np.array([[0, 0, 1], ]))
+    assert event_id2 == event_id
+
+    events3, event_id3 = _handle_duplicate_events(events, event_id, 'merge')
+    np.testing.assert_array_equal(events3, np.array([[0, 0, 3], ]))
+    assert 'aud/vis' in event_id3.keys()
 
 
 def _get_data(preload=False):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #         Denis Engemann <denis.engemann@gmail.com>
+#         Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -60,7 +60,7 @@ rng = np.random.RandomState(42)
 
 
 def test_handle_event_repeated():
-    """Test handling of duplicate events."""
+    """Test handling of repeated events."""
     # A general test case
     EVENT_ID = {'aud': 1, 'vis': 2, 'foo': 3}
     EVENTS = np.array([[0, 0, 1], [0, 0, 2],
@@ -100,7 +100,7 @@ def test_handle_event_repeated():
     np.testing.assert_array_equal(events, np.array([[0, 0, 5], ]))
     del heterogeneous_events
 
-    # Test keeping a homogeneous "prior-to-event" code
+    # Test keeping a homogeneous "prior-to-event" code (=events[:, 1])
     homogeneous_events = np.array([[0, 99, 1], [0, 99, 2],
                                    [1, 0, 1], [2, 0, 2]])
     events, event_id = _handle_event_repeated(homogeneous_events,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -100,6 +100,15 @@ def test_handle_duplicate_events():
     np.testing.assert_array_equal(events, np.array([[0, 0, 5], ]))
     del heterogeneous_events
 
+    # Test keeping a homogeneous "prior-to-event" code
+    homogeneous_events = np.array([[0, 99, 1], [0, 99, 2],
+                                   [1, 0, 1], [2, 0, 2]])
+    events, event_id = _handle_duplicate_events(homogeneous_events,
+                                                EVENT_ID, 'merge')
+    assert set(event_id.keys()) == set(['aud', 'vis', 'aud/vis'])
+    np.testing.assert_array_equal(events, np.array([[0, 99, 3],
+                                                    [1, 0, 1], [2, 0, 2]]))
+
 
 def _get_data(preload=False):
     """Get data."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -71,9 +71,6 @@ def test_handle_event_repeated():
     with pytest.raises(RuntimeError, match='Event time samples were not uniq'):
         _handle_event_repeated(EVENTS, EVENT_ID, event_repeated='error')
 
-    with pytest.raises(ValueError, match='`event_repeated` must be one of '):
-        _handle_event_repeated(EVENTS, EVENT_ID, event_repeated='bogus')
-
     events, event_id = _handle_event_repeated(EVENTS, EVENT_ID, 'drop')
     assert_array_equal(events, [[0, 0, 1], [3, 0, 2], [5, 0, 2], [7, 0, 1]])
     assert event_id == {'aud': 1, 'vis': 2}

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -85,7 +85,7 @@ def test_handle_event_repeated():
     fine_events = np.array([[0, 0, 1], [1, 0, 2]])
     events, event_id = _handle_event_repeated(fine_events, EVENT_ID, 'no')
     assert event_id == EVENT_ID
-    np.testing.assert_array_equal(events, fine_events)
+    assert_array_equal(events, fine_events)
     del fine_events
 
     # Test falling back on 0 for heterogeneous "prior-to-event" codes
@@ -97,7 +97,7 @@ def test_handle_event_repeated():
                                               EVENT_ID, 'merge')
     assert set(event_id.keys()) == set(['aud/vis'])
     assert event_id['aud/vis'] == 5
-    np.testing.assert_array_equal(events, np.array([[0, 0, 5], ]))
+    assert_array_equal(events, np.array([[0, 0, 5], ]))
     del heterogeneous_events
 
     # Test keeping a homogeneous "prior-to-event" code (=events[:, 1])
@@ -106,15 +106,14 @@ def test_handle_event_repeated():
     events, event_id = _handle_event_repeated(homogeneous_events,
                                               EVENT_ID, 'merge')
     assert set(event_id.keys()) == set(['aud', 'vis', 'aud/vis'])
-    np.testing.assert_array_equal(events, np.array([[0, 99, 4],
-                                                    [1, 0, 1], [2, 0, 2]]))
+    assert_array_equal(events, np.array([[0, 99, 4], [1, 0, 1], [2, 0, 2]]))
     del homogeneous_events
 
     # Test dropping instead of merging, if event_codes to be merged are equal
     equal_events = np.array([[0, 0, 1], [0, 0, 1]])
     events, event_id = _handle_event_repeated(equal_events,
                                               EVENT_ID, 'merge')
-    np.testing.assert_array_equal(events, np.array([[0, 0, 1], ]))
+    assert_array_equal(events, np.array([[0, 0, 1], ]))
     assert set(event_id.keys()) == set(['aud'])
 
 


### PR DESCRIPTION
fixes #6665 


# To Do

- [x] update `event_id` by removing a key-value-pair if the value is no longer in `events` after `handle_duplicate_events`
- [x] if `event_repeated` is "merge" but a duplicate actually has the same event code, switch to "drop" behavior
- [x] fix for https://github.com/mne-tools/mne-python/pull/6688/commits/31d1eda98b5b598c43a6fd21d3124694ec532fbd: instead of updating events on every loop iteration, collect indices to delete and deleta all at once. --> see https://github.com/mne-tools/mne-python/pull/6688/commits/323b61ab923631540e8436f49ae5389c0adb38f1
- [x] 2nd fix for https://github.com/mne-tools/mne-python/pull/6688/commits/31d1eda98b5b598c43a6fd21d3124694ec532fbd: "aud/vis" and "vis/aud" should map to the same thing --> see https://github.com/mne-tools/mne-python/pull/6688/commits/e72fcaa12fb888d4f3049065b0bf94601ddd105d
- [x] updated whatsnew