### PR TITLE
MRG, MAINT: Revert dev_head_t as None

### DIFF
--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -6,12 +6,13 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, assert_array_equal
 
+from mne.channels import make_standard_montage
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_kit, read_raw_bti, read_info
 from mne.io.constants import FIFF
 from mne import (read_forward_solution, write_forward_solution,
                  make_forward_solution, convert_forward_solution,
-                 setup_volume_source_space, read_source_spaces,
+                 setup_volume_source_space, read_source_spaces, create_info,
                  make_sphere_model, pick_types_forward, pick_info, pick_types,
                  read_evokeds, read_cov, read_dipole, SourceSpaces)
 from mne.utils import (requires_mne, requires_nibabel,
@@ -438,6 +439,22 @@ def test_make_forward_dipole():
                                    trans=fname_trans)
     assert isinstance(stc, VolSourceEstimate)
     assert_allclose(stc.times, np.arange(0., 0.003, 0.001))
+
+
+@testing.requires_testing_data
+def test_make_forward_no_meg(tmpdir):
+    """Test that we can make and I/O forward solution with no MEG channels."""
+    pos = dict(rr=[[0.05, 0, 0]], nn=[[0, 0, 1.]])
+    src = setup_volume_source_space(pos=pos)
+    bem = make_sphere_model()
+    trans = None
+    montage = make_standard_montage('standard_1020')
+    info = create_info(['Cz'], 1000., 'eeg', montage=montage)
+    fwd = make_forward_solution(info, trans, src, bem)
+    fname = tmpdir.join('test-fwd.fif')
+    write_forward_solution(fname, fwd)
+    fwd_read = read_forward_solution(fname)
+    assert_allclose(fwd['sol']['data'], fwd_read['sol']['data'])
 
 
 run_tests_if_main()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1194,7 +1194,8 @@ def test_add_channels():
     raw_arr = rng.randn(2, raw_eeg.n_times)
     raw_arr = RawArray(raw_arr, raw_arr_info)
     # This should error because of conflicts in Info
-    with pytest.raises(RuntimeError, match='to merge'):
+    raw_arr.info['dev_head_t'] = orig_head_t
+    with pytest.raises(ValueError, match='mutually inconsistent dev_head_t'):
         raw_meg.copy().add_channels([raw_arr])
     raw_meg.copy().add_channels([raw_arr], force_update_info=True)
     # Make sure that values didn't get overwritten

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -27,7 +27,7 @@ from .write import (start_file, end_file, start_block, end_block,
                     write_coord_trans, write_ch_info, write_name_list,
                     write_julian, write_float_matrix, write_id, DATE_NONE)
 from .proc_history import _read_proc_history, _write_proc_history
-from ..transforms import invert_transform
+from ..transforms import invert_transform, Transform
 from ..utils import logger, verbose, warn, object_diff, _validate_type
 from .._digitization.base import _format_dig_points
 from .compensator import get_current_comp
@@ -1826,7 +1826,7 @@ def _empty_info(sfreq):
         'dev_ctf_t', 'dig', 'experimenter', 'utc_offset', 'device_info',
         'file_id', 'highpass', 'hpi_subsystem', 'kit_system_id', 'helium_info',
         'line_freq', 'lowpass', 'meas_date', 'meas_id', 'proj_id', 'proj_name',
-        'subject_info', 'xplotter_layout', 'gantry_angle', 'dev_head_t',
+        'subject_info', 'xplotter_layout', 'gantry_angle',
     )
     _list_keys = ('bads', 'chs', 'comps', 'events', 'hpi_meas', 'hpi_results',
                   'projs', 'proc_history')
@@ -1839,6 +1839,7 @@ def _empty_info(sfreq):
     info['highpass'] = 0.
     info['sfreq'] = float(sfreq)
     info['lowpass'] = info['sfreq'] / 2.
+    info['dev_head_t'] = Transform('meg', 'head')
     info._update_redundant()
     info._check_consistency()
     return info


### PR DESCRIPTION
Reverts a change in the last week that made `info['dev_head_t'] = None` for EEG-only data (really anything using `create_info`). We can discuss if this is correct or not in #6814, but the safe thing to do for 0.19 is to revert it and set it to `Transform('meg', 'head', np.eye(4))`.