### PR TITLE
Fix ica.plot_properties with bad data

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -234,7 +234,7 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
 
 def _get_psd_label_and_std(this_psd, dB, ica, num_std):
     """Handle setting up PSD for one component, for plot_ica_properties."""
-    psd_ylabel = _convert_psds(this_psd[:, :], dB, estimate='auto', scaling=1.,
+    psd_ylabel = _convert_psds(this_psd, dB, estimate='auto', scaling=1.,
                                unit='AU', first_dim='epoch')
     psds_mean = this_psd.mean(axis=0)
     diffs = this_psd - psds_mean

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -234,8 +234,8 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
 
 def _get_psd_label_and_std(this_psd, dB, ica, num_std):
     """Handle setting up PSD for one component, for plot_ica_properties."""
-    psd_ylabel = _convert_psds(this_psd, dB, estimate='auto', scaling=1.,
-                               unit='AU', ch_names=ica.ch_names)
+    psd_ylabel = _convert_psds(this_psd[:, :], dB, estimate='auto', scaling=1.,
+                               unit='AU', first_dim='epoch')
     psds_mean = this_psd.mean(axis=0)
     diffs = this_psd - psds_mean
     # the distribution of power for each frequency bin is highly

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -3033,7 +3033,8 @@ def _set_psd_plot_params(info, proj, picks, ax, area_mode):
             ax_list, make_label)
 
 
-def _convert_psds(psds, dB, estimate, scaling, unit, ch_names):
+def _convert_psds(psds, dB, estimate, scaling, unit, ch_names=None,
+                  first_dim='channel'):
     """Convert PSDs to dB (if necessary) and appropriate units.
 
     The following table summarizes the relationship between the value of
@@ -3052,15 +3053,26 @@ def _convert_psds(psds, dB, estimate, scaling, unit, ch_names):
     where amp are the units corresponding to the variable, as specified by
     ``unit``.
     """
+    _check_option('first_dim', first_dim, ['channel', 'epoch'])
     where = np.where(psds.min(1) <= 0)[0]
-    dead_ch = ', '.join(ch_names[ii] for ii in where)
     if len(where) > 0:
+        # Construct a helpful error message, depending on whether the first
+        # dimension of `psds` are channels or epochs.
         if dB:
-            msg = "Infinite value in PSD for channel(s) %s. " \
-                  "These channels might be dead." % dead_ch
+            bad_value = 'Infinite'
         else:
-            msg = "Zero value in PSD for channel(s) %s. " \
-                  "These channels might be dead." % dead_ch
+            bad_value = 'Zero'
+
+        if first_dim == 'channel':
+            bads = ', '.join(ch_names[ii] for ii in where)
+        else:
+            bads = ', '.join(str(ii) for ii in where)
+
+        msg = "{bad_value} value in PSD for {first_dim}(s) {bads}.".format(
+            bad_value=bad_value, first_dim=first_dim, bads=bads)
+        if first_dim == 'channel':
+            msg += '\nThese channels might be dead.'
+
         warn(msg, UserWarning)
 
     if estimate == 'auto':


### PR DESCRIPTION
When plotting ICA component properties, one of the things that gets plotted is the component PSD. This uses the helper function `_convert_psds` that performs a check on the presense of zeros in the
PSD. When zeros are detected, a warning is printed. To construct the warning message string, it is assumed that the first dimension of the `psds` array contains channels. However, in the case of `ica.plot_properties`, the first dimensions contains epochs. Hence, the construction of the warning message string fails with an index out of bounds error.

This PR adds a flag to the `_convert_psds` helper function to inform it that the first dimension of the `psds` array contains epochs rather than channels.