### PR TITLE
ENH: Add channel types mixin

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,3 +40,5 @@ Bug
 
 API
 ~~~
+
+- New methods :meth:`mne.io.Raw.get_channel_types`, :meth:`mne.Epochs.get_channel_types`, :meth:`mne.Evoked.get_channel_types` by `Daniel McCloy`_.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -3,6 +3,7 @@
 #          Denis Engemann <denis.engemann@gmail.com>
 #          Andrew Dykstra <andrew.r.dykstra@gmail.com>
 #          Teon Brooks <teon.brooks@gmail.com>
+#          Daniel McCloy <dan.mccloy@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -167,6 +168,10 @@ class ContainsMixin(object):
         """The current gradient compensation grade."""
         return get_current_comp(self.info)
 
+    def get_channel_types(self):
+        """Get a list of channel type for each channel."""
+        return [channel_type(self.info, n)
+                for n in range(len(self.info['ch_names']))]
 
 # XXX Eventually de-duplicate with _kind_dict of mne/io/meas_info.py
 _human2fiff = {'ecg': FIFF.FIFFV_ECG_CH,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2672,6 +2672,7 @@ def test_readonly_times():
 
 
 def test_channel_types_mixin():
+    """Test channel types mixin."""
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events[:1], preload=True)
     ch_types = epochs.get_channel_types()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2671,6 +2671,14 @@ def test_readonly_times():
         epochs.times[:] = 0.
 
 
+def test_channel_types_mixin():
+    raw, events = _get_data()[:2]
+    epochs = Epochs(raw, events[:1], preload=True)
+    ch_types = epochs.get_channel_types()
+    assert len(ch_types) == len(epochs.ch_names)
+    assert all(np.in1d(ch_types, ['mag', 'grad', 'eeg', 'eog', 'stim']))
+
+
 def test_average_methods():
     """Test average methods."""
     n_epochs, n_channels, n_times = 5, 10, 20


### PR DESCRIPTION
Following up on a discussion on Gitter a couple months ago, this adds a method `get_channel_types` to Raw, Epochs, and Evoked objects (by attaching the method to the `ContainsMixin`).

cc @jasmainak @cbrnr @larsoner @agramfort 