### PR TITLE
[MRG??][ENH] Change pre-Unix-zero-time to time stamp minutes, not seconds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.20.dev0)
 Changelog
 ~~~~~~~~~
 
-- Change `mne.io.meas_info._stamp_to_dt` and `mne.io.meas_info._dt_to_stamp` so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
+- Change mne.io.meas_info._stamp_to_dt and mne.io.meas_info._dt_to_stamp so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
 
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_.
 
@@ -64,7 +64,7 @@ Changelog
 Bug
 ~~~
 
-- Fix `mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix mne.io.meas_info._stamp_to_dt to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -14,6 +14,9 @@ Current (0.20.dev0)
 
 Changelog
 ~~~~~~~~~
+
+- Change :func:`mne.io.meas_info._stamp_to_dt` and :func:`mne.io.meas_info._dt_to_stamp` so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
+
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_.
 
 - Add command :ref:`gen_mne_setup_source_space` to quickly set up bilateral hemisphere surface-based source space with subsampling by `Victor Ferat`_.
@@ -60,6 +63,8 @@ Changelog
 
 Bug
 ~~~
+
+- Fix :func:`mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.20.dev0)
 Changelog
 ~~~~~~~~~
 
-- Change :func:`mne.io.meas_info._stamp_to_dt` and :func:`mne.io.meas_info._dt_to_stamp` so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
+- Change `mne.io.meas_info._stamp_to_dt` and `mne.io.meas_info._dt_to_stamp` so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
 
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -64,7 +64,7 @@ Changelog
 Bug
 ~~~
 
-- Fix :func:`mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix `mne.io.meas_info._stamp_to_dt` to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.20.dev0)
 Changelog
 ~~~~~~~~~
 
-- Change mne.io.meas_info._stamp_to_dt and mne.io.meas_info._dt_to_stamp so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_.
+- Change date measurement so that dates before Unix time 0 (1970 Jan 1) are represented as 32-bit integers corresponding to minutes instead of seconds by `Alex Rockhill`_
 
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_.
 
@@ -64,7 +64,7 @@ Changelog
 Bug
 ~~~
 
-- Fix mne.io.meas_info._stamp_to_dt to read dates before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
+- Fix date reading before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` to return the modified :class:`~mne.Epochs` or :class:`~mne.Evoked` instance (instead of ``None``) by `Daniel McCloy`_.
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -277,3 +277,5 @@
 .. _Victor Ferat: https://github.com/vferat
 
 .. _Demetres Kostas: https://github.com/kostasde
+
+.. _Alex Rockhill: https://github.com/alexrockhill/

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -122,10 +122,10 @@ def _summarize_str(st):
 def _dt_to_stamp(inp_date):
     """Convert a datetime object to a meas_date."""
     if inp_date.timestamp() > 0:
-        secondsback = int(inp_date.timestamp() // 1)
+        secondsforward = int(inp_date.timestamp() // 1)
     else:
-        secondsback = int(inp_date.timestamp() // 60)
-    return secondsback, inp_date.microsecond
+        secondsforward = int(inp_date.timestamp() // 60)
+    return secondsforward, inp_date.microsecond
 
 
 def _stamp_to_dt(utc_stamp):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -121,7 +121,11 @@ def _summarize_str(st):
 
 def _dt_to_stamp(inp_date):
     """Convert a datetime object to a meas_date."""
-    return int(inp_date.timestamp() // 1), inp_date.microsecond
+    if inp_date.timestamp() > 0:
+        secondsback = int(inp_date.timestamp() // 1)
+    else:
+        secondsback = int(inp_date.timestamp() // 60)
+    return secondsback, inp_date.microsecond
 
 
 def _stamp_to_dt(utc_stamp):
@@ -130,9 +134,11 @@ def _stamp_to_dt(utc_stamp):
     stamp = [int(s) for s in utc_stamp]
     if len(stamp) == 1:  # In case there is no microseconds information
         stamp.append(0)
-    return (datetime.datetime.fromtimestamp(stamp[0],
+    if stamp[0] < 0:
+        stamp[0] *= 60  # convert to minutes if before Unix time zero
+    return (datetime.datetime.fromtimestamp(0,
                                             tz=datetime.timezone.utc) +
-            datetime.timedelta(0, 0, stamp[1]))  # day, sec, μs
+            datetime.timedelta(0, stamp[0], stamp[1]))  # day, sec, μs
 
 
 def _unique_channel_names(ch_names):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -510,6 +510,13 @@ def test_meas_date_convert(tmpdir):
     assert(meas_date == meas_date2)
     assert(meas_datetime == datetime(2012, 9, 7, 1, 33, 5, 835782,
                                      tzinfo=timezone.utc))
+    # test old dates for BIDS anonymization
+    meas_date = (-45557390, 24382)
+    meas_datetime = _stamp_to_dt(meas_date)
+    meas_date2 = _dt_to_stamp(meas_datetime)
+    assert(meas_date == meas_date2)
+    assert(meas_datetime == datetime(1883, 5, 19, 22, 10, 0, 24382,
+                                     tzinfo=timezone.utc))
 
 
 def test_anonymize(tmpdir):


### PR DESCRIPTION
Here is my idea to fix https://github.com/bids-standard/bids-specification/issues/360, https://github.com/mne-tools/mne-python/pull/7016 and https://github.com/mne-tools/mne-bids/pull/280 until 2038: Any timestamp from before Unix time 0 (1970 Jan 1) will be interpreted as representing minutes instead of seconds back from Unix time 0.

The pros of this change will be that dates can be represented well before 1900 with minute-level resolution so you don't lose features like when in the day the scan was collected that are most often thrown away but for experimental debugging in my personal experience can be quite useful (there's a long story I told @jasmainak about NPR being picked up in our EEG until we put a Faraday cage up which would be depended on when they were on or off air). Existing and new data will be completely unaffected so long as their dates are before Unix time zero (we could move the date backward as well, < unix 0 is just the most parsimonious). Most importantly, dates will easily be able to go back far enough for BIDS specs (to the year -2114 Unix time).

The major con is that EEG data from before 1970 would be interpreted incorrectly. As stated previously, if data this old exists and wants to be read into MNE, we could move the convert to minutes date back to 1925. As maybe should be obvious, this won't cause any necessary changes in FIF or recording equipment as it is well past 1970 and therefore any timestamp generated now would be unaffected.
