### PR TITLE
[MRG] Use latest version 0.22.4 of pyvista instead of master

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - pip:
   - mne
   - vtk
-  - https://github.com/pyvista/pyvista/zipball/master
+  - pyvista>=0.22.4
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy
@@ -46,4 +46,3 @@ dependencies:
   - pydocstyle
   - codespell
   - python-picard
-  - panel

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,4 @@ neo
 xlrd
 pydocstyle
 flake8
-https://github.com/pyvista/pyvista/zipball/master
-panel
+pyvista>=0.22.4


### PR DESCRIPTION
This PR updates the package requirements for the pyvista 3d backend. Panel is no longer required as work on notebook integration is under heavy development at the moment.