### PR TITLE
MRG, DOC: Document failure mode better

### DIFF
--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -125,7 +125,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
 def _check_wrapper(fun):
     def run(*args, **kwargs):
         try:
-            fun(*args, **kwargs)
+            return fun(*args, **kwargs)
         except RuntimeError as err:
             msg = str(err.args[0]) if err.args else ''
             if msg.startswith('The task could not be sent to the workers'):

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -129,8 +129,11 @@ def _check_wrapper(fun):
         except RuntimeError as err:
             msg = str(err.args[0]) if err.args else ''
             if msg.startswith('The task could not be sent to the workers'):
-                raise RuntimeError(msg + ' Consider using joblib memmap '
-                                   'caching to get around this problem.')
+                raise RuntimeError(
+                    msg + ' Consider using joblib memmap caching to get '
+                    'around this problem. See mne.set_mmap_min_size, '
+                    'mne.set_cache_dir, and buffer_size parallel function '
+                    'arguments (if applicable).')
             raise
     return run
 

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -109,7 +109,7 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
             kwargs['max_nbytes'] = max_nbytes
 
         n_jobs = check_n_jobs(n_jobs)
-        parallel = Parallel(n_jobs, **kwargs)
+        parallel = _check_wrapper(Parallel(n_jobs, **kwargs))
         my_func = delayed(func)
 
     if total is not None:
@@ -120,6 +120,19 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
     else:
         parallel_out = parallel
     return parallel_out, my_func, n_jobs
+
+
+def _check_wrapper(fun):
+    def run(*args, **kwargs):
+        try:
+            fun(*args, **kwargs)
+        except RuntimeError as err:
+            msg = str(err.args[0]) if err.args else ''
+            if msg.startswith('The task could not be sent to the workers'):
+                raise RuntimeError(msg + ' Consider using joblib memmap '
+                                   'caching to get around this problem.')
+            raise
+    return run
 
 
 def check_n_jobs(n_jobs, allow_cuda=False):


### PR DESCRIPTION
Closes #6284.

@jhouck can you see if it fixes your problem? Based on your problem description, in theory this code snippet should trigger the problem, but it didn't for me on 64-bit Linux so it's probably OS/sys dependent:
```
import time
import numpy as np
import mne
src_fname = (mne.datasets.sample.data_path() +
             '/subjects/fsaverage/bem/fsaverage-ico-5-src.fif')
X = np.random.RandomState(0).randn(33, 545, 20484) * 0.1
src = mne.read_source_spaces(src_fname)
connectivity = mne.spatial_src_connectivity(src)
t0 = time.time()
mne.stats.spatio_temporal_cluster_1samp_test(
    X, connectivity=connectivity, n_jobs=2, buffer_size=None, verbose=True,
    max_step=1)
print(time.time() - t0)
```