### PR TITLE
MAINT: Work around conda/joblib bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ matrix:
                PIP_DEPENDENCIES="codecov flake8 numpydoc codespell pydocstyle codecov check-manifest pytest-sugar pytest-faulthandler twine"
 
         # Linux
+        # As of 2019/09/19 there is a mysterious joblib bug, so temporarily work around it with MNE_FORCE_SERIAL
         - os: linux
           env: CONDA_ENV="environment.yml"
+               MNE_FORCE_SERIAL=true
 
         # OSX conda
         - os: osx


### PR DESCRIPTION
Just a workaround for these errors in `master` until conda/travis/joblib updates (not sure whose fault it is) to fix them:

https://travis-ci.org/mne-tools/mne-python/jobs/586892855

Haven't tried to isolate the problem but basically all `n_jobs > 1` tests fail on one build.