### PR TITLE
MRG, DOC: Better styling and message

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -122,9 +122,6 @@ a:hover code {
     color: rgb(0, 0, 0);
     border: none;
 }
-.alert-info pre {
-    background-color: var(--a-color-lighter);
-}
 .warning {
     background-color: rgb(230, 57, 57);
     color: white;

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -750,6 +750,15 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
 
     Notes
     -----
+    The default model has::
+
+        relative_radii = (0.90, 0.92, 0.97, 1.0)
+        sigmas = (0.33, 1.0, 0.004, 0.33)
+
+    These correspond to compartments (with relative radii in ``m`` and
+    conductivities σ in ``S/m``) for the brain, CSF, skull, and scalp,
+    respectively.
+
     .. versionadded:: 0.9.0
     """
     for name in ('r0', 'head_radius'):


### PR DESCRIPTION
1. Make it clear what the radii/conductivities in `make_sphere_model` stand for.
2. Fix [this wrong code block color in the Note](https://mne.tools/dev/install/mne_c.html#system-requirements) using CSS.

I think the CSS fix is right. Not sure why the `pre` lines (removed here) were introduced in #6812, but they do not seem necessary to make the `See Also` sections render properly.