### PR TITLE
MRG, FIX: mark_flat should ignore skips

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,6 +53,8 @@ Bug
 
 - Fix bug in :func:`mne.write_evokeds` where ``evoked.nave`` was not saved properly when multiple :class:`~mne.Evoked` instances were written to a single file, by `Eric Larson`_
 
+- Fix bug in :func:`mne.preprocessing.mark_flat` where acquisition skips were not handled proeprly, by `Eric Larson`_
+
 - Fix TAL channel parsing (annotations) for EDF-D files by `Clemens Brunner`_
 
 - Fix bug with :func:`mne.viz.plot_dipole_locations` when plotting in head coordinates by `Eric Larson`_


### PR DESCRIPTION
Pretty straightforward fix. Without it, `intervalrecording` gives 306 bad channels. MaxFilter also detects that there should be 21 flat channels.