### PR TITLE
MRG, VIZ: add titles to corrmap matches

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2566,6 +2566,8 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
         if template:
             ttl = 'Subj. {}, {}'.format(subject, ica._ica_names[idx])
             ax.set_title(ttl, fontsize=12)
+        else:
+            ax.set_title('Subj. {}'.format(subject))
         data_ = _merge_grad_data(data_) if merge_grads else data_
         vmin_, vmax_ = _setup_vmin_vmax(data_, None, None)
         plot_topomap(data_.flatten(), pos, vmin=vmin_, vmax=vmax_,


### PR DESCRIPTION
Tiny change to add labels to each ICA corrmap match (so it's easier to tell which subject(s) had no match or multiple matches)

Before this PR:

![before-this-PR](https://user-images.githubusercontent.com/1810515/63982826-f2ce3f80-ca78-11e9-83bb-f28614dd8b36.png)

After this PR:

![after-this-PR](https://user-images.githubusercontent.com/1810515/63982835-f792f380-ca78-11e9-8bab-6f9ead41c374.png)