### PR TITLE
[MRG] ENH Make tolerance easier to set in sparse inverse solvers

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -93,6 +93,8 @@ Bug
 
 - Fix bug in EDF(+) loading, filter values ignored by insufficient regex, by `Demetres Kostas`_
 
+- Fix missing scaling of tolerance parameter in :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.mixed_norm`, by `Mathurin Massias`_
+
 API
 ~~~
 

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -366,7 +366,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
             Vh = Vh[:time_pca]
         M = U * s
 
-    # Scaling to make setting of alpha and tol easy
+    # Scaling to make setting of tol and alpha easy
     tol *= sum_squared(M)
     n_dip_per_pos = 1 if is_fixed_orient(forward) else 3
     alpha_max = norm_l2inf(np.dot(gain.T, M), n_dip_per_pos, copy=False)
@@ -616,7 +616,7 @@ def tf_mixed_norm(evoked, forward, noise_cov,
     n_coefs = n_steps * n_freqs
     phi = _Phi(wsize, tstep, n_coefs)
 
-    # Scaling to make setting of alpha and tol easy
+    # Scaling to make setting of tol and alpha easy
     tol *= sum_squared(M)
     alpha_max = norm_epsilon_inf(gain, M, phi, l1_ratio, n_dip_per_pos)
     alpha_max *= 0.01


### PR DESCRIPTION
#### What does this implement/fix?
Currently the `tol` parameter of `mixed_norm` and `tf_mixed_norm` solvers is used "raw": tol=1e-8 means that the solver will stop if a duality gap below 1e-8 is reached.
However IMO the duality gap should be compared against the primal objective (1e-8 is not a good precision if the optimal primal is around 1e-7, while it may be too precise if the optimal primal is 1000).
A good heuristic is that the primal is of the order of (M ** 2)/sum()  (which is the value of the primal at 0).

I propose to rescale `tol` by ||M||^2. This is done by scikit-learn for the Lasso and MultitaskLasso:
https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/linear_model/_cd_fast.pyx#L161
https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/linear_model/_cd_fast.pyx#L700

The examples don't seem to be affected (here the result of plot_miwed_norm_inverse) left: master, right: this PR), probably since we were oversolving before (the optimal primal is around 1000) 

![image](https://user-images.githubusercontent.com/8993218/68195483-38e2da80-ffb7-11e9-8881-12a5a9e5915f.png)

@agramfort 
