### PR TITLE
FIX: Add brainvision captrack ref channels when set_montage

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -95,6 +95,8 @@ Changelog
 Bug
 ~~~
 
+- Fix setting montage eeg ref position for captrack by `Joan Massich`_
+
 - Fix saving raw read from BDF file using ``tmin`` and ``tmax`` using ``preload=False`` by `Alex Gramfort`_
 
 - Fix :func:`mne.grand_average` to use equal sum-to-one weights (like it used to, before changes to underlying :func:`mne.combine_evoked`) by `Daniel McCloy`_

--- a/mne/channels/_dig_montage_utils.py
+++ b/mne/channels/_dig_montage_utils.py
@@ -182,11 +182,6 @@ def _parse_brainvision_dig_montage(fname, scale=BACK_COMPAT):
     for s in sensors:
         name = s.find('Name').text
 
-        # Need to prune "GND". It is not the reference so
-        # it has not use.
-        if name == 'GND':
-            continue
-
         is_fid = name in FID_NAME_MAP
         coordinates = np.array([float(s.find('X').text),
                                 float(s.find('Y').text),

--- a/mne/channels/_dig_montage_utils.py
+++ b/mne/channels/_dig_montage_utils.py
@@ -182,6 +182,11 @@ def _parse_brainvision_dig_montage(fname, scale=BACK_COMPAT):
     for s in sensors:
         name = s.find('Name').text
 
+        # Need to prune "GND". It is not the reference so
+        # it has not use.
+        if name == 'GND':
+            continue
+
         is_fid = name in FID_NAME_MAP
         coordinates = np.array([float(s.find('X').text),
                                 float(s.find('Y').text),

--- a/mne/channels/_dig_montage_utils.py
+++ b/mne/channels/_dig_montage_utils.py
@@ -182,13 +182,6 @@ def _parse_brainvision_dig_montage(fname, scale=BACK_COMPAT):
     for s in sensors:
         name = s.find('Name').text
 
-        # Need to prune "GND" and "REF": these are not included in the raw
-        # data and will raise errors when we try to do raw.set_montage(...)
-        # XXX eventually this should be stored in ch['loc'][3:6]
-        # but we don't currently have such capabilities here
-        if name in ['GND', 'REF']:
-            continue
-
         is_fid = name in FID_NAME_MAP
         coordinates = np.array([float(s.find('X').text),
                                 float(s.find('Y').text),

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1458,9 +1458,7 @@ def _set_montage(info, montage, update_ch_names=DEPRECATED_PARAM,
                 return np.concatenate((pos, ref_pos))
 
         ch_pos = _mnt._get_ch_pos()
-
-        refs = set(ch_pos.keys()) & {'EEG000', 'GND', 'REF'}
-        eeg_ref_pos = np.zeros(3) if not(refs) else ch_pos.pop(refs.pop())  # XXX: this is random if len(ref)>1
+        eeg_ref_pos = ch_pos.pop('EEG000', np.zeros(3))
 
         # This raises based on info being subset/superset of montage
         _pick_chs = partial(

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1458,7 +1458,9 @@ def _set_montage(info, montage, update_ch_names=DEPRECATED_PARAM,
                 return np.concatenate((pos, ref_pos))
 
         ch_pos = _mnt._get_ch_pos()
-        eeg_ref_pos = ch_pos.pop('EEG000', np.zeros(3))
+
+        refs = set(ch_pos.keys()) & {'EEG000', 'GND', 'REF'}
+        eeg_ref_pos = np.zeros(3) if not(refs) else ch_pos.pop(refs.pop())  # XXX: this is random if len(ref)>1
 
         # This raises based on info being subset/superset of montage
         _pick_chs = partial(

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1459,6 +1459,7 @@ def _set_montage(info, montage, update_ch_names=DEPRECATED_PARAM,
 
         ch_pos = _mnt._get_ch_pos()
         refs = set(ch_pos.keys()) & {'EEG000', 'REF'}
+        assert len(refs) <= 1
         eeg_ref_pos = np.zeros(3) if not(refs) else ch_pos.pop(refs.pop())
 
         # This raises based on info being subset/superset of montage
@@ -1479,7 +1480,7 @@ def _set_montage(info, montage, update_ch_names=DEPRECATED_PARAM,
             _names = _mnt._get_dig_names()
             info['dig'] = _format_dig_points([
                 _mnt.dig[ii] for ii, name in enumerate(_names)
-                if name in matched_ch_names.union({None, 'EEG000'})
+                if name in matched_ch_names.union({None, 'EEG000', 'REF'})
             ])
 
         if _mnt.dev_head_t is not None:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1458,7 +1458,8 @@ def _set_montage(info, montage, update_ch_names=DEPRECATED_PARAM,
                 return np.concatenate((pos, ref_pos))
 
         ch_pos = _mnt._get_ch_pos()
-        eeg_ref_pos = ch_pos.pop('EEG000', np.zeros(3))
+        refs = set(ch_pos.keys()) & {'EEG000', 'REF'}
+        eeg_ref_pos = np.zeros(3) if not(refs) else ch_pos.pop(refs.pop())
 
         # This raises based on info being subset/superset of montage
         _pick_chs = partial(

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -980,9 +980,7 @@ def test_bvct_dig_montage_old_api():  # XXX: to remove in 0.20
                                    test_raw_bv.info['chs']):
         assert_equal(ch_raw['ch_name'], ch_test_raw['ch_name'])
         assert_equal(ch_raw['coord_frame'], FIFF.FIFFV_COORD_HEAD)
-        assert_allclose(ch_raw['loc'], ch_test_raw['loc'], atol=1e-7)
-
-    assert_dig_allclose(raw_bv.info, test_raw_bv.info)
+        assert_allclose(ch_raw['loc'][:3], ch_test_raw['loc'][:3], atol=1e-7)
 
 
 @testing.requires_testing_data

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1014,7 +1014,11 @@ def test_read_dig_captrack(tmpdir):
     raw_bv.set_montage(montage)
 
     test_raw_bv = read_raw_fif(bv_fif_fname)
-    assert_dig_allclose(raw_bv.info, test_raw_bv.info)
+
+    # compare after set_montage using chs loc.
+    for actual, expected in zip(raw_bv.info['chs'], test_raw_bv.info['chs']):
+        assert_allclose(actual['loc'][:3], expected['loc'][:3])
+        assert_allclose(actual['loc'][:6], [-0.005103, 0.05395, 0.144622])
 
 
 def test_set_montage():

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -947,14 +947,6 @@ def test_bvct_dig_montage_old_api():  # XXX: to remove in 0.20
     with pytest.deprecated_call():
         dig_montage = read_dig_montage(bvct=bvct_dig_montage_fname)
 
-    # remove reference that was not used in old API
-    ref_idx = dig_montage.ch_names.index('REF')
-    n_fids = 3
-    del dig_montage.dig[ref_idx + n_fids]
-    del dig_montage.ch_names[ref_idx]
-    for k in range(ref_idx + n_fids, len(dig_montage.dig)):
-        dig_montage.dig[k]['ident'] -= 1
-
     # test round-trip IO
     temp_dir = _TempDir()
     fname_temp = op.join(temp_dir, 'bvct_test.fif')

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -999,6 +999,9 @@ def test_read_dig_captrack(tmpdir):
         '0 extras (headshape), 0 HPIs, 3 fiducials, 66 channels>'
     )
 
+    montage = transform_to_head(montage)  # transform_to_head has to be tested
+    _check_roundtrip(montage=montage, fname=str(tmpdir.join('bvct_test.fif')))
+
     with pytest.deprecated_call():
         assert_allclose(
             actual=np.array([montage.nasion, montage.lpa, montage.rpa]),
@@ -1006,29 +1009,12 @@ def test_read_dig_captrack(tmpdir):
             atol=1e-5,
         )
 
-    # set the montage into a raw file for testing purposes
     raw_bv = read_raw_brainvision(bv_raw_fname)
     raw_bv.set_channel_types({"HEOG": 'eog', "VEOG": 'eog', "ECG": 'ecg'})
     raw_bv.set_montage(montage)
 
     test_raw_bv = read_raw_fif(bv_fif_fname)
-
-    # check the ref
-    # XXX: this should pas but it does not 'cos bv_fif_fname ref is 0,0,0
-    #      montage has 2 refs:
-    #      'GND': [-0.00557997,  0.10879404,  0.0894018 ]
-    #      'REF': [-0.00510269,  0.05394952,  0.14462162]
-    assert_allclose(raw_bv.info['chs'][0]['loc'], test_raw_bv['chs'][0]['loc'])
-
-
-@testing.requires_testing_data
-def test_read_dig_captrack_save_to_fif_roundtrip(tmpdir):
-    """Test reading a captrack montage file."""
-    montage = read_dig_captrack(
-        fname=op.join(data_path, 'montage', 'captrak_coords.bvct')
-    )
-    montage = transform_to_head(montage)  # transform_to_head has to be tested
-    _check_roundtrip(montage=montage, fname=str(tmpdir.join('bvct_test.fif')))
+    assert_dig_allclose(raw_bv.info, test_raw_bv.info)
 
 
 def test_set_montage():

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -990,7 +990,7 @@ def test_read_dig_captrack(tmpdir):
         'AF3', 'AF4', 'AF7', 'AF8', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'CP1',
         'CP2', 'CP3', 'CP4', 'CP5', 'CP6', 'CPz', 'Cz', 'F1', 'F2', 'F3', 'F4',
         'F5', 'F6', 'F7', 'F8', 'FC1', 'FC2', 'FC3', 'FC4', 'FC5', 'FC6',
-        'FT10', 'FT7', 'FT8', 'FT9', 'Fp1', 'Fp2', 'Fz', 'O1', 'O2',
+        'FT10', 'FT7', 'FT8', 'FT9', 'Fp1', 'Fp2', 'Fz', 'GND', 'O1', 'O2',
         'Oz', 'P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'P7', 'P8', 'PO10', 'PO3',
         'PO4', 'PO7', 'PO8', 'PO9', 'POz', 'Pz', 'REF', 'T7', 'T8', 'TP10',
         'TP7', 'TP8', 'TP9'
@@ -1002,7 +1002,7 @@ def test_read_dig_captrack(tmpdir):
     assert montage.ch_names == EXPECTED_CH_NAMES
     assert montage.__repr__() == (
         '<DigMontage | '
-        '0 extras (headshape), 0 HPIs, 3 fiducials, 65 channels>'
+        '0 extras (headshape), 0 HPIs, 3 fiducials, 66 channels>'
     )
 
     montage = transform_to_head(montage)  # transform_to_head has to be tested


### PR DESCRIPTION
fixes #6788

However I'm not sure that this is the right call. It does not
make sense that a single montage has 2 reference points.
And atleast in our test file we have 'GND' and 'REF' in the 
same file. Which also seems to be the case 
in https://github.com/mne-tools/mne-python/blob/master/mne/io/brainvision/tests/data/test.hpts
as reported https://github.com/mne-tools/mne-python/pull/6764#issuecomment-533206722

cc: @sappelhoff, @agramfort