### PR TITLE
Use empirical covariance matrices for beamformer example

### DIFF
--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -56,9 +56,15 @@ evoked = epochs.average()
 forward = mne.read_forward_solution(fname_fwd)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
-# Compute noise and data covariances. For beamformers, you want to use the
-# empirical covariance matrix. Regularization will be applied by the
-# beamformer.
+###############################################################################
+# Compute noise and data covariance matrices.
+#
+# These matrices need to be inverted at some point, but since they are rank
+# deficient, some regularization needs to be done for them to be invertable. 
+# Regularization can be added either by the :func:`mne.compute_covariance`
+# function or later by the :func:`mne.beamformer.make_lcmv` function. In this
+# example, we'll go with the latter option, so we specify ``method='empirical``
+# here.
 noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0,
                                    method='empirical')
 data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
@@ -67,7 +73,9 @@ evoked.plot(time_unit='s')
 
 ###############################################################################
 # Run beamformers and look at maximum outputs
-
+#
+# Regularization is added to the covariance matrices through the ``reg``
+# parameter of :func:`mne.beamformer.make_lcmv`.
 pick_oris = [None, 'normal', 'max-power', None]
 descriptions = ['Free', 'Normal', 'Max-power', 'Fixed']
 
@@ -81,6 +89,7 @@ for pick_ori, desc in zip(pick_oris, descriptions):
         use_forward = mne.convert_forward_solution(forward, force_fixed=True)
     else:
         use_forward = forward
+
     filters = make_lcmv(evoked.info, use_forward, data_cov, reg=0.05,
                         noise_cov=noise_cov, pick_ori=pick_ori,
                         weight_norm='unit-noise-gain', rank='info')

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -60,7 +60,7 @@ forward = mne.convert_forward_solution(forward, surf_ori=True)
 # Compute noise and data covariance matrices.
 #
 # These matrices need to be inverted at some point, but since they are rank
-# deficient, some regularization needs to be done for them to be invertable. 
+# deficient, some regularization needs to be done for them to be invertable.
 # Regularization can be added either by the :func:`mne.compute_covariance`
 # function or later by the :func:`mne.beamformer.make_lcmv` function. In this
 # example, we'll go with the latter option, so we specify ``method='empirical``

--- a/examples/inverse/plot_lcmv_beamformer.py
+++ b/examples/inverse/plot_lcmv_beamformer.py
@@ -56,11 +56,13 @@ evoked = epochs.average()
 forward = mne.read_forward_solution(fname_fwd)
 forward = mne.convert_forward_solution(forward, surf_ori=True)
 
-# Compute regularized noise and data covariances
-noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk',
-                                   rank=None)
+# Compute noise and data covariances. For beamformers, you want to use the
+# empirical covariance matrix. Regularization will be applied by the
+# beamformer.
+noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0,
+                                   method='empirical')
 data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
-                                  method='shrunk', rank=None)
+                                  method='empirical')
 evoked.plot(time_unit='s')
 
 ###############################################################################
@@ -81,7 +83,7 @@ for pick_ori, desc in zip(pick_oris, descriptions):
         use_forward = forward
     filters = make_lcmv(evoked.info, use_forward, data_cov, reg=0.05,
                         noise_cov=noise_cov, pick_ori=pick_ori,
-                        weight_norm='unit-noise-gain', rank=None)
+                        weight_norm='unit-noise-gain', rank='info')
     print(filters)
     # apply this spatial filter to source-reconstruct the evoked data
     stc = apply_lcmv(evoked, filters, max_ori_out='signed')

--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -51,13 +51,20 @@ evoked = epochs.average()
 evoked.plot_joint()
 
 ###############################################################################
-# Compute covariance matrices, fit and apply  spatial filter.
+# Compute covariance matrices.
+#
+# These matrices need to be inverted at some point, but since they are rank
+# deficient, some regularization needs to be done for them to be invertable.
+# Regularization can be added either by the :func:`mne.compute_covariance`
+# function or later by the :func:`mne.beamformer.make_lcmv` function. In this
+# example, we'll go with the latter option, so we specify ``method='empirical``
+# here.
 
 # Read regularized noise covariance and compute regularized data covariance
-noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0, method='shrunk',
-                                   rank=None)
+noise_cov = mne.compute_covariance(epochs, tmin=tmin, tmax=0,
+                                   method='empirical')
 data_cov = mne.compute_covariance(epochs, tmin=0.04, tmax=0.15,
-                                  method='shrunk', rank=None)
+                                  method='empirical')
 
 # Compute weights of free orientation (vector) beamformer with weight
 # normalization (neural activity index, NAI). Providing a noise covariance


### PR DESCRIPTION
When computing covariance matrices to feed into the `make_lcmv` beamformer, you want to set `method='empirical'`, because the beamformer code will take care of any regularization needs. Applying regularization before will make the covariance matrix full rank, bypassing the clever rank estimation routines of the beamformer.

This PR changes the LCMV example `method='shrunk'` -> `method='empirical'`. In case of the example data, not much changes in the resulting figure.