### PR TITLE
MRG, ENH: Speed up I/O

### DIFF
--- a/mne/io/matrix.py
+++ b/mne/io/matrix.py
@@ -7,7 +7,7 @@ from .constants import FIFF
 from .tag import find_tag, has_tag
 from .write import (write_int, start_block, end_block, write_float_matrix,
                     write_name_list)
-from ..utils import logger, verbose
+from ..utils import logger
 
 
 def _transpose_named_matrix(mat):
@@ -17,9 +17,7 @@ def _transpose_named_matrix(mat):
     mat['data'] = mat['data'].T
 
 
-@verbose
-def _read_named_matrix(fid, node, matkind, indent='    ', transpose=False,
-                       verbose=None):
+def _read_named_matrix(fid, node, matkind, indent='    ', transpose=False):
     """Read named matrix from the given node.
 
     Parameters

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -11,7 +11,7 @@ from gzip import GzipFile
 import numpy as np
 from scipy import sparse
 
-from .tag import read_tag_info, read_tag, read_big, Tag, _call_dict_names
+from .tag import read_tag_info, read_tag, Tag, _call_dict_names
 from .tree import make_dir_tree, dir_tree_find
 from .constants import FIFF
 from ..utils import logger, verbose, _file_like
@@ -123,7 +123,7 @@ def fiff_open(fname, preload=False, verbose=None):
         # note that StringIO objects instantiated this way are read-only,
         # but that's okay here since we are using mode "rb" anyway
         with fid as fid_old:
-            fid = BytesIO(read_big(fid_old))
+            fid = BytesIO(fid_old.read())
 
     tag = read_tag_info(fid)
 

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -195,7 +195,7 @@ def _read_matrix(fid, tag, shape, rlims, matrix_coding):
         except KeyError:
             raise RuntimeError('Cannot handle matrix of type %d yet'
                                % matrix_type)
-        data = fid.read(bit * dims.prod())
+        data = fid.read(int(bit * dims.prod()))
         data = np.frombuffer(data, dtype=dtype)
         if matrix_type in (FIFF.FIFFT_COMPLEX_FLOAT,
                            FIFF.FIFFT_COMPLEX_DOUBLE):

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -4,8 +4,6 @@
 # License: BSD (3-clause)
 
 from functools import partial
-import gzip
-import os
 import struct
 
 import numpy as np
@@ -59,83 +57,6 @@ class Tag(object):
                    self.next == tag.next and
                    self.pos == tag.pos and
                    self.data == tag.data)
-
-
-def read_big(fid, size=None):
-    """Read large chunks of data (>16MB) Windows-friendly.
-
-    Parameters
-    ----------
-    fid : file
-        Open file to read from.
-    size : int or None
-        Number of bytes to read. If None, the whole file is read.
-
-    Returns
-    -------
-    buf : bytes
-        The data.
-
-    Notes
-    -----
-    Windows (argh) can't handle reading large chunks of data, so we
-    have to do it piece-wise, possibly related to:
-       http://stackoverflow.com/questions/4226941
-
-    Examples
-    --------
-    This code should work for normal files and .gz files:
-
-        >>> import numpy as np
-        >>> import gzip, os, tempfile, shutil
-        >>> fname = tempfile.mkdtemp()
-        >>> fname_gz = os.path.join(fname, 'temp.gz')
-        >>> fname = os.path.join(fname, 'temp.bin')
-        >>> randgen = np.random.RandomState(9)
-        >>> x = randgen.randn(3000000)  # > 16MB data
-        >>> with open(fname, 'wb') as fid: x.tofile(fid)
-        >>> with open(fname, 'rb') as fid: y = np.frombuffer(read_big(fid))
-        >>> assert np.all(x == y)
-        >>> fid_gz = gzip.open(fname_gz, 'wb')
-        >>> _ = fid_gz.write(x.tostring())
-        >>> fid_gz.close()
-        >>> fid_gz = gzip.open(fname_gz, 'rb')
-        >>> y = np.frombuffer(read_big(fid_gz))
-        >>> assert np.all(x == y)
-        >>> fid_gz.close()
-        >>> shutil.rmtree(os.path.dirname(fname))
-
-    """
-    # buf_size is chosen as a largest working power of 2 (16 MB):
-    buf_size = 16777216
-    if size is None:
-        # it's not possible to get .gz uncompressed or file-like file size
-        if not isinstance(fid, gzip.GzipFile):
-            try:
-                size = os.fstat(fid.fileno()).st_size - fid.tell()
-            except Exception:  # e.g., io.UnsupportedOperation: fileno
-                pass
-
-    if size is not None:
-        # Use pre-buffering method
-        segments = np.r_[np.arange(0, size, buf_size), size]
-        buf = bytearray(b' ' * size)
-        for start, end in zip(segments[:-1], segments[1:]):
-            data = fid.read(int(end - start))
-            if len(data) != end - start:
-                raise ValueError('Read error')
-            buf[start:end] = data
-        buf = bytes(buf)
-    else:
-        # Use presumably less efficient concatenating method
-        buf = [b'']
-        new = fid.read(buf_size)
-        while len(new) > 0:
-            buf.append(new)
-            new = fid.read(buf_size)
-        buf = b''.join(buf)
-
-    return buf
 
 
 def read_tag_info(fid):
@@ -231,6 +152,16 @@ def _read_tag_header(fid):
     return Tag(*struct.unpack('>iIii', s))
 
 
+_matrix_bit_dtype = {
+    FIFF.FIFFT_INT: (4, '>i4'),
+    FIFF.FIFFT_JULIAN: (4, '>i4'),
+    FIFF.FIFFT_FLOAT: (4, '>f4'),
+    FIFF.FIFFT_DOUBLE: (8, '>f8'),
+    FIFF.FIFFT_COMPLEX_FLOAT: (8, '>f4'),
+    FIFF.FIFFT_COMPLEX_DOUBLE: (16, '>f8'),
+}
+
+
 def _read_matrix(fid, tag, shape, rlims, matrix_coding):
     """Read a matrix (dense or sparse) tag."""
     matrix_coding = matrix_coding >> 16
@@ -259,28 +190,17 @@ def _read_matrix(fid, tag, shape, rlims, matrix_coding):
                             'supported at this time')
 
         matrix_type = _data_type & tag.type
-
-        if matrix_type == FIFF.FIFFT_INT:
-            data = np.frombuffer(read_big(fid, 4 * dims.prod()), dtype='>i4')
-        elif matrix_type == FIFF.FIFFT_JULIAN:
-            data = np.frombuffer(read_big(fid, 4 * dims.prod()), dtype='>i4')
-        elif matrix_type == FIFF.FIFFT_FLOAT:
-            data = np.frombuffer(read_big(fid, 4 * dims.prod()), dtype='>f4')
-        elif matrix_type == FIFF.FIFFT_DOUBLE:
-            data = np.frombuffer(read_big(fid, 8 * dims.prod()), dtype='>f8')
-        elif matrix_type == FIFF.FIFFT_COMPLEX_FLOAT:
-            data = np.frombuffer(read_big(fid, 4 * 2 * dims.prod()),
-                                 dtype='>f4')
+        try:
+            bit, dtype = _matrix_bit_dtype[matrix_type]
+        except KeyError:
+            raise RuntimeError('Cannot handle matrix of type %d yet'
+                               % matrix_type)
+        data = fid.read(bit * dims.prod())
+        data = np.frombuffer(data, dtype=dtype)
+        if matrix_type in (FIFF.FIFFT_COMPLEX_FLOAT,
+                           FIFF.FIFFT_COMPLEX_DOUBLE):
             # Note: we need the non-conjugate transpose here
             data = (data[::2] + 1j * data[1::2])
-        elif matrix_type == FIFF.FIFFT_COMPLEX_DOUBLE:
-            data = np.frombuffer(read_big(fid, 8 * 2 * dims.prod()),
-                                 dtype='>f8')
-            # Note: we need the non-conjugate transpose here
-            data = (data[::2] + 1j * data[1::2])
-        else:
-            raise Exception('Cannot handle matrix of type %d yet'
-                            % matrix_type)
         data.shape = dims
     elif matrix_coding in (_matrix_coding_CCS, _matrix_coding_RCS):
         # Find dimensions and return to the beginning of tag data

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -560,8 +560,7 @@ def _add_patch_info(s):
 
 
 @verbose
-def _read_source_spaces_from_tree(fid, tree, patch_stats=False,
-                                  verbose=None):
+def _read_source_spaces_from_tree(fid, tree, patch_stats=False, verbose=None):
     """Read the source spaces from a FIF file.
 
     Parameters
@@ -647,8 +646,7 @@ def read_source_spaces(fname, patch_stats=False, verbose=None):
     return src
 
 
-@verbose
-def _read_one_source_space(fid, this, verbose=None):
+def _read_one_source_space(fid, this):
     """Read one source space."""
     FIFF_BEM_SURF_NTRI = 3104
     FIFF_BEM_SURF_TRIANGLES = 3106


### PR DESCRIPTION
It turns out that our old `read_big` (#342) workaround has some overhead. Removing it in this PR takes the time to `read_forward_solution` down from 0.14 to 0.11 sec. So hopefully some speedups across the board for FIF I/O.

The workaround / bug is from 7 years ago, so I'm hoping that several new Python versions later it has been fixed. We'll see based on how the Azure builds do.