### PR TITLE
More conservative decim warning

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -12,11 +12,10 @@
 Current (0.20.dev0)
 -------------------
 
-- Add reader for NIRx data in :func:`mne.io.read_raw_nirx` by `Robert Luke`_
-
-
 Changelog
 ~~~~~~~~~
+
+- Add reader for NIRx data in :func:`mne.io.read_raw_nirx` by `Robert Luke`_
 
 - Add the ability to ``return_event_id`` in :func:`mne.read_events` for use with MNE-C produced ``-annot.fif`` files, by `Eric Larson`_
 
@@ -25,3 +24,4 @@ Bug
 
 API
 ~~~
+

--- a/examples/datasets/plot_opm_data.py
+++ b/examples/datasets/plot_opm_data.py
@@ -44,7 +44,8 @@ tmin, tmax = -0.5, 1
 event_id = dict(Median=257)
 events = mne.find_events(raw, stim_channel='STI101', mask=257, mask_type='and')
 picks = mne.pick_types(raw.info, meg=True, eeg=False)
-epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
+# we use verbose='error' to suppress warning about decimation causing aliasing
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, verbose='error',
                     reject=reject, picks=picks, proj=False, decim=4)
 evoked = epochs.average()
 evoked.plot()

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -46,9 +46,9 @@ event_id = {'Auditory/Left': 1, 'Auditory/Right': 2,
             'Visual/Left': 3, 'Visual/Right': 4}
 tmin = -0.050
 tmax = 0.400
-decim = 2  # decimate to make the example faster to run, but then use
-           # verbose='error' in the Epochs constructor to suppress warning
-           # about decimation causing aliasing
+# decimate to make the example faster to run, but then use verbose='error' in
+# the Epochs constructor to suppress warning about decimation causing aliasing
+decim = 2
 epochs = mne.Epochs(raw, events, event_id=event_id, tmin=tmin, tmax=tmax,
                     proj=True, picks=picks, baseline=None, preload=True,
                     reject=dict(mag=5e-12), decim=decim, verbose='error')

--- a/examples/decoding/plot_decoding_time_generalization_conditions.py
+++ b/examples/decoding/plot_decoding_time_generalization_conditions.py
@@ -46,10 +46,12 @@ event_id = {'Auditory/Left': 1, 'Auditory/Right': 2,
             'Visual/Left': 3, 'Visual/Right': 4}
 tmin = -0.050
 tmax = 0.400
-decim = 2  # decimate to make the example faster to run
+decim = 2  # decimate to make the example faster to run, but then use
+           # verbose='error' in the Epochs constructor to suppress warning
+           # about decimation causing aliasing
 epochs = mne.Epochs(raw, events, event_id=event_id, tmin=tmin, tmax=tmax,
                     proj=True, picks=picks, baseline=None, preload=True,
-                    reject=dict(mag=5e-12), decim=decim)
+                    reject=dict(mag=5e-12), decim=decim, verbose='error')
 
 ###############################################################################
 # We will train the classifier on all left visual vs auditory trials

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -28,7 +28,7 @@ def _get_data(ch_decim=1):
     # Read evoked
     evoked = mne.read_evokeds(fname_ave, 0, baseline=(None, 0))
     evoked.info['bads'] = ['MEG 2443']
-    evoked.info['lowpass'] = 20  # fake for decim
+    evoked.info['lowpass'] = 16  # fake for decim
     evoked.decimate(12)
     evoked.crop(0.0, 0.3)
     picks = mne.pick_types(evoked.info, meg=True, eeg=False)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -647,7 +647,7 @@ def _check_decim(info, decim, offset):
              'filtered. The decim=%i parameter will result in a sampling '
              'frequency of %g Hz, which can cause aliasing artifacts.'
              % (decim, new_sfreq))
-    elif decim > 1 and new_sfreq < 2.5 * lowpass:
+    elif decim > 1 and new_sfreq < 3 * lowpass:
         warn('The measurement information indicates a low-pass frequency '
              'of %g Hz. The decim=%i parameter will result in a sampling '
              'frequency of %g Hz, which can cause aliasing artifacts.'


### PR DESCRIPTION
the epochs test pass locally, let's see if there are other tests that fail now :)

cc @agramfort @robertoostenveld

@larsoner the rationale here is that a factor of 2.5 is based on MNE-C filter defaults, which had steeper rolloffs than the current MNE-Python default, so 3 is safer (and easier to remember / work with as a rule of thumb in tutorials, etc)