### PR TITLE
MAINT: Migrate style checks to Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,9 @@ env:
 
 matrix:
     include:
-        # No data + style testing
-        - os: linux
-          env: DEPS=nodata MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
-               CONDA_DEPENDENCIES="numpy scipy matplotlib sphinx"
-               PIP_DEPENDENCIES="codecov flake8 https://api.github.com/repos/numpy/numpydoc/zipball/master codespell pydocstyle codecov check-manifest twine"
-
         # Linux
-        # As of 2019/09/19 there is a mysterious joblib bug, so temporarily work around it with MNE_FORCE_SERIAL
         - os: linux
           env: CONDA_ENV="environment.yml"
-               MNE_FORCE_SERIAL=true
 
         # OSX conda
         - os: osx
@@ -42,14 +34,13 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5
                CONDA_DEPENDENCIES="numpy=1.12 scipy=0.18 matplotlib=2.0 pandas=0.19 scikit-learn=0.18"
-               PIP_DEPENDENCIES="codecov nitime"
                CONDA_CHANNELS="conda-forge"
 
-        # Minimal
+        # Minimal (runs with and without testing data)
         - os: linux
           env: DEPS=minimial
                CONDA_DEPENDENCIES="numpy scipy matplotlib"
-               PIP_DEPENDENCIES="codecov"
+               MNE_DONTWRITE_HOME=true MNE_FORCE_SERIAL=true MNE_SKIP_NETWORK_TEST=1
 
 # Setup anaconda
 before_install:
@@ -69,16 +60,18 @@ before_install:
           conda activate base;
           conda env update --file $CONDA_ENV;
           pip uninstall -yq mne;
-          pip install codecov nitime;
           if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
             pip install "pyqt5>=5.10";
           fi;
         fi;
       fi
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
-    - pip install --upgrade pytest pytest-sugar pytest-cov pytest-mock pytest-timeout
+    - pip install --upgrade pytest pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
+    - if [ "${DEPS}" != "minimal" ]; then
+        pip install nitime;
+      fi
     # Don't source mne_setup_sh here because changing PATH etc. can't be done in a script
-    - if [ "${DEPS}" == "" ]; then
+    - if [ "${DEPS}" != "minimal" ]; then
         export MNE_ROOT="${PWD}/minimal_cmds";
         export PATH=${MNE_ROOT}/bin:$PATH;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
@@ -107,12 +100,10 @@ install:
     # Trigger download of testing data. Note that
     # the testing dataset has been constructed to contain the necessary
     # files to act as a FREESURFER_HOME for the coreg tests
-    - if [ "${DEPS}" != "nodata" ]; then
+    - if [ "${DEPS}" != "minimal" ]; then
         python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
-      else
-        export MNE_SKIP_TESTING_DATASET_TESTS=true;
       fi;
-    - if [ "${DEPS}" == "" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    - if [ "${DEPS}" != "minimal" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
         export FREESURFER_HOME=$(python -c 'import mne; print(mne.datasets.testing.data_path())');
         export MNE_SKIP_FS_FLASH_CALL=1;
       fi;
@@ -172,15 +163,20 @@ script:
         done;
       fi;
     # Test run_tests_if_main
-    - if [ "${DEPS}" == "nodata" ]; then
+    - if [ "${DEPS}" == "minimal" ]; then
         pip uninstall -yq mne;
         pip install -e .;
         python mne/tests/test_evoked.py;
       fi;
     - echo pytest -m "${CONDITION}" --cov=mne ${USE_DIRS}
     - pytest -m "${CONDITION}" --cov=mne ${USE_DIRS}
-    - if [ "${DEPS}" == "nodata" ]; then
-        make pep;
+    # run the minimal one with the testing data
+    - if [ "${DEPS}" == "minimal" ]; then
+        export MNE_SKIP_TESTING_DATASET_TESTS=false;
+        python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
+      fi;
+    - if [ "${DEPS}" == "minimal" ]; then
+        pytest -m "${CONDITION}" --cov=mne ${USE_DIRS};
       fi;
 
 after_script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
     displayName: make check-manifest
     condition: always()
   - bash: |
-      pip install twine
+      pip install twine wheel
     displayName: Install twine
     condition: always()
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,35 +25,54 @@ jobs:
   - bash: |
       python -m pip install numpy scipy matplotlib sphinx pytest pytest-cov pytest-timeout pytest-sugar flake8
     displayName: Install dependencies
+    condition: always()
   - bash: |
       make flake
+    displayName: make flake
+    condition: always()
   - bash: |
       pip install pydocstyle
     displayName: Install pydocstyle
+    condition: always()
   - bash: |
       make pydocstyle
+    displayName: make pydocstyle
+    condition: always()
   - bash: |
       pip install codespell
     displayName: Install codespell
+    condition: always()
   - bash: |
       make codespell-error
+    displayName: make codespell-error
+    condition: always()
   - bash: |
       pip install https://api.github.com/repos/numpy/numpydoc/zipball/master pytest pytest-cov pytest-timeout pytest-sugar
-      displayName: Install NumpyDoc validation
+    displayName: Install NumpyDoc validation
+    condition: always()
   - bash: |
       make docstring
+    displayName: make docstring
   - bash: |
       make nesting
+    displayName: make nesting
+    condition: always()
   - bash: |
       pip install check-manifest
-      displayName: Install manifest checker
+    displayName: Install manifest checker
+    condition: always()
   - bash: |
       make check-manifest
+    displayName: make check-manifest
+    condition: always()
   - bash: |
       pip install twine
-      displayName: Install twine
+    displayName: Install twine
+    condition: always()
   - bash: |
       make check-readme
+    displayName: make check-readme
+    condition: always()
 
 - job: Windows
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,57 @@ trigger:
       - maint/*
 
 jobs:
+
+- job: Style
+  pool:
+    vmImage: 'ubuntu-18.04'
+  strategy:
+    matrix:
+      Python37-64bit-fast:
+        PYTHON_VERSION: '3.7'
+        PYTHON_ARCH: 'x64'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(PYTHON_VERSION)
+      architecture: $(PYTHON_ARCH)
+      addToPath: true
+  - bash: |
+      python -m pip install numpy scipy matplotlib sphinx pytest pytest-cov pytest-timeout pytest-sugar flake8
+    displayName: Install dependencies
+  - bash: |
+      make flake
+  - bash: |
+      pip install pydocstyle
+    displayName: Install pydocstyle
+  - bash: |
+      make pydocstyle
+  - bash: |
+      pip install codespell
+    displayName: Install codespell
+  - bash: |
+      make codespell-error
+  - bash: |
+      pip install https://api.github.com/repos/numpy/numpydoc/zipball/master pytest pytest-cov pytest-timeout pytest-sugar
+      displayName: Install NumpyDoc validation
+  - bash: |
+      make docstring
+  - bash: |
+      make nesting
+  - bash: |
+      pip install check-manifest
+      displayName: Install manifest checker
+  - bash: |
+      make check-manifest
+  - bash: |
+      pip install twine
+      displayName: Install twine
+  - bash: |
+      make check-readme
+
 - job: Windows
   pool:
-    vmIMage: 'VS2017-Win2016'
+    vmImage: 'VS2017-Win2016'
   variables:
     MNE_LOGGING_LEVEL: 'warning'
     MNE_FORCE_SERIAL: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
       architecture: $(PYTHON_ARCH)
       addToPath: true
   - bash: |
+      python -m pip install --upgrade pip
       python -m pip install numpy scipy matplotlib sphinx pytest pytest-cov pytest-timeout pytest-sugar flake8
     displayName: Install dependencies
     condition: always()


### PR DESCRIPTION
Trying to:

1. Load balance -- Azure backs up less than Trivis, and
2. Make style checks easier to parse.

This moves the style checks to Azure, in separate steps so they should hopefully show up nicely in separate statuses/prompts.