### PR TITLE
WIP: Allow raw.plot_psd() on fnirs_od and hbo/hbr data

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -379,18 +379,20 @@ class SetChannelsMixin(object):
                        % name)
                 raise ValueError(msg)
 
-    def set_channel_types(self, mapping):
+    @verbose
+    def set_channel_types(self, mapping, verbose=None):
         """Define the sensor type of channels.
 
         Note: The following sensor types are accepted:
             ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst, ecog,
-            hbo, hbr
+            hbo, hbr, fnirs_raw, fnirs_od
 
         Parameters
         ----------
         mapping : dict
             A dictionary mapping a channel to a sensor type (str)
             {'EEG061': 'eog'}.
+        %(verbose_meth)s
 
         Notes
         -----

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -6,15 +6,13 @@ import numpy as np
 import os.path as op
 import itertools
 from distutils.version import LooseVersion
-import logging
 
 from numpy.testing import assert_allclose
 import pytest
 import matplotlib
 import matplotlib.pyplot as plt
 
-from mne import read_events, pick_types, Annotations, create_info,\
-    set_log_level
+from mne import read_events, pick_types, Annotations, create_info
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf, RawArray
 from mne.utils import run_tests_if_main
@@ -423,10 +421,9 @@ def test_plot_raw_psd():
     raw.plot_psd(picks=picks, average=False)
     raw.plot_psd(picks=picks, average=True)
     plt.close('all')
-    old_log_level = set_log_level(logging.CRITICAL)
     raw.set_channel_types({'MEG 0113': 'hbo', 'MEG 0112': 'hbr',
-                           'MEG 0122': 'fnirs_raw', 'MEG 0123': 'fnirs_od'})
-    set_log_level(old_log_level)
+                           'MEG 0122': 'fnirs_raw', 'MEG 0123': 'fnirs_od'},
+                          verbose='error')
     fig = raw.plot_psd()
     assert len(fig.axes) == 10
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -6,13 +6,15 @@ import numpy as np
 import os.path as op
 import itertools
 from distutils.version import LooseVersion
+import logging
 
 from numpy.testing import assert_allclose
 import pytest
 import matplotlib
 import matplotlib.pyplot as plt
 
-from mne import read_events, pick_types, Annotations, create_info
+from mne import read_events, pick_types, Annotations, create_info,\
+    set_log_level
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf, RawArray
 from mne.utils import run_tests_if_main
@@ -421,6 +423,12 @@ def test_plot_raw_psd():
     raw.plot_psd(picks=picks, average=False)
     raw.plot_psd(picks=picks, average=True)
     plt.close('all')
+    old_log_level = set_log_level(logging.CRITICAL)
+    raw.set_channel_types({'MEG 0113': 'hbo', 'MEG 0112': 'hbr',
+                           'MEG 0122': 'fnirs_raw', 'MEG 0123': 'fnirs_od'})
+    set_log_level(old_log_level)
+    fig = raw.plot_psd()
+    assert len(fig.axes) == 10
 
 
 def test_plot_sensors():

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2978,17 +2978,19 @@ def center_cmap(cmap, vmin, vmax, name="cmap_centered"):
 def _set_psd_plot_params(info, proj, picks, ax, area_mode):
     """Set PSD plot params."""
     import matplotlib.pyplot as plt
-    _data_types = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'fnirs_raw')
+    _data_types = ('mag', 'grad', 'eeg', 'seeg', 'ecog', 'fnirs_raw',
+                   'fnirs_od', 'hbo', 'hbr')
     _check_option('area_mode', area_mode, [None, 'std', 'range'])
     picks = _picks_to_idx(info, picks)
 
     # XXX this could be refactored more with e.g., plot_evoked
     # XXX when it's refactored, Report._render_raw will need to be updated
-    megs = ['mag', 'grad', False, False, False, False]
-    eegs = [False, False, True, False, False, False]
-    seegs = [False, False, False, True, False, False]
-    ecogs = [False, False, False, False, True, False]
-    fnirss = [False, False, False, False, False, 'fnirs_raw']
+    megs = ['mag', 'grad', False, False, False, False, False, False, False]
+    eegs = [False, False, True, False, False, False, False, False, False]
+    seegs = [False, False, False, True, False, False, False, False, False]
+    ecogs = [False, False, False, False, True, False, False, False, False]
+    fnirss = [False, False, False, False, False, 'fnirs_raw', 'fnirs_od',
+              'hbo', 'hbr']
     titles = _handle_default('titles', None)
     units = _handle_default('units', None)
     scalings = _handle_default('scalings', None)


### PR DESCRIPTION
#### What does this implement/fix?
Enables `raw.plot_psd()` to work with `fnirs_od`, `hbo`, and `hbr` types.


#### Additional information
This script demonstrates the changes work. Where can I update a test for this?

```python
import mne
import os.path as op

fname_nirx_15_0 = op.join(mne.datasets.testing.data_path(download=False),  'NIRx', 'nirx_15_0_recording')
raw = mne.io.read_raw_nirx(fname_nirx_15_0, preload=True); 

raw.plot_psd();
raw = mne.preprocessing.optical_density(raw)
raw.plot_psd();
raw = mne.preprocessing.beer_lambert_law(raw)
raw.plot_psd();
raw = raw.filter(None, 0.7, h_trans_bandwidth = 0.2)
raw.plot_psd();
raw.plot_psd(average=True);
```
