### PR TITLE
MRG, BUG: Fix interpolation origin bugs

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,7 +55,7 @@ Bug
 
 - Fix bug in :class:`~mne.preprocessing.ICA` where requesting extended infomax via ``fit_params={'extended': True}`` was overridden, by `Daniel McCloy`_.
 
-- Fix bug in :meth:`mne.Epochs.interpolate_bads` where the ``origin`` was not used during MEG or EEG data interpolation by `Eric Larson`_. Old behavior can be achieved using ``origin=(0., 0., 0.)``, and the new default is ``origin='auto'``, which uses a head-digitization-based fit.
+- Fix bug in :meth:`mne.Epochs.interpolate_bads` where the ``origin`` was not used during MEG or EEG data interpolation by `Eric Larson`_. Old behavior can be achieved using ``origin=(0., 0., 0.)`` for EEG and ``origin=(0., 0., 0.04)`` for MEG, and the new default is ``origin='auto'``, which uses a head-digitization-based fit.
 
 - Fix bug in :func:`mne.write_evokeds` where ``evoked.nave`` was not saved properly when multiple :class:`~mne.Evoked` instances were written to a single file, by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,6 +55,8 @@ Bug
 
 - Fix bug in :class:`~mne.preprocessing.ICA` where requesting extended infomax via ``fit_params={'extended': True}`` was overridden, by `Daniel McCloy`_.
 
+- Fix bug in :meth:`mne.Epochs.interpolate_bads` where the ``origin`` was not used during MEG or EEG data interpolation by `Eric Larson`_. Old behavior can be achieved using ``origin=(0., 0., 0.)``, and the new default is ``origin='auto'``, which uses a head-digitization-based fit.
+
 - Fix bug in :func:`mne.write_evokeds` where ``evoked.nave`` was not saved properly when multiple :class:`~mne.Evoked` instances were written to a single file, by `Eric Larson`_
 
 - Fix bug in :func:`mne.preprocessing.mark_flat` where acquisition skips were not handled proeprly, by `Eric Larson`_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -924,7 +924,7 @@ class InterpolationMixin(object):
 
     @verbose
     def interpolate_bads(self, reset_bads=True, mode='accurate',
-                         origin=(0., 0., 0.04), verbose=None):
+                         origin='auto', verbose=None):
         """Interpolate bad MEG and EEG channels.
 
         Operates in place.
@@ -939,8 +939,8 @@ class InterpolationMixin(object):
             channels.
         origin : array-like, shape (3,) | str
             Origin of the sphere in the head coordinate frame and in meters.
-            Can be ``'auto'``, which means a head-digitization-based origin
-            fit. Default is ``(0., 0., 0.04)``.
+            Can be ``'auto'`` (default), which means a head-digitization-based
+            origin fit.
 
             .. versionadded:: 0.17
         %(verbose_meth)s
@@ -954,6 +954,7 @@ class InterpolationMixin(object):
         -----
         .. versionadded:: 0.9.0
         """
+        from ..bem import _check_origin
         from .interpolation import _interpolate_bads_eeg, _interpolate_bads_meg
 
         _check_preload(self, "interpolation")
@@ -961,8 +962,8 @@ class InterpolationMixin(object):
         if len(self.info['bads']) == 0:
             warn('No bad channels to interpolate. Doing nothing...')
             return self
-
-        _interpolate_bads_eeg(self)
+        origin = _check_origin(origin, self.info)
+        _interpolate_bads_eeg(self, origin=origin)
         _interpolate_bads_meg(self, mode=mode, origin=origin)
 
         if reset_bads is True:

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -39,9 +39,20 @@ def _load_data(kind):
     return raw, epochs
 
 
-def test_interpolation_eeg():
+@pytest.mark.parametrize('offset', (0., 0.1))
+@pytest.mark.filterwarnings('ignore:.*than 20 mm from head frame origin.*')
+def test_interpolation_eeg(offset):
     """Test interpolation of EEG channels."""
     raw, epochs_eeg = _load_data('eeg')
+    epochs_eeg = epochs_eeg.copy()
+    # Offsetting the coordinate frame should have no effect on the output
+    for inst in (raw, epochs_eeg):
+        for ch in inst.info['chs']:
+            if ch['kind'] == io.constants.FIFF.FIFFV_EEG_CH:
+                ch['loc'][:3] += offset
+                ch['loc'][3:6] += offset
+        for d in inst.info['dig']:
+            d['r'] += offset
 
     # check that interpolation does nothing if no bads are marked
     epochs_eeg.info['bads'] = []
@@ -64,13 +75,20 @@ def test_interpolation_eeg():
     pos_bad = pos[bads_idx]
     interpolation = _make_interpolation_matrix(pos_good, pos_bad)
     assert interpolation.shape == (1, len(epochs_eeg.ch_names) - 1)
-    ave_after = np.dot(interpolation, evoked_eeg.data[goods_idx])
+    interp_manual = np.dot(interpolation, evoked_eeg.data[goods_idx])
 
     epochs_eeg.info['bads'] = ['EEG 012']
     evoked_eeg = epochs_eeg.average()
-    assert_array_equal(ave_after, evoked_eeg.interpolate_bads().data[bads_idx])
+    interp_zero = evoked_eeg.interpolate_bads(
+        origin=(0., 0., 0.)).data[bads_idx]
+    assert_array_equal(interp_manual, interp_zero)
+    assert_allclose(ave_before, interp_zero, atol=3e-6)
+    assert 0.985 < np.corrcoef(ave_before, interp_zero)[0, 1] < 0.99
+    evoked_eeg.info['bads'] = ['EEG 012']
+    interp_fit = evoked_eeg.interpolate_bads().data[bads_idx]
+    assert_allclose(ave_before, interp_fit, atol=2e-6)
+    assert 0.99 < np.corrcoef(ave_before, interp_fit)[0, 1]  # better
 
-    assert_allclose(ave_before, ave_after, atol=2e-6)
 
     # check that interpolation fails when preload is False
     epochs_eeg.preload = False
@@ -99,10 +117,10 @@ def test_interpolation_eeg():
     orig_data = raw_few[1][0]
     with pytest.warns(None) as w:
         raw_few.interpolate_bads(reset_bads=False)
-    assert len(w) == 0
+    assert len([ww for ww in w if 'more than' not in str(ww.message)]) == 0
     new_data = raw_few[1][0]
     assert (new_data == 0).mean() < 0.5
-    assert np.corrcoef(new_data, orig_data)[0, 1] > 0.1
+    assert np.corrcoef(new_data, orig_data)[0, 1] > 0.2
 
 
 def test_interpolation_meg():
@@ -164,7 +182,7 @@ def _this_interpol(inst, ref_meg=False):
 
 def test_interpolate_meg_ctf():
     """Test interpolation of MEG channels from CTF system."""
-    thresh = .7
+    thresh = .85
     tol = .05  # assert the new interpol correlates at least .05 "better"
     bad = 'MLC22-2622'  # select a good channel to test the interpolation
 
@@ -198,7 +216,7 @@ def test_interpolation_ctf_comp():
     raw_fname = op.join(ctf_dir, 'somMDYO-18av.ds')
     raw = io.read_raw_ctf(raw_fname, preload=True)
     raw.info['bads'] = [raw.ch_names[5], raw.ch_names[-5]]
-    raw.interpolate_bads(mode='fast')
+    raw.interpolate_bads(mode='fast', origin=(0., 0., 0.04))
     assert raw.info['bads'] == []
 
 

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -89,7 +89,6 @@ def test_interpolation_eeg(offset):
     assert_allclose(ave_before, interp_fit, atol=2e-6)
     assert 0.99 < np.corrcoef(ave_before, interp_fit)[0, 1]  # better
 
-
     # check that interpolation fails when preload is False
     epochs_eeg.preload = False
     pytest.raises(RuntimeError, epochs_eeg.interpolate_bads)


### PR DESCRIPTION
Looking at our `interpolation` code:

1. The `origin` was never passed during MEG interpolation.
2. The `origin` was never used during EEG interpolation, despite the fact that it uses a spherical spline expansion.
3. The EEG interpolation estimated an origin using `_fit_sphere` that depended on the points actually being interpolated (which doesn't make much sense, we should be able to trust our dig/channel locs even for these bad channels, otherwise interp will not work)

This code fixes these bugs by:

1. Passing `origin` to the MEG functions
2. Subtracting `origin` from the EEG channel positions before computing the splines
3. Changing the default from `(0., 0., 0.04)` to `'auto'`, which uses a digitization-based head fit (as we do elsewhere, e.g. `maxwell_filter`)

Tests updated to show improved correlation coefficients with the fixes.