### PR TITLE
MRG, FIX: allow arbitrary offset for {Epochs,Evoked}.shift_time

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -84,6 +84,8 @@ Bug
 API
 ~~~
 
+- :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` now allow shifting times by arbitrary amounts (previously only by integer multiples of the sampling period), by `Daniel McCloy`_ and `Eric Larson`_.
+
 - The APIs of :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` are now more similar to :func:`mne.viz.plot_projs_topomap` by `Daniel McCloy`_.
 
 - :func:`mne.viz.plot_projs_topomap` now accepts both :class:`~mne.channels.Layout` and :class:`~mne.Info` (previously one or the other), and will ignore :class:`~mne.Info` if :class:`~mne.channels.Layout` is provided `Daniel McCloy`_.

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -32,7 +32,7 @@ from .bem import _bem_find_surface, _surf_name
 from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
-                    check_fname, _pl, fill_doc, _check_option,
+                    check_fname, _pl, fill_doc, _check_option, ShiftTimeMixin,
                     _svd_lwork, _repeated_svd, ddot, dgemv, dgemm)
 
 
@@ -361,14 +361,12 @@ class Dipole(object):
 def _read_dipole_fixed(fname):
     """Read a fixed dipole FIF file."""
     logger.info('Reading %s ...' % fname)
-    info, nave, aspect_kind, first, last, comment, times, data = \
-        _read_evoked(fname)
-    return DipoleFixed(info, data, times, nave, aspect_kind, first, last,
-                       comment)
+    info, nave, aspect_kind, comment, times, data = _read_evoked(fname)
+    return DipoleFixed(info, data, times, nave, aspect_kind, comment=comment)
 
 
 @fill_doc
-class DipoleFixed(object):
+class DipoleFixed(ShiftTimeMixin):
     """Dipole class for fixed-position dipole fits.
 
     .. note:: This class should usually not be instantiated directly,
@@ -387,9 +385,9 @@ class DipoleFixed(object):
     aspect_kind : int
         The kind of data.
     first : int
-        First sample.
+        First sample. Deprecated, will be removed in 0.21.
     last : int
-        Last sample.
+        Last sample. Deprecated, will be removed in 0.21.
     comment : str
         The dipole comment.
     %(verbose)s
@@ -410,18 +408,22 @@ class DipoleFixed(object):
     """
 
     @verbose
-    def __init__(self, info, data, times, nave, aspect_kind, first, last,
-                 comment, verbose=None):  # noqa: D102
+    def __init__(self, info, data, times, nave, aspect_kind,
+                 first=None, last=None, comment='',
+                 verbose=None):  # noqa: D102
         self.info = info
         self.nave = nave
         self._aspect_kind = aspect_kind
         self.kind = _aspect_rev.get(aspect_kind, 'unknown')
-        self.first = first
-        self.last = last
         self.comment = comment
         self.times = times
+        if first is not None or last is not None:
+            warn(DeprecationWarning, 'first and last are deprecated, '
+                 'do not pass them')
         self.data = data
         self.verbose = verbose
+        self.preload = True
+        self._update_first_last()
 
     def __repr__(self):  # noqa: D105
         s = "n_times : %s" % len(self.times)
@@ -1297,8 +1299,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         out_info._update_redundant()
         out_info._check_consistency()
         dipoles = DipoleFixed(out_info, data, times, evoked.nave,
-                              evoked._aspect_kind, evoked.first, evoked.last,
-                              comment)
+                              evoked._aspect_kind, comment=comment)
     else:
         dipoles = Dipole(times, out[0], out[1], out[2], out[3], comment,
                          out[4], out[5], out[6])

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -54,7 +54,7 @@ from .utils import (_check_fname, check_fname, logger, verbose,
                     _check_pandas_installed, _check_preload, GetEpochsMixin,
                     _prepare_read_metadata, _prepare_write_metadata,
                     _check_event_id, _gen_events, _check_option,
-                    _check_combine)
+                    _check_combine, ShiftTimeMixin)
 from .utils.docs import fill_doc
 
 
@@ -294,7 +294,7 @@ def _handle_event_repeated(events, event_id, event_repeated, selection,
 
 
 @fill_doc
-class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
+class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
                  ToDataFrameMixin, TimeMixin, SizeMixin, GetEpochsMixin):
     """Abstract base class for Epochs-type classes.
@@ -1667,41 +1667,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         self.drop(indices, reason='EQUALIZED_COUNT')
         # actually remove the indices
         return self, indices
-
-    def shift_time(self, tshift, relative=True):
-        """Shift time scale in epoched data.
-
-        Parameters
-        ----------
-        tshift : float
-            The amount of time shift to be applied if relative is True
-            else the first time point. When relative is True, positive value
-            of tshift moves the data forward while negative tshift moves it
-            backward.
-        relative : bool
-            If true, move the time backwards or forwards by specified amount.
-            Else, set the starting time point to the value of tshift.
-
-        Returns
-        -------
-        epochs : instance of Epochs
-            The modified Epochs instance.
-
-        Notes
-        -----
-        Maximum accuracy of time shift is 1 / epochs.info['sfreq']
-        """
-        _check_preload(self, 'shift_time')
-        times = self.times
-        sfreq = self.info['sfreq']
-        old_first = int(self.tmin * sfreq)
-
-        offset = old_first if relative else 0
-
-        first = int(tshift * sfreq) + offset
-        last = first + len(times) - 1
-        self._set_times(np.arange(first, last + 1, dtype=np.float) / sfreq)
-        return self
 
 
 def _check_baseline(baseline, tmin, tmax, sfreq):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -683,8 +683,7 @@ class EvokedArray(Evoked):
 
         self.data = data
 
-        # XXX: this should use round and be tested
-        self.first = int(tmin * info['sfreq'])
+        self.first = round(tmin * info['sfreq'])
         self.last = self.first + np.shape(data)[-1] - 1
         self.times = np.arange(self.first, self.last + 1,
                                dtype=np.float) / info['sfreq']

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -277,6 +277,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.times = self.times[decim_slice].copy()
         self.first = int(self.times[0] * self.info['sfreq'])
         self.last = len(self.times) + self.first - 1
+        # self._update_first_last()
         return self
 
     @copy_function_doc_to_method_doc(plot_evoked)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -117,9 +117,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  verbose=None):  # noqa: D102
         _validate_type(proj, bool, "'proj'")
         # Read the requested data
-        self.info, self.nave, self._aspect_kind, self.first, self.last, \
-            self.comment, self.times, self.data = _read_evoked(
-                fname, condition, kind, allow_maxshield)
+        self.info, self.nave, self._aspect_kind, self.comment, self.times, \
+            self.data = _read_evoked(fname, condition, kind, allow_maxshield)
+        self._update_first_last()
         self.verbose = verbose
         self.preload = True
         # project and baseline correct
@@ -1052,14 +1052,13 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
         data = data.astype(np.float)
 
         if first_time is not None and nsamp is not None:
-            first = int(round(first_time * info['sfreq']))
-            last = first + nsamp - 1
             times = first_time + np.arange(nsamp) / info['sfreq']
         elif first is not None:
             nsamp = last - first + 1
             times = np.arange(first, last + 1) / info['sfreq']
         else:
             raise RuntimeError('Could not read time parameters')
+        del first, last
         if nsamp is not None and data.shape[1] != nsamp:
             raise ValueError('Incorrect number of samples (%d instead of '
                              ' %d)' % (data.shape[1], nsamp))
@@ -1078,7 +1077,7 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
                      for k in range(info['nchan'])])
     data *= cals[:, np.newaxis]
 
-    return info, nave, aspect_kind, first, last, comment, times, data
+    return info, nave, aspect_kind, comment, times, data
 
 
 def write_evokeds(fname, evoked):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -275,9 +275,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.info['sfreq'] = new_sfreq
         self.data = self.data[:, decim_slice].copy()
         self.times = self.times[decim_slice].copy()
-        self.first = int(self.times[0] * self.info['sfreq'])
-        self.last = len(self.times) + self.first - 1
-        # self._update_first_last()
+        self._update_first_last()
         return self
 
     @copy_function_doc_to_method_doc(plot_evoked)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -683,7 +683,7 @@ class EvokedArray(Evoked):
 
         self.data = data
 
-        self.first = round(tmin * info['sfreq'])
+        self.first = int(round(tmin * info['sfreq']))
         self.last = self.first + np.shape(data)[-1] - 1
         self.times = np.arange(self.first, self.last + 1,
                                dtype=np.float) / info['sfreq']

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -34,7 +34,7 @@ from .io.meas_info import read_meas_info, write_meas_info
 from .io.proj import ProjMixin
 from .io.write import (start_file, start_block, end_file, end_block,
                        write_int, write_string, write_float_matrix,
-                       write_id)
+                       write_id, write_float)
 from .io.base import ToDataFrameMixin, TimeMixin, _check_maxshield
 
 _aspect_dict = {
@@ -1132,7 +1132,9 @@ def _write_evokeds(fname, evoked, check=True):
             if e.comment is not None and len(e.comment) > 0:
                 write_string(fid, FIFF.FIFF_COMMENT, e.comment)
 
-            # First and last sample
+            # First time, num. samples, first and last sample
+            write_float(fid, FIFF.FIFF_FIRST_TIME, e.times[0])
+            write_int(fid, FIFF.FIFF_NO_SAMPLES, len(e.times))
             write_int(fid, FIFF.FIFF_FIRST_SAMPLE, e.first)
             write_int(fid, FIFF.FIFF_LAST_SAMPLE, e.last)
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1051,22 +1051,21 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
             data = np.concatenate([e.data[None, :] for e in epoch], axis=0)
         data = data.astype(np.float)
 
-        if first is not None:
-            nsamp = last - first + 1
-        elif first_time is not None:
+        if first_time is not None and nsamp is not None:
             first = int(round(first_time * info['sfreq']))
-            last = first + nsamp
+            last = first + nsamp - 1
+            times = first_time + np.arange(nsamp) / info['sfreq']
+        elif first is not None:
+            nsamp = last - first + 1
+            times = np.arange(first, last + 1) / info['sfreq']
         else:
             raise RuntimeError('Could not read time parameters')
         if nsamp is not None and data.shape[1] != nsamp:
             raise ValueError('Incorrect number of samples (%d instead of '
                              ' %d)' % (data.shape[1], nsamp))
-        nsamp = data.shape[1]
-        last = first + nsamp - 1
         logger.info('    Found the data of interest:')
         logger.info('        t = %10.2f ... %10.2f ms (%s)'
-                    % (1000 * first / info['sfreq'],
-                       1000 * last / info['sfreq'], comment))
+                    % (1000 * times[0], 1000 * times[-1], comment))
         if info['comps'] is not None:
             logger.info('        %d CTF compensation matrices available'
                         % len(info['comps']))
@@ -1079,7 +1078,6 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
                      for k in range(info['nchan'])])
     data *= cals[:, np.newaxis]
 
-    times = np.arange(first, last + 1, dtype=np.float) / info['sfreq']
     return info, nave, aspect_kind, first, last, comment, times, data
 
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2009,8 +2009,7 @@ class FilterMixin(object):
             self._raw_times = self.times
         else:  # isinstance(self, Evoked)
             self.times = new_times
-            self.first = int(self.times[0] * self.info['sfreq'])
-            self.last = len(self.times) + self.first - 1
+            self._update_first_last()
         return self
 
     @verbose

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1382,8 +1382,7 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
     evoked = EvokedArray(data, info_out, times[0], nave=1)
 
     evoked.times = times
-    evoked.first = int(np.round(evoked.times[0] * sfreq))
-    evoked.last = evoked.first + evoked.data.shape[1] - 1
+    evoked._update_first_last()
 
     return evoked
 

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -236,6 +236,9 @@ def test_dipole_fitting_fixed(tmpdir):
     plt.close('all')
     dip_fixed.plot()
     plt.close('all')
+    orig_times = np.array(dip_fixed.times)
+    shift_times = dip_fixed.shift_time(1.).times
+    assert_allclose(shift_times, orig_times + 1)
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -370,7 +370,7 @@ def _check_roundtrip_fixed(dip, tmpdir):
     dip.save(op.join(tempdir, 'test-dip.fif.gz'))
     dip_read = read_dipole(op.join(tempdir, 'test-dip.fif.gz'))
     assert_allclose(dip_read.data, dip_read.data)
-    assert_allclose(dip_read.times, dip.times)
+    assert_allclose(dip_read.times, dip.times, atol=1e-8)
     assert dip_read.info['xplotter_layout'] == dip.info['xplotter_layout']
     assert dip_read.ch_names == dip.ch_names
     for ch_1, ch_2 in zip(dip_read.info['chs'], dip.info['chs']):

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -274,9 +274,15 @@ def test_shift_time_evoked():
     # should shift by 0 samples
     ave.shift_time(1e-6)
     assert_array_equal(first_last, np.array([ave.first, ave.last]))
+    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
+    ave_loaded = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    assert_array_almost_equal(ave.times, ave_loaded.times, 8)
     # should shift by 57 samples
     ave.shift_time(57. / ave.info['sfreq'])
     assert_array_equal(first_last + 57, np.array([ave.first, ave.last]))
+    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
+    ave_loaded = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    assert_array_almost_equal(ave.times, ave_loaded.times, 8)
 
 
 def test_evoked_resample():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -51,14 +51,14 @@ def test_decim():
     assert_array_equal(evoked_dec.data, evoked_dec_3.data)
 
     # Check proper updating of various fields
-    assert evoked_dec.first == -1
-    assert evoked_dec.last == 2
+    assert evoked_dec.first == -2
+    assert evoked_dec.last == 1
     assert_array_equal(evoked_dec.times, [-1, -0.4, 0.2, 0.8])
-    assert evoked_dec_2.first == -1
-    assert evoked_dec_2.last == 2
+    assert evoked_dec_2.first == -2
+    assert evoked_dec_2.last == 1
     assert_array_equal(evoked_dec_2.times, [-0.9, -0.3, 0.3, 0.9])
-    assert evoked_dec_3.first == -1
-    assert evoked_dec_3.last == 2
+    assert evoked_dec_3.first == -2
+    assert evoked_dec_3.last == 1
     assert_array_equal(evoked_dec_3.times, [-1, -0.4, 0.2, 0.8])
 
     # Now let's do it with some real data

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -64,8 +64,8 @@ def test_decim():
     # make sure the time nearest zero is also sample number 0.
     for ev in (evoked_dec, evoked_dec_2, evoked_dec_3):
         lowest_index = np.argmin(np.abs(np.arange(ev.first, ev.last)))
-        idxs_of_times_nearest_zero = (np.where(np.abs(ev.times) ==
-                                      np.min(np.abs(ev.times)))[0])
+        idxs_of_times_nearest_zero = \
+            np.where(np.abs(ev.times) == np.min(np.abs(ev.times)))[0]
         # we use `in` here in case two times are equidistant from 0.
         assert lowest_index in idxs_of_times_nearest_zero
         assert len(idxs_of_times_nearest_zero) in (1, 2)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -259,6 +259,16 @@ def test_shift_time_evoked():
     ave.shift_time(shift)
     assert_allclose(times + shift, ave.times, atol=1e-16, rtol=1e-12)
 
+    # test handling of Evoked.first, Evoked.last
+    ave = read_evokeds(fname, 0)
+    first_last = np.array([ave.first, ave.last])
+    # should shift by 0 samples
+    ave.shift_time(1e-6)
+    assert_array_equal(first_last, np.array([ave.first, ave.last]))
+    # should shift by 57 samples
+    ave.shift_time(57. / ave.info['sfreq'])
+    assert_array_equal(first_last + 57, np.array([ave.first, ave.last]))
+
 
 def test_evoked_resample():
     """Test resampling evoked data."""

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -246,7 +246,7 @@ def test_shift_time_evoked():
     ave_relative = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
 
     assert_allclose(ave_normal.data, ave_relative.data, atol=1e-16, rtol=1e-3)
-    assert_array_almost_equal(ave_normal.times, ave_relative.times, 10)
+    assert_array_almost_equal(ave_normal.times, ave_relative.times, 8)
 
     assert_equal(ave_normal.last, ave_relative.last)
     assert_equal(ave_normal.first, ave_relative.first)
@@ -604,7 +604,7 @@ def test_array_epochs():
     evoked2 = read_evokeds(tmp_fname)[0]
     data2 = evoked2.data
     assert_allclose(data1, data2)
-    assert_allclose(evoked1.times, evoked2.times)
+    assert_array_almost_equal(evoked1.times, evoked2.times, 8)
     assert_equal(evoked1.first, evoked2.first)
     assert_equal(evoked1.last, evoked2.last)
     assert_equal(evoked1.kind, evoked2.kind)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -252,6 +252,13 @@ def test_shift_time_evoked():
     assert_allclose(ave_normal.data, ave_absolute.data, atol=1e-16, rtol=1e-3)
     assert_equal(ave_absolute.first, int(-0.3 * ave.info['sfreq']))
 
+    # subsample shift
+    shift = 1e-6  # 1 μs, should be well below 1/sfreq
+    ave = read_evokeds(fname, 0)
+    times = ave.times
+    ave.shift_time(shift)
+    assert_allclose(times + shift, ave.times, atol=1e-16, rtol=1e-12)
+
 
 def test_evoked_resample():
     """Test resampling evoked data."""

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -61,6 +61,15 @@ def test_decim():
     assert evoked_dec_3.last == 1
     assert_array_equal(evoked_dec_3.times, [-1, -0.4, 0.2, 0.8])
 
+    # make sure the time nearest zero is also sample number 0.
+    for ev in (evoked_dec, evoked_dec_2, evoked_dec_3):
+        lowest_index = np.argmin(np.abs(np.arange(ev.first, ev.last)))
+        idxs_of_times_nearest_zero = (np.where(np.abs(ev.times) ==
+                                      np.min(np.abs(ev.times)))[0])
+        # we use `in` here in case two times are equidistant from 0.
+        assert lowest_index in idxs_of_times_nearest_zero
+        assert len(idxs_of_times_nearest_zero) in (1, 2)
+
     # Now let's do it with some real data
     raw = read_raw_fif(raw_fname)
     events = read_events(event_name)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -54,7 +54,7 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _julian_to_cal, _cal_to_julian, _dt_to_julian,
                        _julian_to_dt)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
-                    _prepare_write_metadata, _FakeNoPandas)
+                    _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _repeated_pinv2,
                      _eig_lwork, _repeated_eig, _inv_lwork, _repeated_inv,
                      dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -462,3 +462,48 @@ class _FakeNoPandas(object):  # noqa: D101
         import mne
         mne.epochs._check_pandas_installed = self._old_check
         mne.utils.mixin._check_pandas_installed = self._old_check
+
+
+class ShiftTimeMixin(object):
+    """Class for shift_time method (Epochs and Evoked)."""
+
+    def shift_time(self, tshift, relative=True):
+        """Shift time scale in epoched or evoked data.
+
+        Parameters
+        ----------
+        tshift : float
+            The (absolute or relative) time shift in seconds. If ``relative``
+            is True, positive tshift increases the time value associated with
+            each sample, while negative tshift decreases it.
+        relative : bool
+            If True, increase or decrease time values by ``tshift`` seconds.
+            Otherwise, shift the time values such that the time of the first
+            sample equals ``tshift``.
+
+        Returns
+        -------
+        epochs : instance of Epochs
+            The modified Epochs instance.
+
+        Notes
+        -----
+        This method allows you to shift the *time* values associated with each
+        data sample by an arbitrary amount. It does *not* resample the signal
+        or change the *data* values in any way.
+        """
+        from ..epochs import BaseEpochs
+        _check_preload(self, 'shift_time')
+        start = tshift + (self.times[0] if relative else 0.)
+        new_times = start + np.arange(len(self.times)) / self.info['sfreq']
+        if isinstance(self, BaseEpochs):
+            self._set_times(new_times)
+        else:
+            self.times = new_times
+            self._update_first_last()
+        return self
+
+    def _update_first_last(self):
+        """Update self.first and self.last (sample indices)."""
+        self.first = int(self.times[0] * self.info['sfreq'])
+        self.last = len(self.times) + self.first - 1

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -505,5 +505,5 @@ class ShiftTimeMixin(object):
 
     def _update_first_last(self):
         """Update self.first and self.last (sample indices)."""
-        self.first = int(self.times[0] * self.info['sfreq'])
+        self.first = round(self.times[0] * self.info['sfreq'])
         self.last = len(self.times) + self.first - 1

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -465,7 +465,7 @@ class _FakeNoPandas(object):  # noqa: D101
 
 
 class ShiftTimeMixin(object):
-    """Class for shift_time method (Epochs and Evoked)."""
+    """Class for shift_time method (Epochs, Evoked, and DipoleFixed)."""
 
     def shift_time(self, tshift, relative=True):
         """Shift time scale in epoched or evoked data.

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -505,5 +505,5 @@ class ShiftTimeMixin(object):
 
     def _update_first_last(self):
         """Update self.first and self.last (sample indices)."""
-        self.first = round(self.times[0] * self.info['sfreq'])
+        self.first = int(round(self.times[0] * self.info['sfreq']))
         self.last = len(self.times) + self.first - 1


### PR DESCRIPTION
- allow `Epochs.shift_time` and `Evoked.shift_time` to shift time by amounts that are not integer-multiples of the sampling period
- refactor so the same code is used for both classes

cc @jjnurminen @larsoner @agramfort 