### PR TITLE
[MRG] Bring back yticks for ICA properties

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -183,7 +183,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     # compute percentage of dropped epochs
     var_percent = float(len(dropped_indices)) / float(len(epoch_var)) * 100.
 
-    var_ax.set_yticks([])
+    # var_ax.set_yticks([])
 
     # histogram & histogram
     _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
@@ -230,10 +230,8 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     image_ax.axhline(0, color='k', linewidth=.5)
 
     # epoch variance
-    var_ax_title = 'Dropped segments : %.2f %%' % var_percent
-    set_title_and_labels(var_ax, var_ax_title,
-                         kind + ' (index)',
-                         'Variance (AU)')
+    var_ax_title = 'Dropped segments: %.2f %%' % var_percent
+    set_title_and_labels(var_ax, var_ax_title, kind, 'Variance (AU)')
 
     hist_ax.set_ylabel("")
     hist_ax.set_yticks([])

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -204,7 +204,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     set_title_and_labels(image_ax, kind + ' image and ERP/ERF', [], kind)
 
     # erp
-    set_title_and_labels(erp_ax, [], 'Time (s)', 'AU\n')
+    set_title_and_labels(erp_ax, [], 'Time (s)', 'AU')
     erp_ax.spines["right"].set_color('k')
     erp_ax.set_xlim(epochs_src.times[[0, -1]])
     # remove half of yticks if more than 5

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -183,8 +183,6 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     # compute percentage of dropped epochs
     var_percent = float(len(dropped_indices)) / float(len(epoch_var)) * 100.
 
-    # var_ax.set_yticks([])
-
     # histogram & histogram
     _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
                                 color="k", alpha=.5)


### PR DESCRIPTION
Fixes #6718. In addition to bringing back the yticks and labels, I've removed the space before the colon in the title, and " (index)" from the x axis label (because "segment" is sufficient).

Here's what it looks like after the changes:
![Figure_1](https://user-images.githubusercontent.com/4377312/64103849-5c00cc00-cd73-11e9-8187-d3f74b28fdf3.png)

I'd also like to change the horizontal position of the y axis label for the ERP/ERF - the "AU" label is too far to the left and should be closer to the actual axis. Anyone know how to do that quickly? Otherwise, this is ready to merge.