### PR TITLE
MAINT: Update README check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx pytest pytest-timeout pytest-cov pytest-mock"
-               PIP_DEPENDENCIES="codecov flake8 numpydoc codespell pydocstyle codecov check-manifest pytest-sugar pytest-faulthandler"
+               PIP_DEPENDENCIES="codecov flake8 numpydoc codespell pydocstyle codecov check-manifest pytest-sugar pytest-faulthandler twine"
 
         # Linux
         - os: linux

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean-so:
 	find . -name "*.pyd" | xargs rm -f
 
 clean-build:
-	rm -rf _build
+	rm -rf build dist
 
 clean-ctags:
 	rm -f tags
@@ -31,6 +31,8 @@ in: inplace # just a shortcut
 inplace:
 	$(PYTHON) setup.py build_ext -i
 
+wheel:
+	$(PYTHON) setup.py sdist -q bdist_wheel
 sample_data:
 	@python -c "import mne; mne.datasets.sample.data_path(verbose=True);"
 
@@ -115,8 +117,8 @@ docstring:
 check-manifest:
 	check-manifest --ignore .circleci*,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store
 
-check-readme:
-	python setup.py check --restructuredtext --strict
+check-readme: clean wheel
+	twine check dist/*
 
 nesting:
 	@echo "Running import nesting tests"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ if __name__ == "__main__":
     if op.exists('MANIFEST'):
         os.remove('MANIFEST')
 
+    with open('README.rst', 'r') as fid:
+        long_description = fid.read()
+
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           include_package_data=True,
@@ -54,7 +57,8 @@ if __name__ == "__main__":
           url=URL,
           version=VERSION,
           download_url=DOWNLOAD_URL,
-          long_description=open('README.rst').read(),
+          long_description=long_description,
+          long_description_content_type='text/x-rst',
           zip_safe=False,  # the package can run out of an .egg file
           classifiers=['Intended Audience :: Science/Research',
                        'Intended Audience :: Developers',


### PR DESCRIPTION
On `master` I see this warning:
```
warning: Check: This command has been deprecated. Use `twine check` instead: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
```
Following their advice we now build the `dist/` and check it, eventually seeing:
```
twine check dist/*
Checking distribution dist/mne-0.19.dev0-py3-none-any.whl: Passed
Checking distribution dist/mne-0.19.dev0.tar.gz: Passed
```