### PR TITLE
MRG, STY: Many style fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx"
-               PIP_DEPENDENCIES="codecov flake8 https://api.github.com/repos/datapythonista/numpydoc/zipball/validation codespell pydocstyle codecov check-manifest twine"
+               PIP_DEPENDENCIES="codecov flake8 https://api.github.com/repos/numpy/numpydoc/zipball/master codespell pydocstyle codecov check-manifest twine"
 
         # Linux
         # As of 2019/09/19 there is a mysterious joblib bug, so temporarily work around it with MNE_FORCE_SERIAL

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx"
-               PIP_DEPENDENCIES="codecov flake8 'https://api.github.com/repos/datapythonista/numpydoc/zipball/validation' codespell pydocstyle codecov check-manifest twine"
+               PIP_DEPENDENCIES="codecov flake8 https://api.github.com/repos/datapythonista/numpydoc/zipball/validation codespell pydocstyle codecov check-manifest twine"
 
         # Linux
         # As of 2019/09/19 there is a mysterious joblib bug, so temporarily work around it with MNE_FORCE_SERIAL

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - os: linux
           env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
                CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx"
-               PIP_DEPENDENCIES="codecov flake8 numpydoc codespell pydocstyle codecov check-manifest twine"
+               PIP_DEPENDENCIES="codecov flake8 'https://api.github.com/repos/datapythonista/numpydoc/zipball/validation' codespell pydocstyle codecov check-manifest twine"
 
         # Linux
         # As of 2019/09/19 there is a mysterious joblib bug, so temporarily work around it with MNE_FORCE_SERIAL

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -602,9 +602,10 @@ numpydoc_xref_ignore = {
     'n_segments', 'n_orient_inv', 'n_orient_fwd',
     # Undocumented (on purpose)
     'RawKIT', 'RawEximia', 'RawEGI', 'RawEEGLAB', 'RawEDF', 'RawCTF', 'RawBTi',
-    'RawBrainVision', 'RawCurry', 'RawNIRX',
+    'RawBrainVision', 'RawCurry', 'RawNIRX', 'RawGDF',
     # sklearn subclasses
     'mapping', 'to', 'any',
     # unlinkable
     'mayavi.mlab.pipeline.surface',
+    'CoregFrame', 'Kit2FiffFrame', 'FiducialsFrame',
 }

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
 - pytest-timeout
 - joblib
 - psutil
-- "https://api.github.com/repos/datapythonista/numpydoc/zipball/validation"
 - flake8
 - spyder
 - numexpr
@@ -33,6 +32,7 @@ dependencies:
 - testpath<0.4
 - pip:
   - mne
+  - https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
   - vtk
   - pyvista>=0.22.4
   - mayavi

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - pytest-timeout
 - joblib
 - psutil
-- numpydoc
+- https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
 - flake8
 - spyder
 - numexpr

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - pytest-timeout
 - joblib
 - psutil
-- https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
+- "https://api.github.com/repos/datapythonista/numpydoc/zipball/validation"
 - flake8
 - spyder
 - numexpr

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
 - testpath<0.4
 - pip:
   - mne
-  - https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
+  - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
   - pyvista>=0.22.4
   - mayavi

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -156,7 +156,6 @@ class Annotations(object):
                        |         |      |
                        |         +------+
 
-
                     [[[ CRASH ]]]
 
         ----------- meas_date=None, orig_time=None -------------------------
@@ -175,7 +174,6 @@ class Annotations(object):
              n                        |      |
              e                        +------+
          orig_time                 onset[0]'
-
     """  # noqa: E501
 
     def __init__(self, onset, duration, description,
@@ -885,7 +883,7 @@ def events_from_annotations(raw, event_id="auto",
     use_rounding : boolean
         If True, use rounding (instead of truncation) when converting
         times to indices. This can help avoid non-unique indices.
-    chunk_duration: float | None
+    chunk_duration : float | None
         Chunk duration in seconds. If ``chunk_duration`` is set to None
         (default), generated events correspond to the annotation onsets.
         If not, :func:`mne.events_from_annotations` returns as many events as

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -563,7 +563,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
     mt_low_bias : bool
         Only use tapers with more than 90%% spectral concentration within
         bandwidth. Only used in 'multitaper' mode. Defaults to True.
-    cwt_n_cycles: float | list of float | None
+    cwt_n_cycles : float | list of float | None
         Number of cycles to use when constructing Morlet wavelets. Fixed number
         or one per frequency. Defaults to 7.
         Only used in 'cwt_morlet' mode.

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -61,7 +61,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
                 each location.
             'vector'
                 Keeps the currents for each direction separate
-
     %(rank_info)s
     weight_norm : 'unit-noise-gain' | 'nai' | None
         If 'unit-noise-gain', the unit-noise gain minimum variance beamformer
@@ -275,7 +274,7 @@ def apply_lcmv(evoked, filters, max_ori_out='signed', verbose=None):
     filters : instance of Beamformer
         LCMV spatial filter (beamformer weights).
         Filter weights returned from :func:`make_lcmv`.
-    max_ori_out: 'signed'
+    max_ori_out : 'signed'
         Specify in case of pick_ori='max-power'.
     %(verbose)s
 
@@ -322,13 +321,12 @@ def apply_lcmv_epochs(epochs, filters, max_ori_out='signed',
     filters : instance of Beamformer
         LCMV spatial filter (beamformer weights)
         Filter weights returned from :func:`make_lcmv`.
-    max_ori_out: 'signed'
+    max_ori_out : 'signed'
         Specify in case of pick_ori='max-power'.
     return_generator : bool
          Return a generator object instead of a list. This allows iterating
          over the stcs without having to keep them all in memory.
     %(verbose)s
-
 
     Returns
     -------
@@ -374,7 +372,7 @@ def apply_lcmv_raw(raw, filters, start=None, stop=None, max_ori_out='signed',
         Index of first time sample (index not time is seconds).
     stop : int
         Index of first time sample not to include (index not time is seconds).
-    max_ori_out: 'signed'
+    max_ori_out : 'signed'
         Specify in case of pick_ori='max-power'.
     %(verbose)s
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -316,10 +316,6 @@ def make_bem_solution(surfs, verbose=None):
     bem : instance of ConductorModel
         The BEM solution.
 
-    Notes
-    -----
-    .. versionadded:: 0.10.0
-
     See Also
     --------
     make_bem_model
@@ -327,6 +323,10 @@ def make_bem_solution(surfs, verbose=None):
     write_bem_surfaces
     read_bem_solution
     write_bem_solution
+
+    Notes
+    -----
+    .. versionadded:: 0.10.0
     """
     logger.info('Approximation method : Linear collocation\n')
     if isinstance(surfs, str):
@@ -558,16 +558,16 @@ def make_bem_model(subject, ico=4, conductivity=(0.3, 0.006, 0.3),
         The BEM surfaces. Use `make_bem_solution` to turn these into a
         `ConductorModel` suitable for forward calculation.
 
-    Notes
-    -----
-    .. versionadded:: 0.10.0
-
     See Also
     --------
     make_bem_solution
     make_sphere_model
     read_bem_surfaces
     write_bem_surfaces
+
+    Notes
+    -----
+    .. versionadded:: 0.10.0
     """
     conductivity = np.array(conductivity, float)
     if conductivity.ndim != 1 or conductivity.size not in (1, 3):
@@ -744,14 +744,14 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
     sphere : instance of ConductorModel
         The resulting spherical conductor model.
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
-
     See Also
     --------
     make_bem_model
     make_bem_solution
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
     """
     for name in ('r0', 'head_radius'):
         param = locals()[name]

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1015,8 +1015,8 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, unit='m',
 
     if ext in SUPPORTED_FILE_EXT['eeglab']:
         if head_size is None:
-            raise(ValueError,
-                  "``head_size`` cannot be None for '{}'".format(ext))
+            raise ValueError(
+                "``head_size`` cannot be None for '{}'".format(ext))
         ch_names, pos = _read_eeglab_locations(fname, unit)
         scale = head_size / np.median(np.linalg.norm(pos, axis=-1))
         pos *= scale
@@ -1037,8 +1037,8 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, unit='m',
 
     elif ext in SUPPORTED_FILE_EXT['generic (Theta-phi in degrees)']:
         if head_size is None:
-            raise(ValueError,
-                  "``head_size`` cannot be None for '{}'".format(ext))
+            raise ValueError(
+                "``head_size`` cannot be None for '{}'".format(ext))
         montage = _read_theta_phi_in_degrees(fname, head_size=head_size,
                                              fid_names=('Nz', 'LPA', 'RPA'))
 

--- a/mne/connectivity/effective.py
+++ b/mne/connectivity/effective.py
@@ -33,12 +33,6 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
     The PSI is computed from the coherency (see spectral_connectivity), details
     can be found in [1].
 
-    References
-    ----------
-    [1] Nolte et al. "Robustly Estimating the Flow Direction of Information in
-    Complex Physical Systems", Physical Review Letters, vol. 100, no. 23,
-    pp. 1-4, Jun. 2008.
-
     Parameters
     ----------
     data : array-like, shape=(n_epochs, n_signals, n_times)
@@ -80,7 +74,7 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
         bandwidth. Only used in 'multitaper' mode.
     cwt_freqs : array
         Array of frequencies of interest. Only used in 'cwt_morlet' mode.
-    cwt_n_cycles: float | array of float
+    cwt_n_cycles : float | array of float
         Number of cycles. Fixed number or one per frequency. Only used in
         'cwt_morlet' mode.
     block_size : int
@@ -109,6 +103,12 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
     n_tapers : int
         The number of DPSS tapers used. Only defined in 'multitaper' mode.
         Otherwise None is returned.
+
+    References
+    ----------
+    [1] Nolte et al. "Robustly Estimating the Flow Direction of Information in
+        Complex Physical Systems", Physical Review Letters, vol. 100, no. 23,
+        pp. 1-4, Jun. 2008.
     """
     logger.info('Estimating phase slope index (PSI)')
     # estimate the coherency

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -615,7 +615,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
         bandwidth. Only used in 'multitaper' mode.
     cwt_freqs : array
         Array of frequencies of interest. Only used in 'cwt_morlet' mode.
-    cwt_n_cycles: float | array of float
+    cwt_n_cycles : float | array of float
         Number of cycles. Fixed number or one per frequency. Only used in
         'cwt_morlet' mode.
     block_size : int
@@ -720,7 +720,6 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
                       E[|Im(Sxy)|]
 
         'wpli2_debiased' : Debiased estimator of squared WPLI [6]_.
-
 
     References
     ----------

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -908,8 +908,8 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
 
     See Also
     --------
-    scale_labels : Add labels to a scaled MRI
-    scale_source_space : Add a source space to a scaled MRI
+    scale_labels : Add labels to a scaled MRI.
+    scale_source_space : Add a source space to a scaled MRI.
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     paths = _find_mri_paths(subject_from, skip_fiducials, subjects_dir)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -908,8 +908,8 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
 
     See Also
     --------
-    scale_labels : add labels to a scaled MRI
-    scale_source_space : add a source space to a scaled MRI
+    scale_labels : Add labels to a scaled MRI
+    scale_source_space : Add a source space to a scaled MRI
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     paths = _find_mri_paths(subject_from, skip_fiducials, subjects_dir)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -410,7 +410,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
 
     See Also
     --------
-    compute_covariance : Estimate noise covariance matrix from epochs
+    compute_covariance : Estimate noise covariance matrix from epochs.
 
     Notes
     -----
@@ -656,7 +656,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
 
     See Also
     --------
-    compute_raw_covariance : Estimate noise covariance from raw data
+    compute_raw_covariance : Estimate noise covariance from raw data.
 
     Notes
     -----

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1329,7 +1329,6 @@ def prepare_noise_cov(noise_cov, info, ch_names=None, rank=None,
         If dict, it will override the following dict (default if None)::
 
             dict(mag=1e12, grad=1e11, eeg=1e5)
-
     %(verbose)s
 
     Returns
@@ -1770,7 +1769,6 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=None, rank=None,
         following default dict (default if None):
 
             dict(mag=1e12, grad=1e11, eeg=1e5)
-
     %(verbose)s
 
     Returns

--- a/mne/datasets/sample/sample.py
+++ b/mne/datasets/sample/sample.py
@@ -41,7 +41,18 @@ def _skip_sample_data():
 
 
 def requires_sample_data(func):
-    """Skip testing data test."""
+    """Skip testing data test.
+
+    Parameters
+    ----------
+    func : callable
+        The function to decorate.False
+
+    Returns
+    -------
+    dec_func : callable
+        The decorated function.
+    """
     import pytest
     return pytest.mark.skipif(_skip_sample_data(),
                               reason='Requires sample dataset')(func)

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -36,15 +36,15 @@ class LinearModel(BaseEstimator):
     patterns_ : ndarray, shape ([n_targets], n_features)
         If fit, the patterns used to restore M/EEG signals.
 
-    Notes
-    -----
-    .. versionadded:: 0.10
-
     See Also
     --------
     CSP
     mne.preprocessing.ICA
     mne.preprocessing.Xdawn
+
+    Notes
+    -----
+    .. versionadded:: 0.10
 
     References
     ----------

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -70,7 +70,6 @@ class ReceptiveField(BaseEstimator):
         :func:`mne.verbose` and :ref:`Logging documentation <tut_logging>`
         for more).
 
-
     Attributes
     ----------
     coef_ : array, shape ([n_outputs, ]n_features, n_delays)

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -248,6 +248,10 @@ class TimeDelayingRidge(BaseEstimator):
 
         .. versionadded:: 0.18
 
+    See Also
+    --------
+    mne.decoding.ReceptiveField
+
     Notes
     -----
     This class is meant to be used with :class:`mne.decoding.ReceptiveField`
@@ -255,10 +259,6 @@ class TimeDelayingRidge(BaseEstimator):
     field and input signal sizes, it should be more CPU and memory
     efficient by using frequency-domain methods (FFTs) to compute the
     auto- and cross-correlations.
-
-    See Also
-    --------
-    mne.decoding.ReceptiveField
     """
 
     _estimator_type = "regressor"

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -81,7 +81,7 @@ class Scaler(TransformerMixin, BaseEstimator):
     info : instance of Info | None
         The measurement info. Only necessary if ``scalings`` is a dict or
         None.
-    scalings : dict, string, default None.
+    scalings : dict, string, default None
         Scaling method to be applied to data channel wise.
 
         * if scalings is None (default), scales mag by 1e15, grad by 1e13,
@@ -224,15 +224,15 @@ class Vectorizer(TransformerMixin):
     This class reshapes an n-dimensional array into an n_samples * n_features
     array, usable by the estimators and transformers of scikit-learn.
 
-    Examples
-    --------
-    clf = make_pipeline(SpatialFilter(), _XdawnTransformer(), Vectorizer(),
-                        LogisticRegression())
-
     Attributes
     ----------
     features_shape_ : tuple
          Stores the original shape of data.
+
+    Examples
+    --------
+    clf = make_pipeline(SpatialFilter(), _XdawnTransformer(), Vectorizer(),
+                        LogisticRegression())
     """
 
     def fit(self, X, y=None):

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1030,7 +1030,6 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         the position is fixed during fitting.
 
         .. versionadded:: 0.12
-
     ori : ndarray, shape (3,) | None
         Orientation of the dipole to use. If None (default), the
         orientation is free to change as a function of time. If an
@@ -1040,7 +1039,6 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         for each time instant.
 
         .. versionadded:: 0.12
-
     %(verbose)s
 
     Returns

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1801,7 +1801,6 @@ class Epochs(BaseEpochs):
                           eeg=40e-6, # V (EEG channels)
                           eog=250e-6 # V (EOG channels)
                           )
-
     flat : dict | None
         Rejection parameters based on flatness of signal.
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
@@ -1923,7 +1922,6 @@ class Epochs(BaseEpochs):
     For example with the event_id {'aud': 1, 'vis': 2} and the events
     [[0, 0, 1], [0, 0, 2]], the "merge" behavior will update both event_id and
     events to be: {'aud/vis': 3} and [[0, 0, 3], ] respectively.
-
     """
 
     @verbose
@@ -2053,6 +2051,12 @@ class EpochsArray(BaseEpochs):
         .. versionadded:: 0.16
     %(verbose)s
 
+    See Also
+    --------
+    create_info
+    EvokedArray
+    io.RawArray
+
     Notes
     -----
     Proper units of measure:
@@ -2063,12 +2067,6 @@ class EpochsArray(BaseEpochs):
     * M: hbo, hbr
     * Am: dipole
     * AU: misc
-
-    See Also
-    --------
-    create_info
-    EvokedArray
-    io.RawArray
     """
 
     @verbose

--- a/mne/event.py
+++ b/mne/event.py
@@ -992,7 +992,7 @@ class AcqParserFIF(object):
 
     See Also
     --------
-    mne.io.Raw.acqparser : Access the parser through a Raw attribute
+    mne.io.Raw.acqparser : Access the parser through a Raw attribute.
 
     Notes
     -----

--- a/mne/event.py
+++ b/mne/event.py
@@ -215,7 +215,7 @@ def read_events(filename, include=None, exclude=None, mask=None,
     mask : int | None
         The value of the digital mask to apply to the stim channel values.
         If None (default), no masking is performed.
-    mask_type: 'and' | 'not_and'
+    mask_type : 'and' | 'not_and'
         The type of operation between the mask and the trigger.
         Choose 'and' (default) for MNE-C masking behavior.
 
@@ -393,7 +393,7 @@ def find_stim_steps(raw, pad_start=None, pad_stop=None, merge=0,
     ----------
     raw : Raw object
         The raw data.
-    pad_start: None | int
+    pad_start : None | int
         Values to assume outside of the stim channel (e.g., if pad_start=0 and
         the stim channel starts with value 5, an event of [0, 0, 5] will be
         inserted at the beginning). With None, no steps will be inserted.
@@ -583,7 +583,7 @@ def find_events(raw, stim_channel=None, output='onset',
         in MNE-C.
 
         .. versionadded:: 0.12
-    mask_type: 'and' | 'not_and'
+    mask_type : 'and' | 'not_and'
         The type of operation between the mask and the trigger.
         Choose 'and' (default) for MNE-C masking behavior.
 
@@ -690,7 +690,6 @@ def find_events(raw, stim_channel=None, output='onset',
              37 '0100101' <- mask
          ----------------
               2 '0000010'
-
     """
     min_samples = min_duration * raw.info['sfreq']
 
@@ -778,6 +777,15 @@ def merge_events(events, ids, new_id, replace_events=True):
     new_events : array, shape (n_events_out, 3)
         The new events
 
+    Notes
+    -----
+    Rather than merging events you can use hierarchical event_id
+    in Epochs. For example, here::
+
+        >>> event_id = {'auditory/left': 1, 'auditory/right': 2}
+
+    And the condition 'auditory' would correspond to either 1 or 2.
+
     Examples
     --------
     Here is quick example of the behavior::
@@ -793,15 +801,6 @@ def merge_events(events, ids, new_id, replace_events=True):
                [341,   0,   2],
                [341,   0,  12],
                [502,   0,   3]])
-
-    Notes
-    -----
-    Rather than merging events you can use hierarchical event_id
-    in Epochs. For example, here::
-
-        >>> event_id = {'auditory/left': 1, 'auditory/right': 2}
-
-    And the condition 'auditory' would correspond to either 1 or 2.
     """
     events = np.asarray(events)
     events_out = events.copy()
@@ -864,9 +863,9 @@ def make_fixed_length_events(raw, id=1, start=0, stop=None, duration=1.,
     stop : float | None
         Maximum time of last event. If None, events extend to the end
         of the recording.
-    duration: float
+    duration : float
         The duration to separate events by.
-    first_samp: bool
+    first_samp : bool
         If True (default), times will have raw.first_samp added to them, as
         in :func:`mne.find_events`. This behavior is not desirable if the
         returned events will be combined with event times that already
@@ -993,7 +992,7 @@ class AcqParserFIF(object):
 
     See Also
     --------
-    mne.io.Raw.acqparser : access the parser through a Raw attribute
+    mne.io.Raw.acqparser : Access the parser through a Raw attribute
 
     Notes
     -----
@@ -1351,10 +1350,10 @@ class AcqParserFIF(object):
             Neuromag acquisition setups that use channel STI016 (channel 16
             turns data into e.g. -32768), similar to ``mne_fix_stim14 --32``
             in MNE-C.
-        mask_type: 'and' | 'not_and'
+        mask_type : 'and' | 'not_and'
             The type of operation between the mask and the trigger.
             Choose 'and' for MNE-C masking behavior.
-        delayed_lookup: bool
+        delayed_lookup : bool
             If True, use the 'delayed lookup' procedure implemented in Elekta
             software. When a trigger transition occurs, the lookup of
             the new trigger value will not happen immediately at the following

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -680,6 +680,10 @@ class EvokedArray(Evoked):
         Type of data, either average or standard_error. Defaults to 'average'.
     %(verbose)s
 
+    See Also
+    --------
+    EpochsArray, io.RawArray, create_info
+
     Notes
     -----
     Proper units of measure:
@@ -689,10 +693,6 @@ class EvokedArray(Evoked):
     * M: hbo, hbr
     * Am: dipole
     * AU: misc
-
-    See Also
-    --------
-    EpochsArray, io.RawArray, create_info
     """
 
     @verbose

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -891,7 +891,6 @@ def create_filter(data, sfreq, l_freq, h_freq, filter_length='auto',
         * Fs1 = Fp1 - l_trans_bandwidth in Hz
         * Fs2 = Fp2 + h_trans_bandwidth in Hz
 
-
     **Band-stop filter**
 
     The frequency response is (approximately) given by::

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1137,7 +1137,6 @@ def compute_depth_prior(forward, info, exp=0.8, limit=10.0,
           Use all channels. Not recommended since the depth weighting will be
           biased toward whichever channel type has the largest values in
           SI units (such as EEG being orders of magnitude larger than MEG).
-
     """
     from ..cov import Covariance, compute_whitener
     _validate_type(forward, Forward, 'forward')
@@ -1333,7 +1332,6 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
     evoked_template. The evoked_template should be from the same MEG system on
     which the original data was acquired. An exception will be raised if the
     forward operator contains channels that are not present in the template.
-
 
     Parameters
     ----------

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -35,7 +35,6 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
 
         $ mne coreg
 
-
     Parameters
     ----------
     tabbed : bool
@@ -112,6 +111,11 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
 
         .. versionadded:: 0.18
     %(verbose)s
+
+    Returns
+    -------
+    frame : instance of CoregFrame
+        The coregistration frame.
 
     Notes
     -----
@@ -191,6 +195,11 @@ def fiducials(subject=None, fid_file=None, subjects_dir=None):
     subjects_dir : None | str
         Overrule the subjects_dir environment variable.
 
+    Returns
+    -------
+    frame : instance of FiducialsFrame
+        The GUI frame.
+
     Notes
     -----
     All parameters are optional, since they can be set through the GUI.
@@ -211,6 +220,10 @@ def kit2fiff():
 
         $ mne kit2fiff
 
+    Returns
+    -------
+    frame : instance of Kit2FiffFrame
+        The GUI frame.
     """
     _check_mayavi_version()
     from ._backend import _check_backend

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -489,23 +489,23 @@ def tf_mixed_norm(evoked, forward, noise_cov,
         Maximum number of iterations.
     tol : float
         Tolerance parameter.
-    weights: None | array | SourceEstimate
+    weights : None | array | SourceEstimate
         Weight for penalty in mixed_norm. Can be None or
         1d array of length n_sources or a SourceEstimate e.g. obtained
         with wMNE or dSPM or fMRI.
-    weights_min: float
+    weights_min : float
         Do not consider in the estimation sources for which weights
         is less than weights_min.
-    pca: bool
+    pca : bool
         If True the rank of the data is reduced to true dimension.
-    debias: bool
+    debias : bool
         Remove coefficient amplitude bias due to L1 penalty.
-    wsize: int or array-like
+    wsize : int or array-like
         Length of the STFT window in samples (must be a multiple of 4).
         If an array is passed, multiple TF dictionaries are used (each having
         its own wsize and tstep) and each entry of wsize must be a multiple
         of 4. See [3]_.
-    tstep: int or array-like
+    tstep : int or array-like
         Step between successive windows in samples (must be a multiple of 2,
         a divider of wsize and smaller than wsize/2) (default: wsize/2).
         If an array is passed, multiple TF dictionaries are used (each having
@@ -535,7 +535,6 @@ def tf_mixed_norm(evoked, forward, noise_cov,
 
         .. versionadded:: 0.18
     %(verbose)s
-
 
     Returns
     -------

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -10,7 +10,7 @@ from scipy import linalg
 
 from .mxne_debiasing import compute_bias
 from ..utils import logger, verbose, sum_squared, warn, dgemm
-from ..time_frequency.stft import stft_norm1, stft_norm2, stft, istft
+from ..time_frequency._stft import stft_norm1, stft_norm2, stft, istft
 
 
 def groups_norm2(A, n_orient):

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -13,7 +13,7 @@ from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            iterative_mixed_norm_solver,
                                            norm_epsilon_inf, norm_epsilon,
                                            _Phi, _PhiT, dgap_l21l1)
-from mne.time_frequency.stft import stft_norm2
+from mne.time_frequency._stft import stft_norm2
 
 
 def _generate_tf_data():

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -33,6 +33,12 @@ class RawArray(BaseRaw):
         .. versionadded:: 0.18
     %(verbose)s
 
+    See Also
+    --------
+    mne.EpochsArray
+    mne.EvokedArray
+    mne.create_info
+
     Notes
     -----
     Proper units of measure:
@@ -42,12 +48,6 @@ class RawArray(BaseRaw):
     * M: hbo, hbr
     * Am: dipole
     * AU: misc
-
-    See Also
-    --------
-    mne.EpochsArray
-    mne.EvokedArray
-    mne.create_info
     """
 
     @verbose

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -307,6 +307,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         .. versionadded:: 0.17
     %(verbose)s
 
+    See Also
+    --------
+    mne.io.Raw : Documentation of attribute and methods.
+
     Notes
     -----
     This class is public to allow for stable type-checking in user
@@ -318,10 +322,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         * _read_segment_file(self, data, idx, fi, start, stop, cals, mult)
           (only needed for types that support on-demand disk reads)
-
-    See Also
-    --------
-    mne.io.Raw : Documentation of attribute and methods.
     """
 
     @verbose

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -812,7 +812,6 @@ def read_raw_brainvision(vhdr_fname,
     See Also
     --------
     mne.io.Raw : Documentation of attribute and methods.
-
     """
     return RawBrainVision(vhdr_fname=vhdr_fname, eog=eog,
                           misc=misc, scale=scale, preload=preload,

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -269,7 +269,6 @@ def read_raw_curry(fname, preload=False, verbose=None):
     -------
     raw : instance of RawCurry
         A Raw object containing Curry data.
-
     """
     return RawCurry(fname, preload, verbose)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -62,6 +62,12 @@ class RawEDF(BaseRaw):
     %(preload)s
     %(verbose)s
 
+    See Also
+    --------
+    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.read_raw_edf : Recommended way to read EDF/EDF+ files.
+    mne.io.read_raw_bdf : Recommended way to read BDF files.
+
     Notes
     -----
     Biosemi devices trigger codes are encoded in 16-bit format, whereas system
@@ -98,12 +104,6 @@ class RawEDF(BaseRaw):
     If channels named 'status' or 'trigger' are present, they are considered as
     STIM channels by default. Use func:`mne.find_events` to parse events
     encoded in such analog stim channels.
-
-    See Also
-    --------
-    mne.io.Raw : Documentation of attributes and methods.
-    mne.io.read_raw_edf : Recommended way to read EDF/EDF+ files.
-    mne.io.read_raw_bdf : Recommended way to read BDF files.
     """
 
     @verbose
@@ -169,16 +169,16 @@ class RawGDF(BaseRaw):
     %(preload)s
     %(verbose)s
 
+    See Also
+    --------
+    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.read_raw_gdf : Recommended way to read GDF files.
+
     Notes
     -----
     If channels named 'status' or 'trigger' are present, they are considered as
     STIM channels by default. Use func:`mne.find_events` to parse events
     encoded in such analog stim channels.
-
-    See Also
-    --------
-    mne.io.Raw : Documentation of attributes and methods.
-    mne.io.read_raw_gdf : Recommended way to read GDF files.
     """
 
     @verbose
@@ -1132,6 +1132,16 @@ def read_raw_edf(input_fname, eog=None, misc=None,
     %(preload)s
     %(verbose)s
 
+    Returns
+    -------
+    raw : instance of RawEDF
+        The raw instance.
+
+    See Also
+    --------
+    mne.io.read_raw_bdf : Reader function for BDF files.
+    mne.io.read_raw_gdf : Reader function for GDF files.
+
     Notes
     -----
     It is worth noting that in some special cases, it may be necessary to shift
@@ -1148,11 +1158,6 @@ def read_raw_edf(input_fname, eog=None, misc=None,
     If channels named 'status' or 'trigger' are present, they are considered as
     STIM channels by default. Use func:`mne.find_events` to parse events
     encoded in such analog stim channels.
-
-    See Also
-    --------
-    mne.io.read_raw_bdf : Reader function for BDF files.
-    mne.io.read_raw_gdf : Reader function for GDF files.
     """
     input_fname = os.path.abspath(input_fname)
     ext = os.path.splitext(input_fname)[1][1:].lower()
@@ -1209,6 +1214,16 @@ def read_raw_bdf(input_fname, eog=None, misc=None,
     %(preload)s
     %(verbose)s
 
+    Returns
+    -------
+    raw : instance of RawEDF
+        The raw instance.
+
+    See Also
+    --------
+    mne.io.read_raw_edf : Reader function for EDF and EDF+ files.
+    mne.io.read_raw_gdf : Reader function for GDF files.
+
     Notes
     -----
     Biosemi devices trigger codes are encoded in 16-bit format, whereas system
@@ -1244,11 +1259,6 @@ def read_raw_bdf(input_fname, eog=None, misc=None,
     If channels named 'status' or 'trigger' are present, they are considered as
     STIM channels by default. Use func:`mne.find_events` to parse events
     encoded in such analog stim channels.
-
-    See Also
-    --------
-    mne.io.read_raw_edf : Reader function for EDF and EDF+ files.
-    mne.io.read_raw_gdf : Reader function for GDF files.
     """
     input_fname = os.path.abspath(input_fname)
     ext = os.path.splitext(input_fname)[1][1:].lower()
@@ -1288,16 +1298,21 @@ def read_raw_gdf(input_fname, eog=None, misc=None,
     %(preload)s
     %(verbose)s
 
-    Notes
-    -----
-    If channels named 'status' or 'trigger' are present, they are considered as
-    STIM channels by default. Use func:`mne.find_events` to parse events
-    encoded in such analog stim channels.
+    Returns
+    -------
+    raw : instance of RawGDF
+        The raw instance.
 
     See Also
     --------
     mne.io.read_raw_edf : Reader function for EDF and EDF+ files.
     mne.io.read_raw_bdf : Reader function for BDF files.
+
+    Notes
+    -----
+    If channels named 'status' or 'trigger' are present, they are considered as
+    STIM channels by default. Use func:`mne.find_events` to parse events
+    encoded in such analog stim channels.
     """
     input_fname = os.path.abspath(input_fname)
     ext = os.path.splitext(input_fname)[1][1:].lower()

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -174,13 +174,13 @@ def read_raw_eeglab(input_fname, eog=(), preload=False,
     raw : instance of RawEEGLAB
         A Raw object containing EEGLAB .set data.
 
-    Notes
-    -----
-    .. versionadded:: 0.11.0
-
     See Also
     --------
     mne.io.Raw : Documentation of attribute and methods.
+
+    Notes
+    -----
+    .. versionadded:: 0.11.0
     """
     return RawEEGLAB(input_fname=input_fname, preload=preload,
                      eog=eog, verbose=verbose, uint16_codec=uint16_codec)
@@ -230,14 +230,13 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None,
     epochs : instance of Epochs
         The epochs.
 
-    Notes
-    -----
-    .. versionadded:: 0.11.0
-
-
     See Also
     --------
     mne.Epochs : Documentation of attribute and methods.
+
+    Notes
+    -----
+    .. versionadded:: 0.11.0
     """
     epochs = EpochsEEGLAB(input_fname=input_fname, events=events, eog=eog,
                           event_id=event_id, verbose=verbose,
@@ -269,13 +268,13 @@ class RawEEGLAB(BaseRaw):
         can therefore help you solve this problem.
     %(verbose)s
 
-    Notes
-    -----
-    .. versionadded:: 0.11.0
-
     See Also
     --------
     mne.io.Raw : Documentation of attribute and methods.
+
+    Notes
+    -----
+    .. versionadded:: 0.11.0
     """
 
     @verbose
@@ -464,13 +463,13 @@ class EpochsEEGLAB(BaseEpochs):
         'latin1' or 'utf-8') should be used when reading character arrays and
         can therefore help you solve this problem.
 
-    Notes
-    -----
-    .. versionadded:: 0.11.0
-
     See Also
     --------
     mne.Epochs : Documentation of attribute and methods.
+
+    Notes
+    -----
+    .. versionadded:: 0.11.0
     """
 
     @verbose

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -129,6 +129,10 @@ def read_raw_egi(input_fname, eog=None, misc=None,
     raw : instance of RawEGI
         A Raw object containing EGI data.
 
+    See Also
+    --------
+    mne.io.Raw : Documentation of attribute and methods.
+
     Notes
     -----
     The trigger channel names are based on the arbitrary user dependent event
@@ -143,10 +147,6 @@ def read_raw_egi(input_fname, eog=None, misc=None,
     As a consequence, triggers have only short durations.
 
     This step will fail if events are not mutually exclusive.
-
-    See Also
-    --------
-    mne.io.Raw : Documentation of attribute and methods.
     """
     if input_fname.endswith('.mff'):
         return _read_raw_egi_mff(input_fname, eog, misc, include,

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -28,21 +28,20 @@ def read_raw_fieldtrip(fname, info, data_name='data'):
 
     Parameters
     ----------
-    fname: str
+    fname : str
         Path and filename of the .mat file containing the data.
-    info: dict or None
+    info : dict or None
         The info dict of the raw data file corresponding to the data to import.
         If this is set to None, limited information is extracted from the
         FieldTrip structure.
-    data_name: str
+    data_name : str
         Name of heading dict/ variable name under which the data was originally
         saved in MATLAB.
 
     Returns
     -------
-    raw: instance of RawArray
+    raw : instance of RawArray
         A Raw Object containing the loaded data.
-
     """
     from ...externals.pymatreader.pymatreader import read_mat
 
@@ -89,24 +88,22 @@ def read_epochs_fieldtrip(fname, info, data_name='data',
 
     Parameters
     ----------
-    fname: str
+    fname : str
         Path and filename of the .mat file containing the data.
-    info: dict or None
+    info : dict or None
         The info dict of the raw data file corresponding to the data to import.
         If this is set to None, limited information is extracted from the
         FieldTrip structure.
-    data_name: str
+    data_name : str
         Name of heading dict/ variable name under which the data was originally
         saved in MATLAB.
-    trialinfo_column: int
+    trialinfo_column : int
         Column of the trialinfo matrix to use for the event codes
 
     Returns
     -------
-    epochs: instance of EpochsArray
+    epochs : instance of EpochsArray
         An EpochsArray containing the loaded data.
-
-
     """
     from ...externals.pymatreader.pymatreader import read_mat
     ft_struct = read_mat(fname,
@@ -143,23 +140,22 @@ def read_evoked_fieldtrip(fname, info, comment=None,
 
     Parameters
     ----------
-    fname: str
+    fname : str
         Path and filename of the .mat file containing the data.
-    info: dict or None
+    info : dict or None
         The info dict of the raw data file corresponding to the data to import.
         If this is set to None, limited information is extracted from the
         FieldTrip structure.
-    comment: str
+    comment : str
         Comment on dataset. Can be the condition.
-    data_name: str
+    data_name : str
         Name of heading dict/ variable name under which the data was originally
         saved in MATLAB.
 
     Returns
     -------
-    evoked: instance of EvokedArray
+    evoked : instance of EvokedArray
         An EvokedArray containing the loaded data.
-
     """
     from ...externals.pymatreader.pymatreader import read_mat
     ft_struct = read_mat(fname,

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -178,7 +178,7 @@ class Info(dict):
     ``info['bads']`` and ``info['description']``. All other entries should
     be considered read-only, or should be modified by functions or methods.
 
-    Parameters
+    Attributes
     ----------
     acq_pars : str | None
         MEG system acquition parameters.
@@ -497,7 +497,6 @@ class Info(dict):
             Original file GUID.
         meas_date : tuple of int
             The helium level meas date.
-
     """
 
     def copy(self):

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -196,6 +196,11 @@ def show_fiff(fname, indent='    ', read_limit=np.inf, max_str=30,
         Provide information about this tag. If None (default), all information
         is shown.
     %(verbose)s
+
+    Returns
+    -------
+    contents : str
+        The contents of the file.
     """
     if output not in [list, str]:
         raise ValueError('output must be list or str')

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -119,7 +119,6 @@ def channel_type(info, idx):
             {'grad', 'mag', 'eeg', 'stim', 'eog', 'emg', 'ecg', 'ref_meg',
              'resp', 'exci', 'ias', 'syst', 'misc', 'seeg', 'bio', 'chpi',
              'dipole', 'gof', 'ecog', 'hbo', 'hbr'}
-
     """
     # This is faster than the original _channel_type_old now in test_pick.py
     # because it uses (at most!) two dict lookups plus one conditional
@@ -161,14 +160,14 @@ def pick_channels(ch_names, include, exclude=[], ordered=False):
 
         .. versionadded:: 0.18
 
-    See Also
-    --------
-    pick_channels_regexp, pick_types
-
     Returns
     -------
     sel : array of int
         Indices of good channels.
+
+    See Also
+    --------
+    pick_channels_regexp, pick_types
     """
     if len(np.unique(ch_names)) != len(ch_names):
         raise RuntimeError('ch_names is not a unique list, picking is unsafe')

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -278,30 +278,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     data according to the desired reference and prevent MNE-Python from
     automatically adding an average reference projection.
 
-    Some common referencing schemes and the corresponding value for the
-    ``ref_channels`` parameter:
-
-    No re-referencing:
-        If the EEG data is already using the proper reference, set
-        ``ref_channels=[]``. This will prevent MNE-Python from automatically
-        adding an average reference projection.
-
-    Average reference:
-        A new virtual reference electrode is created by averaging the current
-        EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
-        automatically excluded if they are properly set in ``info['bads']``.
-
-    A single electrode:
-        Set ``ref_channels`` to a list containing the name of the channel that
-        will act as the new reference, for example ``ref_channels=['Cz']``.
-
-    The mean of multiple electrodes:
-        A new virtual reference electrode is created by computing the average
-        of the current EEG signal recorded from two or more selected channels.
-        Set ``ref_channels`` to a list of channel names, indicating which
-        channels to use. For example, to apply an average mastoid reference,
-        when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
-
     Parameters
     ----------
     inst : instance of Raw | Epochs | Evoked
@@ -342,8 +318,37 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         Array of reference data subtracted from EEG channels. This will be
         ``None`` if ``ref_channels='average'`` and ``projection=True``.
 
+    See Also
+    --------
+    set_bipolar_reference : Convenience function for creating bipolar
+                            references.
+
     Notes
     -----
+    Some common referencing schemes and the corresponding value for the
+    ``ref_channels`` parameter:
+
+    No re-referencing:
+        If the EEG data is already using the proper reference, set
+        ``ref_channels=[]``. This will prevent MNE-Python from automatically
+        adding an average reference projection.
+
+    Average reference:
+        A new virtual reference electrode is created by averaging the current
+        EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
+        automatically excluded if they are properly set in ``info['bads']``.
+
+    A single electrode:
+        Set ``ref_channels`` to a list containing the name of the channel that
+        will act as the new reference, for example ``ref_channels=['Cz']``.
+
+    The mean of multiple electrodes:
+        A new virtual reference electrode is created by computing the average
+        of the current EEG signal recorded from two or more selected channels.
+        Set ``ref_channels`` to a list of channel names, indicating which
+        channels to use. For example, to apply an average mastoid reference,
+        when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
+
     1. If a reference is requested that is not the average reference, this
        function removes any pre-existing average reference projections.
 
@@ -357,11 +362,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
        they are properly set in ``info['bads']``.
 
     .. versionadded:: 0.9.0
-
-    See Also
-    --------
-    set_bipolar_reference : Convenience function for creating bipolar
-                            references.
     """
     _validate_type(inst, (BaseRaw, BaseEpochs, Evoked), "Instance")
 
@@ -476,6 +476,10 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     inst : instance of Raw | Epochs | Evoked
         Data with the specified channels re-referenced.
 
+    See Also
+    --------
+    set_eeg_reference : Convenience function for creating an EEG reference.
+
     Notes
     -----
     1. If the anodes contain any EEG channels, this function removes
@@ -487,10 +491,6 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
     3. The data must be preloaded.
 
     .. versionadded:: 0.9.0
-
-    See Also
-    --------
-    set_eeg_reference : Convenience function for creating an EEG reference.
     """
     if not isinstance(anode, list):
         anode = [anode]

--- a/mne/label.py
+++ b/mne/label.py
@@ -149,7 +149,6 @@ class Label(object):
           is raised.
         * Values of duplicate vertices are summed.
 
-
     Parameters
     ----------
     vertices : array, shape (N,)
@@ -780,7 +779,6 @@ class BiHemiLabel(object):
         A name for the label. It is OK to change that attribute manually.
     subject : str | None
         Subject the label is from.
-
     """
 
     def __init__(self, lh, rh, name=None, color=None):  # noqa: D102
@@ -936,14 +934,14 @@ def write_label(filename, label, verbose=None):
         The label object to save.
     %(verbose)s
 
+    See Also
+    --------
+    write_labels_to_annot
+
     Notes
     -----
     Note that due to file specification limitations, the Label's subject and
     color attributes are not saved to disk.
-
-    See Also
-    --------
-    write_labels_to_annot
     """
     hemi = label.hemi
     path_head, name = op.split(filename)
@@ -965,7 +963,6 @@ def write_label(filename, label, verbose=None):
         fid.write(b'%d\n' % n_vertices)
         for d in data:
             fid.write(b'%d %f %f %f %f\n' % tuple(d))
-    return label
 
 
 def _prep_label_split(label, subject=None, subjects_dir=None):

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -810,8 +810,8 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
 
     See Also
     --------
-    apply_inverse_raw : Apply inverse operator to raw object
-    apply_inverse_epochs : Apply inverse operator to epochs object
+    apply_inverse_raw : Apply inverse operator to raw object.
+    apply_inverse_epochs : Apply inverse operator to epochs object.
 
     Notes
     -----
@@ -994,8 +994,8 @@ def apply_inverse_raw(raw, inverse_operator, lambda2, method="dSPM",
 
     See Also
     --------
-    apply_inverse_epochs : Apply inverse operator to epochs object
-    apply_inverse : Apply inverse operator to evoked object
+    apply_inverse_epochs : Apply inverse operator to epochs object.
+    apply_inverse : Apply inverse operator to evoked object.
     """
     _check_reference(raw, inverse_operator['info']['ch_names'])
     _check_option('method', method, INVERSE_METHODS)
@@ -1192,8 +1192,8 @@ def apply_inverse_epochs(epochs, inverse_operator, lambda2, method="dSPM",
 
     See Also
     --------
-    apply_inverse_raw : Apply inverse operator to raw object
-    apply_inverse : Apply inverse operator to evoked object
+    apply_inverse_raw : Apply inverse operator to raw object.
+    apply_inverse : Apply inverse operator to evoked object.
     """
     stcs = _apply_inverse_epochs_gen(
         epochs, inverse_operator, lambda2, method=method, label=label,

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -768,7 +768,7 @@ def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
     ----------
     evoked : Evoked object
         Evoked data.
-    inverse_operator: instance of InverseOperator
+    inverse_operator : instance of InverseOperator
         Inverse operator.
     lambda2 : float
         The regularization parameter.

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -373,6 +373,11 @@ def source_induced_power(epochs, inverse_operator, freqs, label=None,
     method_params : dict | None
         Additional options for eLORETA. See Notes of :func:`apply_inverse`.
     %(verbose)s
+
+    Returns
+    -------
+    power : array
+        The induced power.
     """  # noqa: E501
     _check_option('method', method, INVERSE_METHODS)
     _check_ori(pick_ori, inverse_operator['source_ori'],
@@ -407,9 +412,9 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
         The raw data
     inverse_operator : instance of InverseOperator
         The inverse operator
-    lambda2: float
+    lambda2 : float
         The regularization parameter
-    method: "MNE" | "dSPM" | "sLORETA"
+    method : "MNE" | "dSPM" | "sLORETA"
         Use minimum norm, dSPM (default), sLORETA, or eLORETA.
     tmin : float
         The beginning of the time interval of interest (in seconds).
@@ -421,20 +426,20 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
         The lower frequency of interest
     fmax : float
         The upper frequency of interest
-    n_fft: int
+    n_fft : int
         Window size for the FFT. Should be a power of 2.
-    overlap: float
+    overlap : float
         The overlap fraction between windows. Should be between 0 and 1.
         0 means no overlap.
     pick_ori : None | "normal"
         If "normal", rather than pooling the orientations by taking the norm,
         only the radial component is kept. This is only implemented
         when working with loose orientations.
-    label: Label
+    label : Label
         Restricts the source estimates to a given label
     nave : int
         The number of averages used to scale the noise covariance matrix.
-    pca: bool
+    pca : bool
         If True, the true dimension of data is estimated before running
         the time-frequency transforms. It reduces the computation times
         e.g. with a dataset that was maxfiltered (true dim is 64).

--- a/mne/misc.py
+++ b/mne/misc.py
@@ -20,7 +20,6 @@ def parse_config(fname):
 
             tmin, tmax, name, grad_reject, mag_reject,
             eeg_reject, eog_reject
-
     """
     reject_params = read_reject_parameters(fname)
 
@@ -63,6 +62,11 @@ def read_reject_parameters(fname):
     ----------
     fname : str
         Filename to read.
+
+    Returns
+    -------
+    params : dict
+        The rejection parameters.
     """
     with open(fname, 'r') as f:
         lines = f.readlines()

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -101,6 +101,11 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         .. versionadded:: 0.20
     %(verbose)s
 
+    Returns
+    -------
+    morph : instance of SourceMorph
+        The :class:`mne.SourceMorph` object.
+
     Notes
     -----
     This function can be used to morph data between hemispheres by setting

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -26,9 +26,9 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
 
     Parameters
     ----------
-    func: callable
+    func : callable
         A function
-    n_jobs: int
+    n_jobs : int
         Number of jobs to run in parallel
     max_nbytes : int, str, or None
         Threshold on the minimum size of arrays passed to the workers that

--- a/mne/preprocessing/_optical_density.py
+++ b/mne/preprocessing/_optical_density.py
@@ -24,7 +24,6 @@ def optical_density(raw):
     -------
     raw : instance of Raw
         The modified raw instance.
-
     """
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')

--- a/mne/preprocessing/_peak_finder.py
+++ b/mne/preprocessing/_peak_finder.py
@@ -44,7 +44,6 @@ def peak_finder(x0, thresh=None, extrema=1, verbose=None):
     array([36, 260]) # doctest: +SKIP
     >>> peak_mags # doctest: +SKIP
     array([0.36900026, 1.76007351]) # doctest: +SKIP
-
     """
     x0 = np.asanyarray(x0)
     s = x0.size

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -31,7 +31,7 @@ def find_eog_events(raw, event_id=998, l_freq=1, h_freq=10,
         High cut-off frequency to apply to the EOG channel in Hz.
     filter_length : str | int | None
         Number of taps to use for filtering.
-    ch_name: str | None
+    ch_name : str | None
         If not None, use specified channel(s) for EOG
     tstart : float
         Start detection after tstart seconds.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -78,7 +78,13 @@ def _make_xy_sfunc(func, ndim_output=False):
 
 # makes score funcs attr accessible for users
 def get_score_funcs():
-    """Get the score functions."""
+    """Get the score functions.
+
+    Returns
+    -------
+    score_funcs : dict
+        The score functions.
+    """
     from scipy import stats
     from scipy.spatial import distance
     score_funcs = Bunch()

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -315,7 +315,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
         Dictionary of parameters to use for IIR filtering.
         See mne.filter.construct_iir_filter for details. If iir_params
         is None and method="iir", 4th order Butterworth will be used.
-    ch_name: str | None
+    ch_name : str | None
         If not None, specify EOG channel name.
     copy : bool
         If False, filtering raw data is done in place. Defaults to True.

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -382,13 +382,13 @@ class Xdawn(_XdawnTransformer):
     correct_overlap_ : bool
         Whether overlap correction was applied.
 
-    Notes
-    -----
-    .. versionadded:: 0.10
-
     See Also
     --------
     mne.decoding.CSP, mne.decoding.SPoC
+
+    Notes
+    -----
+    .. versionadded:: 0.10
 
     References
     ----------

--- a/mne/selection.py
+++ b/mne/selection.py
@@ -45,7 +45,6 @@ def read_selection(name, fname=None, info=None, verbose=None):
         * ``'Left-frontal'``
         * ``'Right-frontal'``
 
-
     Parameters
     ----------
     name : str or list of str

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1663,11 +1663,6 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
             of mass on the spherical surface to help avoid potential issues
             with cortical folding.
 
-        See Also
-        --------
-        mne.Label.center_of_mass
-        mne.vertex_to_mni
-
         Returns
         -------
         vertex : int
@@ -1680,6 +1675,11 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         t : float
             Time of the temporal center of mass (weighted by the sum across
             source vertices).
+
+        See Also
+        --------
+        mne.Label.center_of_mass
+        mne.vertex_to_mni
 
         References
         ----------
@@ -1939,16 +1939,16 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
     shape : tuple
         The shape of the data. A tuple of int (n_dipoles, n_times).
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
-
     See Also
     --------
     SourceEstimate : A container for surface source estimates.
     VolVectorSourceEstimate : A container for volume vector source estimates.
     MixedSourceEstimate : A container for mixed surface + volume source
                           estimates.
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
     """
 
     @verbose
@@ -2018,16 +2018,16 @@ class VolVectorSourceEstimate(_BaseVectorSourceEstimate,
     shape : tuple
         The shape of the data. A tuple of int (n_dipoles, n_times).
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
-
     See Also
     --------
     SourceEstimate : A container for surface source estimates.
     VectorSourceEstimate : A container for vector source estimates.
     MixedSourceEstimate : A container for mixed surface + volume source
                           estimates.
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
     """
 
     _data_ndim = 3
@@ -2067,16 +2067,16 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     shape : tuple
         The shape of the data. A tuple of int (n_dipoles, n_times).
 
-    Notes
-    -----
-    .. versionadded:: 0.15
-
     See Also
     --------
     SourceEstimate : A container for surface source estimates.
     VolSourceEstimate : A container for volume source estimates.
     MixedSourceEstimate : A container for mixed surface + volume source
                           estimates.
+
+    Notes
+    -----
+    .. versionadded:: 0.15
     """
 
     _data_ndim = 3
@@ -2139,16 +2139,16 @@ class MixedSourceEstimate(_BaseSourceEstimate):
     shape : tuple
         The shape of the data. A tuple of int (n_dipoles, n_times).
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
-
     See Also
     --------
     SourceEstimate : A container for surface source estimates.
     VectorSourceEstimate : A container for vector source estimates.
     VolSourceEstimate : A container for volume source estimates.
     VolVectorSourceEstimate : A container for Volume vector source estimates.
+
+    Notes
+    -----
+    .. versionadded:: 0.9.0
     """
 
     _data_ndim = 2

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1148,7 +1148,7 @@ def head_to_mri(pos, subject, mri_head_t, subjects_dir=None,
         The  coordinates (in m) in head coordinate system
     subject : string
         Name of the subject.
-    mri_head_t: instance of Transform
+    mri_head_t : instance of Transform
         MRI<->Head coordinate transformation
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
@@ -1236,7 +1236,7 @@ def head_to_mni(pos, subject, mri_head_t, subjects_dir=None,
         The  coordinates (in m) in head coordinate system
     subject : string
         Name of the subject.
-    mri_head_t: instance of Transform
+    mri_head_t : instance of Transform
         MRI<->Head coordinate transformation
     subjects_dir : string, or None
         Path to SUBJECTS_DIR if it is not set in the environment.
@@ -2517,16 +2517,15 @@ def get_volume_labels_from_src(src, subject, subjects_dir):
     ----------
     src : instance of SourceSpaces
         The source space containing the volume regions
-    subject: str
+    subject : str
         Subject name
-    subjects_dir: str
+    subjects_dir : str
         Freesurfer folder of the subjects
 
     Returns
     -------
     labels_aseg : list of Label
         List of Label of segmented volumes included in src space.
-
     """
     from . import Label
     from . import get_volume_labels_from_aseg

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1105,7 +1105,7 @@ def permutation_cluster_test(
         determine of it can be separated into disjoint sets. In some cases
         (usually with connectivity as a list and many "time" points), this
         can lead to faster clustering, but results should be identical.
-    buffer_size: int or None
+    buffer_size : int or None
         The statistics will be computed for blocks of variables of size
         "buffer_size" at a time. This is option significantly reduces the
         memory requirements when n_jobs > 1 and memory sharing between
@@ -1215,7 +1215,7 @@ def permutation_cluster_1samp_test(
         determine of it can be separated into disjoint sets. In some cases
         (usually with connectivity as a list and many "time" points), this
         can lead to faster clustering, but results should be identical.
-    buffer_size: int or None
+    buffer_size : int or None
         The statistics will be computed for blocks of variables of size
         "buffer_size" at a time. This is option significantly reduces the
         memory requirements when n_jobs > 1 and memory sharing between
@@ -1346,7 +1346,7 @@ def spatio_temporal_cluster_1samp_test(
         determine of it can be separated into disjoint sets. In some cases
         (usually with connectivity as a list and many "time" points), this
         can lead to faster clustering, but results should be identical.
-    buffer_size: int or None
+    buffer_size : int or None
         The statistics will be computed for blocks of variables of size
         "buffer_size" at a time. This is option significantly reduces the
         memory requirements when n_jobs > 1 and memory sharing between
@@ -1404,7 +1404,7 @@ def spatio_temporal_cluster_test(
 
     Parameters
     ----------
-    X: list of arrays
+    X : list of array
         List of data arrays, shape ``(n_observations, n_times, n_vertices)``
         in each group.
     threshold : float | dict | None
@@ -1414,7 +1414,7 @@ def spatio_temporal_cluster_test(
         cluster enhancement (TFCE) will be used, and it must have keys
         ``'start'`` and ``'step'`` to specify the integration parameters,
         see the :ref:`TFCE example <tfce_example>`.
-    n_permutations: int
+    n_permutations : int
         See permutation_cluster_test.
     tail : -1 or 0 or 1 (default = 0)
         See permutation_cluster_test.
@@ -1457,7 +1457,7 @@ def spatio_temporal_cluster_test(
         determine of it can be separated into disjoint sets. In some cases
         (usually with connectivity as a list and many "time" points), this
         can lead to faster clustering, but results should be identical.
-    buffer_size: int or None
+    buffer_size : int or None
         The statistics will be computed for blocks of variables of size
         "buffer_size" at a time. This is option significantly reduces the
         memory requirements when n_jobs > 1 and memory sharing between

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -93,7 +93,6 @@ def bonferroni_correction(pval, alpha=0.05):
         True if a hypothesis is rejected, False if not
     pval_corrected : array
         pvalues adjusted for multiple hypothesis testing to limit FDR
-
     """
     pval = np.asarray(pval)
     pval_corrected = pval * float(pval.size)

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -106,7 +106,6 @@ def f_oneway(*args):
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
            Statistics". Chapter 14.
     .. [2] Heiman, G.W.  Research Methods in Statistics. 2002.
-
     """
     n_classes = len(args)
     n_samples_per_class = np.array([len(a) for a in args])

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -124,8 +124,6 @@ def bootstrap_confidence_interval(arr, ci=.95, n_bootstraps=2000,
     cis : ndarray, shape (2, ...)
         Containing the lower boundary of the CI at `cis[0, ...]` and the upper
         boundary of the CI at `cis[1, ...]`.
-
-
     """
     if stat_fun == "mean":
         def stat_fun(x):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1439,14 +1439,14 @@ def read_tri(fname_in, swap=False, verbose=None):
         Triangulation (each line contains indices for three points which
         together form a face).
 
-    Notes
-    -----
-    .. versionadded:: 0.13.0
-
     See Also
     --------
     read_surface
     write_surface
+
+    Notes
+    -----
+    .. versionadded:: 0.13.0
     """
     with open(fname_in, "r") as fid:
         lines = fid.readlines()

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -43,14 +43,8 @@ public_modules = [
 ]
 
 
-def get_name(func):
-    """Get the name."""
-    parts = []
-    module = inspect.getmodule(func)
-    if module:
-        parts.append(module.__name__)
-    parts.append(func.__name__)
-    return '.'.join(parts)
+def _func_name(func):
+    return '%s.%s' % (inspect.getmodule(func).__name__, func.__name__)
 
 
 # functions to ignore args / docstring of
@@ -85,15 +79,15 @@ error_ignores = (
 def check_parameters_match(func):
     """Check docstring, return list of incorrect results."""
     from numpydoc.validate import validate
-    name_ = get_name(func)
-    skip = (not name_.startswith('mne.') or
-            any(re.match(d, name_) for d in docstring_ignores) or
+    name = _func_name(func)
+    skip = (not name.startswith('mne.') or
+            any(re.match(d, name) for d in docstring_ignores) or
             'deprecation_wrapped' in getattr(
                 getattr(func, '__code__', None), 'co_name', ''))
     if skip:
         return list()
-    incorrect = ['%s : %s : %s' % (err[0], name_, err[1])
-                 for err in validate(name_)['errors']
+    incorrect = ['%s : %s : %s' % (err[0], name, err[1])
+                 for err in validate(name)['errors']
                  if err[0] not in error_ignores]
     return incorrect
 

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -73,7 +73,6 @@ error_ignores = (
     'SA01',  # no see also
     'YD01',  # no yields section
     'SA04',  # no description in See Also
-    'GL02',  # Closing quotes should be placed in the line after (NumpyDoc bug)
     'PR04',  # Parameter "shape (n_channels" has no type
     'RT02',  # The first line of the Returns section should contain only the type, unless multiple values are being returned  # noqa
     # XXX but these we should fix eventually:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -73,6 +73,8 @@ error_ignores = (
     'PR09',  # Parameter description should finish with "."
     'RT04',  # Return value description should start with a capital letter
     'RT05',  # Return value description should finish with "."
+    # XXX should also verify that | is used rather than , to separate params
+    # XXX should maybe also restore the parameter-desc-length < 800 char check
 )
 
 

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -72,14 +72,13 @@ error_ignores = (
     'ES01',  # no extended summary
     'SA01',  # no see also
     'YD01',  # no yields section
-    'SA02',  # missing period at the end of See Also description
     'SA04',  # no description in See Also
     'SS02',  # Summary does not start with a capital letter (NumpyDoc bug)
     'GL02',  # Closing quotes should be placed in the line after (NumpyDoc bug)
     'PR04',  # Parameter "shape (n_channels" has no type
     'RT02',  # The first line of the Returns section should contain only the type, unless multiple values are being returned  # noqa
     # XXX but these we should fix eventually:
-    'PR06',  # Parameter "subject" type should use "str" instead of "string"
+    'PR06',  # Parameter type should use "str" instead of "string"
     'PR08',  # Parameter description should start with a capital letter
     'PR09',  # Parameter description should finish with "."
     'RT04',  # Return value description should start with a capital letter

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -73,7 +73,6 @@ error_ignores = (
     'SA01',  # no see also
     'YD01',  # no yields section
     'SA04',  # no description in See Also
-    'SS02',  # Summary does not start with a capital letter (NumpyDoc bug)
     'GL02',  # Closing quotes should be placed in the line after (NumpyDoc bug)
     'PR04',  # Parameter "shape (n_channels" has no type
     'RT02',  # The first line of the Returns section should contain only the type, unless multiple values are being returned  # noqa

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -43,14 +43,12 @@ public_modules = [
 ]
 
 
-def get_name(func, cls=None):
+def get_name(func):
     """Get the name."""
     parts = []
     module = inspect.getmodule(func)
     if module:
         parts.append(module.__name__)
-    if cls is not None:
-        parts.append(cls.__name__)
     parts.append(func.__name__)
     return '.'.join(parts)
 
@@ -84,10 +82,10 @@ error_ignores = (
 )
 
 
-def check_parameters_match(func, doc=None, cls=None):
+def check_parameters_match(func):
     """Check docstring, return list of incorrect results."""
     from numpydoc.validate import validate
-    name_ = get_name(func, cls=cls)
+    name_ = get_name(func)
     skip = (not name_.startswith('mne.') or
             any(re.match(d, name_) for d in docstring_ignores) or
             'deprecation_wrapped' in getattr(

--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -10,5 +10,5 @@ from .csd import (CrossSpectralDensity, csd_fourier, csd_multitaper,
 from .ar import fit_iir_model_raw
 from .multitaper import (dpss_windows, psd_array_multitaper,
                          tfr_array_multitaper)
-from .stft import stft, istft, stftfreq
+from ._stft import stft, istft, stftfreq
 from ._stockwell import tfr_stockwell, tfr_array_stockwell

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -29,11 +29,6 @@ def stft(x, wsize, tstep=None, verbose=None):
         STFT coefficients for positive frequencies with
         n_step = ceil(T / tstep)
 
-    Examples
-    --------
-    X = stft(x, wsize)
-    X = stft(x, wsize, tstep)
-
     See Also
     --------
     istft
@@ -119,11 +114,6 @@ def istft(X, tstep=None, Tx=None):
     x : array, shape (Tx,)
         vector containing the inverse STFT signal
 
-    Examples
-    --------
-    x = istft(X)
-    x = istft(X, tstep)
-
     See Also
     --------
     stft
@@ -184,7 +174,7 @@ def istft(X, tstep=None, Tx=None):
 
 
 def stftfreq(wsize, sfreq=None):  # noqa: D401
-    """Frequencies of stft transformation.
+    """Compute frequencies of stft transformation.
 
     Parameters
     ----------

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -140,6 +140,14 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
     freqs : ndarray
         The frequencies.
 
+    See Also
+    --------
+    mne.time_frequency.tfr_stockwell
+    mne.time_frequency.tfr_multitaper
+    mne.time_frequency.tfr_array_multitaper
+    mne.time_frequency.tfr_morlet
+    mne.time_frequency.tfr_array_morlet
+
     References
     ----------
     .. [1] Stockwell, R. G. "Why use the S-transform." AMS Pseudo-differential
@@ -159,14 +167,6 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
        (2006). S-transform time-frequency analysis of P300 reveals deficits in
        individuals diagnosed with alcoholism.
        Clinical Neurophysiology 117 2128--2143
-
-    See Also
-    --------
-    mne.time_frequency.tfr_stockwell
-    mne.time_frequency.tfr_multitaper
-    mne.time_frequency.tfr_array_multitaper
-    mne.time_frequency.tfr_morlet
-    mne.time_frequency.tfr_array_morlet
     """
     n_epochs, n_channels = data.shape[:2]
     n_out = data.shape[2] // decim + bool(data.shape[2] % decim)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -494,7 +494,7 @@ def read_csd(fname):
 
     See Also
     --------
-    CrossSpectralDensity.save : For saving CSD objects
+    CrossSpectralDensity.save : For saving CSD objects.
     """
     if not fname.endswith('.h5'):
         fname += '.h5'
@@ -1251,7 +1251,7 @@ def _csd_morlet(data, sfreq, wavelets, tslice=None, use_fft=True, decim=1):
 
     See Also
     --------
-    _vector_to_sym_mat : For converting the CSD to a full matrix
+    _vector_to_sym_mat : For converting the CSD to a full matrix.
     """
     # Compute PSD
     psds = cwt(data, wavelets, use_fft=use_fft, decim=decim)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -836,7 +836,7 @@ def csd_morlet(epochs, frequencies, tmin=None, tmax=None, picks=None,
         Maximum time instant to consider, in seconds. If ``None`` end at last
         sample.
     %(picks_good_data_noref)s
-    n_cycles: float | list of float | None
+    n_cycles : float | list of float | None
         Number of cycles to use when constructing Morlet wavelets. Fixed number
         or one per frequency. Defaults to 7.
     use_fft : bool
@@ -903,7 +903,7 @@ def csd_array_morlet(X, sfreq, frequencies, t0=0, tmin=None, tmax=None,
     ch_names : list of str | None
         A name for each time series. If ``None`` (the default), the series will
         be named 'SERIES###'.
-    n_cycles: float | list of float | None
+    n_cycles : float | list of float | None
         Number of cycles to use when constructing Morlet wavelets. Fixed number
         or one per frequency. Defaults to 7.
     use_fft : bool

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -45,7 +45,6 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
         'zero', 'slinear', 'quadratic, 'cubic') or as an integer specifying the
         order of the spline interpolator to use.
 
-
     Returns
     -------
     v, e : tuple,
@@ -491,7 +490,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         .. note::
             Decimation may create aliasing artifacts, yet decimation
             is done after the convolutions.
-
     output : str, default 'complex'
 
         * 'complex' : single trial complex.
@@ -501,7 +499,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         * 'itc' : inter-trial coherence.
         * 'avg_power_itc' : average of single trial power and inter-trial
           coherence across trials.
-
     %(n_jobs)s
         The number of epochs to process at the same time. The parallelization
         is implemented across channels. Defaults to 1.

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -305,16 +305,6 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     freqs : ndarray, shape (n_freqs,)
         The frequencies.
 
-    References
-    ----------
-    .. [1] Slepian, D. "Prolate spheroidal wave functions, Fourier analysis,
-           and uncertainty V: The discrete case." Bell System Technical
-           Journal, vol. 57, 1978.
-
-    .. [2] Percival D.B. and Walden A.T. "Spectral Analysis for Physical
-           Applications: Multitaper and Conventional Univariate Techniques."
-           Cambridge University Press, 1993.
-
     See Also
     --------
     mne.io.Raw.plot_psd
@@ -326,6 +316,16 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     Notes
     -----
     .. versionadded:: 0.12.0
+
+    References
+    ----------
+    .. [1] Slepian, D. "Prolate spheroidal wave functions, Fourier analysis,
+           and uncertainty V: The discrete case." Bell System Technical
+           Journal, vol. 57, 1978.
+
+    .. [2] Percival D.B. and Walden A.T. "Spectral Analysis for Physical
+           Applications: Multitaper and Conventional Univariate Techniques."
+           Cambridge University Press, 1993.
     """
     # Prep data
     data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj)

--- a/mne/time_frequency/tests/test_stft.py
+++ b/mne/time_frequency/tests/test_stft.py
@@ -2,7 +2,8 @@ import numpy as np
 from scipy import linalg
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
-from mne.time_frequency.stft import stft, istft, stftfreq, stft_norm2
+from mne.time_frequency import stft, istft, stftfreq
+from mne.time_frequency._stft import stft_norm2
 
 
 def test_stft():

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -584,7 +584,7 @@ def cwt(X, Ws, use_fft=True, mode='same', decim=1):
     See Also
     --------
     mne.time_frequency.tfr_morlet : Compute time-frequency decomposition
-                                    with Morlet wavelets
+                                    with Morlet wavelets.
     """
     decim = _check_decim(decim)
     n_signals, n_times = X[:, decim].shape

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -46,7 +46,7 @@ def morlet(sfreq, freqs, n_cycles=7.0, sigma=None, zero_mean=False):
         The sampling Frequency.
     freqs : array
         frequency range of interest (1 x Frequencies)
-    n_cycles: float | array of float, default 7.0
+    n_cycles : float | array of float, default 7.0
         Number of cycles. Fixed number or one per frequency.
     sigma : float, default None
         It controls the width of the wavelet ie its temporal
@@ -680,7 +680,6 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
         If `slice`, returns tfr[..., decim].
 
         .. note:: Decimation may create aliasing artifacts.
-
     %(n_jobs)s
     picks : array-like of int | None, default None
         The indices of the channels to decompose. If None, all available
@@ -754,7 +753,6 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
         .. note::
             Decimation may create aliasing artifacts, yet decimation
             is done after the convolutions.
-
     output : str, default 'complex'
 
         * 'complex' : single trial complex.
@@ -764,7 +762,6 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
         * 'itc' : inter-trial coherence.
         * 'avg_power_itc' : average of single trial power and inter-trial
           coherence across trials.
-
     %(n_jobs)s
         The number of epochs to process at the same time. The parallelization
         is implemented across channels. default 1
@@ -813,7 +810,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     n_cycles : float | ndarray, shape (n_freqs,)
         The number of cycles globally or for each frequency.
         The time-window length is thus T = n_cycles / freq.
-    time_bandwidth : float, (optional), default 4.0 (n_tapers=3).
+    time_bandwidth : float, (optional), default 4.0 (n_tapers=3)
         Time x (Full) Bandwidth product. Should be >= 2.0.
         Choose this along with n_cycles to get desired frequency resolution.
         The number of good tapers (least leakage from far away frequencies)
@@ -832,7 +829,6 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
         If `slice`, returns tfr[..., decim].
 
         .. note:: Decimation may create aliasing artifacts.
-
     %(n_jobs)s
     %(picks_good_data)s
     average : bool, default True
@@ -1034,7 +1030,6 @@ class AverageTFR(_BaseTFR):
         Comment on dataset. Can be the condition.
     method : str | None, default None
         Comment on the method used to compute the data, e.g., morlet wavelet.
-
     """
 
     @verbose
@@ -2295,15 +2290,15 @@ def read_tfrs(fname, condition=None):
         The condition to load. If None, all conditions will be returned.
         Defaults to None.
 
-    See Also
-    --------
-    write_tfrs
-
     Returns
     -------
     tfrs : list of instances of AverageTFR | instance of AverageTFR
         Depending on `condition` either the TFR object or a list of multiple
         TFR objects.
+
+    See Also
+    --------
+    write_tfrs
 
     Notes
     -----

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -34,16 +34,6 @@ def verbose(function):
     dec : callable
         The decorated function
 
-    Examples
-    --------
-    You can use the ``verbose`` argument to set the verbose level on the fly::
-        >>> import mne
-        >>> cov = mne.compute_raw_covariance(raw, verbose='WARNING')  # doctest: +SKIP
-        >>> cov = mne.compute_raw_covariance(raw, verbose='INFO')  # doctest: +SKIP
-        Using up to 49 segments
-        Number of samples used : 5880
-        [done]
-
     See Also
     --------
     set_log_level
@@ -58,6 +48,16 @@ def verbose(function):
     verbosity level for all functions, use :func:`mne.set_log_level`.
 
     This function also serves as a docstring filler.
+
+    Examples
+    --------
+    You can use the ``verbose`` argument to set the verbose level on the fly::
+        >>> import mne
+        >>> cov = mne.compute_raw_covariance(raw, verbose='WARNING')  # doctest: +SKIP
+        >>> cov = mne.compute_raw_covariance(raw, verbose='INFO')  # doctest: +SKIP
+        Using up to 49 segments
+        Number of samples used : 5880
+        [done]
     """  # noqa: E501
     # See https://decorator.readthedocs.io/en/latest/tests.documentation.html
     # #dealing-with-third-party-decorators
@@ -127,6 +127,11 @@ def set_log_level(verbose=None, return_old_level=False):
         it doesn't exist, defaults to INFO.
     return_old_level : bool
         If True, return the old verbosity level.
+
+    Returns
+    -------
+    old_level : int
+        The old level. Only returned if ``return_old_level`` is True.
     """
     from .config import get_config
     if verbose is None:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -33,7 +33,7 @@ def set_cache_dir(cache_dir):
 
     Parameters
     ----------
-    cache_dir: str or None
+    cache_dir : str or None
         Directory to use for temporary file storage. None disables
         temporary file storage.
     """
@@ -48,7 +48,7 @@ def set_memmap_min_size(memmap_min_size):
 
     Parameters
     ----------
-    memmap_min_size: str or None
+    memmap_min_size : str or None
         Threshold on the minimum size of arrays that triggers automated memory
         mapping for parallel processing, e.g., '1M' for 1 megabyte.
         Use None to disable memmaping of large arrays.
@@ -472,7 +472,6 @@ def sys_info(fid=None, show_paths=False):
         cupy:          4.1.0
         pandas:        0.17.1+25.g547750a
         dipy:          0.14.0
-
     """  # noqa: E501
     ljust = 15
     out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -100,7 +100,6 @@ filter_length : str | int
       ``phase="zero-double"``.
     * **int**: Specified length in samples. For fir_design="firwin",
       this should not be used.
-
 """
 docdict['l_trans_bandwidth'] = """
 l_trans_bandwidth : float | str
@@ -571,6 +570,12 @@ def copy_function_doc_to_method_doc(source):
     wrapper : function
         The decorated method
 
+    Notes
+    -----
+    The parsing performed is very basic and will break easily on docstrings
+    that are not formatted exactly according to the ``numpydoc`` standard.
+    Always inspect the resulting docstring when using this decorator.
+
     Examples
     --------
     >>> def plot_function(object, a, b):
@@ -610,12 +615,6 @@ def copy_function_doc_to_method_doc(source):
             -----
             .. versionadded:: 0.13.0
     <BLANKLINE>
-
-    Notes
-    -----
-    The parsing performed is very basic and will break easily on docstrings
-    that are not formatted exactly according to the ``numpydoc`` standard.
-    Always inspect the resulting docstring when using this decorator.
     """
     def wrapper(func):
         doc = source.__doc__.split('\n')

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1819,6 +1819,11 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
         .. versionadded:: 0.19
     %(verbose)s
 
+    Returns
+    -------
+    fig : instance of Figure
+        The figure.
+
     Notes
     -----
     Click on any of the anatomical slices to explore the time series.
@@ -1845,7 +1850,6 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
 
     >>> morph = mne.compute_source_morph(src_sample, subject_to='fsaverage')  # doctest: +SKIP
     >>> fig = stc_vol_sample.plot(morph)  # doctest: +SKIP
-
     """  # noqa: E501
     from matplotlib import pyplot as plt, colors
     from matplotlib.cbook import mplDeprecation
@@ -2548,7 +2552,7 @@ def plot_dipole_locations(dipoles, trans=None, subject=None, subjects_dir=None,
     show : bool
         Show figure if True. Defaults to True.
         Only used if mode equals 'orthoview'.
-    scale: float
+    scale : float
         The scale of the dipoles if ``mode`` is 'arrow' or 'sphere'.
     color : tuple
         The color of the dipoles.
@@ -2678,7 +2682,7 @@ def plot_sensors_connectivity(info, con, picks=None):
     ----------
     info : dict | None
         The measurement info.
-    con: array, shape (n_channels, n_channels)
+    con : array, shape (n_channels, n_channels)
         The computed connectivity measure(s).
     %(picks_good_data)s
         Indices of selected channels.

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -92,7 +92,6 @@ def set_3d_backend(backend_name):
        +--------------------------------------+--------+---------+
        | Exports to movie/GIF                 |        |         |
        +--------------------------------------+--------+---------+
-
     """
     _check_option('backend_name', backend_name, VALID_3D_BACKENDS)
     global MNE_3D_BACKEND
@@ -149,15 +148,15 @@ def set_3d_view(figure, azimuth=None, elevation=None,
 
     Parameters
     ----------
-    figure:
+    figure : object
         The scene which is modified.
-    azimuth: float
+    azimuth : float
         The azimuthal angle of the view.
-    elevation: float
+    elevation : float
         The zenith angle of the view.
-    focalpoint: tuple, shape (3,)
+    focalpoint : tuple, shape (3,)
         The focal point of the view: (x, y, z).
-    distance: float
+    distance : float
         The distance to the focal point.
     """
     _mod._set_3d_view(figure=figure, azimuth=azimuth,
@@ -170,11 +169,11 @@ def set_3d_title(figure, title, size=40):
 
     Parameters
     ----------
-    figure:
+    figure : object
         The scene which is modified.
-    title:
+    title : str
         The title of the scene.
-    size: int
+    size : int
         The size of the title.
     """
     _mod._set_3d_title(figure=figure, title=title, size=size)
@@ -185,16 +184,16 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), handle=None):
 
     Parameters
     ----------
-    size: tuple
+    size : tuple
         The dimensions of the 3d figure (width, height).
-    bgcolor: tuple
+    bgcolor : tuple
         The color of the background.
-    handle: int | None
+    handle : int | None
         The figure identifier.
 
     Returns
     -------
-    figure:
+    figure : object
         The requested empty scene.
     """
     renderer = _mod._Renderer(fig=handle, size=size, bgcolor=bgcolor)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -744,7 +744,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is
         inferred from the data.
-    layout_scale: float
+    layout_scale : float
         Scaling factor for adjusting the relative size of the layout
         on the canvas
     color : list of color | color | None
@@ -909,7 +909,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         significance.
 
         .. versionadded:: 0.16
-    mask_style: None | 'both' | 'contour' | 'mask'
+    mask_style : None | 'both' | 'contour' | 'mask'
         If `mask` is not None: if 'contour', a contour line is drawn around
         the masked areas (``True`` in `mask`). If 'mask', entries not
         ``True`` in `mask` are shown transparently. If 'both', both a contour

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -40,7 +40,6 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
     2. plot latent source around event related time windows (Epochs input)
     3. plot time-locking in ICA space (Evoked input)
 
-
     Parameters
     ----------
     ica : instance of mne.preprocessing.ICA
@@ -262,18 +261,18 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     ----------
     ica : instance of mne.preprocessing.ICA
         The ICA solution.
-    inst: instance of Epochs or Raw
+    inst : instance of Epochs or Raw
         The data to use in plotting properties.
     %(picks_base)s the first five sources.
         If more than one components were chosen in the picks,
         each one will be plotted in a separate figure.
-    axes: list of matplotlib axes | None
+    axes : list of Axes | None
         List of five matplotlib axes to use in plotting: [topomap_axis,
         image_axis, erp_axis, spectrum_axis, variance_axis]. If None a new
         figure with relevant axes is created. Defaults to None.
-    dB: bool
+    dB : bool
         Whether to plot spectrum in dB. Defaults to True.
-    plot_std: bool | float
+    plot_std : bool | float
         Whether to plot standard deviation/confidence intervals in ERP/ERF and
         spectrum plots.
         Defaults to True, which plots one standard deviation above/below for

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -44,7 +44,7 @@ def plot_cov(cov, info, exclude=(), colorbar=True, proj=False, show_svd=True,
     ----------
     cov : instance of Covariance
         The covariance matrix.
-    info: dict
+    info : dict
         Measurement info.
     exclude : list of string | str
         List of channels to exclude. If empty do not exclude any channel.
@@ -199,6 +199,11 @@ def plot_source_spectrogram(stcs, freq_bins, tmin=None, tmax=None,
         If true, a colorbar will be added to the plot.
     show : bool
         Show figure if True.
+
+    Returns
+    -------
+    fig : instance of Figure
+        The figure.
     """
     import matplotlib.pyplot as plt
 
@@ -612,7 +617,7 @@ def plot_dipole_amplitudes(dipoles, colors=None, show=True):
     ----------
     dipoles : list of instance of Dipole
         The dipoles whose amplitudes should be shown.
-    colors: list of color | None
+    colors : list of color | None
         Color to plot with each dipole. If None default colors are used.
     show : bool
         Show figure if True.
@@ -929,7 +934,6 @@ def plot_ideal_filter(freq, gain, axes=None, title='', flim=None, fscale='log',
         >>> gain = [0, 1, 1, 0]
         >>> plot_ideal_filter(freq, gain, flim=(0.1, 100))  #doctest: +ELLIPSIS
         <...Figure...>
-
     """
     import matplotlib.pyplot as plt
     my_freq, my_gain = list(), list()
@@ -1009,7 +1013,7 @@ def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,
     ----------
     csd : instance of CrossSpectralDensity
         The CSD matrix to plot.
-    info: instance of Info | None
+    info : instance of Info | None
         To split the figure by channel-type, provide the measurement info.
         By default, the CSD matrix is plotted as a whole.
     mode : 'csd' | 'coh'

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -55,23 +55,23 @@ def iter_topography(info, layout=None, on_pick=None, fig=None,
     axis_spinecolor : color
         The axis spine color. Defaults to black. In other words,
         the color of the axis' edge lines.
-    layout_scale: float | None
+    layout_scale : float | None
         Scaling factor for adjusting the relative size of the layout
         on the canvas. If None, nothing will be scaled.
-    legend: bool
+    legend : bool
         If True, an additional axis is created in the bottom right corner
         that can be used to, e.g., construct a legend. The index of this
         axis will be -1.
 
     Returns
     -------
-    A generator that can be unpacked into:
+    gen : generator
+        A generator that can be unpacked into:
 
         ax : matplotlib.axis.Axis
             The current axis of the topo plot.
         ch_dx : int
             The related channel index.
-
     """
     return _iter_topography(info, layout, on_pick, fig, fig_facecolor,
                             axis_facecolor, axis_spinecolor, layout_scale,
@@ -582,7 +582,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is
         inferred from the data.
-    layout_scale: float
+    layout_scale : float
         Scaling factor for adjusting the relative size of the layout
         on the canvas
     color : list of color objects | color object | None
@@ -834,7 +834,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
     ----------
     epochs : instance of :class:`~mne.Epochs`
         The epochs.
-    layout: instance of Layout
+    layout : instance of Layout
         System specific sensor positions.
     sigma : float
         The standard deviation of the Gaussian smoothing to apply along
@@ -856,7 +856,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         (data.shape[1] == len(times)).
     cmap : colormap
         Colors to be mapped to the values.
-    layout_scale: float
+    layout_scale : float
         scaling factor for adjusting the relative size of the layout
         on the canvas.
     title : str

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1045,8 +1045,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         (None, True). Defaults to 'RdBu_r'.
 
         .. warning::  Interactive mode works smoothly only for a small amount
-            of topomaps.
-
+                      of topomaps.
     sensors : bool | str
         Add markers for sensor locations to the plot. Accepts matplotlib
         plot format string (e.g., 'r+' for red plusses). If True (default),
@@ -1087,7 +1086,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         topomap you need to pass relevant data - instances of Raw or Epochs
         (for example the data that ICA was trained on). This takes effect
         only when running matplotlib in interactive mode.
-    plot_std: bool | float
+    plot_std : bool | float
         Whether to plot standard deviation in ERP/ERF and spectrum plots.
         Defaults to True, which plots one standard deviation above/below.
         If set to float allows to control how many standard deviations are
@@ -1107,7 +1106,6 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         If None, no rejection is applied. The default is 'auto',
         which applies the rejection parameters used when fitting
         the ICA object.
-
 
     Returns
     -------

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -212,13 +212,12 @@ def mne_analyze_colormap(limits=[5, 10, 15], format='mayavi'):
 
     Examples
     --------
-    The following code will plot a STC using standard MNE limits:
+    The following code will plot a STC using standard MNE limits::
 
-        colormap = mne.viz.mne_analyze_colormap(limits=[5, 10, 15])
-        brain = stc.plot('fsaverage', 'inflated', 'rh', colormap)
-        brain.scale_data_colormap(fmin=-15, fmid=0, fmax=15, transparent=False)
-
-    """
+        >>> colormap = mne.viz.mne_analyze_colormap(limits=[5, 10, 15])  # doctest: +SKIP
+        >>> brain = stc.plot('fsaverage', 'inflated', 'rh', colormap)  # doctest: +SKIP
+        >>> brain.scale_data_colormap(fmin=-15, fmid=0, fmax=15, transparent=False)  # doctest: +SKIP
+    """  # noqa: E501
     # Ensure limits is an array
     limits = np.asarray(limits, dtype='float')
 
@@ -733,7 +732,20 @@ def compare_fiff(fname_1, fname_2, fname_out=None, show=True, indent='    ',
 
 
 def figure_nobar(*args, **kwargs):
-    """Make matplotlib figure with no toolbar."""
+    """Make matplotlib figure with no toolbar.
+
+    Parameters
+    ----------
+    *args : list
+        Arguments to pass to :func:`matplotlib.pyplot.figure`.
+    **kwargs : dict
+        Keyword arguments to pass to :func:`matplotlib.pyplot.figure`.
+
+    Returns
+    -------
+    fig : instance of Figure
+        The figure.
+    """
     from matplotlib import rcParams, pyplot as plt
     old_val = rcParams['toolbar']
     try:
@@ -1298,7 +1310,6 @@ class ClickableImage(object):
     Notes
     -----
     .. versionadded:: 0.9.0
-
     """
 
     def __init__(self, imdata, **kwargs):
@@ -1417,7 +1428,6 @@ def add_background_image(fig, im, set_ratios=None):
     Notes
     -----
     .. versionadded:: 0.9.0
-
     """
     if im is None:
         # Don't do anything and return nothing
@@ -1518,26 +1528,22 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
         array, the channels are divided by picks given in the array.
 
         .. versionadded:: 0.13.0
-
     to_sphere : bool
         Whether to project the 3d locations to a sphere. When False, the
         sensor array appears similar as to looking downwards straight above the
         subject's head. Has no effect when kind='3d'. Defaults to True.
 
         .. versionadded:: 0.14.0
-
     axes : instance of Axes | instance of Axes3D | None
         Axes to draw the sensors to. If ``kind='3d'``, axes must be an instance
         of Axes3D. If None (default), a new axes will be created.
 
         .. versionadded:: 0.13.0
-
     block : bool
         Whether to halt program execution until the figure is closed. Defaults
         to False.
 
         .. versionadded:: 0.13.0
-
     show : bool
         Show figure if True. Defaults to True.
 
@@ -1559,7 +1565,6 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
     :func:`mne.viz.plot_alignment`.
 
     .. versionadded:: 0.12.0
-
     """
     from .evoked import _rgb
     _check_option('kind', kind, ['topomap', '3d', 'select'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pytest-timeout
 joblib
 psutil
 dipy
-numpydoc
+https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
 PySurfer[save_movie]
 nilearn
 neo

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pytest-timeout
 joblib
 psutil
 dipy
-https://api.github.com/repos/datapythonista/numpydoc/zipball/validation
+https://api.github.com/repos/numpy/numpydoc/zipball/master
 PySurfer[save_movie]
 nilearn
 neo


### PR DESCRIPTION
~~WIP until~~ https://github.com/numpy/numpydoc/pull/238 is merged, ~~then I'll change~~ so I've  changed our code to use `numpy/numpydoc/master`.

Basically the Pandas folks had their own docstring validation code that they are now contributing to NumpyDoc, and it found a bunch of inconsistencies in our code. This fixes many of them, but leaves the following for later when someone is bored (there are hundreds and they are annoying):
```
    'PR06',  # Parameter type should use "str" instead of "string"
    'PR08',  # Parameter description should start with a capital letter
    'PR09',  # Parameter description should finish with "."
    'RT04',  # Return value description should start with a capital letter
    'RT05',  # Return value description should finish with "."
```
The only downside I can see is that we lose our "parameter description length" check, but this is easy enough to complain about in the review process.