### PR TITLE
Update 3d tests with renderer fixture

### DIFF
--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -342,7 +342,6 @@ def test_plot_alignment(tmpdir, renderer):
 
 @testing.requires_testing_data
 @requires_pysurfer
-@requires_mayavi
 @traits_test
 def test_limits_to_control_points(renderer):
     """Test functionality for determining control points."""
@@ -582,8 +581,7 @@ def test_plot_vec_source_estimates():
 
 
 @testing.requires_testing_data
-@requires_mayavi
-def test_plot_sensors_connectivity():
+def test_plot_sensors_connectivity(renderer):
     """Test plotting of sensors connectivity."""
     from mne import io, pick_types
 


### PR DESCRIPTION
This small PR updates some missed 3d tests with the `renderer` fixture.

The only test in `test_3d.py` which only `requires_mayavi` is `test_plot_vec_source_estimates`. This one is the next in my list.