### PR TITLE
MRG: switch HF-SEF to v1.1 on zenodo

### DIFF
--- a/mne/datasets/hf_sef/hf_sef.py
+++ b/mne/datasets/hf_sef/hf_sef.py
@@ -53,7 +53,7 @@ def data_path(dataset='evoked', path=None, force_update=False,
     destdir = op.join(path, 'HF_SEF')
 
     urls = {'evoked':
-            'https://osf.io/25f8d/download?version=1',
+            'https://zenodo.org/record/3523071/files/hf_sef_evoked.tar.gz',
             'raw':
             'https://zenodo.org/record/889296/files/hf_sef_raw.tar.gz'}
     hashes = {'evoked': 'a3e36f006dcece8f1da50b602bfc9cbe',

--- a/mne/datasets/hf_sef/hf_sef.py
+++ b/mne/datasets/hf_sef/hf_sef.py
@@ -56,8 +56,8 @@ def data_path(dataset='evoked', path=None, force_update=False,
             'https://zenodo.org/record/3523071/files/hf_sef_evoked.tar.gz',
             'raw':
             'https://zenodo.org/record/889296/files/hf_sef_raw.tar.gz'}
-    hashes = {'evoked': 'a3e36f006dcece8f1da50b602bfc9cbe',
-              'raw': None}  # don't have raw hash yet
+    hashes = {'evoked': '13d34cb5db584e00868677d8fb0aab2b',
+              'raw': '33934351e558542bafa9b262ac071168'}
     _check_option('dataset', dataset, sorted(urls.keys()))
     url = urls[dataset]
     hash_ = hashes[dataset]


### PR DESCRIPTION
#### What does this implement/fix?
Update HF-SEF dataset to a new version (with updated trans) located on zenodo.org.
