### PR TITLE
FIX: plot_bem src

### DIFF
--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -335,8 +335,9 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
                               zorder=1)
 
         for sources in src_points:
-            in_slice = np.logical_and(sources[:, z] > sl - 0.5,
-                                      sources[:, z] < sl + 0.5)
+            slice_size = np.diff(np.unique(np.round(sources[:, z]))).min()
+            in_slice = np.logical_and(sources[:, z] > sl - slice_size,
+                                      sources[:, z] < sl + slice_size)
             ax.scatter(sources[in_slice, x], sources[in_slice, y], marker='.',
                        color='#FF00FF', s=1, zorder=2)
 


### PR DESCRIPTION
`mne.viz.misc.plot_bem` is buggy with `src`, e.g.
https://mne.tools/stable/auto_tutorials/source-modeling/plot_forward.html#sphx-glr-auto-tutorials-source-modeling-plot-forward-py

Because it incorrectly assumes the slice size is `1`. 

This fixes it:
![image](https://user-images.githubusercontent.com/4881164/67689187-3cfd6f80-f99b-11e9-977c-f4c2623dae2f.png)

![image](https://user-images.githubusercontent.com/4881164/67689215-48509b00-f99b-11e9-8c1f-a87e0450e93f.png)
