### PR TITLE
MRG: Change way NIRS frequency is encoded

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -215,6 +215,7 @@ class RawNIRX(BaseRaw):
         # The source location is stored in the second 3 entries of loc.
         # The detector location is stored in the third 3 entries of loc.
         # NIRx NIRSite uses MNI coordinates.
+        # Also encode the light frequency in the structure.
         for ch_idx2 in range(requested_channels.shape[0]):
             # Find source and store location
             src = int(requested_channels[ch_idx2, 0]) - 1
@@ -233,6 +234,8 @@ class RawNIRX(BaseRaw):
             else:
                 info['chs'][ch_idx2 * 2]['loc'][:3] = ch_locs[ch_idx2, :]
                 info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = ch_locs[ch_idx2, :]
+            info['chs'][ch_idx2 * 2]['loc'][9] = fnirs_wavelengths[0]
+            info['chs'][ch_idx2 * 2 + 1]['loc'][9] = fnirs_wavelengths[1]
         raw_extras = {"sd_index": req_ind, 'files': files}
 
         super(RawNIRX, self).__init__(

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -38,6 +38,10 @@ def test_nirx_15_2_short():
                                         "S1-D9 760", "S1-D9 850"]
     assert raw.info['ch_names'][24:26] == ["S5-D13 760", "S5-D13 850"]
 
+    # Test frequency encoding
+    assert raw.info['chs'][0]['loc'][9] == 760
+    assert raw.info['chs'][1]['loc'][9] == 850
+
     # Test info import
     assert raw.info['subject_info'] == dict(sex=1, first_name="MNE",
                                             middle_name="Test",

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -64,9 +64,7 @@ def _channel_frequencies(raw):
     picks = _picks_to_idx(raw.info, 'fnirs_od')
     freqs = np.empty(picks.size, int)
     for ii in picks:
-        ch_name_info = re.match(r'S(\d+)-D(\d+) (\d+)',
-                                raw.info['chs'][ii]['ch_name'])
-        freqs[ii] = ch_name_info.groups()[2]
+        freqs[ii] = raw.info['chs'][ii]['loc'][9]
     return freqs
 
 


### PR DESCRIPTION
#### Reference issue
Addresses issue #7057


#### What does this implement/fix?
Change the way NIRS light frequency is encoded as [suggested by @larsoner](https://github.com/mne-tools/mne-python/pull/6674#issuecomment-546908907)