### PR TITLE
MRG: Make short channel function public

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -363,6 +363,7 @@ Projections:
    corrmap
    optical_density
    beer_lambert_law
+   short_channels
 
 EEG referencing:
 

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -14,7 +14,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.transforms import apply_trans, _get_trans
 from mne.utils import run_tests_if_main
 from mne.preprocessing._beer_lambert_law import _probe_distances,\
-    _short_channels
+    short_channels
 
 fname_nirx_15_0 = op.join(data_path(download=False),
                           'NIRx', 'nirx_15_0_recording')
@@ -56,12 +56,12 @@ def test_nirx_15_2_short():
     # Test which channels are short
     # These are the ones marked as red at
     # https://github.com/mne-tools/mne-testing-data/pull/51 step 4 figure 2
-    short_channels = _short_channels(raw)
-    assert_array_equal(short_channels[:9:2], [False, True, False, True, False])
-    short_channels = _short_channels(raw, threshold=0.003)
-    assert_array_equal(short_channels[:3:2], [False, False])
-    short_channels = _short_channels(raw, threshold=50)
-    assert_array_equal(short_channels[:3:2], [True, True])
+    is_short = short_channels(raw)
+    assert_array_equal(is_short[:9:2], [False, True, False, True, False])
+    is_short = short_channels(raw, threshold=0.003)
+    assert_array_equal(is_short[:3:2], [False, False])
+    is_short = short_channels(raw, threshold=50)
+    assert_array_equal(is_short[:3:2], [True, True])
 
     # Test trigger events
     assert_array_equal(raw.annotations.description, ['3.0', '2.0', '1.0'])

--- a/mne/preprocessing/__init__.py
+++ b/mne/preprocessing/__init__.py
@@ -22,4 +22,4 @@ from .stim import fix_stim_artifact
 from .maxwell import maxwell_filter
 from .xdawn import Xdawn
 from ._optical_density import optical_density
-from ._beer_lambert_law import beer_lambert_law
+from ._beer_lambert_law import beer_lambert_law, short_channels

--- a/mne/preprocessing/_beer_lambert_law.py
+++ b/mne/preprocessing/_beer_lambert_law.py
@@ -124,9 +124,23 @@ def _probe_distances(raw):
     return np.array(dist, float)
 
 
-def _short_channels(raw, threshold=0.01):
-    """Return a vector indicating which channels are short.
+def short_channels(raw, threshold=0.01):
+    """Determine which NIRS channels are short.
 
-    Channels with distance less than `threshold` are reported as short.
+    Channels with a source to detector distance of less than
+    `threshold` are reported as short. The default threshold is 1 cm.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        The optical density data.
+    threshold : float
+        The threshold distance for what is considered short.
+
+    Returns
+    -------
+    short : array of bool
+        Array indicating which channels are short.
+
     """
     return _probe_distances(raw) < threshold

--- a/mne/preprocessing/_beer_lambert_law.py
+++ b/mne/preprocessing/_beer_lambert_law.py
@@ -133,7 +133,7 @@ def short_channels(raw, threshold=0.01):
     Parameters
     ----------
     raw : instance of Raw
-        The optical density data.
+        NIRS data instance.
     threshold : float
         The threshold distance for what is considered short.
 

--- a/mne/preprocessing/_beer_lambert_law.py
+++ b/mne/preprocessing/_beer_lambert_law.py
@@ -125,7 +125,7 @@ def _probe_distances(raw):
 
 
 def short_channels(raw, threshold=0.01):
-    """Determine which NIRS channels are short.
+    r"""Determine which NIRS channels are short.
 
     Channels with a source to detector distance of less than
     `threshold` are reported as short. The default threshold is 1 cm.
@@ -141,6 +141,5 @@ def short_channels(raw, threshold=0.01):
     -------
     short : array of bool
         Array indicating which channels are short.
-
     """
     return _probe_distances(raw) < threshold

--- a/tutorials/preprocessing/plot_70_fnirs_processing.py
+++ b/tutorials/preprocessing/plot_70_fnirs_processing.py
@@ -37,9 +37,9 @@ raw_intensity = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
 # response. To achieve this we pick all the channels that are not considered
 # to be short (less than 1 cm distance between optodes).
 
-short_channels = mne.preprocessing._beer_lambert_law._short_channels(
+is_short = mne.preprocessing._beer_lambert_law.short_channels(
     raw_intensity, threshold=0.01)
-long_channels = np.logical_not(short_channels)
+long_channels = np.logical_not(is_short)
 raw_intensity.pick(mne.pick_channels(raw_intensity.ch_names,
                                      list(compress(raw_intensity.ch_names,
                                                    long_channels))))

--- a/tutorials/preprocessing/plot_70_fnirs_processing.py
+++ b/tutorials/preprocessing/plot_70_fnirs_processing.py
@@ -37,7 +37,7 @@ raw_intensity = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
 # response. To achieve this we pick all the channels that are not considered
 # to be short (less than 1 cm distance between optodes).
 
-is_short = mne.preprocessing._beer_lambert_law.short_channels(
+is_short = mne.preprocessing.short_channels(
     raw_intensity, threshold=0.01)
 long_channels = np.logical_not(is_short)
 raw_intensity.pick(mne.pick_channels(raw_intensity.ch_names,


### PR DESCRIPTION
#### Reference issue
Addresses #7034 


#### What does this implement/fix?
Changes the `_short_channels` function to a public `short_channels()` function and updates tests and tutorial.