### PR TITLE
[MRG] Fix borders on pyvista backend

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - pip:
   - mne
   - vtk
-  - pyvista>=0.22.4
+  - https://github.com/pyvista/pyvista/zipball/master
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/examples/visualization/plot_publication_figure.py
+++ b/examples/visualization/plot_publication_figure.py
@@ -49,7 +49,7 @@ stc.plot(views='lat', hemi='split', size=(800, 400), subject='sample',
 ###############################################################################
 # To make a publication-ready figure, first we'll re-plot the brain on a white
 # background, take a screenshot of it, and then crop out the white margins.
-# While we're at it, let's change the colormap, set custom colormap limits, and
+# While we're at it, let's change the colormap, set custom colormap limits and
 # remove the default colorbar (so we can add a smaller, vertical one later):
 
 colormap = 'viridis'

--- a/examples/visualization/plot_publication_figure.py
+++ b/examples/visualization/plot_publication_figure.py
@@ -69,6 +69,7 @@ brain.close()
 # 255, 255)`` encodes a white pixel, so we'll detect any pixels that differ
 # from that:
 
+screenshot[(screenshot == 0)] = 255
 nonwhite_pix = (screenshot != 255).any(-1)
 nonwhite_row = nonwhite_pix.any(1)
 nonwhite_col = nonwhite_pix.any(0)

--- a/examples/visualization/plot_publication_figure.py
+++ b/examples/visualization/plot_publication_figure.py
@@ -63,15 +63,6 @@ screenshot = brain.screenshot()
 brain.close()
 
 ###############################################################################
-# Here we remove the black borders introduced by the screenshot by selecting
-# the two important parts of the image and concatenating those parts together:
-
-n_rows, n_cols, _ = screenshot.shape
-shot1 = screenshot[1:-1, 1:n_cols // 2 - 1, :]
-shot2 = screenshot[1:-1, n_cols // 2:-1, :]
-screenshot = np.concatenate((shot1, shot2), axis=1)
-
-###############################################################################
 # Now let's crop out the white margins and the white gap between hemispheres.
 # The screenshot has dimensions ``(h, w, 3)``, with the last axis being R, G, B
 # values for each pixel, encoded as integers between ``0`` and ``255``. ``(255,

--- a/examples/visualization/plot_publication_figure.py
+++ b/examples/visualization/plot_publication_figure.py
@@ -63,13 +63,21 @@ screenshot = brain.screenshot()
 brain.close()
 
 ###############################################################################
+# Here we remove the black borders introduced by the screenshot by selecting
+# the two important parts of the image and concatenating those parts together:
+
+n_rows, n_cols, _ = screenshot.shape
+shot1 = screenshot[1:-1, 1:n_cols // 2 - 1, :]
+shot2 = screenshot[1:-1, n_cols // 2:-1, :]
+screenshot = np.concatenate((shot1, shot2), axis=1)
+
+###############################################################################
 # Now let's crop out the white margins and the white gap between hemispheres.
 # The screenshot has dimensions ``(h, w, 3)``, with the last axis being R, G, B
 # values for each pixel, encoded as integers between ``0`` and ``255``. ``(255,
 # 255, 255)`` encodes a white pixel, so we'll detect any pixels that differ
 # from that:
 
-screenshot[(screenshot == 0)] = 255
 nonwhite_pix = (screenshot != 255).any(-1)
 nonwhite_row = nonwhite_pix.any(1)
 nonwhite_col = nonwhite_pix.any(0)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -44,6 +44,7 @@ class _Figure(object):
         self.store['window_size'] = size
         self.store['shape'] = shape
         self.store['off_screen'] = off_screen
+        self.store['border'] = False
 
     def build(self):
         with warnings.catch_warnings():

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ neo
 xlrd
 pydocstyle
 flake8
-pyvista>=0.22.4
+https://github.com/pyvista/pyvista/zipball/master


### PR DESCRIPTION
This is a fastfix for the broken cropping in `examples/visualization/plot_publication_figure`.

![image](https://user-images.githubusercontent.com/18143289/67304654-72661100-f4f4-11e9-8a6c-de36050faff3.png)
