### PR TITLE
[release][DOC] Bump mne version to 0.19 and update navbar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
               if [ "$CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
                 echo html_dev > build.txt;
                 python -c "import mne; mne.datasets._download_all_example_data()";
-              elif [ "$CIRCLE_BRANCH" == "maint/0.18" ]; then
+              elif [ "$CIRCLE_BRANCH" == "maint/0.19" ]; then
                 echo html_stable > build.txt;
                 python -c "import mne; mne.datasets._download_all_example_data()";
               else
@@ -362,7 +362,7 @@ jobs:
             name: Deploy docs
             command: |
               set -e;
-              if [ "${CIRCLE_BRANCH}" == "master" ] || [ "${CIRCLE_BRANCH}" == "maint/0.18" ]; then
+              if [ "${CIRCLE_BRANCH}" == "master" ] || [ "${CIRCLE_BRANCH}" == "maint/0.19" ]; then
                 git config --global user.email "circle@mne.com";
                 git config --global user.name "Circle CI";
                 cd ~/mne-tools.github.io;

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -8,7 +8,8 @@
   </button>
   <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
     <li><a href="https://mne-tools.github.io/dev/index.html">Development</a></li>
-    <li><a href="https://mne-tools.github.io/stable/index.html">v0.18 (stable)</a></li>
+    <li><a href="https://mne-tools.github.io/stable/index.html">v0.19 (stable)</a></li>
+    <li><a href="https://mne-tools.github.io/stable/index.html">v0.18</a></li>
     <li><a href="https://mne-tools.github.io/0.17/index.html">v0.17</a></li>
     <li><a href="https://mne-tools.github.io/0.16/index.html">v0.16</a></li>
     <li><a href="https://mne-tools.github.io/0.15/index.html">v0.15</a></li>

--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -7,10 +7,10 @@
    - "Bug" for bug fixes
    - "API" for backward-incompatible changes
 
-.. _current:
+.. _changes_0_19:
 
-Current (0.19.dev0)
--------------------
+Version 0.18
+------------
 
 Changelog
 ~~~~~~~~~

--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -9,7 +9,7 @@
 
 .. _changes_0_19:
 
-Version 0.18
+Version 0.19
 ------------
 
 Changelog

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,7 +7,7 @@ What's new
 
 .. currentmodule:: mne
 
-.. include:: changes/latest.inc
+.. include:: changes/0.19.inc
 .. include:: changes/0.18.inc
 .. include:: changes/0.17.inc
 .. include:: changes/0.16.inc

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -16,7 +16,7 @@
 # Dev branch marker is: 'X.Y.devN' where N is an integer.
 #
 
-__version__ = '0.19.dev0'
+__version__ = '0.19.0'
 
 # have to import verbose first since it's needed by many things
 from .utils import (set_log_level, set_log_file, verbose, set_config,


### PR DESCRIPTION
Following the Wiki, this PR:

- updates whats new from current to 0.19
- updates navbar

This PR requires (https://github.com/mne-tools/mne-tools.github.io/pull/18)