### PR TITLE
MRG, ENH: Add `src_to` argument to `SourceMorph`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -17,6 +17,8 @@ Changelog
 
 - Add function :func:`mne.make_fixed_length_epochs` to segment raw into fixed length epochs by `Mohammad Daneshzand`_
 
+- Add support for passing a destination source space ``src_to`` in :func:`mne.compute_source_morph` to ensure morphing for multiple subjects results in consistent STCs, by `Eric Larson`_
+
 - Add support for plotting fNIRS channels in :func:`mne.viz.plot_alignment` by `Eric Larson`_
 
 - Add keyboard functionality to interactive colorbar plotting TFRs by `Stefan Repplinger`_

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -113,6 +113,7 @@ morph = mne.compute_source_morph(
     subjects_dir=subjects_dir,
     niter_sdr=[10, 10, 5], niter_affine=[10, 10, 5],  # just for speed
     verbose=True)
-stc.copy().crop(0.05, 0.18).plot(
-    src=morph, mode='stat_map', initial_time=0.1, subjects_dir=subjects_dir,
+stc_fs = morph.apply(stc.copy().crop(0.05, 0.18))
+stc_fs.plot(
+    src=src_fs, mode='stat_map', initial_time=0.1, subjects_dir=subjects_dir,
     clim=dict(kind='value', pos_lims=lims), verbose=True)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -11,7 +11,7 @@ and show activation on ``fsaverage``.
 # License: BSD (3-clause)
 
 import mne
-from mne.datasets import sample
+from mne.datasets import sample, fetch_fsaverage
 from mne.beamformer import make_lcmv, apply_lcmv
 
 print(__doc__)
@@ -23,6 +23,7 @@ data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-vol-7-fwd.fif'
+fetch_fsaverage(subjects_dir, verbose=False)  # ensure BEM exists
 fname_fs_bem = (subjects_dir + '/fsaverage/bem/'
                 'fsaverage-5120-5120-5120-bem-sol.fif')
 

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -113,7 +113,9 @@ src_fs = mne.setup_volume_source_space(
     verbose=True)
 morph = mne.compute_source_morph(
     forward['src'], subject_from='sample', src_to=src_fs,
-    subjects_dir=subjects_dir, verbose=True)
+    subjects_dir=subjects_dir,
+    n_iter_sdr=[10, 10, 5], n_iter_affine=[10, 10, 5],  # just for speed
+    verbose=True)
 stc.copy().crop(0.05, 0.18).plot(
     src=morph, mode='stat_map', initial_time=0.1, subjects_dir=subjects_dir,
     clim=dict(kind='value', pos_lims=lims), verbose=True)

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -23,9 +23,8 @@ data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-vol-7-fwd.fif'
-fetch_fsaverage(subjects_dir, verbose=False)  # ensure BEM exists
-fname_fs_bem = (subjects_dir + '/fsaverage/bem/'
-                'fsaverage-5120-5120-5120-bem-sol.fif')
+fetch_fsaverage(subjects_dir)  # ensure fsaverage src exists
+fname_fs_src = subjects_dir + '/fsaverage/bem/fsaverage-vol-5-src.fif'
 
 # Get epochs
 event_id, tmin, tmax = [1, 2], -0.2, 0.5
@@ -108,13 +107,11 @@ stc.plot(
 # argument to `mne.VolSourceEstimate.plot`. To save a bit of speed when
 # applying the morph, we will crop the STC:
 
-src_fs = mne.setup_volume_source_space(
-    'fsaverage', pos=5., bem=fname_fs_bem, subjects_dir=subjects_dir,
-    verbose=True)
+src_fs = mne.read_source_spaces(fname_fs_src)
 morph = mne.compute_source_morph(
     forward['src'], subject_from='sample', src_to=src_fs,
     subjects_dir=subjects_dir,
-    n_iter_sdr=[10, 10, 5], n_iter_affine=[10, 10, 5],  # just for speed
+    niter_sdr=[10, 10, 5], niter_affine=[10, 10, 5],  # just for speed
     verbose=True)
 stc.copy().crop(0.05, 0.18).plot(
     src=morph, mode='stat_map', initial_time=0.1, subjects_dir=subjects_dir,

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -23,6 +23,8 @@ data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-vol-7-fwd.fif'
+fname_fs_bem = (subjects_dir + '/fsaverage/bem/'
+                'fsaverage-5120-5120-5120-bem-sol.fif')
 
 # Get epochs
 event_id, tmin, tmax = [1, 2], -0.2, 0.5
@@ -105,10 +107,12 @@ stc.plot(
 # argument to `mne.VolSourceEstimate.plot`. To save a bit of speed when
 # applying the morph, we will crop the STC:
 
+src_fs = mne.setup_volume_source_space(
+    'fsaverage', pos=5., bem=fname_fs_bem, subjects_dir=subjects_dir,
+    verbose=True)
 morph = mne.compute_source_morph(
-    forward['src'], 'sample', 'fsaverage', subjects_dir=subjects_dir,
-    zooms=7, verbose=True)
+    forward['src'], subject_from='sample', src_to=src_fs,
+    subjects_dir=subjects_dir, verbose=True)
 stc.copy().crop(0.05, 0.18).plot(
-    src=morph, subject='fsaverage', subjects_dir=subjects_dir,
-    mode='stat_map', clim=dict(kind='value', pos_lims=lims),
-    initial_time=0.1, verbose=True)
+    src=morph, mode='stat_map', initial_time=0.1, subjects_dir=subjects_dir,
+    clim=dict(kind='value', pos_lims=lims), verbose=True)

--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -50,6 +50,8 @@ fname_inv = os.path.join(sample_dir, 'sample_audvis-meg-vol-7-meg-inv.fif')
 
 fname_t1_fsaverage = os.path.join(subjects_dir, 'fsaverage', 'mri',
                                   'brain.mgz')
+fname_bem_fsaverage = (subjects_dir + '/fsaverage/bem/'
+                       'fsaverage-5120-5120-5120-bem-sol.fif')
 
 ###############################################################################
 # Compute example data. For reference see
@@ -76,16 +78,21 @@ stc.crop(0.09, 0.09)
 # taking ``src`` as only argument. See :class:`mne.SourceMorph` for more
 # details.
 #
-# The default parameter setting for *spacing* will cause the reference volumes
+# The default parameter setting for *zooms* will cause the reference volumes
 # to be resliced before computing the transform. A value of '5' would cause
 # the function to reslice to an isotropic voxel size of 5 mm. The higher this
 # value the less accurate but faster the computation will be.
 #
+# The recommended way to use this is to morph to a specific destination source
+# space so that different ``subject_from`` morphs will go to the same space.`
 # A standard usage for volumetric data reads:
 
-morph = mne.compute_source_morph(inverse_operator['src'],
-                                 subject_from='sample', subject_to='fsaverage',
-                                 subjects_dir=subjects_dir)
+src_fs = mne.setup_volume_source_space(
+    'fsaverage', pos=5., bem=fname_bem_fsaverage, subjects_dir=subjects_dir,
+    verbose=True)
+morph = mne.compute_source_morph(
+    inverse_operator['src'], subject_from='sample', subjects_dir=subjects_dir,
+    verbose=True)
 
 ###############################################################################
 # Apply morph to VolSourceEstimate
@@ -143,13 +150,7 @@ display.add_overlay(img_fsaverage, alpha=0.75)
 #
 # Once the environment is set up correctly, no information such as
 # ``subject_from`` or ``subjects_dir`` must be provided, since it can be
-# inferred from the data and used morph to 'fsaverage' by default. SourceMorph
-# can further be used without creating an instance and assigning it to a
-# variable. Instead :func:`mne.compute_source_morph` and
-# :meth:`mne.SourceMorph.apply` can be
-# easily chained into a handy one-liner. Taking this together the shortest
-# possible way to morph data directly would be:
-
-stc_fsaverage_new = mne.compute_source_morph(
-    inverse_operator['src'], subject_from='sample',
-    subjects_dir=subjects_dir).apply(stc)
+# inferred from the data and used morph to 'fsaverage' by default, e.g.::
+#
+#     >>> morph.apply(stc)
+#

--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -91,7 +91,7 @@ src_fs = mne.read_source_spaces(fname_src_fsaverage)
 morph = mne.compute_source_morph(
     inverse_operator['src'], subject_from='sample', subjects_dir=subjects_dir,
     niter_affine=[10, 10, 5], niter_sdr=[10, 10, 5],  # just for speed
-    verbose=True)
+    src_to=src_fs, verbose=True)
 
 ###############################################################################
 # Apply morph to VolSourceEstimate

--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -50,9 +50,8 @@ fname_inv = os.path.join(sample_dir, 'sample_audvis-meg-vol-7-meg-inv.fif')
 
 fname_t1_fsaverage = os.path.join(subjects_dir, 'fsaverage', 'mri',
                                   'brain.mgz')
-fetch_fsaverage(subjects_dir, verbose=False)  # ensure BEM exists
-fname_bem_fsaverage = (subjects_dir + '/fsaverage/bem/'
-                       'fsaverage-5120-5120-5120-bem-sol.fif')
+fetch_fsaverage(subjects_dir)  # ensure fsaverage src exists
+fname_src_fsaverage = subjects_dir + '/fsaverage/bem/fsaverage-vol-5-src.fif'
 
 ###############################################################################
 # Compute example data. For reference see
@@ -88,12 +87,10 @@ stc.crop(0.09, 0.09)
 # space so that different ``subject_from`` morphs will go to the same space.`
 # A standard usage for volumetric data reads:
 
-src_fs = mne.setup_volume_source_space(
-    'fsaverage', pos=5., bem=fname_bem_fsaverage, subjects_dir=subjects_dir,
-    verbose=True)
+src_fs = mne.read_source_spaces(fname_src_fsaverage)
 morph = mne.compute_source_morph(
     inverse_operator['src'], subject_from='sample', subjects_dir=subjects_dir,
-    n_iter_affine=[10, 10, 5], n_iter_sdr=[10, 10, 5],  # just for speed
+    niter_affine=[10, 10, 5], niter_sdr=[10, 10, 5],  # just for speed
     verbose=True)
 
 ###############################################################################

--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -33,7 +33,7 @@ import os
 
 import nibabel as nib
 import mne
-from mne.datasets import sample
+from mne.datasets import sample, fetch_fsaverage
 from mne.minimum_norm import apply_inverse, read_inverse_operator
 from nilearn.plotting import plot_glass_brain
 
@@ -50,6 +50,7 @@ fname_inv = os.path.join(sample_dir, 'sample_audvis-meg-vol-7-meg-inv.fif')
 
 fname_t1_fsaverage = os.path.join(subjects_dir, 'fsaverage', 'mri',
                                   'brain.mgz')
+fetch_fsaverage(subjects_dir, verbose=False)  # ensure BEM exists
 fname_bem_fsaverage = (subjects_dir + '/fsaverage/bem/'
                        'fsaverage-5120-5120-5120-bem-sol.fif')
 

--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -93,6 +93,7 @@ src_fs = mne.setup_volume_source_space(
     verbose=True)
 morph = mne.compute_source_morph(
     inverse_operator['src'], subject_from='sample', subjects_dir=subjects_dir,
+    n_iter_affine=[10, 10, 5], n_iter_sdr=[10, 10, 5],  # just for speed
     verbose=True)
 
 ###############################################################################

--- a/mne/datasets/_fsaverage/base.py
+++ b/mne/datasets/_fsaverage/base.py
@@ -78,8 +78,8 @@ def fetch_fsaverage(subjects_dir=None, verbose=None):
             destination=op.join(subjects_dir),
         ),
         'bem.zip': dict(
-            url='https://osf.io/7ve8g/download?revision=2',
-            hash_='608c438af6a15a19b66232323088b32d',
+            url='https://osf.io/7ve8g/download?revision=4',
+            hash_='b31509cdcf7908af6a83dc5ee8f49fb1',
             manifest=op.join(FSAVERAGE_MANIFEST_PATH, 'bem.txt'),
             destination=op.join(subjects_dir, 'fsaverage'),
         ),

--- a/mne/datasets/_fsaverage/base.py
+++ b/mne/datasets/_fsaverage/base.py
@@ -138,9 +138,6 @@ def _set_montage_coreg_path(subjects_dir=None):
     """
     subjects_dir = _get_create_subjects_dir(subjects_dir)
     old_subjects_dir = get_subjects_dir(None, raise_error=False)
-    if old_subjects_dir is not None and old_subjects_dir != subjects_dir:
-        raise ValueError('The subjects dir is already set to %r, which does '
-                         'not match the provided subjects_dir=%r'
-                         % (old_subjects_dir, subjects_dir))
-    set_config('SUBJECTS_DIR', subjects_dir)
+    if old_subjects_dir is None:
+        set_config('SUBJECTS_DIR', subjects_dir)
     return subjects_dir

--- a/mne/datasets/_fsaverage/bem.txt
+++ b/mne/datasets/_fsaverage/bem.txt
@@ -5,6 +5,7 @@ bem/outer_skin.surf
 bem/brain.surf
 bem/fsaverage-trans.fif
 bem/fsaverage-ico-5-src.fif
+bem/fsaverage-vol-5-src.fif
 bem/outer_skull.surf
 bem/inner_skull.surf
 bem/fsaverage-5120-5120-5120-bem-sol.fif

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -14,21 +14,21 @@ from .fixes import _get_img_fdata
 from .parallel import parallel_func
 from .source_estimate import (VolSourceEstimate, SourceEstimate,
                               VolVectorSourceEstimate, VectorSourceEstimate,
-                              _get_ico_tris)
+                              _BaseSourceEstimate, _get_ico_tris)
 from .source_space import SourceSpaces, _ensure_src
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
-                    warn as warn_, fill_doc, _check_option,
+                    warn as warn_, fill_doc, _check_option, _validate_type,
                     BunchConst, wrapped_stdout)
 from .externals.h5io import read_hdf5, write_hdf5
 
 
 @verbose
 def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
-                         subjects_dir=None, zooms=5,
+                         subjects_dir=None, zooms='auto',
                          niter_affine=(100, 100, 10), niter_sdr=(5, 5, 3),
                          spacing=5, smooth=None, warn=True, xhemi=False,
-                         sparse=False, verbose=False):
+                         sparse=False, src_to=None, verbose=False):
     """Create a SourceMorph from one subject to another.
 
     Method is based on spherical morphing by FreeSurfer for surface
@@ -43,15 +43,25 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
     subject_from : str | None
         Name of the original subject as named in the SUBJECTS_DIR.
         If None (default), then ``src[0]['subject_his_id]'`` will be used.
-    subject_to : str
+    subject_to : str | None
         Name of the subject to which to morph as named in the SUBJECTS_DIR.
+        Default is `'fsaverage'`. If None, ``src_to[0]['subject_his_id']``
+        will be used.
+
+        .. versionchanged:: 0.20
+           Support for subject_to=None.
     subjects_dir : str | None
         Path to SUBJECTS_DIR if it is not set in the environment. The default
         is None.
-    zooms : float | tuple | None
+    zooms : float | tuple | str | None
         The voxel size of volume for each spatial dimension in mm.
         If spacing is None, MRIs won't be resliced, and both volumes
         must have the same number of spatial dimensions.
+        Can also be ``'auto'`` to use ``5.`` if ``src_to is None`` and
+        the zooms from ``src_to`` otherwise.
+
+        .. versionchanged:: 0.20
+           Support for 'auto' mode.
     niter_affine : tuple of int
         Number of levels (``len(niter_affine)``) and number of
         iterations per level - for each successive stage of iterative
@@ -81,6 +91,14 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         Morph as a sparse source estimate. Works only with (Vector)
         SourceEstimate. If True the only parameters used are subject_to and
         subject_from, and spacing has to be None. Default is sparse=False.
+    src_to : instance of SourceSpaces | None
+        The destination source space, only used for volume source spaces.
+        For volumetric morph, this should be passed so that 1) the resulting
+        morph volume is properly constrained to the brain volume, and 2) STCs
+        from multiple subjects morphed to the same destination subject/source
+        space have the vertices.
+
+        .. versionadded:: 0.20
     %(verbose)s
 
     Notes
@@ -118,15 +136,18 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
     if isinstance(src, (SourceEstimate, VectorSourceEstimate)):
         src_data = dict(vertices_from=copy.deepcopy(src.vertices))
         kind = 'surface'
-        subject_from = _check_subject_from(subject_from, src.subject)
+        subject_from = _check_subject_src(subject_from, src.subject)
     else:
         src = _ensure_src(src)
         src_data, kind = _get_src_data(src)
-        subject_from = _check_subject_from(subject_from, src)
-    if not isinstance(subject_to, str):
-        raise TypeError('subject_to must be str, got type %s (%s)'
-                        % (type(subject_to), subject_to))
+        subject_from = _check_subject_src(subject_from, src)
     del src
+    _validate_type(src_to, (SourceSpaces, None), 'src_to')
+    _validate_type(subject_to, (str, None), 'subject_to')
+    if src_to is None and subject_to is None:
+        raise ValueError('subject_to cannot be None when src_to is None')
+    subject_to = _check_subject_src(subject_to, src_to, 'subject_to')
+
     # Params
     warn = False if sparse else warn
 
@@ -164,12 +185,22 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         with warnings.catch_warnings():
             mri_to = nib.load(mri_path_to)
 
+        # deal with `src_to` subsampling
+        zooms_src_to = None
+        if src_to is not None:
+            src_data['to_vox_map'] = (
+                src_to[0]['shape'], src_to[0]['src_mri_t']['trans'] *
+                np.array([[1e3, 1e3, 1e3, 1]]).T)
+            vertices_to = src_to[0]['vertno']
+            zooms_src_to = np.diag(src_data['to_vox_map'][1])[:3]
+            assert (zooms_src_to[0] == zooms_src_to).all()
+            zooms_src_to = tuple(zooms_src_to)
+
         # pre-compute non-linear morph
+        zooms = _check_zooms(mri_from, zooms, zooms_src_to)
         shape, zooms, affine, pre_affine, sdr_morph = _compute_morph_sdr(
             mri_from, mri_to, niter_affine, niter_sdr, zooms)
 
-        # deal with `src_to` subsampling
-        # _validate_type(src_to, (SourceSpaces, None), 'src_to')
     elif kind == 'surface':
         logger.info('surface source space inferred...')
         shape = affine = pre_affine = sdr_morph = None
@@ -328,6 +359,7 @@ class SourceMorph(object):
         # compute vertices_to here (partly for backward compat and no src
         # provided)
         if vertices_to is None and kind == 'volume':
+            assert src_data['to_vox_map'] is None
             vertices_to = self._get_vertices_nz(np.where(src_data['inuse'])[0])
         self.vertices_to = vertices_to
 
@@ -364,6 +396,8 @@ class SourceMorph(object):
         stc_to : VolSourceEstimate | SourceEstimate | VectorSourceEstimate | Nifti1Image | Nifti2Image
             The morphed source estimates.
         """  # noqa: E501
+        _validate_type(stc_from, _BaseSourceEstimate, 'stc_from',
+                       'SourceEstimate or VolSourceEstimate')
         stc = copy.deepcopy(stc_from)
 
         mri_space = mri_resolution if mri_space is None else mri_space
@@ -390,18 +424,28 @@ class SourceMorph(object):
         # here we use mri_resolution=True, mri_space=True because
         # we will slice afterward
         from dipy.align.reslice import reslice
+        from nibabel.processing import resample_from_to
+        from nibabel.spatialimages import SpatialImage
         assert stc_one.data.shape[1] == 1
         img_to = _interpolate_data(stc_one, self, mri_resolution=True,
                                    mri_space=True, output='nifti1')
+        img_to = _get_img_fdata(img_to)
+        assert img_to.ndim == 4 and img_to.shape[-1] == 1
+        img_to = img_to[:, :, :, 0]
 
         # reslice to match morph
         img_to, img_to_affine = reslice(
-            _get_img_fdata(img_to), self.affine, _get_zooms_orig(self),
-            self.zooms)
+            img_to, self.affine, _get_zooms_orig(self), self.zooms)
 
         # morph data
-        img_to[:, :, :, 0] = self.sdr_morph.transform(
-            self.pre_affine.transform(img_to[:, :, :, 0]))
+        img_to = self.sdr_morph.transform(self.pre_affine.transform(img_to))
+
+        # subselect the correct cube if src_to is provided
+        if self.src_data['to_vox_map'] is not None:
+            # order=0 (nearest) should be fine since it's just subselecting
+            img_to = _get_img_fdata(resample_from_to(
+                SpatialImage(img_to, self.affine),
+                self.src_data['to_vox_map'], order=0))
 
         # reshape to nvoxel x nvol:
         # in the MNE definition of volume source spaces,
@@ -446,24 +490,46 @@ class SourceMorph(object):
         write_hdf5(fname, out_dict, overwrite=overwrite)
 
 
+def _check_zooms(mri_from, zooms, zooms_src_to):
+    # use voxel size of mri_from
+    if isinstance(zooms, str) and zooms == 'auto':
+        zooms = zooms_src_to if zooms_src_to is not None else 5.
+    if zooms is None:
+        zooms = mri_from.header.get_zooms()[:3]
+    zooms = np.atleast_1d(zooms).astype(float)
+    if zooms.shape == (1,):
+        zooms = np.repeat(zooms, 3)
+    if zooms.shape != (3,):
+        raise ValueError('zooms must be None, a singleton, or have shape (3,),'
+                         ' got shape %s' % (zooms.shape,))
+    zooms = tuple(zooms)
+    if zooms_src_to is not None:
+        if not np.allclose(zooms_src_to, zooms, atol=1e-6):
+            raise ValueError('If src_to is provided, zooms should be "auto" '
+                             'or match the src_to zooms (%s), got %s'
+                             % (zooms_src_to, zooms))
+        zooms = zooms_src_to
+    return zooms
+
+
 ###############################################################################
 # I/O
-def _check_subject_from(subject_from, src):
+def _check_subject_src(subject, src, name='subject_from', src_name='src'):
     if isinstance(src, str):
         subject_check = src
     elif src is None:  # assume it's correct although dangerous but unlikely
-        subject_check = subject_from
+        subject_check = subject
     else:
         subject_check = src._subject
-    if subject_from is None:
-        subject_from = subject_check
-    elif subject_check is not None and subject_from != subject_check:
-        raise ValueError('subject_from does not match source space subject'
-                         ' (%s != %s)' % (subject_from, subject_check))
-    if subject_from is None:
-        raise ValueError('subject_from could not be inferred, it must be '
-                         'specified')
-    return subject_from
+    if subject is None:
+        subject = subject_check
+    elif subject_check is not None and subject != subject_check:
+        raise ValueError('%s does not match %s subject (%s != %s)'
+                         % (name, src_name, subject, subject_check))
+    if subject is None:
+        raise ValueError('%s could not be inferred from %s, it must be '
+                         'specified' % (name, src_name))
+    return subject
 
 
 def read_source_morph(fname):
@@ -517,21 +583,16 @@ def _morphed_stc_as_volume(morph, stc, mri_resolution, mri_space, output):
     _check_dep(nibabel='2.1.0', dipy=False)
 
     NiftiImage, NiftiHeader = _triage_output(output)
-    new_zooms = None
-
-    # if full MRI resolution, compute zooms from shape and MRI zooms
-    if isinstance(mri_resolution, bool) and mri_resolution:
-        new_zooms = _get_zooms_orig(morph)
 
     # if MRI resolution is set manually as a single value, convert to tuple
-    if isinstance(mri_resolution, (int, float)) and not isinstance(
-            mri_resolution, bool):
+    if isinstance(mri_resolution, (int, float)):
         # use iso voxel size
         new_zooms = (float(mri_resolution),) * 3
-
-    # if MRI resolution is set manually as a tuple, use it
-    if isinstance(mri_resolution, tuple):
+    elif isinstance(mri_resolution, tuple):
         new_zooms = mri_resolution
+    # if full MRI resolution, compute zooms from shape and MRI zooms
+    if isinstance(mri_resolution, bool):
+        new_zooms = _get_zooms_orig(morph) if mri_resolution else None
 
     # create header
     hdr = NiftiHeader()
@@ -539,14 +600,22 @@ def _morphed_stc_as_volume(morph, stc, mri_resolution, mri_space, output):
     hdr['pixdim'][4] = 1e3 * stc.tstep
 
     # setup empty volume
-    img = np.zeros(morph.shape + (stc.shape[1],)).reshape(-1, stc.shape[1])
+    if morph.src_data['to_vox_map'] is not None:
+        shape = morph.src_data['to_vox_map'][0]
+        affine = morph.src_data['to_vox_map'][1]
+    else:
+        shape = morph.shape
+        affine = morph.affine
+    assert stc.data.ndim == 2
+    n_times = stc.data.shape[1]
+    img = np.zeros((np.prod(shape), n_times))
     img[stc.vertices, :] = stc.data
-
-    img = img.reshape(morph.shape + (-1,), order='F')  # match order='F' above
+    img = img.reshape(shape + (n_times,), order='F')  # match order='F' above
+    del shape
 
     # make nifti from data
     with warnings.catch_warnings():  # nibabel<->numpy warning
-        img = NiftiImage(img, morph.affine, header=hdr)
+        img = NiftiImage(img, affine, header=hdr)
 
     # reslice in case of manually defined voxel size
     zooms = morph.zooms[:3]
@@ -593,7 +662,9 @@ def _get_src_data(src):
                              src_t[0]['mri_height'], src_t[0]['mri_depth'],
                              src_t[0]['mri_width']),
                          'interpolator': src_t[0]['interpolator'],
-                         'inuse': src_t[0]['inuse']})
+                         'inuse': src_t[0]['inuse'],
+                         'to_vox_map': None,
+                         })
     else:
         assert src_kind == 'surface'
         src_data = dict(vertices_from=[s['vertno'].copy() for s in src_t])
@@ -727,8 +798,7 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
 ###############################################################################
 # Morph for VolSourceEstimate
 
-def _compute_morph_sdr(mri_from, mri_to, niter_affine=(100, 100, 10),
-                       niter_sdr=(5, 5, 3), zooms=(5., 5., 5.)):
+def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
     """Get a matrix that morphs data from one subject to another."""
     import nibabel as nib
     with np.testing.suppress_warnings():
@@ -736,16 +806,6 @@ def _compute_morph_sdr(mri_from, mri_to, niter_affine=(100, 100, 10),
     from dipy.align.reslice import reslice
 
     logger.info('Computing nonlinear Symmetric Diffeomorphic Registration...')
-
-    # use voxel size of mri_from
-    if zooms is None:
-        zooms = mri_from.header.get_zooms()[:3]
-    zooms = np.atleast_1d(zooms).astype(float)
-    if zooms.shape == (1,):
-        zooms = np.repeat(zooms, 3)
-    if zooms.shape != (3,):
-        raise ValueError('zooms must be None, a singleton, or have shape (3,),'
-                         ' got shape %s' % (zooms.shape,))
 
     # reslice mri_from
     mri_from_res, mri_from_res_affine = reslice(
@@ -1099,12 +1159,18 @@ def _get_zooms_orig(morph):
             zip(morph.zooms, morph.shape, morph.src_data['src_shape_full'])]
 
 
+def _check_vertices_match(v1, v2, name):
+    if not np.array_equal(v1, v2):
+        raise ValueError('vertices do not match between morph (%s) '
+                         'and stc (%s) for the %s:\n%s\n%s'
+                         % (len(v1), len(v2), name, v1, v2))
+
+
 def _apply_morph_data(morph, stc_from):
     """Morph a source estimate from one subject to another."""
     if stc_from.subject is not None and stc_from.subject != morph.subject_from:
         raise ValueError('stc.subject (%s) != morph.subject_from (%s)'
                          % (stc_from.subject, morph.subject_from))
-    vertices_to = morph.vertices_to
     if morph.kind == 'volume':
         if isinstance(stc_from, VolSourceEstimate):
             klass = VolSourceEstimate
@@ -1113,18 +1179,18 @@ def _apply_morph_data(morph, stc_from):
         else:
             raise ValueError('stc_from was type %s but must be a volume '
                              'source estimate' % (type(stc_from),))
-
-        # First get the vertices (vertices_to) you will need the values for
+        vertices_from = np.where(morph.src_data['inuse'])[0]
+        _check_vertices_match(stc_from.vertices, vertices_from, 'volume')
         n_times = np.prod(stc_from.data.shape[1:])
-        data = np.empty((len(vertices_to), n_times))
+        data = np.empty((len(morph.vertices_to), n_times))
         data_from = np.reshape(stc_from.data, (stc_from.data.shape[0], -1))
         # Loop over time points to save memory
         for k in range(n_times):
             this_stc = VolSourceEstimate(
                 data_from[:, k:k + 1], stc_from.vertices, tmin=0., tstep=1.)
             this_img_to = morph._morph_one_vol(this_stc)
-            data[:, k] = this_img_to[vertices_to]
-        data.shape = (len(vertices_to),) + stc_from.data.shape[1:]
+            data[:, k] = this_img_to[morph.vertices_to]
+        data.shape = (len(morph.vertices_to),) + stc_from.data.shape[1:]
     else:
         assert morph.kind == 'surface'
         if not isinstance(stc_from, (SourceEstimate, VectorSourceEstimate)):
@@ -1134,10 +1200,7 @@ def _apply_morph_data(morph, stc_from):
         for hemi, v1, v2 in zip(('left', 'right'),
                                 morph.src_data['vertices_from'],
                                 stc_from.vertices):
-            if not np.array_equal(v1, v2):
-                raise ValueError('vertices do not match between morph (%s) '
-                                 'and stc (%s) for the %s hemisphere:\n%s\n%s'
-                                 % (len(v1), len(v2), hemi, v1, v2))
+            _check_vertices_match(v1, v2, '%s hemisphere' % (hemi,))
 
         # select correct data - since vertices_to can have empty hemispheres,
         # the correct data needs to be selected in order to apply the morph_mat
@@ -1153,6 +1216,6 @@ def _apply_morph_data(morph, stc_from):
         else:
             data = morph_mat * data
             klass = SourceEstimate
-    stc_to = klass(data, vertices_to, stc_from.tmin, stc_from.tstep,
+    stc_to = klass(data, morph.vertices_to, stc_from.tmin, stc_from.tstep,
                    morph.subject_to)
     return stc_to

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -19,7 +19,7 @@ from .source_space import SourceSpaces, _ensure_src
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
-                    BunchConst, wrapped_stdout)
+                    BunchConst, wrapped_stdout, _check_fname)
 from .externals.h5io import read_hdf5, write_hdf5
 
 
@@ -480,6 +480,7 @@ class SourceMorph(object):
             If True, overwrite existing file.
         %(verbose_meth)s
         """
+        fname = _check_fname(fname, overwrite=overwrite, must_exist=False)
         if not fname.endswith('.h5'):
             fname = '%s-morph.h5' % fname
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1695,11 +1695,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
     @verbose
     def __init__(self, data, vertices=None, tmin=None, tstep=None,
                  subject=None, verbose=None):  # noqa: D102
-        if not (isinstance(vertices, np.ndarray) or
-                isinstance(vertices, list)):
-            raise ValueError('Vertices must be a numpy array or a list of '
-                             'arrays')
-
+        _validate_type(vertices, (np.ndarray, list), 'vertices')
         _BaseSourceEstimate.__init__(self, data, vertices=vertices, tmin=tmin,
                                      tstep=tstep, subject=subject,
                                      verbose=verbose)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1900,7 +1900,7 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
                         % (c, 1000 * mi * grid, 1000 * ma * grid))
 
     # Now make the initial grid
-    ns = maxn - minn + 1
+    ns = tuple(maxn - minn + 1)
     npts = np.prod(ns)
     nrow = ns[0]
     ncol = ns[1]

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -21,7 +21,7 @@ from mne.datasets import testing
 from mne.minimum_norm import (apply_inverse, read_inverse_operator,
                               make_inverse_operator)
 from mne.source_space import get_volume_labels_from_aseg
-from mne.utils import (run_tests_if_main, requires_nibabel, _TempDir,
+from mne.utils import (run_tests_if_main, requires_nibabel,
                        requires_dipy, requires_h5py, requires_version)
 from mne.fixes import _get_args
 
@@ -169,10 +169,8 @@ def test_xhemi_morph():
 
 @requires_h5py
 @testing.requires_testing_data
-def test_surface_vector_source_morph():
+def test_surface_vector_source_morph(tmpdir):
     """Test surface and vector source estimate morph."""
-    tempdir = _TempDir()
-
     inverse_operator_surf = read_inverse_operator(fname_inv_surf)
 
     stc_surf = read_source_estimate(fname_smorph, subject='sample')
@@ -203,9 +201,9 @@ def test_surface_vector_source_morph():
     assert 'surface' in repr(source_morph_surf)
 
     # check loading and saving for surf
-    source_morph_surf.save(op.join(tempdir, '42.h5'))
+    source_morph_surf.save(tmpdir.join('42.h5'))
 
-    source_morph_surf_r = read_source_morph(op.join(tempdir, '42.h5'))
+    source_morph_surf_r = read_source_morph(tmpdir.join('42.h5'))
 
     assert (all([read == saved for read, saved in
                  zip(sorted(source_morph_surf_r.__dict__),
@@ -226,10 +224,9 @@ def test_surface_vector_source_morph():
 @requires_dipy()
 @pytest.mark.slowtest
 @testing.requires_testing_data
-def test_volume_source_morph():
+def test_volume_source_morph(tmpdir):
     """Test volume source estimate morph, special cases and exceptions."""
     import nibabel as nib
-    tempdir = _TempDir()
     inverse_operator_vol = read_inverse_operator(fname_inv_vol)
     stc_vol = read_source_estimate(fname_vol, 'sample')
 
@@ -288,18 +285,19 @@ def test_volume_source_morph():
                              subjects_dir=subjects_dir)
 
     # two different ways of saving
-    source_morph_vol.save(op.join(tempdir, 'vol'))
+    source_morph_vol.save(tmpdir.join('vol'))
 
     # check loading
-    source_morph_vol_r = read_source_morph(
-        op.join(tempdir, 'vol-morph.h5'))
+    source_morph_vol_r = read_source_morph(tmpdir.join('vol-morph.h5'))
 
     # check for invalid file name handling ()
     with pytest.raises(IOError, match='not found'):
-        read_source_morph(op.join(tempdir, '42'))
+        read_source_morph(tmpdir.join('42'))
 
     # check morph
     stc_vol_morphed = source_morph_vol.apply(stc_vol)
+    # old way, verts do not match
+    assert not np.array_equal(stc_vol_morphed.vertices, stc_vol.vertices)
 
     # vector
     stc_vol_vec = VolVectorSourceEstimate(
@@ -376,6 +374,25 @@ def test_volume_source_morph():
     stc_surf = read_source_estimate(fname_stc, 'sample')
     with pytest.raises(ValueError, match='stc_from was type'):
         source_morph_vol.apply(stc_surf)
+
+    # src_to
+    # zooms=20 does not match src_to zooms (7)
+    with pytest.raises(ValueError, match='If src_to is provided, zooms shoul'):
+        source_morph_vol = compute_source_morph(
+            fwd['src'], subject_from='sample', src_to=fwd['src'],
+            subjects_dir=subjects_dir, **kwargs)
+    # hack the src_to "zooms" to make it seem like a pos=20. source space
+    fwd['src'][0]['src_mri_t']['trans'][:3, :3] = 0.02 * np.eye(3)
+    source_morph_vol = compute_source_morph(
+        fwd['src'], subject_from='sample', src_to=fwd['src'],
+        subjects_dir=subjects_dir, **kwargs)
+    stc_vol_2 = source_morph_vol.apply(stc_vol)
+    # new way, verts match
+    assert_array_equal(stc_vol.vertices, stc_vol_2.vertices)
+    stc_vol_bad = VolSourceEstimate(
+        stc_vol.data[:-1], stc_vol.vertices[:-1], stc_vol.tmin, stc_vol.tstep)
+    with pytest.raises(ValueError, match='vertices do not match between morp'):
+        source_morph_vol.apply(stc_vol_bad)
 
 
 @pytest.mark.slowtest

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -364,7 +364,7 @@ def test_volume_source_morph():
         compute_source_morph(src=src, subject_from='42')
     with pytest.raises(ValueError, match='output'):
         source_morph_vol.apply(stc_vol, output='42')
-    with pytest.raises(TypeError, match='subject_to must'):
+    with pytest.raises(ValueError, match='subject_to cannot be None'):
         compute_source_morph(src, 'sample', None,
                              subjects_dir=subjects_dir)
     # Check if not morphed, but voxel size not boolean, raise ValueError.
@@ -441,7 +441,7 @@ def test_morph_stc_dense():
             subjects_dir=subjects_dir)
 
     # subject from mismatch
-    with pytest.raises(ValueError, match="does not match source space subj"):
+    with pytest.raises(ValueError, match="subject_from does not match"):
         compute_source_morph(stc_from, subject_from='foo',
                              subjects_dir=subjects_dir)
 


### PR DESCRIPTION
Closes #6265.

- [x] Refactor code a bit
- [x] Add some documentation of orders
- [x] Compute and store `vertices_to` with the object
- [x] Add `src_to` argument
- [x] Ensure `src_to` output is correct
- [x] Update a couple of examples
- [x] Add check that `vertices_from` in `apply` matches the ones during init
- [x] Add `fsaverage-vol-5-src.fif` to `fsaverage` data fetcher for standardization, speed
- [x] Add test for bad `vertices_from` in `stc`
- [x] Add tests using `src_to` (e.g., check `np.array_equal(src_to[0]['vertno'], stc.vertices)`)
- [x] Update `latest.inc`

Pushing now just to make sure everything is still green after initial refactoring that shouldn't change functionality.