### PR TITLE
Fix ytick regression

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -585,9 +585,9 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         vmin=vmin, vmax=vmax, mask_style=mask_style, mask_alpha=mask_alpha,
         mask_cmap=mask_cmap)
 
+    # ignore xlim='tight'; happens automatically with `extent` in imshow
+    xlim = None if xlim == 'tight' else xlim
     if xlim is not None:
-        if xlim == 'tight':
-            xlim = (times[0], times[-1])
         ax.set_xlim(xlim)
 
     if colorbar:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -601,15 +601,17 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
     ax.set(ylabel=ylabel, xlabel='Time (%s)' % (time_unit,), title=t)
     _add_nave(ax, nave)
 
-    if show_names:
-        if show_names == "all":
-            yticks = np.arange(len(picks)).astype(int)
-            yticklabels = np.array(ch_names)[picks]
-        else:
-            yticks = np.round(ax.get_yticks()).astype(int)
-            yticks = np.intersect1d(yticks, np.arange(len(picks), dtype=int))
+    if show_names == "all":
+        yticks = np.arange(len(picks)).astype(int)
+        yticklabels = np.array(ch_names)[picks]
+    else:
+        yticks = np.round(ax.get_yticks()).astype(int)
+        yticks = np.intersect1d(yticks, np.arange(len(picks), dtype=int))
+        if show_names:
             yticklabels = np.array(ch_names)[picks][yticks]
-        ax.set(yticks=yticks, yticklabels=yticklabels)
+        else:
+            yticklabels = np.array(picks)[yticks]
+    ax.set(yticks=yticks, yticklabels=yticklabels)
 
 
 @verbose

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -596,22 +596,16 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
         if cmap[1]:
             ax.CB = DraggableColorbar(cbar, im)
 
-    ylabel = "Channels" if show_names else 'Channel (index)'
+    ylabel = 'Channels' if show_names else 'Channel (index)'
     t = titles[this_type] + ' (%d channel%s' % (len(data), _pl(data)) + t_end
     ax.set(ylabel=ylabel, xlabel='Time (%s)' % (time_unit,), title=t)
     _add_nave(ax, nave)
 
-    if show_names == "all":
-        yticks = np.arange(len(picks)).astype(int)
-        yticklabels = np.array(ch_names)[picks]
-    else:
-        yticks = np.round(ax.get_yticks()).astype(int)
-        yticks = np.intersect1d(yticks, np.arange(len(picks), dtype=int))
-        if show_names:
-            yticklabels = np.array(ch_names)[picks][yticks]
-        else:
-            yticklabels = np.array(picks)[yticks]
-    ax.set(yticks=yticks, yticklabels=yticklabels)
+    yticks = np.arange(len(picks))
+    if show_names != 'all':
+        yticks = np.intersect1d(np.round(ax.get_yticks()).astype(int), yticks)
+    yticklabels = np.array(ch_names)[picks] if show_names else np.array(picks)
+    ax.set(yticks=yticks, yticklabels=yticklabels[yticks])
 
 
 @verbose

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -601,17 +601,15 @@ def _plot_image(data, ax, this_type, picks, cmap, unit, units, scalings, times,
     ax.set(ylabel=ylabel, xlabel='Time (%s)' % (time_unit,), title=t)
     _add_nave(ax, nave)
 
-    if show_names is not False:
+    if show_names:
         if show_names == "all":
             yticks = np.arange(len(picks)).astype(int)
             yticklabels = np.array(ch_names)[picks]
         else:
-            max_tick = len(picks)
-            yticks = [tick for tick in ax.get_yticks() if tick < max_tick]
-            yticks = np.array(yticks).astype(int)
-            # these should only ever be ints right?
+            yticks = np.round(ax.get_yticks()).astype(int)
+            yticks = np.intersect1d(yticks, np.arange(len(picks), dtype=int))
             yticklabels = np.array(ch_names)[picks][yticks]
-        ax.set(yticks=yticks + .5, yticklabels=yticklabels)
+        ax.set(yticks=yticks, yticklabels=yticklabels)
 
 
 @verbose
@@ -939,14 +937,13 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
-    show_names : bool | str
+    show_names : bool | 'auto' | 'all'
         Determines if channel names should be plotted on the y axis. If False,
-        no names are shown. If True, ticks are set automatically and the
-        corresponding channel names are shown. If str, must be "auto" or "all".
-        If "all", all channel names are shown.
-        If "auto", is set to False if `picks` is ``None``; to ``True`` if
-        `picks` is not ``None`` and fewer than 25 picks are shown; to "all"
-        if `picks` is not ``None`` and contains fewer than 25 entries.
+        no names are shown. If True, ticks are set automatically by matplotlib
+        and the corresponding channel names are shown. If "all", all channel
+        names are shown. If "auto", is set to False if `picks` is ``None``,
+        to ``True`` if ``picks`` contains 25 or more entries, or to "all"
+        if ``picks`` contains fewer than 25 entries.
     group_by : None | dict
         If a dict, the values must be picks, and `axes` must also be a dict
         with matching keys, or None. If `axes` is None, one figure and one axis


### PR DESCRIPTION
closes #6943 

also fixes:
- the behavior of the `show_names` param, which was supposed to be showing channel indices when `picks=None` but was showing channel names (which led to a mismatch between the yaxis label "channel (index)" and the ticklabels)
- the overplotting of the same yticklabel several times in some cases (e.g., the test case with only 2 channels)
- clarifies slightly the `show_names` docstring

There is plenty of room for further improvement here, for example aligning the x ticks with the center of the imshow columns, but that will be rather involved and should be done in a separate PR.