### PR TITLE
MRG, ENH: Speed up mne coreg

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,6 +49,8 @@ Changelog
 
 - Speed up :func:`mne.setup_volume_source_space`, especially when ``volume_label is not None`` by `Eric Larson`_
 
+- Speed up :ref:`mne coreg <gen_mne_coreg>` interactive and automated (ICP) alignment by using nearest-neighbor calculations in the MRI coordinate frame, by `Eric Larson`_
+
 - Add :func:`mne.dig_mri_distances` to compute the distances between digitized head points and the MRI head surface by `Alex Gramfort`_ and `Eric Larson`_
 
 - Add scale bars for data channels in :func:`mne.io.Raw.plot` by `Eric Larson`_

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -26,10 +26,10 @@ from .forward._make_forward import (_get_trans, _setup_bem,
 from .forward._compute_forward import (_compute_forwards_meeg,
                                        _prep_field_computation)
 
-from .surface import transform_surface_to, _compute_nearest
+from .surface import (transform_surface_to, _compute_nearest,
+                      _points_outside_surface)
 from .bem import _bem_find_surface, _surf_name
-from .source_space import (_make_volume_source_space, SourceSpaces,
-                           _points_outside_surface)
+from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl, fill_doc, _check_option,

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -60,6 +60,7 @@ multiplications / divisions.
 import os
 import queue
 import re
+import time
 from threading import Thread
 import traceback
 import warnings
@@ -82,7 +83,7 @@ from tvtk.pyface.scene_editor import SceneEditor
 from ..bem import make_bem_solution, write_bem_solution
 from ..coreg import bem_fname, trans_fname
 from ..defaults import DEFAULTS
-from ..surface import _DistanceQuery
+from ..surface import _DistanceQuery, _CheckInside
 from ..transforms import (write_trans, read_trans, apply_trans, rotation,
                           rotation_angles, Transform, _ensure_trans,
                           rot_to_quat, _angle_between_quats)
@@ -170,6 +171,7 @@ class CoregModel(HasPrivateTraits):
     hpi_weight = Float(1.)
     iteration = Int(-1)
     icp_iterations = Int(20)
+    icp_start_time = Float(0.0)
     icp_angle = Float(0.2)
     icp_distance = Float(0.2)
     icp_scale = Float(0.2)
@@ -217,8 +219,8 @@ class CoregModel(HasPrivateTraits):
         desc="Transformation of the scaled MRI to the head coordinate frame.",
         depends_on=['parameters[]'])
     head_mri_t = Property(depends_on=['mri_head_t'])
-    mri_trans = Property(depends_on=['mri_head_t', 'parameters[]',
-                                     'coord_frame'])
+    mri_trans_noscale = Property(depends_on=['mri_head_t', 'coord_frame'])
+    mri_trans = Property(depends_on=['mri_trans_noscale', 'parameters[]'])
     hsp_trans = Property(depends_on=['head_mri_t', 'coord_frame'])
 
     # info
@@ -232,6 +234,11 @@ class CoregModel(HasPrivateTraits):
         desc="Subject guess based on the raw file name.",
         depends_on=['hsp:inst_fname'])
 
+    # Always computed in the MRI coordinate frame for speed
+    # (building the nearest-neighbor tree is slow!)
+    # though it will always need to be rebuilt in (non-uniform) scaling mode
+    nearest_calc = Instance(_DistanceQuery)
+
     # MRI geometry transformed to viewing coordinate system
     processed_high_res_mri_points = Property(
         depends_on=['mri:bem_high_res:surf', 'grow_hair'])
@@ -241,23 +248,20 @@ class CoregModel(HasPrivateTraits):
         depends_on=['processed_high_res_mri_points', 'mri_trans'])
     transformed_low_res_mri_points = Property(
         depends_on=['processed_low_res_mri_points', 'mri_trans'])
-    nearest_calc = Property(
-        Instance(_DistanceQuery),
-        depends_on=['transformed_high_res_mri_points'])
     nearest_transformed_high_res_mri_idx_lpa = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_lpa'])
+        depends_on=['nearest_calc', 'hsp:lpa', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_nasion = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_nasion'])
+        depends_on=['nearest_calc', 'hsp:nasion', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_rpa = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_rpa'])
+        depends_on=['nearest_calc', 'hsp:rpa', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_hsp = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_points'])
+        depends_on=['nearest_calc', 'hsp:points', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_orig_hsp = Property(
-        depends_on=['nearest_calc', 'transformed_orig_hsp_points'])
+        depends_on=['nearest_calc', 'hsp:points', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_eeg = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_eeg_points'])
+        depends_on=['nearest_calc', 'hsp:eeg_points', 'head_mri_t'])
     nearest_transformed_high_res_mri_idx_hpi = Property(
-        depends_on=['nearest_calc', 'transformed_hsp_hpi'])
+        depends_on=['nearest_calc', 'hsp:hpi_points', 'head_mri_t'])
     transformed_mri_lpa = Property(
         depends_on=['mri:lpa', 'mri_trans'])
     transformed_mri_nasion = Property(
@@ -278,7 +282,7 @@ class CoregModel(HasPrivateTraits):
     transformed_hsp_eeg_points = Property(
         depends_on=['hsp:eeg_points', 'hsp_trans'])
     transformed_hsp_hpi = Property(
-        depends_on=['hsp:hpi', 'hsp_trans'])
+        depends_on=['hsp:hpi_points', 'hsp_trans'])
 
     # fit properties
     lpa_distance = Property(
@@ -415,13 +419,17 @@ class CoregModel(HasPrivateTraits):
 
     @cached_property
     def _get_mri_trans(self):
-        mri_scaling = np.ones(4)
-        mri_scaling[:3] = self.parameters[6:9]
+        t = self.mri_trans_noscale.copy()
+        t[:, :3] *= self.parameters[6:9]
+        return t
+
+    @cached_property
+    def _get_mri_trans_noscale(self):
         if self.coord_frame == 'head':
             t = self.mri_head_t
         else:
             t = np.eye(4)
-        return t * mri_scaling
+        return t
 
     @cached_property
     def _get_hsp_trans(self):
@@ -433,34 +441,41 @@ class CoregModel(HasPrivateTraits):
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_lpa(self):
-        return self.nearest_calc.query(self.transformed_hsp_lpa)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.lpa))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_nasion(self):
-        return self.nearest_calc.query(self.transformed_hsp_nasion)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.nasion))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_rpa(self):
-        return self.nearest_calc.query(self.transformed_hsp_rpa)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.rpa))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_hsp(self):
-        return self.nearest_calc.query(self.transformed_hsp_points)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.points))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_orig_hsp(self):
         # This is redundant to some extent with the one above due to
         # overlapping points, but it's fast and the refactoring to
         # remove redundancy would be a pain.
-        return self.nearest_calc.query(self.transformed_orig_hsp_points)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp._hsp_points))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_eeg(self):
-        return self.nearest_calc.query(self.transformed_hsp_eeg_points)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.eeg_points))[1]
 
     @cached_property
     def _get_nearest_transformed_high_res_mri_idx_hpi(self):
-        return self.nearest_calc.query(self.transformed_hsp_hpi)[1]
+        return self.nearest_calc.query(
+            apply_trans(self.head_mri_t, self.hsp.hpi_points))[1]
 
     # MRI view-transformed data
     @cached_property
@@ -469,9 +484,13 @@ class CoregModel(HasPrivateTraits):
                              self.processed_low_res_mri_points)
         return points
 
-    @cached_property
-    def _get_nearest_calc(self):
-        return _DistanceQuery(self.transformed_high_res_mri_points)
+    def _nearest_calc_default(self):
+        return _DistanceQuery(np.zeros((1, 3)))
+
+    @on_trait_change('processed_high_res_mri_points')
+    def _update_nearest_calc(self):
+        self.nearest_calc = _DistanceQuery(
+            self.processed_high_res_mri_points * self.parameters[6:9])
 
     @cached_property
     def _get_transformed_high_res_mri_points(self):
@@ -544,14 +563,17 @@ class CoregModel(HasPrivateTraits):
             mri_points.append(self.transformed_high_res_mri_points[
                 self.nearest_transformed_high_res_mri_idx_hsp])
             hsp_points.append(self.transformed_hsp_points)
+            assert len(mri_points[-1]) == len(hsp_points[-1])
         if self.eeg_weight > 0 and self.has_eeg_data:
             mri_points.append(self.transformed_high_res_mri_points[
                 self.nearest_transformed_high_res_mri_idx_eeg])
             hsp_points.append(self.transformed_hsp_eeg_points)
+            assert len(mri_points[-1]) == len(hsp_points[-1])
         if self.hpi_weight > 0 and self.has_hpi_data:
             mri_points.append(self.transformed_high_res_mri_points[
                 self.nearest_transformed_high_res_mri_idx_hpi])
             hsp_points.append(self.transformed_hsp_hpi)
+            assert len(mri_points[-1]) == len(hsp_points[-1])
         if all(len(h) == 0 for h in hsp_points):
             return None
         mri_points = np.concatenate(mri_points)
@@ -697,6 +719,7 @@ class CoregModel(HasPrivateTraits):
         attr = 'fit_icp_running' if n_scale_params == 0 else 'fits_icp_running'
         setattr(self, attr, True)
         GUI.process_events()  # update the cancel button
+        self.icp_start_time = time.time()
         for self.iteration in range(self.icp_iterations):
             head_pts, mri_pts, weights = self._setup_icp(n_scale_params)
             est = fit_matched_points(mri_pts, head_pts, scale=n_scale_params,
@@ -796,6 +819,9 @@ class CoregModel(HasPrivateTraits):
             val = self.parameters[ii + 6] * 1e2
             if val != getattr(self, key):  # prevent circular
                 setattr(self, key, val)
+        # Only update our nearest-neighbor if necessary
+        if self.parameters[6:9] != self.last_parameters[6:9]:
+            self._update_nearest_calc()
         # Update the status text
         move, angle, percs = self.changes
         text = u'Change:  Δ=%0.1f mm  ∠=%0.2f°' % (move, angle)
@@ -803,8 +829,9 @@ class CoregModel(HasPrivateTraits):
             text += '  Scale ' if n_scale == 1 else '  Sx/y/z '
             text += '/'.join(['%+0.1f%%' % p for p in percs[:n_scale]])
         if self.iteration >= 0:
-            text += u' (iteration %d/%d)' % (self.iteration + 1,
-                                             self.icp_iterations)
+            text += u' (iteration %d/%d, %0.1f sec)' % (
+                self.iteration + 1, self.icp_iterations,
+                time.time() - self.icp_start_time)
         self.last_parameters[:] = self.parameters[:]
         self.status_text = text
 
@@ -1175,6 +1202,7 @@ class FittingOptionsPanel(HasTraits):
     has_eeg_data = DelegatesTo('model')
     has_hpi_data = DelegatesTo('model')
     icp_iterations = DelegatesTo('model')
+    icp_start_time = DelegatesTo('model')
     icp_angle = DelegatesTo('model')
     icp_distance = DelegatesTo('model')
     icp_scale = DelegatesTo('model')
@@ -1935,6 +1963,8 @@ class CoregFrame(HasTraits):
         for p in (self.hsp_obj, self.eeg_obj, self.hpi_obj,
                   self.hsp_lpa_obj, self.hsp_nasion_obj, self.hsp_rpa_obj):
             self.sync_trait('hsp_visible', p, 'visible', mutual=False)
+            self.model.sync_trait('mri_trans_noscale', p, 'project_to_trans',
+                                  mutual=False)
 
         on_pick = self.scene.mayavi_scene.on_mouse_pick
         self.picker = on_pick(self.data_panel.fid_panel._on_pick, type='cell')
@@ -1955,7 +1985,7 @@ class CoregFrame(HasTraits):
 
         self.sync_trait('bgcolor', self.scene, 'background')
 
-        self._update_projections()
+        self._update_projection_surf()
 
         _toggle_mlab_render(self, True)
         self.scene.render()
@@ -2030,13 +2060,20 @@ class CoregFrame(HasTraits):
         self.hsp_cf_obj.nn = nn
         self.hsp_cf_obj.points = pts
 
-    @on_trait_change('model:mri:bem_low_res:surf,'
-                     'model:transformed_low_res_mri_points')
-    def _update_projections(self):
+    @on_trait_change('nearest_calc')
+    def _update_projection_surf(self):
+        if len(self.model.processed_low_res_mri_points) <= 1:
+            return
+        rr = (self.model.processed_low_res_mri_points *
+              self.model.parameters[6:9])
+        surf = dict(rr=rr, tris=self.model.mri.bem_low_res.surf.tris,
+                    nn=self.model.mri.bem_low_res.surf.nn)
+        check_inside = _CheckInside(surf)
+        nearest = _DistanceQuery(rr)
         for p in (self.eeg_obj, self.hsp_obj, self.hpi_obj):
             if p is not None:
-                p.project_to_tris = self.model.mri.bem_low_res.surf.tris
-                p.project_to_points = self.model.transformed_low_res_mri_points
+                p.check_inside = check_inside
+                p.nearest = nearest
 
     @on_trait_change('model:mri:bem_low_res:surf,head_high_res,'
                      'model:transformed_high_res_mri_points')

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -26,10 +26,10 @@ from ..forward import (_magnetic_dipole_field_vec, _merge_meg_eeg_fwds,
                        _compute_forwards, _to_forward_dict,
                        restrict_forward_to_stc, _prep_meg_channels)
 from ..transforms import _get_trans, transform_surface_to
-from ..source_space import (_ensure_src, _points_outside_surface,
-                            _set_source_space_vertices,
+from ..source_space import (_ensure_src, _set_source_space_vertices,
                             setup_volume_source_space)
 from ..source_estimate import _BaseSourceEstimate
+from ..surface import _CheckInside
 from ..utils import (logger, verbose, check_random_state, _pl, _validate_type,
                      warn, _check_preload)
 from ..parallel import check_n_jobs
@@ -822,12 +822,12 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
         _transform_orig_meg_coils(compcoils, dev_head_t)
 
         # Make sure our sensors are all outside our BEM
-        coil_rr = [coil['r0'] for coil in megcoils]
+        coil_rr = np.array([coil['r0'] for coil in megcoils])
 
         # Compute forward
         if forward is None:
             if not bem['is_sphere']:
-                outside = _points_outside_surface(coil_rr, bem_surf, n_jobs,
+                outside = ~_CheckInside(bem_surf)(coil_rr, n_jobs,
                                                   verbose=False)
             elif bem.radius is not None:
                 d = coil_rr - bem['r0']

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -24,9 +24,9 @@ from .io.write import (start_block, end_block, write_int,
 from .bem import read_bem_surfaces, ConductorModel
 from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _tessellate_sphere_surf, _get_surf_neighbors,
-                      _normalize_vectors, _get_solids, _triangle_neighbors,
+                      _normalize_vectors, _triangle_neighbors, mesh_dist,
                       complete_surface_info, _compute_nearest, fast_cross_3d,
-                      mesh_dist)
+                      _CheckInside)
 from .utils import (get_subjects_dir, run_subprocess, has_freesurfer,
                     has_nibabel, check_fname, logger, verbose, _ensure_int,
                     check_version, _get_call_line, warn, _check_fname,
@@ -2242,7 +2242,6 @@ def _pts_in_hull(pts, hull, tolerance=1e-12):
 def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
                           verbose=None):
     """Remove all source space points closer than a given limit (in mm)."""
-    from scipy.spatial import Delaunay
     if src[0]['coord_frame'] == FIFF.FIFFV_COORD_HEAD and mri_head_t is None:
         raise RuntimeError('Source spaces are in head coordinates and no '
                            'coordinate transform was provided!')
@@ -2263,51 +2262,18 @@ def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
     logger.info(out_str + ' (will take a few...)')
 
     # fit a sphere to a surf quickly
-    cm = surf['rr'].mean(0)
-    inner_r = None
-    if not _points_outside_surface(cm[np.newaxis], surf)[0]:  # actually inside
-        # Immediately cull some points from the checks
-        inner_r = np.linalg.norm(surf['rr'] - cm, axis=-1).min()
-    # We could use Delaunay or ConvexHull here, Delaunay is slightly slower
-    # to construct but faster to evaluate
-    # See https://stackoverflow.com/questions/16750618/whats-an-efficient-way-to-find-if-a-point-lies-in-the-convex-hull-of-a-point-cl  # noqa
-    del_tri = Delaunay(surf['rr'])
+    check_inside = _CheckInside(surf)
+
+    # Check that the source is inside surface (often the inner skull)
     for s in src:
         vertno = np.where(s['inuse'])[0]  # can't trust s['vertno'] this deep
         # Convert all points here first to save time
         r1s = s['rr'][vertno]
         if s['coord_frame'] == FIFF.FIFFV_COORD_HEAD:
             r1s = apply_trans(inv_trans['trans'], r1s)
-        inside = np.ones(len(vertno), bool)  # innocent until proven guilty
 
-        # Check that the source is inside surface (often the inner skull)
-        idx = np.where(inside)[0]
-        check_r1s = r1s[idx]
-
-        # Limit to indices that can plausibly be outside the surf
-        if inner_r is not None:
-            mask = np.linalg.norm(check_r1s - cm, axis=-1) >= inner_r
-            idx = idx[mask]
-            check_r1s = check_r1s[mask]
-            logger.info('    Skipping interior check for %d sources that fit '
-                        'inside a sphere of radius %6.1f mm'
-                        % ((~mask).sum(), inner_r * 1000))
-
-        # Use qhull as our first pass (*much* faster than our check)
-        del_outside = del_tri.find_simplex(check_r1s) < 0
-        omit_outside = sum(del_outside)
-        inside[idx[del_outside]] = False
-        idx = idx[~del_outside]
-        check_r1s = check_r1s[~del_outside]
-        logger.info('    Skipping solid angle check for %d points using Qhull'
-                    % (omit_outside,))
-        del del_outside
-
-        # use our more accurate check
-        solid_outside = _points_outside_surface(check_r1s, surf, n_jobs)
-        omit_outside += np.sum(solid_outside)
-        inside[idx[solid_outside]] = False
-        del solid_outside, idx
+        inside = check_inside(r1s, n_jobs)
+        omit_outside = (~inside).sum()
 
         # vectorized nearest using BallTree (or cdist)
         omit_limit = 0
@@ -2315,10 +2281,10 @@ def _filter_source_spaces(surf, limit, mri_head_t, src, n_jobs=1,
             # only check "inside" points
             idx = np.where(inside)[0]
             check_r1s = r1s[idx]
-            if inner_r is not None:
+            if check_inside.inner_r is not None:
                 # ... and those that are at least inner_sphere + limit away
-                mask = (np.linalg.norm(check_r1s - cm, axis=-1) >=
-                        inner_r - limit / 1000.)
+                mask = (np.linalg.norm(check_r1s - check_inside.cm, axis=-1) >=
+                        check_inside.inner_r - limit / 1000.)
                 idx = idx[mask]
                 check_r1s = check_r1s[mask]
             dists = _compute_nearest(
@@ -2357,31 +2323,6 @@ def _adjust_patch_info(s, verbose=None):
             raise RuntimeError('Cannot adjust patch information properly, '
                                'please contact the mne-python developers')
         _add_patch_info(s)
-
-
-@verbose
-def _points_outside_surface(rr, surf, n_jobs=1, verbose=None):
-    """Check whether points are outside a surface.
-
-    Parameters
-    ----------
-    rr : ndarray
-        Nx3 array of points to check.
-    surf : dict
-        Surface with entries "rr" and "tris".
-
-    Returns
-    -------
-    outside : ndarray
-        1D logical array of size N for which points are outside the surface.
-    """
-    rr = np.atleast_2d(rr)
-    assert rr.shape[1] == 3
-    assert n_jobs > 0
-    parallel, p_fun, _ = parallel_func(_get_solids, n_jobs)
-    tot_angles = parallel(p_fun(surf['rr'][tris], rr)
-                          for tris in np.array_split(surf['tris'], n_jobs))
-    return np.abs(np.sum(tot_angles, axis=0) / (2 * np.pi) - 1.0) > 1e-5
 
 
 @verbose

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -483,7 +483,7 @@ class _DistanceQuery(object):
                                      reduce=True, return_distance=True)
 
         # Then cKDTree
-        elif method == 'cKDTree':
+        if method == 'cKDTree':
             try:
                 from scipy.spatial import cKDTree
             except ImportError:
@@ -496,8 +496,7 @@ class _DistanceQuery(object):
         # sets. We can add it later if we think it will help.
 
         # Then the worst: cdist
-        else:
-            assert method == 'cdist'
+        if method == 'cdist':
             self.query = _CDist(xhs).query
 
         self.data = xhs


### PR DESCRIPTION
I realized that the slow parts of `mne coreg` are:

1. Nearest-neighbor computations. This is now sped up by doing all computations in the MRI coordinate frame. This is much faster because the distance tree (KDTree, BallTree) only needs to be built once per subject (unless MRI scaling is used), rather than every time the `head_mri_t` changes.
2. Inside-the-surface computations. Recently calculations for `setup_source_space` were sped up by using a sphere + Delaunay computation to only check questionable points. This PR changes that to be a class (since it really has a "state", which is the surface being checked against) named `_CheckInside`, and uses it in `source_space.py` and the GUI code.

Along the way I also moved the `_points_outside_surface` helper from `source_space.py` to `surface.py` since it's really a surface property.

To test, try doing:
```
mne coreg -d ~/mne_data/MNE-sample-data/subjects -s sample -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
```
Then "Fit Fid" and "Fit Fiducial" on `master` then on this PR. On my workstation it goes from 5 sec to 1.9 sec (8 iterations).

Closes #6738