### PR TITLE
MAINT: Fix CIs

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -73,6 +73,7 @@ def pytest_configure(config):
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:.*mne-realtime.*:DeprecationWarning
     ignore:.*imp.*:DeprecationWarning
+    ignore:Exception creating Regex for oneOf.*:SyntaxWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
Should fix a problem with latest `matplotlib` hitting a SyntaxWarning.