### PR TITLE
FIX: edf(+) no longer misses prefiltering

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -67,6 +67,8 @@ Bug
 
 - Fix ``info['sfreq']`` when decimating in :func:`mne.time_frequency.tfr_multitaper` and :func:`mne.time_frequency.tfr_morlet` and make sure an error is raised when exceed Nyquist frequency by `Adonay Nunes`_
 
+- Fix bug in edf loading, filter values ignored by insufficient regex, by `Demetres Kostas`_
+
 API
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -67,7 +67,7 @@ Bug
 
 - Fix ``info['sfreq']`` when decimating in :func:`mne.time_frequency.tfr_multitaper` and :func:`mne.time_frequency.tfr_morlet` and make sure an error is raised when exceed Nyquist frequency by `Adonay Nunes`_
 
-- Fix bug in edf loading, filter values ignored by insufficient regex, by `Demetres Kostas`_
+- Fix bug in EDF(+) loading, filter values ignored by insufficient regex, by `Demetres Kostas`_
 
 API
 ~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -273,3 +273,5 @@
 .. _Adonay Nunes: https://github.com/AdoNunes
 
 .. _Victor Ferat: https://github.com/vferat
+
+.. _Demetres Kostas: https://github.com/kostasde

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -506,9 +506,8 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
     return info, edf_info, orig_units
 
 
-def _parse_prefilter_string(prefiltering: str):
-    """Parses prefilter string from EDF+ and BDF headers for highpass
-       and lowpass filters"""
+def _parse_prefilter_string(prefiltering):
+    """Parse prefilter string from EDF+ and BDF headers."""
     highpass = np.array(
         [v for hp in [re.findall(r'HP:\s*([0-9]+[.]*[0-9]*)', filt)
                       for filt in prefiltering] for v in hp]

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -590,10 +590,14 @@ def _read_edf_header(fname, exclude):
                                 for ch in channels])[sel]
         prefiltering = [fid.read(80).decode().strip(' \x00')
                         for ch in channels][:-1]
-        highpass = np.ravel([re.findall(r'HP:\s+(\w+)', filt)
-                             for filt in prefiltering])
-        lowpass = np.ravel([re.findall(r'LP:\s+(\w+)', filt)
-                            for filt in prefiltering])
+        highpass = np.array(
+            [v for hp in [re.findall(r'HP:\s*([0-9]+[.]*[0-9]*)', filt)
+                          for filt in prefiltering] for v in hp]
+        )
+        lowpass = np.array(
+            [v for hp in [re.findall(r'LP:\s*([0-9]+[.]*[0-9]*)', filt)
+                          for filt in prefiltering] for v in hp]
+        )
 
         # number of samples per record
         n_samps = np.array([int(fid.read(8).decode()) for ch
@@ -728,10 +732,14 @@ def _read_gdf_header(fname, exclude):
             digital_max = np.fromfile(fid, np.int64, len(channels))
             prefiltering = [fid.read(80).decode().strip(' \x00')
                             for ch in channels][:-1]
-            highpass = np.ravel([re.findall(r'HP:\s+(\w+)', filt)
-                                 for filt in prefiltering])
-            lowpass = np.ravel([re.findall('LP:\\s+(\\w+)', filt)
-                                for filt in prefiltering])
+            highpass = np.array(
+                [v for hp in [re.findall(r'HP:\s*([0-9]+[.]*[0-9]*)', filt)
+                              for filt in prefiltering] for v in hp]
+            )
+            lowpass = np.array(
+                [v for hp in [re.findall(r'LP:\s*([0-9]+[.]*[0-9]*)', filt)
+                              for filt in prefiltering] for v in hp]
+            )
 
             # n samples per record
             n_samps = np.fromfile(fid, np.int32, len(channels))

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -26,6 +26,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.edf.edf import _get_edf_default_event_id
 from mne.io.edf.edf import _read_annotations_edf
 from mne.io.edf.edf import _read_ch
+from mne.io.edf.edf import _parse_prefilter_string
 from mne.io.pick import channel_indices_by_type
 from mne.annotations import events_from_annotations, read_annotations
 from mne.io.meas_info import _kind_dict as _KIND_DICT
@@ -275,6 +276,29 @@ def test_read_annotations(fname, recwarn):
     assert len(annot.onset) == 2
 
 
+def test_edf_prefilter_parse():
+    """Test prefilter strings from header are parsed correctly"""
+    prefilter_basic = ["HP: 0Hz LP: 0Hz"]
+    highpass, lowpass = _parse_prefilter_string(prefilter_basic)
+    assert_array_equal(highpass, ["0"])
+    assert_array_equal(lowpass, ["0"])
+
+    prefilter_normal_multi_ch = ["HP: 1Hz LP: 30Hz"] * 10
+    highpass, lowpass = _parse_prefilter_string(prefilter_normal_multi_ch)
+    assert_array_equal(highpass, ["1"]*10)
+    assert_array_equal(lowpass, ["30"]*10)
+
+    prefilter_unfiltered_ch = prefilter_normal_multi_ch + [""]
+    highpass, lowpass = _parse_prefilter_string(prefilter_unfiltered_ch)
+    assert_array_equal(highpass, ["1"]*10)
+    assert_array_equal(lowpass, ["30"]*10)
+    
+    prefilter_edf_specs_doc = ["HP:0.1Hz LP:75Hz N:50Hz"]
+    highpass, lowpass = _parse_prefilter_string(prefilter_edf_specs_doc)
+    assert_array_equal(highpass, ["0.1"])
+    assert_array_equal(lowpass, ["75"])
+
+    
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname', [test_generator_edf, test_generator_bdf])
 def test_load_generator(fname, recwarn):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -285,20 +285,20 @@ def test_edf_prefilter_parse():
 
     prefilter_normal_multi_ch = ["HP: 1Hz LP: 30Hz"] * 10
     highpass, lowpass = _parse_prefilter_string(prefilter_normal_multi_ch)
-    assert_array_equal(highpass, ["1"]*10)
-    assert_array_equal(lowpass, ["30"]*10)
+    assert_array_equal(highpass, ["1"] * 10)
+    assert_array_equal(lowpass, ["30"] * 10)
 
     prefilter_unfiltered_ch = prefilter_normal_multi_ch + [""]
     highpass, lowpass = _parse_prefilter_string(prefilter_unfiltered_ch)
-    assert_array_equal(highpass, ["1"]*10)
-    assert_array_equal(lowpass, ["30"]*10)
-    
+    assert_array_equal(highpass, ["1"] * 10)
+    assert_array_equal(lowpass, ["30"] * 10)
+
     prefilter_edf_specs_doc = ["HP:0.1Hz LP:75Hz N:50Hz"]
     highpass, lowpass = _parse_prefilter_string(prefilter_edf_specs_doc)
     assert_array_equal(highpass, ["0.1"])
     assert_array_equal(lowpass, ["75"])
 
-    
+
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname', [test_generator_edf, test_generator_bdf])
 def test_load_generator(fname, recwarn):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -277,7 +277,7 @@ def test_read_annotations(fname, recwarn):
 
 
 def test_edf_prefilter_parse():
-    """Test prefilter strings from header are parsed correctly"""
+    """Test prefilter strings from header are parsed correctly."""
     prefilter_basic = ["HP: 0Hz LP: 0Hz"]
     highpass, lowpass = _parse_prefilter_string(prefilter_basic)
     assert_array_equal(highpass, ["0"])


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
N/A


#### What does this implement/fix?
Previously edf(+) loading was incorrectly reporting that high and low pass filtering was always 0 due to the regex never actually capturing the number.

Example `prefiltering` string from edf documentation: "HP:0.1Hz LP:75Hz N:50Hz", previous regex definitely wouldn't capture this, missing the decimal, optional rather than expected white-space. The fix should capture this.

Ravel should work, but seems to fail if one of the findall operations returns nothing, converted to just expand in-place.


#### Additional information

