### PR TITLE
MAINT: Ignore warning for dipy

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -50,7 +50,7 @@ def pytest_configure(config):
     #   we should remove them from here.
     # - This list should also be considered alongside reset_warnings in
     #   doc/conf.py.
-    warning_lines = """
+    warning_lines = r"""
     error::
     ignore::ImportWarning
     ignore:the matrix subclass:PendingDeprecationWarning
@@ -74,6 +74,7 @@ def pytest_configure(config):
     ignore:.*mne-realtime.*:DeprecationWarning
     ignore:.*imp.*:DeprecationWarning
     ignore:Exception creating Regex for oneOf.*:SyntaxWarning
+    ignore:scipy\.gradient is deprecated.*:DeprecationWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
Work around [this warning](https://travis-ci.org/mne-tools/mne-python/jobs/609869541):
```
E       DeprecationWarning: scipy.gradient is deprecated and will be removed in SciPy 2.0.0, use numpy.gradient instead
```
Until dipy pushes a release with https://github.com/nipy/dipy/pull/1994