### PR TITLE
MRG, API: Remove find_edf_events

### DIFF
--- a/doc/changes/0.15.inc
+++ b/doc/changes/0.15.inc
@@ -42,7 +42,7 @@ Changelog
 
 - Add support for GDF files in :func:`mne.io.read_raw_edf` by `Nicolas Barascud`_
 
-- Add :func:`mne.io.find_edf_events` for getting the events as they are in the EDF/GDF header by `Jaakko Leppakangas`_
+- Add ``mne.io.find_edf_events`` for getting the events as they are in the EDF/GDF header by `Jaakko Leppakangas`_
 
 - Speed up :meth:`mne.io.Raw.plot` and :meth:`mne.Epochs.plot` using (automatic) decimation based on low-passing with ``decim='auto'`` parameter by `Eric Larson`_ and `Jaakko Leppakangas`_
 

--- a/doc/changes/0.18.inc
+++ b/doc/changes/0.18.inc
@@ -251,7 +251,7 @@ API
 
 - :class:`Annotations` are now kept sorted (by onset time) during instantiation and :meth:`~Annotations.append` operations, by `Eric Larson`_
 
-- Deprecate :func:`mne.io.find_edf_events` by `Joan Massich`_
+- Deprecate ``mne.io.find_edf_events`` by `Joan Massich`_
 
 - Deprecate ``limit_depth_chs`` in :func:`mne.minimum_norm.make_inverse_operator` in favor of ``depth=dict(limit_depth_chs=...)`` by `Eric Larson`_
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -53,7 +53,6 @@ Reading raw data
    :toctree: generated/
 
    anonymize_info
-   find_edf_events
    read_raw_artemis123
    read_raw_bti
    read_raw_cnt

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -35,7 +35,7 @@ from .bti import read_raw_bti
 from .cnt import read_raw_cnt
 from .ctf import read_raw_ctf
 from .curry import read_raw_curry
-from .edf import read_raw_edf, read_raw_bdf, read_raw_gdf, find_edf_events
+from .edf import read_raw_edf, read_raw_bdf, read_raw_gdf
 from .egi import read_raw_egi
 from .kit import read_raw_kit, read_epochs_kit
 from .fiff import read_raw_fif
@@ -58,7 +58,7 @@ __all__ = [
     _loc_to_coil_trans, _loc_to_eeg_loc, _merge_info, _stamp_to_dt,
     BaseRaw, Info, Projection, Raw, RawArray, RawFIF, add_reference_channels,
     anonymize_info, array, base, brainvision, bti, cnt, concatenate_raws,
-    constants, ctf, edf, eeglab, egi, fiff, fiff_open, find_edf_events, kit,
+    constants, ctf, edf, eeglab, egi, fiff, fiff_open, kit,
     make_eeg_average_ref_proj, nicolet, pick, read_epochs_eeglab,
     read_epochs_fieldtrip, read_epochs_kit, read_evoked_fieldtrip,
     read_fiducials, read_info, read_raw_artemis123, read_raw_bdf,

--- a/mne/io/edf/__init__.py
+++ b/mne/io/edf/__init__.py
@@ -4,4 +4,4 @@
 #
 # License: BSD (3-clause)
 
-from .edf import read_raw_edf, read_raw_bdf, read_raw_gdf, find_edf_events
+from .edf import read_raw_edf, read_raw_bdf, read_raw_gdf

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -23,52 +23,8 @@ from ..base import BaseRaw
 from ..meas_info import _empty_info, _unique_channel_names, DATE_NONE
 from ..constants import FIFF
 from ...filter import resample
-from ...utils import copy_function_doc_to_method_doc, deprecated, fill_doc
-from ...annotations import Annotations, events_from_annotations
-
-
-@deprecated('find_edf_events is deprecated in 0.18, and will be removed'
-            ' in 0.19. Please use `mne.events_from_annotations` instead')
-def find_edf_events(raw):
-    """Get original EDF events as read from the header.
-
-    For GDF, the values are returned in form
-    [n_events, pos, typ, chn, dur]
-    where:
-
-    ========  ===================================  =======
-    name      description                          type
-    ========  ===================================  =======
-    n_events  The number of all events             integer
-    pos       Beginning of the events in samples   array
-    typ       The event identifiers                array
-    chn       The associated channels (0 for all)  array
-    dur       The durations of the events          array
-    ========  ===================================  =======
-
-    For EDF+, the values are returned in form
-    n_events * [onset, dur, desc]
-    where:
-
-    ========  ===================================  =======
-    name      description                          type
-    ========  ===================================  =======
-    onset     Onset of the event in seconds        float
-    dur       Duration of the event in seconds     float
-    desc      Description of the event             str
-    ========  ===================================  =======
-
-    Parameters
-    ----------
-    raw : instance of RawEDF
-        The raw object for finding the events.
-
-    Returns
-    -------
-    events : ndarray
-        The events as they are in the file header.
-    """
-    return events_from_annotations(raw)
+from ...utils import fill_doc
+from ...annotations import Annotations
 
 
 @fill_doc
@@ -188,12 +144,6 @@ class RawEDF(BaseRaw):
                                   self._raw_extras[fi], self.info['chs'],
                                   self._filenames[fi])
 
-    @copy_function_doc_to_method_doc(find_edf_events)
-    @deprecated('find_edf_events is deprecated in 0.18, and will be removed'
-                ' in 0.19. Please use `mne.events_from_annotations` instead')
-    def find_edf_events(self):
-        return events_from_annotations(self)
-
 
 @fill_doc
 class RawGDF(BaseRaw):
@@ -267,12 +217,6 @@ class RawGDF(BaseRaw):
         return _read_segment_file(data, idx, fi, start, stop,
                                   self._raw_extras[fi], self.info['chs'],
                                   self._filenames[fi])
-
-    @copy_function_doc_to_method_doc(find_edf_events)
-    @deprecated('find_edf_events is deprecated in 0.18, and will be removed'
-                ' in 0.19. Please use `mne.events_from_annotations` instead')
-    def find_edf_events(self):
-        return events_from_annotations(self)
 
 
 def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -26,7 +26,6 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.edf.edf import _get_edf_default_event_id
 from mne.io.edf.edf import _read_annotations_edf
 from mne.io.edf.edf import _read_ch
-from mne.io.edf.edf import find_edf_events
 from mne.io.pick import channel_indices_by_type
 from mne.annotations import events_from_annotations, read_annotations
 from mne.io.meas_info import _kind_dict as _KIND_DICT
@@ -208,16 +207,6 @@ def test_to_data_frame(fname):
     df = raw.to_data_frame(index=None, scalings={'eeg': 1e13})
     assert 'time' in df.index.names
     assert_array_equal(df.values[:, 0], raw._data[0] * 1e13)
-
-
-def test_find_edf_events_deprecation():
-    """Test find_edf_events deprecation."""
-    raw = read_raw_edf(edf_path)
-    with pytest.deprecated_call(match="find_edf_events"):
-        raw.find_edf_events()
-
-    with pytest.deprecated_call(match="find_edf_events"):
-        find_edf_events(raw)
 
 
 def test_read_raw_edf_stim_channel_input_parameters():


### PR DESCRIPTION
Will merge when green, then backport since this was supposed to be part of 0.19.

Closes #6829