### PR TITLE
MAINT: DRY code for src subject and better src __repr__

### DIFF
--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -167,7 +167,7 @@ def test_make_dics(tmpdir, _load_forward):
     assert_array_equal(filters['proj'], np.eye(n_channels))
     assert_array_equal(filters['vertices'][0], vertices)
     assert_array_equal(filters['vertices'][1], [])  # Label was on the LH
-    assert filters['subject'] == fwd_free['src'][0]['subject_his_id']
+    assert filters['subject'] == fwd_free['src']._subject
     assert filters['pick_ori'] is None
     assert filters['n_orient'] == n_orient
     assert filters['inversion'] == 'single'

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -340,7 +340,7 @@ def _read_forward_meas_info(tree, fid):
 
 def _subject_from_forward(forward):
     """Get subject id from inverse operator."""
-    return forward['src'][0].get('subject_his_id', None)
+    return forward['src']._subject
 
 
 @verbose

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -228,7 +228,7 @@ def make_stc_from_dipoles(dipoles, src, verbose=None):
     vertices = [np.array(lh_vertno).astype(int),
                 np.array(rh_vertno).astype(int)]
     stc = SourceEstimate(X, vertices=vertices, tmin=tmin, tstep=tstep,
-                         subject=src[0]['subject_his_id'])
+                         subject=src._subject)
     logger.info('[done]')
     return stc
 

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -755,7 +755,7 @@ def _check_reference(inst, ch_names=None):
 
 def _subject_from_inverse(inverse_operator):
     """Get subject id from inverse operator."""
-    return inverse_operator['src'][0].get('subject_his_id', None)
+    return inverse_operator['src']._subject
 
 
 @verbose

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -417,7 +417,7 @@ def _check_subject_from(subject_from, src):
     elif src is None:  # assume it's correct although dangerous but unlikely
         subject_check = subject_from
     else:
-        subject_check = src[0]['subject_his_id']
+        subject_check = src._subject
     if subject_from is None:
         subject_from = subject_check
     elif subject_check is not None and subject_from != subject_check:

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -161,7 +161,7 @@ def simulate_sparse_stc(src, n_dipoles, times,
     """
     rng = check_random_state(random_state)
     src = _ensure_src(src, verbose=False)
-    subject_src = src[0].get('subject_his_id')
+    subject_src = src._subject
     if subject is None:
         subject = subject_src
     elif subject_src is not None and subject != subject_src:
@@ -322,9 +322,8 @@ def simulate_stc(src, labels, stc_data, tmin, tstep, value_fun=None,
             data.append(stc_data_extended[i][idx])
             vertno[i] = vertno[i][idx]
 
-    subject = src[0].get('subject_his_id')
     stc = SourceEstimate(np.concatenate(data), vertices=vertno, tmin=tmin,
-                         tstep=tstep, subject=subject)
+                         tstep=tstep, subject=src._subject)
     return stc
 
 

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -241,7 +241,7 @@ def test_volume_source_morph():
     # inverse_operator_vol['src'][0]['subject_his_id'] nor subject_from is set,
     # but attempting to perform a volume morph
     src = inverse_operator_vol['src']
-    assert src[0]['subject_his_id'] is None  # already None on disk (old!)
+    assert src._subject is None  # already None on disk (old!)
 
     with pytest.raises(ValueError, match='subject_from could not be inferred'):
         compute_source_morph(src=src, subjects_dir=subjects_dir)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -678,7 +678,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     _check_option('coord_frame', coord_frame, ['head', 'meg', 'mri'])
     if src is not None:
         src = _ensure_src(src)
-        src_subject = src[0].get('subject_his_id', None)
+        src_subject = src._subject
         subject = src_subject if subject is None else subject
         if src_subject is not None and subject != src_subject:
             raise ValueError('subject ("%s") did not match the subject name '
@@ -1859,7 +1859,7 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     else:
         src = _ensure_src(src, kind='volume', extra=' or SourceMorph')
         img = stc.as_volume(src, mri_resolution=False)
-        kind, src_subject = 'src subject', src[0].get('subject_his_id', None)
+        kind, src_subject = 'src subject', src._subject
     _print_coord_trans(Transform('mri_voxel', 'ras', img.affine),
                        prefix='Image affine ', units='mm', level='debug')
     subject = _check_subject(src_subject, subject, True, kind=kind)


### PR DESCRIPTION
Changes this:
```
larsoner@bunk:~/python/mne-python$ python -c "import mne; print(mne.read_source_spaces('/home/larsoner/mne_data/MNE-sample-data/subjects/sample/bem/sample-oct-6-src.fif'))"
```
> <SourceSpaces: [<surface (lh), n_vertices=155407, n_used=4098, coordinate_frame=MRI (surface RAS)>, <surface (rh), n_vertices=156866, n_used=4098, coordinate_frame=MRI (surface RAS)>]>

Into this (moving `coord frame` to the end since it's shared/constant, adding `subject`):
> <SourceSpaces: [<surface (lh), n_vertices=155407, n_used=4098>, <surface (rh), n_vertices=156866, n_used=4098>] MRI (surface RAS) coords, subject 'sample'>

And along the way DRYs our use of `src[0]['subject_his_id']` by adding a convenience `@property` to `SourceSpaces`. Maybe it should be public (?), but for now I left as private.