### PR TITLE
ENH: Support path-like objects in mne.make_forward_solution()

### DIFF
--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -30,7 +30,7 @@ from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
 from .utils import (get_subjects_dir, run_subprocess, has_freesurfer,
                     has_nibabel, check_fname, logger, verbose, _ensure_int,
                     check_version, _get_call_line, warn, _check_fname,
-                    _validate_type, _check_path_like)
+                    _check_path_like)
 from .parallel import parallel_func, check_n_jobs
 from .transforms import (invert_transform, apply_trans, _print_coord_trans,
                          combine_transforms, _get_trans,

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -29,7 +29,8 @@ from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       mesh_dist)
 from .utils import (get_subjects_dir, run_subprocess, has_freesurfer,
                     has_nibabel, check_fname, logger, verbose, _ensure_int,
-                    check_version, _get_call_line, warn, _check_fname)
+                    check_version, _get_call_line, warn, _check_fname,
+                    _validate_type)
 from .parallel import parallel_func, check_n_jobs
 from .transforms import (invert_transform, apply_trans, _print_coord_trans,
                          combine_transforms, _get_trans,
@@ -2386,7 +2387,14 @@ def _points_outside_surface(rr, surf, n_jobs=1, verbose=None):
 @verbose
 def _ensure_src(src, kind=None, verbose=None):
     """Ensure we have a source space."""
-    if isinstance(src, str):
+    try:
+        _validate_type(src, 'path-like', 'src')
+        src = str(src)
+        path_like = True
+    except TypeError:
+        path_like = False
+
+    if path_like:
         if not op.isfile(src):
             raise IOError('Source space file "%s" not found' % src)
         logger.info('Reading %s...' % src)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -30,7 +30,7 @@ from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
 from .utils import (get_subjects_dir, run_subprocess, has_freesurfer,
                     has_nibabel, check_fname, logger, verbose, _ensure_int,
                     check_version, _get_call_line, warn, _check_fname,
-                    _validate_type)
+                    _validate_type, _check_path_like)
 from .parallel import parallel_func, check_n_jobs
 from .transforms import (invert_transform, apply_trans, _print_coord_trans,
                          combine_transforms, _get_trans,
@@ -2387,14 +2387,8 @@ def _points_outside_surface(rr, surf, n_jobs=1, verbose=None):
 @verbose
 def _ensure_src(src, kind=None, verbose=None):
     """Ensure we have a source space."""
-    try:
-        _validate_type(src, 'path-like', 'src')
+    if _check_path_like(src):
         src = str(src)
-        path_like = True
-    except TypeError:
-        path_like = False
-
-    if path_like:
         if not op.isfile(src):
             raise IOError('Source space file "%s" not found' % src)
         logger.info('Reading %s...' % src)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -19,7 +19,8 @@ from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.write import start_file, end_file, write_coord_trans
-from .utils import check_fname, logger, verbose, _ensure_int, _validate_type
+from .utils import (check_fname, logger, verbose, _ensure_int, _validate_type,
+                    _check_path_like)
 
 
 # transformation from anterior/left/superior coordinate system to
@@ -432,14 +433,8 @@ def _ensure_trans(trans, fro='mri', to='head'):
 
 def _get_trans(trans, fro='mri', to='head'):
     """Get mri_head_t (from=mri, to=head) from mri filename."""
-    try:
-        _validate_type(trans, 'path-like', 'trans')
+    if _check_path_like(trans):
         trans = str(trans)
-        path_like = True
-    except TypeError:
-        path_like = False
-
-    if path_like:
         if not op.isfile(trans):
             raise IOError('trans file "%s" not found' % trans)
         if op.splitext(trans)[1] in ['.fif', '.gz']:

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -19,8 +19,7 @@ from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.write import start_file, end_file, write_coord_trans
-from .utils import (check_fname, logger, verbose, _ensure_int, _validate_type,
-                    _check_path_like)
+from .utils import check_fname, logger, verbose, _ensure_int, _check_path_like
 
 
 # transformation from anterior/left/superior coordinate system to

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -19,7 +19,7 @@ from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.write import start_file, end_file, write_coord_trans
-from .utils import check_fname, logger, verbose, _ensure_int
+from .utils import check_fname, logger, verbose, _ensure_int, _validate_type
 
 
 # transformation from anterior/left/superior coordinate system to
@@ -432,7 +432,14 @@ def _ensure_trans(trans, fro='mri', to='head'):
 
 def _get_trans(trans, fro='mri', to='head'):
     """Get mri_head_t (from=mri, to=head) from mri filename."""
-    if isinstance(trans, str):
+    try:
+        _validate_type(trans, 'path-like', 'trans')
+        trans = str(trans)
+        path_like = True
+    except TypeError:
+        path_like = False
+
+    if path_like:
         if not op.isfile(trans):
             raise IOError('trans file "%s" not found' % trans)
         if op.splitext(trans)[1] in ['.fif', '.gz']:

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -13,7 +13,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_if_nan, _is_numeric, _ensure_int,  _check_preload,
                     _validate_type, _check_info_inv, _check_pylsl_installed,
                     _check_channels_spatial_filter, _check_one_ch_type,
-                    _check_rank, _check_option, _check_depth, _check_combine)
+                    _check_rank, _check_option, _check_depth, _check_combine,
+                    _check_path_like)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -326,6 +326,26 @@ def _validate_type(item, types=None, item_name=None, type_name=None):
                         % (item_name, type_name, type(item),))
 
 
+def _check_path_like(item):
+    """Validate that `item` is `path-like`.
+
+    Parameters
+    ----------
+    item : object
+        The thing to be checked.
+
+    Returns
+    -------
+    bool
+        ``True`` if `item` is a `path-like` object; ``False`` otherwise.
+    """
+    try:
+        _validate_type(item, types='path-like')
+        return True
+    except TypeError:
+        return False
+
+
 def _check_if_nan(data, msg=" to be plotted"):
     """Raise if any of the values are NaN."""
     if not np.isfinite(data).all():

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -16,7 +16,7 @@ from mne.io.pick import pick_channels_cov
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
                        _check_mayavi_version, _check_info_inv, _check_option,
-                       check_version)
+                       check_version, _check_path_like)
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
@@ -146,3 +146,15 @@ def test_check_option():
            "is 'valid', but got 'bad' instead.")
     with pytest.raises(ValueError, match=msg):
         assert _check_option('option', 'bad', ['valid'])
+
+
+def test_check_path_like():
+    """Test _check_path_like().
+    """
+    str_path = str(base_dir)
+    pathlib_path = Path(base_dir)
+    no_path = dict(foo='bar')
+
+    assert _check_path_like(str_path) is True
+    assert _check_path_like(pathlib_path) is True
+    assert _check_path_like(no_path) is False

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -149,8 +149,7 @@ def test_check_option():
 
 
 def test_check_path_like():
-    """Test _check_path_like().
-    """
+    """Test _check_path_like()."""
     str_path = str(base_dir)
     pathlib_path = Path(base_dir)
     no_path = dict(foo='bar')


### PR DESCRIPTION
#### Reference issue
Completes #6699, #6701.


#### What does this implement/fix?
`mne.make_forward_solution()` now also accepts `path-like` objects for the `trans` and `src` parameters. This was the last function in my workflow (#6699) that hadn't been fixed via #6701.

#### Additional information
- <strike>I introduced the local variable `path_like` to help keep the new `try ... except` blocks as small as possible.
- This PR currently doesn't add any additional tests. I'm not sure if that would be necessary – and how exactly to design them. If you would prefer to have tests, I'd appreciate advice.</strike >
- Also, not sure if I should add a `whats_new` entry,  as this PR more or less just complements #6701.

cc @larsoner 