### PR TITLE
MRG, ENH: Add support for CSD as custom reference type

### DIFF
--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -337,7 +337,7 @@ def _read_forward_meas_info(tree, fid):
     if tag is None:
         tag = find_tag(fid, parent_mri, 236)  # Constant 236 used before v0.11
 
-    info['custom_ref_applied'] = bool(tag.data) if tag is not None else False
+    info['custom_ref_applied'] = int(tag.data) if tag is not None else False
     info._check_consistency()
     return info
 

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -632,6 +632,12 @@ FIFF.FIFFV_PROJ_ITEM_HOMOG_FIELD    = 5
 FIFF.FIFFV_PROJ_ITEM_EEG_AVREF      = 10  # Linear projection related to EEG average reference
 FIFF.FIFFV_MNE_PROJ_ITEM_EEG_AVREF  = FIFF.FIFFV_PROJ_ITEM_EEG_AVREF  # backward compat alias
 #
+# Custom EEG references
+#
+FIFF.FIFFV_MNE_CUSTOM_REF_OFF       = 0
+FIFF.FIFFV_MNE_CUSTOM_REF_ON        = 1
+FIFF.FIFFV_MNE_CUSTOM_REF_CSD       = 2
+#
 # SSS job options
 #
 FIFF.FIFFV_SSS_JOB_NOTHING          = 0   # No SSS, just copy input to output

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -779,6 +779,7 @@ FIFF.FIFF_UNIT_H   = 113  # Henry
 FIFF.FIFF_UNIT_CEL = 114  # celsius
 FIFF.FIFF_UNIT_LM  = 115  # lumen
 FIFF.FIFF_UNIT_LX  = 116  # lux
+FIFF.FIFF_UNIT_V_M2 = 117  # V/m^2
 #
 # Others we need
 #

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -817,6 +817,7 @@ FIFF.FIFFV_COIL_NM_122                = 2  # Neuromag 122 coils
 FIFF.FIFFV_COIL_NM_24                 = 3  # Old 24 channel system in HUT
 FIFF.FIFFV_COIL_NM_MCG_AXIAL          = 4  # The axial devices in the HUCS MCG system
 FIFF.FIFFV_COIL_EEG_BIPOLAR           = 5  # Bipolar EEG lead
+FIFF.FIFFV_COIL_EEG_CSD               = 6  # CSD-transformed EEG lead
 
 FIFF.FIFFV_COIL_DIPOLE             = 200  # Time-varying dipole definition
 # The coil info contains dipole location (r0) and

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -199,7 +199,7 @@ class Info(dict):
     ctf_head_t : dict | None
         The transformation from 4D/CTF head coordinates to Neuromag head
         coordinates. This is only present in 4D/CTF data.
-    custom_ref_applied : bool
+    custom_ref_applied : int
         Whether a custom (=other than average) reference has been applied to
         the EEG data. This flag is checked by some algorithms that require an
         average reference to be set.
@@ -832,7 +832,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
     proj_name = None
     line_freq = None
     gantry_angle = None
-    custom_ref_applied = False
+    custom_ref_applied = FIFF.FIFFV_MNE_CUSTOM_REF_OFF
     xplotter_layout = None
     kit_system_id = None
     for k in range(meas_info['nent']):
@@ -900,7 +900,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
             gantry_angle = float(tag.data)
         elif kind in [FIFF.FIFF_MNE_CUSTOM_REF, 236]:  # 236 used before v0.11
             tag = read_tag(fid, pos)
-            custom_ref_applied = bool(tag.data)
+            custom_ref_applied = int(tag.data)
         elif kind == FIFF.FIFF_XPLOTTER_LAYOUT:
             tag = read_tag(fid, pos)
             xplotter_layout = str(tag.data)
@@ -1827,7 +1827,7 @@ def _empty_info(sfreq):
         info[k] = None
     for k in _list_keys:
         info[k] = list()
-    info['custom_ref_applied'] = False
+    info['custom_ref_applied'] = FIFF.FIFFV_MNE_CUSTOM_REF_OFF
     info['highpass'] = 0.
     info['sfreq'] = float(sfreq)
     info['lowpass'] = info['sfreq'] / 2.

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -30,6 +30,7 @@ _tag_ignore_names = (
     'FIFFV_MNE_CUSTOM_REF_ON',
     'FIFFV_MNE_CUSTOM_REF_OFF',
     'FIFFV_MNE_CUSTOM_REF_CSD',
+    'FIFF_UNIT_V_M2',
 )  # for fiff-constants pending updates
 _ignore_incomplete_enums = (  # XXX eventually we could complete these
     'bem_surf_id', 'cardinal_point_cardiac', 'cond_model', 'coord',

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -31,6 +31,7 @@ _tag_ignore_names = (
     'FIFFV_MNE_CUSTOM_REF_OFF',
     'FIFFV_MNE_CUSTOM_REF_CSD',
     'FIFF_UNIT_V_M2',
+    'FIFFV_COIL_EEG_CSD',
 )  # for fiff-constants pending updates
 _ignore_incomplete_enums = (  # XXX eventually we could complete these
     'bem_surf_id', 'cardinal_point_cardiac', 'cond_model', 'coord',

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -26,7 +26,11 @@ _dir_ignore_names = ('clear', 'copy', 'fromkeys', 'get', 'items', 'keys',
                      'has_key', 'iteritems', 'iterkeys', 'itervalues',  # Py2
                      'viewitems', 'viewkeys', 'viewvalues',  # Py2
                      )
-_tag_ignore_names = ()  # for fiff-constants pending updates
+_tag_ignore_names = (
+    'FIFFV_MNE_CUSTOM_REF_ON',
+    'FIFFV_MNE_CUSTOM_REF_OFF',
+    'FIFFV_MNE_CUSTOM_REF_CSD',
+)  # for fiff-constants pending updates
 _ignore_incomplete_enums = (  # XXX eventually we could complete these
     'bem_surf_id', 'cardinal_point_cardiac', 'cond_model', 'coord',
     'dacq_system', 'diffusion_param', 'gantry_type', 'map_surf',
@@ -254,7 +258,8 @@ def test_constants(tmpdir):
                     if name.startswith('FIFFV_' + check.upper()):
                         break
                 else:
-                    raise RuntimeError('Could not find %s' % (name,))
+                    if name not in _tag_ignore_names:
+                        raise RuntimeError('Could not find %s' % (name,))
             assert check in used_enums, name
             if 'SSS' in check:
                 raise RuntimeError

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -15,7 +15,7 @@ from mne.utils import _fetch_file, requires_good_network
 
 
 # https://github.com/mne-tools/fiff-constants/commits/master
-commit = '07e87ab09bb235052f086b6a92f49019120dd63c'
+commit = '064604db8aeba310c76c93e7c76cc983257105b4'
 
 # These are oddities that we won't address:
 iod_dups = (355, 359)  # these are in both MEGIN and MNE files
@@ -27,11 +27,6 @@ _dir_ignore_names = ('clear', 'copy', 'fromkeys', 'get', 'items', 'keys',
                      'viewitems', 'viewkeys', 'viewvalues',  # Py2
                      )
 _tag_ignore_names = (
-    'FIFFV_MNE_CUSTOM_REF_ON',
-    'FIFFV_MNE_CUSTOM_REF_OFF',
-    'FIFFV_MNE_CUSTOM_REF_CSD',
-    'FIFF_UNIT_V_M2',
-    'FIFFV_COIL_EEG_CSD',
 )  # for fiff-constants pending updates
 _ignore_incomplete_enums = (  # XXX eventually we could complete these
     'bem_surf_id', 'cardinal_point_cardiac', 'cond_model', 'coord',
@@ -46,6 +41,7 @@ _missing_coil_def = (
     3,      # Old 24 channel system in HUT
     4,      # The axial devices in the HUCS MCG system
     5,      # Bipolar EEG electrode position
+    6,      # CSD-transformed EEG electrodes
     200,    # Time-varying dipole definition
     300,    # FNIRS oxyhemoglobin
     301,    # FNIRS deoxyhemoglobin
@@ -307,9 +303,11 @@ def test_constants(tmpdir):
         if key not in _missing_coil_def and key not in coil_def:
             bad_list.append(('    %s,' % key).ljust(10) +
                             '  # ' + fif['coil'][key][1])
-    assert len(bad_list) == 0, '\n' + '\n'.join(bad_list)
+    assert len(bad_list) == 0, \
+        '\nIn fiff-constants, missing from coil_def:\n' + '\n'.join(bad_list)
     # Assert that enum(coil) has all `coil_def.dat` entries
     for key, desc in zip(coil_def, coil_desc):
         if key not in fif['coil']:
             bad_list.append(('    %s,' % key).ljust(10) + '  # ' + desc)
-    assert len(bad_list) == 0, '\n' + '\n'.join(bad_list)
+    assert len(bad_list) == 0, \
+        'In coil_def, missing  from fiff-constants:\n' + '\n'.join(bad_list)

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -128,10 +128,16 @@ def test_apply_reference():
         )
     )
     # Projection concerns channels mentioned in projector
-    pytest.raises(RuntimeError, _apply_reference, raw, ['EEG 001'])
+    with pytest.raises(RuntimeError, match='Inactive signal space'):
+        _apply_reference(raw, ['EEG 001'])
 
     # Projection does not concern channels mentioned in projector, no error
     _apply_reference(raw, ['EEG 003'], ['EEG 004'])
+
+    # CSD cannot be rereferenced
+    raw.info['custom_ref_applied'] = FIFF.FIFFV_MNE_CUSTOM_REF_CSD
+    with pytest.raises(RuntimeError, match="Cannot set.* type 'CSD'"):
+        raw.set_eeg_reference()
 
 
 @testing.requires_testing_data

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -167,39 +167,39 @@ def test_set_eeg_reference():
     raw_nopreload = read_raw_fif(fif_fname, preload=False)
     raw_nopreload.info['projs'] = []
     reref, ref_data = set_eeg_reference(raw_nopreload, projection=True)
-    assert (_has_eeg_average_ref_proj(reref.info['projs']))
-    assert (not reref.info['projs'][0]['active'])
+    assert _has_eeg_average_ref_proj(reref.info['projs'])
+    assert not reref.info['projs'][0]['active']
 
     # Rereference raw data by creating a copy of original data
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'], copy=True)
-    assert (reref.info['custom_ref_applied'])
+    assert reref.info['custom_ref_applied']
     _test_reference(raw, reref, ref_data, ['EEG 001', 'EEG 002'])
 
     # Test that data is modified in place when copy=False
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'],
                                         copy=False)
-    assert (raw is reref)
+    assert raw is reref
 
     # Test moving from custom to average reference
     reref, ref_data = set_eeg_reference(raw, ['EEG 001', 'EEG 002'])
     reref, _ = set_eeg_reference(reref, projection=True)
-    assert (_has_eeg_average_ref_proj(reref.info['projs']))
-    assert_equal(reref.info['custom_ref_applied'], False)
+    assert _has_eeg_average_ref_proj(reref.info['projs'])
+    assert not reref.info['custom_ref_applied']
 
     # When creating an average reference fails, make sure the
     # custom_ref_applied flag remains untouched.
     reref = raw.copy()
-    reref.info['custom_ref_applied'] = True
+    reref.info['custom_ref_applied'] = FIFF.FIFFV_MNE_CUSTOM_REF_ON
     reref.pick_types(eeg=False)  # Cause making average ref fail
     pytest.raises(ValueError, set_eeg_reference, reref, projection=True)
-    assert (reref.info['custom_ref_applied'])
+    assert reref.info['custom_ref_applied'] == FIFF.FIFFV_MNE_CUSTOM_REF_ON
 
     # Test moving from average to custom reference
     reref, ref_data = set_eeg_reference(raw, projection=True)
     reref, _ = set_eeg_reference(reref, ['EEG 001', 'EEG 002'])
     assert not _has_eeg_average_ref_proj(reref.info['projs'])
     assert len(reref.info['projs']) == 0
-    assert_equal(reref.info['custom_ref_applied'], True)
+    assert reref.info['custom_ref_applied'] == FIFF.FIFFV_MNE_CUSTOM_REF_ON
 
     # Test that disabling the reference does not change the data
     assert _has_eeg_average_ref_proj(raw.info['projs'])


### PR DESCRIPTION
Eventually I can roll back the constants tests once we get https://github.com/mne-tools/fiff-constants/pull/23 in. In the meantime we can merge this if it looks reasonable to folks so that #6910 can use it.

As @agramfort pointed out, our inverse checks just look at effectively `bool(info['custom_ref_applied'])`, so we should still be good there.