### PR TITLE
ENH: Add source space SNR estimate

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1132,10 +1132,11 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         forward model for a source with unit amplitude, :math:`a` is the
         source amplitude, :math:`N` is the number of sensors, and
         :math:`s_k^2` is the noise variance on sensor :math:`k`.
-        
-        Reference:
-        Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,
-        Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
+               
+        References:
+        ----------
+        .. [1] Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, 
+        D., Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
         Mapping the Signal-To-Noise-Ratios of Cortical Sources in
         Magnetoencephalography and Electroencephalography.
         Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1099,10 +1099,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
     @verbose
     def estimate_snr(self, info, fwd, cov, verbose=None):
-        """Compute time-varying SNR in the source space
+        """Compute time-varying SNR in the source space.
 
         This function should only be used with source estimates with units
-        nA (i.e., MNE-like solutions, *not* dSPM or sLORETA).
+        nanoAmperes (i.e., MNE-like solutions, *not* dSPM or sLORETA).
 
         Reference:
         Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1099,17 +1099,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
     @verbose
     def estimate_snr(self, info, fwd, cov, verbose=None):
-        """Compute time-varying SNR in the source space.
+        r"""Compute time-varying SNR in the source space.
 
         This function should only be used with source estimates with units
         nanoAmperes (i.e., MNE-like solutions, *not* dSPM or sLORETA).
-
-        Reference:
-        Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,
-        Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
-        Mapping the Signal-To-Noise-Ratios of Cortical Sources in
-        Magnetoencephalography and Electroencephalography.
-        Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
 
         Parameters
         ----------
@@ -1133,12 +1126,19 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
         .. math::
 
-            {\\rm SNR} = 10\\log_10[\\frac{a^2}{N}\\sum_k\\frac{b_k^2}{s_k^2}]
+            {\rm SNR} = 10\log_10[\frac{a^2}{N}\sum_k\frac{b_k^2}{s_k^2}]
 
         where :math:`\\b_k` is the signal on sensor :math:`k` provided by the
         forward model for a source with unit amplitude, :math:`a` is the
         source amplitude, :math:`N` is the number of sensors, and
         :math:`s_k^2` is the noise variance on sensor :math:`k`.
+        
+        Reference:
+        Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,
+        Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
+        Mapping the Signal-To-Noise-Ratios of Cortical Sources in
+        Magnetoencephalography and Electroencephalography.
+        Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
         """
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward
@@ -1153,16 +1153,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         
         # G is gain matrix [ch x src], cov is noise covariance [ch x ch]
         _, _, G, _, _, _, _, cov, _ = _prepare_forward(fwd, info, cov,
-                                                                fixed=True, 
-                                                                loose=0, 
-                                                                rank=None, 
-                                                                pca=False,
-                                                                use_cps=True, 
-                                                                exp=None, 
-                                                                limit_depth_chs=False, 
-                                                                combine_xyz='fro',
-                                                                allow_fixed_depth=True, 
-                                                                limit=None)
+                                fixed=True, loose=0, rank=None, pca=False,
+                                use_cps=True, exp=None, limit_depth_chs=False,
+                                combine_xyz='fro', allow_fixed_depth=True,
+                                limit=None)
 
         N = cov['dim'] # number of sensors/channels    
         b_k2 = (G * G).T

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1142,7 +1142,6 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         """
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward
-        from mne import SourceEstimate
         
         M = np.shape(self.data)[0]
         T = np.shape(self.data)[1]
@@ -1158,11 +1157,11 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
                                 combine_xyz='fro', allow_fixed_depth=True,
                                 limit=None)
 
-        N = cov['dim'] # number of sensors/channels    
+        N = info.cov['dim'] # number of sensors/channels    
         b_k2 = (G * G).T
         s_k2 = np.diag(cov['data'])                
-        scaling = (1/N) * np.sum(b_k2 /s_k2, axis=1)[:, np.newaxis]  
-        snr_stc.data = 10*np.log10((self.data * self.data) * scaling)
+        scaling = (1 / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]  
+        snr_stc.data = 10 * np.log10((self.data * self.data) * scaling)
                         
         return snr_stc
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1143,10 +1143,6 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         """
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward
-
-        n_src, n_times = self.data.shape
-        snr_stc = SourceEstimate(np.zeros((n_src, n_times)), self.vertices, self.tmin, 
-                                 self.tstep, self.subject)
         
         fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
         
@@ -1161,7 +1157,8 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         b_k2 = (G * G).T
         s_k2 = np.diag(cov['data'])                
         scaling = (1 / n_channels) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]  
-        snr_stc.data = 10 * np.log10((self.data * self.data) * scaling)
+        snr_stc = SourceEstimate(10 * np.log10((self.data * self.data) * scaling), 
+                                 self.vertices, self.tmin, self.tstep, self.subject)
                         
         return snr_stc
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1157,7 +1157,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
                                 combine_xyz='fro', allow_fixed_depth=True,
                                 limit=None)
 
-        N = info.cov['dim'] # number of sensors/channels    
+        N = cov['dim'] # number of sensors/channels    
         b_k2 = (G * G).T
         s_k2 = np.diag(cov['data'])                
         scaling = (1 / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]  

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1099,6 +1099,81 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
         return stcs
 
+    @verbose
+    def estimate_snr(self, info, fwd, cov, verbose=None):
+        """Compute time-varying SNR
+
+        This function should only be used with source estimates with units
+        nA (i.e., MNE-like solutions, *not* dSPM or sLORETA).
+
+        Reference:
+        Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,
+        Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
+        Mapping the Signal-To-Noise-Ratios of Cortical Sources in
+        Magnetoencephalography and Electroencephalography.
+        Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
+
+        Parameters
+        ----------
+        info : instance of io.meas_info.Info
+            The measurement info.
+        fwd : instance of Forward
+            The forward solution used to create the source estimate.
+        cov : instance of Covariance
+            The noise covariance used to estimate the resting cortical
+            activations. Should be an evoked covariance, not empty room.
+
+        Returns
+        -------
+        snr_stc : instance of SourceEstimate
+            The source estimate with the SNR computed.
+
+        Notes
+        -----
+        We define the SNR in decibels for each source location at each
+        time point as:
+
+        .. math::
+
+            {\\rm SNR} = 10\\log_10[\\frac{a^2}{N}\\sum_k\\frac{b_k^2}{s_k^2}]
+
+        where :math:`\\b_k` is the signal on sensor :math:`k` provided by the
+        forward model for a source with unit amplitude, :math:`a` is the
+        source amplitude, :math:`N` is the number of sensors, and
+        :math:`s_k^2` is the noise variance on sensor :math:`k`.
+        """
+        from .forward import convert_forward_solution
+        from .minimum_norm.inverse import _prepare_forward
+
+        fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
+        print("done convert forward solution\n")
+
+
+
+        #def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
+        #                     use_cps, exp, limit_depth_chs, combine_xyz,
+        #                     allow_fixed_depth, limit):
+
+    #    return (forward, info_picked, gain, depth_prior, orient_prior, source_std,
+    #            trace_GRGT, noise_cov, whitener)
+        
+        _, _, _, _, _, A, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
+                                                       use_cps=True, exp=None, limit_depth_chs=False, combine_xyz='fro',
+                                                       allow_fixed_depth=True, limit=None)
+
+        print("done _prepare_forward\n")
+        N = cov['dim']
+        print ("N = %d sensors\n" % N)
+        b_k2 = (A * A).T
+        s_k2 = np.diag(cov['data'])
+        
+        print (np.shape(b_k2))
+        print (np.shape(s_k2))
+        scaling = (1. / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]
+    #    print (np.shape(scaling))
+        
+        print("End of SNR Func\n")
+
 
 def _center_of_mass(vertices, values, hemi, surf, subject, subjects_dir,
                     restrict_vertices):
@@ -2745,80 +2820,3 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
         label_tc = label_tc[0]
 
     return label_tc
-
-
-@verbose
-def estimate_snr(self, info, fwd, cov, verbose=None):
-    """Compute time-varying SNR
-
-    This function should only be used with source estimates with units
-    nA (i.e., MNE-like solutions, *not* dSPM or sLORETA).
-
-    Reference:
-    Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, D.,
-    Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
-    Mapping the Signal-To-Noise-Ratios of Cortical Sources in
-    Magnetoencephalography and Electroencephalography.
-    Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
-
-    Parameters
-    ----------
-    info : instance of io.meas_info.Info
-        The measurement info.
-    fwd : instance of Forward
-        The forward solution used to create the source estimate.
-    cov : instance of Covariance
-        The noise covariance used to estimate the resting cortical
-        activations. Should be an evoked covariance, not empty room.
-
-    Returns
-    -------
-    snr_stc : instance of SourceEstimate
-        The source estimate with the SNR computed.
-
-    Notes
-    -----
-    We define the SNR in decibels for each source location at each
-    time point as:
-
-    .. math::
-
-        {\\rm SNR} = 10\\log_10[\\frac{a^2}{N}\\sum_k\\frac{b_k^2}{s_k^2}]
-
-    where :math:`\\b_k` is the signal on sensor :math:`k` provided by the
-    forward model for a source with unit amplitude, :math:`a` is the
-    source amplitude, :math:`N` is the number of sensors, and
-    :math:`s_k^2` is the noise variance on sensor :math:`k`.
-    """
-    from .forward import convert_forward_solution
-    from .minimum_norm.inverse import _prepare_forward
-
-    fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
-    print("done convert forward solution\n")
-
-
-
-    #def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
-    #                     use_cps, exp, limit_depth_chs, combine_xyz,
-    #                     allow_fixed_depth, limit):
-
-#    return (forward, info_picked, gain, depth_prior, orient_prior, source_std,
-#            trace_GRGT, noise_cov, whitener)
-    
-    _, _, _, _, _, A, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
-                                                   use_cps=True, exp=None, limit_depth_chs=False, combine_xyz='fro',
-                                                   allow_fixed_depth=True, limit=None)
-
-    print("done _prepare_forward\n")
-    N = cov['dim']
-    print ("N = %d sensors\n" % N)
-    b_k2 = (A * A).T
-    s_k2 = np.diag(cov['data'])
-    
-    print (np.shape(b_k2))
-    print (np.shape(s_k2))
-    scaling = (1. / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]
-#    print (np.shape(scaling))
-    
-    print("End of SNR Func\n")
-    

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1143,10 +1143,9 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         """
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward
-        
-        M = np.shape(self.data)[0]
-        T = np.shape(self.data)[1]
-        snr_stc = SourceEstimate(np.zeros((M, T)), self.vertices, self.tmin, 
+
+        n_src, n_times = self.data.shape
+        snr_stc = SourceEstimate(np.zeros((n_src, n_times)), self.vertices, self.tmin, 
                                  self.tstep, self.subject)
         
         fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1134,7 +1134,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         source amplitude, :math:`N` is the number of sensors, and
         :math:`s_k^2` is the noise variance on sensor :math:`k`.
                
-        References:
+        References
         ----------
         .. [1] Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, 
                D., Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1145,6 +1145,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward
 
+        snr_stc = self.copy()
         fwd = convert_forward_solution(fwd, surf_ori=True, force_fixed=True)
         print("done convert forward solution\n")
 
@@ -1157,22 +1158,24 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
     #    return (forward, info_picked, gain, depth_prior, orient_prior, source_std,
     #            trace_GRGT, noise_cov, whitener)
         
-        _, _, _, _, _, source_std, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
+        _, _, G, _, _, source_std, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
                                                        use_cps=True, exp=None, limit_depth_chs=False, combine_xyz='fro',
                                                        allow_fixed_depth=True, limit=None)
 
         print("done _prepare_forward\n")
         N = cov['dim']
         print ("N = %d sensors\n" % N)
-        b_k2 = (source_std * source_std).T
+        b_k2 = (G * G).T
         s_k2 = np.diag(cov['data'])
         
         print (np.shape(b_k2))
         print (np.shape(s_k2))
         scaling = (1. / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]
     #    print (np.shape(scaling))
-        
+        snr_stc._data = (snr_stc.data * snr_stc.data) * scaling
+
         print("End of SNR Func\n")
+        return snr_stc
 
 
 def _center_of_mass(vertices, values, hemi, surf, subject, subjects_dir,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1157,10 +1157,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
                                 combine_xyz='fro', allow_fixed_depth=True,
                                 limit=None)
 
-        N = cov['dim'] # number of sensors/channels    
+        n_channels = cov['dim'] # number of sensors/channels    
         b_k2 = (G * G).T
         s_k2 = np.diag(cov['data'])                
-        scaling = (1 / N) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]  
+        scaling = (1 / n_channels) * np.sum(b_k2 / s_k2, axis=1)[:, np.newaxis]  
         snr_stc.data = 10 * np.log10((self.data * self.data) * scaling)
                         
         return snr_stc

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1157,14 +1157,14 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
     #    return (forward, info_picked, gain, depth_prior, orient_prior, source_std,
     #            trace_GRGT, noise_cov, whitener)
         
-        _, _, _, _, _, A, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
+        _, _, _, _, _, source_std, _, cov, _ = _prepare_forward(fwd, info, cov, fixed=True, loose=0, rank=None, pca=False,
                                                        use_cps=True, exp=None, limit_depth_chs=False, combine_xyz='fro',
                                                        allow_fixed_depth=True, limit=None)
 
         print("done _prepare_forward\n")
         N = cov['dim']
         print ("N = %d sensors\n" % N)
-        b_k2 = (A * A).T
+        b_k2 = (source_std * source_std).T
         s_k2 = np.diag(cov['data'])
         
         print (np.shape(b_k2))

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -23,8 +23,8 @@ from .utils import (get_subjects_dir, _check_subject, logger, verbose,
                     fill_doc, _check_option, _validate_type, _check_src_normal)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
-from .io.base import ToDataFrameMixin, TimeMixin
-from .externals.h5io import read_hdf5, write_hdf5
+from .io.base import (ToDataFrameMixin, TimeMixin)
+from .externals.h5io import (read_hdf5, write_hdf5)
 
 def _read_stc(filename):
     """Aux Function."""
@@ -1136,10 +1136,10 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         References:
         ----------
         .. [1] Goldenholz, D. M., Ahlfors, S. P., Hämäläinen, M. S., Sharon, 
-        D., Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
-        Mapping the Signal-To-Noise-Ratios of Cortical Sources in
-        Magnetoencephalography and Electroencephalography.
-        Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
+               D., Ishitobi, M., Vaina, L. M., & Stufflebeam, S. M. (2009).
+               Mapping the Signal-To-Noise-Ratios of Cortical Sources in
+               Magnetoencephalography and Electroencephalography.
+               Human Brain Mapping, 30(4), 1077–1086. doi:10.1002/hbm.20571
         """
         from .forward import convert_forward_solution
         from .minimum_norm.inverse import _prepare_forward

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -23,8 +23,9 @@ from .utils import (get_subjects_dir, _check_subject, logger, verbose,
                     fill_doc, _check_option, _validate_type, _check_src_normal)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
-from .io.base import (ToDataFrameMixin, TimeMixin)
-from .externals.h5io import (read_hdf5, write_hdf5)
+from .io.base import ToDataFrameMixin, TimeMixin
+from .externals.h5io import read_hdf5, write_hdf5
+
 
 def _read_stc(filename):
     """Aux Function."""

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -49,6 +49,10 @@ kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
               size=(600, 600))
 
 stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
+stc.estimate_snr(evoked.info, fwd, cov)
+
+sdfsdfdsf
+
 brain = stc.plot(figure=1, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
 

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -49,13 +49,15 @@ kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
               size=(600, 600))
 
 stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
-stc_snr = stc.estimate_snr(evoked.info, fwd, cov)
+snr_stc = stc.estimate_snr(evoked.info, fwd, cov)
 
-stc_snr.plot(subjects_dir=subjects_dir)
+kwargs2 = dict(initial_time=0.29, hemi='both', subjects_dir=subjects_dir,
+              size=(600, 600),colormap='coolwarm',clim=dict(kind='value', lims=(-20,0,20)))
+snr_stc.plot(figure=1, **kwargs2)
 
 sdfsdfdsf
 
-brain = stc.plot(figure=1, **kwargs)
+brain = stc.plot(figure=3, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
 
 

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -49,7 +49,9 @@ kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
               size=(600, 600))
 
 stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
-stc.estimate_snr(evoked.info, fwd, cov)
+stc_snr = stc.estimate_snr(evoked.info, fwd, cov)
+
+stc_snr.plot(subjects_dir=subjects_dir)
 
 sdfsdfdsf
 

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -49,15 +49,7 @@ kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
               size=(600, 600))
 
 stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
-snr_stc = stc.estimate_snr(evoked.info, fwd, cov)
-
-kwargs2 = dict(initial_time=0.29, hemi='both', subjects_dir=subjects_dir,
-              size=(600, 600),colormap='coolwarm',clim=dict(kind='value', lims=(-20,0,20)))
-snr_stc.plot(figure=1, **kwargs2)
-
-sdfsdfdsf
-
-brain = stc.plot(figure=3, **kwargs)
+brain = stc.plot(figure=1, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
 
 

--- a/tutorials/source-modeling/plot_source_space_SNR.py
+++ b/tutorials/source-modeling/plot_source_space_SNR.py
@@ -45,12 +45,11 @@ inv = make_inverse_operator(evoked.info, fwd, cov, loose=0., depth=0.8,
 
 snr = 3.0
 lambda2 = 1.0 / snr ** 2
-kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
-              size=(600, 600))
 
-stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
+stc = apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True)
 snr_stc = stc.estimate_snr(evoked.info, fwd, cov)
 
-kwargs2 = dict(initial_time=0.29, hemi='both', subjects_dir=subjects_dir,
-              size=(600, 600),colormap='coolwarm',clim=dict(kind='value', lims=(-20,0,20)))
-snr_stc.plot(figure=1, **kwargs2)
+kwargs = dict(initial_time=0.29, hemi='both', subjects_dir=subjects_dir,
+              size=(600, 600), colormap='viridis',
+              clim=dict(kind='value', lims=(-20, 0, 20)))
+snr_stc.plot(figure=1, **kwargs)

--- a/tutorials/source-modeling/plot_source_space_SNR.py
+++ b/tutorials/source-modeling/plot_source_space_SNR.py
@@ -9,7 +9,8 @@ Computing source space SNR
 This example shows example fixed- and free-orientation source localizations
 produced by MNE, dSPM, sLORETA, and eLORETA.
 """
-# Author: Eric Larson <larson.eric.d@gmail.com>
+# Author: Padma Sundaram <tottochan@gmail.com>
+#	  Kaisu Lankinen <klankinen@mgh.harvard.edu>
 #
 # License: BSD (3-clause)
 

--- a/tutorials/source-modeling/plot_source_space_SNR.py
+++ b/tutorials/source-modeling/plot_source_space_SNR.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-.. _tut-mne-fixed-free:
+.. _tut-mne-sourcespace-snr:
 
 ===============================
 Computing source space SNR
 ===============================
 
-This example shows example fixed- and free-orientation source localizations
-produced by MNE, dSPM, sLORETA, and eLORETA.
+This example shows how to compute and plot source space SNR.
 """
 # Author: Padma Sundaram <tottochan@gmail.com>
 #	  Kaisu Lankinen <klankinen@mgh.harvard.edu>

--- a/tutorials/source-modeling/plot_source_space_SNR.py
+++ b/tutorials/source-modeling/plot_source_space_SNR.py
@@ -9,7 +9,7 @@ Computing source space SNR
 This example shows how to compute and plot source space SNR.
 """
 # Author: Padma Sundaram <tottochan@gmail.com>
-#	  Kaisu Lankinen <klankinen@mgh.harvard.edu>
+#         Kaisu Lankinen <klankinen@mgh.harvard.edu>
 #
 # License: BSD (3-clause)
 

--- a/tutorials/source-modeling/plot_source_space_SNR.py
+++ b/tutorials/source-modeling/plot_source_space_SNR.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+.. _tut-mne-fixed-free:
+
+===============================
+Computing source space SNR
+===============================
+
+This example shows example fixed- and free-orientation source localizations
+produced by MNE, dSPM, sLORETA, and eLORETA.
+"""
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import mne
+from mne.datasets import sample
+from mne.minimum_norm import make_inverse_operator, apply_inverse
+
+print(__doc__)
+
+data_path = sample.data_path()
+subjects_dir = data_path + '/subjects'
+
+# Read data
+fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
+evoked = mne.read_evokeds(fname_evoked, condition='Left Auditory',
+                          baseline=(None, 0))
+fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
+fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
+fwd = mne.read_forward_solution(fname_fwd)
+cov = mne.read_cov(fname_cov)
+
+###############################################################################
+# Fixed orientation
+# -----------------
+# First let's create a fixed-orientation inverse, with the default weighting.
+
+inv = make_inverse_operator(evoked.info, fwd, cov, loose=0., depth=0.8,
+                            verbose=True)
+
+###############################################################################
+# Let's look at the current estimates using MNE. We'll take the absolute
+# value of the source estimates to simplify the visualization.
+
+snr = 3.0
+lambda2 = 1.0 / snr ** 2
+kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
+              size=(600, 600))
+
+stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
+snr_stc = stc.estimate_snr(evoked.info, fwd, cov)
+
+kwargs2 = dict(initial_time=0.29, hemi='both', subjects_dir=subjects_dir,
+              size=(600, 600),colormap='coolwarm',clim=dict(kind='value', lims=(-20,0,20)))
+snr_stc.plot(figure=1, **kwargs2)


### PR DESCRIPTION
Co-authors: Padma Sundaram, Kaisu Lankinen (working based on Eric Larson's WIP code from 2015 for this Issue)

#### Reference issue
Fixes #1453 (SNR in Source Space)


#### What does this implement/fix?
We have removed the unnecessary stc object copy in the older version of Eric's WIP code (added to source_estimate.py) and have added a code snippet to test this function in a tutorial file 
(tutorials/source-modeling/plot_source_space_SNR.py)

