### PR TITLE
MAINT: Redirects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,7 +210,12 @@ html_static_path = ['_static', '_images']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+html_extra_path = [
+    'contributing.html',
+    'documentation.html',
+    'getting_started.html',
+    'install_mne_python.html',
+]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/contributing.html
+++ b/doc/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=install/contributing.html">
+</head>
+<body>
+<p>Please follow <a href="install/contributing.html">this link</a>.</p>
+</body>
+</html>

--- a/doc/documentation.html
+++ b/doc/documentation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=overview/index.html">
+</head>
+<body>
+<p>Please follow <a href="overview/index.html">this link</a>.</p>
+</body>
+</html>

--- a/doc/getting_started.html
+++ b/doc/getting_started.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=install/index.html">
+</head>
+<body>
+<p>Please follow <a href="install/index.html">this link</a>.</p>
+</body>
+</html>

--- a/doc/install_mne_python.html
+++ b/doc/install_mne_python.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=install/index.html">
+</head>
+<body>
+<p>Please follow <a href="install/index.html">this link</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Add redirects for common errors (including those returned by "install mne-python", "contribute to mne-python" on google!).

Along with the `.htaccess` changes on MGH this should hopefully fix URL problems.