### PR TITLE
MRG, MAINT: Add test for gh-6300

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -237,7 +237,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.71', misc='0.3')
+    releases = dict(testing='0.72', misc='0.3')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -319,7 +319,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='fc2d5b9eb0a144b1d6ba84dc3b983602',
         somato='f08f17924e23c57a751b3bed4a05fe02',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='28e420d9c298868f4d537e762823ba5b',
+        testing='a7da51964edb2fbb3c59026af617dbcc',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         opm='370ad1dcfd5c47e029e692c85358a374',
         visual_92_categories=['74f50bbeb65740903eadc229c9fa759f',

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -40,6 +40,10 @@ tmp_raw_fname = op.join(base_dir, 'tmp_raw.fif')
 
 fname_2500 = op.join(testing.data_path(download=False), 'BTi', 'erm_HFH',
                      'c,rfDC')
+fname_sim = op.join(testing.data_path(download=False), 'BTi', '4Dsim',
+                    'c,rfDC')
+fname_sim_filt = op.join(testing.data_path(download=False), 'BTi', '4Dsim',
+                         'c,rfDC,fn50,o')
 
 # the 4D exporter doesn't export all channels, so we confine our comparison
 NCH = 248
@@ -343,6 +347,14 @@ def test_nan_trans():
                 if convert:
                     t = _loc_to_coil_trans(bti_info['chs'][idx]['loc'])
                     t = _convert_coil_trans(t, dev_ctf_t, bti_dev_t)
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', (fname_sim, fname_sim_filt))
+@pytest.mark.parametrize('preload', (True, False))
+def test_bti_ch_data(fname, preload):
+    """Test for gh-6048."""
+    read_raw_bti(fname, preload=preload)  # used to fail with ascii decode err
 
 
 run_tests_if_main()


### PR DESCRIPTION
Adds a smoke test using the data from @ebeich. Probably should have been part of #6300, but it's good that it works with no modifications!