### PR TITLE
[BUG] testing reading old data

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,6 +61,8 @@ Changelog
 Bug
 ~~~
 
+- Fix :func:`mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 
 - Fix :func:`mne.read_annotations` for text files with zero or one annotations, by `Adonay Nunes`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Changelog
 Bug
 ~~~
 
-- Fix :func:`mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix `mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Changelog
 Bug
 ~~~
 
-- Fix `mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix mne.io.meas_info._stamp_to_dt to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Changelog
 Bug
 ~~~
 
-- Fix mne.io.meas_info._stamp_to_dt to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix date reading before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -277,3 +277,5 @@
 .. _Victor Ferat: https://github.com/vferat
 
 .. _Demetres Kostas: https://github.com/kostasde
+
+.. _Alex Rockhill: https://github.com/alexrockhill/

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -130,9 +130,9 @@ def _stamp_to_dt(utc_stamp):
     stamp = [int(s) for s in utc_stamp]
     if len(stamp) == 1:  # In case there is no microseconds information
         stamp.append(0)
-    return (datetime.datetime.fromtimestamp(stamp[0],
+    return (datetime.datetime.fromtimestamp(0,
                                             tz=datetime.timezone.utc) +
-            datetime.timedelta(0, 0, stamp[1]))  # day, sec, μs
+            datetime.timedelta(0, stamp[0], stamp[1]))  # day, sec, μs
 
 
 def _unique_channel_names(ch_names):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -510,6 +510,13 @@ def test_meas_date_convert(tmpdir):
     assert(meas_date == meas_date2)
     assert(meas_datetime == datetime(2012, 9, 7, 1, 33, 5, 835782,
                                      tzinfo=timezone.utc))
+    # test old dates for BIDS anonymization
+    meas_date = (-1533443343, 24382)
+    meas_datetime = _stamp_to_dt(meas_date)
+    meas_date2 = _dt_to_stamp(meas_datetime)
+    assert(meas_date == meas_date2)
+    assert(meas_datetime == datetime(1921, 5, 29, 19, 30, 57, 24382,
+                                     tzinfo=timezone.utc))
 
 
 def test_anonymize(tmpdir):


### PR DESCRIPTION
Fixes issue related to https://github.com/mne-tools/mne-bids/pull/280. 

Windows throws an error when datetime.fromtimestamp is less than 0. This is the case for dates before 1970 Jan 1. I suspect that the way mne.io.meas_info._stamp_to_dt uses datetime.fromtimestamp will fail on a Windows OS. I am not by a windows machine and so cannot confirm but if the tests for windows fail, then I will fix it by using datetime.fromtimestamp(0) and then adding the argument that was being passed to fromtimestamp to timedelta. Basically, instead of reading from a timestamp, the number that was to be read from a timestamp will be used to move the time back stamp number of seconds.
