### PR TITLE
[WIP] Make equalize_channels capable of operating on Forward, Covariance and CrossSpectralDensity

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -145,4 +145,4 @@ API
 
 - New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
 
-- New attributes :attr:`mne.Forward.ch_names`, :attr:`mne.Info.ch_names` by `Marijn van Vliet`_
+- New attributes ``mne.Forward.ch_names`` and ``mne.Info.ch_names`` by `Marijn van Vliet`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -69,7 +69,7 @@ Changelog
 
 - Add NIRS support to :func:`mne.viz.plot_topomap` by `Robert Luke`_
 
-- Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and operate on many different object types by `Marijn van Vliet`_
+- Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.io.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 
 Bug
 ~~~
@@ -143,6 +143,6 @@ API
 
 - :meth:`mne.io.Raw.pick_channels`, :meth:`mne.Epochs.pick_channels` and :meth:`mne.Evoked.pick_channels` now have an ``ordered`` parameter to enforce the ordering of the picked channels by `Marijn van Vliet`_
 
-- New methods :meth:`mne.forward.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
+- New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
 
-- New attributes :meth:`mne.forward.Forward.ch_names`, :meth:`mne.io.Info.ch_names` by `Marijn van Vliet`_
+- New attributes :attr:`mne..Forward.ch_names`, :attr:`mne.io.Info.ch_names` by `Marijn van Vliet`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -143,6 +143,6 @@ API
 
 - :meth:`mne.io.Raw.pick_channels`, :meth:`mne.Epochs.pick_channels` and :meth:`mne.Evoked.pick_channels` now have an ``ordered`` parameter to enforce the ordering of the picked channels by `Marijn van Vliet`_
 
-- New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
+- New methods :meth:`mne.forward.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
 
-- New attributes :meth:`mne.Forward.ch_names`, :meth:`mne.Info.ch_names` by `Marijn van Vliet`_
+- New attributes :meth:`mne.forward.Forward.ch_names`, :meth:`mne.io.Info.ch_names` by `Marijn van Vliet`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -69,6 +69,8 @@ Changelog
 
 - Add NIRS support to :func:`mne.viz.plot_topomap` by `Robert Luke`_
 
+- Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and operate on many different object types by `Marijn van Vliet`_
+
 Bug
 ~~~
 
@@ -132,3 +134,15 @@ API
 - New methods :meth:`mne.io.Raw.get_channel_types`, :meth:`mne.Epochs.get_channel_types`, :meth:`mne.Evoked.get_channel_types` by `Daniel McCloy`_.
 
 - Deprecate ``mne.minimum_norm.point_spread_function`` and ``mne.minimum_norm.cross_talk_function`` by `Alex Gramfort`_
+
+- :func:`mne.channels.equalize_channels` no longer operates in-place by default, but instead makes copies of the objects when necessary (see ``copy`` parameter) by `Marijn van Vliet`_
+
+- :func:`mne.channels.equalize_channels` now uses the first object in the list as a template for channel ordering by `Marijn van Vliet`_
+
+- :func:`mne.channels.equalize_channels` now also re-orders the channels to match, in addition to dropping channels that are not shared by all objects by `Marijn van Vliet`_
+
+- :meth:`mne.io.Raw.pick_channels`, :meth:`mne.Epochs.pick_channels` and :meth:`mne.Evoked.pick_channels` now have an ``ordered`` parameter to enforce the ordering of the picked channels by `Marijn van Vliet`_
+
+- New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
+
+- New attributes :meth:`mne.Forward.ch_names`, :meth:`mne.Info.ch_names` by `Marijn van Vliet`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -69,7 +69,7 @@ Changelog
 
 - Add NIRS support to :func:`mne.viz.plot_topomap` by `Robert Luke`_
 
-- Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.io.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
+- Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 
 Bug
 ~~~
@@ -145,4 +145,4 @@ API
 
 - New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
 
-- New attributes :attr:`mne..Forward.ch_names`, :attr:`mne.io.Info.ch_names` by `Marijn van Vliet`_
+- New attributes :attr:`mne.Forward.ch_names`, :attr:`mne.Info.ch_names` by `Marijn van Vliet`_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -90,7 +90,7 @@ def _get_ch_type(inst, ch_type, allow_ref_meg=False):
 
 
 @verbose
-def equalize_channels(instances, copy=False, verbose=None):
+def equalize_channels(instances, copy=True, verbose=None):
     """Equalize channel picks and ordering across multiple MNE-Python objects.
 
     First, all channels that are not common to each object are dropped. Then,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -90,7 +90,7 @@ def _get_ch_type(inst, ch_type, allow_ref_meg=False):
 
 
 @verbose
-def equalize_channels(instances, copy=True, verbose=None):
+def equalize_channels(instances, copy=False, verbose=None):
     """Equalize channel picks and ordering across multiple MNE-Python objects.
 
     First, all channels that are not common to each object are dropped. Then,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -103,8 +103,8 @@ def equalize_channels(candidates, verbose=None):
     ----------
     candidates : list
         A list of MNE-Python objects to equalize the channels for. Objects can
-        be of type Raw, Epochs, Evoked, AverageTFR, Forward, Covariance or
-        CrossSpectralDensity.
+        be of type Raw, Epochs, Evoked, AverageTFR, Forward, Covariance,
+        CrossSpectralDensity or Info.
     %(verbose)s
 
     Notes
@@ -113,6 +113,7 @@ def equalize_channels(candidates, verbose=None):
     """
     from ..cov import Covariance
     from ..io.base import BaseRaw
+    from ..io.meas_info import Info
     from ..epochs import BaseEpochs
     from ..evoked import Evoked
     from ..forward import Forward
@@ -121,9 +122,9 @@ def equalize_channels(candidates, verbose=None):
     # Instances need to have a `ch_names` attribute and a `pick_channels`
     # method that supports `ordered=True`.
     allowed_types = (BaseRaw, BaseEpochs, Evoked, _BaseTFR, Forward,
-                     Covariance, CrossSpectralDensity)
-    allowed_types_str = ("Raw, Epochs, Evoked, TFR, Forward, Covariance or "
-                         "CrossSpectralDensity")
+                     Covariance, CrossSpectralDensity, Info)
+    allowed_types_str = ("Raw, Epochs, Evoked, TFR, Forward, Covariance, "
+                         "CrossSpectralDensity or Info")
     for candidate in candidates:
         _validate_type(candidate, allowed_types, "Instances to be modified",
                        allowed_types_str)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -101,7 +101,7 @@ def equalize_channels(candidates, verbose=None):
 
     Parameters
     ----------
-    candidates : list of inst
+    candidates : list
         A list of MNE-Python objects to equalize the channels for. Objects can
         be of type Raw, Epochs, Evoked, AverageTFR, Forward, Covariance or
         CrossSpectralDensity.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -106,10 +106,10 @@ def equalize_channels(instances, copy=False, verbose=None):
         CrossSpectralDensity or Info.
     copy : bool
         When dropping and/or re-ordering channels, an object will be copied
-        when this parameter is set to ``True`` (the default). When set to
-        ``False`` the dropping and re-ordering of channels happens in-place.
+        when this parameter is set to ``True``. When set to ``False`` (the
+        default) the dropping and re-ordering of channels happens in-place.
 
-        ..versionadded 0.20
+        .. versionadded:: 0.20.0
     %(verbose)s
 
     Returns

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -15,14 +15,15 @@ from numpy.testing import assert_array_equal, assert_equal
 
 from mne.channels import (rename_channels, read_ch_connectivity,
                           find_ch_connectivity, make_1020_channel_selections,
-                          read_custom_montage)
+                          read_custom_montage, equalize_channels)
 from mne.channels.channels import (_ch_neighbor_connectivity,
                                    _compute_ch_connectivity)
 from mne.io import (read_info, read_raw_fif, read_raw_ctf, read_raw_bti,
-                    read_raw_eeglab, read_raw_kit)
+                    read_raw_eeglab, read_raw_kit, RawArray)
 from mne.io.constants import FIFF
 from mne.utils import _TempDir, run_tests_if_main
-from mne import pick_types, pick_channels
+from mne import (pick_types, pick_channels, EpochsArray, make_ad_hoc_cov,
+                 create_info)
 from mne.datasets import testing
 
 io_dir = op.join(op.dirname(__file__), '..', '..', 'io')
@@ -312,6 +313,31 @@ def test_drop_channels():
     raw.drop_channels({"MEG 0132", "MEG 0133"})  # set argument
     pytest.raises(ValueError, raw.drop_channels, ["MEG 0111", 5])
     pytest.raises(ValueError, raw.drop_channels, 5)  # must be list or str
+
+
+def test_equalize_channels():
+    """Test equalizing channels and their ordering."""
+    # This function only tests the generic functionality of equalize_channels.
+    # Additional tests for each instance type are included in the accompanying
+    # test suite for each type.
+    pytest.raises(TypeError, equalize_channels, ['foo', 'bar'],
+                  match='Instances to be modified must be an instance of')
+
+    raw = RawArray([[1.], [2.], [3.], [4.]],
+                   create_info(['CH1', 'CH2', 'CH3', 'CH4'], sfreq=1.))
+    epochs = EpochsArray([[[1.], [2.], [3.]]],
+                         create_info(['CH5', 'CH2', 'CH1'], sfreq=1.))
+    cov = make_ad_hoc_cov(create_info(['CH2', 'CH1', 'CH8'], sfreq=1.,
+                                      ch_types='eeg'))
+    cov['bads'] = ['CH1']
+
+    equalize_channels([epochs, raw, cov])
+
+    # Raw defines the most channels, so should have been used as template for
+    # the ordering of the channels. No bad channels should have been dropped.
+    assert raw.ch_names == ['CH1', 'CH2']
+    assert epochs.ch_names == ['CH1', 'CH2']
+    assert cov.ch_names == ['CH1', 'CH2']
 
 
 run_tests_if_main()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -332,7 +332,8 @@ def test_equalize_channels():
     cov['bads'] = ['CH1']
     ave = EvokedArray([[1.], [2.]], create_info(['CH1', 'CH2'], sfreq=1.))
 
-    raw2, epochs2, cov2, ave2 = equalize_channels([raw, epochs, cov, ave])
+    raw2, epochs2, cov2, ave2 = equalize_channels([raw, epochs, cov, ave],
+                                                  copy=True)
 
     # The Raw object was the first in the list, so should have been used as
     # template for the ordering of the channels. No bad channels should have
@@ -359,4 +360,4 @@ def test_equalize_channels():
     assert epochs is epochs2
 
 
-# run_tests_if_main()
+run_tests_if_main()

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -231,10 +231,30 @@ class Covariance(dict):
         return viz.misc.plot_cov(self, info, exclude, colorbar, proj, show_svd,
                                  show, verbose)
 
-    @copy_function_doc_to_method_doc(pick_channels_cov)
-    def pick_channels(self, include=[], exclude='bads', ordered=False):
-        return pick_channels_cov(self, include=include, exclude=exclude,
-                                 ordered=ordered)
+    def pick_channels(self, ch_names, ordered=False):
+        """Pick channels from this covariance matrix.
+
+        Parameters
+        ----------
+        ch_names : list of str
+            List of channels to keep. All other channels are dropped.
+        ordered : bool
+            If True (default False), ensure that the order of the channels
+            matches the order of ``ch_names``.
+
+        Returns
+        -------
+        cov : instance of Covariance.
+            The modified covariance matrix.
+
+        Notes
+        -----
+        Operates in-place.
+
+        .. versionadded:: 0.20.0
+        """
+        return pick_channels_cov(self, ch_names, exclude=[], ordered=ordered,
+                                 copy=False)
 
 
 ###############################################################################

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -231,6 +231,11 @@ class Covariance(dict):
         return viz.misc.plot_cov(self, info, exclude, colorbar, proj, show_svd,
                                  show, verbose)
 
+    @copy_function_doc_to_method_doc(pick_channels_cov)
+    def pick_channels(self, include=[], exclude='bads', ordered=False):
+        return pick_channels_cov(self, include=include, exclude=exclude,
+                                 ordered=ordered)
+
 
 ###############################################################################
 # IO

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -44,13 +44,21 @@ from ..transforms import (transform_surface_to, invert_transform,
 from ..utils import (_check_fname, get_subjects_dir, has_mne_c, warn,
                      run_subprocess, check_fname, logger, verbose, fill_doc,
                      _validate_type, _check_compensation_grade, _check_option,
-                     _check_stc_units)
+                     _check_stc_units, copy_function_doc_to_method_doc)
 from ..label import Label
 from ..fixes import einsum
 
 
 class Forward(dict):
-    """Forward class to represent info from forward solution."""
+    """Forward class to represent info from forward solution.
+
+    Attributes
+    ----------
+    ch_names : list of str
+        List of channels' names.
+
+        ..versionadded 0.20.0
+    """
 
     def copy(self):
         """Copy the Forward instance."""
@@ -98,6 +106,14 @@ class Forward(dict):
         entr += '>'
 
         return entr
+
+    @property
+    def ch_names(self):
+        return self['info']['ch_names']
+
+    @copy_function_doc_to_method_doc(pick_channels_forward)
+    def pick_channels(self, ch_names, ordered=False):
+        return pick_channels_forward(self, ch_names, ordered=ordered)
 
 
 def _block_diag(A, n):

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -44,7 +44,7 @@ from ..transforms import (transform_surface_to, invert_transform,
 from ..utils import (_check_fname, get_subjects_dir, has_mne_c, warn,
                      run_subprocess, check_fname, logger, verbose, fill_doc,
                      _validate_type, _check_compensation_grade, _check_option,
-                     _check_stc_units, copy_function_doc_to_method_doc)
+                     _check_stc_units)
 from ..label import Label
 from ..fixes import einsum
 
@@ -111,9 +111,33 @@ class Forward(dict):
     def ch_names(self):
         return self['info']['ch_names']
 
-    @copy_function_doc_to_method_doc(pick_channels_forward)
     def pick_channels(self, ch_names, ordered=False):
-        return pick_channels_forward(self, ch_names, ordered=ordered)
+        """Pick channels from this forward operator.
+
+        Parameters
+        ----------
+        orig : dict
+            A forward solution.
+        ch_names : list of str
+            List of channels to include.
+        ordered : bool
+            If true (default False), treat ``include`` as an ordered list
+            rather than a set.
+
+        Returns
+        -------
+        fwd : instance of Forward.
+            The modified forward model.
+
+        Notes
+        -----
+        Operates in-place.
+
+        .. versionadded:: 0.20
+        """
+        return pick_channels_forward(self, ch_names, exclude=[],
+                                     ordered=ordered, copy=False,
+                                     verbose=False)
 
 
 def _block_diag(A, n):

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -57,7 +57,7 @@ class Forward(dict):
     ch_names : list of str
         List of channels' names.
 
-        ..versionadded 0.20.0
+        .. versionadded:: 0.20.0
     """
 
     def copy(self):

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -131,7 +131,7 @@ class Forward(dict):
         -----
         Operates in-place.
 
-        .. versionadded:: 0.20
+        .. versionadded:: 0.20.0
         """
         return pick_channels_forward(self, ch_names, exclude=[],
                                      ordered=ordered, copy=False,

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -116,8 +116,6 @@ class Forward(dict):
 
         Parameters
         ----------
-        orig : dict
-            A forward solution.
         ch_names : list of str
             List of channels to include.
         ordered : bool

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -433,7 +433,7 @@ def test_equalize_channels():
     fwd1 = read_forward_solution(fname_meeg)
     fwd1.pick_channels(['EEG 001', 'EEG 002', 'EEG 003'])
     fwd2 = fwd1.copy().pick_channels(['EEG 002', 'EEG 001'], ordered=True)
-    equalize_channels([fwd1, fwd2])
+    fwd1, fwd2 = equalize_channels([fwd1, fwd2])
     assert fwd1.ch_names == ['EEG 001', 'EEG 002']
     assert fwd2.ch_names == ['EEG 001', 'EEG 002']
 

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -18,6 +18,7 @@ from mne.utils import (requires_mne, run_subprocess,
 from mne.forward import (restrict_forward_to_stc, restrict_forward_to_label,
                          Forward, is_fixed_orient, compute_orient_prior,
                          compute_depth_prior)
+from mne.channels import equalize_channels
 
 data_path = testing.data_path(download=False)
 fname_meeg = op.join(data_path, 'MEG', 'sample',
@@ -424,6 +425,17 @@ def test_priors():
         compute_orient_prior(fwd_surf_ori, -0.5)
     with pytest.raises(ValueError, match='with fixed orientation'):
         compute_orient_prior(fwd_fixed, 0.5)
+
+
+@testing.requires_testing_data
+def test_equalize_channels():
+    """Test equalization of channels for instances of Forward."""
+    fwd1 = read_forward_solution(fname_meeg)
+    fwd1.pick_channels(['EEG 001', 'EEG 002', 'EEG 003'])
+    fwd2 = fwd1.copy().pick_channels(['EEG 002', 'EEG 001'], ordered=True)
+    equalize_channels([fwd1, fwd2])
+    assert fwd1.ch_names == ['EEG 001', 'EEG 002']
+    assert fwd2.ch_names == ['EEG 001', 'EEG 002']
 
 
 run_tests_if_main()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1454,7 +1454,7 @@ def test_equalize_channels():
     raw1.drop_channels(raw1.ch_names[:1])
     raw2.drop_channels(raw2.ch_names[1:2])
     my_comparison = [raw1, raw2]
-    equalize_channels(my_comparison)
+    my_comparison = equalize_channels(my_comparison)
     for e in my_comparison:
         assert ch_names == e.ch_names
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -15,7 +15,7 @@ import operator
 import numpy as np
 from scipy import linalg
 
-from .pick import channel_type
+from .pick import channel_type, pick_channels, pick_info
 from .constants import FIFF
 from .open import fiff_open
 from .tree import dir_tree_find
@@ -660,6 +660,36 @@ class Info(dict):
         """Update the redundant entries."""
         self['ch_names'] = [ch['ch_name'] for ch in self['chs']]
         self['nchan'] = len(self['chs'])
+
+    def pick_channels(self, ch_names, ordered=False):
+        """Pick channels from this Info object.
+
+        Parameters
+        ----------
+        ch_names : list of str
+            List of channels to keep. All other channels are dropped.
+        ordered : bool
+            If True (default False), ensure that the order of the channels
+            matches the order of ``ch_names``.
+
+        Returns
+        -------
+        info : instance of Info.
+            The modified Info object.
+
+        Notes
+        -----
+        Operates in-place.
+
+        .. versionadded:: 0.20.0
+        """
+        sel = pick_channels(self.ch_names, ch_names, exclude=[],
+                            ordered=ordered)
+        return pick_info(self, sel, copy=False, verbose=False)
+
+    @property
+    def ch_names(self):
+        return self['ch_names']
 
 
 def _simplify_info(info):

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -711,7 +711,8 @@ def channel_indices_by_type(info, picks=None):
     return idx_by_type
 
 
-def pick_channels_cov(orig, include=[], exclude='bads', ordered=False):
+def pick_channels_cov(orig, include=[], exclude='bads', ordered=False,
+                      copy=True):
     """Pick channels from covariance matrix.
 
     Parameters
@@ -727,24 +728,33 @@ def pick_channels_cov(orig, include=[], exclude='bads', ordered=False):
         modified instance matches the order of ``include``.
 
         .. versionadded:: 0.20.0
+    copy : bool
+        If True (the default), return a copy of the covariance matrix with the
+        modified channels. If False, channels are modified in-place.
+
+        .. versionadded:: 0.20.0
 
     Returns
     -------
     res : dict
         Covariance solution restricted to selected channels.
     """
-    from ..cov import Covariance
+    if copy:
+        orig = orig.copy()
+
     exclude = orig['bads'] if exclude == 'bads' else exclude
     sel = pick_channels(orig['names'], include=include, exclude=exclude,
                         ordered=ordered)
     data = orig['data'][sel][:, sel] if not orig['diag'] else orig['data'][sel]
     names = [orig['names'][k] for k in sel]
     bads = [name for name in orig['bads'] if name in orig['names']]
-    res = Covariance(
-        data=data, names=names, bads=bads, projs=deepcopy(orig['projs']),
-        nfree=orig['nfree'], eig=None, eigvec=None,
-        method=orig.get('method', None), loglik=orig.get('loglik', None))
-    return res
+
+    orig['data'] = data
+    orig['names'] = names
+    orig['bads'] = bads
+    orig['dim'] = len(data)
+
+    return orig
 
 
 def _mag_grad_dependent(info):

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -711,7 +711,7 @@ def channel_indices_by_type(info, picks=None):
     return idx_by_type
 
 
-def pick_channels_cov(orig, include=[], exclude='bads'):
+def pick_channels_cov(orig, include=[], exclude='bads', ordered=False):
     """Pick channels from covariance matrix.
 
     Parameters
@@ -722,6 +722,11 @@ def pick_channels_cov(orig, include=[], exclude='bads'):
         List of channels to include (if empty, include all available).
     exclude : list of str, (optional) | 'bads'
         Channels to exclude (if empty, do not exclude any). Defaults to 'bads'.
+    ordered : bool
+        If True (default False), ensure that the order of the channels in the
+        modified instance matches the order of ``include``.
+
+        .. versionadded:: 0.20.0
 
     Returns
     -------
@@ -730,7 +735,8 @@ def pick_channels_cov(orig, include=[], exclude='bads'):
     """
     from ..cov import Covariance
     exclude = orig['bads'] if exclude == 'bads' else exclude
-    sel = pick_channels(orig['names'], include=include, exclude=exclude)
+    sel = pick_channels(orig['names'], include=include, exclude=exclude,
+                        ordered=ordered)
     data = orig['data'][sel][:, sel] if not orig['diag'] else orig['data'][sel]
     names = [orig['names'][k] for k in sel]
     bads = [name for name in orig['bads'] if name in orig['names']]

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -741,6 +741,12 @@ def pick_channels_cov(orig, include=[], exclude='bads', ordered=False,
     """
     if copy:
         orig = orig.copy()
+        # A little peculiarity of the cov objects is that these two fields
+        # should not be copied over when None.
+        if 'method' in orig and orig['method'] is None:
+            del orig['method']
+        if 'loglik' in orig and orig['loglik'] is None:
+            del orig['loglik']
 
     exclude = orig['bads'] if exclude == 'bads' else exclude
     sel = pick_channels(orig['names'], include=include, exclude=exclude,

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -658,4 +658,6 @@ def test_equalize_channels():
 
     assert info1.ch_names == ['CH1', 'CH2']
     assert info2.ch_names == ['CH1', 'CH2']
+
+
 run_tests_if_main()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -29,7 +29,7 @@ from mne.io._digitization import (_write_dig_points, _read_dig_points,
                                   _make_dig_points,)
 from mne.io import read_raw_ctf
 from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
-from mne.channels import make_standard_montage
+from mne.channels import make_standard_montage, equalize_channels
 
 fiducials_fname = op.join(op.dirname(__file__), '..', '..', 'data',
                           'fsaverage', 'fsaverage-fiducials.fif')
@@ -650,4 +650,12 @@ def test_field_round_trip(tmpdir):
     assert_object_equal(info, info_read)
 
 
+def test_equalize_channels():
+    """Test equalization of channels for instances of Info."""
+    info1 = create_info(['CH1', 'CH2', 'CH3'], sfreq=1.)
+    info2 = create_info(['CH4', 'CH2', 'CH1'], sfreq=1.)
+    equalize_channels([info1, info2])
+
+    assert info1.ch_names == ['CH1', 'CH2']
+    assert info2.ch_names == ['CH1', 'CH2']
 run_tests_if_main()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -654,7 +654,7 @@ def test_equalize_channels():
     """Test equalization of channels for instances of Info."""
     info1 = create_info(['CH1', 'CH2', 'CH3'], sfreq=1.)
     info2 = create_info(['CH4', 'CH2', 'CH1'], sfreq=1.)
-    equalize_channels([info1, info2])
+    info1, info2 = equalize_channels([info1, info2])
 
     assert info1.ch_names == ['CH1', 'CH2']
     assert info2.ch_names == ['CH1', 'CH2']

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -519,7 +519,7 @@ def test_picks_to_idx():
                        _picks_to_idx(info, 'all'))
     assert_array_equal([0], _picks_to_idx(info, 'data'))
 
-    
+
 def test_pick_channels_cov():
     """Test picking channels from a Covariance object."""
     info = create_info(['CH1', 'CH2', 'CH3'], 1., ch_types='eeg')

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -8,14 +8,14 @@ import numpy as np
 
 from mne import (pick_channels_regexp, pick_types, Epochs,
                  read_forward_solution, rename_channels,
-                 pick_info, pick_channels, create_info)
+                 pick_info, pick_channels, create_info, make_ad_hoc_cov)
 from mne import __file__ as _root_init_fname
 from mne.io import (read_raw_fif, RawArray, read_raw_bti, read_raw_kit,
                     read_info)
 from mne.io.pick import (channel_indices_by_type, channel_type,
                          pick_types_forward, _picks_by_type, _picks_to_idx,
                          get_channel_types, _DATA_CH_TYPES_SPLIT,
-                         _contains_ch_type)
+                         _contains_ch_type, pick_channels_cov)
 from mne.io.constants import FIFF
 from mne.datasets import testing
 from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
@@ -518,6 +518,34 @@ def test_picks_to_idx():
     assert_array_equal(np.arange(len(info['ch_names'])),
                        _picks_to_idx(info, 'all'))
     assert_array_equal([0], _picks_to_idx(info, 'data'))
+
+    
+def test_pick_channels_cov():
+    """Test picking channels from a Covariance object."""
+    info = create_info(['CH1', 'CH2', 'CH3'], 1., ch_types='eeg')
+    cov = make_ad_hoc_cov(info)
+    cov['data'] = np.array([1., 2., 3.])
+
+    cov_copy = pick_channels_cov(cov, ['CH2', 'CH1'], ordered=False, copy=True)
+    assert cov_copy.ch_names == ['CH1', 'CH2']
+    assert_array_equal(cov_copy['data'], [1., 2.])
+
+    # Test re-ordering channels
+    cov_copy = pick_channels_cov(cov, ['CH2', 'CH1'], ordered=True, copy=True)
+    assert cov_copy.ch_names == ['CH2', 'CH1']
+    assert_array_equal(cov_copy['data'], [2., 1.])
+
+    # Test picking in-place
+    pick_channels_cov(cov, ['CH2', 'CH1'], copy=False)
+    assert cov.ch_names == ['CH1', 'CH2']
+    assert_array_equal(cov['data'], [1., 2.])
+
+    # Test whether `method` and `loglik` are dropped when None
+    cov['method'] = None
+    cov['loglik'] = None
+    cov_copy = pick_channels_cov(cov, ['CH1', 'CH2'], copy=True)
+    assert 'method' not in cov_copy
+    assert 'loglik' not in cov_copy
 
 
 run_tests_if_main()

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -742,7 +742,7 @@ def test_equalize_channels():
                                        ch_types='eeg'))
     cov2 = make_ad_hoc_cov(create_info(['CH5', 'CH1', 'CH2'], sfreq=1.0,
                                        ch_types='eeg'))
-    equalize_channels([cov1, cov2])
+    cov1, cov2 = equalize_channels([cov1, cov2])
     assert cov1.ch_names == ['CH1', 'CH2']
     assert cov2.ch_names == ['CH1', 'CH2']
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -21,7 +21,8 @@ from mne import (read_cov, write_cov, Epochs, merge_events,
                  find_events, compute_raw_covariance,
                  compute_covariance, read_evokeds, compute_proj_raw,
                  pick_channels_cov, pick_types, make_ad_hoc_cov,
-                 make_fixed_length_events)
+                 make_fixed_length_events, create_info)
+from mne.channels import equalize_channels
 from mne.datasets import testing
 from mne.fixes import _get_args
 from mne.io import read_raw_fif, RawArray, read_raw_ctf
@@ -733,6 +734,17 @@ def test_cov_ctf():
 
     # make sure comps matrices was not removed from raw
     assert raw.info['comps'], 'Comps matrices removed'
+
+
+def test_equalize_channels():
+    """Test equalization of channels for instances of Covariance."""
+    cov1 = make_ad_hoc_cov(create_info(['CH1', 'CH2', 'CH3', 'CH4'], sfreq=1.0,
+                                       ch_types='eeg'))
+    cov2 = make_ad_hoc_cov(create_info(['CH5', 'CH1', 'CH2'], sfreq=1.0,
+                                       ch_types='eeg'))
+    equalize_channels([cov1, cov2])
+    assert cov1.ch_names == ['CH1', 'CH2']
+    assert cov2.ch_names == ['CH1', 'CH2']
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2057,7 +2057,7 @@ def test_equalize_channels():
     epochs1.drop_channels(epochs1.ch_names[:1])
     epochs2.drop_channels(epochs2.ch_names[1:2])
     my_comparison = [epochs1, epochs2]
-    equalize_channels(my_comparison)
+    my_comparison = equalize_channels(my_comparison)
     for e in my_comparison:
         assert_equal(ch_names, e.ch_names)
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -585,7 +585,7 @@ def test_arithmetic():
     evoked2.reorder_channels(evoked2.ch_names[::-1])
     assert not np.allclose(data2, evoked2.data)
     with pytest.warns(RuntimeWarning, match='reordering'):
-        ev3 = grand_average((evoked1, evoked2))
+        ev3 = combine_evoked([evoked1, evoked2], weights=[0.5, 0.5])
     assert np.allclose(ev3.data, data)
     assert evoked1.ch_names != evoked2.ch_names
     assert evoked1.ch_names == ev3.ch_names

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -497,7 +497,7 @@ def test_equalize_channels():
     evoked1.drop_channels(evoked1.ch_names[:1])
     evoked2.drop_channels(evoked2.ch_names[1:2])
     my_comparison = [evoked1, evoked2]
-    equalize_channels(my_comparison)
+    my_comparison = equalize_channels(my_comparison)
     for e in my_comparison:
         assert_equal(ch_names, e.ch_names)
 

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -21,7 +21,7 @@ from ..externals.h5io import read_hdf5, write_hdf5
 
 
 def pick_channels_csd(csd, include=[], exclude=[], ordered=False, copy=True):
-    """Pick channels from covariance matrix.
+    """Pick channels from cross-spectral density matrix.
 
     Parameters
     ----------

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -7,6 +7,7 @@ import pickle
 from itertools import product
 
 import mne
+from mne.channels import equalize_channels
 from mne.utils import sum_squared, run_tests_if_main, _TempDir, requires_h5py
 from mne.time_frequency import (csd_fourier, csd_multitaper,
                                 csd_morlet, csd_array_fourier,
@@ -538,6 +539,16 @@ def test_csd_morlet():
     epochs_nobase.info['highpass'] = 0
     with pytest.warns(RuntimeWarning, match='baseline'):
         csd = csd_morlet(epochs_nobase, frequencies=[10], decim=20)
+
+
+def test_equalize_channels():
+    """Test equalization of channels for instances of CrossSpectralDensity."""
+    csd1 = _make_csd()
+    csd2 = csd1.copy().pick_channels(['CH2', 'CH1'], ordered=True)
+    equalize_channels([csd1, csd2])
+
+    assert csd1.ch_names == ['CH1', 'CH2']
+    assert csd2.ch_names == ['CH1', 'CH2']
 
 
 run_tests_if_main()

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -545,7 +545,7 @@ def test_equalize_channels():
     """Test equalization of channels for instances of CrossSpectralDensity."""
     csd1 = _make_csd()
     csd2 = csd1.copy().pick_channels(['CH2', 'CH1'], ordered=True)
-    equalize_channels([csd1, csd2])
+    csd1, csd2 = equalize_channels([csd1, csd2])
 
     assert csd1.ch_names == ['CH1', 'CH2']
     assert csd2.ch_names == ['CH1', 'CH2']

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -202,7 +202,7 @@ def test_time_frequency():
     assert_equal(power_drop.ch_names, power_pick.ch_names)
     assert_equal(power_pick.data.shape[0], len(power_drop.ch_names))
 
-    mne.equalize_channels([power_pick, power_drop])
+    power_pick, power_drop = mne.equalize_channels([power_pick, power_drop])
     assert_equal(power_pick.ch_names, power_drop.ch_names)
     assert_equal(power_pick.data.shape, power_drop.data.shape)
 

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -582,7 +582,6 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
         if interpolate_bads:
             all_inst = [inst.interpolate_bads() if len(inst.info['bads']) > 0
                         else inst for inst in all_inst]
-        equalize_channels(all_inst)  # apply equalize_channels
         from ..evoked import combine_evoked as combine
         weights = [1. / len(all_inst)] * len(all_inst)
     else:  # isinstance(all_inst[0], AverageTFR):
@@ -595,6 +594,7 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
             for inst in all_inst:
                 inst.drop_channels(bads)
 
+    equalize_channels(all_inst, copy=False)
     # make grand_average object using combine_[evoked/tfr]
     grand_average = combine(all_inst, weights=weights)
     # change the grand_average.nave to the number of Evokeds


### PR DESCRIPTION
In the process of adding support for DICS whitening (#7021), I now find myself with an `Info`, two CSD matrices and a forward model, all of which need to have exactly the same channels defined in the same order for the computations to work. This is a common theme throughout our codebase and currently, we have a smattering of private helper functions everywhere that deal with equalizing channels one way or another.

However, we also have `mne.channels.equalize_channels`, which job it is to, given a list of instances, equalize the channels amongst them. In this PR, I've extended its capabilities to:

  1. Also deal with `Info`, `Forward`, `Covariance` and `CrossSpectralDensity`
  2. Also re-order the channels to make sure the channel orders are the same.

To accomplish this, I had to give our channel picking functionality a bit of extra love. Adding an  `ordered=True` option for those picking functions that lacked it, and adding `pick_channels` methods to `Forward`, `Covariance` and `CrossSpectralDensity`, so that `equalize_channels` doesn't need to contain a big switch for each supported instance type.

Todo:

  - [x] Add `pick_channels` methods to `Info`, `Forward`, `Covariance` and `CrossSpectralDensity`
  - [x] Add `ch_names` attribute to `Info` and `Forward`
  - [x] Add unit tests
  - [ ] ~~Replace private functions that perform channel equalization with `equalize_channels`~~ Will do in follow-up PR
  - [x] Maybe: add logic to keep objects that already have the proper order untouched for speed
  - [ ] Add "what's new" entry

Question @larsoner: why does `equalize_channels` first find the instance with the most channels defined and uses that as initial set to then intersect with the others to compute the set of common channels? Why not just pick the fist instance? Also, why is the first parameter called `candidates` and not `instances`?