### PR TITLE
MRG, ENH: Fix plot_vector_source_estimates

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -95,7 +95,7 @@ Bug
 
 - Fix missing scaling of tolerance parameter in :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.mixed_norm`, by `Mathurin Massias`_
 
-- Fix the automatic scaling of the glyphs in :func:`plot_vector_source_estimates` by using 10% of the brain width, by `Guillaume Favelier`_
+- Fix the automatic scaling of the glyphs in :func:`mne.viz.plot_vector_source_estimates` by using 10% of the brain width, by `Guillaume Favelier`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -95,6 +95,8 @@ Bug
 
 - Fix missing scaling of tolerance parameter in :func:`mne.inverse_sparse.tf_mixed_norm` and :func:`mne.inverse_sparse.mixed_norm`, by `Mathurin Massias`_
 
+- Fix the automatic scaling of the glyphs in :func:`plot_vector_source_estimates` by using 10% of the brain width, by `Guillaume Favelier`_
+
 API
 ~~~
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2299,12 +2299,6 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         data = getattr(stc, hemi + '_data')
         vertices = stc.vertices[hemi_idx]
         if len(data) > 0:
-            if scale_factor is None:
-                _, y, _ = np.array(brain.geo[hemi].coords).T
-                magnitude = np.linalg.norm(data, axis=1)
-                scale_factor = magnitude.max() / magnitude[:, 0].max()
-                scale_factor *= (np.max(y) - np.min(y)) / 5.
-
             with warnings.catch_warnings(record=True):  # traits warnings
                 brain.add_data(data, colormap=colormap, vertices=vertices,
                                smoothing_steps=smoothing_steps, time=times,
@@ -2314,6 +2308,17 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                                scale_factor=scale_factor,
                                min=scale_pts[0], max=scale_pts[2],
                                **ad_kwargs)
+            if scale_factor is None:
+                # Compute the width of the brain
+                width = np.ptp(brain.geo[hemi].coords[:, 1])
+                # Retrieve the current hemi
+                for b in brain._brain_list:
+                    if b['hemi'] == hemi:
+                        found_hemi = b['brain']
+                layer_id = brain.data['layer_id']
+                # Configure the glyphs scale directly
+                glyphs = found_hemi.data[layer_id]['glyphs']
+                glyphs.glyph.glyph.scale_factor = width / 5.
         brain.scale_data_colormap(fmin=scale_pts[0], fmid=scale_pts[1],
                                   fmax=scale_pts[2], **sd_kwargs)
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2318,7 +2318,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                 layer_id = brain.data['layer_id']
                 # Configure the glyphs scale directly
                 glyphs = found_hemi.data[layer_id]['glyphs']
-                glyphs.glyph.glyph.scale_factor = width / 5.
+                glyphs.glyph.glyph.scale_factor = width * 0.1
         brain.scale_data_colormap(fmin=scale_pts[0], fmid=scale_pts[1],
                                   fmax=scale_pts[2], **sd_kwargs)
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2319,6 +2319,11 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                 # Configure the glyphs scale directly
                 glyphs = found_hemi.data[layer_id]['glyphs']
                 glyphs.glyph.glyph.scale_factor = width * 0.1
+            # depth peeling patch
+            if brain_alpha < 1.0:
+                for ff in brain._figures:
+                    for f in ff:
+                        f.scene.renderer.use_depth_peeling = True
         brain.scale_data_colormap(fmin=scale_pts[0], fmid=scale_pts[1],
                                   fmax=scale_pts[2], **sd_kwargs)
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2299,6 +2299,12 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         data = getattr(stc, hemi + '_data')
         vertices = stc.vertices[hemi_idx]
         if len(data) > 0:
+            if scale_factor is None:
+                _, y, _ = np.array(brain.geo[hemi].coords).T
+                magnitude = np.linalg.norm(data, axis=1)
+                scale_factor = magnitude.max() / magnitude[:, 0].max()
+                scale_factor *= (np.max(y) - np.min(y)) / 5.
+
             with warnings.catch_warnings(record=True):  # traits warnings
                 brain.add_data(data, colormap=colormap, vertices=vertices,
                                smoothing_steps=smoothing_steps, time=times,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2323,7 +2323,8 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
             if brain_alpha < 1.0:
                 for ff in brain._figures:
                     for f in ff:
-                        f.scene.renderer.use_depth_peeling = True
+                        if f.scene is not None:
+                            f.scene.renderer.use_depth_peeling = True
         brain.scale_data_colormap(fmin=scale_pts[0], fmid=scale_pts[1],
                                   fmax=scale_pts[2], **sd_kwargs)
 

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -50,7 +50,7 @@ fig_cov, fig_spectra = mne.viz.plot_cov(noise_cov, raw.info)
 ###############################################################################
 # Compute the evoked response
 # ---------------------------
-# Let's just use MEG channels for simplicity.
+# Let's just use the MEG channels for simplicity.
 
 evoked = epochs.average().pick('meg')
 evoked.plot(time_unit='s')

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -50,7 +50,7 @@ fig_cov, fig_spectra = mne.viz.plot_cov(noise_cov, raw.info)
 ###############################################################################
 # Compute the evoked response
 # ---------------------------
-# Let's just use the MEG channels for simplicity.
+# Let's just use MEG channels for simplicity.
 
 evoked = epochs.average().pick('meg')
 evoked.plot(time_unit='s')


### PR DESCRIPTION
This PR closes #7020: 

- [x] Scale automatically the glyphs when `scale_factor=None`
- [ ] Fix the bug where the glyphs disappears when `brain_alpha` is in [0.8, 1]
- [ ] Experiment with the type of the glyphs (2D or 3D)