### PR TITLE
MRG, ENH: Speed up src filtering and vol label src creation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Changelog
 
 - Speed up morph map generation in :func:`mne.read_morph_map` by ~5-10x by using :func:`numba.jit` by `Eric Larson`_
 
+- Speed up :func:`mne.setup_volume_source_space`, especially when ``volume_label is not None`` by `Eric Larson`_
+
 - Add :func:`mne.dig_mri_distances` to compute the distances between digitized head points and the MRI head surface by `Alex Gramfort`_ and `Eric Larson`_
 
 - Add scale bars for data channels in :func:`mne.io.Raw.plot` by `Eric Larson`_

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1680,7 +1680,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     # Explicit list of points
     if not isinstance(pos, float):
         # Make the grid of sources
-        sp = _make_discrete_source_space(pos)
+        sp = [_make_discrete_source_space(pos)]
     else:
         # Load the brain surface as a template
         if isinstance(bem, str):
@@ -1717,21 +1717,25 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         # Make the grid of sources in MRI space
         if volume_label is not None:
             sp = []
-            for label in volume_label:
+            for li, label in enumerate(volume_label):
                 vol_sp = _make_volume_source_space(surf, pos, exclude, mindist,
-                                                   mri, label)
+                                                   mri, label, first=li == 0)
                 sp.append(vol_sp)
+            logger.info('')
         else:
-            sp = _make_volume_source_space(surf, pos, exclude, mindist, mri,
-                                           volume_label)
+            sp = [_make_volume_source_space(surf, pos, exclude, mindist, mri,
+                                            volume_label)]
+    if volume_label is None:
+        volume_label = ['the whole brain']
+    assert len(volume_label) == len(sp)
 
     # Compute an interpolation matrix to show data in MRI_VOXEL coord frame
-    if not isinstance(sp, list):
-        sp = [sp]
+    assert isinstance(sp, list)
 
     if mri is not None:
-        for s in sp:
-            _add_interpolator(s, mri, add_interpolator)
+        for si, s in enumerate(sp):
+            _add_interpolator(s, mri, add_interpolator, first=si == 0,
+                              volume_label=volume_label[si])
     elif sp[0]['type'] == 'vol':
         # If there is no interpolator, it's actually a discrete source space
         sp[0]['type'] = 'discrete'
@@ -1807,8 +1811,44 @@ def _make_discrete_source_space(pos, coord_frame='mri'):
     return sp
 
 
+def _get_volume_label_mask(mri, volume_label, rr):
+    try:
+        import nibabel as nib
+    except ImportError:
+        raise ImportError("nibabel is required to read segmentation file.")
+
+    logger.info('Selecting voxels from %s' % volume_label)
+
+    # Read the segmentation data using nibabel
+    mgz = nib.load(mri)
+    mgz_data = mgz.get_data()
+
+    # Get the numeric index for this volume label
+    lut = _get_lut()
+    vol_id = _get_lut_id(lut, volume_label, True)
+
+    # Get indices for this volume label in voxel space
+    vox_bool = mgz_data == vol_id
+
+    # Get the 3 dimensional indices in voxel space
+    vox_xyz = np.array(np.where(vox_bool)).T
+
+    # Transform to RAS coordinates
+    # (use tkr normalization or volume won't align with surface sources)
+    trans = _get_mgz_header(mri)['vox2ras_tkr']
+    # Convert transform from mm to m
+    trans[:3] /= 1000.
+    rr_voi = apply_trans(trans, vox_xyz)  # positions of VOI in RAS space
+    # Filter out points too far from volume region voxels
+    dists = _compute_nearest(rr_voi, rr, return_dists=True)[1]
+    # Maximum distance from center of mass of a voxel to any of its corners
+    maxdist = linalg.norm(trans[:3, :3].sum(0) / 2.)
+    return dists <= maxdist
+
+
 def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
-                              volume_label=None, do_neighbors=True, n_jobs=1):
+                              volume_label=None, do_neighbors=True, n_jobs=1,
+                              first=True):
     """Make a source space which covers the volume bounded by surf."""
     # Figure out the grid size in the MRI coordinate frame
     if 'rr' in surf:
@@ -1823,22 +1863,24 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
         maxdist = surf['R']
 
     # Define the sphere which fits the surface
-
-    logger.info('Surface CM = (%6.1f %6.1f %6.1f) mm'
-                % (1000 * cm[0], 1000 * cm[1], 1000 * cm[2]))
-    logger.info('Surface fits inside a sphere with radius %6.1f mm'
-                % (1000 * maxdist))
-    logger.info('Surface extent:')
-    for c, mi, ma in zip('xyz', mins, maxs):
-        logger.info('    %s = %6.1f ... %6.1f mm' % (c, 1000 * mi, 1000 * ma))
+    if first:
+        logger.info('Surface CM = (%6.1f %6.1f %6.1f) mm'
+                    % (1000 * cm[0], 1000 * cm[1], 1000 * cm[2]))
+        logger.info('Surface fits inside a sphere with radius %6.1f mm'
+                    % (1000 * maxdist))
+        logger.info('Surface extent:')
+        for c, mi, ma in zip('xyz', mins, maxs):
+            logger.info('    %s = %6.1f ... %6.1f mm'
+                        % (c, 1000 * mi, 1000 * ma))
     maxn = np.array([np.floor(np.abs(m) / grid) + 1 if m > 0 else -
                      np.floor(np.abs(m) / grid) - 1 for m in maxs], int)
     minn = np.array([np.floor(np.abs(m) / grid) + 1 if m > 0 else -
                      np.floor(np.abs(m) / grid) - 1 for m in mins], int)
-    logger.info('Grid extent:')
-    for c, mi, ma in zip('xyz', minn, maxn):
-        logger.info('    %s = %6.1f ... %6.1f mm'
-                    % (c, 1000 * mi * grid, 1000 * ma * grid))
+    if first:
+        logger.info('Grid extent:')
+        for c, mi, ma in zip('xyz', minn, maxn):
+            logger.info('    %s = %6.1f ... %6.1f mm'
+                        % (c, 1000 * mi * grid, 1000 * ma * grid))
 
     # Now make the initial grid
     ns = maxn - minn + 1
@@ -1858,16 +1900,35 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
     sp['nn'][:, 2] = 1.0
     assert sp['rr'].shape[0] == npts
 
-    logger.info('%d sources before omitting any.', sp['nuse'])
+    if first:
+        logger.info('%d sources before omitting any.', sp['nuse'])
 
     # Exclude infeasible points
     dists = np.linalg.norm(sp['rr'] - cm, axis=1)
     bads = np.where(np.logical_or(dists < exclude, dists > maxdist))[0]
     sp['inuse'][bads] = False
     sp['nuse'] -= len(bads)
-    logger.info('%d sources after omitting infeasible sources not within '
-                '%0.1f - %0.1f mm.',
-                sp['nuse'], 1000 * exclude, 1000 * maxdist)
+    if first:
+        logger.info('%d sources after omitting infeasible sources not within '
+                    '%0.1f - %0.1f mm.',
+                    sp['nuse'], 1000 * exclude, 1000 * maxdist)
+
+    # Restrict sources to volume of interest
+    if volume_label is not None:
+        if not do_neighbors:
+            raise RuntimeError('volume_label cannot be None unless '
+                               'do_neighbors is True')
+        logger.info('')
+        bads = ~_get_volume_label_mask(mri, volume_label, sp['rr'])
+        # Update source info
+        sp['inuse'][bads] = False
+        sp['nuse'] = sp['inuse'].sum()
+        sp['seg_name'] = volume_label
+        sp['mri_file'] = mri
+
+        # Update log
+        logger.info('%d sources remaining after excluding sources too far '
+                    'from VOI voxels', sp['nuse'])
 
     if 'rr' in surf:
         _filter_source_spaces(surf, mindist, None, [sp], n_jobs)
@@ -1885,9 +1946,6 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
                 % (sp['nuse'], mindist))
 
     if not do_neighbors:
-        if volume_label is not None:
-            raise RuntimeError('volume_label cannot be None unless '
-                               'do_neighbors is True')
         return sp
     k = np.arange(npts)
     neigh = np.empty((26, npts), int)
@@ -1962,64 +2020,15 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
     idx3 = np.logical_and(idx2, x < maxn[0])
     neigh[25, idx3] = k[idx3] + 1 - nrow + nplane
 
-    # Restrict sources to volume of interest
-    if volume_label is not None:
-        try:
-            import nibabel as nib
-        except ImportError:
-            raise ImportError("nibabel is required to read segmentation file.")
-
-        logger.info('Selecting voxels from %s' % volume_label)
-
-        # Read the segmentation data using nibabel
-        mgz = nib.load(mri)
-        mgz_data = mgz.get_data()
-
-        # Get the numeric index for this volume label
-        lut = _get_lut()
-        vol_id = _get_lut_id(lut, volume_label, True)
-
-        # Get indices for this volume label in voxel space
-        vox_bool = mgz_data == vol_id
-
-        # Get the 3 dimensional indices in voxel space
-        vox_xyz = np.array(np.where(vox_bool)).T
-
-        # Transform to RAS coordinates
-        # (use tkr normalization or volume won't align with surface sources)
-        trans = _get_mgz_header(mri)['vox2ras_tkr']
-        # Convert transform from mm to m
-        trans[:3] /= 1000.
-        rr_voi = apply_trans(trans, vox_xyz)  # positions of VOI in RAS space
-        # Filter out points too far from volume region voxels
-        dists = _compute_nearest(rr_voi, sp['rr'], return_dists=True)[1]
-        # Maximum distance from center of mass of a voxel to any of its corners
-        maxdist = linalg.norm(trans[:3, :3].sum(0) / 2.)
-        bads = np.where(dists > maxdist)[0]
-
-        # Update source info
-        sp['inuse'][bads] = False
-        sp['vertno'] = np.where(sp['inuse'] > 0)[0]
-        sp['nuse'] = len(sp['vertno'])
-        sp['seg_name'] = volume_label
-        sp['mri_file'] = mri
-
-        # Update log
-        logger.info('%d sources remaining after excluding sources too far '
-                    'from VOI voxels', sp['nuse'])
-
     # Omit unused vertices from the neighborhoods
-    logger.info('Adjusting the neighborhood info...')
+    logger.info('Adjusting the neighborhood info.')
     # remove non source-space points
-    log_inuse = sp['inuse'] > 0
-    neigh[:, np.logical_not(log_inuse)] = -1
+    neigh[:, np.logical_not(sp['inuse'])] = -1
     # remove these points from neigh
-    vertno = np.where(log_inuse)[0]
-    sp['vertno'] = vertno
     old_shape = neigh.shape
     neigh = neigh.ravel()
     checks = np.where(neigh >= 0)[0]
-    removes = np.logical_not(np.in1d(checks, vertno))
+    removes = np.logical_not(np.in1d(checks, sp['vertno']))
     neigh[checks[removes]] = -1
     neigh.shape = old_shape
     neigh = neigh.T
@@ -2087,10 +2096,12 @@ def _get_mgz_header(fname):
     return header
 
 
-def _add_interpolator(s, mri_name, add_interpolator):
+def _add_interpolator(s, mri_name, add_interpolator, first=True,
+                      volume_label='the whole brain'):
     """Compute a sparse matrix to interpolate the data into an MRI volume."""
     # extract transformation information from mri
-    logger.info('Reading %s...' % mri_name)
+    if first:
+        logger.info('Reading %s...' % mri_name)
     header = _get_mgz_header(mri_name)
     mri_width, mri_height, mri_depth = header['dims']
 
@@ -2108,9 +2119,10 @@ def _add_interpolator(s, mri_name, add_interpolator):
         s['interpolator'] = sparse.csr_matrix((nvox, s['np']))
         return
 
-    _print_coord_trans(s['src_mri_t'], 'Source space : ')
-    _print_coord_trans(s['vox_mri_t'], 'MRI volume : ')
-    _print_coord_trans(s['mri_ras_t'], 'MRI volume : ')
+    if first:
+        _print_coord_trans(s['src_mri_t'], 'Source space : ')
+        _print_coord_trans(s['vox_mri_t'], 'MRI volume : ')
+        _print_coord_trans(s['mri_ras_t'], 'MRI volume : ')
 
     #
     # Convert MRI voxels from destination (MRI volume) to source (volume
@@ -2121,7 +2133,7 @@ def _add_interpolator(s, mri_name, add_interpolator):
                                      'mri_voxel', 'mri_voxel')
     combo_trans['trans'] = combo_trans['trans'].astype(np.float32)
 
-    logger.info('Setting up interpolation...')
+    logger.info('Setting up interpolation for %s...' % (volume_label,))
 
     # Loop over slices to save (lots of) memory
     # Note that it is the slowest incrementing index
@@ -2218,7 +2230,7 @@ def _pts_in_hull(pts, hull, tolerance=1e-12):
                    for eq in hull.equations], axis=0)
 
 
-#@verbose
+@verbose
 def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
                           verbose=None):
     """Remove all source space points closer than a given limit (in mm)."""
@@ -2248,7 +2260,7 @@ def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
     if not _points_outside_surface(cm[np.newaxis], surf)[0]:  # actually inside
         # Immediately cull some points from the checks
         inner_r = np.linalg.norm(surf['rr'] - cm, axis=-1).min()
-    # We could use Delaunay or ConvexHull here, Delaunay is slighly slower
+    # We could use Delaunay or ConvexHull here, Delaunay is slightly slower
     # to construct but faster to evaluate
     # See https://stackoverflow.com/questions/16750618/whats-an-efficient-way-to-find-if-a-point-lies-in-the-convex-hull-of-a-point-cl  # noqa
     del_tri = Delaunay(surf['rr'])


### PR DESCRIPTION
Closes #5123.

This was a fun one! @agramfort your original example with `pos=2.` is a bit crazy, it creates 342079. So I tested it with `pos=5.`, which took 36 sec on master:
<details>

```
import os.path as op
import time

from mne.datasets import sample
from mne import setup_volume_source_space

data_path = sample.data_path()
subject = 'sample'
data_dir = op.join(data_path, 'MEG', subject)
subjects_dir = op.join(data_path, 'subjects')
bem_dir = op.join(subjects_dir, subject, 'bem')
fname_aseg = op.join(subjects_dir, subject, 'mri', 'aseg.mgz')
fname_model = op.join(bem_dir, '%s-5120-bem.fif' % subject)
labels_vol = ['Left-Hippocampus',
              'Right-Hippocampus']


def test():
    t0 = time.time()
    # create a mixed src space
    hippocampus = setup_volume_source_space(
        subject,
        mri=fname_aseg,
        pos=5.0,
        bem=fname_model,
        volume_label=labels_vol,
        subjects_dir=subjects_dir,
        verbose=True)
    print(time.time() - t0)


if __name__ == '__main__':
    test()
```
</details>

I cut this in half (18 sec) by:

1. Only checking inside-ness for points that are not clearly inside (fit inside a sphere nested within the mesh)
2. Using `scipy.spatial.Delaunay` (or equivalently `ConvexHull`) to eliminate points that are not within the convex hull of the surface before using the solid angles check.
3. Only checking `min_dist` for points that are inside at all
4. Only checking `min_dist` for those that can possibly exceed it (again using the sphere inside the mesh)
5. Checking `min_dist` using `cKDTree` instead of `BallTree`

This will speed up any `_filter_source_spaces` call (including those in our `fwd` code).

Then I realized that the order of operations for volume labels was:

1. Create the volume source space for the entire `inner_skull` region (including point filtering!)
2. Cull points based on the `aseg` proximity

So if you had two labels, `_filter_source_spaces` was not only called twice, but it operated on the 342079 points instead of the 450 and 516 (for `pos=2.`) that were in the L/R Hip (!). Switching the order of these two made the `pos=5.` code run in 3.3 sec, and even the much tighter `pos=2.0` spacing code run in 4.6 sec instead of taking an eternity.

I also refactored the logging a bit to make it much more readable:

<details>

```
larsoner@bunk:~/Desktop$ python -ui vol.py 
BEM              : /home/larsoner/mne_data/MNE-sample-data/subjects/sample/bem/sample-5120-bem.fif
grid                  : 2.0 mm
mindist               : 5.0 mm
MRI volume            : /home/larsoner/mne_data/MNE-sample-data/subjects/sample/mri/aseg.mgz

Loaded inner skull from /home/larsoner/mne_data/MNE-sample-data/subjects/sample/bem/sample-5120-bem.fif (2562 nodes)
Surface CM = (   0.7  -10.0   44.3) mm
Surface fits inside a sphere with radius   91.8 mm
Surface extent:
    x =  -66.7 ...   68.8 mm
    y =  -88.0 ...   79.0 mm
    z =  -44.5 ...  105.8 mm
Grid extent:
    x =  -68.0 ...   70.0 mm
    y =  -90.0 ...   80.0 mm
    z =  -46.0 ...  106.0 mm
463540 sources before omitting any.
342079 sources after omitting infeasible sources not within 0.0 - 91.8 mm.

Selecting voxels from Left-Hippocampus
450 sources remaining after excluding sources too far from VOI voxels
Source spaces are in MRI coordinates.
Checking that the sources are inside the surface and at least    5.0 mm away (will take a few...)
    Skipping interior check for 395 sources that fit inside a sphere of radius   43.6 mm
    Skipping solid angle check for 0 points using Qhull
450 sources remaining after excluding the sources outside the surface and less than    5.0 mm inside.
Adjusting the neighborhood info.

Selecting voxels from Right-Hippocampus
516 sources remaining after excluding sources too far from VOI voxels
Source spaces are in MRI coordinates.
Checking that the sources are inside the surface and at least    5.0 mm away (will take a few...)
    Skipping interior check for 431 sources that fit inside a sphere of radius   43.6 mm
    Skipping solid angle check for 0 points using Qhull
516 sources remaining after excluding the sources outside the surface and less than    5.0 mm inside.
Adjusting the neighborhood info.

Reading /home/larsoner/mne_data/MNE-sample-data/subjects/sample/mri/aseg.mgz...
Source space : MRI voxel -> MRI (surface RAS)
     0.002000  0.000000  0.000000     -68.00 mm
     0.000000  0.002000  0.000000     -90.00 mm
     0.000000  0.000000  0.002000     -46.00 mm
     0.000000  0.000000  0.000000       1.00
MRI volume : MRI voxel -> MRI (surface RAS)
    -0.001000  0.000000  0.000000     128.00 mm
     0.000000  0.000000  0.001000    -128.00 mm
     0.000000 -0.001000  0.000000     128.00 mm
     0.000000  0.000000  0.000000       1.00
MRI volume : MRI (surface RAS) -> RAS (non-zero origin)
     1.000000 -0.000000 -0.000000      -5.27 mm
    -0.000000  1.000000 -0.000000       9.04 mm
    -0.000000  0.000000  1.000000     -27.29 mm
     0.000000  0.000000  0.000000       1.00
Setting up interpolation for Left-Hippocampus...
 54848/16777216 nonzero values [done]
Setting up interpolation for Right-Hippocampus...
 62720/16777216 nonzero values [done]
```
</details>