### PR TITLE
MRG, ENH: Use sosfiltfilt in raw plotting

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -65,6 +65,8 @@ Changelog
 
 - Add control over dipole colors in :func:`mne.viz.plot_dipole_locations` when using orthoview mode by `Eric Larson`_
 
+- Use second-order-sections filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw <gen_mne_browse_raw>` by `Eric Larson`_
+
 - Add re-referencing functionality for ecog and seeg channel types in :func:`mne.set_eeg_reference` by `Keith Doelling`_
 
 Bug

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -70,6 +70,9 @@ def run():
     parser.add_option("--filterchpi", dest="filterchpi",
                       help="Enable filtering cHPI signals.", default=None,
                       action="store_true")
+    parser.add_option("--verbose", dest='verbose',
+                      help="Enable verbose mode.", default=None,
+                      action="store_true")
 
     options, args = parser.parse_args()
 
@@ -91,6 +94,7 @@ def run():
     filtorder = options.filtorder
     clipping = options.clipping
     filterchpi = options.filterchpi
+    verbose = options.verbose
 
     if raw_in is None:
         parser.print_help()
@@ -117,7 +121,7 @@ def run():
     raw.plot(duration=duration, start=start, n_channels=n_channels,
              group_by=group_by, show_options=show_options, events=events,
              highpass=highpass, lowpass=lowpass, filtorder=filtorder,
-             clipping=clipping)
+             clipping=clipping, verbose=verbose)
     plt.show(block=True)
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1558,13 +1558,14 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              highpass=None, lowpass=None, filtorder=4, clipping=None,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
-             show_scrollbars=True):
+             show_scrollbars=True, verbose=None):
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,
                         lowpass, filtorder, clipping, show_first_samp, proj,
                         group_by, butterfly, decim, noise_cov=noise_cov,
-                        event_id=event_id, show_scrollbars=show_scrollbars)
+                        event_id=event_id, show_scrollbars=show_scrollbars,
+                        verbose=verbose)
 
     @verbose
     @copy_function_doc_to_method_doc(plot_raw_psd)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -684,8 +684,9 @@ def _cart_to_sph(cart):
     cart = np.atleast_2d(cart)
     out = np.empty((len(cart), 3))
     out[:, 0] = np.sqrt(np.sum(cart * cart, axis=1))
+    norm = np.where(out[:, 0] > 0, out[:, 0], 1)  # protect against / 0
     out[:, 1] = np.arctan2(cart[:, 1], cart[:, 0])
-    out[:, 2] = np.arccos(cart[:, 2] / out[:, 0])
+    out[:, 2] = np.arccos(cart[:, 2] / norm)
     out = np.nan_to_num(out)
     return out
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -345,7 +345,7 @@ def test_plot_raw_filtered(filtorder):
         raw.plot(lowpass=raw.info['sfreq'] / 2., filtorder=filtorder)
     with pytest.raises(ValueError, match='highpass must be > 0'):
         raw.plot(highpass=0, filtorder=filtorder)
-    with pytest.raises(ValueError, match=r'Filter order must be'):
+    with pytest.raises(ValueError, match='Filter order must be'):
         raw.plot(lowpass=1, filtorder=-1)
     with pytest.raises(ValueError, match="Invalid value for the 'clipping'"):
         raw.plot(clipping='foo')

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -340,7 +340,7 @@ def test_plot_annotations():
 def test_plot_raw_filtered():
     """Test filtering of raw plots."""
     raw = _get_raw()
-    with pytest.raises(ValueError, match='lowpass must be < Nyquist'):
+    with pytest.raises(ValueError, match='lowpass.*Nyquist'):
         raw.plot(lowpass=raw.info['sfreq'] / 2.)
     with pytest.raises(ValueError, match='highpass must be > 0'):
         raw.plot(highpass=0)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -337,22 +337,21 @@ def test_plot_annotations():
     plt.close('all')
 
 
-def test_plot_raw_filtered():
+@pytest.mark.parametrize('filtorder', (0, 2))  # FIR, IIR
+def test_plot_raw_filtered(filtorder):
     """Test filtering of raw plots."""
     raw = _get_raw()
     with pytest.raises(ValueError, match='lowpass.*Nyquist'):
-        raw.plot(lowpass=raw.info['sfreq'] / 2.)
+        raw.plot(lowpass=raw.info['sfreq'] / 2., filtorder=filtorder)
     with pytest.raises(ValueError, match='highpass must be > 0'):
-        raw.plot(highpass=0)
-    with pytest.raises(ValueError, match=r'lowpass \(1\) must be > highpass'):
-        raw.plot(lowpass=1, highpass=1)
-    with pytest.raises(ValueError, match=r'filtorder \(-1\) must be >= 0'):
+        raw.plot(highpass=0, filtorder=filtorder)
+    with pytest.raises(ValueError, match=r'Filter order must be'):
         raw.plot(lowpass=1, filtorder=-1)
     with pytest.raises(ValueError, match="Invalid value for the 'clipping'"):
         raw.plot(clipping='foo')
-    raw.plot(lowpass=1, clipping='transparent')
-    raw.plot(highpass=1, clipping='clamp')
-    raw.plot(lowpass=40, butterfly=True, filtorder=0)
+    raw.plot(lowpass=40, clipping='transparent', filtorder=filtorder)
+    raw.plot(highpass=1, clipping='clamp', filtorder=filtorder)
+    raw.plot(lowpass=40, butterfly=True, filtorder=filtorder)
     plt.close('all')
 
 


### PR DESCRIPTION
Use more stable high-order filtering in `raw.plot`, and add `--verbose` option to `mne browse_raw` so that this command works (and reports filter info):
```
mne browse_raw clouds_2ae/raw_fif/clouds_2ae_01_raw.fif --allowmaxshield --lowpass 30 --highpass 1 --filtorder 8 --verbose
...
Setting up band-pass filter from 1 - 30 Hz

IIR filter parameters
---------------------
Butterworth bandpass zero-phase (two-pass forward and reverse) non-causal filter:
- Filter order 32 (effective, after forward-backward)
- Cutoffs at 1.00, 30.00 Hz: -6.02, -6.02 dB
```
(yes I know this filter is a bit crazy, but it still should not break things)