### PR TITLE
MRG, MAINT: Remove testpath requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,6 @@ dependencies:
 - traits>=4.6.0
 - pyface>=6
 - traitsui>=6
-- testpath<0.4
 - pip:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master


### PR DESCRIPTION
Let's see if everything works without this workaround. Probably things have been fixed in the last year to take care of whatever it was we were working around. See #7013 for related discussion.

Closes #7013.