### PR TITLE
Optionally return durations from mne.events_from_annotations

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -919,7 +919,7 @@ def events_from_annotations(raw, event_id="auto",
         annotations.description, event_id=event_id, regexp=regexp)
 
     if return_durations:
-        fs = raw.info["sfreq"]
+        sfreq = raw.info["sfreq"]
 
     if chunk_duration is None:
         inds = raw.time_as_index(annotations.onset, use_rounding=use_rounding,
@@ -928,7 +928,7 @@ def events_from_annotations(raw, event_id="auto",
         values = [event_id_[kk] for kk in annotations.description[event_sel]]
         inds = inds[event_sel]
         if return_durations:
-            durs = annotations.duration * fs
+            durs = annotations.duration * sfreq
             durs = durs[event_sel]
     else:
         inds = values = np.array([]).astype(int)
@@ -952,7 +952,7 @@ def events_from_annotations(raw, event_id="auto",
                 values = np.append(values, _values)
                 if return_durations:
                     _durs = np.full(shape=len(_inds),
-                                    fill_value=annot['duration'] * fs,
+                                    fill_value=annot['duration'] * sfreq,
                                     dtype=int)
                     durs = np.append(durs, _durs)
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -225,6 +225,32 @@ def test_chunk_duration(first_samp):
     assert_array_equal(events, expected_events)
 
 
+def test_events_from_annotations_durations():
+    """Test if durations are returned correctly."""
+    raw = RawArray(data=np.empty([10, 10], dtype=np.float64),
+                   info=create_info(ch_names=10, sfreq=1.))
+    raw.info['meas_date'] = 0
+    raw.set_annotations(Annotations(description=['foo', 'bar', 'baz'],
+                                    onset=[0, 5, 6],
+                                    duration=[6, 1, 3], orig_time=None))
+
+    # get all events
+    expected_events = np.array([[0, 5, 6], [0, 0, 0], [3, 1, 2]], dtype=int).T
+    expected_durs = np.array([6, 1, 3], dtype=int)
+
+    events, ids, durs = events_from_annotations(raw, return_durations=True)
+    assert_array_equal(events, expected_events)
+    assert_array_equal(durs, expected_durs)
+
+    # get events longer than 5s (chunk_duration=5)
+    expected_events = np.array([[0], [0], [3]], dtype=int).T
+    expected_durs = np.array([6], dtype=int)
+    events, ids, durs = events_from_annotations(raw, return_durations=True,
+                                                chunk_duration=5)
+    assert_array_equal(events, expected_events)
+    assert_array_equal(durs, expected_durs)
+
+
 def test_crop_more():
     """Test more cropping."""
     raw = mne.io.read_raw_fif(fif_fname).crop(0, 11).load_data()


### PR DESCRIPTION
As discussed in https://github.com/bids-standard/pybv/pull/33, it would be useful if `mne.events_from_annotations` optionally returned annotation durations. In this PR, I've added a new `return_durations` keyword argument (which is `False` by default to keep the previous default behavior). If `return_durations=True`, a third object (1D NumPy array) is returned containing the event durations.

Questions:
1. In my test I rely on dict entries being sorted alphabetically (because `_select_annotations_based_on_description` sorts the descriptions alphabetically and inserts them into a dict - and recent versions of Python retain insertion order). Is this OK?
2. Should I add this change to the "Changelog" or "API" section of whats_new.rst?