### PR TITLE
MRG, MAINT: Clean up manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,42 +27,5 @@ recursive-include mne/html *.css
 
 recursive-include mne/io/artemis123/resources *
 
-recursive-include mne mne/datasets *.csv
-include mne/io/edf/gdf_encodes.txt
+recursive-include mne *.csv
 include mne/datasets/sleep_physionet/SHA1SUMS
-
-### Exclude
-
-recursive-exclude examples/MNE-sample-data *
-recursive-exclude examples/MNE-testing-data *
-recursive-exclude examples/MNE-spm-face *
-recursive-exclude examples/MNE-somato-data *
-exclude Makefile
-exclude .coveragerc
-exclude *.yml
-exclude ignore_words.txt
-exclude .mailmap
-recursive-exclude mne *.pyc
-
-recursive-exclude doc *
-recursive-exclude logo *
-
-exclude CODE_OF_CONDUCT.md
-exclude .github
-exclude .github/CONTRIBUTING.md
-exclude .github/ISSUE_TEMPLATE
-exclude .github/ISSUE_TEMPLATE/blank.md
-exclude .github/ISSUE_TEMPLATE/bug_report.md
-exclude .github/ISSUE_TEMPLATE/feature_request.md
-exclude .github/PULL_REQUEST_TEMPLATE.md
-
-# Test files
-
-recursive-exclude mne/io/tests/data *
-recursive-exclude mne/io/bti/tests/data *
-recursive-exclude mne/io/edf/tests/data *
-recursive-exclude mne/io/kit/tests/data *
-recursive-exclude mne/io/brainvision/tests/data *
-recursive-exclude mne/io/egi/tests/data *
-recursive-exclude mne/io/nicolet/tests/data *
-recursive-exclude mne/preprocessing/tests/data *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,5 +27,42 @@ recursive-include mne/html *.css
 
 recursive-include mne/io/artemis123/resources *
 
-recursive-include mne *.csv
+recursive-include mne mne/datasets *.csv
+include mne/io/edf/gdf_encodes.txt
 include mne/datasets/sleep_physionet/SHA1SUMS
+
+### Exclude
+
+recursive-exclude examples/MNE-sample-data *
+recursive-exclude examples/MNE-testing-data *
+recursive-exclude examples/MNE-spm-face *
+recursive-exclude examples/MNE-somato-data *
+exclude Makefile
+exclude .coveragerc
+exclude *.yml
+exclude ignore_words.txt
+exclude .mailmap
+recursive-exclude mne *.pyc
+
+recursive-exclude doc *
+recursive-exclude logo *
+
+exclude CODE_OF_CONDUCT.md
+exclude .github
+exclude .github/CONTRIBUTING.md
+exclude .github/ISSUE_TEMPLATE
+exclude .github/ISSUE_TEMPLATE/blank.md
+exclude .github/ISSUE_TEMPLATE/bug_report.md
+exclude .github/ISSUE_TEMPLATE/feature_request.md
+exclude .github/PULL_REQUEST_TEMPLATE.md
+
+# Test files
+
+recursive-exclude mne/io/tests/data *
+recursive-exclude mne/io/bti/tests/data *
+recursive-exclude mne/io/edf/tests/data *
+recursive-exclude mne/io/kit/tests/data *
+recursive-exclude mne/io/brainvision/tests/data *
+recursive-exclude mne/io/egi/tests/data *
+recursive-exclude mne/io/nicolet/tests/data *
+recursive-exclude mne/preprocessing/tests/data *

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 wheel:
-	$(PYTHON) setup.py sdist -q bdist_wheel
+	$(PYTHON) setup.py sdist bdist_wheel
+
+wheel_quiet:
+	$(PYTHON) setup.py -q sdist bdist_wheel
+
 sample_data:
 	@python -c "import mne; mne.datasets.sample.data_path(verbose=True);"
 
@@ -117,7 +121,7 @@ docstring:
 check-manifest:
 	check-manifest --ignore .circleci*,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store
 
-check-readme: clean wheel
+check-readme: clean wheel_quiet
 	twine check dist/*
 
 nesting:


### PR DESCRIPTION
Running on `master` (with the `-q` in the right place) we see a lot of warning outputs:
```
$ make wheel_quiet
```
<details>

```
warning: no files found matching 'mne/datasets' under directory 'mne'
warning: no files found matching 'mne/io/edf/gdf_encodes.txt'
warning: no previously-included files matching '*' found under directory 'examples/MNE-sample-data'
warning: no previously-included files matching '*' found under directory 'examples/MNE-testing-data'
warning: no previously-included files matching '*' found under directory 'examples/MNE-spm-face'
warning: no previously-included files matching '*' found under directory 'examples/MNE-somato-data'
warning: no previously-included files found matching 'Makefile'
warning: no previously-included files found matching '.coveragerc'
warning: no previously-included files found matching '*.yml'
warning: no previously-included files found matching 'ignore_words.txt'
warning: no previously-included files found matching '.mailmap'
warning: no previously-included files matching '*.pyc' found under directory 'mne'
warning: no previously-included files matching '*' found under directory 'doc'
warning: no previously-included files matching '*' found under directory 'logo'
warning: no previously-included files found matching 'CODE_OF_CONDUCT.md'
warning: no previously-included files found matching '.github'
warning: no previously-included files found matching '.github/CONTRIBUTING.md'
warning: no previously-included files found matching '.github/ISSUE_TEMPLATE'
warning: no previously-included files found matching '.github/ISSUE_TEMPLATE/blank.md'
warning: no previously-included files found matching '.github/ISSUE_TEMPLATE/bug_report.md'
warning: no previously-included files found matching '.github/ISSUE_TEMPLATE/feature_request.md'
warning: no previously-included files found matching '.github/PULL_REQUEST_TEMPLATE.md'
warning: no previously-included files matching '*' found under directory 'mne/io/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/bti/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/edf/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/kit/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/brainvision/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/egi/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/io/nicolet/tests/data'
warning: no previously-included files matching '*' found under directory 'mne/preprocessing/tests/data'
twine check dist/*
Checking distribution dist/mne-0.19.dev0-py3-none-any.whl: Passed
Checking distribution dist/mne-0.19.dev0.tar.gz: Passed
```

</details>


On this PR it's much cleaner:
```
$ make wheel_quiet
python setup.py -q sdist bdist_wheel
```