### PR TITLE
MRG, MAINT: Updates for sklearn deprecations

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import time
 import numbers
 from ..parallel import parallel_func
-from ..fixes import BaseEstimator, is_classifier
+from ..fixes import BaseEstimator, is_classifier, _get_check_scoring
 from ..utils import check_version, logger, warn, fill_doc
 
 
@@ -435,8 +435,8 @@ def cross_val_multiscore(estimator, X, y=None, groups=None, scoring=None,
 
     from sklearn.base import clone
     from sklearn.utils import indexable
-    from sklearn.metrics import check_scoring
     from sklearn.model_selection._split import check_cv
+    check_scoring = _get_check_scoring()
 
     X, y, groups = indexable(X, y, groups)
 

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -435,7 +435,7 @@ def cross_val_multiscore(estimator, X, y=None, groups=None, scoring=None,
 
     from sklearn.base import clone
     from sklearn.utils import indexable
-    from sklearn.metrics.scorer import check_scoring
+    from sklearn.metrics import check_scoring
     from sklearn.model_selection._split import check_cv
 
     X, y, groups = indexable(X, y, groups)

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -273,7 +273,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         score : array, shape (n_samples, n_estimators)
             Score for each estimator/task.
         """  # noqa: E501
-        from sklearn.metrics.scorer import check_scoring
+        from sklearn.metrics import check_scoring
 
         self._check_Xy(X)
         if X.shape[-1] != len(self.estimators_):
@@ -569,7 +569,7 @@ class GeneralizingEstimator(SlidingEstimator):
         score : array, shape (n_samples, n_estimators, n_slices)
             Score for each estimator / data slice couple.
         """  # noqa: E501
-        from sklearn.metrics.scorer import check_scoring
+        from sklearn.metrics import check_scoring
         self._check_Xy(X)
         # For predictions/transforms the parallelization is across the data and
         # not across the estimators to avoid memory load.

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .mixin import TransformerMixin
 from .base import BaseEstimator, _check_estimator
+from ..fixes import _get_check_scoring
 from ..parallel import parallel_func
 from ..utils import (_validate_type, array_split_idx, ProgressBar,
                      verbose, fill_doc)
@@ -273,7 +274,7 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         score : array, shape (n_samples, n_estimators)
             Score for each estimator/task.
         """  # noqa: E501
-        from sklearn.metrics import check_scoring
+        check_scoring = _get_check_scoring()
 
         self._check_Xy(X)
         if X.shape[-1] != len(self.estimators_):
@@ -569,7 +570,7 @@ class GeneralizingEstimator(SlidingEstimator):
         score : array, shape (n_samples, n_estimators, n_slices)
             Score for each estimator / data slice couple.
         """  # noqa: E501
-        from sklearn.metrics import check_scoring
+        check_scoring = _get_check_scoring()
         self._check_Xy(X)
         # For predictions/transforms the parallelization is across the data and
         # not across the estimators to avoid memory load.

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -205,7 +205,7 @@ def test_cross_val_multiscore():
     # compare to cross-val-score
     X = np.random.rand(20, 3)
     y = np.arange(20) % 2
-    cv = KFold(2, random_state=0)
+    cv = KFold(2, shuffle=False)
     clf = logreg
     assert_array_equal(cross_val_score(clf, X, y, cv=cv),
                        cross_val_multiscore(clf, X, y, cv=cv))

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -205,7 +205,7 @@ def test_cross_val_multiscore():
     # compare to cross-val-score
     X = np.random.rand(20, 3)
     y = np.arange(20) % 2
-    cv = KFold(2, shuffle=False)
+    cv = KFold(2, random_state=0, shuffle=True)
     clf = logreg
     assert_array_equal(cross_val_score(clf, X, y, cv=cv),
                        cross_val_multiscore(clf, X, y, cv=cv))

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -652,6 +652,16 @@ class BaseEstimator(object):
     # ``if type(self).__module__.startswith('sklearn.')``.
 
 
+# newer sklearn deprecates importing from sklearn.metrics.scoring,
+# but older sklearn does not expose check_scoring in sklearn.metrics.
+def _get_check_scoring():
+    try:
+        from sklearn.metrics import check_scoring  # noqa
+    except ImportError:
+        from sklearn.metrics.scoring import check_scoring  # noqa
+    return check_scoring
+
+
 ###############################################################################
 # Copied from sklearn to simplify code paths
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -658,7 +658,7 @@ def _get_check_scoring():
     try:
         from sklearn.metrics import check_scoring  # noqa
     except ImportError:
-        from sklearn.metrics.scoring import check_scoring  # noqa
+        from sklearn.metrics.scorer import check_scoring  # noqa
     return check_scoring
 
 

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -294,7 +294,7 @@ def _mixed_norm_solver_cd(M, G, alpha, lipschitz_constant, maxit=10000,
                           tol=1e-8, verbose=None, init=None, n_orient=1,
                           dgap_freq=10):
     """Solve L21 inverse problem with coordinate descent."""
-    from sklearn.linear_model.coordinate_descent import MultiTaskLasso
+    from sklearn.linear_model import MultiTaskLasso
 
     assert M.ndim == G.ndim and M.shape[0] == G.shape[0]
 
@@ -499,7 +499,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
 
     has_sklearn = True
     try:
-        from sklearn.linear_model.coordinate_descent import MultiTaskLasso  # noqa: F401,E501
+        from sklearn.linear_model import MultiTaskLasso  # noqa: F401
     except ImportError:
         has_sklearn = False
 

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -137,7 +137,7 @@ def test_continuous_regression_with_overlap():
         raw, events, {1: 1}, tmin=0)[1].data.flatten())
 
     # test that sklearn solvers can be used
-    from sklearn.linear_model.ridge import ridge_regression
+    from sklearn.linear_model import ridge_regression
 
     def solver(X, y):
         return ridge_regression(X, y, alpha=0., solver="cholesky")


### PR DESCRIPTION
`sklearn` master has deprecated importing from submodules things that can be imported from higher level ones. Also they emit a warning when `random_state` is passed with `shuffle=False`, since it has no effect.