### PR TITLE
MRG, ENH: Support path-like objects

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1864,7 +1864,8 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
         nodes, tris = read_tri(out_fname, swap=True)
         # Do not write volume info here because the tris are already in
         # standard Freesurfer coords
-        write_surface(op.splitext(out_fname)[0] + '.surf', nodes, tris)
+        write_surface(op.splitext(out_fname)[0] + '.surf', nodes, tris,
+                      overwrite=True)
 
     # Cleanup section
     logger.info("\n---- Cleaning up ----")

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -3,7 +3,9 @@
 #
 # License: BSD (3-clause)
 
+import os
 import os.path as op
+import sys
 import warnings
 import pytest
 # For some unknown reason, on Travis-xenial there are segfaults caused on
@@ -22,6 +24,7 @@ except Exception:
 import numpy as np
 import mne
 from mne.datasets import testing
+from mne.fixes import _fn35
 
 test_path = testing.data_path(download=False)
 s_path = op.join(test_path, 'MEG', 'sample')
@@ -37,7 +40,7 @@ def pytest_configure(config):
         config.addinivalue_line('markers', marker)
 
     # Fixtures
-    for fixture in ('matplotlib_config',):
+    for fixture in ('matplotlib_config', 'fix_pytest_tmpdir_35'):
         config.addinivalue_line('usefixtures', fixture)
 
     # Warnings
@@ -82,6 +85,7 @@ def matplotlib_config():
     # "force" should not really be necessary but should not hurt
     kwargs = dict()
     with warnings.catch_warnings(record=True):  # ignore warning
+        warnings.filterwarnings('ignore')
         matplotlib.use('agg', force=True, **kwargs)  # don't pop up windows
     import matplotlib.pyplot as plt
     assert plt.get_backend() == 'agg'
@@ -103,6 +107,26 @@ def matplotlib_config():
         pass
     else:
         mlab.options.backend = 'test'
+
+
+def _replace(mod, key):
+    orig = getattr(mod, key)
+
+    def func(x, *args, **kwargs):
+        return orig(_fn35(x), *args, **kwargs)
+
+    setattr(mod, key, func)
+
+
+@pytest.fixture(scope='session')
+def fix_pytest_tmpdir_35():
+    """Deal with tmpdir being a LocalPath, which bombs on 3.5."""
+    if sys.version_info >= (3, 6):
+        return
+
+    _replace(os, 'stat')
+    for key in ('splitext', 'realpath', 'join'):
+        _replace(op, key)
 
 
 @pytest.fixture(scope='function', params=[testing._pytest_param()])

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -124,8 +124,9 @@ def fix_pytest_tmpdir_35():
     if sys.version_info >= (3, 6):
         return
 
-    _replace(os, 'stat')
-    for key in ('splitext', 'realpath', 'join'):
+    for key in ('stat', 'mkdir', 'makedirs'):
+        _replace(os, key)
+    for key in ('split', 'splitext', 'realpath', 'join'):
         _replace(op, key)
 
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -15,6 +15,7 @@ at which the fix is no longer needed.
 import inspect
 from distutils.version import LooseVersion
 from math import log
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -1288,3 +1289,19 @@ except ImportError:
     has_numba = False
 else:
     has_numba = True
+
+
+###############################################################################
+# Python 3.5 compat with pathlib.Path-like objects
+
+def _fn35(fname):
+    try:
+        from py._path.common import PathBase
+    except ImportError:
+        pass
+    else:
+        if isinstance(fname, PathBase):
+            fname = str(fname)
+    if isinstance(fname, Path):
+        fname = str(fname)
+    return fname

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1792,9 +1792,11 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
             mindist = ['--mindist', '%g' % mindist]
 
     # src, spacing, bem
-    for element, name in zip((src, spacing, bem), ("src", "spacing", "bem")):
+    for element, name, kind in zip((src, spacing, bem),
+                                   ("src", "spacing", "bem"),
+                                   ('path-like', 'str', 'path-like')):
         if element is not None:
-            _validate_type(element, "str", name, "string or None")
+            _validate_type(element, kind, name, "%s or None" % kind)
 
     # put together the actual call
     cmd = ['mne_do_forward_solution',

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -373,7 +373,7 @@ def test_average_forward_solution(tmpdir):
 
     # modify a fwd solution, save it, use MNE to average with old one
     fwd_copy['sol']['data'] *= 0.5
-    fname_copy = tmpdir.join('copy-fwd.fif')
+    fname_copy = str(tmpdir.join('copy-fwd.fif'))
     write_forward_solution(fname_copy, fwd_copy, overwrite=True)
     cmd = ('mne_average_forward_solutions', '--fwd', fname_meeg, '--fwd',
            fname_copy, '--out', fname_copy)

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -13,7 +13,7 @@ from mne import (read_forward_solution, apply_forward, apply_forward_raw,
                  read_evokeds)
 from mne.io import read_info
 from mne.label import read_label
-from mne.utils import (requires_mne, run_subprocess, _TempDir,
+from mne.utils import (requires_mne, run_subprocess,
                        run_tests_if_main)
 from mne.forward import (restrict_forward_to_stc, restrict_forward_to_label,
                          Forward, is_fixed_orient, compute_orient_prior,
@@ -85,9 +85,8 @@ def test_convert_forward():
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-def test_io_forward():
+def test_io_forward(tmpdir):
     """Test IO for forward solutions."""
-    temp_dir = _TempDir()
     # do extensive tests with MEEG + grad
     n_channels, n_src = 366, 108
     fwd = read_forward_solution(fname_meeg_grad)
@@ -97,7 +96,7 @@ def test_io_forward():
     leadfield = fwd['sol']['data']
     assert_equal(leadfield.shape, (n_channels, n_src))
     assert_equal(len(fwd['sol']['row_names']), n_channels)
-    fname_temp = op.join(temp_dir, 'test-fwd.fif')
+    fname_temp = tmpdir.join('test-fwd.fif')
     with pytest.warns(RuntimeWarning, match='stored on disk'):
         write_forward_solution(fname_temp, fwd, overwrite=True)
 
@@ -167,7 +166,7 @@ def test_io_forward():
 
     # test warnings on bad filenames
     fwd = read_forward_solution(fname_meeg_grad)
-    fwd_badname = op.join(temp_dir, 'test-bad-name.fif.gz')
+    fwd_badname = tmpdir.join('test-bad-name.fif.gz')
     with pytest.warns(RuntimeWarning, match='end with'):
         write_forward_solution(fwd_badname, fwd)
     with pytest.warns(RuntimeWarning, match='end with'):
@@ -230,7 +229,7 @@ def test_apply_forward():
 
 
 @testing.requires_testing_data
-def test_restrict_forward_to_stc():
+def test_restrict_forward_to_stc(tmpdir):
     """Test restriction of source space to source SourceEstimate."""
     start = 0
     stop = 5
@@ -274,8 +273,7 @@ def test_restrict_forward_to_stc():
 
     # Test saving the restricted forward object. This only works if all fields
     # are properly accounted for.
-    temp_dir = _TempDir()
-    fname_copy = op.join(temp_dir, 'copy-fwd.fif')
+    fname_copy = tmpdir.join('copy-fwd.fif')
     with pytest.warns(RuntimeWarning, match='stored on disk'):
         write_forward_solution(fname_copy, fwd_out, overwrite=True)
     fwd_out_read = read_forward_solution(fname_copy)
@@ -285,7 +283,7 @@ def test_restrict_forward_to_stc():
 
 
 @testing.requires_testing_data
-def test_restrict_forward_to_label():
+def test_restrict_forward_to_label(tmpdir):
     """Test restriction of source space to label."""
     fwd = read_forward_solution(fname_meeg)
     fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True,
@@ -344,8 +342,7 @@ def test_restrict_forward_to_label():
 
     # Test saving the restricted forward object. This only works if all fields
     # are properly accounted for.
-    temp_dir = _TempDir()
-    fname_copy = op.join(temp_dir, 'copy-fwd.fif')
+    fname_copy = tmpdir.join('copy-fwd.fif')
     write_forward_solution(fname_copy, fwd_out, overwrite=True)
     fwd_out_read = read_forward_solution(fname_copy)
     compare_forwards(fwd_out, fwd_out_read)
@@ -353,9 +350,8 @@ def test_restrict_forward_to_label():
 
 @testing.requires_testing_data
 @requires_mne
-def test_average_forward_solution():
+def test_average_forward_solution(tmpdir):
     """Test averaging forward solutions."""
-    temp_dir = _TempDir()
     fwd = read_forward_solution(fname_meeg)
     # input not a list
     pytest.raises(TypeError, average_forward_solutions, 1)
@@ -377,7 +373,7 @@ def test_average_forward_solution():
 
     # modify a fwd solution, save it, use MNE to average with old one
     fwd_copy['sol']['data'] *= 0.5
-    fname_copy = op.join(temp_dir, 'copy-fwd.fif')
+    fname_copy = tmpdir.join('copy-fwd.fif')
     write_forward_solution(fname_copy, fwd_copy, overwrite=True)
     cmd = ('mne_average_forward_solutions', '--fwd', fname_meeg, '--fwd',
            fname_copy, '--out', fname_copy)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -14,7 +14,7 @@ from mne import (read_forward_solution, write_forward_solution,
                  setup_volume_source_space, read_source_spaces,
                  make_sphere_model, pick_types_forward, pick_info, pick_types,
                  read_evokeds, read_cov, read_dipole, SourceSpaces)
-from mne.utils import (requires_mne, requires_nibabel, _TempDir,
+from mne.utils import (requires_mne, requires_nibabel,
                        run_tests_if_main, run_subprocess)
 from mne.forward._make_forward import _create_meg_coils, make_forward_dipole
 from mne.forward._compute_forward import _magnetic_dipole_field_vec
@@ -119,7 +119,7 @@ def test_magnetic_dipole():
 @pytest.mark.timeout(60)  # can take longer than 30 sec on Travis
 @testing.requires_testing_data
 @requires_mne
-def test_make_forward_solution_kit():
+def test_make_forward_solution_kit(tmpdir):
     """Test making fwd using KIT, BTI, and CTF (compensated) files."""
     kit_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'kit',
                       'tests', 'data')
@@ -141,8 +141,7 @@ def test_make_forward_solution_kit():
                             'data', 'test_ctf_comp_raw.fif')
 
     # first set up a small testing source space
-    temp_dir = _TempDir()
-    fname_src_small = op.join(temp_dir, 'sample-oct-2-src.fif')
+    fname_src_small = tmpdir.join('sample-oct-2-src.fif')
     src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,
                              add_dist=False)
     write_source_spaces(fname_src_small, src)  # to enable working with MNE-C
@@ -207,8 +206,7 @@ def test_make_forward_solution_kit():
                                subjects_dir=subjects_dir)
     _compare_forwards(fwd, fwd_py, 274, n_src)
 
-    temp_dir = _TempDir()
-    fname_temp = op.join(temp_dir, 'test-ctf-fwd.fif')
+    fname_temp = tmpdir.join('test-ctf-fwd.fif')
     write_forward_solution(fname_temp, fwd_py)
     fwd_py2 = read_forward_solution(fname_temp)
     _compare_forwards(fwd_py, fwd_py2, 274, n_src)
@@ -248,14 +246,13 @@ def test_make_forward_solution_discrete():
 @testing.requires_testing_data
 @requires_mne
 @pytest.mark.timeout(90)  # can take longer than 60 sec on Travis
-def test_make_forward_solution_sphere():
+def test_make_forward_solution_sphere(tmpdir):
     """Test making a forward solution with a sphere model."""
-    temp_dir = _TempDir()
-    fname_src_small = op.join(temp_dir, 'sample-oct-2-src.fif')
+    fname_src_small = tmpdir.join('sample-oct-2-src.fif')
     src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,
                              add_dist=False)
     write_source_spaces(fname_src_small, src)  # to enable working with MNE-C
-    out_name = op.join(temp_dir, 'tmp-fwd.fif')
+    out_name = tmpdir.join('tmp-fwd.fif')
     run_subprocess(['mne_forward_solution', '--meg', '--eeg',
                     '--meas', fname_raw, '--src', fname_src_small,
                     '--mri', fname_trans, '--fwd', out_name])
@@ -293,9 +290,8 @@ def test_make_forward_solution_sphere():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_nibabel(False)
-def test_forward_mixed_source_space():
+def test_forward_mixed_source_space(tmpdir):
     """Test making the forward solution for a mixed source space."""
-    temp_dir = _TempDir()
     # get the surface source space
     surf = read_source_spaces(fname_src)
 
@@ -327,7 +323,7 @@ def test_forward_mixed_source_space():
     assert ((coord_frames == FIFF.FIFFV_COORD_HEAD).all())
 
     # run tests for SourceSpaces.export_volume
-    fname_img = op.join(temp_dir, 'temp-image.mgz')
+    fname_img = tmpdir.join('temp-image.mgz')
 
     # head coordinates and mri_resolution, but trans file
     with pytest.raises(ValueError, match='trans containing mri to head'):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -38,7 +38,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_pandas_index_arguments, fill_doc, copy_doc,
                      check_fname, _get_stim_channel, deprecated,
                      logger, verbose, _time_mask, warn, SizeMixin,
-                     copy_function_doc_to_method_doc,
+                     copy_function_doc_to_method_doc, _validate_type,
                      _check_preload, _get_argvalues, _check_option)
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
 from ..defaults import _handle_default
@@ -348,11 +348,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             if last_samps is None:
                 raise ValueError('last_samps must be given unless preload is '
                                  'an ndarray')
-            if preload is False:
+            if not preload:
                 self.preload = False
                 load_from_disk = False
-            elif preload is not True and not isinstance(preload, str):
-                raise ValueError('bad preload: %s' % preload)
             else:
                 load_from_disk = True
         self._last_samps = np.array(last_samps)
@@ -527,12 +525,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                 raise ValueError('data_buffer has incorrect shape: %s != %s'
                                  % (data_buffer.shape, data_shape))
             data = data_buffer
-        elif isinstance(data_buffer, str):
-            # use a memmap
-            data = np.memmap(data_buffer, mode='w+',
-                             dtype=dtype, shape=data_shape)
         else:
-            data = np.zeros(data_shape, dtype=dtype)
+            data = _allocate_data(data_buffer, data_shape, dtype)
 
         # deal with having multiple files accessed by the raw object
         cumul_lens = np.concatenate(([0], np.array(self._raw_lengths,
@@ -667,8 +661,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     @verbose
     def _preload_data(self, preload, verbose=None):
         """Actually preload the data."""
-        data_buffer = preload if isinstance(preload, (str,
-                                                      np.ndarray)) else None
+        data_buffer = None if not preload else preload
         logger.info('Reading %d ... %d  =  %9.3f ... %9.3f secs...' %
                     (0, len(self.times) - 1, 0., self.times[-1]))
         self._data = self._read_segment(data_buffer=data_buffer)
@@ -1487,13 +1480,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         or all forms of SSS). It is recommended not to concatenate and
         then save raw files for this reason.
         """
+        fname = op.realpath(fname)
         check_fname(fname, 'raw', ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                                    'raw.fif.gz', 'raw_sss.fif.gz',
                                    'raw_tsss.fif.gz', '_meg.fif'))
 
         split_size = _get_split_size(split_size)
-
-        fname = op.realpath(fname)
         if not self.preload and fname in self._filenames:
             raise ValueError('You cannot save data to the same file.'
                              ' Please use a different filename.')
@@ -1805,12 +1797,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                 this_data = self._data
 
             # allocate the buffer
-            if isinstance(preload, str):
-                _data = np.memmap(preload, mode='w+', dtype=this_data.dtype,
-                                  shape=(nchan, nsamp))
-            else:
-                _data = np.empty((nchan, nsamp), dtype=this_data.dtype)
-
+            _data = _allocate_data(preload, (nchan, nsamp), this_data.dtype)
             _data[:, 0:c_ns[0]] = this_data
 
             for ri in range(len(raws)):
@@ -1924,16 +1911,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return int(np.ceil(buffer_size_sec * self.info['sfreq']))
 
 
-def _allocate_data(data, data_buffer, data_shape, dtype):
+def _allocate_data(preload, shape, dtype):
     """Allocate data in memory or in memmap for preloading."""
-    if data is None:
-        # if not already done, allocate array with right type
-        if isinstance(data_buffer, str):
-            # use a memmap
-            data = np.memmap(data_buffer, mode='w+',
-                             dtype=dtype, shape=data_shape)
-        else:
-            data = np.zeros(data_shape, dtype=dtype)
+    if preload in (None, True):  # None comes from _read_segment
+        data = np.zeros(shape, dtype)
+    else:
+        _validate_type(preload, 'path-like', 'preload')
+        data = np.memmap(str(preload), mode='w+', dtype=dtype, shape=shape)
     return data
 
 

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -24,7 +24,7 @@ from ..utils import _mult_cal_one
 from ...annotations import Annotations, _read_annotations_fif
 
 from ...event import AcqParserFIF
-from ...utils import check_fname, logger, verbose, warn, fill_doc
+from ...utils import check_fname, logger, verbose, warn, fill_doc, _file_like
 
 
 @fill_doc
@@ -72,7 +72,7 @@ class Raw(BaseRaw):
     def __init__(self, fname, allow_maxshield=False, preload=False,
                  verbose=None):  # noqa: D102
         raws = []
-        do_check_fname = isinstance(fname, str)
+        do_check_fname = not _file_like(fname)
         next_fname = fname
         while next_fname is not None:
             raw, next_fname, buffer_size_sec = \
@@ -85,7 +85,7 @@ class Raw(BaseRaw):
                     warn('Split raw file detected but next file %s does not '
                          'exist.' % next_fname)
                     break
-        if not isinstance(fname, str):
+        if _file_like(fname):
             # avoid serialization error when copying file-like
             fname = None  # noqa
 
@@ -127,14 +127,12 @@ class Raw(BaseRaw):
         """Read in header information from a raw file."""
         logger.info('Opening raw data file %s...' % fname)
 
-        if do_check_fname:
-            check_fname(fname, 'raw', ('raw.fif', 'raw_sss.fif',
-                                       'raw_tsss.fif', 'raw.fif.gz',
-                                       'raw_sss.fif.gz', 'raw_tsss.fif.gz',
-                                       '_meg.fif'))
-
         #   Read in the whole file if preload is on and .fif.gz (saves time)
-        if isinstance(fname, str):
+        if not _file_like(fname):
+            if do_check_fname:
+                check_fname(fname, 'raw', (
+                    'raw.fif', 'raw_sss.fif', 'raw_tsss.fif', 'raw.fif.gz',
+                    'raw_sss.fif.gz', 'raw_tsss.fif.gz', '_meg.fif'))
             # filename
             fname = op.realpath(fname)
             ext = os.path.splitext(fname)[1].lower()
@@ -412,7 +410,7 @@ class Raw(BaseRaw):
 
 
 def _get_fname_rep(fname):
-    if isinstance(fname, str):
+    if not _file_like(fname):
         return fname
     else:
         return 'File-like %r' % (fname,)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -78,7 +78,7 @@ def test_acq_skip(tmpdir):
     assert_allclose(data, np.concatenate(expected_data, axis=-1), atol=1e-22)
 
     # Check that acquisition skips are handled properly during I/O
-    fname = op.join(str(tmpdir), 'test_raw.fif')
+    fname = tmpdir.join('test_raw.fif')
     raw.save(fname, fmt=raw.orig_format)
     # first: file size should not increase much (orig data is missing
     # 7 of 17 buffers, so if we write them out it should increase the file
@@ -129,7 +129,7 @@ def test_concat(tmpdir):
     # we trim the file to save lots of memory and some time
     raw = read_raw_fif(test_fif_fname)
     raw.crop(0, 2.)
-    test_name = op.join(str(tmpdir), 'test_raw.fif')
+    test_name = tmpdir.join('test_raw.fif')
     raw.save(test_name)
     # now run the standard test
     _test_concat(partial(read_raw_fif), test_name)
@@ -176,7 +176,7 @@ def test_subject_info(tmpdir):
     for key, val in zip(keys, vals):
         subject_info[key] = val
     raw.info['subject_info'] = subject_info
-    out_fname = op.join(str(tmpdir), 'test_subj_info_raw.fif')
+    out_fname = tmpdir.join('test_subj_info_raw.fif')
     raw.save(out_fname, overwrite=True)
     raw_read = read_raw_fif(out_fname)
     for key in keys:
@@ -208,7 +208,7 @@ def test_output_formats(tmpdir):
     # let's fake a raw file with different formats
     raw = read_raw_fif(test_fif_fname).crop(0, 1)
 
-    temp_file = op.join(str(tmpdir), 'raw.fif')
+    temp_file = tmpdir.join('raw.fif')
     for ii, (fmt, tol) in enumerate(zip(formats, tols)):
         # Let's test the overwriting error throwing while we're at it
         if ii > 0:
@@ -233,7 +233,6 @@ def _compare_combo(raw, new, times, n_times):
 def test_multiple_files(tmpdir):
     """Test loading multiple files simultaneously."""
     # split file
-    tempdir = str(tmpdir)
     raw = read_raw_fif(fif_fname).crop(0, 10)
     raw.load_data()
     raw.load_data()  # test no operation
@@ -249,7 +248,7 @@ def test_multiple_files(tmpdir):
     # going in reverse order so the last fname is the first file (need later)
     raws = [None] * len(tmins)
     for ri in range(len(tmins) - 1, -1, -1):
-        fname = op.join(tempdir, 'test_raw_split-%d_raw.fif' % ri)
+        fname = tmpdir.join('test_raw_split-%d_raw.fif' % ri)
         raw.save(fname, tmin=tmins[ri], tmax=tmaxs[ri])
         raws[ri] = read_raw_fif(fname)
         assert (len(raws[ri].times) ==
@@ -359,17 +358,16 @@ def test_multiple_files(tmpdir):
 @testing.requires_testing_data
 def test_split_files(tmpdir):
     """Test writing and reading of split raw files."""
-    tempdir = str(tmpdir)
     raw_1 = read_raw_fif(fif_fname, preload=True)
     # Test a very close corner case
     raw_crop = raw_1.copy().crop(0, 1.)
 
     assert_allclose(raw_1.buffer_size_sec, 10., atol=1e-2)  # samp rate
-    split_fname = op.join(tempdir, 'split_raw_meg.fif')
+    split_fname = tmpdir.join('split_raw_meg.fif')
     # intended filenames
-    split_fname_elekta_part2 = op.join(tempdir, 'split_raw_meg-1.fif')
-    split_fname_bids_part1 = op.join(tempdir, 'split_raw_part-01_meg.fif')
-    split_fname_bids_part2 = op.join(tempdir, 'split_raw_part-02_meg.fif')
+    split_fname_elekta_part2 = tmpdir.join('split_raw_meg-1.fif')
+    split_fname_bids_part1 = tmpdir.join('split_raw_part-01_meg.fif')
+    split_fname_bids_part2 = tmpdir.join('split_raw_part-02_meg.fif')
     raw_1.set_annotations(Annotations([2.], [5.5], 'test'))
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
 
@@ -383,7 +381,7 @@ def test_split_files(tmpdir):
 
     annot = Annotations(np.arange(20), np.ones((20,)), 'test')
     raw_1.set_annotations(annot)
-    split_fname = op.join(tempdir, 'split_raw.fif')
+    split_fname = op.join(tmpdir, 'split_raw.fif')
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
     raw_2 = read_raw_fif(split_fname)
     assert_allclose(raw_2.buffer_size_sec, 1., atol=1e-2)  # samp rate
@@ -464,7 +462,6 @@ def test_split_files(tmpdir):
 
 def test_load_bad_channels(tmpdir):
     """Test reading/writing of bad channels."""
-    tempdir = str(tmpdir)
     # Load correctly marked file (manually done in mne_process_raw)
     raw_marked = read_raw_fif(fif_bad_marked_fname)
     correct_bads = raw_marked.info['bads']
@@ -475,8 +472,8 @@ def test_load_bad_channels(tmpdir):
     # Test normal case
     raw.load_bad_channels(bad_file_works)
     # Write it out, read it in, and check
-    raw.save(op.join(tempdir, 'foo_raw.fif'))
-    raw_new = read_raw_fif(op.join(tempdir, 'foo_raw.fif'))
+    raw.save(tmpdir.join('foo_raw.fif'))
+    raw_new = read_raw_fif(tmpdir.join('foo_raw.fif'))
     assert correct_bads == raw_new.info['bads']
     # Reset it
     raw.info['bads'] = []
@@ -488,14 +485,14 @@ def test_load_bad_channels(tmpdir):
     with pytest.warns(RuntimeWarning, match='1 bad channel'):
         raw.load_bad_channels(bad_file_wrong, force=True)
         # write it out, read it in, and check
-    raw.save(op.join(tempdir, 'foo_raw.fif'), overwrite=True)
-    raw_new = read_raw_fif(op.join(tempdir, 'foo_raw.fif'))
+    raw.save(tmpdir.join('foo_raw.fif'), overwrite=True)
+    raw_new = read_raw_fif(tmpdir.join('foo_raw.fif'))
     assert correct_bads == raw_new.info['bads']
 
     # Check that bad channels are cleared
     raw.load_bad_channels(None)
-    raw.save(op.join(tempdir, 'foo_raw.fif'), overwrite=True)
-    raw_new = read_raw_fif(op.join(tempdir, 'foo_raw.fif'))
+    raw.save(tmpdir.join('foo_raw.fif'), overwrite=True)
+    raw_new = read_raw_fif(tmpdir.join('foo_raw.fif'))
     assert raw_new.info['bads'] == []
 
 
@@ -504,14 +501,13 @@ def test_load_bad_channels(tmpdir):
 def test_io_raw(tmpdir):
     """Test IO for raw data (Neuromag)."""
     rng = np.random.RandomState(0)
-    tempdir = str(tmpdir)
     # test unicode io
     for chars in [u'äöé', 'a']:
         with read_raw_fif(fif_fname) as r:
             assert ('Raw' in repr(r))
             assert (op.basename(fif_fname) in repr(r))
             r.info['description'] = chars
-            temp_file = op.join(tempdir, 'raw.fif')
+            temp_file = tmpdir.join('raw.fif')
             r.save(temp_file, overwrite=True)
             with read_raw_fif(temp_file) as r2:
                 desc2 = r2.info['description']
@@ -524,7 +520,7 @@ def test_io_raw(tmpdir):
     data = rng.randn(raw._data.shape[0], raw._data.shape[1])
     raw._data[:, :] = data
     # save it somewhere
-    fname = op.join(tempdir, 'test_copy_raw.fif')
+    fname = tmpdir.join('test_copy_raw.fif')
     raw.save(fname, buffer_size_sec=1.0)
     # read it in, make sure the whole thing matches
     raw = read_raw_fif(fname)
@@ -541,8 +537,7 @@ def test_io_raw(tmpdir):
     (ctf_fname, 'raw.fif')])
 def test_io_raw_additional(fname_in, fname_out, tmpdir):
     """Test IO for raw data (Neuromag + CTF + gz)."""
-    tempdir = str(tmpdir)
-    fname_out = op.join(tempdir, fname_out)
+    fname_out = tmpdir.join(fname_out)
     raw = read_raw_fif(fname_in)
 
     nchan = raw.info['nchan']
@@ -611,7 +606,7 @@ def test_io_raw_additional(fname_in, fname_out, tmpdir):
         assert_allclose(raw.info['dig'][0]['r'], raw2.info['dig'][0]['r'])
 
     # test warnings on bad filenames
-    raw_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    raw_badname = tmpdir.join('test-bad-name.fif.gz')
     with pytest.warns(RuntimeWarning, match='raw.fif'):
         raw.save(raw_badname)
     with pytest.warns(RuntimeWarning, match='raw.fif'):
@@ -622,7 +617,6 @@ def test_io_raw_additional(fname_in, fname_out, tmpdir):
 def test_io_complex(tmpdir):
     """Test IO with complex data types."""
     rng = np.random.RandomState(0)
-    tempdir = str(tmpdir)
     dtypes = [np.complex64, np.complex128]
 
     raw = _test_raw_reader(partial(read_raw_fif),
@@ -640,15 +634,15 @@ def test_io_complex(tmpdir):
         raw_cp._data = np.array(raw_cp._data, dtype)
         raw_cp._data[picks, start:stop] += imag_rand
         with pytest.warns(RuntimeWarning, match='Saving .* complex data.'):
-            raw_cp.save(op.join(tempdir, 'raw.fif'), picks, tmin=0, tmax=5,
+            raw_cp.save(tmpdir.join('raw.fif'), picks, tmin=0, tmax=5,
                         overwrite=True)
 
-        raw2 = read_raw_fif(op.join(tempdir, 'raw.fif'))
+        raw2 = read_raw_fif(tmpdir.join('raw.fif'))
         raw2_data, _ = raw2[picks, :]
         n_samp = raw2_data.shape[1]
         assert_allclose(raw2_data[:, :n_samp], raw_cp._data[picks, :n_samp])
         # with preloading
-        raw2 = read_raw_fif(op.join(tempdir, 'raw.fif'), preload=True)
+        raw2 = read_raw_fif(tmpdir.join('raw.fif'), preload=True)
         raw2_data, _ = raw2[picks, :]
         n_samp = raw2_data.shape[1]
         assert_allclose(raw2_data[:, :n_samp], raw_cp._data[picks, :n_samp])
@@ -683,7 +677,6 @@ def test_getitem():
 @testing.requires_testing_data
 def test_proj(tmpdir):
     """Test SSP proj operations."""
-    tempdir = str(tmpdir)
     for proj in [True, False]:
         raw = read_raw_fif(fif_fname, preload=False)
         if proj:
@@ -722,8 +715,8 @@ def test_proj(tmpdir):
         raw = read_raw_fif(fif_fname, preload=preload)
 
         # write the file with proj. activated, make sure proj has been applied
-        raw.save(op.join(tempdir, 'raw.fif'), proj=True, overwrite=True)
-        raw2 = read_raw_fif(op.join(tempdir, 'raw.fif'))
+        raw.save(tmpdir.join('raw.fif'), proj=True, overwrite=True)
+        raw2 = read_raw_fif(tmpdir.join('raw.fif'))
         data_proj_2, _ = raw2[:, 0:2]
         assert_allclose(data_proj_1, data_proj_2)
         assert (all(p['active'] for p in raw2.info['projs']))
@@ -741,7 +734,7 @@ def test_proj(tmpdir):
         assert_allclose(data_proj_1, data_proj_2)
         assert_allclose(data_proj_2, np.dot(raw._projector, data_proj_2))
 
-    out_fname = op.join(tempdir, 'test_raw.fif')
+    out_fname = tmpdir.join('test_raw.fif')
     raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
     raw.pick_types(meg=False, eeg=True)
     raw.info['projs'] = [raw.info['projs'][-1]]
@@ -757,7 +750,6 @@ def test_proj(tmpdir):
 @pytest.mark.parametrize('preload', [False, True, 'memmap.dat'])
 def test_preload_modify(preload, tmpdir):
     """Test preloading and modifying data."""
-    tempdir = str(tmpdir)
     rng = np.random.RandomState(0)
     raw = read_raw_fif(fif_fname, preload=preload)
 
@@ -774,7 +766,7 @@ def test_preload_modify(preload, tmpdir):
         else:
             raise
 
-    tmp_fname = op.join(tempdir, 'raw.fif')
+    tmp_fname = tmpdir.join('raw.fif')
     raw.save(tmp_fname, overwrite=True)
 
     raw_new = read_raw_fif(tmp_fname)
@@ -982,7 +974,6 @@ def test_crop():
 @testing.requires_testing_data
 def test_resample(tmpdir):
     """Test resample (with I/O and multiple files)."""
-    tempdir = str(tmpdir)
     raw = read_raw_fif(fif_fname).crop(0, 3)
     raw.load_data()
     raw_resamp = raw.copy()
@@ -990,8 +981,8 @@ def test_resample(tmpdir):
     # test parallel on upsample
     raw_resamp.resample(sfreq * 2, n_jobs=2, npad='auto')
     assert raw_resamp.n_times == len(raw_resamp.times)
-    raw_resamp.save(op.join(tempdir, 'raw_resamp-raw.fif'))
-    raw_resamp = read_raw_fif(op.join(tempdir, 'raw_resamp-raw.fif'),
+    raw_resamp.save(tmpdir.join('raw_resamp-raw.fif'))
+    raw_resamp = read_raw_fif(tmpdir.join('raw_resamp-raw.fif'),
                               preload=True)
     assert sfreq == raw_resamp.info['sfreq'] / 2
     assert raw.n_times == raw_resamp.n_times // 2
@@ -1223,7 +1214,6 @@ def test_add_channels():
 @testing.requires_testing_data
 def test_save(tmpdir):
     """Test saving raw."""
-    tempdir = str(tmpdir)
     raw = read_raw_fif(fif_fname, preload=False)
     # can't write over file being read
     pytest.raises(ValueError, raw.save, fif_fname)
@@ -1236,9 +1226,9 @@ def test_save(tmpdir):
                         orig_time=raw.info['meas_date'][0] + raw._first_time)
     raw.set_annotations(annot)
     annot = raw.annotations
-    new_fname = op.join(op.abspath(op.curdir), 'break_raw.fif')
-    raw.save(op.join(tempdir, new_fname), overwrite=True)
-    new_raw = read_raw_fif(op.join(tempdir, new_fname), preload=False)
+    new_fname = tmpdir.join('break_raw.fif')
+    raw.save(new_fname, overwrite=True)
+    new_raw = read_raw_fif(new_fname, preload=False)
     pytest.raises(ValueError, new_raw.save, new_fname)
     assert_array_almost_equal(annot.onset, new_raw.annotations.onset)
     assert_array_equal(annot.duration, new_raw.annotations.duration)
@@ -1249,8 +1239,6 @@ def test_save(tmpdir):
 @testing.requires_testing_data
 def test_annotation_crop(tmpdir):
     """Test annotation sync after cropping and concatenating."""
-    tempdir = str(tmpdir)
-    new_fname = op.join(op.abspath(op.curdir), 'break_raw.fif')
     annot = Annotations([5., 11., 15.], [2., 1., 3.], ['test', 'test', 'test'])
     raw = read_raw_fif(fif_fname, preload=False)
     raw.set_annotations(annot)
@@ -1274,8 +1262,10 @@ def test_annotation_crop(tmpdir):
                     [1., 1. + 1. / raw.info['sfreq']], atol=1e-3)
 
     # make sure we can overwrite the file we loaded when preload=True
-    new_raw = read_raw_fif(op.join(tempdir, new_fname), preload=True)
-    new_raw.save(op.join(tempdir, new_fname), overwrite=True)
+    new_fname = tmpdir.join('break_raw.fif')
+    raw.save(new_fname)
+    new_raw = read_raw_fif(new_fname, preload=True)
+    new_raw.save(new_fname, overwrite=True)
 
 
 @testing.requires_testing_data
@@ -1288,7 +1278,6 @@ def test_with_statement():
 
 def test_compensation_raw(tmpdir):
     """Test Raw compensation."""
-    tempdir = str(tmpdir)
     raw_3 = read_raw_fif(ctf_comp_fname)
     assert raw_3.compensation_grade == 3
     data_3, times = raw_3[:, :]
@@ -1350,7 +1339,7 @@ def test_compensation_raw(tmpdir):
             assert_allclose(data_3, data_3_new, **tols)
 
     # Try IO with compensation
-    temp_file = op.join(tempdir, 'raw.fif')
+    temp_file = tmpdir.join('raw.fif')
     raw_3.save(temp_file, overwrite=True)
     for preload in (True, False):
         raw_read = read_raw_fif(temp_file, preload=preload)
@@ -1388,10 +1377,9 @@ def test_compensation_raw(tmpdir):
 @requires_mne
 def test_compensation_raw_mne(tmpdir):
     """Test Raw compensation by comparing with MNE-C."""
-    tempdir = str(tmpdir)
 
     def compensate_mne(fname, grad):
-        tmp_fname = op.join(tempdir, 'mne_ctf_test_raw.fif')
+        tmp_fname = tmpdir.join('mne_ctf_test_raw.fif')
         cmd = ['mne_process_raw', '--raw', fname, '--save', tmp_fname,
                '--grad', str(grad), '--projoff', '--filteroff']
         run_subprocess(cmd)
@@ -1473,7 +1461,7 @@ def test_equalize_channels():
 def test_memmap(tmpdir):
     """Test some interesting memmapping cases."""
     # concatenate_raw
-    memmaps = [op.join(str(tmpdir), str(ii)) for ii in range(3)]
+    memmaps = [tmpdir.join(str(ii)) for ii in range(3)]
     raw_0 = read_raw_fif(test_fif_fname, preload=memmaps[0])
     assert raw_0._data.filename == memmaps[0]
     raw_1 = read_raw_fif(test_fif_fname, preload=memmaps[1])
@@ -1518,14 +1506,14 @@ def test_memmap(tmpdir):
 def test_file_like(kind, preload, split, tmpdir):
     """Test handling with file-like objects."""
     if split:
-        fname = op.join(str(tmpdir), 'test_raw.fif')
+        fname = tmpdir.join('test_raw.fif')
         read_raw_fif(test_fif_fname).save(fname, split_size='5MB')
         assert op.isfile(fname)
-        assert op.isfile(fname[:-4] + '-1.fif')
+        assert op.isfile(str(fname)[:-4] + '-1.fif')
     else:
         fname = test_fif_fname
     if preload is str:
-        preload = op.join(str(tmpdir), 'memmap')
+        preload = tmpdir.join('memmap')
     with open(fname, 'rb') as file_fid:
         fid = BytesIO(file_fid.read()) if kind == 'bytes' else file_fid
         assert not fid.closed

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1513,7 +1513,7 @@ def test_file_like(kind, preload, split, tmpdir):
         fname = test_fif_fname
     if preload is str:
         preload = tmpdir.join('memmap')
-    with open(fname, 'rb') as file_fid:
+    with open(str(fname), 'rb') as file_fid:
         fid = BytesIO(file_fid.read()) if kind == 'bytes' else file_fid
         assert not fid.closed
         assert not file_fid.closed

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1377,7 +1377,6 @@ def test_compensation_raw(tmpdir):
 @requires_mne
 def test_compensation_raw_mne(tmpdir):
     """Test Raw compensation by comparing with MNE-C."""
-
     def compensate_mne(fname, grad):
         tmp_fname = tmpdir.join('mne_ctf_test_raw.fif')
         cmd = ['mne_process_raw', '--raw', fname, '--save', tmp_fname,

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy import linalg, sparse
 
 from .constants import FIFF
+from ..fixes import _fn35
 from ..utils import logger, _file_like
 from ..externals.jdcal import jcal2jd
 
@@ -304,6 +305,7 @@ def start_file(fname, id_=None):
         fid = fname
         fid.seek(0)
     else:
+        fname = _fn35(fname)
         if op.splitext(fname)[1].lower() == '.gz':
             logger.debug('Writing using gzip')
             # defaults to compression level 9, which is barely smaller but much

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy import linalg, sparse
 
 from .constants import FIFF
-from ..utils import logger
+from ..utils import logger, _file_like
 from ..externals.jdcal import jcal2jd
 
 
@@ -299,7 +299,11 @@ def start_file(fname, id_=None):
     id_ : dict | None
         ID to use for the FIFF_FILE_ID.
     """
-    if isinstance(fname, str):
+    if _file_like(fname):
+        logger.debug('Writing using %s I/O' % type(fname))
+        fid = fname
+        fid.seek(0)
+    else:
         if op.splitext(fname)[1].lower() == '.gz':
             logger.debug('Writing using gzip')
             # defaults to compression level 9, which is barely smaller but much
@@ -308,10 +312,6 @@ def start_file(fname, id_=None):
         else:
             logger.debug('Writing using normal I/O')
             fid = open(fname, "wb")
-    else:
-        logger.debug('Writing using %s I/O' % type(fname))
-        fid = fname
-        fid.seek(0)
     #   Write the compulsory items
     write_id(fid, FIFF.FIFF_FILE_ID, id_)
     write_int(fid, FIFF.FIFF_DIR_POINTER, -1)

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -1,4 +1,5 @@
 import os.path as op
+from pathlib import Path
 import re
 
 import numpy as np
@@ -189,6 +190,7 @@ def _compare_io(inv_op, out_file_ext='.fif'):
         out_file = op.join(tempdir, 'test-inv.fif.gz')
     else:
         raise ValueError('IO test could not complete')
+    out_file = Path(out_file)
     # Test io operations
     inv_init = copy.deepcopy(inv_op)
     write_inverse_operator(out_file, inv_op)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -19,7 +19,7 @@ from .source_space import (_ensure_src, _get_morph_src_reordering,
                            _ensure_src_subject, SourceSpaces)
 from .utils import (get_subjects_dir, _check_subject, logger, verbose,
                     _time_mask, warn as warn_, copy_function_doc_to_method_doc,
-                    fill_doc, _check_option)
+                    fill_doc, _check_option, _validate_type)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
 from .io.base import ToDataFrameMixin, TimeMixin
@@ -239,6 +239,8 @@ def read_source_estimate(fname, subject=None):
        '*-lh.w' and '*-rh.w'.
     """  # noqa: E501
     fname_arg = fname
+    _validate_type(fname, 'path-like', 'fname')
+    fname = str(fname)
 
     # make sure corresponding file(s) can be found
     ftype = None
@@ -556,6 +558,8 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
             File format to use. Currently, the only allowed values is "h5".
         %(verbose_meth)s
         """
+        _validate_type(fname, 'path-like', 'fname')
+        fname = str(fname)
         if ftype != 'h5':
             raise ValueError('%s objects can only be written as HDF5 files.'
                              % (self.__class__.__name__,))
@@ -1394,6 +1398,8 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
             and "h5". The "w" format only supports a single time point.
         %(verbose_meth)s
         """
+        _validate_type(fname, 'path-like', 'fname')
+        fname = str(fname)
         _check_option('ftype', ftype, ['stc', 'w', 'h5'])
 
         lh_data = self.data[:len(self.lh_vertno)]
@@ -1744,6 +1750,8 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         .. versionadded:: 0.9.0
         """
         import nibabel as nib
+        _validate_type(fname, 'path-like', 'fname')
+        fname = str(fname)
         img = self.as_volume(src, dest=dest, mri_resolution=mri_resolution,
                              format=format)
         nib.save(img, fname)
@@ -1879,6 +1887,8 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
             and "h5". The "w" format only supports a single time point.
         %(verbose_meth)s
         """
+        _validate_type(fname, 'path-like', 'fname')
+        fname = str(fname)
         _check_option('ftype', ftype, ['stc', 'w', 'h5'])
         if ftype == 'stc':
             logger.info('Writing STC to disk...')
@@ -1893,7 +1903,6 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
             _write_w(fname, vertices=self.vertices, data=self.data)
         elif ftype == 'h5':
             super().save(fname, 'h5')
-
         logger.info('[done]')
 
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -238,7 +238,8 @@ class SourceSpaces(list):
     @verbose
     def export_volume(self, fname, include_surfaces=True,
                       include_discrete=True, dest='mri', trans=None,
-                      mri_resolution=False, use_lut=True, verbose=None):
+                      mri_resolution=False, use_lut=True, overwrite=False,
+                      verbose=None):
         """Export source spaces to nifti or mgz file.
 
         Parameters
@@ -267,12 +268,18 @@ class SourceSpaces(list):
         use_lut : bool
             If True, assigns a numeric value to each source space that
             corresponds to a color on the freesurfer lookup table.
+        overwrite : bool
+            If True, overwrite the file if it exists.
+
+            .. versionadded:: 0.19
         %(verbose_meth)s
 
         Notes
         -----
         This method requires nibabel.
         """
+        _check_fname(fname, overwrite)
+        fname = str(fname)
         # import nibabel or raise error
         try:
             import nibabel as nib

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -795,7 +795,8 @@ def _decimate_surface_spacing(surf, spacing):
     return surf
 
 
-def write_surface(fname, coords, faces, create_stamp='', volume_info=None):
+def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
+                  overwrite=False):
     """Write a triangular Freesurfer surface mesh.
 
     Accepts the same data format as is returned by read_surface().
@@ -827,13 +828,15 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None):
             * 'cras' : array of float, shape (3,)
 
         .. versionadded:: 0.13.0
+    overwrite : bool
+        If True, overwrite the file if it exists.
 
     See Also
     --------
     read_surface
     read_tri
     """
-    fname = _check_fname(fname, 'read', True)
+    fname = _check_fname(fname, overwrite=overwrite)
     try:
         import nibabel as nib
         has_nibabel = True

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -26,7 +26,7 @@ from .io.write import (write_int, start_file, end_block, start_block, end_file,
 from .channels.channels import _get_meg_system
 from .transforms import (transform_surface_to, _pol_to_cart, _cart_to_sph,
                          _get_trans, apply_trans)
-from .utils import logger, verbose, get_subjects_dir, warn
+from .utils import logger, verbose, get_subjects_dir, warn, _check_fname
 from .fixes import (_serialize_volume_info, _get_read_geometry, einsum, jit,
                     prange)
 
@@ -575,6 +575,7 @@ def read_surface(fname, read_metadata=False, return_dict=False, verbose=None):
     write_surface
     read_tri
     """
+    fname = _check_fname(fname, 'read', True)
     ret = _get_read_geometry()(fname, read_metadata=read_metadata)
     if return_dict:
         ret += (dict(rr=ret[0], tris=ret[1], ntri=len(ret[1]), use_tris=ret[1],
@@ -832,6 +833,7 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None):
     read_surface
     read_tri
     """
+    fname = _check_fname(fname, 'read', True)
     try:
         import nibabel as nib
         has_nibabel = True

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -123,8 +123,7 @@ def test_make_sphere_model():
 @testing.requires_testing_data
 def test_make_bem_model(tmpdir):
     """Test BEM model creation from Python with I/O."""
-    tempdir = str(tmpdir)
-    fname_temp = op.join(tempdir, 'temp-bem.fif')
+    fname_temp = tmpdir.join('temp-bem.fif')
     for kwargs, fname in zip((dict(), dict(conductivity=[0.3])),
                              [fname_bem_3, fname_bem_1]):
         model = make_bem_model('sample', ico=2, subjects_dir=subjects_dir,
@@ -144,23 +143,22 @@ def test_make_bem_model(tmpdir):
 def test_bem_model_topology(tmpdir):
     """Test BEM model topological checks."""
     # bad topology (not enough neighboring tris)
-    tempdir = str(tmpdir)
-    makedirs(op.join(tempdir, 'foo', 'bem'))
+    makedirs(tmpdir.join('foo', 'bem'))
     for fname in ('inner_skull', 'outer_skull', 'outer_skin'):
         fname += '.surf'
         copy(op.join(subjects_dir, 'sample', 'bem', fname),
-             op.join(tempdir, 'foo', 'bem', fname))
-    outer_fname = op.join(tempdir, 'foo', 'bem', 'outer_skull.surf')
+             tmpdir.join('foo', 'bem', fname))
+    outer_fname = tmpdir.join('foo', 'bem', 'outer_skull.surf')
     rr, tris = read_surface(outer_fname)
     tris = tris[:-1]
     write_surface(outer_fname, rr, tris[:-1])
     with pytest.raises(RuntimeError, match='Surface outer skull is not compl'):
-        make_bem_model('foo', None, subjects_dir=tempdir)
+        make_bem_model('foo', None, subjects_dir=tmpdir)
     # Now get past this error to reach gh-6127 (not enough neighbor tris)
     rr_bad = np.concatenate([rr, np.mean(rr, axis=0, keepdims=True)], axis=0)
     write_surface(outer_fname, rr_bad, tris)
     with pytest.raises(RuntimeError, match='Surface outer skull.*triangles'):
-        make_bem_model('foo', None, subjects_dir=tempdir)
+        make_bem_model('foo', None, subjects_dir=tmpdir)
 
 
 @pytest.mark.slowtest

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -151,12 +151,12 @@ def test_bem_model_topology(tmpdir):
     outer_fname = tmpdir.join('foo', 'bem', 'outer_skull.surf')
     rr, tris = read_surface(outer_fname)
     tris = tris[:-1]
-    write_surface(outer_fname, rr, tris[:-1])
+    write_surface(outer_fname, rr, tris[:-1], overwrite=True)
     with pytest.raises(RuntimeError, match='Surface outer skull is not compl'):
         make_bem_model('foo', None, subjects_dir=tmpdir)
     # Now get past this error to reach gh-6127 (not enough neighbor tris)
     rr_bad = np.concatenate([rr, np.mean(rr, axis=0, keepdims=True)], axis=0)
-    write_surface(outer_fname, rr_bad, tris)
+    write_surface(outer_fname, rr_bad, tris, overwrite=True)
     with pytest.raises(RuntimeError, match='Surface outer skull.*triangles'):
         make_bem_model('foo', None, subjects_dir=tmpdir)
 

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -147,7 +147,7 @@ def test_bem_model_topology(tmpdir):
     for fname in ('inner_skull', 'outer_skull', 'outer_skin'):
         fname += '.surf'
         copy(op.join(subjects_dir, 'sample', 'bem', fname),
-             tmpdir.join('foo', 'bem', fname))
+             str(tmpdir.join('foo', 'bem', fname)))
     outer_fname = tmpdir.join('foo', 'bem', 'outer_skull.surf')
     rr, tris = read_surface(outer_fname)
     tris = tris[:-1]

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -173,7 +173,7 @@ def _assert_reorder(cov_new, cov_orig, order):
 
 def test_ad_hoc_cov(tmpdir):
     """Test ad hoc cov creation and I/O."""
-    out_fname = op.join(str(tmpdir), 'test-cov.fif')
+    out_fname = tmpdir.join('test-cov.fif')
     evoked = read_evokeds(ave_fname)[0]
     cov = make_ad_hoc_cov(evoked.info)
     cov.save(out_fname)
@@ -190,12 +190,11 @@ def test_ad_hoc_cov(tmpdir):
 
 def test_io_cov(tmpdir):
     """Test IO for noise covariance matrices."""
-    tempdir = str(tmpdir)
     cov = read_cov(cov_fname)
     cov['method'] = 'empirical'
     cov['loglik'] = -np.inf
-    cov.save(op.join(tempdir, 'test-cov.fif'))
-    cov2 = read_cov(op.join(tempdir, 'test-cov.fif'))
+    cov.save(tmpdir.join('test-cov.fif'))
+    cov2 = read_cov(tmpdir.join('test-cov.fif'))
     assert_array_almost_equal(cov.data, cov2.data)
     assert_equal(cov['method'], cov2['method'])
     assert_equal(cov['loglik'], cov2['loglik'])
@@ -203,24 +202,24 @@ def test_io_cov(tmpdir):
 
     cov2 = read_cov(cov_gz_fname)
     assert_array_almost_equal(cov.data, cov2.data)
-    cov2.save(op.join(tempdir, 'test-cov.fif.gz'))
-    cov2 = read_cov(op.join(tempdir, 'test-cov.fif.gz'))
+    cov2.save(tmpdir.join('test-cov.fif.gz'))
+    cov2 = read_cov(tmpdir.join('test-cov.fif.gz'))
     assert_array_almost_equal(cov.data, cov2.data)
 
     cov['bads'] = ['EEG 039']
     cov_sel = pick_channels_cov(cov, exclude=cov['bads'])
     assert cov_sel['dim'] == (len(cov['data']) - len(cov['bads']))
     assert cov_sel['data'].shape == (cov_sel['dim'], cov_sel['dim'])
-    cov_sel.save(op.join(tempdir, 'test-cov.fif'))
+    cov_sel.save(tmpdir.join('test-cov.fif'))
 
     cov2 = read_cov(cov_gz_fname)
     assert_array_almost_equal(cov.data, cov2.data)
-    cov2.save(op.join(tempdir, 'test-cov.fif.gz'))
-    cov2 = read_cov(op.join(tempdir, 'test-cov.fif.gz'))
+    cov2.save(tmpdir.join('test-cov.fif.gz'))
+    cov2 = read_cov(tmpdir.join('test-cov.fif.gz'))
     assert_array_almost_equal(cov.data, cov2.data)
 
     # test warnings on bad filenames
-    cov_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    cov_badname = tmpdir.join('test-bad-name.fif.gz')
     with pytest.warns(RuntimeWarning, match='-cov.fif'):
         write_cov(cov_badname, cov)
     with pytest.warns(RuntimeWarning, match='-cov.fif'):
@@ -230,7 +229,6 @@ def test_io_cov(tmpdir):
 @pytest.mark.parametrize('method', (None, ['empirical']))
 def test_cov_estimation_on_raw(method, tmpdir):
     """Test estimation from raw (typically empty room)."""
-    tempdir = str(tmpdir)
     raw = read_raw_fif(raw_fname, preload=True)
     cov_mne = read_cov(erm_cov_fname)
 
@@ -251,8 +249,8 @@ def test_cov_estimation_on_raw(method, tmpdir):
     assert_snr(cov.data, cov_mne.data, 1e2)
 
     # test IO when computation done in Python
-    cov.save(op.join(tempdir, 'test-cov.fif'))  # test saving
-    cov_read = read_cov(op.join(tempdir, 'test-cov.fif'))
+    cov.save(tmpdir.join('test-cov.fif'))  # test saving
+    cov_read = read_cov(tmpdir.join('test-cov.fif'))
     assert cov_read.ch_names == cov.ch_names
     assert cov_read.nfree == cov.nfree
     assert_array_almost_equal(cov.data, cov_read.data)
@@ -308,7 +306,6 @@ def _assert_cov(cov, cov_desired, tol=0.005, nfree=True):
 @pytest.mark.parametrize('rank', ('full', None))
 def test_cov_estimation_with_triggers(rank, tmpdir):
     """Test estimation from raw with triggers."""
-    tempdir = str(tmpdir)
     raw = read_raw_fif(raw_fname)
     raw.set_eeg_reference(projection=True).load_data()
     events = find_events(raw, stim_channel='STI 014')
@@ -350,8 +347,8 @@ def test_cov_estimation_with_triggers(rank, tmpdir):
                   keep_sample_mean=False, method='shrunk', rank=rank)
 
     # test IO when computation done in Python
-    cov.save(op.join(tempdir, 'test-cov.fif'))  # test saving
-    cov_read = read_cov(op.join(tempdir, 'test-cov.fif'))
+    cov.save(tmpdir.join('test-cov.fif'))  # test saving
+    cov_read = read_cov(tmpdir.join('test-cov.fif'))
     _assert_cov(cov, cov_read, 1e-5)
 
     # cov with list of epochs with different projectors

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -1,4 +1,9 @@
-import os
+# -*- coding: utf-8 -*-
+# Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#          Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
 import os.path as op
 from shutil import copytree
 
@@ -174,29 +179,25 @@ def test_discrete_source_space(tmpdir):
 
     # let's make a discrete version with the C code, and with ours
     temp_name = tmpdir.join('temp-src.fif')
-    try:
-        # save
-        temp_pos = tmpdir.join('temp-pos.txt')
-        np.savetxt(temp_pos, np.c_[src[0]['rr'][v], src[0]['nn'][v]])
-        # let's try the spherical one (no bem or surf supplied)
-        run_subprocess(['mne_volume_source_space', '--meters',
-                        '--pos', temp_pos, '--src', temp_name])
-        src_c = read_source_spaces(temp_name)
-        pos_dict = dict(rr=src[0]['rr'][v], nn=src[0]['nn'][v])
-        src_new = setup_volume_source_space(pos=pos_dict)
-        assert src_new.kind == 'discrete'
-        _compare_source_spaces(src_c, src_new, mode='approx')
-        assert_allclose(src[0]['rr'][v], src_new[0]['rr'],
-                        rtol=1e-3, atol=1e-6)
-        assert_allclose(src[0]['nn'][v], src_new[0]['nn'],
-                        rtol=1e-3, atol=1e-6)
+    # save
+    temp_pos = tmpdir.join('temp-pos.txt')
+    np.savetxt(str(temp_pos), np.c_[src[0]['rr'][v], src[0]['nn'][v]])
+    # let's try the spherical one (no bem or surf supplied)
+    run_subprocess(['mne_volume_source_space', '--meters',
+                    '--pos', temp_pos, '--src', temp_name])
+    src_c = read_source_spaces(temp_name)
+    pos_dict = dict(rr=src[0]['rr'][v], nn=src[0]['nn'][v])
+    src_new = setup_volume_source_space(pos=pos_dict)
+    assert src_new.kind == 'discrete'
+    _compare_source_spaces(src_c, src_new, mode='approx')
+    assert_allclose(src[0]['rr'][v], src_new[0]['rr'],
+                    rtol=1e-3, atol=1e-6)
+    assert_allclose(src[0]['nn'][v], src_new[0]['nn'],
+                    rtol=1e-3, atol=1e-6)
 
-        # now do writing
-        write_source_spaces(temp_name, src_c, overwrite=True)
-        src_c2 = read_source_spaces(temp_name)
-    finally:
-        if op.isfile(temp_name):
-            os.remove(temp_name)
+    # now do writing
+    write_source_spaces(temp_name, src_c, overwrite=True)
+    src_c2 = read_source_spaces(temp_name)
     _compare_source_spaces(src_c, src_c2)
 
     # now do MRI
@@ -412,7 +413,7 @@ def test_setup_source_space(tmpdir):
 @pytest.mark.parametrize('spacing', [2, 7])
 def test_setup_source_space_spacing(tmpdir, spacing):
     """Test setting up surface source spaces using a given spacing."""
-    copytree(op.join(subjects_dir, 'sample'), tmpdir.join('sample'))
+    copytree(op.join(subjects_dir, 'sample'), str(tmpdir.join('sample')))
     args = [] if spacing == 7 else ['--spacing', str(spacing)]
     with modified_env(SUBJECTS_DIR=str(tmpdir), SUBJECT='sample'):
         run_subprocess(['mne_setup_source_space'] + args)

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -93,7 +93,6 @@ def test_add_patch_info(monkeypatch):
 @testing.requires_testing_data
 def test_add_source_space_distances_limited(tmpdir):
     """Test adding distances to source space with a dist_limit."""
-    tempdir = str(tmpdir)
     src = read_source_spaces(fname)
     src_new = read_source_spaces(fname)
     del src_new[0]['dist']
@@ -101,7 +100,7 @@ def test_add_source_space_distances_limited(tmpdir):
     n_do = 200  # limit this for speed
     src_new[0]['vertno'] = src_new[0]['vertno'][:n_do].copy()
     src_new[1]['vertno'] = src_new[1]['vertno'][:n_do].copy()
-    out_name = op.join(tempdir, 'temp-src.fif')
+    out_name = tmpdir.join('temp-src.fif')
     add_source_space_distances(src_new, dist_limit=0.007)
     write_source_spaces(out_name, src_new)
     src_new = read_source_spaces(out_name)
@@ -128,7 +127,6 @@ def test_add_source_space_distances_limited(tmpdir):
 @testing.requires_testing_data
 def test_add_source_space_distances(tmpdir):
     """Test adding distances to source space."""
-    tempdir = str(tmpdir)
     src = read_source_spaces(fname)
     src_new = read_source_spaces(fname)
     del src_new[0]['dist']
@@ -136,7 +134,7 @@ def test_add_source_space_distances(tmpdir):
     n_do = 19  # limit this for speed
     src_new[0]['vertno'] = src_new[0]['vertno'][:n_do].copy()
     src_new[1]['vertno'] = src_new[1]['vertno'][:n_do].copy()
-    out_name = op.join(tempdir, 'temp-src.fif')
+    out_name = tmpdir.join('temp-src.fif')
     n_jobs = 2
     assert n_do % n_jobs != 0
     add_source_space_distances(src_new, n_jobs=n_jobs)
@@ -171,15 +169,14 @@ def test_add_source_space_distances(tmpdir):
 @requires_mne
 def test_discrete_source_space(tmpdir):
     """Test setting up (and reading/writing) discrete source spaces."""
-    tempdir = str(tmpdir)
     src = read_source_spaces(fname)
     v = src[0]['vertno']
 
     # let's make a discrete version with the C code, and with ours
-    temp_name = op.join(tempdir, 'temp-src.fif')
+    temp_name = tmpdir.join('temp-src.fif')
     try:
         # save
-        temp_pos = op.join(tempdir, 'temp-pos.txt')
+        temp_pos = tmpdir.join('temp-pos.txt')
         np.savetxt(temp_pos, np.c_[src[0]['rr'][v], src[0]['nn'][v]])
         # let's try the spherical one (no bem or surf supplied)
         run_subprocess(['mne_volume_source_space', '--meters',
@@ -214,9 +211,8 @@ def test_discrete_source_space(tmpdir):
 @testing.requires_testing_data
 def test_volume_source_space(tmpdir):
     """Test setting up volume source spaces."""
-    tempdir = str(tmpdir)
     src = read_source_spaces(fname_vol)
-    temp_name = op.join(tempdir, 'temp-src.fif')
+    temp_name = tmpdir.join('temp-src.fif')
     surf = read_bem_surfaces(fname_bem, s_id=FIFF.FIFFV_BEM_SURF_ID_BRAIN)
     surf['rr'] *= 1e3  # convert to mm
     bem_sol = read_bem_solution(fname_bem_3_sol)
@@ -270,8 +266,7 @@ def test_other_volume_source_spaces(tmpdir):
     # Travis doesn't seem to like them
 
     # let's try the spherical one (no bem or surf supplied)
-    tempdir = str(tmpdir)
-    temp_name = op.join(tempdir, 'temp-src.fif')
+    temp_name = tmpdir.join('temp-src.fif')
     run_subprocess(['mne_volume_source_space',
                     '--grid', '7.0',
                     '--src', temp_name,
@@ -355,7 +350,6 @@ def test_accumulate_normals():
 @testing.requires_testing_data
 def test_setup_source_space(tmpdir):
     """Test setting up ico, oct, and all source spaces."""
-    tempdir = str(tmpdir)
     fname_ico = op.join(data_path, 'subjects', 'fsaverage', 'bem',
                         'fsaverage-ico-5-src.fif')
     # first lets test some input params
@@ -390,7 +384,7 @@ def test_setup_source_space(tmpdir):
 
     # oct-6 (sample) - auto filename + IO
     src = read_source_spaces(fname)
-    temp_name = op.join(tempdir, 'temp-src.fif')
+    temp_name = tmpdir.join('temp-src.fif')
     with pytest.warns(None):  # sklearn equiv neighbors
         src_new = setup_source_space('sample', spacing='oct6',
                                      subjects_dir=subjects_dir, add_dist=False)
@@ -418,13 +412,12 @@ def test_setup_source_space(tmpdir):
 @pytest.mark.parametrize('spacing', [2, 7])
 def test_setup_source_space_spacing(tmpdir, spacing):
     """Test setting up surface source spaces using a given spacing."""
-    tempdir = str(tmpdir)
-    copytree(op.join(subjects_dir, 'sample'), op.join(tempdir, 'sample'))
+    copytree(op.join(subjects_dir, 'sample'), tmpdir.join('sample'))
     args = [] if spacing == 7 else ['--spacing', str(spacing)]
-    with modified_env(SUBJECTS_DIR=tempdir, SUBJECT='sample'):
+    with modified_env(SUBJECTS_DIR=str(tmpdir), SUBJECT='sample'):
         run_subprocess(['mne_setup_source_space'] + args)
-    src = read_source_spaces(op.join(tempdir, 'sample', 'bem',
-                                     'sample-%d-src.fif' % spacing))
+    src = read_source_spaces(tmpdir.join('sample', 'bem',
+                                         'sample-%d-src.fif' % spacing))
     src_new = setup_source_space('sample', spacing=spacing, add_dist=False,
                                  subjects_dir=subjects_dir)
     _compare_source_spaces(src, src_new, mode='approx', nearest=True)
@@ -461,15 +454,14 @@ def test_read_source_spaces():
 @testing.requires_testing_data
 def test_write_source_space(tmpdir):
     """Test reading and writing of source spaces."""
-    tempdir = str(tmpdir)
     src0 = read_source_spaces(fname, patch_stats=False)
-    write_source_spaces(op.join(tempdir, 'tmp-src.fif'), src0)
-    src1 = read_source_spaces(op.join(tempdir, 'tmp-src.fif'),
-                              patch_stats=False)
+    temp_fname = tmpdir.join('tmp-src.fif')
+    write_source_spaces(temp_fname, src0)
+    src1 = read_source_spaces(temp_fname, patch_stats=False)
     _compare_source_spaces(src0, src1)
 
     # test warnings on bad filenames
-    src_badname = op.join(tempdir, 'test-bad-name.fif.gz')
+    src_badname = tmpdir.join('test-bad-name.fif.gz')
     with pytest.warns(RuntimeWarning, match='-src.fif'):
         write_source_spaces(src_badname, src0)
     with pytest.warns(RuntimeWarning, match='-src.fif'):
@@ -550,7 +542,6 @@ def test_get_volume_label_names():
 @requires_nibabel()
 def test_source_space_from_label(tmpdir):
     """Test generating a source space from volume label."""
-    tempdir = str(tmpdir)
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
     label_names = get_volume_labels_from_aseg(aseg_fname)
     volume_label = label_names[int(np.random.rand() * len(label_names))]
@@ -574,7 +565,7 @@ def test_source_space_from_label(tmpdir):
     assert_equal(volume_label, src[0]['seg_name'])
 
     # test reading and writing
-    out_name = op.join(tempdir, 'temp-src.fif')
+    out_name = tmpdir.join('temp-src.fif')
     write_source_spaces(out_name, src)
     src_from_file = read_source_spaces(out_name)
     _compare_source_spaces(src, src_from_file, mode='approx')
@@ -618,7 +609,6 @@ def test_read_volume_from_src():
 @requires_nibabel()
 def test_combine_source_spaces(tmpdir):
     """Test combining source spaces."""
-    tempdir = str(tmpdir)
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
     label_names = get_volume_labels_from_aseg(aseg_fname)
     volume_labels = [label_names[int(np.random.rand() * len(label_names))]
@@ -648,7 +638,7 @@ def test_combine_source_spaces(tmpdir):
     assert_equal(len(src), 4)
 
     # test reading and writing
-    src_out_name = op.join(tempdir, 'temp-src.fif')
+    src_out_name = tmpdir.join('temp-src.fif')
     src.save(src_out_name)
     src_from_file = read_source_spaces(src_out_name)
     _compare_source_spaces(src, src_from_file, mode='approx')
@@ -660,7 +650,7 @@ def test_combine_source_spaces(tmpdir):
     assert (coord_frames == FIFF.FIFFV_COORD_MRI).all()
 
     # test errors for export_volume
-    image_fname = op.join(tempdir, 'temp-image.mgz')
+    image_fname = tmpdir.join('temp-image.mgz')
 
     # source spaces with no volume
     pytest.raises(ValueError, srf.export_volume, image_fname, verbose='error')
@@ -673,7 +663,7 @@ def test_combine_source_spaces(tmpdir):
                   verbose='error')
 
     # unrecognized file type
-    bad_image_fname = op.join(tempdir, 'temp-image.png')
+    bad_image_fname = tmpdir.join('temp-image.png')
     # vertices outside vol space warning
     pytest.raises(ValueError, src.export_volume, bad_image_fname,
                   verbose='error')

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -164,7 +164,8 @@ def test_io_surface():
     for fname in (fname_quad, fname_tri):
         with pytest.warns(None):  # no volume info
             pts, tri, vol_info = read_surface(fname, read_metadata=True)
-        write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info)
+        write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info,
+                      overwrite=True)
         with pytest.warns(None):  # no volume info
             c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
                                                     read_metadata=True)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -138,14 +138,15 @@ def _check_event_id(event_id, events):
 def _check_fname(fname, overwrite=False, must_exist=False):
     """Check for file existence."""
     _validate_type(fname, 'path-like', 'fname')
-    if must_exist and not op.isfile(fname):
-        raise IOError('File "%s" does not exist' % fname)
     if op.isfile(fname):
         if not overwrite:
             raise IOError('Destination file exists. Please use option '
                           '"overwrite=True" to force overwriting.')
         elif overwrite != 'read':
             logger.info('Overwriting existing file.')
+    elif must_exist:
+        raise IOError('File "%s" does not exist' % fname)
+    return str(fname)
 
 
 def _check_subject(class_subject, input_subject, raise_error=True):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -277,7 +277,13 @@ _multi = {
 try:
     _multi['path-like'] += (os.PathLike,)
 except AttributeError:  # only on 3.6+
-    pass
+    try:
+        # At least make PyTest work
+        from py._path.common import PathBase
+    except Exception:  # no py.path
+        pass
+    else:
+        _multi['path-like'] += (PathBase,)
 
 
 def _validate_type(item, types=None, item_name=None, type_name=None):

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -172,7 +172,8 @@ def running_subprocess(command, after="wait", verbose=None, *args, **kwargs):
     if isinstance(command, str):
         command_str = command
     else:
-        command_str = ' '.join(str(s) for s in command)
+        command = [str(s) for s in command]
+        command_str = ' '.join(s for s in command)
     logger.info("Running subprocess: %s" % command_str)
     try:
         p = subprocess.Popen(command, *args, **kwargs)

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -172,7 +172,7 @@ def running_subprocess(command, after="wait", verbose=None, *args, **kwargs):
     if isinstance(command, str):
         command_str = command
     else:
-        command_str = ' '.join(command)
+        command_str = ' '.join(str(s) for s in command)
     logger.info("Running subprocess: %s" % command_str)
     try:
         p = subprocess.Popen(command, *args, **kwargs)

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -8,6 +8,7 @@ import shutil
 
 import numpy as np
 import pytest
+from pathlib import Path
 
 import mne
 from mne.datasets import testing
@@ -29,6 +30,7 @@ def test_check():
     """Test checking functions."""
     pytest.raises(ValueError, check_random_state, 'foo')
     pytest.raises(TypeError, _check_fname, 1)
+    _check_fname(Path('./'))
     pytest.raises(IOError, check_fname, 'foo', 'tets-dip.x', (), ('.fif',))
     pytest.raises(ValueError, _check_subject, None, None)
     pytest.raises(TypeError, _check_subject, None, 1)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -723,7 +723,9 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     ecog_picks = pick_types(info, meg=False, ecog=True, ref_meg=False)
     seeg_picks = pick_types(info, meg=False, seeg=True, ref_meg=False)
 
-    if isinstance(trans, str):
+    if trans is None:
+        trans = Transform('head', 'mri')
+    else:
         if trans == 'auto':
             # let's try to do this in MRI coordinates so they're easy to plot
             subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
@@ -737,10 +739,6 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                     raise
             else:
                 break
-    elif trans is None:
-        trans = Transform('head', 'mri')
-    else:
-        _validate_type(trans, (Transform,), "str, Transform, or None")
     head_mri_t = _ensure_trans(trans, 'head', 'mri')
     dev_head_t = info['dev_head_t']
     del trans

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -8,6 +8,7 @@
 # License: Simplified BSD
 
 import os.path as op
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -209,7 +210,7 @@ def test_plot_alignment(tmpdir, renderer):
     plot_alignment(info, surfaces=[])
     for coord_frame in ('meg', 'head', 'mri'):
         fig = plot_alignment(info, meg=['helmet', 'sensors'], dig=True,
-                             coord_frame=coord_frame, trans=trans_fname,
+                             coord_frame=coord_frame, trans=Path(trans_fname),
                              subject='sample', mri_fiducials=fiducials_path,
                              subjects_dir=subjects_dir, src=src_fname)
     renderer._close_all()


### PR DESCRIPTION
Closes #6699.

- Unifies `preload`-as-`str` handling in `io/base.py`
- Adds `path-like` to `_validate_types`
- Makes `_validate_types` support nested `str` options (e.g. `(None, 'path-like')`)
- Modernizes a number of `tmpdir` uses (@massich you should be happy :) )