### PR TITLE
MRG, FIX: make shift_time return self

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,6 +51,8 @@ Changelog
 Bug
 ~~~
 
+- Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
+
 - Fix bug in :class:`~mne.preprocessing.ICA` where requesting extended infomax via ``fit_params={'extended': True}`` was overridden, by `Daniel McCloy`_.
 
 - Fix bug in :func:`mne.write_evokeds` where ``evoked.nave`` was not saved properly when multiple :class:`~mne.Evoked` instances were written to a single file, by `Eric Larson`_

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1682,6 +1682,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
             If true, move the time backwards or forwards by specified amount.
             Else, set the starting time point to the value of tshift.
 
+        Returns
+        -------
+        epochs : instance of Epochs
+            The modified Epochs instance.
+
         Notes
         -----
         Maximum accuracy of time shift is 1 / epochs.info['sfreq']
@@ -1696,6 +1701,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         first = int(tshift * sfreq) + offset
         last = first + len(times) - 1
         self._set_times(np.arange(first, last + 1, dtype=np.float) / sfreq)
+        return self
 
 
 def _check_baseline(baseline, tmin, tmax, sfreq):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -294,6 +294,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             If true, move the time backwards or forwards by specified amount.
             Else, set the starting time point to the value of tshift.
 
+        Returns
+        -------
+        evoked : instance of Evoked
+            The modified Evoked instance.
+
         Notes
         -----
         Maximum accuracy of time shift is 1 / evoked.info['sfreq']
@@ -307,6 +312,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.last = self.first + len(times) - 1
         self.times = np.arange(self.first, self.last + 1,
                                dtype=np.float) / sfreq
+        return self
 
     @copy_function_doc_to_method_doc(plot_evoked)
     def plot(self, picks=None, exclude='bads', unit=True, show=True, ylim=None,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2707,10 +2707,8 @@ def test_shift_time(relative):
     timeshift = 13.5e-3  # Using sub-ms timeshift to test for sample accuracy.
     raw, events = _get_data()[:2]
     epochs = Epochs(raw, events[:1], preload=True, baseline=None)
-    avg = epochs.average()
-    avg.shift_time(timeshift, relative=relative)
-    epochs.shift_time(timeshift, relative=relative)
-    avg2 = epochs.average()
+    avg = epochs.average().shift_time(timeshift, relative=relative)
+    avg2 = epochs.shift_time(timeshift, relative=relative).average()
     assert_array_equal(avg.times, avg2.times)
     assert_equal(avg.first, avg2.first)
     assert_equal(avg.last, avg2.last)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -220,8 +220,7 @@ def test_shift_time_evoked():
     """Test for shifting of time scale."""
     tempdir = _TempDir()
     # Shift backward
-    ave = read_evokeds(fname, 0)
-    ave.shift_time(-0.1, relative=True)
+    ave = read_evokeds(fname, 0).shift_time(-0.1, relative=True)
     write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
 
     # Shift forward twice the amount


### PR DESCRIPTION
Makes `mne.Epochs.shift_time` and `mne.Evoked.shift_time` return the modified `Epochs` or `Evoked` instance (instead of `None`).