### PR TITLE
DOC: make gist link two words so it's easier to see

### DIFF
--- a/tutorials/io/plot_20_reading_eeg_data.py
+++ b/tutorials/io/plot_20_reading_eeg_data.py
@@ -60,8 +60,8 @@ EDF and EDF+ files can be read using :func:`mne.io.read_raw_edf`.
 The EDF+ files may contain an annotation channel which can be used to store
 trigger information. These annotations are available in ``raw.annotations``.
 
-Saving EDF files is not supported natively yet. This
-`gist <https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be>`__
+Saving EDF files is not supported natively yet. `This gist
+<https://gist.github.com/skjerns/bc660ef59dca0dbd53f00ed38c42f6be>`__
 can be used to save any mne.io.Raw into EDF/EDF+/BDF/BDF+.
 
 


### PR DESCRIPTION
based on the comment in #6963, seems the link was easy to miss. This might help.