### PR TITLE
ENH, API: joint clims for proj topomaps; unify API with Projector.plot_topomap

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,6 +52,8 @@ API
 
 - :func:`mne.viz.plot_projs_topomap` now accepts both :class:`~mne.channels.Layout` and :class:`~mne.Info` (previously one or the other), and will ignore :class:`~mne.Info` if :class:`~mne.channels.Layout` is provided `Daniel McCloy`_.
 
+- :func:`mne.viz.plot_projs_topomap` and the related methods :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` now accept parameter ``vlim`` to control the colormap, with keyword ``'joint'`` computing the colormap jointly across all projectors of a given channel type, by `Daniel McCloy`_.
+
 - New methods :meth:`mne.io.Raw.get_channel_types`, :meth:`mne.Epochs.get_channel_types`, :meth:`mne.Evoked.get_channel_types` by `Daniel McCloy`_.
 
 - Deprecate ``mne.minimum_norm.point_spread_function`` and ``mne.minimum_norm.cross_talk_function`` by `Alex Gramfort`_

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -34,69 +34,16 @@ class Projection(dict):
         s += ", n_channels : %s" % self['data']['ncol']
         return "<Projection  |  %s>" % s
 
-    # Can't use copy_ function here b/c of circular import
+    @fill_doc
     def plot_topomap(self, layout=None, cmap=None, sensors=True,
                      colorbar=False, res=64, size=1, show=True,
                      outlines='head', contours=6, image_interp='bilinear',
-                     axes=None, info=None):
+                     axes=None, vlim=(None, None), info=None):
         """Plot topographic maps of SSP projections.
 
         Parameters
         ----------
-        layout : None | Layout | list of Layout
-            Layout instance specifying sensor positions (does not need to be
-            specified for Neuromag data). Or a list of Layout if projections
-            are from different sensor types.
-        cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-            Colormap to use. If tuple, the first value indicates the colormap to
-            use and the second value is a boolean defining interactivity. In
-            interactive mode (only works if ``colorbar=True``) the colors are
-            adjustable by clicking and dragging the colorbar with left and right
-            mouse button. Left mouse button moves the scale up and down and right
-            mouse button adjusts the range. Hitting space bar resets the range. Up
-            and down arrows can be used to change the colormap. If None (default),
-            'Reds' is used for all positive data, otherwise defaults to 'RdBu_r'.
-            If 'interactive', translates to (None, True).
-        sensors : bool | str
-            Add markers for sensor locations to the plot. Accepts matplotlib plot
-            format string (e.g., 'r+' for red plusses). If True, a circle will be
-            used (via .add_artist). Defaults to True.
-        colorbar : bool
-            Plot a colorbar.
-        res : int
-            The resolution of the topomap image (n pixels along each side).
-        size : scalar
-            Side length of the topomaps in inches (only applies when plotting
-            multiple topomaps at a time).
-        show : bool
-            Show figure if True.
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will be
-            drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos' will
-            serve as image mask, and the 'autoshrink' (bool) field will trigger
-            automated shrinking of the positions due to points outside the outline.
-            Alternatively, a matplotlib patch object can be passed for advanced
-            masking options, either directly or as a function that returns patches
-            (required for multi-axis plots). If None, nothing will be drawn.
-            Defaults to 'head'.
-        contours : int | array of float
-            The number of contour lines to draw. If 0, no contours will be drawn.
-            When an integer, matplotlib ticker locator is used to find suitable
-            values for the contour thresholds (may sometimes be inaccurate, use
-            array for accuracy). If an array, the values represent the levels for
-            the contours. Defaults to 6.
-        image_interp : str
-            The image interpolation to be used. All matplotlib options are
-            accepted.
-        axes : instance of Axes | list | None
-            The axes to plot to. If list, the list must be a list of Axes of
-            the same length as the number of projectors. If instance of Axes,
-            there must be only one projector. Defaults to None.
-        info : instance of Info | None
-            The measurement information to use to determine the layout.
-            If not None, ``layout`` must be None.
+        %(proj_topomap_kwargs)s
 
         Returns
         -------
@@ -109,9 +56,9 @@ class Projection(dict):
         """  # noqa: E501
         from ..viz.topomap import plot_projs_topomap
         with warnings.catch_warnings(record=True):  # tight_layout fails
-            return plot_projs_topomap([self], layout, cmap, sensors, colorbar,
+            return plot_projs_topomap(self, layout, cmap, sensors, colorbar,
                                       res, size, show, outlines,
-                                      contours, image_interp, axes, info)
+                                      contours, image_interp, axes, vlim, info)
 
 
 class ProjMixin(object):
@@ -283,7 +230,8 @@ class ProjMixin(object):
     def plot_projs_topomap(self, ch_type=None, layout=None, cmap=None,
                            sensors=True, colorbar=False, res=64, size=1,
                            show=True, outlines='head', contours=6,
-                           image_interp='bilinear', axes=None):
+                           image_interp='bilinear', axes=None,
+                           vlim=(None, None)):
         """Plot SSP vector.
 
         Parameters
@@ -308,7 +256,7 @@ class ProjMixin(object):
                                      show=show, outlines=outlines,
                                      contours=contours,
                                      image_interp=image_interp, axes=axes,
-                                     info=self.info)
+                                     vlim=vlim, info=self.info)
         else:
             raise ValueError("Info is missing projs. Nothing to plot.")
         return fig

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -44,6 +44,10 @@ class Projection(dict):
         Parameters
         ----------
         %(proj_topomap_kwargs)s
+        info : instance of Info | None
+            The measurement information to use to determine the layout. If both
+            ``info`` and ``layout`` are provided, the layout will take
+            precedence.
 
         Returns
         -------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -420,6 +420,15 @@ docdict["proj_topomap_kwargs"] = """
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of projectors. If instance of Axes,
         there must be only one projector. Defaults to None.
+    vlim : tuple of length 2 | 'joint'
+        Colormap limits to use. If :class:`tuple`, specifies the lower and
+        upper bounds of the colormap (in that order); providing ``None`` for
+        either of these will set the corresponding boundary at the min/max of
+        the data (separately for each projector). The keyword value ``'joint'``
+        will compute the colormap limits jointly across all provided
+        projectors of the same channel type, using the min/max of the projector
+        data. If vlim is ``'joint'``, ``info`` must not be ``None``. Defaults
+        to ``(None, None)``.
 """
 
 # Montage

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -120,6 +120,10 @@ def test_plot_projs_topomap():
     pytest.raises(RuntimeError, eeg_avg.plot_topomap)  # no layout
     eeg_avg.plot_topomap(info=info, **fast_test)
     plt.close('all')
+    # test vlims
+    for vlim in ('joint', (-1, 1), (None, 0.5), (0.5, None), (None, None)):
+        plot_projs_topomap(projs[:-1], vlim=vlim, info=info, colorbar=True)
+    plt.close('all')
 
 
 @pytest.mark.slowtest

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -244,8 +244,6 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
             # each projector should have only one channel type
             assert len(these_ch_types) == 1
             types.append(list(these_ch_types)[0])
-        else:
-            types.append(None)
         data = proj['data']['data'].ravel()
         # check layout
         if layout is not None:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -29,6 +29,7 @@ from ..time_frequency import psd_multitaper
 from ..defaults import _handle_default
 from ..channels.layout import _find_topomap_coords
 from ..io.meas_info import Info
+from ..io.proj import Projection
 
 
 def _prepare_topo_plot(inst, ch_type, layout):
@@ -178,7 +179,7 @@ def _eliminate_zeros(proj):
 def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
                        colorbar=False, res=64, size=1, show=True,
                        outlines='head', contours=6, image_interp='bilinear',
-                       axes=None, info=None):
+                       axes=None, vlim=(None, None), info=None):
     """Plot topographic maps of SSP projections.
 
     Parameters
@@ -203,102 +204,103 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
     from ..channels.layout import (_pair_grad_sensors_ch_names_vectorview,
                                    _pair_grad_sensors_ch_names_neuromag122,
                                    Layout, _merge_grad_data)
-    from ..channels import _get_ch_type
+    from ..channels import _get_ch_type, read_layout
 
-    is_layout_parameter_none = layout is None
-    is_info_parameter_none = info is None
+    # be forgiving if `projs` isn't a list
+    if isinstance(projs, Projection):
+        projs = [projs]
 
-    if info is not None:
-        if not isinstance(info, Info):
-            raise TypeError('info must be an instance of Info, got %s'
-                            % (type(info),))
-    else:
-        if layout is None:
-            from ..channels import read_layout
-            layout = read_layout('Vectorview-all')
-        if not isinstance(layout, (list, tuple)):
-            layout = [layout]
+    # argument checking
+    if info is None and vlim == 'joint':
+        raise ValueError("If vlim is 'joint', info must not be None.")
+    if info is not None and not isinstance(info, Info):
+        raise TypeError('info must be an instance of Info, got {}'
+                        .format(type(info)))
+    if info is None and layout is None:
+        layout = read_layout('Vectorview-all')
+    if isinstance(layout, Layout):
+        layout = [layout]
+    if layout is not None:
         if not isinstance(layout, (list, tuple)):
             raise TypeError('layout must be an instance of Layout, list, '
-                            'or None, got %s' % (type(layout),))
+                            'or None, got {}'.format(type(layout)))
         for l in layout:
             if not isinstance(l, Layout):
                 raise TypeError('All entries in layout list must be of type '
-                                'Layout, got type %s' % (type(l),))
+                                'Layout, got type {}'.format(type(l)))
 
-    n_projs = len(projs)
-    nrows = math.floor(math.sqrt(n_projs))
-    ncols = math.ceil(n_projs / nrows)
-
-    if axes is None:
-        plt.figure()
-        axes = list()
-        for idx in range(len(projs)):
-            ax = plt.subplot(nrows, ncols, idx + 1)
-            axes.append(ax)
-    elif isinstance(axes, plt.Axes):
-        axes = [axes]
-    if len(axes) != len(projs):
-        raise RuntimeError('There must be an axes for each picked projector.')
-    for proj_idx, proj in enumerate(projs):
-        title = proj['desc']
-        title = '\n'.join(title[ii:ii + 22] for ii in range(0, len(title), 22))
-        axes[proj_idx].set_title(title, fontsize=10)
+    types = []
+    datas = []
+    poses = []
+    for proj in projs:
+        # get ch_names, ch_types, data
         proj = _eliminate_zeros(proj)  # gh 5641
         ch_names = _clean_names(proj['data']['col_names'],
                                 remove_whitespace=True)
+        if vlim == 'joint':
+            ch_idxs = np.where(np.in1d(info['ch_names'],
+                                       proj['data']['col_names']))[0]
+            these_ch_types = set([channel_type(info, n) for n in ch_idxs])
+            # each projector should have only one channel type
+            assert len(these_ch_types) == 1
+            types.append(list(these_ch_types)[0])
+        else:
+            types.append(None)
         data = proj['data']['data'].ravel()
-        if layout is not None:  # list of layouts
+        # check layout
+        if layout is not None:
             idx = []
             for l in layout:
-                is_vv = l.kind.startswith('Vectorview')
                 grad_pairs = None
-                if is_vv:
+                # vectorview
+                if l.kind.startswith('Vectorview'):
                     grad_pairs = \
                         _pair_grad_sensors_ch_names_vectorview(ch_names)
                     if grad_pairs:
                         ch_names = [ch_names[i] for i in grad_pairs]
-
-                is_neuromag122 = l.kind.startswith('Neuromag_122')
-                if is_neuromag122:
+                # neuromag 122
+                if l.kind.startswith('Neuromag_122'):
                     grad_pairs = \
                         _pair_grad_sensors_ch_names_neuromag122(ch_names)
                     if grad_pairs:
                         ch_names = [ch_names[i] for i in grad_pairs]
-
+                # make sure this layout has the channels in the current proj
                 l_names = _clean_names(l.names, remove_whitespace=True)
                 idx = [l_names.index(c) for c in ch_names if c in l_names]
                 if len(idx) == 0:
                     continue
+                # handle grad pairs (if present)
                 pos = l.pos[idx]
                 if grad_pairs:
                     shape = (len(idx) // 2, 2, -1)
                     pos = pos.reshape(shape).mean(axis=1)
                     data = _merge_grad_data(data[grad_pairs]).ravel()
                 break
+            # if we didn't find any matching layouts...
             if len(idx) == 0:
                 if ch_names[0].startswith('EEG'):
                     msg = ('Cannot find a proper layout for projection {}.'
                            ' The proper layout of an EEG topomap cannot be'
                            ' inferred from the data. '.format(proj['desc']))
-                    if is_layout_parameter_none and is_info_parameter_none:
+                    if layout is None and info is None:
                         msg += (' For EEG data, valid `layout` or `info` is'
                                 ' required. None was provided, please consider'
                                 ' passing one of them.')
-                    elif not is_layout_parameter_none:
+                    elif info is None:
                         msg += (' A `layout` was provided but could not be'
                                 ' used for display. Please review the `layout`'
                                 ' parameter.')
                     else:  # layout is none, but we have info
                         msg += (' The `info` parameter was provided but could'
-                                ' not be for display. Please review the `info`'
-                                ' parameter.')
+                                ' not be used for display. Please review the'
+                                ' `info` parameter.')
                     raise RuntimeError(msg)
                 else:
                     raise RuntimeError('Cannot find a proper layout for '
-                                       'projection %s, consider explicitly '
+                                       'projection {}, consider explicitly '
                                        'passing a Layout or Info as the layout'
-                                       ' parameter.' % proj['desc'])
+                                       ' parameter.'.format(proj['desc']))
+        # get data / pos from info
         elif info is not None:
             info_names = _clean_names(info['ch_names'],
                                       remove_whitespace=True)
@@ -308,16 +310,57 @@ def plot_projs_topomap(projs, layout=None, cmap=None, sensors=True,
             data = data[data_picks]
             if merge_grads:
                 data = _merge_grad_data(data).ravel()
+        # populate containers
+        datas.append(data)
+        poses.append(pos)
 
-        im = plot_topomap(data, pos[:, :2], vmax=None, cmap=cmap,
-                          sensors=sensors, res=res, axes=axes[proj_idx],
+    # setup axes
+    n_projs = len(projs)
+    nrows = math.floor(math.sqrt(n_projs))
+    ncols = math.ceil(n_projs / nrows)
+    if axes is None:
+        _, axes = plt.subplots(nrows, ncols, squeeze=False)
+        axes = axes.ravel()
+        if len(axes[n_projs:]):
+            [ax.remove() for ax in axes[n_projs:]]
+            axes = axes[:n_projs]
+    elif isinstance(axes, plt.Axes):
+        axes = [axes]
+    if len(axes) != len(projs):
+        raise RuntimeError('There must be an axes for each picked projector.')
+
+    # handle vmin/vmax
+    vlims = [None for _ in range(len(datas))]
+    if vlim == 'joint':
+        for _ch_type in set(types):
+            idx = np.where(np.in1d(types, _ch_type))[0]
+            these_data = np.concatenate(np.array(datas)[idx])
+            norm = all(these_data >= 0)
+            _vl = _setup_vmin_vmax(these_data, vmin=None, vmax=None, norm=norm)
+            for _idx in idx:
+                vlims[_idx] = _vl
+        # make sure we got a vlim for all projs
+        assert all([vl is not None for vl in vlims])
+    else:
+        vlims = [vlim for _ in range(len(datas))]
+
+    # plot
+    for proj, ax, _data, _pos, _vlim in zip(projs, axes, datas, poses, vlims):
+        # title
+        title = proj['desc']
+        title = '\n'.join(title[ii:ii + 22] for ii in range(0, len(title), 22))
+        ax.set_title(title, fontsize=10)
+        # plot
+        vmin, vmax = _vlim
+        im = plot_topomap(_data, _pos[:, :2], vmin=vmin, vmax=vmax, cmap=cmap,
+                          sensors=sensors, res=res, axes=ax,
                           outlines=outlines, contours=contours,
                           image_interp=image_interp, show=False)[0]
 
         if colorbar:
-            _add_colorbar(axes[proj_idx], im, cmap)
+            _add_colorbar(ax, im, cmap)
 
-    fig = axes[0].get_figure()
+    fig = ax.get_figure()
     tight_layout(fig=fig)
     plt_show(show)
     return fig

--- a/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
@@ -111,11 +111,16 @@ for average in (False, True):
 # We create the SSP vectors using :func:`~mne.compute_proj_raw`, and control
 # the number of projectors with parameters ``n_grad`` and ``n_mag``. Once
 # created, the field pattern of the projectors can be easily visualized with
-# :func:`~mne.viz.plot_projs_topomap`.
+# :func:`~mne.viz.plot_projs_topomap`. We include the parameter
+# ``vlim='joint'`` so that the colormap is computed jointly for all projectors
+# of a given channel type; this makes it easier to compare their relative
+# smoothness. Note that for the function to know the types of channels in a
+# projector, you must also provide the corresponding :class:`~mne.Info` object:
 
 # sphinx_gallery_thumbnail_number = 3
 empty_room_projs = mne.compute_proj_raw(empty_room_raw, n_grad=3, n_mag=3)
-mne.viz.plot_projs_topomap(empty_room_projs, colorbar=True)
+mne.viz.plot_projs_topomap(empty_room_projs, colorbar=True, vlim='joint',
+                           info=empty_room_raw.info)
 
 ###############################################################################
 # Notice that the gradiometer-based projectors seem to reflect problems with
@@ -128,8 +133,9 @@ mne.viz.plot_projs_topomap(empty_room_projs, colorbar=True)
 # polarity.
 
 fig, axs = plt.subplots(2, 3)
-mne.viz.plot_projs_topomap(system_projs, axes=axs[0], colorbar=True)
-mne.viz.plot_projs_topomap(empty_room_projs[3:], axes=axs[1], colorbar=True)
+for idx, _projs in enumerate([system_projs, empty_room_projs[3:]]):
+    mne.viz.plot_projs_topomap(_projs, axes=axs[idx], colorbar=True,
+                               vlim='joint', info=empty_room_raw.info)
 
 ###############################################################################
 # Visualizing how projectors affect the signal


### PR DESCRIPTION
Allows plotting multiple projector topomaps with jointly-determined colorbar limits.  API is:

- `vlim='joint'`: within a given channel type, vlims will all be the same, determined by the pooled data for all projectors of that channel type
- `vlim=(None, None)`: vlims determined separately for every projector (default, current behavior)
- `vlim=(None, 0.4)` vmax will be the same (0.4) for all topoplots, but vmin will be data-dependent
- `vlim=(-0.3, None)` vmin will be the same (-0.3) for all topoplots, but vmax will be data-dependent
