### PR TITLE
ENH: Vectorize beamformer computation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Changelog
 
 - Improved :ref:`limo-dataset` usage and :ref:`example <ex-limo-data>` for usage of :func:`mne.stats.linear_regression` by `Jose Alanis`_
 
+- Speed up :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` calculations by vectorizing linear algebra calls by `Dmitrii Altukhov`_ and `Eric Larson`_
+
 - For KIT systems without built-in layout, :func:`mne.channels.find_layout` now falls back on an automatically generated layout, by `Christian Brodbeck`_
 
 - :meth:`mne.Epochs.plot` now takes a ``epochs_colors`` parameter to color specific epoch segments by `Mainak Jas`_

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -276,4 +276,6 @@
 
 .. _Victor Ferat: https://github.com/vferat
 
+.. _Dmitrii Altukhov: https://www.hse.ru/en/org/persons/190873905
+
 .. _Demetres Kostas: https://github.com/kostasde

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -7,6 +7,7 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
+from contextlib import contextmanager
 
 import numpy as np
 from scipy import linalg
@@ -17,9 +18,7 @@ from ..io.proj import make_projector, Projection
 from ..minimum_norm.inverse import _get_vertno, _prepare_forward
 from ..source_space import label_src_vertno_sel
 from ..utils import (verbose, check_fname, _reg_pinv, _check_option, logger,
-                     _pl, _svd_lwork, _repeated_svd, _repeated_pinv2,
-                     _inv_lwork, _repeated_inv, _eig_lwork, _repeated_eig,
-                     LinAlgError, _check_src_normal)
+                     _pl, _check_src_normal, check_version)
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
@@ -103,88 +102,87 @@ def _prepare_beamformer_input(info, forward, label=None, pick_ori=None,
             orient_std)
 
 
-def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk,
-                        svd_lwork, inv_lwork, eig_lwork):
+def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
     """Compute the normalized weights in max-power orientation.
 
-    Uses Eq. 4.47 from [1]_.
+    Uses Eq. 4.47 from [1]_. Operates in place on Wk.
 
     Parameters
     ----------
-    Wk : ndarray, shape (3, n_channels)
+    Wk : ndarray, shape (n_sources, 3, n_channels)
         The set of un-normalized filters at a single source point.
-    Gk : ndarray, shape (n_channels, 3)
+    Gk : ndarray, shape (n_sources, n_channels, 3)
         The leadfield at a single source point.
     Cm_inv_sq : nsarray, snape (n_channels, n_channels)
         The squared inverse covariance matrix.
     reduce_rank : bool
         Whether to reduce the rank of the filter by one.
-    nn : ndarray, shape (3,)
+    nn : ndarray, shape (n_sources, 3)
         The source normal.
-    sk : ndarray, shape (3,)
+    sk : ndarray, shape (n_sources, 3)
         The source prior.
-    svd_lwork : int
-        The svd lwork value.
-    inv_lwork : int
-        The inv lwork value.
-    eig_lwork : int
-        The eig lwork value.
-
-    Returns
-    -------
-    Wk : ndarray, shape (n_dipoles, n_channels)
-        The normalized beamformer filters at the source point in the direction
-        of max power.
 
     References
     ----------
     .. [1] Sekihara & Nagarajan. Adaptive spatial filters for electromagnetic
            brain imaging (2008) Springer Science & Business Media
     """
-    norm_inv = np.dot(Gk.T, np.dot(Cm_inv_sq, Gk))
+    # np.dot Gk with Cm_inv_sq on left and right
+    norm_inv = np.matmul(Gk.transpose(0, 2, 1),
+                         np.matmul(Cm_inv_sq[np.newaxis], Gk))
+
+    # invert this using an eigenvalue decomposition
+    s, u = np.linalg.eigh(norm_inv)
     if reduce_rank:
-        # Use pseudo inverse computation setting smallest
-        # component to zero if the leadfield is not full rank
-        norm = _reg_pinv(norm_inv, rank=norm_inv.shape[0] - 1,
-                         svd_lwork=svd_lwork)[0]
-    else:
-        # Use straight inverse with full rank leadfield
-        try:
-            norm = _repeated_inv(norm_inv, inv_lwork)
-        except LinAlgError:
-            raise ValueError(
-                'Singular matrix detected when estimating spatial filters. '
-                'Consider reducing the rank of the forward operator by using '
-                'reduce_rank=True.'
-            )
+        # These are ordered smallest to largest, so we set the first one
+        # to inf -- then the 1. / s below will turn this to zero, as needed.
+        s[:, 0] = np.inf
+    try:
+        with np.errstate(divide='raise'):
+            s = 1. / s
+    except FloatingPointError:
+        raise ValueError(
+            'Singular matrix detected when estimating spatial filters. '
+            'Consider reducing the rank of the forward operator by using '
+            'reduce_rank=True.'
+        )
+    norm = np.matmul(u * s[:, np.newaxis], u.transpose(0, 2, 1))
+
     # Reapply source covariance after inversion
-    norm *= sk
-    norm *= sk[:, np.newaxis]
-    power = np.dot(norm, np.dot(Wk, Gk))
+    norm *= sk[:, :, np.newaxis]
+    norm *= sk[:, np.newaxis, :]
+    power = np.matmul(norm, np.matmul(Wk, Gk))  # np.dot for each source
 
     # Determine orientation of max power
     assert power.dtype in (np.float64, np.complex128)  # LCMV, DICS
-    eig_vals, eig_vecs = _repeated_eig(power, eig_lwork)
+    eig_vals, eig_vecs = np.linalg.eig(power)
     if not np.iscomplexobj(power) and np.iscomplexobj(eig_vecs):
-        raise ValueError('The eigenspectrum of the leadfield at this voxel is '
+        raise ValueError('The eigenspectrum of the leadfield is '
                          'complex. Consider reducing the rank of the '
                          'leadfield by using reduce_rank=True.')
-
-    idx_max = eig_vals.argmax()
-    max_power_ori = eig_vecs[:, idx_max]
+    idx_max = np.argmax(eig_vals, axis=1)
+    max_power_ori = eig_vecs[np.arange(eig_vecs.shape[0]), :, idx_max]
 
     # set the (otherwise arbitrary) sign to match the normal
-    sign = np.sign(np.dot(max_power_ori, nn)) or 1
+    sign = np.sign(np.sum(max_power_ori * nn, axis=1, keepdims=True))
+    sign[sign == 0] = 1
     max_power_ori *= sign
 
     # Compute the filter in the orientation of max power
-    Wk[:] = np.dot(max_power_ori, Wk)
-    Gk = np.dot(Gk, max_power_ori)
-    denom = np.dot(Gk.T, np.dot(Cm_inv_sq, Gk))
-    denom = np.sqrt(denom)
-    Wk /= denom
+    Wk_max = np.matmul(max_power_ori[:, np.newaxis], Wk)[:, 0]
+    Gk_max = np.matmul(Gk, max_power_ori[:, :, np.newaxis])
+    denom = np.matmul(Gk_max.transpose(0, 2, 1),
+                      np.matmul(Cm_inv_sq[np.newaxis], Gk_max))[:, 0]
+    np.sqrt(denom, out=denom)
+    Wk_max /= denom
+    # All three entries get the same value from this operation
+    Wk[:] = Wk_max[:, np.newaxis]
 
-    return Wk
+
+@contextmanager
+def _noop_indentation_context():
+    """Context manager that does nothing."""
+    yield
 
 
 def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
@@ -238,68 +236,81 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
 
     logger.info('Computing beamformer filters for %d source%s'
                 % (n_sources, _pl(n_sources)))
-    svd_lwork = _svd_lwork((3, 3), Cm.dtype)  # for real or complex
-    real_svd_lwork = _svd_lwork((3, 3))  # for one that will always be real
-    eig_lwork = _eig_lwork((3, 3), Cm.dtype)
-    inv_lwork = _inv_lwork((3, 3), Cm.dtype)
-    for k in range(n_sources):
-        this_sl = slice(n_orient * k, n_orient * k + n_orient)
-        Wk, Gk, sk = W[this_sl], G[:, this_sl], orient_std[this_sl]
+    n_channels = G.shape[0]
+    assert n_orient in (3, 1)
+    Wk = np.reshape(W, (n_sources, n_orient, n_channels))
+    Gk = np.reshape(G.T, (n_sources, n_orient, n_channels)).transpose(0, 2, 1)
+    assert Gk.shape == (n_sources, n_channels, n_orient)
+    sk = np.reshape(orient_std, (n_sources, n_orient))
+    pinv_kwargs = dict()
+    if check_version('numpy', '1.17'):
+        pinv_kwargs['hermitian'] = True
 
+    with _noop_indentation_context():
         if (inversion == 'matrix' and pick_ori == 'max-power' and
                 weight_norm in ['unit-noise-gain', 'nai']):
             # In this case, take a shortcut to compute the filter
-            Wk[:] = _normalized_weights(
-                Wk, Gk, Cm_inv_sq, reduce_rank, nn[k], sk,
-                svd_lwork, inv_lwork, eig_lwork)
+            _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk)
         else:
             # Compute power at the source
-            Ck = np.dot(Wk, Gk)
+            Ck = np.matmul(Wk, Gk)  # np.dot for each source
 
             # Normalize the spatial filters
-            if Wk.ndim == 2 and len(Wk) > 1:
+            if n_orient > 1:
                 # Free source orientation
                 if inversion == 'single':
                     # Invert for each dipole separately using plain division
                     with np.errstate(divide='ignore'):
-                        norm = np.diag(1. / np.diag(Ck))
+                        diags = 1. / np.diagonal(Ck, axis1=1, axis2=2)
+                    # set the diagonal of each 3x3
+                    norm = np.zeros((n_sources, n_orient, n_orient), Ck.dtype)
+                    for k in range(n_sources):
+                        norm[k].flat[::4] = diags[k]
                 elif inversion == 'matrix':
+                    assert Ck.shape[1:] == (3, 3)
                     # Invert for all dipoles simultaneously using matrix
                     # inversion.
-                    assert Ck.shape == (3, 3)
-                    norm = _repeated_pinv2(Ck, svd_lwork)
+                    norm = np.linalg.pinv(Ck, **pinv_kwargs)
                 # Reapply source covariance after inversion
-                norm *= sk
-                norm *= sk[:, np.newaxis]
+                norm *= sk[:, :, np.newaxis]
+                norm *= sk[:, np.newaxis, :]
             else:
-                assert Ck.shape == (1, 1)
+                assert Ck.shape[1:] == (1, 1)
                 # Fixed source orientation
-                norm = np.eye(1) if Ck[0, 0] == 0. else 1. / Ck
-            Wk[:] = np.dot(norm, Wk)
+                with np.errstate(divide='ignore'):
+                    norm = 1. / Ck
+                norm[~np.isfinite(norm)] = 1.
+            assert norm.shape == (n_sources, n_orient, n_orient)
+            assert Wk.shape == (n_sources, n_orient, n_channels)
+            Wk[:] = np.matmul(norm, Wk)  # np.dot for each source
 
             if pick_ori == 'max-power':
                 # Compute the power
                 if inversion == 'single' and weight_norm is not None:
                     # First make the filters unit gain, then apply them to the
                     # cov matrix to compute power.
-                    Wk_norm = Wk / np.sqrt(np.sum(Wk ** 2, axis=1,
-                                                  keepdims=True))
-                    power = Wk_norm.dot(Cm).dot(Wk_norm.T)
+                    Wk_norm = Wk / np.linalg.norm(Wk, axis=2, keepdims=True)
+                    power = np.matmul(np.matmul(Wk_norm, Cm),
+                                      Wk_norm.transpose(0, 2, 1))
                 elif weight_norm is None:
                     # Compute power by applying the spatial filters to
                     # the cov matrix.
-                    power = Wk.dot(Cm).dot(Wk.T)
-
-                # Compute the direction of max power
-                u, s, _ = _repeated_svd(power.real, real_svd_lwork)
-                max_power_ori = u[:, 0]
+                    power = np.matmul(np.matmul(Wk, Cm),
+                                      Wk.transpose(0, 2, 1))
+                assert power.shape == (n_sources, 3, 3)
+                _, u_ = np.linalg.eigh(power.real)
+                max_power_ori = u_[:, :, -1]
+                assert max_power_ori.shape == (n_sources, 3)
 
                 # set the (otherwise arbitrary) sign to match the normal
-                sign = np.sign(np.dot(nn[k], max_power_ori)) or 1  # avoid 0
-                max_power_ori *= sign
-
-                # Re-compute the filter in the direction of max power
-                Wk[:] = max_power_ori.dot(Wk)
+                signs = np.sign(np.sum(max_power_ori * nn, axis=1))
+                signs[signs == 0] = 1.
+                max_power_ori *= signs[:, np.newaxis]
+                # all three entries get the same value from this operation
+                Wk[:] = np.sum(max_power_ori[:, :, np.newaxis] * Wk, axis=1,
+                               keepdims=True)
+    W = Wk.reshape(n_sources * n_orient, n_channels)
+    del Gk, Wk, sk
 
     if pick_ori == 'normal':
         W = W[2::3]

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy import linalg
 
 from ..cov import Covariance, make_ad_hoc_cov
+from ..fixes import pinv
 from ..forward.forward import is_fixed_orient, _restrict_forward_to_src_sel
 from ..io.proj import make_projector, Projection
 from ..minimum_norm.inverse import _get_vertno, _prepare_forward
@@ -270,7 +271,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                     assert Ck.shape[1:] == (3, 3)
                     # Invert for all dipoles simultaneously using matrix
                     # inversion.
-                    norm = np.linalg.pinv(Ck, **pinv_kwargs)
+                    norm = pinv(Ck, **pinv_kwargs)
                 # Reapply source covariance after inversion
                 norm *= sk[:, :, np.newaxis]
                 norm *= sk[:, np.newaxis, :]

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -61,16 +61,6 @@ def _safe_svd(A, **kwargs):
             raise
 
 
-# SciPy 1.0+
-def _check_info(info, driver, positive='did not converge (LAPACK info=%d)'):
-    """Check info return value."""
-    if info < 0:
-        raise ValueError('illegal value in argument %d of internal %s'
-                         % (-info, driver))
-    if info > 0 and positive:
-        raise LinAlgError(("%s " + positive) % (driver, info,))
-
-
 ###############################################################################
 # Backporting nibabel's read_geometry
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -327,6 +327,33 @@ except ImportError:
 
 
 ###############################################################################
+# np.linalg.pinv (NumPy 1.13)
+
+if LooseVersion(np.__version__) >= LooseVersion('1.13'):
+    pinv = np.linalg.pinv
+else:
+    def _makearray(a):
+        new = np.asarray(a)
+        wrap = getattr(a, "__array_prepare__", new.__array_wrap__)
+        return new, wrap
+
+    def pinv(a, rcond=1e-15):
+        """Pseudoinverse."""
+        a, wrap = _makearray(a)
+        rcond = np.asarray(rcond)
+        a = a.conjugate()
+        u, s, vt = np.linalg.svd(a, full_matrices=False)
+        cutoff = rcond[..., np.newaxis] * np.amax(s, axis=-1, keepdims=True)
+        large = s > cutoff
+        s = np.divide(1, s, where=large, out=s)
+        s[~large] = 0
+        res = np.matmul(np.swapaxes(vt, -1, -2),
+                        np.multiply(s[..., np.newaxis],
+                                    np.swapaxes(u, -1, -2)))
+        return wrap(res)
+
+
+###############################################################################
 # NumPy Generator (NumPy 1.17)
 
 def rng_uniform(rng):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -56,5 +56,4 @@ from .numerics import (hashfunc, _compute_row_norms,
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _repeated_pinv2,
-                     _eig_lwork, _repeated_eig, _inv_lwork, _repeated_inv,
                      dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -26,7 +26,6 @@ import numpy as np
 from scipy import linalg
 from scipy.linalg import LinAlgError
 from scipy._lib._util import _asarray_validated
-from ..fixes import _check_info
 
 _d = np.empty(0, np.float64)
 _z = np.empty(0, np.complex128)
@@ -94,91 +93,6 @@ def _repeated_pinv2(x, lwork, rcond=None):
     u[:, :rank] *= psigma_diag
     B = np.transpose(np.conjugate(np.dot(u[:, :rank], vh[:rank])))
     return B
-
-
-###############################################################################
-# linalg.eig
-
-dgeev, dgeev_lwork = linalg.get_lapack_funcs(('geev', 'geev_lwork'), (_d,))
-zgeev, zgeev_lwork = linalg.get_lapack_funcs(('geev', 'geev_lwork'), (_z,))
-
-
-def _eig_lwork(shape, dtype=np.float64):
-    """Set up SVD calculations on identical-shape float64/complex128 arrays."""
-    if dtype == np.float64:
-        geev_lwork = dgeev_lwork
-    else:
-        assert dtype == np.complex128
-        geev_lwork = zgeev_lwork
-    lwork = linalg.decomp._compute_lwork(
-        geev_lwork, shape[0], compute_vl=False, compute_vr=True)
-    return lwork
-
-
-def _repeated_eig(a, lwork, overwrite_a=False):
-    """Mimic scipy.linalg.eig, avoid lwork and get_lapack_funcs overhead."""
-    if a.dtype == np.float64:
-        wr, wi, vl, vr, info = dgeev(
-            a, lwork=lwork, compute_vl=False, compute_vr=True,
-            overwrite_a=overwrite_a)
-        w = wr + _I * wi
-        need_complex = np.any(wi)
-    else:
-        assert a.dtype == np.complex128
-        w, vl, vr, info = zgeev(
-            a, lwork=lwork, compute_vl=False, compute_vr=True,
-            overwrite_a=overwrite_a)
-        need_complex = False
-    _check_info(
-        info, 'eig algorithm (geev)',
-        positive='did not converge (only eigenvalues '
-                 'with order >= %d have converged)')
-    if need_complex:
-        t = w.dtype.char
-        vr = linalg.decomp._make_complex_eigvecs(w, vr, t)
-    return w, vr
-
-
-###############################################################################
-# linalg.inv
-
-dgetrf, dgetri, dgetri_lwork = linalg.get_lapack_funcs(
-    ('getrf', 'getri', 'getri_lwork'), (_d,))
-zgetrf, zgetri, zgetri_lwork = linalg.get_lapack_funcs(
-    ('getrf', 'getri', 'getri_lwork'), (_z,))
-
-
-def _inv_lwork(shape, dtype=np.float64):
-    if dtype == np.float64:
-        getri_lwork = dgetri_lwork
-    else:
-        assert dtype == np.complex128
-        getri_lwork = zgetri_lwork
-    return linalg.lapack._compute_lwork(getri_lwork, shape[0])
-
-
-def _repeated_inv(a, lwork, overwrite_a=False):
-    if a.dtype == np.float64:
-        getrf, getri = dgetrf, dgetri
-    else:
-        assert a.dtype == np.complex128
-        getrf, getri = zgetrf, zgetri
-    lu, piv, info = getrf(a, overwrite_a=overwrite_a)
-    if info == 0:
-        # XXX: the following line fixes curious SEGFAULT when
-        # benchmarking 500x500 matrix inverse. This seems to
-        # be a bug in LAPACK ?getri routine because if lwork is
-        # minimal (when using lwork[0] instead of lwork[1]) then
-        # all tests pass. Further investigation is required if
-        # more such SEGFAULTs occur.
-        lwork = int(1.01 * lwork)
-        inv_a, info = getri(lu, piv, lwork=lwork, overwrite_lu=1)
-    if info > 0:
-        raise LinAlgError("singular matrix")
-    if info < 0:
-        raise ValueError('illegal value in %d-th argument of internal '
-                         'getrf|getri' % -info)
-    return inv_a
 
 
 ###############################################################################


### PR DESCRIPTION
Alternative version of #6763 designed to minimize code differences / maximize diff readability. @dmalt, @britta-wstnr, @wmvanvliet feel free to have a look. I think it ended up pretty readable.

`pytest mne/beamformer/` on `master` takes 33 sec, on this PR it's 26 sec, so pretty nice gains considering the testing overhead.

I have a `_noop_indentation_context` manager in there just to keep the indentation the same so the diff is more readable. Hopefully this makes it easy enough to see how each line was translated from an operation on a single source to operating on all sources simultaneously. Once everyone is happy about the diff, then I can remove that context manager before merge.