### PR TITLE
FIX: Import order in optical density code

### DIFF
--- a/mne/preprocessing/_optical_density.py
+++ b/mne/preprocessing/_optical_density.py
@@ -3,12 +3,12 @@
 #
 # License: BSD (3-clause)
 
+import numpy as np
+
 from ..io import BaseRaw
 from ..io.constants import FIFF
 from ..utils import _validate_type, warn
 from ..io.pick import _picks_to_idx
-
-import numpy as np
 
 
 def optical_density(raw):
@@ -34,7 +34,7 @@ def optical_density(raw):
     # not occur. If they do it is likely due to hardware or movement issues.
     # Set all negative values to abs(x), this also has the benefit of ensuring
     # that the means are all greater than zero for the division below.
-    if len(np.where(raw._data[picks] <= 0)[0]) > 0:
+    if np.any(raw._data[picks] <= 0):
         warn("Negative intensities encountered. Setting to abs(x)")
         raw._data[picks] = np.abs(raw._data[picks])
 

--- a/mne/preprocessing/_optical_density.py
+++ b/mne/preprocessing/_optical_density.py
@@ -1,5 +1,6 @@
 # Authors: Robert Luke <mail@robertluke.net>
 #          Eric Larson <larson.eric.d@gmail.com>
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
 # License: BSD (3-clause)
 

--- a/mne/preprocessing/tests/test_optical_density.py
+++ b/mne/preprocessing/tests/test_optical_density.py
@@ -1,5 +1,6 @@
 # Authors: Robert Luke <mail@robertluke.net>
 #          Eric Larson <larson.eric.d@gmail.com>
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
 # License: BSD (3-clause)
 

--- a/mne/preprocessing/tests/test_optical_density.py
+++ b/mne/preprocessing/tests/test_optical_density.py
@@ -4,16 +4,15 @@
 # License: BSD (3-clause)
 
 import os.path as op
+import pytest as pytest
+import numpy as np
+from numpy.testing import assert_allclose
 
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx, BaseRaw
 from mne.preprocessing import optical_density
 from mne.utils import _validate_type
 from mne.datasets import testing
-
-import pytest as pytest
-import numpy as np
-from numpy.testing import assert_allclose
 
 
 fname_nirx = op.join(data_path(download=False),


### PR DESCRIPTION
#### Reference issue
Import order error as noted by @agramfort [here](https://github.com/mne-tools/mne-python/pull/6827#pullrequestreview-297848958)


#### What does this implement/fix?
Changes the order of imports from general to local

