### PR TITLE
MRG, STY: Style "See Also" the same way as .. note::

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -1,7 +1,8 @@
 :root {
   --a-color-dark: rgb(31, 92, 153);
   --a-color: rgb(41, 122, 204);
-  --a-hover-color: rgb(102, 179, 255);
+  --a-color-light: rgb(102, 179, 255);
+  --a-color-lighter: rgb(204, 230, 255);
 }
 html {
   position: relative;
@@ -41,7 +42,7 @@ a {
 }
 
 a:hover {
-    color: var(--a-hover-color);
+    color: var(--a-color-light);
 }
 
 blockquote {
@@ -89,21 +90,23 @@ a code {
     color: var(--a-color);
 }
 a:hover code {
-    color: var(--a-hover-color);
+    color: var(--a-color-light);
 }
-.note a, .note a code {
+
+/* Background is light */
+.alert-info a, .alert-info a code {
     color: var(--a-color-dark);
 }
-.note a:hover, .note a:hover code {
+.alert-info a:hover, .alert-info a:hover code {
     color: var(--a-color);
 }
-.note {
-    background-color: rgb(204, 230, 255);
+.alert-info {
+    background-color: var(--a-color-lighter);
     color: rgb(0, 0, 0);
     border: none;
 }
-.note pre {
-    background-color: rgb(242, 249, 255);
+.alert-info pre {
+    background-color: var(--a-color-lighter);
 }
 .warning {
     background-color: rgb(230, 57, 57);
@@ -340,7 +343,7 @@ span.classifier a span.xref, span.classifier a code.docutils.literal.notranslate
     color: var(--a-color);
 }
 span.classifier a:hover span.xref, span.classifier a:hover code.docutils.literal.notranslate, span.classifier a.reference.external:hover {
-    color: var(--a-hover-color);
+    color: var(--a-color-light);
 }
 
 /* Allow easier copy-paste in code blocks */


### PR DESCRIPTION
@agramfort complained about See Also entries being blue on blue:

https://mne.tools/dev/generated/mne.channels.read_dig_hpts.html

This stylizes them the same way as `.. note::` sections by changing the CSS def from `.note` to `.alert-info` (which our `.. note::` also gets as a CSS class; `.. note::` gets `.note .alert-info`, whereas `See Also` gets `.admonition .alert-info`).