### PR TITLE
updated latest.inc and documentation of coordinate in transofrm.py

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,7 +34,5 @@ Bug
 
 - Fix IO of TFRs when event_id contain a / in one of the keys by `Alex Gramfort`_
 
-- Fix threshold setting in :func:`mne.preprocessing.ica.corrmap` by `Fahimeh Mamashli`_ and `Eric Larson`_
-
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,5 +34,7 @@ Bug
 
 - Fix IO of TFRs when event_id contain a / in one of the keys by `Alex Gramfort`_
 
+- Fix threshold setting in :func:`mne.preprocessing.ica.corrmap` by `Fahimeh Mamashli`_ and `Eric Larson`_
+
 API
 ~~~

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -84,7 +84,7 @@ class Transform(dict):
         used.
 
     Notes
-    ------
+    -----
     Valid coordinate frames are 'meg','mri','mri_voxel','head','mri_tal','ras'
     'fs_tal','ctf_head','ctf_meg','unknown'
     """

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -82,6 +82,11 @@ class Transform(dict):
     trans : array-like, shape (4, 4) | None
         The transformation matrix. If None, an identity matrix will be
         used.
+    Notes
+    ------
+    Valid coordinate systems are 'meg','mri','mri_voxel','head','mri_tal','ras'
+    'fs_tal','ctf_head','ctf_meg','unknown'
+    
     """
 
     def __init__(self, fro, to, trans=None):  # noqa: D102

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -76,17 +76,17 @@ class Transform(dict):
     Parameters
     ----------
     fro : str | int
-        The starting coordinate frame.
+        The starting coordinate frame. See notes for valid coordinate frames.
     to : str | int
-        The ending coordinate frame.
+        The ending coordinate frame. See notes for valid coordinate frames.
     trans : array-like, shape (4, 4) | None
         The transformation matrix. If None, an identity matrix will be
         used.
+
     Notes
     ------
-    Valid coordinate systems are 'meg','mri','mri_voxel','head','mri_tal','ras'
+    Valid coordinate frames are 'meg','mri','mri_voxel','head','mri_tal','ras'
     'fs_tal','ctf_head','ctf_meg','unknown'
-    
     """
 
     def __init__(self, fro, to, trans=None):  # noqa: D102


### PR DESCRIPTION
#### Reference issue
I updated the latest.inc @agramfort requested. 
Also:
There was no documentation on the coordinate frame in class transform.
I added the notes as follows:

```
    Notes
    ------
    Valid coordinate systems are 'meg','mri','mri_voxel','head','mri_tal','ras'
    'fs_tal','ctf_head','ctf_meg','unknown'
```

#### What does this implement/fix?
information to select options "to" and "fro" 

ready to review for @agramfort and @larsoner 