### PR TITLE
MRG, ENH: MNI Fiducials in `mne coreg`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Changelog
 
 - Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.
 
+- Add automatic fiducial position estimation in :ref:`mne coreg <gen_mne_coreg>` using MNI Talairach fiducial locations in :func:`mne.coreg.get_mni_fiducials` by `Jon Houck`_ and `Eric Larson`_
+
 - Add support for :ref:`mne coreg <gen_mne_coreg>` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
 
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -532,6 +532,7 @@ Step by step instructions for using :func:`gui.coregistration`:
 .. autosummary::
    :toctree: generated/
 
+   coreg.get_mni_fiducials
    gui.coregistration
    gui.fiducials
    create_default_subject

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -5,6 +5,7 @@
 
 import os
 import os.path as op
+import shutil
 import sys
 import warnings
 import pytest
@@ -31,6 +32,7 @@ s_path = op.join(test_path, 'MEG', 'sample')
 fname_evoked = op.join(s_path, 'sample_audvis_trunc-ave.fif')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+subjects_dir = op.join(test_path, 'subjects')
 
 
 def pytest_configure(config):
@@ -203,3 +205,11 @@ def renderer(backend_name):
         from mne.viz.backends import renderer
         yield renderer
         renderer._close_all()
+
+
+@pytest.fixture(scope='function', params=[testing._pytest_param()])
+def subjects_dir_tmp(tmpdir):
+    """Copy MNE-testing-data subjects_dir to a temp dir for manipulation."""
+    for key in ('sample', 'fsaverage'):
+        shutil.copytree(op.join(subjects_dir, key), str(tmpdir.join(key)))
+    return str(tmpdir)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1207,3 +1207,72 @@ def _scale_xfm(subject_to, xfm_fname, mri_name, subject_from, scale,
                 F_mri_ras, 'ras', 'ras'),
             F_ras_mni, 'ras', 'mni_tal')
     _write_fs_xfm(fname_to, T_ras_mni['trans'], kind)
+
+
+def get_mni_fiducials(subject, subjects_dir):
+    """Estimate fiducials for a subject.
+
+    Parameters
+    ----------
+    subject : str
+        Name of the mri subject
+    subjects_dir : None | str
+        Override the SUBJECTS_DIR environment variable
+        (sys.environ['SUBJECTS_DIR'])
+
+    Returns
+    -------
+    fids_mri : list
+        List of estimated fiducials (each point in a dict)
+
+    Notes
+    -----
+    For more details about the coordinate systems and transformations involved,
+    see https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems and
+    :ref:`plot_source_alignment`
+    """
+    from .transforms import _read_fs_xfm
+    if not has_nibabel():
+        raise ImportError('This function requires nibabel.')
+        return
+
+    from nibabel import freesurfer as fs
+
+    subjects_dir = op.join(get_subjects_dir(subjects_dir, raise_error=True),
+                           subject)
+    fname_orig = op.join(subjects_dir, 'mri', 'T1.mgz')
+    fname_tal = op.join(subjects_dir, 'mri', 'transforms', 'talairach.xfm')
+    fname_fids_fs = os.path.join(os.path.dirname(__file__), 'data',
+                                 'fsaverage', 'fsaverage-fiducials.fif')
+
+    # Read fsaverage fiducials file and subject Talairach.
+    fids_default, coord_frame = read_fiducials(fname_fids_fs)
+    xfm_tal = np.matrix(_read_fs_xfm(fname_tal)[0])
+
+    # Get Freesurfer vox2ras and vox2ras-tkr as matrices.
+    mgh = fs.mghformat.load(fname_orig)
+    vox2ras = np.matrix(mgh.header.get_vox2ras())
+    vox2ras_tkr = np.matrix(mgh.header.get_vox2ras_tkr())
+
+    # Get transform for RAS to MNI305.
+    mni305ras = xfm_tal * vox2ras * np.linalg.inv(vox2ras_tkr)
+    mni2ras = np.linalg.inv(mni305ras)
+
+    # Split up fiducials. Convert to mm since this is Freesurfer's unit.
+    lpa = np.append(fids_default[0]['r'] * 1000, 1)
+    nas = np.append(fids_default[1]['r'] * 1000, 1)
+    rpa = np.append(fids_default[2]['r'] * 1000, 1)
+
+    # Apply transformation, to fsaverage (MNI) fiducials, convert from mm.
+    lpa_ras = np.delete(np.dot(mni2ras, lpa.T), 3) / 1000
+    nas_ras = np.delete(np.dot(mni2ras, nas.T), 3) / 1000
+    rpa_ras = np.delete(np.dot(mni2ras, rpa.T), 3) / 1000
+
+    # Build new fiducials structure from old.
+    fids_mri = fids_default
+    # Copy to fiducials.
+    fids_mri[0]['r'] = lpa_ras
+    fids_mri[1]['r'] = nas_ras
+    fids_mri[2]['r'] = rpa_ras
+
+    return fids_mri

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1227,10 +1227,22 @@ def get_mni_fiducials(subject, subjects_dir=None):
 
     Notes
     -----
+    This takes the ``fsaverage-fiducials.fif`` file included with MNE—which
+    contain the LPA, nasion, and RPA for the ``fsaverage`` subject—and
+    transforms them to the given FreeSurfer subject's MRI space.
+    The MRI of ``fsaverage`` is already in MNI Talarach space, so applying
+    the inverse of the given subject's MNI Talairach affine transformation
+    (``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talarach.xfm``) is used
+    to estimate the subject's fiducial locations.
+
     For more details about the coordinate systems and transformations involved,
     see https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems and
-    :ref:`plot_source_alignment`
+    :ref:`plot_source_alignment`.
     """
+    # Eventually we might want to allow using the MNI Talarach with-skull
+    # transformation rather than the standard brain-based MNI Talaranch
+    # transformation, and/or project the points onto the head surface
+    # (if available).
     fname_fids_fs = os.path.join(os.path.dirname(__file__), 'data',
                                  'fsaverage', 'fsaverage-fiducials.fif')
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1230,16 +1230,16 @@ def get_mni_fiducials(subject, subjects_dir=None):
     This takes the ``fsaverage-fiducials.fif`` file included with MNE—which
     contain the LPA, nasion, and RPA for the ``fsaverage`` subject—and
     transforms them to the given FreeSurfer subject's MRI space.
-    The MRI of ``fsaverage`` is already in MNI Talarach space, so applying
+    The MRI of ``fsaverage`` is already in MNI Talairach space, so applying
     the inverse of the given subject's MNI Talairach affine transformation
-    (``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talarach.xfm``) is used
+    (``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talairach.xfm``) is used
     to estimate the subject's fiducial locations.
 
     For more details about the coordinate systems and transformations involved,
     see https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems and
     :ref:`plot_source_alignment`.
     """
-    # Eventually we might want to allow using the MNI Talarach with-skull
+    # Eventually we might want to allow using the MNI Talairach with-skull
     # transformation rather than the standard brain-based MNI Talaranch
     # transformation, and/or project the points onto the head surface
     # (if available).

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -237,7 +237,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.68', misc='0.3')
+    releases = dict(testing='0.70', misc='0.3')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -319,7 +319,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='fc2d5b9eb0a144b1d6ba84dc3b983602',
         somato='f08f17924e23c57a751b3bed4a05fe02',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='f93565bda6900b6464f2869092157bf9',
+        testing='592a922a40406fd40950c825122aa7be',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         opm='370ad1dcfd5c47e029e692c85358a374',
         visual_92_categories=['74f50bbeb65740903eadc229c9fa759f',

--- a/mne/gui/_fiducials_gui.py
+++ b/mne/gui/_fiducials_gui.py
@@ -18,7 +18,8 @@ from traitsui.api import HGroup, Item, VGroup, View, Handler, ArrayEditor
 from traitsui.menu import NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
-from ..coreg import fid_fname, _find_fiducials_files, _find_head_bem
+from ..coreg import (fid_fname, _find_fiducials_files, _find_head_bem,
+                     get_mni_fiducials)
 from ..defaults import DEFAULTS
 from ..io import write_fiducials
 from ..io.constants import FIFF
@@ -197,6 +198,14 @@ class MRIHeadWithFiducialsModel(HasPrivateTraits):
                                          nn=surf['nn'])
         else:
             self.bem_low_res.file = low_res_path
+
+        # Set MNI points
+        try:
+            fids = get_mni_fiducials(subject, subjects_dir)
+        except Exception:  # some problem, leave at origin
+            self.fid.mni_points = None
+        else:
+            self.fid.mni_points = np.array([f['r'] for f in fids], float)
 
         # find fiducials file
         fid_files = _find_fiducials_files(subject, subjects_dir)

--- a/mne/gui/tests/test_fiducials_gui.py
+++ b/mne/gui/tests/test_fiducials_gui.py
@@ -3,26 +3,27 @@
 # License: BSD (3-clause)
 
 import os
+import os.path as op
 
 from numpy.testing import assert_array_equal
 
-from mne.datasets import testing
-from mne.utils import _TempDir, requires_mayavi, run_tests_if_main, traits_test
-
-sample_path = testing.data_path(download=False)
-subjects_dir = os.path.join(sample_path, 'subjects')
+from mne.utils import requires_mayavi, run_tests_if_main, traits_test
 
 
-@testing.requires_testing_data
 @requires_mayavi
 @traits_test
-def test_mri_model():
+def test_mri_model(subjects_dir_tmp):
     """Test MRIHeadWithFiducialsModel Traits Model."""
     from mne.gui._fiducials_gui import MRIHeadWithFiducialsModel
-    tempdir = _TempDir()
-    tgt_fname = os.path.join(tempdir, 'test-fiducials.fif')
+    tgt_fname = op.join(subjects_dir_tmp, 'test-fiducials.fif')
 
-    model = MRIHeadWithFiducialsModel(subjects_dir=subjects_dir)
+    # Remove the two files that will make the fiducials okay via MNI estimation
+    os.remove(op.join(subjects_dir_tmp, 'sample', 'bem',
+                      'sample-fiducials.fif'))
+    os.remove(op.join(subjects_dir_tmp, 'sample', 'mri', 'transforms',
+                      'talairach.xfm'))
+
+    model = MRIHeadWithFiducialsModel(subjects_dir=subjects_dir_tmp)
     model.subject = 'sample'
     assert model.default_fid_fname[-20:] == "sample-fiducials.fif"
     assert not model.can_reset
@@ -33,7 +34,7 @@ def test_mri_model():
     assert not model.can_reset
     assert model.can_save
 
-    bem_fname = os.path.basename(model.bem_high_res.file)
+    bem_fname = op.basename(model.bem_high_res.file)
     assert not model.can_reset
     assert bem_fname == 'sample-head-dense.fif'
 

--- a/mne/io/tests/test_what.py
+++ b/mne/io/tests/test_what.py
@@ -40,7 +40,8 @@ def test_what(tmpdir):
                      fwd='forward', trans='transform', proj='proj',
                      raw='raw', meg='raw', sol='bem solution',
                      bem='bem surfaces', src='src', dense='bem surfaces',
-                     sparse='bem surfaces', head='bem surfaces')
+                     sparse='bem surfaces', head='bem surfaces',
+                     fiducials='fiducials')
     for fname in fnames:
         kind = op.splitext(fname)[0].split('-')[-1]
         if len(kind) > 5:

--- a/mne/io/what.py
+++ b/mne/io/what.py
@@ -33,12 +33,12 @@ def what(fname):
     from ..forward import read_forward_solution
     from ..minimum_norm import read_inverse_operator
     from ..source_space import read_source_spaces
-    from ..bem import read_bem_solution
-    from ..bem import read_bem_surfaces
+    from ..bem import read_bem_solution, read_bem_surfaces
     from ..cov import read_cov
     from ..transforms import read_trans
     from ..event import read_events
     from ..proj import read_proj
+    from .meas_info import read_fiducials
     _check_fname(fname, overwrite='read', must_exist=True)
     checks = OrderedDict()
     checks['raw'] = read_raw_fif
@@ -54,6 +54,7 @@ def what(fname):
     checks['transform'] = read_trans
     checks['events'] = read_events
     checks['proj'] = read_proj
+    checks['fiducials'] = read_fiducials
     for what, func in checks.items():
         args = _get_args(func)
         kwargs = dict()


### PR DESCRIPTION
Taking over parts of #6693.

Todo:

- [x] Add test
- [x] Avoid `np.matrix`
- [x] Incorporate into `mne coreg`
- [x] Update `testing` dataset to include fiducial
- [x] Use MNE standards for `transforms`

On `master`:
```
mne coreg -d ~/mne_data/MNE-sample-data/subjects -s sample -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
```
Produces:

![Screenshot from 2019-09-03 15-35-58](https://user-images.githubusercontent.com/2365790/64203009-93997200-ce60-11e9-91c1-7a9eddba8a69.png)

On this PR:

![Screenshot from 2019-09-03 15-36-14](https://user-images.githubusercontent.com/2365790/64203016-95fbcc00-ce60-11e9-9575-40125f33662a.png)

cc @jhouck 
