### PR TITLE
MRG, ENH: Expose CuPy device selection

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.19.dev0)
 Changelog
 ~~~~~~~~~
 
+- Add :func:`mne.cuda.set_cuda_device` and config variable ``MNE_CUDA_DEVICE`` to select among multiple GPUs (by numeric device ID) by `Daniel McCloy`_.
+
 - Add :func:`mne.channels.make_standard_montage` to create :class:`mne.channels.DigMontage` from templates by `Joan Massich`_ and `Alex Gramfort`_.
 
 - Add :func:`mne.channels.compute_dev_head_t` to compute Device-to-Head transformation from a montage by `Joan Massich`_ and `Alex Gramfort`_.

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1026,3 +1026,4 @@ Logging and Configuration
 
    get_cuda_memory
    init_cuda
+   set_cuda_device

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -63,14 +63,14 @@ def init_cuda(ignore_config=False, verbose=None):
     # Triage possible errors for informative messaging
     _cuda_capable = False
     try:
-        import cupy
+        import cupy  # noqa
     except ImportError:
         warn('module cupy not found, CUDA not enabled')
         return
     try:
         # Initialize CUDA
-        device_id = int(get_config('CUPY_CUDA_DEVICE', '0'))
-        cupy.cuda.Device(device_id).use()
+        device_id = int(get_config('MNE_CUDA_DEVICE', '0'))
+        _set_cuda_device(device_id, verbose)
     except Exception:
         warn('so CUDA device could be initialized, likely a hardware error, '
              'CUDA not enabled%s' % _explain_exception())
@@ -79,6 +79,30 @@ def init_cuda(ignore_config=False, verbose=None):
     _cuda_capable = True
     # Figure out limit for CUDA FFT calculations
     logger.info('Enabling CUDA with %s available memory' % get_cuda_memory())
+
+
+@verbose
+def set_cuda_device(device_id, verbose=None):
+    """Set the CUDA device temporarily for the current session.
+
+    Parameters
+    ----------
+    device_id : int
+        Numeric ID of the CUDA-capable device you want MNE-Python to use.
+    %(verbose)s
+    """
+    if not _cuda_capable:
+        warn('CUDA is not enabled; did you forget to run `init_cuda()`?')
+    else:
+        _set_cuda_device(device_id, verbose)
+
+
+@verbose
+def _set_cuda_device(device_id, verbose=None):
+    """Set the CUDA device."""
+    import cupy
+    cupy.cuda.Device(device_id).use()
+    logger.info('Now using CUDA device {}'.format(device_id))
 
 
 ###############################################################################

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -69,7 +69,8 @@ def init_cuda(ignore_config=False, verbose=None):
         return
     try:
         # Initialize CUDA
-        cupy.cuda.Device()
+        device_id = int(get_config('CUPY_CUDA_DEVICE', '0'))
+        cupy.cuda.Device(device_id).use()
     except Exception:
         warn('so CUDA device could be initialized, likely a hardware error, '
              'CUDA not enabled%s' % _explain_exception())

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -91,10 +91,15 @@ def set_cuda_device(device_id, verbose=None):
         Numeric ID of the CUDA-capable device you want MNE-Python to use.
     %(verbose)s
     """
-    if not _cuda_capable:
-        warn('CUDA is not enabled; did you forget to run `init_cuda()`?')
-    else:
+    if _cuda_capable:
         _set_cuda_device(device_id, verbose)
+    elif get_config('MNE_USE_CUDA', 'false').lower() == 'true':
+        init_cuda()
+        _set_cuda_device(device_id, verbose)
+    else:
+        warn('Could not set CUDA device because CUDA is not enabled; either '
+             'run mne.cuda.init_cuda() first, or set the MNE_USE_CUDA config '
+             'variable to "true".')
 
 
 @verbose

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -67,9 +67,9 @@ def init_cuda(ignore_config=False, verbose=None):
     except ImportError:
         warn('module cupy not found, CUDA not enabled')
         return
+    device_id = int(get_config('MNE_CUDA_DEVICE', '0'))
     try:
         # Initialize CUDA
-        device_id = int(get_config('MNE_CUDA_DEVICE', '0'))
         _set_cuda_device(device_id, verbose)
     except Exception:
         warn('so CUDA device could be initialized, likely a hardware error, '

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -84,6 +84,7 @@ known_config_types = (
     'MNE_COREG_WINDOW_HEIGHT',
     'MNE_COREG_WINDOW_WIDTH',
     'MNE_COREG_SUBJECTS_DIR',
+    'MNE_CUDA_DEVICE',
     'MNE_CUDA_IGNORE_PRECISION',
     'MNE_DATA',
     'MNE_DATASETS_BRAINSTORM_PATH',
@@ -117,7 +118,6 @@ known_config_types = (
     'MNE_USE_CUDA',
     'MNE_SKIP_FS_FLASH_CALL',
     'SUBJECTS_DIR',
-    'CUPY_CUDA_DEVICE',
 )
 
 # These allow for partial matches, e.g. 'MNE_STIM_CHANNEL_1' is okay key

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -117,6 +117,7 @@ known_config_types = (
     'MNE_USE_CUDA',
     'MNE_SKIP_FS_FLASH_CALL',
     'SUBJECTS_DIR',
+    'CUPY_CUDA_DEVICE',
 )
 
 # These allow for partial matches, e.g. 'MNE_STIM_CHANNEL_1' is okay key


### PR DESCRIPTION
Allows the following

```console
(mnedev) drmccloy@colchuck:/opt/mne-python$ git checkout -b expose-cupy-device drammock/expose-cupy-device 
Branch 'expose-cupy-device' set up to track remote branch 'expose-cupy-device' from 'drammock'.
Switched to a new branch 'expose-cupy-device'
(mnedev) drmccloy@colchuck:/opt/mne-python$ python -c "import mne; mne.cuda.init_cuda(verbose=True)"
Now using CUDA device 0
Enabling CUDA with 1.79 GB available memory
(mnedev) drmccloy@colchuck:/opt/mne-python$ MNE_CUDA_DEVICE=1 python -c "import mne; mne.cuda.init_cuda(verbose=True)"
Now using CUDA device 1
Enabling CUDA with 11.09 GB available memory
(mnedev) drmccloy@colchuck:/opt/mne-python$ python -c "import mne; mne.cuda.init_cuda(verbose=True)"
Now using CUDA device 0
Enabling CUDA with 1.79 GB available memory
(mnedev) drmccloy@colchuck:/opt/mne-python$ python -c "import mne; mne.cuda.init_cuda(verbose=True); mne.cuda.set_cuda_device(1, verbose=True);"
Now using CUDA device 0
Enabling CUDA with 1.79 GB available memory
Now using CUDA device 1
(mnedev) drmccloy@colchuck:/opt/mne-python$ python -c "import mne; mne.cuda.set_cuda_device(0, verbose=True)"
<string>:1: RuntimeWarning: CUDA is not enabled; did you forget to run `init_cuda()`?
```