### PR TITLE
DOC: Clearer attribute style

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -27,9 +27,26 @@ p code {
 code.xref, a code {
     font-weight: 600;
 }
+/* .. unless in a param list */
+span.classifier a.reference code.literal {
+    font-weight: bold;
+}
 /* use semibold weight for version dropdown */
 .btn {
     font-weight: 600;
+}
+/* Modify our definition lists to be more like sklearn */
+dl.field-list dt.field-odd, dt.field-even {
+    border-right-style: solid;
+    border-width: 1px;
+    border-color: var(--a-color-lighter);
+}
+dl.field-list dd dl dd {
+    padding-left: 30px;
+}
+dl.field-list dt, dd {
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .navbar-version {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -513,6 +513,7 @@ sphinx_gallery_conf = {
     'show_memory': True,
     'line_numbers': False,  # XXX currently (0.3.dev0) messes with style
     'within_subsection_order': FileNameSortKey,
+    'capture_repr': (),
     'junit': op.join('..', 'test-results', 'sphinx-gallery', 'junit.xml'),
 }
 
@@ -522,7 +523,7 @@ sphinx_gallery_conf = {
 # XXX This hack defines what extra methods numpydoc will document
 docscrape.ClassDoc.extra_public_methods = mne.utils._doc_special_members
 numpydoc_class_members_toctree = False
-numpydoc_attributes_as_param_list = False
+numpydoc_attributes_as_param_list = True
 numpydoc_xref_param_type = True
 numpydoc_xref_aliases = {
     'Popen': 'python:subprocess.Popen',


### PR DESCRIPTION
1. Switches `numpydoc` to use `numpydoc_attributes_as_param_list = True` like in `sklearn` ([requested](https://github.com/mne-tools/mne-python/pull/6938#issuecomment-543051254) by @agramfort)
2. Sets `capture_repr` to make it so the recent SG PR does not change our behavior
3. Tweaks our param list style to look more like `sklearn`

@drammock point (3) is about aesthetic judgment so I'll let you take over and keep / discard / modify as you see fit.