### PR TITLE
ENH: Basic anonymization

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Bug
 
 - Fix handling of repeated events in :class:`mne.Epochs` by `Fahimeh Mamashli`_ and `Alex Gramfort`_
 
+- Fix :func:`mne.io.anonymize_info` to allow shifting dates of service and to match anticipated changes in mne-cpp by `Luke Bloy`_
+
 - Fix reading of cardinals in .htps files (identifier are int not strings) by `Alex Gramfort`_
 
 - Fix IO of TFRs when event_id contain a / in one of the keys by `Alex Gramfort`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -22,6 +22,10 @@ Changelog
 
 - Add support for plotting fNIRS channels in :func:`mne.viz.plot_alignment` by `Eric Larson`_
 
+- Add command line tool :ref:`gen_mne_anonymize` for anonymizing raw fiff files by `Luke Bloy`_
+
+- Add support to :func:`mne.io.anonymize_info` to allow time offset to be applied to dates by `Luke Bloy`_
+
 - Add support for computing resolution matrix to get point spread functions (PSF) and cross-talk functions (CTF) in :func:`mne.minimum_norm.make_resolution_matrix`, :func:`mne.minimum_norm.get_cross_talk`, :func:`mne.minimum_norm.get_point_spread` by `Olaf Hauk`_
 
 - Add keyboard functionality to interactive colorbar plotting TFRs by `Stefan Repplinger`_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -573,17 +573,14 @@ class SetChannelsMixin(object):
                             show=show)
 
     @copy_function_doc_to_method_doc(anonymize_info)
-    def anonymize(self, timeshift=None, keep_his=False):
+    def anonymize(self, daysback=None, keep_his=False):
         """
         .. versionadded:: 0.13.0
         """
-        anonymize_info(self.info, timeshift=timeshift, keep_his=keep_his)
+        anonymize_info(self.info, daysback=daysback, keep_his=keep_his)
         if hasattr(self, 'annotations'):
-            # XXX : anonymize should rather subtract a random date
-            # rather than setting it to None
-            self.annotations.orig_time = None
+            self.annotations.orig_time = self.info['meas_date']
             self.annotations.onset -= self._first_time
-
         return self
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -573,11 +573,11 @@ class SetChannelsMixin(object):
                             show=show)
 
     @copy_function_doc_to_method_doc(anonymize_info)
-    def anonymize(self):
+    def anonymize(self, timeshift=None, keep_his=False):
         """
         .. versionadded:: 0.13.0
         """
-        anonymize_info(self.info)
+        anonymize_info(self.info, timeshift=timeshift, keep_his=keep_his)
         if hasattr(self, 'annotations'):
             # XXX : anonymize should rather subtract a random date
             # rather than setting it to None

--- a/mne/commands/mne_anonymize.py
+++ b/mne/commands/mne_anonymize.py
@@ -19,7 +19,7 @@ import os.path as op
 ANONYMIZE_FILE_PREFIX = 'anon'
 
 
-def mne_anonymize(fif_fname, out_fname, dateback, keep_his, overwrite):
+def mne_anonymize(fif_fname, out_fname, keep_his, daysback, overwrite):
     """Call *anonymize_info* on fif file and save.
 
     Parameters
@@ -30,7 +30,7 @@ def mne_anonymize(fif_fname, out_fname, dateback, keep_his, overwrite):
         Output file name
         relative paths are saved relative to parent dir of fif_fname
         None will save to parent dir of fif_fname with default prefix
-    dateback : int | None
+    daysback : int | None
         Number of days to subtract from all dates.
         If None will default to move date of service to Jan 1 2000
     keep_his : bool
@@ -39,12 +39,8 @@ def mne_anonymize(fif_fname, out_fname, dateback, keep_his, overwrite):
     overwrite : bool
         Overwrite output file if it already exists
     """
-    try:
-        raw = mne.io.read_raw_fif(fif_fname, allow_maxshield=True)
-    except Exception:
-        print("Error not a raw fif file")
-        return
-    raw.anonymize(timeshift=dateback, keep_his=keep_his)
+    raw = mne.io.read_raw_fif(fif_fname, allow_maxshield=True)
+    raw.anonymize(daysback=daysback, keep_his=keep_his)
 
     # determine out_fname
     dir_name = op.split(fif_fname)[0]
@@ -65,19 +61,19 @@ def run():
     parser = get_optparser(__file__)
 
     parser.add_option("-f", "--file", type="string", dest="file",
-                      help="the file to modify.", metavar="FILE",
+                      help="Name of file to modify.", metavar="FILE",
                       default=None)
     parser.add_option("-o", "--output", type="string", dest="output",
-                      help="name of anonymized output file. "
+                      help="Name of anonymized output file."
                       "`anon-` prefix is added to FILE if not given",
                       metavar="OUTFILE", default=None)
     parser.add_option("--keep_his", dest="keep_his", action="store_true",
                       help="Keep the HIS tag (not advised)", default=False)
-    parser.add_option("-d", "--dateback", type="int", dest="dateback",
-                      help="move dates in file backwards by this many days",
+    parser.add_option("-d", "--daysback", type="int", dest="daysback",
+                      help="Move dates in file backwards by this many days.",
                       metavar="N_DAYS", default=None)
     parser.add_option("--overwrite", dest="overwrite", action="store_true",
-                      help="overwrite input file", default=False)
+                      help="Overwrite input file.", default=False)
 
     options, args = parser.parse_args()
     if options.file is None:
@@ -87,13 +83,12 @@ def run():
     fname = options.file
     out_fname = options.output
     keep_his = options.keep_his
-    dateback = options.dateback
+    daysback = options.daysback
     overwrite = options.overwrite
-
     if not fname.endswith('.fif'):
         raise ValueError('%s does not seem to be a .fif file.' % fname)
 
-    mne_anonymize(fname, out_fname, keep_his, dateback, overwrite)
+    mne_anonymize(fname, out_fname, keep_his, daysback, overwrite)
 
 
 is_main = (__name__ == '__main__')

--- a/mne/commands/mne_anonymize.py
+++ b/mne/commands/mne_anonymize.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Anonymize .fif file.
+You can do for example:
+$ mne anonymize -f sample_audvis_raw.fif
+"""
+
+# Authors : Dominik Krzeminski
+#           Luke Bloy <luke.bloy@gmail.com>
+
+import sys
+import mne
+import os
+
+ANONYMIZE_FILE_PREFIX = 'anon'
+
+
+def mne_anonymize(fif_fname, out_fname, dateback, keep_his, overwrite):
+    """Call *anonymize_info* on fif file and save.
+    Parameters
+    ----------
+    fif_fname : str
+        Raw fif File
+    out_fname : str
+        Output file name
+    overwrite : bool
+        Overwrite output file if it already exists
+    """
+    dir_name = os.path.split(fif_fname)[0]
+    fif_fname = os.path.basename(fif_fname)
+
+    try:
+        raw = mne.io.read_raw_fif(os.path.join(dir_name, fif_fname),
+                                  allow_maxshield=True)
+    except Exception:
+        print("Error not a raw fif file")
+        return
+    raw.anonymize(timeshift=dateback, keep_his=keep_his)
+
+    if out_fname is not None:
+        out = out_fname
+    else:
+        out = "{}-{}".format(ANONYMIZE_FILE_PREFIX, fif_fname)
+    raw.save(os.path.join(dir_name, out), overwrite=overwrite)
+
+
+def run():
+    """Run *mne_anonymize* command."""
+    from mne.commands.utils import get_optparser
+
+    parser = get_optparser(__file__)
+
+    parser.add_option("-f", "--file", type="string", dest="file",
+                      help="the file to modify.", metavar="FILE",
+                      default=None)
+    parser.add_option("-o", "--output", type="string", dest="output",
+                      help="name of anonymized output file. "
+                      "`anon-` prefix is added to FILE if not given",
+                      metavar="OUTFILE", default=None)
+    parser.add_option("--keep_his", dest="keep_his", action="store_true",
+                      help="Keep the HIS tag (not advised)", default=False)
+    parser.add_option("-d", "--dateback", type="int", dest="dateback",
+                      help="move dates in file backwards by this many days",
+                      metavar="N_DAYS", default=None)
+    parser.add_option("--overwrite", dest="overwrite", action="store_true",
+                      help="overwrite input file", default=False)
+
+    options, args = parser.parse_args()
+    if options.file is None:
+        parser.print_help()
+        sys.exit(1)
+
+    fname = options.file
+    out_fname = options.output
+    keep_his = options.keep_his
+    dateback = options.dateback
+    overwrite = options.overwrite
+
+    if not fname.endswith('.fif'):
+        raise ValueError('%s does not seem to be a .fif file.' % fname)
+
+    mne_anonymize(fname, out_fname, keep_his, dateback, overwrite)
+
+
+is_main = (__name__ == '__main__')
+if is_main:
+    run()

--- a/mne/commands/mne_anonymize.py
+++ b/mne/commands/mne_anonymize.py
@@ -2,7 +2,10 @@
 # Authors : Dominik Krzeminski
 #           Luke Bloy <luke.bloy@gmail.com>
 
-"""Anonymize .fif file.
+"""Anonymize raw fif file.
+
+To anonymize other file types call :func:`mne.io.anonymize_info` on their
+`info` objects and resave to disk.
 
 Examples
 --------

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -15,7 +15,8 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_make_scalp_surfaces, mne_maxfilter,
                           mne_report, mne_surf2bem, mne_watershed_bem,
                           mne_compare_fiff, mne_flash_bem, mne_show_fiff,
-                          mne_show_info, mne_what, mne_setup_source_space)
+                          mne_show_info, mne_what, mne_setup_source_space,
+                          mne_anonymize)
 from mne.datasets import testing, sample
 from mne.io import read_raw_fif
 from mne.utils import (run_tests_if_main, requires_mne,
@@ -312,6 +313,13 @@ def test_show_info():
     check_usage(mne_show_info)
     with ArgvSetter((raw_fname,)):
         mne_show_info.run()
+
+
+def test_anonymize():
+    """Test mne anonymize."""
+    check_usage(mne_anonymize)
+    with ArgvSetter(('-f', raw_fname)):
+        mne_anonymize.run()
 
 
 run_tests_if_main()

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -323,6 +323,6 @@ def test_anonymize(tmpdir):
         mne_anonymize.run()
     info = read_info(out_fname)
     assert(op.exists(out_fname))
-    assert_equal((946702800, 0), info['meas_date'], )
+    assert_equal(info['meas_date'], (946684800, 0))
 
 run_tests_if_main()

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -18,7 +18,7 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_show_info, mne_what, mne_setup_source_space,
                           mne_anonymize)
 from mne.datasets import testing, sample
-from mne.io import read_raw_fif
+from mne.io import read_raw_fif, read_info
 from mne.utils import (run_tests_if_main, requires_mne,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
                        traits_test, ArgvSetter, modified_env)
@@ -315,11 +315,14 @@ def test_show_info():
         mne_show_info.run()
 
 
-def test_anonymize():
+def test_anonymize(tmpdir):
     """Test mne anonymize."""
     check_usage(mne_anonymize)
-    with ArgvSetter(('-f', raw_fname)):
+    out_fname = op.join(tmpdir, 'anon_test_raw.fif')
+    with ArgvSetter(('-f', raw_fname, '-o', out_fname)):
         mne_anonymize.run()
-
+    info = read_info(out_fname)
+    assert(op.exists(out_fname))
+    assert_equal((946702800, 0), info['meas_date'], )
 
 run_tests_if_main()

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1888,6 +1888,17 @@ def anonymize_info(info, daysback=None, keep_his=False):
 
     Notes
     -----
+    Removes potentially identifying information if it exist in ``info``.
+    Specifically:
+    - Reset 'meas_date', 'file_id', 'meas_id' to default value or as specified
+        by `daysback` parameter.
+    - Reset elements of 'subject_info' to default values.
+        Except for 'birthday' which is adjusted to maintain subject age.
+    - Reset meta info: 'experimenter', 'proj_id', 'proj_name' and
+        'description'.
+    - Reset dates and experimenter in 'proc_history' structure.
+    - Reset dates and meta info in 'helium_info' and 'device_info'
+
     Operates in place.
     """
     _validate_type(info, 'info', "self")

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1876,10 +1876,10 @@ def anonymize_info(info, daysback=None, keep_his=False):
         Measurement information for the dataset.
     daysback : int | None
         Number of days to subtract from all dates.
-        If None daysback moves date of service to Jan 1 2000
+        If None (default) the date of service will be set to Jan 1ˢᵗ 2000.
     keep_his : bool
         If True his_id of subject_info will NOT be overwritten.
-        defaults to False
+        Defaults to False.
 
     Returns
     -------
@@ -1889,14 +1889,23 @@ def anonymize_info(info, daysback=None, keep_his=False):
     Notes
     -----
     Removes potentially identifying information if it exist in ``info``.
-    Specifically:
-    Reset 'meas_date', 'file_id', 'meas_id' to default value or as specified
-    by `daysback` parameter.
-    Reset elements of 'subject_info' to default values.
-    Except for 'birthday' which is adjusted to maintain subject age.
-    Reset meta info: 'experimenter', 'proj_id', 'proj_name' and 'description'.
-    Reset dates and experimenter in 'proc_history' structure.
-    Reset dates and meta info in 'helium_info' and 'device_info'
+    Specifically for each of the following we use:
+
+    - meas_date, file_id, meas_id
+          A default value, or as specified by ``daysback``.
+    - subject_info
+          Default values, except for 'birthday' which is adjusted
+          to maintain the subject age.
+    - experimenter, proj_name, description
+          Default strings.
+    - utc_offset
+          ``None``.
+    - proj_id
+          Zeros.
+    - proc_history
+          Dates use the meas_date logic, and experimenter a default string.
+    - helium_info, device_info
+          Dates use the meas_date logic, meta info uses defaults.
 
     Operates in place.
     """

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1871,9 +1871,12 @@ def anonymize_info(info, timeshift=None, keep_his=False):
     ----------
     info : dict, instance of Info
         Measurement information for the dataset.
-    timeshift : int,
+    timeshift : int | None
         Number of days to subtract from all dates.
-        if None timeshift moves date of service to Jan 1 2000
+        If None timeshift moves date of service to Jan 1 2000
+    keep_his : bool
+        If True his_id of subject_info will NOT be overwritten.
+        defaults to False
 
     Returns
     -------
@@ -1889,7 +1892,7 @@ def anonymize_info(info, timeshift=None, keep_his=False):
     default_anon_dos = datetime.datetime(2000, 1, 1, 0, 0, 0)
     default_str = "mne_anonymize"
     default_subject_id = 0
-    default_desc = ("Anonymized using a time shift" +
+    default_desc = ("Anonymized using a time shift"
                     " to preserve age at acquisition")
 
     if timeshift is None:

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1890,14 +1890,13 @@ def anonymize_info(info, daysback=None, keep_his=False):
     -----
     Removes potentially identifying information if it exist in ``info``.
     Specifically:
-    - Reset 'meas_date', 'file_id', 'meas_id' to default value or as specified
-        by `daysback` parameter.
-    - Reset elements of 'subject_info' to default values.
-        Except for 'birthday' which is adjusted to maintain subject age.
-    - Reset meta info: 'experimenter', 'proj_id', 'proj_name' and
-        'description'.
-    - Reset dates and experimenter in 'proc_history' structure.
-    - Reset dates and meta info in 'helium_info' and 'device_info'
+    Reset 'meas_date', 'file_id', 'meas_id' to default value or as specified
+    by `daysback` parameter.
+    Reset elements of 'subject_info' to default values.
+    Except for 'birthday' which is adjusted to maintain subject age.
+    Reset meta info: 'experimenter', 'proj_id', 'proj_name' and 'description'.
+    Reset dates and experimenter in 'proc_history' structure.
+    Reset dates and meta info in 'helium_info' and 'device_info'
 
     Operates in place.
     """

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -6,7 +6,7 @@
 
 import hashlib
 import os.path as op
-
+from datetime import datetime, timedelta
 
 import pytest
 import numpy as np
@@ -17,13 +17,13 @@ from mne import Epochs, read_events, pick_info, pick_types, Annotations
 from mne.event import make_fixed_length_events
 from mne.datasets import testing
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
-                    _loc_to_coil_trans, read_raw_fif, read_info, write_info,
-                    anonymize_info)
+                    _loc_to_coil_trans, read_raw_fif, read_info, write_info)
 from mne.io.constants import FIFF
-from mne.io.write import DATE_NONE, _generate_meas_id
+from mne.io.write import _generate_meas_id
 from mne.io.meas_info import (Info, create_info, _merge_info,
                               _force_update_info, RAW_INFO_FIELDS,
-                              _bad_chans_comp, _get_valid_units)
+                              _bad_chans_comp, _get_valid_units,
+                              anonymize_info)
 from mne.io._digitization import (_write_dig_points, _read_dig_points,
                                   _make_dig_points,)
 from mne.io import read_raw_ctf
@@ -427,46 +427,80 @@ def test_check_consistency():
     assert_array_equal(info3['ch_names'], ['a', 'b-0', 'b-1', 'c', 'b-2'])
 
 
-def _is_anonymous(inst):
-    """Check all the anonymity fields.
+def _test_anonymize_info(base_info):
+    """Test that sensitive information can be anonymized."""
+    pytest.raises(TypeError, anonymize_info, 'foo')
 
-    inst is either a raw or epochs object.
-    """
-    from collections import namedtuple
-    anonymity_checks = namedtuple("anonymity_checks",
-                                  ["missing_subject_info",
-                                   "anonymous_file_id_secs",
-                                   "anonymous_file_id_usecs",
-                                   "anonymous_meas_id_secs",
-                                   "anonymous_meas_id_usecs",
-                                   "anonymous_meas_date",
-                                   "anonymous_annotations"])
+    default_anon_dos = datetime(2000, 1, 1, 0, 0, 0)
+    default_str = "mne_anonymize"
+    default_subject_id = 0
+    default_desc = ("Anonymized using a time shift" +
+                    " to preserve age at acquisition")
 
-    if 'subject_info' not in inst.info.keys():
-        missing_subject_info = True
-    else:
-        missing_subject_info = inst.info['subject_info'] is None
+    # Test no error for incomplete info
+    info = base_info.copy()
+    info.pop('file_id')
+    anonymize_info(info)
 
-    anonymous_file_id_secs = inst.info['file_id']['secs'] == DATE_NONE[0]
-    anonymous_file_id_usecs = inst.info['file_id']['usecs'] == DATE_NONE[1]
-    anonymous_meas_id_secs = inst.info['meas_id']['secs'] == DATE_NONE[0]
-    anonymous_meas_id_usecs = inst.info['meas_id']['usecs'] == DATE_NONE[1]
-    if inst.info['meas_date'] is None:
-        anonymous_meas_date = True
-    else:
-        assert isinstance(inst.info['meas_date'], tuple)
-        anonymous_meas_date = inst.info['meas_date'] == DATE_NONE
+    # Fake some subject data
+    meas_date = datetime(2010, 1, 1, 0, 0, 0)
+    base_info['meas_date'] = (int(datetime.timestamp(meas_date)), 0)
 
-    anonymous_annotations = (hasattr(inst, 'annotations') and
-                             inst.annotations.orig_time is None)
+    base_info['subject_info'] = dict(id=1, his_id='foobar', last_name='bar',
+                                     first_name='bar', birthday=(1987, 4, 8),
+                                     sex=0, hand=1)
 
-    return anonymity_checks(missing_subject_info,
-                            anonymous_file_id_secs,
-                            anonymous_file_id_usecs,
-                            anonymous_meas_id_secs,
-                            anonymous_meas_id_usecs,
-                            anonymous_meas_date,
-                            anonymous_annotations)
+    # generate expected info...
+    # first expected result with no options.
+    # will move DOS from 2010/1/1 to 2000/1/1 which is 3653 days.
+    exp_info = base_info.copy()
+    exp_info['description'] = default_desc
+    exp_info['experimenter'] = default_str
+    exp_info['proj_name'] = default_str
+    exp_info['proj_id'][:] = 0
+    exp_info['subject_info']['first_name'] = default_str
+    exp_info['subject_info']['last_name'] = default_str
+    exp_info['subject_info']['id'] = default_subject_id
+    exp_info['subject_info']['his_id'] = str(default_subject_id)
+    # this bday is 3653 days different. the change in day is due to a
+    # different number of leap days between 1987 and 1977 than between
+    # 2010 and 2000.
+    exp_info['subject_info']['birthday'] = (1977, 4, 7)
+    exp_info['meas_date'] = (int(datetime.timestamp(default_anon_dos)), 0)
+    for key in ('file_id', 'meas_id'):
+        value = exp_info.get(key)
+        if value is not None:
+            assert 'msecs' not in value
+            value['secs'] = exp_info['meas_date'][0]
+            value['usecs'] = exp_info['meas_date'][1]
+            value['machid'][:] = -1
+
+    # exp 2 tests the keep_his option
+    exp_info_2 = exp_info.copy()
+    exp_info_2['subject_info']['his_id'] = 'foobar'
+
+    # exp 3 tests is a supplied timeshift
+    dt = timedelta(days=43)
+    exp_info_3 = exp_info.copy()
+    exp_info_3['subject_info']['birthday'] = (1987, 2, 24)
+    exp_info_3['meas_date'] = (int(datetime.timestamp(meas_date - dt)), 0)
+    for key in ('file_id', 'meas_id'):
+        value = exp_info_3.get(key)
+        if value is not None:
+            assert 'msecs' not in value
+            value['secs'] = exp_info_3['meas_date'][0]
+            value['usecs'] = exp_info_3['meas_date'][1]
+            value['machid'][:] = -1
+            print(value)
+
+    new_info = anonymize_info(base_info.copy())
+    assert_object_equal(new_info, exp_info)
+
+    new_info = anonymize_info(base_info.copy(), keep_his=True)
+    assert_object_equal(new_info, exp_info_2)
+
+    new_info = anonymize_info(base_info.copy(), timeshift=dt.days)
+    assert_object_equal(new_info, exp_info_3)
 
 
 def test_anonymize(tmpdir):
@@ -479,32 +513,18 @@ def test_anonymize(tmpdir):
                                     duration=[1, 1],
                                     description='dummy',
                                     orig_time=None))
-    raw.info['subject_info'] = dict(id=1, his_id='foobar', last_name='bar',
-                                    first_name='bar', birthday=(1987, 4, 8),
-                                    sex=0, hand=1)
-
-    # Test no error for incomplete info
-    info = raw.info.copy()
-    info.pop('file_id')
-    anonymize_info(info)
 
     # Test instance method
     events = read_events(event_name)
     epochs = Epochs(raw, events[:1], 2, 0., 0.1, baseline=None)
 
-    assert not any(_is_anonymous(raw))
+    _test_anonymize_info(raw.info.copy())
+    _test_anonymize_info(epochs.info.copy())
+
+    # test that annotations are correctly zeroed
     raw.anonymize()
-    assert all(_is_anonymous(raw))
-
-    assert not any(_is_anonymous(epochs)[:-1])  # epochs has no annotations
-    epochs.anonymize()
-    assert all(_is_anonymous(epochs)[:-1])
-
-    # When we write out with raw.save, these get overwritten with the
-    # new save time
-    out_fname = tmpdir.join('test_subj_info_raw.fif')
-    raw.save(out_fname, overwrite=True)
-    assert all(_is_anonymous(read_raw_fif(out_fname)))
+    assert(hasattr(raw, 'annotations') and
+           raw.annotations.orig_time is None)
 
 
 @testing.requires_testing_data

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -24,8 +24,8 @@ from mne.io.meas_info import (Info, create_info, _merge_info,
                               _force_update_info, RAW_INFO_FIELDS,
                               _bad_chans_comp, _get_valid_units, anonymize_info,
                               _datetime_to_meas_date, _meas_date_to_datetime)
-from mne._digitization._utils import (_write_dig_points, _read_dig_points,
-                                      _make_dig_points,)
+from mne.io._digitization import (_write_dig_points, _read_dig_points,
+                                  _make_dig_points,)
 from mne.io import read_raw_ctf
 from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
 from mne.channels import make_standard_montage

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -22,6 +22,7 @@ from mne.report import Report, open_report, _ReportScraper
 from mne.utils import (_TempDir, requires_mayavi, requires_nibabel, Bunch,
                        run_tests_if_main, traits_test, requires_h5py)
 from mne.viz import plot_alignment
+from mne.io.write import DATE_NONE
 
 data_dir = testing.data_path(download=False)
 subjects_dir = op.join(data_dir, 'subjects')
@@ -167,7 +168,16 @@ def test_report_raw_psd_and_date():
 
     # DATE_NONE functionality
     report = Report()
-    raw.anonymize()
+
+    # old style (pre 0.20) date anonymization
+    raw.info['meas_date'] = None
+    for key in ('file_id', 'meas_id'):
+        value = raw.info.get(key)
+        if value is not None:
+            assert 'msecs' not in value
+            value['secs'] = DATE_NONE[0]
+            value['usecs'] = DATE_NONE[1]
+
     raw.save(raw_fname_new, overwrite=True)
     report.parse_folder(data_path=tempdir, render_bem=False,
                         on_error='raise')

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -166,9 +166,17 @@ def test_report_raw_psd_and_date():
     assert 'PSD' in ''.join(report.html)
     assert 'GMT' in ''.join(report.html)
 
+    # test new anonymize functionality
+    report = Report()
+    raw.anonymize()
+    raw.save(raw_fname_new, overwrite=True)
+    report.parse_folder(data_path=tempdir, render_bem=False,
+                        on_error='raise')
+    assert isinstance(report.html, list)
+    assert 'GMT' in ''.join(report.html)
+
     # DATE_NONE functionality
     report = Report()
-
     # old style (pre 0.20) date anonymization
     raw.info['meas_date'] = None
     for key in ('file_id', 'meas_id'):
@@ -177,7 +185,6 @@ def test_report_raw_psd_and_date():
             assert 'msecs' not in value
             value['secs'] = DATE_NONE[0]
             value['usecs'] = DATE_NONE[1]
-
     raw.save(raw_fname_new, overwrite=True)
     report.parse_folder(data_path=tempdir, render_bem=False,
                         on_error='raise')


### PR DESCRIPTION
This modifies the way we were anonymizing meas_info objects to mainly permit time shifting dates.
It also adds an executable for anonymizing raw fif files from the command line.

The goal was to match the current plans in mne_cpp (https://github.com/mne-tools/mne-cpp/pull/393) which is still under development. hence the [WIP] tag.

closes  #6844 and #4982

@LorenzE 