### PR TITLE
DOC: clarify docstring for stc object

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -451,7 +451,7 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         The data in source space. The data can either be a single array or
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
+        space data corresponds to ``np.dot(kernel, sens_data)``.
     vertices : array | list of array, shape (2,)
         Vertex numbers corresponding to the data. If a list, the first element
         of the list contains vertices of left hemisphere and the
@@ -1358,7 +1358,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
         The data in source space. When it is a single array, the
         left hemisphere is stored in data[:len(vertices[0])] and the right
-        hemisphere is stored in data[:-len(vertices[1])].
+        hemisphere is stored in data[-len(vertices[1]):].
         When data is a tuple, it contains two arrays:
 
         - "kernel" shape (n_vertices, n_sensors) and
@@ -1928,7 +1928,7 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
         The data in source space. The data can either be a single array or
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
+        space data corresponds to ``np.dot(kernel, sens_data)``.
     vertices : array of shape (n_dipoles,)
         The indices of the dipoles in the source space.
     tmin : scalar
@@ -2130,7 +2130,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         The data in source space. The data can either be a single array or
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
+        space data corresponds to ``np.dot(kernel, sens_data)``.
     vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1350,12 +1350,18 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
     Parameters
     ----------
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. The data can either be a single array or
-        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
-        "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
+        The data in source space. When it is a single array, the
+        left hemisphere is stored in data[:vertices[0]] and the right
+        hemisphere is stored in data[:-vertices[1]].
+        When data is a tuple, it contains two arrays:
+            "kernel" shape (n_vertices, n_sensors) and
+            "sens_data" shape (n_sensors, n_times).
+        In this case, the source space data corresponds to
+        "numpy.dot(kernel, sens_data)".
     vertices : list of shape (2,)
-        Vertex numbers corresponding to the data.
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2061,10 +2061,8 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     data : array of shape (n_dipoles, 3, n_times)
         The data in source space. Each dipole contains three vectors that
         denote the dipole strength in X, Y and Z directions over time.
-    vertices : list of array, shape (2,)
-        Vertex numbers corresponding to the data. The first element of the list
-        contains vertices of left hemisphere and the second element contains
-        vertices of right hemisphere.
+    vertices : array
+        Vertex numbers corresponding to the data.
     tmin : float
         Time point of the first sample in data.
     tstep : float

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -452,10 +452,8 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
         space data corresponds to ``np.dot(kernel, sens_data)``.
-    vertices : array | list of array, shape (2,)
-        Vertex numbers corresponding to the data. If a list, the first element
-        of the list contains vertices of left hemisphere and the
-        second element contains vertices of right hemisphere.
+    vertices : array | list of array
+        Vertex numbers corresponding to the data.
     tmin : float
         Time point of the first sample in data.
     tstep : float
@@ -2131,10 +2129,9 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
         space data corresponds to ``np.dot(kernel, sens_data)``.
-    vertices : list of array, shape (2,)
-        Vertex numbers corresponding to the data. The first element of the list
-        contains vertices of left hemisphere and the second element contains
-        vertices of right hemisphere.
+    vertices : list of array
+        Vertex numbers corresponding to the data. The list contains arrays
+        with one array per source space.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar
@@ -2150,10 +2147,9 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of array, shape (2,)
-        Vertex numbers corresponding to the data. The first element of the list
-        contains vertices of left hemisphere and the second element contains
-        vertices of right hemisphere.
+    vertices : list of array
+        Vertex numbers corresponding to the data. The list contains arrays
+        with one array per source space.
     data : array of shape (n_dipoles, n_times)
         The data in source space.
     shape : tuple

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -447,13 +447,21 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
     Parameters
     ----------
-    data : array, shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. The data can either be a single array or
-        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
-        "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : array | list of array
-        Vertex numbers corresponding to the data.
+    data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
+        The data in source space. When it is a single array, the
+        left hemisphere is stored in data[:vertices[0]] and the right
+        hemisphere is stored in data[:-vertices[1]].
+        When data is a tuple, it contains two arrays:
+
+        - "kernel" shape (n_vertices, n_sensors) and
+        - "sens_data" shape (n_sensors, n_times).
+
+        In this case, the source space data corresponds to
+        ``np.dot(kernel, sens_data)``.
+    vertices : array | list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : float
         Time point of the first sample in data.
     tstep : float
@@ -1136,8 +1144,10 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
     ----------
     data : array
         The data in source space.
-    vertices : list, shape (2,)
-        Vertex numbers corresponding to the data.
+    vertices : list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar
@@ -1153,8 +1163,10 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of array, shape (2,)
-        The indices of the dipoles in the left and right source space.
+    vertices : list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     data : array
         The data in source space.
     shape : tuple
@@ -1359,7 +1371,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         - "sens_data" shape (n_sensors, n_times).
 
         In this case, the source space data corresponds to
-        "numpy.dot(kernel, sens_data)".
+        ``np.dot(kernel, sens_data)``.
     vertices : list of shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
@@ -1919,12 +1931,18 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
     Parameters
     ----------
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. The data can either be a single array or
-        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
-        "sens_data" shape (n_sensors, n_times). In this case, the source
-        space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : array
-        Vertex numbers corresponding to the data.
+        The data in source space. When it is a single array, the
+        left hemisphere is stored in data[:vertices[0]] and the right
+        hemisphere is stored in data[:-vertices[1]].
+        When data is a tuple, it contains two arrays:
+
+        - "kernel" shape (n_vertices, n_sensors) and
+        - "sens_data" shape (n_sensors, n_times).
+
+        In this case, the source space data corresponds to
+        ``np.dot(kernel, sens_data)``.
+    vertices : array of shape (n_dipoles,)
+        The indices of the dipoles in the source space.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar
@@ -2002,8 +2020,8 @@ class VolVectorSourceEstimate(_BaseVectorSourceEstimate,
     data : array of shape (n_dipoles, 3, n_times)
         The data in source space. Each dipole contains three vectors that
         denote the dipole strength in X, Y and Z directions over time.
-    vertices : array
-        Vertex numbers corresponding to the data.
+    vertices : array of shape (n_dipoles,)
+        The indices of the dipoles in the source space.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar
@@ -2055,8 +2073,10 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     data : array of shape (n_dipoles, 3, n_times)
         The data in source space. Each dipole contains three vectors that
         denote the dipole strength in X, Y and Z directions over time.
-    vertices : array | list of shape (2,)
-        Vertex numbers corresponding to the data.
+    vertices : list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : float
         Time point of the first sample in data.
     tstep : float
@@ -2123,8 +2143,10 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
         space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : list of array
-        Vertex numbers corresponding to the data.
+    vertices : list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : scalar
         Time point of the first sample in data.
     tstep : scalar
@@ -2140,8 +2162,10 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of array
-        The indices of the dipoles in each source space.
+    vertices : list of shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     data : array of shape (n_dipoles, n_times)
         The data in source space.
     shape : tuple

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1354,8 +1354,10 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         left hemisphere is stored in data[:vertices[0]] and the right
         hemisphere is stored in data[:-vertices[1]].
         When data is a tuple, it contains two arrays:
+
         - "kernel" shape (n_vertices, n_sensors) and
         - "sens_data" shape (n_sensors, n_times).
+
         In this case, the source space data corresponds to
         "numpy.dot(kernel, sens_data)".
     vertices : list of shape (2,)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1354,8 +1354,8 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         left hemisphere is stored in data[:vertices[0]] and the right
         hemisphere is stored in data[:-vertices[1]].
         When data is a tuple, it contains two arrays:
-            "kernel" shape (n_vertices, n_sensors) and
-            "sens_data" shape (n_sensors, n_times).
+        - "kernel" shape (n_vertices, n_sensors) and
+        - "sens_data" shape (n_sensors, n_times).
         In this case, the source space data corresponds to
         "numpy.dot(kernel, sens_data)".
     vertices : list of shape (2,)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -447,12 +447,12 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
 
     Parameters
     ----------
-    data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
+    data : array, shape (n_dipoles, n_times) | tuple, shape (2,)
         The data in source space. The data can either be a single array or
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
         space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : array | list of shape (2,)
+    vertices : array | list of array, shape (2,)
         Vertex numbers corresponding to the data. If a list, the first element
         of the list contains vertices of left hemisphere and the
         second element contains vertices of right hemisphere.
@@ -1138,7 +1138,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
     ----------
     data : array
         The data in source space.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.
@@ -1157,7 +1157,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.
@@ -1366,7 +1366,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
 
         In this case, the source space data corresponds to
         ``np.dot(kernel, sens_data)``.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.
@@ -1385,7 +1385,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         The indices of the dipoles in the left and right source space.
     data : array of shape (n_dipoles, n_times)
         The data in source space.
@@ -2061,7 +2061,7 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     data : array of shape (n_dipoles, 3, n_times)
         The data in source space. Each dipole contains three vectors that
         denote the dipole strength in X, Y and Z directions over time.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.
@@ -2131,7 +2131,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
         "sens_data" shape (n_sensors, n_times). In this case, the source
         space data corresponds to "numpy.dot(kernel, sens_data)".
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.
@@ -2150,7 +2150,7 @@ class MixedSourceEstimate(_BaseSourceEstimate):
         The subject name.
     times : array of shape (n_times,)
         The time vector.
-    vertices : list of shape (2,)
+    vertices : list of array, shape (2,)
         Vertex numbers corresponding to the data. The first element of the list
         contains vertices of left hemisphere and the second element contains
         vertices of right hemisphere.

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -448,20 +448,14 @@ class _BaseSourceEstimate(ToDataFrameMixin, TimeMixin):
     Parameters
     ----------
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. When it is a single array, the
-        left hemisphere is stored in data[:vertices[0]] and the right
-        hemisphere is stored in data[:-vertices[1]].
-        When data is a tuple, it contains two arrays:
-
-        - "kernel" shape (n_vertices, n_sensors) and
-        - "sens_data" shape (n_sensors, n_times).
-
-        In this case, the source space data corresponds to
-        ``np.dot(kernel, sens_data)``.
+        The data in source space. The data can either be a single array or
+        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
+        "sens_data" shape (n_sensors, n_times). In this case, the source
+        space data corresponds to "numpy.dot(kernel, sens_data)".
     vertices : array | list of shape (2,)
-        Vertex numbers corresponding to the data. The first element of the list
-        contains vertices of left hemisphere and the second element contains
-        vertices of right hemisphere.
+        Vertex numbers corresponding to the data. If a list, the first element
+        of the list contains vertices of left hemisphere and the
+        second element contains vertices of right hemisphere.
     tmin : float
         Time point of the first sample in data.
     tstep : float
@@ -1363,8 +1357,8 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
     ----------
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
         The data in source space. When it is a single array, the
-        left hemisphere is stored in data[:vertices[0]] and the right
-        hemisphere is stored in data[:-vertices[1]].
+        left hemisphere is stored in data[:len(vertices[0])] and the right
+        hemisphere is stored in data[:-len(vertices[1])].
         When data is a tuple, it contains two arrays:
 
         - "kernel" shape (n_vertices, n_sensors) and
@@ -1931,16 +1925,10 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
     Parameters
     ----------
     data : array of shape (n_dipoles, n_times) | tuple, shape (2,)
-        The data in source space. When it is a single array, the
-        left hemisphere is stored in data[:vertices[0]] and the right
-        hemisphere is stored in data[:-vertices[1]].
-        When data is a tuple, it contains two arrays:
-
-        - "kernel" shape (n_vertices, n_sensors) and
-        - "sens_data" shape (n_sensors, n_times).
-
-        In this case, the source space data corresponds to
-        ``np.dot(kernel, sens_data)``.
+        The data in source space. The data can either be a single array or
+        a tuple with two arrays: "kernel" shape (n_vertices, n_sensors) and
+        "sens_data" shape (n_sensors, n_times). In this case, the source
+        space data corresponds to "numpy.dot(kernel, sens_data)".
     vertices : array of shape (n_dipoles,)
         The indices of the dipoles in the source space.
     tmin : scalar

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2061,8 +2061,10 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     data : array of shape (n_dipoles, 3, n_times)
         The data in source space. Each dipole contains three vectors that
         denote the dipole strength in X, Y and Z directions over time.
-    vertices : array
-        Vertex numbers corresponding to the data.
+    vertices : list of array, shape (2,)
+        Vertex numbers corresponding to the data. The first element of the list
+        contains vertices of left hemisphere and the second element contains
+        vertices of right hemisphere.
     tmin : float
         Time point of the first sample in data.
     tstep : float


### PR DESCRIPTION
Just a tiny tweak to improve and clarify the docstring of SourceEstimate object.