### PR TITLE
MINOR, DOC: clarify expected format of input file in docstr

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1635,7 +1635,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Mark channels as bad from a text file.
 
         This function operates mostly in the style of the C function
-        ``mne_mark_bad_channels``.
+        ``mne_mark_bad_channels``. Each line in the text file will be
+        interpreted as a name of a bad channel.
 
         Parameters
         ----------


### PR DESCRIPTION
I was using the `raw.load_bad_channels()` method for the first time earlier this week.

This PR improves the docstring so that users know what input file to provide.