### PR TITLE
FIX:no error if txt annotation empty 

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,6 +61,8 @@ Bug
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 
+- Fix :func:`mne.read_annotations` for text files with zero or one annotations, by `Adonay Nunes`_
+
 - Fix bug in :class:`~mne.preprocessing.ICA` where requesting extended infomax via ``fit_params={'extended': True}`` was overridden, by `Daniel McCloy`_.
 
 - Fix bug in :meth:`mne.Epochs.interpolate_bads` where the ``origin`` was not used during MEG or EEG data interpolation by `Eric Larson`_. Old behavior can be achieved using ``origin=(0., 0., 0.)`` for EEG and ``origin=(0., 0., 0.04)`` for MEG, and the new default is ``origin='auto'``, which uses a head-digitization-based fit.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -736,6 +736,8 @@ def _read_annotations_txt_parse_header(fname):
 
 
 def _read_annotations_txt(fname):
+    import warnings
+    warnings.filterwarnings("ignore", message=('loadtxt: Empty input file: "%s"' % fname))
     try:
         onset, duration, desc = np.loadtxt(fname, delimiter=',',
                                            dtype=np.bytes_, unpack=True)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -736,13 +736,14 @@ def _read_annotations_txt_parse_header(fname):
 
 
 def _read_annotations_txt(fname):
-    try:
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("ignore")
-            onset, duration, desc = np.loadtxt(fname, delimiter=',',
-                                               dtype=np.bytes_, unpack=True)
-    except ValueError:
-        return [], [], []
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("ignore")
+        out = np.loadtxt(fname, delimiter=',',
+                         dtype=np.bytes_, unpack=True)
+    if len(out) == 0:
+        onset, duration, desc = [], [], []
+    else:
+        onset, duration, desc = out
 
     onset = [float(o.decode()) for o in np.atleast_1d(onset)]
     duration = [float(d.decode()) for d in np.atleast_1d(duration)]

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -740,7 +740,8 @@ def _read_annotations_txt(fname):
         onset, duration, desc = np.loadtxt(fname, delimiter=',',
                                            dtype=np.bytes_, unpack=True)
     except ValueError:
-        onset, duration, desc = [], [], []
+        return [], [], []
+
     onset = [float(o.decode()) for o in onset]
     duration = [float(d.decode()) for d in duration]
     desc = [str(d.decode()).strip() for d in desc]

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -9,7 +9,7 @@ import re
 from copy import deepcopy
 from itertools import takewhile
 import collections
-
+import warnings
 import numpy as np
 
 from .utils import (_pl, check_fname, _validate_type, verbose, warn, logger,
@@ -736,17 +736,17 @@ def _read_annotations_txt_parse_header(fname):
 
 
 def _read_annotations_txt(fname):
-    import warnings
-    warnings.filterwarnings("ignore", message=('loadtxt: Empty input file: "%s"' % fname))
     try:
-        onset, duration, desc = np.loadtxt(fname, delimiter=',',
-                                           dtype=np.bytes_, unpack=True)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore")
+            onset, duration, desc = np.loadtxt(fname, delimiter=',',
+                                               dtype=np.bytes_, unpack=True)
     except ValueError:
         return [], [], []
 
-    onset = [float(o.decode()) for o in onset]
-    duration = [float(d.decode()) for d in duration]
-    desc = [str(d.decode()).strip() for d in desc]
+    onset = [float(o.decode()) for o in np.atleast_1d(onset)]
+    duration = [float(d.decode()) for d in np.atleast_1d(duration)]
+    desc = [str(d.decode()).strip() for d in np.atleast_1d(desc)]
     return onset, duration, desc
 
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -736,8 +736,11 @@ def _read_annotations_txt_parse_header(fname):
 
 
 def _read_annotations_txt(fname):
-    onset, duration, desc = np.loadtxt(fname, delimiter=',',
-                                       dtype=np.bytes_, unpack=True)
+    try:
+        onset, duration, desc = np.loadtxt(fname, delimiter=',',
+                                           dtype=np.bytes_, unpack=True)
+    except ValueError:
+        onset, duration, desc = [], [], []
     onset = [float(o.decode()) for o in onset]
     duration = [float(d.decode()) for d in duration]
     desc = [str(d.decode()).strip() for d in desc]

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -867,9 +867,9 @@ def test_read_annotation_txt_empty(
         dummy_annotation_txt_file_empty):
     """Test empty TXT input/output."""
     annot = read_annotations(str(dummy_annotation_txt_file_empty))
-    assert_array_equal(annot.onset, [])
-    assert_array_equal(annot.duration, [])
-    assert_array_equal(annot.description, [])
+    assert_array_equal(annot.onset, None)
+    assert_array_equal(annot.duration, None)
+    assert_array_equal(annot.description, None)
 
 
 def test_annotations_simple_iteration():

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -853,6 +853,23 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.duration, [42., 48])
     assert_array_equal(annot.description, ['AA', 'BB'])
 
+@pytest.fixture(scope='session')
+def dummy_annotation_txt_one_segment(tmpdir_factory):
+    """Create empty TXT annotations."""
+    content = ("# MNE-Annotations\n"
+               "# onset, duration, description\n"
+               "3.14, 42, AA")
+    fname = tmpdir_factory.mktemp('data').join('one-annotations.txt')
+    fname.write(content)
+    return fname
+
+def test_read_annotation_txt_one_segment(
+        dummy_annotation_txt_one_segment):
+    """Test empty TXT input/output."""
+    annot = read_annotations(str(dummy_annotation_txt_one_segment))
+    assert_array_equal(annot.onset, 3.14)
+    assert_array_equal(annot.duration, 42)
+    assert_array_equal(annot.description, 'AA')
 
 @pytest.fixture(scope='session')
 def dummy_annotation_txt_file_empty(tmpdir_factory):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -854,6 +854,24 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.description, ['AA', 'BB'])
 
 
+@pytest.fixture(scope='session')
+def dummy_annotation_txt_file_empty(tmpdir_factory):
+    """Create empty TXT annotations."""
+    content = ("# MNE-Annotations\n"
+               "# onset, duration, description\n")
+    fname = tmpdir_factory.mktemp('data').join('empty-annotations.txt')
+    fname.write(content)
+    return fname
+
+def test_read_annotation_txt_empty(
+        dummy_annotation_txt_file_empty):
+    """Test empty TXT input/output."""
+    annot = read_annotations(str(dummy_annotation_txt_file_empty))
+    assert_array_equal(annot.onset, [])
+    assert_array_equal(annot.duration, [])
+    assert_array_equal(annot.description, [])
+
+
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -853,6 +853,7 @@ def test_read_annotation_txt_orig_time(
     assert_array_equal(annot.duration, [42., 48])
     assert_array_equal(annot.description, ['AA', 'BB'])
 
+
 @pytest.fixture(scope='session')
 def dummy_annotation_txt_one_segment(tmpdir_factory):
     """Create empty TXT annotations."""
@@ -863,6 +864,7 @@ def dummy_annotation_txt_one_segment(tmpdir_factory):
     fname.write(content)
     return fname
 
+
 def test_read_annotation_txt_one_segment(
         dummy_annotation_txt_one_segment):
     """Test empty TXT input/output."""
@@ -870,6 +872,7 @@ def test_read_annotation_txt_one_segment(
     assert_array_equal(annot.onset, 3.14)
     assert_array_equal(annot.duration, 42)
     assert_array_equal(annot.description, 'AA')
+
 
 @pytest.fixture(scope='session')
 def dummy_annotation_txt_file_empty(tmpdir_factory):
@@ -880,13 +883,14 @@ def dummy_annotation_txt_file_empty(tmpdir_factory):
     fname.write(content)
     return fname
 
+
 def test_read_annotation_txt_empty(
         dummy_annotation_txt_file_empty):
     """Test empty TXT input/output."""
     annot = read_annotations(str(dummy_annotation_txt_file_empty))
-    assert_array_equal(annot.onset, None)
-    assert_array_equal(annot.duration, None)
-    assert_array_equal(annot.description, None)
+    assert_array_equal(annot.onset, np.array([], dtype=np.float64))
+    assert_array_equal(annot.duration, np.array([], dtype=np.float64))
+    assert_array_equal(annot.description, np.array([], dtype='<U1'))
 
 
 def test_annotations_simple_iteration():


### PR DESCRIPTION
  closes #7012

If saved annotation.txt is empty, when reading it it crashes, as it expects to get the onset, duration and description. 

Added a try and except ValueError. It does not crash, just gives a warning.  

