### PR TITLE
MRG, FIX: Compute kernels at proper sample rate

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -697,6 +697,23 @@ def test_compute_tfr():
             assert_array_equal(shape[1:], out.shape)
 
 
+@pytest.mark.parametrize('method', ('multitaper', 'morlet'))
+@pytest.mark.parametrize('decim', (1, slice(1, None, 2), 3))
+def test_compute_tfr_correct(method, decim):
+    """Test that TFR actually gets us our freq back."""
+    sfreq = 1000.
+    t = np.arange(1000) / sfreq
+    f = 50.
+    data = np.sin(2 * np.pi * 50. * t)
+    data *= np.hanning(data.size)
+    data = data[np.newaxis, np.newaxis]
+    freqs = np.arange(10, 111, 10)
+    assert f in freqs
+    tfr = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
+                       n_cycles=2)[0, 0]
+    assert freqs[np.argmax(np.abs(tfr).mean(-1))] == f
+
+
 @requires_pandas
 def test_getitem_epochsTFR():
     """Test GetEpochsMixin in the context of EpochsTFR."""

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -335,8 +335,8 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     # Check data
     epoch_data = np.asarray(epoch_data)
     if epoch_data.ndim != 3:
-        raise ValueError('epoch_data must be of shape '
-                         '(n_epochs, n_chans, n_times)')
+        raise ValueError('epoch_data must be of shape (n_epochs, n_chans, '
+                         'n_times), got %s' % (epoch_data.shape,))
 
     # Check params
     freqs, sfreq, zero_mean, n_cycles, time_bandwidth, decim = \
@@ -344,12 +344,13 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
                          time_bandwidth, use_fft, decim, output)
 
     decim = _check_decim(decim)
-    sfreq /= decim.step
     if (freqs > sfreq / 2.).any():
-        raise ValueError('Cannot compute freq above Nyquist freq '
-                         'after decimation')
+        raise ValueError('Cannot compute freq above Nyquist freq of the data '
+                         '(%0.1f Hz), got %0.1f Hz'
+                         % (sfreq / 2., freqs.max()))
 
-    # Setup wavelet
+    # We decimate *after* decomposition, so we need to create our kernels
+    # for the original sfreq
     if method == 'morlet':
         W = morlet(sfreq, freqs, n_cycles=n_cycles, zero_mean=zero_mean)
         Ws = [W]  # to have same dimensionality as the 'multitaper' case

--- a/tutorials/intro/plot_10_overview.py
+++ b/tutorials/intro/plot_10_overview.py
@@ -269,7 +269,6 @@ aud_epochs.plot_image(picks=['MEG 1332', 'EEG 021'])
 #     :class:`~mne.io.Raw` and ``(n_epochs, n_channels, n_times)`` for
 #     :class:`~mne.Epochs`.
 #
-#
 # Time-frequency analysis
 # ^^^^^^^^^^^^^^^^^^^^^^^
 #

--- a/tutorials/time-freq/plot_sensors_time_frequency.py
+++ b/tutorials/time-freq/plot_sensors_time_frequency.py
@@ -185,8 +185,7 @@ itc.plot_topo(title='Inter-Trial coherence', vmin=0., vmax=1., cmap='Reds')
 #     Baseline correction can be applied to power or done in plots.
 #     To illustrate the baseline correction in plots, the next line is
 #     commented power.apply_baseline(baseline=(-0.5, 0), mode='logratio')
-
-###############################################################################
+#
 # Exercise
 # --------
 #


### PR DESCRIPTION
Follow-up to #6907 to take care of https://app.circleci.com/jobs/github/mne-tools/mne-python/16176/tests

But actually looking deeper at the code, I think we introduced a regression in #6907. Our docs say:

> If `int`, returns tfr[..., ::decim]

In other words, we compute the TFR *then* decimate. It might actually be reasonable to allow freqs above Nyquist-after-decimation here depending on how many cycles wide the wavelets are, for example. 

But in any case, the freqs are currently computed for the wrong sample rate. I'll need to add a regression test for this, since this would have created an errant `decim`-fold change in the frequency locations.