### PR TITLE
ENH gamma_map():  allow returning vector source estimates

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -58,6 +58,8 @@ Changelog
 
 - Add command :ref:`gen_mne_prepare_bem_model` to quickly create a BEM solution using the linear collocation approach by `Victor Ferat`_.
 
+- Allow returning vector source estimates from sparse inverse solvers through ``pick_ori='vector'`` by `Christian Brodbeck`_
+
 Bug
 ~~~
 

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -217,12 +217,7 @@ def gamma_map(evoked, forward, noise_cov, alpha, loose="auto", depth=0.8,
     %(rank_None)s
 
         .. versionadded:: 0.18
-    pick_ori : None | "vector"
-        Only applies to loose/free orientation. By default (None) pooling is
-        performed by taking the norm of current vectors. Set to  "vector" to
-        return vector source estimate.
-
-        .. versionadded:: 0.20
+    %(pick_ori-vec)s
     %(verbose)s
 
     Returns

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -75,6 +75,10 @@ def test_gamma_map():
                     xyz_same_gamma=True, update_mode=1)
     _check_stc(stc, evoked, 68477, 'lh', fwd=forward)
 
+    vec_stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
+                        xyz_same_gamma=True, update_mode=1, pick_ori='vector')
+    _check_stcs(vec_stc.magnitude(), stc)
+
     stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                     xyz_same_gamma=False, update_mode=1)
     _check_stc(stc, evoked, 82010, 'lh', fwd=forward)

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -16,13 +16,11 @@ from mne.cov import regularize
 from mne.inverse_sparse import gamma_map
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne import pick_types_forward
-from mne.utils import run_tests_if_main
-from mne.utils._testing import assert_stcs_equal
+from mne.utils import assert_stcs_equal, run_tests_if_main
 from mne.dipole import Dipole
 
 data_path = testing.data_path(download=False)
-fname_evoked = op.join(data_path, 'MEG', 'sample',
-                       'sample_audvis-ave.fif')
+fname_evoked = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
 fname_cov = op.join(data_path, 'MEG', 'sample', 'sample_audvis-cov.fif')
 fname_fwd = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc-meg-eeg-oct-6-fwd.fif')

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -17,6 +17,7 @@ from mne.inverse_sparse import gamma_map
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne import pick_types_forward
 from mne.utils import run_tests_if_main
+from mne.utils._testing import assert_stcs_equal
 from mne.dipole import Dipole
 
 data_path = testing.data_path(download=False)
@@ -44,16 +45,6 @@ def _check_stc(stc, evoked, idx, hemi, fwd, dist_limit=0., ratio=50.):
     assert amps[0] > ratio * amps[1]
 
 
-def _check_stcs(stc1, stc2):
-    """Check correctness."""
-    assert_allclose(stc1.times, stc2.times)
-    assert_allclose(stc1.data, stc2.data)
-    assert_allclose(stc1.vertices[0], stc2.vertices[0])
-    assert_allclose(stc1.vertices[1], stc2.vertices[1])
-    assert_allclose(stc1.tmin, stc2.tmin)
-    assert_allclose(stc1.tstep, stc2.tstep)
-
-
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_gamma_map():
@@ -77,7 +68,7 @@ def test_gamma_map():
 
     vec_stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                         xyz_same_gamma=True, update_mode=1, pick_ori='vector')
-    _check_stcs(vec_stc.magnitude(), stc)
+    assert_stcs_equal(vec_stc.magnitude(), stc)
 
     stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,
                     xyz_same_gamma=False, update_mode=1)
@@ -88,7 +79,7 @@ def test_gamma_map():
                      return_as_dipoles=True)
     assert (isinstance(dips[0], Dipole))
     stc_dip = make_stc_from_dipoles(dips, forward['src'])
-    _check_stcs(stc, stc_dip)
+    assert_stcs_equal(stc, stc_dip)
 
     # force fixed orientation
     stc = gamma_map(evoked, forward, cov, alpha, tol=1e-4,

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -6,7 +6,7 @@ import os.path as op
 
 import pytest
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_allclose
+from numpy.testing import assert_array_almost_equal
 
 import mne
 from mne.datasets import testing

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -134,7 +134,7 @@ def test_mxne_inverse_standard():
 
     # vector
     stc_nrm = tf_mixed_norm(
-        evoked, forward, cov, loose=1, depth=depth, maxit=100, tol=1e-4,
+        evoked, forward, cov, loose=1, depth=depth, maxit=2, tol=1e-4,
         tstep=4, wsize=16, window=0.1, weights=stc_dspm,
         weights_min=weights_min, alpha=alpha, l1_ratio=l1_ratio)
     stc_vec = tf_mixed_norm(

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -16,8 +16,7 @@ from mne import (read_cov, read_forward_solution, read_evokeds,
 from mne.inverse_sparse import mixed_norm, tf_mixed_norm
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne.minimum_norm import apply_inverse, make_inverse_operator
-from mne.utils import run_tests_if_main
-from mne.utils._testing import assert_stcs_equal
+from mne.utils import assert_stcs_equal, run_tests_if_main
 from mne.dipole import Dipole
 from mne.source_estimate import VolSourceEstimate
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -138,7 +138,7 @@ def test_mxne_inverse_standard():
         tstep=4, wsize=16, window=0.1, weights=stc_dspm,
         weights_min=weights_min, alpha=alpha, l1_ratio=l1_ratio)
     stc_vec = tf_mixed_norm(
-        evoked, forward, cov, loose=1, depth=depth, maxit=100, tol=1e-4,
+        evoked, forward, cov, loose=1, depth=depth, maxit=2, tol=1e-4,
         tstep=4, wsize=16, window=0.1, weights=stc_dspm,
         weights_min=weights_min, alpha=alpha, l1_ratio=l1_ratio,
         pick_ori='vector')

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -141,6 +141,18 @@ def test_mxne_inverse_standard():
     assert_array_almost_equal(stc.times, evoked.times, 5)
     assert stc.vertices[1][0] in label.vertices
 
+    # vector
+    stc_nrm = tf_mixed_norm(
+        evoked, forward, cov, loose=1, depth=depth, maxit=100, tol=1e-4,
+        tstep=4, wsize=16, window=0.1, weights=stc_dspm,
+        weights_min=weights_min, alpha=alpha, l1_ratio=l1_ratio)
+    stc_vec = tf_mixed_norm(
+        evoked, forward, cov, loose=1, depth=depth, maxit=100, tol=1e-4,
+        tstep=4, wsize=16, window=0.1, weights=stc_dspm,
+        weights_min=weights_min, alpha=alpha, l1_ratio=l1_ratio,
+        pick_ori='vector')
+    assert_stcs_equal(stc_vec.magnitude(), stc_nrm)
+
     pytest.raises(ValueError, tf_mixed_norm, evoked, forward, cov,
                   alpha=101, l1_ratio=0.03)
     pytest.raises(ValueError, tf_mixed_norm, evoked, forward, cov,

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -17,6 +17,7 @@ from mne.inverse_sparse import mixed_norm, tf_mixed_norm
 from mne.inverse_sparse.mxne_inverse import make_stc_from_dipoles
 from mne.minimum_norm import apply_inverse, make_inverse_operator
 from mne.utils import run_tests_if_main
+from mne.utils._testing import assert_stcs_equal
 from mne.dipole import Dipole
 from mne.source_estimate import VolSourceEstimate
 
@@ -29,16 +30,6 @@ fname_fwd = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc-meg-eeg-oct-6-fwd.fif')
 label = 'Aud-rh'
 fname_label = op.join(data_path, 'MEG', 'sample', 'labels', '%s.label' % label)
-
-
-def _check_stcs(stc1, stc2):
-    """Check STC correctness."""
-    assert_allclose(stc1.times, stc2.times)
-    assert_allclose(stc1.data, stc2.data)
-    assert_allclose(stc1.vertices[0], stc2.vertices[0])
-    assert_allclose(stc1.vertices[1], stc2.vertices[1])
-    assert_allclose(stc1.tmin, stc2.tmin)
-    assert_allclose(stc1.tstep, stc2.tstep)
 
 
 @pytest.mark.timeout(120)  # ~30 sec on AppVeyor and Travis Linux
@@ -108,7 +99,7 @@ def test_mxne_inverse_standard():
     stc_dip = make_stc_from_dipoles(dips, forward['src'])
     assert isinstance(dips[0], Dipole)
     assert stc_dip.subject == "sample"
-    _check_stcs(stc_cd, stc_dip)
+    assert_stcs_equal(stc_cd, stc_dip)
 
     with pytest.warns(None):  # CD
         stc, _ = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -41,7 +41,7 @@ from ._testing import (run_tests_if_main, run_command_if_main,
                        requires_neuromag2ft, requires_pylsl, assert_object_equal,
                        assert_and_remove_boundary_annot, _raw_annot,
                        assert_dig_allclose, assert_meg_snr, assert_snr,
-                       modified_env)
+                       assert_stcs_equal, modified_env)
 from .numerics import (hashfunc, _compute_row_norms,
                        _reg_pinv, random_permutation, _reject_data_segments,
                        compute_corr, _get_inst_data, array_split_idx,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -433,6 +433,16 @@ def assert_snr(actual, desired, tol):
     assert snr >= tol, '%f < %f' % (snr, tol)
 
 
+def assert_stcs_equal(stc1, stc2):
+    """Check that two STC are equal."""
+    assert_allclose(stc1.times, stc2.times)
+    assert_allclose(stc1.data, stc2.data)
+    assert_array_equal(stc1.vertices[0], stc2.vertices[0])
+    assert_array_equal(stc1.vertices[1], stc2.vertices[1])
+    assert_allclose(stc1.tmin, stc2.tmin)
+    assert_allclose(stc1.tstep, stc2.tstep)
+
+
 def _dig_sort_key(dig):
     """Sort dig keys."""
     return (dig['kind'], dig['ident'])

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -209,6 +209,14 @@ depth : None | float | dict
     keyword arguments to pass to :func:`mne.forward.compute_depth_prior`
     (see docstring for details and defaults).
 """
+docdict['pick_ori-vec'] = """
+    pick_ori : None | "vector"
+        Only applies to loose/free orientation. By default (None) pooling is
+        performed by taking the norm of the current vectors. Use 
+        pick_ori="vector" to return vector source estimate.
+
+        .. versionadded:: 0.20
+"""
 
 # Forward
 docdict['on_missing'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -212,7 +212,7 @@ depth : None | float | dict
 docdict['pick_ori-vec'] = """
     pick_ori : None | "vector"
         Only applies to loose/free orientation. By default (None) pooling is
-        performed by taking the norm of the current vectors. Use 
+        performed by taking the norm of the current vectors. Use
         pick_ori="vector" to return vector source estimate.
 
         .. versionadded:: 0.20


### PR DESCRIPTION
#### What does this implement/fix?
Minor adaptation that allows to return vector source estimates from the `gamma_map()` function. To be consistent with the MNE functions I used `pick_ori` as parameter (rather than a boolean argument for vectors).
