### PR TITLE
FIX: Aligning frequency bins to y-axis (#6930)

### DIFF
--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -15,6 +15,8 @@ Version 0.19.1
 Bug
 ~~~
 
+- Fix plotting of TFRs with linear y-scale (misaligned frequency bins), by `Stefan Repplinger`_ and `Eric Larson`_
+
 - Fix bug in :class:`~mne.preprocessing.ICA` where requesting extended infomax via ``fit_params={'extended': True}`` was overridden, by `Daniel McCloy`_.
 
 - Fix handling of repeated events in :class:`mne.Epochs` by `Fahimeh Mamashli`_ and `Alex Gramfort`_

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2841,7 +2841,10 @@ def _plot_masked_image(ax, data, times, mask=None, yvals=None,
     else:
         # imshow for linear because the y ticks are nicer
         # and the masked areas look better
-        extent = [times[0], times[-1], yvals[0], yvals[-1] + 1]
+        dt = np.median(np.diff(times)) / 2. if len(times) > 1 else 0.1
+        dy = np.median(np.diff(yvals)) / 2. if len(yvals) > 1 else 0.5
+        extent = [times[0] - dt, times[-1] + dt,
+                  yvals[0] - dy, yvals[-1] + dy]
         im_args = dict(interpolation='nearest', origin='lower',
                        extent=extent, aspect='auto', vmin=vmin, vmax=vmax)
 
@@ -2857,8 +2860,9 @@ def _plot_masked_image(ax, data, times, mask=None, yvals=None,
             ax.contour(big_mask, colors=["k"], extent=extent,
                        linewidths=[.75], corner_mask=False,
                        antialiased=False, levels=[.5])
-        time_lims = times[[0, -1]]
-        ylim = yvals[0], yvals[-1] + 1
+        time_lims = [extent[0], extent[1]]
+        if ylim is None:
+            ylim = [extent[2], extent[3]]
 
     ax.set_xlim(time_lims[0], time_lims[-1])
     ax.set_ylim(ylim)


### PR DESCRIPTION
* Update .gitignore

* Change of extent for proper plotting

* Update latest.inc

* Update mne/viz/utils.py

Co-Authored-By: Eric Larson <larson.eric.d@gmail.com>

* Update mne/viz/utils.py

Co-Authored-By: Eric Larson <larson.eric.d@gmail.com>

* Remove first definition of time_lims

* FIX: Conditional

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #1234.


#### What does this implement/fix?
Explain your changes.


#### Additional information
Any additional information you think is important.
